### PR TITLE
chore: remove references to archived honeycomb frontend

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -511,30 +511,7 @@ chore(deps): update React to 18.2.0
 
 ## Debugging
 
-### Frontend Debugging
 
-**React Developer Tools:**
-
-1. Install the [React DevTools browser extension](https://react.dev/learn/react-developer-tools)
-2. Open browser DevTools → React tab
-3. Inspect component tree, props, state, and hooks
-
-**VS Code Debugging:**
-
-1. Add Chrome debug configuration to `.vscode/launch.json`:
-
-```json
-{
-  "type": "chrome",
-  "request": "launch",
-  "name": "Debug Frontend",
-  "url": "http://localhost:3000",
-  "webRoot": "${workspaceFolder}/honeycomb/src"
-}
-```
-
-2. Start the dev server: `npm run dev -w honeycomb`
-3. Press F5 in VS Code
 
 ### Backend Debugging
 
@@ -709,14 +686,6 @@ kill -9 <PID>
 # Or change ports in config.yaml and regenerate
 ```
 
-### Node Modules Issues
-
-```bash
-# Clean everything and reinstall
-npm run clean
-rm -rf node_modules package-lock.json
-npm install
-```
 
 ### Docker Issues
 
@@ -728,15 +697,7 @@ docker compose build --no-cache
 docker compose up
 ```
 
-### TypeScript Errors After Pull
 
-```bash
-# Rebuild TypeScript
-npm run build
-
-# Or restart TS server in VS Code
-# Cmd/Ctrl + Shift + P → "TypeScript: Restart TS Server"
-```
 
 ### Environment Variables Not Loading
 
@@ -746,24 +707,12 @@ npm run generate:env
 
 # Verify files exist
 cat .env
-cat honeycomb/.env
 cat hive/.env
 
 # Restart dev servers after changing env
 ```
 
-### Tests Failing
 
-```bash
-# Run with verbose output
-npm run test -w honeycomb -- --reporter=verbose
-
-# Run single test file
-npm run test -w honeycomb -- src/components/Button.test.tsx
-
-# Clear test cache
-npm run test -w honeycomb -- --clearCache
-```
 
 ---
 


### PR DESCRIPTION
## Description

Removes outdated documentation referencing the archived `honeycomb` frontend application. The `honeycomb` directory no longer exists in the repository, but `DEVELOPER.md` still contained detailed instructions for running, debugging, and testing it. This was causing `No workspaces found` errors for new contributors attempting to follow the guide.

## Type of Change


- Documentation update

## Related Issues

Fixes #1646 

## Changes Made

- Removed the "Frontend Debugging" section (React/Vite tools) from `DEVELOPER.md`.
- Removed the "TypeScript Errors" troubleshooting section.
- Removed the "Tests Failing" section which referenced `npm run test -w honeycomb`.
- Removed references to `honeycomb/.env` in the Environment Variables section.

## Testing

Describe the tests you ran to verify your changes:

- Manual testing performed

*Verified that the `DEVELOPER.md` file renders correctly and that the instructions now align with the current repository structure (Python backend only).*

## Checklist

- My code follows the project's style guidelines
- I have performed a self-review of my code
- I have made corresponding changes to the documentation
- My changes generate no new warnings


## Screenshots (if applicable)

N/A