### PR TITLE
docs : clarify python version tested in CI

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -62,8 +62,10 @@ python -c "import litellm; print('✓ litellm OK')"
 ### Python Version
 
 - **Minimum:** Python 3.11
-- **Recommended:** Python 3.11 or 3.12
-- **Tested on:** Python 3.11, 3.12, 3.13
+- **Recommended:** Python 3.11 (officially tested in CI)
+- **Experimental:** Python 3.12, 3.13 may work but are not currently tested in CI
+
+> **⚠️ Note for Contributors:** Our GitHub Actions CI pipeline currently runs automated tests **only on Python 3.11**. While Python 3.12 and 3.13 are expected to work for basic usage, they do not have comprehensive CI test coverage. For the best development experience and to match our CI environment, **we recommend using Python 3.11**. If you encounter issues with Python 3.12 or 3.13, please [report them](https://github.com/adenhq/hive/issues).
 
 ### System Requirements
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ This guide will help you set up the Aden Agent Framework and build your first ag
 
 ## Prerequisites
 
-- **Python 3.11+** ([Download](https://www.python.org/downloads/)) - Python 3.12 or 3.13 recommended
+- **Python 3.11+** ([Download](https://www.python.org/downloads/)) - **Python 3.11 recommended** (officially CI-tested). Python 3.12/3.13 may work but are currently untested.
 - **pip** - Package installer for Python (comes with Python)
 - **git** - Version control
 - **Claude Code** ([Install](https://docs.anthropic.com/claude/docs/claude-code)) - Optional, for using building skills


### PR DESCRIPTION
Docs previously implied Python 3.11–3.13 were tested, but CI and release workflows currently run only on Python 3.11.

This PR clarifies that Python 3.11 is the recommended contributor version and notes that newer versions (3.12/3.13) may be untested and could encounter dependency compatibility issues.

Fixes #1059.