### PR TITLE
UnicodeEncodeError: 'charmap' codec can't encode character '\u2717'

### DIFF
--- a/core/framework/storage/backend.py
+++ b/core/framework/storage/backend.py
@@ -52,13 +52,13 @@ class FileStorage:
         """Save a run to storage."""
         # Save full run using Pydantic's model_dump_json
         run_path = self.base_path / "runs" / f"{run.id}.json"
-        with open(run_path, "w") as f:
+        with open(run_path, "w",encoding="utf-8") as f:
             f.write(run.model_dump_json(indent=2))
 
         # Save summary
         summary = RunSummary.from_run(run)
         summary_path = self.base_path / "summaries" / f"{run.id}.json"
-        with open(summary_path, "w") as f:
+        with open(summary_path, "w", encoding="utf-8") as f:
             f.write(summary.model_dump_json(indent=2))
 
         # Update indexes


### PR DESCRIPTION
## Description

This PR fixes a Windows-specific encoding issue that caused multiple runtime tests to fail with:
UnicodeEncodeError: 'charmap' codec can't encode character '\u2717'
The error occurred because runtime summary files were written using the default Windows encoding (cp1252), which does not support Unicode characters such as ✗ used in narratives.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #1161 

## Changes Made

Updated file writing in:
core/framework/storage/backend.py
to explicitly use UTF-8 encoding:
open(path, "w", encoding="utf-8")

## Testing

Before:
9 failed, UnicodeEncodeError in test_runtime.py
After:
pytest core/tests/test_runtime.py → all tests passing ✅


## Checklist

 Tests added/updated
 Existing tests passing
 No breaking changes


## Screenshots (if applicable)

<img width="915" height="493" alt="Screenshot 2026-01-27 152919" src="https://github.com/user-attachments/assets/b7af295e-18e7-4ddc-9794-e3bbbcff2e70" />
