### PR TITLE
micro-fix: remove deprecated AST visitor methods (dead code)

### DIFF
--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -75,16 +75,6 @@ class SafeEvalVisitor(ast.NodeVisitor):
     def visit_Constant(self, node: ast.Constant) -> Any:
         return node.value
 
-    # --- Number/String/Bytes/NameConstant (Python < 3.8 compat if needed) ---
-    def visit_Num(self, node: ast.Num) -> Any:
-        return node.n
-
-    def visit_Str(self, node: ast.Str) -> Any:
-        return node.s
-
-    def visit_NameConstant(self, node: ast.NameConstant) -> Any:
-        return node.value
-
     # --- Data Structures ---
     def visit_List(self, node: ast.List) -> list:
         return [self.visit(elt) for elt in node.elts]
@@ -225,10 +215,6 @@ class SafeEvalVisitor(ast.NodeVisitor):
         keywords = {kw.arg: self.visit(kw.value) for kw in node.keywords}
 
         return func(*args, **keywords)
-
-    def visit_Index(self, node: ast.Index) -> Any:
-        # Python < 3.9
-        return self.visit(node.value)
 
 
 def safe_eval(expr: str, context: dict[str, Any] | None = None) -> Any:


### PR DESCRIPTION
## Summary

Remove deprecated AST visitor methods that are dead code in Python 3.11+.

## Changes

Remove from `core/framework/graph/safe_eval.py`:
- `visit_Num` - deprecated since Python 3.8, use `visit_Constant`
- `visit_Str` - deprecated since Python 3.8, use `visit_Constant`
- `visit_NameConstant` - deprecated since Python 3.8, use `visit_Constant`
- `visit_Index` - removed in Python 3.9

**Lines removed:** 14 (well under 20-line micro-fix threshold)

## Why This Qualifies as Micro-fix

- **Dead code removal**: These methods are never called in Python 3.11+
- **Deprecation warnings**: Removing eliminates warnings during tests
- **No functional change**: `visit_Constant` already handles all cases
- **< 20 lines**: Only 14 lines removed

## Verification

```bash
# All tests pass
python -m pytest tests/ -v

# No deprecation warnings
python -W error::DeprecationWarning -c "from framework.graph.safe_eval import safe_eval; safe_eval('1+2')"
```