### PR TITLE
docs(setup): clarify Windows limitations for setup scripts

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -10,7 +10,24 @@ Complete setup guide for building and running goal-driven agents with the Aden A
 ```
 
 > **Note for Windows Users:**  
-> Running the setup script on native Windows shells (PowerShell / Git Bash) may sometimes fail due to Python App Execution Aliases.  
+> Running the setup script on native Windows shells (Command Prompt / PowerShell) will fail,
+because `.sh` scripts require a Unix-like environment.
+ due to Python App Execution Aliases.  
+
+
+ ### Windows (Recommended Options)
+
+Choose ONE of the following:
+
+1. **WSL (Best & Recommended)**
+   - Install WSL 2 (Ubuntu)
+   - Run all setup commands inside WSL
+
+2. **Manual Setup (No Scripts)**
+   - Follow the Manual Setup section below
+   - Do NOT run `.sh` files
+
+
 > It is **strongly recommended to use WSL (Windows Subsystem for Linux)** for a smoother setup experience.
 
 This will:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ cd hive
 ./scripts/setup-python.sh
 ```
 
+> ⚠️ **Windows Users**
+> This script will NOT run in Command Prompt or PowerShell.
+> Please use **WSL (recommended)** or follow the **Manual Setup** in ENVIRONMENT_SETUP.md.
+
+
 This installs:
 - **framework** - Core agent runtime and graph executor
 - **aden_tools** - 19 MCP tools for agent capabilities


### PR DESCRIPTION
This PR improves setup documentation for Windows users.

Running `./scripts/setup-python.sh` in Command Prompt or PowerShell fails,
but this was not clearly stated. Added explicit guidance for using WSL
or manual setup to reduce onboarding friction for first-time contributors.
