### PR TITLE
fix(view_file): truncate by bytes instead of characters

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/view_file/view_file.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/view_file/view_file.py
@@ -58,8 +58,11 @@ def register_tools(mcp: FastMCP) -> None:
             with open(secure_path, "r", encoding=encoding) as f:
                 content = f.read()
 
-            if len(content.encode(encoding)) > max_size:
-                content = content[:max_size]
+            encoded = content.encode(encoding)
+            if len(encoded) > max_size:
+                # Truncate by bytes, not characters, to respect the byte limit
+                # Use errors='ignore' to handle partial multi-byte sequences at cut point
+                content = encoded[:max_size].decode(encoding, errors="ignore")
                 content += "\n\n[... Content truncated due to size limit ...]"
 
             return {


### PR DESCRIPTION
Fixes #1373

### Problem
The `view_file` tool's `max_size` parameter is documented as bytes, but truncation was slicing by character count. For multi-byte UTF-8 characters (emoji, CJK, etc.), the result could exceed the byte limit.

### Solution
Truncate the encoded bytes first, then decode with `errors='ignore'` to handle partial multi-byte sequences at the cut point.

### Testing
Added `test_view_file_with_max_size_truncation_multibyte` to verify byte-level truncation.