### PR TITLE
docs(contributing): add Windows PYTHONPATH troubleshooting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,30 @@ By participating in this project, you agree to abide by our [Code of Conduct](CO
 # Verify installation
 python -c "import framework; import aden_tools; print('✓ Setup complete')"
 
+### Troubleshooting (Windows)
+
+If you encounter:
+
+ModuleNotFoundError: No module named 'aden_tools'
+
+
+This is expected on native Windows unless `PYTHONPATH` is set.
+
+`aden_tools` is not a pip-installable package. It lives inside
+the `exports/` directory.
+
+Run the following in PowerShell:
+
+```powershell
+$env:PYTHONPATH="$PWD\core;$PWD\exports"
+
+Then retry:
+python -c "import framework; import aden_tools"
+
+Note: Some components may still require WSL. Documentation and
+refactor contributions do not require full agent execution.
+
+
 # Install Claude Code skills (optional)
 ./quickstart.sh
 ```


### PR DESCRIPTION
## Description

This PR improves the contributor experience on native Windows by adding
clear troubleshooting guidance for common setup issues encountered during
local development.

Specifically, it documents how to correctly configure `PYTHONPATH` to resolve
module import errors (e.g. `framework`, `aden_tools`) that can occur when running
the framework outside of WSL.

## Type of Change

- [x] Documentation update

## Related Issues

N/A  - contributor experience improvement

## Changes Made

- Added a Windows-specific troubleshooting section under Development Setup
- Clarified required `PYTHONPATH` configuration for native Windows environments
- Explained that `aden_tools` is provided via the repository structure and not
  as a pip-installable package

## Testing

- Manually validated the documented steps on Windows PowerShell
- Confirmed successful imports after applying the troubleshooting guidance

## Checklist

- [x] Changes follow project documentation standards
- [x] Content has been reviewed for clarity and accuracy
- [x] No functional or behavioral changes introduced

