### PR TITLE
fix: prevent 'hive list' crash when exports directory is missing

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -53,3 +53,6 @@ lint.isort.section-order = [
   "first-party",
   "local-folder",
 ]
+
+[project.scripts]
+hive = "framework.cli:main"


### PR DESCRIPTION
## Description
Fixes a crash where running `hive list` on a fresh install raises a `FileNotFoundError` because the `exports/` directory does not exist.

## Changes
- Modified `_interactive_multi` and `list_agents` in `core/framework/runner/cli.py` to check `if not agents_dir.exists()` before listing.
- Returns a graceful "No agents found" message (exit code 0) instead of crashing.

## Related Issue
Closes #1562
(Addresses duplicate issue #1356)