### PR TITLE
fix(list_dir): add isdir check before listing

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/list_dir/list_dir.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/list_dir/list_dir.py
@@ -33,7 +33,10 @@ def register_tools(mcp: FastMCP) -> None:
         try:
             secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
             if not os.path.exists(secure_path):
-                return {"error": f"Directory not found at {path}"}
+                return {"error": f"Path not found: {path}"}
+
+            if not os.path.isdir(secure_path):
+                return {"error": f"Path is not a directory: {path}"}
 
             items = os.listdir(secure_path)
             entries = []


### PR DESCRIPTION
## Description
Fixed `list_dir` crash when given a file path instead of a directory by adding `os.path.isdir()` validation.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #1401

## Changes Made
- Added `os.path.isdir()` check after path existence validation
- Updated error messages: "Path not found" for missing paths, "Path is not a directory" for files
- Prevents `NotADirectoryError` exception

## Testing
- Manual testing: verified error handling for non-existent paths, files, and valid directories