### PR TITLE
fix: make NodeSpec.description optional to improve DX

### DIFF
--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -148,7 +148,7 @@ class NodeSpec(BaseModel):
 
     id: str
     name: str
-    description: str
+    description: str | None = None
 
     # Node behavior type
     node_type: str = Field(
@@ -521,7 +521,8 @@ class NodeResult:
 
             node_context = ""
             if node_spec:
-                node_context = f"\nNode: {node_spec.name}\nPurpose: {node_spec.description}"
+                purpose = node_spec.description or node_spec.name
+                node_context = f"\nNode: {node_spec.name}\nPurpose: {purpose}"
 
             output_json = json.dumps(self.output, indent=2, default=str)[:2000]
             prompt = (
@@ -693,7 +694,7 @@ Keep the same JSON structure but with shorter content values.
             options=[
                 {
                     "id": "llm_execute",
-                    "description": f"Use LLM to {ctx.node_spec.description}",
+                    "description": f"Use LLM to {ctx.node_spec.description or ctx.node_spec.name}",
                     "action_type": "llm_call",
                 }
             ],


### PR DESCRIPTION
# fix: make NodeSpec.description optional to improve DX

## Problem Statement

When initializing a new agent, the `NodeSpec` class raises a strict `ValidationError` if the `description` field is missing from a node definition.

**Error Encountered:**
```python
pydantic_core._pydantic_core.ValidationError: 1 validation error for NodeSpec
description
  Field required [type=missing, input_value={'id': 'analyze_ticket', ...}, input_type=dict]
```

When building agents (especially via `agent.json`), many nodes are self-explanatory based on their name (e.g., `"Analyze Ticket"`). Forcing a mandatory `description` field requires developers to add redundant boilerplate text just to prevent the runtime from crashing.

## Solution

Made the `description` field in `NodeSpec` optional with a `None` default, and added graceful fallback handling where the field is used.

## Changes Made

**File:** `core/framework/graph/node.py`

| Line | Change |
|------|--------|
| 151 | `description: str` → `description: str \| None = None` |
| 523-524 | Added fallback to use `node_spec.name` when description is `None` |
| 697 | Added fallback in LLM decision logging |

## Before & After

**Before (crashes):**
```json
{
  "id": "analyze_ticket",
  "name": "Analyze Ticket"
}
```

**After (works):**
```json
{
  "id": "analyze_ticket", 
  "name": "Analyze Ticket"
}
```

Or optionally:
```json
{
  "id": "analyze_ticket",
  "name": "Analyze Ticket",
  "description": "Analyzes incoming support tickets"
}
```

## Backwards Compatibility

✅ This is a **100% backwards-compatible** change. Existing agents with descriptions will work exactly as before.

## Testing

- Verified that nodes without `description` field no longer raise `ValidationError`
- Verified that logging/summaries gracefully fall back to using the node `name`
