### PR TITLE
micro-fix(core): close anthropic clients to prevent socket leaks

### DIFF
--- a/core/framework/graph/hitl.py
+++ b/core/framework/graph/hitl.py
@@ -195,8 +195,7 @@ Extract the answer for each question. Output JSON with question IDs as keys.
 Example format:
 {{"question-1": "answer here", "question-2": "answer here"}}"""
 
-            # Use context manager to ensure the underlying httpx client
-            # is closed promptly and does not leak sockets.
+            # Direct SDK call — this is a framework utility, not an agent node.
             with anthropic.Anthropic(api_key=api_key) as client:
                 message = client.messages.create(
                     model="claude-3-5-haiku-20241022",

--- a/core/framework/graph/hitl.py
+++ b/core/framework/graph/hitl.py
@@ -195,12 +195,14 @@ Extract the answer for each question. Output JSON with question IDs as keys.
 Example format:
 {{"question-1": "answer here", "question-2": "answer here"}}"""
 
-            client = anthropic.Anthropic(api_key=api_key)
-            message = client.messages.create(
-                model="claude-3-5-haiku-20241022",
-                max_tokens=500,
-                messages=[{"role": "user", "content": prompt}],
-            )
+            # Use context manager to ensure the underlying httpx client
+            # is closed promptly and does not leak sockets.
+            with anthropic.Anthropic(api_key=api_key) as client:
+                message = client.messages.create(
+                    model="claude-3-5-haiku-20241022",
+                    max_tokens=500,
+                    messages=[{"role": "user", "content": prompt}],
+                )
 
             # Parse Haiku's response
             import re

--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -532,12 +532,14 @@ class NodeResult:
                 "understand. Focus on the key information produced."
             )
 
-            client = anthropic.Anthropic(api_key=api_key)
-            message = client.messages.create(
-                model="claude-3-5-haiku-20241022",
-                max_tokens=200,
-                messages=[{"role": "user", "content": prompt}],
-            )
+            # Use context manager to ensure the underlying httpx client
+            # is closed promptly and does not leak sockets.
+            with anthropic.Anthropic(api_key=api_key) as client:
+                message = client.messages.create(
+                    model="claude-3-5-haiku-20241022",
+                    max_tokens=200,
+                    messages=[{"role": "user", "content": prompt}],
+                )
 
             summary = message.content[0].text.strip()
             return f"✓ {summary}"
@@ -1342,12 +1344,14 @@ Output ONLY the JSON object, nothing else."""
         try:
             import anthropic
 
-            client = anthropic.Anthropic(api_key=api_key)
-            message = client.messages.create(
-                model="claude-3-5-haiku-20241022",
-                max_tokens=1000,
-                messages=[{"role": "user", "content": prompt}],
-            )
+            # Use context manager to ensure the underlying httpx client
+            # is closed promptly and does not leak sockets.
+            with anthropic.Anthropic(api_key=api_key) as client:
+                message = client.messages.create(
+                    model="claude-3-5-haiku-20241022",
+                    max_tokens=1000,
+                    messages=[{"role": "user", "content": prompt}],
+                )
 
             # Parse Haiku's response
             response_text = message.content[0].text.strip()

--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -532,8 +532,7 @@ class NodeResult:
                 "understand. Focus on the key information produced."
             )
 
-            # Use context manager to ensure the underlying httpx client
-            # is closed promptly and does not leak sockets.
+            # Direct SDK call — this is a framework utility, not an agent node.
             with anthropic.Anthropic(api_key=api_key) as client:
                 message = client.messages.create(
                     model="claude-3-5-haiku-20241022",
@@ -1344,8 +1343,7 @@ Output ONLY the JSON object, nothing else."""
         try:
             import anthropic
 
-            # Use context manager to ensure the underlying httpx client
-            # is closed promptly and does not leak sockets.
+            # Direct SDK call — this is a framework utility, not an agent node.
             with anthropic.Anthropic(api_key=api_key) as client:
                 message = client.messages.create(
                     model="claude-3-5-haiku-20241022",

--- a/issues/pr-description.md
+++ b/issues/pr-description.md
@@ -1,0 +1,45 @@
+## Description
+
+Wrap inline `anthropic.Anthropic()` instantiations in context managers (`with` blocks) to ensure the underlying `httpx.Client` connection pool is closed after each use, preventing socket leaks.
+
+## Type of Change
+
+- [x] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+
+## Related Issues
+
+Fixes #(issue number)
+
+## Changes Made
+
+- Wrapped `anthropic.Anthropic()` in a `with` block in `core/framework/graph/node.py:535` (summary generation)
+- Wrapped `anthropic.Anthropic()` in a `with` block in `core/framework/graph/node.py:1345` (Haiku output formatting)
+- Wrapped `anthropic.Anthropic()` in a `with` block in `core/framework/graph/hitl.py:198` (HITL response parsing)
+
+## Testing
+
+These calls are utility helpers that fire during node execution logging, output formatting, and HITL interaction. They are wrapped in try/except with fallbacks, so the change is low-risk.
+
+- [ ] Unit tests pass (`cd core && pytest tests/`)
+- [ ] Lint passes (`cd core && ruff check .`)
+- [x] Manual testing performed
+  - Verified syntax with `ast.parse()` on both changed files
+  - Change is mechanical: only adds `with` wrapping and indentation, no logic change
+
+## Checklist
+
+- [x] My code follows the project's style guidelines
+- [x] I have performed a self-review of my code
+- [x] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+
+## Screenshots (if applicable)
+
+N/A


### PR DESCRIPTION
## Description

Wrap inline `anthropic.Anthropic()` instantiations in context managers (`with` blocks) to ensure the underlying `httpx.Client` connection pool is closed after each use, preventing socket leaks.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #2346

## Changes Made

- Wrapped `anthropic.Anthropic()` in a `with` block in `core/framework/graph/node.py:535` (summary generation)
- Wrapped `anthropic.Anthropic()` in a `with` block in `core/framework/graph/node.py:1345` (Haiku output formatting)
- Wrapped `anthropic.Anthropic()` in a `with` block in `core/framework/graph/hitl.py:198` (HITL response parsing)

## Testing

These calls are utility helpers that fire during node execution logging, output formatting, and HITL interaction. They are wrapped in try/except with fallbacks, so the change is low-risk.

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed
  - Verified syntax with `ast.parse()` on both changed files
  - Change is mechanical: only adds `with` wrapping and indentation, no logic change

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
