### PR TITLE
docs(env): improve Windows WSL and Python 3.12 setup instructions

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -150,6 +150,37 @@ claude> /testing-agent
 
 Creates comprehensive test suites for your agent.
 
+## Windows (WSL) Setup Notes
+
+If you are using Windows, it is strongly recommended to set up the project using WSL (Windows Subsystem for Linux) with an Ubuntu distribution.
+
+The setup-python.sh script is designed for Linux/macOS environments and may fail when run directly in Git Bash or PowerShell.
+
+Recommended setup for Windows users
+
+Install WSL and Ubuntu
+https://learn.microsoft.com/windows/wsl/install
+
+Clone the repository inside the WSL home directory (not under /mnt/c):
+
+cd ~
+git clone https://github.com/YOUR_USERNAME/hive.git
+cd hive
+
+
+Create and activate a Python virtual environment (required for Python 3.12 due to PEP 668):
+
+python3 -m venv .venv
+source .venv/bin/activate
+
+
+Run the setup script:
+
+./scripts/setup-python.sh
+
+
+Note: Running the project from /mnt/c may cause permission and script execution issues. Working inside the WSL filesystem (~) is recommended.
+
 ## Troubleshooting
 
 ### "ModuleNotFoundError: No module named 'framework'"


### PR DESCRIPTION
This PR improves onboarding documentation for Windows users.

Changes:
- Added a Windows (WSL) setup section to ENVIRONMENT_SETUP.md
- Clarifies that setup-python.sh is intended for Linux/macOS
- Documents the need to use WSL filesystem instead of /mnt/c
- Explains Python 3.12 virtual environment requirement (PEP 668)

Related issue: #461
