### PR TITLE
Fix/executor max retries

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -181,7 +181,6 @@ class GraphExecutor:
         total_tokens = 0
         total_latency = 0
         node_retry_counts: dict[str, int] = {}  # Track retries per node
-        max_retries_per_node = 3
 
         # Determine entry point (may differ if resuming)
         current_node_id = graph.get_entry_point(session_state)
@@ -302,26 +301,29 @@ class GraphExecutor:
                     # Track retries per node
                     node_retry_counts[current_node_id] = node_retry_counts.get(current_node_id, 0) + 1
 
-                    if node_retry_counts[current_node_id] < max_retries_per_node:
+                    # Use node-specific max_retries (respects NodeSpec.max_retries)
+                    max_retries = node_spec.max_retries
+
+                    if node_retry_counts[current_node_id] < max_retries:
                         # Retry - don't increment steps for retries
                         steps -= 1
-                        self.logger.info(f"   ↻ Retrying ({node_retry_counts[current_node_id]}/{max_retries_per_node})...")
+                        self.logger.info(f"   ↻ Retrying ({node_retry_counts[current_node_id]}/{max_retries})...")
                         continue
                     else:
                         # Max retries exceeded - fail the execution
-                        self.logger.error(f"   ✗ Max retries ({max_retries_per_node}) exceeded for node {current_node_id}")
+                        self.logger.error(f"   ✗ Max retries ({max_retries}) exceeded for node {current_node_id}")
                         self.runtime.report_problem(
                             severity="critical",
-                            description=f"Node {current_node_id} failed after {max_retries_per_node} attempts: {result.error}",
+                            description=f"Node {current_node_id} failed after {max_retries} attempts: {result.error}",
                         )
                         self.runtime.end_run(
                             success=False,
                             output_data=memory.read_all(),
-                            narrative=f"Failed at {node_spec.name} after {max_retries_per_node} retries: {result.error}",
+                            narrative=f"Failed at {node_spec.name} after {max_retries} retries: {result.error}",
                         )
                         return ExecutionResult(
                             success=False,
-                            error=f"Node '{node_spec.name}' failed after {max_retries_per_node} attempts: {result.error}",
+                            error=f"Node '{node_spec.name}' failed after {max_retries} attempts: {result.error}",
                             output=memory.read_all(),
                             steps_executed=steps,
                             total_tokens=total_tokens,

--- a/core/tests/test_executor_max_retries.py
+++ b/core/tests/test_executor_max_retries.py
@@ -1,0 +1,225 @@
+"""
+Tests for GraphExecutor max_retries behavior.
+
+Tests verify that:
+- GraphExecutor respects node_spec.max_retries instead of using hardcoded value
+- Different nodes can have different retry limits
+- Default max_retries (3) is used when not specified
+"""
+
+import asyncio
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+
+from framework.graph.node import NodeSpec, NodeContext, NodeResult, NodeProtocol
+from framework.graph.executor import GraphExecutor, ExecutionResult
+from framework.graph.edge import GraphSpec
+from framework.graph.goal import Goal, SuccessCriterion
+
+
+class MockRuntime:
+    """Mock runtime for testing."""
+
+    def start_run(self, **kwargs):
+        return "run_id"
+
+    def decide(self, **kwargs):
+        return "dec_id"
+
+    def record_outcome(self, **kwargs):
+        pass
+
+    def report_problem(self, **kwargs):
+        pass
+
+    def end_run(self, **kwargs):
+        pass
+
+    def set_node(self, node_id):
+        pass
+
+
+class FailingNode(NodeProtocol):
+    """A node that always fails for testing retry behavior."""
+
+    def __init__(self):
+        self.execution_count = 0
+
+    async def execute(self, ctx: NodeContext) -> NodeResult:
+        self.execution_count += 1
+        return NodeResult(success=False, error="Intentional failure for testing")
+
+
+class TestMaxRetriesRespected:
+    """Tests for Issue #363 - max_retries should be read from node_spec."""
+
+    @pytest.mark.asyncio
+    async def test_respects_custom_max_retries(self, tmp_path):
+        """Test that executor respects node_spec.max_retries instead of hardcoded 3."""
+        # Create a node with max_retries=5
+        node = NodeSpec(
+            id="fail_node",
+            name="Failing Node",
+            description="Always fails",
+            node_type="function",
+            max_retries=5,  # Custom value - should retry 5 times, not 3
+        )
+
+        graph = GraphSpec(
+            id="test-graph",
+            goal_id="goal",
+            entry_node="fail_node",
+            terminal_nodes=["fail_node"],
+            nodes=[node],
+            edges=[],
+        )
+
+        goal = Goal(
+            id="goal",
+            name="Test Goal",
+            description="Test retry behavior",
+            success_criteria=[
+                SuccessCriterion(
+                    id="1",
+                    description="Should fail",
+                    metric="success",
+                    target="false"
+                )
+            ],
+        )
+
+        # Create executor with mock runtime
+        executor = GraphExecutor(runtime=MockRuntime())
+
+        # Register a node that tracks executions
+        failing_node = FailingNode()
+        executor.register_node("fail_node", failing_node)
+
+        # Execute
+        result = await executor.execute(graph, goal)
+
+        # Should have failed after 5 attempts (not 3)
+        assert result.success is False
+        assert "after 5 attempts" in result.error
+        assert failing_node.execution_count == 5
+
+    @pytest.mark.asyncio
+    async def test_respects_high_max_retries(self, tmp_path):
+        """Test that executor handles high max_retries values."""
+        node = NodeSpec(
+            id="fail_node",
+            name="Failing Node",
+            description="Always fails",
+            node_type="function",
+            max_retries=10,  # Even higher retry limit
+        )
+
+        graph = GraphSpec(
+            id="test-graph",
+            goal_id="goal",
+            entry_node="fail_node",
+            terminal_nodes=["fail_node"],
+            nodes=[node],
+            edges=[],
+        )
+
+        goal = Goal(
+            id="goal",
+            name="Test Goal",
+            description="Test high retry count",
+            success_criteria=[
+                SuccessCriterion(
+                    id="1",
+                    description="Should fail",
+                    metric="success",
+                    target="false"
+                )
+            ],
+        )
+
+        executor = GraphExecutor(runtime=MockRuntime())
+        failing_node = FailingNode()
+        executor.register_node("fail_node", failing_node)
+
+        result = await executor.execute(graph, goal)
+
+        # Should have retried 10 times
+        assert result.success is False
+        assert "after 10 attempts" in result.error
+        assert failing_node.execution_count == 10
+
+    @pytest.mark.asyncio
+    async def test_default_max_retries(self, tmp_path):
+        """Test that default max_retries (3) is respected when not set."""
+        # Don't set max_retries - should use default of 3
+        node = NodeSpec(
+            id="fail_node",
+            name="Failing Node",
+            description="Always fails",
+            node_type="function",
+            # max_retries not set - should default to 3
+        )
+
+        assert node.max_retries == 3  # Verify default
+
+        graph = GraphSpec(
+            id="test-graph",
+            goal_id="goal",
+            entry_node="fail_node",
+            terminal_nodes=["fail_node"],
+            nodes=[node],
+            edges=[],
+        )
+
+        goal = Goal(
+            id="goal",
+            name="Test Goal",
+            description="Test default retry count",
+            success_criteria=[
+                SuccessCriterion(
+                    id="1",
+                    description="Should fail",
+                    metric="success",
+                    target="false"
+                )
+            ],
+        )
+
+        executor = GraphExecutor(runtime=MockRuntime())
+        failing_node = FailingNode()
+        executor.register_node("fail_node", failing_node)
+
+        result = await executor.execute(graph, goal)
+
+        # Should have retried 3 times (default)
+        assert result.success is False
+        assert "after 3 attempts" in result.error
+        assert failing_node.execution_count == 3
+
+    @pytest.mark.asyncio
+    async def test_different_nodes_different_retries(self, tmp_path):
+        """Test that different nodes can have different retry limits."""
+        # This is a regression test to ensure per-node config works
+        node1 = NodeSpec(
+            id="node1",
+            name="Node 1",
+            description="First node",
+            node_type="function",
+            max_retries=2,
+        )
+
+        node2 = NodeSpec(
+            id="node2",
+            name="Node 2",
+            description="Second node",
+            node_type="function",
+            max_retries=7,
+        )
+
+        # Each node should have its own retry limit
+        assert node1.max_retries == 2
+        assert node2.max_retries == 7
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/core/tests/test_output_cleaner.py
+++ b/core/tests/test_output_cleaner.py
@@ -1,0 +1,280 @@
+"""
+Tests for OutputCleaner provider auto-detection and configuration.
+
+Tests cover:
+- Provider auto-detection from environment variables
+- Explicit configuration override
+- Backward compatibility with Cerebras
+- Graceful fallback when no provider available
+"""
+
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+from framework.graph.output_cleaner import (
+    CleansingConfig,
+    OutputCleaner,
+    ValidationResult,
+    PROVIDER_CONFIG,
+    _detect_provider,
+)
+
+
+class TestProviderDetection:
+    """Tests for provider auto-detection logic."""
+
+    def test_detect_provider_with_cerebras(self):
+        """Test that Cerebras is detected first when available."""
+        with patch.dict(os.environ, {"CEREBRAS_API_KEY": "test-cerebras-key"}, clear=False):
+            api_key, model, name = _detect_provider()
+            assert api_key == "test-cerebras-key"
+            assert model == "cerebras/llama-3.3-70b"
+            assert name == "Cerebras"
+
+    def test_detect_provider_with_openai(self):
+        """Test OpenAI detection when Cerebras/Groq not available."""
+        env = {
+            "OPENAI_API_KEY": "test-openai-key",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            api_key, model, name = _detect_provider()
+            assert api_key == "test-openai-key"
+            assert model == "gpt-4o-mini"
+            assert name == "OpenAI"
+
+    def test_detect_provider_with_anthropic(self):
+        """Test Anthropic detection."""
+        env = {
+            "ANTHROPIC_API_KEY": "test-anthropic-key",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            api_key, model, name = _detect_provider()
+            assert api_key == "test-anthropic-key"
+            assert model == "claude-3-haiku-20240307"
+            assert name == "Anthropic"
+
+    def test_detect_provider_with_groq(self):
+        """Test Groq detection (should be second priority)."""
+        env = {
+            "GROQ_API_KEY": "test-groq-key",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            api_key, model, name = _detect_provider()
+            assert api_key == "test-groq-key"
+            assert model == "groq/llama-3.3-70b-versatile"
+            assert name == "Groq"
+
+    def test_detect_provider_priority_order(self):
+        """Test that providers are checked in priority order."""
+        # When multiple keys are present, Cerebras should be selected first
+        env = {
+            "CEREBRAS_API_KEY": "cerebras-key",
+            "OPENAI_API_KEY": "openai-key",
+            "ANTHROPIC_API_KEY": "anthropic-key",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            api_key, model, name = _detect_provider()
+            assert name == "Cerebras"
+            assert api_key == "cerebras-key"
+
+    def test_detect_provider_no_keys(self):
+        """Test graceful handling when no API keys are set."""
+        with patch.dict(os.environ, {}, clear=True):
+            api_key, model, name = _detect_provider()
+            assert api_key is None
+            assert model is None
+            assert name is None
+
+    def test_provider_config_structure(self):
+        """Test that PROVIDER_CONFIG has expected structure."""
+        assert len(PROVIDER_CONFIG) >= 6  # At least 6 providers
+        for env_var, model, name in PROVIDER_CONFIG:
+            assert isinstance(env_var, str)
+            assert isinstance(model, str)
+            assert isinstance(name, str)
+            assert env_var.endswith("_API_KEY") or env_var.endswith("_KEY")
+
+
+class TestCleansingConfig:
+    """Tests for CleansingConfig dataclass."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = CleansingConfig()
+        assert config.enabled is True
+        assert config.fast_model is None  # Auto-detect
+        assert config.api_key is None  # Auto-detect
+        assert config.max_retries == 2
+        assert config.fallback_to_raw is True
+        assert config.log_cleanings is True
+
+    def test_explicit_config(self):
+        """Test explicit configuration."""
+        config = CleansingConfig(
+            enabled=True,
+            fast_model="gpt-4o-mini",
+            api_key="my-api-key",
+            max_retries=5,
+        )
+        assert config.fast_model == "gpt-4o-mini"
+        assert config.api_key == "my-api-key"
+        assert config.max_retries == 5
+
+    def test_disabled_config(self):
+        """Test disabled configuration."""
+        config = CleansingConfig(enabled=False)
+        assert config.enabled is False
+
+
+class TestOutputCleanerInitialization:
+    """Tests for OutputCleaner initialization logic."""
+
+    def test_output_cleaner_with_provided_llm(self):
+        """Test OutputCleaner uses provided LLM provider."""
+        mock_llm = MagicMock()
+        config = CleansingConfig()
+        cleaner = OutputCleaner(config=config, llm_provider=mock_llm)
+        assert cleaner.llm == mock_llm
+
+    def test_output_cleaner_disabled(self):
+        """Test OutputCleaner with disabled config."""
+        config = CleansingConfig(enabled=False)
+        cleaner = OutputCleaner(config=config)
+        assert cleaner.llm is None
+
+    def test_output_cleaner_no_provider_available(self):
+        """Test graceful handling when no provider available."""
+        config = CleansingConfig(enabled=True)
+        with patch.dict(os.environ, {}, clear=True):
+            # Mock the import to avoid actual LiteLLM dependency
+            with patch("framework.graph.output_cleaner.LiteLLMProvider", create=True):
+                cleaner = OutputCleaner(config=config)
+                # Should not raise, just log warning and set llm to None
+                assert cleaner.llm is None
+
+    @patch("framework.graph.output_cleaner.LiteLLMProvider")
+    def test_output_cleaner_auto_detect_openai(self, mock_litellm_class):
+        """Test auto-detection with OpenAI."""
+        mock_llm_instance = MagicMock()
+        mock_litellm_class.return_value = mock_llm_instance
+
+        config = CleansingConfig(enabled=True)
+        env = {"OPENAI_API_KEY": "test-openai-key"}
+
+        with patch.dict(os.environ, env, clear=True):
+            cleaner = OutputCleaner(config=config)
+
+            # Verify LiteLLMProvider was created with correct args
+            mock_litellm_class.assert_called_once_with(
+                api_key="test-openai-key",
+                model="gpt-4o-mini",
+                temperature=0.0,
+            )
+            assert cleaner.llm == mock_llm_instance
+
+    @patch("framework.graph.output_cleaner.LiteLLMProvider")
+    def test_output_cleaner_explicit_config(self, mock_litellm_class):
+        """Test explicit configuration takes precedence."""
+        mock_llm_instance = MagicMock()
+        mock_litellm_class.return_value = mock_llm_instance
+
+        config = CleansingConfig(
+            enabled=True,
+            fast_model="custom-model",
+            api_key="custom-key",
+        )
+
+        # Even with OpenAI key in env, explicit config should be used
+        env = {"OPENAI_API_KEY": "openai-key"}
+
+        with patch.dict(os.environ, env, clear=True):
+            cleaner = OutputCleaner(config=config)
+
+            mock_litellm_class.assert_called_once_with(
+                api_key="custom-key",
+                model="custom-model",
+                temperature=0.0,
+            )
+
+    @patch("framework.graph.output_cleaner.LiteLLMProvider")
+    def test_output_cleaner_model_override_with_auto_detect(self, mock_litellm_class):
+        """Test model override with auto-detected provider."""
+        mock_llm_instance = MagicMock()
+        mock_litellm_class.return_value = mock_llm_instance
+
+        # Specify model but not API key
+        config = CleansingConfig(
+            enabled=True,
+            fast_model="gpt-4o",  # Override default model
+        )
+
+        env = {"OPENAI_API_KEY": "openai-key"}
+
+        with patch.dict(os.environ, env, clear=True):
+            cleaner = OutputCleaner(config=config)
+
+            # Should use auto-detected key with overridden model
+            mock_litellm_class.assert_called_once_with(
+                api_key="openai-key",
+                model="gpt-4o",  # Overridden
+                temperature=0.0,
+            )
+
+
+class TestValidationResult:
+    """Tests for ValidationResult dataclass."""
+
+    def test_valid_result(self):
+        """Test valid validation result."""
+        result = ValidationResult(valid=True)
+        assert result.valid is True
+        assert result.errors == []
+        assert result.warnings == []
+
+    def test_invalid_result_with_errors(self):
+        """Test invalid result with errors."""
+        result = ValidationResult(
+            valid=False,
+            errors=["Missing key: 'name'", "Type mismatch"],
+            warnings=["Large string value"],
+        )
+        assert result.valid is False
+        assert len(result.errors) == 2
+        assert len(result.warnings) == 1
+
+
+class TestBackwardCompatibility:
+    """Tests to ensure backward compatibility."""
+
+    @patch("framework.graph.output_cleaner.LiteLLMProvider")
+    def test_cerebras_still_works(self, mock_litellm_class):
+        """Test that existing Cerebras users are not affected."""
+        mock_llm_instance = MagicMock()
+        mock_litellm_class.return_value = mock_llm_instance
+
+        config = CleansingConfig(enabled=True)
+        env = {"CEREBRAS_API_KEY": "cerebras-key"}
+
+        with patch.dict(os.environ, env, clear=True):
+            cleaner = OutputCleaner(config=config)
+
+            # Should use Cerebras (first priority)
+            mock_litellm_class.assert_called_once_with(
+                api_key="cerebras-key",
+                model="cerebras/llama-3.3-70b",
+                temperature=0.0,
+            )
+
+    def test_default_config_no_breaking_changes(self):
+        """Test that default config hasn't changed behavior."""
+        config = CleansingConfig()
+        # enabled should still default to True
+        assert config.enabled is True
+        # These behavior-affecting defaults should remain
+        assert config.fallback_to_raw is True
+        assert config.max_retries == 2
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Summary
The current 
GraphExecutor
 implementation in 
core/framework/graph/executor.py
 ignores the node_spec.max_retries configuration, using a hardcoded value of 3 for all nodes regardless of user settings.

The Problem
Hardcoded Retry Limit: Line 184 declares max_retries_per_node = 3 as a fixed constant, completely bypassing the NodeSpec.max_retries field that users expect to control retry behavior.

User Configuration Ignored: When users define a node with max_retries=10 (for flaky operations) or max_retries=1 (for fail-fast scenarios), their configuration is silently discarded.

No Per-Node Control: All nodes in a graph are forced to use the same retry limit, preventing granular control over execution behavior for different node types.

Proposed Solution
Refactor the retry logic in GraphExecutor.execute() to read from node_spec.max_retries:

Remove Hardcoded Value:

Delete max_retries_per_node = 3 from the execution initialization.
Read Per-Node Configuration:

Inside the retry loop, read max_retries = node_spec.max_retries to respect each node's configured limit.
Update All References:

Update logging, error messages, and comparison logic to use the node-specific value.
Impact
Flexibility: Each node can now have its own retry strategy.
Backward Compatible: Default is still 3 - existing code works unchanged.
User Expectations Met: The 
max_retries
 field on 
NodeSpec
 now actually works.
Affected Files
core/framework/graph/executor.py
core/tests/test_executor_max_retries.py
 (new)
Good
Bad
0 Files With Changes
Review Changes





