### PR TITLE
fix(orchestrator): use valid default model and allow env override (#835)

### DIFF
--- a/core/framework/runner/orchestrator.py
+++ b/core/framework/runner/orchestrator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -31,6 +32,12 @@ class RoutingDecision:
     fallback_agents: list[str] = field(default_factory=list)
 
 
+
+# Default model for routing decisions - using a stable model alias
+# Can be overridden via environment variable
+DEFAULT_ROUTING_MODEL = os.getenv("HIVE_ROUTING_MODEL", "claude-3-haiku-20240307")
+
+
 class AgentOrchestrator:
     """
     Manages multiple agents and routes communications between them.
@@ -55,7 +62,7 @@ class AgentOrchestrator:
     def __init__(
         self,
         llm: LLMProvider | None = None,
-        model: str = "claude-haiku-4-5-20251001",
+        model: str = DEFAULT_ROUTING_MODEL,
     ):
         """
         Initialize the orchestrator.


### PR DESCRIPTION
## Description
Fixes #835 by replacing the invalid hardcoded model `claude-haiku-4-5-20251001` with the stable alias `claude-3-haiku-20240307`.

Also introduces the `HIVE_ROUTING_MODEL` environment variable to allow users to override the default model without code changes.

## Verification
- Verified that `AgentOrchestrator` initializes correctly with the new default.
- Verified that setting `HIVE_ROUTING_MODEL` overrides the default.
- Fixes the crash experienced by users running with default settings.