### PR TITLE
fix(tools): validate Content-Type in web_scrape tool (Closes #487)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - N/A
 
+
 ### Fixed
-- N/A
+- tools: Fixed web_scrape tool attempting to parse non-HTML content (PDF, JSON) as HTML (#487)
 
 ### Security
 - N/A

--- a/tools/src/aden_tools/tools/web_scrape_tool/web_scrape_tool.py
+++ b/tools/src/aden_tools/tools/web_scrape_tool/web_scrape_tool.py
@@ -152,6 +152,17 @@ def register_tools(mcp: FastMCP) -> None:
             if response.status_code != 200:
                 return {"error": f"HTTP {response.status_code}: Failed to fetch URL"}
 
+            # --- START FIX: Validate Content-Type ---
+            # Added validation to prevent parsing non-HTML content (like JSON, PDF, Images)
+            content_type = response.headers.get("content-type", "").lower()
+            if not any(t in content_type for t in ["text/html", "application/xhtml+xml"]):
+                return {
+                    "error": f"Skipping non-HTML content (Content-Type: {content_type})",
+                    "url": url,
+                    "skipped": True
+                }
+            # --- END FIX ---
+
             # Parse HTML
             soup = BeautifulSoup(response.text, "html.parser")
 

--- a/tools/tests/tools/test_web_scrape_tool.py
+++ b/tools/tests/tools/test_web_scrape_tool.py
@@ -50,3 +50,12 @@ class TestWebScrapeTool:
         """selector parameter is accepted."""
         result = web_scrape_fn(url="https://example.com", selector=".content")
         assert isinstance(result, dict)
+
+    def test_non_html_content_rejected(self, web_scrape_fn):
+        """Ensure non-HTML content types (like JSON) are rejected."""
+        # GitHub's Zen API returns text/plain, not html
+        result = web_scrape_fn(url="https://api.github.com/zen")
+        
+        # We expect an error about skipping non-HTML
+        assert "error" in result
+        assert "Skipping non-HTML content" in result["error"]


### PR DESCRIPTION
**Description**
Added validation for the `Content-Type` header to prevent the scraper from attempting to parse non-HTML content (like JSON, PDF, or Images) with BeautifulSoup.

**Fixes**
Closes #487

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**
- [x] My code follows the code style of this project
- [x] I have added tests (verified locally)