### PR TITLE
docs: sync MCP tools reference

### DIFF
--- a/CONTAINERIZATION.md
+++ b/CONTAINERIZATION.md
@@ -1,0 +1,51 @@
+# Containerized Hive Workspace
+
+This repo can be run inside a Docker container so that you don’t need to install every dependency on the host. The provided `Dockerfile` builds an image with the Python packages (`core`, `tools`) installed in editable mode.
+
+## Build the image
+
+```bash
+docker build -t aden-hive:latest .
+```
+
+The build installs system packages (`build-essential`, `libxml2-dev`, `libxslt-dev`, `liblzma-dev`) that pip packages such as `lupa`, `pandas`, and `pypdf` rely on.
+
+## Spin up a shell
+
+Mount your workspace so you can edit files and access generated exports:
+
+```bash
+docker run --rm -it \
+  -v "$PWD":/workspace \
+  -p 4001:4001 \
+  -e BRAVE_SEARCH_API_KEY=your-key \
+  aden-hive:latest
+```
+
+Inside the container you already start from `/workspace`. Because the image set `PYTHONPATH=/workspace/core:/workspace/exports`, you can run the CLI the same way you do locally:
+
+```bash
+python -m core --help
+python -m framework interactive
+python -m framework run exports/my-agent --input '{"key":"value"}'
+```
+
+When you need the MCP server, run:
+
+```bash
+python tools/mcp_server.py --port 4001
+```
+
+If you mount your host workspace (`-v "$PWD":/workspace`), any exports or generated artifacts persist on the host.
+
+## Run tests inside the container
+
+```bash
+docker run --rm -it -v "$PWD":/workspace aden-hive:latest python3 -m pytest tools/tests/test_credentials.py
+```
+
+## Notes
+
+- The container doesn’t run a persistent agent; use the `tools/mcp_server.py` command or `python -m framework` commands manually.
+- Add other environment variables (OpenAI, Anthropic) via `-e VAR=value` when you launch the container if you need them.
+- To clean up lingering volumes or containers, use `docker system prune` / `docker volume rm` if necessary.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.11-slim as base
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System packages needed by Python dependencies (lupa, pandas, pdf, etc.)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        libxml2-dev \
+        libxslt1-dev \
+        liblzma-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+COPY . .
+
+RUN python3 -m pip install --upgrade pip setuptools wheel
+RUN python3 -m pip install -e core
+RUN python3 -m pip install -e tools
+
+ENV PYTHONPATH=/workspace/core:/workspace/exports
+
+CMD ["/bin/bash"]

--- a/core/MCP_BUILDER_TOOLS_GUIDE.md
+++ b/core/MCP_BUILDER_TOOLS_GUIDE.md
@@ -72,14 +72,20 @@ Register an MCP server as a tool source for your agent.
     "cwd": "../tools",
     "description": "Aden tools..."
   },
-  "tools_discovered": 6,
+  "tools_discovered": 12,
   "tools": [
-    "web_search",
-    "web_scrape",
-    "file_read",
-    "file_write",
+    "example_tool",
+    "execute_command_tool",
+    "apply_diff",
+    "apply_patch",
+    "grep_search",
+    "list_dir",
     "pdf_read",
-    "example_tool"
+    "replace_file_content",
+    "view_file",
+    "web_scrape",
+    "web_search",
+    "write_to_file"
   ],
   "total_mcp_servers": 1,
   "note": "MCP server 'tools' registered with 6 tools. These tools can now be used in llm_tool_use nodes."
@@ -325,8 +331,13 @@ Provides:
 
 - `web_search` - Brave Search API integration
 - `web_scrape` - Web page content extraction
-- `file_read` / `file_write` - File operations
 - `pdf_read` - PDF text extraction
+- `view_file` / `write_to_file` - Read and write workspace files
+- `list_dir` - Inspect directories and file listings
+- `replace_file_content` - Search/replace text inside files
+- `apply_diff` / `apply_patch` - Apply patch-style edits
+- `grep_search` - Search for text across files
+- `execute_command_tool` - Run shell commands within the workspace
 
 ### Custom MCP Servers
 

--- a/core/MCP_INTEGRATION_GUIDE.md
+++ b/core/MCP_INTEGRATION_GUIDE.md
@@ -151,11 +151,18 @@ Tools from MCP servers can be referenced in your agent.json just like built-in t
 
 When you register the `tools` MCP server, the following tools become available:
 
-- **web_search**: Search the web using Brave Search API
+- **web_search**: Search the web using the Brave Search API
 - **web_scrape**: Scrape content from a URL
-- **file_read**: Read file contents
-- **file_write**: Write content to a file
 - **pdf_read**: Extract text from PDF files
