### PR TITLE
Fix: Add MockLLMProvider to enable mock mode execution 

### DIFF
--- a/core/framework/llm/__init__.py
+++ b/core/framework/llm/__init__.py
@@ -15,3 +15,9 @@ try:
     __all__.append("LiteLLMProvider")
 except ImportError:
     pass
+
+try:
+    from framework.llm.mock import MockLLMProvider
+    __all__.append("MockLLMProvider")
+except ImportError:
+    pass

--- a/core/framework/llm/mock.py
+++ b/core/framework/llm/mock.py
@@ -1,0 +1,176 @@
+"""Mock LLM Provider for testing and structural validation without real LLM calls."""
+
+import json
+import re
+from typing import Any
+
+from framework.llm.provider import LLMProvider, LLMResponse, Tool, ToolUse, ToolResult
+
+
+class MockLLMProvider(LLMProvider):
+    """
+    Mock LLM provider for testing agents without making real API calls.
+    
+    This provider generates placeholder responses based on the expected output structure,
+    allowing structural validation and graph execution testing without incurring costs
+    or requiring API keys.
+    
+    Example:
+        llm = MockLLMProvider()
+        response = llm.complete(
+            messages=[{"role": "user", "content": "test"}],
+            system="Generate JSON with keys: name, age",
+            json_mode=True
+        )
+        # Returns: {"name": "mock_value", "age": "mock_value"}
+    """
+    
+    def __init__(self, model: str = "mock-model"):
+        """
+        Initialize the mock LLM provider.
+        
+        Args:
+            model: Model name to report in responses (default: "mock-model")
+        """
+        self.model = model
+    
+    def _extract_output_keys(self, system: str) -> list[str]:
+        """
+        Extract expected output keys from the system prompt.
+        
+        Looks for patterns like:
+        - "output_keys: [key1, key2]"
+        - "keys: key1, key2"
+        - "Generate JSON with keys: key1, key2"
+        
+        Args:
+            system: System prompt text
+            
+        Returns:
+            List of extracted key names
+        """
+        keys = []
+        
+        # Pattern 1: output_keys: [key1, key2]
+        match = re.search(r'output_keys:\s*\[(.*?)\]', system, re.IGNORECASE)
+        if match:
+            keys_str = match.group(1)
+            keys = [k.strip().strip('"\'') for k in keys_str.split(',')]
+            return keys
+        
+        # Pattern 2: "keys: key1, key2" or "Generate JSON with keys: key1, key2"
+        match = re.search(r'(?:keys|with keys):\s*([a-zA-Z0-9_,\s]+)', system, re.IGNORECASE)
+        if match:
+            keys_str = match.group(1)
+            keys = [k.strip() for k in keys_str.split(',') if k.strip()]
+            return keys
+        
+        # Pattern 3: Look for JSON schema in system prompt
+        match = re.search(r'\{[^}]*"([a-zA-Z0-9_]+)":\s*', system)
+        if match:
+            # Found at least one key in a JSON-like structure
+            all_matches = re.findall(r'"([a-zA-Z0-9_]+)":\s*', system)
+            if all_matches:
+                return list(set(all_matches))
+        
+        return keys
+    
+    def _generate_mock_response(
+        self,
+        system: str = "",
+        json_mode: bool = False,
+    ) -> str:
+        """
+        Generate a mock response based on the system prompt and mode.
+        
+        Args:
+            system: System prompt (may contain output key hints)
+            json_mode: If True, generate JSON response
+            
+        Returns:
+            Mock response string
+        """
+        if json_mode:
+            # Try to extract expected keys from system prompt
+            keys = self._extract_output_keys(system)
+            
+            if keys:
+                # Generate JSON with the expected keys
+                mock_data = {key: f"mock_{key}_value" for key in keys}
+                return json.dumps(mock_data, indent=2)
+            else:
+                # Fallback: generic mock response
+                return json.dumps({"result": "mock_result_value"}, indent=2)
+        else:
+            # Plain text mock response
+            return "This is a mock response for testing purposes."
+    
+    def complete(
+        self,
+        messages: list[dict[str, Any]],
+        system: str = "",
+        tools: list[Tool] | None = None,
+        max_tokens: int = 1024,
+        response_format: dict[str, Any] | None = None,
+        json_mode: bool = False,
+    ) -> LLMResponse:
+        """
+        Generate a mock completion without calling a real LLM.
+        
+        Args:
+            messages: Conversation history (ignored in mock mode)
+            system: System prompt (used to extract expected output keys)
+            tools: Available tools (ignored in mock mode)
+            max_tokens: Maximum tokens (ignored in mock mode)
+            response_format: Response format (ignored in mock mode)
+            json_mode: If True, generate JSON response
+            
+        Returns:
+            LLMResponse with mock content
+        """
+        content = self._generate_mock_response(system=system, json_mode=json_mode)
+        
+        return LLMResponse(
+            content=content,
+            model=self.model,
+            input_tokens=0,
+            output_tokens=0,
+            stop_reason="mock_complete",
+        )
+    
+    def complete_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        system: str,
+        tools: list[Tool],
+        tool_executor: callable,
+        max_iterations: int = 10,
+    ) -> LLMResponse:
+        """
+        Generate a mock completion without tool use.
+        
+        In mock mode, we skip tool execution and return a final response immediately.
+        
+        Args:
+            messages: Initial conversation (ignored in mock mode)
+            system: System prompt (used to extract expected output keys)
+            tools: Available tools (ignored in mock mode)
+            tool_executor: Tool executor function (ignored in mock mode)
+            max_iterations: Max iterations (ignored in mock mode)
+            
+        Returns:
+            LLMResponse with mock content
+        """
+        # In mock mode, we don't execute tools - just return a final response
+        # Try to generate JSON if the system prompt suggests structured output
+        json_mode = "json" in system.lower() or "output_keys" in system.lower()
+        
+        content = self._generate_mock_response(system=system, json_mode=json_mode)
+        
+        return LLMResponse(
+            content=content,
+            model=self.model,
+            input_tokens=0,
+            output_tokens=0,
+            stop_reason="mock_complete",
+        )

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -409,9 +409,13 @@ class AgentRunner:
             session_id=session_id,
         )
 
