### PR TITLE
feat(tools): add http_request tool for generic HTTP/REST API calls

### DIFF
--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -22,6 +22,7 @@ from .example_tool import register_tools as register_example
 from .web_search_tool import register_tools as register_web_search
 from .web_scrape_tool import register_tools as register_web_scrape
 from .pdf_read_tool import register_tools as register_pdf_read
+from .http_request_tool import register_tools as register_http_request
 
 # Import file system toolkits
 from .file_system_toolkits.view_file import register_tools as register_view_file
@@ -53,6 +54,7 @@ def register_all_tools(
     register_example(mcp)
     register_web_scrape(mcp)
     register_pdf_read(mcp)
+    register_http_request(mcp)
 
     # Tools that need credentials (pass credentials if provided)
     # web_search handles both credential sources internally:
@@ -75,6 +77,7 @@ def register_all_tools(
         "web_search",
         "web_scrape",
         "pdf_read",
+        "http_request",
         "view_file",
         "write_to_file",
         "list_dir",

--- a/tools/src/aden_tools/tools/http_request_tool/README.md
+++ b/tools/src/aden_tools/tools/http_request_tool/README.md
@@ -1,0 +1,155 @@
+# HTTP Request Tool
+
+Make HTTP requests to any URL. Supports REST APIs, webhooks, and general HTTP endpoints.
+
+## Description
+
+A flexible HTTP client tool that supports all common HTTP methods, custom headers, JSON/form bodies, query parameters, and configurable timeouts. Includes built-in SSRF protection to prevent requests to internal/private networks.
+
+## Arguments
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `url` | str | Yes | - | The full URL to request (must start with http:// or https://) |
+| `method` | str | No | `GET` | HTTP method - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS |
+| `headers` | dict | No | `None` | HTTP headers dict (e.g., `{"Authorization": "Bearer token"}`) |
+| `body` | str | No | `None` | Raw request body as string |
+| `json_body` | dict | No | `None` | Request body as dict (auto JSON-encoded, sets Content-Type) |
+| `params` | dict | No | `None` | Query parameters dict (appended to URL) |
+| `timeout` | int | No | `30` | Request timeout in seconds (1-120) |
+| `follow_redirects` | bool | No | `True` | Whether to follow HTTP redirects |
+| `allow_private_ips` | bool | No | `False` | Allow requests to private/internal IPs (security override) |
+
+## Usage Examples
+
+### Basic GET Request
+
+```python
+result = http_request(url="https://api.example.com/users")
+# Returns: {"status_code": 200, "body": [...], "is_json": True, ...}
+```
+
+### POST with JSON Body
+
+```python
+result = http_request(
+    url="https://api.example.com/users",
+    method="POST",
+    json_body={"name": "Alice", "email": "alice@example.com"},
+    headers={"Authorization": "Bearer my-token"}
+)
+```
+
+### GET with Query Parameters
+
+```python
+result = http_request(
+    url="https://api.example.com/search",
+    params={"q": "python", "limit": 10}
+)
+# Requests: https://api.example.com/search?q=python&limit=10
+```
+
+### PUT with Custom Headers
+
+```python
+result = http_request(
+    url="https://api.example.com/users/123",
+    method="PUT",
+    json_body={"name": "Updated Name"},
+    headers={
+        "Authorization": "Bearer token",
+        "X-Custom-Header": "value"
+    }
+)
+```
+
+### POST with Raw Body
+
+```python
+result = http_request(
+    url="https://api.example.com/webhook",
+    method="POST",
+    body="raw text content",
+    headers={"Content-Type": "text/plain"}
+)
+```
+
+## Response Format
+
+### Success Response
+
+```python
+{
+    "status_code": 200,
+    "headers": {
+        "content-type": "application/json",
+        "x-request-id": "abc123",
+        ...
+    },
+    "body": {"data": [...]},  # Parsed JSON if content-type is application/json
+    "is_json": True,
+    "elapsed_ms": 245
+}
+```
+
+### Error Response
+
+```python
+{
+    "error": "Request timed out after 30 seconds"
+}
+```
+
+## Error Handling
+
+Returns error dicts for common issues:
+
+| Error | Cause |
+|-------|-------|
+| `URL is required` | Empty URL provided |
+| `URL must start with http:// or https://` | Invalid URL scheme |
+| `URL must include a hostname` | Malformed URL |
+| `Requests to {host} are not allowed` | Blocked host (localhost, metadata endpoints) |
+| `Requests to private/internal IP addresses are not allowed` | SSRF protection triggered |
+| `Invalid HTTP method: {method}` | Unsupported HTTP method |
+| `Cannot specify both 'body' and 'json_body'` | Conflicting body parameters |
+| `Request timed out after {n} seconds` | Request exceeded timeout |
+| `Too many redirects` | Redirect loop detected |
+| `Connection failed: {error}` | Network/DNS error |
+| `Request failed: {error}` | General HTTP error |
+
+## Security Features
+
+### SSRF Protection
+
+By default, the tool blocks requests to:
+
+- **Localhost**: `localhost`, `127.0.0.1`, `0.0.0.0`
+- **Cloud metadata endpoints**: `169.254.169.254`, `metadata.google.internal`
+- **Private IP ranges**: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
+- **IPv6 private/link-local addresses**
+
+To allow internal requests (e.g., for testing), set `allow_private_ips=True`:
+
+```python
+result = http_request(
+    url="http://192.168.1.100/api/internal",
+    allow_private_ips=True  # Override SSRF protection
+)
+```
+
+### Response Size Limit
+
+Text responses are truncated at 1MB to prevent memory issues.
+
+## Environment Variables
+
+This tool does not require any environment variables. For APIs requiring authentication, pass tokens via the `headers` parameter.
+
+## Notes
+
+- Uses `httpx` library for HTTP requests
+- Automatically parses JSON responses when `Content-Type: application/json`
+- Timeout is clamped to 1-120 seconds
+- Follows redirects by default (configurable)

--- a/tools/src/aden_tools/tools/http_request_tool/__init__.py
+++ b/tools/src/aden_tools/tools/http_request_tool/__init__.py
@@ -1,0 +1,4 @@
+"""HTTP Request Tool - Make HTTP requests to any URL."""
+from .http_request_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/http_request_tool/http_request_tool.py
+++ b/tools/src/aden_tools/tools/http_request_tool/http_request_tool.py
@@ -1,0 +1,220 @@
+"""
+HTTP Request Tool - Make HTTP requests to any URL.
+
+Supports all HTTP methods, custom headers, JSON/form bodies,
+query parameters, and configurable timeouts.
+"""
+from __future__ import annotations
+
+import json
+import ipaddress
+import socket
+from typing import TYPE_CHECKING, Optional
+from urllib.parse import urlparse
+
+import httpx
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialManager
+
+
+# Hosts that are blocked by default to prevent SSRF attacks
+BLOCKED_HOSTS = {
+    "localhost",
+    "127.0.0.1",
+    "0.0.0.0",
+    "169.254.169.254",  # AWS metadata endpoint
+    "metadata.google.internal",  # GCP metadata
+}
+
+# Private IP ranges to block (SSRF protection)
+PRIVATE_IP_RANGES = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),  # Link-local
+    ipaddress.ip_network("::1/128"),  # IPv6 localhost
+    ipaddress.ip_network("fc00::/7"),  # IPv6 private
+    ipaddress.ip_network("fe80::/10"),  # IPv6 link-local
+]
+
+ALLOWED_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}
+
+
+def _is_private_ip(hostname: str) -> bool:
+    """Check if hostname resolves to a private IP address."""
+    try:
+        # Try to parse as IP address directly
+        ip = ipaddress.ip_address(hostname)
+        return any(ip in network for network in PRIVATE_IP_RANGES)
+    except ValueError:
+        # Not an IP address, try to resolve hostname
+        try:
+            ip_str = socket.gethostbyname(hostname)
+            ip = ipaddress.ip_address(ip_str)
+            return any(ip in network for network in PRIVATE_IP_RANGES)
+        except socket.gaierror:
+            # Can't resolve hostname - allow it (will fail later if invalid)
+            return False
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: Optional["CredentialManager"] = None,
+) -> None:
+    """Register HTTP request tools with the MCP server."""
+
+    @mcp.tool()
+    def http_request(
+        url: str,
+        method: str = "GET",
+        headers: Optional[dict] = None,
+        body: Optional[str] = None,
+        json_body: Optional[dict] = None,
+        params: Optional[dict] = None,
+        timeout: int = 30,
+        follow_redirects: bool = True,
+        allow_private_ips: bool = False,
+    ) -> dict:
+        """
+        Make an HTTP request to any URL.
+
+        Use this for calling REST APIs, webhooks, or any HTTP endpoint.
+        Returns status code, headers, and response body.
+
+        Args:
+            url: The full URL to request (must start with http:// or https://)
+            method: HTTP method - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+            headers: Optional dict of HTTP headers (e.g., {"Authorization": "Bearer token"})
+            body: Raw request body as string
+            json_body: Request body as dict (will be JSON-encoded, sets Content-Type)
+            params: Query parameters as dict (appended to URL)
+            timeout: Request timeout in seconds (1-120, default 30)
+            follow_redirects: Whether to follow HTTP redirects (default True)
+            allow_private_ips: Allow requests to private/internal IPs (default False, for security)
+
+        Returns:
+            Dict with status_code, headers, body, is_json, elapsed_ms on success.
+            Dict with error key on failure.
+        """
+        # Validate URL
+        if not url:
+            return {"error": "URL is required"}
+
+        try:
+            parsed = urlparse(url)
+        except Exception:
+            return {"error": "Invalid URL format"}
+
+        # Validate scheme
+        if parsed.scheme not in ("http", "https"):
+            return {"error": "URL must start with http:// or https://"}
+
+        # Validate hostname exists
+        if not parsed.hostname:
+            return {"error": "URL must include a hostname"}
+
+        # Security: Block dangerous hosts
+        hostname_lower = parsed.hostname.lower()
+        if hostname_lower in BLOCKED_HOSTS:
+            return {"error": f"Requests to {parsed.hostname} are not allowed"}
+
+        # Security: Block private IPs (unless explicitly allowed)
+        if not allow_private_ips and _is_private_ip(parsed.hostname):
+            return {
+                "error": f"Requests to private/internal IP addresses are not allowed. "
+                f"Set allow_private_ips=True to override."
+            }
+
+        # Validate method
+        method = method.upper().strip()
+        if method not in ALLOWED_METHODS:
+            return {
+                "error": f"Invalid HTTP method: {method}. "
+                f"Allowed: {', '.join(sorted(ALLOWED_METHODS))}"
+            }
+
+        # Validate and clamp timeout
+        if not isinstance(timeout, (int, float)):
+            timeout = 30
+        timeout = max(1, min(120, int(timeout)))
+
+        # Validate body - can't have both body and json_body
+        if body is not None and json_body is not None:
+            return {"error": "Cannot specify both 'body' and 'json_body'. Use one or the other."}
+
+        # Prepare request kwargs
+        request_kwargs = {
+            "method": method,
+            "url": url,
+            "timeout": float(timeout),
+            "follow_redirects": follow_redirects,
+        }
+
+        # Add headers
+        if headers:
+            if not isinstance(headers, dict):
+                return {"error": "headers must be a dict"}
+            request_kwargs["headers"] = headers
+
+        # Add query params
+        if params:
+            if not isinstance(params, dict):
+                return {"error": "params must be a dict"}
+            request_kwargs["params"] = params
+
+        # Add body
+        if json_body is not None:
+            if not isinstance(json_body, dict):
+                return {"error": "json_body must be a dict"}
+            request_kwargs["json"] = json_body
+        elif body is not None:
+            if not isinstance(body, str):
+                return {"error": "body must be a string"}
+            request_kwargs["content"] = body
+
+        # Make the request
+        try:
+            with httpx.Client() as client:
+                response = client.request(**request_kwargs)
+
+            # Parse response headers
+            response_headers = dict(response.headers)
+
+            # Determine if response is JSON
+            content_type = response_headers.get("content-type", "")
+            is_json = "application/json" in content_type.lower()
+
+            # Parse response body
+            if is_json:
+                try:
+                    response_body = response.json()
+                except json.JSONDecodeError:
+                    response_body = response.text
+                    is_json = False
+            else:
+                # For non-JSON, return text (limit size to prevent memory issues)
+                response_body = response.text
+                if len(response_body) > 1_000_000:  # 1MB limit
+                    response_body = response_body[:1_000_000] + "\n... [truncated, response exceeded 1MB]"
+
+            return {
+                "status_code": response.status_code,
+                "headers": response_headers,
+                "body": response_body,
+                "is_json": is_json,
+                "elapsed_ms": int(response.elapsed.total_seconds() * 1000),
+            }
+
+        except httpx.TimeoutException:
+            return {"error": f"Request timed out after {timeout} seconds"}
+        except httpx.TooManyRedirects:
+            return {"error": "Too many redirects (exceeded limit)"}
+        except httpx.ConnectError as e:
+            return {"error": f"Connection failed: {str(e)}"}
+        except httpx.RequestError as e:
+            return {"error": f"Request failed: {str(e)}"}
+        except Exception as e:
+            return {"error": f"Unexpected error: {str(e)}"}

