### PR TITLE
fix(graph): add logging for JSON parsing failures in worker_node

### DIFF
--- a/core/framework/graph/worker_node.py
+++ b/core/framework/graph/worker_node.py
@@ -11,6 +11,7 @@ appropriate executor based on action type:
 """
 
 import json
+import logging
 import re
 import time
 from collections.abc import Callable
@@ -25,6 +26,8 @@ from framework.graph.plan import (
 )
 from framework.llm.provider import LLMProvider, Tool
 from framework.runtime.core import Runtime
+
+logger = logging.getLogger(__name__)
 
 
 def parse_llm_json_response(text: str) -> tuple[Any | None, str]:
@@ -60,15 +63,22 @@ def parse_llm_json_response(text: str) -> tuple[Any | None, str]:
             try:
                 parsed = json.loads(match.strip())
                 return parsed, match.strip()
-            except json.JSONDecodeError:
+            except json.JSONDecodeError as e:
+                logger.debug(
+                    f"Failed to parse JSON from code block: {e}. "
+                    f"Content preview: {match.strip()[:100]}..."
+                )
                 continue
 
     # No code blocks or parsing failed - try parsing the whole response
     try:
         parsed = json.loads(cleaned)
         return parsed, cleaned
-    except json.JSONDecodeError:
-        pass
+    except json.JSONDecodeError as e:
+        logger.debug(
+            f"Failed to parse entire response as JSON: {e}. "
+            f"Content preview: {cleaned[:100]}..."
+        )
 
     # Try to find JSON-like content (starts with { or [)
     json_start_pattern = r"(\{[\s\S]*\}|\[[\s\S]*\])"
@@ -78,10 +88,18 @@ def parse_llm_json_response(text: str) -> tuple[Any | None, str]:
         try:
             parsed = json.loads(match)
             return parsed, match
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as e:
+            logger.debug(
+                f"Failed to parse JSON pattern: {e}. "
+                f"Content preview: {match[:100]}..."
+            )
             continue
 
-    # Could not parse as JSON
+    # Could not parse as JSON - log warning
+    logger.warning(
+        f"Could not parse LLM response as JSON after trying all strategies. "
+        f"Response preview: {cleaned[:200]}..."
+    )
     return None, cleaned
 
 


### PR DESCRIPTION
## Description

Adds logging to `parse_llm_json_response()` function in `worker_node.py` to improve debugging of JSON parsing failures from LLM responses.

Previously, JSON parsing errors were silently swallowed using bare `continue` and `pass` statements, making it extremely difficult to diagnose why agents failed.

## Changes

- Added `logging` import and logger initialization
- Added debug logs for each parsing strategy failure (code blocks, whole response, JSON patterns)
- Added warning log when all parsing strategies fail
- Included content previews (truncated to 100-200 chars) in log messages
- Maintained existing function behavior (no breaking changes)

## Related Issue

Fixes #921 

## Testing

- [x] Manually tested with malformed JSON inputs
- [x] Verified logging output at DEBUG and WARNING levels
- [x] Confirmed no behavior changes (still returns None on failure)
- [x] All existing tests pass

## Impact

- Improves debugging of agent failures
- Provides visibility into JSON parsing issues
- Consistent with error handling in other parts of the codebase
- No breaking changes or performance impact