### PR TITLE
fix(pdf_read_tool): add path traversal protection, empty file check, …

### DIFF
--- a/tools/src/aden_tools/tools/pdf_read_tool/pdf_read_tool.py
+++ b/tools/src/aden_tools/tools/pdf_read_tool/pdf_read_tool.py
@@ -3,6 +3,13 @@ PDF Read Tool - Parse and extract text from PDF files.
 
 Uses pypdf to read PDF documents and extract text content
 along with metadata.
+
+SECURITY & ROBUSTNESS IMPROVEMENTS:
+- Path traversal protection
+- Empty file validation  
+- Large file rejection (50MB limit)
+- Encrypted PDF graceful handling
+- Better PyPDF2 exception specificity
 """
 from __future__ import annotations
 
@@ -11,6 +18,11 @@ from typing import Any, List
 
 from fastmcp import FastMCP
 from pypdf import PdfReader
+from pypdf.errors import (
+    PdfReadError, 
+    PdfStreamError, 
+    PdfNoOutlinesError
+)
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -63,6 +75,21 @@ def register_tools(mcp: FastMCP) -> None:
         except ValueError as e:
             return {"error": f"Invalid page format: '{pages}'. {str(e)}"}
 
+    def validate_path_security(path: Path) -> dict | None:
+        """SECURITY: Prevent path traversal and validate working directory confinement."""
+        try:
+            # Resolve symlinks and check we're still in working directory
+            resolved_path = path.resolve(strict=True)
+            cwd = Path.cwd().resolve()
+            
+            # Path traversal check: must be relative to cwd
+            if not resolved_path.is_relative_to(cwd):
+                return {"error": f"Path traversal detected: {path}. Must be within working directory."}
+            
+            return None  # Valid
+        except Exception:
+            return {"error": f"Invalid path: {path}"}
+
     @mcp.tool()
     def pdf_read(
         file_path: str,
@@ -86,7 +113,14 @@ def register_tools(mcp: FastMCP) -> None:
             Dict with extracted text and metadata, or error dict
         """
         try:
-            path = Path(file_path).resolve()
+            path = Path(file_path)
+            
+            # SECURITY: Path traversal validation
+            security_error = validate_path_security(path)
+            if security_error:
+                return security_error
+
+            path = path.resolve()
 
             # Validate file exists
             if not path.exists():
@@ -94,6 +128,14 @@ def register_tools(mcp: FastMCP) -> None:
 
             if not path.is_file():
                 return {"error": f"Not a file: {file_path}"}
+
+            # NEW: Empty file check (fixes #269)
+            if path.stat().st_size == 0:
+                return {"error": "Empty PDF file (0 bytes)"}
+
+            # NEW: Large file rejection (memory safety)
+            if path.stat().st_size > 50 * 1024 * 1024:  # 50MB
+                return {"error": "PDF too large (>50MB). Split document or use pdf_chunk tool."}
 
             # Check extension
             if path.suffix.lower() != ".pdf":
@@ -105,14 +147,23 @@ def register_tools(mcp: FastMCP) -> None:
             elif max_pages > 1000:
                 max_pages = 1000
 
-            # Open and read PDF
-            reader = PdfReader(path)
+            # Open and read PDF with specific error handling
+            try:
+                reader = PdfReader(path)
+            except PdfReadError as e:
+                return {"error": f"Corrupted PDF structure: {str(e)[:100]}"}
+            except PdfStreamError as e:
+                return {"error": f"PDF stream error (malformed content): {str(e)[:100]}"}
+            except Exception as e:
+                return {"error": f"Failed to open PDF: {str(e)[:100]}"}
 
-            # Check for encryption
+            # Check for encryption (already handled but more specific)
             if reader.is_encrypted:
-                return {"error": "Cannot read encrypted PDF. Password required."}
+                return {"error": "Encrypted PDF detected. Password support not implemented."}
 
             total_pages = len(reader.pages)
+            if total_pages == 0:
+                return {"error": "PDF contains no readable pages"}
 
             # Parse page range
             page_indices = parse_page_range(pages, total_pages, max_pages)
@@ -122,8 +173,11 @@ def register_tools(mcp: FastMCP) -> None:
             # Extract text from pages
             content_parts = []
             for i in page_indices:
-                page_text = reader.pages[i].extract_text() or ""
-                content_parts.append(f"--- Page {i + 1} ---\n{page_text}")
+                try:
+                    page_text = reader.pages[i].extract_text() or ""
+                    content_parts.append(f"--- Page {i + 1} ---\n{page_text}")
+                except Exception as e:
+                    content_parts.append(f"--- Page {i + 1} ---\n[ERROR extracting page: {str(e)[:50]}]")
 
             content = "\n\n".join(content_parts)
 
@@ -134,24 +188,30 @@ def register_tools(mcp: FastMCP) -> None:
                 "pages_extracted": len(page_indices),
                 "content": content,
                 "char_count": len(content),
+                "truncated": len(page_indices) < total_pages,
             }
 
-            # Add metadata if requested
+            # Add metadata if requested (with safe handling)
             if include_metadata and reader.metadata:
-                meta = reader.metadata
-                result["metadata"] = {
-                    "title": meta.get("/Title"),
-                    "author": meta.get("/Author"),
-                    "subject": meta.get("/Subject"),
-                    "creator": meta.get("/Creator"),
-                    "producer": meta.get("/Producer"),
-                    "created": str(meta.get("/CreationDate")) if meta.get("/CreationDate") else None,
-                    "modified": str(meta.get("/ModDate")) if meta.get("/ModDate") else None,
-                }
+                try:
+                    meta = reader.metadata
+                    result["metadata"] = {
+                        "title": meta.get("/Title", "").strip() or None,
+                        "author": meta.get("/Author", "").strip() or None,
+                        "subject": meta.get("/Subject", "").strip() or None,
+                        "creator": meta.get("/Creator", "").strip() or None,
+                        "producer": meta.get("/Producer", "").strip() or None,
+                        "created": str(meta.get("/CreationDate")).strip() if meta.get("/CreationDate") else None,
+                        "modified": str(meta.get("/ModDate")).strip() if meta.get("/ModDate") else None,
+                    }
+                    # Clean None values
+                    result["metadata"] = {k: v for k, v in result["metadata"].items() if v}
+                except Exception:
+                    result["metadata"] = {"error": "Failed to parse metadata"}
 
             return result
 
         except PermissionError:
-            return {"error": f"Permission denied: {file_path}"}
+            return {"error": f"Permission denied accessing: {file_path}"}
         except Exception as e:
-            return {"error": f"Failed to read PDF: {str(e)}"}
+            return {"error": f"Unexpected error reading PDF: {str(e)[:100]}"}


### PR DESCRIPTION
…50MB limit

- Prevent ../../../etc/passwd attacks with validate_path_security()
- Reject 0-byte files (fixes #269)
- Cap files at 50MB for memory safety
- Specific PyPDF2 error handling (PdfReadError, PdfStreamError)
- Per-page extraction fallbacks
- Clean metadata stripping

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
