### PR TITLE
docs: clarify check() helper docstring in verify_mcp.py

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-Product Roadmap
+# Product Roadmap
 
 Aden Agent Framework aims to help developers build outcome oriented, self-adaptive agents. Please find our roadmap here
 

--- a/core/verify_mcp.py
+++ b/core/verify_mcp.py
@@ -33,7 +33,17 @@ class Colors:
 
 
 def check(description: str) -> bool:
-    """Print check description and return a context manager for result."""
+    """Print check description and return True to indicate check started.
+    
+    This function logs the check description and flushes stdout.
+    Use success(), warning(), or error() to report the check result.
+    
+    Args:
+        description: Brief description of what is being checked.
+        
+    Returns:
+        Always returns True (for legacy compatibility).
+    """
     logger.info(f"Checking {description}... ", extra={"end": ""})
     sys.stdout.flush()
     return True

--- a/core/verify_mcp.py
+++ b/core/verify_mcp.py
@@ -34,13 +34,13 @@ class Colors:
 
 def check(description: str) -> bool:
     """Print check description and return True to indicate check started.
-    
+
     This function logs the check description and flushes stdout.
     Use success(), warning(), or error() to report the check result.
-    
+
     Args:
         description: Brief description of what is being checked.
-        
+
     Returns:
         Always returns True (for legacy compatibility).
     """


### PR DESCRIPTION
## Summary

Updates the `check()` helper function docstring in `core/verify_mcp.py` to accurately describe its behavior.

## Problem

The docstring incorrectly stated the function "returns a context manager for result", but the function actually returns a boolean and is not used as a context manager.

## Changes

**File:** `core/verify_mcp.py`

Updated docstring to clarify:
- The function logs the check description
- Returns `True` for legacy compatibility
- Works with `success()`/`warning()`/`error()` to report results

## Before

```python
def check(description: str) -> bool:
    """Print check description and return a context manager for result."""
```

## After

```python
def check(description: str) -> bool:
    """Print check description and return True to indicate check started.
    
    This function logs the check description and flushes stdout.
    Use success(), warning(), or error() to report the check result.
    
    Args:
        description: Brief description of what is being checked.
        
    Returns:
        Always returns True (for legacy compatibility).
    """
```

Fixes #2116