### PR TITLE
fix/windows-unicode-encoding

### DIFF
--- a/core/framework/storage/backend.py
+++ b/core/framework/storage/backend.py
@@ -52,13 +52,13 @@ class FileStorage:
         """Save a run to storage."""
         # Save full run using Pydantic's model_dump_json
         run_path = self.base_path / "runs" / f"{run.id}.json"
-        with open(run_path, "w") as f:
+        with open(run_path, "w", encoding="utf-8") as f:
             f.write(run.model_dump_json(indent=2))
 
         # Save summary
         summary = RunSummary.from_run(run)
         summary_path = self.base_path / "summaries" / f"{run.id}.json"
-        with open(summary_path, "w") as f:
+        with open(summary_path, "w", encoding="utf-8") as f:
             f.write(summary.model_dump_json(indent=2))
 
         # Update indexes
@@ -72,7 +72,7 @@ class FileStorage:
         run_path = self.base_path / "runs" / f"{run_id}.json"
         if not run_path.exists():
             return None
-        with open(run_path) as f:
+        with open(run_path, encoding="utf-8") as f:
             return Run.model_validate_json(f.read())
 
     def load_summary(self, run_id: str) -> RunSummary | None:
@@ -85,7 +85,7 @@ class FileStorage:
                 return RunSummary.from_run(run)
             return None
 
-        with open(summary_path) as f:
+        with open(summary_path, encoding="utf-8") as f:
             return RunSummary.model_validate_json(f.read())
 
     def delete_run(self, run_id: str) -> bool:
@@ -143,7 +143,7 @@ class FileStorage:
         index_path = self.base_path / "indexes" / index_type / f"{key}.json"
         if not index_path.exists():
             return []
-        with open(index_path) as f:
+        with open(index_path, encoding="utf-8") as f:
             return json.load(f)
 
     def _add_to_index(self, index_type: str, key: str, value: str) -> None:
@@ -152,7 +152,7 @@ class FileStorage:
         values = self._get_index(index_type, key)
         if value not in values:
             values.append(value)
-            with open(index_path, "w") as f:
+            with open(index_path, "w", encoding="utf-8") as f:
                 json.dump(values, f)
 
     def _remove_from_index(self, index_type: str, key: str, value: str) -> None:
@@ -161,7 +161,7 @@ class FileStorage:
         values = self._get_index(index_type, key)
         if value in values:
             values.remove(value)
-            with open(index_path, "w") as f:
+            with open(index_path, "w", encoding="utf-8") as f:
                 json.dump(values, f)
 
     # === UTILITY ===

--- a/core/framework/testing/test_storage.py
+++ b/core/framework/testing/test_storage.py
@@ -65,7 +65,7 @@ class TestStorage:
 
         # Save full test
         test_path = goal_dir / f"{test.id}.json"
-        with open(test_path, "w") as f:
+        with open(test_path, "w", encoding="utf-8") as f:
             f.write(test.model_dump_json(indent=2))
 
         # Update indexes
@@ -79,7 +79,7 @@ class TestStorage:
         test_path = self.base_path / "tests" / goal_id / f"{test_id}.json"
         if not test_path.exists():
             return None
-        with open(test_path) as f:
+        with open(test_path, encoding="utf-8") as f:
             return Test.model_validate_json(f.read())
 
     def delete_test(self, goal_id: str, test_id: str) -> bool:
@@ -175,12 +175,12 @@ class TestStorage:
         # Save with timestamp
         timestamp = result.timestamp.strftime("%Y%m%d_%H%M%S")
         result_path = results_dir / f"{timestamp}.json"
-        with open(result_path, "w") as f:
+        with open(result_path, "w", encoding="utf-8") as f:
             f.write(result.model_dump_json(indent=2))
 
         # Update latest
         latest_path = results_dir / "latest.json"
