### PR TITLE
Fix concurrent modification in ExecutionStream.stop

### DIFF
--- a/core/framework/runtime/execution_stream.py
+++ b/core/framework/runtime/execution_stream.py
@@ -213,7 +213,7 @@ class ExecutionStream:
         self._running = False
 
         # Cancel all active executions
-        for _, task in self._execution_tasks.items():
+        for _, task in list(self._execution_tasks.items()):
             if not task.done():
                 task.cancel()
                 try:


### PR DESCRIPTION
## What this fixes
ExecutionStream.stop could raise `RuntimeError: dictionary changed size during iteration`
when active tasks modify `_execution_tasks` during cancellation/cleanup.

## Why it matters
This breaks graceful shutdown and can leave execution tasks in an
inconsistent state in long-running or concurrent agent workflows.

## Changes
- Iterate over a snapshot of `_execution_tasks` to prevent concurrent
  modification during shutdown.

## Testing
- Manually reviewed shutdown paths.
- No behavior change beyond iteration safety.
- Happy to add a targeted concurrency test if desired.