### PR TITLE
fix(executor): enforce memory_conflict_strategy in parallel branches

### DIFF
--- a/core/framework/graph/__init__.py
+++ b/core/framework/graph/__init__.py
@@ -2,7 +2,7 @@
 
 from framework.graph.code_sandbox import CodeSandbox, safe_eval, safe_exec
 from framework.graph.edge import EdgeCondition, EdgeSpec, GraphSpec
-from framework.graph.executor import GraphExecutor
+from framework.graph.executor import GraphExecutor, MemoryConflictError
 from framework.graph.flexible_executor import ExecutorConfig, FlexibleGraphExecutor
 from framework.graph.goal import Constraint, Goal, GoalStatus, SuccessCriterion
 from framework.graph.judge import HybridJudge, create_default_judge
@@ -45,6 +45,7 @@ __all__ = [
     "GraphSpec",
     # Executor (fixed graph)
     "GraphExecutor",
+    "MemoryConflictError",
     # Plan (flexible execution)
     "Plan",
     "PlanStep",


### PR DESCRIPTION
## Description

ParallelExecutionConfig.memory_conflict_strategy accepts three options ("last_wins", "first_wins", "error") but was never enforced. All parallel branches unconditionally called memory.write_async(key, value), meaning the final value depended on task scheduling rather than the configured strategy. This patch adds conflict-aware writes in _execute_parallel_branches() so the strategy works.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #1728

## Changes Made

- core/framework/graph/executor.py                                                                             
- Added MemoryConflictError(RuntimeError) with key, first-branch, and second-branch context                  
- Introduced a branch_writes: dict[str, str] tracker and read conflict_strategy from ParallelExecutionConfig 
before branch execution                                                                                        
- Replaced the unconditional memory.write_async loop with conflict-aware logic:                              
    - "last_wins" (default) — unchanged behaviour, every branch overwrites                                   
    - "first_wins" — skips the write if another branch already wrote that key                                  
    - "error" — raises MemoryConflictError, caught by existing on_branch_failure handling                      
- Only branch output writes are checked; input-prep writes (lines 870/875) are unchanged                     
- core/framework/graph/__init__.py                                                                             
- Exported MemoryConflictError in imports and __all__                                                        
- core/tests/test_fanout.py                                                                                    
- Added DelayedNode helper (async sleep to control branch completion order)                                  
- Added 5 unit tests covering all strategies and edge cases:                                                 
    - test_memory_conflict_last_wins_uses_latest_value                                                       
    - test_memory_conflict_first_wins_keeps_earliest_value                                                     
    - test_memory_conflict_error_strategy_raises_on_conflict                                                   
    - test_memory_conflict_no_conflict_with_distinct_keys                                                      
    - test_memory_conflict_error_with_continue_others

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed with 5 tests on real parallel nodes and async delays

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
