### PR TITLE
ci: Add Windows runner to GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
 
   test:
     name: Test Python Framework
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description
This PR updates the GitHub Actions CI workflow to run tests on both `ubuntu-latest` and `windows-latest`.

## Motivation and Context
Currently, CI only verifies linux compatibility. This change ensures that the codebase remains compatible with Windows, preventing issues like the recent Unicode processing bugs.

## Changes
- Modified `.github/workflows/ci.yml`: Updated the `test` job to use a build matrix strategy for `os`.

## How Has This Been Tested?
- [x] Implicitly tested by observing previous Windows failures locally.
- [ ] This PR's CI run will serve as the first comprehensive Windows validation.