### PR TITLE
feat(graph): implement HumanInputNode for HITL workflows

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -24,6 +24,7 @@ from framework.graph.node import (
     LLMNode,
     RouterNode,
     FunctionNode,
+    HumanInputNode,
 )
 from framework.graph.edge import GraphSpec
 from framework.graph.validator import OutputValidator
@@ -499,7 +500,7 @@ class GraphExecutor:
 
         if node_spec.node_type == "human_input":
             # Human input nodes are handled specially by HITL mechanism
-            return LLMNode(tool_executor=None, require_tools=False)
+            return HumanInputNode()
 
         # Should never reach here due to validation above
         raise RuntimeError(f"Unhandled node type: {node_spec.node_type}")


### PR DESCRIPTION
## Description

This PR implements the missing `HumanInputNode` class.

Previously, `human_input` was listed as a valid `node_type` in `NodeSpec`, but the `executor.py` logic defaulted to an incorrect `LLMNode` implementation (or crashed), making it impossible to create pause-and-wait workflows.

This change:

1. Adds the `HumanInputNode` class to `core/framework/graph/node.py` which pauses execution and accepts CLI input.
2.  Updates `core/framework/graph/executor.py` to instantiate this class when `node_type="human_input"` is encountered.

## Type of Change

- New feature (non-breaking change that adds functionality)


## Related Issues

Fixes #2307 

## Changes Made

- `core/framework/graph/node.py`: Added `HumanInputNode` class implementing `NodeProtocol`.
- `core/framework/graph/executor.py`: Updated imports and `_get_node_implementation` to return `HumanInputNode()` instead of `LLMNode()`.

## Testing

Describe the tests you ran to verify your changes:

- Manual testing performed

**Verification Procedure**: I created a test script that instantiated a graph with a `human_input` node.

  - Result: The executor successfully paused, printed the prompt "Please enter your favorite color:", waited for keyboard input, and correctly stored the user's input into the specified `output_key`.

## Checklist

- My code follows the project's style guidelines
- I have performed a self-review of my code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable)

N/A