### PR TITLE
fix(csv): handle csv_write with no parent directory

### DIFF
--- a/tools/src/aden_tools/tools/csv_tool/csv_tool.py
+++ b/tools/src/aden_tools/tools/csv_tool/csv_tool.py
@@ -118,7 +118,9 @@ def register_tools(mcp: FastMCP) -> None:
                 return {"error": "columns cannot be empty"}
 
             # Create parent directories if needed
-            os.makedirs(os.path.dirname(secure_path), exist_ok=True)
+            parent_dir = os.path.dirname(secure_path)
+            if parent_dir:
+                os.makedirs(parent_dir, exist_ok=True)
 
             # Write CSV
             with open(secure_path, "w", encoding="utf-8", newline="") as f:

--- a/tools/tests/tools/test_csv_tool.py
+++ b/tools/tests/tools/test_csv_tool.py
@@ -446,6 +446,33 @@ class TestCsvWrite:
         assert "太郎" in content
         assert "東京" in content
 
+    def test_write_no_parent_directory(self, csv_tools, session_dir, tmp_path):
+        """Write CSV to root without parent directory (fixes #1843)."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = csv_tools["csv_write"](
+                path="data.csv",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["id", "value"],
+                rows=[
+                    {"id": "1", "value": "test1"},
+                    {"id": "2", "value": "test2"},
+                ],
+            )
+
+        assert result["success"] is True
+        assert result["rows_written"] == 2
+
+        # Verify file was created at session root
+        csv_file = session_dir / "data.csv"
+        assert csv_file.exists()
+
+        content = csv_file.read_text()
+        assert "id,value" in content
+        assert "1,test1" in content
+        assert "2,test2" in content
+
 
 class TestCsvAppend:
     """Tests for csv_append function."""


### PR DESCRIPTION
## Description

Fixes csv_write failing when writing to CSV path without parent directory (e.g., "data.csv"). The function now guards against empty parent directory paths before attempting to create them.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #1843

## Problem

The csv_write tool failed when the provided CSV path did not include a parent directory (e.g., "data.csv"). The function attempted to create directories using an empty path from `os.path.dirname()`, which resulted in a FileNotFoundError.

## Solution

Added a guard to check if parent_dir is empty before calling os.makedirs():
- Check if `parent_dir` from `os.path.dirname()` is non-empty
- Only call `os.makedirs()` when parent directory exists
- Allows writing CSV files directly to session root without error

## Changes Made

- Added guard against empty parent directory in `csv_write` function
- Added test case `test_write_no_parent_directory` to verify the fix
- All existing CSV tool tests continue to pass

## Testing

- [x] Unit tests pass (`cd tools && python3.12 -m pytest tests/tools/test_csv_tool.py`)
- [x] Lint passes (`cd tools && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Benefits

- CSV files can be written directly to session root without subdirectories
- Prevents FileNotFoundError for simple file paths like "data.csv"
- Maintains backward compatibility with existing nested path usage