### PR TITLE
fix(tools): prevent duplicate registration of web_search tool (#172)

### DIFF
--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -59,7 +59,8 @@ def register_all_tools(
     # web_search handles both credential sources internally:
     # - If credentials provided: uses credentials.get("brave_search")
     # - If credentials is None: falls back to os.getenv("BRAVE_SEARCH_API_KEY")
-    register_web_search(mcp, credentials=credentials)
+    if "web_search" not in mcp._tool_manager._tools:
+        register_web_search(mcp, credentials=credentials)
 
     # Register file system toolkits
     register_view_file(mcp)


### PR DESCRIPTION
## Description

This PR makes `register_all_tools` idempotent by preventing duplicate registration of the `web_search` tool when tool registration is invoked multiple times.

The change is intentionally minimal and ensures `web_search` is registered exactly once, without modifying existing behavior or architecture.

## Related Issue

Fixes #172
