### PR TITLE
docs(setup): clarify virtualenv requirement before running setup script

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -2,6 +2,21 @@
 
 Complete setup guide for building and running goal-driven agents with the Aden Agent Framework.
 
+> ⚠️ **Important: Virtual Environment Required on Modern Systems**
+>
+> On modern systems (macOS with Homebrew Python, Ubuntu 22.04+, WSL),
+> Python may be marked as an **externally managed environment** (PEP 668).
+> In these environments, running the setup script without an active
+> virtual environment can fail.
+>
+> It is strongly recommended to create and activate a project-local
+> virtual environment **before** running the setup script:
+>
+> ```bash
+> python3 -m venv .venv
+> source .venv/bin/activate
+> ```
+
 ## Quick Setup
 
 ```bash


### PR DESCRIPTION
## Description

### Summary

This PR adds a small upfront note to clarify that a Python virtual environment should be created and activated **before** running the setup script on modern systems.

This is related to setup issues caused by **PEP 668 (externally managed Python environments)**, which commonly affect macOS (Homebrew Python), Ubuntu 22.04+, and WSL. While this guidance already exists in the Troubleshooting section, new users often encounter the error during initial setup.

This change keeps the existing documentation intact and surfaces the guidance earlier to improve the first-time setup experience.

Related to #964

### Scope

- Documentation-only change  
- No script or behavior changes


