### PR TITLE
fix: add response_format parameter to AnthropicProvider.complete

### DIFF
--- a/core/framework/llm/anthropic.py
+++ b/core/framework/llm/anthropic.py
@@ -67,6 +67,7 @@ class AnthropicProvider(LLMProvider):
         system: str = "",
         tools: list[Tool] | None = None,
         max_tokens: int = 1024,
+        response_format: dict[str, Any] | None = None,
         json_mode: bool = False,
     ) -> LLMResponse:
         """Generate a completion from Claude (via LiteLLM)."""
@@ -75,6 +76,7 @@ class AnthropicProvider(LLMProvider):
             system=system,
             tools=tools,
             max_tokens=max_tokens,
+            response_format=response_format,
             json_mode=json_mode,
         )
 


### PR DESCRIPTION
- Add response_format parameter to match LLMProvider interface
- Forward response_format to underlying LiteLLMProvider
- Enables polymorphic usage of providers behind LLMProvider interface

Fixes #171

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
