### PR TITLE
fix(storage): use utf-8 encoding for run storage on Windows

### DIFF
--- a/core/framework/storage/backend.py
+++ b/core/framework/storage/backend.py
@@ -52,13 +52,16 @@ class FileStorage:
         """Save a run to storage."""
         # Save full run using Pydantic's model_dump_json
         run_path = self.base_path / "runs" / f"{run.id}.json"
-        with open(run_path, "w") as f:
+        # Use UTF-8 explicitly so summaries are portable across platforms
+        # and can safely include unicode characters (e.g. ✓ / ✗) without
+        # raising UnicodeEncodeError on Windows default encodings.
+        with open(run_path, "w", encoding="utf-8") as f:
             f.write(run.model_dump_json(indent=2))
 
         # Save summary
         summary = RunSummary.from_run(run)
         summary_path = self.base_path / "summaries" / f"{run.id}.json"
-        with open(summary_path, "w") as f:
+        with open(summary_path, "w", encoding="utf-8") as f:
             f.write(summary.model_dump_json(indent=2))
 
         # Update indexes
@@ -72,7 +75,7 @@ class FileStorage:
         run_path = self.base_path / "runs" / f"{run_id}.json"
         if not run_path.exists():
             return None
-        with open(run_path) as f:
+        with open(run_path, encoding="utf-8") as f:
             return Run.model_validate_json(f.read())
 
     def load_summary(self, run_id: str) -> RunSummary | None:
@@ -85,7 +88,7 @@ class FileStorage:
                 return RunSummary.from_run(run)
             return None
 
-        with open(summary_path) as f:
+        with open(summary_path, encoding="utf-8") as f:
             return RunSummary.model_validate_json(f.read())
 
     def delete_run(self, run_id: str) -> bool:
@@ -143,7 +146,7 @@ class FileStorage:
         index_path = self.base_path / "indexes" / index_type / f"{key}.json"
         if not index_path.exists():
             return []
-        with open(index_path) as f:
+        with open(index_path, encoding="utf-8") as f:
             return json.load(f)
 
     def _add_to_index(self, index_type: str, key: str, value: str) -> None:
@@ -152,7 +155,7 @@ class FileStorage:
         values = self._get_index(index_type, key)
         if value not in values:
             values.append(value)
-            with open(index_path, "w") as f:
+            with open(index_path, "w", encoding="utf-8") as f:
                 json.dump(values, f)
 
     def _remove_from_index(self, index_type: str, key: str, value: str) -> None:
@@ -161,7 +164,7 @@ class FileStorage:
         values = self._get_index(index_type, key)
         if value in values:
             values.remove(value)
-            with open(index_path, "w") as f:
+            with open(index_path, "w", encoding="utf-8") as f:
                 json.dump(values, f)
 
     # === UTILITY ===


### PR DESCRIPTION
## Description

Fixes a Windows-specific `UnicodeEncodeError` when saving run summaries and indexes that contain Unicode characters (e.g. ✓ / ✗). On Windows, the default file encoding is `cp1252`, which cannot encode these characters.

This PR updates the file-based storage backend to always use UTF‑8 for JSON files, making run storage consistent across platforms.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issues

N/A (discovered while running the test suite on Windows).

## Changes Made

- Use `encoding="utf-8"` when writing run JSON files.
- Use `encoding="utf-8"` when writing run summary JSON files.
- Use `encoding="utf-8"` when reading/writing index JSON files.

## Testing

- OS: Windows 11, Python 3.11
- Commands:



Result: `16 passed` (previously 10 tests failed with `UnicodeEncodeError` in `FileStorage.save_run`).