### PR TITLE
feat(security): make workspace dir configurable via HIVE_WORKSPACES_DIR (fixes #651)

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/security.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/security.py
@@ -1,7 +1,10 @@
 import os
 
-# Use user home directory for workspaces
-WORKSPACES_DIR = os.path.expanduser("~/.hive/workdir/workspaces")
+# Use environment variable if set, otherwise default to ~/.hive
+WORKSPACES_DIR = os.getenv(
+    "HIVE_WORKSPACES_DIR", 
+    os.path.expanduser("~/.hive/workdir/workspaces")
+)
 
 def get_secure_path(path: str, workspace_id: str, agent_id: str, session_id: str) -> str:
     """Resolve and verify a path within a 3-layer sandbox (workspace/agent/session)."""

--- a/tools/tests/tools/test_security.py
+++ b/tools/tests/tools/test_security.py
@@ -213,3 +213,22 @@ class TestGetSecurePath:
         # However, realpath reveals the escape - callers should check this
         real_path = os.path.realpath(result)
         assert os.path.commonpath([real_path, str(session_dir)]) != str(session_dir)
+
+    def test_custom_env_var_workspace(self, ids, monkeypatch, tmp_path):
+        """Test that HIVE_WORKSPACES_DIR env var is respected."""
+        from aden_tools.tools.file_system_toolkits import security
+        import importlib
+        
+        # 1. Set the environment variable to a temp path
+        custom_dir = tmp_path / "custom_hive"
+        monkeypatch.setenv("HIVE_WORKSPACES_DIR", str(custom_dir))
+        
+        # 2. Reload the module so it picks up the new env var
+        importlib.reload(security)
+        
+        # 3. Run get_secure_path
+        result = security.get_secure_path("file.txt", **ids)
+        
+        # 4. Verify it used the custom directory
+        expected = custom_dir / "test-workspace" / "test-agent" / "test-session" / "file.txt"
+        assert result == str(expected)


### PR DESCRIPTION
### Description
This PR addresses Issue #651.

It makes the agent workspace directory configurable via the `HIVE_WORKSPACES_DIR` environment variable. Currently, the path is hardcoded to `~/.hive/workdir/workspaces`. This change allows users to define a custom storage location, which is critical for CI/CD pipelines and systems with read-only home directories.

### Changes
- Updated `WORKSPACES_DIR` in `tools/src/aden_tools/tools/file_system_toolkits/security.py` to check `os.getenv("HIVE_WORKSPACES_DIR")` before falling back to the default.
- Added `test_custom_env_var_workspace` to `tools/tests/tools/test_security.py` to verify the variable is respected.

### Testing
- Verified locally with `pytest tools/tests/tools/test_security.py` (20 passed).