### PR TITLE
feat(skills): add api_key and api_base support to RuntimeConfig

### DIFF
--- a/.claude/skills/building-agents-construction/SKILL.md
+++ b/.claude/skills/building-agents-construction/SKILL.md
@@ -520,6 +520,8 @@ class RuntimeConfig:
     model: str = "cerebras/zai-glm-4.7"
     temperature: float = 0.7
     max_tokens: int = 4096
+    api_key: str | None = None
+    api_base: str | None = None
 
 default_config = RuntimeConfig()
 
@@ -972,7 +974,11 @@ class {agent_class_name}:
         llm = None
         if not mock_mode:
             # LiteLLMProvider uses environment variables for API keys
-            llm = LiteLLMProvider(model=self.config.model)
+            llm = LiteLLMProvider(
+                model=self.config.model,
+                api_key=self.config.api_key,
+                api_base=self.config.api_base,
+            )
 
         self._graph = GraphSpec(
             id="{agent_name}-graph",

--- a/.claude/skills/building-agents-construction/examples/online_research_agent/agent.py
+++ b/.claude/skills/building-agents-construction/examples/online_research_agent/agent.py
@@ -233,7 +233,11 @@ class OnlineResearchAgent:
         llm = None
         if not mock_mode:
             # LiteLLMProvider uses environment variables for API keys
-            llm = LiteLLMProvider(model=self.config.model)
+            llm = LiteLLMProvider(
+                model=self.config.model,
+                api_key=self.config.api_key,
+                api_base=self.config.api_base,
+            )
 
         self._graph = GraphSpec(
             id="online-research-agent-graph",

--- a/.claude/skills/building-agents-construction/examples/online_research_agent/config.py
+++ b/.claude/skills/building-agents-construction/examples/online_research_agent/config.py
@@ -7,6 +7,8 @@ class RuntimeConfig:
     model: str = "groq/moonshotai/kimi-k2-instruct-0905"
     temperature: float = 0.7
     max_tokens: int = 16384
+    api_key: str | None = None
+    api_base: str | None = None
 
 
 default_config = RuntimeConfig()


### PR DESCRIPTION
## Description
This PR adds support for configuring `api_key` and `api_base` in the agent's runtime configuration. This allows users to provide their own API credentials and custom base URLs (e.g., for local inference or alternative providers) directly through the configuration, which are then passed to the `LiteLLMProvider`.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
Fixes #186

## Changes Made
- Added `api_key` and `api_base` fields to the [RuntimeConfig](/hive/.claude/skills/building-agents-construction/examples/online_research_agent/config.py:4:0-10:31) class in [config.py](/hive/.claude/skills/building-agents-construction/examples/online_research_agent/config.py:0:0-0:0).
- Updated [agent.py](/hive/.claude/skills/building-agents-construction/examples/online_research_agent/agent.py:0:0-0:0) to pass these configuration values to the `LiteLLMProvider` initialization.
- Updated the [SKILL.md](/hive/.claude/skills/building-agents-core/SKILL.md:0:0-0:0) templates in `building-agents-construction` to ensure future agents generated with this skill include this configuration support.

## Testing
Describe the tests you ran to verify your changes:
- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed: Verified that the [RuntimeConfig](/hive/.claude/skills/building-agents-construction/examples/online_research_agent/config.py:4:0-10:31) accepts the new parameters and they are correctly passed to the agent's LLM provider.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (SKILL.md)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes