### PR TITLE
fix: implement explicit tool failure protocol #169

### DIFF
--- a/core/framework/runner/tool_registry.py
+++ b/core/framework/runner/tool_registry.py
@@ -303,8 +303,11 @@ class ToolRegistry:
                             return result
                         except Exception as e:
                             logger.error(f"MCP tool '{tool_name}' execution failed: {e}")
-                            return {"error": str(e)}
-
+                            return(
+                                  f"TOOL_EXECUTION_FAILURE: The tool '{tool_name}' failed to run.\n"
+                                  f"Error: {str(e)}\n"
+                                  "Check your arguments and try again."
+                                  )
                     return executor
 
                 self.register(


### PR DESCRIPTION
## Description

The problem was that when a tool crashed, it returned a dictionary like `{"error": "..."}`. The LLM often ignored this and kept hallucinating that the tool worked.I updated `tool_registry.py` to return a clear text error  instead:`TOOL_EXECUTION_FAILURE: Tool 'name' failed. Error: ...`
Now the Agent explicitly sees that it failed and can try to fix its arguments.
## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)


## Related Issues

Fixes #169 

## Changes Made

- Modified `tool_registry.py` to catch exceptions in `register_mcp_server`.
- Replaced generic dictionary return with an explicit `TOOL_EXECUTION_FAILURE` string.
- Added instructional text to guide the LLM to check its arguments.



## Testing

Describe the tests you ran to verify your changes:

- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
