### PR TITLE
fix(tools): add atomic file writes to prevent race conditions

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/write_to_file/write_to_file.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/write_to_file/write_to_file.py
@@ -1,6 +1,38 @@
 import os
+import sys
+import tempfile
+import time
+import threading
 from mcp.server.fastmcp import FastMCP
 from ..security import get_secure_path
+
+
+# Module-level lock for atomic file operations on Windows
+# Windows doesn't support truly atomic os.replace, so we serialize operations
+_write_lock = threading.Lock()
+
+
+# Cross-platform file locking for atomic append operations
+if sys.platform == 'win32':
+    # On Windows, use threading lock for simplicity as msvcrt only locks byte ranges
+    def _lock_file(f):
+        """Acquire exclusive lock using threading lock (Windows)."""
+        _write_lock.acquire()
+    def _unlock_file(f):
+        """Release lock (Windows)."""
+        try:
+            _write_lock.release()
+        except RuntimeError:
+            pass  # Lock may already be released
+else:
+    import fcntl
+    def _lock_file(f):
+        """Acquire exclusive lock on file (POSIX)."""
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+    def _unlock_file(f):
+        """Release lock on file (POSIX)."""
+        fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
 
 def register_tools(mcp: FastMCP) -> None:
     """Register file write tools with the MCP server."""
@@ -10,6 +42,11 @@ def register_tools(mcp: FastMCP) -> None:
         """
         Purpose
             Create a new file or append content to an existing file.
+            
+        Atomicity
+            Write operations use atomic patterns to prevent race conditions:
+            - Write mode: temp file + atomic rename
+            - Append mode: file locking
 
         When to use
             Append new events to append-only logs
@@ -37,10 +74,50 @@ def register_tools(mcp: FastMCP) -> None:
         """
         try:
             secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
