### PR TITLE
docs: clarify missing exports folder and Windows Python setup

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -87,8 +87,7 @@ Because of this, **agent commands will fail on a fresh clone**.
 
 For example, the following commands will fail unless an agent exists:
 
-```bash
-PYTHONPATH=core:exports python -m support_ticket_agent validate
+
 
 
 

--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -78,7 +78,7 @@ All agent commands must be run from the project root with `PYTHONPATH` set:
 
 ```bash
 # From /hive/ directory
-PYTHONPATH=core:exports python -m agent_name COMMAND
+PYTHONPATH=core:exports python -m support_ticket_agent validate
 ```
 
 ### Example: Support Ticket Agent

--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -72,18 +72,17 @@ For running agents with real LLMs:
 export ANTHROPIC_API_KEY="your-key-here"
 ```
 
-## Important Note About Running Agents
+## Running Agents (Important Note)
 
- **Agents are NOT included by default.**  
+**Agents are NOT included by default.**  
 You must generate an agent (or manually create one under `exports/`) **before running any command like**:
-
-
 
 The `exports/` folder is only created when:
 - You build a new agent using **Claude Code**, or
 - You manually add an agent package under `exports/`
 
 Because of this, **agent commands will fail on a fresh clone**.
+
 
 For example, the following commands will fail unless an agent exists:
 

--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -72,38 +72,38 @@ For running agents with real LLMs:
 export ANTHROPIC_API_KEY="your-key-here"
 ```
 
+
 ## Running Agents (Important Note)
 
 **Agents are NOT included by default.**  
-You must generate an agent (or manually create one under `exports/`) **before running any command like**:
+You must generate an agent (or manually create one under `exports/`) before running any agent command.
 
 The `exports/` folder is only created when:
 - You build a new agent using **Claude Code**, or
 - You manually add an agent package under `exports/`
 
-Because of this, **agent commands will fail on a fresh clone**.
+Because of this, agent commands will fail on a fresh clone.
 
+All agent commands must be run from the project root with `PYTHONPATH` set:
 
-For example, the following commands will fail unless an agent exists:
+```bash
+# From /hive/ directory
+PYTHONPATH=core:exports python -m agent_name COMMAND
 
-
-
-
+# Validate agent structure
+PYTHONPATH=core:exports python -m support_ticket_agent validate
 
 # Show agent information
 PYTHONPATH=core:exports python -m support_ticket_agent info
 
 # Run agent with input
-PYTHONPATH=core:exports python -m support_ticket_agent run --input '{
-  "ticket_content": "My login is broken. Error 401.",
-  "customer_id": "CUST-123",
-  "ticket_id": "TKT-456"
-}'
+PYTHONPATH=core:exports python -m support_ticket_agent run --input '{...}'
 
 # Run in mock mode (no LLM calls)
 PYTHONPATH=core:exports python -m support_ticket_agent run --mock --input '{...}'
-```
 
+
+### Example: Other Agents
 ### Example: Other Agents
 
 ```bash
@@ -115,7 +115,8 @@ PYTHONPATH=core:exports python -m outbound_sales_agent validate
 
 # Personal Assistant Agent
 PYTHONPATH=core:exports python -m personal_assistant_agent run --input '{...}'
-```
+
+
 
 ## Building New Agents
 

--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -77,8 +77,6 @@ export ANTHROPIC_API_KEY="your-key-here"
  **Agents are NOT included by default.**  
 You must generate an agent (or manually create one under `exports/`) **before running any command like**:
 
-```bash
-python -m agent_name
 
 
 The `exports/` folder is only created when:

--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -72,20 +72,27 @@ For running agents with real LLMs:
 export ANTHROPIC_API_KEY="your-key-here"
 ```
 
-## Running Agents
+## Important Note About Running Agents
 
-All agent commands must be run from the project root with `PYTHONPATH` set:
-
-```bash
-# From /hive/ directory
-PYTHONPATH=core:exports python -m support_ticket_agent validate
-```
-
-### Example: Support Ticket Agent
+ **Agents are NOT included by default.**  
+You must generate an agent (or manually create one under `exports/`) **before running any command like**:
 
 ```bash
-# Validate agent structure
+python -m agent_name
+
+
+The `exports/` folder is only created when:
+- You build a new agent using **Claude Code**, or
+- You manually add an agent package under `exports/`
+
+Because of this, **agent commands will fail on a fresh clone**.
+
+For example, the following commands will fail unless an agent exists:
+
+```bash
 PYTHONPATH=core:exports python -m support_ticket_agent validate
+
+
 
 # Show agent information
 PYTHONPATH=core:exports python -m support_ticket_agent info
@@ -344,3 +351,17 @@ When contributing agent packages:
 - **Issues:** https://github.com/adenhq/hive/issues
 - **Discord:** https://discord.com/invite/MXE49hrKDk
 - **Documentation:** https://docs.adenhq.com/
+
+
+---
+
+## Windows (PowerShell) Setup Guide
+
+### Recommended Python Version
+Hive requires **Python 3.11 or newer**.  
+On Windows, multiple Python versions may be installed. Always use **Python 3.11**.
+
+Check available versions:
+```powershell
+py -0
+


### PR DESCRIPTION
### What this PR does

This PR improves the Windows onboarding and environment setup documentation by clarifying two common sources of confusion:

- The repository does not include any agents by default
- Commands like `python -m support_ticket_agent` will fail on a fresh clone until an agent is created under `exports/`

### Why this change is needed

On Windows, users often:
- Run agent commands immediately after cloning
- Encounter `No module named support_ticket_agent`
- Assume PYTHONPATH or installation is broken

This change makes it explicit that:
- `exports/` is created only after building an agent (via Claude Code or manually)
- The error is expected behavior on a clean repo

### Scope of changes

- Documentation-only change
- No code or behavior changes
- Improves first-time developer experience on Windows

### Checklist

- [x] Docs-only change
- [x] No breaking changes
- [x] Follows CONTRIBUTING guidelines
