### PR TITLE
fix(core): respect node and graph level retry configuration

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -181,7 +181,8 @@ class GraphExecutor:
         total_tokens = 0
         total_latency = 0
         node_retry_counts: dict[str, int] = {}  # Track retries per node
-        max_retries_per_node = 3
+        max_retries_limit = graph.max_retries_per_node or 3
+
 
         # Determine entry point (may differ if resuming)
         current_node_id = graph.get_entry_point(session_state)
@@ -296,6 +297,9 @@ class GraphExecutor:
 
                 total_tokens += result.tokens_used
                 total_latency += result.latency_ms
+
+                # Use node-level config if specified, otherwise graph-level, otherwise default 3
+                max_retries_per_node = node_spec.max_retries or max_retries_limit
 
                 # Handle failure
                 if not result.success:


### PR DESCRIPTION
## Description
This PR resolves a bug where `GraphExecutor` hardcoded the retry limit to `3`, ignoring the custom configurations defined at the `NodeSpec` or `GraphSpec` levels. 
By implementing a hierarchical resolution (Node > Graph > Default), developers can now correctly customize retry behavior for flaky nodes or specific agent graphs.
## Changes
- Replaced hardcoded `3` in `GraphExecutor` with a resolution hierarchy: `node_spec.max_retries` -> `graph.max_retries_per_node` -> Default (`3`).
- Ensured resolution happens inside the execution loop to avoid `UnboundLocalError`.

## Verification
- Core tests verified: `cd core && python -m pytest` (206 passed).
- Manual verification: Confirmed that a node with `max_retries: 5` actually retries 5 times before failing.
Closes #239