### PR TITLE
fix: remove duplicate web_search tool registration

### DIFF
--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -49,9 +49,8 @@ def register_all_tools(
     Returns:
         List of registered tool names
     """
-    # Tools that don't need credentials
+    # Tools that don't need external API credentials
     register_example(mcp)
-    register_web_search(mcp)
     register_web_scrape(mcp)
     register_pdf_read(mcp)
 


### PR DESCRIPTION
## Description

Fixed duplicate registration of web_search tool in register_all_tools(). The tool was being registered twice: once without credentials and once with credentials, causing duplicate tool definitions in the MCP server.

## Type of Change

- [ x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

N/A - Found during code review

## Changes Made

Removed duplicate register_web_search(mcp) call on line 54
Kept the correct registration register_web_search(mcp, credentials=credentials) that properly passes credentials
Updated comment to clarify which tools don't need external API credentials

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ x ] Lint passes (`cd core && ruff check .`)
- [ x ] Manual testing performed

## Checklist

- [ x ] My code follows the project's style guidelines
- [ x ] I have performed a self-review of my code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A - No UI changes
