### PR TITLE
Replace hardcoded Anthropic fallback with LiteLLM provider, add LLM_J…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,17 @@ test: ## Run all tests
 install-hooks: ## Install pre-commit hooks
 	pip install pre-commit
 	pre-commit install
+
+setup-venv: ## Create venv, install deps, and set PYTHONPATH (VENV=./.venv)
+	@VENV=$${VENV:-.venv}; \
+	python3 -m venv $$VENV; \
+	$$VENV/bin/pip install --upgrade pip; \
+	$$VENV/bin/pip install -r core/requirements.txt; \
+	$$VENV/bin/pip install -e core -e tools; \
+	PYTHONPATH_LINE='export PYTHONPATH="$(PWD)/core:$(PWD)/exports"'; \
+	ACTIVATE_FILE="$$VENV/bin/activate"; \
+	if ! grep -Fq "$$PYTHONPATH_LINE" "$$ACTIVATE_FILE"; then \
+		printf '\n# Added by make setup-venv\n%s\n' "$$PYTHONPATH_LINE" >> "$$ACTIVATE_FILE"; \
+	fi; \
+	echo "Venv ready: $$VENV"; \
+	echo "Activate with: source $$VENV/bin/activate"

--- a/core/tests/test_llm_judge.py
+++ b/core/tests/test_llm_judge.py
@@ -2,13 +2,13 @@
 Unit tests for the LLMJudge with configurable LLM provider.
 
 Tests cover:
-- Backward compatibility (no provider, uses Anthropic fallback)
+- Fallback behavior (no provider, uses LiteLLM-backed provider)
 - Custom LLM provider injection
 - Response parsing (JSON, markdown code blocks)
 - Error handling
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -258,12 +258,12 @@ class TestLLMJudgeErrorHandling:
 
 
 # ============================================================================
-# LLMJudge Tests - Backward Compatibility (Anthropic Fallback)
+# LLMJudge Tests - Fallback and Legacy Client Behavior
 # ============================================================================
 
 
-class TestLLMJudgeBackwardCompatibility:
-    """Tests for LLMJudge backward compatibility with Anthropic fallback."""
+class TestLLMJudgeFallbackBehavior:
+    """Tests for LLMJudge fallback behavior when no provider is injected."""
 
     def test_init_without_provider(self):
         """Test initialization without a provider (backward compatible)."""
@@ -272,18 +272,34 @@ class TestLLMJudgeBackwardCompatibility:
         assert judge._provider is None
         assert judge._client is None
 
-    def test_evaluate_without_provider_uses_anthropic(self):
-        """Test that evaluate() falls back to Anthropic when no provider is set."""
+    def test_evaluate_without_provider_uses_fallback_provider(self):
+        """Test that evaluate() uses fallback provider when no provider is set."""
         judge = LLMJudge()
+        fallback_provider = MockLLMProvider(
+            response_content='{"passes": true, "explanation": "Fallback response"}'
+        )
+        judge._get_fallback_provider = MagicMock(return_value=fallback_provider)
 
-        # Mock the _get_client method and Anthropic response
+        result = judge.evaluate(
+            constraint="test",
+            source_document="doc",
+            summary="sum",
+            criteria="crit",
+        )
+
+        assert result["passes"] is True
+        assert result["explanation"] == "Fallback response"
+        assert len(fallback_provider.complete_calls) == 1
+
+    def test_legacy_client_used_only_when_mocked(self):
+        """Test that legacy client path is used only when _get_client is mocked."""
+        judge = LLMJudge()
+        judge._get_fallback_provider = MagicMock(return_value=None)
+
         mock_client = MagicMock()
         mock_response = MagicMock()
-        mock_response.content = [
-            MagicMock(text='{"passes": true, "explanation": "Anthropic response"}')
-        ]
+        mock_response.content = [MagicMock(text='{"passes": true, "explanation": "Legacy"}')]
         mock_client.messages.create.return_value = mock_response
