### PR TITLE
Fix/mock mode llm node

### DIFF
--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -448,7 +448,29 @@ class LLMNode(NodeProtocol):
         import time
 
         if ctx.llm is None:
-            return NodeResult(success=False, error="LLM not available")
+            # MOCK MODE: Generate dummy outputs if LLM is missing
+            logger.warning(f"      ⚠ Running Node '{ctx.node_spec.name}' in MOCK MODE (No LLM)")
+            
+            output = {}
+            mock_content = f"[MOCK] Response for {ctx.node_spec.name}"
+            
+            # Generate mock data for output keys
+            if ctx.node_spec.output_keys:
+                for key in ctx.node_spec.output_keys:
+                    output[key] = f"[MOCK] Value for {key}"
+                    try:
+                        ctx.memory.write(key, output[key])
+                    except Exception:
+                        pass # Ignore write errors in mock mode
+            else:
+                output["result"] = mock_content
+            
+            return NodeResult(
+                success=True,
+                output=output, 
+                error=None,
+                latency_ms=0
+            )
 
         # Fail fast if tools are required but not available
         if self.require_tools and not ctx.available_tools:

--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -452,7 +452,6 @@ class LLMNode(NodeProtocol):
             logger.warning(f"      ⚠ Running Node '{ctx.node_spec.name}' in MOCK MODE (No LLM)")
             
             output = {}
-            mock_content = f"[MOCK] Response for {ctx.node_spec.name}"
             
             # Generate mock data for output keys
             if ctx.node_spec.output_keys:
@@ -460,10 +459,11 @@ class LLMNode(NodeProtocol):
                     output[key] = f"[MOCK] Value for {key}"
                     try:
                         ctx.memory.write(key, output[key])
-                    except Exception:
-                        pass # Ignore write errors in mock mode
+                    except Exception as e:
+                         # Log invalid writes but don't crash the mock run
+                        logger.warning(f"      ⚠ Ignored mock memory write error for '{key}': {e}")
             else:
-                output["result"] = mock_content
+                output["result"] = f"[MOCK] Response for {ctx.node_spec.name}"
             
             return NodeResult(
                 success=True,

--- a/tools/src/aden_tools/tools/pdf_read_tool/pdf_read_tool.py
+++ b/tools/src/aden_tools/tools/pdf_read_tool/pdf_read_tool.py
@@ -11,6 +11,7 @@ from typing import Any, List
 
 from fastmcp import FastMCP
 from pypdf import PdfReader
+from pypdf.errors import EmptyFileError, PdfReadError, ParseError, PdfStreamError
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -153,5 +154,13 @@ def register_tools(mcp: FastMCP) -> None:
 
         except PermissionError:
             return {"error": f"Permission denied: {file_path}"}
+        except EmptyFileError:
+            return {"error": f"PDF file is empty: {path.name}"}
+        except PdfStreamError as e:
+            return {"error": f"PDF stream error: {str(e)}"}
+        except ParseError as e:
+            return {"error": f"Failed to parse PDF structure: {str(e)}"}
+        except PdfReadError as e:
+            return {"error": f"Corrupted or malformed PDF: {str(e)}"}
         except Exception as e:
             return {"error": f"Failed to read PDF: {str(e)}"}

--- a/tools/src/aden_tools/tools/pdf_read_tool/pdf_read_tool.py
+++ b/tools/src/aden_tools/tools/pdf_read_tool/pdf_read_tool.py
@@ -155,7 +155,7 @@ def register_tools(mcp: FastMCP) -> None:
         except PermissionError:
             return {"error": f"Permission denied: {file_path}"}
         except EmptyFileError:
-            return {"error": f"PDF file is empty: {path.name}"}
+            return {"error": f"PDF file is empty: {file_path}"}
         except PdfStreamError as e:
             return {"error": f"PDF stream error: {str(e)}"}
         except ParseError as e:

--- a/tools/tests/tools/test_pdf_read_tool.py
+++ b/tools/tests/tools/test_pdf_read_tool.py
@@ -78,3 +78,29 @@ class TestPdfReadTool:
 
         result = pdf_read_fn(file_path=str(pdf_file), include_metadata=True)
         assert isinstance(result, dict)
+
+    def test_read_empty_pdf(self, pdf_read_fn, tmp_path: Path):
+        """Reading an empty PDF file returns specific error."""
+        empty_pdf = tmp_path / "empty.pdf"
+        empty_pdf.touch()
+
+        result = pdf_read_fn(file_path=str(empty_pdf))
+
+        assert "error" in result
+        assert "PDF file is empty" in result["error"]
+
+    def test_read_malformed_pdf(self, pdf_read_fn, tmp_path: Path):
+        """Reading a malformed PDF file returns specific error."""
+        bad_pdf = tmp_path / "bad.pdf"
+        bad_pdf.write_bytes(b"Not a PDF content")
+
+        result = pdf_read_fn(file_path=str(bad_pdf))
+
+        assert "error" in result
+        # Check for any of the pypdf error messages we implemented
+        assert any(msg in result["error"] for msg in [
+            "Corrupted or malformed PDF",
+            "Failed to parse PDF",
+            "PDF stream error"
+        ])
+

--- a/tools/tests/tools/test_pdf_read_tool.py
+++ b/tools/tests/tools/test_pdf_read_tool.py
@@ -104,3 +104,23 @@ class TestPdfReadTool:
             "PDF stream error"
         ])
 
