### PR TITLE
fix(executor): prevent blind mapping of outputs to prevent data corruption (#1196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Fixed
+- core: Fixed FlexibleExecutor silently mapping single generic result to all expected outputs, causing data corruption (#1196)
 - tools: Fixed web_scrape tool attempting to parse non-HTML content (PDF, JSON) as HTML (#487)
 
 ### Security


### PR DESCRIPTION
## Description
Fixes issue #1196: FlexibleExecutor was silently mapping single generic result values to all expected outputs, causing data corruption.

## Changes
- Added strict output validation in `FlexibleExecutor._handle_judgment()`
- Worker must now return all keys in `step.expected_outputs`
- Triggers replanning with detailed error feedback instead of blind mapping
- Added 4 comprehensive test cases to prevent regression

## Testing
- All 26 existing tests pass
- 4 new tests added specifically for output validation scenarios
- Tests cover: valid outputs, missing outputs, regression test, extra outputs

## Checklist
- [x] Tests pass locally
- [x] CHANGELOG.md updated
- [x] Following Conventional Commits format
- [x] Issue #1196 claimed and assigned