### PR TITLE
feat: Add structured error handling with custom exception hierarchy

### DIFF
--- a/core/framework/exceptions.py
+++ b/core/framework/exceptions.py
@@ -1,0 +1,355 @@
+"""
+Hive Framework Exceptions.
+
+A hierarchical exception system for structured error handling across:
+- LLM operations (provider errors, rate limits, API failures)
+- Runner operations (agent loading, tool execution, validation)
+- Orchestrator operations (routing, message relay, capability checks)
+- Graph execution (node failures, edge conditions, execution limits)
+
+All exceptions include:
+- Descriptive messages with context
+- Optional original exception chaining
+- Structured error codes for programmatic handling
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class HiveError(Exception):
+    """
+    Base exception for all Hive framework errors.
+
+    Attributes:
+        message: Human-readable error description
+        error_code: Machine-readable error code for categorization
+        context: Additional context dict for debugging
+        original_error: The underlying exception if this wraps another error
+    """
+
+    def __init__(
+        self,
+        message: str,
+        error_code: str | None = None,
+        context: dict[str, Any] | None = None,
+        original_error: Exception | None = None,
+    ):
+        self.message = message
+        self.error_code = error_code or "HIVE_ERROR"
+        self.context = context or {}
+        self.original_error = original_error
+
+        # Build full message with context
+        full_message = message
+        if context:
+            context_str = ", ".join(f"{k}={v}" for k, v in context.items())
+            full_message = f"{message} [{context_str}]"
+
+        super().__init__(full_message)
+
+        # Chain the original exception if provided
+        if original_error:
+            self.__cause__ = original_error
+
+
+# === LLM Exceptions ===
+
+
+class LLMError(HiveError):
+    """Base exception for LLM provider operations."""
+
+    def __init__(
+        self,
+        message: str,
+        provider: str | None = None,
+        model: str | None = None,
+        **kwargs: Any,
+    ):
+        context = kwargs.pop("context", {})
+        if provider:
+            context["provider"] = provider
+        if model:
+            context["model"] = model
+        super().__init__(message, context=context, **kwargs)
+
+
+class LLMProviderNotAvailableError(LLMError):
+    """Raised when an LLM provider cannot be initialized (missing API key, import failure)."""
+
+    def __init__(self, provider: str, reason: str, **kwargs: Any):
+        super().__init__(
+            f"LLM provider '{provider}' is not available: {reason}",
+            error_code="LLM_PROVIDER_NOT_AVAILABLE",
+            provider=provider,
+            **kwargs,
+        )
+
+
+class LLMAPIError(LLMError):
+    """Raised when an LLM API call fails."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int | None = None,
+        **kwargs: Any,
+    ):
+        context = kwargs.pop("context", {})
+        if status_code:
+            context["status_code"] = status_code
+        super().__init__(
+            message,
+            error_code="LLM_API_ERROR",
+            context=context,
+            **kwargs,
+        )
+
+
+class LLMResponseParseError(LLMError):
+    """Raised when LLM response cannot be parsed (e.g., invalid JSON)."""
+
+    def __init__(self, message: str, response_content: str | None = None, **kwargs: Any):
+        context = kwargs.pop("context", {})
+        if response_content:
+            # Truncate for logging safety
+            context["response_preview"] = response_content[:200]
+        super().__init__(
+            message,
+            error_code="LLM_RESPONSE_PARSE_ERROR",
+            context=context,
+            **kwargs,
+        )
+
+
+# === Runner Exceptions ===
+
+
+class RunnerError(HiveError):
+    """Base exception for agent runner operations."""
+
+    def __init__(self, message: str, agent_name: str | None = None, **kwargs: Any):
+        context = kwargs.pop("context", {})
+        if agent_name:
+            context["agent"] = agent_name
+        super().__init__(message, context=context, **kwargs)
+
+
+class AgentLoadError(RunnerError):
+    """Raised when an agent cannot be loaded from disk."""
+
+    def __init__(self, agent_path: str, reason: str, **kwargs: Any):
+        super().__init__(
+            f"Failed to load agent from '{agent_path}': {reason}",
+            error_code="AGENT_LOAD_ERROR",
+            **kwargs,
+        )
+
+
+class AgentValidationError(RunnerError):
+    """Raised when agent validation fails."""
+
+    def __init__(
+        self,
+        message: str,
+        errors: list[str] | None = None,
+        missing_tools: list[str] | None = None,
+        **kwargs: Any,
+    ):
+        context = kwargs.pop("context", {})
+        if errors:
+            context["errors"] = errors
+        if missing_tools:
+            context["missing_tools"] = missing_tools
+        super().__init__(
+            message,
+            error_code="AGENT_VALIDATION_ERROR",
+            context=context,
+            **kwargs,
+        )
+
+
+class ToolExecutionError(RunnerError):
+    """Raised when a tool execution fails."""
+
+    def __init__(
+        self,
+        tool_name: str,
+        message: str,
+        tool_input: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ):
+        context = kwargs.pop("context", {})
+        context["tool"] = tool_name
+        if tool_input:
+            context["input"] = tool_input
+        super().__init__(
+            f"Tool '{tool_name}' failed: {message}",
+            error_code="TOOL_EXECUTION_ERROR",
+            context=context,
+            **kwargs,
+        )
+
+
+class MCPServerError(RunnerError):
+    """Raised when MCP server registration or communication fails."""
+
+    def __init__(self, server_name: str, message: str, **kwargs: Any):
+        context = kwargs.pop("context", {})
+        context["server"] = server_name
+        super().__init__(
+            f"MCP server '{server_name}' error: {message}",
+            error_code="MCP_SERVER_ERROR",
+            context=context,
+            **kwargs,
+        )
+
+
+# === Orchestrator Exceptions ===
+
+
+class OrchestratorError(HiveError):
+    """Base exception for orchestrator operations."""
+
+    pass
+
+
+class RoutingError(OrchestratorError):
+    """Raised when request routing fails."""
+
+    def __init__(
+        self,
+        message: str,
+        available_agents: list[str] | None = None,
+        **kwargs: Any,
+    ):
+        context = kwargs.pop("context", {})
+        if available_agents:
+            context["available_agents"] = available_agents
+        super().__init__(
+            message,
+            error_code="ROUTING_ERROR",
+            context=context,
+            **kwargs,
+        )
+
+
+class AgentNotFoundError(OrchestratorError):
+    """Raised when a requested agent is not registered."""
+
+    def __init__(self, agent_name: str, **kwargs: Any):
+        super().__init__(
+            f"Agent '{agent_name}' is not registered with the orchestrator",
+            error_code="AGENT_NOT_FOUND",
+            context={"agent": agent_name},
+            **kwargs,
+        )
+
+
+class CapabilityCheckError(OrchestratorError):
+    """Raised when capability checking fails."""
+
+    def __init__(self, agent_name: str, reason: str, **kwargs: Any):
+        super().__init__(
+            f"Capability check failed for '{agent_name}': {reason}",
+            error_code="CAPABILITY_CHECK_ERROR",
+            context={"agent": agent_name},
+            **kwargs,
+        )
+
+
+# === Graph Execution Exceptions ===
+
+
+class GraphExecutionError(HiveError):
+    """Base exception for graph execution errors."""
+
+    def __init__(
+        self,
+        message: str,
+        node_id: str | None = None,
+        graph_id: str | None = None,
+        **kwargs: Any,
+    ):
+        context = kwargs.pop("context", {})
+        if node_id:
+            context["node_id"] = node_id
+        if graph_id:
+            context["graph_id"] = graph_id
+        super().__init__(message, context=context, **kwargs)
+
+
+class NodeExecutionError(GraphExecutionError):
+    """Raised when a node fails to execute."""
+
+    def __init__(
+        self,
+        node_id: str,
+        node_name: str,
+        reason: str,
+        **kwargs: Any,
+    ):
+        super().__init__(
+            f"Node '{node_name}' (id={node_id}) failed: {reason}",
+            error_code="NODE_EXECUTION_ERROR",
+            node_id=node_id,
+            **kwargs,
+        )
+
+
+class MaxIterationsExceededError(GraphExecutionError):
+    """Raised when execution exceeds maximum allowed iterations."""
+
+    def __init__(self, max_iterations: int, **kwargs: Any):
+        super().__init__(
+            f"Execution exceeded maximum iterations ({max_iterations})",
+            error_code="MAX_ITERATIONS_EXCEEDED",
+            context={"max_iterations": max_iterations},
+            **kwargs,
+        )
+
+
+class InvalidGraphError(GraphExecutionError):
+    """Raised when a graph spec is invalid."""
+
+    def __init__(self, errors: list[str], **kwargs: Any):
+        super().__init__(
+            f"Invalid graph: {'; '.join(errors)}",
+            error_code="INVALID_GRAPH",
+            context={"errors": errors},
+            **kwargs,
+        )
+
+
+# === Configuration Exceptions ===
+
+
+class ConfigurationError(HiveError):
+    """Raised for configuration-related errors."""
+
+    def __init__(self, message: str, config_key: str | None = None, **kwargs: Any):
+        context = kwargs.pop("context", {})
+        if config_key:
+            context["config_key"] = config_key
+        super().__init__(
+            message,
+            error_code="CONFIGURATION_ERROR",
+            context=context,
+            **kwargs,
+        )
+
+
+class MissingCredentialError(ConfigurationError):
+    """Raised when a required credential is missing."""
+
+    def __init__(self, credential_name: str, env_var: str, **kwargs: Any):
+        # Remove error_code from kwargs if present to avoid conflict
+        kwargs.pop("error_code", None)
+        super().__init__(
+            f"Missing credential '{credential_name}'. Set environment variable: {env_var}",
+            config_key=env_var,
+            **kwargs,
+        )
+        # Override the error code after initialization
+        self.error_code = "MISSING_CREDENTIAL"

