### PR TITLE
docs(environment): add .env.example for configuration reference

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,50 @@
+# ================================
+# Aden / Hive Environment Variables
+# ================================
+
+# --- LLM Provider Keys (Required for agent execution) ---
+
+# OpenAI API Key (for GPT models)
+OPENAI_API_KEY=
+
+# Anthropic API Key (for Claude models)
+ANTHROPIC_API_KEY=
+
+# Google Gemini API Key (optional)
+GEMINI_API_KEY=
+
+# Mistral API Key (optional)
+MISTRAL_API_KEY=
+
+# Groq API Key (optional)
+GROQ_API_KEY=
+
+
+# --- LiteLLM Configuration (Optional) ---
+
+# Enable LiteLLM logging (true/false)
+LITELLM_LOG=false
+
+# Set default model (example: gpt-4o, claude-3-sonnet)
+DEFAULT_LLM_MODEL=
+
+
+# --- Observability & Runtime (Optional) ---
+
+# Enable verbose agent logging
+ADEN_DEBUG=false
+
+# Agent execution environment
+ENVIRONMENT=development
+
+
+# --- Database / Telemetry (Optional - Self Hosted) ---
+
+# TimescaleDB / Postgres connection (if observability enabled)
+DATABASE_URL=
+
+
+# --- Security (Optional) ---
+
+# Token used for internal API auth (self-hosted)
+ADEN_API_TOKEN=


### PR DESCRIPTION
## Summary

This PR adds a `.env.example` file to document required and optional environment variables used by the Aden/Hive framework.

## Changes Made

- Added example environment variable template for common LLM providers
- Documented optional LiteLLM configuration flags
- Included runtime, observability, and self-hosting related variables
- Added comments to improve developer onboarding and configuration clarity

## Motivation

New contributors and self-hosted users often struggle to identify required environment variables. Providing a template improves onboarding experience and reduces setup friction.

## Testing

- Verified no secrets are committed
- Confirmed compatibility with existing setup workflow

Please let me know if you'd like additional variables documented.
