### PR TITLE
fix(llm): fixed refactor issue for llmprovider

### DIFF
--- a/core/framework/llm/provider.py
+++ b/core/framework/llm/provider.py
@@ -107,4 +107,7 @@ class LLMProvider(ABC):
         Returns:
             Final LLMResponse after tool use completes
         """
-        pass
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support tool execution. "
+            "Use a ToolAwareLLMProvider or override this method."
+        )

--- a/core/framework/llm/provider.py
+++ b/core/framework/llm/provider.py
@@ -85,7 +85,6 @@ class LLMProvider(ABC):
         """
         pass
 
-    @abstractmethod
     def complete_with_tools(
         self,
         messages: list[dict[str, Any]],


### PR DESCRIPTION
## Description
The LLMProvider declares both `complete()` and `complete_with_tools()` as required abstract methods. However, parts of the runtime (eg. `EdgeSpec._llm_decide`) only rely on `complete()` and do not validate whether a provider supports tool usage.

This creates a mismatch between the declared provider contrast and the actual runtime expectations.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Related Issues

Fixes #737

## Changes Made

In `LLMProvider`:
- Added default implementation under `complete_with_tools()`, that will raise error when it's not implemented.
- Removed `@abstractmethod` from `complete_with_tools()`.This makes `complete()` to be required, and makes `complete_with_tools()` to be optional capability. Therefore, providers implement what they actually support, failure happens only when capability is misused, runtime and interface finally agree.

This change aligns the LLMProvider interface with actual runtime usage. Tool execution is treated as an optional capability rather than a required contract, allowing non-tool providers to function correctly while preserving existing behavior for tool-aware providers.

In `EdgeSpec._llm_decide()`:
- Validated tool execution.
- Added `try/except` around JSON parsing
- Added `import logging`, `import re` at the top
- Initialized `proceed` and `reasoning` to avoid NameError

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.

## Impact:
Framework-level correctness: interface expectations misaligned with usage
Developer experience: harder to implement minimal/custom providers
Maintenance: unclear which methods are mandatory for which runtime paths
