### PR TITLE
Test_mcp_server added with smoke tests

### DIFF
--- a/core/tests/test_mcp_server.py
+++ b/core/tests/test_mcp_server.py
@@ -1,0 +1,93 @@
+"""
+Smoke tests for the MCP server module.
+"""
+
+import pytest
+
+
+def _mcp_available() -> bool:
+    """Check if MCP dependencies are installed."""
+    try:
+        import mcp
+        from mcp.server import FastMCP
+        return True
+    except ImportError:
+        return False
+
+
+MCP_AVAILABLE = _mcp_available()
+MCP_SKIP_REASON = "MCP dependencies not installed"
+
+
+class TestMCPDependencies:
+    """Tests for MCP dependency availability."""
+
+    def test_mcp_package_available(self):
+        """Test that the mcp package can be imported."""
+        if not MCP_AVAILABLE:
+            pytest.skip(MCP_SKIP_REASON)
+
+        import mcp
+        assert mcp is not None
+
+    def test_fastmcp_available(self):
+        """Test that FastMCP class is available from mcp server."""
+        if not MCP_AVAILABLE:
+            pytest.skip(MCP_SKIP_REASON)
+
+        from mcp.server import FastMCP
+        assert FastMCP is not None
+
+
+class TestAgentBuilderServerModule:
+    """Tests for the agent_builder_server module."""
+
+    def test_module_importable(self):
+        """Test that framework.mcp.agent_builder_server can be imported."""
+        if not MCP_AVAILABLE:
+            pytest.skip(MCP_SKIP_REASON)
+
+        import framework.mcp.agent_builder_server as module
+        assert module is not None
+
+    def test_mcp_object_exported(self):
+        """Test that the module exports the 'mcp' object (FastMCP instance)."""
+        if not MCP_AVAILABLE:
+            pytest.skip(MCP_SKIP_REASON)
+
+        from framework.mcp.agent_builder_server import mcp
+        from mcp.server import FastMCP
+
+        assert mcp is not None
+        assert isinstance(mcp, FastMCP)
+
+    def test_mcp_server_name(self):
+        """Test that the MCP server has the expected name."""
+        if not MCP_AVAILABLE:
+            pytest.skip(MCP_SKIP_REASON)
+
+        from framework.mcp.agent_builder_server import mcp
+        assert mcp.name == "agent-builder"
+
+
+class TestMCPPackageExports:
+    """Tests for the framework.mcp package exports."""
+
+    def test_package_importable(self):
+        """Test that framework.mcp package can be imported."""
+        if not MCP_AVAILABLE:
+            pytest.skip(MCP_SKIP_REASON)
+
+        import framework.mcp
+        assert framework.mcp is not None
+
+    def test_agent_builder_server_exported(self):
+        """Test that agent_builder_server is exported from framework.mcp."""
+        if not MCP_AVAILABLE:
+            pytest.skip(MCP_SKIP_REASON)
+
+        from framework.mcp import agent_builder_server
+        from mcp.server import FastMCP
+
+        assert agent_builder_server is not None
+        assert isinstance(agent_builder_server, FastMCP)


### PR DESCRIPTION
## Description

Add automated pytest smoke tests for the MCP server module (framework.mcp.agent_builder_server) to catch import/dependency issues in CI before manual testing.

## Type of Change

- [ ]  New feature (non-breaking change that adds functionality)


## Related Issues

[Enhancement]: test - add MCP server smoke test to core/tests (issue 121)

## Changes Made

- Added core/tests/test_mcp_server.py with 7 smoke tests
- Tests verify MCP dependencies (mcp, fastmcp) are available
- Tests verify framework.mcp.agent_builder_server module can be imported
- Tests verify expected exports (mcp object of type FastMCP)
- Tests skip gracefully with pytest.skip() when MCP dependencies aren't installed

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (cd core && pytest tests/)
 - [ ] Lint passes (cd core && ruff check .)
 - [ ] Manual testing performed

With MCP dependencies installed: 7 tests pass

Without MCP dependencies: 7 tests skip 

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
