### PR TITLE
Improve onboarding docs and add minimal Hello Agent example

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -83,6 +83,8 @@ PYTHONPATH=core:exports python -m agent_name COMMAND
 
 ### Example: Support Ticket Agent
 
+These examples assume you have created agents under `exports/` (not included in the main branch by default).
+
 ```bash
 # Validate agent structure
 PYTHONPATH=core:exports python -m support_ticket_agent validate
@@ -126,13 +128,18 @@ Use Claude Code CLI with the agent building skills:
 
 This installs:
 
-- `/building-agents` - Build new agents
+- `/building-agents-core` - Core concepts
+- `/building-agents-construction` - Build new agents
+- `/building-agents-patterns` - Best practices
 - `/testing-agent` - Test agents
+- `/agent-workflow` - End-to-end guided flow
+
+Note: `quickstart.sh` installs skills only. You still need the Claude Code CLI (`claude`) on your PATH.
 
 ### 2. Build an Agent
 
 ```
-claude> /building-agents
+claude> /building-agents-construction
 ```
 
 Follow the prompts to:
@@ -186,12 +193,30 @@ pip install --upgrade "openai>=1.0.0"
 
 ### "No module named 'support_ticket_agent'"
 
-**Cause:** Not running from project root or missing PYTHONPATH
+**Cause:** Not running from project root, missing PYTHONPATH, or no agents have been created yet
 
-**Solution:** Ensure you're in `/home/timothy/oss/hive/` and use:
+**Solution:** Ensure you're in the project root and use:
 
 ```bash
 PYTHONPATH=core:exports python -m support_ticket_agent validate
+```
+
+If you don't have any agents yet, create one first (see [docs/examples/hello-agent.md](docs/examples/hello-agent.md)).
+
+### "claude: command not found"
+
+**Cause:** Claude Code CLI is not installed or not on your PATH.
+
+**Solution:** Install the CLI and ensure the global npm bin directory is on PATH:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+On Git Bash (Windows), you may need:
+
+```bash
+export PATH="/c/Users/<you>/AppData/Roaming/npm:$PATH"
 ```
 
 ### Agent imports fail with "broken installation"
@@ -225,11 +250,8 @@ hive/
 │   ├── pyproject.toml
 │   └── README.md
 │
-└── exports/                 # Agent packages (your agents go here)
-    ├── support_ticket_agent/
-    ├── market_research_agent/
-    ├── outbound_sales_agent/
-    └── personal_assistant_agent/
+└── exports/                 # Agent packages (created locally; gitignored by default)
+    └── your_agent/
 ```
 
 ### Why PYTHONPATH is Required
@@ -256,7 +278,7 @@ This design allows agents in `exports/` to be:
 ### 2. Build Agent (Claude Code)
 
 ```
-claude> /building-agents
+claude> /building-agents-construction
 Enter goal: "Build an agent that processes customer support tickets"
 ```
 
@@ -325,7 +347,7 @@ export AGENT_STORAGE_PATH="/custom/storage"
 
 - **Framework Documentation:** [core/README.md](core/README.md)
 - **Tools Documentation:** [tools/README.md](tools/README.md)
-- **Example Agents:** [exports/](exports/)
+- **Hello Agent Example:** [docs/examples/hello-agent.md](docs/examples/hello-agent.md)
 - **Agent Building Guide:** [.claude/skills/building-agents-construction/SKILL.md](.claude/skills/building-agents-construction/SKILL.md)
 - **Testing Guide:** [.claude/skills/testing-agent/SKILL.md](.claude/skills/testing-agent/SKILL.md)
 

--- a/README.md
+++ b/README.md
@@ -90,16 +90,22 @@ This installs:
 ./quickstart.sh
 
 # Build an agent using Claude Code
-claude> /building-agents
+# Note: quickstart installs skills only; install Claude Code CLI separately if needed.
+claude> /building-agents-construction
+
+# Or use the full guided workflow
+claude> /agent-workflow
 
 # Test your agent
 claude> /testing-agent
 
 # Run your agent
