### PR TITLE
Problems in Graph 

### DIFF
--- a/README.kritiman.md
+++ b/README.kritiman.md
@@ -1,27 +1,39 @@
-Overview
-The Hive AI agent framework currently uses Python’s built-in eval() function in hive/core/framework/graph/node.py within the FunctionNode.execute method:
+# 🔒 Issue B: Unsafe `eval()` in `FunctionNode.execute`
+
+## Overview
+The Hive AI agent framework currently uses Python’s built-in `eval()` function in:
+
+hive/core/framework/graph/node.py
+FunctionNode.execute method
+
+```python
 result = eval(expression)
 This evaluates dynamically generated expressions from user input or external sources.
-Problem:
-Directly calling eval() on untrusted input introduces a critical security vulnerability—it allows arbitrary code execution, manipulation of runtime context, and potential system compromise.
-Risk:
+Problem
+Directly calling eval() on untrusted input introduces a critical security vulnerability, allowing:
+Arbitrary code execution
+Manipulation of runtime context
+Potential system compromise
+Risk
 Code injection via malicious expressions
 Unauthorized access to memory or system resources
 Runtime instability or denial-of-service attacks
 Recommendation
-Replace the unsafe eval() call with a secure expression evaluator:
-Options:
-ast.literal_eval (Python built-in)
+Replace the unsafe eval() call with a secure expression evaluator.
+Options
+1. ast.literal_eval (Python built-in)
 Safely evaluates Python literals (strings, numbers, tuples, lists, dicts, booleans, None)
 Cannot execute arbitrary code
-Official Documentation
 import ast
+
 result = ast.literal_eval(expression)
-Math expression parsers / safe evaluators
+Official Documentation: ast.literal_eval
+2. Math expression parsers / safe evaluators
 Libraries like simpleeval or asteval allow arithmetic and logical expressions safely
 Can define allowed operators and functions
 Example using simpleeval:
 from simpleeval import simple_eval
+
 result = simple_eval(expression)
 Action Items
 Replace eval(expression) with one of the secure alternatives
@@ -33,3 +45,7 @@ Python eval() Security Warning
 Python ast.literal_eval()
 simpleeval GitHub Repository
 asteval Documentation
+
+---
+
+If you want, I can also **write a super concise version** specifically for a GitHub PR description — it’ll be short, formal, and ready to paste. Do you want me to do that?

--- a/README.kritiman.md
+++ b/README.kritiman.md
@@ -1,0 +1,35 @@
+Overview
+The Hive AI agent framework currently uses Python’s built-in eval() function in hive/core/framework/graph/node.py within the FunctionNode.execute method:
+result = eval(expression)
+This evaluates dynamically generated expressions from user input or external sources.
+Problem:
+Directly calling eval() on untrusted input introduces a critical security vulnerability—it allows arbitrary code execution, manipulation of runtime context, and potential system compromise.
+Risk:
+Code injection via malicious expressions
+Unauthorized access to memory or system resources
+Runtime instability or denial-of-service attacks
+Recommendation
+Replace the unsafe eval() call with a secure expression evaluator:
+Options:
+ast.literal_eval (Python built-in)
+Safely evaluates Python literals (strings, numbers, tuples, lists, dicts, booleans, None)
+Cannot execute arbitrary code
+Official Documentation
+import ast
+result = ast.literal_eval(expression)
+Math expression parsers / safe evaluators
+Libraries like simpleeval or asteval allow arithmetic and logical expressions safely
+Can define allowed operators and functions
+Example using simpleeval:
+from simpleeval import simple_eval
+result = simple_eval(expression)
+Action Items
+Replace eval(expression) with one of the secure alternatives
+Limit evaluated expressions strictly to arithmetic and safe literals
+Add unit tests to ensure invalid expressions fail safely
+Document allowed syntax for developers and agent authors
+References
+Python eval() Security Warning
+Python ast.literal_eval()
+simpleeval GitHub Repository
+asteval Documentation

--- a/README.kritiman.md
+++ b/README.kritiman.md
@@ -1,51 +1,72 @@
 # 🔒 Issue B: Unsafe `eval()` in `FunctionNode.execute`
 
 ## Overview
-The Hive AI agent framework currently uses Python’s built-in `eval()` function in:
 
-hive/core/framework/graph/node.py
-FunctionNode.execute method
+The Hive AI agent framework currently uses Python's built-in `eval()` function in:
+
+**File:** `hive/core/framework/graph/node.py`  
+**Method:** `FunctionNode.execute`
 
 ```python
 result = eval(expression)
