### PR TITLE
fix(cli): disable ANSI colours when stdout is not a TTY

### DIFF
--- a/core/verify_mcp.py
+++ b/core/verify_mcp.py
@@ -10,13 +10,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+def supports_color() -> bool:
+    """Return True if the current stdount supposrts ANSI colors."""
+    return sys.stdout.isatty()
 
 class Colors:
-    GREEN = '\033[0;32m'
-    YELLOW = '\033[1;33m'
-    RED = '\033[0;31m'
-    BLUE = '\033[0;34m'
-    NC = '\033[0m'
+    enable_colors = supports_color()
+    
+    GREEN = '\033[0;32m' if enable_colors else ''
+    YELLOW = '\033[1;33m' if enable_colors else ''
+    RED = '\033[0;31m' if enable_colors else ''
+    BLUE = '\033[0;34m' if enable_colors else ''
+    NC = '\033[0m' if enable_colors else ''
 
 
 def check(description: str) -> bool:


### PR DESCRIPTION
## Description

This PR improves the CLI output of the MCP verification script by disabling ANSI color codes when stdout is not a TTY. This prevents raw escape sequences from appearing in non-interactive environments such as CI logs or redirected output.


## Type of Change
	•	Bug fix (non-breaking change that fixes an issue)
	•	New feature (non-breaking change that adds functionality)
	•	Breaking change (fix or feature that would cause existing functionality to not work as expected)
	•	Documentation update
	•	Refactoring (no functional changes)


## Related Issues

N/A


## Changes Made
	•	Detect whether stdout supports ANSI colors using sys.stdout.isatty()
	•	Disable color output automatically when stdout is not a TTY
	•	Preserve existing colored output behavior for interactive terminals


## Testing

 - Describe the tests you ran to verify your changes:
	•	Unit tests pass (cd core && pytest tests/)
	•	Lint passes (cd core && ruff check .)
	•	Manual testing performed

 - Manual testing details:
	•	Ran python core/verify_mcp.py in an interactive terminal
	•	Ran python core/verify_mcp.py | cat to verify clean output without ANSI escape codes


## Checklist
	•	My code follows the project’s style guidelines
	•	I have performed a self-review of my code
	•	I have commented my code, particularly in hard-to-understand areas
	•	I have made corresponding changes to the documentation
	•	My changes generate no new warnings
	•	I have added tests that prove my fix is effective or that my feature works
	•	New and existing unit tests pass locally with my changes

(No new tests were added as this change only affects CLI output formatting.)