+# If your agent doesn't expose a module entrypoint, use: python -m core run exports/your_agent --input '{...}'
 PYTHONPATH=core:exports python -m your_agent_name run --input '{...}'
 ```
 
 **[📖 Complete Setup Guide](ENVIRONMENT_SETUP.md)** - Detailed instructions for agent development
+**Minimal Example:** [docs/examples/hello-agent.md](docs/examples/hello-agent.md)
 
 ## Features
 
@@ -221,7 +227,7 @@ Choose other frameworks when you need:
 hive/
 ├── core/                   # Core framework - Agent runtime, graph executor, protocols
 ├── tools/                  # MCP Tools Package - 19 tools for agent capabilities
-├── exports/                # Agent packages - Pre-built agents and examples
+├── exports/                # Agent packages (created locally; gitignored by default)
 ├── docs/                   # Documentation and guides
 ├── scripts/                # Build and utility scripts
 ├── .claude/                # Claude Code skills for building agents
@@ -247,7 +253,10 @@ For building and running goal-driven agents with the framework:
 # - All dependencies
 
 # Build new agents using Claude Code skills
-claude> /building-agents
+claude> /building-agents-construction
+
+# Or use the full guided workflow
+claude> /agent-workflow
 
 # Test agents
 claude> /testing-agent

--- a/docs/examples/hello-agent.md
+++ b/docs/examples/hello-agent.md
@@ -1,0 +1,65 @@
+# Hello Agent (Minimal Example)
+
+This is a minimal, end-to-end agent you can create locally. The `exports/` directory
+is gitignored by default, so you create it on your machine.
+
+## 1) Create the agent folder
+
+```bash
+mkdir -p exports/hello_agent
+```
+
+## 2) Create `agent.json`
+
+Create `exports/hello_agent/agent.json` with:
+
+```json
+{
+  "graph": {
+    "id": "hello-agent-graph",
+    "goal_id": "hello-goal",
+    "entry_node": "hello",
+    "terminal_nodes": ["hello"],
+    "nodes": [
+      {
+        "id": "hello",
+        "name": "Hello",
+        "description": "Generate a friendly greeting.",
+        "node_type": "llm_generate",
+        "input_keys": ["name"],
+        "output_keys": ["response"],
+        "system_prompt": "Return JSON with key response. Greet {name} in one sentence."
+      }
+    ],
+    "edges": []
+  },
+  "goal": {
+    "id": "hello-goal",
+    "name": "Hello Agent",
+    "description": "Greet the user by name.",
+    "success_criteria": [
+      {
+        "id": "greeted",
+        "description": "The response greets the provided name.",
+        "metric": "output_contains",
+        "target": "name"
+      }
+    ]
+  }
+}
+```
+
+## 3) Validate and run
+
+```bash
+PYTHONPATH=core:exports python -m core validate exports/hello_agent
+PYTHONPATH=core:exports python -m core run exports/hello_agent --input "{\"name\":\"Aden\"}"
+```
+
+## 4) Run without paid APIs (local model)
+
+If you have Ollama running locally:
+
+```bash
+PYTHONPATH=core:exports python -m core --model ollama/llama3 run exports/hello_agent --input "{\"name\":\"Aden\"}"
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,8 +34,10 @@ python -c "import framework; import aden_tools; print('✓ Setup complete')"
 ./quickstart.sh
 
 # Start Claude Code and build an agent
-claude> /building-agents
+claude> /building-agents-construction
 ```
+
+Note: `quickstart.sh` installs skills only. You still need the Claude Code CLI (`claude`) on your PATH.
 
 Follow the interactive prompts to:
 1. Define your agent's goal
@@ -46,15 +48,8 @@ Follow the interactive prompts to:
 ### Option 2: From an Example
 
 ```bash
