### PR TITLE
fix(tool_registry):Fixed Mock executor in ToolRegistry.discover_from_module() to capture tool_name

### DIFF
--- a/core/framework/runner/tool_registry.py
+++ b/core/framework/runner/tool_registry.py
@@ -164,8 +164,12 @@ class ToolRegistry:
 
                     self.register(name, tool, make_executor(name))
                 else:
-                    # Register tool without executor (will use mock)
-                    self.register(name, tool, lambda inputs: {"mock": True, "inputs": inputs})
+                    # Register tool without executor (will use mock) - capture 'name'
+                    self.register(
+                        name,
+                        tool,
+                        lambda inputs, n=name: {"mock": True, "tool_name": n, "inputs": inputs},
+                    )
                 count += 1
 
         # Check for @tool decorated functions


### PR DESCRIPTION
## Description

Brief description of the changes in this PR.
Fix a bug in ToolRegistry.discover_from_module where mock executors used a bare lambda and therefore returned identical responses for every tool. The mock executor now captures the tool name so each mock response identifies the tool that produced it.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #184 

## Changes Made
Replace the bare lambda mock executor with a lambda that captures name (adds "tool_name": <name> to mock results).

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [X] Manual testing performed

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
