### PR TITLE
Fix Windows compatibility issues in test suites

### DIFF
--- a/core/framework/schemas/decision.py
+++ b/core/framework/schemas/decision.py
@@ -172,10 +172,18 @@ class Decision(BaseModel):
 
     def summary_for_builder(self) -> str:
         """Generate a one-line summary for Builder to quickly understand."""
-        status = "✓" if self.was_successful else "✗"
+        # Use ASCII for Windows to avoid UnicodeEncodeError if encoding not set
+        import sys
+
+        is_windows = sys.platform == "win32"
+        success_mark = "[v]" if is_windows else "✓"
+        failure_mark = "[x]" if is_windows else "✗"
+
+        status = success_mark if self.was_successful else failure_mark
+        arrow = "->" if is_windows else "→"
         quality = ""
         if self.evaluation:
             quality = f" [quality: {self.evaluation.outcome_quality:.1f}]"
         chosen = self.chosen_option
         action = chosen.description if chosen else "unknown action"
-        return f"{status} [{self.node_id}] {self.intent} → {action}{quality}"
+        return f"{status} [{self.node_id}] {self.intent} {arrow} {action}{quality}"

--- a/tools/tests/tools/test_file_system_toolkits.py
+++ b/tools/tests/tools/test_file_system_toolkits.py
@@ -575,7 +575,10 @@ class TestExecuteCommandTool:
         # Create a test file
         (tmp_path / "testfile.txt").write_text("content")
 
-        result = execute_command_fn(command=f"ls {tmp_path}", **mock_workspace)
+        import sys
+
+        cmd = f"dir {tmp_path}" if sys.platform == "win32" else f"ls {tmp_path}"
+        result = execute_command_fn(command=cmd, **mock_workspace)
 
         assert result["success"] is True
         assert result["return_code"] == 0
@@ -583,6 +586,11 @@ class TestExecuteCommandTool:
 
     def test_execute_command_with_pipe(self, execute_command_fn, mock_workspace, mock_secure_path):
         """Executing a command with pipe works correctly."""
+        import sys
+
+        if sys.platform == "win32":
+            pytest.skip("tr command not available on Windows")
+
         result = execute_command_fn(command="echo 'hello world' | tr 'a-z' 'A-Z'", **mock_workspace)
 
         assert result["success"] is True


### PR DESCRIPTION
Fixes Windows compatibility issues in the test suites.
Fixes #2305 
## Description
This PR addresses two main issues that were causing test failures on Windows environments:
1. `UnicodeEncodeError` in `Decision.summary_for_builder` due to the use of special characters ('✓', '✗', '→') which are not always supported in Windows consoles.
2. Missing Unix commands ([ls](cci:1://file:///c:/Users/Soham/Downloads/ycombinator/hive/core/framework/mcp/agent_builder_server.py:1712:0-1777:5), [tr](cci:1://file:///c:/Users/Soham/Downloads/ycombinator/hive/core/framework/mcp/agent_builder_server.py:2471:0-2478:30)) in [test_file_system_toolkits.py](cci:7://file:///c:/Users/Soham/Downloads/ycombinator/hive/tools/tests/tools/test_file_system_toolkits.py:0:0-0:0), causing [test_execute_command_list_files](cci:1://file:///c:/Users/Soham/Downloads/ycombinator/hive/tools/tests/tools/test_file_system_toolkits.py:570:4-584:49) and [test_execute_command_with_pipe](cci:1://file:///c:/Users/Soham/Downloads/ycombinator/hive/tools/tests/tools/test_file_system_toolkits.py:586:4-597:48) to fail.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Modified [core/framework/schemas/decision.py](cci:7://file:///c:/Users/Soham/Downloads/ycombinator/hive/core/framework/schemas/decision.py:0:0-0:0): Added a check for `sys.platform == "win32"` to explicitly use ASCII characters (`[v]`, `[x]`, `->`) on Windows, while preserving the original characters for other platforms.
- Modified [tools/tests/tools/test_file_system_toolkits.py](cci:7://file:///c:/Users/Soham/Downloads/ycombinator/hive/tools/tests/tools/test_file_system_toolkits.py:0:0-0:0):
    - Updated [test_execute_command_list_files](cci:1://file:///c:/Users/Soham/Downloads/ycombinator/hive/tools/tests/tools/test_file_system_toolkits.py:570:4-584:49) to use [dir](cci:1://file:///c:/Users/Soham/Downloads/ycombinator/hive/tools/tests/tools/test_file_system_toolkits.py:282:4-287:54) on Windows and [ls](cci:1://file:///c:/Users/Soham/Downloads/ycombinator/hive/core/framework/mcp/agent_builder_server.py:1712:0-1777:5) on other platforms.
    - Added a `pytest.skip` to [test_execute_command_with_pipe](cci:1://file:///c:/Users/Soham/Downloads/ycombinator/hive/tools/tests/tools/test_file_system_toolkits.py:586:4-597:48) on Windows since the [tr](cci:1://file:///c:/Users/Soham/Downloads/ycombinator/hive/core/framework/mcp/agent_builder_server.py:2471:0-2478:30) command is unavailable.

## Testing
- [x] Unit tests pass (`pytest tools/tests/tools/test_file_system_toolkits.py`)
- [x] Unit tests pass (`pytest core/tests/test_builder.py`)
- [x] Manual testing performed on Windows Environment

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

