### PR TITLE
micro-fix: quickstart.sh succeeds but fails to install 'claude' CLI

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -299,6 +299,16 @@ fi
 
 echo ""
 
+# Install Claude CLI if missing
+echo -e "${BLUE}Installing Claude CLI...${NC}"
+if command -v npm &> /dev/null; then
+    npm install -g @anthropic-ai/claude-code
+    echo -e "${GREEN}  ✓ Claude CLI installed${NC}"
+else
+    echo -e "${YELLOW}  ⚠ npm not found, skipping Claude CLI install${NC}"
+fi
+echo ""
+
 # ============================================================
 # Step 7: Success Summary
 # ============================================================


### PR DESCRIPTION
## Summary
Fixes #203

The `quickstart.sh` script currently completes with a success message but fails to install the required `@anthropic-ai/claude-code` package. This leaves the user unable to run the `claude` command as instructed in the final output.

## Changes
- Added `npm install -g @anthropic-ai/claude-code` to the setup script.
- Added a safety check to ensure `npm` is available before attempting install.

## Testing
- Verified in a fresh Codespaces environment.
- After running the updated script, the `claude` command is correctly available in the path.