### PR TITLE
fix(docs): correct MCP tools count from 19 to 12

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ feat(component): add new feature description
 ## Project Structure
 
 - `core/` - Core framework (agent runtime, graph executor, protocols)
-- `tools/` - MCP Tools Package (19 tools for agent capabilities)
+- `tools/` - MCP Tools Package (12 tools for agent capabilities)
 - `exports/` - Agent packages and examples
 - `docs/` - Documentation
 - `scripts/` - Build and utility scripts

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -23,7 +23,7 @@ Aden Agent Framework is a Python-based system for building goal-driven, self-imp
 | Package       | Directory  | Description                             | Tech Stack   |
 | ------------- | ---------- | --------------------------------------- | ------------ |
 | **framework** | `/core`    | Core runtime, graph executor, protocols | Python 3.11+ |
-| **tools**     | `/tools`   | 19 MCP tools for agent capabilities     | Python 3.11+ |
+| **tools**     | `/tools`   | 12 MCP tools for agent capabilities     | Python 3.11+ |
 | **exports**   | `/exports` | Agent packages and examples             | Python 3.11+ |
 | **skills**    | `.claude`  | Claude Code skills for building/testing | Markdown     |
 
@@ -157,14 +157,14 @@ hive/                                    # Repository root
 │   ├── MCP_INTEGRATION_GUIDE.md         # MCP server integration guide
 │   └── docs/                            # Protocol documentation
 │
-├── tools/                               # TOOLS PACKAGE (19 MCP tools)
+├── tools/                               # TOOLS PACKAGE (12 MCP tools)
 │   ├── src/
 │   │   └── aden_tools/
 │   │       ├── tools/                   # Individual tool implementations
 │   │       │   ├── web_search_tool/
 │   │       │   ├── web_scrape_tool/
 │   │       │   ├── file_system_toolkits/
-│   │       │   └── ...                  # 19 tools total
+│   │       │   └── ...                  # 12 tools total
 │   │       ├── mcp_server.py            # HTTP MCP server
 │   │       └── __init__.py
 │   ├── pyproject.toml                   # Package metadata

--- a/README.es.md
+++ b/README.es.md
@@ -30,7 +30,7 @@
   <img src="https://img.shields.io/badge/OpenAI-supported-412991?style=flat-square&logo=openai" alt="OpenAI" />
   <img src="https://img.shields.io/badge/Anthropic-supported-d4a574?style=flat-square" alt="Anthropic" />
   <img src="https://img.shields.io/badge/Google_Gemini-supported-4285F4?style=flat-square&logo=google" alt="Gemini" />
-  <img src="https://img.shields.io/badge/MCP-19_Tools-00ADD8?style=flat-square" alt="MCP" />
+  <img src="https://img.shields.io/badge/MCP-12_Tools-00ADD8?style=flat-square" alt="MCP" />
 </p>
 
 ## Descripción General
@@ -81,7 +81,7 @@ cd hive
 
 Esto instala:
 - **framework** - Runtime del agente principal y ejecutor de grafos
-- **aden_tools** - 19 herramientas MCP para capacidades de agentes
+- **aden_tools** - 12 herramientas MCP para capacidades de agentes
 - Todas las dependencias requeridas
 
 ### Construye Tu Primer Agente
