### PR TITLE
docs(tools): fix tool name in README table (execute_command → execute_command_tool)

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -67,7 +67,7 @@ python mcp_server.py
 | `apply_diff`           | Apply diff patches to files                    |
 | `apply_patch`          | Apply unified patches to files                 |
 | `grep_search`          | Search file contents with regex                |
-| `execute_command`      | Execute shell commands                         |
+| `execute_command_tool` | Execute shell commands                         |
 | `web_search`           | Search the web using Brave Search API          |
 | `web_scrape`           | Scrape and extract content from webpages       |
 | `pdf_read`             | Read and extract text from PDF files           |


### PR DESCRIPTION
## Summary

- Fix the "Available Tools" table in `tools/README.md` to use the correct tool name `execute_command_tool` instead of `execute_command`
- The registered name in `__init__.py` and the tool's own README both use `execute_command_tool`

## Test plan

- [x] Verify the table now matches the runtime name in `tools/src/aden_tools/tools/__init__.py`
- [x] Confirm the tool's own README uses `execute_command_tool`

Fixes #901