+```
+
 This evaluates dynamically generated expressions from user input or external sources.
-Problem
-Directly calling eval() on untrusted input introduces a critical security vulnerability, allowing:
-Arbitrary code execution
-Manipulation of runtime context
-Potential system compromise
-Risk
-Code injection via malicious expressions
-Unauthorized access to memory or system resources
-Runtime instability or denial-of-service attacks
-Recommendation
-Replace the unsafe eval() call with a secure expression evaluator.
-Options
-1. ast.literal_eval (Python built-in)
-Safely evaluates Python literals (strings, numbers, tuples, lists, dicts, booleans, None)
-Cannot execute arbitrary code
+
+## Problem
+
+Directly calling `eval()` on untrusted input introduces a **critical security vulnerability**, allowing:
+
+- Arbitrary code execution
+- Manipulation of runtime context
+- Potential system compromise
+
+## Risk
+
+- **Code injection** via malicious expressions
+- **Unauthorized access** to memory or system resources
+- **Runtime instability** or denial-of-service attacks
+
+## Recommendation
+
+Replace the unsafe `eval()` call with a **secure expression evaluator**.
+
+## Options
+
+### 1. `ast.literal_eval` (Python built-in)
+
+Safely evaluates Python literals (strings, numbers, tuples, lists, dicts, booleans, None). **Cannot execute arbitrary code.**
+
+```python
 import ast
 
 result = ast.literal_eval(expression)
-Official Documentation: ast.literal_eval
-2. Math expression parsers / safe evaluators
-Libraries like simpleeval or asteval allow arithmetic and logical expressions safely
-Can define allowed operators and functions
-Example using simpleeval:
+```
+
+**Official Documentation:** [ast.literal_eval](https://docs.python.org/3/library/ast.html#ast.literal_eval)
+
+### 2. Math expression parsers / safe evaluators
+
+Libraries like `simpleeval` or `asteval` allow arithmetic and logical expressions safely. Can define allowed operators and functions.
+
+**Example using `simpleeval`:**
+
+```python
 from simpleeval import simple_eval
 
 result = simple_eval(expression)
-Action Items
-Replace eval(expression) with one of the secure alternatives
-Limit evaluated expressions strictly to arithmetic and safe literals
-Add unit tests to ensure invalid expressions fail safely
-Document allowed syntax for developers and agent authors
-References
-Python eval() Security Warning
-Python ast.literal_eval()
-simpleeval GitHub Repository
-asteval Documentation
+```
 
----
+## Action Items
 
-If you want, I can also **write a super concise version** specifically for a GitHub PR description — it’ll be short, formal, and ready to paste. Do you want me to do that?
+1. Replace `eval(expression)` with one of the secure alternatives
+2. Limit evaluated expressions strictly to arithmetic and safe literals
+3. Add unit tests to ensure invalid expressions fail safely
+4. Document allowed syntax for developers and agent authors
+
+## References
+
+- [Python eval() Security Warning](https://docs.python.org/3/library/functions.html#eval)
+- [Python ast.literal_eval()](https://docs.python.org/3/library/ast.html#ast.literal_eval)
+- [simpleeval GitHub Repository](https://github.com/danthedeckie/simpleeval)
+- [asteval Documentation](https://newville.github.io/asteval/)

--- a/README.kritiman.md
+++ b/README.kritiman.md
@@ -1,35 +1,38 @@
-# 🔒 Issue B: Unsafe `eval()` in `FunctionNode.execute`
+You can update your README to reflect the **current implementation of `FunctionNode`** while keeping it formal and precise. Since your class no longer uses `eval()` directly but may handle arbitrary expressions, the README should focus on **safe alternatives and developer guidance**. Here's a clean, updated version in Markdown:
+
+````markdown
+# 🔒 Issue : Unsafe `eval()` in node.py and edge.py 
 
 ## Overview
 
-The Hive AI agent framework currently uses Python's built-in `eval()` function in:
+The Hive AI agent framework previously used Python's built-in `eval()` function in:
 
 **File:** `hive/core/framework/graph/node.py`  
 **Method:** `FunctionNode.execute`
 
 ```python
 result = eval(expression)
