### PR TITLE
fix(security): handle unix-style absolute paths correctly on Windows

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/security.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/security.py
@@ -13,10 +13,14 @@ def get_secure_path(path: str, workspace_id: str, agent_id: str, session_id: str
     session_dir = os.path.abspath(os.path.join(WORKSPACES_DIR, workspace_id, agent_id, session_id))
     os.makedirs(session_dir, exist_ok=True)
 
+    # Normalize whitespace to prevent bypass via leading spaces/tabs
+    path = path.strip()
+
     # Treat both OS-absolute paths AND Unix-style leading slashes as absolute-style
     if os.path.isabs(path) or path.startswith(("/", "\\")):
-        # Strip leading separators so path becomes relative to session_dir
-        rel_path = path.lstrip("/\\")
+        # Strip exactly one leading separator to make path relative to session_dir,
+        # preserving any subsequent separators (e.g. UNC paths like //server/share)
+        rel_path = path[1:] if path and path[0] in ("/", "\\") else path
         final_path = os.path.abspath(os.path.join(session_dir, rel_path))
     else:
         final_path = os.path.abspath(os.path.join(session_dir, path))
@@ -24,9 +28,10 @@ def get_secure_path(path: str, workspace_id: str, agent_id: str, session_id: str
     # Verify path is within session_dir
     try:
         common_prefix = os.path.commonpath([final_path, session_dir])
-    except ValueError:
-        # Fails on Windows if paths are on different drives
-        raise ValueError(f"Access denied: Path '{path}' is outside the session sandbox.")
+    except ValueError as err:
+        # commonpath raises ValueError when paths are on different drives (Windows)
+        # or when mixing absolute and relative paths
+        raise ValueError(f"Access denied: Path '{path}' is outside the session sandbox.") from err
 
     if common_prefix != session_dir:
         raise ValueError(f"Access denied: Path '{path}' is outside the session sandbox.")

--- a/tools/src/aden_tools/tools/file_system_toolkits/security.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/security.py
@@ -16,13 +16,19 @@ def get_secure_path(path: str, workspace_id: str, agent_id: str, session_id: str
     # Resolve absolute path
     if os.path.isabs(path):
         # Treat absolute paths as relative to the session root if they start with /
-        rel_path = path.lstrip(os.sep)
+        # FIX: Strip both native separator AND forward slash to handle Unix-style paths on Windows
+        rel_path = path.lstrip(os.sep + '/')
         final_path = os.path.abspath(os.path.join(session_dir, rel_path))
     else:
         final_path = os.path.abspath(os.path.join(session_dir, path))
 
     # Verify path is within session_dir
-    common_prefix = os.path.commonpath([final_path, session_dir])
+    try:
+        common_prefix = os.path.commonpath([final_path, session_dir])
+    except ValueError:
+        # Fails on Windows if paths are on different drives
+        raise ValueError(f"Access denied: Path '{path}' is outside the session sandbox.")
+
     if common_prefix != session_dir:
         raise ValueError(f"Access denied: Path '{path}' is outside the session sandbox.")
 

--- a/tools/src/aden_tools/tools/file_system_toolkits/security.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/security.py
@@ -9,15 +9,14 @@ def get_secure_path(path: str, workspace_id: str, agent_id: str, session_id: str
     if not workspace_id or not agent_id or not session_id:
         raise ValueError("workspace_id, agent_id, and session_id are all required")
 
-    # Ensure session directory exists: runtime/workspace_id/agent_id/session_id
-    session_dir = os.path.join(WORKSPACES_DIR, workspace_id, agent_id, session_id)
+    # Ensure session directory exists
+    session_dir = os.path.abspath(os.path.join(WORKSPACES_DIR, workspace_id, agent_id, session_id))
     os.makedirs(session_dir, exist_ok=True)
 
-    # Resolve absolute path
-    if os.path.isabs(path):
-        # Treat absolute paths as relative to the session root if they start with /
-        # FIX: Strip both native separator AND forward slash to handle Unix-style paths on Windows
-        rel_path = path.lstrip(os.sep + '/')
+    # Treat both OS-absolute paths AND Unix-style leading slashes as absolute-style
+    if os.path.isabs(path) or path.startswith(("/", "\\")):
+        # Strip leading separators so path becomes relative to session_dir
+        rel_path = path.lstrip("/\\")
         final_path = os.path.abspath(os.path.join(session_dir, rel_path))
     else:
         final_path = os.path.abspath(os.path.join(session_dir, path))


### PR DESCRIPTION
## Description

Fixes cross-platform path normalization issue in `get_secure_path`.

On Windows, `os.path.isabs()` returns False for Unix-style absolute paths (e.g., `/etc/passwd`). This caused such paths to bypass the intended normalization logic.

This update explicitly treats paths starting with `/` or `\` as absolute-style paths and safely normalizes them relative to the session sandbox directory.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #499

## Changes Made

- Detect Unix-style leading slashes as absolute-style paths on Windows
- Normalize such paths safely relative to the session directory
- Ensure sandbox boundary enforcement still works cross-platform

## Testing

- Verified path resolution behavior for:
  - Unix-style absolute paths on Windows
  - Windows absolute paths
  - Relative paths
  - Path traversal attempts (`../`)
- Existing security path tests now pass on Windows

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced
