### PR TITLE
fix(security): prevent path traversal in delete_session

### DIFF
--- a/core/framework/mcp/agent_builder_server.py
+++ b/core/framework/mcp/agent_builder_server.py
@@ -9,6 +9,7 @@ Usage:
 
 import json
 import os
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Annotated
@@ -30,6 +31,8 @@ mcp = FastMCP("agent-builder")
 # Session persistence directory
 SESSIONS_DIR = Path(".agent-builder-sessions")
 ACTIVE_SESSION_FILE = SESSIONS_DIR / ".active"
+
+SAFE_SESSION_ID = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 # Session storage
@@ -131,11 +134,19 @@ def _save_session(session: BuildSession):
 
 def _load_session(session_id: str) -> BuildSession:
     """Load session from disk."""
-    session_file = SESSIONS_DIR / f"{session_id}.json"
+    if not SAFE_SESSION_ID.match(session_id):
+        raise ValueError(f"Invalid session ID format: {session_id}")
+
+    sessions_dir = SESSIONS_DIR.resolve()
+    session_file = (sessions_dir / f"{session_id}.json").resolve()
+
+    if not session_file.is_relative_to(sessions_dir):
+        raise ValueError("Access denied: invalid session path")
+
     if not session_file.exists():
         raise ValueError(f"Session '{session_id}' not found")
 
-    with open(session_file) as f:
+    with open(session_file, "r", encoding="utf-8") as f:
         data = json.load(f)
 
     return BuildSession.from_dict(data)
@@ -270,7 +281,15 @@ def delete_session(session_id: Annotated[str, "ID of the session to delete"]) ->
     """Delete a saved agent building session."""
     global _session
 
-    session_file = SESSIONS_DIR / f"{session_id}.json"
+    if not SAFE_SESSION_ID.match(session_id):
+        return json.dumps({"success": False, "error": f"Invalid session ID format: {session_id}"})
+
+    sessions_dir = SESSIONS_DIR.resolve()
+    session_file = (sessions_dir / f"{session_id}.json").resolve()
+
+    if not session_file.is_relative_to(sessions_dir):
+        return json.dumps({"success": False, "error": "Access denied: invalid session path"})
+
     if not session_file.exists():
         return json.dumps({"success": False, "error": f"Session '{session_id}' not found"})
 
@@ -283,7 +302,7 @@ def delete_session(session_id: Annotated[str, "ID of the session to delete"]) ->
             _session = None
 
         if ACTIVE_SESSION_FILE.exists():
-            with open(ACTIVE_SESSION_FILE) as f:
+            with open(ACTIVE_SESSION_FILE, "r", encoding="utf-8") as f:
                 active_id = f.read().strip()
                 if active_id == session_id:
                     ACTIVE_SESSION_FILE.unlink()


### PR DESCRIPTION
## Description

Fixes a critical path traversal vulnerability in delete_session that allowed attackers to delete arbitrary .json files outside the `.agent-builder-sessions` directory.

**Example attack:** `delete_session(session_id="../../package")` would delete package.json.

## Related Issues

Fixes #1000

## Changes Made

- Added `SAFE_SESSION_ID` regex pattern to validate session IDs
- Added path resolution and containment checks
- Applied fix to both [_load_session](cci:1://file:///C:/Users/siddh/OneDrive/Desktop/open_source/testing_bugs/testing_verifyting/hive_fork/core/framework/mcp/agent_builder_server.py:134:0-151:39) and [delete_session](cci:1://file:///C:/Users/siddh/OneDrive/Desktop/open_source/testing_bugs/testing_verifyting/hive_fork/core/framework/mcp/agent_builder_server.py:278:0-317:62)

## Testing

- Existing project tests pass (7/7)
- Path traversal attempts are blocked