### PR TITLE
Fix/mcp server loading

### DIFF
--- a/.claude/skills/building-agents-construction/SKILL.md
+++ b/.claude/skills/building-agents-construction/SKILL.md
@@ -520,6 +520,8 @@ class RuntimeConfig:
     model: str = "cerebras/zai-glm-4.7"
     temperature: float = 0.7
     max_tokens: int = 4096
+    api_key: str | None = None
+    api_base: str | None = None
 
 default_config = RuntimeConfig()
 
@@ -972,7 +974,11 @@ class {agent_class_name}:
         llm = None
         if not mock_mode:
             # LiteLLMProvider uses environment variables for API keys
-            llm = LiteLLMProvider(model=self.config.model)
+            llm = LiteLLMProvider(
+                model=self.config.model,
+                api_key=self.config.api_key,
+                api_base=self.config.api_base,
+            )
 
         self._graph = GraphSpec(
             id="{agent_name}-graph",

--- a/.claude/skills/building-agents-construction/SKILL.md
+++ b/.claude/skills/building-agents-construction/SKILL.md
@@ -964,12 +964,21 @@ class {agent_class_name}:
                 with open(mcp_config_path) as f:
                     mcp_servers = json.load(f)
 
-                for server_name, server_config in mcp_servers.items():
-                    server_config["name"] = server_name
-                    # Resolve relative cwd paths
-                    if "cwd" in server_config and not Path(server_config["cwd"]).is_absolute():
-                        server_config["cwd"] = str(agent_dir / server_config["cwd"])
-                    tool_registry.register_mcp_server(server_config)
+                # Handle both dict (legacy) and list (new) formats
+                if "servers" in mcp_servers and isinstance(mcp_servers["servers"], list):
+                    # New format: {"servers": [{...}]}
+                    for server_config in mcp_servers["servers"]:
+                        cwd = server_config.get("cwd")
+                        if cwd and not Path(cwd).is_absolute():
+                            server_config["cwd"] = str(agent_dir / cwd)
+                        tool_registry.register_mcp_server(server_config)
+                else:
+                    # Legacy format: {"server_name": {...}}
+                    for server_name, server_config in mcp_servers.items():
+                        server_config["name"] = server_name
+                        if "cwd" in server_config and not Path(server_config["cwd"]).is_absolute():
+                            server_config["cwd"] = str(agent_dir / server_config["cwd"])
+                        tool_registry.register_mcp_server(server_config)
 
         llm = None
         if not mock_mode:

--- a/.claude/skills/building-agents-construction/examples/online_research_agent/agent.py
+++ b/.claude/skills/building-agents-construction/examples/online_research_agent/agent.py
@@ -233,7 +233,11 @@ class OnlineResearchAgent:
         llm = None
         if not mock_mode:
             # LiteLLMProvider uses environment variables for API keys
-            llm = LiteLLMProvider(model=self.config.model)
+            llm = LiteLLMProvider(
+                model=self.config.model,
+                api_key=self.config.api_key,
+                api_base=self.config.api_base,
+            )
 
         self._graph = GraphSpec(
             id="online-research-agent-graph",

--- a/.claude/skills/building-agents-construction/examples/online_research_agent/agent.py
+++ b/.claude/skills/building-agents-construction/examples/online_research_agent/agent.py
@@ -223,12 +223,21 @@ class OnlineResearchAgent:
             with open(mcp_config_path) as f:
                 mcp_servers = json.load(f)
 
-            for server_name, server_config in mcp_servers.items():
-                server_config["name"] = server_name
-                # Resolve relative cwd paths
-                if "cwd" in server_config and not Path(server_config["cwd"]).is_absolute():
-                    server_config["cwd"] = str(agent_dir / server_config["cwd"])
-                tool_registry.register_mcp_server(server_config)
+            # Handle both dict (legacy) and list (new) formats
+            if "servers" in mcp_servers and isinstance(mcp_servers["servers"], list):
+                # New format: {"servers": [{...}]}
+                for server_config in mcp_servers["servers"]:
+                    cwd = server_config.get("cwd")
+                    if cwd and not Path(cwd).is_absolute():
+                        server_config["cwd"] = str(agent_dir / cwd)
+                    tool_registry.register_mcp_server(server_config)
+            else:
+                # Legacy format: {"server_name": {...}}
+                for server_name, server_config in mcp_servers.items():
+                    server_config["name"] = server_name
+                    if "cwd" in server_config and not Path(server_config["cwd"]).is_absolute():
+                        server_config["cwd"] = str(agent_dir / server_config["cwd"])
+                    tool_registry.register_mcp_server(server_config)
 
         llm = None
         if not mock_mode:

--- a/.claude/skills/building-agents-construction/examples/online_research_agent/config.py
+++ b/.claude/skills/building-agents-construction/examples/online_research_agent/config.py
@@ -7,6 +7,8 @@ class RuntimeConfig:
     model: str = "groq/moonshotai/kimi-k2-instruct-0905"
     temperature: float = 0.7
     max_tokens: int = 16384
+    api_key: str | None = None
+    api_base: str | None = None
 
 
 default_config = RuntimeConfig()


### PR DESCRIPTION
## Description

This PR fixes a bug where agent execution would fail with a `TypeError` if [mcp_servers.json](/hive/.claude/skills/building-agents-construction/examples/online_research_agent/mcp_servers.json:0:0-0:0) was formatted as a list under a `"servers"` key (which can happen with the latest generator outputs) instead of the expected dictionary format.

The changes update the loading logic in both the `online_research_agent` example and the [SKILL.md](/hive/.claude/skills/building-agents-core/SKILL.md:0:0-0:0) templates to robustly handle both formats:
1.  **New Format:** Checks for a `"servers"` list and iterates through it.
2.  **Legacy Format:** Falls back to iterating over dictionary items if the keys are server names.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #188

## Changes Made

- Modified [agent.py](/hive/.claude/skills/building-agents-construction/examples/online_research_agent/agent.py:0:0-0:0) in `examples/online_research_agent/` to support dual loading strategies for [mcp_servers.json](/hive/.claude/skills/building-agents-construction/examples/online_research_agent/mcp_servers.json:0:0-0:0).
- Updated the [SKILL.md](/hive/.claude/skills/building-agents-core/SKILL.md:0:0-0:0) template in `building-agents-construction` to ensure future generated agents include this robust loading logic.
- Added logic to correctly handle relative `cwd` paths for both formats.

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed: Verified the code logic now accepts both `{"servers": [...]}` and `{"server_name": {...}}` structures without raising a `TypeError`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (SKILL.md templates)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes