### PR TITLE
fix(csv_sql): prevent SQL injection via DuckDB parameter binding

### DIFF
--- a/tools/src/aden_tools/tools/csv_tool/csv_tool.py
+++ b/tools/src/aden_tools/tools/csv_tool/csv_tool.py
@@ -284,17 +284,6 @@ def register_tools(mcp: FastMCP) -> None:
         Query a CSV file using SQL (powered by DuckDB).
 
         The CSV file is loaded as a table named 'data'. Use standard SQL syntax.
-
-        Args:
-            path: Path to the CSV file (relative to session sandbox)
-            workspace_id: Workspace identifier
-            agent_id: Agent identifier
-            session_id: Session identifier
-            query: SQL query to execute. The CSV is available as table 'data'.
-                Example: "SELECT * FROM data WHERE price > 100 ORDER BY name LIMIT 10"
-
-        Returns:
-            dict with query results, columns, and row count
         """
         try:
             import duckdb
@@ -318,8 +307,9 @@ def register_tools(mcp: FastMCP) -> None:
             if not query or not query.strip():
                 return {"error": "query cannot be empty"}
 
-            query_upper = query.strip().upper()
-            if not query_upper.startswith("SELECT"):
+            # Security: allow SELECT/WITH only
+            query_upper = query.lstrip().upper()
+            if not (query_upper.startswith("SELECT") or query_upper.startswith("WITH")):
                 return {"error": "Only SELECT queries are allowed for security reasons"}
 
             # Disallowed keywords for security
@@ -339,9 +329,9 @@ def register_tools(mcp: FastMCP) -> None:
                     return {"error": f"'{keyword}' is not allowed in queries"}
 
             # Block obvious multi-statement / injection attempts
-            forbidden_tokens = [";", "--", "/*", "*/"]
-            for token in forbidden_tokens:
-                if token in query:
+            q_lower = query.lower()
+            for token in [";", "--", "/*", "*/"]:
+                if token in q_lower:
                     return {"error": "Multiple statements or comments are not allowed"}
 
             con = duckdb.connect(":memory:")
@@ -349,14 +339,13 @@ def register_tools(mcp: FastMCP) -> None:
                 # SAFE: parameter binding (no string interpolation)
                 con.execute(
                     "CREATE TABLE data AS SELECT * FROM read_csv_auto(?)",
-                    [secure_path],
+                    [str(secure_path)],
                 )
 
                 result = con.execute(query)
                 columns = [desc[0] for desc in result.description]
                 rows = result.fetchall()
 
-                # Convert to list of dicts
                 rows_as_dicts = [dict(zip(columns, row, strict=False)) for row in rows]
 
                 return {

--- a/tools/src/aden_tools/tools/csv_tool/csv_tool.py
+++ b/tools/src/aden_tools/tools/csv_tool/csv_tool.py
@@ -2,6 +2,7 @@
 
 import csv
 import os
+import re
 
 from fastmcp import FastMCP
 
@@ -335,21 +336,15 @@ def register_tools(mcp: FastMCP) -> None:
             if not (query_upper.startswith("SELECT") or query_upper.startswith("WITH")):
                 return {"error": "Only SELECT queries are allowed for security reasons"}
 
-            # Disallowed keywords for security
-            disallowed = [
-                "INSERT",
-                "UPDATE",
-                "DELETE",
-                "DROP",
-                "CREATE",
-                "ALTER",
-                "TRUNCATE",
-                "EXEC",
-                "EXECUTE",
-            ]
-            for keyword in disallowed:
-                if keyword in query_upper:
-                    return {"error": f"'{keyword}' is not allowed in queries"}
+            # Disallowed keywords for security (word-boundary match to avoid
+            # false positives on column names like created_at, updated_at, etc.)
+            _WRITE_PATTERN = re.compile(
+                r"\b(INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|TRUNCATE|EXEC|EXECUTE)\b",
+                re.IGNORECASE,
+            )
+            match = _WRITE_PATTERN.search(query)
+            if match:
+                return {"error": f"'{match.group().upper()}' is not allowed in queries"}
 
             # Block obvious multi-statement / injection attempts
             q_lower = query.lower()

--- a/tools/src/aden_tools/tools/csv_tool/csv_tool.py
+++ b/tools/src/aden_tools/tools/csv_tool/csv_tool.py
@@ -169,9 +169,7 @@ def register_tools(mcp: FastMCP) -> None:
             secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
 
             if not os.path.exists(secure_path):
-                return {
-                    "error": f"File not found: {path}. Use csv_write to create a new file."
-                }
+                return {"error": f"File not found: {path}. Use csv_write to create a new file."}
 
             if not path.lower().endswith(".csv"):
                 return {"error": "File must have .csv extension"}
@@ -284,6 +282,31 @@ def register_tools(mcp: FastMCP) -> None:
         Query a CSV file using SQL (powered by DuckDB).
 
         The CSV file is loaded as a table named 'data'. Use standard SQL syntax.
+
+        Args:
+            path: Path to the CSV file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+            query: SQL query to execute. The CSV is available as table 'data'.
+                   Example: "SELECT * FROM data WHERE price > 100 ORDER BY name LIMIT 10"
+
+        Returns:
+            dict with query results, columns, and row count
+
+        Examples:
+            # Filter rows
+            query="SELECT * FROM data WHERE status = 'pending'"
+
+            # Aggregate data
+            query="SELECT category, COUNT(*) as count, "
+                  "AVG(price) as avg_price FROM data GROUP BY category"
+
+            # Sort and limit
+            query="SELECT name, price FROM data ORDER BY price DESC LIMIT 5"
+
+            # Search text (case-insensitive)
+            query="SELECT * FROM data WHERE LOWER(name) LIKE '%phone%'"
         """
         try:
             import duckdb
