### PR TITLE
docs: add AWS ECS/Fargate deployment plan and terraform structure

### DIFF
--- a/docs/deployment/aws-ecs.md
+++ b/docs/deployment/aws-ecs.md
@@ -1,18 +1,19 @@
 # Deploying Hive on AWS using ECS/Fargate (Terraform)
 
-This document describes a recommended approach to self-host Hive on AWS using
-ECS/Fargate and Terraform. The goal is to provide a production-ready but minimal
-deployment path that can be easily extended.
+This document describes a production-ready Terraform layout to run Hive on AWS
+ECS/Fargate behind an Application Load Balancer, reusing an existing VPC.
 
 ---
 
 ## Architecture Overview
 
-- AWS VPC (reusing the existing modular VPC setup)
+- Existing AWS VPC (provided as variables)
+- Public subnets for the ALB
+- Private subnets for ECS tasks
 - ECS Cluster (Fargate)
 - Application Load Balancer (HTTP + WebSocket support)
-- IAM Task Role (least privilege)
-- AWS Secrets Manager for sensitive config
+- IAM task roles with least privilege
+- AWS Secrets Manager integration (optional)
 - CloudWatch Logs for observability
 
 Hive runs as a containerized service behind an ALB. WebSocket connections are
@@ -24,48 +25,180 @@ handled natively by ALB.
 
 - AWS account
 - Terraform >= 1.5
-- Docker
-- An existing VPC provisioned via Terraform
+- Existing VPC + subnets (public + private)
+- Container image for Hive (ECR or public registry)
 
 ---
 
-## High-Level Deployment Steps
+## Terraform Layout
 
-1. Provision networking (VPC, subnets, routing)
-2. Create an ECS cluster
-3. Define a Task Definition for Hive
-4. Create an ECS Service (Fargate)
-5. Attach an Application Load Balancer
-6. Configure logging and secrets
-7. Access Hive via the ALB DNS name
-
----
-
-## Configuration Notes
-
-### Container
-- Hive runs as a single container per task
-- CPU / memory are configurable via Terraform variables
-- Environment variables and secrets are injected at runtime
-
-### Load Balancer
-- ALB supports WebSockets by default
-- Health checks should target a lightweight HTTP endpoint (e.g. `/health`)
-
-### Scaling
-- Initial deployment targets a single replica
-- ECS Service Auto Scaling can be added later
+```
+infra/terraform/aws/
+  modules/
+    alb/
+    ecs/
+    iam/
+    observability/
+  envs/
+    dev/
+```
 
 ---
 
-## Observability
+## Configuration
 
