### PR TITLE
docs: fix project root path in troubleshooting

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -188,7 +188,9 @@ pip install --upgrade "openai>=1.0.0"
 
 **Cause:** Not running from project root or missing PYTHONPATH
 
-**Solution:** Ensure you're in `/home/timothy/oss/hive/` and use:
+**Solution:** Ensure you're in the project root (the `hive/` directory) and use:
+
+**Note:** Agent packages live under `exports/`, so `PYTHONPATH=core:exports` must be set when running agents.
 
 ```bash
 PYTHONPATH=core:exports python -m support_ticket_agent validate


### PR DESCRIPTION
## Description
Fixes troubleshooting instructions by removing the hardcoded `/home/timothy/oss/hive/` path and replacing it with a generic “project root (hive/ directory)” note. Also clarifies that agent packages live under `exports/` and require `PYTHONPATH=core:exports`.

## Type of Change
- Documentation update

## Related Issues
- N/A

## Changes Made
- Updated troubleshooting path to avoid Linux-specific `/home/...` reference
- Added clarification about running commands from project root and using `PYTHONPATH`

## Testing
- Verified markdown formatting renders correctly on GitHub
