### PR TITLE
docs: add Windows User Guide for environment setup

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -80,6 +80,43 @@ For running agents with real LLMs:
 export ANTHROPIC_API_KEY="your-key-here"
 ```
 
+## Windows User Guide
+
+Specific instructions for Windows users on PowerShell or CMD.
+
+### Virtual Environment Activation
+
+- **PowerShell:** `.venv\Scripts\Activate.ps1`
+- **CMD:** `.venv\Scripts\activate.bat`
+
+### Environment Variables
+
+Unix-style `export` commands will not work. Use the following syntax:
+
+**PowerShell:**
+```powershell
+$env:VAR_NAME="value"
+```
+
+**CMD:**
+```cmd
+set VAR_NAME=value
+```
+
+### Running Agents (PYTHONPATH)
+
+**CRITICAL:** Windows uses a semi-colon (`;`) for path separation, whereas Unix uses a colon (`:`).
+
+**PowerShell:**
+```powershell
+$env:PYTHONPATH="core;exports"; python -m agent_name COMMAND
+```
+
+**CMD:**
+```cmd
+set PYTHONPATH=core;exports && python -m agent_name COMMAND
+```
+
 ## Running Agents
 
 All agent commands must be run from the project root with `PYTHONPATH` set:


### PR DESCRIPTION
## Description
Fixes: #999 
This PR adds a dedicated Windows User Guide section to ENVIRONMENT_SETUP.md to fix onboarding issues caused by Unix-style shell commands that do not work on Windows PowerShell or CMD.

The change clarifies:

- Virtual environment activation on Windows
- Correct environment variable syntax
- Proper PYTHONPATH usage using a semicolon (;) instead of a colon (:)
- This resolves a high-impact onboarding issue for Windows users without affecting existing Unix/macOS instructions.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

N/A (documentation improvement addressing onboarding friction)

## Changes Made

- Added a Windows User Guide section to ENVIRONMENT_SETUP.md
- Documented PowerShell and CMD-specific commands for:
                    -  Virtual environment activation
                    -  Environment variable configuration
                    -  Running agents with correct PYTHONPATH formatting on Windows

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

### Manual Verification

- Verified markdown renders correctly
- Confirmed Windows commands use correct syntax ($env:, set, ;)
- Ensured placement is before execution steps
- Confirmed no Unix-specific instructions were removed or altered

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A (documentation-only change)
