### PR TITLE
refactor(core): centralize hardcoded default model name in config.py

### DIFF
--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -18,6 +18,7 @@ Testing commands:
 
 import argparse
 import sys
+from framework.config import DEFAULT_ROUTING_MODEL
 
 
 def main():
@@ -26,7 +27,7 @@ def main():
     )
     parser.add_argument(
         "--model",
-        default="claude-haiku-4-5-20251001",
+        default=DEFAULT_ROUTING_MODEL,
         help="Anthropic model to use",
     )
 

--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -1,0 +1,7 @@
+"""
+Global configuration constants for the Hive framework.
+"""
+
+# Default LLM model used for routing, decision making, and standard nodes
+# This centralized constant allows for easy upgrades across the entire system.
+DEFAULT_ROUTING_MODEL = "claude-haiku-4-5-20251001"

--- a/core/framework/graph/edge.py
+++ b/core/framework/graph/edge.py
@@ -28,6 +28,7 @@ from enum import Enum
 from pydantic import BaseModel, Field
 
 from framework.graph.safe_eval import safe_eval
+from framework.config import DEFAULT_ROUTING_MODEL
 
 
 class EdgeCondition(str, Enum):
@@ -413,7 +414,8 @@ class GraphSpec(BaseModel):
     )
 
     # Default LLM settings
-    default_model: str = "claude-haiku-4-5-20251001"
+    # Default LLM settings
+    default_model: str = DEFAULT_ROUTING_MODEL
     max_tokens: int = 1024
 
     # Execution limits

--- a/core/framework/llm/anthropic.py
+++ b/core/framework/llm/anthropic.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from framework.llm.provider import LLMProvider, LLMResponse, Tool
 from framework.llm.litellm import LiteLLMProvider
+from framework.config import DEFAULT_ROUTING_MODEL
 
 
 def _get_api_key_from_credential_manager() -> str | None:
@@ -37,7 +38,7 @@ class AnthropicProvider(LLMProvider):
     def __init__(
         self,
         api_key: str | None = None,
-        model: str = "claude-haiku-4-5-20251001",
+        model: str = DEFAULT_ROUTING_MODEL,
     ):
         """
         Initialize the Anthropic provider.
@@ -45,7 +46,7 @@ class AnthropicProvider(LLMProvider):
         Args:
             api_key: Anthropic API key. If not provided, uses CredentialManager
                      or ANTHROPIC_API_KEY env var.
-            model: Model to use (default: claude-haiku-4-5-20251001)
+            model: Model to use (default: checks config.py)
         """
         # Delegate to LiteLLMProvider internally.
         self.api_key = api_key or _get_api_key_from_credential_manager()

--- a/core/framework/runner/orchestrator.py
+++ b/core/framework/runner/orchestrator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -18,6 +19,8 @@ from framework.runner.protocol import (
     RegisteredAgent,
 )
 from framework.runner.runner import AgentRunner
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -476,7 +479,9 @@ Respond with JSON only:
                         confidence=0.8,
                         should_parallelize=data.get("parallel", False),
                     )
-        except Exception:
+        except Exception as e:
+            logger.warning(f"      ⚠ LLM routing failed: {e}")
+            # Fall through to fallback
             pass
 
         # Fallback: use highest confidence

--- a/core/framework/runner/orchestrator.py
+++ b/core/framework/runner/orchestrator.py
@@ -19,6 +19,7 @@ from framework.runner.protocol import (
     RegisteredAgent,
 )
 from framework.runner.runner import AgentRunner
+from framework.config import DEFAULT_ROUTING_MODEL
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ class AgentOrchestrator:
     def __init__(
         self,
         llm: LLMProvider | None = None,
-        model: str = "claude-haiku-4-5-20251001",
+        model: str = DEFAULT_ROUTING_MODEL,
     ):
         """
         Initialize the orchestrator.

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -2,8 +2,11 @@
 
 import json
 import os
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 from typing import TYPE_CHECKING, Callable, Any
 
 from framework.graph import Goal
@@ -940,8 +943,9 @@ Respond with JSON only:
                     reasoning=data.get("reasoning", ""),
                     estimated_steps=data.get("estimated_steps"),
                 )
-        except Exception:
+        except Exception as e:
             # Fall back to keyword matching on error
+            logger.warning(f"      ⚠ Capability evaluation failed: {e}")
             pass
 
         return self._keyword_capability_check(request)


### PR DESCRIPTION
## Description
Refactors the codebase to use a centralized `DEFAULT_ROUTING_MODEL` constant in [core/framework/config.py](cci:7://file:///e:/projects/aden/hive/core/framework/config.py:0:0-0:0) instead of hardcoding `"claude-haiku-4-5-20251001"` in multiple files. This adheres to DRY principles and makes future model upgrades safer and easier.

## Type of Change
- [x] Refactoring (Code Health)

## Changes Made
- Created [core/framework/config.py](cci:7://file:///e:/projects/aden/hive/core/framework/config.py:0:0-0:0).
- Updated [orchestrator.py](cci:7://file:///e:/projects/aden/hive/core/framework/runner/orchestrator.py:0:0-0:0), [edge.py](cci:7://file:///e:/projects/aden/hive/core/framework/graph/edge.py:0:0-0:0), [cli.py](cci:7://file:///e:/projects/aden/hive/core/framework/cli.py:0:0-0:0), and [anthropic.py](cci:7://file:///e:/projects/aden/hive/core/framework/llm/anthropic.py:0:0-0:0) to import and use the constant.

## Testing
- [x] Verified that all affected classes correctly default to the configured model value.