### PR TITLE
fix(executor): allow resuming steps from AWAITING_APPROVAL status

### DIFF
--- a/core/framework/graph/plan.py
+++ b/core/framework/graph/plan.py
@@ -159,7 +159,7 @@ class PlanStep(BaseModel):
 
     def is_ready(self, completed_step_ids: set[str]) -> bool:
         """Check if this step is ready to execute (all dependencies met)."""
-        if self.status != StepStatus.PENDING:
+        if self.status not in (StepStatus.PENDING, StepStatus.AWAITING_APPROVAL):
             return False
         return all(dep in completed_step_ids for dep in self.dependencies)
 

--- a/core/tests/test_flexible_executor.py
+++ b/core/tests/test_flexible_executor.py
@@ -426,6 +426,67 @@ class TestFlexibleExecutorIntegration:
         assert len(executor.judge.rules) == 1
         assert executor.judge.rules[0].id == "custom_rule"
 
+    def test_execution_approval_and_resume(self, tmp_path):
+        """Test pausing for approval and resuming."""
+        import asyncio
+        from framework.runtime.core import Runtime
+        from framework.graph.flexible_executor import FlexibleGraphExecutor
+        from framework.graph.plan import (
+            Plan, PlanStep, ActionSpec, ActionType, 
+            StepStatus, ExecutionStatus, ApprovalResult, ApprovalDecision
+        )
+        from framework.graph.goal import Goal
+
+        async def run_test():
+            runtime = Runtime(storage_path=tmp_path / "runtime")
+            executor = FlexibleGraphExecutor(runtime=runtime)
+
+            # Create a function to be called
+            def echo_func(msg):
+                return msg
+            
+            executor.register_function("echo", echo_func)
+
+            # Create plan with one step requiring approval
+            step = PlanStep(
+                id="step_1",
+                description="Echo hello",
+                action=ActionSpec(
+                    action_type=ActionType.FUNCTION, 
+                    function_name="echo",
+                    function_args={"msg": "hello"}
+                ),
+                requires_approval=True
+            )
+            
+            plan = Plan(
+                id="plan_1",
+                goal_id="goal_1", 
+                description="Test Plan",
+                steps=[step]
+            )
+            goal = Goal(id="goal_1", name="Test", description="Test")
+
+            # 1. First run - should pause
+            result1 = await executor.execute_plan(plan, goal)
+            
+            assert result1.status == ExecutionStatus.AWAITING_APPROVAL
+            assert plan.steps[0].status == StepStatus.AWAITING_APPROVAL
+            
+            # 2. Add approval callback
+            def auto_approve(request):
+                return ApprovalResult(decision=ApprovalDecision.APPROVE)
+                
+            executor.set_approval_callback(auto_approve)
+            
+            # 3. Resume - should complete
+            result2 = await executor.execute_plan(plan, goal)
+            
+            assert result2.status == ExecutionStatus.COMPLETED
+            assert plan.steps[0].status == StepStatus.COMPLETED
+
+        asyncio.run(run_test())
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixed a critical bug where `FlexibleGraphExecutor` would fail to resume execution after pausing for human input.

## Problem

When a step requires human approval (`requires_approval=True`), the executor correctly pauses execution and sets the step status to `AWAITING_APPROVAL`.

However, when `execute_plan` is called again to resume execution (for example, after the user approves the step), the executor fails to pick the step back up. This occurs because `PlanStep.is_ready()` strictly checked for `self.status == StepStatus.PENDING` and ignored steps in `AWAITING_APPROVAL`.

As a result, the executor incorrectly concluded that there were no executable steps available, causing a soft-lock where execution could not resume.

## Fix

Updated `PlanStep.is_ready()` in `core/framework/graph/plan.py` to treat both `PENDING` and `AWAITING_APPROVAL` statuses as valid candidate states for execution, subject to dependency checks.

## Verification

* Added regression test `test_execution_approval_and_resume` in `core/tests/test_flexible_executor.py` to validate the Pause -> Approve -> Resume workflow
* Verified all existing tests pass.

Fixes #328 