-- Application logs are sent to CloudWatch Logs
-- Future work may include OpenTelemetry integration
+Key variables to review in `infra/terraform/aws/envs/dev/terraform.tfvars`:
+
+- `vpc_id`, `public_subnet_ids`, `private_subnet_ids`  
+  Existing networking (VPC + subnets). ALB uses public subnets; ECS tasks use private subnets.
+
+- `image`  
+  Container image for Hive (ECR or public registry).
+
+- `container_port`  
+  The port exposed by the Hive container and used by the ALB target group.
+
+- `health_check_path`  
+  HTTP path used by the ALB health check (default is a placeholder; confirm the actual Hive endpoint).
+
+- `env_vars`  
+  Optional environment variables injected into the task.
+
+- `secrets`  
+  Optional Secrets Manager injection as ECS container secrets:
+  `[{ name = "KEY", arn = "arn:aws:secretsmanager:..." }]`
+
+---
+
+## Networking & Security Model
+
+- **ALB security group**: allows inbound HTTP (80) from `0.0.0.0/0`.
+- **ECS task security group**: allows inbound traffic **only** on `container_port` and **only** from the ALB security group.
+- **ECS tasks** run in **private subnets** (`assign_public_ip = false`).
+- **ALB** runs in **public subnets**.
+
+This setup keeps the service private while exposing only the ALB publicly.
+
+---
+
+## Observability (Logs)
+
+- A CloudWatch Log Group is created with configurable retention (`log_retention_days`).
+- ECS tasks are configured to send container logs to CloudWatch using the `awslogs` driver.
+
+To view logs:
+
+- AWS Console → CloudWatch Logs → Log groups → `/ecs/<name_prefix>`
+- Or via CLI (optional): `aws logs tail ...`
+
+---
+
+## Secrets (Optional)
+
+If you use AWS Secrets Manager, provide `secrets` in `terraform.tfvars`:
+
+secrets = [
+{ name = "OPENAI_API_KEY", arn = "arn:aws:secretsmanager:REGION:ACCOUNT:secret:mysecret" }
+]
+
+---
+
+## Verification
+
+After terraform apply, retrieve the URL:
+
+```bash
+terraform output alb_url
+```
+
+Basic checks:
+
+Open alb_url in a browser and confirm the service responds.
+Confirm target health: AWS Console → EC2 → Target Groups → Targets should be healthy.
+Confirm ECS service is stable: ECS → Cluster → Service → Tasks running.
+
+---
+
+## Troubleshooting
+
+### Targets are unhealthy
+
+Verify container_port matches the actual port Hive listens on.
+Verify health_check_path exists and returns 200-399.
+Check CloudWatch logs for the task to confirm Hive started correctly.
+
+### ECS service keeps restarting
+
+Inspect task logs in CloudWatch.
+Confirm the container image is valid and the entrypoint runs Hive successfully.
+
+### No response from the ALB
+
+Confirm ALB listener is on port 80.
+Confirm security groups allow ALB → ECS on container_port.
+Confirm tasks are running in the expected subnets.
+
+---
+
+## Deployment Steps (Dev)
+
+1. Copy and edit the example variables file:
+
+```bash
+cd infra/terraform/aws/envs/dev
+cp terraform.tfvars.example terraform.tfvars
+```
+
+2. Update values in `terraform.tfvars`:
+
+- `vpc_id`, `public_subnet_ids`, `private_subnet_ids`
+- `image` (container image)
+- `container_port` and `health_check_path`
+- `env_vars` and `secrets` (optional)
+
+3. Initialize Terraform:
+
+```bash
+terraform init
+```
+
+4. Validate and plan:
+
+```bash
+terraform fmt
+terraform validate
+terraform plan
+```
+
+5. Apply:
+
+```bash
+terraform apply
+```
+
+6. Get the ALB URL:
+
+```bash
+terraform output alb_url
+```
+
+---
+
+## Notes
+
+- ALB listens on port 80 and forwards to the ECS target group.
+- ECS tasks run in private subnets; ALB runs in public subnets.
+- ECS tasks only allow inbound traffic from the ALB security group.
+- The ECS task execution role includes `AmazonECSTaskExecutionRolePolicy`.
+- Optional Secrets Manager access is controlled via `secrets` ARNs.
+- Log retention defaults to 14 days (configurable).
+- ALB supports WebSockets by default.
+- The initial setup uses desired_count (default 1) to keep the deployment minimal. For production, increase desired_count and consider adding autoscaling.
+- You must provide real VPC/subnet IDs from your AWS account.
+- Defaults are placeholders, confirm the actual Hive port/endpoint.
 
 ---
 
 ## Status
 
-This document defines the intended deployment model.
-The Terraform implementation will be provided in a follow-up PR.
+Terraform implementation is available under `infra/terraform/aws/`.

--- a/docs/deployment/aws-ecs.md
+++ b/docs/deployment/aws-ecs.md
@@ -1,0 +1,71 @@
+# Deploying Hive on AWS using ECS/Fargate (Terraform)
+
+This document describes a recommended approach to self-host Hive on AWS using
+ECS/Fargate and Terraform. The goal is to provide a production-ready but minimal
+deployment path that can be easily extended.
+
+---
+
+## Architecture Overview
+
+- AWS VPC (reusing the existing modular VPC setup)
+- ECS Cluster (Fargate)
+- Application Load Balancer (HTTP + WebSocket support)
+- IAM Task Role (least privilege)
+- AWS Secrets Manager for sensitive config
+- CloudWatch Logs for observability
+
+Hive runs as a containerized service behind an ALB. WebSocket connections are
+handled natively by ALB.
+
+---
+
+## Prerequisites
+
+- AWS account
+- Terraform >= 1.5
+- Docker
+- An existing VPC provisioned via Terraform
+
+---
+
+## High-Level Deployment Steps
+
+1. Provision networking (VPC, subnets, routing)
+2. Create an ECS cluster
+3. Define a Task Definition for Hive
+4. Create an ECS Service (Fargate)
+5. Attach an Application Load Balancer
+6. Configure logging and secrets
+7. Access Hive via the ALB DNS name
+
+---
+
+## Configuration Notes
+
+### Container
+- Hive runs as a single container per task
+- CPU / memory are configurable via Terraform variables
+- Environment variables and secrets are injected at runtime
+
+### Load Balancer
+- ALB supports WebSockets by default
+- Health checks should target a lightweight HTTP endpoint (e.g. `/health`)
+
+### Scaling
+- Initial deployment targets a single replica
+- ECS Service Auto Scaling can be added later
+
+---
+
+## Observability
+
+- Application logs are sent to CloudWatch Logs
+- Future work may include OpenTelemetry integration
+
+---
+
+## Status
+
+This document defines the intended deployment model.
+The Terraform implementation will be provided in a follow-up PR.

