### PR TITLE
docs(setup): add Windows App Execution Aliases troubleshooting guide

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -208,6 +208,38 @@ pip uninstall -y framework tools
 ./scripts/setup-python.sh
 ```
 
+### Windows: "Python was not found" or redirects to Microsoft Store
+
+**Platform:** Windows 10/11
+
+**Symptom:** Running `./scripts/setup-python.sh` or `python` commands results in:
+```
+Python was not found; run without arguments to install from the Microsoft Store,
+or disable this shortcut from Settings > Manage App Execution Aliases.
+```
+
+**Cause:** Windows creates fake `python.exe` and `python3.exe` aliases through App Execution Aliases that redirect to the Microsoft Store instead of your actual Python installation.
+
+**Solution:** Disable the Windows App Execution Aliases:
+
+1. Open **Settings** (Windows + I)
+2. Navigate to **Apps** → **Advanced app settings** → **App execution aliases**
+3. Disable both:
+   - **python.exe** (App Installer)
+   - **python3.exe** (App Installer)
+4. Restart your terminal
+5. Verify Python is now accessible:
+   ```bash
+   python --version
+   # Should show your installed Python version (e.g., Python 3.13.5)
+   ```
+
+**Alternative:** Ensure your actual Python installation is in your system PATH before the App Execution Aliases path. You can verify this by checking:
+```powershell
+where.exe python
+# Should show your Python installation path first, not a WindowsApps path
+```
+
 ## Package Structure
 
 The Hive framework consists of three Python packages:


### PR DESCRIPTION
# Docs: Add Windows App Execution Aliases troubleshooting guide

Fixes #365

## Summary

Added comprehensive troubleshooting documentation to `ENVIRONMENT_SETUP.md` to help Windows users who encounter Python detection failures due to Windows App Execution Aliases. This addresses a common setup blocker for first-time contributors on Windows 10/11.

## Problem

On Windows 10/11, the operating system creates fake executable aliases for `python.exe` and `python3.exe` through the App Execution Aliases feature. These aliases don't execute actual Python installations; instead, they redirect to the Microsoft Store, causing the setup script to fail with:

```
Python was not found; run without arguments to install from the Microsoft Store,
or disable this shortcut from Settings > Manage App Execution Aliases.
```

This is confusing and blocks the setup process for contributors who have Python installed but encounter this redirect.

## Changes Made

### Added Troubleshooting Entry to `ENVIRONMENT_SETUP.md`

**Location:** Troubleshooting section (after "Agent imports fail with 'broken installation'")

**Content Added:**
1. **Clear symptom identification** - Exact error message users will see
2. **Platform specification** - Windows 10/11
3. **Root cause explanation** - How Windows App Execution Aliases work
4. **Step-by-step solution** - Navigation path through Windows Settings
5. **Verification steps** - How to confirm Python is now accessible
6. **Alternative approach** - PATH management for advanced users

The documentation includes:
- Navigation instructions: Settings → Apps → Advanced app settings → App execution aliases
- Specific aliases to disable: `python.exe` and `python3.exe`
- Verification command: `python --version`
- Alternative PATH verification: `where.exe python`

## Documentation Structure

```markdown
### Windows: "Python was not found" or redirects to Microsoft Store

**Platform:** Windows 10/11

**Symptom:** Running `./scripts/setup-python.sh` or `python` commands results in:
[error message]

**Cause:** [explanation]

**Solution:** [step-by-step instructions]

**Alternative:** [PATH management approach]
```

## Benefits

✅ **Reduces friction** for first-time Windows contributors
✅ **Clear navigation** through Windows settings
✅ **Multiple solutions** (disable aliases or fix PATH)
✅ **Verification steps** to confirm the fix worked
✅ **Follows existing format** in the troubleshooting section

## Testing

- ✅ Markdown formatting validated
- ✅ Follows existing documentation style
- ✅ Consistent with other troubleshooting entries
- ✅ Step-by-step instructions verified against Windows 11

## Related Issues

This addresses the issue reported in #365 where the setup process was confusing and blocked for Windows users with App Execution Aliases enabled.

## Screenshots (Optional for Reviewers)

The new troubleshooting entry appears in the Troubleshooting section of `ENVIRONMENT_SETUP.md`, providing clear guidance for Windows users encountering this specific error.

---

**Checklist:**
- [x] Follows conventional commits format (`docs(setup): ...`)
- [x] Targets the correct file (`ENVIRONMENT_SETUP.md`)
- [x] Clear, actionable instructions
- [x] Includes verification steps
- [x] Follows existing documentation structure
- [x] Fixes the reported issue (#365)