-# Copy an example agent
-cp -r exports/support_ticket_agent exports/my_agent
-
-# Customize the agent
-cd exports/my_agent
-# Edit agent.json, tools.py, README.md
-
-# Validate the agent
-PYTHONPATH=core:exports python -m my_agent validate
+# Create a minimal example agent
+# Follow: docs/examples/hello-agent.md
 ```
 
 ## Project Structure
@@ -78,14 +73,14 @@ hive/
 │       │   └── file_system_toolkits/
 │       └── mcp_server.py   # HTTP MCP server
 │
-├── exports/                # Agent Packages
-│   ├── support_ticket_agent/
-│   ├── market_research_agent/
-│   └── ...                 # Your agents go here
+├── exports/                # Agent packages (created locally; gitignored by default)
+│   └── your_agent/
 │
 ├── .claude/                # Claude Code Skills
 │   └── skills/
-│       ├── building-agents/
+│       ├── building-agents-construction/
+│       ├── building-agents-core/
+│       ├── building-agents-patterns/
 │       └── testing-agent/
 │
 └── docs/                   # Documentation
@@ -143,7 +138,7 @@ PYTHONPATH=core:exports python -m my_agent test --type success
 
 1. **Detailed Setup**: See [ENVIRONMENT_SETUP.md](../ENVIRONMENT_SETUP.md)
 2. **Developer Guide**: See [DEVELOPER.md](../DEVELOPER.md)
-3. **Agent Patterns**: Explore examples in `/exports`
+3. **Hello Agent Example**: See [docs/examples/hello-agent.md](examples/hello-agent.md)
 4. **Custom Tools**: Learn to integrate MCP servers
 5. **Join Community**: [Discord](https://discord.com/invite/MXE49hrKDk)
 
@@ -183,9 +178,23 @@ pip uninstall -y framework tools
 ./scripts/setup-python.sh
 ```
 
+### "claude: command not found"
+
+Install the Claude Code CLI and make sure your global npm bin directory is on PATH:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+On Git Bash (Windows), you may need:
+
+```bash
+export PATH="/c/Users/<you>/AppData/Roaming/npm:$PATH"
+```
+
 ## Getting Help
 
 - **Documentation**: Check the `/docs` folder
 - **Issues**: [github.com/adenhq/hive/issues](https://github.com/adenhq/hive/issues)
 - **Discord**: [discord.com/invite/MXE49hrKDk](https://discord.com/invite/MXE49hrKDk)
-- **Examples**: Explore `/exports` for working agents
+- **Examples**: See [docs/examples/hello-agent.md](examples/hello-agent.md)

--- a/tools/src/aden_tools/tools/file_system_toolkits/view_file/view_file.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/view_file/view_file.py
@@ -31,6 +31,21 @@ def register_tools(mcp: FastMCP) -> None:
             Dict with file content and metadata, or error dict
         """
         try:
+            if not isinstance(path, str) or not path.strip():
+                return {"error": "Invalid path: must be a non-empty string"}
+            if "\x00" in path:
+                return {"error": "Invalid path: contains null byte"}
+            if os.path.isabs(path):
+                return {"error": "Invalid path: must be relative to the session root"}
+
+            for field_name, field_value in {
+                "workspace_id": workspace_id,
+                "agent_id": agent_id,
+                "session_id": session_id,
+            }.items():
+                if not isinstance(field_value, str) or not field_value.strip():
+                    return {"error": f"Invalid {field_name}: must be a non-empty string"}
+
             secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
             if not os.path.exists(secure_path):
                 return {"error": f"File not found at {path}"}


### PR DESCRIPTION
## Summary
- add minimal Hello Agent example (agent.json + run commands)
- clarify exports/ is local + gitignored; fix references to missing example agents
- update skill names after quickstart.sh and document Claude CLI PATH issue
- add basic input validation for file read tool (view_file)

## Issues
Fixes #225
Fixes #220
Fixes #203
Fixes #200
Fixes #195
Fixes #178
Fixes #206
Fixes #60

## Testing
Not run (docs-only + small validation change).