@@ -364,7 +387,5 @@ def register_tools(mcp: FastMCP) -> None:
         except Exception as e:
             error_msg = str(e)
             if "Catalog Error" in error_msg:
-                return {
-                    "error": f"SQL error: {error_msg}. Remember the table is named 'data'."
-                }
+                return {"error": f"SQL error: {error_msg}. Remember the table is named 'data'."}
             return {"error": f"Query failed: {error_msg}"}

--- a/tools/src/aden_tools/tools/csv_tool/csv_tool.py
+++ b/tools/src/aden_tools/tools/csv_tool/csv_tool.py
@@ -169,7 +169,9 @@ def register_tools(mcp: FastMCP) -> None:
             secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
 
             if not os.path.exists(secure_path):
-                return {"error": f"File not found: {path}. Use csv_write to create a new file."}
+                return {
+                    "error": f"File not found: {path}. Use csv_write to create a new file."
+                }
 
             if not path.lower().endswith(".csv"):
                 return {"error": "File must have .csv extension"}
@@ -289,24 +291,10 @@ def register_tools(mcp: FastMCP) -> None:
             agent_id: Agent identifier
             session_id: Session identifier
             query: SQL query to execute. The CSV is available as table 'data'.
-                   Example: "SELECT * FROM data WHERE price > 100 ORDER BY name LIMIT 10"
+                Example: "SELECT * FROM data WHERE price > 100 ORDER BY name LIMIT 10"
 
         Returns:
             dict with query results, columns, and row count
