### PR TITLE
feat(tools): Add messaging tool with Slack and Discord support

### DIFF
--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -45,11 +45,17 @@ ocr = [
 sql = [
     "duckdb>=1.0.0",
 ]
+messaging = [
+    # Optional: Official Slack SDK for advanced features
+    # Core implementation uses httpx which is already a dependency
+    "slack-sdk>=3.27.0",
+]
 all = [
     "RestrictedPython>=7.0",
     "pytesseract>=0.3.10",
     "pillow>=10.0.0",
     "duckdb>=1.0.0",
+    "slack-sdk>=3.27.0",
 ]
 
 [build-system]

--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -24,6 +24,7 @@ Usage:
 Credential categories:
 - llm.py: LLM provider credentials (anthropic, openai, etc.)
 - search.py: Search tool credentials (brave_search, google_search, etc.)
+- messaging.py: Messaging platform credentials (slack, discord_webhook)
 
 To add a new credential:
 1. Find the appropriate category file (or create a new one)
@@ -32,11 +33,13 @@ To add a new credential:
 """
 from .base import CredentialError, CredentialManager, CredentialSpec
 from .llm import LLM_CREDENTIALS
+from .messaging import MESSAGING_CREDENTIALS
 from .search import SEARCH_CREDENTIALS
 
 # Merged registry of all credentials
 CREDENTIAL_SPECS = {
     **LLM_CREDENTIALS,
+    **MESSAGING_CREDENTIALS,
     **SEARCH_CREDENTIALS,
 }
 
@@ -49,5 +52,6 @@ __all__ = [
     "CREDENTIAL_SPECS",
     # Category registries (for direct access if needed)
     "LLM_CREDENTIALS",
+    "MESSAGING_CREDENTIALS",
     "SEARCH_CREDENTIALS",
 ]

--- a/tools/src/aden_tools/credentials/messaging.py
+++ b/tools/src/aden_tools/credentials/messaging.py
@@ -1,0 +1,37 @@
+"""
+Messaging platform credentials.
+
+Credentials for Slack and Discord integrations.
+"""
+from .base import CredentialSpec
+
+MESSAGING_CREDENTIALS = {
+    "slack": CredentialSpec(
+        env_var="SLACK_BOT_TOKEN",
+        tools=[
+            "messaging_send",
+            "messaging_read",
+            "messaging_react",
+            "messaging_upload",
+            "messaging_list_channels",
+            "messaging_validate",
+        ],
+        required=False,  # Optional - only needed if using Slack
+        help_url="https://api.slack.com/apps",
+        description="Slack Bot Token (xoxb-...) for Slack integration. "
+                    "Required scopes: chat:write, channels:history, reactions:write, "
+                    "files:write, channels:read",
+    ),
+    "discord_webhook": CredentialSpec(
+        env_var="DISCORD_WEBHOOK_URL",
+        tools=[
+            "messaging_send",
+            "messaging_upload",
+            "messaging_validate",
+        ],
+        required=False,  # Optional - only needed if using Discord
+        help_url="https://support.discord.com/hc/en-us/articles/228383668",
+        description="Discord Webhook URL for sending messages. "
+                    "Create in Server Settings > Integrations > Webhooks",
+    ),
+}

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
 # Import register_tools from each tool module
 from .example_tool import register_tools as register_example
+from .messaging_tool import register_tools as register_messaging
 from .web_search_tool import register_tools as register_web_search
 from .web_scrape_tool import register_tools as register_web_scrape
 from .pdf_read_tool import register_tools as register_pdf_read
@@ -61,6 +62,9 @@ def register_all_tools(
     # - If credentials is None: falls back to os.getenv("BRAVE_SEARCH_API_KEY")
     register_web_search(mcp, credentials=credentials)
 
+    # Messaging tools (Slack, Discord) - credentials are optional per-platform
+    register_messaging(mcp, credentials=credentials)
+
     # Register file system toolkits
     register_view_file(mcp)
     register_write_to_file(mcp)
@@ -74,6 +78,12 @@ def register_all_tools(
 
     return [
         "example_tool",
+        "messaging_send",
+        "messaging_read",
+        "messaging_react",
+        "messaging_upload",
+        "messaging_list_channels",
+        "messaging_validate",
         "web_search",
         "web_scrape",
         "pdf_read",

--- a/tools/src/aden_tools/tools/messaging_tool/README.md
+++ b/tools/src/aden_tools/tools/messaging_tool/README.md
@@ -1,0 +1,253 @@
+# Messaging Tool
+
+Send messages to Slack and Discord from Hive agents.
+
+## Description
+
+A unified messaging interface for integrating Hive agents with popular team communication platforms. Supports:
+
+- **Slack**: Full integration via Bot Token (send, read, react, upload files, list channels)
+- **Discord**: Webhook-based integration (send messages, upload files)
+
+## Features
+
+| Feature | Slack | Discord |
+|---------|-------|---------|
+| Send messages | ✅ | ✅ |
+| Read messages | ✅ | ❌ |
+| Add reactions | ✅ | ❌ |
+| Upload files | ✅ | ✅ |
+| List channels | ✅ | ❌ |
+| Thread replies | ✅ | ✅ |
+| Rich formatting | ✅ (Blocks) | ✅ (Embeds) |
+
+## Setup
+
+### Slack Setup
+
+1. Create a Slack App at https://api.slack.com/apps
+2. Add the following Bot Token Scopes under "OAuth & Permissions":
+   - `chat:write` - Send messages
+   - `channels:history` - Read public channel messages
+   - `channels:read` - List channels
+   - `reactions:write` - Add reactions
+   - `files:write` - Upload files
+3. Install the app to your workspace
+4. Copy the Bot User OAuth Token (starts with `xoxb-`)
+5. Set the environment variable:
+   ```bash
+   export SLACK_BOT_TOKEN=xoxb-your-token-here
+   ```
+
+### Discord Setup
+
+1. Open your Discord server
+2. Go to Server Settings → Integrations → Webhooks
+3. Click "New Webhook"
+4. Configure the webhook (name, channel, avatar)
+5. Copy the Webhook URL
+6. Set the environment variable:
+   ```bash
+   export DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+   ```
+
+## Tools
+
+### messaging_send
+
+Send a message to Slack or Discord.
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `platform` | str | Yes | - | Platform: "slack" or "discord" |
+| `message` | str | Yes | - | Message text (markdown supported) |
+| `channel` | str | Slack only | "" | Channel ID (e.g., "C1234567890") |
+| `thread_id` | str | No | "" | Thread ID for replies (Slack: message timestamp) |
+| `username` | str | No | "" | Override bot username (Discord only) |
+| `avatar_url` | str | No | "" | Override bot avatar (Discord only) |
+
+**Example:**
+```python
+# Slack
+messaging_send(platform="slack", channel="C123", message="Hello team!")
+
+# Discord
+messaging_send(platform="discord", message="Alert: Build completed!")
+```
+
+### messaging_read
+
+Read recent messages from a Slack channel.
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `channel` | str | Yes | - | Slack channel ID |
+| `limit` | int | No | 10 | Number of messages (1-100) |
+| `before` | str | No | "" | Fetch messages before this timestamp |
+
+**Example:**
+```python
+result = messaging_read(channel="C123", limit=5)
+for msg in result["messages"]:
+    print(f"{msg['author']}: {msg['content']}")
+```
+
+### messaging_react
+
+Add an emoji reaction to a Slack message.
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `channel` | str | Yes | - | Channel ID containing the message |
+| `message_id` | str | Yes | - | Message timestamp (ts) |
+| `emoji` | str | Yes | - | Emoji name without colons (e.g., "thumbsup") |
+
+**Example:**
+```python
+messaging_react(channel="C123", message_id="1234567890.123456", emoji="white_check_mark")
+```
+
+### messaging_upload
+
+Upload a file to Slack or Discord.
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `platform` | str | Yes | - | Platform: "slack" or "discord" |
+| `filename` | str | Yes | - | Name for the file |
+| `content` | str | Yes | - | File content as string |
+| `channel` | str | Slack only | "" | Channel ID for Slack |
+| `title` | str | No | "" | File title (Slack only) |
+| `comment` | str | No | "" | Message to accompany the file |
+
+**Example:**
+```python
+messaging_upload(
+    platform="slack",
+    channel="C123",
+    filename="report.txt",
+    content="Here is the daily report...",
+    title="Daily Report",
+    comment="Please review"
+)
+```
+
+### messaging_list_channels
+
+List available Slack channels.
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `include_private` | bool | No | False | Include private channels |
+| `limit` | int | No | 100 | Maximum channels to return (1-1000) |
+
+**Example:**
+```python
+result = messaging_list_channels(include_private=False, limit=50)
+for ch in result["channels"]:
+    print(f"#{ch['name']} ({ch['id']})")
+```
+
+### messaging_validate
+
+Validate messaging credentials for a platform.
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `platform` | str | Yes | - | Platform: "slack" or "discord" |
+
+**Example:**
+```python
+result = messaging_validate(platform="slack")
+if result["valid"]:
+    print(f"Connected as {result['user']} to {result['team']}")
+else:
+    print(f"Error: {result['error']}")
+```
+
+## Environment Variables
+
+| Variable | Required For | Description |
+|----------|--------------|-------------|
+| `SLACK_BOT_TOKEN` | Slack | Bot OAuth Token (xoxb-...) |
+| `DISCORD_WEBHOOK_URL` | Discord | Discord Webhook URL |
+
+## Error Handling
+
+The tools return error dicts for common issues:
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `SLACK_BOT_TOKEN environment variable not set` | Missing Slack token | Set the environment variable |
+| `DISCORD_WEBHOOK_URL environment variable not set` | Missing Discord webhook | Set the environment variable |
+| `Channel is required for Slack messages` | No channel specified | Provide `channel` argument |
+| `Unknown platform: X` | Invalid platform | Use "slack" or "discord" |
+| `channel_not_found` | Invalid Slack channel | Check channel ID/name |
+| `not_in_channel` | Bot not in channel | Invite the bot to the channel |
+| `invalid_auth` | Invalid Slack token | Check your bot token |
+
+## Rate Limiting
+
+### Slack
+- Tier 1 methods (posting): ~1 request/second
+- Tier 2 methods (reading): ~20 requests/minute
+- Tier 3 methods (listing): ~50 requests/minute
+
+The tool does not implement automatic retries. Handle rate limit errors (`ratelimited`) in your agent logic.
+
+### Discord
+- Webhooks: ~30 requests/minute per webhook
+- Discord returns `429 Too Many Requests` when rate limited
+
+## Examples
+
+### Agent: Daily Standup Reminder
+
+```python
+# Send reminder to Slack
+messaging_send(
+    platform="slack",
+    channel="#engineering",
+    message="🌅 *Daily Standup in 15 minutes!*\n\nPlease prepare your updates."
+)
+```
+
+### Agent: Build Notification to Discord
+
+```python
+# Send build status to Discord
+messaging_send(
+    platform="discord",
+    message="✅ **Build #1234 Succeeded**\n\nBranch: `main`\nDuration: 5m 32s",
+    username="Build Bot",
+    avatar_url="https://example.com/build-bot.png"
+)
+```
+
+### Agent: Monitor Channel Activity
+
+```python
+# Read recent messages and react to important ones
+messages = messaging_read(channel="C123", limit=10)
+for msg in messages["messages"]:
+    if "urgent" in msg["content"].lower():
+        messaging_react(
+            channel="C123",
+            message_id=msg["id"],
+            emoji="rotating_light"
+        )
+```
+
+## Limitations
+
+### Discord Webhooks
+- **Cannot read messages** - Webhooks are send-only
+- **Cannot add reactions** - Requires a bot with gateway connection
+- **Cannot list channels** - Webhook is bound to a single channel
+
+For full Discord bot functionality, consider using the `discord.py` library directly.
+
+### Slack
+- Bot must be invited to channels before it can post
+- Some features require additional OAuth scopes
+- Enterprise Grid workspaces may have additional restrictions

--- a/tools/src/aden_tools/tools/messaging_tool/__init__.py
+++ b/tools/src/aden_tools/tools/messaging_tool/__init__.py
@@ -1,0 +1,10 @@
+"""
+Messaging Tool - Send messages to Slack and Discord.
+
+Supports:
+- Slack: Send, read, react, file upload via Bot Token
+- Discord: Send messages and files via Webhooks
+"""
+from .messaging_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/messaging_tool/formatters.py
+++ b/tools/src/aden_tools/tools/messaging_tool/formatters.py
@@ -1,0 +1,193 @@
+"""
+Message formatting utilities for Slack and Discord.
+
+Provides helpers for converting between formats and creating
+rich message content.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def markdown_to_slack(text: str) -> str:
+    """
+    Convert common markdown to Slack mrkdwn format.
+    
+    Slack uses a slightly different markdown syntax:
+    - Bold: **text** -> *text*
+    - Italic: *text* or _text_ -> _text_
+    - Strikethrough: ~~text~~ -> ~text~
+    - Code blocks: ```lang -> ```
+    - Links: [text](url) -> <url|text>
+    
+    Args:
+        text: Standard markdown text
+        
+    Returns:
+        Slack mrkdwn formatted text
+    """
+    import re
+    
+    # Convert bold: **text** -> *text*
+    text = re.sub(r'\*\*(.+?)\*\*', r'*\1*', text)
+    
+    # Convert strikethrough: ~~text~~ -> ~text~
+    text = re.sub(r'~~(.+?)~~', r'~\1~', text)
+    
+    # Convert links: [text](url) -> <url|text>
+    text = re.sub(r'\[(.+?)\]\((.+?)\)', r'<\2|\1>', text)
+    
+    return text
+
+
+def markdown_to_discord(text: str) -> str:
+    """
+    Ensure markdown is Discord-compatible.
+    
+    Discord supports standard markdown, so minimal conversion needed.
+    This function mainly validates and cleans the input.
+    
+    Args:
+        text: Standard markdown text
+        
+    Returns:
+        Discord-compatible markdown text
+    """
+    # Discord supports standard markdown, just return as-is
+    # Could add validation or sanitization here if needed
+    return text
+
+
+def create_slack_blocks(
+    text: str,
+    header: str | None = None,
+    footer: str | None = None,
+    divider: bool = False,
+) -> list[dict[str, Any]]:
+    """
+    Create Slack Block Kit blocks for rich formatting.
+    
+    Args:
+        text: Main message text
+        header: Optional header text
+        footer: Optional footer/context text
+        divider: Whether to add a divider after the message
+        
+    Returns:
+        List of Slack block objects
+    """
+    blocks: list[dict[str, Any]] = []
+    
+    if header:
+        blocks.append({
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": header,
+                "emoji": True,
+            },
+        })
+    
+    blocks.append({
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": markdown_to_slack(text),
+        },
+    })
+    
+    if footer:
+        blocks.append({
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": footer,
+                }
+            ],
+        })
+    
+    if divider:
+        blocks.append({"type": "divider"})
+    
+    return blocks
+
+
+def create_discord_embed(
+    title: str,
+    description: str,
+    color: int = 0x5865F2,
+    fields: list[tuple[str, str, bool]] | None = None,
+    footer: str | None = None,
+    thumbnail_url: str | None = None,
+) -> dict[str, Any]:
+    """
+    Create a Discord embed object.
+    
+    Args:
+        title: Embed title
+        description: Embed description (markdown supported)
+        color: Embed color as integer
+        fields: List of (name, value, inline) tuples
+        footer: Footer text
+        thumbnail_url: URL for thumbnail image
+        
+    Returns:
+        Discord embed object
+    """
+    embed: dict[str, Any] = {
+        "title": title,
+        "description": markdown_to_discord(description),
+        "color": color,
+    }
+    
+    if fields:
+        embed["fields"] = [
+            {"name": name, "value": value, "inline": inline}
+            for name, value, inline in fields
+        ]
+    
+    if footer:
+        embed["footer"] = {"text": footer}
+    
+    if thumbnail_url:
+        embed["thumbnail"] = {"url": thumbnail_url}
+    
+    return embed
+
+
+# Common emoji mappings between platforms
+EMOJI_MAP = {
+    # Slack -> Discord (mostly the same)
+    "+1": "thumbsup",
+    "-1": "thumbsdown",
+    "white_check_mark": "white_check_mark",
+    "x": "x",
+    "eyes": "eyes",
+    "rocket": "rocket",
+    "tada": "tada",
+    "fire": "fire",
+    "heart": "heart",
+    "star": "star",
+}
+
+
+def normalize_emoji(emoji: str, platform: str = "slack") -> str:
+    """
+    Normalize emoji name for a specific platform.
+    
+    Args:
+        emoji: Emoji name (with or without colons)
+        platform: Target platform ('slack' or 'discord')
+        
+    Returns:
+        Normalized emoji name without colons
+    """
+    # Remove colons
+    emoji = emoji.strip(":")
+    
+    # Apply mapping if exists
+    if emoji in EMOJI_MAP:
+        emoji = EMOJI_MAP[emoji]
+    
+    return emoji

