### PR TITLE
Fix Unicode encoding errors on Windows when saving decision summaries

### DIFF
--- a/core/framework/storage/backend.py
+++ b/core/framework/storage/backend.py
@@ -52,13 +52,13 @@ class FileStorage:
         """Save a run to storage."""
         # Save full run using Pydantic's model_dump_json
         run_path = self.base_path / "runs" / f"{run.id}.json"
-        with open(run_path, "w") as f:
+        with open(run_path, "w", encoding="utf-8") as f:
             f.write(run.model_dump_json(indent=2))
 
         # Save summary
         summary = RunSummary.from_run(run)
         summary_path = self.base_path / "summaries" / f"{run.id}.json"
-        with open(summary_path, "w") as f:
+        with open(summary_path, "w", encoding="utf-8") as f:
             f.write(summary.model_dump_json(indent=2))
 
         # Update indexes


### PR DESCRIPTION
## Problem
19 tests were failing on Windows with `UnicodeEncodeError` when saving decision summaries containing Unicode symbols ✓ (U+2713) and ✗ (U+2717). The issue occurred because Python was attempting to write JSON files using Windows' default CP1252 encoding, which doesn't support these Unicode characters.

## Root Cause  
The `FileStorage.save_run()` method in `core/framework/storage/backend.py` was opening files without specifying encoding, causing Python to default to the system's locale encoding (CP1252 on Windows).

## Solution
Added `encoding="utf-8"` parameter when opening files for writing in both:
- Run data files (`runs/{run_id}.json`)  
- Summary files (`summaries/{run_id}.json`)

## Impact
- ✅ Fixes 19 failing tests on Windows
- ✅ Preserves the visual UX of Unicode symbols (✓/✗) in decision summaries  
- ✅ Maintains cross-platform compatibility (Windows/Linux/macOS)
- ✅ No breaking changes - all existing functionality preserved

## Testing
- All 184 tests now pass on Windows
- Unicode symbols display correctly in decision summaries
- JSON files are properly saved and can be read back without issues

## Files Changed
- `core/framework/storage/backend.py` - Added UTF-8 encoding specification