### PR TITLE
Fix: validate Content-Type before HTML parsing

### DIFF
--- a/tools/src/aden_tools/tools/web_scrape_tool/web_scrape_tool.py
+++ b/tools/src/aden_tools/tools/web_scrape_tool/web_scrape_tool.py
@@ -151,6 +151,14 @@ def register_tools(mcp: FastMCP) -> None:
 
             if response.status_code != 200:
                 return {"error": f"HTTP {response.status_code}: Failed to fetch URL"}
+            
+            # Validate Content-Type
+            content_type = response.headers.get("Content-Type", "").lower()
+            if "text/html" not in content_type:
+             return {
+        "error": f"Unsupported Content-Type: {content_type}",
+        "url": str(response.url),
+    }
 
             # Parse HTML
             soup = BeautifulSoup(response.text, "html.parser")


### PR DESCRIPTION
### Summary
This PR fixes an issue where the web scraper attempted to parse non-HTML responses
without validating the Content-Type.

### Changes
- Added Content-Type validation before HTML parsing
- Non-HTML responses are safely skipped or handled

### Related Issue
Closes #<612>