--- a/core/framework/runner/orchestrator.py
+++ b/core/framework/runner/orchestrator.py
@@ -209,7 +209,7 @@ class AgentOrchestrator:
 
             responses = await asyncio.gather(*tasks, return_exceptions=True)
 
-            for agent_name, response in zip(routing.selected_agents, responses):
+            for agent_name, response in zip(routing.selected_agents, responses, strict=True):
                 if isinstance(response, Exception):
                     results[agent_name] = {"error": str(response)}
                 else:
@@ -330,7 +330,7 @@ class AgentOrchestrator:
 
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        for name, result in zip(agent_names, results):
+        for name, result in zip(agent_names, results, strict=True):
             if isinstance(result, Exception):
                 responses[name] = AgentMessage(
                     type=MessageType.RESPONSE,
@@ -359,7 +359,7 @@ class AgentOrchestrator:
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
         capabilities = {}
-        for name, result in zip(agent_names, results):
+        for name, result in zip(agent_names, results, strict=True):
             if isinstance(result, Exception):
                 capabilities[name] = CapabilityResponse(
                     agent_name=name,

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -4,24 +4,25 @@ import json
 import logging
 import os
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Any
+from typing import TYPE_CHECKING, Any
 
 from framework.graph import Goal
-from framework.graph.edge import GraphSpec, EdgeSpec, EdgeCondition, AsyncEntryPointSpec
+from framework.graph.edge import AsyncEntryPointSpec, EdgeCondition, EdgeSpec, GraphSpec
+from framework.graph.executor import ExecutionResult, GraphExecutor
 from framework.graph.node import NodeSpec
-from framework.graph.executor import GraphExecutor, ExecutionResult
 from framework.llm.provider import LLMProvider, Tool
 from framework.runner.tool_registry import ToolRegistry
-from framework.runtime.core import Runtime
 
 # Multi-entry-point runtime imports
-from framework.runtime.agent_runtime import AgentRuntime, AgentRuntimeConfig, create_agent_runtime
+from framework.runtime.agent_runtime import AgentRuntime, create_agent_runtime
+from framework.runtime.core import Runtime
 from framework.runtime.execution_stream import EntryPointSpec
 
 if TYPE_CHECKING:
-    from framework.runner.protocol import CapabilityResponse, AgentMessage
+    from framework.runner.protocol import AgentMessage, CapabilityResponse
 
 logger = logging.getLogger(__name__)
 
@@ -135,7 +136,7 @@ def load_agent_export(data: str | dict) -> tuple[GraphSpec, Goal]:
     )
 
     # Build Goal
-    from framework.graph.goal import SuccessCriterion, Constraint
+    from framework.graph.goal import Constraint, SuccessCriterion
 
     success_criteria = []
     for sc_data in goal_data.get("success_criteria", []):
@@ -804,7 +805,12 @@ class AgentRunner:
             entry_node=self.graph.entry_node,
             terminal_nodes=self.graph.terminal_nodes,
             success_criteria=[
-                {"id": sc.id, "description": sc.description, "metric": sc.metric, "target": sc.target}
+                {
+                    "id": sc.id,
+                    "description": sc.description,
+                    "metric": sc.metric,
+                    "target": sc.target,
+                }
                 for sc in self.goal.success_criteria
             ],
             constraints=[
@@ -854,7 +860,7 @@ class AgentRunner:
 
             # Check tool credentials (Tier 2)
             missing_creds = cred_manager.get_missing_for_tools(info.required_tools)
-            for cred_name, spec in missing_creds:
+            for _cred_name, spec in missing_creds:
                 missing_credentials.append(spec.env_var)
                 affected_tools = [t for t in info.required_tools if t in spec.tools]
                 tools_str = ", ".join(affected_tools)
@@ -864,9 +870,9 @@ class AgentRunner:
                 warnings.append(warning_msg)
 
             # Check node type credentials (e.g., ANTHROPIC_API_KEY for LLM nodes)
-            node_types = list(set(node.node_type for node in self.graph.nodes))
+            node_types = list({node.node_type for node in self.graph.nodes})
             missing_node_creds = cred_manager.get_missing_for_node_types(node_types)
-            for cred_name, spec in missing_node_creds:
+            for _cred_name, spec in missing_node_creds:
                 if spec.env_var not in missing_credentials:  # Avoid duplicates
                     missing_credentials.append(spec.env_var)
                     affected_types = [t for t in node_types if t in spec.node_types]
@@ -892,7 +898,9 @@ class AgentRunner:
             missing_credentials=missing_credentials,
         )
 
-    async def can_handle(self, request: dict, llm: LLMProvider | None = None) -> "CapabilityResponse":
+    async def can_handle(
+        self, request: dict, llm: LLMProvider | None = None
+    ) -> "CapabilityResponse":
         """
         Ask the agent if it can handle this request.
 
@@ -905,7 +913,7 @@ class AgentRunner:
         Returns:
             CapabilityResponse with level, confidence, and reasoning
         """
-        from framework.runner.protocol import CapabilityResponse, CapabilityLevel
+        from framework.runner.protocol import CapabilityLevel, CapabilityResponse
 
         # Use provided LLM or set up our own
         eval_llm = llm
@@ -961,7 +969,7 @@ Respond with JSON only:
             )
 
             # Parse response
