### PR TITLE
docs: add Windows examples for PYTHONPATH-based agent commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,22 @@ claude> /building-agents
 # Test agents
 claude> /testing-agent
 
-# Run agents
+# Run agents (macOS / Linux)
+```bash
 PYTHONPATH=core:exports python -m agent_name run --input '{...}'
+```
+
+# Run agents (Windows – PowerShell)
+```powershell
+$env:PYTHONPATH="core;exports"
+python -m agent_name run --input "{...}"
+```
+
+# Run agents (Windows – cmd.exe)
+```bat
+set PYTHONPATH=core;exports
+python -m agent_name run --input "{...}"
+```
 ```
 
 See [ENVIRONMENT_SETUP.md](ENVIRONMENT_SETUP.md) for complete setup instructions.


### PR DESCRIPTION
The README previously used a Unix-style PYTHONPATH command, which doesn’t work on Windows.
This PR adds PowerShell and cmd.exe equivalents while keeping macOS/Linux instructions unchanged.

Docs-only change.