### PR TITLE
feat: reusable building blocks, MCP node options, safe_eval deprecati…

### DIFF
--- a/CHANGES_SUMMARY.md
+++ b/CHANGES_SUMMARY.md
@@ -1,0 +1,28 @@
+# Summary of Changes (Session)
+
+## 1. Contributor issue: Remove LLM dependency from Agent Builder MCP Server
+
+- **Issue**: MCP test-generation tools had a hardcoded Anthropic dependency; contributors requested provider-agnostic behavior.
+- **Resolution**: Option A was already implemented—`generate_constraint_tests` and `generate_success_tests` return guidelines/templates only; no LLM calls in the MCP server.
+- **Updates**:
+  - Documented resolution in `issues/remove-llm-dependency-from-mcp-server.md`.
+  - Clarified `tools/mcp_server.py` docstring: no LLM/API key required at server startup; credentials validated at agent load time.
+  - Added a design note in `core/framework/mcp/agent_builder_server.py` (testing tools section) to avoid reintroducing LLM dependency.
+
+## 2. Reusable Agent Building Blocks
+
+- **Goal**: Library of ready-to-use building blocks (retry, approval/HITL, validation) so agents can reuse patterns instead of copy-pasting.
+- **Implementation**:
+  - **NodeSpec** (`core/framework/graph/node.py`): Added `pause_for_hitl`, `approval_message`, `approval_timeout_seconds`.
+  - **add_node / update_node** (`core/framework/mcp/agent_builder_server.py`): New optional params—`max_retries`, `retry_on`, `output_schema`, `max_validation_retries`, `pause_for_hitl`, `approval_message`. Update uses `None` = leave unchanged.
+  - **Pause nodes**: Validation/export now treats a node as a pause node if `pause_for_hitl` is True or description contains `"PAUSE"` (backward compatible).
+  - **Blocks library** (`core/framework/blocks/`): New package with `BlockSpec`, `get_block`, `list_blocks`. Presets: retry (default, aggressive, none, on_network), approval (required, with_message, with_timeout), validation (default, strict, none).
+  - **MCP tools**: `list_blocks(category?)` and `apply_block(block_id, target_node_id, overrides?)` to list and apply presets to nodes.
+  - **Docs**: `core/MCP_BUILDER_TOOLS_GUIDE.md` and `.claude/skills/building-agents-construction/SKILL.md` updated with building-blocks usage and optional node params.
+  - **Tests**: `core/tests/test_blocks.py` added for the blocks registry.
+
+## 3. safe_eval deprecation warnings (Python 3.14)
+
+- **File**: `core/framework/graph/safe_eval.py`
+- **Change**: Removed deprecated `visit_Num`, `visit_Str`, and `visit_NameConstant`; literals are handled only by `visit_Constant` (Python 3.8+ uses `ast.Constant` for all constants).
+- **Result**: Deprecation warnings from pytest are gone.

--- a/core/framework/blocks/__init__.py
+++ b/core/framework/blocks/__init__.py
@@ -1,0 +1,13 @@
+"""
+Reusable building blocks for agent nodes.
+
+Provides presets for retry, approval/HITL, and validation that can be applied
+to nodes via MCP (apply_block) or used as reference when configuring add_node/update_node.
+
+Blocks are configuration deltas only; the executor already respects NodeSpec fields
+like max_retries, pause_for_hitl, output_schema, etc.
+"""
+
+from framework.blocks.registry import BlockSpec, get_block, list_blocks
+
+__all__ = ["BlockSpec", "get_block", "list_blocks"]

