### PR TITLE
docs: clarify example agent generation in getting started challenge

### DIFF
--- a/docs/quizzes/01-getting-started.md
+++ b/docs/quizzes/01-getting-started.md
@@ -76,6 +76,13 @@ Clone your fork and explore the codebase:
 ```bash
 git clone https://github.com/YOUR_USERNAME/hive.git
 cd hive
+
+> **Note:** Some example agents referenced elsewhere in the documentation
+> (for example, under an `exports/` directory) are generated when running
+> `quickstart.sh` using Claude Code. Contributors without Claude access
+> may not see these generated agents and can proceed with the exploration
+> tasks using the existing repository structure.
+
 ```
 
 Answer these questions:


### PR DESCRIPTION
This PR adds a small clarification to the Getting Started challenge noting
that some example agents (e.g. under `exports/`) are generated via
`quickstart.sh` using Claude Code and may not appear for contributors
without Claude access.

Scope intentionally kept minimal:
- Documentation-only change
- No workflow or code changes

This helps reduce onboarding confusion while remaining compatible with
broader onboarding improvements discussed in #255.

Closes #240