-        # Create LLM provider (if not mock mode and API key available)
+        # Create LLM provider
         # Uses LiteLLM which auto-detects the provider from model name
-        if not self.mock_mode:
+        if self.mock_mode:
+            # Use mock LLM for testing without real API calls
+            from framework.llm.mock import MockLLMProvider
+            self._llm = MockLLMProvider(model=self.model)
+        else:
             # Detect required API key from model name
             api_key_env = self._get_api_key_env_var(self.model)
             if api_key_env and os.environ.get(api_key_env):


### PR DESCRIPTION
## Description

Fixes the mock mode execution bug where agents failed immediately with "LLM not available" error.

## Problem

When running agents with `mock_mode=True`, execution failed because:
- `AgentRunner._setup()` set `llm=None` in mock mode
- `LLMNode.execute()` checked for `None` and returned error immediately
- No mock LLM provider existed to handle mock mode execution

## Solution

Created MockLLMProvider class that:
- Implements the LLMProvider interface
- Generates placeholder JSON responses based on system prompts
- Extracts expected output keys using regex patterns
- Returns zero tokens and minimal latency for fast testing
- Supports both complete() and complete_with_tools() methods

## Changes Made

1. **New File**: core/framework/llm/mock.py
   - Created MockLLMProvider class
   - Implements mock response generation
   - Extracts output keys from system prompts

2. **Modified**: core/framework/runner/runner.py
   - Updated _setup() to use MockLLMProvider when mock_mode=True
   - Changed from setting llm=None to instantiating mock provider

3. **Modified**: core/framework/llm/__init__.py
   - Added MockLLMProvider to module exports

## Testing

Created test script that verifies:
- ✅ Agent loads successfully in mock mode
- ✅ Nodes execute without real LLM calls
- ✅ Mock responses generated correctly
- ✅ Zero tokens used, zero cost
- ✅ Fast execution with minimal latency

## Use Cases

Mock mode is now useful for:
- **Structural validation** - Verify graph connections work
- **CI/CD testing** - Test without API credentials
- **Rapid iteration** - Fast feedback on agent design
- **Cost-free testing** - No LLM API charges

## Breaking Changes

None. This is a bug fix that enables existing mock mode functionality.