### PR TITLE
docs: add Mac/Homebrew Python virtualenv setup instructions

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -206,3 +206,21 @@ pip uninstall -y framework tools
 - **Issues**: [github.com/adenhq/hive/issues](https://github.com/adenhq/hive/issues)
 - **Discord**: [discord.com/invite/MXE49hrKDk](https://discord.com/invite/MXE49hrKDk)
 - **Build Agents**: Use `/building-agents` skill to create agents
+### Mac / Homebrew Users
+
+If you installed Python using Homebrew, your system Python may still point to an older version
+(e.g. Python 3.9), which can cause setup errors.
+
+To ensure the correct Python version (3.11+) is used, create your virtual environment
+with the explicit Homebrew Python path:
+
+```bash
+# Check available Python versions
+ls /opt/homebrew/bin/python3*
+
+# Create virtual environment with the correct Python version
+/opt/homebrew/bin/python3.14 -m venv venv
+source venv/bin/activate
+
+# Then run the setup script
+./scripts/setup-python.sh


### PR DESCRIPTION
### What changed
Added a new **Mac / Homebrew Users** section to `docs/getting-started.md`.

This section explains how to explicitly create a virtual environment using the
Homebrew-installed Python (3.11+) to avoid common setup issues.

### Why this change
On macOS, Homebrew users may still have their system Python pointing to an older
version, which can cause setup failures and PEP 668 related errors.
These instructions make the setup clearer and more reliable for Mac users.

### Scope
- Documentation-only change
- No code or behavior changes

### Checklist
- [x] Updated existing documentation file
- [x] Kept changes minimal and scoped
- [x] Followed contributing guidelines
