### PR TITLE
feature: cursor-aligned agent skils

### DIFF
--- a/.cursor/skills/agent-workflow
+++ b/.cursor/skills/agent-workflow
@@ -1,0 +1,1 @@
+../../.claude/skills/agent-workflow

--- a/.cursor/skills/building-agents-construction
+++ b/.cursor/skills/building-agents-construction
@@ -1,0 +1,1 @@
+../../.claude/skills/building-agents-construction

--- a/.cursor/skills/building-agents-core
+++ b/.cursor/skills/building-agents-core
@@ -1,0 +1,1 @@
+../../.claude/skills/building-agents-core

--- a/.cursor/skills/building-agents-patterns
+++ b/.cursor/skills/building-agents-patterns
@@ -1,0 +1,1 @@
+../../.claude/skills/building-agents-patterns

--- a/.cursor/skills/testing-agent
+++ b/.cursor/skills/testing-agent
@@ -1,0 +1,1 @@
+../../.claude/skills/testing-agent


### PR DESCRIPTION
fixes #1461

## Summary

Add Cursor IDE support for existing Claude Code skills by creating symlinks in `.cursor/skills/`.

## Changes

- Created `.cursor/skills/` directory
- Added symlinks to all 5 existing skills:
  - `agent-workflow`
  - `building-agents-core`
  - `building-agents-construction`
  - `building-agents-patterns`
  - `testing-agent`

## Why symlinks?

- Single source of truth - updates to `.claude/skills/` are reflected in both IDEs
- No duplication or sync issues
- Cursor automatically loads skills from `.cursor/skills/`, `.claude/skills/`, and `.codex/skills/`

## Testing

Skills can be invoked in Cursor by typing `/` in Agent chat and searching for the skill name.
