### PR TITLE
fix(executor): add type validation for session state memory

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -167,10 +167,14 @@ class GraphExecutor:
 
         # Restore session state if provided
         if session_state and "memory" in session_state:
-            # Restore memory from previous session
-            for key, value in session_state["memory"].items():
-                memory.write(key, value)
-            self.logger.info(f"📥 Restored session state with {len(session_state['memory'])} memory keys")
+            memory_data = session_state["memory"]
+            if isinstance(memory_data, dict):
+                # Restore memory from previous session
+                for key, value in memory_data.items():
+                    memory.write(key, value)
+                self.logger.info(f"📥 Restored session state with {len(memory_data)} memory keys")
+            else:
+                self.logger.warning(f"⚠️ Invalid memory data type in session state: {type(memory_data).__name__}, expected dict")
 
         # Write new input data to memory (each key individually)
         if input_data:


### PR DESCRIPTION
## Summary

Fixes #590

The code was directly iterating over `session_state["memory"]` without validating it was actually a dict. If it was `None` or another type, this would raise a `TypeError`.

## Changes

Added `isinstance()` check before iterating:

```python
# Before
for key, value in session_state["memory"].items():  # Could crash if not dict

# After  
memory_data = session_state["memory"]
if isinstance(memory_data, dict):
    for key, value in memory_data.items():
        memory.write(key, value)
else:
    self.logger.warning(f"⚠️ Invalid memory data type: {type(memory_data).__name__}")
```

## Test plan

- [x] Code review of the fix
- [x] Verified warning message includes the actual type name for debugging

---
Generated with [Claude Code](https://claude.com/claude-code)