### PR TITLE
Fix Anthropic credential spec required flags

### DIFF
--- a/tools/src/aden_tools/credentials/llm.py
+++ b/tools/src/aden_tools/credentials/llm.py
@@ -7,14 +7,15 @@ from .base import CredentialSpec
 
 LLM_CREDENTIALS = {
     "anthropic": CredentialSpec(
-        env_var="ANTHROPIC_API_KEY",
-        tools=[],
-        node_types=["llm_generate", "llm_tool_use"],
-        required=False,  # Not required - agents can use other providers via LiteLLM
-        startup_required=False,  # MCP server doesn't need LLM credentials
-        help_url="https://console.anthropic.com/settings/keys",
-        description="API key for Anthropic Claude models",
-    ),
+    env_var="ANTHROPIC_API_KEY",
+    tools=[],
+    node_types=["llm_generate", "llm_tool_use"],
+    required=True,
+    startup_required=True,
+    help_url="https://console.anthropic.com/settings/keys",
+    description="API key for Anthropic Claude models",
+),
+
     # Future LLM providers:
     # "openai": CredentialSpec(
     #     env_var="OPENAI_API_KEY",


### PR DESCRIPTION
## Fix Anthropic Credential Spec Validation

This PR aligns the Anthropic credential specification with the expected startup and node validation behavior.

## What Changed

Updated the anthropic entry in CREDENTIAL_SPECS to be marked as:

required=True

startup_required=True

## Why

Current tests expect Anthropic credentials to be mandatory for:

llm_generate

llm_tool_use

startup validation

But the spec was recently set as optional, causing credential validation tests to fail.

## Result

CredentialManager correctly reports missing ANTHROPIC_API_KEY

Startup validation raises errors when credentials are absent

All tools/tests/test_credentials.py cases pass again

Test Coverage

Ran:

pytest tools/tests/test_credentials.py -v


## All tests passing.