### PR TITLE
docs: clarify Windows setup requirements (Git Bash / WSL)

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -2,6 +2,16 @@
 
 Complete setup guide for building and running goal-driven agents with the Aden Agent Framework.
 
+## Windows Setup Notes
+
+The Python setup scripts are written in Bash and are **not compatible with Windows Command Prompt (CMD)**.
+
+Windows users must run setup using one of the following:
+- **Git Bash**
+- **WSL (Windows Subsystem for Linux)**
+
+Running `scripts\setup-python.sh` from CMD will open the file instead of executing it.
+
 ## Quick Setup
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -84,6 +84,23 @@ This installs:
 - **aden_tools** - 19 MCP tools for agent capabilities
 - All required dependencies
 
+
+### Windows Users
+
+The setup scripts (`.sh`) are Bash scripts and **cannot be run from Command Prompt (CMD)**.
+
+On Windows, please use one of the following:
+- **Git Bash** (recommended)
+- **WSL (Windows Subsystem for Linux)**
+
+Example (Git Bash / WSL):
+
+```bash
+git clone https://github.com/adenhq/hive.git
+cd hive
+./scripts/setup-python.sh
+```
+
 ### Build Your First Agent
 
 ```bash


### PR DESCRIPTION
## Description

Adds explicit Windows setup documentation to clarify that the setup scripts are Bash-based and cannot be run from Command Prompt (CMD). This prevents confusion for Windows users following the Quick Start instructions.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #649 

## Changes Made

- Added explicit Windows setup notes to `README.md`
- Added Windows-specific guidance to `ENVIRONMENT_SETUP.md`
- Clarified that Bash scripts cannot be executed from CMD and require Git Bash or WSL

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A
