### PR TITLE
docs(contributing): clarify agents, exports directory, and API keys

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,44 @@ cd tools && python -m pytest
 PYTHONPATH=core:exports python -m agent_name test
 ```
 
+## Understanding Agents and the `exports/` Directory
+
+This repository is **framework-first** and does not include any agents by default.
+
+### Where are the agents?
+
+Agents are expected to live in an `exports/` directory at the repository root.  
+This directory is **not created automatically** when you clone the repo.
+
+You must create it manually if you want to build or run agents:
+
+```bash
+mkdir exports
+```
+
+Each subdirectory inside exports/ represents a single agent.
+
+### Why does the CLI show no agents?
+
+If the `exports/` directory does not exist, or if it exists but contains no agents, CLI commands such as:
+
+```bash
+python -m framework.cli list
+```
+
+may show no output. This is expected behavior.
+
+### Do I need an LLM API key?
+
+No API key is required to:
+
+- develop the core framework
+- run tests
+- improve documentation
+- work on tooling or CLI behavior
+
+An LLM API key is only required when running agents that make live model calls.
+
 ## Questions?
 
 Feel free to open an issue for questions or join our [Discord community](https://discord.com/invite/MXE49hrKDk).


### PR DESCRIPTION
## What this PR does

Clarifies onboarding documentation for new contributors by explaining:
- where agents are expected to live (`exports/`)
- why the CLI may show no agents by default
- when an LLM API key is (and is not) required

## Why this change is needed

As a first-time contributor, it was unclear why:
- the `exports/` directory did not exist after cloning
- CLI commands returned no agents
- documentation referenced agents without explaining how they are created

This PR documents the intended workflow and reduces setup friction for new contributors.

## Verification

- Verified locally that creating an empty `exports/` directory results in the CLI message:
  `No agents found in exports`
- No code changes included
