### PR TITLE
fix(storage): add locking for index writes

### DIFF
--- a/core/tests/test_storage_concurrency.py
+++ b/core/tests/test_storage_concurrency.py
@@ -1,0 +1,73 @@
+import concurrent.futures
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from framework.schemas.run import Run, RunStatus
+from framework.storage.backend import FileStorage
+
+
+def _make_run(run_id: str, goal_id: str) -> Run:
+    return Run(id=run_id, goal_id=goal_id, status=RunStatus.COMPLETED)
+
+
+def test_concurrent_adds_do_not_lose_entries():
+    goal_id = "goal_concurrent"
+    workers = 6
+    runs_per_worker = 8
+    expected = workers * runs_per_worker
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        storage = FileStorage(tmpdir)
+
+        def worker(worker_id: int):
+            for i in range(runs_per_worker):
+                run = _make_run(f"run_{worker_id}_{i}", goal_id)
+                storage.save_run(run)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = [executor.submit(worker, w) for w in range(workers)]
+            concurrent.futures.wait(futures)
+
+        indexed = storage.get_runs_by_goal(goal_id)
+        assert len(indexed) == expected, f"Expected {expected}, got {len(indexed)}"
+        assert len(indexed) == len(set(indexed)), "Index contains duplicates"
+
+
+def test_concurrent_adds_and_deletes_remain_consistent():
+    goal_id = "goal_mixed"
+    initial_runs = 10
+    workers = 4
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        storage = FileStorage(tmpdir)
+
+        for i in range(initial_runs):
+            storage.save_run(_make_run(f"seed_{i}", goal_id))
+
+        def worker(worker_id: int):
+            # add
+            for i in range(3):
+                storage.save_run(_make_run(f"w{worker_id}_add_{i}", goal_id))
+            # delete some
+            if worker_id % 2 == 0:
+                storage.delete_run(f"seed_{worker_id}")
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = [executor.submit(worker, w) for w in range(workers)]
+            concurrent.futures.wait(futures)
+
+        indexed = set(storage.get_runs_by_goal(goal_id))
+        actual_files = {p.stem for p in (Path(tmpdir) / "runs").glob("*.json")}
+
+        # Index should be subset of actual files, and missing only expected deletes
+        assert indexed.issubset(actual_files)
+        assert len(actual_files) >= len(indexed)
+
+
+@pytest.mark.parametrize("missing_goal", ["no_such_goal", ""], ids=["absent", "empty"])
+def test_get_index_handles_missing_files(missing_goal: str):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        storage = FileStorage(tmpdir)
+        assert storage.get_runs_by_goal(missing_goal) == []


### PR DESCRIPTION
## Description
- Add cross-platform file locking (POSIX/Windows) around index read-modify-write to prevent race conditions that drop run IDs
- Harden index loading against malformed/empty JSON
- Add concurrency regression tests covering parallel adds and mixed add/delete operations

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
Fixes #<issue-number>

## Changes Made
- Wrapped `_add_to_index` and `_remove_from_index` with cross-platform file locks
- Added safe JSON parsing for index files
- Added `core/tests/test_storage_concurrency.py` with concurrent add and add/delete coverage

## Testing
- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed
- Note: `pytest` not installed locally; please run in CI or after installing `pytest`:
  - `PYTHONPATH=core:exports python -m pytest core/tests/test_storage_concurrency.py -q`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (locking context manager)
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (pending pytest install)

## Screenshots (if applicable)
N/A