### PR TITLE
validation: enforce bounds on Option.confidence

### DIFF
--- a/core/framework/schemas/decision.py
+++ b/core/framework/schemas/decision.py
@@ -45,7 +45,7 @@ class Option(BaseModel):
     cons: list[str] = Field(default_factory=list)
 
     # Agent's confidence in this option (0-1)
-    confidence: float = 0.5
+    confidence: float = Field(0.5, ge=0.0, le=1.0)
 
     model_config = {"extra": "allow"}
 


### PR DESCRIPTION
Fixes #245 

What:
Adds validation to Option.confidence to ensure values remain between 0.0 and 1.0.

Why:
confidence represents probability-like certainty. Unbounded values (e.g. -1 or 500)
break semantic meaning and may cause downstream scoring issues.

Changes:
- Added Pydantic field constraints (ge=0.0, le=1.0), consistent with existing fields.

Risk:
Low. Validation pattern already exists in this schema.
<img width="935" height="199" alt="Screenshot 2026-01-25 181841" src="https://github.com/user-attachments/assets/0bb30573-3d16-48cb-bf8a-39a766b6bb41" />

