### PR TITLE
Avoid private semaphore access in ExecutionStream.get_stats

### DIFF
--- a/core/framework/runtime/execution_stream.py
+++ b/core/framework/runtime/execution_stream.py
@@ -462,5 +462,8 @@ class ExecutionStream:
             "completed_executions": len(self._execution_results),
             "status_counts": statuses,
             "max_concurrent": self.entry_spec.max_concurrent,
-            "available_slots": self._semaphore._value,
+            "available_slots": max(
+                0,
+                self.entry_spec.max_concurrent - statuses.get("running", 0),
+            ),
         }


### PR DESCRIPTION
## Summary\n- Compute available slots from tracked running count instead of accessing syncio.Semaphore._value\n- Keeps stats aligned with public data and avoids reliance on private internals\n\n## Testing\n- Not run (logic-only change)\n\nCloses #609