### PR TITLE
fix(output_cleaner): add validation and error handling for JSON parsing

### DIFF
--- a/core/framework/graph/output_cleaner.py
+++ b/core/framework/graph/output_cleaner.py
@@ -268,7 +268,23 @@ Return ONLY valid JSON matching the expected schema. No explanations, no markdow
                 if match:
                     cleaned_text = match.group(1).strip()
 
-            cleaned = json.loads(cleaned_text)
+            # Validate cleaned_text before parsing
+            if not cleaned_text or not cleaned_text.strip():
+                raise ValueError(
+                    "Empty or whitespace-only cleaned text - LLM returned no content"
+                )
+
+            # Parse JSON with explicit error handling
+            try:
+                cleaned = json.loads(cleaned_text)
+            except json.JSONDecodeError as e:
+                # Log the actual content for debugging (truncated if too long)
+                preview = cleaned_text[:200] + "..." if len(cleaned_text) > 200 else cleaned_text
+                logger.error(
+                    f"✗ Failed to parse cleaned JSON: {e}\n"
+                    f"  Content preview: {repr(preview)}"
+                )
+                raise
 
             if isinstance(cleaned, dict):
                 self.cleansing_count += 1
@@ -288,7 +304,8 @@ Return ONLY valid JSON matching the expected schema. No explanations, no markdow
                         f"Cleaning produced {type(cleaned)}, expected dict"
                     )
 
-        except json.JSONDecodeError as e:
+        except (json.JSONDecodeError, ValueError) as e:
+            # Handle both JSON parsing errors and validation errors (empty text)
             logger.error(f"✗ Failed to parse cleaned JSON: {e}")
             if self.config.fallback_to_raw:
                 logger.info("↩ Falling back to raw output")


### PR DESCRIPTION
## Description

This PR fixes the issue where `json.loads()` in `output_cleaner.py` was called without sufficient validation, causing crashes on empty or invalid cleaned output.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #817

## Changes Made

- Added explicit validation for empty or whitespace-only `cleaned_text` before `json.loads()`
- Improved error handling to catch both `JSONDecodeError` and `ValueError`
- Added content preview in error logs for better debugging (truncated to 200 chars)
- Ensured cleaning cycle fails gracefully without crashing

## Why This Matters

Previously, when the LLM returned empty or whitespace-only content, `json.loads()` would be called on an empty string, causing parsing errors that weren't handled granularly. This could crash the cleaning cycle.

Now:
- Empty outputs are detected and handled explicitly
- Parsing failures include content preview for debugging
- The cleaning cycle fails gracefully and falls back to raw output when configured

## Testing

- [x] Verified validation catches empty strings
- [x] Verified validation catches whitespace-only strings
- [x] Verified error handling works for both JSONDecodeError and ValueError
- [x] Verified error logs include content preview
- [x] Verified fallback behavior works correctly

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Before/After

**Before:**on
cleaned = json.loads(cleaned_text)  # Could crash on empty string