### PR TITLE
docs(readme): clarify Windows setup requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
  
 [![Apache 2.0 License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/adenhq/hive/blob/main/LICENSE)
-[![Y Combinator](https://img.shields.io/badge/Y%20Combinator-Aden-orange)](https://www.ycombinator.com/companies/aden)
+[![Y Combinator](https://img.shields.io/badge/Y%20Combinator-Aden-orange)](https://www.ycombinator.com/companies/aden)  
 [![Docker Pulls](https://img.shields.io/docker/pulls/adenhq/hive?logo=Docker&labelColor=%23528bff)](https://hub.docker.com/u/adenhq)
 [![Discord](https://img.shields.io/discord/1172610340073242735?logo=discord&labelColor=%235462eb&logoColor=%23f5f5f5&color=%235462eb)](https://discord.com/invite/MXE49hrKDk)
 [![Twitter Follow](https://img.shields.io/twitter/follow/teamaden?logo=X&color=%23f5f5f5)](https://x.com/aden_hq)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 
 ## Quick Start
 
+### Windows Users
+
+- Python 3.11 or higher is required.
+- Using WSL (Windows Subsystem for Linux) is recommended for best compatibility.
+- Alternatively, PowerShell or Git Bash can be used with Python 3.11+ installed.
+- Ensure "App Execution Aliases" for Python are disabled in Windows settings.
+
+
 ### Prerequisites
 
 - [Python 3.11+](https://www.python.org/downloads/) for agent development

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="README.ru.md">Русский</a> |
   <a href="README.ko.md">한국어</a>
 </p>
-
+ 
 [![Apache 2.0 License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/adenhq/hive/blob/main/LICENSE)
 [![Y Combinator](https://img.shields.io/badge/Y%20Combinator-Aden-orange)](https://www.ycombinator.com/companies/aden)
 [![Docker Pulls](https://img.shields.io/docker/pulls/adenhq/hive?logo=Docker&labelColor=%23528bff)](https://hub.docker.com/u/adenhq)


### PR DESCRIPTION
What this PR does:
- Adds a clear Windows-specific setup section to the README

Why this change:
- Helps Windows users avoid common setup issues
- Improves onboarding for new contributors

Testing:
- Documentation-only change, no tests required

What this PR does:
Why this change:
Testing:

Fixes #747