-```
+````
 
-This evaluates dynamically generated expressions from user input or external sources.
+This allowed evaluating dynamically generated expressions from user input or external sources. Although `FunctionNode` now executes deterministic Python functions via `self.func`, any future usage of user-provided expressions may still pose a risk.
 
 ## Problem
 
-Directly calling `eval()` on untrusted input introduces a **critical security vulnerability**, allowing:
+Directly evaluating untrusted input introduces a **critical security vulnerability**, allowing:
 
-- Arbitrary code execution
-- Manipulation of runtime context
-- Potential system compromise
+* Arbitrary code execution
+* Manipulation of runtime context
+* Potential system compromise
 
 ## Risk
 
-- **Code injection** via malicious expressions
-- **Unauthorized access** to memory or system resources
-- **Runtime instability** or denial-of-service attacks
+* **Code injection** via malicious expressions
+* **Unauthorized access** to memory or system resources
+* **Runtime instability** or denial-of-service attacks
 
 ## Recommendation
 
-Replace the unsafe `eval()` call with a **secure expression evaluator**.
+If `FunctionNode` or similar nodes need to execute user-provided expressions, use **secure expression evaluators** instead of `eval()`.
 
 ## Options
 
@@ -47,7 +50,7 @@ result = ast.literal_eval(expression)
 
 ### 2. Math expression parsers / safe evaluators
 
-Libraries like `simpleeval` or `asteval` allow arithmetic and logical expressions safely. Can define allowed operators and functions.
+Libraries like `simpleeval` or `asteval` allow arithmetic and logical expressions safely. You can define allowed operators and functions.
 
 **Example using `simpleeval`:**
 
@@ -59,14 +62,16 @@ result = simple_eval(expression)
 
 ## Action Items
 
-1. Replace `eval(expression)` with one of the secure alternatives
-2. Limit evaluated expressions strictly to arithmetic and safe literals
-3. Add unit tests to ensure invalid expressions fail safely
-4. Document allowed syntax for developers and agent authors
+1. Replace any `eval(expression)` calls with one of the secure alternatives
+2. Restrict evaluated expressions strictly to arithmetic and safe literals
+3. Add unit tests to ensure invalid or malicious expressions fail safely
+4. Document allowed syntax and usage for developers and agent authors
 
 ## References
 
-- [Python eval() Security Warning](https://docs.python.org/3/library/functions.html#eval)
-- [Python ast.literal_eval()](https://docs.python.org/3/library/ast.html#ast.literal_eval)
-- [simpleeval GitHub Repository](https://github.com/danthedeckie/simpleeval)
-- [asteval Documentation](https://newville.github.io/asteval/)
+* [Python eval() Security Warning](https://docs.python.org/3/library/functions.html#eval)
+* [Python ast.literal_eval()](https://docs.python.org/3/library/ast.html#ast.literal_eval)
+* [simpleeval GitHub Repository](https://github.com/danthedeckie/simpleeval)
+* [asteval Documentation](https://newville.github.io/asteval/)
+
+```

--- a/core/framework/graph/worker_node.py
+++ b/core/framework/graph/worker_node.py
@@ -353,7 +353,7 @@ class WorkerNode:
         for key, value in args.items():
             if isinstance(value, str) and value.startswith("$"):
                 ref_key = value[1:]  # Remove $
-                resolved_args[key] = args.get(ref_key, value)
+                resolved_args[key] = inputs.get(ref_key, value)
             else:
                 resolved_args[key] = value
         args = resolved_args


### PR DESCRIPTION
````markdown
# 🔒 Issue : Unsafe `eval()` in node.py and edge.py
## Overview

The Hive AI agent framework previously used Python's built-in `eval()` function in:

**File:** `hive/core/framework/graph/node.py`  
**Method:** `FunctionNode.execute`

```python
result = eval(expression)
````

This allowed evaluating dynamically generated expressions from user input or external sources. Although `FunctionNode` now executes deterministic Python functions via `self.func`, any future usage of user-provided expressions may still pose a risk.

## Problem

Directly evaluating untrusted input introduces a **critical security vulnerability**, allowing:

* Arbitrary code execution
* Manipulation of runtime context
* Potential system compromise

## Risk

* **Code injection** via malicious expressions
* **Unauthorized access** to memory or system resources
* **Runtime instability** or denial-of-service attacks

## Recommendation

If `FunctionNode` or similar nodes need to execute user-provided expressions, use **secure expression evaluators** instead of `eval()`.

## Options

### 1. `ast.literal_eval` (Python built-in)

Safely evaluates Python literals (strings, numbers, tuples, lists, dicts, booleans, None). **Cannot execute arbitrary code.**

```python
import ast

result = [ast.literal_eval](https://docs.python.org/3/library/ast.html#ast.literal_eval)(expression)
```

**Official Documentation:** [ast.literal_eval](https://docs.python.org/3/library/ast.html#ast.literal_eval)

### 2. Math expression parsers / safe evaluators

Libraries like `simpleeval` or `asteval` allow arithmetic and logical expressions safely. You can define allowed operators and functions.

**Example using `simpleeval`:**

```python
from simpleeval import simple_eval

result = simple_eval(expression)
```

## Action Items

1. Replace any `eval(expression)` calls with one of the secure alternatives
2. Restrict evaluated expressions strictly to arithmetic and safe literals
3. Add unit tests to ensure invalid or malicious expressions fail safely
4. Document allowed syntax and usage for developers and agent authors

## References

* [[Python eval() Security Warning](https://docs.python.org/3/library/functions.html#eval)](https://docs.python.org/3/library/functions.html#eval)
* [[Python ast.literal_eval()](https://docs.python.org/3/library/ast.html#ast.literal_eval)](https://docs.python.org/3/library/ast.html#ast.literal_eval)
* [[simpleeval GitHub Repository](https://github.com/danthedeckie/simpleeval)](https://github.com/danthedeckie/simpleeval)
* [[asteval Documentation](https://newville.github.io/asteval/)](https://newville.github.io/asteval/)

```