### PR TITLE
Remove hardcoded local path from troubleshooting docs

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -188,7 +188,7 @@ pip install --upgrade "openai>=1.0.0"
 
 **Cause:** Not running from project root or missing PYTHONPATH
 
-**Solution:** Ensure you're in `/home/timothy/oss/hive/` and use:
+**Solution:** Ensure you're in the project root (e.g., /path/to/hive) and use:
 
 ```bash
 PYTHONPATH=core:exports python -m support_ticket_agent validate


### PR DESCRIPTION
Fixes #322

Replaces a hardcoded local filesystem path in the troubleshooting section
with a generic project-root instruction to avoid confusion for contributors
on different systems.