--- a/core/framework/blocks/registry.py
+++ b/core/framework/blocks/registry.py
@@ -1,0 +1,159 @@
+"""
+Block registry: presets for retry, approval/HITL, and validation.
+
+Each block is a named preset that applies a delta (dict) to a NodeSpec.
+Deltas use only keys that NodeSpec supports and that can be set via MCP
+(max_retries, retry_on, output_schema, max_validation_retries, pause_for_hitl, approval_message).
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class BlockSpec:
+    """A reusable building block: id, metadata, and delta to apply to a node."""
+
+    id: str
+    name: str
+    description: str
+    category: str  # "retry" | "approval" | "validation"
+    delta: dict[str, Any] = field(default_factory=dict)
+
+    def apply_to_node_dict(self, node_data: dict[str, Any], overrides: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Merge this block's delta (and optional overrides) into a node dict. Returns a new dict."""
+        out = dict(node_data)
+        for key, value in self.delta.items():
+            out[key] = value
+        if overrides:
+            for key, value in overrides.items():
+                out[key] = value
+        return out
+
+
+# -----------------------------------------------------------------------------
+# Retry blocks
+# -----------------------------------------------------------------------------
+
+RETRY_DEFAULT = BlockSpec(
+    id="retry_default",
+    name="Retry with backoff (default)",
+    description="3 retries with exponential backoff; good for transient failures.",
+    category="retry",
+    delta={"max_retries": 3, "retry_on": []},
+)
+
+RETRY_AGGRESSIVE = BlockSpec(
+    id="retry_aggressive",
+    name="Retry aggressive",
+    description="5 retries with backoff; use for flaky external APIs.",
+    category="retry",
+    delta={"max_retries": 5, "retry_on": []},
+)
+
+RETRY_NONE = BlockSpec(
+    id="retry_none",
+    name="No retries",
+    description="Fail immediately on first error; use when retries are not safe.",
+    category="retry",
+    delta={"max_retries": 0, "retry_on": []},
+)
+
+RETRY_ON_NETWORK = BlockSpec(
+    id="retry_on_network",
+    name="Retry on network errors",
+    description="3 retries, only on timeout/connection/rate_limit style errors.",
+    category="retry",
+    delta={"max_retries": 3, "retry_on": ["timeout", "connection", "rate_limit", "rate limit"]},
+)
+
+# -----------------------------------------------------------------------------
+# Approval / HITL blocks
+# -----------------------------------------------------------------------------
+
+APPROVAL_REQUIRED = BlockSpec(
+    id="approval_required",
+    name="Human approval required",
+    description="Execution pauses at this node for human approval; resume via entry point.",
+    category="approval",
+    delta={"pause_for_hitl": True, "approval_message": "Please review and approve to continue."},
+)
+
+APPROVAL_WITH_MESSAGE = BlockSpec(
+    id="approval_with_message",
+    name="Approval with custom message",
+    description="Pause for approval; set approval_message via overrides when applying.",
+    category="approval",
+    delta={"pause_for_hitl": True, "approval_message": None},  # caller should override
+)
+
+# Approval with timeout: metadata only for future runner/CLI use (Phase 2)
+APPROVAL_WITH_TIMEOUT = BlockSpec(
+    id="approval_with_timeout",
+    name="Approval with timeout (metadata)",
+    description="Pause for approval; stores approval_timeout_seconds in extra metadata for future escalation.",
+    category="approval",
+    delta={
+        "pause_for_hitl": True,
+        "approval_message": "Please review and approve to continue (will escalate if no response).",
+        # Store in model extra; executor does not use yet
+        "approval_timeout_seconds": 300,
+    },
+)
+
+# -----------------------------------------------------------------------------
+# Validation blocks
+# -----------------------------------------------------------------------------
+
+VALIDATION_DEFAULT = BlockSpec(
+    id="validation_default",
+    name="Output validation (default)",
+    description="Validate node output; up to 2 retries with feedback to LLM on validation failure.",
+    category="validation",
+    delta={"max_validation_retries": 2, "output_schema": {}},
+)
+
+VALIDATION_STRICT = BlockSpec(
+    id="validation_strict",
+    name="Strict output validation",
+    description="Up to 3 validation retries; use when output shape must be correct.",
+    category="validation",
+    delta={"max_validation_retries": 3, "output_schema": {}},
+)
+
+VALIDATION_NONE = BlockSpec(
+    id="validation_none",
+    name="No output validation",
+    description="No validation retries; use when output is free-form.",
+    category="validation",
+    delta={"max_validation_retries": 0, "output_schema": {}},
+)
+
+# -----------------------------------------------------------------------------
+# Registry
+# -----------------------------------------------------------------------------
+
+_BLOCKS: dict[str, BlockSpec] = {
+    RETRY_DEFAULT.id: RETRY_DEFAULT,
+    RETRY_AGGRESSIVE.id: RETRY_AGGRESSIVE,
+    RETRY_NONE.id: RETRY_NONE,
+    RETRY_ON_NETWORK.id: RETRY_ON_NETWORK,
+    APPROVAL_REQUIRED.id: APPROVAL_REQUIRED,
+    APPROVAL_WITH_MESSAGE.id: APPROVAL_WITH_MESSAGE,
+    APPROVAL_WITH_TIMEOUT.id: APPROVAL_WITH_TIMEOUT,
+    VALIDATION_DEFAULT.id: VALIDATION_DEFAULT,
+    VALIDATION_STRICT.id: VALIDATION_STRICT,
+    VALIDATION_NONE.id: VALIDATION_NONE,
+}
+
+
+def get_block(block_id: str) -> BlockSpec | None:
+    """Return the block with the given id, or None."""
+    return _BLOCKS.get(block_id)
+
+
+def list_blocks(category: str | None = None) -> list[BlockSpec]:
+    """Return all blocks, optionally filtered by category (retry, approval, validation)."""
+    if category is None:
+        return list(_BLOCKS.values())
+    return [b for b in _BLOCKS.values() if b.category == category]