--- a/docs/infra/aws-terrafrom-structure.md
+++ b/docs/infra/aws-terrafrom-structure.md
@@ -1,0 +1,75 @@
+# AWS Terraform Module Structure for Hive
+
+This document proposes a modular Terraform layout for deploying Hive on AWS.
+The structure builds on the existing VPC module and keeps components loosely
+coupled for future cloud expansion.
+
+---
+
+## Directory Layout
+
+infra/terraform/aws/
+  modules/
+    network/        # Existing VPC module
+    ecs/            # ECS cluster, task definition, service
+    alb/            # Application Load Balancer
+    iam/            # Task roles and policies
+    observability/  # CloudWatch logs, metrics (optional)
+  envs/
+    dev/
+      main.tf
+      variables.tf
+      outputs.tf
+	  
+---
+
+## Module Responsibilities
+
+### network
+Responsible for all networking primitives required by the deployment.
+
+VPC
+Public / private subnets
+Routing and NAT
+
+### ecs
+Defines the compute layer where Hive runs.
+
+ECS Cluster
+Task Definition
+ECS Service (Fargate)
+
+### alb
+Manages ingress traffic to the Hive service.
+
+Application Load Balancer
+Listener and target group configuration
+Health checks
+Native WebSocket support
+
+### iam
+Provides identity and access management with least-privilege principles.
+
+ECS task execution role
+ECS task role
+Fine-grained policies for logs and secrets access
+
+
+### observability
+Handles logging and basic observability concerns.
+
+CloudWatch log groups
+Log retention configuration
+
+### Design Principles
+
+Environment-agnostic modules
+Minimal assumptions about runtime
+Explicit inputs and outputs
+Cloud-specific logic isolated inside modules
+
+### Next Steps
+
+Implement ECS, ALB, and IAM modules
+Provide example dev environment
+Add optional autoscaling and HTTPS support

--- a/infra/terraform/aws/envs/dev/.gitignore
+++ b/infra/terraform/aws/envs/dev/.gitignore
@@ -1,0 +1,6 @@
+terraform.tfvars
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.*
+crash.log

--- a/infra/terraform/aws/envs/dev/main.tf
+++ b/infra/terraform/aws/envs/dev/main.tf
@@ -1,0 +1,62 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+  default_tags {
+    tags = {
+      Project = "hive"
+      Env     = "dev"
+    }
+  }
+}
+
+module "iam" {
+  source               = "../../modules/iam"
+  name_prefix          = var.name_prefix
+  secrets_manager_arns = [for s in var.secrets : s.arn]
+}
+
+module "observability" {
+  source            = "../../modules/observability"
+  name_prefix       = var.name_prefix
+  retention_in_days = var.log_retention_days
+}
+
+module "alb" {
+  source            = "../../modules/alb"
+  name_prefix       = var.name_prefix
+  vpc_id            = var.vpc_id
+  public_subnet_ids = var.public_subnet_ids
+  container_port    = var.container_port
+  health_check_path = var.health_check_path
+}
+
+module "ecs" {
+  source                  = "../../modules/ecs"
+  name_prefix             = var.name_prefix
+  aws_region              = var.aws_region
+  vpc_id                  = var.vpc_id
+  private_subnet_ids      = var.private_subnet_ids
+  container_port          = var.container_port
+  image                   = var.image
+  cpu                     = var.cpu
+  memory                  = var.memory
+  desired_count           = var.desired_count
+  env_vars                = var.env_vars
+  secrets                 = var.secrets
+  task_execution_role_arn = module.iam.task_execution_role_arn
+  task_role_arn           = module.iam.task_role_arn
+  log_group_name          = module.observability.log_group_name
+  target_group_arn        = module.alb.target_group_arn
+  alb_sg_id               = module.alb.alb_sg_id
+  listener_arn            = module.alb.listener_arn
+}

