### PR TITLE
Fix race condition in ConcurrentStorage.stop() causing data loss

### DIFF
--- a/core/framework/storage/concurrent.py
+++ b/core/framework/storage/concurrent.py
@@ -107,10 +107,7 @@ class ConcurrentStorage:
 
         self._running = False
 
-        # Flush remaining items
-        await self._flush_pending()
-
-        # Cancel batch task
+        # Cancel batch task first to prevent queue competition
         if self._batch_task:
             self._batch_task.cancel()
             try:
@@ -118,6 +115,9 @@ class ConcurrentStorage:
             except asyncio.CancelledError:
                 pass
             self._batch_task = None
+
+        # Now flush remaining items (batch task is stopped)
+        await self._flush_pending()
 
         logger.info("ConcurrentStorage stopped")
 


### PR DESCRIPTION
Fixes #755

Problem:
The stop() method had a critical race condition where _flush_pending() and _batch_task competed for queue items, causing:
- Data loss during shutdown
- Queue items processed twice or lost
- Batch writer cancelled mid-write

Root Cause:
The method called _flush_pending() while _batch_task was still running. Both operations drained the same queue simultaneously, leading to conflicts.

Solution:
Reordered shutdown sequence to:
1. Cancel batch task first
2. Wait for task completion (handles CancelledError with final flush)
3. Then flush any remaining items

This eliminates queue competition because:
- _batch_writer() flushes its current batch when cancelled
- After cancellation completes, _flush_pending() safely processes remaining items
- No race condition, no data loss

Changes:
- Moved batch task cancellation before _flush_pending()
- Ensures clean shutdown sequence
- Prevents queue drain conflicts

Testing:
- All 209 tests pass
- No duplicate flushes
- Clean shutdown guaranteed

Impact:
- Prevents data loss during graceful shutdown
- Eliminates race condition between flush operations
- Ensures all writes complete before stop returns

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

