### PR TITLE
Docs/fix anthropic startup claim

### DIFF
--- a/core/MCP_BUILDER_TOOLS_GUIDE.md
+++ b/core/MCP_BUILDER_TOOLS_GUIDE.md
@@ -410,4 +410,4 @@ If credentials are missing, you'll receive a response like:
 | ------------ | ---------------------- | ----------------------------------------------------- |
 | `web_search` | `BRAVE_SEARCH_API_KEY` | [brave.com/search/api](https://brave.com/search/api/) |
 
-Note: The MCP server itself requires `ANTHROPIC_API_KEY` at startup for LLM operations.
+Note: LLM credentials (e.g., `ANTHROPIC_API_KEY`) are optional and only validated when an agent uses LLM nodes.

--- a/core/framework/mcp/agent_builder_server.py
+++ b/core/framework/mcp/agent_builder_server.py
@@ -2785,7 +2785,8 @@ def run_tests(
     env = os.environ.copy()
     pythonpath = env.get("PYTHONPATH", "")
     project_root = Path(__file__).parent.parent.parent.parent.resolve()
-    env["PYTHONPATH"] = f"{project_root}:{pythonpath}"
+    sep = os.pathsep
+    env["PYTHONPATH"] = f"{project_root}{sep}{pythonpath}" if pythonpath else str(project_root)
 
     # Run pytest
     try:

--- a/tools/mcp_server.py
+++ b/tools/mcp_server.py
@@ -16,13 +16,12 @@ Usage:
 
 Environment Variables:
     MCP_PORT              - Server port (default: 4001)
-    ANTHROPIC_API_KEY     - Required at startup for testing/LLM nodes
+    ANTHROPIC_API_KEY     - Optional; only needed for agents using Anthropic models
     BRAVE_SEARCH_API_KEY  - Required for web_search tool (validated at agent load time)
 
 Note:
-    Two-tier credential validation:
-    - Tier 1 (startup): ANTHROPIC_API_KEY must be set before server starts
-    - Tier 2 (agent load): Tool credentials validated when agent is loaded
+    Credential validation occurs at agent load time, not server startup.
+    Set credentials in environment or .env file before running agents that need them.
     See aden_tools.credentials for details.
 """
 import argparse


### PR DESCRIPTION
Description
This PR fixes documentation that incorrectly claimed ANTHROPIC_API_KEY is required at MCP server startup. It also fixes a cross-platform bug in the test runner's PYTHONPATH construction.

Type of Change
 Bug fix
 Documentation update

Related Issues

Fixes incorrect startup requirement claim in MCP documentation and Windows PYTHONPATH separator bug.

Changes Made

mcp_server.py: Updated docstring to clarify ANTHROPIC_API_KEY is optional, not required at startup
MCP_BUILDER_TOOLS_GUIDE.md: Removed incorrect claim about startup requirement for LLM credentials
agent_builder_server.py: Fixed PYTHONPATH to use [@] os.pathsep for Windows compatibility

Testing

Verified credential validation logic in [aden_tools.credentials] (startup_required=False for anthropic)
Confirmed MCP server starts without ANTHROPIC_API_KEY
Manual verification of cross-platform path separator usage

Checklist

My changes follow the project’s style guidelines
I have performed a self-review of my changes
Documentation has been updated accordingly

Fixes #569  