### PR TITLE
Clarify first-time contributor setup notes

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -67,6 +67,12 @@ cd hive
 ./scripts/setup-python.sh
 ```
 
+**First-time contributor notes**
+- Claude Code skills are optional unless you plan to build new agents.
+- It is normal if `exports/` is missing or empty initially (often gitignored); it gets populated when generating or adding agents.
+- Many local run commands below use `PYTHONPATH=core:exports`.
+
+
 The setup script performs these actions:
 
 1. Checks Python version (3.11+)

--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -9,6 +9,12 @@ Complete setup guide for building and running goal-driven agents with the Aden A
 ./scripts/setup-python.sh
 ```
 
+**First-time contributor notes**
+- Claude Code skills are optional unless you plan to build new agents.
+- It is normal if `exports/` is missing or empty initially (often gitignored); it gets populated when generating or adding agents.
+- Many local run commands below use `PYTHONPATH=core:exports`.
+
+
 > **Note for Windows Users:**  
 > Running the setup script on native Windows shells (PowerShell / Git Bash) may sometimes fail due to Python App Execution Aliases.  
 > It is **strongly recommended to use WSL (Windows Subsystem for Linux)** for a smoother setup experience.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 - [Python 3.11+](https://www.python.org/downloads/) for agent development
 - [Docker](https://docs.docker.com/get-docker/) (v20.10+) - Optional, for containerized tools
 
+**First-time contributor notes**
+- Claude Code skills are optional unless you plan to build new agents.
+- It is normal if `exports/` is missing or empty initially (often gitignored); it gets populated when generating or adding agents.
+- Many local run commands below use `PYTHONPATH=core:exports`.
+
+
 ### Installation
 
 ```bash


### PR DESCRIPTION
This PR adds a short, consistent “First-time contributor notes” block across onboarding docs to reduce confusion for new contributors.

Changes:
- Clarifies optional tooling vs running existing agents
- Notes that `exports/` may be missing or empty initially
- Points to the local run commands shown in docs (`PYTHONPATH=core:exports`)

Docs-only; no code or script changes.

Closes https://github.com/adenhq/hive/issues/2239
