### PR TITLE
Clarify quickstart.sh behavior for new contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ This installs:
 - All required dependencies
 
 ### Build Your First Agent
+#### What Does `quickstart.sh` Do?
+
+The `quickstart.sh` script prepares your local environment for building agents with Hive.
+
+Specifically, it:
+- Installs required Claude Code skills (one-time setup)
+- Configures tooling needed for agent generation
+- Prepares the environment for interactive `claude>` commands
+
+The script is safe to re-run if your environment changes or setup needs to be refreshed.
 
 ```bash
 # Install Claude Code skills (one-time)


### PR DESCRIPTION
## Description

This PR adds a short explanation of what the `quickstart.sh` script does,
to reduce confusion for first-time contributors running the Quick Start.

This is a documentation-only change focused on onboarding clarity.

## Changes Made

- Explained the purpose of `quickstart.sh`
- Clarified that the script is safe to re-run

## Testing

Not applicable — documentation-only changes.

