### PR TITLE
fix: disable ANSI colors when unsupported in setup script

### DIFF
--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -8,12 +8,21 @@
 
 set -e
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+# Colors for output (disable if terminal does not support ANSI colors)
+if [ -t 1 ] && command -v tput >/dev/null 2>&1 && [ "$(tput colors 2>/dev/null || echo 0)" -ge 8 ]; then
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[0;33m'
+  BLUE='\033[0;34m'
+  NC='\033[0m' # No Color
+else
+  RED=''
+  GREEN=''
+  YELLOW=''
+  BLUE=''
+  NC=''
+fi
+
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Description
Disables ANSI color escape sequences when the terminal does not support them (e.g., Windows Git Bash), preventing raw codes like `\033[0;34m` from appearing in setup output.

## Type of Change
- Bug fix (non-breaking)

## Testing
- Ran `./scripts/setup-python.sh` on Windows (Git Bash) with Python 3.12 venv