### PR TITLE
fix(deps): resolve OpenAI + LiteLLM dependency conflict (#450)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Fixed
+- core: Resolve OpenAI + LiteLLM dependency conflict by explicitly declaring `openai>=1.0.0` in requirements and pyproject.toml; clean install no longer requires manual upgrade (#450)
 - tools: Fixed web_scrape tool attempting to parse non-HTML content (PDF, JSON) as HTML (#487)
 
 ### Security

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "pydantic>=2.0",
     "anthropic>=0.40.0",
     "httpx>=0.27.0",
+    "openai>=1.0.0",  # required by litellm
     "litellm>=1.81.0",
     "mcp>=1.0.0",
     "fastmcp>=2.0.0",

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -2,6 +2,8 @@
 pydantic>=2.0
 anthropic>=0.40.0
 httpx>=0.27.0
+# LLM integration (litellm requires openai>=1.0.0)
+openai>=1.0.0
 litellm>=1.81.0
 
 # MCP server dependencies

--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -121,29 +121,7 @@ else
 fi
 echo ""
 
-# Fix openai version compatibility with litellm
-echo "=================================================="
-echo "Fixing Package Compatibility"
-echo "=================================================="
-echo ""
-
-# Check openai version
-OPENAI_VERSION=$($PYTHON_CMD -c "import openai; print(openai.__version__)" 2>/dev/null || echo "not_installed")
-
-if [ "$OPENAI_VERSION" = "not_installed" ]; then
-    echo "Installing openai package..."
-    $PYTHON_CMD -m pip install "openai>=1.0.0" > /dev/null 2>&1
-    echo -e "${GREEN}✓${NC} openai package installed"
-elif [[ "$OPENAI_VERSION" =~ ^0\. ]]; then
-    echo -e "${YELLOW}Found old openai version: $OPENAI_VERSION${NC}"
-    echo "Upgrading to openai 1.x+ for litellm compatibility..."
-    $PYTHON_CMD -m pip install --upgrade "openai>=1.0.0" > /dev/null 2>&1
-    OPENAI_VERSION=$($PYTHON_CMD -c "import openai; print(openai.__version__)" 2>/dev/null)
-    echo -e "${GREEN}✓${NC} openai upgraded to $OPENAI_VERSION"
-else
-    echo -e "${GREEN}✓${NC} openai $OPENAI_VERSION is compatible"
-fi
-echo ""
+# openai>=1.0.0 is declared in core/pyproject.toml; no post-install fix needed.
 
 # Verify installations
 echo "=================================================="


### PR DESCRIPTION
## Description

Resolves [#450](https://github.com/adenhq/hive/issues/450): dependency conflict between `openai` and `litellm` that blocks clean installation. The framework did not declare `openai>=1.0.0`, so pip could install an incompatible `openai` and users had to run `pip install --upgrade "openai>=1.0.0"` manually after `pip install -e core/`.

This PR declares `openai>=1.0.0` in core deps so `pip install -e core/` works without post-install steps, and removes the compatibility workaround from `scripts/setup-python.sh`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #450

## Changes Made

- **core/requirements.txt** — Added `openai>=1.0.0` before `litellm>=1.81.0` with comment: `# LLM integration (litellm requires openai>=1.0.0)`.
- **core/pyproject.toml** — Added `"openai>=1.0.0"` to `dependencies` with inline comment `# required by litellm`.
- **scripts/setup-python.sh** — Removed the post-install "Fixing Package Compatibility" block (openai check/install/upgrade). Replaced with a single-line comment that `openai>=1.0.0` is declared in core deps.
- **CHANGELOG.md** — Under `### Fixed` [Unreleased], added:  
  `core: Resolve OpenAI + LiteLLM dependency conflict by explicitly declaring openai>=1.0.0 in requirements and pyproject.toml; clean install no longer requires manual upgrade (#450)`.

## Testing

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

### Manual testing

1. **Fresh install (new venv):**
   python3 -m venv .venv450
   .venv450/bin/pip install -e ./core
   .venv450/bin/python -c "import litellm; import openai; print('openai:', openai.__version__); print('✓ OK')"
   