### PR TITLE
fix(llm): correct type annotation from lowercase `callable` to `Callable`

### DIFF
--- a/core/framework/llm/anthropic.py
+++ b/core/framework/llm/anthropic.py
@@ -1,9 +1,9 @@
 """Anthropic Claude LLM provider - backward compatible wrapper around LiteLLM."""
 
 import os
-from typing import Any
+from typing import Any, Callable
 
-from framework.llm.provider import LLMProvider, LLMResponse, Tool
+from framework.llm.provider import LLMProvider, LLMResponse, Tool, ToolUse, ToolResult
 from framework.llm.litellm import LiteLLMProvider
 
 
@@ -85,7 +85,7 @@ class AnthropicProvider(LLMProvider):
         messages: list[dict[str, Any]],
         system: str,
         tools: list[Tool],
-        tool_executor: callable,
+        tool_executor: Callable[[ToolUse], ToolResult],
         max_iterations: int = 10,
     ) -> LLMResponse:
         """Run a tool-use loop until Claude produces a final response (via LiteLLM)."""

--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -8,14 +8,14 @@ See: https://docs.litellm.ai/docs/providers
 """
 
 import json
-from typing import Any
+from typing import Any, Callable
 
 try:
     import litellm
 except ImportError:
     litellm = None
 
-from framework.llm.provider import LLMProvider, LLMResponse, Tool, ToolUse
+from framework.llm.provider import LLMProvider, LLMResponse, Tool, ToolUse, ToolResult
 
 
 class LiteLLMProvider(LLMProvider):
@@ -154,7 +154,7 @@ class LiteLLMProvider(LLMProvider):
         messages: list[dict[str, Any]],
         system: str,
         tools: list[Tool],
-        tool_executor: callable,
+        tool_executor: Callable[[ToolUse], ToolResult],
         max_iterations: int = 10,
     ) -> LLMResponse:
         """Run a tool-use loop until the LLM produces a final response."""

--- a/core/framework/llm/provider.py
+++ b/core/framework/llm/provider.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Callable
 
 
 @dataclass
@@ -86,7 +86,7 @@ class LLMProvider(ABC):
         messages: list[dict[str, Any]],
         system: str,
         tools: list[Tool],
-        tool_executor: callable,
+        tool_executor: Callable[["ToolUse"], "ToolResult"],
         max_iterations: int = 10,
     ) -> LLMResponse:
         """


### PR DESCRIPTION
## Summary

Fixes #599

The `callable` keyword in Python is a builtin function (to check if something is callable), NOT a type annotation. For type hints, we need `Callable` from the `typing` module.

## Changes

Updated all three LLM provider files:
- `core/framework/llm/provider.py`
- `core/framework/llm/anthropic.py`  
- `core/framework/llm/litellm.py`

**Before:**
```python
tool_executor: callable,
```

**After:**
```python
tool_executor: Callable[[ToolUse], ToolResult],
```

This also adds proper type information about the function signature - it takes a `ToolUse` and returns a `ToolResult`.

## Test plan

- [x] Verified with `grep` that no lowercase `callable` type hints remain
- [x] Imports added: `from typing import Callable` and `ToolResult` where needed

---
Generated with [Claude Code](https://claude.com/claude-code)