### PR TITLE
fix: validate non-negative limit and offset in csv_read function

### DIFF
--- a/tools/src/aden_tools/tools/csv_tool/csv_tool.py
+++ b/tools/src/aden_tools/tools/csv_tool/csv_tool.py
@@ -34,6 +34,8 @@ def register_tools(mcp: FastMCP) -> None:
         Returns:
             dict with success status, data, and metadata
         """
+        if (offset < 0 or (limit is not None and limit < 0)):
+            return {"error": "offset and limit must be non-negative"}
         try:
             secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
 

--- a/tools/tests/tools/test_csv_tool.py
+++ b/tools/tests/tools/test_csv_tool.py
@@ -154,6 +154,49 @@ class TestCsvRead:
         # First row should be id=50
         assert result["rows"][0] == {"id": "50", "value": "500"}
 
+    def test_negative_limit(self, csv_tool_fn, basic_csv, tmp_path):
+        """Return error for negative limit."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = csv_tool_fn(
+                path="basic.csv",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                limit=-1,
+            )
+
+        assert "error" in result
+        assert "non-negative" in result["error"].lower()
+
+    def test_negative_offset(self, csv_tool_fn, basic_csv, tmp_path):
+        """Return error for negative offset."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = csv_tool_fn(
+                path="basic.csv",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                offset=-1,
+            )
+
+        assert "error" in result
+        assert "non-negative" in result["error"].lower()
+
+    def test_negative_limit_and_offset(self, csv_tool_fn, basic_csv, tmp_path):
+        """Return error for both negative limit and offset."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = csv_tool_fn(
+                path="basic.csv",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                limit=-5,
+                offset=-10,
+            )
+
+        assert "error" in result
+        assert "non-negative" in result["error"].lower()
+
     def test_file_not_found(self, csv_tool_fn, session_dir, tmp_path):
         """Return error for non-existent file."""
         with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):


### PR DESCRIPTION
## Description

Added input validation to the `csv_read` function to prevent negative values for `limit` and `offset` parameters. The function now returns a clear error message when either parameter is negative, preventing unexpected behavior and potential issues with CSV file processing.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #1848 

## Changes Made

- Added validation check in `csv_read` function to ensure `offset` and `limit` parameters are non-negative
- Returns `{"error": "offset and limit must be non-negative"}` when validation fails
- Added comprehensive test coverage for negative parameter scenarios:
  - `test_negative_limit`: Verifies error is returned when limit is negative
  - `test_negative_offset`: Verifies error is returned when offset is negative
  - `test_negative_limit_and_offset`: Verifies error is returned when both parameters are negative

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed
- [x] Added 3 new test cases specifically for negative parameter validation

**Test Results:**
- `test_negative_limit`: Validates that `limit=-1` returns error with "non-negative" message
- `test_negative_offset`: Validates that `offset=-1` returns error with "non-negative" message
- `test_negative_limit_and_offset`: Validates that `limit=-5, offset=-10` returns error with "non-negative" message

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A - This is a backend validation change with no UI components.
