### PR TITLE
fix: align AnthropicProvider.complete with LLMProvider (response_format)

### DIFF
--- a/core/framework/llm/anthropic.py
+++ b/core/framework/llm/anthropic.py
@@ -67,6 +67,7 @@ class AnthropicProvider(LLMProvider):
         system: str = "",
         tools: list[Tool] | None = None,
         max_tokens: int = 1024,
+        response_format: dict[str, Any] | None = None,
         json_mode: bool = False,
     ) -> LLMResponse:
         """Generate a completion from Claude (via LiteLLM)."""
@@ -75,6 +76,7 @@ class AnthropicProvider(LLMProvider):
             system=system,
             tools=tools,
             max_tokens=max_tokens,
+            response_format=response_format,
             json_mode=json_mode,
         )
 


### PR DESCRIPTION
AnthropicProvider.complete() was missing the `response_format` parameter that exists on the base `LLMProvider.complete()` interface.

This breaks polymorphic usage when switching providers behind the `LLMProvider` abstraction and can raise a `TypeError` if `response_format` is passed while using `AnthropicProvider`.

## Changes
- Added `response_format` to `AnthropicProvider.complete()`
- Forwarded `response_format` to the underlying `LiteLLMProvider.complete()`
- Added a unit test in `test_litellm_provider.py` to verify parameter forwarding

## Related Issue
Fixes #171

## Testing
- Unit tests pass (`cd core && pytest tests/`)
