### PR TITLE
Fix: symlink sandbox escape in get_secure_path

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/security.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/security.py
@@ -13,13 +13,16 @@ def get_secure_path(path: str, workspace_id: str, agent_id: str, session_id: str
     session_dir = os.path.join(WORKSPACES_DIR, workspace_id, agent_id, session_id)
     os.makedirs(session_dir, exist_ok=True)
 
+    session_dir=os.path.realpath(session_dir)
+
+    is_absolute_path = os.path.isabs(path) or path.startswith(("/","\\"))
     # Resolve absolute path
-    if os.path.isabs(path):
+    if is_absolute_path:
         # Treat absolute paths as relative to the session root if they start with /
-        rel_path = path.lstrip(os.sep)
-        final_path = os.path.abspath(os.path.join(session_dir, rel_path))
+        rel_path = path.lstrip("/\\")
+        final_path = os.path.realpath(os.path.join(session_dir, rel_path))
     else:
-        final_path = os.path.abspath(os.path.join(session_dir, path))
+        final_path = os.path.realpath(os.path.join(session_dir, path))
 
     # Verify path is within session_dir
     common_prefix = os.path.commonpath([final_path, session_dir])


### PR DESCRIPTION
## Description

This PR fixes a sandbox escape vulnerability in `get_secure_path()` by ensuring that paths cannot bypass the session directory through symbolic links. The update also improves absolute-path handling across platforms, including Unix-style paths on Windows.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #1167

## Changes Made

- Replaced `os.path.abspath()` with `os.path.realpath()` to prevent symlink-based sandbox escape.
- Resolved the session sandbox directory using `realpath()` before validation.
- Improved absolute path detection for cross-platform support by handling Unix-style paths on Windows.

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable (no UI changes).
