### PR TITLE
fix(scripts): improve terminal output readability [micro-fix]

### DIFF
--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -8,12 +8,20 @@
 
 set -e
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+# Colors for output - disabled on Windows for compatibility
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; then
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    NC=''
+else
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    BLUE='\033[0;34m'
+    NC='\033[0m' # No Color
+fi
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Description

This PR addresses issue #2271.

It adds an OS check to the setup-python.sh script to detect Windows environments (Git Bash/MSYS) and disable ANSI color escape sequences. This ensures that the setup summary and verification steps are clean and readable for Windows-based contributors without affecting the experience for Mac/Linux users.

Fixes: #2271

Micro-fix: Yes (Under 20 lines, non-functional UI/UX improvement)

## Type of Change

[x] Bug fix (non-breaking change that fixes an issue)
[ ] New feature (non-breaking change that adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[ ] Documentation update
[x] Refactoring (no functional changes)

## Related Issues

Fixes #2271

## Changes Made

-Added a conditional check using $OSTYPE to identify Windows/MSYS environments.
-Set color variables (RED, GREEN, etc.) to empty strings on Windows to prevent raw escape sequences from printing.
-Preserved existing ANSI color logic for Unix-based systems.

## Testing

[x] Manual testing performed

## Checklist

-[x] My code follows the project's style guidelines
-[x] I have performed a self-review of my code
-[x] I have commented my code, particularly in hard-to-understand areas
-[x] My changes generate no new warnings
-[x] New and existing unit tests pass locally with my changes (N/A for script-only UI fix)