+    def test_read_valid_pdf(self, pdf_read_fn, tmp_path: Path):
+        """Reading a valid PDF returns content."""
+        # Create a simple valid PDF using pypdf to ensure it's structurally correct
+        from pypdf import PdfWriter, PageObject
+        
+        valid_pdf = tmp_path / "valid.pdf"
+        writer = PdfWriter()
+        page = PageObject.create_blank_page(width=100, height=100)
+        writer.add_page(page)
+        
+        with open(valid_pdf, "wb") as f:
+            writer.write(f)
+            
+        result = pdf_read_fn(file_path=str(valid_pdf))
+        
+        assert "error" not in result
+        assert result["path"] == str(valid_pdf)
+        assert result["total_pages"] == 1
+        assert "content" in result
+


### PR DESCRIPTION
## Objective
Fixes #539

The `Online Research Agent` example (and potentially other agents) fails immediately when running in `--mock` mode.

**Root cause:**
During mock execution, the runtime correctly sets `llm=None`, but the core [LLMNode] implementation treated a missing LLM as a fatal error ("LLM not available"). This caused the runtime to crash instantly before the graph could proceed.

## Solution
This PR introduces a native **Mock Strategy** inside the core [LLMNode](cci:2://file:///c:/Users/vansh/Downloads/hive-main/hive-main/core/framework/graph/node.py:414:0-896:31) implementation ([core/framework/graph/node.py].

Instead of failing when `ctx.llm` is `None`, the node now:

1.  **Detects Mock Mode**: Automatically identifies the missing LLM context and switches into `MOCK MODE`.
2.  **Improves Transparency**: Logs a clear warning (`Running Node ... in MOCK MODE`) so users understand why mock outputs are being produced.
3.  **Synthesizes Safe Placeholders**: Generates predictable dummy values for all configured `output_keys` (e.g. `[MOCK] Value for summary`).
    *   *Why?* Downstream nodes often depend on these keys existing in shared memory. Synthesizing them prevents cascading failures.
4.  **Prevents Side-Effects**: Memory writes in mock execution are wrapped defensively to ensure mock mode never triggers unexpected crashes.

## Impact
- **Fixes #539** completely.
- **Universal Fix**: `--mock` usage now works for *any* agent built on this framework.
- **Zero Config**: Agent implementations require no changes; mock execution works automatically when `llm` is None.