### PR TITLE
feat: native debugger

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -72,6 +72,7 @@ class GraphExecutor:
         tool_executor: Callable | None = None,
         node_registry: dict[str, NodeProtocol] | None = None,
         approval_callback: Callable | None = None,
+        step_callback: Callable | None = None,
         cleansing_config: CleansingConfig | None = None,
     ):
         """
@@ -92,6 +93,7 @@ class GraphExecutor:
         self.tool_executor = tool_executor
         self.node_registry = node_registry or {}
         self.approval_callback = approval_callback
+        self.step_callback = step_callback
         self.validator = OutputValidator()
         self.logger = logging.getLogger(__name__)
 
@@ -221,6 +223,10 @@ class GraphExecutor:
                 self.logger.info(f"\n▶ Step {steps}: {node_spec.name} ({node_spec.node_type})")
                 self.logger.info(f"   Inputs: {node_spec.input_keys}")
                 self.logger.info(f"   Outputs: {node_spec.output_keys}")
+
+                # Debug hook: Call step_callback if present
+                if self.step_callback:
+                    await self.step_callback(steps, node_spec, memory)
 
                 # Build context for node
                 ctx = self._build_context(

--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -37,6 +37,11 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         help="Run in mock mode (no real LLM calls)",
     )
     run_parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable interactive debug mode (step-by-step)",
+    )
+    run_parser.add_argument(
         "--output", "-o",
         type=str,
         help="Write results to file instead of stdout",
@@ -201,6 +206,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         runner = AgentRunner.load(
             args.agent_path,
             mock_mode=args.mock,
+            debug_mode=args.debug,
             model=getattr(args, "model", "claude-haiku-4-5-20251001"),
         )
     except FileNotFoundError as e:

--- a/core/framework/runner/debugger.py
+++ b/core/framework/runner/debugger.py
@@ -1,0 +1,116 @@
+"""Console debugger for interactive agent execution."""
+
+import asyncio
+import json
+from typing import Any
+
+from framework.graph.node import NodeSpec, SharedMemory
+
+
+class ConsoleDebugger:
+    """
+    Interactive debugger for the agent runner.
+    
+    Allows stepping through execution, inspecting state, and controlling flow.
+    """
+
+    def __init__(self):
+        self._disabled = False
+
+    async def on_step(self, step: int, node: NodeSpec, memory: SharedMemory) -> None:
+        """
+        Callback invoked before each execution step.
+        
+        Args:
+            step: Current step number
+            node: Node about to be executed
+            memory: Current state of shared memory
+        """
+        if self._disabled:
+            return
+
+        print()
+        print("=" * 60)
+        print(f"🐞 DEBUGGER PAUSE (Step {step})")
+        print("=" * 60)
+        print(f"Next Node: {node.name} ({node.id})")
+        print(f"Type:      {node.node_type}")
+        print(f"Inputs:    {node.input_keys}")
+        print()
+
+        while True:
+            try:
+                # Use a specific prompt to indicate debug mode
+                cmd_input = input("(debug) ").strip()
+            except (EOFError, KeyboardInterrupt):
+                print("\nAborting...")
+                # Exit the process cleanly
+                import sys
+                sys.exit(1)
+
+            if not cmd_input:
+                continue
+            
+            # Parse command
+            parts = cmd_input.split()
+            cmd = parts[0].lower()
+            args = parts[1:]
+
+            if cmd in ("n", "next", ""):
+                # Execute next step
+                print("▶ Executing step...")
+                return
+
+            elif cmd in ("c", "continue"):
+                # Disable debugger and continue to end
+                self._disabled = True
+                print("▶ Continuing execution (debugger disabled)...")
+                return
+
+            elif cmd in ("i", "inspect", "p", "print"):
+                # Inspect memory value
+                if not args:
+                    print("Usage: inspect <key> or inspect *")
+                    continue
+                
+                key = args[0]
+                state = memory.read_all_sync()
+                
+                if key == "*":
+                    print(json.dumps(state, indent=2, default=str))
+                elif key in state:
+                    val = state[key]
+                    if isinstance(val, (dict, list)):
+                        print(json.dumps(val, indent=2, default=str))
+                    else:
+                        print(val)
+                else:
+                    print(f"Key '{key}' not found in memory.")
+
+            elif cmd in ("l", "list"):
+                # List all keys in memory
+                state = memory.read_all_sync()
+                print(f"Memory keys ({len(state)}):")
+                for k in sorted(state.keys()):
+                    type_name = type(state[k]).__name__
+                    val_preview = str(state[k])
+                    if len(val_preview) > 50:
+                        val_preview = val_preview[:47] + "..."
+                    print(f"  {k} ({type_name}): {val_preview}")
+
+            elif cmd in ("q", "quit", "exit"):
+                print("Aborting execution...")
+                import sys
+                sys.exit(0)
+
+            elif cmd in ("h", "help", "?"):
+                print("Commands:")
+                print("  n, next, <enter>  : Execute next step")
+                print("  c, continue       : Continue to end (disable debugger)")
+                print("  i, inspect <key>  : Print value of memory key (* for all)")
+                print("  l, list           : List all memory keys")
+                print("  q, quit           : Abort execution")
+                print("  h, help           : Show this help")
+
+            else:
+                print(f"Unknown command: {cmd}")

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -195,6 +195,7 @@ class AgentRunner:
         graph: GraphSpec,
         goal: Goal,
         mock_mode: bool = False,
+        debug_mode: bool = False,
         storage_path: Path | None = None,
         model: str = "cerebras/zai-glm-4.7",
     ):
@@ -214,6 +215,7 @@ class AgentRunner:
         self.graph = graph
         self.goal = goal
         self.mock_mode = mock_mode
+        self.debug_mode = debug_mode
         self.model = model
 
         # Set up storage
@@ -254,6 +256,7 @@ class AgentRunner:
         cls,
         agent_path: str | Path,
         mock_mode: bool = False,
+        debug_mode: bool = False,
         storage_path: Path | None = None,
         model: str = "cerebras/zai-glm-4.7",
     ) -> "AgentRunner":
@@ -284,6 +287,7 @@ class AgentRunner:
             graph=graph,
             goal=goal,
             mock_mode=mock_mode,
+            debug_mode=debug_mode,
             storage_path=storage_path,
             model=model,
         )
@@ -470,12 +474,20 @@ class AgentRunner:
         self._runtime = Runtime(storage_path=self._storage_path)
 
         # Create executor
+        step_callback = None
+        if self.debug_mode:
+            from framework.runner.debugger import ConsoleDebugger
+            debugger = ConsoleDebugger()
+            step_callback = debugger.on_step
+            print("🐞 Debug mode enabled")
+
         self._executor = GraphExecutor(
             runtime=self._runtime,
             llm=self._llm,
             tools=tools,
             tool_executor=tool_executor,
             approval_callback=self._approval_callback,
+            step_callback=step_callback,
         )
 
     def _setup_agent_runtime(self, tools: list, tool_executor: Callable | None) -> None:

--- a/tests/dummy_agent/agent.json
+++ b/tests/dummy_agent/agent.json
@@ -1,0 +1,1 @@
+{"graph": {"id": "dummy", "goal_id": "test", "entry_node": "start", "nodes": [{"id": "start", "name": "Start", "node_type": "llm_generate", "input_keys": [], "output_keys": []}], "edges": [], "terminal_nodes": ["start"]}, "goal": {"id": "test", "name": "Test", "description": "Test", "success_criteria": [], "constraints": []}}


### PR DESCRIPTION
## Description

Implement a native debugging mode that allows step-by-step execution of agents, state inspection, and manual control via the CLI.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
## Related Issues

Fixes #350 

## Changes Made
- Modify GraphExecutor.__init__: Add step_callback: Callable | None.
- Modify GraphExecutor.execute:
- Inside the execution loop (before node_impl.execute), call self.step_callback if it exists.
- Modify AgentRunner.__init__: Add debug_mode: bool = False.
- Modify AgentRunner._setup_legacy_executor:
- If debug_mode is True, create a ConsoleDebugger instance.
- Pass ConsoleDebugger.on_step as the step_callback to GraphExecutor
- Create ConsoleDebugger class:
- Implements async def on_step(self, step, node, memory).
- Functionality:
- Print current step info (Node name, Type).
- Wait for user input via input().
- Commands:
           - n / next: Execute next step.
           - c / continue: Run to completion (disable stepping).
           - i / inspect <key>: Show memory value.
           - q / quit: Abort execution. 
- Modify run command:
- Add --debug flag.
- Pass debug_mode=True to AgentRunner
