### PR TITLE
fix(tools): handle non-HTML content and add PDF URL support

### DIFF
--- a/tools/src/aden_tools/tools/pdf_read_tool/pdf_read_tool.py
+++ b/tools/src/aden_tools/tools/pdf_read_tool/pdf_read_tool.py
@@ -2,14 +2,16 @@
 PDF Read Tool - Manage Accounting and Financial Operations.
 
 Uses pypdf to read PDF documents and extract text content
-along with metadata.
+along with metadata. Supports both local file paths and URLs.
 """
 
 from __future__ import annotations
 
+import tempfile
 from pathlib import Path
 from typing import Any
 
+import httpx
 from fastmcp import FastMCP
 from pypdf import PdfReader
 
@@ -98,9 +100,10 @@ def register_tools(mcp: FastMCP) -> None:
 
         Returns text content with page markers and optional metadata.
         Use for reading PDFs, reports, documents, or any PDF file.
+        Supports both local file paths and URLs.
 
         Args:
-            file_path: Path to the PDF file to read (absolute or relative)
+            file_path: Path or URL to the PDF file (local path, or http/https URL)
             pages: Page range - 'all'/None for all, '5' for single,
                 '1-10' for range, '1,3,5' for specific
             max_pages: Maximum number of pages to process (1-1000, memory safety)
@@ -109,8 +112,46 @@ def register_tools(mcp: FastMCP) -> None:
         Returns:
             Dict with extracted text and metadata, or error dict
         """
+        temp_file = None
         try:
-            path = Path(file_path).resolve()
+            # Check if input is a URL
+            is_url = file_path.startswith(("http://", "https://"))
+            
+            if is_url:
+                # Download PDF from URL to temporary file
+                try:
+                    response = httpx.get(
+                        file_path,
+                        headers={"User-Agent": "AdenBot/1.0 (PDF Reader)"},
+                        follow_redirects=True,
+                        timeout=60.0,
+                    )
+                    
+                    if response.status_code != 200:
+                        return {"error": f"Failed to download PDF: HTTP {response.status_code}"}
+                    
+                    # Validate content-type
+                    content_type = response.headers.get("content-type", "").lower()
+                    if "application/pdf" not in content_type:
+                        return {
+                            "error": f"URL does not point to a PDF file. Content-Type: {content_type}",
+                            "content_type": content_type,
+                            "url": file_path,
+                        }
+                    
+                    # Save to temporary file
+                    temp_file = tempfile.NamedTemporaryFile(mode='wb', suffix='.pdf', delete=False)
+                    temp_file.write(response.content)
+                    temp_file.close()
+                    path = Path(temp_file.name)
+                    
+                except httpx.TimeoutException:
+                    return {"error": "PDF download timed out"}
+                except httpx.RequestError as e:
+                    return {"error": f"Failed to download PDF: {str(e)}"}
+            else:
+                # Local file path
+                path = Path(file_path).resolve()
 
             # Validate file exists
             if not path.exists():
@@ -192,3 +233,10 @@ def register_tools(mcp: FastMCP) -> None:
             return {"error": f"Permission denied: {file_path}"}
         except Exception as e:
             return {"error": f"Failed to read PDF: {str(e)}"}
+        finally:
+            # Clean up temporary file if it was created
+            if temp_file is not None:
+                try:
+                    Path(temp_file.name).unlink(missing_ok=True)
+                except Exception:
+                    pass  # Ignore cleanup errors

--- a/tools/src/aden_tools/tools/pdf_read_tool/pdf_read_tool.py
+++ b/tools/src/aden_tools/tools/pdf_read_tool/pdf_read_tool.py
@@ -116,7 +116,7 @@ def register_tools(mcp: FastMCP) -> None:
         try:
             # Check if input is a URL
             is_url = file_path.startswith(("http://", "https://"))
-            
+
             if is_url:
                 # Download PDF from URL to temporary file
                 try:
