### PR TITLE
docs(setup): add Windows/WSL and Python 3.12+ setup guidance

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -2,6 +2,47 @@
 
 Complete setup guide for building and running goal-driven agents with the Aden Agent Framework.
 
+## Platform-Specific Notes
+
+### Windows Users
+
+The setup scripts are bash-based and require **WSL (Windows Subsystem for Linux)**.
+
+1. **Install WSL** (if not already installed):
+   ```powershell
+   wsl --install
+   ```
+
+2. **Clone to a native Linux path** (important!):
+   ```bash
+   # Correct - clone inside WSL's native filesystem
+   cd ~
+   git clone https://github.com/adenhq/hive.git
+   cd hive
+   
+   # Avoid - do NOT clone to /mnt/c/ (Windows mount)
+   # This causes permission and script execution issues
+   ```
+
+3. Continue with the Quick Setup below.
+
+### Python 3.12+ on Ubuntu/Debian (PEP 668)
+
+Python 3.12+ on Ubuntu/Debian uses "externally managed" environments (PEP 668), which blocks global pip installs. **You must use a virtual environment**:
+
+```bash
+# Create a virtual environment
+python3 -m venv .venv
+
+# Activate it (required before running setup)
+source .venv/bin/activate
+
+# Now run the setup script
+./scripts/setup-python.sh
+```
+
+> **Note:** Always activate the virtual environment (`source .venv/bin/activate`) before working with the project.
+
 ## Quick Setup
 
 ```bash
@@ -20,6 +61,14 @@ This will:
 ## Manual Setup (Alternative)
 
 If you prefer to set up manually or the script fails:
+
+### 0. Create Virtual Environment (Python 3.12+ / Ubuntu)
+
+```bash
+# Required for Python 3.12+ on Ubuntu/Debian
+python3 -m venv .venv
+source .venv/bin/activate
+```
 
 ### 1. Install Core Framework
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 
 - [Python 3.11+](https://www.python.org/downloads/) for agent development
 - [Docker](https://docs.docker.com/get-docker/) (v20.10+) - Optional, for containerized tools
+- **Windows users:** [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) is required (setup scripts are bash-based)
 
 ### Installation
 
@@ -75,9 +76,14 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 git clone https://github.com/adenhq/hive.git
 cd hive
 
+# Python 3.12+ on Ubuntu/Debian: create a virtual environment first
+python3 -m venv .venv && source .venv/bin/activate
+
 # Run Python environment setup
 ./scripts/setup-python.sh
 ```
+
+> **Windows/WSL users:** Clone to a native Linux path (e.g., `~/hive`), not `/mnt/c/...`. See [ENVIRONMENT_SETUP.md](ENVIRONMENT_SETUP.md) for details.
 
 This installs:
 - **framework** - Core agent runtime and graph executor

--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -70,6 +70,33 @@ fi
 echo -e "${GREEN}✓${NC} pip detected"
 echo ""
 
+# Check if running in a virtual environment (required for Python 3.12+ on Ubuntu/Debian)
+IN_VENV=$($PYTHON_CMD -c 'import sys; print(1 if (hasattr(sys, "real_prefix") or (hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix)) else 0)')
+
+if [ "$IN_VENV" = "0" ]; then
+    # Check if we're on a system with externally managed Python (PEP 668)
+    if [ -f "/usr/lib/python${PYTHON_VERSION}/EXTERNALLY-MANAGED" ] || [ -f "/usr/lib/python3/EXTERNALLY-MANAGED" ]; then
+        echo -e "${RED}Error: Python is externally managed (PEP 668) and no virtual environment is active.${NC}"
+        echo ""
+        echo "On Python 3.12+ with Ubuntu/Debian, you must use a virtual environment."
+        echo ""
+        echo "To fix this, run:"
+        echo -e "  ${BLUE}python3 -m venv .venv${NC}"
+        echo -e "  ${BLUE}source .venv/bin/activate${NC}"
+        echo -e "  ${BLUE}./scripts/setup-python.sh${NC}"
+        echo ""
+        exit 1
+    else
+        echo -e "${YELLOW}Warning: Not running in a virtual environment.${NC}"
+        echo -e "${YELLOW}Consider using a virtual environment for isolation:${NC}"
+        echo -e "${YELLOW}  python3 -m venv .venv && source .venv/bin/activate${NC}"
+        echo ""
+    fi
+else
+    echo -e "${GREEN}✓${NC} Virtual environment detected"
+    echo ""
+fi
+
 # Upgrade pip, setuptools, and wheel
 echo "Upgrading pip, setuptools, and wheel..."
 if ! $PYTHON_CMD -m pip install --upgrade pip setuptools wheel; then


### PR DESCRIPTION
## Summary

Addresses onboarding issues for Windows users and Python 3.12+ environments (PEP 668).

## Problem

While setting up Hive on Windows, new contributors may encounter:
- `setup-python.sh` doesn't work on Windows without WSL
- Cloning to `/mnt/c/` in WSL causes permission/execution issues
- Python 3.12+ on Ubuntu/Debian blocks global pip installs (PEP 668)
- Setup script fails without a virtual environment on modern Python

## Changes

### Documentation
- **ENVIRONMENT_SETUP.md**: Added "Platform-Specific Notes" section covering:
  - Windows/WSL requirements and proper clone location
  - Python 3.12+ virtual environment requirement
  - Step-by-step venv creation instructions
- **README.md**: Added WSL prerequisite note and venv step in Quick Start

### Script Improvements  
- **scripts/setup-python.sh**: Added virtual environment detection
  - Detects PEP 668 (`EXTERNALLY-MANAGED`) and fails with clear instructions
  - Shows warning on other systems when venv is not active

## Testing

Verified on Ubuntu 24.04 (WSL) with Python 3.12:
- Without venv: Script correctly fails with helpful error message
- With venv: Setup completes successfully

## Checklist

- [x] Documentation updated
- [x] Tested on target platform (Windows/WSL + Python 3.12)
- [x] Follows commit conventions