### PR TITLE
micro-fix: remove debug print statements that leak API key

### DIFF
--- a/core/framework/credentials/aden/client.py
+++ b/core/framework/credentials/aden/client.py
@@ -254,9 +254,6 @@ class AdenCredentialClient:
     ) -> httpx.Response:
         """Make a request with retry logic."""
         client = self._get_client()
-        print(client.base_url)
-        print(client.headers)
-        print(method, path, kwargs)
         last_error: Exception | None = None
 
         for attempt in range(self.config.retry_attempts):


### PR DESCRIPTION
## Summary

Fixes #2301

Removes debug `print()` statements from `AdenCredentialClient._request_with_retry()` that were accidentally left in production code and could expose sensitive information (including API keys) to stdout/logs.

## Problem

The `_request_with_retry()` method contained three debug print statements that exposed:

- The API base URL  
- HTTP headers including the `Authorization` header with API key  
- Request method, path, and parameters  

Affected code:

    def _request_with_retry(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
        client = self._get_client()

        print(client.base_url)        # Leaks API endpoint
        print(client.headers)         # 🚨 Leaks API key in Authorization header
        print(method, path, kwargs)   # Leaks request details

This could result in output such as:

    {
      "Authorization": "Bearer sk-aden-xxxxxxxxxxxxxx",
      ...
    }

## Solution

Removed all three debug print statements.

No functional logic was affected since these statements:

- Were outside the retry loop  
- Did not modify return values  
- Were only meant for debugging output  

## Security Impact

Before:

- API key exposed to stdout  
- Credentials visible in logs  
- Risk of key theft from log files  

After:

- No sensitive data printed to stdout  
- Clean production logs  
- Secure handling of credentials  

## Testing

- ruff check — All checks passed  
- ruff format --check — Already formatted  
- Verified no functional logic was changed  
- Retry logic remains intact and functional  