-        with open(latest_path, "w") as f:
+        with open(latest_path, "w", encoding="utf-8") as f:
             f.write(result.model_dump_json(indent=2))
 
     def get_latest_result(self, test_id: str) -> TestResult | None:
@@ -188,7 +188,7 @@ class TestStorage:
         latest_path = self.base_path / "results" / test_id / "latest.json"
         if not latest_path.exists():
             return None
-        with open(latest_path) as f:
+        with open(latest_path, encoding="utf-8") as f:
             return TestResult.model_validate_json(f.read())
 
     def get_result_history(self, test_id: str, limit: int = 10) -> list[TestResult]:
@@ -204,7 +204,7 @@ class TestStorage:
 
         results = []
         for f in result_files:
-            with open(f) as file:
+            with open(f, encoding="utf-8") as file:
                 results.append(TestResult.model_validate_json(file.read()))
 
         return results
@@ -216,7 +216,7 @@ class TestStorage:
         index_path = self.base_path / "indexes" / index_type / f"{key}.json"
         if not index_path.exists():
             return []
-        with open(index_path) as f:
+        with open(index_path, encoding="utf-8") as f:
             return json.load(f)
 
     def _add_to_index(self, index_type: str, key: str, value: str) -> None:
@@ -225,7 +225,7 @@ class TestStorage:
         values = self._get_index(index_type, key)
         if value not in values:
             values.append(value)
-            with open(index_path, "w") as f:
+            with open(index_path, "w", encoding="utf-8") as f:
                 json.dump(values, f)
 
     def _remove_from_index(self, index_type: str, key: str, value: str) -> None:
@@ -234,7 +234,7 @@ class TestStorage:
         values = self._get_index(index_type, key)
         if value in values:
             values.remove(value)
-            with open(index_path, "w") as f:
+            with open(index_path, "w", encoding="utf-8") as f:
                 json.dump(values, f)
 
     # === UTILITY ===


### PR DESCRIPTION
Fixes UnicodeEncodeError on Windows by explicitly specifying UTF-8 encoding in all JSON file operations.

 This matches JSON RFC 7159 standard and ensures cross-platform compatibility.


## Description
Fixed UnicodeEncodeError when writing JSON files containing Unicode characters (✓ ✗ →) on Windows systems by adding explicit UTF-8 encoding to all file operations.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #412

## Files Affected
- backend.py
- test_storage.py

## Changes Made
- Add UTF-8 encoding to file operations for Windows compatibility (#412 )
  - `core/framework/storage/backend.py`
    - `save_run()` (Line 56, 62)
    - `load_run()` (Line 66)
    - `load_summary()` (Line 73)
    - `_get_index()` (Line 127)
    - `_add_to_index()` (Line 142)
    - `_remove_from_index()` (Line 155)
  - `core/framework/testing/test_storage.py`
    - `save_test()` (Line 68)
    - `load_test()` (Line 78)
    - `save_result()` (Line 183, 193)
    - `get_latest_result()` (Line 208)
    - `get_result_history()` (Line 220)
    - `_get_index()` (Line 230)
    - `_add_to_index()` (Line 241)
    - `_remove_from_index()` (Line 253)

## Testing
- [x] Unit tests pass (`cd core && pytest tests/`)
  - Result: 184/184 tests passing 
  
- [x] Lint passes for modified files
  - `core/framework/storage/backend.py`: No issues
  - `core/framework/testing/test_storage.py`: No issues
  
- [x] Manual testing performed
  - Tested on Windows 11
  - Verified UTF-8 encoding works correctly
  - Cross-platform verified (Windows, Linux, macOS)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Changes are minimal and focused (UTF-8 encoding specs only)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally (184/184)
- [x] No breaking changes to API or behavior
- [x] UTF-8 encoding is applied consistently across both files

## Screenshots 
<img width="962" height="921" alt="image" src="https://github.com/user-attachments/assets/31cda010-a144-41ea-9e4a-642f493b949f" />

