### PR TITLE
fix(micro-fix): setup script now creates missing exports directory (#1645)

### DIFF
--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -145,6 +145,24 @@ else
 fi
 echo ""
 
+# Ensure exports directory exists
+echo "=================================================="
+echo "Checking Directory Structure"
+echo "=================================================="
+echo ""
+
+if [ ! -d "$PROJECT_ROOT/exports" ]; then
+    echo "Creating exports directory..."
+    mkdir -p "$PROJECT_ROOT/exports"
+    echo "# Agent Exports" > "$PROJECT_ROOT/exports/README.md"
+    echo "" >> "$PROJECT_ROOT/exports/README.md"
+    echo "This directory is the default location for generated agent packages." >> "$PROJECT_ROOT/exports/README.md"
+    echo -e "${GREEN}✓${NC} Created exports directory"
+else
+    echo -e "${GREEN}✓${NC} exports directory exists"
+fi
+echo ""
+
 # Verify installations
 echo "=================================================="
 echo "Verifying Installation"


### PR DESCRIPTION
**Problem**
As reported in #1645 and #696, the `exports/` directory is referenced in the documentation and setup output but is missing from a fresh clone. This causes confusion for new contributors.

**Solution**
Updated `scripts/setup-python.sh` to:
1. Check if the `exports/` directory exists.
2. Create it if missing.
3. Add a basic README to explain the folder's purpose.

**Testing**
- [x] Ran `./scripts/setup-python.sh` on a fresh environment (macOS).
- [x] Verified `exports/` directory was created successfully.