### PR TITLE
docs: add brief context explaining Aden

### DIFF
--- a/docs/quizzes/01-getting-started.md
+++ b/docs/quizzes/01-getting-started.md
@@ -2,6 +2,9 @@
 
 Welcome to Aden! This challenge will help you get familiar with our project and community. Complete all tasks to earn your first badge!
 
+Aden is an open-source platform for building, running, and observing autonomous agents. It provides a control plane, SDKs, and tools that help developers experiment with agent workflows in a structured and reproducible way.
+
+
 **Difficulty:** Beginner
 **Time:** ~30 minutes
 **Prerequisites:** GitHub account


### PR DESCRIPTION
### What this PR does
Adds a short introductory paragraph explaining what Aden is
before the Getting Started tasks.

### Why this change is needed
The challenge currently assumes readers already know what Aden is.
Providing brief context helps first-time contributors understand the
project before completing the tasks.

### Scope
- Documentation only
- No logic or behavior changes

