### PR TITLE
docs(developer): clarify agent setup and common first-time errors

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -127,12 +127,12 @@ PYTHONPATH=core:exports python -m support_ticket_agent validate
  ```
 This does not indicate a setup failure.
 Agent packages are created only when:
- Using Claude Code skills to generate an agent, or
+ - Using Claude Code skills to generate an agent, or
  
- Manually adding an agent package under `exports/` 
+ - Manually adding an agent package under `exports/` 
 ---
 
-## Project Structure
+### Project Structure
 
 ```
 hive/                                    # Repository root

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -98,8 +98,9 @@ Get API keys:
 # Install building-agents and testing-agent skills
 ./quickstart.sh
 ```
+This installs Claude Code skills used to build and test agents, but does not generate any agent packages by default.
 
-This installs:
+Installed skills include:
 
 - `/building-agents` - Build new goal-driven agents
 - `/testing-agent` - Test agents with evaluation framework
@@ -112,10 +113,23 @@ python -c "import framework; print('✓ framework OK')"
 python -c "import aden_tools; print('✓ aden_tools OK')"
 python -c "import litellm; print('✓ litellm OK')"
 
-# Run an example agent
+```
+Note: Example agent commands assume that an agent package already exists under `exports/`
+
+On a clean clone, the `exports/` directory may not exist yet, and running agent-specific
+commands such as 
+```bash
 PYTHONPATH=core:exports python -m support_ticket_agent validate
 ```
-
+ may result in 
+ ```bash 
+ No module named <agent_name>
+ ```
+This does not indicate a setup failure.
+Agent packages are created only when:
+ Using Claude Code skills to generate an agent, or
+ 
+ Manually adding an agent package under `exports/` 
 ---
 
 ## Project Structure


### PR DESCRIPTION
### Summary
Clarifies common first-time contributor confusion around agent execution on a clean clone.

### Motivation
After running the full setup locally (`setup-python.sh` and `quickstart.sh`), agent-specific example commands failed despite a successful installation because no agent packages are generated by default. This was confusing as a new contributor.

### Changes
- Clarified that `quickstart.sh` installs Claude Code skills but does not generate agents
- Documented that the `exports/` directory may not exist on a clean clone
- Explained why agent commands may fail with `No module named <agent_name>` and that this does not indicate a setup failure.

### Scope
Documentation-only change. No code or behavior changes.