@@ -126,25 +126,27 @@ def register_tools(mcp: FastMCP) -> None:
                         follow_redirects=True,
                         timeout=60.0,
                     )
-                    
+
                     if response.status_code != 200:
                         return {"error": f"Failed to download PDF: HTTP {response.status_code}"}
-                    
+
                     # Validate content-type
                     content_type = response.headers.get("content-type", "").lower()
                     if "application/pdf" not in content_type:
                         return {
-                            "error": f"URL does not point to a PDF file. Content-Type: {content_type}",
+                            "error": (
+                                f"URL does not point to a PDF file. Content-Type: {content_type}"
+                            ),
                             "content_type": content_type,
                             "url": file_path,
                         }
-                    
+
                     # Save to temporary file
-                    temp_file = tempfile.NamedTemporaryFile(mode='wb', suffix='.pdf', delete=False)
+                    temp_file = tempfile.NamedTemporaryFile(mode="wb", suffix=".pdf", delete=False)
                     temp_file.write(response.content)
                     temp_file.close()
                     path = Path(temp_file.name)
-                    
+
                 except httpx.TimeoutException:
                     return {"error": "PDF download timed out"}
                 except httpx.RequestError as e:

--- a/tools/tests/tools/test_pdf_read_tool.py
+++ b/tools/tests/tools/test_pdf_read_tool.py
@@ -1,7 +1,7 @@
 """Tests for pdf_read tool (FastMCP)."""
 
 from pathlib import Path
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import MagicMock, Mock, patch
 
 import httpx
 import pytest
@@ -114,11 +114,12 @@ class TestPdfReadTool:
         assert result.get("truncated") is True
         assert "truncation_warning" in result
 
+
 class TestPdfReadUrlSupport:
     """Tests for URL download support in pdf_read tool."""
 
-    @patch('httpx.get')
-    @patch('aden_tools.tools.pdf_read_tool.pdf_read_tool.PdfReader')
+    @patch("httpx.get")
+    @patch("aden_tools.tools.pdf_read_tool.pdf_read_tool.PdfReader")
     def test_url_download_succeeds(self, mock_pdf_reader, mock_get, pdf_read_fn):
         """Valid PDF URL downloads and parses successfully."""
         # Mock HTTP response
@@ -143,7 +144,7 @@ class TestPdfReadUrlSupport:
         assert "PDF text content" in result["content"]
         mock_get.assert_called_once()
 
-    @patch('httpx.get')
+    @patch("httpx.get")
     def test_url_non_pdf_content_type(self, mock_get, pdf_read_fn):
         """URL returning non-PDF content-type returns error."""
         mock_response = Mock()
@@ -159,7 +160,7 @@ class TestPdfReadUrlSupport:
         assert "content_type" in result
         assert "text/html" in result["content_type"]
 
-    @patch('httpx.get')
+    @patch("httpx.get")
     def test_url_http_404_error(self, mock_get, pdf_read_fn):
         """URL returning 404 returns appropriate error."""
         mock_response = Mock()
@@ -171,7 +172,7 @@ class TestPdfReadUrlSupport:
         assert "error" in result
         assert "404" in result["error"]
 
-    @patch('httpx.get')
+    @patch("httpx.get")
     def test_url_http_500_error(self, mock_get, pdf_read_fn):
         """URL returning 500 returns appropriate error."""
         mock_response = Mock()
@@ -183,7 +184,7 @@ class TestPdfReadUrlSupport:
         assert "error" in result
         assert "500" in result["error"]
 
-    @patch('httpx.get')
+    @patch("httpx.get")
     def test_url_timeout_error(self, mock_get, pdf_read_fn):
         """URL request timeout returns appropriate error."""
         mock_get.side_effect = httpx.TimeoutException("Timeout")
@@ -193,7 +194,7 @@ class TestPdfReadUrlSupport:
         assert "error" in result
         assert "timed out" in result["error"].lower()
 
