### PR TITLE
docs: clarify that exports/ is user-generated, not included in repo

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -596,10 +596,11 @@ pip install -e .
 # Option 1: Use Claude Code skill (recommended)
 claude> /building-agents
 
-# Option 2: Copy from example
-cp -r exports/support_ticket_agent exports/my_new_agent
+# Option 2: Create manually
+# Note: exports/ is initially empty (gitignored). Create your agent directory:
+mkdir -p exports/my_new_agent
 cd exports/my_new_agent
-# Edit agent.json, tools.py, README.md
+# Create agent.json, tools.py, README.md (see Agent Package Structure below)
 
 # Option 3: Use the agent builder MCP tools (advanced)
 # See core/MCP_BUILDER_TOOLS_GUIDE.md

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,15 +43,17 @@ Follow the interactive prompts to:
 3. Generate the agent package
 4. Test the agent
 
-### Option 2: From an Example
+### Option 2: Create Agent Manually
+
+> **Note:** The `exports/` directory is where your agents are created. It is not included in the repository (gitignored) because agents are user-generated via Claude Code skills or created manually.
 
 ```bash
-# Copy an example agent
-cp -r exports/support_ticket_agent exports/my_agent
+# Create exports directory if it doesn't exist
+mkdir -p exports/my_agent
 
-# Customize the agent
+# Create your agent structure
 cd exports/my_agent
-# Edit agent.json, tools.py, README.md
+# Create agent.json, tools.py, README.md (see DEVELOPER.md for structure)
 
 # Validate the agent
 PYTHONPATH=core:exports python -m my_agent validate
@@ -78,10 +80,8 @@ hive/
 │       │   └── file_system_toolkits/
 │       └── mcp_server.py   # HTTP MCP server
 │
-├── exports/                # Agent Packages
-│   ├── support_ticket_agent/
-│   ├── market_research_agent/
-│   └── ...                 # Your agents go here
+├── exports/                # Agent Packages (user-generated, not in repo)
+│   └── your_agent/         # Your agents created via /building-agents
 │
 ├── .claude/                # Claude Code Skills
 │   └── skills/
@@ -143,7 +143,7 @@ PYTHONPATH=core:exports python -m my_agent test --type success
 
 1. **Detailed Setup**: See [ENVIRONMENT_SETUP.md](../ENVIRONMENT_SETUP.md)
 2. **Developer Guide**: See [DEVELOPER.md](../DEVELOPER.md)
-3. **Agent Patterns**: Explore examples in `/exports`
+3. **Build Agents**: Use `/building-agents` skill in Claude Code
 4. **Custom Tools**: Learn to integrate MCP servers
 5. **Join Community**: [Discord](https://discord.com/invite/MXE49hrKDk)
 
@@ -188,4 +188,4 @@ pip uninstall -y framework tools
 - **Documentation**: Check the `/docs` folder
 - **Issues**: [github.com/adenhq/hive/issues](https://github.com/adenhq/hive/issues)
 - **Discord**: [discord.com/invite/MXE49hrKDk](https://discord.com/invite/MXE49hrKDk)
-- **Examples**: Explore `/exports` for working agents
+- **Build Agents**: Use `/building-agents` skill to create agents


### PR DESCRIPTION
## Summary
Fixes #202 

The documentation references `exports/` directory with example agents like `support_ticket_agent`, but this directory is gitignored and doesn't exist in the repository. This causes immediate onboarding failures for new contributors.

## Changes Made
- Updated `docs/getting-started.md`:
  - Clarified that `exports/` is user-generated (not included in repo)
  - Removed references to non-existent `support_ticket_agent`
  - Updated project structure diagram
  - Fixed "Next Steps" and "Getting Help" sections

- Updated `DEVELOPER.md`:
  - Fixed "Creating a New Agent" section to explain exports/ is initially empty

## Testing
- Verified all documentation references are accurate
- No code changes, documentation only