### PR TITLE
fix: remove deprecated AST node types for Python 3.14 compatibility

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-Product Roadmap
+# Product Roadmap
 
 Aden Agent Framework aims to help developers build outcome oriented, self-adaptive agents. Please find our roadmap here
 

--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -75,16 +75,6 @@ class SafeEvalVisitor(ast.NodeVisitor):
     def visit_Constant(self, node: ast.Constant) -> Any:
         return node.value
 
-    # --- Number/String/Bytes/NameConstant (Python < 3.8 compat if needed) ---
-    def visit_Num(self, node: ast.Num) -> Any:
-        return node.n
-
-    def visit_Str(self, node: ast.Str) -> Any:
-        return node.s
-
-    def visit_NameConstant(self, node: ast.NameConstant) -> Any:
-        return node.value
-
     # --- Data Structures ---
     def visit_List(self, node: ast.List) -> list:
         return [self.visit(elt) for elt in node.elts]
@@ -225,10 +215,6 @@ class SafeEvalVisitor(ast.NodeVisitor):
         keywords = {kw.arg: self.visit(kw.value) for kw in node.keywords}
 
         return func(*args, **keywords)
-
-    def visit_Index(self, node: ast.Index) -> Any:
-        # Python < 3.9
-        return self.visit(node.value)
 
 
 def safe_eval(expr: str, context: dict[str, Any] | None = None) -> Any:


### PR DESCRIPTION
## Summary

- Removes deprecated `visit_Num`, `visit_Str`, `visit_NameConstant` methods from `SafeEvalVisitor`
- Also removes `visit_Index` which was deprecated in Python 3.9
- Eliminates 3+ deprecation warnings during test runs
- Ensures compatibility with Python 3.14 (when these AST node types will be removed)

## Changes

**File:** `core/framework/graph/safe_eval.py`

Removed:
- `visit_Num(self, node: ast.Num)` - deprecated, use `ast.Constant`
- `visit_Str(self, node: ast.Str)` - deprecated, use `ast.Constant`  
- `visit_NameConstant(self, node: ast.NameConstant)` - deprecated, use `ast.Constant`
- `visit_Index(self, node: ast.Index)` - deprecated since Python 3.9

The existing `visit_Constant` method already handles all these cases since Python 3.8+.

## Why This is Safe

1. Project requires Python 3.11+ (per `pyproject.toml`)
2. `ast.Constant` handles all literal values since Python 3.8
3. `ast.Index` was completely removed in Python 3.9
4. These methods were dead code - never executed in Python 3.8+

## Test Plan

- [x] Verified `safe_eval` works correctly with numbers, strings, and booleans
- [x] Ran with `-W error::DeprecationWarning` - no warnings
- [x] All existing tests continue to pass

Fixes #2132