### PR TITLE
micro-fix: validate required keys in MCP server config

### DIFF
--- a/core/framework/runner/tool_registry.py
+++ b/core/framework/runner/tool_registry.py
@@ -113,6 +113,7 @@ class ToolRegistry:
         self.register(tool_name, tool, executor)
 
     def discover_from_module(self, module_path: Path) -> int:
+	
         """
         Load tools from a Python module file.
 
@@ -241,6 +242,12 @@ class ToolRegistry:
         self,
         server_config: dict[str, Any],
     ) -> int:
+        required_keys = {"name", "transport"}
+        missing = required_keys - server_config.key()
+        if missing:
+            missing_keys = ", ".join(sorted(missing))
+            raise ValueError(f"server_config is missing required key(s): {missing_keys}")
+
         """
         Register an MCP server and discover its tools.
 


### PR DESCRIPTION
Fixes #1379

## Description

Adds explicit validation for required MCP server configuration keys
(name, transport) to fail fast with clear error messages.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
