### PR TITLE
fix(credentials): correct OAuth2 imports to framework package

### DIFF
--- a/core/framework/credentials/tests/test_credential_store.py
+++ b/core/framework/credentials/tests/test_credential_store.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from core.framework.credentials import (
+from framework.credentials import (
     CompositeStorage,
     CredentialKey,
     CredentialKeyNotFoundError,
@@ -640,7 +640,7 @@ class TestOAuth2Module:
 
     def test_oauth2_token_from_response(self):
         """Test creating OAuth2Token from token response."""
-        from core.framework.credentials.oauth2 import OAuth2Token
+        from framework.credentials.oauth2 import OAuth2Token
 
         response = {
             "access_token": "xxx",
@@ -659,7 +659,7 @@ class TestOAuth2Module:
 
     def test_token_is_expired(self):
         """Test token expiration check."""
-        from core.framework.credentials.oauth2 import OAuth2Token
+        from framework.credentials.oauth2 import OAuth2Token
 
         # Not expired
         future = datetime.now(UTC) + timedelta(hours=1)
@@ -673,7 +673,7 @@ class TestOAuth2Module:
 
     def test_token_can_refresh(self):
         """Test token refresh capability check."""
-        from core.framework.credentials.oauth2 import OAuth2Token
+        from framework.credentials.oauth2 import OAuth2Token
 
         with_refresh = OAuth2Token(access_token="xxx", refresh_token="yyy")
         assert with_refresh.can_refresh
@@ -683,7 +683,7 @@ class TestOAuth2Module:
 
     def test_oauth2_config_validation(self):
         """Test OAuth2Config validation."""
-        from core.framework.credentials.oauth2 import OAuth2Config, TokenPlacement
+        from framework.credentials.oauth2 import OAuth2Config, TokenPlacement
 
         # Valid config
         config = OAuth2Config(


### PR DESCRIPTION


**fix(credentials): correct OAuth2 imports in credential store tests**

---

## 📌 Description

This PR fixes failing credential store OAuth2 tests caused by outdated import paths.

The framework has been modularized under the `framework` package, but the OAuth2 test suite still referenced the old namespace:

```python
from core.framework.credentials.oauth2 import OAuth2Token
```

On clean installs or standard test runs, this results in:

```
ModuleNotFoundError: No module named 'core'
```

This PR updates those imports to the correct provider-agnostic module location.

---

## ✅ What Changed

* Updated OAuth2-related tests in:

  ```
  framework/credentials/tests/test_credential_store.py
  ```

* Replaced invalid imports:

  ```python
  from core.framework.credentials.oauth2 import ...
  ```

  with the correct ones:

  ```python
  from framework.credentials.oauth2 import ...
  ```

---

## ✅ Why This Matters

* Prevents test failures in clean environments where `core` is not a valid import root
* Ensures credential framework tests remain consistent with the current package layout
* Improves contributor experience by eliminating confusing import errors
* Keeps OAuth2 module coverage intact without requiring legacy namespace support

---

## ✅ Testing

Ran locally:

```powershell
pytest -q
```

Result:

* All OAuth2 credential store tests now pass successfully
* No behavior change outside test imports

---

## 🔗 Related Issue
#1725 

Fixes the failing OAuth2 import errors observed during `pytest` runs on fresh environments.

---

## ✅ Checklist

* [x] Fix is minimal and scoped only to test imports
* [x] No production code paths affected
* [x] All tests pass locally
* [x] Improves correctness for current package structure

