### PR TITLE
Chore 2010 timeout handling with context mgr

### DIFF
--- a/core/framework/runtime/agent_runtime.py
+++ b/core/framework/runtime/agent_runtime.py
@@ -275,6 +275,7 @@ class AgentRuntime:
         self,
         entry_point_id: str,
         input_data: dict[str, Any],
+        *,
         timeout: float | None = None,
         session_state: dict[str, Any] | None = None,
     ) -> ExecutionResult | None:
@@ -294,7 +295,10 @@ class AgentRuntime:
         stream = self._streams.get(entry_point_id)
         if stream is None:
             raise ValueError(f"Entry point '{entry_point_id}' not found")
-        return await stream.wait_for_completion(exec_id, timeout)
+        if timeout is None:
+            return await stream.wait_for_completion(exec_id)
+        async with asyncio.timeout(timeout):
+            return await stream.wait_for_completion(exec_id)
 
     async def get_goal_progress(self) -> dict[str, Any]:
         """

--- a/core/framework/runtime/event_bus.py
+++ b/core/framework/runtime/event_bus.py
@@ -411,6 +411,7 @@ class EventBus:
         event_type: EventType,
         stream_id: str | None = None,
         execution_id: str | None = None,
+        *,
         timeout: float | None = None,
     ) -> AgentEvent | None:
         """

--- a/core/framework/runtime/execution_stream.py
+++ b/core/framework/runtime/execution_stream.py
@@ -430,6 +430,7 @@ class ExecutionStream:
     async def wait_for_completion(
         self,
         execution_id: str,
+        *,
         timeout: float | None = None,
     ) -> ExecutionResult | None:
         """

--- a/core/tests/test_plan_dependency_resolution.py
+++ b/core/tests/test_plan_dependency_resolution.py
@@ -6,7 +6,6 @@ instead of hanging indefinitely.
 """
 
 import pytest
-from datetime import datetime
 
 from framework.graph.plan import (
     Plan,


### PR DESCRIPTION
## Description

Use context managers to handle timeouts.
Enforce timeout param as keyword-only to ensure it is always called as key=value pair
Remove unused import in test_plan_dependency_resolution.py to avoid lint check error when running GitHub Actions.

## Related Issues

Fixes #2010 