### PR TITLE
docs: (web_scrape_tool)document respect_robots_txt argument (#2278)

### DIFF
--- a/tools/src/aden_tools/tools/web_scrape_tool/README.md
+++ b/tools/src/aden_tools/tools/web_scrape_tool/README.md
@@ -14,6 +14,7 @@ Use when you need to read the content of a specific URL, extract data from a web
 | `selector` | str | No | `None` | CSS selector to target specific content (e.g., 'article', '.main-content') |
 | `include_links` | bool | No | `False` | Include extracted links in the response |
 | `max_length` | int | No | `50000` | Maximum length of extracted text (1000-500000) |
+| `respect_robots_txt` | bool | No | `True` | Whether to respect robots.txt rules (ethical scraping; default True) |
 
 ## Environment Variables
 
@@ -34,3 +35,4 @@ Returns error dicts for common issues:
 - Follows redirects automatically
 - Removes script, style, nav, footer, header, aside, noscript, and iframe elements
 - Auto-detects main content using article, main, or common content class selectors
+- By default, the tool respects robots.txt for ethical scraping. Set `respect_robots_txt` to `False` to override (not recommended).


### PR DESCRIPTION
## Description

This PR updates the Web Scrape Tool documentation to include the `respect_robots_txt` argument, making the tool’s ethical scraping behavior explicit and matching the documented API to the actual implementation.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #2278

## Changes Made

- Added `respect_robots_txt` to the Arguments table in the Web Scrape Tool README
- Updated Notes section to clarify default robots.txt behavior and ethical scraping

## Testing

- [x] Manual review of the updated documentation for accuracy and clarity

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if applicable)

N/A