### PR TITLE
fix: enforce CodeSandbox timeout on Windows

### DIFF
--- a/core/framework/graph/code_sandbox.py
+++ b/core/framework/graph/code_sandbox.py
@@ -225,8 +225,80 @@ class CodeSandbox:
                 signal.alarm(0)
                 signal.signal(signal.SIGALRM, old_handler)
         else:
-            # Windows: no timeout support, just execute
+            # Windows: use threading-based timeout
             yield
+
+    def _execute_with_timeout_windows(
+        self,
+        code: str,
+        namespace: dict[str, Any],
+        timeout_seconds: int,
+    ) -> None:
+        """
+        Execute code with timeout on Windows using ThreadPoolExecutor.
+
+        Raises:
+            TimeoutError: If execution exceeds timeout
+            Exception: Any exception from the executed code
+        """
+        import concurrent.futures
+
+        exception_holder = [None]  # Use list to allow modification in nested function
+
+        def run_code():
+            try:
+                compiled = compile(code, "<sandbox>", "exec")
+                exec(compiled, namespace)
+            except Exception as e:
+                exception_holder[0] = e
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(run_code)
+            try:
+                future.result(timeout=timeout_seconds)
+            except concurrent.futures.TimeoutError:
+                raise TimeoutError(f"Code execution timed out after {timeout_seconds} seconds")
+
+        # Re-raise any exception from the executed code
+        if exception_holder[0] is not None:
+            raise exception_holder[0]
+
+    def _eval_with_timeout_windows(
+        self,
+        expression: str,
+        namespace: dict[str, Any],
+        timeout_seconds: int,
+    ) -> Any:
+        """
+        Evaluate expression with timeout on Windows using ThreadPoolExecutor.
+
+        Raises:
+            TimeoutError: If execution exceeds timeout
+            Exception: Any exception from the evaluated expression
+        """
+        import concurrent.futures
+
+        result_holder = [None]
+        exception_holder = [None]
+
+        def run_eval():
+            try:
+                result_holder[0] = eval(expression, namespace)
+            except Exception as e:
+                exception_holder[0] = e
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(run_eval)
+            try:
+                future.result(timeout=timeout_seconds)
+            except concurrent.futures.TimeoutError:
+                raise TimeoutError(f"Code execution timed out after {timeout_seconds} seconds")
+
+        # Re-raise any exception from the evaluated expression
+        if exception_holder[0] is not None:
+            raise exception_holder[0]
+
+        return result_holder[0]
 
     def _create_namespace(self, inputs: dict[str, Any]) -> dict[str, Any]:
         """Create isolated namespace for code execution."""
@@ -281,10 +353,15 @@ class CodeSandbox:
         start_time = time.time()
 
         try:
-            with self._timeout_context(self.timeout_seconds):
-                # Compile and execute
-                compiled = compile(code, "<sandbox>", "exec")
-                exec(compiled, namespace)
+            # Use platform-appropriate timeout mechanism
+            if hasattr(signal, 'SIGALRM'):
+                # Unix: use signal-based timeout
+                with self._timeout_context(self.timeout_seconds):
+                    compiled = compile(code, "<sandbox>", "exec")
+                    exec(compiled, namespace)
+            else:
+                # Windows: use thread-based timeout
+                self._execute_with_timeout_windows(code, namespace, self.timeout_seconds)
 
             execution_time_ms = int((time.time() - start_time) * 1000)
 
@@ -357,8 +434,14 @@ class CodeSandbox:
         namespace = self._create_namespace(inputs)
 
         try:
-            with self._timeout_context(self.timeout_seconds):
-                result = eval(expression, namespace)
+            # Use platform-appropriate timeout mechanism
+            if hasattr(signal, 'SIGALRM'):
+                # Unix: use signal-based timeout
+                with self._timeout_context(self.timeout_seconds):
+                    result = eval(expression, namespace)
+            else:
+                # Windows: use thread-based timeout
+                result = self._eval_with_timeout_windows(expression, namespace, self.timeout_seconds)
 
             return SandboxResult(success=True, result=result)
 

--- a/core/tests/test_code_sandbox.py
+++ b/core/tests/test_code_sandbox.py
@@ -1,0 +1,69 @@
+"""Tests for CodeSandbox timeout enforcement."""
+
+import pytest
+import time
+
+from framework.graph.code_sandbox import CodeSandbox, SandboxResult
+
+
+class TestCodeSandboxTimeout:
+    """Test timeout enforcement on all platforms."""
+
+    def test_timeout_on_long_running_code(self):
+        """Code exceeding timeout should fail with TimeoutError."""
+        sandbox = CodeSandbox(timeout_seconds=1)
+
+        # This loop takes several seconds to complete
+        result = sandbox.execute('x = 0\nwhile x < 100000000: x += 1')
+
+        assert result.success is False
+        assert result.error is not None
+        assert "timed out" in result.error.lower()
+
+    def test_fast_code_completes_successfully(self):
+        """Code completing within timeout should succeed."""
+        sandbox = CodeSandbox(timeout_seconds=5)
+
+        result = sandbox.execute('x = 1 + 2\nresult = x * 3')
+
+        assert result.success is True
+        assert result.error is None
+        assert result.variables.get('result') == 9
+
+    def test_timeout_on_expression(self):
+        """Expression exceeding timeout should fail."""
+        sandbox = CodeSandbox(timeout_seconds=1)
+
+        # Long-running expression (nested loop via list comprehension)
+        result = sandbox.execute_expression('[x*y for x in range(10000) for y in range(10000)]')
+
+        assert result.success is False
+        assert result.error is not None
+        assert "timed out" in result.error.lower()
+
+    def test_fast_expression_completes(self):
+        """Expression completing within timeout should succeed."""
+        sandbox = CodeSandbox(timeout_seconds=5)
+
+        result = sandbox.execute_expression('1 + 2 + 3')
+
+        assert result.success is True
+        assert result.result == 6
+
+    def test_code_validation_still_works(self):
+        """Code validation should still block dangerous operations."""
+        sandbox = CodeSandbox(timeout_seconds=5)
+
+        # Import should be blocked
+        result = sandbox.execute('import os')
+
+        assert result.success is False
+        assert "validation failed" in result.error.lower()
+
+    def test_timeout_returns_correct_error_type(self):
+        """Timeout should return TimeoutError message."""
+        sandbox = CodeSandbox(timeout_seconds=1)
+
+        result = sandbox.execute('x = 0\nwhile x < 100000000: x += 1')
+
+        assert "TimeoutError" in result.error or "timed out" in result.error.lower()


### PR DESCRIPTION
## Summary
Enforces CodeSandbox execution timeouts on Windows by replacing the no-op else branch with a ThreadPoolExecutor-based timeout mechanism.

## Linked Issue
Fixes #456

## Details
- Keeps the existing SIGALRM implementation on Unix
- On Windows, executes sandboxed code using `concurrent.futures.ThreadPoolExecutor` with configurable timeout
- On timeout, raises `TimeoutError` and ensures the result reports failure instead of success
- Applies to both `execute()` and `execute_expression()` methods

## Testing
- Added tests in `core/tests/test_code_sandbox.py`
- Verified on Windows that long-running code now times out as expected
- All 6 tests pass