### PR TITLE
fix: add validation for num_results in web_search tool

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-Product Roadmap
+# Product Roadmap
 
 Aden Agent Framework aims to help developers build outcome oriented, self-adaptive agents. Please find our roadmap here
 

--- a/tools/src/aden_tools/tools/web_search_tool/web_search_tool.py
+++ b/tools/src/aden_tools/tools/web_search_tool/web_search_tool.py
@@ -164,6 +164,11 @@ def register_tools(
         if not query or len(query) > 500:
             return {"error": "Query must be 1-500 characters"}
 
+        if num_results < 1:
+            return {"error": "num_results must be at least 1"}
+        if num_results > 20:
+            return {"error": "num_results cannot exceed 20"}
+
         creds = _get_credentials()
         google_available = creds["google_api_key"] and creds["google_cse_id"]
         brave_available = bool(creds["brave_api_key"])


### PR DESCRIPTION
## Summary

- Adds input validation for `num_results` parameter in `web_search` tool
- Returns clear error messages for invalid values
- Prevents undefined behavior when negative/zero values are passed to APIs

## Changes

**File:** `tools/src/aden_tools/tools/web_search_tool/web_search_tool.py`

Added validation after query validation:
```python
if num_results < 1:
    return {"error": "num_results must be at least 1"}
if num_results > 20:
    return {"error": "num_results cannot exceed 20"}
```

## Why 20 as the upper limit?

- Google Custom Search API: max 10 results per request
- Brave Search API: max 20 results per request
- Using 20 to accommodate both providers (Google results are already capped at 10 internally)

## Test Plan

- [x] Verified validation logic correctly rejects negative values
- [x] Verified validation logic correctly rejects zero
- [x] Verified validation logic correctly rejects values > 20
- [x] Verified valid values (1-20) pass validation

Fixes #2101