### PR TITLE
fix(core): add error logging for silent pass statements

### DIFF
--- a/core/framework/graph/worker_node.py
+++ b/core/framework/graph/worker_node.py
@@ -302,8 +302,13 @@ class WorkerNode:
             if inputs:
                 try:
                     prompt = prompt.format(**inputs)
-                except (KeyError, ValueError):
-                    pass  # Keep original prompt if formatting fails
+                except (KeyError, ValueError) as e :
+                    # warning
+                    logger.warning(
+                        f"Prompt formatting failed for action '{action.name}' in node '{self.id}'. "
+                        f"Missing or invalid keys in inputs. Error: {e}. "
+                        "Proceeding with unformatted prompt template."
+                    )
 
             # Always append context data so LLM can personalize
             # This ensures the LLM has access to lead info, company context, etc.
@@ -463,8 +468,13 @@ class WorkerNode:
                 if isinstance(parsed, dict):
                     # Unpack all fields from the JSON response
                     outputs.update(parsed)
-            except (json.JSONDecodeError, TypeError):
-                pass  # Keep result as-is if not valid JSON
+            except (json.JSONDecodeError, TypeError) as e:
+                # warning
+                logger.warning(
+                    f"Failed to unpack JSON outputs for tool '{tool_name}'. "
+                    f"Content is not a valid JSON dictionary: {e}. "
+                    "Proceeding with raw result content."
+                )
 
             return StepExecutionResult(
                 success=True,

--- a/core/framework/mcp/agent_builder_server.py
+++ b/core/framework/mcp/agent_builder_server.py
@@ -6,7 +6,7 @@ Exposes tools for building goal-driven agents via the Model Context Protocol.
 Usage:
     python -m framework.mcp.agent_builder_server
 """
-
+import logging
 import json
 import os
 from datetime import datetime
@@ -22,6 +22,10 @@ from framework.graph.plan import Plan
 from framework.testing.prompts import (
     PYTEST_TEST_FILE_HEADER,
 )
+
+
+logger = logging.getLogger(__name__)
+
 
 # Initialize MCP server
 mcp = FastMCP("agent-builder")
@@ -214,8 +218,10 @@ def list_sessions() -> str:
                             "has_goal": data.get("goal") is not None,
                         }
                     )
-            except Exception:
-                pass  # Skip corrupted files
+            except Exception as e :
+                # Log the specific file path and the error details
+                logger.error(f"Failed to load agent building session from {session_file}: {e}", exc_info=True)
+                continue  # Explicitly skip to the next file
 
     # Check which session is currently active
     active_id = None
@@ -223,8 +229,11 @@ def list_sessions() -> str:
         try:
             with open(ACTIVE_SESSION_FILE) as f:
                 active_id = f.read().strip()
-        except Exception:
-            pass
+                
+        except Exception as e:
+            logger.warning(f"Could not read active session file {ACTIVE_SESSION_FILE}: {e}")
+            # active_id remains None as the safe fallback
+           
 
     return json.dumps(
         {


### PR DESCRIPTION
Replaced silent 'pass' blocks with descriptive logging in agent_builder_server and worker_node to improve debuggability of corrupted sessions and malformed tool outputs.

## Description

This PR improves the observability of the framework by replacing silent pass blocks with descriptive logging. Previously, issues like malformed agent sessions or failed tool output parsing would fail silently, making it difficult for developers to diagnose why certain data was missing or skipped.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)


## Related Issues

Fixes #546 

## Changes Made

- Change 1 
agent_builder_server.py:
Initialized the logger and added an import for the logging module.
Added an error log in the session loading loop to identify corrupted session files.
Added a warning log if the active session file cannot be read.

- Change 2
worker_node.py:
Replaced silent pass with a warning log when prompt template formatting fails, including the action name and node ID for context.
Added a warning log when tool outputs fail to parse as JSON, ensuring developers know when field unpacking was skipped

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (PYTHONPATH=core:exports python -m pytest core)
- [x] Manual testing performed: Verified that the module imports correctly and that the logging initialization does not interfere with the FastMCP setup.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes


