### PR TITLE
chore(issues): mark LLM dependency issue as resolved

### DIFF
--- a/issues/remove-llm-dependency-from-mcp-server.md
+++ b/issues/remove-llm-dependency-from-mcp-server.md
@@ -1,11 +1,24 @@
 # Issue: Remove LLM Dependency from Agent Builder MCP Server
 
+> [!NOTE]
+> **STATUS: RESOLVED** ✅
+>
+> This issue has been fixed. The `generate_constraint_tests` and `generate_success_tests` functions
+> no longer use an internal LLM call. They now return templates and guidelines for the calling agent
+> to write tests directly using the Write tool.
+>
+> **Resolution details:**
+> - Removed hardcoded `AnthropicProvider` imports and instantiation
+> - Functions now return structured JSON with test templates and guidelines
+> - The calling agent (Claude) is responsible for writing tests, not the MCP server
+> - This aligns with MCP's role as a protocol, not an LLM wrapper
+
 ## Summary
 
-The `agent_builder_server.py` MCP server has a hardcoded dependency on `AnthropicProvider` for test generation, which:
-1. Breaks when users don't have an Anthropic API key
-2. Is redundant since the calling agent (Claude) can write tests directly
-3. Violates the principle that MCP servers should be provider-agnostic utilities
+The `agent_builder_server.py` MCP server ~~has~~ **had** a hardcoded dependency on `AnthropicProvider` for test generation, which:
+1. ~~Breaks~~ Broke when users don't have an Anthropic API key
+2. ~~Is~~ Was redundant since the calling agent (Claude) can write tests directly
+3. ~~Violates~~ Violated the principle that MCP servers should be provider-agnostic utilities
 
 ## Affected Code
 


### PR DESCRIPTION
📝 Description
Updates the issue tracking document to reflect that the LLM dependency issue has been resolved in the current codebase.
## 🔧 Changes Made
- Added "RESOLVED" status banner to issues/remove-llm-dependency-from-mcp-server.md
- Updated summary to past tense
- Documented resolution: functions now return templates instead of using LLM
✅ Verification
- Searched codebase: no AnthropicProvider references in agent_builder_server.py
- Confirmed generate_constraint_tests and generate_success_tests return templates
- Verified docstrings document the new behavior
📊 Impact
- Cleans up issue tracker
- Prevents duplicate work on already-fixed issues
- Documents the architectural decision