### PR TITLE
Improve EventBus handler error logging to include traceback

### DIFF
--- a/core/framework/runtime/event_bus.py
+++ b/core/framework/runtime/event_bus.py
@@ -235,8 +235,8 @@ class EventBus:
             async with self._semaphore:
                 try:
                     await handler(event)
-                except Exception as e:
-                    logger.error(f"Handler error for {event.type}: {e}")
+                except Exception:
+                    logger.exception(f"Handler error for {event.type}")
 
         # Run all handlers concurrently
         await asyncio.gather(*[run_handler(h) for h in handlers], return_exceptions=True)


### PR DESCRIPTION
Fixes #1475

Summary
Currently, EventBus logs handler errors using logger.error, which logs only the exception message.

This change updates the logging to use logger.exception, which includes the full traceback, improving debuggability of async handler failures.

Notes
No functional changes
No API changes
All core tests pass locally (282/282)

