### PR TITLE
fix(stream-runtime): eliminate end_run race condition and remove dead…

### DIFF
--- a/core/framework/runtime/execution_stream.py
+++ b/core/framework/runtime/execution_stream.py
@@ -301,6 +301,9 @@ class ExecutionStream:
         self._execution_tasks.clear()
         self._active_executions.clear()
 
+        # Wait for any in-flight saves to complete
+        await self._runtime.await_pending_saves()
+
         logger.info(f"ExecutionStream '{self.stream_id}' stopped")
 
         # Emit stream stopped event


### PR DESCRIPTION
  ## Related Issues                                                                                              
                                                                                                                 
  Fixes #1289                                                                                                    
  Fixes #1605        

## Description                                                                                                 
                                                                                                                 
  `StreamRuntime.end_run()` fires an untracked background task that cleans up `_runs` and `_current_nodes` in its
   `finally` block. Between `end_run()` returning and the `finally` executing, `decide()` and `record_outcome()` 
  can still find the run, write to it, and then have that data silently discarded. Additionally, `_global_lock`  
  and `_run_locks` are `asyncio.Lock` instances that can never be acquired from the synchronous public API — dead
   code that gives a false sense of thread safety.                                                               
                                                                                                                 
  ## Type of Change                                                                                              
                                                                                                                 
  - [x] Bug fix (non-breaking change that fixes an issue)                                                        
                                                                                                                 
                                                                                            
                                                                                                                 
  ## Changes Made                                                                                                
                                                                                                                 
  - Move dict cleanup (`_runs.pop`, `_current_nodes.pop`) from async `_save_run` into synchronous `end_run` so   
  tracking state is removed deterministically before the background persist begins                               
  - Track save tasks in `_pending_saves` dict with a `done_callback` for automatic cleanup                       
  - Add `await_pending_saves()` so `ExecutionStream.stop()` can drain in-flight saves on shutdown                
  - Remove `_global_lock` and `_run_locks` — both unusable from sync methods                                     
                                                                                                                 
  ## Testing                                                                                                     
                                                                                                                 
  - [x] Unit tests pass (`cd core && pytest tests/`)                                                             
  - [x] Lint passes (`cd core && ruff check .`)                                                                  
  - [x] Manual testing performed                                                                                 
                                                                                                                 
  ## Checklist                                                                                                   
                                                                                                                 
  - [x] My code follows the project's style guidelines                                                           
  - [x] I have performed a self-review of my code                                                                
  - [x] My changes generate no new warnings                                                                      
  - [x] New and existing unit tests pass locally with my changes