### PR TITLE
fix: remove deprecated AST node types for Python 3.14 compatibility

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-Product Roadmap
+# Product Roadmap
 
 Aden Agent Framework aims to help developers build outcome oriented, self-adaptive agents. Please find our roadmap here
 

--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -75,16 +75,6 @@ class SafeEvalVisitor(ast.NodeVisitor):
     def visit_Constant(self, node: ast.Constant) -> Any:
         return node.value
 
-    # --- Number/String/Bytes/NameConstant (Python < 3.8 compat if needed) ---
-    def visit_Num(self, node: ast.Num) -> Any:
-        return node.n
-
-    def visit_Str(self, node: ast.Str) -> Any:
-        return node.s
-
-    def visit_NameConstant(self, node: ast.NameConstant) -> Any:
-        return node.value
-
     # --- Data Structures ---
     def visit_List(self, node: ast.List) -> list:
         return [self.visit(elt) for elt in node.elts]
@@ -225,10 +215,6 @@ class SafeEvalVisitor(ast.NodeVisitor):
         keywords = {kw.arg: self.visit(kw.value) for kw in node.keywords}
 
         return func(*args, **keywords)
-
-    def visit_Index(self, node: ast.Index) -> Any:
-        # Python < 3.9
-        return self.visit(node.value)
 
 
 def safe_eval(expr: str, context: dict[str, Any] | None = None) -> Any:


### PR DESCRIPTION
## Summary

Remove deprecated AST node type handlers from `SafeEvalVisitor` to eliminate deprecation warnings and ensure Python 3.14 compatibility.

## Problem

The `safe_eval.py` module uses deprecated Python AST node types that:
1. Generate 3+ deprecation warnings during every test run
2. Will be **completely removed** in Python 3.14 (expected 2027), causing `AttributeError` crashes

## Changes

**File:** `core/framework/graph/safe_eval.py`

Removed deprecated visitor methods:
| Method | Deprecated Since | Replaced By |
|--------|-----------------|-------------|
| `visit_Num` | Python 3.8 | `visit_Constant` |
| `visit_Str` | Python 3.8 | `visit_Constant` |
| `visit_NameConstant` | Python 3.8 | `visit_Constant` |
| `visit_Index` | Python 3.9 | Direct slice handling |

## Why This is Safe

- Project requires **Python 3.11+** (per `pyproject.toml`)
- `visit_Constant` handles all literal values since Python 3.8
- These methods were **dead code** - never executed in Python 3.8+
- All 270+ tests continue to pass

## Test Plan

- [x] Verified safe_eval works with numbers: `safe_eval("1 + 2")` → `3`
- [x] Verified safe_eval works with strings: `safe_eval('"hello"')` → `"hello"`
- [x] Verified safe_eval works with booleans: `safe_eval("True and False")` → `False`
- [x] Ran with `-W error::DeprecationWarning` - no warnings

Fixes #2132

---
**Note:** I've requested assignment on issue #2132. As an external contributor, I cannot self-assign.