### PR TITLE
fix(credentials): require Anthropic key for llm workflows (#1660)

### DIFF
--- a/tools/src/aden_tools/credentials/llm.py
+++ b/tools/src/aden_tools/credentials/llm.py
@@ -10,8 +10,8 @@ LLM_CREDENTIALS = {
         env_var="ANTHROPIC_API_KEY",
         tools=[],
         node_types=["llm_generate", "llm_tool_use"],
-        required=False,  # Not required - agents can use other providers via LiteLLM
-        startup_required=False,  # MCP server doesn't need LLM credentials
+        required=True,  # Agents require Anthropic credentials by default
+        startup_required=True,  # MCP server startup validation should enforce it
         help_url="https://console.anthropic.com/settings/keys",
         description="API key for Anthropic Claude models",
     ),


### PR DESCRIPTION
Fix Summary
• Mark the Anthropic  as  and  so the default LLM credential is enforced both at runtime and during MCP startup validation.
• This ensures  reports missing credentials for / nodes and the related tests no longer fail.

Testing
• ============================= test session starts ==============================
platform darwin -- Python 3.13.7, pytest-8.3.4, pluggy-1.6.0
rootdir: /Users/mac2020/Desktop/AIDEN/hive/tools
configfile: pyproject.toml
plugins: anyio-4.12.1, xdist-3.8.0, asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 47 items

tools/tests/test_credentials.py ........................................ [ 85%]
.......                                                                  [100%]

============================== 47 passed in 0.03s ==============================

Closes #1660