### PR TITLE
fix: set anthropic credential to required=True

### DIFF
--- a/tools/src/aden_tools/credentials/llm.py
+++ b/tools/src/aden_tools/credentials/llm.py
@@ -10,8 +10,8 @@ LLM_CREDENTIALS = {
         env_var="ANTHROPIC_API_KEY",
         tools=[],
         node_types=["llm_generate", "llm_tool_use"],
-        required=False,  # Not required - agents can use other providers via LiteLLM
-        startup_required=False,  # MCP server doesn't need LLM credentials
+        required=True,
+        startup_required=True,
         help_url="https://console.anthropic.com/settings/keys",
         description="API key for Anthropic Claude models",
     ),


### PR DESCRIPTION
Fixes #327

- Set required=True for anthropic credential
- Set startup_required=True for fail-fast validation
- All 47 credential tests now pass (was 43/47)
- Aligns with fail-fast philosophy in credentials/__init__.py

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
