### PR TITLE
feat(cli): structured error handling with actionable guidance

### DIFF
--- a/core/framework/errors.py
+++ b/core/framework/errors.py
@@ -1,0 +1,297 @@
+"""Structured CLI error handling with actionable guidance.
+
+Provides user-friendly error messages with remediation hints,
+inspired by the diagnostic-first approach of tools like rustc and cargo.
+
+Usage:
+    @cli_error_handler
+    def cmd_run(args):
+        ...
+
+    # Or as context manager:
+    with CLIErrorContext(verbose=True):
+        ...
+
+    # Or raise directly:
+    raise CLIError("Agent schema key 'steps' not found",
+                   hint="The agent graph uses 'nodes' instead of 'steps'.")
+"""
+
+from __future__ import annotations
+
+import functools
+import sys
+import traceback
+from collections.abc import Callable
+
+# ---------------------------------------------------------------------------
+# Core error type
+# ---------------------------------------------------------------------------
+
+
+class CLIError(Exception):
+    """A CLI error that carries a user-facing message and optional remediation hint."""
+
+    def __init__(self, message: str, hint: str = "", details: str = ""):
+        self.message = message
+        self.hint = hint
+        self.details = details
+        super().__init__(message)
+
+
+# ---------------------------------------------------------------------------
+# Error mapping registry
+# ---------------------------------------------------------------------------
+
+_ERROR_MAP: list[tuple[type, Callable[[Exception], CLIError | None]]] = []
+
+
+def _register(exc_type: type):
+    """Decorator to register an exception mapper."""
+
+    def decorator(fn: Callable[[Exception], CLIError | None]):
+        _ERROR_MAP.append((exc_type, fn))
+        return fn
+
+    return decorator
+
+
+@_register(KeyError)
+def _map_key_error(exc: KeyError) -> CLIError | None:
+    key = exc.args[0] if exc.args else "unknown"
+    known_renames = {
+        "steps": ("nodes", "The agent graph uses 'nodes' instead of 'steps'."),
+        "actions": ("nodes", "The agent graph uses 'nodes' instead of 'actions'."),
+        "transitions": ("edges", "The agent graph uses 'edges' instead of 'transitions'."),
+    }
+    if key in known_renames:
+        new_key, explanation = known_renames[key]
+        return CLIError(
+            f"Agent schema key '{key}' not found.",
+            hint=(
+                f"{explanation}\n"
+                f"  This may indicate an outdated agent export. Try re-exporting, then run:\n"
+                f"    hive validate <agent_path>"
+            ),
+        )
+    return CLIError(
+        f"Missing key: '{key}'",
+        hint=(
+            "This usually means the agent schema is missing a required field.\n"
+            "  Run 'hive validate <agent_path>' to check for schema issues."
+        ),
+    )
+
+
+@_register(FileNotFoundError)
+def _map_file_not_found(exc: FileNotFoundError) -> CLIError:
+    path = str(exc.filename or exc.args[0] if exc.args else "unknown")
+    if "agent.json" in path:
+        return CLIError(
+            f"Agent not found at: {path}",
+            hint=(
+                "Verify the path points to a valid agent directory containing agent.json.\n"
+                "  List available agents with:\n"
+                "    hive list"
+            ),
+        )
+    return CLIError(
+        f"File not found: {path}",
+        hint="Check that the path exists and you have read permissions.",
+    )
+
+
+@_register(ModuleNotFoundError)
+def _map_module_not_found(exc: ModuleNotFoundError) -> CLIError:
+    module = exc.name or str(exc)
+    if module == "framework" or module.startswith("framework."):
+        return CLIError(
+            f"Cannot import '{module}'.",
+            hint=(
+                "The framework package is not on PYTHONPATH.\n"
+                "  Run from project root with:\n"
+                "    PYTHONPATH=core:exports python -m framework <command>\n"
+                "  Or install in editable mode:\n"
+                "    pip install -e core/"
+            ),
+        )
+    return CLIError(
+        f"Module '{module}' not found.",
+        hint=(
+            "A required Python package is missing. Install it with:\n"
+            f"    pip install {module}\n"
+            "  If this is an agent dependency, check the agent's requirements."
+        ),
+    )
+
+
+@_register(PermissionError)
+def _map_permission_error(exc: PermissionError) -> CLIError:
+    return CLIError(
+        f"Permission denied: {exc}",
+        hint="Check file permissions or try running with appropriate privileges.",
+    )
+
+
+def _try_map_connection_error(exc: Exception) -> CLIError | None:
+    """Handle connection-related errors from various HTTP libraries."""
+    exc_type = type(exc).__qualname__
+    exc_module = type(exc).__module__ or ""
+
+    # httpx errors
+    if "httpx" in exc_module or "ConnectError" in exc_type:
+        return CLIError(
+            "Cannot connect to the API endpoint.",
+            hint=(
+                "Check your network connection and API configuration.\n"
+                "  Verify your API key is set:\n"
+                "    export ANTHROPIC_API_KEY='sk-ant-...'\n"
+                "  If using a proxy, check HTTPS_PROXY / HTTP_PROXY."
+            ),
+        )
+    return None
+
+
+def _try_map_auth_error(exc: Exception) -> CLIError | None:
+    """Handle authentication errors from API clients."""
+    exc_type = type(exc).__qualname__
+    msg_lower = str(exc).lower()
+
+    if "auth" in exc_type.lower() or "authentication" in msg_lower or "401" in str(exc):
+        return CLIError(
+            "API authentication failed.",
+            hint=(
+                "Your API key may be invalid or expired.\n"
+                "  Set a valid key:\n"
+                "    export ANTHROPIC_API_KEY='sk-ant-...'\n"
+                "  Verify at: https://console.anthropic.com/settings/keys"
+            ),
+        )
+    if "rate" in msg_lower and "limit" in msg_lower:
+        return CLIError(
+            "API rate limit exceeded.",
+            hint=(
+                "Wait a moment and try again, or use a different model:\n"
+                "    hive run <agent> --model claude-haiku-4-5-20251001"
+            ),
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Error formatting
+# ---------------------------------------------------------------------------
+
+
+def format_error(error: CLIError, verbose: bool = False) -> str:
+    """Format a CLIError for terminal output."""
+    lines = [f"Error: {error.message}"]
+    if error.hint:
+        lines.append(f"  Hint: {error.hint}")
+    if error.details:
+        lines.append(f"  Details: {error.details}")
+    if verbose and error.__cause__:
+        lines.append("")
+        lines.append("Traceback (use --verbose for full trace):")
+        tb_line = traceback.format_exception_only(type(error.__cause__), error.__cause__)[-1]
+        lines.append(tb_line.strip())
+    return "\n".join(lines)
+
+
+def _resolve_error(exc: Exception) -> CLIError:
+    """Attempt to map a raw exception to a CLIError with actionable guidance."""
+    # 1. Already a CLIError — pass through
+    if isinstance(exc, CLIError):
+        return exc
+
+    # 2. Try registered mappers (exact type match first, then subclass)
+    for exc_type, mapper in _ERROR_MAP:
+        if isinstance(exc, exc_type):
+            result = mapper(exc)
+            if result is not None:
+                return result
+
+    # 3. Try heuristic mappers for network/auth errors
+    for heuristic in (_try_map_connection_error, _try_map_auth_error):
+        result = heuristic(exc)
+        if result is not None:
+            return result
+
+    # 4. Fallback — generic error with traceback hint
+    return CLIError(
+        str(exc) or type(exc).__name__,
+        hint=(
+            "An unexpected error occurred.\n"
+            "  Re-run with --verbose for the full traceback.\n"
+            "  If the problem persists, report it at:\n"
+            "    https://github.com/adenhq/hive/issues"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Decorator for CLI command functions
+# ---------------------------------------------------------------------------
+
+
+def cli_error_handler(fn: Callable) -> Callable:
+    """Wrap a CLI command function with structured error handling.
+
+    Catches unhandled exceptions and prints user-friendly diagnostics.
+    The wrapped function should accept ``args`` (argparse.Namespace)
+    and return an int exit code.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(args, *a, **kw):
+        try:
+            return fn(args, *a, **kw)
+        except CLIError as e:
+            verbose = getattr(args, "verbose", False)
+            print(format_error(e, verbose=verbose), file=sys.stderr)
+            if verbose:
+                traceback.print_exc(file=sys.stderr)
+            return 1
+        except SystemExit:
+            raise
+        except KeyboardInterrupt:
+            print("\nInterrupted.", file=sys.stderr)
+            return 130
+        except Exception as e:
+            verbose = getattr(args, "verbose", False)
+            cli_err = _resolve_error(e)
+            cli_err.__cause__ = e
+            print(format_error(cli_err, verbose=verbose), file=sys.stderr)
+            if verbose:
+                traceback.print_exc(file=sys.stderr)
+            return 1
+
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Context manager variant
+# ---------------------------------------------------------------------------
+
+
+class CLIErrorContext:
+    """Context manager that catches exceptions and prints structured diagnostics."""
+
+    def __init__(self, verbose: bool = False):
+        self.verbose = verbose
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_val is None:
+            return False
+        if isinstance(exc_val, (SystemExit, KeyboardInterrupt)):
+            return False
+
+        cli_err = _resolve_error(exc_val)
+        cli_err.__cause__ = exc_val
+        print(format_error(cli_err, verbose=self.verbose), file=sys.stderr)
+        if self.verbose:
+            traceback.print_exception(exc_type, exc_val, exc_tb, file=sys.stderr)
+        return True

--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -202,7 +202,7 @@ def cmd_run(args: argparse.Namespace) -> int:
                 f"Invalid JSON in --input: {e}",
                 hint=(
                     "Ensure the input is valid JSON. Example:\n"
-                    "    hive run <agent> --input '{\"key\": \"value\"}'"
+                    '    hive run <agent> --input \'{"key": "value"}\''
                 ),
             ) from e
     elif args.input_file:
@@ -484,7 +484,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
             f"Invalid JSON in --input: {e}",
             hint=(
                 "Ensure the input is valid JSON. Example:\n"
-                "    hive dispatch --input '{\"key\": \"value\"}'"
+                '    hive dispatch --input \'{"key": "value"}\''
             ),
         ) from e
 
@@ -508,8 +508,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
                 raise CLIError(
                     f"Agent not found: {agent_path}",
                     hint=(
-                        f"No agent.json in '{agent_path}'.\n"
-                        "  List available agents with: hive list"
+                        f"No agent.json in '{agent_path}'.\n  List available agents with: hive list"
                     ),
                 )
             agent_paths.append((agent_name, agent_path))

--- a/core/tests/test_cli_errors.py
+++ b/core/tests/test_cli_errors.py
@@ -1,0 +1,200 @@
+"""Tests for structured CLI error handling."""
+
+import argparse
+
+import pytest
+
+from framework.errors import (
+    CLIError,
+    CLIErrorContext,
+    _resolve_error,
+    cli_error_handler,
+    format_error,
+)
+
+# ---------------------------------------------------------------------------
+# CLIError basics
+# ---------------------------------------------------------------------------
+
+
+class TestCLIError:
+    def test_message_and_hint(self):
+        err = CLIError("something broke", hint="try this")
+        assert err.message == "something broke"
+        assert err.hint == "try this"
+        assert str(err) == "something broke"
+
+    def test_defaults(self):
+        err = CLIError("oops")
+        assert err.hint == ""
+        assert err.details == ""
+
+
+# ---------------------------------------------------------------------------
+# Error formatting
+# ---------------------------------------------------------------------------
+
+
+class TestFormatError:
+    def test_basic_format(self):
+        err = CLIError("Agent not found", hint="Run hive list")
+        output = format_error(err)
+        assert "Error: Agent not found" in output
+        assert "Hint: Run hive list" in output
+
+    def test_no_hint(self):
+        err = CLIError("Boom")
+        output = format_error(err)
+        assert "Error: Boom" in output
+        assert "Hint" not in output
+
+    def test_with_details(self):
+        err = CLIError("Bad input", details="line 3, col 5")
+        output = format_error(err)
+        assert "Details: line 3, col 5" in output
+
+
+# ---------------------------------------------------------------------------
+# Error resolution (exception mapping)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveError:
+    def test_key_error_known_rename(self):
+        result = _resolve_error(KeyError("steps"))
+        assert "steps" in result.message
+        assert "nodes" in result.hint
+
+    def test_key_error_unknown(self):
+        result = _resolve_error(KeyError("foo_bar"))
+        assert "foo_bar" in result.message
+        assert "hive validate" in result.hint
+
+    def test_file_not_found_agent(self):
+        exc = FileNotFoundError("agent.json not found")
+        exc.filename = "/path/to/agent.json"
+        result = _resolve_error(exc)
+        assert "agent.json" in result.message.lower() or "agent" in result.message.lower()
+        assert "hive list" in result.hint
+
+    def test_file_not_found_generic(self):
+        exc = FileNotFoundError("no such file")
+        exc.filename = "/some/config.yaml"
+        result = _resolve_error(exc)
+        assert "config.yaml" in result.message
+
+    def test_module_not_found_framework(self):
+        exc = ModuleNotFoundError("No module named 'framework'")
+        exc.name = "framework"
+        result = _resolve_error(exc)
+        assert "PYTHONPATH" in result.hint
+
+    def test_module_not_found_third_party(self):
+        exc = ModuleNotFoundError("No module named 'pandas'")
+        exc.name = "pandas"
+        result = _resolve_error(exc)
+        assert "pip install pandas" in result.hint
+
+    def test_permission_error(self):
+        result = _resolve_error(PermissionError("access denied"))
+        assert "Permission" in result.message or "permission" in result.message
+
+    def test_generic_fallback(self):
+        result = _resolve_error(RuntimeError("unexpected thing"))
+        assert "unexpected thing" in result.message
+        assert "--verbose" in result.hint
+
+    def test_cli_error_passthrough(self):
+        original = CLIError("custom", hint="custom hint")
+        result = _resolve_error(original)
+        assert result is original
+
+
+# ---------------------------------------------------------------------------
+# Decorator
+# ---------------------------------------------------------------------------
+
+
+class TestCLIErrorHandler:
+    def test_normal_return(self):
+        @cli_error_handler
+        def good_cmd(args):
+            return 0
+
+        assert good_cmd(argparse.Namespace()) == 0
+
+    def test_catches_cli_error(self, capsys):
+        @cli_error_handler
+        def bad_cmd(args):
+            raise CLIError("test error", hint="test hint")
+
+        result = bad_cmd(argparse.Namespace())
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Error: test error" in captured.err
+        assert "Hint: test hint" in captured.err
+
+    def test_catches_generic_exception(self, capsys):
+        @cli_error_handler
+        def exploding_cmd(args):
+            raise KeyError("steps")
+
+        result = exploding_cmd(argparse.Namespace())
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "steps" in captured.err
+
+    def test_keyboard_interrupt(self, capsys):
+        @cli_error_handler
+        def interrupted_cmd(args):
+            raise KeyboardInterrupt()
+
+        result = interrupted_cmd(argparse.Namespace())
+        assert result == 130
+
+    def test_system_exit_passthrough(self):
+        @cli_error_handler
+        def exiting_cmd(args):
+            raise SystemExit(42)
+
+        with pytest.raises(SystemExit) as exc_info:
+            exiting_cmd(argparse.Namespace())
+        assert exc_info.value.code == 42
+
+    def test_verbose_shows_traceback(self, capsys):
+        @cli_error_handler
+        def failing_cmd(args):
+            raise ValueError("details matter")
+
+        result = failing_cmd(argparse.Namespace(verbose=True))
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "ValueError" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Context manager
+# ---------------------------------------------------------------------------
+
+
+class TestCLIErrorContext:
+    def test_suppresses_exception(self, capsys):
+        with CLIErrorContext():
+            raise RuntimeError("boom")
+
+        captured = capsys.readouterr()
+        assert "boom" in captured.err
+
+    def test_no_exception(self):
+        with CLIErrorContext():
+            pass  # no error
+
+    def test_keyboard_interrupt_propagates(self):
+        with pytest.raises(KeyboardInterrupt):
+            with CLIErrorContext():
+                raise KeyboardInterrupt()
+
+    def test_system_exit_propagates(self):
+        with pytest.raises(SystemExit):
+            with CLIErrorContext():
+                raise SystemExit(1)


### PR DESCRIPTION
## Summary

- Introduces a **diagnostic-first error system** for CLI commands, replacing raw Python tracebacks with user-friendly messages and actionable remediation hints
- Implements a `CLIError` exception class with `message`, `hint`, and `details` fields, following the pattern proposed by @Janhvi2909 (Smart Remediation approach)
- Wraps all CLI entry points (`run`, `info`, `validate`, `list`, `dispatch`, `shell`) with a `@cli_error_handler` decorator that maps common exceptions to structured diagnostics
- Adds a last-resort handler at the top-level `main()` to catch anything that escapes command-level handling

### Error mappings included

| Exception | Guidance |
|-----------|----------|
| `KeyError` (e.g. `'steps'`) | Suggests correct schema key (`'nodes'`), recommends `hive validate` |
| `FileNotFoundError` (agent) | Points to `hive list` for discovery |
| `ModuleNotFoundError` (`framework`) | Shows correct `PYTHONPATH` setup |
| `ModuleNotFoundError` (third-party) | Suggests `pip install <module>` |
| `PermissionError` | Advises checking file permissions |
| Connection errors (`httpx`) | Suggests checking API key and network |
| Auth errors (401) | Points to API key configuration |
| Rate limit errors | Suggests waiting or switching model |
| Unknown errors | Recommends `--verbose` and links to issue tracker |

### Example output

**Before:**
```
KeyError: 'steps'
```

**After:**
```
Error: Agent schema key 'steps' not found.
  Hint: The agent graph uses 'nodes' instead of 'steps'.
  This may indicate an outdated agent export. Try re-exporting, then run:
    hive validate <agent_path>
```

## Test plan

- [x] 24 unit tests covering all error paths (CLIError, formatting, resolution, decorator, context manager)
- [x] All existing framework tests pass unchanged
- [x] Ruff lint passes with zero errors
- [ ] Manual verification: run `hive run nonexistent/` and confirm structured error output
- [ ] Manual verification: run with `--verbose` and confirm traceback is shown
- [ ] Review by @Janhvi2909 to validate Smart Remediation alignment

Closes #1337