### PR TITLE
fix:  unvalidated API response access

### DIFF
--- a/core/framework/graph/hitl.py
+++ b/core/framework/graph/hitl.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
+from framework.graph.node import extract_text_from_response
+
 
 class HITLInputType(str, Enum):
     """Type of input expected from human."""
@@ -200,7 +202,10 @@ Example format:
 
             # Parse Haiku's response
             import re
-            response_text = message.content[0].text.strip()
+            text = extract_text_from_response(message)
+            if text is None:
+                raise ValueError("No text content in API response")
+            response_text = text.strip()
             json_match = re.search(r'\{[^{}]*\}', response_text, re.DOTALL)
 
             if json_match:

--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -6,6 +6,8 @@ import json
 import sys
 from pathlib import Path
 
+from framework.graph.node import extract_text_from_response
+
 
 def register_commands(subparsers: argparse._SubParsersAction) -> None:
     """Register runner commands with the main CLI."""
@@ -640,7 +642,10 @@ Output ONLY valid JSON, no explanation:"""
             messages=[{"role": "user", "content": prompt}]
         )
 
-        json_str = message.content[0].text.strip()
+        text = extract_text_from_response(message)
+        if text is None:
+            raise ValueError("No text content in API response")
+        json_str = text.strip()
         # Remove markdown code blocks if present
         if json_str.startswith("```"):
             json_str = json_str.split("```")[1]

--- a/core/framework/testing/llm_judge.py
+++ b/core/framework/testing/llm_judge.py
@@ -21,6 +21,8 @@ Usage in tests:
 import json
 from typing import Any
 
+from framework.graph.node import extract_text_from_response
+
 
 class LLMJudge:
     """
@@ -92,7 +94,10 @@ Only output the JSON, nothing else."""
             )
 
             # Parse the response
-            text = response.content[0].text.strip()
+            raw_text = extract_text_from_response(response)
+            if raw_text is None:
+                raise ValueError("No text content in API response")
+            text = raw_text.strip()
             # Handle potential markdown code blocks
             if text.startswith("```"):
                 text = text.split("```")[1]


### PR DESCRIPTION
 ## Description

  Adds safe text extraction from Anthropic API responses to prevent `IndexError` and `AttributeError` when the API returns empty content or tool use blocks.

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Refactoring (no functional changes)

  ## Related Issues

  Fixes #816 

  ## Changes Made

  - Added `extract_text_from_response()` helper function in `core/framework/graph/node.py`
  - Fixed 5 locations that accessed `message.content[0].text` unsafely:
    - `node.py:341` - `generate_summary()` method
    - `node.py:824` - `_format_inputs_with_haiku()` method
    - `hitl.py:203` - `process()` method
    - `cli.py:643` - `_parse_user_input_with_llm()` function
    - `llm_judge.py:95` - `evaluate()` method
  - Added imports for the helper function in affected files

  ## Testing

  Describe the tests you ran to verify your changes:

  - [x] Unit tests pass (`cd core && pytest tests/`)
  - Lint passes (`cd core && ruff check .`) : My changes did NOT introduce new lint errors. But the codebase has 374 total lint errors pre-existing in the entire core/ directory: unsorted imports inside functions, single quotes, long lines. 
  - [x] Manual testing performed

  **Verification:**
  ```bash
  from framework.graph.node import extract_text_from_response
  from framework.graph import hitl
  from framework.runner import cli
  from framework.testing.llm_judge import LLMJudge
  print('All imports successful')
  
```
  Checklist
  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - I have added tests that prove my fix is effective or that my feature works
  - New and existing unit tests pass locally with my changes

  Screenshots (if applicable)

  N/A