### PR TITLE
fix(repo): add .gitattributes for cross-platform line ending consistency

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,59 @@
+# Auto detect text files and normalize line endings to LF
+* text=auto
+
+# Explicitly declare text files
+*.md text
+*.py text
+*.sh text eol=lf
+*.js text
+*.ts text
+*.json text
+*.yml text
+*.yaml text
+*.toml text
+*.txt text
+*.cfg text
+*.ini text
+*.rst text
+*.html text
+*.css text
+
+# Ensure shell scripts always use LF (required for Unix/Mac)
+*.sh text eol=lf
+quickstart.sh text eol=lf
+scripts/* text eol=lf
+
+# Windows-specific files use CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=lf
+
+# Binary files - do not modify
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.whl binary
+*.pyc binary
+*.pyo binary
+*.so binary
+*.dylib binary
+*.dll binary
+*.exe binary
+*.zip binary
+*.tar binary
+*.gz binary
+*.bz2 binary
+*.7z binary
+*.rar binary
+
+# Python specific
+*.pickle binary
+*.pkl binary
+
+# Git and editor configs
+.gitignore text
+.gitattributes text
+.editorconfig text


### PR DESCRIPTION
Fixes #950

Adds a .gitattributes file to:
- Normalize line endings (LF) across all platforms
- Eliminate CRLF warnings for Windows contributors
- Ensure shell scripts maintain LF endings for Unix compatibility
- Mark binary files to prevent Git modification

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