@@ -210,7 +210,7 @@ Elige otros frameworks cuando necesites:
 ```
 hive/
 ├── core/                   # Framework principal - Runtime de agentes, ejecutor de grafos, protocolos
-├── tools/                  # Paquete de Herramientas MCP - 19 herramientas para capacidades de agentes
+├── tools/                  # Paquete de Herramientas MCP - 12 herramientas para capacidades de agentes
 ├── exports/                # Paquetes de Agentes - Agentes pre-construidos y ejemplos
 ├── docs/                   # Documentación y guías
 ├── scripts/                # Scripts de construcción y utilidades
@@ -233,7 +233,7 @@ Para construir y ejecutar agentes orientados a objetivos con el framework:
 
 # Esto instala:
 # - paquete framework (runtime principal)
-# - paquete aden_tools (19 herramientas MCP)
+# - paquete aden_tools (12 herramientas MCP)
 # - Todas las dependencias
 
 # Construir nuevos agentes usando habilidades de Claude Code

--- a/README.ja.md
+++ b/README.ja.md
@@ -30,7 +30,7 @@
   <img src="https://img.shields.io/badge/OpenAI-supported-412991?style=flat-square&logo=openai" alt="OpenAI" />
   <img src="https://img.shields.io/badge/Anthropic-supported-d4a574?style=flat-square" alt="Anthropic" />
   <img src="https://img.shields.io/badge/Google_Gemini-supported-4285F4?style=flat-square&logo=google" alt="Gemini" />
-  <img src="https://img.shields.io/badge/MCP-19_Tools-00ADD8?style=flat-square" alt="MCP" />
+  <img src="https://img.shields.io/badge/MCP-12_Tools-00ADD8?style=flat-square" alt="MCP" />
 </p>
 
 ## 概要
@@ -81,7 +81,7 @@ cd hive
 
 これにより以下がインストールされます：
 - **framework** - コアエージェントランタイムとグラフエグゼキュータ
-- **aden_tools** - エージェント機能のための19個のMCPツール
+- **aden_tools** - エージェント機能のための12個のMCPツール
 - すべての必要な依存関係
 
 ### 最初のエージェントを構築
@@ -210,7 +210,7 @@ Adenを選択する場合：
 ```
 hive/
 ├── core/                   # コアフレームワーク - エージェントランタイム、グラフエグゼキュータ、プロトコル
-├── tools/                  # MCPツールパッケージ - エージェント機能のための19個のツール
+├── tools/                  # MCPツールパッケージ - エージェント機能のための12個のツール
 ├── exports/                # エージェントパッケージ - 事前構築されたエージェントと例
 ├── docs/                   # ドキュメントとガイド
 ├── scripts/                # ビルドとユーティリティスクリプト
@@ -233,7 +233,7 @@ hive/
 
 # これにより以下がインストールされます：
 # - frameworkパッケージ（コアランタイム）
-# - aden_toolsパッケージ（19個のMCPツール）
+# - aden_toolsパッケージ（12個のMCPツール）
 # - すべての依存関係
 
 # Claude Codeスキルを使用して新しいエージェントを構築

--- a/README.ko.md
+++ b/README.ko.md
@@ -30,7 +30,7 @@
   <img src="https://img.shields.io/badge/OpenAI-supported-412991?style=flat-square&logo=openai" alt="OpenAI" />
   <img src="https://img.shields.io/badge/Anthropic-supported-d4a574?style=flat-square" alt="Anthropic" />
   <img src="https://img.shields.io/badge/Google_Gemini-supported-4285F4?style=flat-square&logo=google" alt="Gemini" />
-  <img src="https://img.shields.io/badge/MCP-19_Tools-00ADD8?style=flat-square" alt="MCP" />
+  <img src="https://img.shields.io/badge/MCP-12_Tools-00ADD8?style=flat-square" alt="MCP" />
 </p>
 
 ## 개요
@@ -81,7 +81,7 @@ cd hive
 
 다음 요소들이 설치됩니다:
 - **framework** - 핵심 에이전트 런타임 및 그래프 실행기
-- **aden_tools** - 에이전트 기능을 위한 19개의 MCP 도구
+- **aden_tools** - 에이전트 기능을 위한 12개의 MCP 도구
 - 필요한 모든 의존성
 
 ### 첫 번째 에이전트 만들기
