### PR TITLE
fix: MCP client resource leak and plan validation for missing step IDs

### DIFF
--- a/core/framework/mcp/agent_builder_server.py
+++ b/core/framework/mcp/agent_builder_server.py
@@ -2251,8 +2251,12 @@ def validate_plan(
         return False
 
     for step in steps:
-        if has_cycle(step.get("id", ""), set(), set()):
-            errors.append(f"Circular dependency detected involving step '{step.get('id')}'")
+        step_id = step.get("id")
+        if not step_id:
+            # Skip steps without IDs - they should have been caught in earlier validation
+            continue
+        if has_cycle(step_id, set(), set()):
+            errors.append(f"Circular dependency detected involving step '{step_id}'")
             break
 
     # === CONTEXT FLOW VALIDATION ===


### PR DESCRIPTION
## Description

Two bug fixes in the MCP layer:

1. **MCP client resource leak (`mcp_client.py`)**  
   The STDIO context manager and session were never closed on disconnect. The code only set `_stdio_context` and `_session` to `None` without calling `__aexit__()`, leaving file handles and MCP subprocesses open. Over time this led to "too many open files" and similar production failures.  
   **Fix:** Explicitly close both async context managers before stopping the event loop.

2. **Plan validation (`agent_builder_server.py`)**  
   Circular-dependency checks used `step.get("id", "")` for steps without an `id`. Multiple such steps were treated as the same step (`""`), which broke cycle detection and could produce wrong validation results.  
   **Fix:** Skip steps with missing or empty IDs and only run the check for steps that have an `id`.

---

## Type of Change

Bug fix (non-breaking change that fixes an issue)

---

## Related Issues

Fixes #(issue number)

---

## Changes Made

**`core/framework/runner/mcp_client.py`**
- Added async `cleanup_connection()` that runs on disconnect.
- Call `await self._session.__aexit__(None, None, None)` before clearing session references.
- Call `await self._stdio_context.__aexit__(None, None, None)` to close streams and terminate the MCP subprocess.
- Schedule cleanup via `asyncio.run_coroutine_threadsafe()` in the STDIO event loop before stopping it.
- Wrap cleanup in try/except and log warnings on failure.
- Increase disconnect timeout from 2s to 5s for cleanup and thread join.

**`core/framework/mcp/agent_builder_server.py`**
- In `validate_plan` circular-dependency loop, use `step.get("id")` and skip steps with missing or empty IDs instead of `step.get("id", "")`.
- Use a single `step_id` variable when appending circular-dependency errors.

---

## Testing

Manual testing performed:
- Verified MCP client disconnect/reconnect and that STDIO subprocesses and streams are closed.
- Validated plans with and without step IDs to confirm circular-dependency checks behave correctly.

---

## Checklist

- My code follows the project's style guidelines  
- I have performed a self-review of my code  
- I have commented my code, particularly in hard-to-understand areas  
- My changes generate no new warnings  

---

## Screenshots (if applicable)

N/A