### PR TITLE
Fix PYTHONPATH separator for MCP run_tests on Windows

### DIFF
--- a/core/framework/mcp/agent_builder_server.py
+++ b/core/framework/mcp/agent_builder_server.py
@@ -2785,7 +2785,8 @@ def run_tests(
     env = os.environ.copy()
     pythonpath = env.get("PYTHONPATH", "")
     project_root = Path(__file__).parent.parent.parent.parent.resolve()
-    env["PYTHONPATH"] = f"{project_root}:{pythonpath}"
+    sep = os.pathsep
+    env["PYTHONPATH"] = f"{project_root}{sep}{pythonpath}" if pythonpath else str(project_root)
 
     # Run pytest
     try:


### PR DESCRIPTION
Description
Fix MCP [run_tests](vscode-file://vscode-app/c:/Users/mishr/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) PYTHONPATH construction to use the platform-specific separator ([os.pathsep](vscode-file://vscode-app/c:/Users/mishr/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)), restoring test imports on Windows while keeping Unix behavior unchanged.

Type of Change
 Bug fix
Related Issues
Closes #<1425>

Changes Made
Build PYTHONPATH with [os.pathsep](vscode-file://vscode-app/c:/Users/mishr/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and avoid leading separators when existing PYTHONPATH is empty.

Testing
 Manual verification of MCP [run_tests](vscode-file://vscode-app/c:/Users/mishr/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on Windows (imports resolve)

Checklist
 My changes follow the project's style guidelines
 I have performed a self-review of my changes