--- a/tools/src/aden_tools/tools/messaging_tool/messaging_tool.py
+++ b/tools/src/aden_tools/tools/messaging_tool/messaging_tool.py
@@ -1,0 +1,506 @@
+"""
+Messaging Tool - Send messages to Slack and Discord.
+
+Provides a unified interface for messaging across platforms:
+- Slack: Full support (send, read, react, upload, list channels)
+- Discord: Webhook-based (send, upload only)
+
+Requires appropriate credentials:
+- Slack: SLACK_BOT_TOKEN environment variable
+- Discord: DISCORD_WEBHOOK_URL environment variable
+"""
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Optional
+
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialManager
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: Optional["CredentialManager"] = None,
+) -> None:
+    """Register messaging tools with the MCP server."""
+
+    def _get_slack_token() -> str | None:
+        """Get Slack token from credentials or environment."""
+        if credentials is not None:
+            return credentials.get("slack")
+        return os.getenv("SLACK_BOT_TOKEN")
+
+    def _get_discord_webhook() -> str | None:
+        """Get Discord webhook URL from credentials or environment."""
+        if credentials is not None:
+            return credentials.get("discord_webhook")
+        return os.getenv("DISCORD_WEBHOOK_URL")
+
+    @mcp.tool()
+    def messaging_send(
+        platform: str,
+        message: str,
+        channel: str = "",
+        thread_id: str = "",
+        username: str = "",
+        avatar_url: str = "",
+    ) -> dict:
+        """
+        Send a message to Slack or Discord.
+
+        For Slack, requires SLACK_BOT_TOKEN. For Discord, requires DISCORD_WEBHOOK_URL.
+
+        Args:
+            platform: Platform to send to - "slack" or "discord"
+            message: Message text (markdown supported on both platforms)
+            channel: Channel ID for Slack (e.g., "C1234567890" or "#general").
+                     Ignored for Discord webhooks (channel determined by webhook URL).
+            thread_id: Optional thread ID to reply to (Slack: message timestamp)
+            username: Override bot username (Discord only)
+            avatar_url: Override bot avatar URL (Discord only)
+
+        Returns:
+            Dict with 'success', 'message_id', and optional 'error'
+        """
+        platform = platform.lower().strip()
+
+        if platform not in ("slack", "discord"):
+            return {
+                "error": f"Unknown platform: {platform}. Use 'slack' or 'discord'.",
+            }
+
+        if not message:
+            return {"error": "Message cannot be empty"}
+
+        if platform == "slack":
+            token = _get_slack_token()
+            if not token:
+                return {
+                    "error": "SLACK_BOT_TOKEN environment variable not set",
+                    "help": "Get a bot token at https://api.slack.com/apps",
+                }
+
+            if not channel:
+                return {"error": "Channel is required for Slack messages"}
+
+            from .platforms.slack import SlackPlatform
+
+            try:
+                with SlackPlatform(token) as slack:
+                    result = slack.send_message(
+                        channel=channel,
+                        text=message,
+                        thread_id=thread_id if thread_id else None,
+                    )
+
+                    if result.success:
+                        return {
+                            "success": True,
+                            "platform": "slack",
+                            "message_id": result.message_id,
+                            "channel": result.channel,
+                            "thread_id": result.thread_id,
+                        }
+                    else:
+                        return {
+                            "success": False,
+                            "error": result.error,
+                        }
+            except Exception as e:
+                return {"error": f"Slack error: {str(e)}"}
+
+        else:  # discord
+            webhook_url = _get_discord_webhook()
+            if not webhook_url:
+                return {
+                    "error": "DISCORD_WEBHOOK_URL environment variable not set",
+                    "help": "Create a webhook at https://support.discord.com/hc/en-us/articles/228383668",
+                }
+
+            from .platforms.discord import DiscordPlatform
+
+            try:
+                kwargs = {}
+                if username:
+                    kwargs["username"] = username
+                if avatar_url:
+                    kwargs["avatar_url"] = avatar_url
+
+                with DiscordPlatform(webhook_url) as discord:
+                    result = discord.send_message(
+                        channel="",  # Ignored for webhooks
+                        text=message,
+                        thread_id=thread_id if thread_id else None,
+                        **kwargs,
+                    )
+
+                    if result.success:
+                        return {
+                            "success": True,
+                            "platform": "discord",
+                            "message_id": result.message_id,
+                            "channel": result.channel,
+                        }
+                    else:
+                        return {
+                            "success": False,
+                            "error": result.error,
+                        }
+            except Exception as e:
+                return {"error": f"Discord error: {str(e)}"}
+
+    @mcp.tool()
+    def messaging_read(
+        channel: str,
+        limit: int = 10,
+        before: str = "",
+    ) -> dict:
+        """
+        Read recent messages from a Slack channel.
+
+        Note: Only supported for Slack. Discord webhooks cannot read messages.
+        Requires SLACK_BOT_TOKEN with channels:history scope.
+
+        Args:
+            channel: Slack channel ID (e.g., "C1234567890")
+            limit: Number of messages to return (1-100, default 10)
+            before: Fetch messages before this timestamp (optional)
+
+        Returns:
+            Dict with 'success', 'messages' list, and optional 'error'
+        """
+        token = _get_slack_token()
+        if not token:
+            return {
+                "error": "SLACK_BOT_TOKEN environment variable not set",
+                "help": "Get a bot token at https://api.slack.com/apps",
+            }
+
+        if not channel:
+            return {"error": "Channel ID is required"}
+
+        limit = max(1, min(100, limit))
+
+        from .platforms.slack import SlackPlatform
+
+        try:
+            with SlackPlatform(token) as slack:
+                messages = slack.get_messages(
+                    channel=channel,
+                    limit=limit,
+                    before=before if before else None,
+                )
+
+                return {
+                    "success": True,
+                    "platform": "slack",
+                    "channel": channel,
+                    "messages": [
+                        {
+                            "id": msg.id,
+                            "content": msg.content,
+                            "author": msg.author,
+                            "timestamp": msg.timestamp,
+                            "thread_id": msg.thread_id,
+                            "reply_count": msg.metadata.get("reply_count", 0),
+                        }
+                        for msg in messages
+                    ],
+                    "count": len(messages),
+                }
+        except Exception as e:
+            return {"error": f"Failed to read messages: {str(e)}"}
+
+    @mcp.tool()
+    def messaging_react(
+        channel: str,
+        message_id: str,
+        emoji: str,
+    ) -> dict:
+        """
+        Add an emoji reaction to a Slack message.
+
+        Note: Only supported for Slack. Discord webhooks cannot add reactions.
+        Requires SLACK_BOT_TOKEN with reactions:write scope.
+
+        Args:
+            channel: Slack channel ID containing the message
+            message_id: Message timestamp (ts) to react to
+            emoji: Emoji name without colons (e.g., "thumbsup", "rocket", "white_check_mark")
+
+        Returns:
+            Dict with 'success' and optional 'error'
+        """
+        token = _get_slack_token()
+        if not token:
+            return {
+                "error": "SLACK_BOT_TOKEN environment variable not set",
+                "help": "Get a bot token at https://api.slack.com/apps",
+            }
+
+        if not channel:
+            return {"error": "Channel ID is required"}
+        if not message_id:
+            return {"error": "Message ID (timestamp) is required"}
+        if not emoji:
+            return {"error": "Emoji name is required"}
+
+        from .platforms.slack import SlackPlatform
+
+        try:
+            with SlackPlatform(token) as slack:
+                result = slack.add_reaction(
+                    channel=channel,
+                    message_id=message_id,
+                    emoji=emoji,
+                )
+
+                return {
+                    "success": result.get("success", False),
+                    "platform": "slack",
+                    "channel": channel,
+                    "message_id": message_id,
+                    "emoji": emoji,
+                    "error": result.get("error"),
+                }
+        except Exception as e:
+            return {"error": f"Failed to add reaction: {str(e)}"}
+
+    @mcp.tool()
+    def messaging_upload(
+        platform: str,
+        filename: str,
+        content: str,
+        channel: str = "",
+        title: str = "",
+        comment: str = "",
+    ) -> dict:
+        """
+        Upload a file to Slack or Discord.
+
+        For Slack, requires SLACK_BOT_TOKEN with files:write scope.
+        For Discord, requires DISCORD_WEBHOOK_URL.
+
+        Args:
+            platform: Platform to upload to - "slack" or "discord"
+            filename: Name for the file (e.g., "report.txt", "data.json")
+            content: File content as string (will be encoded to UTF-8)
+            channel: Channel ID for Slack. Ignored for Discord webhooks.
+            title: Optional title for the file (Slack only)
+            comment: Optional message to accompany the file
+
+        Returns:
+            Dict with 'success', 'file_id', 'url', and optional 'error'
+        """
+        platform = platform.lower().strip()
+
+        if platform not in ("slack", "discord"):
+            return {
+                "error": f"Unknown platform: {platform}. Use 'slack' or 'discord'.",
+            }
+
+        if not filename:
+            return {"error": "Filename is required"}
+        if not content:
+            return {"error": "Content is required"}
+
+        # Encode content to bytes
+        content_bytes = content.encode("utf-8")
+
+        if platform == "slack":
+            token = _get_slack_token()
+            if not token:
+                return {
+                    "error": "SLACK_BOT_TOKEN environment variable not set",
+                    "help": "Get a bot token at https://api.slack.com/apps",
+                }
+
+            if not channel:
+                return {"error": "Channel is required for Slack file uploads"}
+
+            from .platforms.slack import SlackPlatform
+
+            try:
+                with SlackPlatform(token) as slack:
+                    result = slack.upload_file(
+                        channel=channel,
+                        filename=filename,
+                        content=content_bytes,
+                        title=title if title else None,
+                        comment=comment if comment else None,
+                    )
+
+                    if result.success:
+                        return {
+                            "success": True,
+                            "platform": "slack",
+                            "file_id": result.file_id,
+                            "url": result.url,
+                        }
+                    else:
+                        return {
+                            "success": False,
+                            "error": result.error,
+                        }
+            except Exception as e:
+                return {"error": f"Slack upload error: {str(e)}"}
+
+        else:  # discord
+            webhook_url = _get_discord_webhook()
+            if not webhook_url:
+                return {
+                    "error": "DISCORD_WEBHOOK_URL environment variable not set",
+                    "help": "Create a webhook at https://support.discord.com/hc/en-us/articles/228383668",
+                }
+
+            from .platforms.discord import DiscordPlatform
+
+            try:
+                with DiscordPlatform(webhook_url) as discord:
+                    result = discord.upload_file(
+                        channel="",  # Ignored for webhooks
+                        filename=filename,
+                        content=content_bytes,
+                        comment=comment if comment else None,
+                    )
+
+                    if result.success:
+                        return {
+                            "success": True,
+                            "platform": "discord",
+                            "file_id": result.file_id,
+                            "url": result.url,
+                        }
+                    else:
+                        return {
+                            "success": False,
+                            "error": result.error,
+                        }
+            except Exception as e:
+                return {"error": f"Discord upload error: {str(e)}"}
+
+    @mcp.tool()
+    def messaging_list_channels(
+        include_private: bool = False,
+        limit: int = 100,
+    ) -> dict:
+        """
+        List available Slack channels.
+
+        Note: Only supported for Slack. Discord webhooks cannot list channels.
+        Requires SLACK_BOT_TOKEN with channels:read scope.
+
+        Args:
+            include_private: Whether to include private channels (default False)
+            limit: Maximum number of channels to return (1-1000, default 100)
+
+        Returns:
+            Dict with 'success', 'channels' list, and optional 'error'
+        """
+        token = _get_slack_token()
+        if not token:
+            return {
+                "error": "SLACK_BOT_TOKEN environment variable not set",
+                "help": "Get a bot token at https://api.slack.com/apps",
+            }
+
+        limit = max(1, min(1000, limit))
+
+        from .platforms.slack import SlackPlatform
+
+        try:
+            with SlackPlatform(token) as slack:
+                channels = slack.list_channels(
+                    include_private=include_private,
+                    limit=limit,
+                )
+
+                return {
+                    "success": True,
+                    "platform": "slack",
+                    "channels": [
+                        {
+                            "id": ch.id,
+                            "name": ch.name,
+                            "is_private": ch.is_private,
+                            "member_count": ch.member_count,
+                        }
+                        for ch in channels
+                    ],
+                    "count": len(channels),
+                }
+        except Exception as e:
+            return {"error": f"Failed to list channels: {str(e)}"}
+
+    @mcp.tool()
+    def messaging_validate(
+        platform: str,
+    ) -> dict:
+        """
+        Validate messaging credentials for a platform.
+
+        Tests that the configured credentials are valid and working.
+
+        Args:
+            platform: Platform to validate - "slack" or "discord"
+
+        Returns:
+            Dict with 'valid' bool, platform info if valid, and 'error' if invalid
+        """
+        platform = platform.lower().strip()
+
+        if platform not in ("slack", "discord"):
+            return {
+                "valid": False,
+                "error": f"Unknown platform: {platform}. Use 'slack' or 'discord'.",
+            }
+
+        if platform == "slack":
+            token = _get_slack_token()
+            if not token:
+                return {
+                    "valid": False,
+                    "error": "SLACK_BOT_TOKEN environment variable not set",
+                    "help": "Get a bot token at https://api.slack.com/apps",
+                }
+
+            from .platforms.slack import SlackPlatform
+
+            try:
+                with SlackPlatform(token) as slack:
+                    result = slack.validate_credentials()
+                    return {
+                        "platform": "slack",
+                        **result,
+                    }
+            except Exception as e:
+                return {
+                    "valid": False,
+                    "error": str(e),
+                }
+
+        else:  # discord
+            webhook_url = _get_discord_webhook()
+            if not webhook_url:
+                return {
+                    "valid": False,
+                    "error": "DISCORD_WEBHOOK_URL environment variable not set",
+                    "help": "Create a webhook at https://support.discord.com/hc/en-us/articles/228383668",
+                }
+
+            from .platforms.discord import DiscordPlatform
+
+            try:
+                with DiscordPlatform(webhook_url) as discord:
+                    result = discord.validate_credentials()
+                    return {
+                        "platform": "discord",
+                        **result,
+                    }
+            except Exception as e:
+                return {
+                    "valid": False,
+                    "error": str(e),
+                }