--- a/tools/tests/tools/test_http_request_tool.py
+++ b/tools/tests/tools/test_http_request_tool.py
@@ -1,0 +1,453 @@
+"""Tests for http_request tool (FastMCP)."""
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+
+from fastmcp import FastMCP
+from aden_tools.tools.http_request_tool import register_tools
+
+
+@pytest.fixture
+def http_request_fn(mcp: FastMCP):
+    """Register and return the http_request tool function."""
+    register_tools(mcp)
+    return mcp._tool_manager._tools["http_request"].fn
+
+
+class TestHttpRequestValidation:
+    """Tests for input validation."""
+
+    def test_empty_url_returns_error(self, http_request_fn):
+        """Empty URL returns error."""
+        result = http_request_fn(url="")
+        assert "error" in result
+        assert "required" in result["error"].lower()
+
+    def test_invalid_scheme_returns_error(self, http_request_fn):
+        """Non-http/https scheme returns error."""
+        result = http_request_fn(url="ftp://example.com")
+        assert "error" in result
+        assert "http://" in result["error"] or "https://" in result["error"]
+
+    def test_file_scheme_returns_error(self, http_request_fn):
+        """File scheme is blocked."""
+        result = http_request_fn(url="file:///etc/passwd")
+        assert "error" in result
+
+    def test_missing_hostname_returns_error(self, http_request_fn):
+        """URL without hostname returns error."""
+        result = http_request_fn(url="http://")
+        assert "error" in result
+        assert "hostname" in result["error"].lower()
+
+    def test_invalid_method_returns_error(self, http_request_fn):
+        """Invalid HTTP method returns error."""
+        result = http_request_fn(url="https://example.com", method="INVALID")
+        assert "error" in result
+        assert "method" in result["error"].lower()
+
+    def test_both_body_and_json_body_returns_error(self, http_request_fn):
+        """Specifying both body and json_body returns error."""
+        result = http_request_fn(
+            url="https://example.com",
+            body="raw",
+            json_body={"key": "value"}
+        )
+        assert "error" in result
+        assert "both" in result["error"].lower()
+
+    def test_headers_must_be_dict(self, http_request_fn):
+        """Non-dict headers returns error."""
+        result = http_request_fn(
+            url="https://example.com",
+            headers="invalid"
+        )
+        assert "error" in result
+        assert "dict" in result["error"].lower()
+
+    def test_params_must_be_dict(self, http_request_fn):
+        """Non-dict params returns error."""
+        result = http_request_fn(
+            url="https://example.com",
+            params="invalid"
+        )
+        assert "error" in result
+        assert "dict" in result["error"].lower()
+
+    def test_json_body_must_be_dict(self, http_request_fn):
+        """Non-dict json_body returns error."""
+        result = http_request_fn(
+            url="https://example.com",
+            json_body="invalid"
+        )
+        assert "error" in result
+        assert "dict" in result["error"].lower()
+
+    def test_body_must_be_string(self, http_request_fn):
+        """Non-string body returns error."""
+        result = http_request_fn(
+            url="https://example.com",
+            body={"key": "value"}
+        )
+        assert "error" in result
+        assert "string" in result["error"].lower()
+
+
+class TestSsrfProtection:
+    """Tests for SSRF protection."""
+
+    def test_localhost_blocked(self, http_request_fn):
+        """Requests to localhost are blocked."""
+        result = http_request_fn(url="http://localhost/api")
+        assert "error" in result
+        assert "not allowed" in result["error"].lower()
+
+    def test_127_0_0_1_blocked(self, http_request_fn):
+        """Requests to 127.0.0.1 are blocked."""
+        result = http_request_fn(url="http://127.0.0.1/api")
+        assert "error" in result
+        assert "not allowed" in result["error"].lower()
+
+    def test_0_0_0_0_blocked(self, http_request_fn):
+        """Requests to 0.0.0.0 are blocked."""
+        result = http_request_fn(url="http://0.0.0.0/api")
+        assert "error" in result
+        assert "not allowed" in result["error"].lower()
+
+    def test_aws_metadata_blocked(self, http_request_fn):
+        """Requests to AWS metadata endpoint are blocked."""
+        result = http_request_fn(url="http://169.254.169.254/latest/meta-data/")
+        assert "error" in result
+        assert "not allowed" in result["error"].lower()
+
+    def test_private_ip_10_x_blocked(self, http_request_fn):
+        """Requests to 10.x.x.x private IPs are blocked."""
+        result = http_request_fn(url="http://10.0.0.1/api")
+        assert "error" in result
+        assert "private" in result["error"].lower() or "not allowed" in result["error"].lower()
+
+    def test_private_ip_172_16_blocked(self, http_request_fn):
+        """Requests to 172.16.x.x private IPs are blocked."""
+        result = http_request_fn(url="http://172.16.0.1/api")
+        assert "error" in result
+        assert "private" in result["error"].lower() or "not allowed" in result["error"].lower()
+
+    def test_private_ip_192_168_blocked(self, http_request_fn):
+        """Requests to 192.168.x.x private IPs are blocked."""
+        result = http_request_fn(url="http://192.168.1.1/api")
+        assert "error" in result
+        assert "private" in result["error"].lower() or "not allowed" in result["error"].lower()
+
+    def test_allow_private_ips_override(self, http_request_fn):
+        """allow_private_ips=True allows private IP requests (but they may fail connection)."""
+        # This will fail at connection time, but should NOT be blocked by SSRF check
+        result = http_request_fn(
+            url="http://192.168.1.1/api",
+            allow_private_ips=True,
+            timeout=1
+        )
+        # Should either succeed or fail with connection error, not SSRF error
+        if "error" in result:
+            assert "private" not in result["error"].lower() or "allow" in result["error"].lower()
+
+
+class TestHttpMethods:
+    """Tests for HTTP method handling."""
+
+    def test_get_method_default(self, http_request_fn):
+        """GET is the default method."""
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "text/plain"}
+            mock_response.text = "OK"
+            mock_response.elapsed.total_seconds.return_value = 0.1
+            mock_client.return_value.__enter__.return_value.request.return_value = mock_response
+
+            result = http_request_fn(url="https://example.com/api")
+
+            call_args = mock_client.return_value.__enter__.return_value.request.call_args
+            assert call_args.kwargs["method"] == "GET"
+
+    def test_post_method(self, http_request_fn):
+        """POST method works."""
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 201
+            mock_response.headers = {"content-type": "application/json"}
+            mock_response.json.return_value = {"id": 1}
+            mock_response.elapsed.total_seconds.return_value = 0.1
+            mock_client.return_value.__enter__.return_value.request.return_value = mock_response
+
+            result = http_request_fn(
+                url="https://example.com/api",
+                method="POST",
+                json_body={"name": "test"}
+            )
+
+            assert result["status_code"] == 201
+            call_args = mock_client.return_value.__enter__.return_value.request.call_args
+            assert call_args.kwargs["method"] == "POST"
+            assert call_args.kwargs["json"] == {"name": "test"}
+
+    def test_method_case_insensitive(self, http_request_fn):
+        """HTTP method is case-insensitive."""
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "text/plain"}
+            mock_response.text = "OK"
+            mock_response.elapsed.total_seconds.return_value = 0.1
+            mock_client.return_value.__enter__.return_value.request.return_value = mock_response
+
+            result = http_request_fn(url="https://example.com/api", method="post")
+
+            call_args = mock_client.return_value.__enter__.return_value.request.call_args
+            assert call_args.kwargs["method"] == "POST"
+
+    @pytest.mark.parametrize("method", ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"])
+    def test_all_allowed_methods(self, http_request_fn, method):
+        """All allowed HTTP methods are accepted."""
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "text/plain"}
+            mock_response.text = "OK"
+            mock_response.elapsed.total_seconds.return_value = 0.1
+            mock_client.return_value.__enter__.return_value.request.return_value = mock_response
+
+            result = http_request_fn(url="https://example.com/api", method=method)
+
+            assert "error" not in result
+            assert result["status_code"] == 200
+
+
+class TestResponseParsing:
+    """Tests for response parsing."""
+
+    def test_json_response_parsed(self, http_request_fn):
+        """JSON responses are automatically parsed."""
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "application/json; charset=utf-8"}
+            mock_response.json.return_value = {"data": [1, 2, 3]}
+            mock_response.elapsed.total_seconds.return_value = 0.1
+            mock_client.return_value.__enter__.return_value.request.return_value = mock_response
+
+            result = http_request_fn(url="https://api.example.com/data")
+
+            assert result["is_json"] is True
+            assert result["body"] == {"data": [1, 2, 3]}
+
+    def test_text_response_not_parsed(self, http_request_fn):
+        """Text responses are returned as-is."""
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "text/html"}
+            mock_response.text = "<html>Hello</html>"
+            mock_response.elapsed.total_seconds.return_value = 0.1
+            mock_client.return_value.__enter__.return_value.request.return_value = mock_response
+
+            result = http_request_fn(url="https://example.com")
+
+            assert result["is_json"] is False
+            assert result["body"] == "<html>Hello</html>"
+
+    def test_response_includes_headers(self, http_request_fn):
+        """Response includes headers."""
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {
+                "content-type": "application/json",
+                "x-request-id": "abc123"
+            }
+            mock_response.json.return_value = {}
+            mock_response.elapsed.total_seconds.return_value = 0.1
+            mock_client.return_value.__enter__.return_value.request.return_value = mock_response
+
+            result = http_request_fn(url="https://api.example.com")
+
+            assert "headers" in result
+            assert result["headers"]["x-request-id"] == "abc123"
+
+    def test_response_includes_elapsed_time(self, http_request_fn):
+        """Response includes elapsed time in milliseconds."""
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "text/plain"}
+            mock_response.text = "OK"
+            mock_response.elapsed.total_seconds.return_value = 0.245
+            mock_client.return_value.__enter__.return_value.request.return_value = mock_response
+
+            result = http_request_fn(url="https://example.com")
+
+            assert result["elapsed_ms"] == 245
+
+
+class TestErrorHandling:
+    """Tests for error handling."""
+
+    def test_timeout_error(self, http_request_fn):
+        """Timeout returns appropriate error."""
+        import httpx
+
+        with patch("httpx.Client") as mock_client:
+            mock_client.return_value.__enter__.return_value.request.side_effect = httpx.TimeoutException("timeout")
+
+            result = http_request_fn(url="https://example.com", timeout=5)
+
+            assert "error" in result
+            assert "timed out" in result["error"].lower()
+            assert "5" in result["error"]
+
+    def test_connection_error(self, http_request_fn):
+        """Connection error returns appropriate error."""
+        import httpx
+
+        with patch("httpx.Client") as mock_client:
+            mock_client.return_value.__enter__.return_value.request.side_effect = httpx.ConnectError("connection refused")
+
+            result = http_request_fn(url="https://example.com")
+
+            assert "error" in result
+            assert "connection" in result["error"].lower() or "failed" in result["error"].lower()
+
+    def test_too_many_redirects(self, http_request_fn):
+        """Too many redirects returns appropriate error."""
+        import httpx
+
+        with patch("httpx.Client") as mock_client:
+            mock_client.return_value.__enter__.return_value.request.side_effect = httpx.TooManyRedirects("too many")
+
+            result = http_request_fn(url="https://example.com")
+
+            assert "error" in result
+            assert "redirect" in result["error"].lower()
+
+
+class TestTimeoutHandling:
+    """Tests for timeout configuration."""
+
+    def test_timeout_clamped_minimum(self, http_request_fn):
+        """Timeout is clamped to minimum of 1."""
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "text/plain"}
+            mock_response.text = "OK"
+            mock_response.elapsed.total_seconds.return_value = 0.1
+            mock_client.return_value.__enter__.return_value.request.return_value = mock_response
+
+            result = http_request_fn(url="https://example.com", timeout=0)
+
+            call_args = mock_client.return_value.__enter__.return_value.request.call_args
+            assert call_args.kwargs["timeout"] == 1.0
+
+    def test_timeout_clamped_maximum(self, http_request_fn):
+        """Timeout is clamped to maximum of 120."""
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "text/plain"}
+            mock_response.text = "OK"
+            mock_response.elapsed.total_seconds.return_value = 0.1
+            mock_client.return_value.__enter__.return_value.request.return_value = mock_response
+
+            result = http_request_fn(url="https://example.com", timeout=999)
+
+            call_args = mock_client.return_value.__enter__.return_value.request.call_args
+            assert call_args.kwargs["timeout"] == 120.0
+
+
+class TestRequestOptions:
+    """Tests for request options."""
+
+    def test_custom_headers_sent(self, http_request_fn):
+        """Custom headers are included in request."""
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "text/plain"}
+            mock_response.text = "OK"
+            mock_response.elapsed.total_seconds.return_value = 0.1
+            mock_client.return_value.__enter__.return_value.request.return_value = mock_response
+
+            result = http_request_fn(
+                url="https://api.example.com",
+                headers={"Authorization": "Bearer token123"}
+            )
+
+            call_args = mock_client.return_value.__enter__.return_value.request.call_args
+            assert call_args.kwargs["headers"]["Authorization"] == "Bearer token123"
+
+    def test_query_params_sent(self, http_request_fn):
+        """Query params are included in request."""
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "text/plain"}
+            mock_response.text = "OK"
+            mock_response.elapsed.total_seconds.return_value = 0.1
+            mock_client.return_value.__enter__.return_value.request.return_value = mock_response
+
+            result = http_request_fn(
+                url="https://api.example.com/search",
+                params={"q": "test", "limit": 10}
+            )
+
+            call_args = mock_client.return_value.__enter__.return_value.request.call_args
+            assert call_args.kwargs["params"] == {"q": "test", "limit": 10}
+
+    def test_follow_redirects_default_true(self, http_request_fn):
+        """follow_redirects defaults to True."""
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "text/plain"}
+            mock_response.text = "OK"
+            mock_response.elapsed.total_seconds.return_value = 0.1
+            mock_client.return_value.__enter__.return_value.request.return_value = mock_response
+
+            result = http_request_fn(url="https://example.com")
+
+            call_args = mock_client.return_value.__enter__.return_value.request.call_args
+            assert call_args.kwargs["follow_redirects"] is True
+
+    def test_follow_redirects_can_be_disabled(self, http_request_fn):
+        """follow_redirects can be set to False."""
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 302
+            mock_response.headers = {"content-type": "text/plain", "location": "/new"}
+            mock_response.text = ""
+            mock_response.elapsed.total_seconds.return_value = 0.1
+            mock_client.return_value.__enter__.return_value.request.return_value = mock_response
+
+            result = http_request_fn(url="https://example.com", follow_redirects=False)
+
+            call_args = mock_client.return_value.__enter__.return_value.request.call_args
+            assert call_args.kwargs["follow_redirects"] is False
+            assert result["status_code"] == 302
+
+    def test_raw_body_sent(self, http_request_fn):
+        """Raw body is sent as content."""
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "text/plain"}
+            mock_response.text = "OK"
+            mock_response.elapsed.total_seconds.return_value = 0.1
+            mock_client.return_value.__enter__.return_value.request.return_value = mock_response
+
+            result = http_request_fn(
+                url="https://api.example.com/webhook",
+                method="POST",
+                body="raw content here"
+            )
+
+            call_args = mock_client.return_value.__enter__.return_value.request.call_args
+            assert call_args.kwargs["content"] == "raw content here"


