### PR TITLE
fix: improve pdf_read error handling for malformed PDFs

### DIFF
--- a/tools/src/aden_tools/tools/pdf_read_tool/pdf_read_tool.py
+++ b/tools/src/aden_tools/tools/pdf_read_tool/pdf_read_tool.py
@@ -11,6 +11,7 @@ from typing import Any, List
 
 from fastmcp import FastMCP
 from pypdf import PdfReader
+from pypdf.errors import EmptyFileError, PdfReadError, ParseError, PdfStreamError
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -153,5 +154,13 @@ def register_tools(mcp: FastMCP) -> None:
 
         except PermissionError:
             return {"error": f"Permission denied: {file_path}"}
+        except EmptyFileError:
+            return {"error": f"PDF file is empty: {path.name}"}
+        except PdfStreamError as e:
+            return {"error": f"PDF stream error: {str(e)}"}
+        except ParseError as e:
+            return {"error": f"Failed to parse PDF structure: {str(e)}"}
+        except PdfReadError as e:
+            return {"error": f"Corrupted or malformed PDF: {str(e)}"}
         except Exception as e:
             return {"error": f"Failed to read PDF: {str(e)}"}

--- a/tools/tests/tools/test_pdf_read_tool.py
+++ b/tools/tests/tools/test_pdf_read_tool.py
@@ -78,3 +78,29 @@ class TestPdfReadTool:
 
         result = pdf_read_fn(file_path=str(pdf_file), include_metadata=True)
         assert isinstance(result, dict)
+
+    def test_read_empty_pdf(self, pdf_read_fn, tmp_path: Path):
+        """Reading an empty PDF file returns specific error."""
+        empty_pdf = tmp_path / "empty.pdf"
+        empty_pdf.touch()
+
+        result = pdf_read_fn(file_path=str(empty_pdf))
+
+        assert "error" in result
+        assert "PDF file is empty" in result["error"]
+
+    def test_read_malformed_pdf(self, pdf_read_fn, tmp_path: Path):
+        """Reading a malformed PDF file returns specific error."""
+        bad_pdf = tmp_path / "bad.pdf"
+        bad_pdf.write_bytes(b"Not a PDF content")
+
+        result = pdf_read_fn(file_path=str(bad_pdf))
+
+        assert "error" in result
+        # Check for any of the pypdf error messages we implemented
+        assert any(msg in result["error"] for msg in [
+            "Corrupted or malformed PDF",
+            "Failed to parse PDF",
+            "PDF stream error"
+        ])
+


### PR DESCRIPTION
## Objective
Fixes #269

The `pdf_read` tool previously relied on a generic `except Exception` catch-all. This masked specific failure modes (like empty files or corrupted headers) and returned vague error messages, making it difficult for agents to self-correct or report meaningful issues to users.

This PR implements specific exception handling using `pypdf`'s native error hierarchy to provide crisp, actionable feedback.

## Changes
- **Specific Exception Handling**: 
  - `EmptyFileError`: Returns `"PDF file is empty: <filename>"`
  - `PdfStreamError`: Returns `"PDF stream error: <details>"`
  - `ParseError`: Returns `"Failed to parse PDF structure: <details>"`
  - `PdfReadError`: Returns `"Corrupted or malformed PDF: <details>"`
- **Robustness**: Replaced the generic fallback with these specific handlers first, preserving the fallback for truly unexpected system errors.
- **Testing**: Added comprehensive unit tests covering:
  - Empty PDF files (0 bytes)
  - Malformed/Corrupted PDF content (random bytes)
  - Verification that valid PDFs and metadata extraction still work as expected.

## Testing Verified
Ran the full test suite for the tools package:
```bash
python -m pytest tools/tests/tools/test_pdf_read_tool.py