### PR TITLE
feat(runtime): add persistent shared state for agent runtime

### DIFF
--- a/core/framework/runtime/agent_runtime.py
+++ b/core/framework/runtime/agent_runtime.py
@@ -123,7 +123,8 @@ class AgentRuntime:
         )
 
         # Initialize shared components
-        self._state_manager = SharedStateManager()
+        # Inject storage into SharedStateManager for persistence
+        self._state_manager = SharedStateManager(storage=self._storage)
         self._event_bus = EventBus(max_history=self._config.max_history)
         self._outcome_aggregator = OutcomeAggregator(goal, self._event_bus)
 


### PR DESCRIPTION
## Summary
Implements persistent shared state feature that allows state to survive process restarts and maintain long-term memory across sessions.

## Changes
- Extended FileStorage to support states/ directory structure (global/, stream/, execution/)
- Added state persistence methods to ConcurrentStorage (save_state, load_state)
- Updated SharedStateManager to accept ConcurrentStorage and implement lazy loading
- Implemented async write-through for performance (memory-first, batched disk writes)
- Wired storage injection into AgentRuntime
- Added comprehensive tests for persistence, lazy loading, and backward compatibility

## Features
- ✅ Transparent persistence: state automatically saved to disk
- ✅ Lazy loading: state loaded from disk only when needed
- ✅ Async write-through: fast memory updates with batched disk writes
- ✅ Backward compatible: works without storage (in-memory only)
- ✅ Thread-safe: uses existing locking mechanisms

## Testing
All tests pass:
- 4 existing tests (backward compatibility maintained)
- 5 new persistent state tests (save/load, lazy loading, write-through, restart, backward compat)

## Related Issues
Fixes #940
Fixes #945