### PR TITLE
fix: respect active virtualenv on Windows during python setup

### DIFF
--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -32,10 +32,14 @@ if ! command -v python &> /dev/null && ! command -v python3 &> /dev/null; then
     exit 1
 fi
 
-# Use python3 if available, otherwise python
-PYTHON_CMD="python3"
-if ! command -v python3 &> /dev/null; then
+# Prefer active virtualenv Python if present
+if [ -n "$VIRTUAL_ENV" ]; then
     PYTHON_CMD="python"
+else
+    PYTHON_CMD="python3"
+    if ! command -v python3 &> /dev/null; then
+        PYTHON_CMD="python"
+    fi
 fi
 
 # Check Python version


### PR DESCRIPTION
Fixes #650

### Summary
On Windows (Git Bash), `setup-python.sh` always preferred `python3`, which resolves to system
Python even when a virtualenv is active. This caused setup to fail with
"pip is not installed" errors.

### Changes
- Prefer the active virtualenv's `python` when `VIRTUAL_ENV` is set
- Preserve existing behavior for non-Windows environments

### Result
- Setup succeeds when a venv is active
- Avoids conflicts with multiple Python installations on Windows
