### PR TITLE
Docs: improve Windows setup and agent usage clarity

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -72,6 +72,14 @@ For running agents with real LLMs:
 export ANTHROPIC_API_KEY="your-key-here"
 ```
 
+ On Windows PowerShell, use the following instead of export:
+
+
+ ```powershell
+ $env:ANTHROPIC_API_KEY="your-key-here"
+```
+
+
 ## Running Agents
 
 All agent commands must be run from the project root with `PYTHONPATH` set:
@@ -79,6 +87,28 @@ All agent commands must be run from the project root with `PYTHONPATH` set:
 ```bash
 # From /hive/ directory
 PYTHONPATH=core:exports python -m agent_name COMMAND
+```
+
+### Windows (PowerShell)
+
+Linux-style commands like the above do not work in PowerShell. Use the following instead:
+
+
+```powershell
+$env:PYTHONPATH="core;exports"
+python -m agent_name COMMAND
+```
+
+### agent_name Placeholder
+
+`agent_name` is a placeholder value.
+
+Replace it with the actual agent module name located inside the `exports/` directory.
+
+Example:
+
+```powershell
+python -m my_agent run --input "{...}"
 ```
 
 ### Example: Support Ticket Agent
@@ -230,6 +260,16 @@ hive/
     ├── market_research_agent/
     ├── outbound_sales_agent/
     └── personal_assistant_agent/
+```
+
+### exports Directory Note
+
+The `exports/` directory may not exist after cloning the repository.
+
+If you are creating or running agents locally, create it manually from the project root:
+
+```powershell
+mkdir exports
 ```
 
 ### Why PYTHONPATH is Required


### PR DESCRIPTION
## Description

This PR improves the setup documentation, especially for Windows users.
The changes are based on setting up the project locally and fixing the confusion I faced during onboarding.

## Type of Change

- [x] Documentation update


## Related Issues

Related to the Windows setup and agent usage confusion discussed in the setup docs.

Fixes #(https://github.com/adenhq/hive/issues/408)

## Changes Made

- Added Windows PowerShell instructions for setting ANTHROPIC_API_KEY
- Added Windows PowerShell instructions for setting PYTHONPATH
- Clarified that agent_name is a placeholder and must be replaced with a real agent module
- Added a note explaining that the exports/ directory may need to be created manually

## Testing

[x] Manual testing performed (setup and agent commands tested locally on Windows)

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My changes follow the project's documentation style
- [x]  I have performed a self-review of my changes
- [x]  I have updated the documentation where needed
- [x]  My changes do not introduce any warnings or breaking changes

