### PR TITLE
feat: Implement Self-Reflection Tool

### DIFF
--- a/tools/src/aden_tools/tools/reflection_tool/__init__.py
+++ b/tools/src/aden_tools/tools/reflection_tool/__init__.py
@@ -1,0 +1,5 @@
+"""Reflection Tool - Introspection capabilities for agents."""
+
+from .reflection_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/reflection_tool/reflection_tool.py
+++ b/tools/src/aden_tools/tools/reflection_tool/reflection_tool.py
@@ -1,0 +1,83 @@
+"""
+Reflection Tool - Allows agents to inspect their own execution history.
+"""
+
+from typing import Any
+
+from framework.runtime.event_bus import EventBus
+from mcp.server.fastmcp import FastMCP
+
+
+class ReflectionTool:
+    """
+    Tool for agents to query their own event history.
+    """
+
+    def __init__(self, event_bus: EventBus):
+        self.event_bus = event_bus
+
+    async def get_recent_events(
+        self, limit: int = 10, event_type: str | None = None
+    ) -> list[dict[str, Any]]:
+        """
+        Get the most recent events from the agent's execution history.
+
+        Args:
+            limit: Number of events to return (max 100)
+            event_type: Optional filter by event type (e.g., 'execution_failed', 'tool_use')
+        """
+        limit = min(limit, 100)
+
+        # We need to map string event_type to Enum if needed, or update EventBus
+        # For now, we assume EventBus handles filtering by string if we cast it or
+        # we do manual filtering here if EventBus requires Enum.
+
+        # Looking at EventBus implementation:
+        # get_history(event_type: EventType | None ...)
+
+        # So we need to convert string to EventType if provided.
+        from framework.runtime.event_bus import EventType
+
+        e_type = None
+        if event_type:
+            try:
+                e_type = EventType(event_type)
+            except ValueError:
+                # If invalid type is passed, return empty list or ignored?
+                # Let's return error message or just ignore filtering for robustness?
+                # Best to return empty or error. Let's return empty events.
+                return []
+
+        events = self.event_bus.get_history(event_type=e_type, limit=limit)
+        return [e.to_dict() for e in events]
+
+    async def get_execution_stats(self) -> dict[str, Any]:
+        """Get statistics about the current execution session."""
+        return self.event_bus.get_stats()
+
+
+def register_tools(mcp: FastMCP, event_bus: EventBus) -> None:
+    """Register reflection tools with MCP server."""
+    tool = ReflectionTool(event_bus)
+
+    @mcp.tool()
+    async def get_recent_events(limit: int = 10, event_type: str | None = None) -> str:
+        """
+        Get recent events from the agent's execution history.
+        Useful for understanding what happened previously, debugging errors,
+        or checking previous tool outputs.
+        """
+        import json
+
+        events = await tool.get_recent_events(limit, event_type)
+        return json.dumps(events, indent=2)
+
+    @mcp.tool()
+    async def get_execution_stats() -> str:
+        """
+        Get statistics about the current execution session (success/failure counts, etc).
+        """
+        import json
+
+        stats = await tool.get_execution_stats()
+        return json.dumps(stats, indent=2)

--- a/tools/tests/test_reflection_tool.py
+++ b/tools/tests/test_reflection_tool.py
@@ -1,0 +1,54 @@
+"""
+Tests for Reflection Tool.
+"""
+
+import pytest
+
+from aden_tools.tools.reflection_tool.reflection_tool import ReflectionTool
+from framework.runtime.event_bus import AgentEvent, EventBus, EventType
+
+
+@pytest.mark.asyncio
+async def test_get_recent_events():
+    """Should return list of events from EventBus."""
+    bus = EventBus()
+    tool = ReflectionTool(bus)
+
+    # Populate bus
+    await bus.publish(AgentEvent(EventType.EXECUTION_STARTED, "s1", "e1"))
+    await bus.publish(AgentEvent(EventType.EXECUTION_COMPLETED, "s1", "e1", data={"res": 1}))
+
+    events = await tool.get_recent_events(limit=5)
+
+    assert len(events) == 2
+    assert events[0]["type"] == EventType.EXECUTION_COMPLETED.value
+    assert events[1]["type"] == EventType.EXECUTION_STARTED.value
+
+
+@pytest.mark.asyncio
+async def test_get_recent_events_filtered():
+    """Should filter events by type."""
+    bus = EventBus()
+    tool = ReflectionTool(bus)
+
+    await bus.publish(AgentEvent(EventType.EXECUTION_STARTED, "s1", "e1"))
+    await bus.publish(AgentEvent(EventType.EXECUTION_COMPLETED, "s1", "e1"))
+
+    events = await tool.get_recent_events(limit=5, event_type="execution_started")
+
+    assert len(events) == 1
+    assert events[0]["type"] == EventType.EXECUTION_STARTED.value
+
+
+@pytest.mark.asyncio
+async def test_get_execution_stats():
+    """Should return stats from EventBus."""
+    bus = EventBus()
+    tool = ReflectionTool(bus)
+
+    await bus.publish(AgentEvent(EventType.EXECUTION_STARTED, "s1"))
+
+    stats = await tool.get_execution_stats()
+
+    assert stats["total_events"] == 1
+    assert "execution_started" in stats["events_by_type"]


### PR DESCRIPTION
## Description
Adds a Self-Reflection Tool to allow agents to inspect their own execution history.

### Changes
- Adds `ReflectionTool` in `tools/src/aden_tools/tools/reflection_tool/`.
- Adds tests in `tools/tests/test_reflection_tool.py`.

### Verification
Run `pytest tools/tests/test_reflection_tool.py`.

Fixes #1556
