### PR TITLE
docs: clarify illustrative output sanitization example

### DIFF
--- a/docs/articles/building-production-ai-agents.md
+++ b/docs/articles/building-production-ai-agents.md
@@ -364,6 +364,8 @@ class AgentRequest(BaseModel):
 ```
 
 ### Output Sanitization
+> **Note:** The following snippet is illustrative and shows a simplified example
+> of output sanitization logic. Actual implementations may differ.
 ```python
 def sanitize_output(result):
     # Remove any leaked secrets


### PR DESCRIPTION
Fixes issue #880 
Clarifies that validation and sanitization snippets are illustrative examples
and may not reflect the exact runtime implementation.
