### PR TITLE
Improve setup guidance for macOS Homebrew Python (PEP 668)

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -9,6 +9,21 @@ Complete setup guide for building and running goal-driven agents with the Aden A
 ./scripts/setup-python.sh
 ```
 
+## macOS (Homebrew Python)
+
+If you installed Python using Homebrew, pip enforces PEP 668 and blocks
+system-wide package installation.
+
+Before running the setup script, create and activate a virtual environment:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+./scripts/setup-python.sh
+```
+
+This avoids externally-managed-environment errors.
+
 This will:
 
 - Check Python version (requires 3.11+)

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ cd hive
 ./scripts/setup-python.sh
 ```
 
+> macOS users with Homebrew Python should activate a virtual environment
+> before running the setup script. See ENVIRONMENT_SETUP.md.
+
 This installs:
 - **framework** - Core agent runtime and graph executor
 - **aden_tools** - 19 MCP tools for agent capabilities

--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -73,6 +73,14 @@ echo ""
 # Upgrade pip, setuptools, and wheel
 echo "Upgrading pip, setuptools, and wheel..."
 if ! $PYTHON_CMD -m pip install --upgrade pip setuptools wheel; then
+    echo ""
+    echo "If you are using Homebrew Python on macOS, pip may be blocked by PEP 668."
+    echo "Please create and activate a virtual environment before running this script:"
+    echo ""
+    echo "  python3 -m venv .venv"
+    echo "  source .venv/bin/activate"
+    echo "  ./scripts/setup-python.sh"
+    echo ""
   echo "Error: Failed to upgrade pip. Please check your python/venv configuration."
   exit 1
 fi


### PR DESCRIPTION
Fixes #313

This PR improves the first-time setup experience on macOS when using
Homebrew Python, which enforces PEP 668 and blocks system-wide pip installs.

Changes:
- Documented the need to use a virtual environment for Homebrew Python
- Added a clear, actionable error message in setup-python.sh when pip is blocked

Tested on macOS with Python 3.13 (Homebrew).

