### PR TITLE
docs: add setup instructions for copying .env.example to .env

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -72,6 +72,14 @@ For running agents with real LLMs:
 export ANTHROPIC_API_KEY="your-key-here"
 ```
 
+Some MCP tools read credentials from `tools/.env`. Create it from the template and add your keys:
+
+```bash
+cp tools/.env.example tools/.env
+```
+
+Then open `tools/.env` and set values like `ANTHROPIC_API_KEY` and `BRAVE_SEARCH_API_KEY`.
+
 ## Running Agents
 
 All agent commands must be run from the project root with `PYTHONPATH` set:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ cd hive
 
 # Run Python environment setup
 ./scripts/setup-python.sh
+
+# Copy tool environment template
+cp tools/.env.example tools/.env
+
+# Edit tools/.env with your API keys
 ```
 
 This installs:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -137,6 +137,12 @@ export OPENAI_API_KEY="your-key-here"        # Optional
 export BRAVE_SEARCH_API_KEY="your-key-here"  # Optional, for web search
 ```
 
+Some MCP tools read from `tools/.env`. Create it from the template and add your keys:
+
+```bash
+cp tools/.env.example tools/.env
+```
+
 Get your API keys:
 - **Anthropic**: [console.anthropic.com](https://console.anthropic.com/)
 - **OpenAI**: [platform.openai.com](https://platform.openai.com/)


### PR DESCRIPTION
## Summary

Add clear instructions for new contributors to copy `tools/.env.example` to `tools/.env` and configure their API keys.

## Problem

New contributors get frustrated when trying to set up the project because the documentation doesn't mention copying `tools/.env.example` to `tools/.env`. This leads to cryptic errors when running tools that require environment variables like `ANTHROPIC_API_KEY` and `BRAVE_SEARCH_API_KEY`.

## Solution

Added setup instructions in:
- **README.md** - Quick Start section
- **ENVIRONMENT_SETUP.md** - API Keys section  
- **docs/getting-started.md** - API Keys Setup section

The instructions guide users to:
1. Copy `tools/.env.example` to `tools/.env`
2. Edit the `.env` file with their actual API keys

## Testing

Documentation-only changes. Verified that:
- `tools/.env.example` exists with the referenced keys
- Instructions follow existing documentation style

Fixes #520