### PR TITLE
Fix Anthropic credential validation for LLM nodes

### DIFF
--- a/tools/src/aden_tools/credentials/llm.py
+++ b/tools/src/aden_tools/credentials/llm.py
@@ -10,8 +10,8 @@ LLM_CREDENTIALS = {
         env_var="ANTHROPIC_API_KEY",
         tools=[],
         node_types=["llm_generate", "llm_tool_use"],
-        required=False,  # Not required - agents can use other providers via LiteLLM
-        startup_required=False,  # MCP server doesn't need LLM credentials
+        required=True,  # Required for default LLM nodes
+        startup_required=True,  # Validated at startup to fail fast
         help_url="https://console.anthropic.com/settings/keys",
         description="API key for Anthropic Claude models",
     ),


### PR DESCRIPTION
## Description

Fix credential validation for Anthropic by marking the anthropic credential as required and startup-required.
This aligns the credential specs with expected behavior for LLM node types and resolves failing credential validation tests.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)
Na

## Changes Made

-Updated anthropic credential spec to required=True
-Updated anthropic credential spec to startup_required=True
-Ensured credential validation behaves correctly for llm_generate and llm_tool_use node types

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed
Test result: 380 passed, 3 warnings

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Na