-            json_match = re.search(r'\{[^{}]*\}', response.content, re.DOTALL)
+            json_match = re.search(r"\{[^{}]*\}", response.content, re.DOTALL)
             if json_match:
                 data = json.loads(json_match.group())
                 level_map = {
@@ -1000,7 +1008,7 @@ Respond with JSON only:
 
     def _keyword_capability_check(self, request: dict) -> "CapabilityResponse":
         """Simple keyword-based capability check (fallback when no LLM)."""
-        from framework.runner.protocol import CapabilityResponse, CapabilityLevel
+        from framework.runner.protocol import CapabilityLevel, CapabilityResponse
 
         info = self.info()
         request_str = json.dumps(request).lower()

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -1,7 +1,9 @@
 """Agent Runner - loads and runs exported agents."""
 
 import json
+import logging
 import os
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Any
@@ -20,6 +22,8 @@ from framework.runtime.execution_stream import EntryPointSpec
 
 if TYPE_CHECKING:
     from framework.runner.protocol import CapabilityResponse, AgentMessage
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -369,19 +373,59 @@ class AgentRunner:
 
         Args:
             config_path: Path to mcp_servers.json file
+
+        Note:
+            Errors during loading are logged as warnings, not raised,
+            to allow partial functionality when some servers fail.
         """
         try:
             with open(config_path) as f:
                 config = json.load(f)
+        except FileNotFoundError:
+            logger.debug("MCP servers config not found at %s, skipping", config_path)
+            return
+        except json.JSONDecodeError as e:
+            logger.warning(
+                "Invalid JSON in MCP servers config at %s: %s",
+                config_path,
+                str(e),
+            )
+            return
+        except OSError as e:
+            logger.warning(
+                "Failed to read MCP servers config from %s: %s",
+                config_path,
+                str(e),
+            )
+            return
 
-            servers = config.get("servers", [])
-            for server_config in servers:
-                try:
-                    self._tool_registry.register_mcp_server(server_config)
-                except Exception as e:
-                    print(f"Warning: Failed to register MCP server '{server_config.get('name', 'unknown')}': {e}")
-        except Exception as e:
-            print(f"Warning: Failed to load MCP servers config from {config_path}: {e}")
+        servers = config.get("servers", [])
+        if not servers:
+            logger.debug("No MCP servers defined in %s", config_path)
+            return
+
+        registered_count = 0
+        for server_config in servers:
+            server_name = server_config.get("name", "unknown")
+            try:
+                self._tool_registry.register_mcp_server(server_config)
+                registered_count += 1
+                logger.debug("Registered MCP server: %s", server_name)
+            except Exception as e:
+                logger.warning(
+                    "Failed to register MCP server '%s': %s",
+                    server_name,
+                    str(e),
+                    exc_info=logger.isEnabledFor(logging.DEBUG),
+                )
+
+        if registered_count > 0:
+            logger.info(
+                "Registered %d/%d MCP servers from %s",
+                registered_count,
+                len(servers),
+                config_path,
+            )
 
     def set_approval_callback(self, callback: Callable) -> None:
         """
@@ -917,7 +961,6 @@ Respond with JSON only:
             )
 
             # Parse response
-            import re
             json_match = re.search(r'\{[^{}]*\}', response.content, re.DOTALL)
             if json_match:
                 data = json.loads(json_match.group())
@@ -934,9 +977,24 @@ Respond with JSON only:
                     reasoning=data.get("reasoning", ""),
                     estimated_steps=data.get("estimated_steps"),
                 )
-        except Exception:
-            # Fall back to keyword matching on error
-            pass
+            else:
+                logger.warning(
+                    "Capability check LLM response did not contain valid JSON for agent '%s'",
+                    info.name,
+                )
+        except json.JSONDecodeError as e:
+            logger.warning(
+                "Failed to parse capability check response for agent '%s': %s",
+                info.name,
+                str(e),
+            )
+        except Exception as e:
+            logger.warning(
+                "Capability check failed for agent '%s', falling back to keyword matching: %s",
+                info.name,
+                str(e),
+                exc_info=logger.isEnabledFor(logging.DEBUG),
+            )
 
         return self._keyword_capability_check(request)
 

--- a/core/tests/test_error_handling_integration.py
+++ b/core/tests/test_error_handling_integration.py
@@ -1,0 +1,391 @@
+"""Integration tests for error handling in runner and orchestrator.
+
+Run with:
+    cd core
+    pytest tests/test_error_handling_integration.py -v
+"""
+
+import json
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from pathlib import Path
+
+from framework.llm.provider import LLMProvider, LLMResponse
+from framework.runner.orchestrator import AgentOrchestrator, RoutingDecision
+from framework.runner.protocol import CapabilityLevel, CapabilityResponse
+
+
+class TestOrchestratorErrorHandling:
+    """Test orchestrator handles errors gracefully with proper logging."""
+
+    @pytest.fixture
+    def mock_llm(self):
+        """Create a mock LLM provider."""
+        mock = Mock(spec=LLMProvider)
+        return mock
+
+    @pytest.fixture
+    def orchestrator(self, mock_llm):
+        """Create an orchestrator with mock LLM."""
+        return AgentOrchestrator(llm=mock_llm)
+
+    @pytest.mark.asyncio
+    async def test_llm_route_handles_invalid_json_response(self, orchestrator, mock_llm, caplog):
+        """Test that invalid JSON from LLM triggers fallback routing with logging."""
+        # Return response that doesn't contain valid JSON
+        mock_llm.complete.return_value = LLMResponse(
+            content="This is not valid JSON at all, just some text",
+            model="test-model",
+        )
+
+        capable = [
+            ("agent_a", CapabilityResponse(
+                agent_name="agent_a",
+                level=CapabilityLevel.CAN_HANDLE,
+                confidence=0.9,
+                reasoning="Can handle this request",
+            )),
+            ("agent_b", CapabilityResponse(
+                agent_name="agent_b",
+                level=CapabilityLevel.CAN_HANDLE,
+                confidence=0.7,
+                reasoning="Can also handle",
+            )),
+        ]
+
+        # Register mock agents
+        orchestrator._agents = {
+            "agent_a": Mock(),
+            "agent_b": Mock(),
+        }
+
+        import logging
+        with caplog.at_level(logging.WARNING):
+            result = await orchestrator._llm_route(
+                request={"task": "test"},
+                intent="test intent",
+                capable=capable,
+            )
+
+        # Should fall back to highest confidence agent
+        assert result.selected_agents == ["agent_a"]
+        assert "Fallback" in result.reasoning
+        # Should log warning about invalid JSON
+        assert "valid JSON" in caplog.text or "fallback" in caplog.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_llm_route_handles_json_parse_error(self, orchestrator, mock_llm, caplog):
+        """Test that JSON parse errors trigger fallback with logging."""
+        # Return response with malformed JSON (missing closing brace)
+        mock_llm.complete.return_value = LLMResponse(
+            content='{"selected": ["agent_a", "reasoning": "incomplete json"',
+            model="test-model",
+        )
+
+        capable = [
+            ("agent_a", CapabilityResponse(
+                agent_name="agent_a",
+                level=CapabilityLevel.CAN_HANDLE,
+                confidence=0.8,
+                reasoning="Ready to handle",
+            )),
+        ]
+
+        orchestrator._agents = {"agent_a": Mock()}
+
+        import logging
+        with caplog.at_level(logging.WARNING):
+            result = await orchestrator._llm_route(
+                request={"task": "test"},
+                intent=None,
+                capable=capable,
+            )
+
+        assert result.selected_agents == ["agent_a"]
+        assert "Fallback" in result.reasoning
+
+    @pytest.mark.asyncio
+    async def test_llm_route_handles_api_error(self, orchestrator, mock_llm, caplog):
+        """Test that LLM API errors trigger fallback with logging."""
+        mock_llm.complete.side_effect = Exception("API connection failed")
+
+        capable = [
+            ("agent_a", CapabilityResponse(
+                agent_name="agent_a",
+                level=CapabilityLevel.CAN_HANDLE,
+                confidence=0.8,
+                reasoning="Ready",
+            )),
+        ]
+
+        orchestrator._agents = {"agent_a": Mock()}
+
+        import logging
+        with caplog.at_level(logging.WARNING):
+            result = await orchestrator._llm_route(
+                request={"task": "test"},
+                intent=None,
+                capable=capable,
+            )
+
+        assert result.selected_agents == ["agent_a"]
+        # Should log the error
+        assert "API connection failed" in caplog.text or "failed unexpectedly" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_llm_route_success_path(self, orchestrator, mock_llm):
+        """Test that valid LLM response is processed correctly."""
+        mock_llm.complete.return_value = LLMResponse(
+            content='{"selected": ["agent_a"], "parallel": false, "reasoning": "Best fit"}',
+            model="test-model",
+        )
+
+        capable = [
+            ("agent_a", CapabilityResponse(
+                agent_name="agent_a",
+                level=CapabilityLevel.CAN_HANDLE,
+                confidence=0.9,
+                reasoning="Can handle",
+            )),
+            ("agent_b", CapabilityResponse(
+                agent_name="agent_b",
+                level=CapabilityLevel.CAN_HANDLE,
+                confidence=0.7,
+                reasoning="Also capable",
+            )),
+        ]
+
+        orchestrator._agents = {
+            "agent_a": Mock(),
+            "agent_b": Mock(),
+        }
+
+        result = await orchestrator._llm_route(
+            request={"task": "test"},
+            intent="test",
+            capable=capable,
+        )
+
+        # Should use LLM's selection
+        assert result.selected_agents == ["agent_a"]
+        assert result.reasoning == "Best fit"
+        assert result.confidence == 0.8
+
+
+class TestMCPServerErrorHandling:
+    """Test MCP server configuration error handling."""
+
+    def test_handles_missing_config_file(self, tmp_path, caplog):
+        """Test graceful handling of missing MCP config."""
+        from framework.runner.runner import AgentRunner
+        from framework.graph.edge import GraphSpec
+        from framework.graph import Goal
+
+        # Create minimal agent structure
+        agent_path = tmp_path / "test_agent"
+        agent_path.mkdir()
+
+        # Create minimal graph and goal
+        graph = GraphSpec(
+            id="test",
+            goal_id="test-goal",
+            entry_node="start",
+            terminal_nodes=["end"],
+            nodes=[],
+            edges=[],
+        )
+        goal = Goal(
+            id="test-goal",
+            name="Test Goal",
+            description="Test",
+            success_criteria=[],
+            constraints=[],
+        )
+
+        # Create runner (will try to load MCP config)
+        runner = AgentRunner(
+            agent_path=agent_path,
+            graph=graph,
+            goal=goal,
+            mock_mode=True,
+        )
+
+        # Config file doesn't exist - should not raise
+        nonexistent_config = agent_path / "nonexistent_mcp.json"
+        runner._load_mcp_servers_from_config(nonexistent_config)
+
+        # Should not have registered any servers
+        assert runner._tool_registry is not None
+
+    def test_handles_invalid_json_config(self, tmp_path, caplog):
+        """Test graceful handling of invalid JSON in config."""
+        from framework.runner.runner import AgentRunner
+        from framework.graph.edge import GraphSpec
+        from framework.graph import Goal
+
+        agent_path = tmp_path / "test_agent"
+        agent_path.mkdir()
+
+        # Create invalid JSON config
+        config_path = agent_path / "mcp_servers.json"
+        config_path.write_text("{ this is not valid json }")
+
+        graph = GraphSpec(
+            id="test",
+            goal_id="test-goal",
+            entry_node="start",
+            terminal_nodes=["end"],
+            nodes=[],
+            edges=[],
+        )
+        goal = Goal(
+            id="test-goal",
+            name="Test Goal",
+            description="Test",
+            success_criteria=[],
+            constraints=[],
+        )
+
+        runner = AgentRunner(
+            agent_path=agent_path,
+            graph=graph,
+            goal=goal,
+            mock_mode=True,
+        )
+
+        import logging
+        with caplog.at_level(logging.WARNING):
+            runner._load_mcp_servers_from_config(config_path)
+
+        assert "Invalid JSON" in caplog.text
+
+    def test_handles_partial_server_failures(self, tmp_path, caplog):
+        """Test that one failing server doesn't prevent others from loading."""
+        from framework.runner.runner import AgentRunner
+        from framework.graph.edge import GraphSpec
+        from framework.graph import Goal
+
+        agent_path = tmp_path / "test_agent"
+        agent_path.mkdir()
+
+        # Create valid JSON with multiple servers
+        config_path = agent_path / "mcp_servers.json"
+        config_path.write_text(json.dumps({
+            "servers": [
+                {"name": "good_server", "transport": "stdio", "command": "test"},
+                {"name": "bad_server", "transport": "stdio", "command": "test"},
+                {"name": "another_good", "transport": "stdio", "command": "test"},
+            ]
+        }))
+
+        graph = GraphSpec(
+            id="test",
+            goal_id="test-goal",
+            entry_node="start",
+            terminal_nodes=["end"],
+            nodes=[],
+            edges=[],
+        )
+        goal = Goal(
+            id="test-goal",
+            name="Test Goal",
+            description="Test",
+            success_criteria=[],
+            constraints=[],
+        )
+
+        runner = AgentRunner(
+            agent_path=agent_path,
+            graph=graph,
+            goal=goal,
+            mock_mode=True,
+        )
+
+        # Mock the tool registry to fail on specific server
+        original_register = runner._tool_registry.register_mcp_server
+
+        def side_effect(config):
+            if config["name"] == "bad_server":
+                raise Exception("Connection refused")
+            return original_register(config)
+
+        runner._tool_registry.register_mcp_server = Mock(side_effect=side_effect)
+
+        import logging
+        with caplog.at_level(logging.WARNING):
+            runner._load_mcp_servers_from_config(config_path)
+
+        # Should have tried to register all 3
+        assert runner._tool_registry.register_mcp_server.call_count == 3
+        # Should log warning for the bad one
+        assert "bad_server" in caplog.text
+
+    def test_handles_empty_servers_list(self, tmp_path, caplog):
+        """Test handling of config with empty servers list."""
+        from framework.runner.runner import AgentRunner
+        from framework.graph.edge import GraphSpec
+        from framework.graph import Goal
+
+        agent_path = tmp_path / "test_agent"
+        agent_path.mkdir()
+
+        # Create config with empty servers list
+        config_path = agent_path / "mcp_servers.json"
+        config_path.write_text(json.dumps({"servers": []}))
+
+        graph = GraphSpec(
+            id="test",
+            goal_id="test-goal",
+            entry_node="start",
+            terminal_nodes=["end"],
+            nodes=[],
+            edges=[],
+        )
+        goal = Goal(
+            id="test-goal",
+            name="Test Goal",
+            description="Test",
+            success_criteria=[],
+            constraints=[],
+        )
+
+        runner = AgentRunner(
+            agent_path=agent_path,
+            graph=graph,
+            goal=goal,
+            mock_mode=True,
+        )
+
+        import logging
+        with caplog.at_level(logging.DEBUG):
+            runner._load_mcp_servers_from_config(config_path)
+
+        assert "No MCP servers defined" in caplog.text
+
+
+class TestAnthropicCredentialHandling:
+    """Test Anthropic credential manager error handling."""
+
+    def test_falls_back_to_env_var_when_aden_tools_not_installed(self, caplog, monkeypatch):
+        """Test fallback to environment variable when aden_tools not available."""
+        from framework.llm.anthropic import _get_api_key_from_credential_manager
+
+        # Set up env var
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-from-env")
+
+        import logging
+        with caplog.at_level(logging.DEBUG):
+            result = _get_api_key_from_credential_manager()
+
+        # Should get key from environment
+        assert result == "test-key-from-env"
+
+    def test_returns_none_when_no_key_available(self, monkeypatch):
+        """Test returns None when no API key is available."""
+        from framework.llm.anthropic import _get_api_key_from_credential_manager
+
+        # Remove env var
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        result = _get_api_key_from_credential_manager()
+        assert result is None

--- a/core/tests/test_exceptions.py
+++ b/core/tests/test_exceptions.py
@@ -1,0 +1,316 @@
+"""Tests for the Hive exception hierarchy.
+
+Run with:
+    cd core
+    pytest tests/test_exceptions.py -v
+"""
+
+import pytest
+
+from framework.exceptions import (
+    HiveError,
+    LLMError,
+    LLMProviderNotAvailableError,
+    LLMAPIError,
+    LLMResponseParseError,
+    RunnerError,
+    AgentLoadError,
+    AgentValidationError,
+    ToolExecutionError,
+    MCPServerError,
+    OrchestratorError,
+    RoutingError,
+    AgentNotFoundError,
+    CapabilityCheckError,
+    GraphExecutionError,
+    NodeExecutionError,
+    MaxIterationsExceededError,
+    InvalidGraphError,
+    ConfigurationError,
+    MissingCredentialError,
+)
+
+
+class TestHiveErrorBase:
+    """Test base HiveError functionality."""
+
+    def test_basic_message(self):
+        """Test basic error with just a message."""
+        error = HiveError("Something went wrong")
+        assert str(error) == "Something went wrong"
+        assert error.message == "Something went wrong"
+        assert error.error_code == "HIVE_ERROR"
+
+    def test_with_error_code(self):
+        """Test error with custom error code."""
+        error = HiveError("Failed", error_code="CUSTOM_CODE")
+        assert error.error_code == "CUSTOM_CODE"
+
+    def test_with_context(self):
+        """Test error with context dict."""
+        error = HiveError("Failed", context={"key": "value", "count": 42})
+        assert "key=value" in str(error)
+        assert "count=42" in str(error)
+        assert error.context == {"key": "value", "count": 42}
+
+    def test_with_original_error(self):
+        """Test exception chaining."""
+        original = ValueError("original problem")
+        error = HiveError("Wrapped error", original_error=original)
+        assert error.original_error is original
+        assert error.__cause__ is original
+
+    def test_inheritance(self):
+        """Test that HiveError inherits from Exception."""
+        error = HiveError("test")
+        assert isinstance(error, Exception)
+
+
+class TestLLMExceptions:
+    """Test LLM-related exceptions."""
+
+    def test_llm_error_with_provider_and_model(self):
+        """Test LLMError with provider and model context."""
+        error = LLMError("API failed", provider="anthropic", model="claude-3")
+        assert error.context["provider"] == "anthropic"
+        assert error.context["model"] == "claude-3"
+        assert "API failed" in str(error)
+
+    def test_llm_provider_not_available(self):
+        """Test LLMProviderNotAvailableError."""
+        error = LLMProviderNotAvailableError("anthropic", "missing API key")
+        assert "anthropic" in str(error)
+        assert "missing API key" in str(error)
+        assert error.error_code == "LLM_PROVIDER_NOT_AVAILABLE"
+        assert error.context["provider"] == "anthropic"
+
+    def test_llm_api_error_with_status(self):
+        """Test LLMAPIError with status code."""
+        error = LLMAPIError("Rate limit exceeded", status_code=429)
+        assert error.context["status_code"] == 429
+        assert error.error_code == "LLM_API_ERROR"
+
+    def test_llm_response_parse_error(self):
+        """Test LLMResponseParseError with truncated response preview."""
+        long_response = "this is not json" * 50
+        error = LLMResponseParseError(
+            "Invalid JSON",
+            response_content=long_response,
+        )
+        # Should truncate long responses
+        assert len(error.context["response_preview"]) <= 200
+        assert error.error_code == "LLM_RESPONSE_PARSE_ERROR"
+
+
+class TestRunnerExceptions:
+    """Test runner-related exceptions."""
+
+    def test_runner_error_with_agent_name(self):
+        """Test RunnerError with agent name context."""
+        error = RunnerError("Runner failed", agent_name="my-agent")
+        assert error.context["agent"] == "my-agent"
+
+    def test_agent_load_error(self):
+        """Test AgentLoadError."""
+        error = AgentLoadError("/path/to/agent", "file not found")
+        assert "/path/to/agent" in str(error)
+        assert "file not found" in str(error)
+        assert error.error_code == "AGENT_LOAD_ERROR"
+
+    def test_agent_validation_error(self):
+        """Test AgentValidationError with errors and missing tools."""
+        error = AgentValidationError(
+            "Validation failed",
+            errors=["No entry node", "Cycle detected"],
+            missing_tools=["send_email", "read_file"],
+        )
+        assert error.context["errors"] == ["No entry node", "Cycle detected"]
+        assert error.context["missing_tools"] == ["send_email", "read_file"]
+        assert error.error_code == "AGENT_VALIDATION_ERROR"
+
+    def test_tool_execution_error(self):
+        """Test ToolExecutionError."""
+        error = ToolExecutionError(
+            "send_email",
+            "SMTP connection failed",
+            tool_input={"to": "test@example.com"},
+        )
+        assert "send_email" in str(error)
+        assert error.context["tool"] == "send_email"
+        assert error.context["input"] == {"to": "test@example.com"}
+        assert error.error_code == "TOOL_EXECUTION_ERROR"
+
+    def test_mcp_server_error(self):
+        """Test MCPServerError."""
+        error = MCPServerError("tools-server", "Connection refused")
+        assert "tools-server" in str(error)
+        assert error.context["server"] == "tools-server"
+        assert error.error_code == "MCP_SERVER_ERROR"
+
+
+class TestOrchestratorExceptions:
+    """Test orchestrator-related exceptions."""
+
+    def test_orchestrator_error_inheritance(self):
+        """Test OrchestratorError inherits from HiveError."""
+        error = OrchestratorError("Orchestrator failed")
+        assert isinstance(error, HiveError)
+
+    def test_routing_error(self):
+        """Test RoutingError with available agents."""
+        error = RoutingError(
+            "No capable agents",
+            available_agents=["agent_a", "agent_b"],
+        )
+        assert error.context["available_agents"] == ["agent_a", "agent_b"]
+        assert error.error_code == "ROUTING_ERROR"
+
+    def test_agent_not_found(self):
+        """Test AgentNotFoundError."""
+        error = AgentNotFoundError("missing_agent")
+        assert "missing_agent" in str(error)
+        assert error.error_code == "AGENT_NOT_FOUND"
+        assert error.context["agent"] == "missing_agent"
+
+    def test_capability_check_error(self):
+        """Test CapabilityCheckError."""
+        error = CapabilityCheckError("agent_x", "LLM timeout")
+        assert "agent_x" in str(error)
+        assert "LLM timeout" in str(error)
+        assert error.error_code == "CAPABILITY_CHECK_ERROR"
+
+
+class TestGraphExceptions:
+    """Test graph execution exceptions."""
+
+    def test_graph_execution_error_with_ids(self):
+        """Test GraphExecutionError with node and graph IDs."""
+        error = GraphExecutionError(
+            "Execution failed",
+            node_id="node_123",
+            graph_id="graph_456",
+        )
+        assert error.context["node_id"] == "node_123"
+        assert error.context["graph_id"] == "graph_456"
+
+    def test_node_execution_error(self):
+        """Test NodeExecutionError."""
+        error = NodeExecutionError(
+            node_id="node_123",
+            node_name="ProcessData",
+            reason="timeout after 30s",
+        )
+        assert "ProcessData" in str(error)
+        assert "node_123" in str(error)
+        assert error.context["node_id"] == "node_123"
+        assert error.error_code == "NODE_EXECUTION_ERROR"
+
+    def test_max_iterations_exceeded(self):
+        """Test MaxIterationsExceededError."""
+        error = MaxIterationsExceededError(100)
+        assert "100" in str(error)
+        assert error.context["max_iterations"] == 100
+        assert error.error_code == "MAX_ITERATIONS_EXCEEDED"
+
+    def test_invalid_graph_error(self):
+        """Test InvalidGraphError."""
+        error = InvalidGraphError(["No entry node", "Cycle detected"])
+        assert "No entry node" in str(error)
+        assert "Cycle detected" in str(error)
+        assert error.context["errors"] == ["No entry node", "Cycle detected"]
+        assert error.error_code == "INVALID_GRAPH"
+
+
+class TestConfigurationExceptions:
+    """Test configuration-related exceptions."""
+
+    def test_configuration_error(self):
+        """Test ConfigurationError."""
+        error = ConfigurationError("Invalid config", config_key="api_url")
+        assert error.context["config_key"] == "api_url"
+        assert error.error_code == "CONFIGURATION_ERROR"
+
+    def test_missing_credential_error(self):
+        """Test MissingCredentialError."""
+        error = MissingCredentialError("anthropic", "ANTHROPIC_API_KEY")
+        assert "anthropic" in str(error)
+        assert "ANTHROPIC_API_KEY" in str(error)
+        assert error.error_code == "MISSING_CREDENTIAL"
+        assert error.context["config_key"] == "ANTHROPIC_API_KEY"
+
+
+class TestExceptionChaining:
+    """Test exception chaining behavior."""
+
+    def test_preserves_traceback(self):
+        """Test that exception chaining preserves traceback."""
+        try:
+            try:
+                raise ValueError("original")
+            except ValueError as e:
+                raise LLMAPIError("wrapped", original_error=e) from e
+        except LLMAPIError as e:
+            assert e.__cause__ is not None
+            assert isinstance(e.__cause__, ValueError)
+
+    def test_chained_exception_is_accessible(self):
+        """Test that original error is accessible via attribute."""
+        original = KeyError("missing_key")
+        error = HiveError("Wrapped", original_error=original)
+        assert error.original_error is original
+
+
+class TestExceptionHierarchy:
+    """Test the exception class hierarchy."""
+
+    def test_llm_errors_inherit_from_hive_error(self):
+        """Test that all LLM exceptions inherit from HiveError."""
+        assert issubclass(LLMError, HiveError)
+        assert issubclass(LLMProviderNotAvailableError, LLMError)
+        assert issubclass(LLMAPIError, LLMError)
+        assert issubclass(LLMResponseParseError, LLMError)
+
+    def test_runner_errors_inherit_from_hive_error(self):
+        """Test that all runner exceptions inherit from HiveError."""
+        assert issubclass(RunnerError, HiveError)
+        assert issubclass(AgentLoadError, RunnerError)
+        assert issubclass(AgentValidationError, RunnerError)
+        assert issubclass(ToolExecutionError, RunnerError)
+        assert issubclass(MCPServerError, RunnerError)
+
+    def test_orchestrator_errors_inherit_from_hive_error(self):
+        """Test that all orchestrator exceptions inherit from HiveError."""
+        assert issubclass(OrchestratorError, HiveError)
+        assert issubclass(RoutingError, OrchestratorError)
+        assert issubclass(AgentNotFoundError, OrchestratorError)
+        assert issubclass(CapabilityCheckError, OrchestratorError)
+
+    def test_graph_errors_inherit_from_hive_error(self):
+        """Test that all graph exceptions inherit from HiveError."""
+        assert issubclass(GraphExecutionError, HiveError)
+        assert issubclass(NodeExecutionError, GraphExecutionError)
+        assert issubclass(MaxIterationsExceededError, GraphExecutionError)
+        assert issubclass(InvalidGraphError, GraphExecutionError)
+
+    def test_config_errors_inherit_from_hive_error(self):
+        """Test that all config exceptions inherit from HiveError."""
+        assert issubclass(ConfigurationError, HiveError)
+        assert issubclass(MissingCredentialError, ConfigurationError)
+
+    def test_all_exceptions_can_be_caught_as_exception(self):
+        """Test that all custom exceptions can be caught as base Exception."""
+        exceptions = [
+            HiveError("test"),
+            LLMError("test"),
+            LLMProviderNotAvailableError("provider", "reason"),
+            RunnerError("test"),
+            OrchestratorError("test"),
+            GraphExecutionError("test"),
+            ConfigurationError("test"),
+        ]
+
+        for exc in exceptions:
+            try:
+                raise exc
+            except Exception as e:
+                assert e is exc


