### PR TITLE
refactor: remove LLM dependency from MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive documentation
 
 ### Changed
-- N/A
+- **MCP Server**:
+  - Removed hardcoded LLM dependency from test generation tools
+  - Refactored test generation to use templates and guidelines
+  - Made test generation provider-agnostic
+  - Updated test generation to be handled by the calling agent
+- **Testing**:
+  - Added new test cases for LLM provider independence
+  - Updated test infrastructure to work without LLM dependencies
+- **Documentation**:
+  - Updated MCP server documentation to reflect new test generation approach
+  - Added clear guidelines for test template usage
 
 ### Deprecated
 - N/A

--- a/core/framework/__init__.py
+++ b/core/framework/__init__.py
@@ -26,7 +26,7 @@ from framework.schemas.decision import Decision, Option, Outcome, DecisionEvalua
 from framework.schemas.run import Run, RunSummary, Problem
 from framework.runtime.core import Runtime
 from framework.builder.query import BuilderQuery
-from framework.llm import LLMProvider, AnthropicProvider
+from framework.llm import LLMProvider, get_available_providers
 from framework.runner import AgentRunner, AgentOrchestrator
 
 # Testing framework
@@ -40,6 +40,31 @@ from framework.testing import (
     DebugTool,
 )
 
+# Make LLM imports optional
+_llm_providers = {}
+try:
+    from framework.llm import AnthropicProvider
+    _llm_providers['anthropic'] = AnthropicProvider
+except ImportError:
+    pass
+
+try:
+    from framework.llm import LiteLLMProvider
+    _llm_providers['litellm'] = LiteLLMProvider
+except ImportError:
+    pass
+
+def get_llm_provider(name):
+    """Get an LLM provider by name if available.
+    
+    Args:
+        name: Name of the provider ('anthropic', 'litellm', etc.)
+        
+    Returns:
+        The provider class if available, None otherwise
+    """
+    return _llm_providers.get(name)
+
 __all__ = [
     # Schemas
     "Decision",
@@ -48,6 +73,9 @@ __all__ = [
     "DecisionEvaluation",
     "Run",
     "RunSummary",
+    # LLM
+    "get_llm_provider",
+    "get_available_providers",
     "Problem",
     # Runtime
     "Runtime",

--- a/core/framework/llm/__init__.py
+++ b/core/framework/llm/__init__.py
@@ -1,7 +1,40 @@
-"""LLM provider abstraction."""
+"""
+LLM provider abstraction with optional dependencies.
 
+This module provides a unified interface for different LLM providers.
+Providers are loaded dynamically to avoid hard dependencies.
+"""
+
+__all__ = ["LLMProvider", "LLMResponse", "get_available_providers"]
+
+from typing import Dict, Type, List
+
+# Core provider interface
 from framework.llm.provider import LLMProvider, LLMResponse
-from framework.llm.anthropic import AnthropicProvider
-from framework.llm.litellm import LiteLLMProvider
 
-__all__ = ["LLMProvider", "LLMResponse", "AnthropicProvider", "LiteLLMProvider"]
+# Provider implementations (imported on demand)
+_available_providers: Dict[str, Type[LLMProvider]] = {}
+
+# Try to import providers (but don't fail if they're not available)
+try:
+    from framework.llm.anthropic import AnthropicProvider
+    _available_providers["anthropic"] = AnthropicProvider
+    __all__.append("AnthropicProvider")
+except ImportError:
+    pass
+
+try:
+    from framework.llm.litellm import LiteLLMProvider
+    _available_providers["litellm"] = LiteLLMProvider
+    __all__.append("LiteLLMProvider")
+except ImportError:
+    pass
+
+def get_available_providers() -> Dict[str, Type[LLMProvider]]:
+    """
+    Get a dictionary of available LLM providers.
+    
+    Returns:
+        Dict[str, Type[LLMProvider]]: Mapping of provider names to their classes
+    """
+    return _available_providers.copy()

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -1,0 +1,106 @@
+# LLM Provider Configuration
+
+Hive's MCP server supports multiple LLM providers through a flexible provider system. This document explains how to configure and use different LLM providers.
+
+## Available Providers
+
+1. **LiteLLMProvider** (Default)
+   - Supports multiple LLM backends through LiteLLM
+   - Recommended for most use cases
+
+2. **AnthropicProvider**
+   - For Anthropic models (Claude)
+   - Maintained for backward compatibility
+
+## Configuration
+
+### Setting Up the Default Provider
+
+In your application startup code:
+
+```python
+from framework.llm.litellm import LiteLLMProvider
+from framework.llm.anthropic import AnthropicProvider
+
+# Set up LiteLLM (recommended)
+set_llm_provider(LiteLLMProvider, model="gpt-4")
+
+# Or with Anthropic
+# set_llm_provider(AnthropicProvider, model="claude-3-haiku-20240307")
+```
+
+### Environment Variables
+
+For LiteLLM:
+```bash
+# For OpenAI
+LITELLM_MODEL=gpt-4
+OPENAI_API_KEY=your-openai-key
+
+# For Anthropic via LiteLLM
+LITELLM_MODEL=claude-3-haiku-20240307
+ANTHROPIC_API_KEY=your-anthropic-key
+```
+
+For direct Anthropic:
+```bash
+ANTHROPIC_API_KEY=your-anthropic-key
+```
+
+## Using the LLM Provider
+
+### In Test Generation
+
+```python
+# Generate constraint tests
+result = generate_constraint_tests(
+    goal_id="goal123",
+    goal_json=goal_json,
+    agent_path="exports/my_agent",
+    llm_provider=get_llm_provider()  # Uses default provider if not specified
+)
+
+# Generate success tests
+result = generate_success_tests(
+    goal_id="goal123",
+    goal_json=goal_json,
+    agent_path="exports/my_agent",
+    llm_provider=get_llm_provider()  # Optional
+)
+```
+
+## Error Handling
+
+Common errors and solutions:
+
+1. **No LLM Provider Configured**
+   ```
+   Error: No LLM provider configured. Call set_llm_provider() first.
+   ```
+   - **Solution**: Call `set_llm_provider()` at application startup
+
+2. **Authentication Failed**
+   ```
+   Error: Failed to initialize LLM provider: Authentication failed
+   ```
+   - **Solution**: Verify your API keys and environment variables
+
+3. **Model Not Available**
+   ```
+   Error: Model not found: gpt-5
+   ```
+   - **Solution**: Check the model name and your provider's documentation
+
+## Best Practices
+
+1. **Provider Selection**
+   - Use `LiteLLMProvider` for most cases as it supports multiple backends
+   - Only use `AnthropicProvider` if you specifically need direct Anthropic API access
+
+2. **Error Handling**
+   - Always wrap LLM calls in try/except blocks
+   - Implement retries for transient failures
+
+3. **Testing**
+   - Mock LLM calls in unit tests
+   - Test with different providers in different environments

--- a/tests/test_agent_builder_no_llm.py
+++ b/tests/test_agent_builder_no_llm.py
@@ -1,0 +1,93 @@
+"""
+Test that the agent builder can work without LLM dependencies.
+"""
+import sys
+import os
+import json
+import pytest
+from pathlib import Path
+
+# Add the core directory to the path
+sys.path.insert(0, str(Path(__file__).parent.parent / "core"))
+
+# Sample test data
+SAMPLE_GOAL_JSON = """
+{
+    "id": "test_goal",
+    "name": "Test Goal",
+    "description": "A test goal",
+    "success_criteria": [
+        {
+            "id": "crit_1",
+            "description": "Test criteria",
+            "metric": "success",
+            "target": "true",
+            "weight": 1.0,
+            "met": false
+        }
+    ],
+    "constraints": [
+        {
+            "id": "const_1",
+            "description": "Test constraint",
+            "constraint_type": "hard",
+            "category": "test",
+            "check": "lambda x: True"
+        }
+    ]
+}
+"""
+
+def test_import_agent_builder_no_llm():
+    """Test that we can import agent_builder_server without LLM dependencies."""
+    # Mock the LLM imports
+    import builtins
+    original_import = builtins.__import__
+    
+    def mock_import(name, *args, **kwargs):
+        if 'anthropic' in name or 'openai' in name:
+            raise ImportError(f"{name} not available")
+        return original_import(name, *args, **kwargs)
+    
+    builtins.__import__ = mock_import
+    
+    try:
+        # Try to import the module
+        import core.framework.mcp.agent_builder_server as abs_mod
+        assert hasattr(abs_mod, 'generate_constraint_tests')
+        assert hasattr(abs_mod, 'generate_success_tests')
+    finally:
+        # Restore the original import
+        builtins.__import__ = original_import
+
+def test_generate_tests_without_llm():
+    """Test that test generation works without LLM."""
+    from core.framework.mcp.agent_builder_server import (
+        generate_constraint_tests,
+        generate_success_tests
+    )
+    
+    # Test constraint test generation
+    constraint_result = generate_constraint_tests(
+        goal_id="test_goal",
+        goal_json=SAMPLE_GOAL_JSON,
+        agent_path="exports/test_agent"
+    )
+    constraint_data = json.loads(constraint_result)
+    assert "test_guidelines" in constraint_data
+    assert "test_template" in constraint_data
+    
+    # Test success test generation
+    success_result = generate_success_tests(
+        goal_id="test_goal",
+        goal_json=SAMPLE_GOAL_JSON,
+        node_names="test_node",
+        tool_names="test_tool",
+        agent_path="exports/test_agent"
+    )
+    success_data = json.loads(success_result)
+    assert "test_guidelines" in success_data
+    assert "test_template" in success_data
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_import_no_llm.py
+++ b/tests/test_import_no_llm.py
@@ -1,0 +1,145 @@
+"""Test LLM provider configuration and usage with no LLM dependencies."""
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock, AsyncMock, ANY, call
+from typing import Optional, Type
+
+# Add project root to path (fixed indentation)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Import the base provider class first
+from core.framework.llm.provider import LLMProvider, LLMResponse
+
+# Create a mock provider class that inherits from LLMProvider
+class MockLLMProvider(LLMProvider):
+    model: str = "test-model"
+    
+    def __init__(self, **data):
+        super().__init__(**data)
+        self._generate = AsyncMock()
+        self._complete_with_tools = AsyncMock()
+        self._generate_with_tools = AsyncMock()
+        
+    async def generate(self, prompt: str, **kwargs):
+        return await self._generate(prompt, **kwargs)
+        
+    async def complete_with_tools(self, prompt: str, tools: list, **kwargs):
+        return await self._complete_with_tools(prompt, tools, **kwargs)
+        
+    async def generate_with_tools(self, prompt: str, tools: list, **kwargs):
+        return await self._generate_with_tools(prompt, tools, **kwargs)
+
+# Now patch the imports before importing the rest of the modules
+with patch('core.framework.llm.litellm.LiteLLMProvider', new=MockLLMProvider):
+    from core.framework.llm.litellm import LiteLLMProvider
+    from core.framework.mcp.agent_builder_server import (
+        set_llm_provider,
+        get_llm_provider
+    )
+
+# Apply the patch at the module level
+import sys
+import core.framework.llm.litellm as litellm_module
+litellm_module.LiteLLMProvider = MockLLMProvider
+
+# Also patch the provider in the agent_builder_server module
+import core.framework.mcp.agent_builder_server as abs_module
+abs_module.LLMProvider = LLMProvider  # Make sure the base class is available
+abs_module.LiteLLMProvider = MockLLMProvider  # Patch the provider
+
+class TestLLMProviderConfig(unittest.IsolatedAsyncioTestCase):
+    """Test LLM provider configuration."""
+
+    def setUp(self):
+        """Reset provider before each test."""
+        set_llm_provider(None)
+
+    def test_set_and_get_provider(self):
+        """Test setting and getting a provider."""
+        # Create a test provider instance
+        test_provider = MockLLMProvider(model="test-model")
+        
+        # Set and get the provider
+        set_llm_provider(test_provider)
+        retrieved = get_llm_provider()
+        
+        # Verify
+        self.assertEqual(retrieved, test_provider)
+        self.assertEqual(retrieved.model, "test-model")
+
+    def test_default_provider(self):
+        """Test that get_llm_provider returns the default provider."""
+        # Set a mock provider first
+        test_provider = MockLLMProvider()
+        set_llm_provider(test_provider)
+        
+        # Now get it back
+        provider_instance = get_llm_provider()
+        self.assertIsNotNone(provider_instance)
+        self.assertIsInstance(provider_instance, MockLLMProvider)
+
+    @patch.dict(os.environ, {"LITELLM_MODEL": "gpt-4"})
+    def test_environment_config(self):
+        """Test provider configuration from environment."""
+        # This test verifies that the environment variable is used to configure the model
+        provider = LiteLLMProvider(model="gpt-4")
+        self.assertEqual(provider.model, "gpt-4")
+
+    async def test_provider_generate(self):
+        """Test generating text with the provider."""
+        # Create a test provider with a mock generate method
+        test_provider = MockLLMProvider(model="test-model")
+        
+        # Setup the mock response
+        mock_response = MagicMock()
+        mock_response.content = "Test response"
+        mock_response.model = "test-model"
+        mock_response.input_tokens = 5
+        mock_response.output_tokens = 7
+        mock_response.stop_reason = "stop"
+        
+        # Configure the mock
+        test_provider._generate.return_value = mock_response
+        
+        # Call the method
+        response = await test_provider.generate("Test prompt")
+        
+        # Verify the response
+        self.assertEqual(response.content, "Test response")
+        self.assertEqual(response.model, "test-model")
+        self.assertEqual(response.input_tokens, 5)
+        self.assertEqual(response.output_tokens, 7)
+        self.assertEqual(response.stop_reason, "stop")
+        
+        # Verify the method was called correctly
+        test_provider._generate.assert_awaited_once_with("Test prompt")
+
+    def test_error_handling(self):
+        """Test error handling for provider configuration."""
+        # Save the original provider
+        original_provider = get_llm_provider(raise_if_none=False)
+        
+        try:
+            # Clear the provider
+            set_llm_provider(None)
+            
+            # Should raise when raise_if_none=True
+            with self.assertRaises(ValueError):
+                get_llm_provider(raise_if_none=True)
+            
+            # Should return None when raise_if_none=False
+            provider = get_llm_provider(raise_if_none=False)
+            self.assertIsNone(provider)
+            
+            # Test with an invalid provider type
+            with self.assertRaises(ValueError):
+                set_llm_provider("not_a_provider")
+                
+        finally:
+            # Restore the original provider
+            set_llm_provider(original_provider)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,0 +1,160 @@
+"""Test LLM provider configuration and usage."""
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock, AsyncMock, ANY, call
+from typing import Optional, Type
+
+# Add project root to path (fixed indentation)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Import the base provider class first
+from core.framework.llm.provider import LLMProvider
+
+# First, import the base classes
+from core.framework.llm.provider import LLMProvider, LLMResponse
+
+# Create a mock provider class that inherits from LLMProvider
+class MockLLMProvider(LLMProvider):
+    model: str = "test-model"
+    
+    def __init__(self, **data):
+        super().__init__(**data)
+        self._generate = AsyncMock()
+        self._complete_with_tools = AsyncMock()
+        self._generate_with_tools = AsyncMock()
+        
+    async def generate(self, prompt: str, **kwargs):
+        return await self._generate(prompt, **kwargs)
+        
+    async def complete_with_tools(self, prompt: str, tools: list, **kwargs):
+        return await self._complete_with_tools(prompt, tools, **kwargs)
+        
+    async def generate_with_tools(self, prompt: str, tools: list, **kwargs):
+        return await self._generate_with_tools(prompt, tools, **kwargs)
+        
+    # Helper methods for testing
+    def setup_generate(self, content: str = "Test response", **kwargs):
+        mock_response = LLMResponse(
+            content=content,
+            model=self.model,
+            input_tokens=kwargs.get('input_tokens', 5),
+            output_tokens=kwargs.get('output_tokens', 7),
+            stop_reason=kwargs.get('stop_reason', 'stop'),
+            raw_response=None
+        )
+        self._generate.return_value = mock_response
+        return mock_response
+
+# Now patch the imports
+with patch('core.framework.llm.litellm.LiteLLMProvider', new=MockLLMProvider):
+    from core.framework.llm.litellm import LiteLLMProvider
+    from core.framework.mcp.agent_builder_server import (
+        set_llm_provider,
+        get_llm_provider
+    )
+
+# Apply the patch at the module level
+import sys
+import core.framework.llm.litellm as litellm_module
+litellm_module.LiteLLMProvider = MockLLMProvider
+
+# Also patch the provider in the agent_builder_server module
+import core.framework.mcp.agent_builder_server as abs_module
+abs_module.LLMProvider = LLMProvider  # Make sure the base class is available
+abs_module.LiteLLMProvider = MockLLMProvider  # Patch the provider
+
+
+class TestLLMProviderConfig(unittest.IsolatedAsyncioTestCase):
+    """Test LLM provider configuration."""
+
+    def setUp(self):
+        """Reset provider before each test."""
+        set_llm_provider(None)
+
+    def test_set_and_get_provider(self):
+        """Test setting and getting a provider."""
+        # Create a test provider instance
+        test_provider = MockLLMProvider(model="test-model")
+        
+        # Set and get the provider
+        set_llm_provider(test_provider)
+        retrieved = get_llm_provider()
+        
+        # Verify
+        self.assertEqual(retrieved, test_provider)
+        self.assertEqual(retrieved.model, "test-model")
+
+    def test_default_provider(self):
+        """Test that get_llm_provider returns the default provider."""
+        # Set a mock provider first
+        test_provider = MockLLMProvider()
+        set_llm_provider(test_provider)
+        
+        # Now get it back
+        provider_instance = get_llm_provider()
+        self.assertIsNotNone(provider_instance)
+        self.assertIsInstance(provider_instance, MockLLMProvider)
+
+    @patch.dict(os.environ, {"LITELLM_MODEL": "gpt-4"})
+    def test_environment_config(self):
+        """Test provider configuration from environment."""
+        # This test verifies that the environment variable is used to configure the model
+        with patch('core.framework.llm.litellm.LiteLLMProvider', new=MockLLMProvider):
+            provider = LiteLLMProvider(model="gpt-4")
+            self.assertEqual(provider.model, "gpt-4")
+
+    async def test_provider_generate(self):
+        """Test generating text with the provider."""
+        # Create a test provider with a mock generate method
+        test_provider = MockLLMProvider(model="test-model")
+        
+        # Setup the mock response
+        mock_response = test_provider.setup_generate(
+            content="Test response",
+            input_tokens=5,
+            output_tokens=7,
+            stop_reason="stop"
+        )
+        
+        # Call the method
+        response = await test_provider.generate("Test prompt")
+        
+        # Verify the response
+        self.assertEqual(response.content, "Test response")
+        self.assertEqual(response.model, "test-model")
+        self.assertEqual(response.input_tokens, 5)
+        self.assertEqual(response.output_tokens, 7)
+        self.assertEqual(response.stop_reason, "stop")
+        
+        # Verify the method was called correctly
+        test_provider._generate.assert_awaited_once_with("Test prompt")
+
+    def test_error_handling(self):
+        """Test error handling for provider configuration."""
+        # Save the original provider
+        original_provider = get_llm_provider(raise_if_none=False)
+        
+        try:
+            # Clear the provider
+            set_llm_provider(None)
+            
+            # Should raise when raise_if_none=True
+            with self.assertRaises(ValueError):
+                get_llm_provider(raise_if_none=True)
+            
+            # Should return None when raise_if_none=False
+            provider = get_llm_provider(raise_if_none=False)
+            self.assertIsNone(provider)
+            
+            # Test with an invalid provider type
+            with self.assertRaises(ValueError):
+                set_llm_provider("not_a_provider")
+                
+        finally:
+            # Restore the original provider
+            set_llm_provider(original_provider)
+
+
+if __name__ == "__main__":
+    unittest.main(argv=['first-arg-is-ignored'], exit=False)  # Non-exit for pytest compatibility


### PR DESCRIPTION
- Removed hardcoded AnthropicProvider from test generation
- Implemented template-based test generation
- Added provider-agnostic test utilities
- Updated documentation and CHANGELOG
- Added comprehensive test cases for LLM independence

This change makes the MCP server more flexible by removing the hard dependency on specific LLM providers for test generation.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
