### PR TITLE
fix: remove unused web search tool registration

### DIFF
--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -51,7 +51,6 @@ def register_all_tools(
     """
     # Tools that don't need credentials
     register_example(mcp)
-    register_web_search(mcp)
     register_web_scrape(mcp)
     register_pdf_read(mcp)
 


### PR DESCRIPTION
## Description

The `web_search` tool is registered twice in `tools/src/aden_tools/tools/__init__.py`, causing the second registration to overwrite the first. This is unnecessary since the tool already handles both credential sources (CredentialManager and environment variables) internally.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #172

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code