--- a/tools/src/aden_tools/tools/messaging_tool/platforms/__init__.py
+++ b/tools/src/aden_tools/tools/messaging_tool/platforms/__init__.py
@@ -1,0 +1,12 @@
+"""Platform adapters for messaging services."""
+from .base import MessagingPlatform, Message, SendResult
+from .slack import SlackPlatform
+from .discord import DiscordPlatform
+
+__all__ = [
+    "MessagingPlatform",
+    "Message",
+    "SendResult",
+    "SlackPlatform",
+    "DiscordPlatform",
+]

--- a/tools/src/aden_tools/tools/messaging_tool/platforms/base.py
+++ b/tools/src/aden_tools/tools/messaging_tool/platforms/base.py
@@ -1,0 +1,223 @@
+"""
+Base classes for messaging platform adapters.
+
+Provides abstract interface that all platform implementations must follow.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+
+@dataclass
+class Message:
+    """Represents a message from a messaging platform."""
+    
+    id: str
+    """Unique message identifier (Slack: ts, Discord: message_id)"""
+    
+    channel: str
+    """Channel ID or name where message was posted"""
+    
+    content: str
+    """Message text content"""
+    
+    author: str
+    """Author username or ID"""
+    
+    timestamp: str
+    """ISO 8601 timestamp or platform-specific timestamp"""
+    
+    thread_id: Optional[str] = None
+    """Parent thread ID if this is a reply"""
+    
+    metadata: dict[str, Any] = field(default_factory=dict)
+    """Additional platform-specific metadata"""
+
+
+@dataclass
+class SendResult:
+    """Result of sending a message."""
+    
+    success: bool
+    """Whether the message was sent successfully"""
+    
+    message_id: Optional[str] = None
+    """ID of the sent message (for reactions, threading, etc.)"""
+    
+    thread_id: Optional[str] = None
+    """Thread ID if message started or is in a thread"""
+    
+    channel: Optional[str] = None
+    """Channel where message was posted"""
+    
+    error: Optional[str] = None
+    """Error message if success is False"""
+    
+    raw_response: Optional[dict[str, Any]] = None
+    """Raw API response for debugging"""
+
+
+@dataclass
+class Channel:
+    """Represents a channel/conversation."""
+    
+    id: str
+    """Unique channel identifier"""
+    
+    name: str
+    """Human-readable channel name"""
+    
+    is_private: bool = False
+    """Whether this is a private channel/DM"""
+    
+    member_count: Optional[int] = None
+    """Number of members (if available)"""
+
+
+@dataclass
+class FileUploadResult:
+    """Result of uploading a file."""
+    
+    success: bool
+    """Whether the file was uploaded successfully"""
+    
+    file_id: Optional[str] = None
+    """Platform-specific file identifier"""
+    
+    url: Optional[str] = None
+    """URL to access the file (if available)"""
+    
+    error: Optional[str] = None
+    """Error message if success is False"""
+
+
+class MessagingPlatform(ABC):
+    """
+    Abstract base class for messaging platform adapters.
+    
+    All platform implementations (Slack, Discord, etc.) must implement
+    this interface to ensure consistent behavior across platforms.
+    """
+    
+    @property
+    @abstractmethod
+    def platform_name(self) -> str:
+        """Return the platform name (e.g., 'slack', 'discord')."""
+        pass
+    
+    @abstractmethod
+    def send_message(
+        self,
+        channel: str,
+        text: str,
+        thread_id: Optional[str] = None,
+        **kwargs: Any,
+    ) -> SendResult:
+        """
+        Send a message to a channel.
+        
+        Args:
+            channel: Channel ID or name
+            text: Message text (markdown supported on most platforms)
+            thread_id: Optional thread to reply to
+            **kwargs: Platform-specific options
+            
+        Returns:
+            SendResult with success status and message details
+        """
+        pass
+    
+    @abstractmethod
+    def get_messages(
+        self,
+        channel: str,
+        limit: int = 10,
+        before: Optional[str] = None,
+    ) -> List[Message]:
+        """
+        Get recent messages from a channel.
+        
+        Args:
+            channel: Channel ID
+            limit: Maximum number of messages to return (1-100)
+            before: Fetch messages before this timestamp/ID
+            
+        Returns:
+            List of Message objects, newest first
+        """
+        pass
+    
+    @abstractmethod
+    def add_reaction(
+        self,
+        channel: str,
+        message_id: str,
+        emoji: str,
+    ) -> dict[str, Any]:
+        """
+        Add an emoji reaction to a message.
+        
+        Args:
+            channel: Channel ID containing the message
+            message_id: Message ID/timestamp to react to
+            emoji: Emoji name (without colons, e.g., 'thumbsup')
+            
+        Returns:
+            Dict with 'success' bool and optional 'error' string
+        """
+        pass
+    
+    @abstractmethod
+    def upload_file(
+        self,
+        channel: str,
+        filename: str,
+        content: bytes,
+        title: Optional[str] = None,
+        comment: Optional[str] = None,
+    ) -> FileUploadResult:
+        """
+        Upload a file to a channel.
+        
+        Args:
+            channel: Channel ID to upload to
+            filename: Name for the file
+            content: File content as bytes
+            title: Optional title for the file
+            comment: Optional message to accompany the file
+            
+        Returns:
+            FileUploadResult with success status and file details
+        """
+        pass
+    
+    @abstractmethod
+    def list_channels(
+        self,
+        include_private: bool = False,
+        limit: int = 100,
+    ) -> List[Channel]:
+        """
+        List available channels.
+        
+        Args:
+            include_private: Whether to include private channels/DMs
+            limit: Maximum number of channels to return
+            
+        Returns:
+            List of Channel objects
+        """
+        pass
+    
+    def validate_credentials(self) -> dict[str, Any]:
+        """
+        Validate that credentials are properly configured.
+        
+        Returns:
+            Dict with 'valid' bool, 'error' string if invalid,
+            and optional 'user' info if valid
+        """
+        # Default implementation - subclasses should override
+        return {"valid": True}

--- a/tools/src/aden_tools/tools/messaging_tool/platforms/discord.py
+++ b/tools/src/aden_tools/tools/messaging_tool/platforms/discord.py
@@ -1,0 +1,348 @@
+"""
+Discord platform adapter using Discord Webhooks.
+
+Uses webhook URLs for sending messages - no bot token required.
+This is a simpler integration that supports sending but not reading.
+
+Limitations of Webhooks (vs Bot):
+- Cannot read messages (send only)
+- Cannot add reactions
+- Cannot list channels
+- Limited to channels where webhook is configured
+
+For full Discord bot functionality, consider using discord.py library.
+"""
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+import httpx
+
+from .base import (
+    Channel,
+    FileUploadResult,
+    Message,
+    MessagingPlatform,
+    SendResult,
+)
+
+
+class DiscordPlatform(MessagingPlatform):
+    """
+    Discord platform adapter using Webhooks.
+    
+    Webhooks provide a simple way to send messages without a bot.
+    
+    Example:
+        platform = DiscordPlatform(webhook_url="https://discord.com/api/webhooks/...")
+        result = platform.send_message("", "Hello from Hive!")  # channel ignored for webhooks
+    """
+    
+    DEFAULT_TIMEOUT = 30.0
+    
+    def __init__(
+        self,
+        webhook_url: str,
+        timeout: float = DEFAULT_TIMEOUT,
+    ):
+        """
+        Initialize Discord webhook adapter.
+        
+        Args:
+            webhook_url: Discord webhook URL
+            timeout: HTTP request timeout in seconds
+        """
+        self._webhook_url = webhook_url
+        self._timeout = timeout
+        self._client = httpx.Client(timeout=timeout)
+    
+    @property
+    def platform_name(self) -> str:
+        return "discord"
+    
+    def send_message(
+        self,
+        channel: str,
+        text: str,
+        thread_id: Optional[str] = None,
+        **kwargs: Any,
+    ) -> SendResult:
+        """
+        Send a message via Discord webhook.
+        
+        Note: channel parameter is ignored for webhooks - the webhook
+        is already configured for a specific channel.
+        
+        Args:
+            channel: Ignored for webhooks (channel is determined by webhook URL)
+            text: Message content (Discord markdown supported)
+            thread_id: Thread ID to reply to (if webhook supports threads)
+            **kwargs: Additional options:
+                - username: Override the webhook's default username
+                - avatar_url: Override the webhook's default avatar
+                - embeds: List of embed objects for rich messages
+                - tts: Whether this is a TTS message
+                
+        Returns:
+            SendResult with message details
+        """
+        payload: dict[str, Any] = {
+            "content": text,
+        }
+        
+        # Optional overrides
+        if "username" in kwargs:
+            payload["username"] = kwargs["username"]
+        if "avatar_url" in kwargs:
+            payload["avatar_url"] = kwargs["avatar_url"]
+        if "embeds" in kwargs:
+            payload["embeds"] = kwargs["embeds"]
+        if kwargs.get("tts"):
+            payload["tts"] = True
+        
+        # Thread support
+        url = self._webhook_url
+        if thread_id:
+            url = f"{url}?thread_id={thread_id}"
+        
+        # Add wait=true to get message details in response
+        if "?" in url:
+            url = f"{url}&wait=true"
+        else:
+            url = f"{url}?wait=true"
+        
+        try:
+            response = self._client.post(url, json=payload)
+            
+            if response.status_code == 204:
+                # Success but no content (when wait=false)
+                return SendResult(
+                    success=True,
+                    message_id=None,
+                )
+            
+            if response.status_code not in (200, 201):
+                error_data = response.json() if response.content else {}
+                error_msg = error_data.get("message", f"HTTP {response.status_code}")
+                return SendResult(
+                    success=False,
+                    error=error_msg,
+                    raw_response=error_data,
+                )
+            
+            data = response.json()
+            return SendResult(
+                success=True,
+                message_id=data.get("id"),
+                channel=data.get("channel_id"),
+                raw_response=data,
+            )
+            
+        except httpx.HTTPStatusError as e:
+            return SendResult(
+                success=False,
+                error=f"HTTP {e.response.status_code}: {e.response.text}",
+            )
+        except httpx.RequestError as e:
+            return SendResult(
+                success=False,
+                error=f"Network error: {str(e)}",
+            )
+    
+    def get_messages(
+        self,
+        channel: str,
+        limit: int = 10,
+        before: Optional[str] = None,
+    ) -> List[Message]:
+        """
+        Get messages - NOT SUPPORTED for webhooks.
+        
+        Discord webhooks can only send messages, not read them.
+        Returns empty list with a warning.
+        
+        For reading messages, use a Discord Bot with the discord.py library.
+        """
+        # Webhooks cannot read messages
+        return []
+    
+    def add_reaction(
+        self,
+        channel: str,
+        message_id: str,
+        emoji: str,
+    ) -> dict[str, Any]:
+        """
+        Add reaction - NOT SUPPORTED for webhooks.
+        
+        Discord webhooks cannot add reactions.
+        For reactions, use a Discord Bot.
+        """
+        return {
+            "success": False,
+            "error": "Discord webhooks cannot add reactions. Use a Discord Bot instead.",
+        }
+    
+    def upload_file(
+        self,
+        channel: str,
+        filename: str,
+        content: bytes,
+        title: Optional[str] = None,
+        comment: Optional[str] = None,
+    ) -> FileUploadResult:
+        """
+        Upload a file via Discord webhook.
+        
+        Args:
+            channel: Ignored for webhooks
+            filename: Name for the file
+            content: File content as bytes
+            title: Ignored for Discord (use comment instead)
+            comment: Message to accompany the file
+            
+        Returns:
+            FileUploadResult with file details
+        """
+        files = {"file": (filename, content)}
+        data: dict[str, Any] = {}
+        
+        if comment:
+            data["content"] = comment
+        
+        url = f"{self._webhook_url}?wait=true"
+        
+        try:
+            response = self._client.post(url, data=data, files=files)
+            
+            if response.status_code not in (200, 201):
+                error_data = response.json() if response.content else {}
+                return FileUploadResult(
+                    success=False,
+                    error=error_data.get("message", f"HTTP {response.status_code}"),
+                )
+            
+            data = response.json()
+            attachments = data.get("attachments", [])
+            
+            if attachments:
+                return FileUploadResult(
+                    success=True,
+                    file_id=attachments[0].get("id"),
+                    url=attachments[0].get("url"),
+                )
+            
+            return FileUploadResult(
+                success=True,
+                file_id=data.get("id"),
+            )
+            
+        except (httpx.HTTPStatusError, httpx.RequestError) as e:
+            return FileUploadResult(
+                success=False,
+                error=str(e),
+            )
+    
+    def list_channels(
+        self,
+        include_private: bool = False,
+        limit: int = 100,
+    ) -> List[Channel]:
+        """
+        List channels - NOT SUPPORTED for webhooks.
+        
+        Discord webhooks are bound to a single channel and cannot list others.
+        For listing channels, use a Discord Bot.
+        """
+        return []
+    
+    def validate_credentials(self) -> dict[str, Any]:
+        """
+        Validate the Discord webhook URL.
+        
+        Makes a GET request to the webhook URL to verify it's valid.
+        """
+        try:
+            # GET on webhook URL returns webhook info
+            response = self._client.get(self._webhook_url)
+            
+            if response.status_code == 200:
+                data = response.json()
+                return {
+                    "valid": True,
+                    "name": data.get("name"),
+                    "channel_id": data.get("channel_id"),
+                    "guild_id": data.get("guild_id"),
+                }
+            else:
+                return {
+                    "valid": False,
+                    "error": f"HTTP {response.status_code}",
+                }
+        except httpx.RequestError as e:
+            return {
+                "valid": False,
+                "error": str(e),
+            }
+    
+    def send_embed(
+        self,
+        title: str,
+        description: str,
+        color: int = 0x5865F2,  # Discord blurple
+        fields: list[dict[str, Any]] | None = None,
+        footer: str | None = None,
+        thumbnail_url: str | None = None,
+        image_url: str | None = None,
+        author_name: str | None = None,
+        author_icon_url: str | None = None,
+    ) -> SendResult:
+        """
+        Send a rich embed message.
+        
+        This is a convenience method for creating Discord embeds.
+        
+        Args:
+            title: Embed title
+            description: Embed description
+            color: Embed color as integer (default: Discord blurple)
+            fields: List of field dicts with 'name', 'value', and optional 'inline'
+            footer: Footer text
+            thumbnail_url: URL for thumbnail image
+            image_url: URL for main image
+            author_name: Author name
+            author_icon_url: Author icon URL
+            
+        Returns:
+            SendResult with message details
+        """
+        embed: dict[str, Any] = {
+            "title": title,
+            "description": description,
+            "color": color,
+        }
+        
+        if fields:
+            embed["fields"] = fields
+        if footer:
+            embed["footer"] = {"text": footer}
+        if thumbnail_url:
+            embed["thumbnail"] = {"url": thumbnail_url}
+        if image_url:
+            embed["image"] = {"url": image_url}
+        if author_name:
+            embed["author"] = {"name": author_name}
+            if author_icon_url:
+                embed["author"]["icon_url"] = author_icon_url
+        
+        return self.send_message("", "", embeds=[embed])
+    
+    def close(self) -> None:
+        """Close the HTTP client."""
+        self._client.close()
+    
+    def __enter__(self) -> "DiscordPlatform":
+        return self
+    
+    def __exit__(self, *args: Any) -> None:
+        self.close()

--- a/tools/src/aden_tools/tools/messaging_tool/platforms/slack.py
+++ b/tools/src/aden_tools/tools/messaging_tool/platforms/slack.py
@@ -1,0 +1,394 @@
+"""
+Slack platform adapter using the Slack Web API.
+
+Uses httpx for HTTP calls to avoid additional dependencies.
+Requires a Slack Bot Token (xoxb-...) with appropriate scopes.
+
+Required Bot Token Scopes:
+- chat:write - Send messages
+- channels:history - Read public channel messages
+- groups:history - Read private channel messages (optional)
+- reactions:write - Add reactions
+- files:write - Upload files
+- channels:read - List channels
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, List, Optional
+
+import httpx
+
+from .base import (
+    Channel,
+    FileUploadResult,
+    Message,
+    MessagingPlatform,
+    SendResult,
+)
+
+
+class SlackPlatform(MessagingPlatform):
+    """
+    Slack platform adapter using the Web API.
+    
+    Example:
+        platform = SlackPlatform(token="xoxb-...")
+        result = platform.send_message("#general", "Hello from Hive!")
+    """
+    
+    BASE_URL = "https://slack.com/api"
+    DEFAULT_TIMEOUT = 30.0
+    
+    def __init__(self, token: str, timeout: float = DEFAULT_TIMEOUT):
+        """
+        Initialize Slack platform adapter.
+        
+        Args:
+            token: Slack Bot Token (xoxb-...)
+            timeout: HTTP request timeout in seconds
+        """
+        self._token = token
+        self._timeout = timeout
+        self._client = httpx.Client(
+            base_url=self.BASE_URL,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json; charset=utf-8",
+            },
+            timeout=timeout,
+        )
+    
+    @property
+    def platform_name(self) -> str:
+        return "slack"
+    
+    def _handle_response(self, response: httpx.Response) -> dict[str, Any]:
+        """Parse Slack API response and handle errors."""
+        response.raise_for_status()
+        data = response.json()
+        
+        if not data.get("ok", False):
+            error = data.get("error", "Unknown error")
+            raise SlackAPIError(error, data)
+        
+        return data
+    
+    def send_message(
+        self,
+        channel: str,
+        text: str,
+        thread_id: Optional[str] = None,
+        **kwargs: Any,
+    ) -> SendResult:
+        """
+        Send a message to a Slack channel.
+        
+        Args:
+            channel: Channel ID (C...) or name (#general)
+            text: Message text (Slack markdown supported)
+            thread_id: Thread timestamp to reply to
+            **kwargs: Additional options (blocks, attachments, etc.)
+            
+        Returns:
+            SendResult with message details
+        """
+        payload: dict[str, Any] = {
+            "channel": channel,
+            "text": text,
+        }
+        
+        if thread_id:
+            payload["thread_ts"] = thread_id
+        
+        # Support advanced features
+        if "blocks" in kwargs:
+            payload["blocks"] = kwargs["blocks"]
+        if "attachments" in kwargs:
+            payload["attachments"] = kwargs["attachments"]
+        if "unfurl_links" in kwargs:
+            payload["unfurl_links"] = kwargs["unfurl_links"]
+        if "unfurl_media" in kwargs:
+            payload["unfurl_media"] = kwargs["unfurl_media"]
+        
+        try:
+            response = self._client.post("/chat.postMessage", json=payload)
+            data = self._handle_response(response)
+            
+            return SendResult(
+                success=True,
+                message_id=data.get("ts"),
+                thread_id=data.get("message", {}).get("thread_ts"),
+                channel=data.get("channel"),
+                raw_response=data,
+            )
+        except SlackAPIError as e:
+            return SendResult(
+                success=False,
+                error=str(e),
+                raw_response=e.response_data,
+            )
+        except httpx.HTTPStatusError as e:
+            return SendResult(
+                success=False,
+                error=f"HTTP {e.response.status_code}: {e.response.text}",
+            )
+        except httpx.RequestError as e:
+            return SendResult(
+                success=False,
+                error=f"Network error: {str(e)}",
+            )
+    
+    def get_messages(
+        self,
+        channel: str,
+        limit: int = 10,
+        before: Optional[str] = None,
+    ) -> List[Message]:
+        """
+        Get recent messages from a Slack channel.
+        
+        Args:
+            channel: Channel ID (C...)
+            limit: Number of messages to return (1-100)
+            before: Fetch messages before this timestamp
+            
+        Returns:
+            List of Message objects, newest first
+        """
+        limit = max(1, min(100, limit))
+        
+        params: dict[str, Any] = {
+            "channel": channel,
+            "limit": limit,
+        }
+        
+        if before:
+            params["latest"] = before
+        
+        try:
+            response = self._client.get("/conversations.history", params=params)
+            data = self._handle_response(response)
+            
+            messages = []
+            for msg in data.get("messages", []):
+                # Skip non-message types (join, leave, etc.)
+                if msg.get("subtype") and msg.get("subtype") != "bot_message":
+                    continue
+                
+                messages.append(Message(
+                    id=msg.get("ts", ""),
+                    channel=channel,
+                    content=msg.get("text", ""),
+                    author=msg.get("user", msg.get("bot_id", "unknown")),
+                    timestamp=self._ts_to_iso(msg.get("ts", "")),
+                    thread_id=msg.get("thread_ts"),
+                    metadata={
+                        "reactions": msg.get("reactions", []),
+                        "reply_count": msg.get("reply_count", 0),
+                        "files": msg.get("files", []),
+                    },
+                ))
+            
+            return messages
+            
+        except (SlackAPIError, httpx.HTTPStatusError, httpx.RequestError):
+            return []
+    
+    def add_reaction(
+        self,
+        channel: str,
+        message_id: str,
+        emoji: str,
+    ) -> dict[str, Any]:
+        """
+        Add an emoji reaction to a message.
+        
+        Args:
+            channel: Channel ID containing the message
+            message_id: Message timestamp (ts)
+            emoji: Emoji name without colons (e.g., 'thumbsup')
+            
+        Returns:
+            Dict with 'success' and optional 'error'
+        """
+        # Remove colons if present
+        emoji = emoji.strip(":")
+        
+        payload = {
+            "channel": channel,
+            "timestamp": message_id,
+            "name": emoji,
+        }
+        
+        try:
+            response = self._client.post("/reactions.add", json=payload)
+            self._handle_response(response)
+            return {"success": True}
+        except SlackAPIError as e:
+            # "already_reacted" is not really an error
+            if "already_reacted" in str(e):
+                return {"success": True, "note": "Already reacted"}
+            return {"success": False, "error": str(e)}
+        except (httpx.HTTPStatusError, httpx.RequestError) as e:
+            return {"success": False, "error": str(e)}
+    
+    def upload_file(
+        self,
+        channel: str,
+        filename: str,
+        content: bytes,
+        title: Optional[str] = None,
+        comment: Optional[str] = None,
+    ) -> FileUploadResult:
+        """
+        Upload a file to a Slack channel.
+        
+        Args:
+            channel: Channel ID to upload to
+            filename: Name for the file
+            content: File content as bytes
+            title: Optional title for the file
+            comment: Optional message to accompany the file
+            
+        Returns:
+            FileUploadResult with file details
+        """
+        # Use multipart form data for file upload
+        files = {"file": (filename, content)}
+        data: dict[str, Any] = {
+            "channels": channel,
+            "filename": filename,
+        }
+        
+        if title:
+            data["title"] = title
+        if comment:
+            data["initial_comment"] = comment
+        
+        try:
+            # File uploads need different headers
+            response = httpx.post(
+                f"{self.BASE_URL}/files.upload",
+                headers={"Authorization": f"Bearer {self._token}"},
+                data=data,
+                files=files,
+                timeout=self._timeout,
+            )
+            response_data = response.json()
+            
+            if not response_data.get("ok", False):
+                return FileUploadResult(
+                    success=False,
+                    error=response_data.get("error", "Upload failed"),
+                )
+            
+            file_info = response_data.get("file", {})
+            return FileUploadResult(
+                success=True,
+                file_id=file_info.get("id"),
+                url=file_info.get("permalink"),
+            )
+            
+        except (httpx.HTTPStatusError, httpx.RequestError) as e:
+            return FileUploadResult(
+                success=False,
+                error=str(e),
+            )
+    
+    def list_channels(
+        self,
+        include_private: bool = False,
+        limit: int = 100,
+    ) -> List[Channel]:
+        """
+        List available Slack channels.
+        
+        Args:
+            include_private: Whether to include private channels
+            limit: Maximum number of channels to return
+            
+        Returns:
+            List of Channel objects
+        """
+        limit = max(1, min(1000, limit))
+        
+        types = ["public_channel"]
+        if include_private:
+            types.append("private_channel")
+        
+        params = {
+            "types": ",".join(types),
+            "limit": limit,
+            "exclude_archived": True,
+        }
+        
+        try:
+            response = self._client.get("/conversations.list", params=params)
+            data = self._handle_response(response)
+            
+            channels = []
+            for ch in data.get("channels", []):
+                channels.append(Channel(
+                    id=ch.get("id", ""),
+                    name=ch.get("name", ""),
+                    is_private=ch.get("is_private", False),
+                    member_count=ch.get("num_members"),
+                ))
+            
+            return channels
+            
+        except (SlackAPIError, httpx.HTTPStatusError, httpx.RequestError):
+            return []
+    
+    def validate_credentials(self) -> dict[str, Any]:
+        """
+        Validate the Slack bot token.
+        
+        Returns:
+            Dict with 'valid' bool and user/bot info if valid
+        """
+        try:
+            response = self._client.get("/auth.test")
+            data = self._handle_response(response)
+            
+            return {
+                "valid": True,
+                "user": data.get("user"),
+                "user_id": data.get("user_id"),
+                "team": data.get("team"),
+                "team_id": data.get("team_id"),
+            }
+        except (SlackAPIError, httpx.HTTPStatusError, httpx.RequestError) as e:
+            return {
+                "valid": False,
+                "error": str(e),
+            }
+    
+    def _ts_to_iso(self, ts: str) -> str:
+        """Convert Slack timestamp to ISO 8601 format."""
+        try:
+            # Slack ts is Unix timestamp with microseconds: "1234567890.123456"
+            unix_ts = float(ts)
+            dt = datetime.fromtimestamp(unix_ts)
+            return dt.isoformat()
+        except (ValueError, TypeError):
+            return ts
+    
+    def close(self) -> None:
+        """Close the HTTP client."""
+        self._client.close()
+    
+    def __enter__(self) -> "SlackPlatform":
+        return self
+    
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+
+class SlackAPIError(Exception):
+    """Exception raised when Slack API returns an error."""
+    
+    def __init__(self, message: str, response_data: dict[str, Any] | None = None):
+        super().__init__(message)
+        self.response_data = response_data or {}