--- a/infra/terraform/aws/envs/dev/outputs.tf
+++ b/infra/terraform/aws/envs/dev/outputs.tf
@@ -1,0 +1,14 @@
+output "alb_url" {
+  description = "HTTP URL for the ALB."
+  value       = "http://${module.alb.alb_dns_name}"
+}
+
+output "ecs_cluster_name" {
+  description = "ECS cluster name."
+  value       = module.ecs.cluster_name
+}
+
+output "ecs_service_name" {
+  description = "ECS service name."
+  value       = module.ecs.service_name
+}

--- a/infra/terraform/aws/envs/dev/terraform.tfvars.example
+++ b/infra/terraform/aws/envs/dev/terraform.tfvars.example
@@ -1,0 +1,27 @@
+aws_region         = "us-east-1"
+name_prefix        = "hive-dev"
+
+vpc_id             = "vpc-0123456789abcdef0"
+public_subnet_ids  = ["subnet-0123456789abcdef0", "subnet-0123456789abcdef1"]
+private_subnet_ids = ["subnet-0123456789abcdef2", "subnet-0123456789abcdef3"]
+
+image              = "123456789012.dkr.ecr.us-east-1.amazonaws.com/hive:latest"
+container_port     = 4000
+health_check_path  = "/health"
+
+cpu           = 512
+memory        = 1024
+desired_count = 1
+
+env_vars = {
+  NODE_ENV = "production"
+}
+
+secrets = [
+  {
+    name = "ANTHROPIC_API_KEY"
+    arn  = "arn:aws:secretsmanager:us-east-1:123456789012:secret:anthropic"
+  }
+]
+
+log_retention_days = 14

--- a/infra/terraform/aws/envs/dev/variables.tf
+++ b/infra/terraform/aws/envs/dev/variables.tf
@@ -1,0 +1,80 @@
+variable "aws_region" {
+  description = "AWS region to deploy into."
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "Prefix for AWS resources."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "Existing VPC ID."
+  type        = string
+}
+
+variable "public_subnet_ids" {
+  description = "Public subnet IDs for the ALB."
+  type        = list(string)
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs for ECS tasks."
+  type        = list(string)
+}
+
+variable "image" {
+  description = "Container image for Hive."
+  type        = string
+}
+
+variable "container_port" {
+  description = "Container port exposed by Hive."
+  type        = number
+  default     = 4000
+}
+
+variable "health_check_path" {
+  description = "ALB health check path."
+  type        = string
+  default     = "/health"
+}
+
+variable "cpu" {
+  description = "CPU units for the ECS task (e.g. 256, 512)."
+  type        = number
+  default     = 512
+}
+
+variable "memory" {
+  description = "Memory (MiB) for the ECS task (e.g. 1024)."
+  type        = number
+  default     = 1024
+}
+
+variable "desired_count" {
+  description = "Desired number of tasks."
+  type        = number
+  default     = 1
+}
+
+variable "env_vars" {
+  description = "Environment variables for the container."
+  type        = map(string)
+  default     = {}
+}
+
+variable "secrets" {
+  description = "Secrets Manager ARNs exposed as container secrets."
+  type = list(object({
+    name = string
+    arn  = string
+  }))
+  default = []
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log retention in days."
+  type        = number
+  default     = 14
+}

--- a/infra/terraform/aws/modules/alb/main.tf
+++ b/infra/terraform/aws/modules/alb/main.tf
@@ -1,0 +1,62 @@
+terraform {
+  required_version = ">= 1.5.0"
+}
+
+resource "aws_security_group" "alb" {
+  name        = "${var.name_prefix}-alb"
+  description = "ALB security group"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "HTTP from anywhere"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_lb" "this" {
+  name               = substr("${var.name_prefix}-alb", 0, 32)
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = var.public_subnet_ids
+}
+
+resource "aws_lb_target_group" "this" {
+  name        = substr("${var.name_prefix}-tg", 0, 32)
+  port        = var.container_port
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    enabled             = true
+    interval            = 30
+    path                = var.health_check_path
+    protocol            = "HTTP"
+    matcher             = "200-399"
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+}

--- a/infra/terraform/aws/modules/alb/outputs.tf
+++ b/infra/terraform/aws/modules/alb/outputs.tf
@@ -1,0 +1,19 @@
+output "alb_dns_name" {
+  description = "ALB DNS name."
+  value       = aws_lb.this.dns_name
+}
+
+output "alb_sg_id" {
+  description = "Security group ID for the ALB."
+  value       = aws_security_group.alb.id
+}
+
+output "target_group_arn" {
+  description = "Target group ARN for the ECS service."
+  value       = aws_lb_target_group.this.arn
+}
+
+output "listener_arn" {
+  description = "ALB listener ARN."
+  value       = aws_lb_listener.http.arn
+}

