### PR TITLE
fix: add Python 3.13 classifier to tools/pyproject.toml

### DIFF
--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 dependencies = [


### PR DESCRIPTION
## Description
Add Python 3.13 classifier to tools/pyproject.toml to match advertised support in ENVIRONMENT_SETUP.md

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
Fixes #(paste the issue number from the GitHub issue)

## Changes Made
- Added "Programming Language :: Python :: 3.13" classifier to tools/pyproject.toml

## Testing
This is a metadata-only change (PyPI classifier), no functional code changed.
- [x] Manual verification: confirmed Python 3.13 classifier is present in tools/pyproject.toml
- [ ] Unit tests pass (not applicable for metadata change)
- [ ] Lint passes (not applicable for metadata change)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (not applicable)
- [ ] I have made corresponding changes to the documentation (not needed)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective (not applicable for metadata)
- [ ] New and existing unit tests pass locally with my changes (not applicable)

## Screenshots (if applicable)
N/A - metadata change only
