### PR TITLE
docs: add mock mode usage example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ claude> /testing-agent
 
 # Run your agent
 PYTHONPATH=core:exports python -m your_agent_name run --input '{...}'
+
+## Run your agent in Mock Mode (No API Key required)
+PYTHONPATH=core:exports python -m your_agent_name run --input '{...}' --mock
 ```
 
 **[📖 Complete Setup Guide](ENVIRONMENT_SETUP.md)** - Detailed instructions for agent development


### PR DESCRIPTION
## Description

This PR adds explicit examples for running agents in "Mock Mode" to the Quick Start section of the ```README.md```

Currently, the documentation only shows the standard execution command, which requires an API key. New users or contributors often want to test the framework without incurring costs or setting up providers immediately. Documenting the ```--mock``` flag lowers the barrier to entry and helps users verify their installation quickly.

## Type of Change

- Documentation update

## Related Issues

Fixes #1243 

## Changes Made

- Updated the Build Your First Agent section in ```README.md.```

- Added a command example for running an agent with the ```--mock``` flag.

## Testing

- Manual testing performed

## Verification
- Verified that the new text renders correctly in the Markdown preview.

- Confirmed that the command ```PYTHONPATH=core:exports python -m online_research_agent run --input '{...}' --mock``` is valid and supported by the codebase (verified in previous testing).

## Checklist

- My code follows the project's style guidelines
- I have performed a self-review of my code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
