### PR TITLE
fix(runtime): execution stream memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ exports/*
 .agent-builder-sessions/*
 
 .venv
+venv/*

--- a/.gitignore
+++ b/.gitignore
@@ -70,4 +70,3 @@ exports/*
 .agent-builder-sessions/*
 
 .venv
-venv/*

--- a/core/framework/runtime/agent_runtime.py
+++ b/core/framework/runtime/agent_runtime.py
@@ -33,6 +33,8 @@ class AgentRuntimeConfig:
     cache_ttl: float = 60.0
     batch_interval: float = 0.1
     max_history: int = 1000
+    execution_result_max: int = 1000
+    execution_result_ttl_seconds: float | None = None
 
 
 class AgentRuntime:
@@ -206,6 +208,8 @@ class AgentRuntime:
                     llm=self._llm,
                     tools=self._tools,
                     tool_executor=self._tool_executor,
+                    result_retention_max=self._config.execution_result_max,
+                    result_retention_ttl_seconds=self._config.execution_result_ttl_seconds,
                 )
                 await stream.start()
                 self._streams[ep_id] = stream

--- a/core/tests/test_execution_stream.py
+++ b/core/tests/test_execution_stream.py
@@ -1,0 +1,121 @@
+"""Tests for ExecutionStream retention behavior."""
+
+import json
+
+import pytest
+
+from framework.graph import NodeSpec, Goal, SuccessCriterion
+from framework.graph.edge import GraphSpec
+from framework.llm.provider import LLMProvider, LLMResponse, Tool
+from framework.runtime.event_bus import EventBus
+from framework.runtime.execution_stream import ExecutionStream, EntryPointSpec
+from framework.runtime.outcome_aggregator import OutcomeAggregator
+from framework.runtime.shared_state import SharedStateManager
+from framework.storage.concurrent import ConcurrentStorage
+
+
+class DummyLLMProvider(LLMProvider):
+    """Deterministic LLM provider for execution stream tests."""
+
+    def complete(
+        self,
+        messages: list[dict[str, object]],
+        system: str = "",
+        tools: list[Tool] | None = None,
+        max_tokens: int = 1024,
+        response_format: dict[str, object] | None = None,
+        json_mode: bool = False,
+    ) -> LLMResponse:
+        return LLMResponse(content=json.dumps({"result": "ok"}), model="dummy")
+
+    def complete_with_tools(
+        self,
+        messages: list[dict[str, object]],
+        system: str,
+        tools: list[Tool],
+        tool_executor: callable,
+        max_iterations: int = 10,
+    ) -> LLMResponse:
+        return LLMResponse(content=json.dumps({"result": "ok"}), model="dummy")
+
+
+@pytest.mark.asyncio
+async def test_execution_stream_retention(tmp_path):
+    goal = Goal(
+        id="test-goal",
+        name="Test Goal",
+        description="Retention test",
+        success_criteria=[
+            SuccessCriterion(
+                id="result",
+                description="Result present",
+                metric="output_contains",
+                target="result",
+            )
+        ],
+        constraints=[],
+    )
+
+    node = NodeSpec(
+        id="hello",
+        name="Hello",
+        description="Return a result",
+        node_type="llm_generate",
+        input_keys=["user_name"],
+        output_keys=["result"],
+        system_prompt='Return JSON: {"result": "ok"}',
+    )
+
+    graph = GraphSpec(
+        id="test-graph",
+        goal_id=goal.id,
+        version="1.0.0",
+        entry_node="hello",
+        entry_points={"start": "hello"},
+        terminal_nodes=["hello"],
+        pause_nodes=[],
+        nodes=[node],
+        edges=[],
+        default_model="dummy",
+        max_tokens=10,
+    )
+
+    storage = ConcurrentStorage(tmp_path)
+    await storage.start()
+
+    stream = ExecutionStream(
+        stream_id="start",
+        entry_spec=EntryPointSpec(
+            id="start",
+            name="Start",
+            entry_node="hello",
+            trigger_type="manual",
+            isolation_level="shared",
+        ),
+        graph=graph,
+        goal=goal,
+        state_manager=SharedStateManager(),
+        storage=storage,
+        outcome_aggregator=OutcomeAggregator(goal, EventBus()),
+        event_bus=None,
+        llm=DummyLLMProvider(),
+        tools=[],
+        tool_executor=None,
+        result_retention_max=3,
+        result_retention_ttl_seconds=None,
+    )
+
+    await stream.start()
+
+    for i in range(5):
+        execution_id = await stream.execute({"user_name": f"user-{i}"})
+        result = await stream.wait_for_completion(execution_id, timeout=5)
+        assert result is not None
+        assert execution_id not in stream._active_executions
+        assert execution_id not in stream._completion_events
+        assert execution_id not in stream._execution_tasks
+
+    assert len(stream._execution_results) <= 3
+
+    await stream.stop()
+    await storage.stop()


### PR DESCRIPTION
## Description

ExecutionStream never removes per-execution entries from _active_executions and _completion_events. In long-running services or high-throughput runs, memory grows without bound and can eventually OOM.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #440

## Changes Made
Implement bounded retention for execution results while.

- Implemented bounded retention for execution results
- Cleaned in-flight state immediately to prevent memory growth without losing short-term query ability

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
