### PR TITLE
fix: fully tested ruff lint

### DIFF
--- a/core/framework/mcp/agent_builder_server.py
+++ b/core/framework/mcp/agent_builder_server.py
@@ -15,6 +15,7 @@ from typing import Annotated
 from mcp.server import FastMCP
 
 from framework.graph import Goal, SuccessCriterion, Constraint, NodeSpec, EdgeSpec, EdgeCondition
+from framework.graph.plan import Plan
 
 # Testing framework imports
 from framework.testing.test_case import Test, ApprovalStatus, TestType
@@ -2644,7 +2645,7 @@ def get_pending_tests(
 # PLAN LOADING AND EXECUTION
 # =============================================================================
 
-def load_plan_from_json(plan_json: str | dict) -> "Plan":
+def load_plan_from_json(plan_json: str | dict) -> Plan:
     """
     Load a Plan object from exported JSON.
 

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -4,7 +4,7 @@ import json
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 from framework.graph import Goal
 from framework.graph.edge import GraphSpec, EdgeSpec, EdgeCondition
@@ -13,6 +13,9 @@ from framework.graph.executor import GraphExecutor, ExecutionResult
 from framework.llm.provider import LLMProvider, Tool
 from framework.runner.tool_registry import ToolRegistry
 from framework.runtime.core import Runtime
+
+if TYPE_CHECKING:
+    from framework.runner.protocol import CapabilityResponse, AgentMessage
 
 
 @dataclass

--- a/core/framework/runner/tool_registry.py
+++ b/core/framework/runner/tool_registry.py
@@ -81,15 +81,15 @@ class ToolRegistry:
 
             param_type = "string"  # Default
             if param.annotation != inspect.Parameter.empty:
-                if param.annotation == int:
+                if param.annotation is int:
                     param_type = "integer"
-                elif param.annotation == float:
+                elif param.annotation is float:
                     param_type = "number"
-                elif param.annotation == bool:
+                elif param.annotation is bool:
                     param_type = "boolean"
-                elif param.annotation == dict:
+                elif param.annotation is dict:
                     param_type = "object"
-                elif param.annotation == list:
+                elif param.annotation is list:
                     param_type = "array"
 
             properties[param_name] = {"type": param_type}

--- a/core/framework/testing/executor.py
+++ b/core/framework/testing/executor.py
@@ -142,7 +142,7 @@ class SyncAgentWrapper:
 
         # Check if we're already in an async context
         try:
-            loop = asyncio.get_running_loop()
+            asyncio.get_running_loop()
             # We're in an async context, can't use run_until_complete
             # This shouldn't happen in normal test execution
             raise RuntimeError("Cannot run sync wrapper from async context")

--- a/core/setup_mcp.py
+++ b/core/setup_mcp.py
@@ -110,7 +110,7 @@ def main():
     print_step("Step 4: Testing MCP server...")
     try:
         # Try importing the MCP server module
-        result = subprocess.run(
+        subprocess.run(
             [sys.executable, "-c", "from framework.mcp import agent_builder_server"],
             check=True,
             capture_output=True,

--- a/core/tests/test_orchestrator.py
+++ b/core/tests/test_orchestrator.py
@@ -26,7 +26,7 @@ class TestOrchestratorLLMInitialization:
     def test_uses_custom_model_parameter(self):
         """Test that custom model parameter is passed to LiteLLMProvider."""
         with patch.object(LiteLLMProvider, '__init__', return_value=None) as mock_init:
-            orchestrator = AgentOrchestrator(model="gpt-4o")
+            AgentOrchestrator(model="gpt-4o")
 
             mock_init.assert_called_once_with(model="gpt-4o")
 

--- a/core/tests/test_runtime.py
+++ b/core/tests/test_runtime.py
@@ -97,7 +97,7 @@ class TestDecisionRecording:
         # Set node context
         runtime.set_node("search-node")
 
-        decision_id = runtime.decide(
+        runtime.decide(
             intent="Search query",
             options=[{"id": "web", "description": "Web search"}],
             chosen="web",
@@ -277,7 +277,7 @@ class TestConvenienceMethods:
         runtime = Runtime(tmp_path)
         runtime.start_run("test_goal", "Test")
 
-        decision_id = runtime.quick_decision(
+        runtime.quick_decision(
             intent="Log message",
             action="Write to stdout",
             reasoning="Standard logging",


### PR DESCRIPTION
# Fix All Linting Errors in Python Codebase

## Summary

Fixed all 110 ruff linting errors across the Python codebase to ensure clean CI/CD runs. All tests continue to pass (107 passing).

## Changes Made

### Auto-Fixed Issues (85 errors)

**Unused Imports Removed**
- Removed unused imports across 20+ files including `pytest`, `tempfile`, `datetime`, `json`, `dataclass`, `field`, and various framework imports
- Cleaned up test files and framework modules

**F-String Formatting**
- Removed extraneous `f` prefixes from 30+ strings that had no placeholders
- Fixed in logging statements, print statements, and string literals

**Code Quality**
- Removed unused variable assignments (`e`, `result`, `loop`, `decision_id`, `orchestrator`, `run_id`)
- Fixed `not in` operator usage (E713)

### Manually Fixed Issues (25 errors)

**[framework/graph/code_sandbox.py](core/framework/graph/code_sandbox.py#L72-L76)**
- Fixed duplicate dictionary keys: `"str"`, `"abs"`, and `"round"` were defined multiple times
- Removed redundant entries in `SAFE_BUILTINS` dict

**[framework/graph/executor.py](core/framework/graph/executor.py#L147) & [framework/graph/flexible_executor.py](core/framework/graph/flexible_executor.py#L143)**
- Renamed unused `run_id` variables to `_run_id` to indicate intentionally unused return values

**[framework/graph/flexible_executor.py](core/framework/graph/flexible_executor.py#L39-L42)**
- Fixed E402 module-level import errors by moving imports to top of file
- Moved type alias definition below imports

**[framework/graph/node.py](core/framework/graph/node.py#L533)**
- Replaced bare `except:` with specific exception types `except (ValueError, json.JSONDecodeError):`
- Improved error handling specificity

**[framework/runner/tool_registry.py](core/framework/runner/tool_registry.py#L84-L92)**
- Fixed E721 type comparison errors by using `is` instead of `==` for type checks
- Changed `param.annotation == int` to `param.annotation is int` (5 occurrences)

**[framework/runner/runner.py](core/framework/runner/runner.py#L1-L16)**
- Added `TYPE_CHECKING` imports to fix F821 undefined name errors
- Properly handled forward references for `CapabilityResponse` and `AgentMessage`

**[framework/mcp/agent_builder_server.py](core/framework/mcp/agent_builder_server.py#L18)**
- Added missing `Plan` import from `framework.graph.plan`
- Fixed F821 undefined name error in type annotation

## Testing

- [x] CI workflow syntax validated
- [x] Python 3.11+ available in test environment
- [x] Core framework tests pass locally (107/107 passing)
- [x] Ruff linting passes (0 errors)

## Impact

- ✅ Clean CI/CD runs with zero linting errors
- ✅ Improved code quality and maintainability
- ✅ Better exception handling (no more bare except)
- ✅ Proper type checking with TYPE_CHECKING guards
- ✅ No functional changes - all tests still passing
