### PR TITLE
docs(env-setup): clarify quick setup and virtualenv recommendation

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -8,6 +8,12 @@ Complete setup guide for building and running goal-driven agents with the Aden A
 # Run the automated setup script
 ./scripts/setup-python.sh
 ```
+> 💡 **Recommended:** Use a virtual environment to avoid dependency conflicts.
+>
+> ```bash
+> python -m venv .venv
+> source .venv/bin/activate
+> ```
 
 This will:
 
@@ -51,6 +57,15 @@ python -c "import litellm; print('✓ litellm OK')"
 ```
 
 ## Requirements
+
+### Supported Platforms
+
+- macOS (Apple Silicon & Intel)
+- Linux (Ubuntu, Debian, Arch)
+- Windows via WSL2
+
+> Native Windows (without WSL) is not officially supported.
+
 
 ### Python Version
 
@@ -151,6 +166,16 @@ claude> /testing-agent
 Creates comprehensive test suites for your agent.
 
 ## Troubleshooting
+
+### "Permission denied" when running setup script
+
+If you see `permission denied: ./scripts/setup-python.sh`
+**Solution:** Run:
+
+```bash
+chmod +x ./scripts/setup-python.sh
+./scripts/setup-python.sh
+
 
 ### "ModuleNotFoundError: No module named 'framework'"
 


### PR DESCRIPTION
## Description

Clarifies the Quick Setup section by adding a recommended virtual environment step and improves setup guidance to reduce common environment and permission issues during installation.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
N/A

## Changes Made

- Added a recommended Python virtual environment setup to the Quick Setup section
- Improved clarity around running the automated setup script
- Added troubleshooting note for permission errors when running the setup script

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
N/A
