### PR TITLE
fix(testing): make Pytest templates provider-agnostic

### DIFF
--- a/core/framework/testing/prompts.py
+++ b/core/framework/testing/prompts.py
@@ -11,7 +11,7 @@ PYTEST_TEST_FILE_HEADER = '''"""
 
 {description}
 
-REQUIRES: ANTHROPIC_API_KEY for real testing.
+REQUIRES: An LLM API key (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.) for real testing.
 """
 
 import os
@@ -19,26 +19,51 @@ import pytest
 from exports.{agent_module} import default_agent
 
 
+# Supported LLM providers and their environment variable names
+_SUPPORTED_PROVIDERS = [
+    ("anthropic", "ANTHROPIC_API_KEY"),
+    ("openai", "OPENAI_API_KEY"),
+    ("cerebras", "CEREBRAS_API_KEY"),
+    ("groq", "GROQ_API_KEY"),
+    ("together", "TOGETHER_API_KEY"),
+    ("mistral", "MISTRAL_API_KEY"),
+]
+
+
 def _get_api_key():
-    """Get API key from CredentialManager or environment."""
+    """Get API key from CredentialManager or environment.
+    
+    Checks multiple providers in order of preference, returning the first
+    available key. This allows tests to run with any supported LLM provider.
+    """
+    # First, try CredentialManager for managed credentials
     try:
         from aden_tools.credentials import CredentialManager
         creds = CredentialManager()
-        if creds.is_available("anthropic"):
-            return creds.get("anthropic")
-    except ImportError:
+        for provider, _ in _SUPPORTED_PROVIDERS:
+            if creds.is_available(provider):
+                return creds.get(provider)
+    except (ImportError, Exception):
         pass
-    return os.environ.get("ANTHROPIC_API_KEY")
+    
+    # Fallback: check environment variables for any supported provider
+    for _, env_var in _SUPPORTED_PROVIDERS:
+        key = os.environ.get(env_var)
+        if key:
+            return key
+    
+    return None
 
 
 # Skip all tests if no API key and not in mock mode
 pytestmark = pytest.mark.skipif(
     not _get_api_key() and not os.environ.get("MOCK_MODE"),
-    reason="API key required. Set ANTHROPIC_API_KEY or use MOCK_MODE=1."
+    reason="API key required. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or another provider key. Or use MOCK_MODE=1."
 )
 
 
 '''
+
 
 # Template for conftest.py with shared fixtures
 PYTEST_CONFTEST_TEMPLATE = '''"""Shared test fixtures for {agent_name} tests."""
@@ -47,16 +72,58 @@ import os
 import pytest
 
 
+# Supported LLM providers and their environment variable names
+_SUPPORTED_PROVIDERS = [
+    ("anthropic", "ANTHROPIC_API_KEY"),
+    ("openai", "OPENAI_API_KEY"),
+    ("cerebras", "CEREBRAS_API_KEY"),
+    ("groq", "GROQ_API_KEY"),
+    ("together", "TOGETHER_API_KEY"),
+    ("mistral", "MISTRAL_API_KEY"),
+]
+
+
 def _get_api_key():
-    """Get API key from CredentialManager or environment."""
+    """Get API key from CredentialManager or environment.
+    
+    Checks multiple providers in order of preference, returning the first
+    available key. This allows tests to run with any supported LLM provider.
+    """
+    # First, try CredentialManager for managed credentials
     try:
         from aden_tools.credentials import CredentialManager
         creds = CredentialManager()
-        if creds.is_available("anthropic"):
-            return creds.get("anthropic")
-    except ImportError:
+        for provider, _ in _SUPPORTED_PROVIDERS:
+            if creds.is_available(provider):
+                return creds.get(provider)
+    except (ImportError, Exception):
         pass
-    return os.environ.get("ANTHROPIC_API_KEY")
+    
+    # Fallback: check environment variables for any supported provider
+    for _, env_var in _SUPPORTED_PROVIDERS:
+        key = os.environ.get(env_var)
+        if key:
+            return key
+    
+    return None
+
+
+def _get_available_provider():
+    """Return the name of the first available provider, or None."""
+    try:
+        from aden_tools.credentials import CredentialManager
+        creds = CredentialManager()
+        for provider, _ in _SUPPORTED_PROVIDERS:
+            if creds.is_available(provider):
+                return provider
+    except (ImportError, Exception):
+        pass
+    
+    for provider, env_var in _SUPPORTED_PROVIDERS:
+        if os.environ.get(env_var):
+            return provider
+    
+    return None
 
 
 @pytest.fixture
@@ -72,17 +139,22 @@ def check_api_key():
         if os.environ.get("MOCK_MODE"):
             print("\\n⚠️  Running in MOCK MODE - structure validation only")
             print("   This does NOT test LLM behavior or agent quality")
-            print("   Set ANTHROPIC_API_KEY for real testing\\n")
+            print("   Set an LLM provider API key for real testing\\n")
         else:
             pytest.fail(
-                "\\n❌ ANTHROPIC_API_KEY not set!\\n\\n"
+                "\\n❌ No LLM API key found!\\n\\n"
                 "Real testing requires an API key. Choose one:\\n"
-                "1. Set API key (RECOMMENDED):\\n"
+                "1. Set an API key (RECOMMENDED):\\n"
                 "   export ANTHROPIC_API_KEY='your-key-here'\\n"
+                "   export OPENAI_API_KEY='your-key-here'\\n"
+                "   (or any other supported provider)\\n"
                 "2. Run structure validation only:\\n"
                 "   MOCK_MODE=1 pytest exports/{agent_name}/tests/\\n\\n"
                 "Note: Mock mode does NOT validate agent behavior or quality."
             )
+    else:
+        provider = _get_available_provider()
+        print(f"\\n✓ Using {{provider}} for LLM testing\\n")
 
 
 @pytest.fixture
@@ -94,3 +166,4 @@ def sample_inputs():
         "edge_case": {{"query": ""}},
     }}
 '''
+


### PR DESCRIPTION
Fixes #938

The test templates now support multiple LLM providers instead of requiring Anthropic specifically:
- Anthropic (ANTHROPIC_API_KEY)
- OpenAI (OPENAI_API_KEY)
- Cerebras (CEREBRAS_API_KEY)
- Groq (GROQ_API_KEY)
- Together (TOGETHER_API_KEY)
- Mistral (MISTRAL_API_KEY)

Changes:
- Refactored _get_api_key() to iterate over supported providers
- Added _get_available_provider() helper for logging
- Updated error messages and docstrings
- Maintains backward compatibility with CredentialManager

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
