### PR TITLE
fix(llm): handle tool execution exceptions in LiteLLMProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - N/A
 
 ### Fixed
-- N/A
+- Fixed crash in `LiteLLMProvider.complete_with_tools()` when tool execution raises exceptions. Tool failures are now gracefully handled and returned as structured error results, allowing the LLM to retry or use alternative tools instead of crashing the entire agent session.
 
 ### Security
 - N/A


### PR DESCRIPTION
## Summary

Fixes a critical bug where exceptions raised during tool execution in `LiteLLMProvider.complete_with_tools()` would crash the entire LLM generation loop, causing loss of conversation context and preventing graceful error recovery.

## Problem

The `complete_with_tools()` method only caught `JSONDecodeError` when parsing tool arguments, but did not handle exceptions raised during actual tool execution. When a tool raised an exception:

- ❌ The entire LLM generation process crashed
- ❌ Conversation context was lost
- ❌ The agent could not recover or retry
- ⚠️ Security concern: Uncaught exceptions could leak sensitive stack trace information

## Solution

- Wrapped `tool_executor(tool_use)` calls in comprehensive try/except blocks
- Convert tool exceptions into structured `ToolResult` errors with error details
- Normalize unexpected return types (dict/str) from custom executors into `ToolResult`
- Added error logging for tool failures
- Tool failures are now communicated back to the LLM, allowing it to:
  - Retry with different parameters
  - Use alternative tools
  - Inform the user about the failure

## Changes

- **`core/framework/llm/litellm.py`**: Added exception handling and result normalization in `complete_with_tools()`
- **`core/tests/test_litellm_provider.py`**: Added regression test `test_complete_with_tools_tool_exception_is_captured`
- **`CHANGELOG.md`**: Documented the fix

## Testing

All 23 tests pass, including the new regression test that verifies:
- Tool exceptions are caught (no crash)
- Errors are converted to `ToolResult` with `is_error=True`
- The LLM loop continues and receives the error message
- Conversation context is preserved

uv run pytest tests/test_litellm_provider.py -v
# 23 passed