### PR TITLE
docs: clarify when LLM API keys are required vs optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+---
+noteId: "2aecbda0fd0411f088eb375fc53985b6"
+tags: []
+
+---
+
 <p align="center">
   <img width="100%" alt="Hive Banner" src="https://storage.googleapis.com/aden-prod-assets/website/aden-title-card.png" />
 </p>
@@ -417,4 +423,5 @@ For enterprise inquiries, contact the Aden team through [adenhq.com](https://ade
 <p align="center">
   Made with 🔥 Passion in San Francisco
 </p>
+
 

--- a/README.md
+++ b/README.md
@@ -417,3 +417,4 @@ For enterprise inquiries, contact the Aden team through [adenhq.com](https://ade
 <p align="center">
   Made with 🔥 Passion in San Francisco
 </p>
+

--- a/README.md
+++ b/README.md
@@ -68,6 +68,29 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 - [Python 3.11+](https://www.python.org/downloads/) for agent development
 - [Docker](https://docs.docker.com/get-docker/) (v20.10+) - Optional, for containerized tools
 
+## 🔑 LLM API Keys: Required vs Optional
+
+LLM API keys are **not required** for many contribution paths.
+
+### ✅ LLM API keys are NOT required for:
+- Cloning the repository
+- Running the Python setup script (`./scripts/setup-python.sh`)
+- Installing framework dependencies and developer tools
+- Documentation improvements
+- Framework, tooling, or developer-experience contributions
+
+### 🔐 LLM API keys ARE required for:
+- Building agents using `/building-agents`
+- Testing agents using `/testing-agent`
+- Running agents via the runtime
+
+> 💡 Contributors without LLM credits can still make meaningful contributions
+> by improving documentation, tooling, tests, and developer experience.
+
+Optional alternatives such as **local models (e.g., Ollama)** may be explored
+for development and experimentation.
+
+
 ### Installation
 
 ```bash


### PR DESCRIPTION
This PR clarifies when LLM API keys are required versus optional for contributors.

While setting up the project locally, I noticed that contributors without LLM credits may assume they cannot contribute, even though many workflows (documentation, tooling, framework improvements) do not require keys.

This change adds a short section under Quick Start → Prerequisites to make this distinction explicit and improve onboarding clarity.

Closes #1033