### PR TITLE
Add MathTool for safe arithmetic evaluation

### DIFF
--- a/tools/src/aden_tools/tools/math_tool/README.md
+++ b/tools/src/aden_tools/tools/math_tool/README.md
@@ -1,0 +1,28 @@
+# Math Tool
+
+A safe, deterministic arithmetic evaluator for agents.
+
+## Description
+
+This tool provides a safe way for agents to perform mathematical calculations. Unlike using an LLM to "guess" the answer to a math problem, this tool uses a strict Python abstract syntax tree (AST) evaluator to compute the exact result. It is sandboxed and does not allow execution of arbitrary code, imports, or external calls.
+
+## Capabilities
+
+Safely evaluates expressions containing:
+- Integers and Floats
+- Basic operators: `+`, `-`, `*`, `/`
+- Exponents: `**`
+- Parentheses for grouping: `( )`
+
+## Arguments
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `expression` | str | Yes | - | The mathematical expression to evaluate (e.g., `(10 + 2) * 5`) |
+
+## Error Handling
+
+Returns error strings for various failure cases:
+- `Error: Invalid syntax in expression` - Malformed math string
+- `Error: Division by zero` - e.g., `1/0`
+- `Error: Unsupported syntax: <type>` - Only arithmetic is allowed (no variables/functions)

--- a/tools/src/aden_tools/tools/math_tool/__init__.py
+++ b/tools/src/aden_tools/tools/math_tool/__init__.py
@@ -1,0 +1,5 @@
+"""Math Tool package."""
+
+from .math_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/math_tool/math_tool.py
+++ b/tools/src/aden_tools/tools/math_tool/math_tool.py
@@ -1,0 +1,106 @@
+"""
+Math Tool - A safe arithmetic evaluator for agents.
+
+Uses Python's AST to strictly limit operations to basic arithmetic,
+preventing any arbitrary code execution.
+"""
+
+import ast
+import operator
+from typing import Any, Union
+
+from fastmcp import FastMCP
+
+# Safe operators whitelist
+OPERATORS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.Pow: operator.pow,
+    ast.USub: operator.neg,
+    ast.UAdd: operator.pos,
+}
+
+
+def _safe_eval(node: Union[ast.AST, None]) -> Union[int, float]:
+    """
+    Recursively evaluate an AST node if it represents a safe arithmetic operation.
+    
+    Args:
+        node: The AST node to evaluate
+        
+    Returns:
+        The numerical result of the evaluation
+        
+    Raises:
+        ValueError: If the node or its children contain unsafe/unsupported operations
+    """
+    if node is None:
+        return 0
+
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, (int, float)):
+            return node.value
+        raise ValueError(f"Unsupported constant type: {type(node.value)}")
+
+    if isinstance(node, ast.BinOp):
+        op_type = type(node.op)
+        if op_type in OPERATORS:
+            left = _safe_eval(node.left)
+            right = _safe_eval(node.right)
+            return OPERATORS[op_type](left, right)
+        raise ValueError(f"Unsupported operator: {op_type.__name__}")
+
+    if isinstance(node, ast.UnaryOp):
+        op_type = type(node.op)
+        if op_type in OPERATORS:
+            operand = _safe_eval(node.operand)
+            return OPERATORS[op_type](operand)
+        raise ValueError(f"Unsupported unary operator: {op_type.__name__}")
+
+    if isinstance(node, ast.Expression):
+        return _safe_eval(node.body)
+
+    raise ValueError(f"Unsupported syntax: {type(node).__name__}")
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register math tools with the MCP server."""
+
+    @mcp.tool()
+    def calculate(expression: str) -> str:
+        """
+        Safely evaluate a mathematical expression.
+        
+        Supports basic arithmetic: +, -, *, /, ** (power), and parentheses.
+        Does NOT support variables, functions, or imports.
+        
+        Args:
+            expression: The mathematical expression to evaluate (e.g., "2 + 2 * 5")
+            
+        Returns:
+            The string result of the calculation or an error message.
+        """
+        try:
+            # Parse the expression into an AST
+            # mode='eval' ensures we only accept expressions, not statements
+            tree = ast.parse(expression, mode='eval')
+            
+            # Evaluate the safe subset
+            result = _safe_eval(tree.body)
+            
+            # Format result
+            # If it's an integer float (e.g. 4.0), pretty print as 4
+            if isinstance(result, float) and result.is_integer():
+                return str(int(result))
+            return str(result)
+
+        except SyntaxError:
+            return "Error: Invalid syntax in expression"
+        except ZeroDivisionError:
+            return "Error: Division by zero"
+        except ValueError as e:
+            return f"Error: {str(e)}"
+        except Exception as e:
+            return f"Error: {str(e)}"


### PR DESCRIPTION
**Fixes #2121**

**What this PR does:**
Adds a MathTool that allows agents to safely evaluate mathematical expressions
using a restricted AST-based evaluator.

**Why this is useful:**
LLMs are unreliable for precise arithmetic. A deterministic math tool improves
agent reliability for analytics, planning, and sales workflows.

**Scope:**
- New tool only
- No changes to core runtime or executor

**Testing:**
- Manual testing with valid and invalid expressions
