### PR TITLE
micro-fix: Initialize dotenv in CLI entry point to ensure env vars load

### DIFF
--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -18,9 +18,11 @@ Testing commands:
 
 import argparse
 import sys
+from dotenv import load_dotenv
 
 
 def main():
+    load_dotenv()
     parser = argparse.ArgumentParser(description="Goal Agent - Build and run goal-driven agents")
     parser.add_argument(
         "--model",


### PR DESCRIPTION
## Summary
Fixed a bug where the agent runtime would attempt to initialize configuration settings before loading environment variables from the `.env` file, causing a crash on startup or missing keys.

## Changes
* Added `load_dotenv()` to the top of the `main()` function in `core/framework/cli.py`.
* Added `from dotenv import load_dotenv` import.

## Verification
* Created a local `.env` file with test variables.
* Verified that `cli.py` now successfully reads these variables immediately upon execution.