### PR TITLE
Feat/core framework - MCP Tool Integration

### DIFF
--- a/.claude/skills/building-agents
+++ b/.claude/skills/building-agents
@@ -1,0 +1,1 @@
+../../core/.claude/skills/building-agents

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ __pycache__/
 .cache/
 tmp/
 temp/
+
+exports/*

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "agent-builder": {
+      "command": "python",
+      "args": ["-m", "framework.mcp.agent_builder_server"],
+      "cwd": "/home/timothy/oss/hive/core"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -82,130 +82,69 @@ Traditional agent frameworks require you to manually design workflows, define ag
 
 ```mermaid
 flowchart TB
-    subgraph USER["👤 User / Developer"]
-        GOAL[("🎯 Define Goal<br/>& Success Criteria")]
-        INPUT[("💬 Runtime Input")]
-    end
-
-    subgraph BUILDER["🏗️ Builder Layer (via Claude/LLM)"]
-        direction TB
-        PHASE1["Phase 1: Goal Draft<br/>(constraints, criteria)"]
-        PHASE2["Phase 2: Add Nodes<br/>(llm_tool_use, router, etc)"]
-        PHASE3["Phase 3: Add Edges<br/>(routing logic)"]
-        PHASE4["Phase 4: Test & Validate"]
-        PHASE5["Phase 5: Export Agent"]
-        QUERY["Query & Analysis<br/>(find patterns, suggest improvements)"]
-    end
-
-    subgraph EXPORT["📦 Exported Agent"]
+    subgraph BUILD["🏗️ AGENT BUILD PROCESS"]
         direction LR
-        AGENT_JSON["agent.json<br/>(graph spec + goal)"]
-        TOOLS_PY["tools.py<br/>(custom tools)"]
-        MCP_JSON["mcp_servers.json<br/>(MCP configs)"]
+        GOAL["🎯 Define Goal<br/>+ Success Criteria"]
+        BUILDER["🤖 Builder Agent<br/>(Claude/LLM)"]
+        GRAPH["Create Agent Graph<br/>• Add Nodes<br/>• Define Edges<br/>• Test & Validate"]
+        EXPORT["📦 Export<br/>agent.json<br/>tools.py<br/>mcp_servers.json"]
+
+        GOAL --> BUILDER
+        BUILDER --> GRAPH
+        GRAPH --> EXPORT
     end
 
-    subgraph RUNNER["🚀 Runner Layer"]
-        direction TB
-        AGENT_RUNNER["AgentRunner<br/>(loads agent)"]
-        TOOL_REG["ToolRegistry<br/>(discovers tools)"]
-        MCP_CLIENT["MCPClient<br/>(connects to servers)"]
-        ORCHESTRATOR["Orchestrator<br/>(multi-agent routing)"]
-    end
+    subgraph RUNTIME["🚀 AGENT EXECUTION"]
+        direction LR
+        INPUT["💬 User Input"]
+        RUNNER["AgentRunner<br/>• Load agent.json<br/>• ToolRegistry<br/>• MCP Integration"]
+        EXECUTOR["Graph Executor<br/>• Step-by-step<br/>• State management"]
 
-    subgraph GRAPH["⚙️ Graph Executor"]
-        direction TB
-        EXECUTOR["GraphExecutor<br/>(step-by-step execution)"]
-        subgraph NODES["Node Types"]
-            LLM_NODE["LLM Generate/Tool Use"]
-            ROUTER["Router (conditional/LLM)"]
-            FUNCTION["Function Node"]
-            HITL_NODE["Human-in-the-Loop"]
-            JUDGE["Judge (evaluation)"]
+        subgraph NODES["Node Execution"]
+            direction TB
+            LLM_NODE["LLM Nodes<br/>(generate/tool use)"]
+            ROUTER["Router Nodes<br/>(conditional/LLM)"]
+            FUNC["Function Nodes"]
+            HITL["Human-in-the-Loop"]
         end
+
+        INPUT --> RUNNER
+        RUNNER --> EXECUTOR
+        EXECUTOR --> NODES
     end
 
-    subgraph NODE_CTX["📋 Node Context (per execution)"]
+    subgraph INFRA["⚙️ CORE INFRASTRUCTURE"]
         direction LR
-        CTX_RUNTIME["Runtime<br/>(decision recorder)"]
-        CTX_MEMORY["SharedMemory<br/>(cross-node state)"]
-        CTX_TOOLS["Available Tools"]
-        CTX_LLM["LLM Provider"]
+
+        subgraph CTX["Node Context (Runtime)"]
+            direction TB
+            RUNTIME_DEC["Decision Recorder<br/>intent → options → choice"]
+            MEMORY["Shared Memory"]
+            TOOLS["Tool Access"]
+        end
+
+        LLM["🧠 LLM Providers<br/>Claude • GPT-4 • Gemini"]
+
+        STORAGE[("💾 Storage<br/>Decision History<br/>Metrics & Analytics")]
+
+        DASHBOARD["📊 Dashboard<br/>Monitoring • Costs • KPIs"]
     end
 
-    subgraph RUNTIME["📝 Runtime Layer"]
-        direction TB
-        DECISION_REC["Decision Recording<br/>(intent, options, choice, reasoning)"]
-        OUTCOME_REC["Outcome Recording<br/>(success/failure, metrics)"]
-    end
+    EXPORT --> RUNNER
+    NODES --> CTX
+    CTX --> LLM
+    CTX --> STORAGE
+    STORAGE --> DASHBOARD
+    STORAGE -.->|Self-Improve| BUILDER
 
-    subgraph LLM["🧠 LLM Layer"]
-        direction LR
-        ANTHROPIC["Anthropic<br/>(Claude)"]
-        OPENAI["OpenAI<br/>(GPT-4)"]
-        GOOGLE["Google<br/>(Gemini)"]
-    end
-
-    subgraph STORAGE["💾 Storage Layer"]
-        direction TB
-        RUN_STORE[("Run Storage<br/>(all decisions & outcomes)")]
-        CONTROL_DB[("Control Plane DB<br/>(metrics, policies, users)")]
-    end
-
-    subgraph DASHBOARD["📊 Dashboard (Honeycomb)"]
-        ANALYTICS["Agent Analytics"]
-        MONITOR["Execution Monitoring"]
-        COSTS["Cost Tracking"]
-    end
-
-    %% Build Flow
-    GOAL --> PHASE1
-    PHASE1 --> PHASE2
-    PHASE2 --> PHASE3
-    PHASE3 --> PHASE4
-    PHASE4 --> PHASE5
-    PHASE5 --> EXPORT
-
-    %% Runtime Flow
-    INPUT --> AGENT_RUNNER
-    EXPORT --> AGENT_RUNNER
-    AGENT_RUNNER --> TOOL_REG & MCP_CLIENT
-    TOOL_REG --> EXECUTOR
-    MCP_CLIENT --> TOOL_REG
-    AGENT_RUNNER --> EXECUTOR
-
-    EXECUTOR --> NODES
-    NODES --> NODE_CTX
-    NODE_CTX --> CTX_RUNTIME
-    CTX_RUNTIME --> DECISION_REC
-    DECISION_REC --> OUTCOME_REC
-    OUTCOME_REC --> RUN_STORE
-
-    NODE_CTX --> CTX_LLM
-    CTX_LLM --> LLM
-
-    %% Feedback Loop
-    RUN_STORE -->|"Analyze runs"| QUERY
-    QUERY -->|"Suggest improvements"| PHASE2
-
-    %% Multi-agent
-    ORCHESTRATOR -.->|"Route to agents"| AGENT_RUNNER
-
-    %% Dashboard Integration
-    RUN_STORE --> DASHBOARD
-    CONTROL_DB --> DASHBOARD
-
-    %% HITL Pause
-    HITL_NODE -.->|"Pause for approval"| USER
-
-    style USER fill:#e8f5e9,stroke:#2e7d32
-    style BUILDER fill:#e3f2fd,stroke:#1565c0
+    style BUILD fill:#e3f2fd,stroke:#1565c0,stroke-width:2px
+    style RUNTIME fill:#fff3e0,stroke:#ef6c00,stroke-width:2px
+    style INFRA fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
+    style NODES fill:#ffe0b2,stroke:#e65100
+    style CTX fill:#fce4ec,stroke:#c2185b
+    style GOAL fill:#e8f5e9,stroke:#2e7d32
     style EXPORT fill:#fff9c4,stroke:#f57f17
-    style RUNNER fill:#ede7f6,stroke:#5e35b1
-    style GRAPH fill:#fff3e0,stroke:#ef6c00
-    style NODE_CTX fill:#fce4ec,stroke:#c2185b
-    style RUNTIME fill:#e0f2f1,stroke:#00695c
-    style LLM fill:#f3e5f5,stroke:#7b1fa2
-    style STORAGE fill:#eceff1,stroke:#37474f
+    style STORAGE fill:#eceff1,stroke:#455a64
     style DASHBOARD fill:#e0f7fa,stroke:#00838f
 ```
 

--- a/README.md
+++ b/README.md
@@ -81,71 +81,48 @@ docker compose up
 Traditional agent frameworks require you to manually design workflows, define agent interactions, and handle failures reactively. Aden flips this paradigm—**you describe outcomes, and the system builds itself**.
 
 ```mermaid
-flowchart TB
-    subgraph BUILD["🏗️ AGENT BUILD PROCESS"]
-        direction LR
-        GOAL["🎯 Define Goal<br/>+ Success Criteria"]
-        BUILDER["🤖 Builder Agent<br/>(Claude/LLM)"]
-        GRAPH["Create Agent Graph<br/>• Add Nodes<br/>• Define Edges<br/>• Test & Validate"]
-        EXPORT["📦 Export<br/>agent.json<br/>tools.py<br/>mcp_servers.json"]
-
-        GOAL --> BUILDER
-        BUILDER --> GRAPH
-        GRAPH --> EXPORT
+flowchart LR
+    subgraph BUILD["🏗️ BUILD"]
+        GOAL["Define Goal<br/>+ Success Criteria"] --> NODES["Add Nodes<br/>LLM/Router/Function"]
+        NODES --> EDGES["Connect Edges<br/>on_success/failure/conditional"]
+        EDGES --> TEST["Test & Validate"] --> APPROVE["Approve & Export"]
     end
 
-    subgraph RUNTIME["🚀 AGENT EXECUTION"]
-        direction LR
-        INPUT["💬 User Input"]
-        RUNNER["AgentRunner<br/>• Load agent.json<br/>• ToolRegistry<br/>• MCP Integration"]
-        EXECUTOR["Graph Executor<br/>• Step-by-step<br/>• State management"]
+    subgraph EXPORT["📦 EXPORT"]
+        direction TB
+        JSON["agent.json<br/>(GraphSpec)"]
+        TOOLS["tools.py<br/>(Functions)"]
+        MCP["mcp_servers.json<br/>(Integrations)"]
+    end
 
-        subgraph NODES["Node Execution"]
-            direction TB
-            LLM_NODE["LLM Nodes<br/>(generate/tool use)"]
-            ROUTER["Router Nodes<br/>(conditional/LLM)"]
-            FUNC["Function Nodes"]
-            HITL["Human-in-the-Loop"]
+    subgraph RUN["🚀 RUNTIME"]
+        LOAD["AgentRunner<br/>Load + Parse"] --> SETUP["Setup Runtime<br/>+ ToolRegistry"]
+        SETUP --> EXEC["GraphExecutor<br/>Execute Nodes"]
+
+        subgraph DECISION["Decision Recording"]
+            DEC1["runtime.decide()<br/>intent → options → choice"]
+            DEC2["runtime.record_outcome()<br/>success, result, metrics"]
         end
-
-        INPUT --> RUNNER
-        RUNNER --> EXECUTOR
-        EXECUTOR --> NODES
     end
 
-    subgraph INFRA["⚙️ CORE INFRASTRUCTURE"]
-        direction LR
-
-        subgraph CTX["Node Context (Runtime)"]
-            direction TB
-            RUNTIME_DEC["Decision Recorder<br/>intent → options → choice"]
-            MEMORY["Shared Memory"]
-            TOOLS["Tool Access"]
-        end
-
-        LLM["🧠 LLM Providers<br/>Claude • GPT-4 • Gemini"]
-
-        STORAGE[("💾 Storage<br/>Decision History<br/>Metrics & Analytics")]
-
-        DASHBOARD["📊 Dashboard<br/>Monitoring • Costs • KPIs"]
+    subgraph INFRA["⚙️ INFRASTRUCTURE"]
+        CTX["NodeContext<br/>memory • llm • tools"]
+        STORE[("FileStorage<br/>Runs & Decisions")]
     end
 
-    EXPORT --> RUNNER
-    NODES --> CTX
-    CTX --> LLM
-    CTX --> STORAGE
-    STORAGE --> DASHBOARD
-    STORAGE -.->|Self-Improve| BUILDER
+    APPROVE --> EXPORT
+    EXPORT --> LOAD
+    EXEC --> DECISION
+    EXEC --> CTX
+    DECISION --> STORE
+    STORE -.->|"Analyze & Improve"| NODES
 
-    style BUILD fill:#bbdefb,stroke:#1565c0,stroke-width:2px,color:#000
-    style RUNTIME fill:#ffe082,stroke:#ef6c00,stroke-width:2px,color:#000
-    style INFRA fill:#e1bee7,stroke:#7b1fa2,stroke-width:2px,color:#000
-    style NODES fill:#ffcc80,stroke:#e65100,stroke-width:2px,color:#000
-    style CTX fill:#f8bbd0,stroke:#c2185b,stroke-width:2px,color:#000
-    style GOAL fill:#c8e6c9,stroke:#2e7d32,stroke-width:2px,color:#000
-    style EXPORT fill:#fff59d,stroke:#f57f17,stroke-width:2px,color:#000
-    style STORAGE fill:#b0bec5,stroke:#455a64,stroke-width:2px,color:#000
-    style DASHBOARD fill:#b2ebf2,stroke:#00838f,stroke-width:2px,color:#000
+    style BUILD fill:#ffbe42,stroke:#cc5d00,stroke-width:3px,color:#333
+    style EXPORT fill:#fff59d,stroke:#ed8c00,stroke-width:2px,color:#333
+    style RUN fill:#ffb100,stroke:#cc5d00,stroke-width:3px,color:#333
+    style DECISION fill:#ffcc80,stroke:#ed8c00,stroke-width:2px,color:#333
+    style INFRA fill:#e8763d,stroke:#cc5d00,stroke-width:3px,color:#fff
+    style STORE fill:#ed8c00,stroke:#cc5d00,stroke-width:2px,color:#fff
 ```
 
 ### The Aden Advantage

--- a/README.md
+++ b/README.md
@@ -137,15 +137,15 @@ flowchart TB
     STORAGE --> DASHBOARD
     STORAGE -.->|Self-Improve| BUILDER
 
-    style BUILD fill:#e3f2fd,stroke:#1565c0,stroke-width:2px
-    style RUNTIME fill:#fff3e0,stroke:#ef6c00,stroke-width:2px
-    style INFRA fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
-    style NODES fill:#ffe0b2,stroke:#e65100
-    style CTX fill:#fce4ec,stroke:#c2185b
-    style GOAL fill:#e8f5e9,stroke:#2e7d32
-    style EXPORT fill:#fff9c4,stroke:#f57f17
-    style STORAGE fill:#eceff1,stroke:#455a64
-    style DASHBOARD fill:#e0f7fa,stroke:#00838f
+    style BUILD fill:#bbdefb,stroke:#1565c0,stroke-width:2px,color:#000
+    style RUNTIME fill:#ffe082,stroke:#ef6c00,stroke-width:2px,color:#000
+    style INFRA fill:#e1bee7,stroke:#7b1fa2,stroke-width:2px,color:#000
+    style NODES fill:#ffcc80,stroke:#e65100,stroke-width:2px,color:#000
+    style CTX fill:#f8bbd0,stroke:#c2185b,stroke-width:2px,color:#000
+    style GOAL fill:#c8e6c9,stroke:#2e7d32,stroke-width:2px,color:#000
+    style EXPORT fill:#fff59d,stroke:#f57f17,stroke-width:2px,color:#000
+    style STORAGE fill:#b0bec5,stroke:#455a64,stroke-width:2px,color:#000
+    style DASHBOARD fill:#b2ebf2,stroke:#00838f,stroke-width:2px,color:#000
 ```
 
 ### The Aden Advantage

--- a/core/.mcp.json
+++ b/core/.mcp.json
@@ -3,7 +3,7 @@
     "agent-builder": {
       "command": "python",
       "args": ["-m", "framework.mcp.agent_builder_server"],
-      "cwd": "/home/timothy/aden/worker-bee"
+      "cwd": "/home/timothy/oss/hive/core"
     }
   }
 }

--- a/core/MCP_BUILDER_TOOLS_GUIDE.md
+++ b/core/MCP_BUILDER_TOOLS_GUIDE.md
@@ -1,0 +1,334 @@
+# Agent Builder MCP Tools - MCP Integration Guide
+
+This guide explains how to use the new MCP integration tools in the agent builder MCP server.
+
+## Overview
+
+The agent builder now supports registering external MCP servers as tool sources. This allows you to:
+
+1. Register MCP servers (like aden-tools) during agent building
+2. Discover available tools from those servers
+3. Use those tools in your agent nodes
+4. Automatically generate `mcp_servers.json` configuration on export
+
+## New MCP Tools
+
+### `add_mcp_server`
+
+Register an MCP server as a tool source for your agent.
+
+**Parameters:**
+- `name` (string, required): Unique name for the MCP server
+- `transport` (string, required): Transport type - "stdio" or "http"
+- `command` (string): Command to run (for stdio transport)
+- `args` (string): JSON array of command arguments (for stdio)
+- `cwd` (string): Working directory (for stdio)
+- `env` (string): JSON object of environment variables (for stdio)
+- `url` (string): Server URL (for http transport)
+- `headers` (string): JSON object of HTTP headers (for http)
+- `description` (string): Description of the MCP server
+
+**Example - STDIO:**
+```json
+{
+  "name": "add_mcp_server",
+  "arguments": {
+    "name": "aden-tools",
+    "transport": "stdio",
+    "command": "python",
+    "args": "[\"mcp_server.py\", \"--stdio\"]",
+    "cwd": "../aden-tools",
+    "description": "Aden tools for web search and file operations"
+  }
+}
+```
+
+**Example - HTTP:**
+```json
+{
+  "name": "add_mcp_server",
+  "arguments": {
+    "name": "remote-tools",
+    "transport": "http",
+    "url": "http://localhost:4001",
+    "description": "Remote tool server"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "server": {
+    "name": "aden-tools",
+    "transport": "stdio",
+    "command": "python",
+    "args": ["mcp_server.py", "--stdio"],
+    "cwd": "../aden-tools",
+    "description": "Aden tools..."
+  },
+  "tools_discovered": 6,
+  "tools": [
+    "web_search",
+    "web_scrape",
+    "file_read",
+    "file_write",
+    "pdf_read",
+    "example_tool"
+  ],
+  "total_mcp_servers": 1,
+  "note": "MCP server 'aden-tools' registered with 6 tools. These tools can now be used in llm_tool_use nodes."
+}
+```
+
+### `list_mcp_servers`
+
+List all registered MCP servers.
+
+**Parameters:** None
+
+**Response:**
+```json
+{
+  "mcp_servers": [
+    {
+      "name": "aden-tools",
+      "transport": "stdio",
+      "command": "python",
+      "args": ["mcp_server.py", "--stdio"],
+      "cwd": "../aden-tools",
+      "description": "Aden tools..."
+    }
+  ],
+  "total": 1
+}
+```
+
+### `list_mcp_tools`
+
+List tools available from registered MCP servers.
+
+**Parameters:**
+- `server_name` (string, optional): Name of specific server to list tools from. If omitted, lists tools from all servers.
+
+**Example:**
+```json
+{
+  "name": "list_mcp_tools",
+  "arguments": {
+    "server_name": "aden-tools"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "tools_by_server": {
+    "aden-tools": [
+      {
+        "name": "web_search",
+        "description": "Search the web for information using Brave Search API...",
+        "parameters": ["query", "num_results", "country"]
+      },
+      {
+        "name": "web_scrape",
+        "description": "Scrape and extract text content from a webpage...",
+        "parameters": ["url", "selector", "include_links", "max_length"]
+      }
+    ]
+  },
+  "total_tools": 6,
+  "note": "Use these tool names in the 'tools' parameter when adding llm_tool_use nodes"
+}
+```
+
+### `remove_mcp_server`
+
+Remove a registered MCP server.
+
+**Parameters:**
+- `name` (string, required): Name of the MCP server to remove
+
+**Example:**
+```json
+{
+  "name": "remove_mcp_server",
+  "arguments": {
+    "name": "aden-tools"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "removed": "aden-tools",
+  "remaining_servers": 0
+}
+```
+
+## Workflow Example
+
+Here's a complete workflow for building an agent with MCP tools:
+
+### 1. Create Session
+```json
+{
+  "name": "create_session",
+  "arguments": {
+    "name": "web-research-agent"
+  }
+}
+```
+
+### 2. Register MCP Server
+```json
+{
+  "name": "add_mcp_server",
+  "arguments": {
+    "name": "aden-tools",
+    "transport": "stdio",
+    "command": "python",
+    "args": "[\"mcp_server.py\", \"--stdio\"]",
+    "cwd": "../aden-tools"
+  }
+}
+```
+
+### 3. List Available Tools
+```json
+{
+  "name": "list_mcp_tools",
+  "arguments": {
+    "server_name": "aden-tools"
+  }
+}
+```
+
+### 4. Set Goal
+```json
+{
+  "name": "set_goal",
+  "arguments": {
+    "goal_id": "web-research",
+    "name": "Web Research Agent",
+    "description": "Search the web and summarize findings",
+    "success_criteria": "[{\"id\": \"search-success\", \"description\": \"Successfully retrieve search results\", \"metric\": \"results_count\", \"target\": \">= 3\", \"weight\": 1.0}]"
+  }
+}
+```
+
+### 5. Add Node with MCP Tool
+```json
+{
+  "name": "add_node",
+  "arguments": {
+    "node_id": "web-searcher",
+    "name": "Web Search",
+    "description": "Search the web for information",
+    "node_type": "llm_tool_use",
+    "input_keys": "[\"query\"]",
+    "output_keys": "[\"search_results\"]",
+    "system_prompt": "Search for {query} using the web_search tool",
+    "tools": "[\"web_search\"]"
+  }
+}
+```
+
+Note: `web_search` is now available because we registered the aden-tools MCP server!
+
+### 6. Export Agent
+```json
+{
+  "name": "export_graph",
+  "arguments": {}
+}
+```
+
+The export will create:
+- `exports/web-research-agent/agent.json` - Agent specification
+- `exports/web-research-agent/README.md` - Documentation
+- `exports/web-research-agent/mcp_servers.json` - **MCP server configuration** ✨
+
+## MCP Configuration File
+
+When you export an agent with registered MCP servers, an `mcp_servers.json` file is automatically created:
+
+```json
+{
+  "servers": [
+    {
+      "name": "aden-tools",
+      "transport": "stdio",
+      "command": "python",
+      "args": ["mcp_server.py", "--stdio"],
+      "cwd": "../aden-tools",
+      "description": "Aden tools for web search and file operations"
+    }
+  ]
+}
+```
+
+This file is automatically loaded by the AgentRunner when the agent is executed, making the MCP tools available at runtime.
+
+## Using the Exported Agent
+
+Once exported, load and run the agent normally:
+
+```python
+from framework.runner.runner import AgentRunner
+
+# Load agent - MCP servers auto-load from mcp_servers.json
+runner = AgentRunner.load("exports/web-research-agent")
+
+# Run with input
+result = await runner.run({"query": "latest AI breakthroughs"})
+
+# The web_search tool from aden-tools is automatically available!
+```
+
+## Benefits
+
+1. **Discoverable Tools**: See what tools are available before using them
+2. **Validation**: Connection is tested when registering the server
+3. **Automatic Configuration**: No manual file editing required
+4. **Documentation**: README includes MCP server information
+5. **Runtime Ready**: Exported agents work immediately with configured tools
+
+## Common MCP Servers
+
+### aden-tools
+Provides:
+- `web_search` - Brave Search API integration
+- `web_scrape` - Web page content extraction
+- `file_read` / `file_write` - File operations
+- `pdf_read` - PDF text extraction
+
+### Custom MCP Servers
+You can register any MCP server that follows the Model Context Protocol specification.
+
+## Troubleshooting
+
+### "Failed to connect to MCP server"
+
+- Verify the `command` and `args` are correct
+- Check that the server is accessible at the specified path/URL
+- Ensure any required environment variables are set
+- For STDIO: verify the command can be executed from the `cwd`
+- For HTTP: verify the server is running and accessible
+
+### Tools not appearing
+
+- Use `list_mcp_tools` to verify tools were discovered
+- Check the tool names match exactly (case-sensitive)
+- Ensure the MCP server is still registered (`list_mcp_servers`)
+
+### Export doesn't include mcp_servers.json
+
+- Verify you registered at least one MCP server
+- Check `get_session_status` to see `mcp_servers_count > 0`
+- Re-export the agent after registering servers

--- a/core/MCP_INTEGRATION_GUIDE.md
+++ b/core/MCP_INTEGRATION_GUIDE.md
@@ -1,0 +1,361 @@
+# MCP Integration Guide
+
+This guide explains how to integrate Model Context Protocol (MCP) servers with the Hive Core Framework, enabling agents to use tools from external MCP servers.
+
+## Overview
+
+The framework provides built-in support for MCP servers, allowing you to:
+
+- **Register MCP servers** via STDIO or HTTP transport
+- **Auto-discover tools** from registered servers
+- **Use MCP tools** seamlessly in your agents
+- **Manage multiple MCP servers** simultaneously
+
+## Quick Start
+
+### 1. Register an MCP Server Programmatically
+
+```python
+from framework.runner.runner import AgentRunner
+
+# Load your agent
+runner = AgentRunner.load("exports/my-agent")
+
+# Register aden-tools MCP server
+runner.register_mcp_server(
+    name="aden-tools",
+    transport="stdio",
+    command="python",
+    args=["-m", "aden_tools.mcp_server", "--stdio"],
+    cwd="/path/to/aden-tools"
+)
+
+# Tools are now available to your agent
+result = await runner.run({"input": "data"})
+```
+
+### 2. Use Configuration File
+
+Create `mcp_servers.json` in your agent folder:
+
+```json
+{
+  "servers": [
+    {
+      "name": "aden-tools",
+      "transport": "stdio",
+      "command": "python",
+      "args": ["-m", "aden_tools.mcp_server", "--stdio"],
+      "cwd": "../aden-tools"
+    }
+  ]
+}
+```
+
+The framework will automatically load and register these servers when you load the agent:
+
+```python
+runner = AgentRunner.load("exports/my-agent")  # MCP servers auto-loaded
+```
+
+## Transport Types
+
+### STDIO Transport
+
+Best for local MCP servers running as subprocesses:
+
+```python
+runner.register_mcp_server(
+    name="local-tools",
+    transport="stdio",
+    command="python",
+    args=["-m", "my_tools.server", "--stdio"],
+    cwd="/path/to/my-tools",
+    env={
+        "API_KEY": "your-key-here"
+    }
+)
+```
+
+**Configuration:**
+- `command`: Executable to run (e.g., "python", "node")
+- `args`: List of command-line arguments
+- `cwd`: Working directory for the process
+- `env`: Environment variables (optional)
+
+### HTTP Transport
+
+Best for remote MCP servers or containerized deployments:
+
+```python
+runner.register_mcp_server(
+    name="remote-tools",
+    transport="http",
+    url="http://localhost:4001",
+    headers={
+        "Authorization": "Bearer token"
+    }
+)
+```
+
+**Configuration:**
+- `url`: Base URL of the MCP server
+- `headers`: HTTP headers to include (optional)
+
+## Using MCP Tools in Agents
+
+Once registered, MCP tools are available just like any other tool:
+
+### In Node Specifications
+
+```python
+from framework.builder.workflow import WorkflowBuilder
+
+builder = WorkflowBuilder()
+
+# Add a node that uses MCP tools
+builder.add_node(
+    node_id="researcher",
+    name="Web Researcher",
+    node_type="llm_tool_use",
+    system_prompt="Research the topic using web_search",
+    tools=["web_search"],  # Tool from aden-tools MCP server
+    input_keys=["topic"],
+    output_keys=["findings"]
+)
+```
+
+### In Agent.json
+
+Tools from MCP servers can be referenced in your agent.json just like built-in tools:
+
+```json
+{
+  "nodes": [
+    {
+      "id": "searcher",
+      "name": "Web Searcher",
+      "node_type": "llm_tool_use",
+      "system_prompt": "Search for information about {topic}",
+      "tools": ["web_search", "web_scrape"],
+      "input_keys": ["topic"],
+      "output_keys": ["results"]
+    }
+  ]
+}
+```
+
+## Available Tools from aden-tools
+
+When you register the `aden-tools` MCP server, the following tools become available:
+
+- **web_search**: Search the web using Brave Search API
+- **web_scrape**: Scrape content from a URL
+- **file_read**: Read file contents
+- **file_write**: Write content to a file
+- **pdf_read**: Extract text from PDF files
+
+## Environment Variables
+
+Some MCP tools require environment variables. You can pass them in the configuration:
+
+### Via Programmatic Registration
+
+```python
+runner.register_mcp_server(
+    name="aden-tools",
+    transport="stdio",
+    command="python",
+    args=["-m", "aden_tools.mcp_server", "--stdio"],
+    cwd="../aden-tools",
+    env={
+        "BRAVE_SEARCH_API_KEY": os.environ["BRAVE_SEARCH_API_KEY"]
+    }
+)
+```
+
+### Via Configuration File
+
+```json
+{
+  "servers": [
+    {
+      "name": "aden-tools",
+      "transport": "stdio",
+      "command": "python",
+      "args": ["-m", "aden_tools.mcp_server", "--stdio"],
+      "cwd": "../aden-tools",
+      "env": {
+        "BRAVE_SEARCH_API_KEY": "${BRAVE_SEARCH_API_KEY}"
+      }
+    }
+  ]
+}
+```
+
+The framework will substitute `${VAR_NAME}` with values from the environment.
+
+## Multiple MCP Servers
+
+You can register multiple MCP servers to access different sets of tools:
+
+```json
+{
+  "servers": [
+    {
+      "name": "aden-tools",
+      "transport": "stdio",
+      "command": "python",
+      "args": ["-m", "aden_tools.mcp_server", "--stdio"],
+      "cwd": "../aden-tools"
+    },
+    {
+      "name": "database-tools",
+      "transport": "http",
+      "url": "http://localhost:5001"
+    },
+    {
+      "name": "analytics-tools",
+      "transport": "http",
+      "url": "http://analytics-server:6001"
+    }
+  ]
+}
+```
+
+All tools from all servers will be available to your agent.
+
+## Best Practices
+
+### 1. Use STDIO for Development
+
+STDIO transport is easier to debug and doesn't require managing server processes:
+
+```python
+runner.register_mcp_server(
+    name="dev-tools",
+    transport="stdio",
+    command="python",
+    args=["-m", "my_tools.server", "--stdio"]
+)
+```
+
+### 2. Use HTTP for Production
+
+HTTP transport is better for:
+- Containerized deployments
+- Shared tools across multiple agents
+- Remote tool execution
+
+```python
+runner.register_mcp_server(
+    name="prod-tools",
+    transport="http",
+    url="http://tools-service:8000"
+)
+```
+
+### 3. Handle Cleanup
+
+Always clean up MCP connections when done:
+
+```python
+try:
+    runner = AgentRunner.load("exports/my-agent")
+    runner.register_mcp_server(...)
+    result = await runner.run(input_data)
+finally:
+    runner.cleanup()  # Disconnects all MCP servers
+```
+
+Or use context manager:
+
+```python
+async with AgentRunner.load("exports/my-agent") as runner:
+    runner.register_mcp_server(...)
+    result = await runner.run(input_data)
+    # Automatic cleanup
+```
+
+### 4. Tool Name Conflicts
+
+If multiple MCP servers provide tools with the same name, the last registered server wins. To avoid conflicts:
+
+- Use unique tool names in your MCP servers
+- Register servers in priority order (most important last)
+- Use separate agents for different tool sets
+
+## Troubleshooting
+
+### Connection Errors
+
+If you get connection errors with STDIO transport:
+
+1. Check that the command and path are correct
+2. Verify the MCP server starts successfully standalone
+3. Check environment variables are set correctly
+4. Look at stderr output for error messages
+
+### Tool Not Found
+
+If a tool is registered but not found:
+
+1. Verify the server registered successfully (check logs)
+2. List available tools: `runner._tool_registry.get_registered_names()`
+3. Check tool name spelling in your node configuration
+
+### HTTP Server Not Responding
+
+If HTTP transport fails:
+
+1. Verify the server is running: `curl http://localhost:4001/health`
+2. Check firewall settings
+3. Verify the URL and port are correct
+
+## Example: Full Agent with MCP Tools
+
+Here's a complete example of an agent that uses MCP tools:
+
+```python
+import asyncio
+from pathlib import Path
+from framework.runner.runner import AgentRunner
+
+async def main():
+    # Create agent path
+    agent_path = Path("exports/web-research-agent")
+
+    # Load agent
+    runner = AgentRunner.load(agent_path)
+
+    # Register MCP server
+    runner.register_mcp_server(
+        name="aden-tools",
+        transport="stdio",
+        command="python",
+        args=["-m", "aden_tools.mcp_server", "--stdio"],
+        cwd="../aden-tools",
+        env={
+            "BRAVE_SEARCH_API_KEY": "your-api-key"
+        }
+    )
+
+    # Run agent
+    result = await runner.run({
+        "query": "latest developments in quantum computing"
+    })
+
+    print(f"Research complete: {result}")
+
+    # Cleanup
+    runner.cleanup()
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+## See Also
+
+- [MCP_SERVER_GUIDE.md](MCP_SERVER_GUIDE.md) - Building your own MCP servers
+- [examples/mcp_integration_example.py](examples/mcp_integration_example.py) - More examples
+- [examples/mcp_servers.json](examples/mcp_servers.json) - Example configuration

--- a/core/README.md
+++ b/core/README.md
@@ -75,10 +75,70 @@ The MCP server provides tools for:
 - Defining goals with success criteria
 - Adding nodes (llm_generate, llm_tool_use, router, function)
 - Connecting nodes with edges
+- **Registering MCP servers as tool sources** ✨
+- **Discovering tools from MCP servers** ✨
 - Validating and exporting agent graphs
 - Testing nodes and full agent graphs
 
-See [MCP_SERVER_GUIDE.md](MCP_SERVER_GUIDE.md) for detailed instructions.
+When you register an MCP server during agent building, the tools from that server become available to your agent, and an `mcp_servers.json` configuration file is automatically created on export.
+
+See [MCP_SERVER_GUIDE.md](MCP_SERVER_GUIDE.md) for agent builder instructions and [MCP_BUILDER_TOOLS_GUIDE.md](MCP_BUILDER_TOOLS_GUIDE.md) for MCP integration tools.
+
+## MCP Tool Integration
+
+The framework also supports **connecting to MCP servers as tool providers**, allowing your agents to use tools from external MCP servers (like aden-tools). This enables you to extend your agents with powerful external capabilities.
+
+### Quick Example
+
+```python
+from framework.runner.runner import AgentRunner
+
+# Load an agent
+runner = AgentRunner.load("exports/task-planner")
+
+# Register an MCP server with tools
+runner.register_mcp_server(
+    name="aden-tools",
+    transport="stdio",
+    command="python",
+    args=["mcp_server.py", "--stdio"],
+    cwd="../aden-tools"
+)
+
+# Tools from the MCP server are now available to your agent
+result = await runner.run({"query": "Search for AI news"})
+```
+
+### Auto-loading MCP Servers
+
+Create `mcp_servers.json` in your agent folder:
+
+```json
+{
+  "servers": [
+    {
+      "name": "aden-tools",
+      "transport": "stdio",
+      "command": "python",
+      "args": ["mcp_server.py", "--stdio"],
+      "cwd": "../aden-tools"
+    }
+  ]
+}
+```
+
+MCP servers will be automatically loaded when you load the agent.
+
+### Available Tools from aden-tools
+
+When you register the aden-tools MCP server, these tools become available:
+- `web_search` - Search the web using Brave Search API
+- `web_scrape` - Extract content from web pages
+- `file_read` - Read file contents
+- `file_write` - Write content to files
+- `pdf_read` - Extract text from PDF files
+
+See [MCP_INTEGRATION_GUIDE.md](MCP_INTEGRATION_GUIDE.md) for detailed instructions on MCP tool integration.
 
 ## Quick Start
 

--- a/core/README.md
+++ b/core/README.md
@@ -64,7 +64,7 @@ To use the agent builder with Claude Desktop or other MCP clients, add this to y
     "agent-builder": {
       "command": "python",
       "args": ["-m", "framework.mcp.agent_builder_server"],
-      "cwd": "/path/to/goal-agent"
+      "cwd": "/path/to/hive/core"
     }
   }
 }
@@ -78,45 +78,81 @@ The MCP server provides tools for:
 - Validating and exporting agent graphs
 - Testing nodes and full agent graphs
 
+See [MCP_SERVER_GUIDE.md](MCP_SERVER_GUIDE.md) for detailed instructions.
+
 ## Quick Start
 
-### Calculator Agent
+### Running Agents
 
-Run an LLM-powered calculator:
+The framework comes with pre-built example agents in the `exports/` directory:
 
 ```bash
-# Single calculation
-python -m framework calculate "2 + 3 * 4"
+# List available agents
+python -m framework list exports/
 
-# Interactive mode
-python -m framework interactive
+# Show agent information
+python -m framework info exports/task-planner
 
-# Analyze runs with Builder
-python -m framework analyze calculator
+# Run an agent
+python -m framework run exports/task-planner --input '{"objective": "Build a web scraper"}'
+
+# Interactive shell mode (with human-in-the-loop approval)
+python -m framework shell exports/task-planner
 ```
 
-### Using the Runtime
+### Available Commands
+
+- `run` - Execute an exported agent with given input
+- `info` - Display agent details (goal, nodes, edges, success criteria)
+- `validate` - Check that an agent is valid and runnable
+- `list` - List all exported agents in a directory
+- `dispatch` - Route requests to multiple agents using the orchestrator
+- `shell` - Start an interactive session with an agent
+
+### Building Agents Programmatically
+
+You can build agents using the MCP server (recommended) or programmatically:
 
 ```python
 from framework import Runtime
 
-runtime = Runtime("/path/to/storage")
+# Initialize runtime with storage path
+runtime = Runtime("./storage")
 
-# Start a run
-run_id = runtime.start_run("my_goal", "Description of what we're doing")
+# Start a run for a goal
+run_id = runtime.start_run(
+    goal_id="data-processor",
+    goal_description="Process data with quality checks",
+    input_data={"dataset": "customers.csv"}
+)
+
+# Set the current node context
+runtime.set_node("processor-node")
 
 # Record a decision
 decision_id = runtime.decide(
     intent="Choose how to process the data",
     options=[
-        {"id": "fast", "description": "Quick processing", "pros": ["Fast"], "cons": ["Less accurate"]},
-        {"id": "thorough", "description": "Detailed processing", "pros": ["Accurate"], "cons": ["Slower"]},
+        {
+            "id": "fast",
+            "description": "Quick processing",
+            "action_type": "tool_call",
+            "pros": ["Fast"],
+            "cons": ["Less accurate"]
+        },
+        {
+            "id": "thorough",
+            "description": "Detailed processing",
+            "action_type": "tool_call",
+            "pros": ["Accurate"],
+            "cons": ["Slower"]
+        },
     ],
     chosen="thorough",
     reasoning="Accuracy is more important for this task"
 )
 
-# Record the outcome
+# Record the outcome of the decision
 runtime.record_outcome(
     decision_id=decision_id,
     success=True,
@@ -125,58 +161,133 @@ runtime.record_outcome(
 )
 
 # End the run
-runtime.end_run(success=True, narrative="Successfully processed all data")
+runtime.end_run(
+    success=True,
+    narrative="Successfully processed all data",
+    output_data={"total_processed": 100}
+)
 ```
 
-### Analyzing with Builder
+### Analyzing Agent Behavior with Builder
+
+The BuilderQuery interface allows you to analyze agent runs and identify improvements:
 
 ```python
 from framework import BuilderQuery
 
-query = BuilderQuery("/path/to/storage")
+# Initialize Builder query interface
+query = BuilderQuery("./storage")
 
-# Find patterns across runs
-patterns = query.find_patterns("my_goal")
-print(f"Success rate: {patterns.success_rate:.1%}")
+# Find patterns across runs for a goal
+patterns = query.find_patterns("data-processor")
+if patterns:
+    print(f"Success rate: {patterns.success_rate:.1%}")
+    print(f"Runs analyzed: {patterns.run_count}")
 
-# Analyze a failure
-analysis = query.analyze_failure("run_123")
-print(f"Root cause: {analysis.root_cause}")
-print(f"Suggestions: {analysis.suggestions}")
+    # Show problematic nodes
+    for node_id, failure_rate in patterns.problematic_nodes:
+        print(f"Node '{node_id}' has {failure_rate:.1%} failure rate")
 
-# Get improvement recommendations
-suggestions = query.suggest_improvements("my_goal")
+# Analyze a specific failure
+analysis = query.analyze_failure("run_20260119_143022_abc123")
+if analysis:
+    print(f"Failure point: {analysis.failure_point}")
+    print(f"Root cause: {analysis.root_cause}")
+    print(f"\nSuggestions:")
+    for suggestion in analysis.suggestions:
+        print(f"  - {suggestion}")
+
+# Get improvement recommendations for a goal
+suggestions = query.suggest_improvements("data-processor")
 for s in suggestions:
     print(f"[{s['priority']}] {s['recommendation']}")
+    print(f"  Reason: {s['reason']}")
+
+# Get performance metrics for a specific node
+perf = query.get_node_performance("processor-node")
+print(f"Node: {perf['node_id']}")
+print(f"Success rate: {perf['success_rate']:.1%}")
+print(f"Avg latency: {perf['avg_latency_ms']:.0f}ms")
 ```
 
 ## Architecture
 
+The framework consists of several layers:
+
 ```
 ┌─────────────────┐
-│  Human Engineer │  ← Supervision, approval
+│  Human Engineer │  ← Supervision, approval via HITL
 └────────┬────────┘
          │
 ┌────────▼────────┐
-│   Builder LLM   │  ← Analyzes runs, suggests improvements
+│   Builder LLM   │  ← Analyzes runs, suggests improvements (via MCP)
 │  (BuilderQuery) │
 └────────┬────────┘
          │
 ┌────────▼────────┐
-│   Agent LLM     │  ← Executes tasks, records decisions
-│    (Runtime)    │
+│   Agent Graph   │  ← Node-based execution flow
+│   (AgentRunner) │     (llm_generate, llm_tool_use, router, function)
+└────────┬────────┘
+         │
+┌────────▼────────┐
+│    Runtime      │  ← Records decisions, outcomes, problems
+│   (Decision DB) │
 └─────────────────┘
 ```
 
 ## Key Concepts
 
+### Graph-Based Agents
+
+Agents are defined as directed graphs with:
+- **Nodes**: Execution steps (llm_generate, llm_tool_use, router, function)
+- **Edges**: Control flow between nodes, including conditional routing
+- **Goal**: What the agent is designed to accomplish with success criteria
+- **Constraints**: Hard and soft limits on agent behavior
+
+### Decision Recording
+
 - **Decision**: The atomic unit of agent behavior. Captures intent, options, choice, and reasoning.
-- **Run**: A complete execution with all decisions and outcomes.
-- **Runtime**: Interface agents use to record their behavior.
-- **BuilderQuery**: Interface Builder uses to analyze agent behavior.
+- **Outcome**: Result of executing a decision (success/failure, latency, tokens, state changes)
+- **Run**: A complete execution trace with all decisions and outcomes
+- **Problem**: Issues reported during execution with severity and suggested fixes
+
+### Analysis & Improvement
+
+- **Runtime**: Interface agents use to record their behavior during execution
+- **BuilderQuery**: Interface for analyzing agent runs and identifying patterns
+- **PatternAnalysis**: Cross-run analysis showing success rates, common failures, problematic nodes
+- **FailureAnalysis**: Deep dive into why a specific run failed with suggestions
+
+### Human-in-the-Loop (HITL)
+
+- **Approval Callbacks**: Nodes can require human approval before execution
+- **Interactive Shell**: Chat-like interface for running agents with approval prompts
+- **Session State**: Agents can pause and resume based on user input
+
+### Multi-Agent Orchestration
+
+- **AgentOrchestrator**: Dispatch requests to multiple agents
+- **Agent Discovery**: Automatically discover and register agents from a directory
+- **Dispatch Strategy**: Route requests to the most appropriate agent(s)
+
+## Example Agents
+
+The `exports/` directory contains example agents you can run or use as templates:
+
+- **task-planner**: Breaks down complex objectives into actionable tasks with dependencies
+- **research-summary-agent**: Conducts research and generates summaries
+- **outbound-sales-agent**: Handles outbound sales workflows
+- **youtube-comments-research**: Analyzes YouTube comments for insights
+
+Each agent includes:
+- `agent.json`: Graph definition with nodes, edges, goal, and constraints
+- `README.md`: Agent documentation
+- `tools.py` (optional): Custom tool implementations
 
 ## Requirements
 
 - Python 3.11+
 - pydantic >= 2.0
 - anthropic >= 0.40.0 (for LLM-powered agents)
+- mcp, fastmcp (optional, for MCP server)

--- a/core/examples/mcp_integration_example.py
+++ b/core/examples/mcp_integration_example.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+Example: Integrating MCP Servers with the Core Framework
+
+This example demonstrates how to:
+1. Register MCP servers programmatically
+2. Use MCP tools in agents
+3. Load MCP servers from configuration files
+"""
+
+import asyncio
+from pathlib import Path
+
+from framework.runner.runner import AgentRunner
+
+
+async def example_1_programmatic_registration():
+    """Example 1: Register MCP server programmatically"""
+    print("\n=== Example 1: Programmatic MCP Server Registration ===\n")
+
+    # Load an existing agent
+    runner = AgentRunner.load("exports/task-planner")
+
+    # Register aden-tools MCP server via STDIO
+    num_tools = runner.register_mcp_server(
+        name="aden-tools",
+        transport="stdio",
+        command="python",
+        args=["-m", "aden_tools.mcp_server", "--stdio"],
+        cwd="../aden-tools",
+    )
+
+    print(f"Registered {num_tools} tools from aden-tools MCP server")
+
+    # List all available tools
+    tools = runner._tool_registry.get_tools()
+    print(f"\nAvailable tools: {list(tools.keys())}")
+
+    # Run the agent with MCP tools available
+    result = await runner.run({
+        "objective": "Search for 'Claude AI' and summarize the top 3 results"
+    })
+
+    print(f"\nAgent result: {result}")
+
+    # Cleanup
+    runner.cleanup()
+
+
+async def example_2_http_transport():
+    """Example 2: Connect to MCP server via HTTP"""
+    print("\n=== Example 2: HTTP MCP Server Connection ===\n")
+
+    # First, start the aden-tools MCP server in HTTP mode:
+    # cd aden-tools && python mcp_server.py --port 4001
+
+    runner = AgentRunner.load("exports/task-planner")
+
+    # Register aden-tools via HTTP
+    num_tools = runner.register_mcp_server(
+        name="aden-tools-http",
+        transport="http",
+        url="http://localhost:4001",
+    )
+
+    print(f"Registered {num_tools} tools from HTTP MCP server")
+
+    # Cleanup
+    runner.cleanup()
+
+
+async def example_3_config_file():
+    """Example 3: Load MCP servers from configuration file"""
+    print("\n=== Example 3: Load from Configuration File ===\n")
+
+    # Create a test agent folder with mcp_servers.json
+    test_agent_path = Path("exports/task-planner")
+
+    # Copy example config (in practice, you'd place this in your agent folder)
+    import shutil
+    shutil.copy(
+        "examples/mcp_servers.json",
+        test_agent_path / "mcp_servers.json"
+    )
+
+    # Load agent - MCP servers will be auto-discovered
+    runner = AgentRunner.load(test_agent_path)
+
+    # Tools are automatically available
+    tools = runner._tool_registry.get_tools()
+    print(f"Available tools: {list(tools.keys())}")
+
+    # Cleanup
+    runner.cleanup()
+
+    # Clean up the test config
+    (test_agent_path / "mcp_servers.json").unlink()
+
+
+async def example_4_custom_agent_with_mcp_tools():
+    """Example 4: Build custom agent that uses MCP tools"""
+    print("\n=== Example 4: Custom Agent with MCP Tools ===\n")
+
+    from framework.builder.workflow import WorkflowBuilder
+
+    # Create a workflow builder
+    builder = WorkflowBuilder()
+
+    # Define goal
+    builder.set_goal(
+        goal_id="web-researcher",
+        name="Web Research Agent",
+        description="Search the web and summarize findings"
+    )
+
+    # Add success criteria
+    builder.add_success_criterion(
+        "search-results",
+        "Successfully retrieve at least 3 web search results"
+    )
+    builder.add_success_criterion(
+        "summary",
+        "Provide a clear, concise summary of the findings"
+    )
+
+    # Add nodes that will use MCP tools
+    builder.add_node(
+        node_id="web-searcher",
+        name="Web Search",
+        description="Search the web for information",
+        node_type="llm_tool_use",
+        system_prompt="Search for {query} and return the top results. Use the web_search tool.",
+        tools=["web_search"],  # This tool comes from aden-tools MCP server
+        input_keys=["query"],
+        output_keys=["search_results"],
+    )
+
+    builder.add_node(
+        node_id="summarizer",
+        name="Summarize Results",
+        description="Summarize the search results",
+        node_type="llm_generate",
+        system_prompt="Summarize the following search results in 2-3 sentences: {search_results}",
+        input_keys=["search_results"],
+        output_keys=["summary"],
+    )
+
+    # Connect nodes
+    builder.add_edge("web-searcher", "summarizer")
+
+    # Set entry point
+    builder.set_entry("web-searcher")
+    builder.set_terminal("summarizer")
+
+    # Export the agent
+    export_path = Path("exports/web-research-agent")
+    export_path.mkdir(parents=True, exist_ok=True)
+    builder.export(export_path)
+
+    # Load and register MCP server
+    runner = AgentRunner.load(export_path)
+    runner.register_mcp_server(
+        name="aden-tools",
+        transport="stdio",
+        command="python",
+        args=["-m", "aden_tools.mcp_server", "--stdio"],
+        cwd="../aden-tools",
+    )
+
+    # Run the agent
+    result = await runner.run({"query": "latest AI breakthroughs 2026"})
+
+    print(f"\nAgent completed with result:\n{result}")
+
+    # Cleanup
+    runner.cleanup()
+
+
+async def main():
+    """Run all examples"""
+    print("=" * 60)
+    print("MCP Integration Examples")
+    print("=" * 60)
+
+    try:
+        # Run examples
+        await example_1_programmatic_registration()
+        # await example_2_http_transport()  # Requires HTTP server running
+        # await example_3_config_file()
+        # await example_4_custom_agent_with_mcp_tools()
+
+    except Exception as e:
+        print(f"\nError running example: {e}")
+        import traceback
+        traceback.print_exc()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/core/examples/mcp_servers.json
+++ b/core/examples/mcp_servers.json
@@ -1,0 +1,22 @@
+{
+  "servers": [
+    {
+      "name": "aden-tools",
+      "description": "Aden tools including web search, file operations, and PDF reading",
+      "transport": "stdio",
+      "command": "python",
+      "args": ["mcp_server.py", "--stdio"],
+      "cwd": "../aden-tools",
+      "env": {
+        "BRAVE_SEARCH_API_KEY": "${BRAVE_SEARCH_API_KEY}"
+      }
+    },
+    {
+      "name": "aden-tools-http",
+      "description": "Aden tools via HTTP (for Docker deployments)",
+      "transport": "http",
+      "url": "http://localhost:4001",
+      "headers": {}
+    }
+  ]
+}

--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -392,10 +392,10 @@ class LLMNode(NodeProtocol):
 
                 def executor(tool_use: ToolUse) -> ToolResult:
                     logger.info(f"         🔧 Tool call: {tool_use.name}({', '.join(f'{k}={v}' for k, v in tool_use.input.items())})")
-                    result = self.tool_executor(ctx, tool_use)
+                    result = self.tool_executor(tool_use)
                     # Truncate long results
-                    result_str = str(result.output)[:150]
-                    if len(str(result.output)) > 150:
+                    result_str = str(result.content)[:150]
+                    if len(str(result.content)) > 150:
                         result_str += "..."
                     logger.info(f"         ✓ Tool result: {result_str}")
                     return result

--- a/core/framework/mcp/agent_builder_server.py
+++ b/core/framework/mcp/agent_builder_server.py
@@ -31,6 +31,7 @@ class BuildSession:
         self.goal: Goal | None = None
         self.nodes: list[NodeSpec] = []
         self.edges: list[EdgeSpec] = []
+        self.mcp_servers: list[dict] = []  # MCP server configurations
 
 
 # Global session
@@ -310,6 +311,155 @@ def add_edge(
 
 
 @mcp.tool()
+def update_node(
+    node_id: Annotated[str, "ID of the node to update"],
+    name: Annotated[str, "Updated human-readable name"] = "",
+    description: Annotated[str, "Updated description"] = "",
+    node_type: Annotated[str, "Updated type: llm_generate, llm_tool_use, router, or function"] = "",
+    input_keys: Annotated[str, "Updated JSON array of input keys"] = "",
+    output_keys: Annotated[str, "Updated JSON array of output keys"] = "",
+    system_prompt: Annotated[str, "Updated instructions for LLM nodes"] = "",
+    tools: Annotated[str, "Updated JSON array of tool names"] = "",
+    routes: Annotated[str, "Updated JSON object mapping conditions to target node IDs"] = "",
+) -> str:
+    """Update an existing node in the agent graph. Only provided fields will be updated."""
+    session = get_session()
+
+    # Find the node
+    node = None
+    for n in session.nodes:
+        if n.id == node_id:
+            node = n
+            break
+
+    if not node:
+        return json.dumps({"valid": False, "errors": [f"Node '{node_id}' not found"]})
+
+    # Update fields if provided
+    if name:
+        node.name = name
+    if description:
+        node.description = description
+    if node_type:
+        node.node_type = node_type
+    if input_keys:
+        node.input_keys = json.loads(input_keys)
+    if output_keys:
+        node.output_keys = json.loads(output_keys)
+    if system_prompt:
+        node.system_prompt = system_prompt
+    if tools:
+        node.tools = json.loads(tools)
+    if routes:
+        node.routes = json.loads(routes)
+
+    # Validate
+    errors = []
+    warnings = []
+
+    if node.node_type == "llm_tool_use" and not node.tools:
+        errors.append(f"Node '{node_id}' of type llm_tool_use must specify tools")
+    if node.node_type == "router" and not node.routes:
+        errors.append(f"Router node '{node_id}' must specify routes")
+    if node.node_type in ("llm_generate", "llm_tool_use") and not node.system_prompt:
+        warnings.append(f"LLM node '{node_id}' should have a system_prompt")
+
+    return json.dumps({
+        "valid": len(errors) == 0,
+        "errors": errors,
+        "warnings": warnings,
+        "node": node.model_dump(),
+        "total_nodes": len(session.nodes),
+        "approval_required": True,
+        "approval_question": {
+            "component_type": "node",
+            "component_name": node.name,
+            "question": f"Do you approve this updated {node.node_type} node: {node.name}?",
+            "header": "Approve Node Update",
+            "options": [
+                {
+                    "label": "✓ Approve (Recommended)",
+                    "description": f"Updated node '{node.name}' looks good"
+                },
+                {
+                    "label": "✗ Reject & Modify",
+                    "description": "Need to change node configuration"
+                },
+                {
+                    "label": "⏸ Pause & Review",
+                    "description": "I need more time to review this update"
+                }
+            ]
+        }
+    }, default=str)
+
+
+@mcp.tool()
+def delete_node(
+    node_id: Annotated[str, "ID of the node to delete"],
+) -> str:
+    """Delete a node from the agent graph. Also removes all edges connected to this node."""
+    session = get_session()
+
+    # Find the node
+    node_idx = None
+    for i, n in enumerate(session.nodes):
+        if n.id == node_id:
+            node_idx = i
+            break
+
+    if node_idx is None:
+        return json.dumps({"valid": False, "errors": [f"Node '{node_id}' not found"]})
+
+    # Remove the node
+    removed_node = session.nodes.pop(node_idx)
+
+    # Remove all edges connected to this node
+    removed_edges = [e.id for e in session.edges if e.source == node_id or e.target == node_id]
+    session.edges = [
+        e for e in session.edges
+        if not (e.source == node_id or e.target == node_id)
+    ]
+
+    return json.dumps({
+        "valid": True,
+        "deleted_node": removed_node.model_dump(),
+        "removed_edges": removed_edges,
+        "total_nodes": len(session.nodes),
+        "total_edges": len(session.edges),
+        "message": f"Node '{node_id}' and {len(removed_edges)} connected edge(s) removed"
+    }, default=str)
+
+
+@mcp.tool()
+def delete_edge(
+    edge_id: Annotated[str, "ID of the edge to delete"],
+) -> str:
+    """Delete an edge from the agent graph."""
+    session = get_session()
+
+    # Find the edge
+    edge_idx = None
+    for i, e in enumerate(session.edges):
+        if e.id == edge_id:
+            edge_idx = i
+            break
+
+    if edge_idx is None:
+        return json.dumps({"valid": False, "errors": [f"Edge '{edge_id}' not found"]})
+
+    # Remove the edge
+    removed_edge = session.edges.pop(edge_idx)
+
+    return json.dumps({
+        "valid": True,
+        "deleted_edge": removed_edge.model_dump(),
+        "total_edges": len(session.edges),
+        "message": f"Edge '{edge_id}' removed: {removed_edge.source} → {removed_edge.target}"
+    }, default=str)
+
+
+@mcp.tool()
 def validate_graph() -> str:
     """Validate the complete graph. Checks for unreachable nodes, missing connections, and context flow."""
     session = get_session()
@@ -584,6 +734,18 @@ def _generate_readme(session: BuildSession, export_data: dict, all_tools: set) -
 
 {chr(10).join(f"- `{tool}`" for tool in sorted(all_tools)) if all_tools else "No tools required"}
 
+{"## MCP Tool Sources" if session.mcp_servers else ""}
+
+{chr(10).join(f'''### {s["name"]} ({s["transport"]})
+{s.get("description", "")}
+
+**Configuration:**
+''' + (f'''- Command: `{s.get("command")}`
+- Args: `{s.get("args")}`
+- Working Directory: `{s.get("cwd")}`''' if s["transport"] == "stdio" else f'''- URL: `{s.get("url")}`''') for s in session.mcp_servers) if session.mcp_servers else ""}
+
+{"Tools from these MCP servers are automatically loaded when the agent runs." if session.mcp_servers else ""}
+
 ## Usage
 
 ### Basic Usage
@@ -754,30 +916,51 @@ def export_graph() -> str:
     with open(readme_path, "w") as f:
         f.write(readme_content)
 
+    # Write mcp_servers.json if MCP servers are configured
+    mcp_servers_path = None
+    mcp_servers_size = 0
+    if session.mcp_servers:
+        mcp_config = {
+            "servers": session.mcp_servers
+        }
+        mcp_servers_path = exports_dir / "mcp_servers.json"
+        with open(mcp_servers_path, "w") as f:
+            json.dump(mcp_config, f, indent=2)
+        mcp_servers_size = mcp_servers_path.stat().st_size
+
     # Get file sizes
     agent_json_size = agent_json_path.stat().st_size
     readme_size = readme_path.stat().st_size
 
+    files_written = {
+        "agent_json": {
+            "path": str(agent_json_path),
+            "size_bytes": agent_json_size,
+        },
+        "readme": {
+            "path": str(readme_path),
+            "size_bytes": readme_size,
+        },
+    }
+
+    if mcp_servers_path:
+        files_written["mcp_servers"] = {
+            "path": str(mcp_servers_path),
+            "size_bytes": mcp_servers_size,
+        }
+
     return json.dumps({
         "success": True,
         "agent": export_data["agent"],
-        "files_written": {
-            "agent_json": {
-                "path": str(agent_json_path),
-                "size_bytes": agent_json_size,
-            },
-            "readme": {
-                "path": str(readme_path),
-                "size_bytes": readme_size,
-            },
-        },
+        "files_written": files_written,
         "graph": graph_spec,
         "goal": session.goal.model_dump(),
         "evaluation_rules": _evaluation_rules,
         "required_tools": list(all_tools),
         "node_count": len(session.nodes),
         "edge_count": len(edges_list),
-        "note": f"Agent exported to {exports_dir}. Files: agent.json, README.md",
+        "mcp_servers_count": len(session.mcp_servers),
+        "note": f"Agent exported to {exports_dir}. Files: agent.json, README.md" + (", mcp_servers.json" if session.mcp_servers else ""),
     }, default=str, indent=2)
 
 
@@ -792,8 +975,253 @@ def get_session_status() -> str:
         "goal_name": session.goal.name if session.goal else None,
         "node_count": len(session.nodes),
         "edge_count": len(session.edges),
+        "mcp_servers_count": len(session.mcp_servers),
         "nodes": [n.id for n in session.nodes],
         "edges": [(e.source, e.target) for e in session.edges],
+        "mcp_servers": [s["name"] for s in session.mcp_servers],
+    })
+
+
+@mcp.tool()
+def add_mcp_server(
+    name: Annotated[str, "Unique name for the MCP server"],
+    transport: Annotated[str, "Transport type: 'stdio' or 'http'"],
+    command: Annotated[str, "Command to run (for stdio transport)"] = "",
+    args: Annotated[str, "JSON array of command arguments (for stdio)"] = "[]",
+    cwd: Annotated[str, "Working directory (for stdio)"] = "",
+    env: Annotated[str, "JSON object of environment variables (for stdio)"] = "{}",
+    url: Annotated[str, "Server URL (for http transport)"] = "",
+    headers: Annotated[str, "JSON object of HTTP headers (for http)"] = "{}",
+    description: Annotated[str, "Description of the MCP server"] = "",
+) -> str:
+    """
+    Register an MCP server as a tool source for this agent.
+
+    The MCP server will be saved in mcp_servers.json when the agent is exported,
+    and tools from this server will be available to the agent at runtime.
+
+    Example for stdio:
+        add_mcp_server(
+            name="aden-tools",
+            transport="stdio",
+            command="python",
+            args='["mcp_server.py", "--stdio"]',
+            cwd="../aden-tools"
+        )
+
+    Example for http:
+        add_mcp_server(
+            name="remote-tools",
+            transport="http",
+            url="http://localhost:4001"
+        )
+    """
+    session = get_session()
+
+    # Validate transport
+    if transport not in ["stdio", "http"]:
+        return json.dumps({
+            "success": False,
+            "error": f"Invalid transport '{transport}'. Must be 'stdio' or 'http'"
+        })
+
+    # Check for duplicate
+    if any(s["name"] == name for s in session.mcp_servers):
+        return json.dumps({
+            "success": False,
+            "error": f"MCP server '{name}' already registered"
+        })
+
+    # Parse JSON inputs
+    try:
+        args_list = json.loads(args)
+        env_dict = json.loads(env)
+        headers_dict = json.loads(headers)
+    except json.JSONDecodeError as e:
+        return json.dumps({
+            "success": False,
+            "error": f"Invalid JSON: {e}"
+        })
+
+    # Validate required fields
+    errors = []
+    if transport == "stdio" and not command:
+        errors.append("command is required for stdio transport")
+    if transport == "http" and not url:
+        errors.append("url is required for http transport")
+
+    if errors:
+        return json.dumps({"success": False, "errors": errors})
+
+    # Build server config
+    server_config = {
+        "name": name,
+        "transport": transport,
+        "description": description,
+    }
+
+    if transport == "stdio":
+        server_config["command"] = command
+        server_config["args"] = args_list
+        if cwd:
+            server_config["cwd"] = cwd
+        if env_dict:
+            server_config["env"] = env_dict
+    else:  # http
+        server_config["url"] = url
+        if headers_dict:
+            server_config["headers"] = headers_dict
+
+    # Try to connect and discover tools
+    try:
+        from framework.runner.mcp_client import MCPClient, MCPServerConfig
+
+        mcp_config = MCPServerConfig(
+            name=name,
+            transport=transport,
+            command=command if transport == "stdio" else None,
+            args=args_list if transport == "stdio" else [],
+            env=env_dict,
+            cwd=cwd if cwd else None,
+            url=url if transport == "http" else None,
+            headers=headers_dict,
+            description=description,
+        )
+
+        with MCPClient(mcp_config) as client:
+            tools = client.list_tools()
+            tool_names = [t.name for t in tools]
+
+            # Add to session
+            session.mcp_servers.append(server_config)
+
+            return json.dumps({
+                "success": True,
+                "server": server_config,
+                "tools_discovered": len(tool_names),
+                "tools": tool_names,
+                "total_mcp_servers": len(session.mcp_servers),
+                "note": f"MCP server '{name}' registered with {len(tool_names)} tools. These tools can now be used in llm_tool_use nodes.",
+            }, indent=2)
+
+    except Exception as e:
+        return json.dumps({
+            "success": False,
+            "error": f"Failed to connect to MCP server: {str(e)}",
+            "suggestion": "Check that the command/url is correct and the server is accessible"
+        })
+
+
+@mcp.tool()
+def list_mcp_servers() -> str:
+    """List all registered MCP servers for this agent."""
+    session = get_session()
+
+    if not session.mcp_servers:
+        return json.dumps({
+            "mcp_servers": [],
+            "total": 0,
+            "note": "No MCP servers registered. Use add_mcp_server to add tool sources."
+        })
+
+    return json.dumps({
+        "mcp_servers": session.mcp_servers,
+        "total": len(session.mcp_servers),
+    }, indent=2)
+
+
+@mcp.tool()
+def list_mcp_tools(
+    server_name: Annotated[str, "Name of the MCP server to list tools from"] = "",
+) -> str:
+    """
+    List tools available from registered MCP servers.
+
+    If server_name is provided, lists tools from that specific server.
+    Otherwise, lists all tools from all registered servers.
+    """
+    session = get_session()
+
+    if not session.mcp_servers:
+        return json.dumps({
+            "success": False,
+            "error": "No MCP servers registered"
+        })
+
+    # Filter servers if name provided
+    servers_to_query = session.mcp_servers
+    if server_name:
+        servers_to_query = [s for s in session.mcp_servers if s["name"] == server_name]
+        if not servers_to_query:
+            return json.dumps({
+                "success": False,
+                "error": f"MCP server '{server_name}' not found"
+            })
+
+    all_tools = {}
+
+    for server_config in servers_to_query:
+        try:
+            from framework.runner.mcp_client import MCPClient, MCPServerConfig
+
+            mcp_config = MCPServerConfig(
+                name=server_config["name"],
+                transport=server_config["transport"],
+                command=server_config.get("command"),
+                args=server_config.get("args", []),
+                env=server_config.get("env", {}),
+                cwd=server_config.get("cwd"),
+                url=server_config.get("url"),
+                headers=server_config.get("headers", {}),
+                description=server_config.get("description", ""),
+            )
+
+            with MCPClient(mcp_config) as client:
+                tools = client.list_tools()
+
+                all_tools[server_config["name"]] = [
+                    {
+                        "name": t.name,
+                        "description": t.description,
+                        "parameters": list(t.input_schema.get("properties", {}).keys()),
+                    }
+                    for t in tools
+                ]
+
+        except Exception as e:
+            all_tools[server_config["name"]] = {
+                "error": f"Failed to connect: {str(e)}"
+            }
+
+    total_tools = sum(len(tools) if isinstance(tools, list) else 0 for tools in all_tools.values())
+
+    return json.dumps({
+        "success": True,
+        "tools_by_server": all_tools,
+        "total_tools": total_tools,
+        "note": "Use these tool names in the 'tools' parameter when adding llm_tool_use nodes",
+    }, indent=2)
+
+
+@mcp.tool()
+def remove_mcp_server(
+    name: Annotated[str, "Name of the MCP server to remove"],
+) -> str:
+    """Remove a registered MCP server."""
+    session = get_session()
+
+    for i, server in enumerate(session.mcp_servers):
+        if server["name"] == name:
+            session.mcp_servers.pop(i)
+            return json.dumps({
+                "success": True,
+                "removed": name,
+                "remaining_servers": len(session.mcp_servers)
+            })
+
+    return json.dumps({
+        "success": False,
+        "error": f"MCP server '{name}' not found"
     })
 
 

--- a/core/framework/runner/mcp_client.py
+++ b/core/framework/runner/mcp_client.py
@@ -1,0 +1,353 @@
+"""MCP Client for connecting to Model Context Protocol servers.
+
+This module provides a client for connecting to MCP servers and invoking their tools.
+Supports both STDIO and HTTP transports using the official MCP Python SDK.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MCPServerConfig:
+    """Configuration for an MCP server connection."""
+
+    name: str
+    transport: Literal["stdio", "http"]
+
+    # For STDIO transport
+    command: str | None = None
+    args: list[str] = field(default_factory=list)
+    env: dict[str, str] = field(default_factory=dict)
+    cwd: str | None = None
+
+    # For HTTP transport
+    url: str | None = None
+    headers: dict[str, str] = field(default_factory=dict)
+
+    # Optional metadata
+    description: str = ""
+
+
+@dataclass
+class MCPTool:
+    """A tool available from an MCP server."""
+
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+    server_name: str
+
+
+class MCPClient:
+    """
+    Client for communicating with MCP servers.
+
+    Supports both STDIO and HTTP transports using the official MCP SDK.
+    Manages the connection lifecycle and provides methods to list and invoke tools.
+    """
+
+    def __init__(self, config: MCPServerConfig):
+        """
+        Initialize the MCP client.
+
+        Args:
+            config: Server configuration
+        """
+        self.config = config
+        self._session = None
+        self._read_stream = None
+        self._write_stream = None
+        self._http_client: httpx.Client | None = None
+        self._tools: dict[str, MCPTool] = {}
+        self._connected = False
+
+    def _run_async(self, coro):
+        """
+        Run an async coroutine, handling both sync and async contexts.
+
+        Args:
+            coro: Coroutine to run
+
+        Returns:
+            Result of the coroutine
+        """
+        try:
+            # Try to get the current event loop
+            asyncio.get_running_loop()
+            # If we're here, we're in an async context
+            # Create a new thread to run the coroutine
+            import threading
+
+            result = None
+            exception = None
+
+            def run_in_thread():
+                nonlocal result, exception
+                try:
+                    new_loop = asyncio.new_event_loop()
+                    asyncio.set_event_loop(new_loop)
+                    try:
+                        result = new_loop.run_until_complete(coro)
+                    finally:
+                        new_loop.close()
+                except Exception as e:
+                    exception = e
+
+            thread = threading.Thread(target=run_in_thread)
+            thread.start()
+            thread.join()
+
+            if exception:
+                raise exception
+            return result
+        except RuntimeError:
+            # No event loop running, we can use asyncio.run
+            return asyncio.run(coro)
+
+    def connect(self) -> None:
+        """Connect to the MCP server."""
+        if self._connected:
+            return
+
+        if self.config.transport == "stdio":
+            self._connect_stdio()
+        elif self.config.transport == "http":
+            self._connect_http()
+        else:
+            raise ValueError(f"Unsupported transport: {self.config.transport}")
+
+        # Discover tools
+        self._discover_tools()
+        self._connected = True
+
+    def _connect_stdio(self) -> None:
+        """Connect to MCP server via STDIO transport using MCP SDK."""
+        if not self.config.command:
+            raise ValueError("command is required for STDIO transport")
+
+        try:
+            # Import MCP SDK
+            from mcp import StdioServerParameters
+
+            # Create server parameters
+            server_params = StdioServerParameters(
+                command=self.config.command,
+                args=self.config.args,
+                env=self.config.env or None,
+                cwd=self.config.cwd,
+            )
+
+            # Store for later use in async context
+            self._server_params = server_params
+
+            logger.info(f"Connected to MCP server '{self.config.name}' via STDIO")
+        except Exception as e:
+            raise RuntimeError(f"Failed to connect to MCP server: {e}")
+
+    def _connect_http(self) -> None:
+        """Connect to MCP server via HTTP transport."""
+        if not self.config.url:
+            raise ValueError("url is required for HTTP transport")
+
+        self._http_client = httpx.Client(
+            base_url=self.config.url,
+            headers=self.config.headers,
+            timeout=30.0,
+        )
+
+        # Test connection
+        try:
+            response = self._http_client.get("/health")
+            response.raise_for_status()
+            logger.info(f"Connected to MCP server '{self.config.name}' via HTTP at {self.config.url}")
+        except Exception as e:
+            logger.warning(f"Health check failed for MCP server '{self.config.name}': {e}")
+            # Continue anyway, server might not have health endpoint
+
+    def _discover_tools(self) -> None:
+        """Discover available tools from the MCP server."""
+        try:
+            if self.config.transport == "stdio":
+                tools_list = self._run_async(self._list_tools_stdio_async())
+            else:
+                tools_list = self._list_tools_http()
+
+            self._tools = {}
+            for tool_data in tools_list:
+                tool = MCPTool(
+                    name=tool_data["name"],
+                    description=tool_data.get("description", ""),
+                    input_schema=tool_data.get("inputSchema", {}),
+                    server_name=self.config.name,
+                )
+                self._tools[tool.name] = tool
+
+            logger.info(f"Discovered {len(self._tools)} tools from '{self.config.name}': {list(self._tools.keys())}")
+        except Exception as e:
+            logger.error(f"Failed to discover tools from '{self.config.name}': {e}")
+            raise
+
+    async def _list_tools_stdio_async(self) -> list[dict]:
+        """List tools via STDIO protocol using MCP SDK."""
+        from mcp import ClientSession
+        from mcp.client.stdio import stdio_client
+
+        async with stdio_client(self._server_params) as (read, write):
+            async with ClientSession(read, write) as session:
+                # Initialize the session
+                await session.initialize()
+
+                # List tools
+                response = await session.list_tools()
+
+                # Convert tools to dict format
+                tools_list = []
+                for tool in response.tools:
+                    tools_list.append({
+                        "name": tool.name,
+                        "description": tool.description,
+                        "inputSchema": tool.inputSchema,
+                    })
+
+                return tools_list
+
+    def _list_tools_http(self) -> list[dict]:
+        """List tools via HTTP protocol."""
+        if not self._http_client:
+            raise RuntimeError("HTTP client not initialized")
+
+        try:
+            # Use MCP over HTTP protocol
+            response = self._http_client.post(
+                "/mcp/v1",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tools/list",
+                    "params": {},
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            if "error" in data:
+                raise RuntimeError(f"MCP error: {data['error']}")
+
+            return data.get("result", {}).get("tools", [])
+        except Exception as e:
+            raise RuntimeError(f"Failed to list tools via HTTP: {e}")
+
+    def list_tools(self) -> list[MCPTool]:
+        """
+        Get list of available tools.
+
+        Returns:
+            List of MCPTool objects
+        """
+        if not self._connected:
+            self.connect()
+
+        return list(self._tools.values())
+
+    def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> Any:
+        """
+        Invoke a tool on the MCP server.
+
+        Args:
+            tool_name: Name of the tool to invoke
+            arguments: Tool arguments
+
+        Returns:
+            Tool result
+        """
+        if not self._connected:
+            self.connect()
+
+        if tool_name not in self._tools:
+            raise ValueError(f"Unknown tool: {tool_name}")
+
+        if self.config.transport == "stdio":
+            return self._run_async(self._call_tool_stdio_async(tool_name, arguments))
+        else:
+            return self._call_tool_http(tool_name, arguments)
+
+    async def _call_tool_stdio_async(self, tool_name: str, arguments: dict[str, Any]) -> Any:
+        """Call tool via STDIO protocol using MCP SDK."""
+        from mcp import ClientSession
+        from mcp.client.stdio import stdio_client
+
+        async with stdio_client(self._server_params) as (read, write):
+            async with ClientSession(read, write) as session:
+                # Initialize the session
+                await session.initialize()
+
+                # Call tool
+                result = await session.call_tool(tool_name, arguments=arguments)
+
+                # Extract content
+                if result.content:
+                    # MCP returns content as a list of content items
+                    if len(result.content) > 0:
+                        content_item = result.content[0]
+                        # Check if it's a text content item
+                        if hasattr(content_item, 'text'):
+                            return content_item.text
+                        elif hasattr(content_item, 'data'):
+                            return content_item.data
+                    return result.content
+
+                return None
+
+    def _call_tool_http(self, tool_name: str, arguments: dict[str, Any]) -> Any:
+        """Call tool via HTTP protocol."""
+        if not self._http_client:
+            raise RuntimeError("HTTP client not initialized")
+
+        try:
+            response = self._http_client.post(
+                "/mcp/v1",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/call",
+                    "params": {
+                        "name": tool_name,
+                        "arguments": arguments,
+                    },
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            if "error" in data:
+                raise RuntimeError(f"Tool execution error: {data['error']}")
+
+            return data.get("result", {}).get("content", [])
+        except Exception as e:
+            raise RuntimeError(f"Failed to call tool via HTTP: {e}")
+
+    def disconnect(self) -> None:
+        """Disconnect from the MCP server."""
+        if self._http_client:
+            self._http_client.close()
+            self._http_client = None
+
+        self._connected = False
+        logger.info(f"Disconnected from MCP server '{self.config.name}'")
+
+    def __enter__(self):
+        """Context manager entry."""
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit."""
+        self.disconnect()

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -1,6 +1,7 @@
 # Core dependencies
 pydantic>=2.0
 anthropic>=0.40.0
+httpx>=0.27.0
 
 # MCP server dependencies
 mcp


### PR DESCRIPTION
# MCP Tool Integration

## Summary

This PR adds comprehensive Model Context Protocol (MCP) server integration to the Hive Core Framework, enabling agents to dynamically discover and use tools from external MCP servers. The integration works at both the runtime level (AgentRunner) and the agent building level (agent builder MCP server).

## Overview

**What is this?**
- Agents can now connect to MCP servers (like aden-tools) to access external tools
- Tools are auto-discovered and seamlessly integrated into the framework's tool system
- Supports both STDIO and HTTP transports
- Works with configuration files or programmatic registration

**Why is this important?**
- Massively extends agent capabilities without modifying core framework
- Enables tool reuse across multiple agents
- Standardizes on the Model Context Protocol
- Makes agents composable with external tool ecosystems

## Key Features

### 🔌 Runtime MCP Integration

**New Components:**
- **MCPClient** ([`framework/runner/mcp_client.py`](core/framework/runner/mcp_client.py)) - Connects to MCP servers via STDIO/HTTP
- **Enhanced ToolRegistry** ([`framework/runner/tool_registry.py`](core/framework/runner/tool_registry.py)) - Registers and manages MCP tools
- **Enhanced AgentRunner** ([`framework/runner/runner.py`](core/framework/runner/runner.py)) - Auto-loads MCP servers from config

**Usage:**

```python
from framework.runner.runner import AgentRunner

# Option 1: Programmatic registration
runner = AgentRunner.load("exports/my-agent")
runner.register_mcp_server(
    name="aden-tools",
    transport="stdio",
    command="python",
    args=["mcp_server.py", "--stdio"],
    cwd="../aden-tools"
)

# Option 2: Auto-load from mcp_servers.json
runner = AgentRunner.load("exports/my-agent")
# Tools automatically available!

result = await runner.run({"query": "AI news"})
```

### 🛠️ Agent Builder MCP Integration

**New MCP Tools for Agent Building:**
- `add_mcp_server` - Register MCP servers as tool sources
- `list_mcp_servers` - View registered servers
- `list_mcp_tools` - Browse available tools
- `remove_mcp_server` - Unregister servers

**Workflow:**
```
1. User: "Build an agent that can search the web"
2. Claude (via agent builder):
   - Calls add_mcp_server(name="aden-tools", ...)
   - Calls list_mcp_tools() → sees web_search
   - Creates node with tools=["web_search"]
   - Calls export_graph()
3. Output: agent.json, README.md, mcp_servers.json ✨
```

**Benefits:**
- Tools discoverable during agent building
- Connection validated before use
- Automatic `mcp_servers.json` generation
- README auto-documents MCP sources

## Changes by File

### New Files

#### Core Integration
- **`framework/runner/mcp_client.py`** (353 lines)
  - MCP client with STDIO/HTTP support
  - Uses official MCP Python SDK
  - Async/sync context handling
  - Tool discovery and invocation

#### Documentation
- **`MCP_INTEGRATION_GUIDE.md`** (361 lines)
  - Complete guide for runtime integration
  - STDIO/HTTP examples
  - Configuration reference
  - Troubleshooting

- **`MCP_BUILDER_TOOLS_GUIDE.md`** (334 lines)
  - Guide for agent builder tools
  - Workflow examples
  - Tool reference

#### Examples
- **`examples/mcp_integration_example.py`** (199 lines)
  - Working code examples
  - Multiple integration patterns

- **`examples/mcp_servers.json`** (22 lines)
  - Example configuration file
  - STDIO and HTTP examples

### Modified Files

#### Agent Builder Enhancement
- **`framework/mcp/agent_builder_server.py`** (+450 lines)
  - Added 4 new MCP tools
  - Enhanced export to generate `mcp_servers.json`
  - Updated README generation
  - BuildSession now tracks MCP servers

#### Runtime Enhancement
- **`framework/runner/runner.py`** (+69 lines)
  - `register_mcp_server()` public API
  - Auto-load from `mcp_servers.json`
  - Cleanup of MCP connections

- **`framework/runner/tool_registry.py`** (+132 lines)
  - `register_mcp_server()` method
  - MCP tool to framework Tool conversion
  - Connection lifecycle management

#### Documentation
- **`README.md`** (+62 lines)
  - MCP Tool Integration section
  - Quick start examples
  - Tool availability documentation

#### Dependencies
- **`requirements.txt`** (+1 line)
  - Added `httpx>=0.27.0` for HTTP transport

## Testing

### Automated Tests
- ✅ MCP Client STDIO connection
- ✅ Tool Registry integration
- ✅ AgentRunner integration
- ✅ Config file auto-loading

All integration tests passing with aden-tools MCP server.

### Manual Testing
The agent builder MCP tools are best tested through Claude Desktop or other MCP clients:

1. Register the agent builder MCP server in Claude Desktop
2. Ask Claude to build an agent with web search
3. Claude uses `add_mcp_server` and `list_mcp_tools`
4. Exported agent includes `mcp_servers.json`
5. Agent runs successfully with MCP tools

## Example: Web Research Agent

**Build via Agent Builder:**
```
User: "Create an agent that searches the web and summarizes results"

Claude calls:
├─ create_session("web-researcher")
├─ add_mcp_server(name="aden-tools", transport="stdio", ...)
├─ list_mcp_tools() → discovers web_search
├─ set_goal(...)
├─ add_node(tools=["web_search"], ...)
└─ export_graph()

Output:
exports/web-researcher/
├── agent.json
├── README.md
└── mcp_servers.json ← Auto-generated!
```

**Run the Agent:**
```python
runner = AgentRunner.load("exports/web-researcher")
# MCP servers auto-load, web_search ready!

result = await runner.run({"query": "latest AI breakthroughs"})
```

## Architecture

```
┌─────────────────────────────────────────────────────────┐
│                    AgentRunner                          │
│  ┌───────────────────────────────────────────────────┐  │
│  │              Tool Registry                        │  │
│  │  ┌─────────────┐  ┌──────────────────────────┐   │  │
│  │  │ Built-in    │  │  MCP Servers             │   │  │
│  │  │ Tools       │  │  ┌────────────────────┐  │   │  │
│  │  └─────────────┘  │  │ MCP Client         │  │   │  │
│  │                   │  │  ├─ aden-tools     │  │   │  │
│  │                   │  │  ├─ custom-tools   │  │   │  │
│  │                   │  │  └─ remote-tools   │  │   │  │
│  │                   │  └────────────────────┘  │   │  │
│  │                   └──────────────────────────┘   │  │
│  └───────────────────────────────────────────────────┘  │
│                                                          │
│  Loads from: mcp_servers.json (auto) or API (manual)    │
└─────────────────────────────────────────────────────────┘
```

## Benefits

### For Users
- ✅ Access powerful tools without framework changes
- ✅ Reuse tools across multiple agents
- ✅ Simple configuration via JSON
- ✅ Tools auto-documented in agent README

### For Developers
- ✅ Extend agents with external capabilities
- ✅ Standardized tool integration pattern
- ✅ Clean separation of concerns
- ✅ Easy to add new tool sources

### For the Ecosystem
- ✅ Interoperability with MCP ecosystem
- ✅ Tool sharing across frameworks
- ✅ Community tool libraries
- ✅ Standardized tool protocol

## Future Enhancements

Potential improvements for future PRs:
- Connection pooling for better performance
- Tool usage analytics and metrics
- MCP server health monitoring
- WebSocket transport support
- Tool filtering and namespacing
- Version pinning for reproducibility

## Breaking Changes

None. This is purely additive functionality.

## Migration Guide

No migration needed. Existing agents continue to work unchanged.

To adopt MCP integration:
1. Add `mcp_servers.json` to your agent folder (optional)
2. Or call `runner.register_mcp_server()` programmatically
3. Tools are immediately available to your agent

## Documentation

- [MCP_INTEGRATION_GUIDE.md](core/MCP_INTEGRATION_GUIDE.md) - Runtime integration guide
- [MCP_BUILDER_TOOLS_GUIDE.md](core/MCP_BUILDER_TOOLS_GUIDE.md) - Agent builder tools guide
- [examples/mcp_integration_example.py](core/examples/mcp_integration_example.py) - Working examples

## Related

- Works with aden-tools MCP server (tested)
- Compatible with any MCP-compliant server
- Integrates with existing tool registry system
- Uses official MCP Python SDK

---

**Summary:** This PR transforms the Hive Core Framework from a closed tool system to an open, extensible platform that can integrate with any MCP server. Agents can now access entire tool ecosystems, making them significantly more powerful and capable.

