### PR TITLE
feat: Add Audit Trail MCP Tools for compliance reporting

### DIFF
--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -22,6 +22,7 @@ from .example_tool import register_tools as register_example
 from .web_search_tool import register_tools as register_web_search
 from .web_scrape_tool import register_tools as register_web_scrape
 from .pdf_read_tool import register_tools as register_pdf_read
+from .audit_trail_tool import register_tools as register_audit_trail
 
 # Import file system toolkits
 from .file_system_toolkits.view_file import register_tools as register_view_file
@@ -71,6 +72,9 @@ def register_all_tools(
     register_grep_search(mcp)
     register_execute_command(mcp)
     register_csv(mcp)
+    
+    # Register audit trail tool
+    register_audit_trail(mcp)
 
     return [
         "example_tool",
@@ -90,6 +94,7 @@ def register_all_tools(
         "csv_append",
         "csv_info",
         "csv_sql",
+        "audit_trail",
     ]
 
 

--- a/tools/src/aden_tools/tools/audit_trail_tool/__init__.py
+++ b/tools/src/aden_tools/tools/audit_trail_tool/__init__.py
@@ -1,0 +1,4 @@
+"""Audit Trail Tool package."""
+from .audit_trail_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/audit_trail_tool/audit_trail_tool.py
+++ b/tools/src/aden_tools/tools/audit_trail_tool/audit_trail_tool.py
@@ -1,0 +1,405 @@
+"""
+Audit Trail Tool - Generate compliance-friendly decision timelines.
+
+Provides tools for:
+- Generating audit trails from agent runs
+- Querying decision history
+- Exporting audit reports in various formats
+
+Usage:
+    # Register with MCP server
+    from audit_trail_tool import register_tools
+    register_tools(mcp)
+    
+    # Then use via MCP:
+    # - generate_audit_trail: Create an audit report from a run
+    # - get_decision_timeline: Get chronological decision list
+    # - export_audit_report: Export to JSON/CSV/Markdown
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Annotated
+
+from fastmcp import FastMCP
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register audit trail tools with the MCP server."""
+
+    @mcp.tool()
+    def generate_audit_trail(
+        run_id: Annotated[str, "The ID of the run to generate audit trail for"],
+        storage_path: Annotated[str, "Path to the storage directory (default: ./storage)"] = "./storage",
+        include_decisions: Annotated[bool, "Include detailed decision records"] = True,
+        include_metrics: Annotated[bool, "Include performance metrics"] = True,
+    ) -> str:
+        """
+        Generate a comprehensive audit trail for an agent run.
+        
+        Returns a structured audit report including:
+        - Run metadata (goal, timing, outcome)
+        - Decision timeline with reasoning
+        - Performance metrics
+        - Any problems or violations
+        
+        Use this for compliance, debugging, or analysis.
+        """
+        try:
+            storage = Path(storage_path)
+            run_file = storage / "runs" / f"{run_id}.json"
+            
+            if not run_file.exists():
+                return json.dumps({
+                    "error": f"Run not found: {run_id}",
+                    "hint": f"Check that the run exists in {storage_path}/runs/",
+                })
+            
+            with open(run_file) as f:
+                run_data = json.load(f)
+            
+            # Build audit trail
+            audit_trail = {
+                "audit_report": {
+                    "generated_at": datetime.now().isoformat(),
+                    "run_id": run_id,
+                    "report_type": "agent_execution_audit",
+                },
+                "run_summary": {
+                    "goal_id": run_data.get("goal_id"),
+                    "goal_description": run_data.get("goal_description"),
+                    "status": run_data.get("status"),
+                    "started_at": run_data.get("started_at"),
+                    "completed_at": run_data.get("completed_at"),
+                    "duration_ms": run_data.get("metrics", {}).get("duration_ms"),
+                    "narrative": run_data.get("narrative"),
+                },
+                "input_output": {
+                    "input_data": run_data.get("input_data", {}),
+                    "output_data": run_data.get("output_data", {}),
+                },
+            }
+            
+            # Add decisions if requested
+            if include_decisions:
+                decisions = run_data.get("decisions", [])
+                audit_trail["decision_timeline"] = [
+                    {
+                        "decision_id": d.get("id"),
+                        "node_id": d.get("node_id"),
+                        "timestamp": d.get("timestamp"),
+                        "intent": d.get("intent"),
+                        "options_considered": len(d.get("options", [])),
+                        "chosen_option": d.get("chosen_option_id"),
+                        "reasoning": d.get("reasoning"),
+                        "outcome": d.get("outcome", {}).get("success") if d.get("outcome") else None,
+                    }
+                    for d in decisions
+                ]
+                audit_trail["decision_count"] = len(decisions)
+            
+            # Add metrics if requested
+            if include_metrics:
+                metrics = run_data.get("metrics", {})
+                audit_trail["performance_metrics"] = {
+                    "total_tokens": metrics.get("total_tokens", 0),
+                    "total_cost_usd": metrics.get("total_cost_usd", 0),
+                    "duration_ms": metrics.get("duration_ms", 0),
+                    "nodes_executed": metrics.get("nodes_executed", []),
+                    "tools_used": metrics.get("tools_used", []),
+                }
+            
+            # Add problems
+            problems = run_data.get("problems", [])
+            if problems:
+                audit_trail["problems"] = problems
+            
+            return json.dumps(audit_trail, indent=2, default=str)
+            
+        except Exception as e:
+            return json.dumps({"error": f"Failed to generate audit trail: {e}"})
+
+    @mcp.tool()
+    def get_decision_timeline(
+        run_id: Annotated[str, "The ID of the run"],
+        storage_path: Annotated[str, "Path to the storage directory"] = "./storage",
+        node_filter: Annotated[str, "Filter to specific node ID (optional)"] = "",
+    ) -> str:
+        """
+        Get a chronological timeline of decisions made during a run.
+        
+        Returns a list of decisions with:
+        - What the agent was trying to do
+        - What options it considered
+        - What it chose and why
+        - Whether it worked
+        
+        Useful for understanding agent behavior and debugging.
+        """
+        try:
+            storage = Path(storage_path)
+            run_file = storage / "runs" / f"{run_id}.json"
+            
+            if not run_file.exists():
+                return json.dumps({"error": f"Run not found: {run_id}"})
+            
+            with open(run_file) as f:
+                run_data = json.load(f)
+            
+            decisions = run_data.get("decisions", [])
+            
+            # Filter by node if specified
+            if node_filter:
+                decisions = [d for d in decisions if d.get("node_id") == node_filter]
+            
+            # Build timeline
+            timeline = []
+            for i, d in enumerate(decisions, 1):
+                options = d.get("options", [])
+                chosen_id = d.get("chosen_option_id")
+                chosen_option = next((o for o in options if o.get("id") == chosen_id), None)
+                
+                timeline.append({
+                    "step": i,
+                    "decision_id": d.get("id"),
+                    "node_id": d.get("node_id"),
+                    "timestamp": d.get("timestamp"),
+                    "intent": d.get("intent"),
+                    "options": [
+                        {
+                            "id": o.get("id"),
+                            "description": o.get("description"),
+                            "was_chosen": o.get("id") == chosen_id,
+                        }
+                        for o in options
+                    ],
+                    "chosen": {
+                        "option_id": chosen_id,
+                        "description": chosen_option.get("description") if chosen_option else None,
+                    },
+                    "reasoning": d.get("reasoning"),
+                    "outcome": {
+                        "success": d.get("outcome", {}).get("success"),
+                        "summary": d.get("outcome", {}).get("summary"),
+                    } if d.get("outcome") else None,
+                })
+            
+            return json.dumps({
+                "run_id": run_id,
+                "total_decisions": len(timeline),
+                "node_filter": node_filter or None,
+                "timeline": timeline,
+            }, indent=2, default=str)
+            
+        except Exception as e:
+            return json.dumps({"error": f"Failed to get decision timeline: {e}"})
+
+    @mcp.tool()
+    def export_audit_report(
+        run_id: Annotated[str, "The ID of the run"],
+        storage_path: Annotated[str, "Path to the storage directory"] = "./storage",
+        output_format: Annotated[str, "Output format: 'json', 'markdown', or 'csv'"] = "markdown",
+        output_file: Annotated[str, "Output file path (optional, returns content if not provided)"] = "",
+    ) -> str:
+        """
+        Export an audit report in the specified format.
+        
+        Formats:
+        - json: Structured JSON for programmatic use
+        - markdown: Human-readable document
+        - csv: Spreadsheet-compatible decision log
+        
+        Can either return the content or write to a file.
+        """
+        try:
+            storage = Path(storage_path)
+            run_file = storage / "runs" / f"{run_id}.json"
+            
+            if not run_file.exists():
+                return json.dumps({"error": f"Run not found: {run_id}"})
+            
+            with open(run_file) as f:
+                run_data = json.load(f)
+            
+            content = ""
+            
+            if output_format == "json":
+                content = json.dumps(run_data, indent=2, default=str)
+                
+            elif output_format == "markdown":
+                content = _format_markdown_report(run_data)
+                
+            elif output_format == "csv":
+                content = _format_csv_decisions(run_data)
+                
+            else:
+                return json.dumps({"error": f"Unknown format: {output_format}. Use 'json', 'markdown', or 'csv'"})
+            
+            # Write to file if specified
+            if output_file:
+                output_path = Path(output_file)
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_text(content)
+                return json.dumps({
+                    "success": True,
+                    "output_file": str(output_path),
+                    "format": output_format,
+                    "size_bytes": len(content),
+                })
+            
+            return content
+            
+        except Exception as e:
+            return json.dumps({"error": f"Failed to export audit report: {e}"})
+
+    @mcp.tool()
+    def list_runs(
+        storage_path: Annotated[str, "Path to the storage directory"] = "./storage",
+        goal_id: Annotated[str, "Filter to specific goal (optional)"] = "",
+        status: Annotated[str, "Filter by status: 'completed', 'failed', 'running' (optional)"] = "",
+        limit: Annotated[int, "Maximum number of runs to return"] = 20,
+    ) -> str:
+        """
+        List available runs for audit.
+        
+        Returns run IDs with basic metadata for filtering and selection.
+        Use this to find runs before generating detailed audit trails.
+        """
+        try:
+            storage = Path(storage_path)
+            runs_dir = storage / "runs"
+            
+            if not runs_dir.exists():
+                return json.dumps({
+                    "error": "No runs directory found",
+                    "hint": f"Check that {storage_path}/runs/ exists",
+                })
+            
+            runs = []
+            for run_file in sorted(runs_dir.glob("*.json"), reverse=True):
+                if len(runs) >= limit:
+                    break
+                    
+                try:
+                    with open(run_file) as f:
+                        run_data = json.load(f)
+                    
+                    # Apply filters
+                    if goal_id and run_data.get("goal_id") != goal_id:
+                        continue
+                    if status and run_data.get("status") != status:
+                        continue
+                    
+                    runs.append({
+                        "run_id": run_data.get("id"),
+                        "goal_id": run_data.get("goal_id"),
+                        "status": run_data.get("status"),
+                        "started_at": run_data.get("started_at"),
+                        "decision_count": len(run_data.get("decisions", [])),
+                    })
+                    
+                except Exception:
+                    continue
+            
+            return json.dumps({
+                "total_found": len(runs),
+                "limit": limit,
+                "filters": {
+                    "goal_id": goal_id or None,
+                    "status": status or None,
+                },
+                "runs": runs,
+            }, indent=2, default=str)
+            
+        except Exception as e:
+            return json.dumps({"error": f"Failed to list runs: {e}"})
+
+
+def _format_markdown_report(run_data: dict) -> str:
+    """Format run data as a Markdown report."""
+    lines = [
+        f"# Agent Run Audit Report",
+        f"",
+        f"**Run ID:** {run_data.get('id')}",
+        f"**Generated:** {datetime.now().isoformat()}",
+        f"",
+        f"## Summary",
+        f"",
+        f"| Property | Value |",
+        f"|----------|-------|",
+        f"| Goal | {run_data.get('goal_description', 'N/A')} |",
+        f"| Status | {run_data.get('status', 'N/A')} |",
+        f"| Started | {run_data.get('started_at', 'N/A')} |",
+        f"| Completed | {run_data.get('completed_at', 'N/A')} |",
+        f"",
+        f"## Narrative",
+        f"",
+        f"{run_data.get('narrative', 'No narrative provided.')}",
+        f"",
+    ]
+    
+    # Decisions
+    decisions = run_data.get("decisions", [])
+    if decisions:
+        lines.extend([
+            f"## Decision Timeline",
+            f"",
+            f"| # | Node | Intent | Chosen | Outcome |",
+            f"|---|------|--------|--------|---------|",
+        ])
+        
+        for i, d in enumerate(decisions, 1):
+            outcome = d.get("outcome", {})
+            outcome_str = "✓" if outcome.get("success") else "✗" if outcome.get("success") is False else "—"
+            lines.append(
+                f"| {i} | {d.get('node_id', 'N/A')} | {d.get('intent', 'N/A')[:50]} | {d.get('chosen_option_id', 'N/A')} | {outcome_str} |"
+            )
+        
+        lines.append("")
+    
+    # Metrics
+    metrics = run_data.get("metrics", {})
+    if metrics:
+        lines.extend([
+            f"## Performance Metrics",
+            f"",
+            f"- **Total Tokens:** {metrics.get('total_tokens', 0):,}",
+            f"- **Total Cost:** ${metrics.get('total_cost_usd', 0):.4f}",
+            f"- **Duration:** {metrics.get('duration_ms', 0):,}ms",
+            f"",
+        ])
+    
+    # Problems
+    problems = run_data.get("problems", [])
+    if problems:
+        lines.extend([
+            f"## Problems",
+            f"",
+        ])
+        for p in problems:
+            lines.append(f"- **{p.get('severity', 'unknown')}:** {p.get('description', 'No description')}")
+        lines.append("")
+    
+    return "\n".join(lines)
+
+
+def _format_csv_decisions(run_data: dict) -> str:
+    """Format decisions as CSV."""
+    lines = ["decision_id,node_id,timestamp,intent,chosen_option,reasoning,success"]
+    
+    for d in run_data.get("decisions", []):
+        outcome = d.get("outcome", {})
+        success = "true" if outcome.get("success") else "false" if outcome.get("success") is False else ""
+        
+        # Escape CSV fields
+        intent = (d.get("intent") or "").replace('"', '""')
+        reasoning = (d.get("reasoning") or "").replace('"', '""')
+        
+        lines.append(
+            f'"{d.get("id", "")}","{d.get("node_id", "")}","{d.get("timestamp", "")}",'
+            f'"{intent}","{d.get("chosen_option_id", "")}","{reasoning}","{success}"'
+        )
+    
+    return "\n".join(lines)

--- a/tools/tests/tools/test_audit_trail_tool.py
+++ b/tools/tests/tools/test_audit_trail_tool.py
@@ -1,0 +1,300 @@
+"""Tests for the Audit Trail Tool."""
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.audit_trail_tool import register_tools
+
+
+@pytest.fixture
+def mcp():
+    """Create a FastMCP server for testing."""
+    return FastMCP("test-server")
+
+
+@pytest.fixture
+def storage_with_runs(tmp_path):
+    """Create a temporary storage directory with sample runs."""
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    
+    # Create sample run data
+    sample_run = {
+        "id": "run-001",
+        "goal_id": "goal-test",
+        "goal_description": "Test the system",
+        "status": "completed",
+        "started_at": "2024-01-15T10:00:00Z",
+        "completed_at": "2024-01-15T10:05:00Z",
+        "narrative": "Agent successfully completed the test.",
+        "input_data": {"query": "test"},
+        "output_data": {"result": "success"},
+        "decisions": [
+            {
+                "id": "decision-1",
+                "node_id": "node-analyze",
+                "timestamp": "2024-01-15T10:01:00Z",
+                "intent": "Analyze the input",
+                "options": [
+                    {"id": "opt-1", "description": "Use method A"},
+                    {"id": "opt-2", "description": "Use method B"},
+                ],
+                "chosen_option_id": "opt-1",
+                "reasoning": "Method A is faster",
+                "outcome": {"success": True, "summary": "Analysis complete"},
+            },
+            {
+                "id": "decision-2",
+                "node_id": "node-execute",
+                "timestamp": "2024-01-15T10:03:00Z",
+                "intent": "Execute the plan",
+                "options": [
+                    {"id": "exec-1", "description": "Run in parallel"},
+                    {"id": "exec-2", "description": "Run sequentially"},
+                ],
+                "chosen_option_id": "exec-1",
+                "reasoning": "Parallel is more efficient",
+                "outcome": {"success": True, "summary": "Execution complete"},
+            },
+        ],
+        "metrics": {
+            "total_tokens": 1500,
+            "total_cost_usd": 0.0045,
+            "duration_ms": 300000,
+            "nodes_executed": ["node-analyze", "node-execute"],
+            "tools_used": ["web_search"],
+        },
+        "problems": [],
+    }
+    
+    (runs_dir / "run-001.json").write_text(json.dumps(sample_run))
+    
+    # Create a failed run
+    failed_run = {
+        "id": "run-002",
+        "goal_id": "goal-test",
+        "goal_description": "Another test",
+        "status": "failed",
+        "started_at": "2024-01-15T11:00:00Z",
+        "completed_at": "2024-01-15T11:02:00Z",
+        "narrative": "Agent failed due to an error.",
+        "decisions": [],
+        "metrics": {},
+        "problems": [
+            {"severity": "error", "description": "API rate limit exceeded"}
+        ],
+    }
+    
+    (runs_dir / "run-002.json").write_text(json.dumps(failed_run))
+    
+    return tmp_path
+
+
+class TestAuditTrailRegistration:
+    """Test tool registration."""
+    
+    def test_register_tools(self, mcp):
+        """Test that tools are registered correctly."""
+        register_tools(mcp)
+        # If no exception, registration succeeded
+        assert True
+
+
+class TestGenerateAuditTrail:
+    """Test generate_audit_trail tool."""
+    
+    def test_generate_audit_trail_success(self, mcp, storage_with_runs):
+        """Test generating an audit trail for a valid run."""
+        register_tools(mcp)
+        
+        # Get the tool
+        tool = mcp._tool_manager._tools.get("generate_audit_trail")
+        assert tool is not None
+        
+        # Call the tool function directly
+        result = tool.fn(
+            run_id="run-001",
+            storage_path=str(storage_with_runs),
+        )
+        
+        data = json.loads(result)
+        
+        assert "audit_report" in data
+        assert data["audit_report"]["run_id"] == "run-001"
+        assert "run_summary" in data
+        assert data["run_summary"]["status"] == "completed"
+        assert "decision_timeline" in data
+        assert len(data["decision_timeline"]) == 2
+        assert "performance_metrics" in data
+    
+    def test_generate_audit_trail_not_found(self, mcp, storage_with_runs):
+        """Test error handling for non-existent run."""
+        register_tools(mcp)
+        
+        tool = mcp._tool_manager._tools.get("generate_audit_trail")
+        result = tool.fn(
+            run_id="run-nonexistent",
+            storage_path=str(storage_with_runs),
+        )
+        
+        data = json.loads(result)
+        assert "error" in data
+        assert "not found" in data["error"].lower()
+
+
+class TestGetDecisionTimeline:
+    """Test get_decision_timeline tool."""
+    
+    def test_get_timeline_success(self, mcp, storage_with_runs):
+        """Test getting a decision timeline."""
+        register_tools(mcp)
+        
+        tool = mcp._tool_manager._tools.get("get_decision_timeline")
+        result = tool.fn(
+            run_id="run-001",
+            storage_path=str(storage_with_runs),
+        )
+        
+        data = json.loads(result)
+        
+        assert data["run_id"] == "run-001"
+        assert data["total_decisions"] == 2
+        assert len(data["timeline"]) == 2
+        
+        # Check first decision
+        first = data["timeline"][0]
+        assert first["step"] == 1
+        assert first["node_id"] == "node-analyze"
+        assert first["chosen"]["option_id"] == "opt-1"
+    
+    def test_get_timeline_with_filter(self, mcp, storage_with_runs):
+        """Test filtering timeline by node."""
+        register_tools(mcp)
+        
+        tool = mcp._tool_manager._tools.get("get_decision_timeline")
+        result = tool.fn(
+            run_id="run-001",
+            storage_path=str(storage_with_runs),
+            node_filter="node-execute",
+        )
+        
+        data = json.loads(result)
+        
+        assert data["total_decisions"] == 1
+        assert data["node_filter"] == "node-execute"
+        assert data["timeline"][0]["node_id"] == "node-execute"
+
+
+class TestExportAuditReport:
+    """Test export_audit_report tool."""
+    
+    def test_export_json(self, mcp, storage_with_runs):
+        """Test exporting as JSON."""
+        register_tools(mcp)
+        
+        tool = mcp._tool_manager._tools.get("export_audit_report")
+        result = tool.fn(
+            run_id="run-001",
+            storage_path=str(storage_with_runs),
+            output_format="json",
+        )
+        
+        # Should be valid JSON
+        data = json.loads(result)
+        assert data["id"] == "run-001"
+    
+    def test_export_markdown(self, mcp, storage_with_runs):
+        """Test exporting as Markdown."""
+        register_tools(mcp)
+        
+        tool = mcp._tool_manager._tools.get("export_audit_report")
+        result = tool.fn(
+            run_id="run-001",
+            storage_path=str(storage_with_runs),
+            output_format="markdown",
+        )
+        
+        assert "# Agent Run Audit Report" in result
+        assert "run-001" in result
+        assert "## Decision Timeline" in result
+    
+    def test_export_csv(self, mcp, storage_with_runs):
+        """Test exporting as CSV."""
+        register_tools(mcp)
+        
+        tool = mcp._tool_manager._tools.get("export_audit_report")
+        result = tool.fn(
+            run_id="run-001",
+            storage_path=str(storage_with_runs),
+            output_format="csv",
+        )
+        
+        lines = result.strip().split("\n")
+        assert lines[0] == "decision_id,node_id,timestamp,intent,chosen_option,reasoning,success"
+        assert len(lines) == 3  # Header + 2 decisions
+    
+    def test_export_to_file(self, mcp, storage_with_runs, tmp_path):
+        """Test exporting to a file."""
+        register_tools(mcp)
+        
+        output_file = tmp_path / "output" / "report.md"
+        
+        tool = mcp._tool_manager._tools.get("export_audit_report")
+        result = tool.fn(
+            run_id="run-001",
+            storage_path=str(storage_with_runs),
+            output_format="markdown",
+            output_file=str(output_file),
+        )
+        
+        data = json.loads(result)
+        assert data["success"] is True
+        assert output_file.exists()
+        assert "# Agent Run Audit Report" in output_file.read_text()
+
+
+class TestListRuns:
+    """Test list_runs tool."""
+    
+    def test_list_all_runs(self, mcp, storage_with_runs):
+        """Test listing all runs."""
+        register_tools(mcp)
+        
+        tool = mcp._tool_manager._tools.get("list_runs")
+        result = tool.fn(storage_path=str(storage_with_runs))
+        
+        data = json.loads(result)
+        
+        assert data["total_found"] == 2
+        run_ids = [r["run_id"] for r in data["runs"]]
+        assert "run-001" in run_ids
+        assert "run-002" in run_ids
+    
+    def test_list_runs_by_status(self, mcp, storage_with_runs):
+        """Test filtering runs by status."""
+        register_tools(mcp)
+        
+        tool = mcp._tool_manager._tools.get("list_runs")
+        result = tool.fn(
+            storage_path=str(storage_with_runs),
+            status="failed",
+        )
+        
+        data = json.loads(result)
+        
+        assert data["total_found"] == 1
+        assert data["runs"][0]["run_id"] == "run-002"
+        assert data["runs"][0]["status"] == "failed"
+    
+    def test_list_runs_empty_storage(self, mcp, tmp_path):
+        """Test listing runs from non-existent storage."""
+        register_tools(mcp)
+        
+        tool = mcp._tool_manager._tools.get("list_runs")
+        result = tool.fn(storage_path=str(tmp_path / "nonexistent"))
+        
+        data = json.loads(result)
+        assert "error" in data


### PR DESCRIPTION
Fixes #1365

## Changes
- Add generate_audit_trail tool for audit reports
- Add get_decision_timeline tool for decision lists
- Add export_audit_report tool (JSON/Markdown/CSV)
- Add list_runs tool to query runs
- Include test suite

## Type of Change
- [x] New feature