### PR TITLE
Fix/starlette dependency

### DIFF
--- a/CONTAINERIZATION.md
+++ b/CONTAINERIZATION.md
@@ -1,0 +1,55 @@
+# Containerized Hive Workspace
+
+This repo can be run entirely inside Docker so you don’t need to install every dependency on the host. The provided `Dockerfile` builds an image with the Python packages (`core`, `tools`) installed in editable mode, and the accompanying `docker-compose.yml` file orchestrates the agent shell plus the MCP tools server.
+
+## Build the image
+
+```bash
+docker build -t aden-hive:latest .
+```
+
+The build installs system packages (`build-essential`, `libxml2-dev`, `libxslt-dev`, `liblzma-dev`) that pip packages such as `lupa`, `pandas`, and `pypdf` rely on.
+
+## Docker Compose
+
+Use `docker compose` to build and run the agent and MCP server from the same base image.
+
+### Build all services
+
+```bash
+docker compose build
+```
+
+### Run the MCP tools server
+
+```bash
+docker compose up tools
+```
+
+This starts `python tools/mcp_server.py --port 4001` inside the container and exposes port 4001 on your host. Supply any required credentials (e.g., `BRAVE_SEARCH_API_KEY`) via a `.env` file or `export` statements before running.
+
+### Open an interactive agent shell
+
+```bash
+docker compose run --rm agent
+```
+
+That drops you into `/workspace` with `PYTHONPATH=/workspace/core:/workspace/exports`, so you can run the framework CLI just like on your host:
+
+```bash
+python -m core --help
+python -m framework interactive
+python -m framework run exports/my-agent --input '{"key":"value"}'
+```
+
+### Run tests inside the container
+
+```bash
+docker compose run --rm agent python3 -m pytest tools/tests/test_credentials.py
+```
+
+## Notes
+
+- The `agent` service simply hands you an editable shell; run any CLI command from there. The `tools` service keeps the MCP server running on port 4001.
+- Persist exports/artifacts by mounting your repository as a volume (`-v "$PWD":/workspace` is handled automatically by the Compose YAML).
+- To stop `docker compose up tools`, Ctrl+C the logs or run `docker compose down`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.11-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        libxml2-dev \
+        libxslt1-dev \
+        liblzma-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+COPY . .
+
+RUN python3 -m pip install --upgrade pip setuptools wheel
+RUN python3 -m pip install -e core
+RUN python3 -m pip install -e tools
+
+ENV PYTHONPATH=/workspace/core:/workspace/exports
+
+CMD ["/bin/bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  agent:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: aden-hive:latest
+    working_dir: /workspace
+    volumes:
+      - .:/workspace:cached
+    environment:
+      PYTHONPATH: /workspace/core:/workspace/exports
+    entrypoint: ["/bin/bash"]
+    tty: true
+
+  tools:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: aden-hive:tools
+    working_dir: /workspace
+    volumes:
+      - .:/workspace:cached
+    environment:
+      MCP_PORT: 4001
+      BRAVE_SEARCH_API_KEY: ${BRAVE_SEARCH_API_KEY:-}
+    ports:
+      - "4001:4001"
+    command: python tools/mcp_server.py --port 4001

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "fastmcp>=2.0.0",
     "diff-match-patch>=20230430",
     "python-dotenv>=1.0.0",
+    "starlette>=0.40,<0.42",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
**Issue Addressed**

- The FastAPI-powered components within the tools package began failing when the Starlette dependency was upgraded beyond version 0.42.
- Starlette 0.42+ introduced breaking changes:
- Removal of anyio integration.
- Altered routing behaviors that FastAPI relied on.
- Because the dependency was previously unconstrained, fresh installs could inadvertently pull these newer versions.

**This led to two classes of problems:**

- Hard failures: runtime import errors when expected modules or functions were missing.
- Soft regressions: subtle request-handling differences that broke assumptions in the MCP tools server and FastAPI routes.


**Fix Applied**

Commit https://github.com/adenhq/hive/commit/ee2bc070cbdbc8598340dd4ca92b4e0e987d325d (chore: pin starlette for FastAPI compatibility) introduced a strict dependency bound in pyproject.toml:

toml
starlette >=0.40, <0.42

**This ensures that:**

- Pip installs only the Starlette versions (0.40 and 0.41) known to be compatible with the current FastAPI stack.
- Future installs are protected from pulling incompatible releases.
- The MCP tools server and FastAPI routes remain stable and predictable.

**Impact**

- Prevents runtime errors caused by missing imports.
- Guards against subtle routing regressions that could compromise request handling.
- Provides a clear compatibility boundary until the codebase can be updated to support newer Starlette releases.
- Improves developer experience by ensuring consistent behavior across environments and deployments.