-            os.makedirs(os.path.dirname(secure_path), exist_ok=True)
-            mode = "a" if append else "w"
-            with open(secure_path, mode, encoding="utf-8") as f:
-                f.write(content)
+            dir_path = os.path.dirname(secure_path)
+            os.makedirs(dir_path, exist_ok=True)
+            
+            if append:
+                # Append mode: use file locking to prevent interleaved writes
+                with open(secure_path, "a", encoding="utf-8") as f:
+                    _lock_file(f)
+                    try:
+                        f.write(content)
+                        f.flush()
+                        os.fsync(f.fileno())
+                    finally:
+                        _unlock_file(f)
+            else:
+                # Write mode: atomic temp file + rename to prevent partial writes
+                # Use lock on Windows to serialize replace operations (not truly atomic)
+                fd, temp_path = tempfile.mkstemp(dir=dir_path, prefix='.tmp_write_')
+                try:
+                    with os.fdopen(fd, 'w', encoding='utf-8') as f:
+                        f.write(content)
+                        f.flush()
+                        os.fsync(f.fileno())
+                    
+                    # Serialize the replace operation to avoid Windows race conditions
+                    with _write_lock:
+                        # Retry logic for Windows where replace can fail under contention
+                        max_retries = 3
+                        for attempt in range(max_retries):
+                            try:
+                                os.replace(temp_path, secure_path)
+                                break
+                            except PermissionError:
+                                if attempt < max_retries - 1:
+                                    time.sleep(0.01 * (attempt + 1))  # Brief backoff
+                                else:
+                                    raise
+                except Exception:
+                    # Clean up temp file on failure
+                    try:
+                        os.unlink(temp_path)
+                    except OSError:
+                        pass
+                    raise
+            
             return {
                 "success": True,
                 "path": path,

--- a/tools/tests/tools/test_file_system_toolkits.py
+++ b/tools/tests/tools/test_file_system_toolkits.py
@@ -202,6 +202,88 @@ class TestWriteToFileTool:
         assert created_file.exists()
         assert created_file.read_text() == ""
 
+    def test_concurrent_writes_no_corruption(self, write_to_file_fn, mock_workspace, mock_secure_path, tmp_path):
+        """Concurrent writes to the same file should not corrupt data (atomic writes)."""
+        import concurrent.futures
+        import threading
+
+        results = []
+        errors = []
+        num_writers = 10
+        content_per_writer = "X" * 100  # Each writer writes 100 characters
+
+        def writer_task(writer_id):
+            try:
+                result = write_to_file_fn(
+                    path="concurrent_test.txt",
+                    content=f"[{writer_id}]{content_per_writer}\n",
+                    **mock_workspace
+                )
+                results.append((writer_id, result))
+            except Exception as e:
+                errors.append((writer_id, str(e)))
+
+        # Run concurrent writes
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_writers) as executor:
+            futures = [executor.submit(writer_task, i) for i in range(num_writers)]
+            concurrent.futures.wait(futures)
+
+        # All writes should succeed
+        assert len(errors) == 0, f"Errors occurred: {errors}"
+        failed_results = [(r[0], r[1]) for r in results if not r[1].get("success")]
+        assert all(r[1].get("success") for r in results), f"Not all writes succeeded. Failed: {failed_results}"
+
+        # File should exist and contain valid content (last write wins for overwrite mode)
+        created_file = tmp_path / "concurrent_test.txt"
+        assert created_file.exists()
+        content = created_file.read_text()
+        # Content should be a complete write, not corrupted/interleaved
+        assert content.startswith("[")
+        assert content.endswith("\n")
+        assert len(content) > 100  # Should have the full content
+
+    def test_concurrent_appends_no_interleaving(self, write_to_file_fn, mock_workspace, mock_secure_path, tmp_path):
+        """Concurrent appends should not interleave content (file locking)."""
+        import concurrent.futures
+
+        # Create initial file
+        test_file = tmp_path / "append_concurrent.txt"
+        test_file.write_text("")
+
+        results = []
+        num_writers = 10
+        content_per_writer = "Y" * 50
+
+        def appender_task(writer_id):
+            result = write_to_file_fn(
+                path="append_concurrent.txt",
+                content=f"[{writer_id}]{content_per_writer}\n",
+                append=True,
+                **mock_workspace
+            )
+            results.append((writer_id, result))
+
+        # Run concurrent appends
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_writers) as executor:
+            futures = [executor.submit(appender_task, i) for i in range(num_writers)]
+            concurrent.futures.wait(futures)
+
+        # All appends should succeed
+        assert all(r[1].get("success") for r in results), "Not all appends succeeded"
+
+        # File should contain all writes without interleaving
+        content = test_file.read_text()
+        lines = content.strip().split("\n")
+        
+        # Should have exactly num_writers lines
+        assert len(lines) == num_writers, f"Expected {num_writers} lines, got {len(lines)}"
+        
+        # Each line should be complete (not interleaved)
+        for line in lines:
+            assert line.startswith("[")
+            assert "]" in line
+            assert "Y" * 50 in line
+
 
 class TestListDirTool:
     """Tests for list_dir tool."""


### PR DESCRIPTION
- Implement temp file + rename pattern for write mode
- Add threading lock for Windows atomicity
- Add file locking for append mode to prevent interleaving
- Add concurrency tests to verify fix

Fixes race condition in write_to_file.py where concurrent writes could cause partial writes, interleaved content, or file corruption.

## Description

This PR fixes a race condition in [write_to_file.py] where non-atomic file operations caused data corruption, partial writes, or interleaved content when multiple agents or threads attempted to write to the same file concurrently.


The fix implements:
1. **Atomic Overwrites**: Uses the `tempfile` + `os.replace` pattern. Content is written to a temporary file first, then atomically renamed to the target path.
2. **File Locking**: Implements platform-specific file locking mechanisms (using `fcntl` on POSIX and `threading.Lock` on Windows) to serialize append operations.
3. **Windows Compatibility**: Adds retry logic and serialization for `os.replace` on Windows, where the operation can fail under contention due to file locking quirks.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #688 

## Testing
I ran the following tests to verify the changes:
- [x] Unit tests pass (`cd tools && python -m pytest`) - All 42 tests passed.
- [x] Concurrency tests passed verifying no data loss or corruption with 10 concurrent writers.
- [x] Manual testing performed.


## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (added comments for the locking logic)
- [x] I have made corresponding changes to the documentation (docstrings updated)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

NA
