### PR TITLE
fix(graph): offload synchronous FunctionNode execution to thread

### DIFF
--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -15,6 +15,8 @@ Protocol:
     The framework provides NodeContext with everything the node needs.
 """
 
+import asyncio
+import inspect
 import logging
 from abc import ABC, abstractmethod
 from typing import Any, Callable
@@ -1110,8 +1112,11 @@ class FunctionNode(NodeProtocol):
         start = time.time()
 
         try:
-            # Call the function
-            result = self.func(**ctx.input_data)
+            # Call the function - run sync functions in a thread to avoid blocking event loop
+            if inspect.iscoroutinefunction(self.func):
+                result = await self.func(**ctx.input_data)
+            else:
+                result = await asyncio.to_thread(self.func, **ctx.input_data)
 
             latency_ms = int((time.time() - start) * 1000)
 


### PR DESCRIPTION
## Description

Fixes critical issue where `FunctionNode` executes synchronous functions directly on the asyncio event loop, causing the entire agent runtime to freeze during blocking I/O operations or heavy computations. This change offloads synchronous function execution to a separate thread while preserving support for native async functions.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #718

## Changes Made

- Added `asyncio` and `inspect` imports to `core/framework/graph/node.py`
- Modified `FunctionNode.execute()` to detect whether the wrapped function is synchronous or asynchronous using `inspect.iscoroutinefunction()`
- Implemented `asyncio.to_thread()` to offload synchronous function calls to a thread pool executor
- Preserved existing behavior for async functions by awaiting them directly

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed
  - Tested with blocking I/O function (simulated 5s sleep) - event loop remained responsive
  - Tested with async function - works as expected
  - Tested with CPU-bound sync function - offloaded successfully to thread

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A - This is a backend concurrency fix with no UI changes.

***

### Additional Notes for Reviewers

**Before this fix:**
```python
# Blocking call on event loop
result = self.func(**ctx.input_data)  # ❌ Blocks everything
```

**After this fix:**
```python
# Non-blocking execution
if inspect.iscoroutinefunction(self.func):
    result = await self.func(**ctx.input_data)  # ✅ Native async
else:
    result = await asyncio.to_thread(self.func, **ctx.input_data)  # ✅ Offloaded
```

This ensures concurrent agent workflows, heartbeats, and other async tasks continue running even when a FunctionNode performs heavy I/O or computation.