### PR TITLE
docs: remove stray 'orchestration' text from project structure

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -151,7 +151,6 @@ hive/                                    # Repository root
 │       └── agent-workflow/              # Complete workflow 
 |           ├── SKILL.md
 │           └── examples
-orchestration
 │
 ├── core/                                # CORE FRAMEWORK PACKAGE
 │   ├── framework/                       # Main package code


### PR DESCRIPTION
### Summary
Removes a stray "orchestration" line that appears in the Project Structure
directory tree in DEVELOPER.md.

This looks like a merge artifact and can confuse readers.

Documentation-only change; no functional impact.

Closes  #1998