### PR TITLE
fix: add version constraints for mcp and fastmcp in requirements.txt

### DIFF
--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -5,8 +5,8 @@ httpx>=0.27.0
 litellm>=1.81.0
 
 # MCP server dependencies
-mcp
-fastmcp
+mcp>=1.0.0
+fastmcp>=2.0.0
 
 # Testing (required for test framework)
 pytest>=8.0


### PR DESCRIPTION
## Summary

Align dependency constraints between `requirements.txt` and `pyproject.toml` by adding minimum versions for `mcp` and `fastmcp`.

## Why

The core package already declares:
- `mcp>=1.0.0`
- `fastmcp>=2.0.0`

But `requirements.txt` allowed older versions, which can lead to confusing install-time/runtime incompatibilities (especially when contributors install via `pip install -r requirements.txt`).

## Changes

- Add `mcp>=1.0.0` constraint
- Add `fastmcp>=2.0.0` constraint

Fixes #209

## Test plan

- [ ] Install via `pip install -r requirements.txt`
- [ ] Run CI / unit tests