### PR TITLE
Add Claude Code CLI installation instructions

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -46,7 +46,10 @@ Ensure you have installed:
 - **Python 3.11+** - [Download](https://www.python.org/downloads/) (3.12 or 3.13 recommended)
 - **pip** - Package installer for Python (comes with Python)
 - **git** - Version control
-- **Claude Code** - [Install](https://docs.anthropic.com/claude/docs/claude-code) (optional, for using building skills)
+- **Claude Code** - [Install](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) (Required for building agents)
+  ```bash
+  npm install -g @anthropic-ai/claude-code
+  ```
 
 Verify installation:
 
@@ -54,6 +57,7 @@ Verify installation:
 python --version    # Should be 3.11+
 pip --version       # Should be latest
 git --version       # Any recent version
+claude --version    # Should verify Claude Code installation
 ```
 
 ### Step-by-Step Setup

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 
 - [Python 3.11+](https://www.python.org/downloads/) for agent development
 - [Docker](https://docs.docker.com/get-docker/) (v20.10+) - Optional, for containerized tools
+- [Claude Code CLI](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) - Required for creating new agents
 
 ### Installation
 


### PR DESCRIPTION
## Description
This PR adds missing installation and verification instructions for the `Claude Code CLI`, which is a prerequisite for the agent-building workflow.

## Motivation and Context
Closes #1147

New contributors were getting blocked because the quickstart guide referenced `claude` commands without explaining how to install the tool.

## Changes
- Updated `README.md`: Added Claude Code CLI to prerequisites.
- Updated `DEVELOPER.md`: Added explicit npm install command and `claude --version` verification step.