### PR TITLE
fix(tools): handle absolute paths safely in get_secure_path on Windows

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/security.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/security.py
@@ -13,9 +13,8 @@ def get_secure_path(path: str, workspace_id: str, agent_id: str, session_id: str
     os.makedirs(session_dir, exist_ok=True)
     
     # Resolve absolute path
-    if os.path.isabs(path):
-        # Treat absolute paths as relative to the session root if they start with /
-        rel_path = path.lstrip(os.sep)
+    if os.path.isabs(path) or path.startswith(("/", "\\")):
+        rel_path = path.lstrip("/\\")
         final_path = os.path.abspath(os.path.join(session_dir, rel_path))
     else:
         final_path = os.path.abspath(os.path.join(session_dir, path))


### PR DESCRIPTION
### What this PR does
- Fixes `get_secure_path` to safely handle absolute paths on Windows
- Ensures absolute paths are treated as relative to the session sandbox
- Preserves path traversal protection

### Notes
- Symlink-related tests fail locally on Windows due to OS privilege restrictions (WinError 1314)
- These tests pass on Linux CI where symlinks are supported
