### PR TITLE
fix: add is_running() and is_closed() checks to _run_async() to prevent deadlock

### DIFF
--- a/core/framework/runner/mcp_client.py
+++ b/core/framework/runner/mcp_client.py
@@ -86,10 +86,14 @@ class MCPClient:
         """
         # If we have a persistent loop (for STDIO), use it
         if self._loop is not None:
-            future = asyncio.run_coroutine_threadsafe(coro, self._loop)
-            return future.result()
+            # Check if loop is running AND not closed
+            if self._loop.is_running() and not self._loop.is_closed():
+                future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+                return future.result()
+            # else: fall through to the standard approach below
+            # This handles the case when STDIO loop exists but is stopped/closed
 
-        # Otherwise, use the standard approach
+        # Standard approach: handle both sync and async contexts
         try:
             # Try to get the current event loop
             asyncio.get_running_loop()


### PR DESCRIPTION
## Summary
Fixes #625 - Potential deadlock in `_run_async()` when event loop exists but is not running or is closed.

## Problem

The `_run_async()` method in `MCPClient` only checks if `self._loop is not None` before calling `run_coroutine_threadsafe()`. However, if the loop exists but is not running or is closed, the coroutine gets scheduled but never executes.

**Original code:**

    def _run_async(self, coro):
        if self._loop is not None:
            # BUG: Only checks existence, not state!
            future = asyncio.run_coroutine_threadsafe(coro, self._loop)
            return future.result()  # Waits forever → DEADLOCK

**When this happens:**
- STDIO transport loop crashes
- Loop is stopped externally  
- Loop is closed unexpectedly

Result: `future.result()` waits forever → **deadlock**

## Solution

Added **two safety checks** before using `run_coroutine_threadsafe()`:

    if self._loop is not None:
        if self._loop.is_running() and not self._loop.is_closed():
            future = asyncio.run_coroutine_threadsafe(coro, self._loop)
            return future.result()
        else:
            return asyncio.run(coro)  # Safe fallback

## Edge Cases Covered

| Scenario | Before Fix | After Fix |
|----------|-----------|-----------|
| Loop is `None` | ✅ Works | ✅ Works |
| Loop running normally | ✅ Works | ✅ Works |
| Loop exists but **stopped** | ❌ DEADLOCK | ✅ Falls back to `asyncio.run()` |
| Loop exists but **closed** | ❌ ERROR | ✅ Falls back to `asyncio.run()` |

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related

- Discussion: PR #534 review comments
- Issue: #625