### PR TITLE
refactor(core): remove hardcoded Anthropic dependency from Node

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -69,7 +69,9 @@ python -c "import litellm; print('✓ litellm OK')"
 For running agents with real LLMs:
 
 ```bash
-export ANTHROPIC_API_KEY="your-key-here"
+# Universal LLM Configuration
+export LLM_API_KEY="your-key-here"
+export LLM_MODEL="gpt-4o" # Optional, defaults to gpt-4o-mini
 ```
 
 ## Running Agents
@@ -308,7 +310,9 @@ Add to `.vscode/settings.json`:
 ### Required for LLM Operations
 
 ```bash
-export ANTHROPIC_API_KEY="sk-ant-..."
+# Universal LLM Configuration
+export LLM_API_KEY="sk-..."
+export LLM_MODEL="gpt-4o" # Optional, defaults to gpt-4o-mini
 ```
 
 ### Optional Configuration


### PR DESCRIPTION
## Description

Replaced hardcoded `AnthropicProvider` and `Cerebras` logic in [core/framework/graph/node.py](cci:7://file:///e:/projects/aden/hive/core/framework/graph/node.py:0:0-0:0) with a generic `LiteLLMProvider`.

**Why:** The previous code forced users to use Anthropic or Cerebras keys for internal node utilities (like JSON extraction and summarization), causing errors for users attempting to use other providers (OpenAI, Ollama, etc.).

**Fix:** The framework now respects the universal `LLM_MODEL` and `LLM_API_KEY` environment variables for these internal tasks.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)

## Changes Made

- Updated [_extract_json](cci:1://file:///e:/projects/aden/hive/core/framework/graph/node.py:637:4-751:17) in [node.py](cci:7://file:///e:/projects/aden/hive/core/framework/graph/node.py:0:0-0:0) to use `LiteLLMProvider`.
- Updated [to_summary](cci:1://file:///e:/projects/aden/hive/core/framework/graph/node.py:290:4-351:35) in [node.py](cci:7://file:///e:/projects/aden/hive/core/framework/graph/node.py:0:0-0:0) to use `LiteLLMProvider`.
- Renamed `_format_inputs_with_haiku` to [_format_inputs_with_llm](cci:1://file:///e:/projects/aden/hive/core/framework/graph/node.py:759:4-847:65) to be model-agnostic.
- Updated [ENVIRONMENT_SETUP.md](cci:7://file:///e:/projects/aden/hive/ENVIRONMENT_SETUP.md:0:0-0:0) to document the new universal `LLM_API_KEY` and `LLM_MODEL` variables.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Manual testing performed (Verified [_extract_json](cci:1://file:///e:/projects/aden/hive/core/framework/graph/node.py:637:4-751:17) uses `LiteLLMProvider` correctly with a verification script)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings