### PR TITLE
[Feature]: Link goal evaluation outcomes to individual runs

### DIFF
--- a/core/framework/runtime/execution_stream.py
+++ b/core/framework/runtime/execution_stream.py
@@ -60,6 +60,7 @@ class ExecutionContext:
     entry_point: str
     input_data: dict[str, Any]
     isolation_level: IsolationLevel
+    run_id: str | None = None
     session_state: dict[str, Any] | None = None  # For resuming from pause
     started_at: datetime = field(default_factory=datetime.now)
     completed_at: datetime | None = None
@@ -333,6 +334,14 @@ class ExecutionStream:
                     input_data=ctx.input_data,
                     session_state=ctx.session_state,
                 )
+                
+                # Capture run_id from StreamRuntime
+                run = self._runtime.get_run(execution_id)
+                if run:
+                    ctx.run_id = run.id
+                    logger.debug(
+                        f"Linked execution {execution_id} to run {run.id}"
+                    )
 
                 # Store result with retention
                 self._record_execution_result(execution_id, result)

--- a/core/framework/runtime/stream_runtime.py
+++ b/core/framework/runtime/stream_runtime.py
@@ -262,6 +262,7 @@ class StreamRuntime:
             self._outcome_aggregator.record_decision(
                 stream_id=self.stream_id,
                 execution_id=execution_id,
+                run_id=run.id,
                 decision=decision,
             )
 
@@ -315,6 +316,7 @@ class StreamRuntime:
             self._outcome_aggregator.record_outcome(
                 stream_id=self.stream_id,
                 execution_id=execution_id,
+                run_id=run.id,
                 decision_id=decision_id,
                 outcome=outcome,
             )

--- a/core/framework/runtime/tests/test_run_id_propagation.py
+++ b/core/framework/runtime/tests/test_run_id_propagation.py
@@ -1,0 +1,102 @@
+"""
+Tests for run_id propagation across StreamRuntime and OutcomeAggregator.
+
+Ensures:
+1. StreamRuntime creates a run with a stable run_id
+2. Decisions propagate run_id into OutcomeAggregator
+3. Outcomes propagate run_id into OutcomeAggregator
+4. Aggregated records can be traced back to run_id
+"""
+
+import pytest
+
+from framework.runtime.stream_runtime import StreamRuntime
+from framework.runtime.outcome_aggregator import OutcomeAggregator
+from framework.schemas.decision import DecisionType
+from framework.graph.goal import Goal, SuccessCriterion
+from framework.storage.concurrent import ConcurrentStorage
+
+
+@pytest.fixture
+def sample_goal():
+    return Goal(
+        id="goal-1",
+        name="Test Goal",
+        description="Validate run_id propagation",
+        success_criteria=[
+            SuccessCriterion(
+                id="sc-1",
+                description="Decision succeeds",
+                metric="custom",
+                target="100%",
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def storage(tmp_path):
+    return ConcurrentStorage(tmp_path)
+
+
+@pytest.fixture
+def aggregator(sample_goal):
+    return OutcomeAggregator(goal=sample_goal)
+
+
+def test_run_id_propagation_to_outcome_aggregator(storage, aggregator):
+    """
+    Validate that run_id created in StreamRuntime is propagated
+    into OutcomeAggregator for both decisions and outcomes.
+    """
+
+    runtime = StreamRuntime(
+        stream_id="test-stream",
+        storage=storage,
+        outcome_aggregator=aggregator,
+    )
+
+    execution_id = "exec-123"
+
+    # --- Start run ---
+    run_id = runtime.start_run(
+        execution_id=execution_id,
+        goal_id="goal-1",
+        goal_description="Run ID propagation test",
+    )
+
+    assert run_id is not None
+
+    # --- Record decision ---
+    decision_id = runtime.decide(
+        execution_id=execution_id,
+        intent="Test decision",
+        options=[{"id": "opt-1", "description": "Only option"}],
+        chosen="opt-1",
+        reasoning="Single-path decision",
+        decision_type=DecisionType.CUSTOM,
+    )
+
+    assert decision_id != ""
+
+    # --- Record outcome ---
+    runtime.record_outcome(
+        execution_id=execution_id,
+        decision_id=decision_id,
+        success=True,
+        result={"ok": True},
+        summary="Decision succeeded",
+    )
+
+    # --- Validate aggregator state ---
+    assert len(aggregator._decisions) == 1
+
+    record = aggregator._decisions[0]
+
+    assert record.stream_id == "test-stream"
+    assert record.execution_id == execution_id
+    assert record.decision.id == decision_id
+    assert record.outcome is not None
+    assert record.outcome.success is True
+
+    assert record.run_id == run_id


### PR DESCRIPTION
## Description

This PR adds run-level traceability to Hive’s runtime by propagating the
`run_id` generated by `StreamRuntime` into `OutcomeAggregator` for both
decisions and outcomes. This allows aggregated results to be attributed
back to the specific run that produced them, improving observability and
debugging in concurrent execution scenarios.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Fixes #1743

## Changes Made

- Added `run_id` to `ExecutionContext`
- Captured the active run’s `run_id` during execution
- Propagated `run_id` through `StreamRuntime` into `OutcomeAggregator`
- Extended internal aggregation records without modifying public APIs
- Added a focused unit test validating end-to-end propagation

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest core/framework/runtime/tests/test_run_id_propagation.py`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