-
         judge._get_client = MagicMock(return_value=mock_client)
 
         result = judge.evaluate(
@@ -294,48 +310,7 @@ class TestLLMJudgeBackwardCompatibility:
         )
 
         assert result["passes"] is True
-        assert result["explanation"] == "Anthropic response"
-        mock_client.messages.create.assert_called_once()
-
-    def test_anthropic_client_lazy_loaded(self):
-        """Test that Anthropic client is lazy-loaded only when needed."""
-        # Patch anthropic import
-        with patch.dict("sys.modules", {"anthropic": MagicMock()}):
-            judge = LLMJudge()
-
-            # Client should not be loaded yet
-            assert judge._client is None
-
-    def test_anthropic_import_error_handling(self):
-        """Test handling when anthropic package is not installed."""
-        judge = LLMJudge()
-
-        # Remove anthropic from sys.modules if present and mock ImportError
-        with patch.dict("sys.modules", {"anthropic": None}):
-            import_error = ImportError("No module named 'anthropic'")
-            with patch("builtins.__import__", side_effect=import_error):
-                with pytest.raises(RuntimeError, match="anthropic package required"):
-                    judge._get_client()
-
-    def test_anthropic_client_uses_correct_model(self):
-        """Test that Anthropic fallback uses the correct model."""
-        judge = LLMJudge()
-
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.content = [MagicMock(text='{"passes": true, "explanation": "OK"}')]
-        mock_client.messages.create.return_value = mock_response
-
-        judge._get_client = MagicMock(return_value=mock_client)
-
-        judge.evaluate(
-            constraint="test",
-            source_document="doc",
-            summary="sum",
-            criteria="crit",
-        )
-
-        # Check that the correct model was used
+        assert result["explanation"] == "Legacy"
         call_kwargs = mock_client.messages.create.call_args[1]
         assert call_kwargs["model"] == "claude-haiku-4-5-20251001"
         assert call_kwargs["max_tokens"] == 500


### PR DESCRIPTION
## Description

This PR makes `LLMJudge` provider-agnostic by replacing the hardcoded `AnthropicProvider` fallback with a LiteLLM-based provider. This enables semantic evaluation to work with any LiteLLM-supported provider (OpenAI, Gemini, DeepSeek, Ollama, etc.) without requiring Anthropic API keys, aligning with the framework's multi-provider architecture.

Additionally, adds a `setup-venv` Makefile target for easy virtual environment setup with all dependencies.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Fixes the issue where `LLMJudge` would fail for users with non-Anthropic LLM setups, breaking semantic evaluation functionality despite the framework claiming provider-agnostic support.

## Changes Made

- **LLMJudge provider-agnostic fallback**: Replaced hardcoded `AnthropicProvider` with `LiteLLMProvider` in `_get_fallback_provider()`
- **Environment variable support**: Added `LLM_JUDGE_MODEL` env var to configure the judge model (e.g., `gpt-4o-mini`, `ollama/llama3`, `gemini/gemini-1.5-flash`)
- **Code-level model parameter**: Added optional `model` parameter to `LLMJudge.__init__()` for programmatic model selection
- **Backward compatibility**: Default fallback model remains `claude-3-haiku-20240307` to preserve existing behavior
- **Test updates**: Updated test suite to reflect new fallback behavior while maintaining backward compatibility for legacy mocked client path
- **Makefile enhancement**: Added `setup-venv` target that creates venv, installs dependencies from `requirements.txt`, installs packages in editable mode, and sets `PYTHONPATH`

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`) - **372 passed, 1 skipped**
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed - Verified `LLMJudge` works with different models via `model` parameter and `LLM_JUDGE_MODEL` env var

**Test Results:**
<img width="695" height="366" alt="image" src="https://github.com/user-attachments/assets/d5d81c26-5bd2-4a49-af86-39ac21933f0a" />

<img width="830" height="472" alt="image" src="https://github.com/user-attachments/assets/bdcff095-4cac-412d-b208-7a84e41a4a03" />