--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -205,6 +205,20 @@ class NodeSpec(BaseModel):
     max_retries: int = Field(default=3)
     retry_on: list[str] = Field(default_factory=list, description="Error types to retry on")
 
+    # Human-in-the-loop (HITL): when True, execution pauses at this node for approval/resume
+    pause_for_hitl: bool = Field(
+        default=False,
+        description="If True, execution pauses at this node for human input; resume via entry_points",
+    )
+    approval_message: str | None = Field(
+        default=None,
+        description="Message to show when requesting approval (for pause/HITL nodes)",
+    )
+    approval_timeout_seconds: int | None = Field(
+        default=None,
+        description="Optional timeout for approval; for future escalation (runner/CLI)",
+    )
+
     # Pydantic model for output validation
     output_model: type[BaseModel] | None = Field(
         default=None,

--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -75,16 +75,6 @@ class SafeEvalVisitor(ast.NodeVisitor):
     def visit_Constant(self, node: ast.Constant) -> Any:
         return node.value
 
-    # --- Number/String/Bytes/NameConstant (Python < 3.8 compat if needed) ---
-    def visit_Num(self, node: ast.Num) -> Any:
-        return node.n
-
-    def visit_Str(self, node: ast.Str) -> Any:
-        return node.s
-
-    def visit_NameConstant(self, node: ast.NameConstant) -> Any:
-        return node.value
-
     # --- Data Structures ---
     def visit_List(self, node: ast.List) -> list:
         return [self.visit(elt) for elt in node.elts]

--- a/core/tests/test_blocks.py
+++ b/core/tests/test_blocks.py
@@ -1,0 +1,65 @@
+"""
+Tests for framework.blocks (building blocks registry).
+"""
+
+import pytest
+
+from framework.blocks import BlockSpec, get_block, list_blocks
+
+
+class TestBlocksRegistry:
+    """Tests for block registry."""
+
+    def test_list_blocks_returns_all(self):
+        blocks = list_blocks()
+        assert len(blocks) >= 3
+        ids = {b.id for b in blocks}
+        assert "retry_default" in ids
+        assert "approval_required" in ids
+        assert "validation_default" in ids
+
+    def test_list_blocks_filter_by_category(self):
+        retry_blocks = list_blocks(category="retry")
+        assert len(retry_blocks) >= 1
+        assert all(b.category == "retry" for b in retry_blocks)
+
+        approval_blocks = list_blocks(category="approval")
+        assert len(approval_blocks) >= 1
+        assert all(b.category == "approval" for b in approval_blocks)
+
+        validation_blocks = list_blocks(category="validation")
+        assert len(validation_blocks) >= 1
+        assert all(b.category == "validation" for b in validation_blocks)
+
+    def test_get_block_returns_block(self):
+        b = get_block("retry_default")
+        assert b is not None
+        assert b.id == "retry_default"
+        assert b.category == "retry"
+        assert "max_retries" in b.delta
+
+    def test_get_block_unknown_returns_none(self):
+        assert get_block("nonexistent_block") is None
+
+    def test_retry_default_delta(self):
+        b = get_block("retry_default")
+        assert b.delta["max_retries"] == 3
+        assert b.delta["retry_on"] == []
+
+    def test_approval_required_delta(self):
+        b = get_block("approval_required")
+        assert b.delta["pause_for_hitl"] is True
+        assert "approval_message" in b.delta
+
+    def test_apply_to_node_dict_merges_delta(self):
+        b = get_block("retry_default")
+        node_data = {"id": "test-node", "max_retries": 1}
+        out = b.apply_to_node_dict(node_data)
+        assert out["max_retries"] == 3
+        assert out["id"] == "test-node"
+
+    def test_apply_to_node_dict_with_overrides(self):
+        b = get_block("retry_default")
+        node_data = {"id": "test-node"}
+        out = b.apply_to_node_dict(node_data, overrides={"max_retries": 5})
+        assert out["max_retries"] == 5


### PR DESCRIPTION
…on fix

- Building blocks: add core/framework/blocks/ with retry, approval, validation presets
- MCP: extend add_node/update_node with max_retries, retry_on, output_schema, max_validation_retries, pause_for_hitl, approval_message
- NodeSpec: add pause_for_hitl, approval_message, approval_timeout_seconds
- MCP tools: list_blocks(category?), apply_block(block_id, target_node_id, overrides?)
- Pause nodes: detect via pause_for_hitl or legacy PAUSE in description
- Docs: MCP_BUILDER_TOOLS_GUIDE.md and building-agents-construction SKILL.md updated
- Tests: add core/tests/test_blocks.py
- safe_eval: remove deprecated visit_Num/visit_Str/visit_NameConstant (use visit_Constant only)
- Add CHANGES_SUMMARY.md for session summary

## Description

Brief description of the changes in this PR.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