--- a/tools/tests/tools/messaging/__init__.py
+++ b/tools/tests/tools/messaging/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for messaging tool."""

--- a/tools/tests/tools/messaging/test_discord.py
+++ b/tools/tests/tools/messaging/test_discord.py
@@ -1,0 +1,233 @@
+"""Tests for Discord platform adapter."""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from aden_tools.tools.messaging_tool.platforms.discord import DiscordPlatform
+
+
+class TestDiscordPlatform:
+    """Tests for DiscordPlatform class."""
+
+    def test_platform_name(self):
+        """Platform name is 'discord'."""
+        platform = DiscordPlatform(webhook_url="https://discord.com/api/webhooks/123/abc")
+        assert platform.platform_name == "discord"
+        platform.close()
+
+    @patch("httpx.Client")
+    def test_send_message_success(self, mock_client_class):
+        """Successful message send."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id": "987654321",
+            "channel_id": "456",
+        }
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        platform = DiscordPlatform(webhook_url="https://discord.com/api/webhooks/123/abc")
+        result = platform.send_message(channel="", text="Hello!")
+
+        assert result.success is True
+        assert result.message_id == "987654321"
+        assert result.channel == "456"
+
+        # Verify payload
+        call_args = mock_client.post.call_args
+        assert "content" in call_args[1]["json"]
+        assert call_args[1]["json"]["content"] == "Hello!"
+
+    @patch("httpx.Client")
+    def test_send_message_with_username_override(self, mock_client_class):
+        """Message with custom username."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "123"}
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        platform = DiscordPlatform(webhook_url="https://discord.com/api/webhooks/123/abc")
+        result = platform.send_message(
+            channel="",
+            text="Hello!",
+            username="CustomBot",
+            avatar_url="https://example.com/avatar.png",
+        )
+
+        assert result.success is True
+
+        call_args = mock_client.post.call_args
+        assert call_args[1]["json"]["username"] == "CustomBot"
+        assert call_args[1]["json"]["avatar_url"] == "https://example.com/avatar.png"
+
+    @patch("httpx.Client")
+    def test_send_message_with_embeds(self, mock_client_class):
+        """Message with embeds."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "123"}
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        embed = {
+            "title": "Test Embed",
+            "description": "This is a test",
+            "color": 0x5865F2,
+        }
+
+        platform = DiscordPlatform(webhook_url="https://discord.com/api/webhooks/123/abc")
+        result = platform.send_message(channel="", text="", embeds=[embed])
+
+        assert result.success is True
+
+        call_args = mock_client.post.call_args
+        assert "embeds" in call_args[1]["json"]
+        assert call_args[1]["json"]["embeds"][0]["title"] == "Test Embed"
+
+    @patch("httpx.Client")
+    def test_send_message_error(self, mock_client_class):
+        """API error handling."""
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.content = b'{"message": "Invalid webhook"}'
+        mock_response.json.return_value = {"message": "Invalid webhook"}
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        platform = DiscordPlatform(webhook_url="https://discord.com/api/webhooks/invalid")
+        result = platform.send_message(channel="", text="Hello!")
+
+        assert result.success is False
+        assert "Invalid webhook" in result.error
+
+    def test_get_messages_not_supported(self):
+        """get_messages returns empty list for webhooks."""
+        platform = DiscordPlatform(webhook_url="https://discord.com/api/webhooks/123/abc")
+        messages = platform.get_messages(channel="C123")
+
+        assert messages == []
+        platform.close()
+
+    def test_add_reaction_not_supported(self):
+        """add_reaction returns error for webhooks."""
+        platform = DiscordPlatform(webhook_url="https://discord.com/api/webhooks/123/abc")
+        result = platform.add_reaction(channel="C123", message_id="123", emoji="thumbsup")
+
+        assert result["success"] is False
+        assert "cannot" in result["error"].lower()
+        platform.close()
+
+    def test_list_channels_not_supported(self):
+        """list_channels returns empty list for webhooks."""
+        platform = DiscordPlatform(webhook_url="https://discord.com/api/webhooks/123/abc")
+        channels = platform.list_channels()
+
+        assert channels == []
+        platform.close()
+
+    @patch("httpx.Client")
+    def test_upload_file_success(self, mock_client_class):
+        """Successful file upload."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id": "123",
+            "attachments": [
+                {"id": "456", "url": "https://cdn.discord.com/attachments/..."},
+            ],
+        }
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        platform = DiscordPlatform(webhook_url="https://discord.com/api/webhooks/123/abc")
+        result = platform.upload_file(
+            channel="",
+            filename="test.txt",
+            content=b"Hello, World!",
+            comment="Here's a file",
+        )
+
+        assert result.success is True
+        assert result.file_id == "456"
+        assert "discord" in result.url
+
+    @patch("httpx.Client")
+    def test_validate_credentials_success(self, mock_client_class):
+        """Successful credential validation."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "name": "Test Webhook",
+            "channel_id": "123",
+            "guild_id": "456",
+        }
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        platform = DiscordPlatform(webhook_url="https://discord.com/api/webhooks/123/abc")
+        result = platform.validate_credentials()
+
+        assert result["valid"] is True
+        assert result["name"] == "Test Webhook"
+
+    @patch("httpx.Client")
+    def test_validate_credentials_invalid(self, mock_client_class):
+        """Invalid webhook validation."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        platform = DiscordPlatform(webhook_url="https://discord.com/api/webhooks/invalid")
+        result = platform.validate_credentials()
+
+        assert result["valid"] is False
+        assert "404" in result["error"]
+
+    @patch("httpx.Client")
+    def test_send_embed_convenience_method(self, mock_client_class):
+        """send_embed convenience method."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "123"}
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        platform = DiscordPlatform(webhook_url="https://discord.com/api/webhooks/123/abc")
+        result = platform.send_embed(
+            title="Alert",
+            description="Something happened!",
+            color=0xFF0000,
+            footer="Powered by Hive",
+        )
+
+        assert result.success is True
+
+        call_args = mock_client.post.call_args
+        embeds = call_args[1]["json"]["embeds"]
+        assert len(embeds) == 1
+        assert embeds[0]["title"] == "Alert"
+        assert embeds[0]["color"] == 0xFF0000
+        assert embeds[0]["footer"]["text"] == "Powered by Hive"
+
+    def test_context_manager(self):
+        """Platform can be used as context manager."""
+        with DiscordPlatform(webhook_url="https://discord.com/api/webhooks/123/abc") as platform:
+            assert platform.platform_name == "discord"

