### PR TITLE
fix: add missing 'hive' CLI entry point for Windows

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -53,3 +53,6 @@ lint.isort.section-order = [
   "first-party",
   "local-folder",
 ]
+
+[project.scripts]
+hive = "framework.cli:main"


### PR DESCRIPTION
## Description
This PR adds the missing `[project.scripts]` section to `core/pyproject.toml`. This fixes the issue where the `hive` CLI command was not being generated during installation, specifically on Windows.

## Related Issue
Fixes #1536
Relates to #1334

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
1. Manually modified `core/pyproject.toml` locally.
2. Ran `pip install -e core`.
3. Verified `hive --help` successfully prints the CLI usage menu on Windows 11 (PowerShell).