### PR TITLE
docs(contributing): add setup instructions for Windows users

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,19 @@ python -c "import framework; import aden_tools; print('✓ Setup complete')"
 # Install Claude Code skills (optional)
 ./quickstart.sh
 ```
+### Windows (PowerShell)
+```powershell
+# Create and activate virtual environment
+python -m venv venv
+.\venv\Scripts\Activate.ps1
+
+# Install packages
+pip install -e core
+pip install -e tools
+pip install pytest
+
+# Verify installation
+python -c "import framework; import aden_tools; print('✓ Setup complete')"
 
 ## Commit Convention
 


### PR DESCRIPTION
I noticed the current CONTRIBUTING.md only provided setup instructions for macOS/Linux via a shell script. While setting up my own development environment on Windows 11, I documented the specific PowerShell steps required to get the Aden framework running.

Changes

Added a dedicated "Windows (PowerShell)" section to CONTRIBUTING.md.

Included steps for venv creation, activation, and editable package installation.

Verified the installation with the suggested success command.

This addition will make the onboarding process much smoother for Windows-based contributors.