### PR TITLE
Fix testing CLI documentation to match actual arguments

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -141,8 +141,8 @@ python -m framework test-run <agent_path> --goal <goal_id> --parallel 4
 # Debug failed tests
 python -m framework test-debug <agent_path> <test_name>
 
-# List tests for a goal
-python -m framework test-list <goal_id>
+# List tests for an agent (optionally filter by type)
+python -m framework test-list <agent_path> [--type constraint|success|edge_case|all]
 ```
 
 For detailed testing workflows, see the [testing-agent skill](.claude/skills/testing-agent/SKILL.md).

--- a/core/framework/testing/__init__.py
+++ b/core/framework/testing/__init__.py
@@ -27,8 +27,8 @@ Testing tools are integrated into the main agent_builder_server.py:
 
 ```bash
 python -m framework test-run <agent_path> --goal <goal_id>
-python -m framework test-debug <goal_id> <test_id>
-python -m framework test-list <agent_path> --goal <goal_id>
+python -m framework test-debug <agent_path> <test_name>
+python -m framework test-list <agent_path> [--type constraint|success|edge_case|all]
 ```
 """
 


### PR DESCRIPTION
Fixes #717 

Updates testing CLI documentation examples to match the actual
command arguments accepted by the CLI, preventing copy-paste errors
for contributors.
