### PR TITLE
fix: format [node.py](http://_vscodecontentref_/0) with ruff to resolve CI linting failure

### DIFF
--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -165,7 +165,7 @@ class NodeSpec(BaseModel):
     )
     nullable_output_keys: list[str] = Field(
         default_factory=list,
-        description="Output keys that can be None without triggering validation errors"
+        description="Output keys that can be None without triggering validation errors",
     )
 
     # Optional schemas for validation and cleansing


### PR DESCRIPTION
Fixes CI linting failure by formatting core/framework/graph/node.py with ruff.

## Changes
- Formatted core/framework/graph/node.py according to project style guide

## Verification
- ✅ `ruff check core/ tools/` passes
- ✅ `ruff format --check core/ tools/` passes
- ✅ All 146 files pass formatting checks