### PR TITLE
fix(scripts): improve Python detection on Windows using py launcher

### DIFF
--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -25,18 +25,19 @@ echo "  Aden Agent Framework - Python Setup"
 echo "=================================================="
 echo ""
 
-# Check for Python
-if ! command -v python &> /dev/null && ! command -v python3 &> /dev/null; then
+# Detect Python interpreter
+if [[ "$OS" == "Windows_NT" ]] && command -v py &> /dev/null; then
+    PYTHON_CMD="py -3.11"
+elif command -v python3 &> /dev/null; then
+    PYTHON_CMD="python3"
+elif command -v python &> /dev/null; then
+    PYTHON_CMD="python"
+else
     echo -e "${RED}Error: Python is not installed.${NC}"
     echo "Please install Python 3.11+ from https://python.org"
     exit 1
 fi
 
-# Use python3 if available, otherwise python
-PYTHON_CMD="python3"
-if ! command -v python3 &> /dev/null; then
-    PYTHON_CMD="python"
-fi
 
 # Check Python version
 PYTHON_VERSION=$($PYTHON_CMD -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')


### PR DESCRIPTION
This PR fixes Python detection during setup on Windows.

Issue:
- setup-python.sh assumes `python` or `python3` resolves correctly
- On Windows, App Execution Aliases and Anaconda can hijack `python`
- Setup fails even when Python 3.11 is installed

Fix:
- Detect Windows and prefer the official Python launcher (`py -3.11`) when available
- Preserve existing behavior on macOS/Linux

Tested on Windows with Git Bash.
