### PR TITLE
fix(framework): session context override for consistent tool sandbox …

### DIFF
--- a/.claude/skills/building-agents-construction/SKILL.md
+++ b/.claude/skills/building-agents-construction/SKILL.md
@@ -953,6 +953,16 @@ class {agent_class_name}:
 
         tool_registry = ToolRegistry()
 
+        # Set session context for consistent sandbox paths across all tool calls
+        # This ensures all tools use the same workspace_id/agent_id/session_id
+        # so files created by one tool can be found by other tools
+        import uuid
+        tool_registry.set_session_context(
+            workspace_id="{agent_name}",
+            agent_id=self.goal.id.replace("-", "_"),
+            session_id=str(uuid.uuid4())[:8],
+        )
+
         # Load MCP servers if not in mock mode
         if not mock_mode:
             agent_dir = Path(__file__).parent
@@ -1508,6 +1518,35 @@ response = AskUserQuestion(
 ```
 
 ## Framework Features
+
+### Session Context - Consistent File Paths Across Tools
+
+**IMPORTANT**: Tools that access files (csv_read, csv_write, execute_command_tool, etc.) use sandbox paths based on `workspace_id`, `agent_id`, and `session_id`. Without consistent values, files created by one tool cannot be found by other tools.
+
+**How it works**:
+
+```python
+tool_registry = ToolRegistry()
+
+# Set session context ONCE - all tools will use these values
+tool_registry.set_session_context(
+    workspace_id="my_agent",           # Usually agent name
+    agent_id=self.goal.id,             # Usually goal ID
+    session_id=str(uuid.uuid4())[:8],  # Unique per run
+)
+
+# Files are stored at:
+# ~/.hive/workdir/workspaces/{workspace_id}/{agent_id}/{session_id}/{filename}
+```
+
+**Why this matters**:
+
+- LLMs may pass different IDs to different tool calls
+- Session context **overrides** LLM-provided values
+- Ensures all files end up in the same folder
+- No need to specify IDs in node prompts
+
+**Node prompts should NOT specify workspace_id/agent_id/session_id** - the framework handles this automatically.
 
 ### OutputCleaner - Automatic I/O Validation and Cleaning
 

--- a/.claude/skills/building-agents-construction/examples/online_research_agent/agent.py
+++ b/.claude/skills/building-agents-construction/examples/online_research_agent/agent.py
@@ -1,4 +1,6 @@
 """Agent graph construction for Online Research Agent."""
+import uuid
+
 from framework.graph import EdgeSpec, EdgeCondition, Goal, SuccessCriterion, Constraint
 from framework.graph.edge import GraphSpec
 from framework.graph.executor import ExecutionResult
@@ -214,6 +216,13 @@ class OnlineResearchAgent:
         storage_path.mkdir(parents=True, exist_ok=True)
 
         tool_registry = ToolRegistry()
+
+        # Set session context for consistent sandbox paths across all tool calls
+        tool_registry.set_session_context(
+            workspace_id="online_research",
+            agent_id=self.goal.id.replace("-", "_"),
+            session_id=str(uuid.uuid4())[:8],
+        )
 
         # Load MCP servers (always load, needed for tool validation)
         agent_dir = Path(__file__).parent

--- a/core/framework/runner/tool_registry.py
+++ b/core/framework/runner/tool_registry.py
@@ -293,7 +293,8 @@ class ToolRegistry:
                     def executor(inputs: dict) -> Any:
                         try:
                             # Inject session context for tools that need it
-                            merged_inputs = {**registry_ref._session_context, **inputs}
+                            # Session context takes precedence over LLM-provided values
+                            merged_inputs = {**inputs, **registry_ref._session_context}
                             result = client_ref.call_tool(tool_name, merged_inputs)
                             # MCP tools return content array, extract the result
                             if isinstance(result, list) and len(result) > 0:


### PR DESCRIPTION
## Description
  - Fix merge order bug in ToolRegistry that caused LLM-provided values to override session context
  - Add documentation for Session Context feature in building-agents skills
  - Update example agent with set_session_context() usage

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
Fixes #(561)

## Changes Made
 - Fix merge order in `tool_registry.py` so session context overrides LLM-provided values
 - Add Session Context documentation section in building-agents-construction skill
 - Add `set_session_context()` example in online_research_agent

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
