### PR TITLE
ci: Add Windows runner to GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
 
   test:
     name: Test Python Framework
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description

Updated the GitHub Actions CI workflow to run tests on both `ubuntu-latest` and `windows-latest`. This ensures the framework remains compatible with Windows and catches platform-specific regressions (like encoding errors) early.

## Type of Change


- [x] New feature (non-breaking change that adds functionality)


## Related Issues

Fixes #736

## Changes Made

- Modified `.github/workflows/ci.yml` to replace the single `runs-on: ubuntu-latest` with a matrix strategy:
  ```yaml
  strategy:
    matrix:
      os: [ubuntu-latest, windows-latest]

## Testing

Describe the tests you ran to verify your changes:

 - Unit tests pass (`cd core && pytest tests/`)
 - Lint passes (`cd core && ruff check .`)

## Checklist

- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A
