### PR TITLE
ci: make Validate Agent Exports skip clearly when exports/ is missing or empty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,31 @@ jobs:
       - name: Validate exported agents
         run: |
           # Check that agent exports have valid structure
-          for agent_dir in exports/*/; do
+          if [ ! -d "exports" ]; then
+            echo "No exports/ directory found, skipping validation"
+            exit 0
+          fi
+
+          shopt -s nullglob
+          agent_dirs=(exports/*/)
+          shopt -u nullglob
+
+          if [ ${#agent_dirs[@]} -eq 0 ]; then
+            echo "No agent directories in exports/, skipping validation"
+            exit 0
+          fi
+
+          validated=0
+          for agent_dir in "${agent_dirs[@]}"; do
             if [ -f "$agent_dir/agent.json" ]; then
               echo "Validating $agent_dir"
               python -c "import json; json.load(open('$agent_dir/agent.json'))"
+              validated=$((validated + 1))
             fi
           done
+
+          if [ "$validated" -eq 0 ]; then
+            echo "No agent.json files found in exports/, skipping validation"
+          else
+            echo "Validated $validated agent(s)"
+          fi


### PR DESCRIPTION
## Summary

- Make the "Validate Agent Exports" CI job explicit when there's nothing to validate
- Previously, the bash glob `exports/*/` would silently do nothing when `exports/` was missing or empty, and the job would pass without validating anything
- Now the job logs clear messages: "No exports/ directory found, skipping validation" or "No agent directories in exports/, skipping validation"
- Reports the count of validated agents when successful

## Changes

- Check if `exports/` directory exists before attempting validation
- Use `nullglob` to handle empty directories properly (no literal `exports/*/` iteration)
- Log explicit skip messages when there's nothing to validate
- Report "Validated N agent(s)" on success

## Test plan

- [x] CI passes when `exports/` is missing (current repo state)
- [x] CI logs "No exports/ directory found, skipping validation" instead of silent pass
- [ ] CI validates agents correctly when `exports/` contains agent directories with `agent.json`

Fixes #887