### PR TITLE
docs: fix Claude Code installation on Windows (PATH + verification)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,32 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 
 ### Prerequisites
 
+### Windows Notes for Claude Code
+
+On Windows, Claude Code is not installed by default and must be installed explicitly.
+
+1. Install Claude Code using the official installer:
+   https://docs.anthropic.com/en/docs/claude-code/getting-started
+2. 2. Restart your terminal and verify the CLI is on PATH:
+   ```bash
+   claude --help
+   ```
+
+⚠️ If you see:
+   bash: claude: command not found
+then Claude Code is either not installed or not discoverable on PATH.
+Ensure the install directory is added to PATH and restart Git Bash.
+---
+⚠️ Verification note
+Running `claude` without arguments may fail with:
+   Credit balance too low
+even if Claude Code is installed correctly.
+Use:
+   claude --help
+to verify installation without requiring API credits.
+
+
+
 - [Python 3.11+](https://www.python.org/downloads/) for agent development
 - [Docker](https://docs.docker.com/get-docker/) (v20.10+) - Optional, for containerized tools
 


### PR DESCRIPTION
### What this PR does

On Windows, following the current README results in `claude: command not found` even after installing Claude Code. In addition, running `claude` for verification can fail with a misleading “credit balance too low” error.

This PR documents the actual working installation and verification flow for Windows users.

Specifically, it:

- Clarifies that Claude Code is not installed by default on Windows  
- Links to the official installer  
- Adds a reliable verification command (`claude --help`)  
- Documents the common `command not found` failure mode  
- Explains the misleading “credit balance too low” verification error  
- Calls out PATH and Git Bash restart requirements  

### Why this change is needed

Without these steps, Windows users hit hard failures during setup that are not actionable and are easy to misdiagnose. This change makes the onboarding flow deterministic and debuggable on Windows.
