### PR TITLE
fix(runtime): use safe dictionary access in trigger_and_wait()

### DIFF
--- a/core/framework/runtime/agent_runtime.py
+++ b/core/framework/runtime/agent_runtime.py
@@ -285,7 +285,9 @@ class AgentRuntime:
             ExecutionResult or None if timeout
         """
         exec_id = await self.trigger(entry_point_id, input_data, session_state=session_state)
-        stream = self._streams[entry_point_id]
+        stream = self._streams.get(entry_point_id)
+        if stream is None:
+            raise ValueError(f"Entry point '{entry_point_id}' not found")
         return await stream.wait_for_completion(exec_id, timeout)
 
     async def get_goal_progress(self) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- Replace direct dictionary access `self._streams[entry_point_id]` with `.get()` method
- Add explicit ValueError when stream is not found
- Prevents potential KeyError if entry point is removed between trigger() and accessing _streams

## Test plan
- [x] Syntax verified
- [ ] Existing tests should pass (no behavior change for valid cases)
- [ ] Test with invalid entry_point_id should raise ValueError instead of KeyError

Fixes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)