### PR TITLE
fix: usage guide

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "agent-builder": {
+      "command": "python",
+      "args": ["-m", "framework.mcp.agent_builder_server"],
+      "cwd": "core",
+      "env": {
+        "PYTHONPATH": "../tools/src"
+      }
+    },
+    "tools": {
+      "command": "python",
+      "args": ["mcp_server.py", "--stdio"],
+      "cwd": "tools",
+      "env": {
+        "PYTHONPATH": "src"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ PYTHONPATH=core:exports python -m your_agent_name run --input '{...}'
 
 **[📖 Complete Setup Guide](ENVIRONMENT_SETUP.md)** - Detailed instructions for agent development
 
+### Cursor IDE Support
+
+Skills are also available in Cursor. To enable:
+
+1. Open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`)
+2. Run `MCP: Enable` to enable MCP servers
+3. Restart Cursor to load the MCP servers from `.cursor/mcp.json`
+4. Type `/` in Agent chat and search for skills (e.g., `/building-agents-construction`)
+
 ## Features
 
 - **Goal-Driven Development** - Define objectives in natural language; the coding agent generates the agent graph and connection code to achieve them
@@ -226,6 +235,7 @@ hive/
 ├── docs/                   # Documentation and guides
 ├── scripts/                # Build and utility scripts
 ├── .claude/                # Claude Code skills for building agents
+├── .cursor/                # Cursor IDE skills (symlinks to .claude/skills)
 ├── ENVIRONMENT_SETUP.md    # Python setup guide for agent development
 ├── DEVELOPER.md            # Developer guide
 ├── CONTRIBUTING.md         # Contribution guidelines

--- a/pr-message.md
+++ b/pr-message.md
@@ -1,0 +1,31 @@
+## Summary
+
+Add Cursor IDE support for existing Claude Code skills and MCP servers.
+
+## Changes
+
+- Created `.cursor/skills/` directory with symlinks to all 5 existing skills:
+  - `agent-workflow`
+  - `building-agents-core`
+  - `building-agents-construction`
+  - `building-agents-patterns`
+  - `testing-agent`
+- Added `.cursor/mcp.json` with MCP server configuration (same as `.mcp.json`)
+
+## Why symlinks for skills?
+
+- Single source of truth - updates to `.claude/skills/` are reflected in both IDEs
+- No duplication or sync issues
+- Cursor automatically loads skills from `.cursor/skills/`, `.claude/skills/`, and `.codex/skills/`
+
+## MCP Configuration
+
+Cursor requires `.cursor/mcp.json` for project-level MCP servers. This enables:
+- `agent-builder` - Agent building MCP server
+- `tools` - Hive tools MCP server
+
+## Setup in Cursor
+
+1. **Enable MCP**: Open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`) and run `MCP: Enable`
+2. **Restart Cursor** to load the MCP servers from `.cursor/mcp.json`
+3. **Skills**: Type `/` in Agent chat and search for the skill name


### PR DESCRIPTION
fixes #1461 

## Summary

Add Cursor IDE support for existing Claude Code skills and MCP servers.

## Changes

- Created `.cursor/skills/` directory with symlinks to all 5 existing skills:
  - `agent-workflow`
  - `building-agents-core`
  - `building-agents-construction`
  - `building-agents-patterns`
  - `testing-agent`
- Added `.cursor/mcp.json` with MCP server configuration (same as `.mcp.json`)

## Why symlinks for skills?

- Single source of truth - updates to `.claude/skills/` are reflected in both IDEs
- No duplication or sync issues
- Cursor automatically loads skills from `.cursor/skills/`, `.claude/skills/`, and `.codex/skills/`

## MCP Configuration

Cursor requires `.cursor/mcp.json` for project-level MCP servers. This enables:
- `agent-builder` - Agent building MCP server
- `tools` - Hive tools MCP server

## Setup in Cursor

1. **Enable MCP**: Open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`) and run `MCP: Enable`
2. **Restart Cursor** to load the MCP servers from `.cursor/mcp.json`
3. **Skills**: Type `/` in Agent chat and search for the skill name
