### PR TITLE
fix(security): remove debug print statements that leak API key

### DIFF
--- a/core/framework/credentials/aden/client.py
+++ b/core/framework/credentials/aden/client.py
@@ -254,9 +254,6 @@ class AdenCredentialClient:
     ) -> httpx.Response:
         """Make a request with retry logic."""
         client = self._get_client()
-        print(client.base_url)
-        print(client.headers)
-        print(method, path, kwargs)
         last_error: Exception | None = None
 
         for attempt in range(self.config.retry_attempts):


### PR DESCRIPTION
## Summary

- Remove debug `print()` statements in `_request_with_retry()` that expose sensitive information
- These statements printed `client.headers` which contains the `Authorization` header with the API key
- Fixes security vulnerability where API keys could leak to stdout/logs

## Changes

Removed the following lines from `core/framework/credentials/aden/client.py`:
```python
print(client.base_url)
print(client.headers)        # Leaked API key
print(method, path, kwargs)
```

## Test plan

- [x] Verified the debug statements are removed
- [x] No functional changes to the retry logic

Fixes #2301