### PR TITLE
feat(infra): add Kubernetes manifests for scalable deployment

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,104 @@
+# Kubernetes Deployment Manifests
+
+Deploy the Hive Agent Framework to Kubernetes for scalable, production-ready agent execution.
+
+## Quick Start
+
+```bash
+# 1. Create secrets (required)
+kubectl create secret generic hive-secrets \
+  --from-literal=ANTHROPIC_API_KEY=<your-api-key>
+
+# 2. Apply manifests
+kubectl apply -f deploy/k8s/
+
+# 3. Verify deployment
+kubectl get pods -l app=hive
+kubectl logs -l app=hive -f
+```
+
+## Manifests
+
+| File | Description |
+|------|-------------|
+| `deployment.yaml` | Deployment with replicas, resource limits, health probes |
+| `service.yaml` | ClusterIP service for internal networking |
+| `configmap.yaml` | Non-sensitive configuration values |
+
+## Configuration
+
+### Required Secrets
+
+Create before deploying:
+
+```bash
+kubectl create secret generic hive-secrets \
+  --from-literal=ANTHROPIC_API_KEY=<your-api-key>
+```
+
+### ConfigMap Customization
+
+Override defaults:
+
+```bash
+kubectl create configmap hive-config \
+  --from-literal=LOG_LEVEL=DEBUG \
+  --from-literal=DEFAULT_MODEL=claude-3-opus-20240229 \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+### Resource Limits
+
+Default resources (adjust in `deployment.yaml`):
+
+| Resource | Request | Limit |
+|----------|---------|-------|
+| Memory | 512Mi | 2Gi |
+| CPU | 250m | 1000m |
+| Storage | 10Gi | - |
+
+## Scaling
+
+```bash
+# Scale replicas
+kubectl scale deployment hive-tools --replicas=5
+
+# Auto-scaling (requires metrics-server)
+kubectl autoscale deployment hive-tools \
+  --min=2 --max=10 --cpu-percent=70
+```
+
+## Health Checks
+
+The deployment includes:
+- **Liveness probe**: Restarts unhealthy pods
+- **Readiness probe**: Routes traffic only to ready pods
+
+Endpoint: `GET /health` on port 4001
+
+## Cloud Provider Notes
+
+### AWS EKS
+Uncomment the AWS annotations in `service.yaml` for NLB.
+
+### GCP GKE
+Uncomment the GCP annotations for internal load balancer.
+
+### Azure AKS
+Uncomment the Azure annotations for internal load balancer.
+
+## Troubleshooting
+
+```bash
+# Check pod status
+kubectl describe pod -l app=hive
+
+# View logs
+kubectl logs -l app=hive --tail=100
+
+# Shell into container
+kubectl exec -it deployment/hive-tools -- /bin/bash
+
+# Check events
+kubectl get events --sort-by=.metadata.creationTimestamp
+```

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -1,0 +1,44 @@
+# Hive Agent Framework - ConfigMap
+# Non-sensitive configuration for the Hive deployment
+#
+# Usage:
+#   kubectl apply -f deploy/k8s/configmap.yaml
+#
+# To override values:
+#   kubectl create configmap hive-config --from-literal=LOG_LEVEL=DEBUG --dry-run=client -o yaml | kubectl apply -f -
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hive-config
+  labels:
+    app: hive
+data:
+  # Logging configuration
+  LOG_LEVEL: "INFO"
+
+  # Storage paths
+  AGENT_STORAGE_PATH: "/app/workdir/workspaces"
+  ADEN_CREDENTIALS_PATH: "/app/credentials"
+
+  # Python configuration
+  PYTHONPATH: "core:exports"
+  PYTHONUNBUFFERED: "1"
+
+  # Server configuration
+  MCP_SERVER_HOST: "0.0.0.0"
+  MCP_SERVER_PORT: "4001"
+
+  # Feature flags
+  ENABLE_TELEMETRY: "true"
+  ENABLE_COST_TRACKING: "true"
+
+  # LLM defaults (can be overridden per-agent)
+  DEFAULT_LLM_PROVIDER: "anthropic"
+  DEFAULT_MODEL: "claude-3-5-sonnet-20241022"
+  MAX_TOKENS: "4096"
+
+  # Agent runtime settings
+  MAX_RETRIES: "3"
+  RETRY_DELAY_SECONDS: "1"
+  EXECUTION_TIMEOUT_SECONDS: "300"

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -1,0 +1,108 @@
+# Hive Agent Framework - Kubernetes Deployment
+# Deploys the MCP tools server and agent runtime
+#
+# Usage:
+#   kubectl apply -f deploy/k8s/
+#
+# Prerequisites:
+#   - Create secrets: kubectl create secret generic hive-secrets --from-literal=ANTHROPIC_API_KEY=<your-key>
+#   - Build and push image: docker build -t your-registry/hive-tools:latest tools/
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hive-tools
+  labels:
+    app: hive
+    component: tools
+    version: v1
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: hive
+      component: tools
+  template:
+    metadata:
+      labels:
+        app: hive
+        component: tools
+        version: v1
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      containers:
+        - name: hive-tools
+          image: adenhq/hive-tools:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 4001
+              protocol: TCP
+          env:
+            - name: PYTHONPATH
+              value: "core:exports"
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hive-secrets
+                  key: ANTHROPIC_API_KEY
+            - name: AGENT_STORAGE_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: hive-config
+                  key: AGENT_STORAGE_PATH
+            - name: LOG_LEVEL
+              valueFrom:
+                configMapKeyRef:
+                  name: hive-config
+                  key: LOG_LEVEL
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: workspaces
+              mountPath: /app/workdir/workspaces
+      volumes:
+        - name: workspaces
+          persistentVolumeClaim:
+            claimName: hive-workspaces-pvc
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+---
+# PersistentVolumeClaim for workspace data
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hive-workspaces-pvc
+  labels:
+    app: hive
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: standard

--- a/deploy/k8s/service.yaml
+++ b/deploy/k8s/service.yaml
@@ -1,0 +1,53 @@
+# Hive Agent Framework - Kubernetes Service
+# Provides internal cluster networking for the Hive tools server
+#
+# Service Types:
+#   - ClusterIP (default): Internal cluster access only
+#   - LoadBalancer: External access (uncomment annotations for cloud providers)
+#   - NodePort: Access via node IP + port
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: hive-tools
+  labels:
+    app: hive
+    component: tools
+  # Uncomment for cloud provider load balancers:
+  # annotations:
+  #   # AWS
+  #   service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+  #   # GCP
+  #   cloud.google.com/load-balancer-type: "Internal"
+  #   # Azure
+  #   service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+spec:
+  type: ClusterIP
+  selector:
+    app: hive
+    component: tools
+  ports:
+    - name: http
+      port: 4001
+      targetPort: http
+      protocol: TCP
+---
+# Headless service for StatefulSet scenarios (if needed)
+apiVersion: v1
+kind: Service
+metadata:
+  name: hive-tools-headless
+  labels:
+    app: hive
+    component: tools
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app: hive
+    component: tools
+  ports:
+    - name: http
+      port: 4001
+      targetPort: http
+      protocol: TCP


### PR DESCRIPTION
# feat(infra): Add Kubernetes manifests for scalable deployment

## Context

Closes #2258

Current deployment relies on local execution. To support multi-region scaling, this PR adds standard Kubernetes manifests.

## Changes

Created `deploy/k8s/` directory with:

| File | Description |
|------|-------------|
| `deployment.yaml` | Pod deployment with replicas, resources, health probes |
| `service.yaml` | ClusterIP service for internal networking |
| `configmap.yaml` | Non-sensitive configuration management |
| `README.md` | Documentation for K8s deployment |

## Deployment Features

### `deployment.yaml`
- **Replicas**: 2 (configurable via `kubectl scale`)
- **Resource limits**: 512Mi-2Gi memory, 250m-1000m CPU
- **Health probes**: Liveness + Readiness on `/health`
- **Security**: Non-root user (UID 1001)
- **Persistence**: PVC for workspace data (10Gi)
- **Secrets**: Pulls `ANTHROPIC_API_KEY` from K8s secret

### `service.yaml`
- ClusterIP for internal access
- Cloud provider annotations (AWS/GCP/Azure) ready
- Headless service option for StatefulSet scenarios

### `configmap.yaml`
- Logging configuration (`LOG_LEVEL`)
- Storage paths (`AGENT_STORAGE_PATH`)
- LLM defaults (`DEFAULT_MODEL`, `MAX_TOKENS`)
- Feature flags (`ENABLE_TELEMETRY`, `ENABLE_COST_TRACKING`)

## Quick Start

```bash
# Create secrets
kubectl create secret generic hive-secrets \
  --from-literal=ANTHROPIC_API_KEY=<your-key>

# Deploy
kubectl apply -f deploy/k8s/

# Verify
kubectl get pods -l app=hive
```

## Scaling

```bash
# Manual scaling
kubectl scale deployment hive-tools --replicas=5

# Auto-scaling
kubectl autoscale deployment hive-tools --min=2 --max=10 --cpu-percent=70
```

## Testing

- [x] YAML syntax validated
- [x] Labels and selectors consistent
- [x] Health check endpoints match existing Dockerfile
- [x] Resource limits are production-appropriate
