### PR TITLE
refactor(runtime): replace print() with logging in docstring examples (#637)

### DIFF
--- a/core/framework/runtime/agent_runtime.py
+++ b/core/framework/runtime/agent_runtime.py
@@ -81,7 +81,7 @@ class AgentRuntime:
 
         # Check goal progress
         progress = await runtime.get_goal_progress()
-        print(f"Progress: {progress['overall_progress']:.1%}")
+        logger.info(f"Progress: {progress['overall_progress']:.1%}")
 
         # Stop runtime
         await runtime.stop()

--- a/core/framework/runtime/event_bus.py
+++ b/core/framework/runtime/event_bus.py
@@ -96,7 +96,7 @@ class EventBus:
 
         # Subscribe to execution events
         async def on_execution_complete(event: AgentEvent):
-            print(f"Execution {event.execution_id} completed")
+            logger.info(f"Execution {event.execution_id} completed")
 
         bus.subscribe(
             event_types=[EventType.EXECUTION_COMPLETED],

--- a/core/framework/runtime/outcome_aggregator.py
+++ b/core/framework/runtime/outcome_aggregator.py
@@ -72,7 +72,7 @@ class OutcomeAggregator:
 
         # Evaluate goal progress
         progress = await aggregator.evaluate_goal_progress()
-        print(f"Goal progress: {progress['overall_progress']:.1%}")
+        logger.info(f"Goal progress: {progress['overall_progress']:.1%}")
     """
 
     def __init__(


### PR DESCRIPTION
## Description
Replace `print()` statements with `logger.info()` in docstring examples for core runtime components.
## Problem
As noted in #637, the docstring examples were using `print()` which:
- Demonstrates poor practices for library usage
- Could be copied by users and cause stdout pollution
## Solution
Changed 3 docstring examples to use `logger.info()` instead:
- `agent_runtime.py` (line 84)
- `event_bus.py` (line 99)  
- `outcome_aggregator.py` (line 75)
## Testing
- ✅ All files compile without syntax errors
- ✅ Verified no `print()` statements remain in runtime/
Fixes #637