### PR TITLE
Add contributor onboarding section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ If you're interested in contributing to Hive:
 
 We welcome PRs that improve developer experience, documentation clarity, and onboarding flow.
 
+
 ### Prerequisites
 
 - [Python 3.11+](https://www.python.org/downloads/) for agent development

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ If you're interested in contributing to Hive:
 
 We welcome PRs that improve developer experience, documentation clarity, and onboarding flow.
 
-
 ### Prerequisites
 
 - [Python 3.11+](https://www.python.org/downloads/) for agent development

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 - **[Report Issues](https://github.com/adenhq/hive/issues)** - Bug reports and feature requests
 
 ## Quick Start
+### New Contributors
+
+If you're interested in contributing to Hive:
+
+- Start by reviewing **CONTRIBUTING.md**
+- Browse open issues and comment to get assigned before working on changes
+- For first-time contributors, documentation improvements are a great place to begin
+- Explore `core/` for agent runtime logic and `docs/` for guides
+
+We welcome PRs that improve developer experience, documentation clarity, and onboarding flow.
+
 
 ### Prerequisites
 


### PR DESCRIPTION
## Description

This PR adds a new section under **Quick Links** in the README to provide guidance for new contributors.  
The section, titled "New Contributors," helps first-time developers understand how to start contributing to Hive, including reviewing **CONTRIBUTING.md**, browsing and commenting on open issues to get assigned, and exploring key project folders such as `core/` for agent runtime logic and `docs/` for documentation and guides.  
The addition improves developer onboarding, clarifies the contribution workflow, and encourages meaningful contributions without modifying existing core content or documentation.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

- Helps address general onboarding and beginner contribution experience (no specific issue)

## Changes Made

- Added a "New Contributors" section under Quick Links in README.md
- Included step-by-step guidance for first-time contributors
- Highlighted important files and folders for newcomers

## Testing

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual review of README to ensure formatting and links are correct

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


N/A — Documentation change only