@@ -221,7 +221,7 @@ Aden은 에이전트 개발에 대해 근본적으로 다른 접근 방식을 �
 ```
 hive/
 ├── core/                   # 핵심 프레임워크 – 에이전트 런타임, 그래프 실행기, 프로토콜
-├── tools/                  # MCP 도구 패키지 – 에이전트 기능을 위한 19개 도구
+├── tools/                  # MCP 도구 패키지 – 에이전트 기능을 위한 12개 도구
 ├── exports/                # 에이전트 패키지 – 사전 제작된 에이전트 및 예제
 ├── docs/                   # 문서 및 가이드
 ├── scripts/                # 빌드 및 유틸리티 스크립트
@@ -244,7 +244,7 @@ hive/
 
 # 다음 항목들이 설치됨:
 # - framework 패키지 (핵심 런타임)
-# - aden_tools 패키지 (19개의 MCP 도구)
+# - aden_tools 패키지 (12개의 MCP 도구)
 # - 모든 의존성
 
 # Claude Code 스킬을 사용해 새 에이전트 생성
@@ -364,7 +364,7 @@ Aden은 기본적으로 Docker Compose 배포를 지원하며, 프로덕션 및 
 
 **Q: Aden은 어떤 모니터링 및 디버깅 도구를 제공하나요?**
 
-Aden은 다음과 같은 포괄적인 관측성 기능을 제공합니다. 실시간 에이전트 실행 모니터링을 위한 WebSocket 스트리밍, TimescaleDB 기반의 비용 및 성능 메트릭 분석, Kubernetes 연동을 위한 헬스 체크 엔드포인트, 예산 관리, 에이전트 상태, 정책 제어를 위한 19개의 MCP 도구
+Aden은 다음과 같은 포괄적인 관측성 기능을 제공합니다. 실시간 에이전트 실행 모니터링을 위한 WebSocket 스트리밍, TimescaleDB 기반의 비용 및 성능 메트릭 분석, Kubernetes 연동을 위한 헬스 체크 엔드포인트, 예산 관리, 에이전트 상태, 정책 제어를 위한 12개의 MCP 도구
 
 **Q: Aden은 어떤 프로그래밍 언어를 지원하나요?**
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
   <img src="https://img.shields.io/badge/OpenAI-supported-412991?style=flat-square&logo=openai" alt="OpenAI" />
   <img src="https://img.shields.io/badge/Anthropic-supported-d4a574?style=flat-square" alt="Anthropic" />
   <img src="https://img.shields.io/badge/Google_Gemini-supported-4285F4?style=flat-square&logo=google" alt="Gemini" />
-  <img src="https://img.shields.io/badge/MCP-19_Tools-00ADD8?style=flat-square" alt="MCP" />
+  <img src="https://img.shields.io/badge/MCP-12_Tools-00ADD8?style=flat-square" alt="MCP" />
 </p>
 
 ## Overview
@@ -81,7 +81,7 @@ cd hive
 
 This installs:
 - **framework** - Core agent runtime and graph executor
-- **aden_tools** - 19 MCP tools for agent capabilities
+- **aden_tools** - 12 MCP tools for agent capabilities
 - All required dependencies
 
 ### Build Your First Agent
@@ -221,7 +221,7 @@ Choose other frameworks when you need:
 ```
 hive/
 ├── core/                   # Core framework - Agent runtime, graph executor, protocols
-├── tools/                  # MCP Tools Package - 19 tools for agent capabilities
+├── tools/                  # MCP Tools Package - 12 tools for agent capabilities
 ├── exports/                # Agent packages - Pre-built agents and examples
 ├── docs/                   # Documentation and guides
 ├── scripts/                # Build and utility scripts
@@ -244,7 +244,7 @@ For building and running goal-driven agents with the framework:
 
 # This installs:
 # - framework package (core runtime)
-# - aden_tools package (19 MCP tools)
+# - aden_tools package (12 MCP tools)
 # - All dependencies
 
 # Build new agents using Claude Code skills
@@ -363,7 +363,7 @@ Yes, Aden fully supports human-in-the-loop workflows through intervention nodes 
 
 **Q: What monitoring and debugging tools does Aden provide?**
 
