### PR TITLE
Prevent silent run loss on async persistence failure

### DIFF
--- a/core/tests/test_stream_runtime_save.py
+++ b/core/tests/test_stream_runtime_save.py
@@ -1,0 +1,97 @@
+"""Tests for StreamRuntime save behavior and retry handling."""
+
+import asyncio
+
+import pytest
+
+from framework.runtime.stream_runtime import StreamRuntime
+
+
+class FailingStorage:
+    """Storage that always fails to save."""
+
+    def __init__(self) -> None:
+        self.called = asyncio.Event()
+
+    async def save_run(self, run, immediate: bool = False) -> None:
+        self.called.set()
+        raise RuntimeError("save failed")
+
+
+class FlakyStorage:
+    """Storage that fails once, then succeeds."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.called = asyncio.Event()
+
+    async def save_run(self, run, immediate: bool = False) -> None:
+        self.calls += 1
+        self.called.set()
+        if self.calls == 1:
+            raise RuntimeError("transient failure")
+
+
+class WorkingStorage:
+    """Storage that always succeeds."""
+
+    def __init__(self) -> None:
+        self.called = asyncio.Event()
+
+    async def save_run(self, run, immediate: bool = False) -> None:
+        self.called.set()
+        return None
+
+
+@pytest.mark.asyncio
+async def test_failed_save_does_not_drop_run():
+    storage = FailingStorage()
+    runtime = StreamRuntime(stream_id="s1", storage=storage)
+
+    execution_id = "exec-1"
+    runtime.start_run(execution_id=execution_id, goal_id="goal")
+    runtime.end_run(execution_id=execution_id, success=True)
+
+    await storage.called.wait()
+
+    failed = runtime.get_failed_saves()
+    assert execution_id in failed
+    assert failed[execution_id]["attempts"] == 1
+    assert "save failed" in failed[execution_id]["last_error"]
+    assert runtime.get_run(execution_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_retry_success_cleans_up():
+    storage = FlakyStorage()
+    runtime = StreamRuntime(stream_id="s2", storage=storage, base_delay=0.0)
+
+    execution_id = "exec-2"
+    runtime.start_run(execution_id=execution_id, goal_id="goal")
+    runtime.end_run(execution_id=execution_id, success=True)
+
+    await storage.called.wait()
+    storage.called.clear()
+    assert execution_id in runtime.get_failed_saves()
+
+    result = await runtime.retry_failed_saves(max_attempts=3, base_delay=0.0)
+    await storage.called.wait()
+    assert result["saved"] == 1
+    assert storage.calls == 2
+    assert runtime.get_failed_saves() == {}
+    assert runtime.get_run(execution_id) is None
+
+
+@pytest.mark.asyncio
+async def test_successful_save_cleans_up():
+    storage = WorkingStorage()
+    runtime = StreamRuntime(stream_id="s3", storage=storage)
+
+    execution_id = "exec-3"
+    runtime.start_run(execution_id=execution_id, goal_id="goal")
+    runtime.end_run(execution_id=execution_id, success=True)
+
+    await storage.called.wait()
+
+    assert runtime.get_failed_saves() == {}
+    assert runtime.get_run(execution_id) is None


### PR DESCRIPTION
## Description

Prevents silent loss of run data when async persistence fails in `StreamRuntime`.

Previously, if `save_run` raised inside the async persistence task, the run was still removed from in-memory state, making retries and post-run inspection impossible. This change ensures failed saves are retained, tracked, and only cleaned up after a successful persistence.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #1075

## Changes Made

- Retain runs in memory when async persistence fails
- Track failed saves with bounded retries and exponential backoff
- Clean up execution state only after a successful save
- Add deterministic tests covering failure retention, retry cleanup, and success cleanup

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
