### PR TITLE
fix(tools): avoid duplicate web_search registration

### DIFF
--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -51,7 +51,6 @@ def register_all_tools(
     """
     # Tools that don't need credentials
     register_example(mcp)
-    register_web_search(mcp)
     register_web_scrape(mcp)
     register_pdf_read(mcp)
 


### PR DESCRIPTION
Fixes #257

Removed a redundant `register_web_search` call during tool initialization to prevent double registration.

## Testing
- Ran `python -m pytest` in `tools/`
- 140 tests passed locally
- 5 known failures remain in credentials/security tests (pre-existing, unrelated to this change)