-
-        Examples:
-            # Filter rows
-            query="SELECT * FROM data WHERE status = 'pending'"
-
-            # Aggregate data
-            query="SELECT category, COUNT(*) as count, "
-                  "AVG(price) as avg_price FROM data GROUP BY category"
-
-            # Sort and limit
-            query="SELECT name, price FROM data ORDER BY price DESC LIMIT 5"
-
-            # Search text (case-insensitive)
-            query="SELECT * FROM data WHERE LOWER(name) LIKE '%phone%'"
         """
         try:
             import duckdb
@@ -330,7 +318,6 @@ def register_tools(mcp: FastMCP) -> None:
             if not query or not query.strip():
                 return {"error": "query cannot be empty"}
 
-            # Security: only allow SELECT statements
             query_upper = query.strip().upper()
             if not query_upper.startswith("SELECT"):
                 return {"error": "Only SELECT queries are allowed for security reasons"}
@@ -351,13 +338,20 @@ def register_tools(mcp: FastMCP) -> None:
                 if keyword in query_upper:
                     return {"error": f"'{keyword}' is not allowed in queries"}
 
-            # Execute query using in-memory DuckDB
+            # Block obvious multi-statement / injection attempts
+            forbidden_tokens = [";", "--", "/*", "*/"]
+            for token in forbidden_tokens:
+                if token in query:
+                    return {"error": "Multiple statements or comments are not allowed"}
+
             con = duckdb.connect(":memory:")
             try:
-                # Load CSV as 'data' table
-                con.execute(f"CREATE TABLE data AS SELECT * FROM read_csv_auto('{secure_path}')")
+                # SAFE: parameter binding (no string interpolation)
+                con.execute(
+                    "CREATE TABLE data AS SELECT * FROM read_csv_auto(?)",
+                    [secure_path],
+                )
 
-                # Execute user query
                 result = con.execute(query)
                 columns = [desc[0] for desc in result.description]
                 rows = result.fetchall()
@@ -374,12 +368,14 @@ def register_tools(mcp: FastMCP) -> None:
                     "rows": rows_as_dicts,
                     "row_count": len(rows_as_dicts),
                 }
+
             finally:
                 con.close()
 
         except Exception as e:
             error_msg = str(e)
-            # Make DuckDB errors more readable
             if "Catalog Error" in error_msg:
-                return {"error": f"SQL error: {error_msg}. Remember the table is named 'data'."}
+                return {
+                    "error": f"SQL error: {error_msg}. Remember the table is named 'data'."
+                }
             return {"error": f"Query failed: {error_msg}"}

--- a/tools/tests/tools/test_csv_tool.py
+++ b/tools/tests/tools/test_csv_tool.py
@@ -752,8 +752,32 @@ class TestCsvSql:
         names = [row["name"] for row in result["rows"]]
         assert "Alice" in names
         assert "Bob" in names
-  
-    
+
+    # --- NEW: security regression tests required by Issue #1256 ---
+
+    def test_reject_non_select(self, csv_tools, products_csv, tmp_path):
+        """Reject any non-SELECT / non-WITH query."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = csv_tools["csv_sql"](
+                path=products_csv.name,
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="DROP TABLE data",
+            )
+        assert "error" in result
+
+    def test_reject_multi_statement(self, csv_tools, products_csv, tmp_path):
+        """Reject multi-statement queries with semicolons."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = csv_tools["csv_sql"](
+                path=products_csv.name,
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="SELECT * FROM data; DROP TABLE data",
+            )
+        assert "error" in result
 
     def test_where_clause(self, csv_tools, products_csv, tmp_path):
         """Filter with WHERE clause."""

--- a/tools/tests/tools/test_csv_tool.py
+++ b/tools/tests/tools/test_csv_tool.py
@@ -779,6 +779,53 @@ class TestCsvSql:
             )
         assert "error" in result
 
+    def test_reject_sql_comment_dash(self, csv_tools, products_csv, tmp_path):
+        """Reject queries with SQL line comments."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = csv_tools["csv_sql"](
+                path=products_csv.name,
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="SELECT * FROM data -- WHERE id = 1",
+            )
+        assert "error" in result
+
+    def test_with_cte_allowed(self, csv_tools, products_csv, tmp_path):
+        """Allow valid WITH (CTE) queries."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = csv_tools["csv_sql"](
+                path=products_csv.name,
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query=(
+                    "WITH electronics AS (SELECT * FROM data"
+                    " WHERE category = 'Electronics')"
+                    " SELECT * FROM electronics"
+                ),
+            )
+        assert result["success"] is True
+
+    def test_keyword_in_column_name_allowed(self, csv_tools, session_dir, tmp_path):
+        """Column names like created_at should not trigger keyword blocking."""
+        csv_file = session_dir / "timestamps.csv"
+        csv_file.write_text(
+            "created_at,updated_at,value\n2024-01-01,2024-01-02,100\n",
+            encoding="utf-8",
+        )
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = csv_tools["csv_sql"](
+                path="timestamps.csv",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="SELECT created_at, updated_at FROM data",
+            )
+        assert "error" not in result, result
+        assert result["success"] is True
+
     def test_where_clause(self, csv_tools, products_csv, tmp_path):
         """Filter with WHERE clause."""
         with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):

--- a/tools/tests/tools/test_csv_tool.py
+++ b/tools/tests/tools/test_csv_tool.py
@@ -732,6 +732,29 @@ class TestCsvSql:
         assert "id" in result["columns"]
         assert "name" in result["columns"]
 
+    def test_path_with_single_quote(self, csv_tools, session_dir, tmp_path):
+        """Regression: CSV paths containing single quotes should work (parameter binding)."""
+        csv_file = session_dir / "O'Reilly.csv"
+        csv_file.write_text("name,age\nAlice,21\nBob,22\n", encoding="utf-8")
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = csv_tools["csv_sql"](
+                path="O'Reilly.csv",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="SELECT * FROM data",
+            )
+
+        assert "error" not in result, result
+        assert result["success"] is True
+        assert result["row_count"] == 2
+        names = [row["name"] for row in result["rows"]]
+        assert "Alice" in names
+        assert "Bob" in names
+  
+    
+
     def test_where_clause(self, csv_tools, products_csv, tmp_path):
         """Filter with WHERE clause."""
         with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):


### PR DESCRIPTION
Fixes #1256

## Description
Prevents SQL injection in `csv_sql` by removing SQL string interpolation and using DuckDB parameter binding for CSV paths.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Replaced DuckDB SQL f-string interpolation with parameter binding
- Blocked multi-statement and comment-based injection attempts (`;`, `--`, `/* */`)
- Enforced SELECT-only queries

## Testing
- [x] Unit tests pass (`pytest tools/tests/tools/test_csv_tool.py`)
- [x] Lint passes (`ruff format` and `ruff check`)
- [ ] Manual testing performed

> Note: Full test suite has known Windows / PYTHONPATH issues. Targeted csv_tool tests pass locally.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation (not required)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing relevant unit tests pass locally



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CSV SQL validation to allow WITH/CTE queries, detect and reject destructive or multi-statement/comment patterns, and use parameterized CSV loading to safely handle filenames with special characters.
* **Tests**
  * Added regression and security tests covering WITH queries, rejection of disallowed SQL patterns, and filenames containing special characters (e.g., apostrophes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->