### PR TITLE
docs: add Mac/Homebrew Python version fix to troubleshooting

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -178,6 +178,20 @@ source .venv/bin/activate  # macOS/Linux
 ./scripts/setup-python.sh
 ```
 
+> **Mac/Homebrew Users:** If after creating the venv you still get `Error: Python 3.11+ is required (found 3.9)`, your venv picked up an older system Python. Create the venv with the explicit Homebrew Python path instead:
+>
+> ```bash
+> # Find your Python 3.11+ installation
+> which python3.14  # or python3.12, python3.13
+>
+> # Create venv with explicit path (adjust version as needed)
+> /opt/homebrew/bin/python3.14 -m venv .venv
+> source .venv/bin/activate
+>
+> # Then run setup
+> ./scripts/setup-python.sh
+> ```
+
 Always activate the venv before running agents:
 
 ```bash

--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -165,7 +165,7 @@ class NodeSpec(BaseModel):
     )
     nullable_output_keys: list[str] = Field(
         default_factory=list,
-        description="Output keys that can be None without triggering validation errors"
+        description="Output keys that can be None without triggering validation errors",
     )
 
     # Optional schemas for validation and cleansing


### PR DESCRIPTION
Fixes #1772

## Description

Adds documentation to help Mac/Homebrew users who encounter Python version mismatch when creating a virtual environment.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #1772

## Changes Made

- Added a note in the "externally-managed-environment" troubleshooting section for Mac/Homebrew users
- Explains how to find the correct Python path using `which`
- Shows how to create a venv with the explicit Homebrew Python path to avoid version mismatch

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

> Tested on macOS with Homebrew Python 3.14. Verified the instructions resolve the `Error: Python 3.11+ is required (found 3.9)` issue.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A - Documentation only change