### PR TITLE
fix: setup-python.sh failing on Ubuntu due to PEP 668

### DIFF
--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -60,6 +60,28 @@ fi
 echo -e "${GREEN}✓${NC} Python version check passed"
 echo ""
 
+
+# --------------------------------------------------
+# Ensure virtual environment (PEP 668 safe)
+# --------------------------------------------------
+
+if [ -z "$VIRTUAL_ENV" ]; then
+    VENV_DIR="$PROJECT_ROOT/.venv"
+
+    if [ ! -d "$VENV_DIR" ]; then
+        echo "Creating virtual environment at .venv..."
+        $PYTHON_CMD -m venv "$VENV_DIR"
+    fi
+
+    echo "Activating virtual environment..."
+    source "$VENV_DIR/bin/activate"
+
+    # Ensure pip inside venv
+    PYTHON_CMD="python"
+fi
+
+
+
 # Check for pip
 if ! $PYTHON_CMD -m pip --version &> /dev/null; then
     echo -e "${RED}Error: pip is not installed${NC}"


### PR DESCRIPTION
## Problem
On Ubuntu with Python 3.12, `scripts/setup-python.sh` fails during pip upgrade
due to PEP 668 (externally-managed-environment).

## Root Cause
The setup script runs pip commands outside of a virtual environment,
which is disallowed on modern Debian/Ubuntu Python distributions.

## Solution
Automatically create and activate a local `.venv` before running pip
commands when not already inside a virtual environment.

## Tested
- Ubuntu + Python 3.12
- Fresh clone running ./scripts/setup-python.sh

<img width="806" height="1002" alt="Screenshot 2026-01-25 171042" src="https://github.com/user-attachments/assets/b77f5321-24bc-4bbb-a7aa-e7687e7d1dc2" />
<img width="1919" height="545" alt="Screenshot 2026-01-25 171019" src="https://github.com/user-attachments/assets/89a2a886-44a4-4677-9bac-a2671f0f930f" />
