### PR TITLE
micro-fix: Reset runtime node context between runs

### DIFF
--- a/core/framework/runtime/core.py
+++ b/core/framework/runtime/core.py
@@ -78,6 +78,9 @@ class Runtime:
         Returns:
             The run ID
         """
+        # Reset node context so the next decision does not inherit a stale node
+        self._current_node = "unknown"
+
         run_id = f"run_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
 
         self._current_run = Run(
@@ -116,6 +119,8 @@ class Runtime:
         # Save to storage
         self.storage.save_run(self._current_run)
         self._current_run = None
+        # Reset node context when a run ends to keep the runtime state clean
+        self._current_node = "unknown"
 
     def set_node(self, node_id: str) -> None:
         """Set the current node context for subsequent decisions."""


### PR DESCRIPTION
## Summary
This PR fixes a runtime state leak where the node context from a previous run could be reused in a subsequent run, causing the first decision of the new run to be attributed to the wrong node. The runtime now resets its node context at both run start and run end to ensure clean boundaries between executions.

## Problem
`Runtime` stores the current node in `_current_node`. While `_current_run` was cleared on `end_run`, the node context was not, so a new run could inherit the old node id. Any decision created before calling `set_node` (e.g., `quick_decision`) would be tagged with the stale node, corrupting decision attribution and downstream analytics.

## Solution
- Reset `_current_node` to a neutral default when `start_run` is called.
- Reset `_current_node` again when `end_run` completes, ensuring clean teardown even if the caller reuses the same `Runtime` instance.

## Changes
- Reset node context on run start and end in [core/framework/runtime/core.py](core/framework/runtime/core.py#L78-L136).
- Add a regression test that verifies the first decision of a new run defaults to `unknown` rather than the previous run’s node in [core/tests/test_runtime.py](core/tests/test_runtime.py#L131-L165).

## Testing
- `pytest core/tests/test_runtime.py::TestDecisionRecording::test_node_context_resets_between_runs`
