### PR TITLE
docs: improve quickstart with concrete agent example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,10 @@ claude> /building-agents
 claude> /testing-agent
 
 # Run your agent
-PYTHONPATH=core:exports python -m your_agent_name run --input '{...}'
+# Example agent name: sales_agent
+# Example task: generate sales outreach plan
+PYTHONPATH=core:exports python -m sales_agent run --input '{"task":"generate sales outreach plan"}'
+
 ```
 
 **[📖 Complete Setup Guide](ENVIRONMENT_SETUP.md)** - Detailed instructions for agent development


### PR DESCRIPTION
This PR adds a clear, concrete example agent name and task to the Quick Start section to help first-time users understand how to run their first agent.

