### PR TITLE
micro-fix: Improve Windows setup instructions

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -10,8 +10,9 @@ Complete setup guide for building and running goal-driven agents with the Aden A
 ```
 
 > **Note for Windows Users:**  
-> Running the setup script on native Windows shells (PowerShell / Git Bash) may sometimes fail due to Python App Execution Aliases.  
-> It is **strongly recommended to use WSL (Windows Subsystem for Linux)** for a smoother setup experience.
+> Use **Git Bash** instead of Command Prompt or PowerShell when running the setup script.  
+> WSL may cause networking or proxy issues in some environments.
+
 
 This will:
 


### PR DESCRIPTION
Updated Windows setup guidance to recommend Git Bash instead of WSL and clarified the setup process for Windows users.

