### PR TITLE
fix: create virtualenv in setup script to avoid PEP 668 issues

### DIFF
--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -60,6 +60,21 @@ fi
 echo -e "${GREEN}✓${NC} Python version check passed"
 echo ""
 
+# Create virtual environment (PEP 668 safe)
+VENV_DIR="$PROJECT_ROOT/.venv"
+
+if [ ! -d "$VENV_DIR" ]; then
+    echo "Creating virtual environment..."
+    $PYTHON_CMD -m venv "$VENV_DIR"
+fi
+
+# Activate virtual environment
+source "$VENV_DIR/bin/activate"
+
+# Use venv python from now on
+PYTHON_CMD="python"
+
+
 # Check for pip
 if ! $PYTHON_CMD -m pip --version &> /dev/null; then
     echo -e "${RED}Error: pip is not installed${NC}"
@@ -72,7 +87,7 @@ echo ""
 
 # Upgrade pip, setuptools, and wheel
 echo "Upgrading pip, setuptools, and wheel..."
-if ! $PYTHON_CMD -m pip install --upgrade pip setuptools wheel; then
+if ! $PYTHON_CMD -m pip install --upgrade --no-cache-dir pip setuptools wheel; then
   echo "Error: Failed to upgrade pip. Please check your python/venv configuration."
   exit 1
 fi
@@ -195,10 +210,9 @@ echo "  PYTHONPATH=core:exports python -m agent_name validate"
 echo "  PYTHONPATH=core:exports python -m agent_name info"
 echo "  PYTHONPATH=core:exports python -m agent_name run --input '{...}'"
 echo ""
-echo "Available commands for your new agent:"
-echo "  PYTHONPATH=core:exports python -m support_ticket_agent validate"
-echo "  PYTHONPATH=core:exports python -m support_ticket_agent info"
-echo "  PYTHONPATH=core:exports python -m support_ticket_agent run --input '{\"ticket_content\":\"...\",\"customer_id\":\"...\",\"ticket_id\":\"...\"}'"
+echo "Note:"
+echo "  Replace 'agent_name' with the module name of your exported agent."
+echo "  See README.md for examples and agent structure."
 echo ""
 echo "To build new agents, use Claude Code skills:"
 echo "  • /building-agents - Build a new agent"


### PR DESCRIPTION
## Description

Fixes the setup-python.sh script so it works on modern systems (macOS & Ubuntu) by:
- Creating a virtual environment before installing packages (PEP 668 safe)
- Avoiding hardcoded references to support_ticket_agent or exports/
- Updating pip, setuptools, and wheel with --no-cache-dir to reduce errors
- Improving guidance in the setup completion messages
This ensures new contributors can run the setup script successfully without hitting permission or package issues.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #721

## Changes Made

- Added creation and activation of virtual environment in setup-python.sh
- Updated pip install commands with --no-cache-dir
- Removed hardcoded references to non-existing agent in final instructions
- Updated setup completion messages to be more general and clear

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A
