### PR TITLE
Fix storage path traversal and deadlock

### DIFF
--- a/core/framework/storage/backend.py
+++ b/core/framework/storage/backend.py
@@ -84,6 +84,7 @@ class FileStorage:
 
     def save_run(self, run: Run) -> None:
         """Save a run to storage."""
+        self._validate_key(run.id)
         # Save full run using Pydantic's model_dump_json
         run_path = self.base_path / "runs" / f"{run.id}.json"
         with open(run_path, "w") as f:
@@ -103,6 +104,7 @@ class FileStorage:
 
     def load_run(self, run_id: str) -> Run | None:
         """Load a run from storage."""
+        self._validate_key(run_id)
         run_path = self.base_path / "runs" / f"{run_id}.json"
         if not run_path.exists():
             return None
@@ -111,6 +113,7 @@ class FileStorage:
 
     def load_summary(self, run_id: str) -> RunSummary | None:
         """Load just the summary (faster than full run)."""
+        self._validate_key(run_id)
         summary_path = self.base_path / "summaries" / f"{run_id}.json"
         if not summary_path.exists():
             # Fall back to computing from full run
@@ -124,6 +127,7 @@ class FileStorage:
 
     def delete_run(self, run_id: str) -> bool:
         """Delete a run from storage."""
+        self._validate_key(run_id)
         run_path = self.base_path / "runs" / f"{run_id}.json"
         summary_path = self.base_path / "summaries" / f"{run_id}.json"
 

--- a/core/framework/storage/concurrent.py
+++ b/core/framework/storage/concurrent.py
@@ -195,6 +195,9 @@ class ConcurrentStorage:
             for node_id in run.metrics.nodes_executed:
                 index_lock_keys.append(f"index:by_node:{node_id}")
 
+            # Ensure deterministic lock acquisition order to prevent deadlocks
+            index_lock_keys.sort()
+
             # Collect index locks
             index_locks = [await get_lock(k) for k in index_lock_keys]
 

--- a/core/tests/test_path_traversal_fix.py
+++ b/core/tests/test_path_traversal_fix.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from framework.storage.backend import FileStorage
+from framework.schemas.run import Run
 
 
 class TestPathTraversalProtection:
@@ -170,6 +171,22 @@ class TestPathTraversalProtection:
         """Block attempts to modify sudoers file."""
         with pytest.raises(ValueError):
             storage._add_to_index("by_status", "../../../../etc/sudoers", "ALL=(ALL) NOPASSWD:ALL")
+
+    def test_blocks_run_id_traversal_on_save(self, storage):
+        """Save should block path traversal in run IDs."""
+        run = Run(id="../evil", goal_id="goal")
+        with pytest.raises(ValueError):
+            storage.save_run(run)
+
+    def test_blocks_run_id_traversal_on_load(self, storage):
+        """Load should block path traversal in run IDs."""
+        with pytest.raises(ValueError):
+            storage.load_run("../../secret")
+
+    def test_blocks_run_id_traversal_on_delete(self, storage):
+        """Delete should block path traversal in run IDs."""
+        with pytest.raises(ValueError):
+            storage.delete_run("../escape")
 
 
 class TestPathTraversalWithActualFiles:


### PR DESCRIPTION
Fixes a path traversal vulnerability in FileStorage by validating run IDs on save/load/delete, and prevents potential deadlocks in ConcurrentStorage by enforcing deterministic index lock ordering. Adds tests for run_id traversal attempts.

Type of Change
 → Bug fix (non-breaking change that fixes an issue)
 → New feature (non-breaking change that adds functionality)
 → Breaking change (fix or feature that would cause existing functionality to not work as expected)
 → Documentation update
 → Refactoring (no functional changes)

Related Issues
Fixes #1901

Changes Made
→ Validate run IDs in FileStorage run operations to prevent path traversal.
→ Sort index lock keys before acquiring locks in ConcurrentStorage.
→ Add tests covering run_id traversal attempts.

Testing
Describe the tests you ran to verify your changes:

→ Unit tests pass (python -m pytest [test_path_traversal_fix.py](http://_vscodecontentref_/0) core/tests/test_storage.py)
→ Lint passes (cd core && ruff check .)
→ Manual testing performed

Checklist
→ My code follows the project's style guidelines
→ I have performed a self-review of my code
→ I have commented my code, particularly in hard-to-understand areas
→ I have made corresponding changes to the documentation
→ My changes generate no new warnings
→ I have added tests that prove my fix is effective or that my feature works
→ New and existing unit tests pass locally with my changes