### PR TITLE
feat(tools): add markdown formatting tool

### DIFF
--- a/core/framework/mcp/agent_builder_server.py
+++ b/core/framework/mcp/agent_builder_server.py
@@ -524,11 +524,13 @@ def add_node(
         tools_list = json.loads(tools)
         routes_dict = json.loads(routes)
     except json.JSONDecodeError as e:
-        return json.dumps({
-            "valid": False,
-            "errors": [f"Invalid JSON input: {e}"],
-            "warnings": [],
-        })
+        return json.dumps(
+            {
+                "valid": False,
+                "errors": [f"Invalid JSON input: {e}"],
+                "warnings": [],
+            }
+        )
 
     # Validate credentials for tools BEFORE adding the node
     cred_error = _validate_tool_credentials(tools_list)
@@ -717,11 +719,13 @@ def update_node(
         tools_list = json.loads(tools) if tools else None
         routes_dict = json.loads(routes) if routes else None
     except json.JSONDecodeError as e:
-        return json.dumps({
-            "valid": False,
-            "errors": [f"Invalid JSON input: {e}"],
-            "warnings": [],
-        })
+        return json.dumps(
+            {
+                "valid": False,
+                "errors": [f"Invalid JSON input: {e}"],
+                "warnings": [],
+            }
+        )
 
     # Validate credentials for new tools BEFORE updating
     if tools_list:

--- a/tools/README.md
+++ b/tools/README.md
@@ -75,6 +75,10 @@ python mcp_server.py
 | `web_search`           | Search the web (Google or Brave, auto-detected) |
 | `web_scrape`           | Scrape and extract content from webpages       |
 | `pdf_read`             | Read and extract text from PDF files           |
+| `markdown_to_html`     | Convert markdown to HTML                       |
+| `html_to_markdown`     | Convert HTML to markdown                       |
+| `format_text`          | Apply markdown formatting to text              |
+| `create_markdown_table`| Create markdown tables from data               |
 
 ## Project Structure
 

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -45,11 +45,17 @@ ocr = [
 sql = [
     "duckdb>=1.0.0",
 ]
+markdown = [
+    "markdown>=3.0.0",
+    "html2text>=2020.0.0",
+]
 all = [
     "RestrictedPython>=7.0",
     "pytesseract>=0.3.10",
     "pillow>=10.0.0",
     "duckdb>=1.0.0",
+    "markdown>=3.0.0",
+    "html2text>=2020.0.0",
 ]
 
 [build-system]

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -35,6 +35,7 @@ from .file_system_toolkits.replace_file_content import (
 # Import file system toolkits
 from .file_system_toolkits.view_file import register_tools as register_view_file
 from .file_system_toolkits.write_to_file import register_tools as register_write_to_file
+from .markdown_tool import register_tools as register_markdown
 from .pdf_read_tool import register_tools as register_pdf_read
 from .web_scrape_tool import register_tools as register_web_scrape
 from .web_search_tool import register_tools as register_web_search
@@ -59,6 +60,7 @@ def register_all_tools(
     register_example(mcp)
     register_web_scrape(mcp)
     register_pdf_read(mcp)
+    register_markdown(mcp)
 
     # Tools that need credentials (pass credentials if provided)
     # web_search supports multiple providers (Google, Brave) with auto-detection
@@ -80,6 +82,10 @@ def register_all_tools(
         "web_search",
         "web_scrape",
         "pdf_read",
+        "markdown_to_html",
+        "html_to_markdown",
+        "format_text",
+        "create_markdown_table",
         "view_file",
         "write_to_file",
         "list_dir",

--- a/tools/src/aden_tools/tools/markdown_tool/README.md
+++ b/tools/src/aden_tools/tools/markdown_tool/README.md
@@ -1,0 +1,244 @@
+# Markdown Tool
+
+Format text and convert between markdown and HTML for content-generating agents.
+
+## Description
+
+The `markdown_tool` provides text formatting and conversion capabilities, enabling agents to create formatted content, generate reports, and convert between markdown and HTML formats. Essential for Blog Writer Agents, Knowledge Agents, and Report Agents.
+
+## Tools
+
+### `markdown_to_html`
+
+Convert markdown text to HTML for emails, web pages, or rich text display.
+
+**Arguments:**
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `content` | str | Yes | - | Markdown text to convert (1-100,000 chars) |
+| `extensions` | list[str] | No | `["tables", "fenced_code", "nl2br"]` | Markdown extensions to enable |
+
+**Returns:**
+```python
+{
+    "success": True,
+    "html": "<h1>Title</h1><p>Content...</p>",
+    "input_length": 50,
+    "output_length": 120
+}
+```
+
+**Example:**
+```python
+markdown_to_html(
+    content="# Report\n\n**Key findings:**\n- Sales up 20%\n- New customers: 150"
+)
+```
+
+### `html_to_markdown`
+
+Convert HTML to markdown text for processing or storage.
+
+**Arguments:**
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `html` | str | Yes | - | HTML text to convert (1-100,000 chars) |
+| `strip_tags` | bool | No | `False` | Remove tags without markdown equivalents |
+
+**Returns:**
+```python
+{
+    "success": True,
+    "markdown": "# Title\n\nContent...",
+    "input_length": 120,
+    "output_length": 50
+}
+```
+
+**Example:**
+```python
+html_to_markdown(
+    html="<h1>Title</h1><p>Content with <strong>bold</strong> text</p>"
+)
+```
+
+### `format_text`
+
+Apply markdown formatting to text.
+
+**Arguments:**
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `text` | str | Yes | - | Text to format (1-10,000 chars) |
+| `style` | str | Yes | - | Formatting style (see below) |
+
+**Supported Styles:**
+- `bold` - **Bold text**
+- `italic` - *Italic text*
+- `code` - `Inline code`
+- `heading1` - # Heading 1
+- `heading2` - ## Heading 2
+- `heading3` - ### Heading 3
+- `blockquote` - > Quote
+- `strikethrough` - ~~Strikethrough~~
+
+**Returns:**
+```python
+{
+    "success": True,
+    "formatted": "**Important message**",
+    "style": "bold"
+}
+```
+
+**Example:**
+```python
+format_text(
+    text="Important message",
+    style="bold"
+)
+```
+
+### `create_markdown_table`
+
+Create a markdown table from headers and rows.
+
+**Arguments:**
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `headers` | list[str] | Yes | - | Column headers |
+| `rows` | list[list[str]] | Yes | - | Table rows (each row is a list of cells) |
+| `alignment` | list[str] | No | `["left", ...]` | Column alignments ("left", "center", "right") |
+
+**Returns:**
+```python
+{
+    "success": True,
+    "table": "| Name | Age |\n| --- | --- |\n| Alice | 30 |",
+    "num_rows": 1,
+    "num_cols": 2
+}
+```
+
+**Example:**
+```python
+create_markdown_table(
+    headers=["Name", "Age", "City"],
+    rows=[
+        ["Alice", "30", "NYC"],
+        ["Bob", "25", "LA"]
+    ],
+    alignment=["left", "center", "left"]
+)
+```
+
+## Environment Variables
+
+This tool does not require any environment variables.
+
+## Dependencies
+
+The tool requires the following Python packages:
+- `markdown>=3.0.0` - For markdown to HTML conversion
+- `html2text>=2020.0.0` - For HTML to markdown conversion
+
+Install with:
+```bash
+pip install markdown html2text
+# Or install with optional dependencies
+pip install tools[markdown]
+```
+
+## Use Cases
+
+### Blog Writer Agent
+```python
+# Format blog post content
+content = """
+# My Blog Post
+
+This is an introduction with **bold** text.
+
+## Key Points
+- Point 1
+- Point 2
+
+Visit [my website](https://example.com) for more.
+"""
+
+result = markdown_to_html(content=content)
+# Use result["html"] for publishing
+```
+
+### Report Generation Agent
+```python
+# Create formatted report with table
+headers = ["Metric", "Q1", "Q2", "Q3"]
+rows = [
+    ["Revenue", "$100K", "$120K", "$150K"],
+    ["Customers", "500", "650", "800"]
+]
+
+table = create_markdown_table(headers=headers, rows=rows, alignment=["left", "right", "right", "right"])
+
+report = f"""
+# Quarterly Report
+
+{table["table"]}
+
+## Summary
+Revenue increased by **50%** over the quarter.
+"""
+
+html_report = markdown_to_html(content=report)
+```
+
+### Documentation Agent
+```python
+# Generate README with formatted sections
+title = format_text(text="Project Name", style="heading1")
+subtitle = format_text(text="Installation", style="heading2")
+code = format_text(text="pip install package", style="code")
+
+readme = f"{title['formatted']}\n\n{subtitle['formatted']}\n\nInstall with: {code['formatted']}"
+```
+
+### Email Agent
+```python
+# Convert markdown email to HTML
+email_content = """
+Hi **John**,
+
+Your order has been shipped!
+
+- Order #: 12345
+- Tracking: ABC123
+
+Thanks for your purchase!
+"""
+
+html_email = markdown_to_html(content=email_content)
+# Send html_email["html"] via email service
+```
+
+## Error Handling
+
+All tools return error dicts for validation issues:
+
+- Empty content: `{"error": "content cannot be empty"}`
+- Content too long: `{"error": "content must be 100,000 characters or less"}`
+- Invalid style: `{"error": "Invalid style: xyz. Valid styles: ..."}`
+- Missing dependency: `{"error": "markdown library not installed. Install with: ..."}`
+- Table mismatch: `{"error": "Row 0 has 3 columns, but headers have 2 columns"}`
+
+## Notes
+
+- Default markdown extensions: `tables`, `fenced_code`, `nl2br`
+- HTML conversion preserves links, images, and emphasis
+- Table alignment defaults to left if not specified
+- All tools validate input length to prevent memory issues
+- Markdown syntax is GitHub-flavored markdown compatible

--- a/tools/src/aden_tools/tools/markdown_tool/__init__.py
+++ b/tools/src/aden_tools/tools/markdown_tool/__init__.py
@@ -1,0 +1,3 @@
+from .markdown_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/markdown_tool/markdown_tool.py
+++ b/tools/src/aden_tools/tools/markdown_tool/markdown_tool.py
@@ -219,8 +219,7 @@ def register_tools(mcp: FastMCP) -> None:
                 if len(row) != num_cols:
                     return {
                         "error": (
-                            f"Row {i} has {len(row)} columns, "
-                            f"but headers have {num_cols} columns"
+                            f"Row {i} has {len(row)} columns, but headers have {num_cols} columns"
                         )
                     }
 
@@ -230,8 +229,7 @@ def register_tools(mcp: FastMCP) -> None:
             elif len(alignment) != num_cols:
                 return {
                     "error": (
-                        f"alignment has {len(alignment)} items, "
-                        f"but headers have {num_cols} columns"
+                        f"alignment has {len(alignment)} items, but headers have {num_cols} columns"
                     )
                 }
 

--- a/tools/src/aden_tools/tools/markdown_tool/markdown_tool.py
+++ b/tools/src/aden_tools/tools/markdown_tool/markdown_tool.py
@@ -1,0 +1,273 @@
+"""
+Markdown Tool - Format text and convert between markdown and HTML.
+
+Provides text formatting and conversion capabilities for content-generating agents.
+"""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register markdown formatting tools with the MCP server."""
+
+    @mcp.tool()
+    def markdown_to_html(
+        content: str,
+        extensions: list[str] | None = None,
+    ) -> dict:
+        """
+        Convert markdown text to HTML.
+
+        Use this when you need to convert markdown content to HTML for emails,
+        web pages, or rich text display.
+
+        Args:
+            content: Markdown text to convert (1-100,000 chars)
+            extensions: Optional list of markdown extensions to enable
+                       (e.g., ["tables", "fenced_code", "codehilite"])
+
+        Returns:
+            Dict with HTML output or error message
+        """
+        try:
+            import markdown
+        except ImportError:
+            return {
+                "error": (
+                    "markdown library not installed. Install with: "
+                    "pip install markdown  or  pip install tools[markdown]"
+                )
+            }
+
+        try:
+            # Validate input
+            if not content or not content.strip():
+                return {"error": "content cannot be empty"}
+            if len(content) > 100_000:
+                return {"error": "content must be 100,000 characters or less"}
+
+            # Convert markdown to HTML
+            if extensions:
+                md = markdown.Markdown(extensions=extensions)
+            else:
+                # Default extensions for common use cases
+                md = markdown.Markdown(extensions=["tables", "fenced_code", "nl2br"])
+
+            html = md.convert(content)
+
+            return {
+                "success": True,
+                "html": html,
+                "input_length": len(content),
+                "output_length": len(html),
+            }
+
+        except Exception as e:
+            return {"error": f"Conversion failed: {str(e)}"}
+
+    @mcp.tool()
+    def html_to_markdown(
+        html: str,
+        strip_tags: bool = False,
+    ) -> dict:
+        """
+        Convert HTML to markdown text.
+
+        Use this when you need to convert HTML content to markdown for
+        processing or storage.
+
+        Args:
+            html: HTML text to convert (1-100,000 chars)
+            strip_tags: If True, remove tags that don't have markdown equivalents
+
+        Returns:
+            Dict with markdown output or error message
+        """
+        try:
+            import html2text
+        except ImportError:
+            return {
+                "error": (
+                    "html2text library not installed. Install with: "
+                    "pip install html2text  or  pip install tools[markdown]"
+                )
+            }
+
+        try:
+            # Validate input
+            if not html or not html.strip():
+                return {"error": "html cannot be empty"}
+            if len(html) > 100_000:
+                return {"error": "html must be 100,000 characters or less"}
+
+            # Convert HTML to markdown
+            h = html2text.HTML2Text()
+            h.ignore_links = False
+            h.ignore_images = False
+            h.ignore_emphasis = False
+            h.body_width = 0  # Don't wrap lines
+            h.skip_internal_links = strip_tags
+
+            markdown_text = h.handle(html)
+
+            return {
+                "success": True,
+                "markdown": markdown_text,
+                "input_length": len(html),
+                "output_length": len(markdown_text),
+            }
+
+        except Exception as e:
+            return {"error": f"Conversion failed: {str(e)}"}
+
+    @mcp.tool()
+    def format_text(
+        text: str,
+        style: str,
+    ) -> dict:
+        """
+        Apply markdown formatting to text.
+
+        Use this when you need to format text with markdown syntax.
+
+        Args:
+            text: Text to format (1-10,000 chars)
+            style: Formatting style - "bold", "italic", "code", "heading1",
+                   "heading2", "heading3", "blockquote", "strikethrough"
+
+        Returns:
+            Dict with formatted text or error message
+        """
+        try:
+            # Validate input
+            if not text or not text.strip():
+                return {"error": "text cannot be empty"}
+            if len(text) > 10_000:
+                return {"error": "text must be 10,000 characters or less"}
+
+            # Apply formatting
+            style = style.lower().strip()
+            formatted = text
+
+            if style == "bold":
+                formatted = f"**{text}**"
+            elif style == "italic":
+                formatted = f"*{text}*"
+            elif style == "code":
+                formatted = f"`{text}`"
+            elif style == "heading1":
+                formatted = f"# {text}"
+            elif style == "heading2":
+                formatted = f"## {text}"
+            elif style == "heading3":
+                formatted = f"### {text}"
+            elif style == "blockquote":
+                formatted = f"> {text}"
+            elif style == "strikethrough":
+                formatted = f"~~{text}~~"
+            else:
+                return {
+                    "error": (
+                        f"Invalid style: {style}. "
+                        "Valid styles: bold, italic, code, heading1, heading2, "
+                        "heading3, blockquote, strikethrough"
+                    )
+                }
+
+            return {
+                "success": True,
+                "formatted": formatted,
+                "style": style,
+            }
+
+        except Exception as e:
+            return {"error": f"Formatting failed: {str(e)}"}
+
+    @mcp.tool()
+    def create_markdown_table(
+        headers: list[str],
+        rows: list[list[str]],
+        alignment: list[str] | None = None,
+    ) -> dict:
+        """
+        Create a markdown table from headers and rows.
+
+        Use this when you need to format data as a markdown table.
+
+        Args:
+            headers: List of column headers
+            rows: List of rows, where each row is a list of cell values
+            alignment: Optional list of alignments for each column
+                      ("left", "center", "right"). Defaults to left.
+
+        Returns:
+            Dict with markdown table or error message
+        """
+        try:
+            # Validate input
+            if not headers:
+                return {"error": "headers cannot be empty"}
+            if not rows:
+                return {"error": "rows cannot be empty"}
+
+            num_cols = len(headers)
+
+            # Validate all rows have same number of columns
+            for i, row in enumerate(rows):
+                if len(row) != num_cols:
+                    return {
+                        "error": (
+                            f"Row {i} has {len(row)} columns, "
+                            f"but headers have {num_cols} columns"
+                        )
+                    }
+
+            # Set default alignment
+            if alignment is None:
+                alignment = ["left"] * num_cols
+            elif len(alignment) != num_cols:
+                return {
+                    "error": (
+                        f"alignment has {len(alignment)} items, "
+                        f"but headers have {num_cols} columns"
+                    )
+                }
+
+            # Build table
+            lines = []
+
+            # Header row
+            header_row = "| " + " | ".join(headers) + " |"
+            lines.append(header_row)
+
+            # Separator row with alignment
+            separators = []
+            for align in alignment:
+                align = align.lower().strip()
+                if align == "center":
+                    separators.append(":---:")
+                elif align == "right":
+                    separators.append("---:")
+                else:  # left or default
+                    separators.append("---")
+            separator_row = "| " + " | ".join(separators) + " |"
+            lines.append(separator_row)
+
+            # Data rows
+            for row in rows:
+                data_row = "| " + " | ".join(str(cell) for cell in row) + " |"
+                lines.append(data_row)
+
+            table = "\n".join(lines)
+
+            return {
+                "success": True,
+                "table": table,
+                "num_rows": len(rows),
+                "num_cols": num_cols,
+            }
+
+        except Exception as e:
+            return {"error": f"Table creation failed: {str(e)}"}

--- a/tools/tests/tools/test_markdown_tool.py
+++ b/tools/tests/tools/test_markdown_tool.py
@@ -1,0 +1,315 @@
+"""Tests for markdown_tool - Text formatting and markdown/HTML conversion."""
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.markdown_tool.markdown_tool import register_tools
+
+
+@pytest.fixture
+def markdown_tools(mcp: FastMCP):
+    """Register and return markdown tool functions."""
+    register_tools(mcp)
+    return {
+        "markdown_to_html": mcp._tool_manager._tools["markdown_to_html"].fn,
+        "html_to_markdown": mcp._tool_manager._tools["html_to_markdown"].fn,
+        "format_text": mcp._tool_manager._tools["format_text"].fn,
+        "create_markdown_table": mcp._tool_manager._tools["create_markdown_table"].fn,
+    }
+
+
+class TestMarkdownToHtml:
+    """Tests for markdown_to_html function."""
+
+    def test_basic_conversion(self, markdown_tools):
+        """Convert simple markdown to HTML."""
+        result = markdown_tools["markdown_to_html"](content="# Hello\n\nWorld")
+
+        assert result["success"] is True
+        assert "<h1>Hello</h1>" in result["html"]
+        assert "<p>World</p>" in result["html"]
+
+    def test_bold_and_italic(self, markdown_tools):
+        """Convert markdown with bold and italic."""
+        result = markdown_tools["markdown_to_html"](content="**bold** and *italic*")
+
+        assert result["success"] is True
+        assert "<strong>bold</strong>" in result["html"]
+        assert "<em>italic</em>" in result["html"]
+
+    def test_lists(self, markdown_tools):
+        """Convert markdown lists."""
+        result = markdown_tools["markdown_to_html"](content="- Item 1\n- Item 2")
+
+        assert result["success"] is True
+        assert "<ul>" in result["html"]
+        assert "<li>Item 1</li>" in result["html"]
+
+    def test_empty_content_error(self, markdown_tools):
+        """Empty content returns error."""
+        result = markdown_tools["markdown_to_html"](content="")
+
+        assert "error" in result
+        assert "cannot be empty" in result["error"]
+
+    def test_whitespace_only_error(self, markdown_tools):
+        """Whitespace-only content returns error."""
+        result = markdown_tools["markdown_to_html"](content="   \n\n   ")
+
+        assert "error" in result
+        assert "cannot be empty" in result["error"]
+
+    def test_content_too_long_error(self, markdown_tools):
+        """Content over 100,000 chars returns error."""
+        long_content = "a" * 100_001
+        result = markdown_tools["markdown_to_html"](content=long_content)
+
+        assert "error" in result
+        assert "100,000 characters" in result["error"]
+
+    def test_max_length_valid(self, markdown_tools):
+        """Content exactly 100,000 chars is valid."""
+        max_content = "a" * 100_000
+        result = markdown_tools["markdown_to_html"](content=max_content)
+
+        assert result["success"] is True
+
+    def test_returns_lengths(self, markdown_tools):
+        """Returns input and output lengths."""
+        result = markdown_tools["markdown_to_html"](content="# Test")
+
+        assert "input_length" in result
+        assert "output_length" in result
+        assert result["input_length"] == 6
+
+
+class TestHtmlToMarkdown:
+    """Tests for html_to_markdown function."""
+
+    def test_basic_conversion(self, markdown_tools):
+        """Convert simple HTML to markdown."""
+        result = markdown_tools["html_to_markdown"](html="<h1>Hello</h1><p>World</p>")
+
+        assert result["success"] is True
+        assert "# Hello" in result["markdown"]
+        assert "World" in result["markdown"]
+
+    def test_bold_and_italic(self, markdown_tools):
+        """Convert HTML with bold and italic."""
+        result = markdown_tools["html_to_markdown"](
+            html="<strong>bold</strong> and <em>italic</em>"
+        )
+
+        assert result["success"] is True
+        assert "**bold**" in result["markdown"]
+        assert "*italic*" in result["markdown"] or "_italic_" in result["markdown"]
+
+    def test_links(self, markdown_tools):
+        """Convert HTML links."""
+        result = markdown_tools["html_to_markdown"](html='<a href="https://example.com">link</a>')
+
+        assert result["success"] is True
+        assert "[link]" in result["markdown"]
+        assert "https://example.com" in result["markdown"]
+
+    def test_empty_html_error(self, markdown_tools):
+        """Empty HTML returns error."""
+        result = markdown_tools["html_to_markdown"](html="")
+
+        assert "error" in result
+        assert "cannot be empty" in result["error"]
+
+    def test_html_too_long_error(self, markdown_tools):
+        """HTML over 100,000 chars returns error."""
+        long_html = "<p>" + ("a" * 100_000) + "</p>"
+        result = markdown_tools["html_to_markdown"](html=long_html)
+
+        assert "error" in result
+        assert "100,000 characters" in result["error"]
+
+
+class TestFormatText:
+    """Tests for format_text function."""
+
+    def test_bold_formatting(self, markdown_tools):
+        """Apply bold formatting."""
+        result = markdown_tools["format_text"](text="Hello", style="bold")
+
+        assert result["success"] is True
+        assert result["formatted"] == "**Hello**"
+        assert result["style"] == "bold"
+
+    def test_italic_formatting(self, markdown_tools):
+        """Apply italic formatting."""
+        result = markdown_tools["format_text"](text="Hello", style="italic")
+
+        assert result["success"] is True
+        assert result["formatted"] == "*Hello*"
+
+    def test_code_formatting(self, markdown_tools):
+        """Apply code formatting."""
+        result = markdown_tools["format_text"](text="print('hi')", style="code")
+
+        assert result["success"] is True
+        assert result["formatted"] == "`print('hi')`"
+
+    def test_heading1_formatting(self, markdown_tools):
+        """Apply heading1 formatting."""
+        result = markdown_tools["format_text"](text="Title", style="heading1")
+
+        assert result["success"] is True
+        assert result["formatted"] == "# Title"
+
+    def test_heading2_formatting(self, markdown_tools):
+        """Apply heading2 formatting."""
+        result = markdown_tools["format_text"](text="Subtitle", style="heading2")
+
+        assert result["success"] is True
+        assert result["formatted"] == "## Subtitle"
+
+    def test_heading3_formatting(self, markdown_tools):
+        """Apply heading3 formatting."""
+        result = markdown_tools["format_text"](text="Section", style="heading3")
+
+        assert result["success"] is True
+        assert result["formatted"] == "### Section"
+
+    def test_blockquote_formatting(self, markdown_tools):
+        """Apply blockquote formatting."""
+        result = markdown_tools["format_text"](text="Quote", style="blockquote")
+
+        assert result["success"] is True
+        assert result["formatted"] == "> Quote"
+
+    def test_strikethrough_formatting(self, markdown_tools):
+        """Apply strikethrough formatting."""
+        result = markdown_tools["format_text"](text="Old", style="strikethrough")
+
+        assert result["success"] is True
+        assert result["formatted"] == "~~Old~~"
+
+    def test_case_insensitive_style(self, markdown_tools):
+        """Style is case-insensitive."""
+        result = markdown_tools["format_text"](text="Test", style="BOLD")
+
+        assert result["success"] is True
+        assert result["formatted"] == "**Test**"
+
+    def test_invalid_style_error(self, markdown_tools):
+        """Invalid style returns error."""
+        result = markdown_tools["format_text"](text="Test", style="invalid")
+
+        assert "error" in result
+        assert "Invalid style" in result["error"]
+
+    def test_empty_text_error(self, markdown_tools):
+        """Empty text returns error."""
+        result = markdown_tools["format_text"](text="", style="bold")
+
+        assert "error" in result
+        assert "cannot be empty" in result["error"]
+
+    def test_text_too_long_error(self, markdown_tools):
+        """Text over 10,000 chars returns error."""
+        long_text = "a" * 10_001
+        result = markdown_tools["format_text"](text=long_text, style="bold")
+
+        assert "error" in result
+        assert "10,000 characters" in result["error"]
+
+
+class TestCreateMarkdownTable:
+    """Tests for create_markdown_table function."""
+
+    def test_basic_table(self, markdown_tools):
+        """Create basic markdown table."""
+        result = markdown_tools["create_markdown_table"](
+            headers=["Name", "Age"], rows=[["Alice", "30"], ["Bob", "25"]]
+        )
+
+        assert result["success"] is True
+        assert "| Name | Age |" in result["table"]
+        assert "| --- | --- |" in result["table"]
+        assert "| Alice | 30 |" in result["table"]
+        assert "| Bob | 25 |" in result["table"]
+        assert result["num_rows"] == 2
+        assert result["num_cols"] == 2
+
+    def test_table_with_left_alignment(self, markdown_tools):
+        """Create table with left alignment."""
+        result = markdown_tools["create_markdown_table"](
+            headers=["A", "B"], rows=[["1", "2"]], alignment=["left", "left"]
+        )
+
+        assert result["success"] is True
+        assert "| --- | --- |" in result["table"]
+
+    def test_table_with_center_alignment(self, markdown_tools):
+        """Create table with center alignment."""
+        result = markdown_tools["create_markdown_table"](
+            headers=["A", "B"], rows=[["1", "2"]], alignment=["center", "center"]
+        )
+
+        assert result["success"] is True
+        assert "| :---: | :---: |" in result["table"]
+
+    def test_table_with_right_alignment(self, markdown_tools):
+        """Create table with right alignment."""
+        result = markdown_tools["create_markdown_table"](
+            headers=["A", "B"], rows=[["1", "2"]], alignment=["right", "right"]
+        )
+
+        assert result["success"] is True
+        assert "| ---: | ---: |" in result["table"]
+
+    def test_table_with_mixed_alignment(self, markdown_tools):
+        """Create table with mixed alignment."""
+        result = markdown_tools["create_markdown_table"](
+            headers=["Name", "Score", "Status"],
+            rows=[["Alice", "95", "Pass"]],
+            alignment=["left", "right", "center"],
+        )
+
+        assert result["success"] is True
+        assert "| --- | ---: | :---: |" in result["table"]
+
+    def test_empty_headers_error(self, markdown_tools):
+        """Empty headers returns error."""
+        result = markdown_tools["create_markdown_table"](headers=[], rows=[["1"]])
+
+        assert "error" in result
+        assert "headers cannot be empty" in result["error"]
+
+    def test_empty_rows_error(self, markdown_tools):
+        """Empty rows returns error."""
+        result = markdown_tools["create_markdown_table"](headers=["A"], rows=[])
+
+        assert "error" in result
+        assert "rows cannot be empty" in result["error"]
+
+    def test_mismatched_columns_error(self, markdown_tools):
+        """Mismatched column count returns error."""
+        result = markdown_tools["create_markdown_table"](headers=["A", "B"], rows=[["1", "2", "3"]])
+
+        assert "error" in result
+        assert "has 3 columns" in result["error"]
+        assert "headers have 2 columns" in result["error"]
+
+    def test_mismatched_alignment_error(self, markdown_tools):
+        """Mismatched alignment count returns error."""
+        result = markdown_tools["create_markdown_table"](
+            headers=["A", "B"], rows=[["1", "2"]], alignment=["left"]
+        )
+
+        assert "error" in result
+        assert "alignment has 1 items" in result["error"]
+        assert "headers have 2 columns" in result["error"]
+
+    def test_default_alignment(self, markdown_tools):
+        """Default alignment is left."""
+        result = markdown_tools["create_markdown_table"](
+            headers=["A"], rows=[["1"]], alignment=None
+        )
+
+        assert result["success"] is True
+        assert "| --- |" in result["table"]


### PR DESCRIPTION
## Description

Adds `markdown_tool` for text formatting and markdown/HTML conversion, enabling content-generating agents (Blog Writer Agent, Knowledge Agent, Report Agents) to create formatted output.

## Changes

- **New tool**: `markdown_tool` with 4 functions:
  - `markdown_to_html` - Convert markdown to HTML
  - `html_to_markdown` - Convert HTML to markdown  
  - `format_text` - Apply markdown formatting (bold, italic, headings, etc.)
  - `create_markdown_table` - Generate tables from data
- **Dependencies**: Added `markdown>=3.0.0` and `html2text>=2020.0.0` as optional dependencies
- **Tests**: 35 comprehensive tests, all passing
- **Documentation**: Complete README with examples and use cases

## Related Issue

Closes #1545 

## Testing

- [x] All 35 tests passing
- [x] Ruff linting passed
- [x] Ruff formatting passed
- [x] No breaking changes

## Impact

- Enables Blog Writer Agent (ROADMAP) to format content
- Enables Knowledge Agent (ROADMAP) to generate documentation
- Supports report generation use cases
- No impact on existing tools