### PR TITLE
Add test for missing message argument in example_tool

### DIFF
--- a/tools/tests/tools/test_example_tool.py
+++ b/tools/tests/tools/test_example_tool.py
@@ -14,6 +14,11 @@ def example_tool_fn(mcp: FastMCP):
 
 class TestExampleTool:
     """Tests for example_tool function."""
+    def test_missing_message_argument_error(self, example_tool_fn):
+        """Calling tool without required message returns error."""
+        result = example_tool_fn()
+
+        assert "Error" in result
 
     def test_valid_message(self, example_tool_fn):
         """Basic message returns unchanged."""


### PR DESCRIPTION
### Summary
Adds a test to verify example_tool behavior when required message argument is missing.

### What Changed
- Added edge case test for calling example_tool without arguments

### Testing
- Ran pytest locally