--- a/tools/tests/tools/messaging/test_slack.py
+++ b/tools/tests/tools/messaging/test_slack.py
@@ -1,0 +1,279 @@
+"""Tests for Slack platform adapter."""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from aden_tools.tools.messaging_tool.platforms.slack import SlackPlatform, SlackAPIError
+
+
+class TestSlackPlatform:
+    """Tests for SlackPlatform class."""
+
+    def test_platform_name(self):
+        """Platform name is 'slack'."""
+        platform = SlackPlatform(token="xoxb-test")
+        assert platform.platform_name == "slack"
+        platform.close()
+
+    @patch("httpx.Client")
+    def test_send_message_success(self, mock_client_class):
+        """Successful message send."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ok": True,
+            "ts": "1234567890.123456",
+            "channel": "C123",
+            "message": {},
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        platform = SlackPlatform(token="xoxb-test")
+        result = platform.send_message(channel="C123", text="Hello!")
+
+        assert result.success is True
+        assert result.message_id == "1234567890.123456"
+        assert result.channel == "C123"
+
+        # Verify API call
+        mock_client.post.assert_called_once()
+        call_args = mock_client.post.call_args
+        assert call_args[0][0] == "/chat.postMessage"
+        assert call_args[1]["json"]["channel"] == "C123"
+        assert call_args[1]["json"]["text"] == "Hello!"
+
+    @patch("httpx.Client")
+    def test_send_message_with_thread(self, mock_client_class):
+        """Message send with thread_id."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ok": True,
+            "ts": "1234567890.123456",
+            "channel": "C123",
+            "message": {"thread_ts": "1234567890.000000"},
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        platform = SlackPlatform(token="xoxb-test")
+        result = platform.send_message(
+            channel="C123",
+            text="Reply!",
+            thread_id="1234567890.000000",
+        )
+
+        assert result.success is True
+
+        # Verify thread_ts was included
+        call_args = mock_client.post.call_args
+        assert call_args[1]["json"]["thread_ts"] == "1234567890.000000"
+
+    @patch("httpx.Client")
+    def test_send_message_api_error(self, mock_client_class):
+        """API error handling."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ok": False,
+            "error": "channel_not_found",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        platform = SlackPlatform(token="xoxb-test")
+        result = platform.send_message(channel="C999", text="Hello!")
+
+        assert result.success is False
+        assert "channel_not_found" in result.error
+
+    @patch("httpx.Client")
+    def test_get_messages_success(self, mock_client_class):
+        """Successful message fetch."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ok": True,
+            "messages": [
+                {"ts": "1234567890.123456", "text": "Hello", "user": "U123"},
+                {"ts": "1234567890.123457", "text": "World", "user": "U456"},
+            ],
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        platform = SlackPlatform(token="xoxb-test")
+        messages = platform.get_messages(channel="C123", limit=10)
+
+        assert len(messages) == 2
+        assert messages[0].content == "Hello"
+        assert messages[1].content == "World"
+
+    @patch("httpx.Client")
+    def test_get_messages_filters_subtypes(self, mock_client_class):
+        """Subtypes like 'channel_join' are filtered out."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ok": True,
+            "messages": [
+                {"ts": "1234567890.123456", "text": "Hello", "user": "U123"},
+                {"ts": "1234567890.123457", "text": "joined", "user": "U456", "subtype": "channel_join"},
+                {"ts": "1234567890.123458", "text": "Bot msg", "bot_id": "B123", "subtype": "bot_message"},
+            ],
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        platform = SlackPlatform(token="xoxb-test")
+        messages = platform.get_messages(channel="C123", limit=10)
+
+        # Should have 2 messages (normal + bot_message), channel_join filtered
+        assert len(messages) == 2
+
+    @patch("httpx.Client")
+    def test_add_reaction_success(self, mock_client_class):
+        """Successful reaction add."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"ok": True}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        platform = SlackPlatform(token="xoxb-test")
+        result = platform.add_reaction(
+            channel="C123",
+            message_id="1234567890.123456",
+            emoji="thumbsup",
+        )
+
+        assert result["success"] is True
+
+        # Verify emoji was stripped of colons
+        call_args = mock_client.post.call_args
+        assert call_args[1]["json"]["name"] == "thumbsup"
+
+    @patch("httpx.Client")
+    def test_add_reaction_strips_colons(self, mock_client_class):
+        """Colons are stripped from emoji name."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"ok": True}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        platform = SlackPlatform(token="xoxb-test")
+        result = platform.add_reaction(
+            channel="C123",
+            message_id="1234567890.123456",
+            emoji=":rocket:",
+        )
+
+        assert result["success"] is True
+        call_args = mock_client.post.call_args
+        assert call_args[1]["json"]["name"] == "rocket"
+
+    @patch("httpx.Client")
+    def test_list_channels_success(self, mock_client_class):
+        """Successful channel list."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ok": True,
+            "channels": [
+                {"id": "C123", "name": "general", "is_private": False, "num_members": 50},
+                {"id": "C456", "name": "random", "is_private": False, "num_members": 30},
+            ],
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        platform = SlackPlatform(token="xoxb-test")
+        channels = platform.list_channels()
+
+        assert len(channels) == 2
+        assert channels[0].id == "C123"
+        assert channels[0].name == "general"
+        assert channels[1].member_count == 30
+
+    @patch("httpx.Client")
+    def test_validate_credentials_success(self, mock_client_class):
+        """Successful credential validation."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ok": True,
+            "user": "testbot",
+            "user_id": "U123",
+            "team": "Test Team",
+            "team_id": "T123",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        platform = SlackPlatform(token="xoxb-test")
+        result = platform.validate_credentials()
+
+        assert result["valid"] is True
+        assert result["user"] == "testbot"
+        assert result["team"] == "Test Team"
+
+    @patch("httpx.Client")
+    def test_validate_credentials_invalid_token(self, mock_client_class):
+        """Invalid token validation."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ok": False,
+            "error": "invalid_auth",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        platform = SlackPlatform(token="xoxb-invalid")
+        result = platform.validate_credentials()
+
+        assert result["valid"] is False
+        assert "invalid_auth" in result["error"]
+
+    def test_context_manager(self):
+        """Platform can be used as context manager."""
+        with SlackPlatform(token="xoxb-test") as platform:
+            assert platform.platform_name == "slack"
+
+
+class TestSlackAPIError:
+    """Tests for SlackAPIError exception."""
+
+    def test_error_message(self):
+        """Error includes message."""
+        error = SlackAPIError("channel_not_found")
+        assert "channel_not_found" in str(error)
+
+    def test_error_with_response_data(self):
+        """Error includes response data."""
+        error = SlackAPIError(
+            "channel_not_found",
+            response_data={"ok": False, "error": "channel_not_found"},
+        )
+        assert error.response_data["error"] == "channel_not_found"

