### PR TITLE
docs(setup): recommend repo-local .venv

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,10 @@ If a high-quality PR is submitted for a "stale" assigned issue (no activity for 
 ## Development Setup
 
 ```bash
+# Create and activate a repo-local virtual environment (recommended)
+python3 -m venv .venv
+source .venv/bin/activate
+
 # Install Python packages
 ./scripts/setup-python.sh
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -63,7 +63,11 @@ git --version       # Any recent version
 git clone https://github.com/adenhq/hive.git
 cd hive
 
-# 2. Run automated Python setup
+# 2. Create and activate a repo-local virtual environment (recommended)
+python3 -m venv .venv
+source .venv/bin/activate
+
+# 3. Run automated Python setup
 ./scripts/setup-python.sh
 ```
 

--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -5,9 +5,15 @@ Complete setup guide for building and running goal-driven agents with the Aden A
 ## Quick Setup
 
 ```bash
+# Create and activate a repo-local virtual environment (recommended)
+python3 -m venv .venv
+source .venv/bin/activate
+
 # Run the automated setup script
 ./scripts/setup-python.sh
 ```
+
+> **Note:** If you see `error: externally-managed-environment` (PEP 668), you're installing into an OS-managed Python. Activating `.venv` avoids modifying system Python (recommended over `--break-system-packages`).
 
 > **Note for Windows Users:**  
 > Running the setup script on native Windows shells (PowerShell / Git Bash) may sometimes fail due to Python App Execution Aliases.  

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 git clone https://github.com/adenhq/hive.git
 cd hive
 
+# Create and activate a repo-local virtual environment (recommended)
+python3 -m venv .venv
+source .venv/bin/activate
+
 # Run Python environment setup
 ./scripts/setup-python.sh
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,10 +18,14 @@ The fastest way to get started:
 git clone https://github.com/adenhq/hive.git
 cd hive
 
-# 2. Run automated Python setup
+# 2. Create and activate a repo-local virtual environment (recommended)
+python3 -m venv .venv
+source .venv/bin/activate
+
+# 3. Run automated Python setup
 ./scripts/setup-python.sh
 
-# 3. Verify installation
+# 4. Verify installation
 python -c "import framework; import aden_tools; print('✓ Setup complete')"
 ```
 


### PR DESCRIPTION
## Description

Improve first-time setup reliability by recommending a repo-local `.venv/` before running `./scripts/setup-python.sh`. This avoids PEP 668 `externally-managed-environment` failures when contributors are using an OS/Homebrew-managed Python.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Related: #333

## Changes Made

- Add `.venv` create/activate steps to the primary setup entrypoints (`README.md`, `DEVELOPER.md`, `CONTRIBUTING.md`, `docs/getting-started.md`).
- Add a short note in `ENVIRONMENT_SETUP.md` explaining the common PEP 668 failure mode and why `.venv` is recommended.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed (docs-only; no runtime behavior changes)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A - docs-only)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (pytest reports pre-existing DeprecationWarnings unrelated to this PR)
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A - docs-only)
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A
