### PR TITLE
fix(setup): require virtualenv for Python 3.12+

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -150,6 +150,37 @@ claude> /testing-agent
 
 Creates comprehensive test suites for your agent.
 
+## Windows (WSL) Setup Notes
+
+If you are using Windows, it is strongly recommended to set up the project using WSL (Windows Subsystem for Linux) with an Ubuntu distribution.
+
+The setup-python.sh script is designed for Linux/macOS environments and may fail when run directly in Git Bash or PowerShell.
+
+Recommended setup for Windows users
+
+Install WSL and Ubuntu
+https://learn.microsoft.com/windows/wsl/install
+
+Clone the repository inside the WSL home directory (not under /mnt/c):
+
+cd ~
+git clone https://github.com/YOUR_USERNAME/hive.git
+cd hive
+
+
+Create and activate a Python virtual environment (required for Python 3.12 due to PEP 668):
+
+python3 -m venv .venv
+source .venv/bin/activate
+
+
+Run the setup script:
+
+./scripts/setup-python.sh
+
+
+Note: Running the project from /mnt/c may cause permission and script execution issues. Working inside the WSL filesystem (~) is recommended.
+
 ## Troubleshooting
 
 ### "ModuleNotFoundError: No module named 'framework'"

--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -60,6 +60,22 @@ fi
 echo -e "${GREEN}✓${NC} Python version check passed"
 echo ""
 
+# Python 3.12+ requires a virtual environment (PEP 668)
+if [ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -ge 12 ]; then
+    if [ -z "$VIRTUAL_ENV" ]; then
+        echo -e "${RED}Error: Python 3.12+ detected without an active virtual environment.${NC}"
+        echo ""
+        echo "Python 3.12 enforces system-managed packages (PEP 668)."
+        echo "Please create and activate a virtual environment before running this script:"
+        echo ""
+        echo "  python3 -m venv .venv"
+        echo "  source .venv/bin/activate"
+        echo ""
+        exit 1
+    fi
+fi
+
+
 # Check for pip
 if ! $PYTHON_CMD -m pip --version &> /dev/null; then
     echo -e "${RED}Error: pip is not installed${NC}"


### PR DESCRIPTION
This PR adds a guard in setup-python.sh to detect Python 3.12+
running outside an active virtual environment and exit early
with a clear, actionable error message.

This prevents pip failures caused by PEP 668 system-managed
environments and improves onboarding for new contributors.
