### PR TITLE
chore(scripts): use project .venv and fix ANSI color rendering

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -69,6 +69,27 @@ fi
 echo -e "${GREEN}  ✓ Python version OK${NC}"
 echo ""
 
+# ------------------------------------------------------------
+# Setup project virtual environment (pyvenv)
+# ------------------------------------------------------------
+VENV_DIR="$SCRIPT_DIR/.venv"
+if [ -z "$VIRTUAL_ENV" ]; then
+    echo -e "${BLUE}Using virtual environment:${NC} $VENV_DIR"
+    if [ ! -d "$VENV_DIR" ]; then
+        echo "  Creating virtual environment..."
+        if ! $PYTHON_CMD -m venv "$VENV_DIR"; then
+            echo -e "${RED}  ✗ Failed to create virtual environment${NC}"
+            exit 1
+        fi
+    fi
+    # Activate the venv for this shell
+    . "$VENV_DIR/bin/activate"
+    PYTHON_CMD="python"
+else
+    echo -e "${BLUE}Using active virtual environment:${NC} $VIRTUAL_ENV"
+    PYTHON_CMD="python"
+fi
+
 # Check for pip
 if ! $PYTHON_CMD -m pip --version &> /dev/null; then
     echo -e "${RED}Error: pip is not installed${NC}"
@@ -292,7 +313,7 @@ else
     echo -e "${YELLOW}  ⚠ ANTHROPIC_API_KEY not found${NC}"
     echo ""
     echo "    For real agent testing, you'll need to set your API key:"
-    echo "    ${BLUE}export ANTHROPIC_API_KEY='your-key-here'${NC}"
+    echo -e "    ${BLUE}export ANTHROPIC_API_KEY='your-key-here'${NC}"
     echo ""
     echo "    Or add it to your .env file or credential manager."
 fi
@@ -321,16 +342,16 @@ echo "  • /agent-workflow              - Complete workflow"
 echo ""
 echo "Usage:"
 echo "  1. Open Claude Code in this directory:"
-echo "     ${BLUE}cd $SCRIPT_DIR && claude${NC}"
+echo -e "     ${BLUE}cd $SCRIPT_DIR && claude${NC}"
 echo ""
 echo "  2. Build a new agent:"
-echo "     ${BLUE}/building-agents-construction${NC}"
+echo -e "     ${BLUE}/building-agents-construction${NC}"
 echo ""
 echo "  3. Test an existing agent:"
-echo "     ${BLUE}/testing-agent${NC}"
+echo -e "     ${BLUE}/testing-agent${NC}"
 echo ""
 echo "  4. Or use the complete workflow:"
-echo "     ${BLUE}/agent-workflow${NC}"
+echo -e "     ${BLUE}/agent-workflow${NC}"
 echo ""
 echo "MCP Tools available (when running from this directory):"
 echo "  • mcp__agent-builder__create_session"

--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -60,6 +60,27 @@ fi
 echo -e "${GREEN}✓${NC} Python version check passed"
 echo ""
 
+# ------------------------------------------------------------
+# Setup project virtual environment (pyvenv)
+# ------------------------------------------------------------
+VENV_DIR="$PROJECT_ROOT/.venv"
+if [ -z "$VIRTUAL_ENV" ]; then
+    echo -e "${BLUE}Using virtual environment:${NC} $VENV_DIR"
+    if [ ! -d "$VENV_DIR" ]; then
+        echo "Creating virtual environment..."
+        if ! $PYTHON_CMD -m venv "$VENV_DIR"; then
+            echo -e "${RED}✗${NC} Failed to create virtual environment"
+            exit 1
+        fi
+    fi
+    # Activate the venv for this shell
+    . "$VENV_DIR/bin/activate"
+    PYTHON_CMD="python"
+else
+    echo -e "${BLUE}Using active virtual environment:${NC} $VIRTUAL_ENV"
+    PYTHON_CMD="python"
+fi
+
 # Check for pip
 if ! $PYTHON_CMD -m pip --version &> /dev/null; then
     echo -e "${RED}Error: pip is not installed${NC}"
@@ -190,7 +211,7 @@ echo "  • All dependencies and compatibility fixes applied"
 echo ""
 echo "To run agents, use:"
 echo ""
-echo "  ${BLUE}# From project root:${NC}"
+echo -e "  ${BLUE}# From project root:${NC}"
 echo "  PYTHONPATH=core:exports python -m agent_name validate"
 echo "  PYTHONPATH=core:exports python -m agent_name info"
 echo "  PYTHONPATH=core:exports python -m agent_name run --input '{...}'"


### PR DESCRIPTION
<!-- filepath: /home/arnavs/Projects/OSS/hive/PR_DESCRIPTION.md -->

## Description

This PR ensures setup scripts (`quickstart.sh` and `scripts/setup-python.sh`) run entirely inside a project-local Python virtual environment (`.venv`) for consistent, isolated dependencies across machines. It also fixes ANSI color rendering by switching colorized output lines to use `echo -e` so escape sequences are properly interpreted instead of printing literally.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #263

## Changes Made

- `quickstart.sh`
  - Adds `.venv` bootstrap: creates and activates `./.venv` when not already in a venv; subsequent operations use the venv Python.
  - Keeps Python 3.11+ requirement and runs installs inside the venv.
  - Uses `echo -e` for lines that include ANSI color variables.

- `scripts/setup-python.sh`
  - Adds `.venv` bootstrap at project root (`../.venv`): creates and activates when not already in a venv; subsequent operations use the venv Python.
  - Keeps Python 3.11+ requirement and runs installs inside the venv.
  - Uses `echo -e` for colorized lines where needed.

- Documentation
  - Added `PR_DESCRIPTION.md` for PR template reference
  - Added `BUG_REPORT.md` documenting the ANSI color issue

## Testing

Describe the tests you ran to verify your changes:

- [x] Manual testing performed on Linux bash
  - Venv is created when missing and activated correctly
  - All `pip` and Python commands execute within the venv
  - Colorized output (blue and reset codes) renders as expected with `echo -e`
  - Python 3.11+ version check works as designed
- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] No new or existing unit tests broken by these changes (setup scripts only)

## Screenshots (if applicable)

N/A - Setup script output improvements (CLI formatting only)

## Local Testing

```bash
# From project root
python3 -m venv .venv
source .venv/bin/activate
./quickstart.sh
# or
./scripts/setup-python.sh
```

**Expected output:** Colorized text renders in blue/green/red instead of printing `\033[...]` sequences.