### PR TITLE
fix(stream): avoid private Semaphore._value attribute access

### DIFF
--- a/core/framework/runtime/execution_stream.py
+++ b/core/framework/runtime/execution_stream.py
@@ -454,6 +454,10 @@ class ExecutionStream:
         for ctx in self._active_executions.values():
             statuses[ctx.status] = statuses.get(ctx.status, 0) + 1
 
+        # Calculate available slots from running count instead of accessing private _value
+        running_count = statuses.get("running", 0)
+        available_slots = self.entry_spec.max_concurrent - running_count
+
         return {
             "stream_id": self.stream_id,
             "entry_point": self.entry_spec.id,
@@ -462,5 +466,5 @@ class ExecutionStream:
             "completed_executions": len(self._execution_results),
             "status_counts": statuses,
             "max_concurrent": self.entry_spec.max_concurrent,
-            "available_slots": self._semaphore._value,
+            "available_slots": available_slots,
         }


### PR DESCRIPTION
## Summary
- Replace access to `self._semaphore._value` with calculation from running execution count
- Private attributes are implementation details that may change between Python versions

## Changes
```python
# Before (fragile)
"available_slots": self._semaphore._value,

# After (robust)
running_count = statuses.get("running", 0)
available_slots = self.entry_spec.max_concurrent - running_count
```

## Test plan
- [x] Syntax verified
- [ ] Existing tests should pass
- [ ] Stats output remains equivalent for normal operation

Fixes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)