### PR TITLE
feat: add unit tests for CLI and fix list command bug

### DIFF
--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -458,7 +458,7 @@ def cmd_list(args: argparse.Namespace) -> int:
             print(f"  {agent['name']}")
             print(f"    Path: {agent['path']}")
             print(f"    Description: {agent['description']}")
-            print(f"    Steps: {agent['steps']}, Tools: {agent['tools']}")
+            print(f"    Nodes: {agent['nodes']}, Tools: {agent['tools']}")
             print()
 
     return 0

--- a/core/tests/test_cli.py
+++ b/core/tests/test_cli.py
@@ -1,0 +1,123 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+import argparse
+from pathlib import Path
+import io
+
+# Import the module under test
+# Note: Adjust the import path if necessary based on how tests are run
+from framework.runner import cli
+
+class TestCli(unittest.TestCase):
+    
+    def setUp(self):
+        # Create a dummy arguments object
+        self.args = argparse.Namespace()
+        self.args.json = False
+        self.args.agent_path = "/tmp/dummy_agent"
+        self.args.directory = "/tmp/agents"
+        self.args.quiet = False
+        self.args.verbose = False
+    
+    @patch('framework.runner.AgentRunner')
+    def test_cmd_info_success(self, mock_runner_cls):
+        # Setup mock
+        mock_runner = MagicMock()
+        mock_runner_cls.load.return_value = mock_runner
+        
+        mock_info = MagicMock()
+        mock_info.name = "Test Agent"
+        mock_info.description = "A test agent"
+        mock_info.goal_name = "Test Goal"
+        mock_info.goal_description = "Do something"
+        mock_info.node_count = 5
+        mock_info.nodes = [{"id": "start", "name": "Start", "input_keys": [], "output_keys": []}]
+        mock_info.edges = []
+        mock_info.success_criteria = []
+        mock_info.constraints = []
+        mock_info.required_tools = ["tool1"]
+        mock_info.has_tools_module = True
+        
+        mock_runner.info.return_value = mock_info
+        
+        # Capture stdout
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            ret = cli.cmd_info(self.args)
+            
+        # Assertions
+        self.assertEqual(ret, 0)
+        output = mock_stdout.getvalue()
+        self.assertIn("Agent: Test Agent", output)
+        self.assertIn("Goal: Test Goal", output)
+        
+        # Verify cleanup was called
+        mock_runner.cleanup.assert_called_once()
+        
+    @patch('framework.runner.AgentRunner')
+    def test_cmd_info_file_not_found(self, mock_runner_cls):
+        # Setup mock to raise FileNotFoundError
+        mock_runner_cls.load.side_effect = FileNotFoundError("Agent not found")
+        
+        # Capture stderr
+        with patch('sys.stderr', new_callable=io.StringIO) as mock_stderr:
+            ret = cli.cmd_info(self.args)
+            
+        self.assertEqual(ret, 1)
+        self.assertIn("Error: Agent not found", mock_stderr.getvalue())
+
+    @patch('framework.runner.AgentRunner')
+    def test_cmd_validate_success(self, mock_runner_cls):
+        mock_runner = MagicMock()
+        mock_runner_cls.load.return_value = mock_runner
+        
+        mock_validation = MagicMock()
+        mock_validation.valid = True
+        mock_validation.errors = []
+        mock_validation.warnings = []
+        mock_validation.missing_tools = []
+        
+        mock_runner.validate.return_value = mock_validation
+        
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            ret = cli.cmd_validate(self.args)
+            
+        self.assertEqual(ret, 0)
+        self.assertIn("Agent is valid", mock_stdout.getvalue())
+        mock_runner.cleanup.assert_called_once()
+    
+    @patch('pathlib.Path.exists')
+    @patch('pathlib.Path.iterdir')
+    @patch('framework.runner.AgentRunner')
+    def test_cmd_list_agents(self, mock_runner_cls, mock_iterdir, mock_exists):
+        # Setup filesystem mocks
+        mock_exists.return_value = True
+        
+        # Mock directory structure
+        agent_dir_1 = MagicMock(spec=Path)
+        agent_dir_1.is_dir.return_value = True
+        agent_dir_1.__str__.return_value = "/tmp/agents/agent1"
+        # Mock agent.json existence for this dir
+        agent_json_1 = MagicMock(spec=Path)
+        agent_json_1.exists.return_value = True
+        agent_dir_1.__truediv__.return_value = agent_json_1
+        
+        mock_iterdir.return_value = [agent_dir_1]
+        
+        # Setup Runner mock
+        mock_runner = MagicMock()
+        mock_runner_cls.load.return_value = mock_runner
+        
+        mock_info = MagicMock()
+        mock_info.name = "Agent 1"
+        mock_info.description = "Desc 1"
+        mock_info.node_count = 3
+        mock_info.required_tools = []
+        mock_runner.info.return_value = mock_info
+        
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            ret = cli.cmd_list(self.args)
+            
+        self.assertEqual(ret, 0)
+        self.assertIn("Agent 1", mock_stdout.getvalue())
+        mock_runner.cleanup.assert_called_once()


### PR DESCRIPTION
## Description

This PR adds the first set of unit tests for the CLI module ([core/framework/runner/cli.py](cci:7://file:///Users/sohail/hive/core/framework/runner/cli.py:0:0-0:0)) to improve test coverage and stability. While writing the tests, I identified and fixed a bug in the `aden list` command where it was trying to access a non-existent key (`steps`), causing a crash.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (adding tests)

## Related Issues

Fixes #(issue number)

## Changes Made

- Created [core/tests/test_cli.py](cci:7://file:///Users/sohail/hive/core/tests/test_cli.py:0:0-0:0) with unit tests for:
  - [cmd_info](cci:1://file:///Users/sohail/hive/core/framework/runner/cli.py:316:0-376:12): Verified success output and file not found handling.
  - [cmd_validate](cci:1://file:///Users/sohail/hive/core/framework/runner/cli.py:379:0-410:39): Verified valid agent validation.
  - [cmd_list](cci:1://file:///Users/sohail/hive/core/framework/runner/cli.py:413:0-463:12): Verified listing agents in a directory.
- Fixed a bug in [core/framework/runner/cli.py](cci:7://file:///Users/sohail/hive/core/framework/runner/cli.py:0:0-0:0):
  - Changed `agent['steps']` (which caused a `KeyError`) to `agent['nodes']` to match the data structure.
- Used `unittest.mock` to mock [AgentRunner](cci:2://file:///Users/sohail/hive/core/framework/runner/runner.py:174:0-1105:22), `sys.stdout`, and file system operations for fast, isolated testing.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`python3 -m unittest core/tests/test_cli.py`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes