### PR TITLE
fix: validate num_results in web_search

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-Product Roadmap
+# Product Roadmap
 
 Aden Agent Framework aims to help developers build outcome oriented, self-adaptive agents. Please find our roadmap here
 

--- a/tools/src/aden_tools/tools/web_search_tool/web_search_tool.py
+++ b/tools/src/aden_tools/tools/web_search_tool/web_search_tool.py
@@ -164,6 +164,11 @@ def register_tools(
         if not query or len(query) > 500:
             return {"error": "Query must be 1-500 characters"}
 
+        if num_results < 1:
+            return {"error": "num_results must be at least 1"}
+        if num_results > 20:
+            return {"error": "num_results cannot exceed 20"}
+
         creds = _get_credentials()
         google_available = creds["google_api_key"] and creds["google_cse_id"]
         brave_available = bool(creds["brave_api_key"])


### PR DESCRIPTION
## Summary

Adds validation for the `num_results` parameter in the `web_search` tool.

## Problem

`web_search` accepted negative/zero values for `num_results`, which could be forwarded to Brave/Google APIs and cause undefined behavior or confusing provider errors.

## Change

**File:** `tools/src/aden_tools/tools/web_search_tool/web_search_tool.py`

- Return an error if `num_results < 1`
- Return an error if `num_results > 20`

(Brave supports up to 20; Google is capped internally at 10.)

## Test plan

- `num_results=-1` returns an error
- `num_results=0` returns an error
- `num_results=21` returns an error
- `num_results=10` proceeds normally

Fixes #2101