### PR TITLE
test(credentials): decouple tests from default anthropic spec

### DIFF
--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -32,9 +32,11 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0.0",
-    "pytest-asyncio>=0.21.0",
+  "pytest>=7.0.0",
+  "pytest-asyncio>=0.21.0",
+  "ruff>=0.6.0",
 ]
+
 sandbox = [
     "RestrictedPython>=7.0",
 ]
@@ -51,6 +53,9 @@ all = [
     "pillow>=10.0.0",
     "duckdb>=1.0.0",
 ]
+[project.scripts]
+
+aden-tools-credentials = "aden_tools.credentials.cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/src/aden_tools/credentials/__main__.py
+++ b/tools/src/aden_tools/credentials/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/src/aden_tools/credentials/cli.py
+++ b/tools/src/aden_tools/credentials/cli.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+
+from .base import CredentialError, CredentialManager
+
+
+def _split_csv(value: str) -> list[str]:
+    return [x.strip() for x in value.split(",") if x.strip()]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="aden-tools-credentials",
+        description="Check and validate Aden Tools credentials.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    check = sub.add_parser("check", help="Check for missing credentials.")
+    check.add_argument(
+        "--node-types",
+        default="",
+        help="Comma-separated node types (e.g. llm_generate,llm_tool_use).",
+    )
+    check.add_argument(
+        "--startup",
+        action="store_true",
+        help="Validate startup-required credentials.",
+    )
+
+    args = parser.parse_args(argv)
+    creds = CredentialManager()
+
+    if args.cmd != "check":
+        return 2
+
+    if args.startup:
+        try:
+            creds.validate_startup()
+            print("✓ All startup-required credentials are present.")
+            return 0
+        except CredentialError as e:
+            print(str(e))
+            return 1
+
+    node_types = _split_csv(args.node_types)
+    if not node_types:
+        parser.error("Provide --startup or --node-types")
+
+    missing = creds.get_missing_for_node_types(node_types)
+
+    if not missing:
+        print("✓ All required credentials are present.")
+        return 0
+
+    print("✗ Missing required credentials:\n")
+    for _cred_name, spec in missing:
+        print(f"- {spec.env_var}: {spec.description}")
+        if spec.help_url:
+            print(f"  Help: {spec.help_url}")
+    return 1

--- a/tools/tests/tools/test_credentials_cli.py
+++ b/tools/tests/tools/test_credentials_cli.py
@@ -1,0 +1,61 @@
+import aden_tools.credentials.cli as cli
+from aden_tools.credentials.base import CredentialManager, CredentialSpec
+
+CUSTOM_SPECS = {
+    "anthropic": CredentialSpec(
+        env_var="ANTHROPIC_API_KEY",
+        tools=[],
+        node_types=["llm_generate", "llm_tool_use"],
+        required=True,
+        startup_required=True,
+        help_url="https://console.anthropic.com/settings/keys",
+        description="API key for Anthropic Claude models",
+    )
+}
+
+
+def test_cli_check_node_types_missing_key(monkeypatch, tmp_path, capsys):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    def _cm():
+        return CredentialManager(specs=CUSTOM_SPECS, dotenv_path=tmp_path / ".env")
+
+    monkeypatch.setattr(cli, "CredentialManager", _cm)
+
+    code = cli.main(["check", "--node-types", "llm_generate,llm_tool_use"])
+    out = capsys.readouterr().out
+
+    assert code == 1
+    assert "Missing required credentials" in out
+    assert "ANTHROPIC_API_KEY" in out
+
+
+def test_cli_check_startup_missing_key(monkeypatch, tmp_path, capsys):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    def _cm():
+        return CredentialManager(specs=CUSTOM_SPECS, dotenv_path=tmp_path / ".env")
+
+    monkeypatch.setattr(cli, "CredentialManager", _cm)
+
+    code = cli.main(["check", "--startup"])
+    out = capsys.readouterr().out
+
+    assert code == 1
+    assert "Server startup failed" in out
+    assert "ANTHROPIC_API_KEY" in out
+
+
+def test_cli_check_ok_when_key_present(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    def _cm():
+        return CredentialManager(specs=CUSTOM_SPECS, dotenv_path=tmp_path / ".env")
+
+    monkeypatch.setattr(cli, "CredentialManager", _cm)
+
+    code = cli.main(["check", "--node-types", "llm_generate,llm_tool_use"])
+    out = capsys.readouterr().out
+
+    assert code == 0
+    assert "All required credentials are present" in out


### PR DESCRIPTION
Description

Adds a small CLI entrypoint to check Aden Tools credential requirements by node types or startup requirements, and updates credential validation behavior/tests to match the new optional-by-default Anthropic spec.

Type of Change

 Bug fix (non-breaking change that fixes an issue)

 New feature (non-breaking change that adds functionality)
 Related Issues

Fixes #1592

Changes Made

Added aden-tools-credentials CLI (aden_tools.credentials.cli) to validate credentials via check --node-types and check --startup.

Registered CLI entrypoint in pyproject.toml under [project.scripts].

Updated credential validation/tests to use custom specs where required/startup_required behavior must be enforced (instead of relying on the default Anthropic spec which is optional by default).
Testing

Describe the tests you ran to verify your changes:

 Unit tests pass (cd tools && python -m pytest)

 Lint passes (cd tools && ruff check .)

 Manual testing performed

Checklist

 My code follows the project's style guidelines

 I have performed a self-review of my code

 I have commented my code, particularly in hard-to-understand areas

 My changes generate no new warnings

 I have added tests that prove my fix is effective or that my feature works

 New and existing unit tests pass locally with my changes