### PR DESCRIPTION
## Description

Adds a new `http_request` tool to the Aden tools library that enables agents to make HTTP requests to any URL. This is a foundational tool that supports REST API integrations, webhook triggers, and general HTTP communication.

The implementation includes built-in SSRF protection, comprehensive input validation, automatic JSON response parsing, and configurable timeouts.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #885

## Changes Made

- Added `tools/src/aden_tools/tools/http_request_tool/http_request_tool.py` - Main implementation with:
  - Support for all HTTP methods (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS)
  - Custom headers and query parameters
  - JSON body and raw body support
  - SSRF protection (blocks localhost, private IPs, cloud metadata endpoints)
  - Configurable timeouts (1-120 seconds)
  - Automatic JSON response parsing
  - Response size limiting (1MB max)
- Added `tools/src/aden_tools/tools/http_request_tool/__init__.py` - Module exports
- Added `tools/src/aden_tools/tools/http_request_tool/README.md` - Full documentation with usage examples
- Updated `tools/src/aden_tools/tools/__init__.py` - Registered new tool in `register_all_tools()`
- Added `tools/tests/tools/test_http_request_tool.py` - 42 comprehensive tests covering:
  - Input validation (URL, method, headers, body, params)
  - SSRF protection (localhost, private IPs, metadata endpoints)
  - All HTTP methods
  - Response parsing (JSON and text)
  - Error handling (timeouts, connection errors, redirects)
  - Request options (headers, params, follow_redirects)

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd tools && python3 -m pytest tests/tools/test_http_request_tool.py -v`)
- [x] Lint passes (no linter errors)
- [x] Manual testing performed

**Test Results:**
```
42 passed in 9.08s
```

All test categories:
- `TestHttpRequestValidation` - 10 tests
- `TestSsrfProtection` - 8 tests
- `TestHttpMethods` - 10 tests
- `TestResponseParsing` - 4 tests
- `TestErrorHandling` - 3 tests
- `TestTimeoutHandling` - 2 tests
- `TestRequestOptions` - 5 tests

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A - This is a backend tool with no UI changes.