### PR TITLE
fix(storage): enforce utf-8 encoding to fix windows crash

### DIFF
--- a/core/framework/storage/backend.py
+++ b/core/framework/storage/backend.py
@@ -52,13 +52,13 @@ class FileStorage:
         """Save a run to storage."""
         # Save full run using Pydantic's model_dump_json
         run_path = self.base_path / "runs" / f"{run.id}.json"
-        with open(run_path, "w") as f:
+        with open(run_path, "w", encoding="utf-8") as f:
             f.write(run.model_dump_json(indent=2))
 
         # Save summary
         summary = RunSummary.from_run(run)
         summary_path = self.base_path / "summaries" / f"{run.id}.json"
-        with open(summary_path, "w") as f:
+        with open(summary_path, "w", encoding="utf-8") as f: 
             f.write(summary.model_dump_json(indent=2))
 
         # Update indexes


### PR DESCRIPTION
## Description

The storage backend was using the default system encoding when saving run summaries. On Windows (where the default is cp1252), this caused a UnicodeEncodeError when attempting to write Unicode status symbols (like ✓ and ✗) to the JSON files. This PR explicitly adds encoding="utf-8" to the open() calls in backend.py to ensure cross-platform compatibility and prevent crashes on Windows.

## Type of Change

[x] Bug fix (non-breaking change that fixes an issue)

[ ] New feature (non-breaking change that adds functionality)

[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

[ ] Documentation update

[ ] Refactoring (no functional changes)

## Related Issues

Fixes Windows compatibility crash in storage backend.

## Changes Made

Added encoding="utf-8" to the save_run method in core/framework/storage/backend.py (for both full run and summary files).

## Testing

Verified on Windows 11 with Python 3.14:

[x] Unit tests pass (cd core && pytest tests/) - All 206 tests passed successfully.

[ ] Lint passes (cd core && ruff check .)

[x] Manual testing performed

## Checklist

[x] My code follows the project's style guidelines

[x] I have performed a self-review of my code

[x] My changes generate no new warnings

[x] New and existing unit tests pass locally with my changes

