### PR TITLE
docs(readme): add virtual environment setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 git clone https://github.com/adenhq/hive.git
 cd hive
 
+# Create and activate a virtual environment(Recommended)
+python3 -m venv .venv
+source .venv/bin/activate 
+
 # Run Python environment setup
 ./scripts/setup-python.sh
 ```


### PR DESCRIPTION
**What does this PR do?** 
This PR adds instructions to create and activate a Python virtual environment before running the setup script.

**Why is this change needed?** 
On modern Linux distributions (and some macOS setups) enforcing PEP 668, running pip globally causes an externally-managed-environment error. Adding the venv step ensures the setup-python.sh script runs successfully for all users.

**Related Issue**: Documentation fix 
