### PR TITLE
fix(shell_script): Fixed shell script to correctly detect python versions

### DIFF
--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -32,6 +32,7 @@ elif command -v python3.11 >/dev/null 2>&1; then
     PYTHON_CMD="python3.11"
 elif command -v python3 >/dev/null 2>&1; then
     PYTHON_CMD="python3"
+# Use python3 if available, otherwise python
 elif command -v python >/dev/null 2>&1; then
     PYTHON_CMD="python"
 else

--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -25,17 +25,19 @@ echo "  Aden Agent Framework - Python Setup"
 echo "=================================================="
 echo ""
 
-# Check for Python
-if ! command -v python &> /dev/null && ! command -v python3 &> /dev/null; then
+# Check for Python (allow override via PYTHON env var, prefer python3.11)
+if [ -n "$PYTHON" ]; then
+    PYTHON_CMD="$PYTHON"
+elif command -v python3.11 >/dev/null 2>&1; then
+    PYTHON_CMD="python3.11"
+elif command -v python3 >/dev/null 2>&1; then
+    PYTHON_CMD="python3"
+elif command -v python >/dev/null 2>&1; then
+    PYTHON_CMD="python"
+else
     echo -e "${RED}Error: Python is not installed.${NC}"
     echo "Please install Python 3.11+ from https://python.org"
     exit 1
-fi
-
-# Use python3 if available, otherwise python
-PYTHON_CMD="python3"
-if ! command -v python3 &> /dev/null; then
-    PYTHON_CMD="python"
 fi
 
 # Check Python version


### PR DESCRIPTION
## Description

Brief description of the changes in this PR.
Improve Python detection in setup script to prefer explicit PYTHON, then python3.11, then python3/python: updated setup-python.sh  to honor PYTHON env var and prefer python3.11, with clearer error messaging for WSL/Ubuntu 22.04.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #182

## Changes Made
Improved Python detection in setup-python.sh prefer explicit PYTHON env var, then python3.11, then python3/python, and emit clearer messages when Python/pip are missing. See setup-python.sh.

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [X] Manual testing performed

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
