### PR TITLE
docs: highlight PYTHONPATH requirement in Quick Setup sections

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -21,6 +21,15 @@ This will:
 - Fix package compatibility issues (openai + litellm)
 - Verify all installations
 
+> [!CAUTION]
+> **Critical Requirement:** All agent commands require `PYTHONPATH=core:exports`:
+> ```bash
+> PYTHONPATH=core:exports python -m agent_name run --input '{...}'
+> ```
+> **Missing this will cause:** `ModuleNotFoundError: No module named 'agent_name'`
+> 
+> See [Why PYTHONPATH is Required](#why-pythonpath-is-required) for details.
+
 ## Alpine Linux Setup
 
 If you are using Alpine Linux (e.g., inside a Docker container), you must install system dependencies and use a virtual environment before running the setup script:

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ This installs:
 - **aden_tools** - 19 MCP tools for agent capabilities
 - All required dependencies
 
+> [!IMPORTANT]
+> **PYTHONPATH Required:** All agent commands must include `PYTHONPATH=core:exports`:
+> ```bash
+> PYTHONPATH=core:exports python -m agent_name run --input '{...}'
+> ```
+> Without this, you'll get `ModuleNotFoundError: No module named 'agent_name'`.
+
 ### Build Your First Agent
 
 ```bash


### PR DESCRIPTION
# docs: highlight PYTHONPATH requirement in Quick Setup sections

## Problem

The `PYTHONPATH=core:exports` requirement is critical but buried deep in the documentation (explained late in ENVIRONMENT_SETUP.md). This is:

- Easy to miss
- A hard requirement, not an optional tip
- Causes users to hit confusing errors:

```
ModuleNotFoundError: No module named 'support_ticket_agent'
```

See Issue #2261: [PYTHONPATH requirement is critical but buried](https://github.com/adenhq/hive/issues/2261)

## Solution

Added prominent warning callouts in **both** Quick Setup sections:

### README.md (Quick Start section)

```markdown
> [!IMPORTANT]
> **PYTHONPATH Required:** All agent commands must include `PYTHONPATH=core:exports`:
> ```bash
> PYTHONPATH=core:exports python -m agent_name run --input '{...}'
> ```
> Without this, you'll get `ModuleNotFoundError: No module named 'agent_name'`.
```

### ENVIRONMENT_SETUP.md (Quick Setup section)

```markdown
> [!CAUTION]
> **Critical Requirement:** All agent commands require `PYTHONPATH=core:exports`:
> ```bash
> PYTHONPATH=core:exports python -m agent_name run --input '{...}'
> ```
> **Missing this will cause:** `ModuleNotFoundError: No module named 'agent_name'`
>
> See [Why PYTHONPATH is Required](#why-pythonpath-is-required) for details.
```

## Files Changed

| File | Change |
|------|--------|
| `README.md` | Added `[!IMPORTANT]` callout after Installation section |
| `ENVIRONMENT_SETUP.md` | Added `[!CAUTION]` callout after Quick Setup section with link to existing explanation |

## Why This Approach

1. **Early visibility** - Users see the warning before running any commands
2. **Clear error message** - Shows exactly what error they'll hit without this
3. **Non-intrusive** - Uses GitHub-flavored markdown callouts that render nicely
4. **Links to details** - ENVIRONMENT_SETUP.md links to the existing "Why PYTHONPATH is Required" section

## Screenshots

The callouts will render as colored boxes in GitHub:
- `[!IMPORTANT]` = Blue box
- `[!CAUTION]` = Red box

## Testing

- Verified markdown renders correctly on GitHub
- Confirmed links work properly

Fixes #2261
