### PR TITLE
Docs: Fixed the .claude/ url to open the right file

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -145,7 +145,7 @@ python -m framework test-debug <agent_path> <test_name>
 python -m framework test-list <goal_id>
 ```
 
-For detailed testing workflows, see the [testing-agent skill](.claude/skills/testing-agent/SKILL.md).
+For detailed testing workflows, see the [testing-agent skill](../.claude/skills/testing-agent/SKILL.md).
 
 ### Analyzing Agent Behavior with Builder
 


### PR DESCRIPTION
## Related Issues

Fixes #1971

## Changes Made

Changes made to `core/README.md`
Change the URL from `.claude/skills/testing-agent/SKILL.md to  `../.claude/skills/testing-agent/SKILL.md`

As the File was in `core/` and not root.