### PR TITLE
fix(mcp setup python): use same python interpreter as setup

### DIFF
--- a/core/setup_mcp.py
+++ b/core/setup_mcp.py
@@ -93,7 +93,7 @@ def main():
         config = {
             "mcpServers": {
                 "agent-builder": {
-                    "command": "python",
+                    "command": sys.executable,
                     "args": ["-m", "framework.mcp.agent_builder_server"],
                     "cwd": str(script_dir)
                 }
@@ -141,7 +141,7 @@ def main():
     example_config = {
         "mcpServers": {
             "agent-builder": {
-                "command": "python",
+                "command": sys.executable,
                 "args": ["-m", "framework.mcp.agent_builder_server"],
                 "cwd": str(script_dir)
             }


### PR DESCRIPTION
## Description

This PR fixes an environment mismatch in the MCP setup process.

The setup script installs and verifies the framework using sys.executable, but the generated .mcp.json and example configuration previously used "command": "python", which could point to a different interpreter. This caused MCP clients to fail at runtime in environments using pyenv, virtualenv, or conda.

This change ensures the MCP server is always executed using the same Python interpreter used during setup.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Updated generated .mcp.json to use sys.executable instead of a hardcoded python command
- Updated the example MCP configuration output to use the same Python interpreter
- Ensured MCP runtime uses the same environment as the setup and verification steps

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
