### PR TITLE
docs(web_scrape): add missing respect_robots_txt parameter documentation

### DIFF
--- a/tools/src/aden_tools/tools/web_scrape_tool/README.md
+++ b/tools/src/aden_tools/tools/web_scrape_tool/README.md
@@ -8,12 +8,13 @@ Use when you need to read the content of a specific URL, extract data from a web
 
 ## Arguments
 
-| Argument | Type | Required | Default | Description |
-|----------|------|----------|---------|-------------|
-| `url` | str | Yes | - | URL of the webpage to scrape |
-| `selector` | str | No | `None` | CSS selector to target specific content (e.g., 'article', '.main-content') |
-| `include_links` | bool | No | `False` | Include extracted links in the response |
-| `max_length` | int | No | `50000` | Maximum length of extracted text (1000-500000) |
+| Argument             | Type | Required | Default | Description                                                                |
+| -------------------- | ---- | -------- | ------- | -------------------------------------------------------------------------- |
+| `url`                | str  | Yes      | -       | URL of the webpage to scrape                                               |
+| `selector`           | str  | No       | `None`  | CSS selector to target specific content (e.g., 'article', '.main-content') |
+| `include_links`      | bool | No       | `False` | Include extracted links in the response                                    |
+| `max_length`         | int  | No       | `50000` | Maximum length of extracted text (1000-500000)                             |
+| `respect_robots_txt` | bool | No       | `True`  | Whether to respect robots.txt rules for ethical scraping                   |
 
 ## Environment Variables
 
@@ -22,6 +23,7 @@ This tool does not require any environment variables.
 ## Error Handling
 
 Returns error dicts for common issues:
+
 - `HTTP <status>: Failed to fetch URL` - Server returned error status
 - `No elements found matching selector: <selector>` - CSS selector matched nothing
 - `Request timed out` - Request exceeded 30s timeout
@@ -34,3 +36,5 @@ Returns error dicts for common issues:
 - Follows redirects automatically
 - Removes script, style, nav, footer, header, aside, noscript, and iframe elements
 - Auto-detects main content using article, main, or common content class selectors
+- Respects robots.txt by default for ethical web scraping (can be disabled with `respect_robots_txt=False`)
+- Returns `blocked_by_robots_txt: True` in error dict if scraping is blocked by robots.txt


### PR DESCRIPTION
Fixes #2278

- Added respect_robots_txt parameter to Arguments table
- Added notes about robots.txt behavior and error handling
- Parameter defaults to True for ethical web scraping

## Description

Adds missing `respect_robots_txt` parameter documentation to the Web Scrape Tool README.


## Changes

- Added `respect_robots_txt` parameter to the Arguments table with correct type, default value, and description
- Added notes explaining robots.txt default behavior and error handling
- Documented that the parameter defaults to `True` for ethical web scraping

## Related Issues

Fixes #(issue number)

## Changes Made

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change


## Verification

- [x] Documentation accurately reflects the implementation in `web_scrape_tool.py`
- [x] Parameter details match the code (type: bool, default: True)
- [x] Added comprehensive notes about behavior
- [x] Followed conventional commit format
- [x] No code changes (documentation only)


Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
