### PR TITLE
fix(setup): improve Windows python alias detection

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -220,7 +220,6 @@ pip uninstall -y framework tools
 3. Toggle **OFF** all entries for `python.exe` and `python3.exe`.
 4. Re-run `scripts/setup-python.sh` or use the `py` launcher.
 
-
 ## Package Structure
 
 The Hive framework consists of three Python packages:

--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -208,6 +208,19 @@ pip uninstall -y framework tools
 ./scripts/setup-python.sh
 ```
 
+### "Python was not found..." (Windows Store Redirect)
+
+**Symptom:** Running python opens the Microsoft Store or says "Python was not found...".
+
+**Cause:** Windows 10/11 "App Execution Aliases" enable fake `python.exe` and `python3.exe` commands by default.
+
+**Solution:**
+1. Open **Windows Settings**.
+2. Search for **"Manage app execution aliases"**.
+3. Toggle **OFF** all entries for `python.exe` and `python3.exe`.
+4. Re-run `scripts/setup-python.sh` or use the `py` launcher.
+
+
 ## Package Structure
 
 The Hive framework consists of three Python packages:

--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -32,24 +32,28 @@ if ! command -v python &> /dev/null && ! command -v python3 &> /dev/null; then
     exit 1
 fi
 
-# Detect Windows "App Execution Aliases" (fake python.exe)
-if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
-    # Capture stderr to check for the store message
-    PYTHON_CHECK_ERR=$(python --version 2>&1 >/dev/null || true)
-    
-    if [[ "$PYTHON_CHECK_ERR" == *"Microsoft Store"* ]]; then
-        echo -e "${RED}Error: Windows 'App Execution Aliases' are intercepting Python.${NC}"
-        echo ""
-        echo "Windows defaults to a fake 'python.exe' that redirects to the Microsoft Store."
-        echo ""
-        echo "SOLUTION:"
-        echo "1. Open Windows Settings"
-        echo "2. Search for 'Manage app execution aliases'"
-        echo "3. Turn OFF the toggles for 'python.exe' and 'python3.exe'"
-        echo ""
-        echo "Alternatively, try running this script with the 'py' launcher if installed."
-        exit 1
-    fi
+# Detect Windows "App Execution Aliases" (fake python.exe / python3.exe)
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" || "$OSTYPE" == cygwin* ]]; then
+    for PYTHON_CANDIDATE in python python3; do
+        if command -v "$PYTHON_CANDIDATE" >/dev/null 2>&1; then
+            # Capture stderr to check for the store message
+            PYTHON_CHECK_ERR=$("$PYTHON_CANDIDATE" --version 2>&1 >/dev/null || true)
+            
+            if [[ "$PYTHON_CHECK_ERR" == *"Microsoft Store"* ]]; then
+                echo -e "${RED}Error: Windows 'App Execution Aliases' are intercepting Python.${NC}"
+                echo ""
+                echo "Windows defaults to a fake 'python.exe' that redirects to the Microsoft Store."
+                echo ""
+                echo "SOLUTION:"
+                echo "1. Open Windows Settings"
+                echo "2. Search for 'Manage app execution aliases'"
+                echo "3. Turn OFF the toggles for 'python.exe' and 'python3.exe'"
+                echo ""
+                echo "Alternatively, try running this script with the 'py' launcher if installed."
+                exit 1
+            fi
+        fi
+    done
 fi
 
 # Use python3 if available, otherwise python

--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -32,6 +32,26 @@ if ! command -v python &> /dev/null && ! command -v python3 &> /dev/null; then
     exit 1
 fi
 
+# Detect Windows "App Execution Aliases" (fake python.exe)
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
+    # Capture stderr to check for the store message
+    PYTHON_CHECK_ERR=$(python --version 2>&1 >/dev/null || true)
+    
+    if [[ "$PYTHON_CHECK_ERR" == *"Microsoft Store"* ]]; then
+        echo -e "${RED}Error: Windows 'App Execution Aliases' are intercepting Python.${NC}"
+        echo ""
+        echo "Windows defaults to a fake 'python.exe' that redirects to the Microsoft Store."
+        echo ""
+        echo "SOLUTION:"
+        echo "1. Open Windows Settings"
+        echo "2. Search for 'Manage app execution aliases'"
+        echo "3. Turn OFF the toggles for 'python.exe' and 'python3.exe'"
+        echo ""
+        echo "Alternatively, try running this script with the 'py' launcher if installed."
+        exit 1
+    fi
+fi
+
 # Use python3 if available, otherwise python
 PYTHON_CMD="python3"
 if ! command -v python3 &> /dev/null; then


### PR DESCRIPTION
## Objective
Fixes #365

On Windows 10/11, the "App Execution Aliases" feature (enabled by default) creates fake `python.exe` and `python3.exe` binaries that redirect to the Microsoft Store. This causes `scripts/setup-python.sh` to fail confusingly, even if the user has Python installed elsewhere.

## Changes
- **Script Logic**: Updated `scripts/setup-python.sh` to detect this specific condition (checking stderr for "Microsoft Store").
- **User Experience**: If detected, the script now exits with a clear error message and step-by-step instructions:
  > Error: Windows 'App Execution Aliases' are intercepting Python.
  > SOLUTION: Open Windows Settings -> "Manage app execution aliases" -> Turn OFF python.exe.
- **Documentation**: Added a dedicated entry to `ENVIRONMENT_SETUP.md` explaining the symptom and fix.

## Testing Verified
- Setup script logic verified by simulation.
- Documentation preview checked.