--- a/infra/terraform/aws/modules/alb/variables.tf
+++ b/infra/terraform/aws/modules/alb/variables.tf
@@ -1,0 +1,25 @@
+variable "name_prefix" {
+  description = "Prefix used for ALB resources."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID for the ALB and target group."
+  type        = string
+}
+
+variable "public_subnet_ids" {
+  description = "Public subnet IDs for the ALB."
+  type        = list(string)
+}
+
+variable "container_port" {
+  description = "Container port the target group should route to."
+  type        = number
+}
+
+variable "health_check_path" {
+  description = "Health check path for the target group."
+  type        = string
+  default     = "/health"
+}

--- a/infra/terraform/aws/modules/ecs/main.tf
+++ b/infra/terraform/aws/modules/ecs/main.tf
@@ -1,0 +1,97 @@
+terraform {
+  required_version = ">= 1.5.0"
+}
+
+resource "aws_security_group" "ecs" {
+  name        = "${var.name_prefix}-ecs"
+  description = "ECS service security group"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description     = "Traffic from ALB"
+    from_port       = var.container_port
+    to_port         = var.container_port
+    protocol        = "tcp"
+    security_groups = [var.alb_sg_id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_ecs_cluster" "this" {
+  name = "${var.name_prefix}-cluster"
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = "${var.name_prefix}-task"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = tostring(var.cpu)
+  memory                   = tostring(var.memory)
+  execution_role_arn       = var.task_execution_role_arn
+  task_role_arn            = var.task_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "hive"
+      image     = var.image
+      essential = true
+      portMappings = [
+        {
+          containerPort = var.container_port
+          protocol      = "tcp"
+        }
+      ]
+      environment = [
+        for key, value in var.env_vars : {
+          name  = key
+          value = value
+        }
+      ]
+      secrets = [
+        for secret in var.secrets : {
+          name      = secret.name
+          valueFrom = secret.arn
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = var.log_group_name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "this" {
+  name            = "${var.name_prefix}-service"
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.this.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [aws_security_group.ecs.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = var.target_group_arn
+    container_name   = "hive"
+    container_port   = var.container_port
+  }
+
+  depends_on = [var.listener_arn]
+
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 200
+}

--- a/infra/terraform/aws/modules/ecs/outputs.tf
+++ b/infra/terraform/aws/modules/ecs/outputs.tf
@@ -1,0 +1,15 @@
+output "cluster_name" {
+  description = "ECS cluster name."
+  value       = aws_ecs_cluster.this.name
+}
+
+output "service_name" {
+  description = "ECS service name."
+  value       = aws_ecs_service.this.name
+}
+
+output "task_security_group_id" {
+  description = "Security group ID for the ECS service."
+  value       = aws_security_group.ecs.id
+}
+

--- a/infra/terraform/aws/modules/ecs/variables.tf
+++ b/infra/terraform/aws/modules/ecs/variables.tf
@@ -1,0 +1,89 @@
+variable "name_prefix" {
+  description = "Prefix used for ECS resources."
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region for logging configuration."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID for the ECS service security group."
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs for ECS tasks."
+  type        = list(string)
+}
+
+variable "container_port" {
+  description = "Container port exposed by the task."
+  type        = number
+}
+
+variable "image" {
+  description = "Container image for Hive."
+  type        = string
+}
+
+variable "cpu" {
+  description = "CPU units for the task definition."
+  type        = number
+}
+
+variable "memory" {
+  description = "Memory (MiB) for the task definition."
+  type        = number
+}
+
+variable "desired_count" {
+  description = "Number of desired ECS tasks."
+  type        = number
+}
+
+variable "env_vars" {
+  description = "Environment variables for the container."
+  type        = map(string)
+  default     = {}
+}
+
+variable "secrets" {
+  description = "Secrets Manager ARNs exposed as container secrets."
+  type = list(object({
+    name = string
+    arn  = string
+  }))
+  default = []
+}
+
+variable "task_execution_role_arn" {
+  description = "IAM task execution role ARN."
+  type        = string
+}
+
+variable "task_role_arn" {
+  description = "IAM task role ARN."
+  type        = string
+}
+
+variable "log_group_name" {
+  description = "CloudWatch log group name."
+  type        = string
+}
+
+variable "target_group_arn" {
+  description = "Target group ARN for the service."
+  type        = string
+}
+
+variable "alb_sg_id" {
+  description = "ALB security group ID to allow inbound traffic."
+  type        = string
+}
+
+variable "listener_arn" {
+  description = "ALB listener ARN used to enforce creation order before ECS service attaches the target group."
+  type        = string
+}

--- a/infra/terraform/aws/modules/iam/main.tf
+++ b/infra/terraform/aws/modules/iam/main.tf
@@ -1,0 +1,50 @@
+terraform {
+  required_version = ">= 1.5.0"
+}
+
+data "aws_iam_policy_document" "task_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task_execution" {
+  name               = "${var.name_prefix}-task-exec"
+  assume_role_policy = data.aws_iam_policy_document.task_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+data "aws_iam_policy_document" "task_policy" {
+  dynamic "statement" {
+    for_each = length(var.secrets_manager_arns) > 0 ? [1] : []
+    content {
+      actions   = ["secretsmanager:GetSecretValue"]
+      resources = var.secrets_manager_arns
+    }
+  }
+}
+
+resource "aws_iam_role" "task" {
+  name               = "${var.name_prefix}-task"
+  assume_role_policy = data.aws_iam_policy_document.task_assume_role.json
+}
+
+resource "aws_iam_policy" "task" {
+  count  = length(var.secrets_manager_arns) > 0 ? 1 : 0
+  name   = "${var.name_prefix}-task-secrets"
+  policy = data.aws_iam_policy_document.task_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "task" {
+  count      = length(var.secrets_manager_arns) > 0 ? 1 : 0
+  role       = aws_iam_role.task.name
+  policy_arn = aws_iam_policy.task[0].arn
+}

--- a/infra/terraform/aws/modules/iam/outputs.tf
+++ b/infra/terraform/aws/modules/iam/outputs.tf
@@ -1,0 +1,9 @@
+output "task_execution_role_arn" {
+  description = "ARN of the ECS task execution role."
+  value       = aws_iam_role.task_execution.arn
+}
+
+output "task_role_arn" {
+  description = "ARN of the ECS task role."
+  value       = aws_iam_role.task.arn
+}

--- a/infra/terraform/aws/modules/iam/variables.tf
+++ b/infra/terraform/aws/modules/iam/variables.tf
@@ -1,0 +1,10 @@
+variable "name_prefix" {
+  description = "Prefix used for IAM role names."
+  type        = string
+}
+
+variable "secrets_manager_arns" {
+  description = "List of Secrets Manager ARNs the task can read."
+  type        = list(string)
+  default     = []
+}

--- a/infra/terraform/aws/modules/observability/main.tf
+++ b/infra/terraform/aws/modules/observability/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.5.0"
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/ecs/${var.name_prefix}"
+  retention_in_days = var.retention_in_days
+}

--- a/infra/terraform/aws/modules/observability/outputs.tf
+++ b/infra/terraform/aws/modules/observability/outputs.tf
@@ -1,0 +1,9 @@
+output "log_group_name" {
+  description = "CloudWatch log group name."
+  value       = aws_cloudwatch_log_group.this.name
+}
+
+output "log_group_arn" {
+  description = "CloudWatch log group ARN."
+  value       = aws_cloudwatch_log_group.this.arn
+}

--- a/infra/terraform/aws/modules/observability/variables.tf
+++ b/infra/terraform/aws/modules/observability/variables.tf
@@ -1,0 +1,10 @@
+variable "name_prefix" {
+  description = "Prefix used for log group naming."
+  type        = string
+}
+
+variable "retention_in_days" {
+  description = "CloudWatch log retention in days."
+  type        = number
+  default     = 14
+}


### PR DESCRIPTION
## Description

Adds AWS deployment documentation for Hive, outlining a recommended ECS/Fargate approach and a modular Terraform structure for AWS deployments. This PR is documentation-only and sets the groundwork for a follow-up infra PR.
- terraform validate ✅
- terraform plan ✅ (using terraform.tfvars.example; real VPC/subnet IDs required for apply)


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #DevOps-Challenge

## Changes Made

- Added `docs/deployment/aws-ecs.md` describing an AWS ECS/Fargate deployment model (ALB/WebSocket notes, logging/secrets, high-level steps).
- Added `docs/infra/aws-terraform-structure.md` proposing a modular Terraform layout for AWS deployments (modules, responsibilities, design principles, next steps).

## Testing

Documentation-only change.

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed (verified markdown structure and links)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A for docs-only)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (docs-only)
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A for docs-only)
- [ ] New and existing unit tests pass locally with my changes (N/A for docs-only)

## Screenshots (if applicable)

N/A