-    @patch('httpx.get')
+    @patch("httpx.get")
     def test_url_network_error(self, mock_get, pdf_read_fn):
         """Network error returns appropriate error."""
         mock_get.side_effect = httpx.RequestError("Connection failed")
@@ -203,8 +204,8 @@ class TestPdfReadUrlSupport:
         assert "error" in result
         assert "failed to download" in result["error"].lower()
 
-    @patch('httpx.get')
-    @patch('aden_tools.tools.pdf_read_tool.pdf_read_tool.PdfReader')
+    @patch("httpx.get")
+    @patch("aden_tools.tools.pdf_read_tool.pdf_read_tool.PdfReader")
     def test_url_with_http_scheme(self, mock_pdf_reader, mock_get, pdf_read_fn):
         """HTTP URLs (not HTTPS) are handled correctly."""
         mock_response = Mock()
@@ -238,9 +239,9 @@ class TestPdfReadUrlSupport:
         if "error" in result:
             assert "download" not in result["error"].lower()
 
-    @patch('httpx.get')
-    @patch('aden_tools.tools.pdf_read_tool.pdf_read_tool.PdfReader')
-    @patch('aden_tools.tools.pdf_read_tool.pdf_read_tool.tempfile.NamedTemporaryFile')
+    @patch("httpx.get")
+    @patch("aden_tools.tools.pdf_read_tool.pdf_read_tool.PdfReader")
+    @patch("aden_tools.tools.pdf_read_tool.pdf_read_tool.tempfile.NamedTemporaryFile")
     def test_temporary_file_cleanup(self, mock_tempfile, mock_pdf_reader, mock_get, pdf_read_fn):
         """Temporary file is cleaned up after processing."""
         # Mock HTTP response
@@ -263,13 +264,13 @@ class TestPdfReadUrlSupport:
         mock_reader_instance.metadata = None
         mock_pdf_reader.return_value = mock_reader_instance
 
-        result = pdf_read_fn(file_path="https://example.com/doc.pdf")
+        pdf_read_fn(file_path="https://example.com/doc.pdf")
 
         # Verify temp file operations
         mock_temp.write.assert_called_once()
         mock_temp.close.assert_called_once()
 
-    @patch('httpx.get')
+    @patch("httpx.get")
     def test_url_json_content_type(self, mock_get, pdf_read_fn):
         """URL returning JSON returns appropriate error."""
         mock_response = Mock()

--- a/tools/tests/tools/test_pdf_read_tool.py
+++ b/tools/tests/tools/test_pdf_read_tool.py
@@ -1,7 +1,9 @@
 """Tests for pdf_read tool (FastMCP)."""
 
 from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock
 
+import httpx
 import pytest
 from fastmcp import FastMCP
 
@@ -111,3 +113,174 @@ class TestPdfReadTool:
         # New behavior: explicit truncation metadata instead of silent truncation
         assert result.get("truncated") is True
         assert "truncation_warning" in result
