### PR TITLE
guard decide_and_execute without active run

### DIFF
--- a/core/framework/runtime/core.py
+++ b/core/framework/runtime/core.py
@@ -322,6 +322,9 @@ class Runtime:
             **kwargs,
         )
 
+        if not decision_id:
+            raise RuntimeError("decide_and_execute called with no active run")
+
         # Execute and measure
         start = time.time()
         try:

--- a/core/tests/test_runtime.py
+++ b/core/tests/test_runtime.py
@@ -336,6 +336,48 @@ class TestConvenienceMethods:
 
         runtime.end_run(success=False)
 
+    def test_decide_and_execute_without_run(self, tmp_path: Path):
+        """decide_and_execute should fail fast when no run is active."""
+        runtime = Runtime(tmp_path)
+        executed = False
+
+        def do_action():
+            nonlocal executed
+            executed = True
+            return {"ok": True}
+
+        with pytest.raises(RuntimeError, match="no active run"):
+            runtime.decide_and_execute(
+                intent="Compute value",
+                options=[{"id": "compute", "description": "Run computation"}],
+                chosen="compute",
+                reasoning="Need the value",
+                executor=do_action,
+            )
+
+        assert executed is False
+
+    def test_decide_and_execute_without_run(self, tmp_path: Path):
+        """decide_and_execute should fail fast when no run is active."""
+        runtime = Runtime(tmp_path)
+        executed = False
+
+        def do_action():
+            nonlocal executed
+            executed = True
+            return {"ok": True}
+
+        with pytest.raises(RuntimeError, match="no active run"):
+            runtime.decide_and_execute(
+                intent="Compute value",
+                options=[{"id": "compute", "description": "Run computation"}],
+                chosen="compute",
+                reasoning="Need the value",
+                executor=do_action,
+            )
+
+        assert executed is False
+
 
 class TestNarrativeGeneration:
     """Test automatic narrative generation."""


### PR DESCRIPTION
## Description
Fail fast in `Runtime.decide_and_execute` when no run is active and add a regression test to ensure the executor never runs without a valid run context.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #145

## Changes Made

- Added a guard in `decide_and_execute` to raise when there is no active run
- Added a test to verify no execution occurs without an active run

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`python3.11 -m pytest core/tests/test_runtime.py -v`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes