### PR TITLE
docs: improve Windows onboarding and clarify Claude Code setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 <!-- - **[Roadmap](https://adenhq.com/roadmap)** - Upcoming features and plans -->
 - **[Report Issues](https://github.com/adenhq/hive/issues)** - Bug reports and feature requests
 
+> ⚠️ **Windows Users**
+>
+> This project assumes a Unix-like shell and a working `python` executable on PATH.
+>
+> On Windows:
+> - Use **Git Bash** or **WSL** (not Command Prompt or PowerShell).
+> - Install **Python 3.11+** from https://www.python.org/downloads/
+> - During install, check **“Add Python to PATH”**.
+> - Disable the Microsoft Store Python alias:
+>   Settings → Apps → Advanced app settings → App execution aliases → turn off `python.exe`.
+>
+> The setup and quickstart scripts will fail in CMD/PowerShell.
+
 ## Quick Start
 
 ### Prerequisites
@@ -69,6 +82,8 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 - [Docker](https://docs.docker.com/get-docker/) (v20.10+) - Optional, for containerized tools
 
 ### Installation
+
+> ⚠️ Requires a Unix-like shell (macOS, Linux, Git Bash, or WSL)
 
 ```bash
 # Clone the repository
@@ -84,19 +99,35 @@ This installs:
 - **aden_tools** - 19 MCP tools for agent capabilities
 - All required dependencies
 
+### Claude Code Requirement
+
+Hive depends on **Claude Code** for building and testing agents.
+
+Before running any `claude>` commands or `./quickstart.sh`:
+
+1. Install Claude Code from the official docs:  
+   https://docs.anthropic.com/claude/docs/claude-code-overview
+
+2. Verify installation:
+```bash
+claude
+```
+You should see a usage menu printed.  
+If `claude` is not found, agent building commands will not work.
+
 ### Build Your First Agent
 
 ```bash
-# Install Claude Code skills (one-time)
+Install Claude Code skills (one-time)
 ./quickstart.sh
 
-# Build an agent using Claude Code
+Build an agent using Claude Code
 claude> /building-agents
 
-# Test your agent
+Test your agent
 claude> /testing-agent
 
-# Run your agent
+Run your agent
 PYTHONPATH=core:exports python -m your_agent_name run --input '{...}'
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,29 +61,34 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 <!-- - **[Roadmap](https://adenhq.com/roadmap)** - Upcoming features and plans -->
 - **[Report Issues](https://github.com/adenhq/hive/issues)** - Bug reports and feature requests
 
+
+## Quick Start
+
+### Prerequisites
+
 > ⚠️ **Windows Users**
->
+> 
 > This project assumes a Unix-like shell and a working `python` executable on PATH.
->
+> 
 > On Windows:
 > - Use **Git Bash** or **WSL** (not Command Prompt or PowerShell).
 > - Install **Python 3.11+** from https://www.python.org/downloads/
 > - During install, check **“Add Python to PATH”**.
 > - Disable the Microsoft Store Python alias:
 >   Settings → Apps → Advanced app settings → App execution aliases → turn off `python.exe`.
->
-> The setup and quickstart scripts will fail in CMD/PowerShell.
+> 
+> The setup and quickstart scripts are not supported in CMD/PowerShell and are expected to fail.
 
-## Quick Start
 
-### Prerequisites
 
 - [Python 3.11+](https://www.python.org/downloads/) for agent development
 - [Docker](https://docs.docker.com/get-docker/) (v20.10+) - Optional, for containerized tools
 
 ### Installation
 
-> ⚠️ Requires a Unix-like shell (macOS, Linux, Git Bash, or WSL)
+> ⚠️ Requires a Unix-like shell (macOS, Linux, Git Bash, or WSL).  
+  See the Windows Users note above for setup details.
+
 
 ```bash
 # Clone the repository


### PR DESCRIPTION
### **What this PR does**
(I initially tried running the setup scripts from PowerShell and hit multiple failures before realizing a Unix-like shell was required)

While setting up Hive on Windows, I ran into a few confusing points that caused avoidable setup failures. This PR tightens up the README to make the onboarding flow clearer, especially for Windows users.

Specifically, it:

- Adds a clear **Windows Users** note under Prerequisites
- Explains that setup and quickstart scripts won’t work in CMD/PowerShell
- Calls out the need for Git Bash or WSL on Windows
- Clarifies Python PATH and Microsoft Store alias issues
- Makes Claude Code installation and verification more explicit
- Removes a redundant Unix-shell warning later in the README

### **Why this change is needed**

During my first setup on Windows, it wasn’t obvious that:
- A Unix-like shell is required
- CMD/PowerShell will fail for setup scripts
- Claude Code is a hard requirement for building and testing agents
- The Microsoft Store Python alias can break the setup
I hit multiple errors before figuring this out manually. These changes reflect that real setup friction and make the correct path obvious for new contributors.

### **Impact**

- Reduces onboarding friction for Windows users
- Prevents common setup failures related to shell and PATH issues
- Makes Claude Code’s role in the workflow explicit
- Improves first-run success for new contributors

### **Notes**

All changes are documentation-only and based on issues encountered during a fresh Windows setup.