+
+class TestPdfReadUrlSupport:
+    """Tests for URL download support in pdf_read tool."""
+
+    @patch('httpx.get')
+    @patch('aden_tools.tools.pdf_read_tool.pdf_read_tool.PdfReader')
+    def test_url_download_succeeds(self, mock_pdf_reader, mock_get, pdf_read_fn):
+        """Valid PDF URL downloads and parses successfully."""
+        # Mock HTTP response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/pdf"}
+        mock_response.content = b"%PDF-1.4\nfake pdf content"
+        mock_get.return_value = mock_response
+
+        # Mock PdfReader
+        mock_reader_instance = MagicMock()
+        mock_reader_instance.is_encrypted = False
+        mock_reader_instance.pages = [MagicMock()]
+        mock_reader_instance.pages[0].extract_text.return_value = "PDF text content"
+        mock_reader_instance.metadata = None
+        mock_pdf_reader.return_value = mock_reader_instance
+
+        result = pdf_read_fn(file_path="https://example.com/document.pdf")
+
+        assert "error" not in result
+        assert "content" in result
+        assert "PDF text content" in result["content"]
+        mock_get.assert_called_once()
+
+    @patch('httpx.get')
+    def test_url_non_pdf_content_type(self, mock_get, pdf_read_fn):
+        """URL returning non-PDF content-type returns error."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/html"}
+        mock_response.content = b"<html>Not a PDF</html>"
+        mock_get.return_value = mock_response
+
+        result = pdf_read_fn(file_path="https://example.com/page.html")
+
+        assert "error" in result
+        assert "does not point to a pdf" in result["error"].lower()
+        assert "content_type" in result
+        assert "text/html" in result["content_type"]
+
+    @patch('httpx.get')
+    def test_url_http_404_error(self, mock_get, pdf_read_fn):
+        """URL returning 404 returns appropriate error."""
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_get.return_value = mock_response
+
+        result = pdf_read_fn(file_path="https://example.com/missing.pdf")
+
+        assert "error" in result
+        assert "404" in result["error"]
+
+    @patch('httpx.get')
+    def test_url_http_500_error(self, mock_get, pdf_read_fn):
+        """URL returning 500 returns appropriate error."""
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_get.return_value = mock_response
+
+        result = pdf_read_fn(file_path="https://example.com/error.pdf")
+
+        assert "error" in result
+        assert "500" in result["error"]
+
+    @patch('httpx.get')
+    def test_url_timeout_error(self, mock_get, pdf_read_fn):
+        """URL request timeout returns appropriate error."""
+        mock_get.side_effect = httpx.TimeoutException("Timeout")
+
+        result = pdf_read_fn(file_path="https://example.com/slow.pdf")
+
+        assert "error" in result
+        assert "timed out" in result["error"].lower()
+
+    @patch('httpx.get')
+    def test_url_network_error(self, mock_get, pdf_read_fn):
+        """Network error returns appropriate error."""
+        mock_get.side_effect = httpx.RequestError("Connection failed")
+
+        result = pdf_read_fn(file_path="https://example.com/doc.pdf")
+
+        assert "error" in result
+        assert "failed to download" in result["error"].lower()
+
+    @patch('httpx.get')
+    @patch('aden_tools.tools.pdf_read_tool.pdf_read_tool.PdfReader')
+    def test_url_with_http_scheme(self, mock_pdf_reader, mock_get, pdf_read_fn):
+        """HTTP URLs (not HTTPS) are handled correctly."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/pdf"}
+        mock_response.content = b"%PDF-1.4\ncontent"
+        mock_get.return_value = mock_response
+
+        mock_reader_instance = MagicMock()
+        mock_reader_instance.is_encrypted = False
+        mock_reader_instance.pages = [MagicMock()]
+        mock_reader_instance.pages[0].extract_text.return_value = "Text"
+        mock_reader_instance.metadata = None
+        mock_pdf_reader.return_value = mock_reader_instance
+
+        result = pdf_read_fn(file_path="http://example.com/doc.pdf")
+
+        assert "error" not in result
+        mock_get.assert_called_once()
+
+    def test_local_file_path_still_works(self, pdf_read_fn, tmp_path: Path):
+        """Local file paths still work (backward compatibility)."""
+        pdf_file = tmp_path / "local.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4")
+
+        result = pdf_read_fn(file_path=str(pdf_file))
+
+        # Will error due to invalid PDF, but should not treat as URL
+        assert isinstance(result, dict)
+        # Should not have URL-specific errors
+        if "error" in result:
+            assert "download" not in result["error"].lower()
+
+    @patch('httpx.get')
+    @patch('aden_tools.tools.pdf_read_tool.pdf_read_tool.PdfReader')
+    @patch('aden_tools.tools.pdf_read_tool.pdf_read_tool.tempfile.NamedTemporaryFile')
+    def test_temporary_file_cleanup(self, mock_tempfile, mock_pdf_reader, mock_get, pdf_read_fn):
+        """Temporary file is cleaned up after processing."""
+        # Mock HTTP response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/pdf"}
+        mock_response.content = b"%PDF-1.4\ncontent"
+        mock_get.return_value = mock_response
+
+        # Mock temporary file
+        mock_temp = MagicMock()
+        mock_temp.name = "/tmp/test.pdf"
+        mock_tempfile.return_value = mock_temp
+
+        # Mock PdfReader
+        mock_reader_instance = MagicMock()
+        mock_reader_instance.is_encrypted = False
+        mock_reader_instance.pages = [MagicMock()]
+        mock_reader_instance.pages[0].extract_text.return_value = "Text"
+        mock_reader_instance.metadata = None
+        mock_pdf_reader.return_value = mock_reader_instance
+
+        result = pdf_read_fn(file_path="https://example.com/doc.pdf")
+
+        # Verify temp file operations
+        mock_temp.write.assert_called_once()
+        mock_temp.close.assert_called_once()
+
+    @patch('httpx.get')
+    def test_url_json_content_type(self, mock_get, pdf_read_fn):
+        """URL returning JSON returns appropriate error."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.content = b'{"error": "not a pdf"}'
+        mock_get.return_value = mock_response
+
+        result = pdf_read_fn(file_path="https://api.example.com/data")
+
+        assert "error" in result
+        assert "does not point to a pdf" in result["error"].lower()
+        assert "content_type" in result
+        assert "application/json" in result["content_type"]


### PR DESCRIPTION
## Description

This PR fixes silent failures in `web_scrape` tool when encountering non-HTML content and extends `pdf_read` tool with URL download support, enabling agents to handle PDF URLs discovered during web scraping operations.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #424 

## Changes Made

### Part 1: Content-Type Validation in `web_scrape` Tool (Bug Fix)
- Added HTTP response `Content-Type` header validation before BeautifulSoup parsing
- Returns structured error message when non-HTML content is encountered (PDF, JSON, images, etc.)
- Error includes `content_type`, `url`, and clear guidance for agents to take alternative actions
- Prevents silent failures with empty/garbage results

### Part 2: URL Support in `pdf_read` Tool (Feature Enhancement)
- Extended `pdf_read` to accept both local file paths and HTTP/HTTPS URLs
- Downloads PDF content to temporary file when URL is provided
- Validates `Content-Type: application/pdf` before parsing
- Automatic cleanup of temporary files using finally block
- Maintains full backward compatibility with existing local file path usage

### Part 3: Comprehensive Test Coverage
- Added 8 new tests for `web_scrape` content-type validation
- Added 10 new tests for `pdf_read` URL download support
- Uses mocking to avoid real network calls in tests
- All tests focus on error handling, edge cases, and validation

## Testing

### Unit Tests
- [x] All tests for `web_scrape_tool` pass (14 tests total: 6 existing + 8 new)
- [x] All tests for `pdf_read_tool` pass (17 tests total: 7 existing + 10 new)
- [x] Total: 31 tests passing

### Manual Testing
- [x] Tested `web_scrape` with real HTML pages (succeeds)
- [x] Tested `web_scrape` with PDF URLs (returns clear error as expected)
- [x] Tested `pdf_read` with local PDF files (backward compatible)
- [x] Tested `pdf_read` with PDF URLs (downloads and parses successfully)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (docstrings updated)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Implementation Details

### Agent Workflow
This PR enables the following intelligent workflow for agents:

```
Agent encounters PDF URL
↓
Calls web_scrape(pdf_url)
↓
Receives clear error: "Cannot scrape non-HTML content. Content-Type: application/pdf"
↓
Agent understands the issue
↓
Calls pdf_read(pdf_url) instead
↓
Successfully extracts PDF content
```

### Alternative Approach Considered
The issue document discusses an alternative modular approach (separate `download_file` tool) that adheres more strictly to Single Responsibility Principle. This PR implements the direct URL support in `pdf_read` for simplicity, but the alternative is documented for future consideration.

---

**Issue Link:** #424 
