### PR TITLE
docs: Fix Recurring UnicodeEncodeError on Windows (Fixes #1676)

### DIFF
--- a/core/framework/storage/backend.py
+++ b/core/framework/storage/backend.py
@@ -52,13 +52,13 @@ class FileStorage:
         """Save a run to storage."""
         # Save full run using Pydantic's model_dump_json
         run_path = self.base_path / "runs" / f"{run.id}.json"
-        with open(run_path, "w") as f:
+        with open(run_path, "w", encoding="utf-8") as f:
             f.write(run.model_dump_json(indent=2))
 
         # Save summary
         summary = RunSummary.from_run(run)
         summary_path = self.base_path / "summaries" / f"{run.id}.json"
-        with open(summary_path, "w") as f:
+        with open(summary_path, "w", encoding="utf-8") as f:
             f.write(summary.model_dump_json(indent=2))
 
         # Update indexes
@@ -72,7 +72,7 @@ class FileStorage:
         run_path = self.base_path / "runs" / f"{run_id}.json"
         if not run_path.exists():
             return None
-        with open(run_path) as f:
+        with open(run_path, encoding="utf-8") as f:
             return Run.model_validate_json(f.read())
 
     def load_summary(self, run_id: str) -> RunSummary | None:
@@ -85,7 +85,7 @@ class FileStorage:
                 return RunSummary.from_run(run)
             return None
 
-        with open(summary_path) as f:
+        with open(summary_path, encoding="utf-8") as f:
             return RunSummary.model_validate_json(f.read())
 
     def delete_run(self, run_id: str) -> bool:
@@ -143,7 +143,7 @@ class FileStorage:
         index_path = self.base_path / "indexes" / index_type / f"{key}.json"
         if not index_path.exists():
             return []
-        with open(index_path) as f:
+        with open(index_path, encoding="utf-8") as f:
             return json.load(f)
 
     def _add_to_index(self, index_type: str, key: str, value: str) -> None:
@@ -152,7 +152,7 @@ class FileStorage:
         values = self._get_index(index_type, key)
         if value not in values:
             values.append(value)
-            with open(index_path, "w") as f:
+            with open(index_path, "w", encoding="utf-8") as f:
                 json.dump(values, f)
 
     def _remove_from_index(self, index_type: str, key: str, value: str) -> None:
@@ -161,7 +161,7 @@ class FileStorage:
         values = self._get_index(index_type, key)
         if value in values:
             values.remove(value)
-            with open(index_path, "w") as f:
+            with open(index_path, "w", encoding="utf-8") as f:
                 json.dump(values, f)
 
     # === UTILITY ===

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -43,6 +43,7 @@ lint.select = [
   "Q",   # flake8-quotes errors
   "UP",  # py-upgrade
   "W",   # pycodestyle warnings
+  "PLW1514",  # unspecified-encoding - catch open() without encoding
 ]
 
 lint.isort.combine-as-imports = true


### PR DESCRIPTION
## Description
This PR fixes a critical Windows compatibility issue (`UnicodeEncodeError`) reported in #1676.
A comprehensive fix has been applied to all 7 unsafe file operations in [backend.py](cci:7://file:///d:/hive/core/framework/storage/backend.py:0:0-0:0), along with a Ruff lint rule (`PLW1514`) to prevent regressions.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
**Fixes #1676**

## Changes Made
- Added `encoding="utf-8"` in [backend.py](cci:7://file:///d:/hive/core/framework/storage/backend.py:0:0-0:0) (7 locations)
- Added Ruff rule `PLW1514`
- Verified on Windows 11

## Testing
- [x] Unit tests pass: 209 passed ✅