-Aden includes comprehensive observability features: real-time WebSocket streaming for live agent execution monitoring, TimescaleDB-powered analytics for cost and performance metrics, health check endpoints for Kubernetes integration, and 19 MCP tools for budget management, agent status, and policy control.
+Aden includes comprehensive observability features: real-time WebSocket streaming for live agent execution monitoring, TimescaleDB-powered analytics for cost and performance metrics, health check endpoints for Kubernetes integration, and 12 MCP tools for budget management, agent status, and policy control.
 
 **Q: What programming languages does Aden support?**
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -30,7 +30,7 @@
   <img src="https://img.shields.io/badge/OpenAI-supported-412991?style=flat-square&logo=openai" alt="OpenAI" />
   <img src="https://img.shields.io/badge/Anthropic-supported-d4a574?style=flat-square" alt="Anthropic" />
   <img src="https://img.shields.io/badge/Google_Gemini-supported-4285F4?style=flat-square&logo=google" alt="Gemini" />
-  <img src="https://img.shields.io/badge/MCP-19_Tools-00ADD8?style=flat-square" alt="MCP" />
+  <img src="https://img.shields.io/badge/MCP-12_Tools-00ADD8?style=flat-square" alt="MCP" />
 </p>
 
 ## Visão Geral
@@ -81,7 +81,7 @@ cd hive
 
 Isto instala:
 - **framework** - Runtime do agente principal e executor de grafos
-- **aden_tools** - 19 ferramentas MCP para capacidades de agentes
+- **aden_tools** - 12 ferramentas MCP para capacidades de agentes
 - Todas as dependências necessárias
 
 ### Construa Seu Primeiro Agente
@@ -210,7 +210,7 @@ Escolha outros frameworks quando você precisar de:
 ```
 hive/
 ├── core/                   # Framework principal - Runtime de agentes, executor de grafos, protocolos
-├── tools/                  # Pacote de Ferramentas MCP - 19 ferramentas para capacidades de agentes
+├── tools/                  # Pacote de Ferramentas MCP - 12 ferramentas para capacidades de agentes
 ├── exports/                # Pacotes de Agentes - Agentes pré-construídos e exemplos
 ├── docs/                   # Documentação e guias
 ├── scripts/                # Scripts de build e utilitários
@@ -233,7 +233,7 @@ Para construir e executar agentes orientados a objetivos com o framework:
 
 # Isto instala:
 # - pacote framework (runtime principal)
-# - pacote aden_tools (19 ferramentas MCP)
+# - pacote aden_tools (12 ferramentas MCP)
 # - Todas as dependências
 
 # Construir novos agentes usando habilidades Claude Code

--- a/README.ru.md
+++ b/README.ru.md
@@ -30,7 +30,7 @@
   <img src="https://img.shields.io/badge/OpenAI-supported-412991?style=flat-square&logo=openai" alt="OpenAI" />
   <img src="https://img.shields.io/badge/Anthropic-supported-d4a574?style=flat-square" alt="Anthropic" />
   <img src="https://img.shields.io/badge/Google_Gemini-supported-4285F4?style=flat-square&logo=google" alt="Gemini" />
-  <img src="https://img.shields.io/badge/MCP-19_Tools-00ADD8?style=flat-square" alt="MCP" />
+  <img src="https://img.shields.io/badge/MCP-12_Tools-00ADD8?style=flat-square" alt="MCP" />
 </p>
 
 ## Обзор
@@ -81,7 +81,7 @@ cd hive
 
 Это установит:
 - **framework** - Основная среда выполнения агентов и исполнитель графов
-- **aden_tools** - 19 инструментов MCP для возможностей агентов
+- **aden_tools** - 12 инструментов MCP для возможностей агентов
 - Все необходимые зависимости
 
 ### Создайте своего первого агента
@@ -210,7 +210,7 @@ Aden использует принципиально иной подход к р
 ```
 hive/
 ├── core/                   # Основной фреймворк - Среда выполнения агентов, исполнитель графов, протоколы
-├── tools/                  # Пакет инструментов MCP - 19 инструментов для возможностей агентов
+├── tools/                  # Пакет инструментов MCP - 12 инструментов для возможностей агентов
 ├── exports/                # Пакеты агентов - Предварительно созданные агенты и примеры
 ├── docs/                   # Документация и руководства
 ├── scripts/                # Скрипты сборки и утилиты
@@ -233,7 +233,7 @@ hive/
 
 # Это установит:
 # - пакет framework (основная среда выполнения)
