### PR TITLE
feat(scripts): Add native Windows setup script

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -7,6 +7,9 @@ Complete setup guide for building and running goal-driven agents with the Aden A
 ```bash
 # Run the automated setup script
 ./scripts/setup-python.sh
+
+# Or on Windows (PowerShell):
+.\scripts\setup-python.ps1
 ```
 
 This will:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ cd hive
 
 # Run Python environment setup
 ./scripts/setup-python.sh
+
+# Or on Windows (PowerShell):
+.\scripts\setup-python.ps1
 ```
 
 This installs:

--- a/scripts/setup-python.ps1
+++ b/scripts/setup-python.ps1
@@ -1,0 +1,100 @@
+$ErrorActionPreference = "Stop"
+
+Write-Host "=================================================="
+Write-Host "  Aden Agent Framework - Python Setup (Windows)"
+Write-Host "=================================================="
+Write-Host ""
+
+# 1. Determine Python Command
+$PYTHON_CMD = "python"
+if (Get-Command "py" -ErrorAction SilentlyContinue) {
+    if (-not (Get-Command "python" -ErrorAction SilentlyContinue)) {
+        $PYTHON_CMD = "py"
+    }
+}
+
+try {
+    & $PYTHON_CMD --version | Out-Null
+} catch {
+    Write-Host "Error: Python not found." -ForegroundColor Red
+    exit 1
+}
+
+# 2. Check Version
+$VerScript = "import sys; print(str(sys.version_info.major) + '.' + str(sys.version_info.minor))"
+$VersionStr = & $PYTHON_CMD -c $VerScript
+Write-Host "Detected Python: $VersionStr" -ForegroundColor Cyan
+
+$Parts = $VersionStr.Split('.')
+$Major = [int]$Parts[0]
+$Minor = [int]$Parts[1]
+
+if ($Major -lt 3 -or ($Major -eq 3 -and $Minor -lt 11)) {
+    Write-Host "Error: Python 3.11+ is required." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "[OK] Python version OK" -ForegroundColor Green
+Write-Host ""
+
+# 3. Pip
+Write-Host "Checking pip..."
+& $PYTHON_CMD -m pip --version | Out-Null
+Write-Host "[OK] pip detected" -ForegroundColor Green
+Write-Host ""
+
+# 4. Install Core
+$ProjectRoot = Resolve-Path "."
+$CoreDir = Join-Path $ProjectRoot "core"
+if (Test-Path $CoreDir) {
+    Write-Host "Installing framework from core/..."
+    Push-Location $CoreDir
+    try {
+        & $PYTHON_CMD -m pip install -e .
+        Write-Host "[OK] Framework installed" -ForegroundColor Green
+    } catch {
+        Write-Host "[!] Framework install failed" -ForegroundColor Yellow
+    }
+    Pop-Location
+} else {
+    Write-Host "[!] Core directory not found" -ForegroundColor Yellow
+}
+
+# 5. Install Tools
+$ToolsDir = Join-Path $ProjectRoot "tools"
+if (Test-Path $ToolsDir) {
+    Write-Host "Installing tools from tools/..."
+    Push-Location $ToolsDir
+    try {
+        & $PYTHON_CMD -m pip install -e .
+        Write-Host "[OK] Tools installed" -ForegroundColor Green
+    } catch {
+        Write-Host "[X] Tools install failed" -ForegroundColor Red
+        exit 1
+    }
+    Pop-Location
+} else {
+    Write-Host "[X] Tools directory not found" -ForegroundColor Red
+    exit 1
+}
+
+# 6. OpenAI Fix
+Write-Host "Checking openai..."
+$CheckOpenAI = "import openai; print(openai.__version__)"
+try {
+    $OpenAIVer = & $PYTHON_CMD -c $CheckOpenAI 2>$null
+    if ($OpenAIVer -and $OpenAIVer.StartsWith("0.")) {
+        Write-Host "Upgrading openai..."
+        & $PYTHON_CMD -m pip install "openai>=1.0.0"
+    }
+} catch {
+    Write-Host "Installing openai..."
+    & $PYTHON_CMD -m pip install "openai>=1.0.0"
+}
+Write-Host "[OK] openai check complete" -ForegroundColor Green
+
+Write-Host ""
+Write-Host "Setup Complete!" -ForegroundColor Green
+Write-Host "To run agents:"
+Write-Host '$env:PYTHONPATH="core;exports"'
+Write-Host "python -m agent_name run ..."


### PR DESCRIPTION
## Description
Added a native PowerShell setup script (`scripts/setup-python.ps1`) to allow Windows users to install dependencies without requiring WSL or Bash emulators. This addresses the lack of native Windows support in the current setup process.

## Changes Made
- **[NEW]** `scripts/setup-python.ps1`: A PowerShell equivalent of the existing bash setup script. It handles:
  - Python 3.11+ version checking
  - Installing `framework` and `aden_tools` in editable mode
  - `openai` package compatibility fixes
- **[UPDATE]** `ENVIRONMENT_SETUP.md`: Added instructions for Windows users.
- **[UPDATE]** `README.md`: Added the Windows setup command to the Quick Start section.

## Verification
- [x] Verified execution on Windows (PowerShell)
- [x] Confirmed package installation (framework, tools, openai)
- [x] Verified no regressions in existing scripts

## Checklist
- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation