### PR TITLE
docs: fix ruff formatter command in developer guide

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -148,7 +148,7 @@ hive/                                    # Repository root
 │       ├── testing-agent/               # Skills for testing agents
 │       │   ├── SKILL.md
 │       |   └── examples
-│       └── agent-workflow/              # Complete workflow 
+│       └── agent-workflow/              # Complete workflow
 |           ├── SKILL.md
 │           └── examples
 │
@@ -375,7 +375,7 @@ def test_ticket_categorization():
 - **PEP 8** - Follow Python style guide
 - **Type hints** - Use for function signatures and class attributes
 - **Docstrings** - Document classes and public functions
-- **Black** - Code formatter (run with `black .`)
+- **Ruff** - Linter + formatter (run with `make format`)
 
 ```python
 # Good
@@ -520,8 +520,6 @@ chore(deps): update React to 18.2.0
 ---
 
 ## Debugging
-
-
 
 ### Backend Debugging
 
@@ -696,7 +694,6 @@ kill -9 <PID>
 # Or change ports in config.yaml and regenerate
 ```
 
-
 ### Docker Issues
 
 ```bash
@@ -706,8 +703,6 @@ docker system prune -f
 docker compose build --no-cache
 docker compose up
 ```
-
-
 
 ### Environment Variables Not Loading
 
@@ -721,8 +716,6 @@ cat hive/.env
 
 # Restart dev servers after changing env
 ```
-
-
 
 ---
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -239,13 +239,11 @@ claude> /testing-agent
    ```
 
 2. **Design the Workflow**
-
    - The skill guides you through defining nodes
    - Each node is a unit of work (LLM call, function, router)
    - Edges define how execution flows
 
 3. **Generate the Agent**
-
    - The skill generates a complete Python package in `exports/`
    - Includes: `agent.json`, `tools.py`, `README.md`
 
@@ -375,7 +373,7 @@ def test_ticket_categorization():
 - **PEP 8** - Follow Python style guide
 - **Type hints** - Use for function signatures and class attributes
 - **Docstrings** - Document classes and public functions
-- **Ruff** - Linter + formatter (run with `make format`)
+- **Ruff** - Linter + formatter (run with `make check`)
 
 ```python
 # Good


### PR DESCRIPTION
## Description

Update DEVELOPER.md to reference the correct formatter command (make format) for Ruff instead of black ..

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

Updated the Python code style section to use make format as the Ruff formatter command.

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
