### PR TITLE
docs: clarify open-source scope and contributor expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ Build reliable, self-improving AI agents without hardcoding workflows. Define yo
 
 Visit [adenhq.com](https://adenhq.com) for complete documentation, examples, and guides.
 
+## Open-Source Scope
+This repository contains the open-source core of the Aden Agent Framework,
+focused primarily on the Python-based agent runtime, tools, and examples.
+
+Other platform components such as the hosted control plane, web dashboard,
+and frontend UI (React/TypeScript) are part of Aden’s managed platform and
+are not included in this repository.
+
+If you are getting started as a contributor, please refer to the Python-based
+agent development workflow described below and in the Getting Started guide.
+
 ## What is Aden
 
 <p align="center">


### PR DESCRIPTION
## What this PR does
- Clarifies which parts of the Aden platform are included in this open-source repository
- Sets clear expectations for contributors regarding frontend and platform components

## Why
While onboarding locally, it was unclear which parts of the platform were open-source
due to references to frontend and backend components that are not present in this repo.

This change helps reduce contributor confusion and improves onboarding clarity.