### PR TITLE
Fix setup-python.sh for PEP 668 by using virtualenv on macOS

### DIFF
--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -70,6 +70,27 @@ fi
 echo -e "${GREEN}✓${NC} pip detected"
 echo ""
 
+# --------------------------------------------------
+# Handle externally managed Python environments (PEP 668)
+# --------------------------------------------------
+if $PYTHON_CMD -m pip install --dry-run pip 2>&1 | grep -q "externally managed"; then
+    echo -e "${YELLOW}Detected externally managed Python environment (PEP 668).${NC}"
+    echo "Creating and activating virtual environment..."
+
+    $PYTHON_CMD -m venv .venv
+    source .venv/bin/activate
+
+    echo -e "${GREEN}✓${NC} Virtual environment created and activated (.venv)"
+fi
+
+# Upgrade pip, setuptools, and wheel
+echo "Upgrading pip, setuptools, and wheel..."
+if ! $PYTHON_CMD -m pip install --upgrade pip setuptools wheel; then
+  echo "Error: Failed to upgrade pip. Please check your python/venv configuration."
+  exit 1
+fi
+
+
 # Upgrade pip, setuptools, and wheel
 echo "Upgrading pip, setuptools, and wheel..."
 if ! $PYTHON_CMD -m pip install --upgrade pip setuptools wheel; then


### PR DESCRIPTION
## Description

Fixes the `setup-python.sh` script on macOS with Homebrew Python.  
The script previously failed under PEP 668 (externally managed environments) when upgrading pip system-wide.  
This update detects such environments and automatically creates and uses a virtual environment to safely install dependencies.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #206

## Changes Made

- Detect externally managed Python environments (PEP 668)
- Create and activate a virtual environment when required
- Upgrade pip, setuptools, and wheel inside the virtual environment
- Avoid modifying the system Python

## Testing

- [x] Manual testing on macOS with Homebrew Python
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings