### PR TITLE
Create exports directory automatically on CLI startup

### DIFF
--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -18,9 +18,10 @@ Testing commands:
 
 import argparse
 import sys
-
+from pathlib import Path
 
 def main():
+    Path("exports").mkdir(parents=True, exist_ok=True)
     parser = argparse.ArgumentParser(description="Goal Agent - Build and run goal-driven agents")
     parser.add_argument(
         "--model",


### PR DESCRIPTION
### Description

This PR fixes a first-run issue where the CLI fails if the `exports/` directory
does not already exist.

On a fresh setup, running commands like:

```bash
python -m framework shell
```
results in an error because the CLI assumes the exports/ directory is present.
This can be confusing for new users following the README or quick-start steps.

This change ensures the exports/ directory is created automatically on CLI
startup, allowing the CLI to run successfully without any manual setup.

## Type of Change
- Bug fix (non-breaking change that fixes an issue)

## Related Issues
Fixes #1356

## Changes Made
- Automatically create the exports/ directory during CLI initialization
- Prevent first-run CLI failures when no agents have been exported yet