### PR TITLE
Fix pytest test discovery for tools suite

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths =
+    core/tests
+    tools/tests
+python_files = test_*.py
+addopts = -ra

--- a/tools/tests/__init__.py
+++ b/tools/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Aden Tools test suite."""

--- a/tools/tests/tools/__init__.py
+++ b/tools/tests/tools/__init__.py
@@ -1,1 +1,0 @@
-"""Tool-specific tests."""


### PR DESCRIPTION
### Summary

Pytest collection fails due to test package/import confusion under `tools/tests`.

### Changes

- Add repo-root `pytest.ini` with explicit `testpaths`
- Remove unnecessary `__init__.py` files under `tools/tests` so tests are not treated as an importable package

### Result

`pytest` now collects successfully across core + tools test suites.

Tested:

```bash
pytest
```