-# - пакет aden_tools (19 инструментов MCP)
+# - пакет aden_tools (12 инструментов MCP)
 # - Все зависимости
 
 # Создать новых агентов с помощью навыков Claude Code

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,7 +30,7 @@
   <img src="https://img.shields.io/badge/OpenAI-supported-412991?style=flat-square&logo=openai" alt="OpenAI" />
   <img src="https://img.shields.io/badge/Anthropic-supported-d4a574?style=flat-square" alt="Anthropic" />
   <img src="https://img.shields.io/badge/Google_Gemini-supported-4285F4?style=flat-square&logo=google" alt="Gemini" />
-  <img src="https://img.shields.io/badge/MCP-19_Tools-00ADD8?style=flat-square" alt="MCP" />
+  <img src="https://img.shields.io/badge/MCP-12_Tools-00ADD8?style=flat-square" alt="MCP" />
 </p>
 
 ## 概述
@@ -81,7 +81,7 @@ cd hive
 
 这将安装：
 - **framework** - 核心智能体运行时和图执行器
-- **aden_tools** - 19 个 MCP 工具提供智能体能力
+- **aden_tools** - 12 个 MCP 工具提供智能体能力
 - 所有必需的依赖项
 
 ### 构建您的第一个智能体
@@ -210,7 +210,7 @@ Aden 在智能体开发方面采取了根本不同的方法。虽然大多数框
 ```
 hive/
 ├── core/                   # 核心框架 - 智能体运行时、图执行器、协议
-├── tools/                  # MCP 工具包 - 19 个工具提供智能体能力
+├── tools/                  # MCP 工具包 - 12 个工具提供智能体能力
 ├── exports/                # 智能体包 - 预构建的智能体和示例
 ├── docs/                   # 文档和指南
 ├── scripts/                # 构建和实用脚本
@@ -233,7 +233,7 @@ hive/
 
 # 这将安装：
 # - framework 包（核心运行时）
-# - aden_tools 包（19 个 MCP 工具）
+# - aden_tools 包（12 个 MCP 工具）
 # - 所有依赖项
 
 # 使用 Claude Code 技能构建新智能体

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -87,7 +87,7 @@ hive/
 │   └── pyproject.toml      # Package metadata
 │
 ├── tools/                  # MCP Tools Package
-│   └── src/aden_tools/     # 19 tools for agent capabilities
+│   └── src/aden_tools/     # 12 tools for agent capabilities
 │       ├── tools/          # Individual tool implementations
 │       │   ├── web_search_tool/
 │       │   ├── web_scrape_tool/

--- a/docs/quizzes/02-architecture-deep-dive.md
+++ b/docs/quizzes/02-architecture-deep-dive.md
@@ -48,7 +48,7 @@ Explore the backend code and document:
 3. What authentication method is used for API requests?
 
 ### Task 2.2: MCP Tools Deep Dive 🔧
-The MCP server provides 19 tools. Categorize them and answer:
+The MCP server provides 12 tools. Categorize them and answer:
 
 1. List all **Budget tools** (tools with "budget" in the name)
 2. List all **Analytics tools**


### PR DESCRIPTION
## Summary

Fixes #591

The documentation across multiple files claimed there were 19 MCP tools, but the actual codebase only has 12 tools registered in `tools/src/aden_tools/tools/__init__.py`.

## Changes

Updated all references from "19 tools" to "12 tools" in:
- `README.md` (badge + text)
- All translated READMEs (es, ja, ko, pt, ru, zh-CN)
- `DEVELOPER.md`
- `CONTRIBUTING.md`
- `docs/getting-started.md`
- `docs/quizzes/02-architecture-deep-dive.md`

## Actual tools (12 total)

1. example_tool
2. web_search
3. web_scrape
4. pdf_read
5. view_file
6. write_to_file
7. list_dir
8. replace_file_content
9. apply_diff
10. apply_patch
11. grep_search
12. execute_command_tool

## Test plan

- [x] Verified tool count in `tools/src/aden_tools/tools/__init__.py`
- [x] Searched for any remaining "19" references

---
Generated with [Claude Code](https://claude.com/claude-code)