--- a/tools/tests/tools/test_messaging_tool.py
+++ b/tools/tests/tools/test_messaging_tool.py
@@ -1,0 +1,391 @@
+"""Tests for messaging tool (FastMCP)."""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from fastmcp import FastMCP
+from aden_tools.tools.messaging_tool import register_tools
+from aden_tools.credentials import CredentialManager
+
+
+@pytest.fixture
+def mcp():
+    """Create a FastMCP instance."""
+    return FastMCP("test")
+
+
+@pytest.fixture
+def registered_mcp(mcp: FastMCP):
+    """Create a FastMCP instance with messaging tools registered."""
+    register_tools(mcp)
+    return mcp
+
+
+def get_tool_fn(mcp: FastMCP, name: str):
+    """Get a tool function by name."""
+    return mcp._tool_manager._tools[name].fn
+
+
+class TestMessagingSend:
+    """Tests for messaging_send tool."""
+
+    def test_unknown_platform_returns_error(self, registered_mcp):
+        """Unknown platform returns helpful error."""
+        fn = get_tool_fn(registered_mcp, "messaging_send")
+        result = fn(platform="telegram", message="hello")
+
+        assert "error" in result
+        assert "telegram" in result["error"].lower()
+        assert "slack" in result["error"].lower() or "discord" in result["error"].lower()
+
+    def test_empty_message_returns_error(self, registered_mcp):
+        """Empty message returns error."""
+        fn = get_tool_fn(registered_mcp, "messaging_send")
+        result = fn(platform="slack", message="", channel="C123")
+
+        assert "error" in result
+        assert "empty" in result["error"].lower()
+
+    def test_slack_missing_token_returns_error(self, registered_mcp, monkeypatch):
+        """Slack without token returns helpful error."""
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+
+        fn = get_tool_fn(registered_mcp, "messaging_send")
+        result = fn(platform="slack", message="hello", channel="C123")
+
+        assert "error" in result
+        assert "SLACK_BOT_TOKEN" in result["error"]
+        assert "help" in result
+
+    def test_slack_missing_channel_returns_error(self, registered_mcp, monkeypatch):
+        """Slack without channel returns error."""
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test-token")
+
+        fn = get_tool_fn(registered_mcp, "messaging_send")
+        result = fn(platform="slack", message="hello", channel="")
+
+        assert "error" in result
+        assert "channel" in result["error"].lower()
+
+    def test_discord_missing_webhook_returns_error(self, registered_mcp, monkeypatch):
+        """Discord without webhook returns helpful error."""
+        monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
+
+        fn = get_tool_fn(registered_mcp, "messaging_send")
+        result = fn(platform="discord", message="hello")
+
+        assert "error" in result
+        assert "DISCORD_WEBHOOK_URL" in result["error"]
+        assert "help" in result
+
+    @patch("httpx.Client")
+    def test_slack_send_success(self, mock_client_class, registered_mcp, monkeypatch):
+        """Successful Slack message send."""
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test-token")
+
+        # Mock the HTTP response
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ok": True,
+            "ts": "1234567890.123456",
+            "channel": "C123",
+            "message": {"thread_ts": None},
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
+
+        fn = get_tool_fn(registered_mcp, "messaging_send")
+        result = fn(platform="slack", message="Hello!", channel="C123")
+
+        assert result["success"] is True
+        assert result["platform"] == "slack"
+        assert result["message_id"] == "1234567890.123456"
+
+    @patch("httpx.Client")
+    def test_discord_send_success(self, mock_client_class, registered_mcp, monkeypatch):
+        """Successful Discord webhook send."""
+        monkeypatch.setenv("DISCORD_WEBHOOK_URL", "https://discord.com/api/webhooks/123/abc")
+
+        # Mock the HTTP response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id": "987654321",
+            "channel_id": "456",
+        }
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
+
+        fn = get_tool_fn(registered_mcp, "messaging_send")
+        result = fn(platform="discord", message="Hello!")
+
+        assert result["success"] is True
+        assert result["platform"] == "discord"
+        assert result["message_id"] == "987654321"
+
+
+class TestMessagingRead:
+    """Tests for messaging_read tool."""
+
+    def test_missing_token_returns_error(self, registered_mcp, monkeypatch):
+        """Missing Slack token returns helpful error."""
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+
+        fn = get_tool_fn(registered_mcp, "messaging_read")
+        result = fn(channel="C123")
+
+        assert "error" in result
+        assert "SLACK_BOT_TOKEN" in result["error"]
+
+    def test_missing_channel_returns_error(self, registered_mcp, monkeypatch):
+        """Missing channel returns error."""
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test-token")
+
+        fn = get_tool_fn(registered_mcp, "messaging_read")
+        result = fn(channel="")
+
+        assert "error" in result
+        assert "channel" in result["error"].lower()
+
+    @patch("httpx.Client")
+    def test_read_success(self, mock_client_class, registered_mcp, monkeypatch):
+        """Successful message read."""
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test-token")
+
+        # Mock the HTTP response
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ok": True,
+            "messages": [
+                {
+                    "ts": "1234567890.123456",
+                    "text": "Hello world",
+                    "user": "U123",
+                    "thread_ts": None,
+                },
+                {
+                    "ts": "1234567890.123457",
+                    "text": "Another message",
+                    "user": "U456",
+                },
+            ],
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
+
+        fn = get_tool_fn(registered_mcp, "messaging_read")
+        result = fn(channel="C123", limit=10)
+
+        assert result["success"] is True
+        assert result["platform"] == "slack"
+        assert result["count"] == 2
+        assert len(result["messages"]) == 2
+
+
+class TestMessagingReact:
+    """Tests for messaging_react tool."""
+
+    def test_missing_token_returns_error(self, registered_mcp, monkeypatch):
+        """Missing Slack token returns error."""
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+
+        fn = get_tool_fn(registered_mcp, "messaging_react")
+        result = fn(channel="C123", message_id="1234.5678", emoji="thumbsup")
+
+        assert "error" in result
+        assert "SLACK_BOT_TOKEN" in result["error"]
+
+    def test_missing_channel_returns_error(self, registered_mcp, monkeypatch):
+        """Missing channel returns error."""
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test-token")
+
+        fn = get_tool_fn(registered_mcp, "messaging_react")
+        result = fn(channel="", message_id="1234.5678", emoji="thumbsup")
+
+        assert "error" in result
+        assert "channel" in result["error"].lower()
+
+    def test_missing_message_id_returns_error(self, registered_mcp, monkeypatch):
+        """Missing message_id returns error."""
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test-token")
+
+        fn = get_tool_fn(registered_mcp, "messaging_react")
+        result = fn(channel="C123", message_id="", emoji="thumbsup")
+
+        assert "error" in result
+        assert "message" in result["error"].lower()
+
+    def test_missing_emoji_returns_error(self, registered_mcp, monkeypatch):
+        """Missing emoji returns error."""
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test-token")
+
+        fn = get_tool_fn(registered_mcp, "messaging_react")
+        result = fn(channel="C123", message_id="1234.5678", emoji="")
+
+        assert "error" in result
+        assert "emoji" in result["error"].lower()
+
+    @patch("httpx.Client")
+    def test_react_success(self, mock_client_class, registered_mcp, monkeypatch):
+        """Successful reaction add."""
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test-token")
+
+        # Mock the HTTP response
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"ok": True}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
+
+        fn = get_tool_fn(registered_mcp, "messaging_react")
+        result = fn(channel="C123", message_id="1234.5678", emoji="thumbsup")
+
+        assert result["success"] is True
+        assert result["emoji"] == "thumbsup"
+
+
+class TestMessagingUpload:
+    """Tests for messaging_upload tool."""
+
+    def test_unknown_platform_returns_error(self, registered_mcp):
+        """Unknown platform returns error."""
+        fn = get_tool_fn(registered_mcp, "messaging_upload")
+        result = fn(platform="teams", filename="test.txt", content="hello")
+
+        assert "error" in result
+        assert "teams" in result["error"].lower()
+
+    def test_missing_filename_returns_error(self, registered_mcp, monkeypatch):
+        """Missing filename returns error."""
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test-token")
+
+        fn = get_tool_fn(registered_mcp, "messaging_upload")
+        result = fn(platform="slack", filename="", content="hello", channel="C123")
+
+        assert "error" in result
+        assert "filename" in result["error"].lower()
+
+    def test_missing_content_returns_error(self, registered_mcp, monkeypatch):
+        """Missing content returns error."""
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test-token")
+
+        fn = get_tool_fn(registered_mcp, "messaging_upload")
+        result = fn(platform="slack", filename="test.txt", content="", channel="C123")
+
+        assert "error" in result
+        assert "content" in result["error"].lower()
+
+
+class TestMessagingListChannels:
+    """Tests for messaging_list_channels tool."""
+
+    def test_missing_token_returns_error(self, registered_mcp, monkeypatch):
+        """Missing Slack token returns error."""
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+
+        fn = get_tool_fn(registered_mcp, "messaging_list_channels")
+        result = fn()
+
+        assert "error" in result
+        assert "SLACK_BOT_TOKEN" in result["error"]
+
+    @patch("httpx.Client")
+    def test_list_channels_success(self, mock_client_class, registered_mcp, monkeypatch):
+        """Successful channel list."""
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test-token")
+
+        # Mock the HTTP response
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ok": True,
+            "channels": [
+                {"id": "C123", "name": "general", "is_private": False, "num_members": 50},
+                {"id": "C456", "name": "random", "is_private": False, "num_members": 30},
+            ],
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
+
+        fn = get_tool_fn(registered_mcp, "messaging_list_channels")
+        result = fn()
+
+        assert result["success"] is True
+        assert result["count"] == 2
+        assert len(result["channels"]) == 2
+        assert result["channels"][0]["name"] == "general"
+
+
+class TestMessagingValidate:
+    """Tests for messaging_validate tool."""
+
+    def test_unknown_platform_returns_error(self, registered_mcp):
+        """Unknown platform returns error."""
+        fn = get_tool_fn(registered_mcp, "messaging_validate")
+        result = fn(platform="telegram")
+
+        assert result["valid"] is False
+        assert "telegram" in result["error"].lower()
+
+    def test_slack_missing_token_returns_invalid(self, registered_mcp, monkeypatch):
+        """Missing Slack token returns invalid."""
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+
+        fn = get_tool_fn(registered_mcp, "messaging_validate")
+        result = fn(platform="slack")
+
+        assert result["valid"] is False
+        assert "SLACK_BOT_TOKEN" in result["error"]
+
+    def test_discord_missing_webhook_returns_invalid(self, registered_mcp, monkeypatch):
+        """Missing Discord webhook returns invalid."""
+        monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
+
+        fn = get_tool_fn(registered_mcp, "messaging_validate")
+        result = fn(platform="discord")
+
+        assert result["valid"] is False
+        assert "DISCORD_WEBHOOK_URL" in result["error"]
+
+
+class TestCredentialManagerIntegration:
+    """Tests for CredentialManager integration."""
+
+    def test_uses_credential_manager_for_slack(self, mcp):
+        """Uses CredentialManager when provided."""
+        creds = CredentialManager.for_testing({"slack": "xoxb-test-token"})
+        register_tools(mcp, credentials=creds)
+
+        # Tool should be registered
+        assert "messaging_send" in mcp._tool_manager._tools
+
+    def test_uses_credential_manager_for_discord(self, mcp):
+        """Uses CredentialManager for Discord when provided."""
+        creds = CredentialManager.for_testing({
+            "discord_webhook": "https://discord.com/api/webhooks/123/abc"
+        })
+        register_tools(mcp, credentials=creds)
+
+        # Tool should be registered
+        assert "messaging_send" in mcp._tool_manager._tools


