### PR TITLE
test(decision) : added direct tests for Decision computed properties

### DIFF
--- a/core/tests/test_decision.py
+++ b/core/tests/test_decision.py
@@ -1,0 +1,183 @@
+import pytest
+from datetime import datetime
+
+from framework.schemas.decision import (
+    Decision, 
+    Option, 
+    Outcome, 
+    DecisionEvaluation, 
+    DecisionType
+)
+
+class TestDecision:
+    """Test the Decision class."""
+    def test_chosen_option_found(self):
+        """Test retrieving the chosen option when it exists."""
+        opt1 = Option(id="opt1", description="Option 1", action_type="generate")
+        opt2 = Option(id="opt2", description="Option 2", action_type="generate")
+        
+        decision = Decision(
+            id="d1",
+            node_id="node1",
+            intent="Test intent",
+            options=[opt1, opt2],
+            chosen_option_id="opt2"
+        )
+        
+        assert decision.chosen_option == opt2
+        assert decision.chosen_option.id == "opt2"
+
+    def test_chosen_option_none(self):
+        """Test retrieving chosen option returns none when not found."""
+        opt1 = Option(id="opt1", description="Option 1", action_type="generate")
+        
+        decision = Decision(
+            id="d1",
+            node_id="node1",
+            intent="Test intent",
+            options=[opt1],
+            chosen_option_id="opt_nonexistent"
+        )
+        
+        assert decision.chosen_option is None
+
+    def test_was_successful_true(self):
+        """Test was_successful returns true for successful outcome."""
+        decision = Decision(
+            id="d1",
+            node_id="node1",
+            intent="Test intent",
+            options=[],
+            outcome=Outcome(success=True)
+        )
+        
+        assert decision.was_successful is True
+
+    def test_was_successful_false(self):
+        """Test was_successful returns False for failed outcome."""
+        decision = Decision(
+            id="d1",
+            node_id="node1",
+            intent="Test intent",
+            options=[],
+            outcome=Outcome(success=False, error="Failed")
+        )
+        
+        assert decision.was_successful is False
+
+    def test_was_successful_no_outcome(self):
+        """Test was_successful returns False when no outcome exists."""
+        decision = Decision(
+            id="d1",
+            node_id="node1",
+            intent="Test intent",
+            options=[]
+        )
+        
+        assert decision.was_successful is False
+
+    def test_was_good_decision_no_eval(self):
+        """Test was_good_decision falls back to success status when no evaluation."""
+        # successful case
+        d1 = Decision(
+            id="d1",
+            node_id="node1",
+            intent="Test intent",
+            outcome=Outcome(success=True)
+        )
+        assert d1.was_good_decision is True
+
+        # failing case
+        d2 = Decision(
+            id="d2",
+            node_id="node1",
+            intent="Test intent",
+            outcome=Outcome(success=False)
+        )
+        assert d2.was_good_decision is False
+
+    def test_was_good_decision_eval_good(self):
+        """Test was_good_decision returns True for good evaluation."""
+        decision = Decision(
+            id="d1",
+            node_id="node1",
+            intent="Test intent",
+            evaluation=DecisionEvaluation(
+                goal_aligned=True,
+                outcome_quality=0.8
+            )
+        )
+        assert decision.was_good_decision is True
+
+    def test_was_good_decision_eval_bad_alignment(self):
+        """Test was_good_decision returns False if not goal aligned."""
+        decision = Decision(
+            id="d1",
+            node_id="node1",
+            intent="Test intent",
+            evaluation=DecisionEvaluation(
+                goal_aligned=False,
+                outcome_quality=0.9
+            )
+        )
+        assert decision.was_good_decision is False
+
+    def test_was_good_decision_eval_bad_quality(self):
+        """Test was_good_decision returns False if quality is low."""
+        decision = Decision(
+            id="d1",
+            node_id="node1",
+            intent="Test intent",
+            evaluation=DecisionEvaluation(
+                goal_aligned=True,
+                outcome_quality=0.4
+            )
+        )
+        assert decision.was_good_decision is False
+
+    def test_summary_for_builder_success(self):
+        """Test summary string for successful decision."""
+        opt = Option(id="opt1", description="Do magic", action_type="generate")
+        decision = Decision(
+            id="d1",
+            node_id="gen_node",
+            intent="Generate code",
+            options=[opt],
+            chosen_option_id="opt1",
+            outcome=Outcome(success=True)
+        )
+        
+        summary = decision.summary_for_builder()
+        assert "✓ [gen_node] Generate code → Do magic" in summary
+        assert "quality" not in summary
+
+    def test_summary_for_builder_failure(self):
+        """Test summary string for failed decision."""
+        opt = Option(id="opt1", description="Do magic", action_type="generate")
+        decision = Decision(
+            id="d1",
+            node_id="gen_node",
+            intent="Generate code",
+            options=[opt],
+            chosen_option_id="opt1",
+            outcome=Outcome(success=False)
+        )
+        
+        summary = decision.summary_for_builder()
+        assert "✗ [gen_node] Generate code → Do magic" in summary
+
+    def test_summary_for_builder_with_eval(self):
+        """Test summary string includes quality when available."""
+        opt = Option(id="opt1", description="Do magic", action_type="generate")
+        decision = Decision(
+            id="d1",
+            node_id="gen_node",
+            intent="Generate code",
+            options=[opt],
+            chosen_option_id="opt1",
+            outcome=Outcome(success=True),
+            evaluation=DecisionEvaluation(goal_aligned=True, outcome_quality=0.9)
+        )
+        
+        summary = decision.summary_for_builder()
+        assert "quality: 0.9" in summary


### PR DESCRIPTION
This PR closes issue: #60 

## Description

This PR adds comprehensive unit tests for the `Decision` schema in `hive/core/framework/schemas/decision.py`. It aims to ensure the reliability of decision tracking, specifically covering key properties like `chosen_option`, `was_successful`, and `was_good_decision`, as well as the `summary_for_builder` method.


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Related Issues

Fixes #60 

## Changes Made

- Created `hive/core/tests/test_decision.py`
- Implemented `test_chosen_option_found` and `test_chosen_option_none`
- Implemented `test_was_successful_true`, `test_was_successful_false`, and `test_was_successful_no_outcome`
- Implemented logic verification for `was_good_decision` (success fallback, alignment check, quality check)
- Added tests for `summary_for_builder` formatting (success, failure, quality inclusion)

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
N/A
