### PR TITLE
docs: add Windows Quick Start to README

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -2,6 +2,16 @@
 
 Complete setup guide for building and running goal-driven agents with the Aden Agent Framework.
 
+## Windows Setup Notes
+
+The Python setup scripts are written in Bash and are **not compatible with Windows Command Prompt (CMD)**.
+
+Windows users must run setup using one of the following:
+- **Git Bash**
+- **WSL (Windows Subsystem for Linux)**
+
+Running `scripts\setup-python.sh` from CMD will open the file instead of executing it.
+
 ## Quick Setup
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -63,6 +63,26 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 
 ## Quick Start
 
+### Windows Quick Start
+
+> ⚠️ **Important for Windows users**
+>
+> The setup scripts (`.sh`) are **Bash scripts** and **cannot be run from Command Prompt (CMD)** or PowerShell directly.
+
+#### Option 1: Use Git Bash (Recommended)
+
+1. Install **Git for Windows** (includes Git Bash):  
+   https://git-scm.com/download/win
+
+2. Open **Git Bash**
+
+3. Run:
+   ```bash
+   git clone https://github.com/adenhq/hive.git
+   cd hive
+   ./scripts/setup-python.sh
+
+
 ### Prerequisites
 
 - [Python 3.11+](https://www.python.org/downloads/) for agent development

--- a/README.md
+++ b/README.md
@@ -84,6 +84,23 @@ This installs:
 - **aden_tools** - 19 MCP tools for agent capabilities
 - All required dependencies
 
+
+### Windows Users
+
+The setup scripts (`.sh`) are Bash scripts and **cannot be run from Command Prompt (CMD)**.
+
+On Windows, please use one of the following:
+- **Git Bash** (recommended)
+- **WSL (Windows Subsystem for Linux)**
+
+Example (Git Bash / WSL):
+
+```bash
+git clone https://github.com/adenhq/hive.git
+cd hive
+./scripts/setup-python.sh
+```
+
 ### Build Your First Agent
 
 ```bash


### PR DESCRIPTION
## Description

Adds a dedicated Windows Quick Start section to the root README.md to clearly document how Windows users should run the setup using Git Bash or WSL, and to explicitly warn that Bash scripts cannot be executed from Command Prompt (CMD).

This reduces onboarding friction and prevents repeated setup-related issues from Windows contributors.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Related to Windows setup and onboarding improvements.
(No direct issue linked for this change.)

## Changes Made

- Added a Windows Quick Start section under ## Quick Start in the root README.md
- Documented supported Windows setup options (Git Bash and WSL)
- Explicitly clarified that .sh scripts cannot be run from CMD

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed (documentation reviewed for clarity and correctness)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A (documentation-only change)
