### PR TITLE
Clarify onboarding flow and agent generation requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,30 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 - **Adapt** - Continuous evaluation, supervision, and adaptation ensure agents improve over time
 - **Infra** - Shared memory, LLM integrations, tools, and skills power every agent
 
+
+## Agent Generation and Exports
+
+This repository starts in a framework-only state.
+
+Exported agents (located under `exports/`) are generated dynamically using
+Claude Code skills such as `/building-agents`.
+
+### Important notes for first-time contributors
+
+- The `exports/` directory does not exist on a fresh clone
+- Agent modules (e.g. `support_ticket_agent`) are created only after running
+  the Claude Code agent generation workflow
+- Agent generation and testing require Anthropic API credits
+
+If you want to explore the framework without generating agents, you can:
+- Inspect example agents under `examples/`
+- Run the framework CLI directly:
+  ```bash
+  PYTHONPATH=core python -m framework.cli --help
+
+
+
+
 ## Quick Links
 
 - **[Documentation](https://docs.adenhq.com/)** - Complete guides and API reference
@@ -59,6 +83,10 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 - **[Changelog](https://github.com/adenhq/hive/releases)** - Latest updates and releases
 <!-- - **[Roadmap](https://adenhq.com/roadmap)** - Upcoming features and plans -->
 - **[Report Issues](https://github.com/adenhq/hive/issues)** - Bug reports and feature requests
+
+
+
+
 
 ## Quick Start
 


### PR DESCRIPTION
### Summary
This PR clarifies the onboarding flow for first-time contributors by explaining
that exported agents are generated dynamically and are not present in a fresh
clone of the repository.

### Changes
- Document that the repo starts in a framework-only state
- Clarify when and how the `exports/` directory is created
- Call out the Anthropic API credit requirement for agent generation
- Provide a framework-only exploration path for contributors

### Motivation
While setting up the project, I noticed that the README assumes exported agents
already exist, which can be confusing for new contributors and candidates.
This change aims to reduce that initial friction without altering behavior.
