### PR TITLE
feat(graph): add native Pydantic validation for LLM node outputs

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -499,8 +499,8 @@ chore(deps): update React to 18.2.0
 
 1. Create a feature branch from `main`
 2. Make your changes with clear commits
-3. Run tests locally: `npm run test`
-4. Run linting: `npm run lint`
+3. Run tests locally: `python -m pytest core/tests`
+4. Run linting: `ruff check .`
 5. Push and create a PR
 6. Fill out the PR template
 7. Request review from CODEOWNERS

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -75,7 +75,7 @@ timeline
 - [ ] User-driven log analysis (OSS approach)
 
 ### Data Validation
-- [ ] Natively Support data validation of LLMs output with Pydantic
+- [x] Natively Support data validation of LLMs output with Pydantic
 
 ### Developer Experience
 - [ ] **Debugging mode**

--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -259,10 +259,11 @@ class GraphExecutor:
 
                 if result.success:
                     # Validate output before accepting it
-                    if result.output and node_spec.output_keys:
+                    if result.output and (node_spec.output_keys or hasattr(node_spec, "output_model")):
                         validation = self.validator.validate_all(
                             output=result.output,
                             expected_keys=node_spec.output_keys,
+                            model_class=getattr(node_spec, "output_model", None),
                             check_hallucination=True,
                         )
                         if not validation.success:

--- a/core/tests/test_pydantic_node_validation.py
+++ b/core/tests/test_pydantic_node_validation.py
@@ -1,0 +1,135 @@
+import pytest
+from pydantic import BaseModel, Field
+from framework.graph.node import NodeSpec, LLMNode, NodeContext, SharedMemory, register_model
+from framework.runtime.core import Runtime
+from framework.llm.provider import LLMProvider, LLMResponse
+from unittest.mock import MagicMock
+
+class UserProfile(BaseModel):
+    name: str
+    age: int
+    interests: list[str]
+
+def test_llm_node_pydantic_validation():
+    # 1. Setup mock LLM
+    mock_llm = MagicMock(spec=LLMProvider)
+    # The LLM returns a JSON string that matches the Pydantic model
+    mock_llm.complete.return_value = LLMResponse(
+        content='{"name": "Alice", "age": 30, "interests": ["coding", "hiking"]}',
+        model="test-model"
+    )
+
+    # 2. Setup NodeSpec with Pydantic model
+    # register_model("UserProfile", UserProfile)
+    node_spec = NodeSpec(
+        id="test_node",
+        name="Test Node",
+        description="A test node with Pydantic output",
+        node_type="llm_generate",
+        output_model=UserProfile
+    )
+
+    # 3. Setup Context
+    runtime = MagicMock(spec=Runtime)
+    memory = SharedMemory()
+    ctx = NodeContext(
+        runtime=runtime,
+        node_id="test_node",
+        node_spec=node_spec,
+        memory=memory,
+        llm=mock_llm
+    )
+
+    # 4. Execute node
+    node = LLMNode()
+    import asyncio
+    result = asyncio.run(node.execute(ctx))
+
+    # 5. Verify results
+    assert result.success
+    assert result.output["name"] == "Alice"
+    assert result.output["age"] == 30
+    assert result.output["interests"] == ["coding", "hiking"]
+    
+    # Verify memory was written
+    assert memory.read("name") == "Alice"
+    assert memory.read("age") == 30
+
+def test_llm_node_pydantic_validation_failure():
+    # 1. Setup mock LLM
+    mock_llm = MagicMock(spec=LLMProvider)
+    # The LLM returns a JSON string that DOES NOT match the Pydantic model (age is missing)
+    mock_llm.complete.return_value = LLMResponse(
+        content='{"name": "Alice", "interests": ["coding"]}',
+        model="test-model"
+    )
+
+    # 2. Setup NodeSpec with Pydantic model
+    node_spec = NodeSpec(
+        id="test_node",
+        name="Test Node",
+        description="A test node with Pydantic output",
+        node_type="llm_generate",
+        output_model=UserProfile
+    )
+
+    # 3. Setup Context
+    runtime = MagicMock(spec=Runtime)
+    memory = SharedMemory()
+    ctx = NodeContext(
+        runtime=runtime,
+        node_id="test_node",
+        node_spec=node_spec,
+        memory=memory,
+        llm=mock_llm
+    )
+
+    # 4. Execute node
+    node = LLMNode()
+    import asyncio
+    result = asyncio.run(node.execute(ctx))
+
+    # 5. Verify results
+    assert not result.success
+    assert "Pydantic validation failed" in result.error
+
+def test_llm_node_pydantic_registry():
+    # 1. Register model
+    register_model("UserProfile", UserProfile)
+    
+    # 2. Setup mock LLM
+    mock_llm = MagicMock(spec=LLMProvider)
+    mock_llm.complete.return_value = LLMResponse(
+        content='{"name": "Bob", "age": 25, "interests": ["gaming"]}',
+        model="test-model"
+    )
+
+    # 3. Setup NodeSpec with model NAME
+    node_spec = NodeSpec(
+        id="test_node",
+        name="Test Node",
+        description="A test node with Pydantic output name",
+        node_type="llm_generate",
+        output_model="UserProfile"
+    )
+
+    # 4. Setup Context
+    runtime = MagicMock(spec=Runtime)
+    memory = SharedMemory()
+    ctx = NodeContext(
+        runtime=runtime,
+        node_id="test_node",
+        node_spec=node_spec,
+        memory=memory,
+        llm=mock_llm
+    )
+
+    # 5. Execute node
+    node = LLMNode()
+    import asyncio
+    result = asyncio.run(node.execute(ctx))
+
+    # 6. Verify results
+    assert result.success
+    assert result.output["name"] == "Bob"
+


### PR DESCRIPTION
## Description

This PR implements native Pydantic validation for LLM nodes, fulfilling a key item in the Phase 1 Foundation of the project roadmap. It introduces a first-class way to define structured outputs using Pydantic models, which are automatically injected into LLM prompts and strictly validated upon response.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Refactoring (minor fixes to existing dev commands)

## Related Issues

Fixes #2195

## Changes Made

- **Node Specification**: Enhanced `NodeSpec` with an `output_model` field and implemented a `MODEL_REGISTRY` to allow referencing Pydantic classes by string names (crucial for JSON-defined agents).
- **LLM Prompting**: Updated `LLMNode` to automatically generate JSON schemas from Pydantic models and append them to system prompts, ensuring the LLM understands the required output format.
- **Strict Validation**: Integrated `model_validate` into the `LLMNode` execution flow. The node now performs type conversion and validation, returning an explicit error if the LLM output is malformed.
- **Validation Utility**: Added `validate_pydantic` to the `OutputValidator` and updated `GraphExecutor` to enforce these checks during graph traversal.
- **Developer Experience**: 
    - Updated `DEVELOPER.md` to correct the `npm` testing/linting commands to the actual `pytest` and `ruff` commands used in the core framework.
    - Updated `ROADMAP.md` to mark item #78 as completed.

## Testing

- [x] **Unit tests pass**: Created `core/tests/test_pydantic_node_validation.py` covering success cases, validation failures, and model registry lookups.
- [x] **Verified Command**: `PYTHONPATH=core python -m pytest core/tests/test_pydantic_node_validation.py`
- [x] **Manual testing**: Verified that complex nested models are correctly handled and that validation errors are logged properly in the runtime.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes