### PR TITLE
feat: add OpenTelemetry integration for distributed tracing

### DIFF
--- a/core/framework/observability/__init__.py
+++ b/core/framework/observability/__init__.py
@@ -1,0 +1,121 @@
+"""
+Hive Observability - OpenTelemetry Distributed Tracing.
+
+This module provides production-ready observability for Hive agents through
+OpenTelemetry integration. It enables distributed tracing across graph
+executions, LLM calls, tool invocations, and agent decisions.
+
+Quick Start:
+    # Enable via environment variables
+    export HIVE_TRACING_ENABLED=true
+    export HIVE_OTLP_ENDPOINT=http://localhost:4317
+    export HIVE_SERVICE_NAME=my-research-agent
+
+    # Or programmatically
+    from framework.observability import get_tracer, TracingConfig
+
+    config = TracingConfig(
+        enabled=True,
+        service_name="my-agent",
+        otlp_endpoint="http://jaeger:4317",
+    )
+    tracer = get_tracer(config)
+
+Usage Patterns:
+
+    1. Graph Execution Tracing:
+        ```python
+        with tracer.trace_run(run_id, graph.id) as run_span:
+            with tracer.trace_node(node.id, node.name, node.node_type) as node_span:
+                result = await node.execute(ctx)
+                tracer.record_node_result(node_span, result.success, result.tokens_used)
+        ```
+
+    2. LLM Call Tracing:
+        ```python
+        with tracer.trace_llm_call(model, "complete") as llm_span:
+            response = await llm.complete(messages)
+            tracer.record_llm_result(llm_span, response.input_tokens, response.output_tokens)
+        ```
+
+    3. Parallel Execution with Context Propagation:
+        ```python
+        # Capture context before spawning parallel tasks
+        carrier = tracer.capture_context_for_parallel()
+
+        async def parallel_node(node):
+            with carrier.activate():  # Restores parent context
+                return await execute_node(node)
+
+        results = await asyncio.gather(*[parallel_node(n) for n in nodes])
+        ```
+
+Span Hierarchy:
+    hive.run (root)
+    └── node.{name}
+        ├── llm.complete
+        │   └── tool.{name}  (if tools used)
+        ├── decision
+        └── node.{next_name}
+            └── ...
+
+Attributes:
+    All spans include these attributes when available:
+    - hive.run_id: Unique execution run identifier
+    - hive.graph_id: Graph being executed
+    - hive.node_id: Current node
+    - hive.success: Whether operation succeeded
+    - hive.tokens_used: Total tokens consumed
+    - hive.latency_ms: Operation duration
+
+Integration with Backends:
+    - Jaeger: Works out of box with OTLP endpoint
+    - Datadog: Use OTLP ingest or DD agent
+    - Grafana Tempo: OTLP compatible
+    - Any OTLP-compatible backend
+"""
+
+from framework.observability.config import (
+    TracingConfig,
+    get_default_config,
+    set_default_config,
+)
+from framework.observability.context import (
+    HiveContextCarrier,
+    attach_context,
+    capture_context,
+    extract_context_from_headers,
+    get_graph_id,
+    get_node_id,
+    get_run_id,
+    inject_context_to_headers,
+)
+from framework.observability.tracer import (
+    HiveTracer,
+    SpanTimer,
+    get_tracer,
+    reset_tracer,
+    traced_function,
+)
+
+__all__ = [
+    # Configuration
+    "TracingConfig",
+    "get_default_config",
+    "set_default_config",
+    # Tracer
+    "HiveTracer",
+    "get_tracer",
+    "reset_tracer",
+    "traced_function",
+    "SpanTimer",
+    # Context propagation
+    "HiveContextCarrier",
+    "capture_context",
+    "attach_context",
+    "get_run_id",
+    "get_graph_id",
+    "get_node_id",
+    "inject_context_to_headers",
+    "extract_context_from_headers",
+]

--- a/core/framework/observability/config.py
+++ b/core/framework/observability/config.py
@@ -1,0 +1,170 @@
+"""
+OpenTelemetry Configuration for Hive.
+
+Provides environment-based configuration for distributed tracing with
+sensible defaults and zero-config operation.
+
+Environment Variables:
+    HIVE_TRACING_ENABLED: Enable/disable tracing (default: false)
+    HIVE_OTLP_ENDPOINT: OTLP collector endpoint (default: http://localhost:4317)
+    HIVE_SERVICE_NAME: Service name for traces (default: hive-agent)
+    HIVE_TRACING_SAMPLE_RATE: Sampling rate 0.0-1.0 (default: 1.0)
+    HIVE_TRACING_CONSOLE_EXPORT: Export spans to console for debugging (default: false)
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class TracingConfig:
+    """
+    Configuration for OpenTelemetry tracing.
+
+    Immutable configuration object that can be created from environment
+    variables or passed explicitly.
+
+    Attributes:
+        enabled: Whether tracing is enabled
+        service_name: Service name for span identification
+        otlp_endpoint: OTLP collector gRPC endpoint
+        sample_rate: Probability of sampling a trace (0.0-1.0)
+        console_export: Also export spans to console (for debugging)
+        resource_attributes: Additional resource attributes for all spans
+        max_queue_size: Maximum spans queued before dropping
+        max_export_batch_size: Maximum spans per export batch
+        export_timeout_ms: Timeout for exporting spans
+    """
+
+    enabled: bool = False
+    service_name: str = "hive-agent"
+    otlp_endpoint: str = "http://localhost:4317"
+    sample_rate: float = 1.0
+    console_export: bool = False
+    resource_attributes: dict[str, Any] = field(default_factory=dict)
+    max_queue_size: int = 2048
+    max_export_batch_size: int = 512
+    export_timeout_ms: int = 30000
+
+    @classmethod
+    def from_env(cls) -> TracingConfig:
+        """
+        Create configuration from environment variables.
+
+        This is the recommended way to configure tracing in production.
+        All settings have sensible defaults for zero-config operation.
+
+        Returns:
+            TracingConfig populated from environment variables
+        """
+        def parse_bool(value: str | None, default: bool = False) -> bool:
+            if value is None:
+                return default
+            return value.lower() in ("true", "1", "yes", "on")
+
+        def parse_float(value: str | None, default: float) -> float:
+            if value is None:
+                return default
+            try:
+                return float(value)
+            except ValueError:
+                return default
+
+        def parse_int(value: str | None, default: int) -> int:
+            if value is None:
+                return default
+            try:
+                return int(value)
+            except ValueError:
+                return default
+
+        # Parse resource attributes from HIVE_TRACING_RESOURCE_* env vars
+        resource_attrs = {}
+        for key, value in os.environ.items():
+            if key.startswith("HIVE_TRACING_RESOURCE_"):
+                attr_name = key[len("HIVE_TRACING_RESOURCE_"):].lower()
+                resource_attrs[attr_name] = value
+
+        return cls(
+            enabled=parse_bool(os.environ.get("HIVE_TRACING_ENABLED")),
+            service_name=os.environ.get("HIVE_SERVICE_NAME", "hive-agent"),
+            otlp_endpoint=os.environ.get(
+                "HIVE_OTLP_ENDPOINT", "http://localhost:4317"
+            ),
+            sample_rate=parse_float(
+                os.environ.get("HIVE_TRACING_SAMPLE_RATE"), 1.0
+            ),
+            console_export=parse_bool(
+                os.environ.get("HIVE_TRACING_CONSOLE_EXPORT")
+            ),
+            resource_attributes=resource_attrs,
+            max_queue_size=parse_int(
+                os.environ.get("HIVE_TRACING_MAX_QUEUE_SIZE"), 2048
+            ),
+            max_export_batch_size=parse_int(
+                os.environ.get("HIVE_TRACING_MAX_BATCH_SIZE"), 512
+            ),
+            export_timeout_ms=parse_int(
+                os.environ.get("HIVE_TRACING_EXPORT_TIMEOUT_MS"), 30000
+            ),
+        )
+
+    def with_overrides(self, **kwargs: Any) -> TracingConfig:
+        """
+        Create a new config with specific values overridden.
+
+        Args:
+            **kwargs: Fields to override
+
+        Returns:
+            New TracingConfig with overrides applied
+        """
+        current = {
+            "enabled": self.enabled,
+            "service_name": self.service_name,
+            "otlp_endpoint": self.otlp_endpoint,
+            "sample_rate": self.sample_rate,
+            "console_export": self.console_export,
+            "resource_attributes": dict(self.resource_attributes),
+            "max_queue_size": self.max_queue_size,
+            "max_export_batch_size": self.max_export_batch_size,
+            "export_timeout_ms": self.export_timeout_ms,
+        }
+        current.update(kwargs)
+        return TracingConfig(**current)
+
+
+# Default configuration singleton (lazy-loaded from environment)
+_default_config: TracingConfig | None = None
+
+
+def get_default_config() -> TracingConfig:
+    """
+    Get the default tracing configuration.
+
+    Lazily loads from environment on first call.
+    Thread-safe for concurrent access.
+
+    Returns:
+        The default TracingConfig instance
+    """
+    global _default_config
+    if _default_config is None:
+        _default_config = TracingConfig.from_env()
+    return _default_config
+
+
+def set_default_config(config: TracingConfig) -> None:
+    """
+    Set the default tracing configuration.
+
+    Use this for testing or programmatic configuration.
+
+    Args:
+        config: The configuration to use as default
+    """
+    global _default_config
+    _default_config = config

--- a/core/framework/observability/context.py
+++ b/core/framework/observability/context.py
@@ -1,0 +1,287 @@
+"""
+Trace Context Propagation for Hive.
+
+This module provides utilities for propagating OpenTelemetry context
+across async boundaries, especially during parallel node execution.
+
+The key insight is that when nodes execute in parallel via asyncio.gather(),
+each task needs the parent's trace context explicitly attached to maintain
+proper parent-child span relationships.
+
+Usage:
+    # Before spawning parallel tasks
+    parent_ctx = capture_context()
+
+    async def run_with_context(node):
+        with attach_context(parent_ctx):
+            return await execute_node(node)
+
+    # All child spans correctly nest under parent
+    results = await asyncio.gather(*[run_with_context(n) for n in nodes])
+"""
+
+from __future__ import annotations
+
+import contextvars
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+
+# Lazy imports for optional OpenTelemetry dependency
+if TYPE_CHECKING:
+    from opentelemetry.context import Context
+
+# ContextVar for Hive-specific run correlation
+_current_run_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "hive_run_id", default=None
+)
+
+_current_graph_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "hive_graph_id", default=None
+)
+
+_current_node_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "hive_node_id", default=None
+)
+
+
+def set_run_context(
+    run_id: str,
+    graph_id: str | None = None,
+) -> tuple[contextvars.Token, contextvars.Token | None]:
+    """
+    Set the current run context in contextvars.
+
+    This should be called at the start of a graph execution to establish
+    the run_id for all child spans.
+
+    Args:
+        run_id: Unique identifier for this execution run
+        graph_id: Optional graph identifier
+
+    Returns:
+        Tokens for resetting the context (use in finally block)
+    """
+    run_token = _current_run_id.set(run_id)
+    graph_token = _current_graph_id.set(graph_id) if graph_id else None
+    return run_token, graph_token
+
+
+def reset_run_context(
+    run_token: contextvars.Token,
+    graph_token: contextvars.Token | None,
+) -> None:
+    """
+    Reset the run context using tokens from set_run_context.
+
+    Args:
+        run_token: Token from setting run_id
+        graph_token: Token from setting graph_id (may be None)
+    """
+    _current_run_id.reset(run_token)
+    if graph_token is not None:
+        _current_graph_id.reset(graph_token)
+
+
+def get_run_id() -> str | None:
+    """Get the current run_id from context."""
+    return _current_run_id.get()
+
+
+def get_graph_id() -> str | None:
+    """Get the current graph_id from context."""
+    return _current_graph_id.get()
+
+
+def set_node_context(node_id: str) -> contextvars.Token:
+    """
+    Set the current node context.
+
+    Args:
+        node_id: The node being executed
+
+    Returns:
+        Token for resetting
+    """
+    return _current_node_id.set(node_id)
+
+
+def reset_node_context(token: contextvars.Token) -> None:
+    """Reset node context using token."""
+    _current_node_id.reset(token)
+
+
+def get_node_id() -> str | None:
+    """Get the current node_id from context."""
+    return _current_node_id.get()
+
+
+def capture_context() -> "Context | None":
+    """
+    Capture the current OpenTelemetry context for propagation.
+
+    Use this before spawning parallel tasks to preserve the trace context.
+
+    Returns:
+        The current OTel context, or None if OTel is not available
+    """
+    try:
+        from opentelemetry import context as otel_context
+        return otel_context.get_current()
+    except ImportError:
+        return None
+
+
+@contextmanager
+def attach_context(ctx: "Context | None"):
+    """
+    Attach a captured context in a parallel task.
+
+    This is a context manager that attaches the captured OTel context
+    and detaches it when the block exits.
+
+    Args:
+        ctx: Context captured via capture_context()
+
+    Yields:
+        None
+
+    Example:
+        parent_ctx = capture_context()
+
+        async def parallel_task():
+            with attach_context(parent_ctx):
+                # Spans created here are children of parent
+                ...
+    """
+    if ctx is None:
+        yield
+        return
+
+    try:
+        from opentelemetry import context as otel_context
+        token = otel_context.attach(ctx)
+        try:
+            yield
+        finally:
+            otel_context.detach(token)
+    except ImportError:
+        yield
+
+
+def get_current_span_context() -> dict[str, Any]:
+    """
+    Get the current span context as a dictionary.
+
+    Useful for serializing context across process boundaries
+    (e.g., for distributed agents).
+
+    Returns:
+        Dict with trace_id, span_id, and trace_flags if available
+    """
+    try:
+        from opentelemetry import trace
+        from opentelemetry.trace import format_trace_id, format_span_id
+
+        span = trace.get_current_span()
+        ctx = span.get_span_context()
+
+        if ctx.is_valid:
+            return {
+                "trace_id": format_trace_id(ctx.trace_id),
+                "span_id": format_span_id(ctx.span_id),
+                "trace_flags": ctx.trace_flags,
+                "is_remote": ctx.is_remote,
+            }
+    except ImportError:
+        pass
+
+    return {}
+
+
+def inject_context_to_headers(headers: dict[str, str]) -> dict[str, str]:
+    """
+    Inject trace context into HTTP headers for distributed tracing.
+
+    Args:
+        headers: Existing headers dict
+
+    Returns:
+        Headers with trace context injected
+    """
+    try:
+        from opentelemetry.propagate import inject
+        inject(headers)
+    except ImportError:
+        pass
+    return headers
+
+
+def extract_context_from_headers(headers: dict[str, str]) -> "Context | None":
+    """
+    Extract trace context from HTTP headers.
+
+    Args:
+        headers: Headers containing trace context
+
+    Returns:
+        Extracted context or None
+    """
+    try:
+        from opentelemetry.propagate import extract
+        return extract(headers)
+    except ImportError:
+        return None
+
+
+class HiveContextCarrier:
+    """
+    Context carrier for Hive-specific context propagation.
+
+    This packages both OpenTelemetry context and Hive-specific
+    run context for propagation across async boundaries.
+    """
+
+    def __init__(self):
+        """Capture current context."""
+        self.otel_context = capture_context()
+        self.run_id = get_run_id()
+        self.graph_id = get_graph_id()
+        self.node_id = get_node_id()
+
+    @contextmanager
+    def activate(self):
+        """
+        Activate this carrier's context in a new async task.
+
+        Usage:
+            carrier = HiveContextCarrier()
+
+            async def parallel_task():
+                with carrier.activate():
+                    # Full context restored
+                    ...
+        """
+        # Restore Hive context
+        run_token = None
+        graph_token = None
+        node_token = None
+
+        if self.run_id:
+            run_token = _current_run_id.set(self.run_id)
+        if self.graph_id:
+            graph_token = _current_graph_id.set(self.graph_id)
+        if self.node_id:
+            node_token = _current_node_id.set(self.node_id)
+
+        try:
+            # Restore OTel context
+            with attach_context(self.otel_context):
+                yield
+        finally:
+            # Reset Hive context
+            if run_token is not None:
+                _current_run_id.reset(run_token)
+            if graph_token is not None:
+                _current_graph_id.reset(graph_token)
+            if node_token is not None:
+                _current_node_id.reset(node_token)

--- a/core/framework/observability/examples.py
+++ b/core/framework/observability/examples.py
@@ -1,0 +1,369 @@
+"""
+OpenTelemetry Tracing Examples for Hive.
+
+This module provides practical examples of how to use Hive's distributed
+tracing capabilities in different scenarios.
+
+Quick Start:
+    1. Start Jaeger: docker run -d -p 16686:16686 -p 4317:4317 jaegertracing/all-in-one
+    2. Set environment variables:
+       export HIVE_TRACING_ENABLED=true
+       export HIVE_OTLP_ENDPOINT=http://localhost:4317
+    3. Run your Hive agent
+    4. View traces at http://localhost:16686
+
+Examples in this file:
+    - Basic tracing setup
+    - Custom span attributes
+    - Parallel execution with context propagation
+    - Error handling and exception recording
+    - Integration with existing code
+"""
+
+import asyncio
+from typing import Any
+
+
+# =============================================================================
+# EXAMPLE 1: Basic Tracing Setup
+# =============================================================================
+
+def example_basic_setup():
+    """
+    Basic tracing setup using environment variables.
+
+    Set these environment variables before running:
+        HIVE_TRACING_ENABLED=true
+        HIVE_OTLP_ENDPOINT=http://localhost:4317
+        HIVE_SERVICE_NAME=my-research-agent
+    """
+    from framework.observability import get_tracer, TracingConfig
+
+    # Option 1: Use environment variables (recommended for production)
+    tracer = get_tracer()  # Automatically loads from env
+
+    # Option 2: Programmatic configuration (useful for testing)
+    config = TracingConfig(
+        enabled=True,
+        service_name="my-agent",
+        otlp_endpoint="http://localhost:4317",
+        console_export=True,  # Also print spans to console for debugging
+    )
+    tracer = get_tracer(config)
+
+    # Use the tracer
+    with tracer.trace_run("run_001", "research_graph"):
+        print("Executing with tracing enabled!")
+
+
+# =============================================================================
+# EXAMPLE 2: Manual Span Creation
+# =============================================================================
+
+async def example_manual_spans():
+    """
+    Create spans manually for custom operations.
+
+    This is useful when you have operations that aren't automatically
+    traced by the framework.
+    """
+    from framework.observability import get_tracer
+
+    tracer = get_tracer()
+
+    # Create a run span (root of the trace)
+    with tracer.trace_run(
+        run_id="run_manual_001",
+        graph_id="custom_graph",
+        goal_id="goal_123",
+        goal_description="Analyze customer feedback",
+    ) as run_span:
+
+        # Create a node span
+        with tracer.trace_node(
+            node_id="analyze_sentiment",
+            node_name="Sentiment Analyzer",
+            node_type="llm_generate",
+            input_keys=["feedback_text"],
+            output_keys=["sentiment_score", "confidence"],
+        ) as node_span:
+
+            # Simulate some work
+            await asyncio.sleep(0.1)
+
+            # Create an LLM call span
+            with tracer.trace_llm_call(
+                model="claude-3-haiku-20240307",
+                operation="complete",
+                message_count=3,
+            ) as llm_span:
+
+                # Simulate LLM call
+                await asyncio.sleep(0.2)
+
+                # Record LLM metrics
+                tracer.record_llm_result(
+                    span=llm_span,
+                    input_tokens=150,
+                    output_tokens=50,
+                    model="claude-3-haiku-20240307",
+                    stop_reason="end_turn",
+                )
+
+            # Record node result
+            tracer.record_node_result(
+                span=node_span,
+                success=True,
+                tokens_used=200,
+                latency_ms=300,
+            )
+
+        # Add custom attributes to run span
+        if run_span:
+            run_span.set_attribute("hive.custom_metric", 42)
+
+
+# =============================================================================
+# EXAMPLE 3: Parallel Execution with Context Propagation
+# =============================================================================
+
+async def example_parallel_execution():
+    """
+    Properly propagate trace context to parallel tasks.
+
+    This is CRITICAL for maintaining correct span hierarchy when
+    executing nodes in parallel with asyncio.gather().
+    """
+    from framework.observability import get_tracer
+
+    tracer = get_tracer()
+
+    async def process_item(carrier, item_id: str):
+        """Process a single item with proper context."""
+        # IMPORTANT: Activate the carrier to restore parent context
+        with carrier.activate():
+            with tracer.trace_node(
+                node_id=f"process_{item_id}",
+                node_name=f"Process Item {item_id}",
+                node_type="function",
+            ) as span:
+                await asyncio.sleep(0.05)  # Simulate work
+                if span:
+                    span.set_attribute("item.id", item_id)
+                return f"result_{item_id}"
+
+    with tracer.trace_run("parallel_run_001", "batch_processor"):
+        with tracer.trace_node(
+            node_id="batch_orchestrator",
+            node_name="Batch Orchestrator",
+            node_type="function",
+        ):
+            # CRITICAL: Capture context BEFORE creating parallel tasks
+            carrier = tracer.capture_context_for_parallel()
+
+            # All parallel tasks will have their spans correctly
+            # nested under the orchestrator span
+            results = await asyncio.gather(
+                process_item(carrier, "a"),
+                process_item(carrier, "b"),
+                process_item(carrier, "c"),
+                process_item(carrier, "d"),
+            )
+
+            print(f"Processed {len(results)} items")
+
+
+# =============================================================================
+# EXAMPLE 4: Error Handling
+# =============================================================================
+
+async def example_error_handling():
+    """
+    Properly record errors and exceptions in traces.
+    """
+    from framework.observability import get_tracer
+
+    tracer = get_tracer()
+
+    with tracer.trace_run("error_run_001", "error_demo"):
+        with tracer.trace_node(
+            node_id="risky_operation",
+            node_name="Risky Operation",
+            node_type="llm_tool_use",
+        ) as node_span:
+            try:
+                # Simulate an operation that might fail
+                raise ValueError("Something went wrong!")
+
+            except Exception as e:
+                # Record the exception on the span
+                tracer.record_exception(node_span, e)
+
+                # Record failure in node result
+                tracer.record_node_result(
+                    span=node_span,
+                    success=False,
+                    error=str(e),
+                )
+
+                # Re-raise or handle as appropriate
+                print(f"Caught and recorded error: {e}")
+
+
+# =============================================================================
+# EXAMPLE 5: Custom Tool Tracing
+# =============================================================================
+
+async def example_tool_tracing():
+    """
+    Trace custom tool invocations.
+    """
+    from framework.observability import get_tracer
+
+    tracer = get_tracer()
+
+    async def call_web_search(query: str) -> dict[str, Any]:
+        """Simulated web search tool."""
+        with tracer.trace_tool_call(
+            tool_name="web_search",
+            tool_input={"query": query},
+        ) as tool_span:
+            # Simulate API call
+            await asyncio.sleep(0.1)
+
+            result = {
+                "results": ["Result 1", "Result 2"],
+                "total": 2,
+            }
+
+            if tool_span:
+                tool_span.set_attribute("tool.results_count", result["total"])
+
+            return result
+
+    with tracer.trace_run("tool_run_001", "search_agent"):
+        with tracer.trace_node(
+            node_id="search_node",
+            node_name="Web Searcher",
+            node_type="llm_tool_use",
+        ):
+            results = await call_web_search("Hive AI agents")
+            print(f"Found {results['total']} results")
+
+
+# =============================================================================
+# EXAMPLE 6: Integration with GraphExecutor
+# =============================================================================
+
+def example_executor_integration():
+    """
+    The GraphExecutor automatically traces executions.
+
+    When you use the standard GraphExecutor, tracing is automatic:
+    - Each run creates a root span
+    - Each node execution creates a child span
+    - LLM calls within nodes create nested spans
+    - Tool calls create their own spans
+
+    Just enable tracing via environment variables and run your agent!
+    """
+    example_code = '''
+    # This is already done for you in GraphExecutor!
+    # Just enable tracing:
+
+    export HIVE_TRACING_ENABLED=true
+    export HIVE_OTLP_ENDPOINT=http://localhost:4317
+
+    # Then run your agent normally:
+
+    from framework.graph.executor import GraphExecutor
+    from framework.runtime.core import Runtime
+
+    runtime = Runtime("/path/to/storage")
+    executor = GraphExecutor(runtime=runtime, llm=my_llm)
+
+    # Tracing happens automatically!
+    result = await executor.execute(graph, goal, input_data)
+
+    # View traces in Jaeger at http://localhost:16686
+    '''
+    print(example_code)
+
+
+# =============================================================================
+# EXAMPLE 7: Viewing Traces in Jaeger
+# =============================================================================
+
+def example_jaeger_setup():
+    """
+    Instructions for setting up Jaeger to view traces.
+    """
+    instructions = '''
+    ╔══════════════════════════════════════════════════════════════════╗
+    ║                    JAEGER SETUP GUIDE                            ║
+    ╠══════════════════════════════════════════════════════════════════╣
+    ║                                                                  ║
+    ║  1. Start Jaeger with Docker:                                    ║
+    ║                                                                  ║
+    ║     docker run -d --name jaeger \\                                ║
+    ║       -p 16686:16686 \\                                           ║
+    ║       -p 4317:4317 \\                                             ║
+    ║       jaegertracing/all-in-one:latest                            ║
+    ║                                                                  ║
+    ║  2. Configure Hive:                                              ║
+    ║                                                                  ║
+    ║     export HIVE_TRACING_ENABLED=true                             ║
+    ║     export HIVE_OTLP_ENDPOINT=http://localhost:4317              ║
+    ║     export HIVE_SERVICE_NAME=my-research-agent                   ║
+    ║                                                                  ║
+    ║  3. Run your Hive agent                                          ║
+    ║                                                                  ║
+    ║  4. View traces at: http://localhost:16686                       ║
+    ║                                                                  ║
+    ║  Useful Jaeger queries:                                          ║
+    ║  • service=hive-agent                                            ║
+    ║  • service=hive-agent AND hive.run_id="run_123"                  ║
+    ║  • service=hive-agent AND hive.node_type="llm_tool_use"          ║
+    ║  • service=hive-agent AND error=true                             ║
+    ║                                                                  ║
+    ╚══════════════════════════════════════════════════════════════════╝
+    '''
+    print(instructions)
+
+
+# =============================================================================
+# RUN EXAMPLES
+# =============================================================================
+
+if __name__ == "__main__":
+    import os
+
+    # Enable console export for demo
+    os.environ["HIVE_TRACING_ENABLED"] = "true"
+    os.environ["HIVE_TRACING_CONSOLE_EXPORT"] = "true"
+
+    print("\n" + "=" * 60)
+    print("HIVE OPENTELEMETRY TRACING EXAMPLES")
+    print("=" * 60)
+
+    print("\n--- Example: Jaeger Setup ---")
+    example_jaeger_setup()
+
+    print("\n--- Example: Basic Setup ---")
+    example_basic_setup()
+
+    print("\n--- Example: Manual Spans ---")
+    asyncio.run(example_manual_spans())
+
+    print("\n--- Example: Parallel Execution ---")
+    asyncio.run(example_parallel_execution())
+
+    print("\n--- Example: Error Handling ---")
+    asyncio.run(example_error_handling())
+
+    print("\n--- Example: Tool Tracing ---")
+    asyncio.run(example_tool_tracing())
+
+    print("\n" + "=" * 60)
+    print("Examples complete! Enable OTLP endpoint to see traces in Jaeger.")
+    print("=" * 60)

--- a/core/framework/observability/tracer.py
+++ b/core/framework/observability/tracer.py
@@ -1,0 +1,675 @@
+"""
+HiveTracer - OpenTelemetry Integration for Hive Agent Tracing.
+
+This module provides the core tracing functionality for Hive, enabling
+distributed tracing across graph executions, LLM calls, and tool invocations.
+
+The tracer automatically:
+- Creates hierarchical spans for graph → node → LLM/tool execution
+- Propagates context across parallel node execution
+- Records key attributes (run_id, tokens, latency, cost)
+- Exports to any OTLP-compatible backend (Jaeger, Datadog, Grafana, etc.)
+
+Usage:
+    from framework.observability import get_tracer
+
+    tracer = get_tracer()
+
+    with tracer.trace_run(run_id, graph_id) as run_span:
+        with tracer.trace_node(node_id, node_name, node_type) as node_span:
+            with tracer.trace_llm_call(model, node_id) as llm_span:
+                response = await llm.complete(...)
+                llm_span.set_attribute("hive.tokens", response.total_tokens)
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from contextlib import contextmanager
+from functools import wraps
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
+
+from framework.observability.config import TracingConfig, get_default_config
+from framework.observability.context import (
+    HiveContextCarrier,
+    capture_context,
+    get_graph_id,
+    get_node_id,
+    get_run_id,
+    reset_run_context,
+    set_node_context,
+    reset_node_context,
+    set_run_context,
+)
+
+if TYPE_CHECKING:
+    from opentelemetry.trace import Span, Tracer
+
+logger = logging.getLogger(__name__)
+
+# Type variable for decorated functions
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+class HiveTracer:
+    """
+    OpenTelemetry integration for Hive agent tracing.
+
+    This class provides context-manager-based tracing for all Hive operations.
+    It gracefully degrades to no-ops when tracing is disabled or OTel is unavailable.
+
+    Key features:
+    - Hierarchical span creation (run → node → llm/tool)
+    - Automatic run_id propagation via contextvars
+    - Context capture/attach for parallel execution
+    - Zero overhead when disabled
+    - Graceful degradation without OTel dependency
+
+    Attributes:
+        enabled: Whether tracing is currently enabled
+        config: The TracingConfig being used
+    """
+
+    def __init__(self, config: TracingConfig | None = None):
+        """
+        Initialize the HiveTracer.
+
+        Args:
+            config: Tracing configuration. If None, loads from environment.
+        """
+        self.config = config or get_default_config()
+        self._tracer: "Tracer | None" = None
+        self._initialized = False
+
+        if self.config.enabled:
+            self._initialize_otel()
+
+    @property
+    def enabled(self) -> bool:
+        """Whether tracing is enabled and initialized."""
+        return self.config.enabled and self._initialized
+
+    def _initialize_otel(self) -> None:
+        """Initialize OpenTelemetry SDK components."""
+        try:
+            from opentelemetry import trace
+            from opentelemetry.sdk.trace import TracerProvider
+            from opentelemetry.sdk.trace.export import BatchSpanProcessor
+            from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+
+            # Build resource with service name and custom attributes
+            resource_attrs = {
+                SERVICE_NAME: self.config.service_name,
+                "hive.version": "1.0.0",  # TODO: Get from package version
+            }
+            resource_attrs.update(self.config.resource_attributes)
+            resource = Resource.create(resource_attrs)
+
+            # Create provider
+            provider = TracerProvider(resource=resource)
+
+            # Add OTLP exporter
+            if self.config.otlp_endpoint:
+                try:
+                    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+                        OTLPSpanExporter,
+                    )
+
+                    exporter = OTLPSpanExporter(
+                        endpoint=self.config.otlp_endpoint,
+                        insecure=self.config.otlp_endpoint.startswith("http://"),
+                    )
+                    processor = BatchSpanProcessor(
+                        exporter,
+                        max_queue_size=self.config.max_queue_size,
+                        max_export_batch_size=self.config.max_export_batch_size,
+                        export_timeout_millis=self.config.export_timeout_ms,
+                    )
+                    provider.add_span_processor(processor)
+                    logger.info(
+                        f"OTLP exporter configured: {self.config.otlp_endpoint}"
+                    )
+                except ImportError:
+                    logger.warning(
+                        "OTLP exporter not available. Install opentelemetry-exporter-otlp"
+                    )
+
+            # Add console exporter for debugging
+            if self.config.console_export:
+                try:
+                    from opentelemetry.sdk.trace.export import (
+                        ConsoleSpanExporter,
+                        SimpleSpanProcessor,
+                    )
+
+                    console_processor = SimpleSpanProcessor(ConsoleSpanExporter())
+                    provider.add_span_processor(console_processor)
+                    logger.info("Console span exporter enabled")
+                except ImportError:
+                    pass
+
+            # Set as global provider
+            trace.set_tracer_provider(provider)
+            self._tracer = trace.get_tracer(
+                self.config.service_name,
+                "1.0.0",
+            )
+            self._initialized = True
+            logger.info(f"Tracing initialized: service={self.config.service_name}")
+
+        except ImportError as e:
+            logger.warning(f"OpenTelemetry not available: {e}")
+            self._initialized = False
+
+    def _get_base_attributes(self) -> dict[str, Any]:
+        """Get base attributes to include on all spans."""
+        attrs = {}
+        run_id = get_run_id()
+        graph_id = get_graph_id()
+        node_id = get_node_id()
+
+        if run_id:
+            attrs["hive.run_id"] = run_id
+        if graph_id:
+            attrs["hive.graph_id"] = graph_id
+        if node_id:
+            attrs["hive.node_id"] = node_id
+
+        return attrs
+
+    @contextmanager
+    def trace_run(
+        self,
+        run_id: str,
+        graph_id: str,
+        goal_id: str | None = None,
+        goal_description: str | None = None,
+    ):
+        """
+        Create the root span for an entire graph execution run.
+
+        This sets up the run context in contextvars so all child spans
+        automatically include the run_id.
+
+        Args:
+            run_id: Unique identifier for this run
+            graph_id: Identifier for the graph being executed
+            goal_id: Optional goal identifier
+            goal_description: Optional goal description
+
+        Yields:
+            The span object (or None if tracing disabled)
+
+        Example:
+            with tracer.trace_run(run_id, graph.id) as span:
+                result = await executor.execute(graph, goal)
+        """
+        # Always set run context, even if tracing disabled
+        run_token, graph_token = set_run_context(run_id, graph_id)
+
+        if not self.enabled or self._tracer is None:
+            try:
+                yield None
+            finally:
+                reset_run_context(run_token, graph_token)
+            return
+
+        attributes = {
+            "hive.run_id": run_id,
+            "hive.graph_id": graph_id,
+        }
+        if goal_id:
+            attributes["hive.goal_id"] = goal_id
+        if goal_description:
+            attributes["hive.goal_description"] = goal_description[:200]  # Truncate
+
+        try:
+            with self._tracer.start_as_current_span(
+                "hive.run",
+                attributes=attributes,
+            ) as span:
+                yield span
+        finally:
+            reset_run_context(run_token, graph_token)
+
+    @contextmanager
+    def trace_node(
+        self,
+        node_id: str,
+        node_name: str,
+        node_type: str,
+        input_keys: list[str] | None = None,
+        output_keys: list[str] | None = None,
+    ):
+        """
+        Create a span for node execution.
+
+        Args:
+            node_id: Unique identifier for the node
+            node_name: Human-readable node name
+            node_type: Node type (llm_generate, llm_tool_use, router, etc.)
+            input_keys: Input memory keys this node reads
+            output_keys: Output memory keys this node writes
+
+        Yields:
+            The span object (or None if tracing disabled)
+        """
+        node_token = set_node_context(node_id)
+
+        if not self.enabled or self._tracer is None:
+            try:
+                yield None
+            finally:
+                reset_node_context(node_token)
+            return
+
+        attributes = self._get_base_attributes()
+        attributes.update({
+            "hive.node_id": node_id,
+            "hive.node_name": node_name,
+            "hive.node_type": node_type,
+        })
+        if input_keys:
+            attributes["hive.input_keys"] = ",".join(input_keys)
+        if output_keys:
+            attributes["hive.output_keys"] = ",".join(output_keys)
+
+        try:
+            with self._tracer.start_as_current_span(
+                f"node.{node_name}",
+                attributes=attributes,
+            ) as span:
+                yield span
+        finally:
+            reset_node_context(node_token)
+
+    @contextmanager
+    def trace_llm_call(
+        self,
+        model: str,
+        operation: str = "complete",
+        system_prompt_length: int | None = None,
+        message_count: int | None = None,
+        tools_count: int | None = None,
+    ):
+        """
+        Create a span for an LLM API call.
+
+        Args:
+            model: Model identifier (e.g., "claude-3-haiku-20240307")
+            operation: Operation type ("complete" or "complete_with_tools")
+            system_prompt_length: Length of system prompt
+            message_count: Number of messages in conversation
+            tools_count: Number of tools available
+
+        Yields:
+            The span object (or None if tracing disabled)
+
+        Example:
+            with tracer.trace_llm_call(self.model) as span:
+                response = litellm.completion(...)
+                if span:
+                    span.set_attribute("hive.input_tokens", response.input_tokens)
+                    span.set_attribute("hive.output_tokens", response.output_tokens)
+        """
+        if not self.enabled or self._tracer is None:
+            yield None
+            return
+
+        attributes = self._get_base_attributes()
+        attributes.update({
+            "hive.llm.model": model,
+            "hive.llm.operation": operation,
+            "gen_ai.system": self._infer_provider(model),
+            "gen_ai.request.model": model,
+        })
+
+        if system_prompt_length is not None:
+            attributes["hive.llm.system_prompt_length"] = system_prompt_length
+        if message_count is not None:
+            attributes["hive.llm.message_count"] = message_count
+        if tools_count is not None:
+            attributes["hive.llm.tools_count"] = tools_count
+
+        with self._tracer.start_as_current_span(
+            f"llm.{operation}",
+            attributes=attributes,
+        ) as span:
+            yield span
+
+    @contextmanager
+    def trace_tool_call(
+        self,
+        tool_name: str,
+        tool_input: dict[str, Any] | None = None,
+    ):
+        """
+        Create a span for a tool invocation.
+
+        Args:
+            tool_name: Name of the tool being invoked
+            tool_input: Input parameters for the tool
+
+        Yields:
+            The span object (or None if tracing disabled)
+        """
+        if not self.enabled or self._tracer is None:
+            yield None
+            return
+
+        attributes = self._get_base_attributes()
+        attributes.update({
+            "hive.tool.name": tool_name,
+        })
+
+        # Add sanitized tool input (avoid sensitive data)
+        if tool_input:
+            attributes["hive.tool.input_keys"] = ",".join(tool_input.keys())
+
+        with self._tracer.start_as_current_span(
+            f"tool.{tool_name}",
+            attributes=attributes,
+        ) as span:
+            yield span
+
+    @contextmanager
+    def trace_decision(
+        self,
+        intent: str,
+        options_count: int,
+        chosen_option: str,
+    ):
+        """
+        Create a span for an agent decision.
+
+        Args:
+            intent: What the agent was trying to accomplish
+            options_count: Number of options considered
+            chosen_option: ID of the chosen option
+
+        Yields:
+            The span object (or None if tracing disabled)
+        """
+        if not self.enabled or self._tracer is None:
+            yield None
+            return
+
+        attributes = self._get_base_attributes()
+        attributes.update({
+            "hive.decision.intent": intent[:200],  # Truncate long intents
+            "hive.decision.options_count": options_count,
+            "hive.decision.chosen": chosen_option,
+        })
+
+        with self._tracer.start_as_current_span(
+            "decision",
+            attributes=attributes,
+        ) as span:
+            yield span
+
+    def record_node_result(
+        self,
+        span: "Span | None",
+        success: bool,
+        tokens_used: int = 0,
+        latency_ms: int = 0,
+        error: str | None = None,
+    ) -> None:
+        """
+        Record the result of a node execution on its span.
+
+        Args:
+            span: The span to update (may be None if tracing disabled)
+            success: Whether the node succeeded
+            tokens_used: Total tokens consumed
+            latency_ms: Execution time in milliseconds
+            error: Error message if failed
+        """
+        if span is None:
+            return
+
+        try:
+            from opentelemetry.trace import Status, StatusCode
+
+            span.set_attribute("hive.success", success)
+            span.set_attribute("hive.tokens_used", tokens_used)
+            span.set_attribute("hive.latency_ms", latency_ms)
+
+            if success:
+                span.set_status(Status(StatusCode.OK))
+            else:
+                span.set_status(Status(StatusCode.ERROR, error or "Unknown error"))
+                if error:
+                    span.set_attribute("hive.error", error[:500])
+        except ImportError:
+            pass
+
+    def record_llm_result(
+        self,
+        span: "Span | None",
+        input_tokens: int,
+        output_tokens: int,
+        model: str | None = None,
+        stop_reason: str | None = None,
+    ) -> None:
+        """
+        Record LLM call results on its span.
+
+        Args:
+            span: The span to update
+            input_tokens: Prompt tokens
+            output_tokens: Completion tokens
+            model: Actual model used (may differ from requested)
+            stop_reason: Why generation stopped
+        """
+        if span is None:
+            return
+
+        span.set_attribute("hive.llm.input_tokens", input_tokens)
+        span.set_attribute("hive.llm.output_tokens", output_tokens)
+        span.set_attribute("hive.llm.total_tokens", input_tokens + output_tokens)
+
+        # Also use semantic conventions for AI/ML
+        span.set_attribute("gen_ai.usage.prompt_tokens", input_tokens)
+        span.set_attribute("gen_ai.usage.completion_tokens", output_tokens)
+
+        if model:
+            span.set_attribute("gen_ai.response.model", model)
+        if stop_reason:
+            span.set_attribute("gen_ai.response.finish_reasons", [stop_reason])
+
+    def record_exception(
+        self,
+        span: "Span | None",
+        exception: Exception,
+    ) -> None:
+        """
+        Record an exception on a span.
+
+        Args:
+            span: The span to update
+            exception: The exception that occurred
+        """
+        if span is None:
+            return
+
+        try:
+            from opentelemetry.trace import Status, StatusCode
+
+            span.record_exception(exception)
+            span.set_status(Status(StatusCode.ERROR, str(exception)))
+        except ImportError:
+            pass
+
+    def capture_context_for_parallel(self) -> HiveContextCarrier:
+        """
+        Capture the current context for propagation to parallel tasks.
+
+        Returns:
+            A HiveContextCarrier that can be activated in parallel tasks
+        """
+        return HiveContextCarrier()
+
+    def get_current_span(self) -> "Span | None":
+        """
+        Get the currently active span.
+
+        Returns:
+            The current span or None
+        """
+        if not self.enabled:
+            return None
+
+        try:
+            from opentelemetry import trace
+            return trace.get_current_span()
+        except ImportError:
+            return None
+
+    def add_event(
+        self,
+        name: str,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        """
+        Add an event to the current span.
+
+        Args:
+            name: Event name
+            attributes: Event attributes
+        """
+        span = self.get_current_span()
+        if span is not None:
+            span.add_event(name, attributes=attributes or {})
+
+    def _infer_provider(self, model: str) -> str:
+        """Infer the LLM provider from model name."""
+        model_lower = model.lower()
+        if "claude" in model_lower or "anthropic" in model_lower:
+            return "anthropic"
+        elif "gpt" in model_lower or "openai" in model_lower:
+            return "openai"
+        elif "gemini" in model_lower:
+            return "google"
+        elif "mistral" in model_lower:
+            return "mistral"
+        elif "llama" in model_lower:
+            return "meta"
+        elif "deepseek" in model_lower:
+            return "deepseek"
+        else:
+            return "unknown"
+
+
+# Global tracer instance (lazy-loaded)
+_global_tracer: HiveTracer | None = None
+
+
+def get_tracer(config: TracingConfig | None = None) -> HiveTracer:
+    """
+    Get the global HiveTracer instance.
+
+    Creates the tracer on first call with the provided or default config.
+    Subsequent calls return the same instance (config parameter ignored).
+
+    Args:
+        config: Optional configuration (only used on first call)
+
+    Returns:
+        The global HiveTracer instance
+    """
+    global _global_tracer
+    if _global_tracer is None:
+        _global_tracer = HiveTracer(config)
+    return _global_tracer
+
+
+def reset_tracer() -> None:
+    """
+    Reset the global tracer.
+
+    Use this for testing or to reconfigure tracing.
+    """
+    global _global_tracer
+    _global_tracer = None
+
+
+def traced_function(
+    span_name: str | None = None,
+    attributes: dict[str, Any] | None = None,
+) -> Callable[[F], F]:
+    """
+    Decorator to trace a function.
+
+    Args:
+        span_name: Custom span name (defaults to function name)
+        attributes: Additional span attributes
+
+    Returns:
+        Decorated function
+
+    Example:
+        @traced_function(span_name="my_operation")
+        async def my_function():
+            ...
+    """
+    def decorator(func: F) -> F:
+        name = span_name or func.__name__
+
+        @wraps(func)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            tracer = get_tracer()
+            if not tracer.enabled or tracer._tracer is None:
+                return await func(*args, **kwargs)
+
+            with tracer._tracer.start_as_current_span(
+                name,
+                attributes=attributes or {},
+            ):
+                return await func(*args, **kwargs)
+
+        @wraps(func)
+        def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            tracer = get_tracer()
+            if not tracer.enabled or tracer._tracer is None:
+                return func(*args, **kwargs)
+
+            with tracer._tracer.start_as_current_span(
+                name,
+                attributes=attributes or {},
+            ):
+                return func(*args, **kwargs)
+
+        import asyncio
+        if asyncio.iscoroutinefunction(func):
+            return async_wrapper  # type: ignore
+        return sync_wrapper  # type: ignore
+
+    return decorator
+
+
+class SpanTimer:
+    """
+    Context manager for timing operations and recording to span.
+
+    Usage:
+        with SpanTimer(span, "hive.operation_ms") as timer:
+            # Do work
+            pass
+        # Duration automatically recorded to span
+    """
+
+    def __init__(self, span: "Span | None", attribute_name: str):
+        self.span = span
+        self.attribute_name = attribute_name
+        self.start_time: float = 0
+
+    def __enter__(self) -> "SpanTimer":
+        self.start_time = time.perf_counter()
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        if self.span is not None:
+            duration_ms = int((time.perf_counter() - self.start_time) * 1000)
+            self.span.set_attribute(self.attribute_name, duration_ms)

--- a/core/tests/test_observability.py
+++ b/core/tests/test_observability.py
@@ -1,0 +1,723 @@
+"""
+Comprehensive Test Suite for Hive OpenTelemetry Integration.
+
+This module tests the observability infrastructure including:
+- Configuration loading and environment variables
+- Tracer initialization and graceful degradation
+- Context propagation for parallel execution
+- Span hierarchy and attribute recording
+- Integration with mocked OpenTelemetry
+
+Run with: pytest core/tests/test_observability.py -v
+"""
+
+import asyncio
+import os
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# =============================================================================
+# CONFIGURATION TESTS
+# =============================================================================
+
+
+class TestTracingConfig:
+    """Test TracingConfig creation and environment parsing."""
+
+    def test_default_config_values(self):
+        """Default config should have tracing disabled."""
+        from framework.observability.config import TracingConfig
+
+        config = TracingConfig()
+
+        assert config.enabled is False
+        assert config.service_name == "hive-agent"
+        assert config.otlp_endpoint == "http://localhost:4317"
+        assert config.sample_rate == 1.0
+        assert config.console_export is False
+
+    def test_config_from_env_enabled(self, monkeypatch):
+        """Config should parse HIVE_TRACING_ENABLED correctly."""
+        from framework.observability.config import TracingConfig
+
+        monkeypatch.setenv("HIVE_TRACING_ENABLED", "true")
+        monkeypatch.setenv("HIVE_SERVICE_NAME", "test-agent")
+        monkeypatch.setenv("HIVE_OTLP_ENDPOINT", "http://jaeger:4317")
+
+        config = TracingConfig.from_env()
+
+        assert config.enabled is True
+        assert config.service_name == "test-agent"
+        assert config.otlp_endpoint == "http://jaeger:4317"
+
+    @pytest.mark.parametrize("value,expected", [
+        ("true", True),
+        ("True", True),
+        ("TRUE", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        ("false", False),
+        ("False", False),
+        ("0", False),
+        ("no", False),
+        ("off", False),
+        ("", False),
+        ("invalid", False),
+    ])
+    def test_config_bool_parsing(self, monkeypatch, value, expected):
+        """Boolean environment variables should parse correctly."""
+        from framework.observability.config import TracingConfig
+
+        monkeypatch.setenv("HIVE_TRACING_ENABLED", value)
+        config = TracingConfig.from_env()
+        assert config.enabled is expected
+
+    def test_config_sample_rate_parsing(self, monkeypatch):
+        """Sample rate should parse as float."""
+        from framework.observability.config import TracingConfig
+
+        monkeypatch.setenv("HIVE_TRACING_SAMPLE_RATE", "0.5")
+        config = TracingConfig.from_env()
+        assert config.sample_rate == 0.5
+
+    def test_config_sample_rate_invalid(self, monkeypatch):
+        """Invalid sample rate should use default."""
+        from framework.observability.config import TracingConfig
+
+        monkeypatch.setenv("HIVE_TRACING_SAMPLE_RATE", "invalid")
+        config = TracingConfig.from_env()
+        assert config.sample_rate == 1.0
+
+    def test_config_resource_attributes(self, monkeypatch):
+        """Resource attributes should be parsed from HIVE_TRACING_RESOURCE_* vars."""
+        from framework.observability.config import TracingConfig
+
+        monkeypatch.setenv("HIVE_TRACING_RESOURCE_ENVIRONMENT", "production")
+        monkeypatch.setenv("HIVE_TRACING_RESOURCE_VERSION", "1.0.0")
+
+        config = TracingConfig.from_env()
+
+        assert config.resource_attributes["environment"] == "production"
+        assert config.resource_attributes["version"] == "1.0.0"
+
+    def test_config_with_overrides(self):
+        """with_overrides should create new config with changes."""
+        from framework.observability.config import TracingConfig
+
+        original = TracingConfig(enabled=False, service_name="original")
+        modified = original.with_overrides(enabled=True, service_name="modified")
+
+        # Original unchanged
+        assert original.enabled is False
+        assert original.service_name == "original"
+
+        # Modified has new values
+        assert modified.enabled is True
+        assert modified.service_name == "modified"
+
+    def test_config_immutable(self):
+        """TracingConfig should be immutable (frozen dataclass)."""
+        from framework.observability.config import TracingConfig
+
+        config = TracingConfig()
+
+        with pytest.raises(AttributeError):
+            config.enabled = True  # type: ignore
+
+
+# =============================================================================
+# CONTEXT PROPAGATION TESTS
+# =============================================================================
+
+
+class TestContextPropagation:
+    """Test context propagation utilities for parallel execution."""
+
+    def test_run_context_set_and_get(self):
+        """Run context should be set and retrieved correctly."""
+        from framework.observability.context import (
+            get_run_id,
+            reset_run_context,
+            set_run_context,
+        )
+
+        # Initially None
+        assert get_run_id() is None
+
+        # Set context
+        run_token, graph_token = set_run_context("run_123", "graph_456")
+
+        try:
+            assert get_run_id() == "run_123"
+        finally:
+            reset_run_context(run_token, graph_token)
+
+        # After reset, should be None again
+        assert get_run_id() is None
+
+    def test_context_isolation_in_tasks(self):
+        """Context should be isolated between async tasks by default."""
+        from framework.observability.context import get_run_id, set_run_context
+
+        async def check_context():
+            # Should not see parent context (contextvars are task-local)
+            return get_run_id()
+
+        async def main():
+            run_token, _ = set_run_context("parent_run", None)
+
+            # Start a new task - it won't inherit the context
+            result = await asyncio.create_task(check_context())
+
+            # Context is NOT automatically propagated to new tasks
+            # (This is the problem we solve with HiveContextCarrier)
+            return result
+
+        # Note: In Python 3.11+, contextvars ARE copied to tasks
+        # This test may need adjustment based on Python version
+        result = asyncio.run(main())
+        # The behavior depends on Python version, so we just check it runs
+
+    def test_hive_context_carrier_propagation(self):
+        """HiveContextCarrier should propagate context to parallel tasks."""
+        from framework.observability.context import (
+            HiveContextCarrier,
+            get_run_id,
+            set_run_context,
+            reset_run_context,
+        )
+
+        async def parallel_task(carrier: HiveContextCarrier):
+            with carrier.activate():
+                return get_run_id()
+
+        async def main():
+            run_token, graph_token = set_run_context("propagated_run", "graph_1")
+            try:
+                # Capture context
+                carrier = HiveContextCarrier()
+
+                # Run parallel tasks with carrier
+                results = await asyncio.gather(
+                    parallel_task(carrier),
+                    parallel_task(carrier),
+                    parallel_task(carrier),
+                )
+
+                return results
+            finally:
+                reset_run_context(run_token, graph_token)
+
+        results = asyncio.run(main())
+
+        # All tasks should see the propagated run_id
+        assert all(r == "propagated_run" for r in results)
+
+    def test_node_context_set_and_get(self):
+        """Node context should be set and retrieved correctly."""
+        from framework.observability.context import (
+            get_node_id,
+            reset_node_context,
+            set_node_context,
+        )
+
+        assert get_node_id() is None
+
+        token = set_node_context("node_abc")
+        try:
+            assert get_node_id() == "node_abc"
+        finally:
+            reset_node_context(token)
+
+        assert get_node_id() is None
+
+
+# =============================================================================
+# TRACER TESTS
+# =============================================================================
+
+
+class TestHiveTracer:
+    """Test HiveTracer functionality."""
+
+    def test_tracer_disabled_by_default(self):
+        """Tracer should be disabled when config.enabled is False."""
+        from framework.observability.config import TracingConfig
+        from framework.observability.tracer import HiveTracer
+
+        config = TracingConfig(enabled=False)
+        tracer = HiveTracer(config)
+
+        assert tracer.enabled is False
+
+    def test_tracer_context_managers_noop_when_disabled(self):
+        """Context managers should be no-ops when tracing disabled."""
+        from framework.observability.config import TracingConfig
+        from framework.observability.tracer import HiveTracer
+
+        config = TracingConfig(enabled=False)
+        tracer = HiveTracer(config)
+
+        # All context managers should work but yield None
+        with tracer.trace_run("run_1", "graph_1") as span:
+            assert span is None
+
+        with tracer.trace_node("node_1", "Test Node", "llm_generate") as span:
+            assert span is None
+
+        with tracer.trace_llm_call("gpt-4") as span:
+            assert span is None
+
+        with tracer.trace_tool_call("calculator") as span:
+            assert span is None
+
+    def test_tracer_graceful_without_otel(self):
+        """Tracer should work gracefully without OpenTelemetry installed."""
+        from framework.observability.config import TracingConfig
+        from framework.observability.tracer import HiveTracer
+
+        # Even with enabled=True, if OTel isn't available it should gracefully degrade
+        config = TracingConfig(enabled=True)
+
+        # Mock ImportError for opentelemetry
+        with patch.dict('sys.modules', {'opentelemetry': None}):
+            tracer = HiveTracer(config)
+            # Should not raise, just be disabled
+            assert tracer._initialized is False or tracer.enabled is False
+
+    def test_get_tracer_singleton(self):
+        """get_tracer should return singleton instance."""
+        from framework.observability.tracer import get_tracer, reset_tracer
+
+        reset_tracer()  # Clear any existing
+
+        tracer1 = get_tracer()
+        tracer2 = get_tracer()
+
+        assert tracer1 is tracer2
+
+        reset_tracer()  # Cleanup
+
+    def test_tracer_captures_context_for_parallel(self):
+        """capture_context_for_parallel should return a HiveContextCarrier."""
+        from framework.observability.config import TracingConfig
+        from framework.observability.tracer import HiveTracer
+        from framework.observability.context import HiveContextCarrier
+
+        config = TracingConfig(enabled=False)
+        tracer = HiveTracer(config)
+
+        carrier = tracer.capture_context_for_parallel()
+
+        assert isinstance(carrier, HiveContextCarrier)
+
+
+# =============================================================================
+# SPAN HIERARCHY TESTS (with mocked OTel)
+# =============================================================================
+
+
+class MockSpan:
+    """Mock OpenTelemetry span for testing."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.attributes: dict[str, Any] = {}
+        self.events: list[tuple[str, dict]] = []
+        self.status = None
+        self.exception = None
+        self.ended = False
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        self.attributes[key] = value
+
+    def add_event(self, name: str, attributes: dict | None = None) -> None:
+        self.events.append((name, attributes or {}))
+
+    def set_status(self, status: Any) -> None:
+        self.status = status
+
+    def record_exception(self, exception: Exception) -> None:
+        self.exception = exception
+
+    def end(self) -> None:
+        self.ended = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.end()
+
+
+class MockTracer:
+    """Mock OpenTelemetry tracer for testing span creation."""
+
+    def __init__(self):
+        self.spans: list[MockSpan] = []
+
+    @contextmanager
+    def start_as_current_span(self, name: str, attributes: dict | None = None):
+        span = MockSpan(name)
+        if attributes:
+            for k, v in attributes.items():
+                span.set_attribute(k, v)
+        self.spans.append(span)
+        yield span
+
+
+class TestSpanHierarchy:
+    """Test span creation and hierarchy with mocked OTel."""
+
+    def test_trace_run_creates_span_with_attributes(self):
+        """trace_run should create span with correct attributes."""
+        from framework.observability.config import TracingConfig
+        from framework.observability.tracer import HiveTracer
+
+        config = TracingConfig(enabled=True)
+        tracer = HiveTracer(config)
+
+        # Replace internal tracer with mock
+        mock_tracer = MockTracer()
+        tracer._tracer = mock_tracer
+        tracer._initialized = True
+
+        with tracer.trace_run(
+            run_id="run_123",
+            graph_id="graph_456",
+            goal_id="goal_789",
+            goal_description="Test goal",
+        ):
+            pass
+
+        assert len(mock_tracer.spans) == 1
+        span = mock_tracer.spans[0]
+
+        assert span.name == "hive.run"
+        assert span.attributes["hive.run_id"] == "run_123"
+        assert span.attributes["hive.graph_id"] == "graph_456"
+        assert span.attributes["hive.goal_id"] == "goal_789"
+
+    def test_trace_node_includes_run_context(self):
+        """trace_node should include run_id from context."""
+        from framework.observability.config import TracingConfig
+        from framework.observability.tracer import HiveTracer
+        from framework.observability.context import set_run_context, reset_run_context
+
+        config = TracingConfig(enabled=True)
+        tracer = HiveTracer(config)
+
+        mock_tracer = MockTracer()
+        tracer._tracer = mock_tracer
+        tracer._initialized = True
+
+        # Set run context
+        run_token, graph_token = set_run_context("run_abc", "graph_def")
+
+        try:
+            with tracer.trace_node(
+                node_id="node_1",
+                node_name="Test Node",
+                node_type="llm_generate",
+                input_keys=["input1", "input2"],
+                output_keys=["output1"],
+            ):
+                pass
+        finally:
+            reset_run_context(run_token, graph_token)
+
+        assert len(mock_tracer.spans) == 1
+        span = mock_tracer.spans[0]
+
+        assert span.name == "node.Test Node"
+        assert span.attributes["hive.run_id"] == "run_abc"
+        assert span.attributes["hive.node_id"] == "node_1"
+        assert span.attributes["hive.node_type"] == "llm_generate"
+        assert span.attributes["hive.input_keys"] == "input1,input2"
+        assert span.attributes["hive.output_keys"] == "output1"
+
+    def test_trace_llm_call_attributes(self):
+        """trace_llm_call should record model and operation."""
+        from framework.observability.config import TracingConfig
+        from framework.observability.tracer import HiveTracer
+
+        config = TracingConfig(enabled=True)
+        tracer = HiveTracer(config)
+
+        mock_tracer = MockTracer()
+        tracer._tracer = mock_tracer
+        tracer._initialized = True
+
+        with tracer.trace_llm_call(
+            model="claude-3-haiku-20240307",
+            operation="complete",
+            system_prompt_length=100,
+            message_count=5,
+            tools_count=3,
+        ):
+            pass
+
+        span = mock_tracer.spans[0]
+
+        assert span.name == "llm.complete"
+        assert span.attributes["hive.llm.model"] == "claude-3-haiku-20240307"
+        assert span.attributes["hive.llm.operation"] == "complete"
+        assert span.attributes["gen_ai.system"] == "anthropic"
+        assert span.attributes["hive.llm.system_prompt_length"] == 100
+        assert span.attributes["hive.llm.message_count"] == 5
+        assert span.attributes["hive.llm.tools_count"] == 3
+
+    def test_record_node_result_success(self):
+        """record_node_result should set success attributes."""
+        from framework.observability.tracer import HiveTracer
+        from framework.observability.config import TracingConfig
+
+        config = TracingConfig(enabled=True)
+        tracer = HiveTracer(config)
+
+        mock_span = MockSpan("test")
+
+        # Call record_node_result - it will try to import trace but
+        # our MockSpan handles set_attribute directly
+        tracer.record_node_result(
+            span=mock_span,
+            success=True,
+            tokens_used=1500,
+            latency_ms=250,
+        )
+
+        assert mock_span.attributes["hive.success"] is True
+        assert mock_span.attributes["hive.tokens_used"] == 1500
+        assert mock_span.attributes["hive.latency_ms"] == 250
+
+    def test_record_llm_result_attributes(self):
+        """record_llm_result should set token counts."""
+        from framework.observability.tracer import HiveTracer
+        from framework.observability.config import TracingConfig
+
+        config = TracingConfig(enabled=True)
+        tracer = HiveTracer(config)
+
+        mock_span = MockSpan("test")
+
+        tracer.record_llm_result(
+            span=mock_span,
+            input_tokens=500,
+            output_tokens=150,
+            model="claude-3-opus",
+            stop_reason="end_turn",
+        )
+
+        assert mock_span.attributes["hive.llm.input_tokens"] == 500
+        assert mock_span.attributes["hive.llm.output_tokens"] == 150
+        assert mock_span.attributes["hive.llm.total_tokens"] == 650
+        assert mock_span.attributes["gen_ai.usage.prompt_tokens"] == 500
+        assert mock_span.attributes["gen_ai.response.model"] == "claude-3-opus"
+
+    def test_provider_inference(self):
+        """_infer_provider should correctly identify providers."""
+        from framework.observability.tracer import HiveTracer
+        from framework.observability.config import TracingConfig
+
+        tracer = HiveTracer(TracingConfig())
+
+        assert tracer._infer_provider("claude-3-haiku-20240307") == "anthropic"
+        assert tracer._infer_provider("gpt-4o-mini") == "openai"
+        assert tracer._infer_provider("gemini-1.5-pro") == "google"
+        assert tracer._infer_provider("mistral-large") == "mistral"
+        assert tracer._infer_provider("llama-3.1-70b") == "meta"
+        assert tracer._infer_provider("deepseek-chat") == "deepseek"
+        assert tracer._infer_provider("unknown-model") == "unknown"
+
+
+# =============================================================================
+# INTEGRATION TESTS
+# =============================================================================
+
+
+class TestTracerIntegration:
+    """Integration tests for the complete tracing flow."""
+
+    @pytest.mark.asyncio
+    async def test_nested_span_hierarchy(self):
+        """Test that spans nest correctly: run → node → llm → tool."""
+        from framework.observability.config import TracingConfig
+        from framework.observability.tracer import HiveTracer
+
+        config = TracingConfig(enabled=True)
+        tracer = HiveTracer(config)
+
+        mock_tracer = MockTracer()
+        tracer._tracer = mock_tracer
+        tracer._initialized = True
+
+        with tracer.trace_run("run_1", "graph_1") as run_span:
+            with tracer.trace_node("node_1", "Research", "llm_tool_use") as node_span:
+                with tracer.trace_llm_call("claude-3-haiku") as llm_span:
+                    with tracer.trace_tool_call("web_search", {"query": "test"}) as tool_span:
+                        pass
+
+        # Should have 4 spans created
+        assert len(mock_tracer.spans) == 4
+
+        span_names = [s.name for s in mock_tracer.spans]
+        assert "hive.run" in span_names
+        assert "node.Research" in span_names
+        assert "llm.complete" in span_names
+        assert "tool.web_search" in span_names
+
+    @pytest.mark.asyncio
+    async def test_parallel_execution_context_propagation(self):
+        """Test context propagation in parallel execution scenario."""
+        from framework.observability.config import TracingConfig
+        from framework.observability.tracer import HiveTracer
+        from framework.observability.context import get_run_id
+
+        config = TracingConfig(enabled=True)
+        tracer = HiveTracer(config)
+
+        mock_tracer = MockTracer()
+        tracer._tracer = mock_tracer
+        tracer._initialized = True
+
+        async def parallel_node(carrier, node_id: str):
+            """Simulate a node running in parallel."""
+            with carrier.activate():
+                # Should see the run_id from parent context
+                run_id = get_run_id()
+                with tracer.trace_node(node_id, f"Node {node_id}", "llm_generate"):
+                    await asyncio.sleep(0.01)  # Simulate work
+                return run_id
+
+        with tracer.trace_run("parallel_run", "graph_1"):
+            # Capture context before parallel execution
+            carrier = tracer.capture_context_for_parallel()
+
+            # Run nodes in parallel
+            results = await asyncio.gather(
+                parallel_node(carrier, "node_a"),
+                parallel_node(carrier, "node_b"),
+                parallel_node(carrier, "node_c"),
+            )
+
+        # All parallel nodes should have seen the same run_id
+        assert all(r == "parallel_run" for r in results)
+
+        # Should have 1 run span + 3 node spans
+        assert len(mock_tracer.spans) == 4
+
+    def test_exception_recording(self):
+        """Test that exceptions are recorded on spans."""
+        from framework.observability.config import TracingConfig
+        from framework.observability.tracer import HiveTracer
+
+        config = TracingConfig(enabled=True)
+        tracer = HiveTracer(config)
+
+        mock_span = MockSpan("test")
+
+        test_error = ValueError("Something went wrong")
+
+        # Call record_exception - MockSpan handles record_exception directly
+        tracer.record_exception(mock_span, test_error)
+
+        assert mock_span.exception is test_error
+
+
+# =============================================================================
+# DECORATOR TESTS
+# =============================================================================
+
+
+class TestTracedFunctionDecorator:
+    """Test the @traced_function decorator."""
+
+    @pytest.mark.asyncio
+    async def test_traced_async_function(self):
+        """@traced_function should work with async functions."""
+        from framework.observability.tracer import traced_function, reset_tracer
+
+        reset_tracer()
+
+        @traced_function(span_name="test_operation")
+        async def my_async_function(x: int) -> int:
+            return x * 2
+
+        result = await my_async_function(5)
+
+        assert result == 10
+
+        reset_tracer()
+
+    def test_traced_sync_function(self):
+        """@traced_function should work with sync functions."""
+        from framework.observability.tracer import traced_function, reset_tracer
+
+        reset_tracer()
+
+        @traced_function(span_name="sync_operation")
+        def my_sync_function(x: int) -> int:
+            return x * 3
+
+        result = my_sync_function(5)
+
+        assert result == 15
+
+        reset_tracer()
+
+
+# =============================================================================
+# SPAN TIMER TESTS
+# =============================================================================
+
+
+class TestSpanTimer:
+    """Test SpanTimer context manager."""
+
+    def test_span_timer_records_duration(self):
+        """SpanTimer should record duration as attribute."""
+        from framework.observability.tracer import SpanTimer
+        import time
+
+        mock_span = MockSpan("test")
+
+        with SpanTimer(mock_span, "hive.operation_ms"):
+            time.sleep(0.05)  # 50ms
+
+        # Should have recorded approximately 50ms
+        assert "hive.operation_ms" in mock_span.attributes
+        duration = mock_span.attributes["hive.operation_ms"]
+        assert 40 <= duration <= 100  # Allow some variance
+
+    def test_span_timer_noop_with_none_span(self):
+        """SpanTimer should handle None span gracefully."""
+        from framework.observability.tracer import SpanTimer
+
+        # Should not raise
+        with SpanTimer(None, "hive.operation_ms"):
+            pass
+
+
+# =============================================================================
+# CLEANUP
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def reset_global_state():
+    """Reset global state before and after each test."""
+    from framework.observability.tracer import reset_tracer
+    from framework.observability.config import set_default_config, TracingConfig
+
+    reset_tracer()
+    set_default_config(TracingConfig())
+
+    yield
+
+    reset_tracer()
+    set_default_config(TracingConfig())


### PR DESCRIPTION
## Description

Implements production-ready OpenTelemetry distributed tracing for Hive, enabling end-to-end observability across graph executions, LLM calls, and tool invocations. This addresses Issue #3 and incorporates community feedback for context propagation in parallel execution and `hive.run_id` correlation.


## Key Features

- **Hierarchical span creation**: `hive.run` → `node.*` → `llm.*` → `tool.*`
- **Context propagation for parallel nodes** via `contextvars` (addresses community feedback)
- **`hive.run_id` on all spans** for Jaeger/Datadog filtering (addresses community feedback)
- **Zero overhead when disabled** - all operations become no-ops
- **Graceful degradation** without OpenTelemetry installed
- 
## Type of Change

 [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Closes #1435

## Changes Made

## New Files (2,300+ lines)

| File | Purpose |
|------|---------|
| `core/framework/observability/__init__.py` | Public API exports with comprehensive docstrings |
| `core/framework/observability/config.py` | `TracingConfig` dataclass with environment-based configuration |
| `core/framework/observability/context.py` | Context propagation via `contextvars` for parallel execution |
| `core/framework/observability/tracer.py` | `HiveTracer` class with span creation and attribute recording |
| `core/framework/observability/examples.py` | 7 practical examples including Jaeger setup guide |
| `core/tests/test_observability.py` | 42 test cases covering config, context, spans, and integration |

### Modified Files

| File | Changes |
|------|---------|
| `core/framework/graph/executor.py` | Added `trace_run`, `trace_node`, automatic span attribute recording |
| `core/framework/llm/litellm.py` | Added `trace_llm_call`, `trace_tool_call`, token/latency metrics |

## Architecture

### Span Hierarchy
```
hive.run (root)
├── hive.run_id: "run_20260129_123456_abc123"
├── hive.graph_id: "research_agent"
├── hive.goal_id: "goal_001"
└── node.Research
    ├── hive.node_type: "llm_tool_use"
    ├── hive.success: true
    ├── hive.tokens_used: 1500
    └── llm.complete_with_tools
        ├── hive.llm.model: "claude-3-haiku"
        ├── hive.llm.input_tokens: 500
        ├── hive.llm.output_tokens: 150
        └── tool.web_search
            └── hive.tool.success: true
```

### Context Propagation for Parallel Execution

```python
# Capture context before spawning parallel tasks
carrier = tracer.capture_context_for_parallel()

async def parallel_node(node):
    with carrier.activate():  # Restores parent context
        return await execute_node(node)

# All spans correctly nested under parent
results = await asyncio.gather(*[parallel_node(n) for n in nodes])
```

## Configuration

```bash
# Enable tracing
export HIVE_TRACING_ENABLED=true
export HIVE_OTLP_ENDPOINT=http://localhost:4317
export HIVE_SERVICE_NAME=my-research-agent

# Optional: Console export for debugging
export HIVE_TRACING_CONSOLE_EXPORT=true
```

## Testing

```bash
cd /Users/mustkeemk/Documents/Projects/hive
source .venv/bin/activate
cd core
python -m pytest tests/test_observability.py -v
```

### Test Results

```
======================== 42 passed, 3 warnings in 1.27s ========================
```

| Test Category | Tests | Status |
|---------------|-------|--------|
| Configuration (`TestTracingConfig`) | 10 | PASS |
| Context Propagation (`TestContextPropagation`) | 4 | PASS |
| HiveTracer (`TestHiveTracer`) | 5 | PASS |
| Span Hierarchy (`TestSpanHierarchy`) | 6 | PASS |
| Integration (`TestTracerIntegration`) | 3 | PASS |
| Decorators (`TestTracedFunctionDecorator`) | 2 | PASS |
| SpanTimer (`TestSpanTimer`) | 2 | PASS |

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (examples.py)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Addresses community feedback on context propagation
- [x] Addresses community feedback on `hive.run_id` attribute

## Jaeger Integration

To view traces locally:

```bash
# Start Jaeger
docker run -d -p 16686:16686 -p 4317:4317 jaegertracing/all-in-one

# Enable tracing and run your agent
export HIVE_TRACING_ENABLED=true
export HIVE_OTLP_ENDPOINT=http://localhost:4317

# View traces at http://localhost:16686
# Filter by: service=hive-agent AND hive.run_id="run_123"
```

## Screenshots (if applicable)

<img width="976" height="682" alt="Screenshot 2026-01-29 at 8 05 37 AM" src="https://github.com/user-attachments/assets/ab986974-8ac3-4ebf-9b91-363bcf4d2240" />

