### PR TITLE
fix: add input validation for num_results in web_search tool

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-Product Roadmap
+# Product Roadmap
 
 Aden Agent Framework aims to help developers build outcome oriented, self-adaptive agents. Please find our roadmap here
 

--- a/tools/src/aden_tools/tools/web_search_tool/web_search_tool.py
+++ b/tools/src/aden_tools/tools/web_search_tool/web_search_tool.py
@@ -161,8 +161,15 @@ def register_tools(
         Returns:
             Dict with search results, total count, and provider used
         """
+        # Validate query
         if not query or len(query) > 500:
             return {"error": "Query must be 1-500 characters"}
+
+        # Validate num_results (Brave supports 1-20, Google supports 1-10)
+        if num_results < 1:
+            return {"error": "num_results must be at least 1"}
+        if num_results > 20:
+            return {"error": "num_results cannot exceed 20"}
 
         creds = _get_credentials()
         google_available = creds["google_api_key"] and creds["google_cse_id"]


### PR DESCRIPTION
## Summary

Add input validation for the `num_results` parameter in the `web_search` tool to prevent invalid values from being passed to search APIs.

## Problem

The `web_search` function accepts `num_results` without validation, allowing negative or zero values. This causes:
- Undefined behavior when passed to Brave/Google APIs
- Confusing error messages from downstream services
- Potential API quota waste

## Changes

**File:** `tools/src/aden_tools/tools/web_search_tool/web_search_tool.py`

Added validation after query validation:
```python
# Validate num_results (Brave supports 1-20, Google supports 1-10)
if num_results < 1:
    return {"error": "num_results must be at least 1"}
if num_results > 20:
    return {"error": "num_results cannot exceed 20"}
```

## Design Decisions

| Constraint | Value | Rationale |
|------------|-------|-----------|
| Minimum | 1 | A search with 0 results is meaningless |
| Maximum | 20 | Brave API max is 20, Google is 10 (capped internally) |
| Error format | `{"error": "..."}` | Consistent with existing validation errors |

## Test Plan

- [x] `num_results=-1` → `{"error": "num_results must be at least 1"}`
- [x] `num_results=0` → `{"error": "num_results must be at least 1"}`
- [x] `num_results=21` → `{"error": "num_results cannot exceed 20"}`
- [x] `num_results=10` → proceeds with search

Fixes #2101

---
**Note:** I've requested assignment on issue #2101. As an external contributor, I cannot self-assign.