### PR TITLE
quickstart: Add skills for other agents

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -209,8 +209,8 @@ get_skills_dir() {
         claude)   echo "$HOME/.claude/skills" ;;
         opencode) echo "$HOME/.opencode/skills" ;;
         codex)    echo "$HOME/.codex/skills" ;;
-        cursor)    echo "$HOME/.cursor/skills" ;;
-        gemini)    echo "$HOME/.gemini/skills" ;;
+        cursor)   echo "$HOME/.cursor/skills" ;;
+        gemini)   echo "$HOME/.gemini/skills" ;;
         github)   echo "$HOME/.github/skills" ;;
         *)        echo "" ;;
     esac


### PR DESCRIPTION
## Description

If we use other agents except `Claude Code`, we don't see the skills available in those agents. We need to add the skills for each of the available third party agents: `Claude, Codex, Cursor, Gemini, Github Copilot, OpenCode`. We are taking user inputs regarding the agent that users want to use and add skills only to that specific agents. Also replaced hardcoded skill insertion with a loop.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #2396


## Changes Made


## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
