### PR TITLE
perf(llm): add provider caching to avoid repeated instantiation (#843)

### DIFF
--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -745,16 +745,16 @@ class LLMNode(NodeProtocol):
             raise ValueError("Cannot parse JSON and no API key for LLM cleanup (set CEREBRAS_API_KEY or ANTHROPIC_API_KEY)")
 
         # Use fast LLM to clean the response (Cerebras llama-3.3-70b preferred)
-        from framework.llm.litellm import LiteLLMProvider
+        from framework.llm.litellm import get_provider
         if os.environ.get("CEREBRAS_API_KEY"):
-            cleaner_llm = LiteLLMProvider(
+            cleaner_llm = get_provider(
                 api_key=os.environ.get("CEREBRAS_API_KEY"),
                 model="cerebras/llama-3.3-70b",
                 temperature=0.0
             )
         else:
             # Fallback to Anthropic Haiku via LiteLLM for consistency
-            cleaner_llm = LiteLLMProvider(
+            cleaner_llm = get_provider(
                 api_key=api_key,
                 model="claude-3-5-haiku-20241022",
                 temperature=0.0

--- a/core/framework/graph/output_cleaner.py
+++ b/core/framework/graph/output_cleaner.py
@@ -88,12 +88,12 @@ class OutputCleaner:
         elif config.enabled:
             # Create dedicated fast LLM provider for cleaning
             try:
-                from framework.llm.litellm import LiteLLMProvider
+                from framework.llm.litellm import get_provider
                 import os
 
                 api_key = os.environ.get("CEREBRAS_API_KEY")
                 if api_key:
-                    self.llm = LiteLLMProvider(
+                    self.llm = get_provider(
                         api_key=api_key,
                         model=config.fast_model,
                         temperature=0.0,  # Deterministic cleaning

--- a/core/framework/runner/orchestrator.py
+++ b/core/framework/runner/orchestrator.py
@@ -71,8 +71,8 @@ class AgentOrchestrator:
 
         # Auto-create LLM - LiteLLM auto-detects provider and API key from model name
         if self._llm is None:
-            from framework.llm.litellm import LiteLLMProvider
-            self._llm = LiteLLMProvider(model=self._model)
+            from framework.llm.litellm import get_provider
+            self._llm = get_provider(model=self._model)
 
     def register(
         self,

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -415,8 +415,8 @@ class AgentRunner:
             # Detect required API key from model name
             api_key_env = self._get_api_key_env_var(self.model)
             if api_key_env and os.environ.get(api_key_env):
-                from framework.llm.litellm import LiteLLMProvider
-                self._llm = LiteLLMProvider(model=self.model)
+                from framework.llm.litellm import get_provider
+                self._llm = get_provider(model=self.model)
             elif api_key_env:
                 print(f"Warning: {api_key_env} not set. LLM calls will fail.")
                 print(f"Set it with: export {api_key_env}=your-api-key")


### PR DESCRIPTION
## Description
Fixes #843 by implementing a caching mechanism for `LiteLLMProvider` instances.

Previously, provider instances were re-created on every use (e.g., in `AgentOrchestrator`, `Node`, `OutputCleaner`). This PR adds a `get_provider()` factory function using a module-level cache to reuse instances when the configuration is identical.

## Changes
- Added `get_provider()` factory in `core/framework/llm/litellm.py`
- Added robust cache key generation (handles unhashable kwargs)
- Updated `orchestrator.py`, `runner.py`, `node.py`, `output_cleaner.py` to use the factory

## Verification
- Verified that identical configurations return the same instance (caching works)
- Verified that unhashable arguments (e.g. dicts in kwargs) do not cause crashes
- Verified existing imports and functionality