### PR TITLE
docs: fix Claude Code installation and PATH issues on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,32 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 
 ### Prerequisites
 
+### Windows Notes for Claude Code
+
+On Windows, Claude Code is not installed by default and must be installed explicitly.
+
+1. Install Claude Code using the official installer:
+   https://docs.anthropic.com/en/docs/claude-code/getting-started
+2. 2. Restart your terminal and verify the CLI is on PATH:
+   ```bash
+   claude --help
+   ```
+
+⚠️ If you see:
+   bash: claude: command not found
+then Claude Code is either not installed or not discoverable on PATH.
+Ensure the install directory is added to PATH and restart Git Bash.
+---
+⚠️ Verification note
+Running `claude` without arguments may fail with:
+   Credit balance too low
+even if Claude Code is installed correctly.
+Use:
+   claude --help
+to verify installation without requiring API credits.
+
+
+
 - [Python 3.11+](https://www.python.org/downloads/) for agent development
 - [Docker](https://docs.docker.com/get-docker/) (v20.10+) - Optional, for containerized tools
 


### PR DESCRIPTION
### What this PR does

On Windows, following the current README can result in `claude: command not found`
even when Claude Code is installed correctly.

This PR documents the actual working installation and verification steps on Windows,
including common PATH and shell-related pitfalls.

### Details
- Clarifies that Claude Code is not installed by default on Windows
- Adds explicit install + verification steps (`claude --help`)
- Documents why `claude` may fail due to PATH or shell differences
- Notes that `Credit balance too low` can appear even when installation is correct

These issues were encountered while setting up Hive on Windows and are reproducible
with the current documentation.

Tested on: Windows 11 + Git Bash