### PR DESCRIPTION
## Description

Add a custom exception hierarchy and replace bare `except Exception: pass` clauses with proper error handling and logging. This improves debuggability without changing external behavior.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Related Issues

N/A - proactive improvement

## Changes Made

- Add `framework/exceptions.py` with hierarchical exception classes:
  - `HiveError` (base) → `LLMError`, `RunnerError`, `OrchestratorError`, `GraphExecutionError`, `ConfigurationError`
  - Each includes `error_code`, `context` dict, and exception chaining support
- Replace bare `except Exception: pass` in `orchestrator.py` `_llm_route()` with specific handlers + logging
- Replace bare `except Exception: pass` in `runner.py` `can_handle()` with specific handlers + logging
- Replace `print()` statements in `runner.py` `_load_mcp_servers_from_config()` with proper logging
- Add debug logging to `anthropic.py` `_get_api_key_from_credential_manager()` for credential fallback
- Add 32 unit tests for exception classes
- Add 10 integration tests for error handling paths

## Testing

- [x] Unit tests pass (`pytest tests/test_exceptions.py` - 32 tests)
- [x] Integration tests pass (`pytest tests/test_error_handling_integration.py` - 10 tests)
- [x] Existing tests pass (`pytest tests/test_orchestrator.py` - 8 tests)
- [x] Lint passes on new files (`ruff check framework/exceptions.py framework/llm/anthropic.py`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A - backend changes only