### PR TITLE
fix: resolve shell injection, deprecated asyncio API, and OAuth2 toke…

### DIFF
--- a/core/framework/credentials/oauth2/base_provider.py
+++ b/core/framework/credentials/oauth2/base_provider.py
@@ -478,9 +478,12 @@ class BaseOAuth2Provider(CredentialProvider):
         if not access_token:
             return {}
 
+        # Use get_key() to get the actual string value, not the CredentialKey object
+        token_type = credential.get_key("token_type") or "Bearer"
+
         token = OAuth2Token(
             access_token=access_token,
-            token_type=credential.keys.get("token_type", "Bearer") or "Bearer",
+            token_type=token_type,
         )
 
         return self.format_for_request(token)

--- a/core/framework/credentials/oauth2/lifecycle.py
+++ b/core/framework/credentials/oauth2/lifecycle.py
@@ -157,7 +157,7 @@ class TokenLifecycleManager:
             New OAuth2Token
         """
         # Run in executor to avoid blocking
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         token = await loop.run_in_executor(
             None, lambda: self.provider.client_credentials_grant(scopes=scopes)
         )
@@ -287,7 +287,7 @@ class TokenLifecycleManager:
 
     async def _async_refresh_token(self, credential: CredentialObject) -> TokenRefreshResult:
         """Async wrapper for token refresh."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, lambda: self._sync_refresh_token(credential))
 
     def _sync_refresh_token(self, credential: CredentialObject) -> TokenRefreshResult:

--- a/core/framework/storage/concurrent.py
+++ b/core/framework/storage/concurrent.py
@@ -206,7 +206,7 @@ class ConcurrentStorage:
                     return await with_locks(locks[1:], callback)
 
             async def perform_save():
-                loop = asyncio.get_event_loop()
+                loop = asyncio.get_running_loop()
                 await loop.run_in_executor(None, self._base_storage.save_run, run)
 
             await with_locks(index_locks, perform_save)
@@ -235,7 +235,7 @@ class ConcurrentStorage:
         # CRITICAL: Acquire lock to trigger LRU update
         lock_key = f"run:{run_id}"
         async with await self._get_lock(lock_key):
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             run = await loop.run_in_executor(None, self._base_storage.load_run, run_id)
 
         # Update cache
@@ -257,7 +257,7 @@ class ConcurrentStorage:
         # Load from storage
         lock_key = f"summary:{run_id}"
         async with await self._get_lock(lock_key):
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             summary = await loop.run_in_executor(None, self._base_storage.load_summary, run_id)
 
         # Update cache
@@ -270,7 +270,7 @@ class ConcurrentStorage:
         """Delete a run from storage."""
         lock_key = f"run:{run_id}"
         async with await self._get_lock(lock_key):
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             result = await loop.run_in_executor(None, self._base_storage.delete_run, run_id)
 
         # Clear cache
@@ -284,7 +284,7 @@ class ConcurrentStorage:
     async def get_runs_by_goal(self, goal_id: str) -> list[str]:
         """Get all run IDs for a goal."""
         async with await self._get_lock(f"index:by_goal:{goal_id}"):
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             return await loop.run_in_executor(None, self._base_storage.get_runs_by_goal, goal_id)
 
     async def get_runs_by_status(self, status: str | RunStatus) -> list[str]:
@@ -292,23 +292,23 @@ class ConcurrentStorage:
         if isinstance(status, RunStatus):
             status = status.value
         async with await self._get_lock(f"index:by_status:{status}"):
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             return await loop.run_in_executor(None, self._base_storage.get_runs_by_status, status)
 
     async def get_runs_by_node(self, node_id: str) -> list[str]:
         """Get all run IDs that executed a node."""
         async with await self._get_lock(f"index:by_node:{node_id}"):
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             return await loop.run_in_executor(None, self._base_storage.get_runs_by_node, node_id)
 
     async def list_all_runs(self) -> list[str]:
         """List all run IDs."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self._base_storage.list_all_runs)
 
     async def list_all_goals(self) -> list[str]:
         """List all goal IDs that have runs."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self._base_storage.list_all_goals)
 
     # === BATCH OPERATIONS ===
@@ -402,7 +402,7 @@ class ConcurrentStorage:
 
     async def get_stats(self) -> dict:
         """Get storage statistics."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         base_stats = await loop.run_in_executor(None, self._base_storage.get_stats)
 
         return {


### PR DESCRIPTION
## Summary

This PR addresses critical security vulnerabilities, a logic bug, and deprecated API usage across the Hive codebase.

## Changes

| File | Issue | Fix |
|------|-------|-----|
| `execute_command_tool.py` | Shell injection via `shell=True` | Use `shell=False` with `shlex.split()` for safe command parsing |
| `csv_tool.py` | SQL injection via f-string interpolation | Parameterized queries + expanded dangerous keyword blocking |
| `node.py` | Unsafe `eval()` in docstring example | Replaced with `safe_eval()` to demonstrate secure patterns |
| `concurrent.py` | Deprecated `asyncio.get_event_loop()` | Replaced with `asyncio.get_running_loop()` (10 occurrences) |
| `lifecycle.py` | Deprecated `asyncio.get_event_loop()` | Replaced with `asyncio.get_running_loop()` (2 occurrences) |
| `base_provider.py` | Token type retrieval returns wrong type | Changed `credential.keys.get()` to `credential.get_key()` |

## Security Impact

- **Shell Injection**: Prevents arbitrary command execution via malicious input
- **SQL Injection**: Prevents DuckDB query manipulation and unauthorized file access
- **Unsafe Eval**: Documentation now guides users toward secure evaluation

## Deprecation Fixes

- `asyncio.get_event_loop()` is deprecated in Python 3.10+ and will be removed in future versions

## Checklist

- [x] Code follows project style guidelines
- [x] No new dependencies added
- [x] Changes are backwards compatible
- [x] Security vulnerabilities addressed