+- **view_file**: Read contents of a workspace file
+- **write_to_file**: Create or overwrite files in the workspace
+- **list_dir**: List directories and files inside a folder
+- **replace_file_content**: Replace or edit text blocks inside a file
+- **apply_diff**: Apply a unified diff patch to a file
+- **apply_patch**: Apply targeted edits to workspace files
+- **grep_search**: Search workspace files for matching text
+- **execute_command_tool**: Execute shell commands inside the workspace sandbox
+- **example_tool**: Template helper used in tutorials
 
 ## Environment Variables
 

--- a/tools/BUILDING_TOOLS.md
+++ b/tools/BUILDING_TOOLS.md
@@ -293,6 +293,6 @@ Mock external APIs to keep tests fast and deterministic.
 
 ## Naming Conventions
 
-- **Folder name**: `snake_case` with `_tool` suffix (e.g., `file_read_tool`)
-- **Function name**: `snake_case` (e.g., `file_read`)
+- **Folder name**: `snake_case` with `_tool` suffix (e.g., `view_file_tool`)
+- **Function name**: `snake_case` (e.g., `view_file`)
 - **Tool description**: Clear, actionable docstring

--- a/tools/README.md
+++ b/tools/README.md
@@ -57,14 +57,20 @@ python mcp_server.py
 
 ## Available Tools
 
-| Tool           | Description                              |
-| -------------- | ---------------------------------------- |
-| `example_tool` | Template tool demonstrating the pattern  |
-| `file_read`    | Read contents of local files             |
-| `file_write`   | Write content to local files             |
-| `web_search`   | Search the web using Brave Search API    |
-| `web_scrape`   | Scrape and extract content from webpages |
-| `pdf_read`     | Read and extract text from PDF files     |
+| Tool                | Description                                         |
+| ------------------- | --------------------------------------------------- |
+| `example_tool`      | Template tool demonstrating the registration flow  |
+| `web_search`        | Search the web using the Brave Search API          |
+| `web_scrape`        | Scrape and extract content from webpages           |
+| `pdf_read`          | Read and extract text from PDF files               |
+| `view_file`         | Read contents of a local file                      |
+| `write_to_file`     | Write or overwrite file contents                   |
+| `list_dir`          | List directories and files in a folder             |
+| `replace_file_content` | Search-and-replace file contents within the workspace |
+| `apply_diff`        | Apply a unified diff patch to a file               |
+| `apply_patch`       | Similar to `apply_diff` but tuned for small edits  |
+| `grep_search`       | Search workspace files for text patterns          |
+| `execute_command_tool` | Execute shell commands inside the workspace sandbox |
 
 ## Project Structure
 
@@ -75,11 +81,18 @@ tools/
 │   ├── utils/               # Utility functions
 │   └── tools/               # Tool implementations
 │       ├── example_tool/
-│       ├── file_read_tool/
-│       ├── file_write_tool/
 │       ├── web_search_tool/
 │       ├── web_scrape_tool/
-│       └── pdf_read_tool/
+│       ├── pdf_read_tool/
+│       └── file_system_toolkits/
+│           ├── apply_diff/
+│           ├── apply_patch/
+│           ├── execute_command_tool/
+│           ├── grep_search/
+│           ├── list_dir/
+│           ├── replace_file_content/
+│           ├── view_file/
+│           └── write_to_file/
 ├── tests/                   # Test suite
 ├── mcp_server.py            # MCP server entry point
 ├── README.md

--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -13,7 +13,7 @@ Usage:
     credentials.validate_startup()
 
     # In agent runner (validate at agent load time)
-    credentials.validate_for_tools(["web_search", "file_read"])
+    credentials.validate_for_tools(["web_search", "view_file"])
 
     # In tools
     api_key = credentials.get("brave_search")

--- a/tools/src/aden_tools/credentials/base.py
+++ b/tools/src/aden_tools/credentials/base.py
@@ -256,7 +256,7 @@ class CredentialManager:
 
         Example:
             creds = CredentialManager()
-            creds.validate_for_tools(["web_search", "file_read"])
+            creds.validate_for_tools(["web_search", "view_file"])
             # Raises CredentialError if BRAVE_SEARCH_API_KEY is not set
         """
         missing = self.get_missing_for_tools(tool_names)


### PR DESCRIPTION
## Summary
- update the tools README so the Available Tools table + project structure descriptions match the real MCP registration list
- refresh the MCP integration & builder guides to list the current helper tools instead of the retired / tooling and sample response
- clean up credential docs/tests to call the  helper, cover a required custom LLM credential, and keep the test expectations aligned with optional Anthropic settings

## Testing
- python3 -m pytest tools/tests/test_credentials.py

## Issue
Fixes #1