### PR TITLE
fix(csv): use parameterized query in csv_sql to prevent SQL injection

### DIFF
--- a/tools/src/aden_tools/tools/csv_tool/csv_tool.py
+++ b/tools/src/aden_tools/tools/csv_tool/csv_tool.py
@@ -349,7 +349,7 @@ def register_tools(mcp: FastMCP) -> None:
             con = duckdb.connect(":memory:")
             try:
                 # Load CSV as 'data' table
-                con.execute(f"CREATE TABLE data AS SELECT * FROM read_csv_auto('{secure_path}')")
+                con.execute("CREATE TABLE data AS SELECT * FROM read_csv_auto(?)", [secure_path])
 
                 # Execute user query
                 result = con.execute(query)

--- a/tools/tests/tools/test_csv_tool.py
+++ b/tools/tests/tools/test_csv_tool.py
@@ -820,3 +820,20 @@ class TestCsvSql:
         assert result["success"] is True
         assert result["row_count"] == 1
         assert result["rows"][0]["名前"] == "商品B"
+
+    def test_single_quote_in_filename(self, csv_tools, session_dir, tmp_path):
+        """Filenames with single quotes should not break SQL query."""
+        csv_file = session_dir / "report'2024.csv"
+        csv_file.write_text("id,value\n1,100\n2,200\n")
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = csv_tools["csv_sql"](
+                path="report'2024.csv",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="SELECT * FROM data",
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 2


### PR DESCRIPTION
## Summary

- Replace f-string path interpolation with DuckDB parameterized query in `csv_sql` to prevent SQL injection via filenames containing single quotes
- Add regression test verifying that CSV files with single-quote characters in their filenames are handled correctly

## Details

**File:** `tools/src/aden_tools/tools/csv_tool/csv_tool.py:352`

**Before (vulnerable):**
```python
con.execute(f"CREATE TABLE data AS SELECT * FROM read_csv_auto('{secure_path}')")
```

**After (safe):**
```python
con.execute("CREATE TABLE data AS SELECT * FROM read_csv_auto(?)", [secure_path])
```

The `secure_path` variable comes from `get_secure_path()`, which validates the path stays within the session sandbox but does not sanitize for SQL metacharacters. A filename like `report'2024.csv` would produce malformed SQL:
```sql
CREATE TABLE data AS SELECT * FROM read_csv_auto('/path/to/report'2024.csv')
```

Using DuckDB's native parameterized queries ensures the path is properly escaped by the database driver regardless of filename content.

## Test plan

- [x] All 46 existing csv_tool tests pass
- [x] New `test_single_quote_in_filename` test passes — confirms the fix handles single-quote filenames
- [x] Ruff lint and format checks pass

Closes #1915

🤖 Generated with [Claude Code](https://claude.com/claude-code)