### PR TITLE
fix(types): correct type annotation from lowercase 'callable' to 'Callable'

### DIFF
--- a/core/framework/llm/mock.py
+++ b/core/framework/llm/mock.py
@@ -2,9 +2,10 @@
 
 import json
 import re
+from collections.abc import Callable
 from typing import Any
 
-from framework.llm.provider import LLMProvider, LLMResponse, Tool
+from framework.llm.provider import LLMProvider, LLMResponse, Tool, ToolResult, ToolUse
 
 
 class MockLLMProvider(LLMProvider):
@@ -143,7 +144,7 @@ class MockLLMProvider(LLMProvider):
         messages: list[dict[str, Any]],
         system: str,
         tools: list[Tool],
-        tool_executor: callable,
+        tool_executor: Callable[[ToolUse], ToolResult],
         max_iterations: int = 10,
     ) -> LLMResponse:
         """

--- a/core/framework/runtime/core.py
+++ b/core/framework/runtime/core.py
@@ -8,6 +8,7 @@ handles all the structured logging.
 
 import logging
 import uuid
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -299,7 +300,7 @@ class Runtime:
         options: list[dict[str, Any]],
         chosen: str,
         reasoning: str,
-        executor: callable,
+        executor: Callable,
         **kwargs,
     ) -> tuple[str, Any]:
         """

--- a/core/tests/test_execution_stream.py
+++ b/core/tests/test_execution_stream.py
@@ -1,6 +1,7 @@
 """Tests for ExecutionStream retention behavior."""
 
 import json
+from collections.abc import Callable
 
 import pytest
 
@@ -33,7 +34,7 @@ class DummyLLMProvider(LLMProvider):
         messages: list[dict[str, object]],
         system: str,
         tools: list[Tool],
-        tool_executor: callable,
+        tool_executor: Callable,
         max_iterations: int = 10,
     ) -> LLMResponse:
         return LLMResponse(content=json.dumps({"result": "ok"}), model="dummy")


### PR DESCRIPTION
## Description

Found a few places still using lowercase `callable` as a type hint instead of `Callable` from `collections.abc`. These got missed when the same issue was fixed in the LLM module (commit 1c78174).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #922

## Changes Made

- `core/framework/runtime/core.py`: Added `Callable` import, fixed `executor: callable` → `executor: Callable`
- `core/framework/llm/mock.py`: Added `Callable` import + `ToolUse`/`ToolResult`, fixed `tool_executor: callable` → `tool_executor: Callable[[ToolUse], ToolResult]`
- `core/tests/test_execution_stream.py`: Added `Callable` import, fixed `tool_executor: callable` → `tool_executor: Callable`

## Testing

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

Verified imports work:
```bash
python3 -c "from framework.runtime.core import Runtime; from framework.llm.mock import MockLLMProvider; print('OK')"
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes