### PR TITLE
feat: add content type check for HTML parsing in register_tools

### DIFF
--- a/tools/src/aden_tools/tools/web_scrape_tool/web_scrape_tool.py
+++ b/tools/src/aden_tools/tools/web_scrape_tool/web_scrape_tool.py
@@ -152,6 +152,14 @@ def register_tools(mcp: FastMCP) -> None:
             if response.status_code != 200:
                 return {"error": f"HTTP {response.status_code}: Failed to fetch URL"}
 
+            content_type = response.headers.get("Content-Type", "")
+            if "text/html" not in content_type.lower():
+                return {
+                    "error": "Unsupported Content-Type for HTML parsing",
+                    "content_type": content_type,
+                    "url": str(response.url),
+                }
+
             # Parse HTML
             soup = BeautifulSoup(response.text, "html.parser")
 


### PR DESCRIPTION
## Description
Add a Content-Type guard to the web scraping tool so HTML parsing only runs on text/html responses, returning a controlled error for non-HTML payloads.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #612 

## Changes Made

- Validate Content-Type before running BeautifulSoup
- Return a clear error payload for non-HTML responses.
- Include the response content_type and url in the error details.

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
N/A
