### PR TITLE
docs: clarify Claude Code building agent skills

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -101,8 +101,11 @@ Get API keys:
 
 This installs:
 
-- `/building-agents` - Build new goal-driven agents
+- `/building-agents-construction` - Create agent structure and workflows
+- `/building-agents-core` - Core agent logic and runtime concepts
+- `/building-agents-patterns` - Reusable agent design patterns
 - `/testing-agent` - Test agents with evaluation framework
+
 
 ### Verify Setup
 
@@ -213,7 +216,9 @@ The fastest way to build agents is using the Claude Code skills:
 ./quickstart.sh
 
 # Build a new agent
-claude> /building-agents
+claude> /building-agents-construction
+claude> /building-agents-core
+claude> /building-agents-patterns
 
 # Test the agent
 claude> /testing-agent
@@ -224,7 +229,7 @@ claude> /testing-agent
 1. **Define Your Goal**
 
    ```
-   claude> /building-agents
+   claude> /building-agents-construction
    Enter goal: "Build an agent that processes customer support tickets"
    ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,7 +34,7 @@ python -c "import framework; import aden_tools; print('✓ Setup complete')"
 ./quickstart.sh
 
 # Start Claude Code and build an agent
-claude> /building-agents
+claude> /building-agents-construction
 ```
 
 Follow the interactive prompts to:
@@ -160,7 +160,7 @@ PYTHONPATH=core:exports python -m my_agent test --type success
 
 1. **Detailed Setup**: See [ENVIRONMENT_SETUP.md](../ENVIRONMENT_SETUP.md)
 2. **Developer Guide**: See [DEVELOPER.md](../DEVELOPER.md)
-3. **Build Agents**: Use `/building-agents` skill in Claude Code
+3. **Build Agents**: Use `/building-agents-construction`, `/building-agents-core`, and `/building-agents-patterns` in Claude Code
 4. **Custom Tools**: Learn to integrate MCP servers
 5. **Join Community**: [Discord](https://discord.com/invite/MXE49hrKDk)
 


### PR DESCRIPTION
### What this PR does

This PR fixes incorrect documentation references to a non-existent `building-agents` skill.

The docs now correctly reflect the actual Claude Code skills available in the repository:
- `building-agents-construction`
- `building-agents-core`
- `building-agents-patterns`
- `testing-agent`

### Why this is needed

The previous documentation was confusing for newcomers, as it referenced a skill that does not exist.
This change aligns the docs with the real `.claude/skills` structure.

### Related issue
Closes #1442