### PR TITLE
docs: clarify that exports/ contains user-created agents

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -81,7 +81,11 @@ All agent commands must be run from the project root with `PYTHONPATH` set:
 PYTHONPATH=core:exports python -m agent_name COMMAND
 ```
 
-### Example: Support Ticket Agent
+> **Note:** The `exports/` directory is where your custom agents are stored. It is intentionally excluded from the repository (via `.gitignore`) since agents are user-generated. You must first create an agent using the `/building-agents` skill (see [Building New Agents](#building-new-agents)) before running these commands.
+
+### Example Commands
+
+Once you've built an agent (e.g., `support_ticket_agent`), you can run:
 
 ```bash
 # Validate agent structure
@@ -101,7 +105,9 @@ PYTHONPATH=core:exports python -m support_ticket_agent run --input '{
 PYTHONPATH=core:exports python -m support_ticket_agent run --mock --input '{...}'
 ```
 
-### Example: Other Agents
+### Other Agent Examples
+
+These are example agent names you might create:
 
 ```bash
 # Market Research Agent
@@ -186,13 +192,19 @@ pip install --upgrade "openai>=1.0.0"
 
 ### "No module named 'support_ticket_agent'"
 
-**Cause:** Not running from project root or missing PYTHONPATH
+**Cause:** Agent not created yet, not running from project root, or missing PYTHONPATH
 
-**Solution:** Ensure you're in `/home/timothy/oss/hive/` and use:
+**Solution:**
 
-```bash
-PYTHONPATH=core:exports python -m support_ticket_agent validate
-```
+1. First, create an agent using Claude Code:
+   ```
+   claude> /building-agents
+   ```
+
+2. Then run from the project root with PYTHONPATH:
+   ```bash
+   PYTHONPATH=core:exports python -m your_agent_name validate
+   ```
 
 ### Agent imports fail with "broken installation"
 
@@ -225,11 +237,8 @@ hive/
 │   ├── pyproject.toml
 │   └── README.md
 │
-└── exports/                 # Agent packages (your agents go here)
-    ├── support_ticket_agent/
-    ├── market_research_agent/
-    ├── outbound_sales_agent/
-    └── personal_assistant_agent/
+└── exports/                 # Agent packages (your agents go here, not in repo)
+    └── your_agent_name/     # Created via /building-agents skill
 ```
 
 ### Why PYTHONPATH is Required
@@ -325,7 +334,7 @@ export AGENT_STORAGE_PATH="/custom/storage"
 
 - **Framework Documentation:** [core/README.md](core/README.md)
 - **Tools Documentation:** [tools/README.md](tools/README.md)
-- **Example Agents:** [exports/](exports/)
+- **Example Agents:** Create your own using `/building-agents` skill
 - **Agent Building Guide:** [.claude/skills/building-agents-construction/SKILL.md](.claude/skills/building-agents-construction/SKILL.md)
 - **Testing Guide:** [.claude/skills/testing-agent/SKILL.md](.claude/skills/testing-agent/SKILL.md)
 


### PR DESCRIPTION
## Summary

This PR clarifies the documentation around the `exports/` directory, which is a common source of confusion for new contributors.

## Problem

Issue #220 reports that the `ENVIRONMENT_SETUP.md` documentation references example agents under `exports/` (e.g., `support_ticket_agent`, `market_research_agent`), but:

1. The `exports/` directory doesn't exist in the repository
2. 2. It's intentionally excluded via `.gitignore`
This causes confusion when users try to run the example commands and get "No module named" errors.

## Solution

Updated `ENVIRONMENT_SETUP.md` to:

1. **Add a clear note** explaining that `exports/` is where user-created agents are stored and is intentionally excluded from the repo
2. 2. **Clarify the workflow** - users must first create an agent using `/building-agents` skill before running commands
3. 3. **Update the package structure diagram** to reflect the actual repo state
4. 4. **Improve troubleshooting section** for the "No module named" error to include the missing agent creation step
5. 5. **Fix the Additional Resources section** to point users to the agent creation skill instead of a non-existent directory
## Type of Change

- [x] Documentation update
## Related Issues

Fixes #220 
## Changes Made

- Added note in "Running Agents" section explaining the `exports/` directory purpose
- - Updated section headers for clarity
- - Fixed package structure to show `exports/` as user-generated
- - Enhanced troubleshooting for missing agent modules
- - Updated Additional Resources link
## Testing

- [x] Manual testing performed - verified all internal links work correctly
- [ ] - [x] Confirmed the documentation flow is now logical for new users
## Checklist

- [x] My code follows the project's style guidelines
- [ ] - [x] I have performed a self-review of my code
- [ ] - [x] I have made corresponding changes to the documentation
- [ ] - [x] My changes generate no new warnings