### PR TITLE
Add test execution and debugging tools to MCP server

### DIFF
--- a/.claude/skills/testing-agent/SKILL.md
+++ b/.claude/skills/testing-agent/SKILL.md
@@ -1029,6 +1029,19 @@ mcp__agent-builder__debug_test(
 )
 ```
 
+### Test Execution Tools
+
+- `run_agent_tests` - Execute pytest and get structured results
+  - Supports specific test files, verbose mode, and pytest markers
+  - Returns detailed output for CI/CD integration
+  
+- `list_agent_tests` - List all test files in agent directory
+  - Optional details including test function counts
+  
+- `debug_test_failure` - Re-run failing test with maximum verbosity
+  - Shows local variables and full tracebacks
+  - Useful for diagnosing complex test failures
+
 ## run_tests Options
 
 ```python


### PR DESCRIPTION
## Summary
Adds test execution and debugging utilities to the MCP server, complementing the existing test generation tools.

## Motivation
Currently, the MCP server provides tools to generate test guidelines (`generate_constraint_tests`, `generate_success_tests`) but lacks tools to execute and debug those tests. This PR completes the testing workflow by adding execution and debugging capabilities.

## Changes
✅ **`run_agent_tests`** - Execute pytest with flexible options
  - Run all tests or specific test files
  - Support for verbose mode and pytest markers
  - Structured JSON output for CI/CD integration
  - 5-minute timeout with proper error handling

✅ **`list_agent_tests`** - List test files with optional details
  - Basic listing of all test files
  - Optional detailed mode showing test counts and function names
  - File size information

✅ **`debug_test_failure`** - Re-run failing tests with maximum verbosity
  - Shows local variables on failure
  - Full traceback output
  - Useful for diagnosing complex test failures

✅ **Documentation updates** - Updated `.claude/skills/testing-agent/SKILL.md`

## Testing
Tested locally with sample agent tests:
```powershell
# Run all tests in an agent
run_agent_tests("exports/sample_agent")

# Run specific test file with verbose output
run_agent_tests("exports/sample_agent", test_file="test_constraints.py", verbose=True)

# List all tests with details
list_agent_tests("exports/sample_agent", include_details=True)

# Debug a specific failing test
debug_test_failure("exports/sample_agent", "test_constraint_budget_exceeds")