### PR DESCRIPTION

Fixes #1030

## Summary

Add a unified messaging tool for integrating Hive agents with Slack and Discord, enabling agents to communicate with teams through popular messaging platforms.

## Features

### Slack (Full Integration via Bot Token)
- ✅ Send messages to channels and threads
- ✅ Read channel history
- ✅ Add emoji reactions
- ✅ Upload files
- ✅ List available channels
- ✅ Validate credentials

### Discord (Webhook Integration)
- ✅ Send messages via webhooks
- ✅ Upload files
- ✅ Custom username/avatar per message
- ✅ Rich embeds support

## New Tools

| Tool | Description |
|------|-------------|
| `messaging_send` | Send message to Slack or Discord |
| `messaging_read` | Read messages from Slack channel |
| `messaging_react` | Add emoji reaction (Slack) |
| `messaging_upload` | Upload file to Slack or Discord |
| `messaging_list_channels` | List Slack channels |
| `messaging_validate` | Validate platform credentials |

## Files Changed

```
tools/
├── pyproject.toml # Added httpx dependency
├── src/aden_tools/
│ ├── credentials/
│ │ ├── init.py # Export messaging credentials
│ │ └── messaging.py # NEW: Credential specs
│ └── tools/
│ ├── init.py # Register messaging tool
│ └── messaging_tool/ # NEW: Complete package
│ ├── README.md # Documentation
│ ├── init.py
│ ├── formatters.py # Rich message formatting
│ ├── messaging_tool.py # MCP tool definitions
│ └── platforms/
│ ├── init.py
│ ├── base.py # Abstract base classes
│ ├── discord.py # Discord webhook adapter
│ └── slack.py # Slack API adapter
└── tests/tools/
├── messaging/
│ ├── test_discord.py # Discord platform tests
│ └── test_slack.py # Slack platform tests
└── test_messaging_tool.py # Integration tests
```