### PR TITLE
feature: aden sync provider for credential store

### DIFF
--- a/core/framework/credentials/__init__.py
+++ b/core/framework/credentials/__init__.py
@@ -31,6 +31,13 @@ Quick Start:
 For OAuth2 support:
     from core.framework.credentials.oauth2 import BaseOAuth2Provider, OAuth2Config
 
+For Aden server sync:
+    from core.framework.credentials.aden import (
+        AdenCredentialClient,
+        AdenClientConfig,
+        AdenSyncProvider,
+    )
+
 For Vault integration:
     from core.framework.credentials.vault import HashiCorpVaultStorage
 """
@@ -62,6 +69,21 @@ from .storage import (
 from .store import CredentialStore
 from .template import TemplateResolver
 
+# Aden sync components (lazy import to avoid httpx dependency when not needed)
+# Usage: from core.framework.credentials.aden import AdenSyncProvider
+# Or: from core.framework.credentials import AdenSyncProvider
+try:
+    from .aden import (
+        AdenCachedStorage,
+        AdenClientConfig,
+        AdenCredentialClient,
+        AdenSyncProvider,
+    )
+
+    _ADEN_AVAILABLE = True
+except ImportError:
+    _ADEN_AVAILABLE = False
+
 __all__ = [
     # Main store
     "CredentialStore",
@@ -89,4 +111,12 @@ __all__ = [
     "CredentialRefreshError",
     "CredentialValidationError",
     "CredentialDecryptionError",
+    # Aden sync (optional - requires httpx)
+    "AdenSyncProvider",
+    "AdenCredentialClient",
+    "AdenClientConfig",
+    "AdenCachedStorage",
 ]
+
+# Track Aden availability for runtime checks
+ADEN_AVAILABLE = _ADEN_AVAILABLE

--- a/core/framework/credentials/aden/__init__.py
+++ b/core/framework/credentials/aden/__init__.py
@@ -1,0 +1,77 @@
+"""
+Aden Credential Sync.
+
+Components for synchronizing credentials with the Aden authentication server.
+
+The Aden server handles OAuth2 authorization flows and maintains refresh tokens.
+These components fetch and cache access tokens locally while delegating
+lifecycle management to Aden.
+
+Components:
+- AdenCredentialClient: HTTP client for Aden API
+- AdenSyncProvider: CredentialProvider that syncs with Aden
+- AdenCachedStorage: Storage with local cache + Aden fallback
+
+Quick Start:
+    from core.framework.credentials import CredentialStore
+    from core.framework.credentials.storage import EncryptedFileStorage
+    from core.framework.credentials.aden import (
+        AdenCredentialClient,
+        AdenClientConfig,
+        AdenSyncProvider,
+    )
+
+    # Configure
+    client = AdenCredentialClient(AdenClientConfig(
+        base_url=os.environ["ADEN_API_URL"],
+        api_key=os.environ["ADEN_API_KEY"],
+    ))
+
+    provider = AdenSyncProvider(client=client)
+
+    store = CredentialStore(
+        storage=EncryptedFileStorage(),
+        providers=[provider],
+        auto_refresh=True,
+    )
+
+    # Initial sync
+    provider.sync_all(store)
+
+    # Use normally
+    token = store.get_key("hubspot", "access_token")
+
+See docs/aden-credential-sync.md for detailed documentation.
+"""
+
+from .client import (
+    AdenAuthenticationError,
+    AdenClientConfig,
+    AdenClientError,
+    AdenCredentialClient,
+    AdenCredentialResponse,
+    AdenIntegrationInfo,
+    AdenNotFoundError,
+    AdenRateLimitError,
+    AdenRefreshError,
+)
+from .provider import AdenSyncProvider
+from .storage import AdenCachedStorage
+
+__all__ = [
+    # Client
+    "AdenCredentialClient",
+    "AdenClientConfig",
+    "AdenCredentialResponse",
+    "AdenIntegrationInfo",
+    # Client errors
+    "AdenClientError",
+    "AdenAuthenticationError",
+    "AdenNotFoundError",
+    "AdenRateLimitError",
+    "AdenRefreshError",
+    # Provider
+    "AdenSyncProvider",
+    # Storage
+    "AdenCachedStorage",
+]

--- a/core/framework/credentials/aden/__init__.py
+++ b/core/framework/credentials/aden/__init__.py
@@ -21,10 +21,9 @@ Quick Start:
         AdenSyncProvider,
     )
 
-    # Configure
+    # Configure (API key loaded from ADEN_API_KEY env var)
     client = AdenCredentialClient(AdenClientConfig(
         base_url=os.environ["ADEN_API_URL"],
-        api_key=os.environ["ADEN_API_KEY"],
     ))
 
     provider = AdenSyncProvider(client=client)

--- a/core/framework/credentials/aden/client.py
+++ b/core/framework/credentials/aden/client.py
@@ -1,0 +1,447 @@
+"""
+Aden Credential Client.
+
+HTTP client for communicating with the Aden authentication server.
+The Aden server handles OAuth2 authorization flows and token management.
+This client fetches tokens and delegates refresh operations to Aden.
+
+Usage:
+    client = AdenCredentialClient(AdenClientConfig(
+        base_url="https://hive.adenhq.com",
+        api_key=os.environ["ADEN_API_KEY"],
+    ))
+
+    # Fetch a credential
+    response = client.get_credential("hubspot")
+    if response:
+        print(f"Token expires at: {response.expires_at}")
+
+    # Request a refresh
+    refreshed = client.request_refresh("hubspot")
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class AdenClientError(Exception):
+    """Base exception for Aden client errors."""
+
+    pass
+
+
+class AdenAuthenticationError(AdenClientError):
+    """Raised when API key is invalid or revoked."""
+
+    pass
+
+
+class AdenNotFoundError(AdenClientError):
+    """Raised when integration is not found."""
+
+    pass
+
+
+class AdenRefreshError(AdenClientError):
+    """Raised when token refresh fails."""
+
+    def __init__(
+        self,
+        message: str,
+        requires_reauthorization: bool = False,
+        reauthorization_url: str | None = None,
+    ):
+        super().__init__(message)
+        self.requires_reauthorization = requires_reauthorization
+        self.reauthorization_url = reauthorization_url
+
+
+class AdenRateLimitError(AdenClientError):
+    """Raised when rate limited."""
+
+    def __init__(self, message: str, retry_after: int = 60):
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+@dataclass
+class AdenClientConfig:
+    """Configuration for Aden API client."""
+
+    base_url: str
+    """Base URL of the Aden server (e.g., 'https://hive.adenhq.com')."""
+
+    api_key: str
+    """Agent's API key for authenticating with Aden."""
+
+    tenant_id: str | None = None
+    """Optional tenant ID for multi-tenant deployments."""
+
+    timeout: float = 30.0
+    """Request timeout in seconds."""
+
+    retry_attempts: int = 3
+    """Number of retry attempts for transient failures."""
+
+    retry_delay: float = 1.0
+    """Base delay between retries in seconds (exponential backoff)."""
+
+
+@dataclass
+class AdenCredentialResponse:
+    """Response from Aden server containing credential data."""
+
+    integration_id: str
+    """Unique identifier for the integration (e.g., 'hubspot')."""
+
+    integration_type: str
+    """Type of integration (e.g., 'hubspot', 'github', 'slack')."""
+
+    access_token: str
+    """The access token for API calls."""
+
+    token_type: str = "Bearer"
+    """Token type (usually 'Bearer')."""
+
+    expires_at: datetime | None = None
+    """When the access token expires (UTC)."""
+
+    scopes: list[str] = field(default_factory=list)
+    """OAuth2 scopes granted to this token."""
+
+    metadata: dict[str, Any] = field(default_factory=dict)
+    """Additional integration-specific metadata."""
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AdenCredentialResponse:
+        """Create from API response dictionary."""
+        expires_at = None
+        if data.get("expires_at"):
+            expires_at = datetime.fromisoformat(data["expires_at"].replace("Z", "+00:00"))
+
+        return cls(
+            integration_id=data["integration_id"],
+            integration_type=data["integration_type"],
+            access_token=data["access_token"],
+            token_type=data.get("token_type", "Bearer"),
+            expires_at=expires_at,
+            scopes=data.get("scopes", []),
+            metadata=data.get("metadata", {}),
+        )
+
+
+@dataclass
+class AdenIntegrationInfo:
+    """Information about an available integration."""
+
+    integration_id: str
+    integration_type: str
+    status: str  # "active", "requires_reauth", "expired"
+    expires_at: datetime | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AdenIntegrationInfo:
+        """Create from API response dictionary."""
+        expires_at = None
+        if data.get("expires_at"):
+            expires_at = datetime.fromisoformat(data["expires_at"].replace("Z", "+00:00"))
+
+        return cls(
+            integration_id=data["integration_id"],
+            integration_type=data["integration_type"],
+            status=data["status"],
+            expires_at=expires_at,
+        )
+
+
+class AdenCredentialClient:
+    """
+    HTTP client for Aden credential server.
+
+    Handles communication with the Aden authentication server,
+    including fetching credentials, requesting refreshes, and
+    reporting usage statistics.
+
+    The client automatically handles:
+    - Retries with exponential backoff for transient failures
+    - Proper error classification (auth, not found, rate limit, etc.)
+    - Request headers for authentication and tenant isolation
+
+    Usage:
+        config = AdenClientConfig(
+            base_url="https://hive.adenhq.com",
+            api_key="your-agent-api-key",
+            tenant_id="optional-tenant-id",
+        )
+
+        client = AdenCredentialClient(config)
+
+        # Fetch a credential
+        cred = client.get_credential("hubspot")
+        if cred:
+            headers = {"Authorization": f"Bearer {cred.access_token}"}
+
+        # List all integrations
+        integrations = client.list_integrations()
+        for info in integrations:
+            print(f"{info.integration_id}: {info.status}")
+
+        # Clean up
+        client.close()
+    """
+
+    def __init__(self, config: AdenClientConfig):
+        """
+        Initialize the Aden client.
+
+        Args:
+            config: Client configuration including base URL and API key.
+        """
+        self.config = config
+        self._client: httpx.Client | None = None
+
+    def _get_client(self) -> httpx.Client:
+        """Get or create the HTTP client."""
+        if self._client is None:
+            headers = {
+                "Authorization": f"Bearer {self.config.api_key}",
+                "Content-Type": "application/json",
+                "User-Agent": "hive-credential-store/1.0",
+            }
+
+            if self.config.tenant_id:
+                headers["X-Tenant-ID"] = self.config.tenant_id
+
+            self._client = httpx.Client(
+                base_url=self.config.base_url,
+                timeout=self.config.timeout,
+                headers=headers,
+            )
+
+        return self._client
+
+    def _request_with_retry(
+        self,
+        method: str,
+        path: str,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        """Make a request with retry logic."""
+        client = self._get_client()
+        last_error: Exception | None = None
+
+        for attempt in range(self.config.retry_attempts):
+            try:
+                response = client.request(method, path, **kwargs)
+
+                # Handle specific error codes
+                if response.status_code == 401:
+                    raise AdenAuthenticationError("Agent API key is invalid or revoked")
+
+                if response.status_code == 404:
+                    raise AdenNotFoundError(f"Integration not found: {path}")
+
+                if response.status_code == 429:
+                    retry_after = int(response.headers.get("Retry-After", 60))
+                    raise AdenRateLimitError(
+                        "Rate limited by Aden server",
+                        retry_after=retry_after,
+                    )
+
+                if response.status_code == 400:
+                    data = response.json()
+                    if data.get("error") == "refresh_failed":
+                        raise AdenRefreshError(
+                            data.get("message", "Token refresh failed"),
+                            requires_reauthorization=data.get("requires_reauthorization", False),
+                            reauthorization_url=data.get("reauthorization_url"),
+                        )
+
+                # Success or other error
+                response.raise_for_status()
+                return response
+
+            except (httpx.ConnectError, httpx.TimeoutException) as e:
+                last_error = e
+                if attempt < self.config.retry_attempts - 1:
+                    delay = self.config.retry_delay * (2**attempt)
+                    logger.warning(
+                        f"Aden request failed (attempt {attempt + 1}), retrying in {delay}s: {e}"
+                    )
+                    time.sleep(delay)
+                else:
+                    raise AdenClientError(f"Failed to connect to Aden server: {e}") from e
+
+            except (
+                AdenAuthenticationError,
+                AdenNotFoundError,
+                AdenRefreshError,
+                AdenRateLimitError,
+            ):
+                # Don't retry these errors
+                raise
+
+        # Should not reach here, but just in case
+        raise AdenClientError(
+            f"Request failed after {self.config.retry_attempts} attempts"
+        ) from last_error
+
+    def get_credential(self, integration_id: str) -> AdenCredentialResponse | None:
+        """
+        Fetch the current credential for an integration.
+
+        The Aden server may refresh the token internally if it's expired
+        before returning it.
+
+        Args:
+            integration_id: The integration identifier (e.g., 'hubspot').
+
+        Returns:
+            Credential response with access token, or None if not found.
+
+        Raises:
+            AdenAuthenticationError: If API key is invalid.
+            AdenClientError: For connection failures.
+        """
+        try:
+            response = self._request_with_retry("GET", f"/v1/credentials/{integration_id}")
+            data = response.json()
+            return AdenCredentialResponse.from_dict(data)
+        except AdenNotFoundError:
+            return None
+
+    def request_refresh(self, integration_id: str) -> AdenCredentialResponse:
+        """
+        Request the Aden server to refresh the token.
+
+        Use this when the local store detects an expired or near-expiry token.
+        The Aden server handles the actual OAuth2 refresh token flow.
+
+        Args:
+            integration_id: The integration identifier.
+
+        Returns:
+            Credential response with new access token.
+
+        Raises:
+            AdenRefreshError: If refresh fails (may require re-authorization).
+            AdenNotFoundError: If integration not found.
+            AdenAuthenticationError: If API key is invalid.
+            AdenRateLimitError: If rate limited.
+        """
+        response = self._request_with_retry("POST", f"/v1/credentials/{integration_id}/refresh")
+        data = response.json()
+        return AdenCredentialResponse.from_dict(data)
+
+    def list_integrations(self) -> list[AdenIntegrationInfo]:
+        """
+        List all integrations available for this agent/tenant.
+
+        Returns:
+            List of integration info objects.
+
+        Raises:
+            AdenAuthenticationError: If API key is invalid.
+            AdenClientError: For connection failures.
+        """
+        response = self._request_with_retry("GET", "/v1/credentials")
+        data = response.json()
+        return [AdenIntegrationInfo.from_dict(item) for item in data.get("integrations", [])]
+
+    def validate_token(self, integration_id: str) -> dict[str, Any]:
+        """
+        Check if a token is still valid without fetching it.
+
+        Args:
+            integration_id: The integration identifier.
+
+        Returns:
+            Dict with 'valid' bool and optional 'expires_at', 'reason',
+            'requires_reauthorization', 'reauthorization_url'.
+
+        Raises:
+            AdenNotFoundError: If integration not found.
+            AdenAuthenticationError: If API key is invalid.
+        """
+        response = self._request_with_retry("GET", f"/v1/credentials/{integration_id}/validate")
+        return response.json()
+
+    def report_usage(
+        self,
+        integration_id: str,
+        operation: str,
+        status: str = "success",
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """
+        Report credential usage statistics to Aden.
+
+        This is optional and used for analytics/billing.
+
+        Args:
+            integration_id: The integration identifier.
+            operation: Operation name (e.g., 'api_call').
+            status: Operation status ('success', 'error').
+            metadata: Additional operation metadata.
+        """
+        try:
+            self._request_with_retry(
+                "POST",
+                f"/v1/credentials/{integration_id}/usage",
+                json={
+                    "operation": operation,
+                    "status": status,
+                    "timestamp": datetime.utcnow().isoformat() + "Z",
+                    "metadata": metadata or {},
+                },
+            )
+        except Exception as e:
+            # Usage reporting is best-effort, don't fail on errors
+            logger.warning(f"Failed to report usage for '{integration_id}': {e}")
+
+    def health_check(self) -> dict[str, Any]:
+        """
+        Check Aden server health and connectivity.
+
+        Returns:
+            Dict with 'status', 'version', 'timestamp', and optionally 'error'.
+        """
+        try:
+            client = self._get_client()
+            response = client.get("/health")
+            if response.status_code == 200:
+                data = response.json()
+                data["latency_ms"] = response.elapsed.total_seconds() * 1000
+                return data
+            return {
+                "status": "degraded",
+                "error": f"Unexpected status code: {response.status_code}",
+            }
+        except Exception as e:
+            return {
+                "status": "unhealthy",
+                "error": str(e),
+            }
+
+    def close(self) -> None:
+        """Close the HTTP client and release resources."""
+        if self._client:
+            self._client.close()
+            self._client = None
+
+    def __enter__(self) -> AdenCredentialClient:
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        """Context manager exit."""
+        self.close()

--- a/core/framework/credentials/aden/provider.py
+++ b/core/framework/credentials/aden/provider.py
@@ -14,10 +14,9 @@ Usage:
         AdenSyncProvider,
     )
 
-    # Configure client
+    # Configure client (API key loaded from ADEN_API_KEY env var)
     client = AdenCredentialClient(AdenClientConfig(
         base_url=os.environ["ADEN_API_URL"],
-        api_key=os.environ["ADEN_API_KEY"],
     ))
 
     # Create provider
@@ -409,10 +408,8 @@ class AdenSyncProvider(CredentialProvider):
 
         return CredentialObject(
             id=aden_response.integration_id,
-            name=f"{aden_response.integration_type.title()} Integration",
             credential_type=CredentialType.OAUTH2,
             keys=keys,
             provider_id=self.provider_id,
             auto_refresh=True,
-            metadata=aden_response.metadata,
         )

--- a/core/framework/credentials/aden/provider.py
+++ b/core/framework/credentials/aden/provider.py
@@ -1,0 +1,418 @@
+"""
+Aden Sync Provider.
+
+Provider that synchronizes credentials with the Aden authentication server.
+The Aden server is the authoritative source for OAuth2 tokens - this provider
+fetches and caches tokens locally while delegating refresh operations to Aden.
+
+Usage:
+    from core.framework.credentials import CredentialStore
+    from core.framework.credentials.storage import EncryptedFileStorage
+    from core.framework.credentials.aden import (
+        AdenCredentialClient,
+        AdenClientConfig,
+        AdenSyncProvider,
+    )
+
+    # Configure client
+    client = AdenCredentialClient(AdenClientConfig(
+        base_url=os.environ["ADEN_API_URL"],
+        api_key=os.environ["ADEN_API_KEY"],
+    ))
+
+    # Create provider
+    provider = AdenSyncProvider(client=client)
+
+    # Create store
+    store = CredentialStore(
+        storage=EncryptedFileStorage(),
+        providers=[provider],
+        auto_refresh=True,
+    )
+
+    # Initial sync from Aden
+    provider.sync_all(store)
+
+    # Use normally - auto-refreshes via Aden when needed
+    token = store.get_key("hubspot", "access_token")
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from pydantic import SecretStr
+
+from ..models import CredentialKey, CredentialObject, CredentialRefreshError, CredentialType
+from ..provider import CredentialProvider
+from .client import (
+    AdenClientError,
+    AdenCredentialClient,
+    AdenCredentialResponse,
+    AdenRefreshError,
+)
+
+if TYPE_CHECKING:
+    from ..store import CredentialStore
+
+logger = logging.getLogger(__name__)
+
+
+class AdenSyncProvider(CredentialProvider):
+    """
+    Provider that synchronizes credentials with the Aden server.
+
+    The Aden server handles OAuth2 authorization flows and maintains
+    refresh tokens. This provider:
+
+    - Fetches access tokens from the Aden server
+    - Delegates token refresh to the Aden server
+    - Caches tokens locally in the credential store
+    - Optionally reports usage statistics back to Aden
+
+    Key benefits:
+    - Client secrets never leave the Aden server
+    - Refresh token security (stored only on Aden)
+    - Centralized audit logging
+    - Multi-tenant support
+
+    Usage:
+        client = AdenCredentialClient(AdenClientConfig(
+            base_url="https://hive.adenhq.com",
+            api_key=os.environ["ADEN_API_KEY"],
+        ))
+
+        provider = AdenSyncProvider(client=client)
+
+        store = CredentialStore(
+            storage=EncryptedFileStorage(),
+            providers=[provider],
+            auto_refresh=True,
+        )
+    """
+
+    def __init__(
+        self,
+        client: AdenCredentialClient,
+        provider_id: str = "aden_sync",
+        refresh_buffer_minutes: int = 5,
+        report_usage: bool = False,
+    ):
+        """
+        Initialize the Aden sync provider.
+
+        Args:
+            client: Configured Aden API client.
+            provider_id: Unique identifier for this provider instance.
+                        Useful for multi-tenant scenarios (e.g., 'aden_tenant_123').
+            refresh_buffer_minutes: Minutes before expiry to trigger refresh.
+                                   Default is 5 minutes.
+            report_usage: Whether to report usage statistics to Aden server.
+        """
+        self._client = client
+        self._provider_id = provider_id
+        self._refresh_buffer = timedelta(minutes=refresh_buffer_minutes)
+        self._report_usage = report_usage
+
+    @property
+    def provider_id(self) -> str:
+        """Unique identifier for this provider."""
+        return self._provider_id
+
+    @property
+    def supported_types(self) -> list[CredentialType]:
+        """Credential types this provider can manage."""
+        return [CredentialType.OAUTH2, CredentialType.BEARER_TOKEN]
+
+    def can_handle(self, credential: CredentialObject) -> bool:
+        """
+        Check if this provider can handle a credential.
+
+        Returns True if:
+        - Credential type is supported (OAUTH2 or BEARER_TOKEN)
+        - Credential's provider_id matches this provider, OR
+        - Credential has '_aden_managed' metadata flag
+        """
+        if credential.credential_type not in self.supported_types:
+            return False
+
+        # Check if credential is explicitly linked to this provider
+        if credential.provider_id == self.provider_id:
+            return True
+
+        # Check for Aden-managed flag in metadata
+        aden_flag = credential.keys.get("_aden_managed")
+        if aden_flag and aden_flag.value.get_secret_value() == "true":
+            return True
+
+        return False
+
+    def refresh(self, credential: CredentialObject) -> CredentialObject:
+        """
+        Refresh credential by requesting new token from Aden server.
+
+        The Aden server handles the actual OAuth2 refresh token flow.
+        This method simply fetches the result.
+
+        Args:
+            credential: The credential to refresh.
+
+        Returns:
+            Updated credential with new access token.
+
+        Raises:
+            CredentialRefreshError: If refresh fails.
+        """
+        try:
+            # Request Aden to refresh the token
+            aden_response = self._client.request_refresh(credential.id)
+
+            # Update credential with new values
+            credential = self._update_credential_from_aden(credential, aden_response)
+
+            logger.info(f"Refreshed credential '{credential.id}' via Aden server")
+
+            # Report usage if enabled
+            if self._report_usage:
+                self._client.report_usage(
+                    integration_id=credential.id,
+                    operation="token_refresh",
+                    status="success",
+                )
+
+            return credential
+
+        except AdenRefreshError as e:
+            logger.error(f"Aden refresh failed for '{credential.id}': {e}")
+
+            if e.requires_reauthorization:
+                raise CredentialRefreshError(
+                    f"Integration '{credential.id}' requires re-authorization. "
+                    f"Visit: {e.reauthorization_url or 'your Aden dashboard'}"
+                ) from e
+
+            raise CredentialRefreshError(
+                f"Failed to refresh credential '{credential.id}': {e}"
+            ) from e
+
+        except AdenClientError as e:
+            logger.error(f"Aden client error for '{credential.id}': {e}")
+
+            # Check if local token is still valid
+            access_key = credential.keys.get("access_token")
+            if access_key and access_key.expires_at:
+                if datetime.now(UTC) < access_key.expires_at:
+                    logger.warning(f"Aden unavailable, using cached token for '{credential.id}'")
+                    return credential
+
+            raise CredentialRefreshError(
+                f"Aden server unavailable and token expired for '{credential.id}'"
+            ) from e
+
+    def validate(self, credential: CredentialObject) -> bool:
+        """
+        Validate credential via Aden server introspection.
+
+        Args:
+            credential: The credential to validate.
+
+        Returns:
+            True if credential is valid.
+        """
+        try:
+            result = self._client.validate_token(credential.id)
+            return result.get("valid", False)
+        except AdenClientError:
+            # Fall back to local validation
+            access_key = credential.keys.get("access_token")
+            if access_key is None:
+                return False
+
+            if access_key.expires_at is None:
+                # No expiration - assume valid
+                return True
+
+            return datetime.now(UTC) < access_key.expires_at
+
+    def should_refresh(self, credential: CredentialObject) -> bool:
+        """
+        Check if credential should be refreshed.
+
+        Returns True if access_token is expired or within the refresh buffer.
+
+        Args:
+            credential: The credential to check.
+
+        Returns:
+            True if credential should be refreshed.
+        """
+        access_key = credential.keys.get("access_token")
+        if access_key is None:
+            return False
+
+        if access_key.expires_at is None:
+            return False
+
+        # Refresh if within buffer of expiration
+        return datetime.now(UTC) >= (access_key.expires_at - self._refresh_buffer)
+
+    def fetch_from_aden(self, integration_id: str) -> CredentialObject | None:
+        """
+        Fetch credential directly from Aden server.
+
+        Use this for initial population or when local cache is missing.
+
+        Args:
+            integration_id: The integration identifier (e.g., 'hubspot').
+
+        Returns:
+            CredentialObject if found, None otherwise.
+
+        Raises:
+            AdenClientError: For connection failures.
+        """
+        aden_response = self._client.get_credential(integration_id)
+        if aden_response is None:
+            return None
+
+        return self._aden_response_to_credential(aden_response)
+
+    def sync_all(self, store: CredentialStore) -> int:
+        """
+        Sync all credentials from Aden server to local store.
+
+        Fetches the list of available integrations from Aden and
+        populates the local credential store with current tokens.
+
+        Args:
+            store: The credential store to populate.
+
+        Returns:
+            Number of credentials synced.
+        """
+        synced = 0
+
+        try:
+            integrations = self._client.list_integrations()
+
+            for info in integrations:
+                if info.status != "active":
+                    logger.warning(
+                        f"Skipping integration '{info.integration_id}': status={info.status}"
+                    )
+                    continue
+
+                try:
+                    cred = self.fetch_from_aden(info.integration_id)
+                    if cred:
+                        store.save_credential(cred)
+                        synced += 1
+                        logger.info(f"Synced credential '{info.integration_id}' from Aden")
+                except Exception as e:
+                    logger.warning(f"Failed to sync '{info.integration_id}': {e}")
+
+        except AdenClientError as e:
+            logger.error(f"Failed to list integrations from Aden: {e}")
+
+        return synced
+
+    def report_credential_usage(
+        self,
+        credential: CredentialObject,
+        operation: str,
+        status: str = "success",
+        metadata: dict | None = None,
+    ) -> None:
+        """
+        Report credential usage to Aden server.
+
+        Args:
+            credential: The credential that was used.
+            operation: Operation name (e.g., 'api_call').
+            status: Operation status ('success', 'error').
+            metadata: Additional metadata.
+        """
+        if self._report_usage:
+            self._client.report_usage(
+                integration_id=credential.id,
+                operation=operation,
+                status=status,
+                metadata=metadata or {},
+            )
+
+    def _update_credential_from_aden(
+        self,
+        credential: CredentialObject,
+        aden_response: AdenCredentialResponse,
+    ) -> CredentialObject:
+        """Update credential object from Aden response."""
+        # Update access token
+        credential.keys["access_token"] = CredentialKey(
+            name="access_token",
+            value=SecretStr(aden_response.access_token),
+            expires_at=aden_response.expires_at,
+        )
+
+        # Update scopes if present
+        if aden_response.scopes:
+            credential.keys["scope"] = CredentialKey(
+                name="scope",
+                value=SecretStr(" ".join(aden_response.scopes)),
+            )
+
+        # Mark as Aden-managed
+        credential.keys["_aden_managed"] = CredentialKey(
+            name="_aden_managed",
+            value=SecretStr("true"),
+        )
+
+        # Store integration type
+        credential.keys["_integration_type"] = CredentialKey(
+            name="_integration_type",
+            value=SecretStr(aden_response.integration_type),
+        )
+
+        # Update timestamps
+        credential.last_refreshed = datetime.now(UTC)
+        credential.provider_id = self.provider_id
+
+        return credential
+
+    def _aden_response_to_credential(
+        self,
+        aden_response: AdenCredentialResponse,
+    ) -> CredentialObject:
+        """Convert Aden response to CredentialObject."""
+        keys: dict[str, CredentialKey] = {
+            "access_token": CredentialKey(
+                name="access_token",
+                value=SecretStr(aden_response.access_token),
+                expires_at=aden_response.expires_at,
+            ),
+            "_aden_managed": CredentialKey(
+                name="_aden_managed",
+                value=SecretStr("true"),
+            ),
+            "_integration_type": CredentialKey(
+                name="_integration_type",
+                value=SecretStr(aden_response.integration_type),
+            ),
+        }
+
+        if aden_response.scopes:
+            keys["scope"] = CredentialKey(
+                name="scope",
+                value=SecretStr(" ".join(aden_response.scopes)),
+            )
+
+        return CredentialObject(
+            id=aden_response.integration_id,
+            name=f"{aden_response.integration_type.title()} Integration",
+            credential_type=CredentialType.OAUTH2,
+            keys=keys,
+            provider_id=self.provider_id,
+            auto_refresh=True,
+            metadata=aden_response.metadata,
+        )

--- a/core/framework/credentials/aden/storage.py
+++ b/core/framework/credentials/aden/storage.py
@@ -1,0 +1,307 @@
+"""
+Aden Cached Storage.
+
+Storage backend that combines local cache with Aden server fallback.
+Provides offline resilience by caching credentials locally while
+keeping them synchronized with the Aden server.
+
+Usage:
+    from core.framework.credentials import CredentialStore
+    from core.framework.credentials.storage import EncryptedFileStorage
+    from core.framework.credentials.aden import (
+        AdenCredentialClient,
+        AdenClientConfig,
+        AdenSyncProvider,
+        AdenCachedStorage,
+    )
+
+    # Configure
+    client = AdenCredentialClient(AdenClientConfig(
+        base_url=os.environ["ADEN_API_URL"],
+        api_key=os.environ["ADEN_API_KEY"],
+    ))
+    provider = AdenSyncProvider(client=client)
+
+    # Create cached storage
+    storage = AdenCachedStorage(
+        local_storage=EncryptedFileStorage(),
+        aden_provider=provider,
+        cache_ttl_seconds=300,  # Re-check Aden every 5 minutes
+    )
+
+    # Create store
+    store = CredentialStore(
+        storage=storage,
+        providers=[provider],
+        auto_refresh=True,
+    )
+
+    # Credentials automatically fetched from Aden on first access
+    # Cached locally for 5 minutes
+    # Falls back to cache if Aden is unreachable
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from ..storage import CredentialStorage
+
+if TYPE_CHECKING:
+    from ..models import CredentialObject
+    from .provider import AdenSyncProvider
+
+logger = logging.getLogger(__name__)
+
+
+class AdenCachedStorage(CredentialStorage):
+    """
+    Storage with local cache and Aden server fallback.
+
+    This storage provides:
+    - **Reads**: Try local cache first, fallback to Aden if stale/missing
+    - **Writes**: Always write to local cache
+    - **Offline resilience**: Uses cached credentials when Aden is unreachable
+
+    The cache TTL determines how long to trust local credentials before
+    checking with the Aden server for updates. This balances:
+    - Performance (fewer network calls)
+    - Freshness (tokens stay current)
+    - Resilience (works during brief outages)
+
+    Usage:
+        storage = AdenCachedStorage(
+            local_storage=EncryptedFileStorage(),
+            aden_provider=provider,
+            cache_ttl_seconds=300,  # 5 minutes
+        )
+
+        store = CredentialStore(
+            storage=storage,
+            providers=[provider],
+        )
+
+        # First access fetches from Aden
+        # Subsequent accesses use cache until TTL expires
+        token = store.get_key("hubspot", "access_token")
+    """
+
+    def __init__(
+        self,
+        local_storage: CredentialStorage,
+        aden_provider: AdenSyncProvider,
+        cache_ttl_seconds: int = 300,
+        prefer_local: bool = True,
+    ):
+        """
+        Initialize Aden-cached storage.
+
+        Args:
+            local_storage: Local storage backend for caching (e.g., EncryptedFileStorage).
+            aden_provider: Provider for fetching from Aden server.
+            cache_ttl_seconds: How long to trust local cache before checking Aden.
+                              Default is 300 seconds (5 minutes).
+            prefer_local: If True, use local cache when available and fresh.
+                         If False, always check Aden first.
+        """
+        self._local = local_storage
+        self._aden_provider = aden_provider
+        self._cache_ttl = timedelta(seconds=cache_ttl_seconds)
+        self._prefer_local = prefer_local
+        self._cache_timestamps: dict[str, datetime] = {}
+
+    def save(self, credential: CredentialObject) -> None:
+        """
+        Save credential to local cache.
+
+        Args:
+            credential: The credential to save.
+        """
+        self._local.save(credential)
+        self._cache_timestamps[credential.id] = datetime.now(UTC)
+        logger.debug(f"Cached credential '{credential.id}'")
+
+    def load(self, credential_id: str) -> CredentialObject | None:
+        """
+        Load credential from cache, with Aden fallback.
+
+        The loading strategy depends on the `prefer_local` setting:
+
+        If prefer_local=True (default):
+        1. Check if local cache exists and is fresh (within TTL)
+        2. If fresh, return cached credential
+        3. If stale or missing, fetch from Aden
+        4. Update local cache with Aden response
+        5. If Aden fails, fall back to stale cache
+
+        If prefer_local=False:
+        1. Always try to fetch from Aden first
+        2. Update local cache with response
+        3. Fall back to local cache only if Aden fails
+
+        Args:
+            credential_id: The credential identifier.
+
+        Returns:
+            CredentialObject if found, None otherwise.
+        """
+        local_cred = self._local.load(credential_id)
+
+        # If we prefer local and have a fresh cache, use it
+        if self._prefer_local and local_cred and self._is_cache_fresh(credential_id):
+            logger.debug(f"Using cached credential '{credential_id}'")
+            return local_cred
+
+        # Try to fetch from Aden
+        try:
+            aden_cred = self._aden_provider.fetch_from_aden(credential_id)
+            if aden_cred:
+                # Update local cache
+                self.save(aden_cred)
+                logger.debug(f"Fetched credential '{credential_id}' from Aden")
+                return aden_cred
+        except Exception as e:
+            logger.warning(f"Failed to fetch '{credential_id}' from Aden: {e}")
+
+            # Fall back to local cache if Aden fails
+            if local_cred:
+                logger.info(f"Using stale cached credential '{credential_id}'")
+                return local_cred
+
+        # Return local credential if it exists (may be None)
+        return local_cred
+
+    def delete(self, credential_id: str) -> bool:
+        """
+        Delete credential from local cache.
+
+        Note: This does NOT delete the credential from the Aden server.
+        It only removes the local cache entry.
+
+        Args:
+            credential_id: The credential identifier.
+
+        Returns:
+            True if credential existed and was deleted.
+        """
+        self._cache_timestamps.pop(credential_id, None)
+        return self._local.delete(credential_id)
+
+    def list_all(self) -> list[str]:
+        """
+        List credentials from local cache.
+
+        Returns:
+            List of credential IDs in local cache.
+        """
+        return self._local.list_all()
+
+    def exists(self, credential_id: str) -> bool:
+        """
+        Check if credential exists in local cache.
+
+        Args:
+            credential_id: The credential identifier.
+
+        Returns:
+            True if credential exists locally.
+        """
+        return self._local.exists(credential_id)
+
+    def _is_cache_fresh(self, credential_id: str) -> bool:
+        """
+        Check if local cache is still fresh (within TTL).
+
+        Args:
+            credential_id: The credential identifier.
+
+        Returns:
+            True if cache is fresh, False if stale or not cached.
+        """
+        cached_at = self._cache_timestamps.get(credential_id)
+        if cached_at is None:
+            return False
+        return datetime.now(UTC) - cached_at < self._cache_ttl
+
+    def invalidate_cache(self, credential_id: str) -> None:
+        """
+        Invalidate cache for a specific credential.
+
+        The next load() call will fetch from Aden regardless of TTL.
+
+        Args:
+            credential_id: The credential identifier.
+        """
+        self._cache_timestamps.pop(credential_id, None)
+        logger.debug(f"Invalidated cache for '{credential_id}'")
+
+    def invalidate_all(self) -> None:
+        """Invalidate all cache entries."""
+        self._cache_timestamps.clear()
+        logger.debug("Invalidated all cache entries")
+
+    def sync_all_from_aden(self) -> int:
+        """
+        Sync all credentials from Aden server to local cache.
+
+        Fetches the list of available integrations from Aden and
+        updates the local cache with current tokens.
+
+        Returns:
+            Number of credentials synced.
+        """
+        synced = 0
+
+        try:
+            integrations = self._aden_provider._client.list_integrations()
+
+            for info in integrations:
+                if info.status != "active":
+                    logger.warning(
+                        f"Skipping integration '{info.integration_id}': status={info.status}"
+                    )
+                    continue
+
+                try:
+                    cred = self._aden_provider.fetch_from_aden(info.integration_id)
+                    if cred:
+                        self.save(cred)
+                        synced += 1
+                        logger.info(f"Synced credential '{info.integration_id}' from Aden")
+                except Exception as e:
+                    logger.warning(f"Failed to sync '{info.integration_id}': {e}")
+
+        except Exception as e:
+            logger.error(f"Failed to list integrations from Aden: {e}")
+
+        return synced
+
+    def get_cache_info(self) -> dict[str, dict]:
+        """
+        Get cache status information for all credentials.
+
+        Returns:
+            Dict mapping credential_id to cache info (cached_at, is_fresh, ttl_remaining).
+        """
+        now = datetime.now(UTC)
+        info = {}
+
+        for cred_id in self.list_all():
+            cached_at = self._cache_timestamps.get(cred_id)
+            if cached_at:
+                ttl_remaining = (cached_at + self._cache_ttl - now).total_seconds()
+                info[cred_id] = {
+                    "cached_at": cached_at.isoformat(),
+                    "is_fresh": ttl_remaining > 0,
+                    "ttl_remaining_seconds": max(0, ttl_remaining),
+                }
+            else:
+                info[cred_id] = {
+                    "cached_at": None,
+                    "is_fresh": False,
+                    "ttl_remaining_seconds": 0,
+                }
+
+        return info

--- a/core/framework/credentials/aden/tests/__init__.py
+++ b/core/framework/credentials/aden/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Aden credential sync components."""

--- a/core/framework/credentials/aden/tests/test_aden_sync.py
+++ b/core/framework/credentials/aden/tests/test_aden_sync.py
@@ -1,0 +1,670 @@
+"""
+Tests for Aden credential sync components.
+
+Tests cover:
+- AdenCredentialClient: HTTP client for Aden API
+- AdenSyncProvider: Provider that syncs with Aden
+- AdenCachedStorage: Storage with local cache + Aden fallback
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import Mock
+
+import pytest
+from pydantic import SecretStr
+
+from framework.credentials import (
+    CredentialKey,
+    CredentialObject,
+    CredentialStore,
+    CredentialType,
+    InMemoryStorage,
+)
+from framework.credentials.aden import (
+    AdenCachedStorage,
+    AdenClientConfig,
+    AdenClientError,
+    AdenCredentialClient,
+    AdenCredentialResponse,
+    AdenIntegrationInfo,
+    AdenRefreshError,
+    AdenSyncProvider,
+)
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def aden_config():
+    """Create a test Aden client config."""
+    return AdenClientConfig(
+        base_url="https://api.test-aden.com",
+        api_key="test-api-key",
+        tenant_id="test-tenant",
+        timeout=5.0,
+        retry_attempts=2,
+        retry_delay=0.1,
+    )
+
+
+@pytest.fixture
+def mock_client(aden_config):
+    """Create a mock Aden client."""
+    client = Mock(spec=AdenCredentialClient)
+    client.config = aden_config
+    return client
+
+
+@pytest.fixture
+def aden_response():
+    """Create a sample Aden credential response."""
+    return AdenCredentialResponse(
+        integration_id="hubspot",
+        integration_type="hubspot",
+        access_token="test-access-token",
+        token_type="Bearer",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        scopes=["crm.objects.contacts.read", "crm.objects.contacts.write"],
+        metadata={"portal_id": "12345"},
+    )
+
+
+@pytest.fixture
+def provider(mock_client):
+    """Create an AdenSyncProvider with mock client."""
+    return AdenSyncProvider(
+        client=mock_client,
+        provider_id="test_aden",
+        refresh_buffer_minutes=5,
+        report_usage=False,
+    )
+
+
+@pytest.fixture
+def local_storage():
+    """Create an in-memory storage for testing."""
+    return InMemoryStorage()
+
+
+@pytest.fixture
+def cached_storage(local_storage, provider):
+    """Create an AdenCachedStorage for testing."""
+    return AdenCachedStorage(
+        local_storage=local_storage,
+        aden_provider=provider,
+        cache_ttl_seconds=60,
+        prefer_local=True,
+    )
+
+
+# =============================================================================
+# AdenCredentialResponse Tests
+# =============================================================================
+
+
+class TestAdenCredentialResponse:
+    """Tests for AdenCredentialResponse dataclass."""
+
+    def test_from_dict_basic(self):
+        """Test creating response from dict."""
+        data = {
+            "integration_id": "github",
+            "integration_type": "github",
+            "access_token": "ghp_xxxxx",
+        }
+
+        response = AdenCredentialResponse.from_dict(data)
+
+        assert response.integration_id == "github"
+        assert response.integration_type == "github"
+        assert response.access_token == "ghp_xxxxx"
+        assert response.token_type == "Bearer"
+        assert response.expires_at is None
+        assert response.scopes == []
+
+    def test_from_dict_full(self):
+        """Test creating response with all fields."""
+        data = {
+            "integration_id": "hubspot",
+            "integration_type": "hubspot",
+            "access_token": "token123",
+            "token_type": "Bearer",
+            "expires_at": "2026-01-28T15:30:00Z",
+            "scopes": ["read", "write"],
+            "metadata": {"key": "value"},
+        }
+
+        response = AdenCredentialResponse.from_dict(data)
+
+        assert response.integration_id == "hubspot"
+        assert response.access_token == "token123"
+        assert response.expires_at is not None
+        assert response.scopes == ["read", "write"]
+        assert response.metadata == {"key": "value"}
+
+
+class TestAdenIntegrationInfo:
+    """Tests for AdenIntegrationInfo dataclass."""
+
+    def test_from_dict(self):
+        """Test creating integration info from dict."""
+        data = {
+            "integration_id": "slack",
+            "integration_type": "slack",
+            "status": "active",
+            "expires_at": "2026-02-01T00:00:00Z",
+        }
+
+        info = AdenIntegrationInfo.from_dict(data)
+
+        assert info.integration_id == "slack"
+        assert info.integration_type == "slack"
+        assert info.status == "active"
+        assert info.expires_at is not None
+
+
+# =============================================================================
+# AdenSyncProvider Tests
+# =============================================================================
+
+
+class TestAdenSyncProvider:
+    """Tests for AdenSyncProvider."""
+
+    def test_provider_id(self, provider):
+        """Test provider ID."""
+        assert provider.provider_id == "test_aden"
+
+    def test_supported_types(self, provider):
+        """Test supported credential types."""
+        assert CredentialType.OAUTH2 in provider.supported_types
+        assert CredentialType.BEARER_TOKEN in provider.supported_types
+
+    def test_can_handle_oauth2(self, provider):
+        """Test can_handle returns True for OAUTH2 credentials with matching provider_id."""
+        cred = CredentialObject(
+            id="test",
+            credential_type=CredentialType.OAUTH2,
+            keys={},
+            provider_id="test_aden",
+        )
+
+        assert provider.can_handle(cred) is True
+
+    def test_can_handle_aden_managed(self, provider):
+        """Test can_handle returns True for Aden-managed credentials."""
+        cred = CredentialObject(
+            id="test",
+            credential_type=CredentialType.OAUTH2,
+            keys={
+                "_aden_managed": CredentialKey(
+                    name="_aden_managed",
+                    value=SecretStr("true"),
+                )
+            },
+        )
+
+        assert provider.can_handle(cred) is True
+
+    def test_can_handle_wrong_type(self, provider):
+        """Test can_handle returns False for unsupported types."""
+        cred = CredentialObject(
+            id="test",
+            credential_type=CredentialType.API_KEY,
+            keys={},
+        )
+
+        assert provider.can_handle(cred) is False
+
+    def test_refresh_success(self, provider, mock_client, aden_response):
+        """Test successful credential refresh."""
+        mock_client.request_refresh.return_value = aden_response
+
+        cred = CredentialObject(
+            id="hubspot",
+            credential_type=CredentialType.OAUTH2,
+            keys={
+                "access_token": CredentialKey(
+                    name="access_token",
+                    value=SecretStr("old-token"),
+                )
+            },
+            provider_id="test_aden",
+        )
+
+        refreshed = provider.refresh(cred)
+
+        assert refreshed.keys["access_token"].value.get_secret_value() == "test-access-token"
+        assert refreshed.keys["_aden_managed"].value.get_secret_value() == "true"
+        assert refreshed.last_refreshed is not None
+        mock_client.request_refresh.assert_called_once_with("hubspot")
+
+    def test_refresh_requires_reauth(self, provider, mock_client):
+        """Test refresh that requires re-authorization."""
+        mock_client.request_refresh.side_effect = AdenRefreshError(
+            "Token revoked",
+            requires_reauthorization=True,
+            reauthorization_url="https://aden.com/reauth",
+        )
+
+        cred = CredentialObject(
+            id="hubspot",
+            credential_type=CredentialType.OAUTH2,
+            keys={},
+        )
+
+        from framework.credentials import CredentialRefreshError
+
+        with pytest.raises(CredentialRefreshError) as exc_info:
+            provider.refresh(cred)
+
+        assert "re-authorization" in str(exc_info.value).lower()
+
+    def test_refresh_aden_unavailable_cached_valid(self, provider, mock_client):
+        """Test refresh falls back to cache when Aden is unavailable and token is valid."""
+        mock_client.request_refresh.side_effect = AdenClientError("Connection failed")
+
+        # Token expires in 1 hour - still valid
+        future = datetime.now(UTC) + timedelta(hours=1)
+        cred = CredentialObject(
+            id="hubspot",
+            credential_type=CredentialType.OAUTH2,
+            keys={
+                "access_token": CredentialKey(
+                    name="access_token",
+                    value=SecretStr("cached-token"),
+                    expires_at=future,
+                )
+            },
+        )
+
+        # Should return the cached credential instead of failing
+        result = provider.refresh(cred)
+
+        assert result.keys["access_token"].value.get_secret_value() == "cached-token"
+
+    def test_should_refresh_expired(self, provider):
+        """Test should_refresh returns True for expired token."""
+        past = datetime.now(UTC) - timedelta(hours=1)
+        cred = CredentialObject(
+            id="test",
+            credential_type=CredentialType.OAUTH2,
+            keys={
+                "access_token": CredentialKey(
+                    name="access_token",
+                    value=SecretStr("token"),
+                    expires_at=past,
+                )
+            },
+        )
+
+        assert provider.should_refresh(cred) is True
+
+    def test_should_refresh_within_buffer(self, provider):
+        """Test should_refresh returns True when within buffer."""
+        # Expires in 3 minutes (buffer is 5 minutes)
+        soon = datetime.now(UTC) + timedelta(minutes=3)
+        cred = CredentialObject(
+            id="test",
+            credential_type=CredentialType.OAUTH2,
+            keys={
+                "access_token": CredentialKey(
+                    name="access_token",
+                    value=SecretStr("token"),
+                    expires_at=soon,
+                )
+            },
+        )
+
+        assert provider.should_refresh(cred) is True
+
+    def test_should_refresh_still_valid(self, provider):
+        """Test should_refresh returns False for valid token."""
+        future = datetime.now(UTC) + timedelta(hours=1)
+        cred = CredentialObject(
+            id="test",
+            credential_type=CredentialType.OAUTH2,
+            keys={
+                "access_token": CredentialKey(
+                    name="access_token",
+                    value=SecretStr("token"),
+                    expires_at=future,
+                )
+            },
+        )
+
+        assert provider.should_refresh(cred) is False
+
+    def test_fetch_from_aden(self, provider, mock_client, aden_response):
+        """Test fetching credential from Aden."""
+        mock_client.get_credential.return_value = aden_response
+
+        cred = provider.fetch_from_aden("hubspot")
+
+        assert cred is not None
+        assert cred.id == "hubspot"
+        assert cred.keys["access_token"].value.get_secret_value() == "test-access-token"
+        assert cred.auto_refresh is True
+
+    def test_fetch_from_aden_not_found(self, provider, mock_client):
+        """Test fetch returns None when not found."""
+        mock_client.get_credential.return_value = None
+
+        cred = provider.fetch_from_aden("nonexistent")
+
+        assert cred is None
+
+    def test_sync_all(self, provider, mock_client, aden_response):
+        """Test syncing all credentials."""
+        mock_client.list_integrations.return_value = [
+            AdenIntegrationInfo(
+                integration_id="hubspot",
+                integration_type="hubspot",
+                status="active",
+            ),
+            AdenIntegrationInfo(
+                integration_id="github",
+                integration_type="github",
+                status="requires_reauth",  # Should be skipped
+            ),
+        ]
+        mock_client.get_credential.return_value = aden_response
+
+        store = CredentialStore(storage=InMemoryStorage())
+        synced = provider.sync_all(store)
+
+        assert synced == 1  # Only active one was synced
+        assert store.get_credential("hubspot") is not None
+
+    def test_validate_via_aden(self, provider, mock_client):
+        """Test validation via Aden introspection."""
+        mock_client.validate_token.return_value = {"valid": True}
+
+        cred = CredentialObject(
+            id="hubspot",
+            credential_type=CredentialType.OAUTH2,
+            keys={},
+        )
+
+        assert provider.validate(cred) is True
+
+    def test_validate_fallback_to_local(self, provider, mock_client):
+        """Test validation falls back to local check when Aden fails."""
+        mock_client.validate_token.side_effect = AdenClientError("Failed")
+
+        future = datetime.now(UTC) + timedelta(hours=1)
+        cred = CredentialObject(
+            id="hubspot",
+            credential_type=CredentialType.OAUTH2,
+            keys={
+                "access_token": CredentialKey(
+                    name="access_token",
+                    value=SecretStr("token"),
+                    expires_at=future,
+                )
+            },
+        )
+
+        assert provider.validate(cred) is True
+
+
+# =============================================================================
+# AdenCachedStorage Tests
+# =============================================================================
+
+
+class TestAdenCachedStorage:
+    """Tests for AdenCachedStorage."""
+
+    def test_save_updates_cache_timestamp(self, cached_storage):
+        """Test save updates cache timestamp."""
+        cred = CredentialObject(
+            id="test",
+            credential_type=CredentialType.OAUTH2,
+            keys={
+                "access_token": CredentialKey(
+                    name="access_token",
+                    value=SecretStr("token"),
+                )
+            },
+        )
+
+        cached_storage.save(cred)
+
+        assert "test" in cached_storage._cache_timestamps
+        assert cached_storage.exists("test")
+
+    def test_load_from_fresh_cache(self, cached_storage, local_storage):
+        """Test load returns cached credential when fresh."""
+        cred = CredentialObject(
+            id="test",
+            credential_type=CredentialType.OAUTH2,
+            keys={
+                "access_token": CredentialKey(
+                    name="access_token",
+                    value=SecretStr("cached-token"),
+                )
+            },
+        )
+
+        # Save to both local storage and update timestamp
+        local_storage.save(cred)
+        cached_storage._cache_timestamps["test"] = datetime.now(UTC)
+
+        loaded = cached_storage.load("test")
+
+        assert loaded is not None
+        assert loaded.keys["access_token"].value.get_secret_value() == "cached-token"
+
+    def test_load_from_aden_when_stale(
+        self, cached_storage, local_storage, provider, mock_client, aden_response
+    ):
+        """Test load fetches from Aden when cache is stale."""
+        # Create stale cached credential
+        cred = CredentialObject(
+            id="hubspot",
+            credential_type=CredentialType.OAUTH2,
+            keys={
+                "access_token": CredentialKey(
+                    name="access_token",
+                    value=SecretStr("stale-token"),
+                )
+            },
+        )
+        local_storage.save(cred)
+
+        # Set cache timestamp to be stale (2 minutes ago, TTL is 60 seconds)
+        cached_storage._cache_timestamps["hubspot"] = datetime.now(UTC) - timedelta(minutes=2)
+
+        # Mock Aden response
+        mock_client.get_credential.return_value = aden_response
+
+        loaded = cached_storage.load("hubspot")
+
+        assert loaded is not None
+        assert loaded.keys["access_token"].value.get_secret_value() == "test-access-token"
+
+    def test_load_falls_back_to_stale_when_aden_fails(
+        self, cached_storage, local_storage, provider, mock_client
+    ):
+        """Test load falls back to stale cache when Aden fails."""
+        # Create stale cached credential
+        cred = CredentialObject(
+            id="hubspot",
+            credential_type=CredentialType.OAUTH2,
+            keys={
+                "access_token": CredentialKey(
+                    name="access_token",
+                    value=SecretStr("stale-token"),
+                )
+            },
+        )
+        local_storage.save(cred)
+        cached_storage._cache_timestamps["hubspot"] = datetime.now(UTC) - timedelta(minutes=2)
+
+        # Aden fails
+        mock_client.get_credential.side_effect = AdenClientError("Connection failed")
+
+        loaded = cached_storage.load("hubspot")
+
+        assert loaded is not None
+        assert loaded.keys["access_token"].value.get_secret_value() == "stale-token"
+
+    def test_delete_removes_cache_timestamp(self, cached_storage, local_storage):
+        """Test delete removes cache timestamp."""
+        cred = CredentialObject(
+            id="test",
+            credential_type=CredentialType.OAUTH2,
+            keys={},
+        )
+        cached_storage.save(cred)
+
+        assert "test" in cached_storage._cache_timestamps
+
+        cached_storage.delete("test")
+
+        assert "test" not in cached_storage._cache_timestamps
+        assert not cached_storage.exists("test")
+
+    def test_invalidate_cache(self, cached_storage, local_storage):
+        """Test invalidate_cache removes timestamp."""
+        cred = CredentialObject(
+            id="test",
+            credential_type=CredentialType.OAUTH2,
+            keys={},
+        )
+        cached_storage.save(cred)
+
+        cached_storage.invalidate_cache("test")
+
+        assert "test" not in cached_storage._cache_timestamps
+        # Credential still exists in local storage
+        assert local_storage.exists("test")
+
+    def test_invalidate_all(self, cached_storage):
+        """Test invalidate_all clears all timestamps."""
+        for i in range(3):
+            cached_storage._cache_timestamps[f"test_{i}"] = datetime.now(UTC)
+
+        cached_storage.invalidate_all()
+
+        assert len(cached_storage._cache_timestamps) == 0
+
+    def test_is_cache_fresh(self, cached_storage):
+        """Test _is_cache_fresh logic."""
+        # Fresh cache
+        cached_storage._cache_timestamps["fresh"] = datetime.now(UTC)
+        assert cached_storage._is_cache_fresh("fresh") is True
+
+        # Stale cache
+        cached_storage._cache_timestamps["stale"] = datetime.now(UTC) - timedelta(minutes=5)
+        assert cached_storage._is_cache_fresh("stale") is False
+
+        # No cache
+        assert cached_storage._is_cache_fresh("nonexistent") is False
+
+    def test_get_cache_info(self, cached_storage, local_storage):
+        """Test get_cache_info returns status for all credentials."""
+        # Add some credentials
+        for name in ["fresh", "stale"]:
+            cred = CredentialObject(
+                id=name,
+                credential_type=CredentialType.OAUTH2,
+                keys={},
+            )
+            local_storage.save(cred)
+
+        cached_storage._cache_timestamps["fresh"] = datetime.now(UTC)
+        cached_storage._cache_timestamps["stale"] = datetime.now(UTC) - timedelta(minutes=5)
+
+        info = cached_storage.get_cache_info()
+
+        assert "fresh" in info
+        assert info["fresh"]["is_fresh"] is True
+        assert info["fresh"]["ttl_remaining_seconds"] > 0
+
+        assert "stale" in info
+        assert info["stale"]["is_fresh"] is False
+        assert info["stale"]["ttl_remaining_seconds"] == 0
+
+
+# =============================================================================
+# Integration Tests
+# =============================================================================
+
+
+class TestAdenIntegration:
+    """Integration tests for Aden sync components."""
+
+    def test_full_workflow(self, mock_client, aden_response):
+        """Test full workflow: sync, get, refresh."""
+        # Setup
+        mock_client.list_integrations.return_value = [
+            AdenIntegrationInfo(
+                integration_id="hubspot",
+                integration_type="hubspot",
+                status="active",
+            ),
+        ]
+        mock_client.get_credential.return_value = aden_response
+        mock_client.request_refresh.return_value = AdenCredentialResponse(
+            integration_id="hubspot",
+            integration_type="hubspot",
+            access_token="refreshed-token",
+            expires_at=datetime.now(UTC) + timedelta(hours=2),
+            scopes=[],
+        )
+
+        provider = AdenSyncProvider(client=mock_client)
+        storage = InMemoryStorage()
+        store = CredentialStore(
+            storage=storage,
+            providers=[provider],
+            auto_refresh=True,
+        )
+
+        # Initial sync
+        synced = provider.sync_all(store)
+        assert synced == 1
+
+        # Get credential
+        cred = store.get_credential("hubspot")
+        assert cred is not None
+        assert cred.keys["access_token"].value.get_secret_value() == "test-access-token"
+
+        # Simulate expiration
+        cred.keys["access_token"] = CredentialKey(
+            name="access_token",
+            value=SecretStr("test-access-token"),
+            expires_at=datetime.now(UTC) - timedelta(hours=1),  # Expired
+        )
+        storage.save(cred)
+
+        # Refresh should be triggered
+        refreshed = provider.refresh(cred)
+        assert refreshed.keys["access_token"].value.get_secret_value() == "refreshed-token"
+
+    def test_cached_storage_with_store(self, mock_client, aden_response):
+        """Test AdenCachedStorage with CredentialStore."""
+        mock_client.get_credential.return_value = aden_response
+
+        provider = AdenSyncProvider(client=mock_client)
+        local_storage = InMemoryStorage()
+        cached_storage = AdenCachedStorage(
+            local_storage=local_storage,
+            aden_provider=provider,
+            cache_ttl_seconds=300,
+        )
+
+        # First load fetches from Aden
+        cred = cached_storage.load("hubspot")
+        assert cred is not None
+        mock_client.get_credential.assert_called_once()
+
+        # Second load uses cache
+        mock_client.get_credential.reset_mock()
+        cred2 = cached_storage.load("hubspot")
+        assert cred2 is not None
+        mock_client.get_credential.assert_not_called()

--- a/docs/aden-credential-sync.md
+++ b/docs/aden-credential-sync.md
@@ -1,0 +1,632 @@
+# Aden Credential Sync Integration
+
+Implementation guideline for integrating the Hive credential store with the Aden authentication server.
+
+## Overview
+
+The Aden server handles OAuth2 authorization code flows (user login, consent, token generation). The local credential store acts as a **driver** that:
+
+1. Fetches tokens from the Aden server on demand
+2. Caches tokens locally for performance and offline resilience
+3. Delegates refresh operations to the Aden server
+4. Optionally reports usage statistics back to Aden
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Local Agent Environment                       │
+│                                                                  │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │                   CredentialStore                         │   │
+│  │  ┌────────────────────┐  ┌────────────────────────────┐  │   │
+│  │  │EncryptedFileStorage│  │    AdenSyncProvider        │  │   │
+│  │  │  (local cache)     │  │  - Fetches from Aden       │  │   │
+│  │  │  ~/.hive/creds     │  │  - Delegates refresh       │  │   │
+│  │  └────────────────────┘  │  - Reports usage           │  │   │
+│  │                          └─────────────┬──────────────┘  │   │
+│  └────────────────────────────────────────┼─────────────────┘   │
+│                                           │                      │
+└───────────────────────────────────────────┼──────────────────────┘
+                                            │ HTTPS
+                                            ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                       Aden Server                                │
+│                                                                  │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │              Integration Management                       │   │
+│  │  - HubSpot, GitHub, Slack, etc.                          │   │
+│  │  - Handles OAuth2 auth code flow                         │   │
+│  │  - Stores refresh tokens securely                        │   │
+│  │  - Performs token refresh on request                     │   │
+│  └──────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Aden API Contract
+
+The Aden server must expose these REST endpoints.
+
+### Authentication
+
+All requests include:
+
+- `Authorization: Bearer {agent_api_key}` - Agent's API key
+- `X-Tenant-ID: {tenant_id}` - (Optional) For multi-tenant deployments
+
+### Endpoints
+
+#### 1. Get Credential
+
+Fetch the current access token for an integration. The Aden server should refresh internally if the token is expired.
+
+```
+GET /v1/credentials/{integration_id}
+
+Headers:
+  Authorization: Bearer {agent_api_key}
+  X-Tenant-ID: {tenant_id}  (optional)
+
+Response 200 OK:
+{
+  "integration_id": "hubspot",
+  "integration_type": "hubspot",
+  "access_token": "CJTFwvnuLxIFAgEY...",
+  "token_type": "Bearer",
+  "expires_at": "2026-01-28T15:30:00Z",
+  "scopes": ["crm.objects.contacts.read", "crm.objects.contacts.write"],
+  "metadata": {
+    "portal_id": "12345678",
+    "connected_at": "2026-01-15T10:00:00Z"
+  }
+}
+
+Response 404 Not Found:
+{
+  "error": "integration_not_found",
+  "message": "No integration 'hubspot' found for this tenant"
+}
+
+Response 401 Unauthorized:
+{
+  "error": "invalid_api_key",
+  "message": "Agent API key is invalid or revoked"
+}
+```
+
+#### 2. Request Token Refresh
+
+Explicitly request the Aden server to refresh the token. Use this when the local store detects an expired or near-expiry token.
+
+```
+POST /v1/credentials/{integration_id}/refresh
+
+Headers:
+  Authorization: Bearer {agent_api_key}
+
+Response 200 OK:
+{
+  "integration_id": "hubspot",
+  "integration_type": "hubspot",
+  "access_token": "NEW_ACCESS_TOKEN...",
+  "token_type": "Bearer",
+  "expires_at": "2026-01-28T16:30:00Z",
+  "scopes": ["crm.objects.contacts.read", "crm.objects.contacts.write"],
+  "metadata": {}
+}
+
+Response 400 Bad Request:
+{
+  "error": "refresh_failed",
+  "message": "Refresh token is invalid or revoked. User must re-authorize.",
+  "requires_reauthorization": true,
+  "reauthorization_url": "https://hive.adenhq.com/integrations/hubspot/connect"
+}
+
+Response 429 Too Many Requests:
+{
+  "error": "rate_limited",
+  "message": "Too many refresh requests. Try again later.",
+  "retry_after": 60
+}
+```
+
+#### 3. List Integrations
+
+List all integrations available for this agent/tenant.
+
+```
+GET /v1/credentials
+
+Headers:
+  Authorization: Bearer {agent_api_key}
+
+Response 200 OK:
+{
+  "integrations": [
+    {
+      "integration_id": "hubspot",
+      "integration_type": "hubspot",
+      "status": "active",
+      "expires_at": "2026-01-28T15:30:00Z"
+    },
+    {
+      "integration_id": "github",
+      "integration_type": "github",
+      "status": "active",
+      "expires_at": null
+    },
+    {
+      "integration_id": "slack",
+      "integration_type": "slack",
+      "status": "requires_reauth",
+      "expires_at": null
+    }
+  ],
+  "tenant_id": "tenant-123"
+}
+```
+
+#### 4. Validate Token
+
+Check if a token is still valid without fetching it.
+
+```
+GET /v1/credentials/{integration_id}/validate
+
+Headers:
+  Authorization: Bearer {agent_api_key}
+
+Response 200 OK:
+{
+  "valid": true,
+  "expires_at": "2026-01-28T15:30:00Z",
+  "expires_in_seconds": 3600
+}
+
+Response 200 OK (invalid):
+{
+  "valid": false,
+  "reason": "token_expired",
+  "requires_reauthorization": false
+}
+
+Response 200 OK (needs reauth):
+{
+  "valid": false,
+  "reason": "refresh_token_revoked",
+  "requires_reauthorization": true,
+  "reauthorization_url": "https://hive.adenhq.com/integrations/hubspot/connect"
+}
+```
+
+#### 5. Report Usage (Optional)
+
+Report credential usage statistics back to Aden for analytics/billing.
+
+```
+POST /v1/credentials/{integration_id}/usage
+
+Headers:
+  Authorization: Bearer {agent_api_key}
+  Content-Type: application/json
+
+Request:
+{
+  "operation": "api_call",
+  "status": "success",
+  "timestamp": "2026-01-28T14:00:00Z",
+  "metadata": {
+    "endpoint": "/crm/v3/objects/contacts",
+    "method": "GET",
+    "response_code": 200
+  }
+}
+
+Response 200 OK:
+{
+  "received": true
+}
+```
+
+#### 6. Health Check
+
+```
+GET /health
+
+Response 200 OK:
+{
+  "status": "healthy",
+  "version": "1.2.3",
+  "timestamp": "2026-01-28T14:00:00Z"
+}
+```
+
+---
+
+## Local Implementation Components
+
+### File Structure
+
+```
+core/framework/credentials/
+├── aden/
+│   ├── __init__.py          # Module exports
+│   ├── client.py            # AdenCredentialClient - HTTP client
+│   ├── provider.py          # AdenSyncProvider - CredentialProvider impl
+│   └── storage.py           # AdenCachedStorage - Optional cached storage
+└── ... (existing files)
+```
+
+### 1. Aden Client (`client.py`)
+
+HTTP client for communicating with the Aden server.
+
+```python
+@dataclass
+class AdenClientConfig:
+    """Configuration for Aden API client."""
+    base_url: str                    # e.g., "https://hive.adenhq.com"
+    api_key: str                     # Agent's API key
+    tenant_id: str | None = None     # For multi-tenant
+    timeout: float = 30.0
+    retry_attempts: int = 3
+    retry_delay: float = 1.0
+
+
+@dataclass
+class AdenCredentialResponse:
+    """Response from Aden server."""
+    integration_id: str
+    integration_type: str
+    access_token: str
+    token_type: str = "Bearer"
+    expires_at: datetime | None = None
+    scopes: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class AdenCredentialClient:
+    """HTTP client for Aden credential server."""
+
+    def __init__(self, config: AdenClientConfig): ...
+
+    def get_credential(self, integration_id: str) -> AdenCredentialResponse | None:
+        """Fetch credential from Aden. Returns None if not found."""
+
+    def request_refresh(self, integration_id: str) -> AdenCredentialResponse:
+        """Request Aden to refresh the token."""
+
+    def list_integrations(self) -> list[dict]:
+        """List all available integrations."""
+
+    def validate_token(self, integration_id: str) -> dict:
+        """Check if token is valid."""
+
+    def report_usage(self, integration_id: str, operation: str, status: str, metadata: dict) -> None:
+        """Report usage statistics."""
+
+    def health_check(self) -> dict:
+        """Check Aden server health."""
+```
+
+### 2. Aden Sync Provider (`provider.py`)
+
+Implements `CredentialProvider` interface, delegates refresh to Aden.
+
+```python
+class AdenSyncProvider(CredentialProvider):
+    """
+    Provider that synchronizes credentials with Aden server.
+
+    Usage:
+        client = AdenCredentialClient(AdenClientConfig(
+            base_url="https://hive.adenhq.com",
+            api_key=os.environ["ADEN_API_KEY"],
+        ))
+
+        provider = AdenSyncProvider(client=client)
+
+        store = CredentialStore(
+            storage=EncryptedFileStorage(),
+            providers=[provider],
+            auto_refresh=True,
+        )
+    """
+
+    def __init__(
+        self,
+        client: AdenCredentialClient,
+        provider_id: str = "aden_sync",
+        refresh_buffer_minutes: int = 5,
+        report_usage: bool = False,
+    ): ...
+
+    @property
+    def provider_id(self) -> str: ...
+
+    @property
+    def supported_types(self) -> list[CredentialType]:
+        return [CredentialType.OAUTH2, CredentialType.BEARER_TOKEN]
+
+    def refresh(self, credential: CredentialObject) -> CredentialObject:
+        """Refresh by calling Aden server."""
+
+    def validate(self, credential: CredentialObject) -> bool:
+        """Validate via Aden introspection."""
+
+    def should_refresh(self, credential: CredentialObject) -> bool:
+        """Check if within refresh buffer of expiration."""
+
+    def fetch_from_aden(self, integration_id: str) -> CredentialObject | None:
+        """Fetch credential directly from Aden (for initial population)."""
+
+    def sync_all(self, store: CredentialStore) -> int:
+        """Sync all integrations from Aden to local store. Returns count."""
+```
+
+### 3. Aden Cached Storage (`storage.py`) - Optional
+
+Storage backend that combines local cache with Aden fallback.
+
+```python
+class AdenCachedStorage(CredentialStorage):
+    """
+    Storage with local cache + Aden fallback.
+
+    - Reads: Try local first, fallback to Aden if stale/missing
+    - Writes: Always write to local cache
+    - Provides offline resilience
+
+    Usage:
+        storage = AdenCachedStorage(
+            local_storage=EncryptedFileStorage(),
+            aden_provider=provider,
+            cache_ttl_seconds=300,  # 5 minutes
+        )
+    """
+
+    def __init__(
+        self,
+        local_storage: CredentialStorage,
+        aden_provider: AdenSyncProvider,
+        cache_ttl_seconds: int = 300,
+    ): ...
+
+    def load(self, credential_id: str) -> CredentialObject | None:
+        """Load from cache, fallback to Aden if stale."""
+
+    def save(self, credential: CredentialObject) -> None:
+        """Save to local cache."""
+
+    def sync_all_from_aden(self) -> int:
+        """Pull all credentials from Aden to local cache."""
+```
+
+---
+
+## Integration Patterns
+
+### Pattern A: Provider-Only (Recommended)
+
+Simple setup where local storage is just a cache, Aden handles refresh.
+
+```python
+from core.framework.credentials import CredentialStore
+from core.framework.credentials.storage import EncryptedFileStorage
+from core.framework.credentials.aden import AdenCredentialClient, AdenClientConfig, AdenSyncProvider
+
+# Configure
+client = AdenCredentialClient(AdenClientConfig(
+    base_url=os.environ["ADEN_API_URL"],
+    api_key=os.environ["ADEN_API_KEY"],
+    tenant_id=os.environ.get("ADEN_TENANT_ID"),
+))
+
+provider = AdenSyncProvider(client=client)
+
+store = CredentialStore(
+    storage=EncryptedFileStorage(),  # ~/.hive/credentials
+    providers=[provider],
+    auto_refresh=True,
+)
+
+# Initial sync from Aden
+provider.sync_all(store)
+
+# Use normally - auto-refreshes via Aden when needed
+token = store.get_key("hubspot", "access_token")
+```
+
+### Pattern B: With Cached Storage (Offline Resilience)
+
+For environments that may lose connectivity to Aden temporarily.
+
+```python
+from core.framework.credentials.aden import AdenCachedStorage
+
+storage = AdenCachedStorage(
+    local_storage=EncryptedFileStorage(),
+    aden_provider=provider,
+    cache_ttl_seconds=300,  # Re-check Aden every 5 min
+)
+
+store = CredentialStore(
+    storage=storage,
+    providers=[provider],
+    auto_refresh=True,
+)
+
+# Credentials automatically fetched from Aden on first access
+# Cached locally for 5 minutes
+# Falls back to cache if Aden is unreachable
+```
+
+### Pattern C: Multi-Tenant
+
+```python
+def create_tenant_store(tenant_id: str) -> CredentialStore:
+    client = AdenCredentialClient(AdenClientConfig(
+        base_url=os.environ["ADEN_API_URL"],
+        api_key=os.environ[f"ADEN_API_KEY_{tenant_id}"],
+        tenant_id=tenant_id,
+    ))
+
+    provider = AdenSyncProvider(client=client, provider_id=f"aden_{tenant_id}")
+
+    return CredentialStore(
+        storage=EncryptedFileStorage(f"~/.hive/credentials/{tenant_id}"),
+        providers=[provider],
+    )
+```
+
+---
+
+## Error Handling
+
+### Aden Unavailable
+
+```python
+class AdenSyncProvider:
+    def refresh(self, credential: CredentialObject) -> CredentialObject:
+        try:
+            return self._refresh_via_aden(credential)
+        except httpx.ConnectError:
+            # Network unavailable
+            if not self._is_token_expired(credential):
+                logger.warning(f"Aden unavailable, using cached token")
+                return credential
+            raise CredentialRefreshError("Aden unavailable and token expired")
+```
+
+### Re-authorization Required
+
+When refresh token is revoked, Aden returns `requires_reauthorization: true`.
+
+```python
+if response.get("requires_reauthorization"):
+    raise CredentialRefreshError(
+        f"Integration '{integration_id}' requires re-authorization. "
+        f"Visit: {response.get('reauthorization_url')}"
+    )
+```
+
+### Rate Limiting
+
+```python
+if response.status_code == 429:
+    retry_after = response.headers.get("Retry-After", 60)
+    raise CredentialRefreshError(
+        f"Rate limited. Retry after {retry_after} seconds."
+    )
+```
+
+---
+
+## Security Considerations
+
+### Agent API Keys
+
+- Each agent deployment gets a unique API key from Aden
+- Keys are scoped to specific tenants/integrations
+- Store in environment variable: `ADEN_API_KEY`
+- Keys can be rotated without affecting stored credentials
+
+### Token Security
+
+- Access tokens cached locally are encrypted (EncryptedFileStorage)
+- Refresh tokens NEVER leave the Aden server
+- Short cache TTLs limit exposure window
+- TLS required for all Aden communication
+
+### Audit Trail
+
+- Aden maintains full audit log of token access
+- Usage reporting (optional) provides per-agent visibility
+- Local store logs refresh attempts
+
+---
+
+## Environment Variables
+
+| Variable              | Required | Description                    |
+| --------------------- | -------- | ------------------------------ |
+| `ADEN_API_URL`        | Yes      | Base URL of Aden auth server   |
+| `ADEN_API_KEY`        | Yes      | Agent's API key for Aden       |
+| `ADEN_TENANT_ID`      | No       | Tenant ID for multi-tenant     |
+| `HIVE_CREDENTIAL_KEY` | Yes      | Encryption key for local cache |
+
+---
+
+## Migration from Direct OAuth2
+
+If currently using `BaseOAuth2Provider` directly:
+
+```python
+# Before: Direct OAuth2 refresh
+provider = HubSpotOAuth2Provider(
+    client_id="...",
+    client_secret="...",
+)
+
+# After: Delegate to Aden
+provider = AdenSyncProvider(
+    client=AdenCredentialClient(AdenClientConfig(
+        base_url="https://hive.adenhq.com",
+        api_key="...",
+    ))
+)
+
+# Store usage unchanged
+store = CredentialStore(
+    storage=EncryptedFileStorage(),
+    providers=[provider],
+)
+```
+
+The Aden server now handles:
+
+- Client credentials (client_id, client_secret)
+- Refresh token storage
+- Token refresh logic
+- Rate limiting with providers
+
+---
+
+## Testing
+
+### Mock Aden Server
+
+For local development/testing:
+
+```python
+from unittest.mock import Mock
+
+mock_client = Mock(spec=AdenCredentialClient)
+mock_client.get_credential.return_value = AdenCredentialResponse(
+    integration_id="hubspot",
+    integration_type="hubspot",
+    access_token="test-token",
+    expires_at=datetime.now(UTC) + timedelta(hours=1),
+)
+
+provider = AdenSyncProvider(client=mock_client)
+```
+
+### Integration Tests
+
+Test against Aden staging environment:
+
+```python
+@pytest.mark.integration
+def test_aden_sync():
+    client = AdenCredentialClient(AdenClientConfig(
+        base_url=os.environ["ADEN_STAGING_URL"],
+        api_key=os.environ["ADEN_STAGING_API_KEY"],
+    ))
+
+    # Should successfully fetch
+    response = client.get_credential("hubspot")
+    assert response is not None
+    assert response.access_token
+```

--- a/docs/aden-credential-sync.md
+++ b/docs/aden-credential-sync.md
@@ -267,7 +267,7 @@ HTTP client for communicating with the Aden server.
 class AdenClientConfig:
     """Configuration for Aden API client."""
     base_url: str                    # e.g., "https://hive.adenhq.com"
-    api_key: str                     # Agent's API key
+    api_key: str | None = None       # Loaded from ADEN_API_KEY env var if not provided
     tenant_id: str | None = None     # For multi-tenant
     timeout: float = 30.0
     retry_attempts: int = 3
@@ -320,9 +320,9 @@ class AdenSyncProvider(CredentialProvider):
     Provider that synchronizes credentials with Aden server.
 
     Usage:
+        # API key loaded from ADEN_API_KEY env var by default
         client = AdenCredentialClient(AdenClientConfig(
             base_url="https://hive.adenhq.com",
-            api_key=os.environ["ADEN_API_KEY"],
         ))
 
         provider = AdenSyncProvider(client=client)
@@ -417,9 +417,9 @@ from core.framework.credentials.storage import EncryptedFileStorage
 from core.framework.credentials.aden import AdenCredentialClient, AdenClientConfig, AdenSyncProvider
 
 # Configure
+# API key loaded from ADEN_API_KEY env var by default
 client = AdenCredentialClient(AdenClientConfig(
     base_url=os.environ["ADEN_API_URL"],
-    api_key=os.environ["ADEN_API_KEY"],
     tenant_id=os.environ.get("ADEN_TENANT_ID"),
 ))
 
@@ -466,6 +466,7 @@ store = CredentialStore(
 
 ```python
 def create_tenant_store(tenant_id: str) -> CredentialStore:
+    # Explicit api_key for per-tenant credentials
     client = AdenCredentialClient(AdenClientConfig(
         base_url=os.environ["ADEN_API_URL"],
         api_key=os.environ[f"ADEN_API_KEY_{tenant_id}"],


### PR DESCRIPTION
## Description

closes #1924

This PR introduces a comprehensive credential management system for Hive agents, including secure local storage, automatic validation, and integration with the Aden authentication server for OAuth2 token management.

## Key Features

### 1. Credential Store Core (`core/framework/credentials/`)

- **Key-vault structure**: Credentials as objects with multiple keys (e.g., `access_token`, `refresh_token`)
- **Template resolution**: `{{cred.key}}` patterns for secure credential injection
- **Multiple storage backends**: Encrypted files, environment variables, HashiCorp Vault
- **Provider system**: Extensible lifecycle management (refresh, validate, revoke)
- **Default path**: `~/.hive/credentials` with Fernet encryption (AES-128-CBC + HMAC)

### 2. Aden Server Integration (`core/framework/credentials/aden/`)

New module for syncing credentials with the Aden authentication server:

- **`AdenCredentialClient`**: HTTP client with retry logic, error handling, rate limiting
- **`AdenSyncProvider`**: Implements `CredentialProvider`, delegates token refresh to Aden
- **`AdenCachedStorage`**: Local cache + Aden fallback for offline resilience

```python
from core.framework.credentials.aden import (
    AdenCredentialClient,
    AdenClientConfig,
    AdenSyncProvider,
)

client = AdenCredentialClient(AdenClientConfig(
    base_url=os.environ["ADEN_API_URL"],
    api_key=os.environ["ADEN_API_KEY"],
))

provider = AdenSyncProvider(client=client)
store = CredentialStore(
    storage=EncryptedFileStorage(),
    providers=[provider],
    auto_refresh=True,
)

# Tokens auto-refresh via Aden when needed
token = store.get_key("hubspot", "access_token")
```

### 3. Automatic Credential Validation

`AgentRunner.run()` now validates credentials before execution:

- Fails fast with actionable error messages
- Lists missing credentials with help URLs
- Prevents cryptic errors deep in execution

### 4. Agent Builder MCP Tools

New credential tools in `agent_builder_server.py`:

| Tool | Purpose |
|------|---------|
| `check_missing_credentials` | Scans agent tools/nodes, reports missing credentials |
| `store_credential` | Saves credential to encrypted store |
| `list_stored_credentials` | Lists stored credentials (IDs only, no secrets) |
| `delete_stored_credential` | Removes credential from store |
| `verify_credentials` | Validates agent is ready to run |

### 5. Skills

**`/setup-credentials`** - Interactive credential setup for agents:
- Detects missing credentials from agent config
- Collects values from user securely
- Stores in encrypted credential store
- Verifies setup is complete

**`/testing-agent`** - Updated to check ALL credentials:
- Not just LLM API keys, but tool-specific credentials too
- Presents all missing credentials at once
- Links to setup documentation

## Files Changed

### New Files

```
core/framework/credentials/aden/
├── __init__.py              # Module exports
├── client.py                # AdenCredentialClient (HTTP client)
├── provider.py              # AdenSyncProvider
├── storage.py               # AdenCachedStorage
└── tests/
    └── test_aden_sync.py    # 30 tests

.claude/skills/setup-credentials/
└── SKILL.md                 # Credential setup skill

docs/
├── aden-credential-sync.md  # Aden integration guide
└── credential-store-usage.md # Usage documentation
```

### Modified Files

```
core/framework/credentials/
├── __init__.py              # Export Aden components
├── storage.py               # Default path ~/.hive/credentials
└── store.py                 # with_encrypted_storage() default path

core/framework/runner/runner.py
└── run()                    # Auto-validate credentials before execution

core/framework/mcp/agent_builder_server.py
└── 5 new credential MCP tools

.claude/skills/
├── testing-agent/SKILL.md   # Check all credentials, not just LLM
└── agent-workflow/SKILL.md  # Added setup-credentials to workflow

tools/src/aden_tools/
├── credentials/__init__.py  # Export INTEGRATION_CREDENTIALS
├── credentials/integrations.py  # HubSpot credential spec
└── tools/hubspot_tool/      # HubSpot CRM integration (12 tools)
```

## Test Results

```
core/framework/credentials/tests/test_credential_store.py  63 passed
core/framework/credentials/aden/tests/test_aden_sync.py    30 passed
tools/src/aden_tools/tools/hubspot_tool/tests/             41 passed
────────────────────────────────────────────────────────────────────
Total                                                      134 passed
```

## Environment Variables

| Variable | Required | Description |
|----------|----------|-------------|
| `HIVE_CREDENTIAL_KEY` | Yes | Fernet encryption key for local store |
| `ADEN_API_URL` | For Aden sync | Aden server base URL |
| `ADEN_API_KEY` | For Aden sync | Agent API key for Aden |
| `ADEN_TENANT_ID` | Optional | Multi-tenant identifier |

## Breaking Changes

None. All changes are additive and backward-compatible.

## Security Notes

- Access tokens cached locally are encrypted with Fernet (AES-128-CBC + HMAC)
- Refresh tokens **never** leave the Aden server
- `SecretStr` from Pydantic prevents accidental logging of secrets
- Credential values are never exposed in MCP tool responses

## Related Issues

- Closes #1924  (integration for agents)
