### PR TITLE
Fix: Remove deprecated AST visitors in safe_eval.py

### DIFF
--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -76,14 +76,9 @@ class SafeEvalVisitor(ast.NodeVisitor):
         return node.value
 
     # --- Number/String/Bytes/NameConstant (Python < 3.8 compat if needed) ---
-    def visit_Num(self, node: ast.Num) -> Any:
-        return node.n
+   
 
-    def visit_Str(self, node: ast.Str) -> Any:
-        return node.s
-
-    def visit_NameConstant(self, node: ast.NameConstant) -> Any:
-        return node.value
+  
 
     # --- Data Structures ---
     def visit_List(self, node: ast.List) -> list:
@@ -226,9 +221,7 @@ class SafeEvalVisitor(ast.NodeVisitor):
 
         return func(*args, **keywords)
 
-    def visit_Index(self, node: ast.Index) -> Any:
-        # Python < 3.9
-        return self.visit(node.value)
+  
 
 
 def safe_eval(expr: str, context: dict[str, Any] | None = None) -> Any:


### PR DESCRIPTION
##DESCRIPTION

Removes deprecated AST node visitors (`Num`, `Str`, `NameConstant`, `Index`) and relies on `ast.Constant`.

This eliminates Python 3.12 deprecation warnings while keeping behavior unchanged.
