### PR TITLE
[micro-fix] Correct WorkflowBuilder import to GraphBuilder in MCP example

### DIFF
--- a/core/examples/mcp_integration_example.py
+++ b/core/examples/mcp_integration_example.py
@@ -99,10 +99,10 @@ async def example_4_custom_agent_with_mcp_tools():
     """Example 4: Build custom agent that uses MCP tools"""
     print("\n=== Example 4: Custom Agent with MCP Tools ===\n")
 
-    from framework.builder.workflow import WorkflowBuilder
+    from framework.builder.workflow import GraphBuilder
 
     # Create a workflow builder
-    builder = WorkflowBuilder()
+    builder = GraphBuilder()
 
     # Define goal
     builder.set_goal(


### PR DESCRIPTION
Fixes #1600

## Summary
Fixes ImportError in MCP integration example by correcting class name from `WorkflowBuilder` to `GraphBuilder`.

## Problem
`mcp_integration_example.py` references `WorkflowBuilder` which doesn't exist in the codebase, causing:
```python
ImportError: cannot import name 'WorkflowBuilder' from 'framework.builder.workflow'
```

Verified by searching entire codebase - no `WorkflowBuilder` class exists, only `GraphBuilder`.

## Solution
Changed two lines in `core/examples/mcp_integration_example.py`:
- Line 102: Import changed from `WorkflowBuilder` to `GraphBuilder`
- Line 105: Instantiation changed from `WorkflowBuilder()` to `GraphBuilder()`

## Testing
Verified the correct class exists:
```bash
$ python -c "from framework.builder.workflow import GraphBuilder; print('OK')"
OK
```

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation example correction

## Additional Context
Discovered while manually exploring Hive's API without Claude Code. Built custom agents and tried to follow the MCP integration example, which led to finding this import error.