### PR TITLE
feat(cli): add --version / -V flag

### DIFF
--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -18,7 +18,23 @@ Testing commands:
 
 import argparse
 import sys
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+
+
+def _get_version() -> str:
+    """Return the installed framework version, falling back to pyproject.toml."""
+    try:
+        return version("framework")
+    except PackageNotFoundError:
+        pass
+    # Fallback: read version from pyproject.toml directly
+    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    if pyproject.exists():
+        for line in pyproject.read_text().splitlines():
+            if line.strip().startswith("version"):
+                return line.split("=", 1)[1].strip().strip('"').strip("'")
+    return "unknown"
 
 
 def _configure_paths():
@@ -56,6 +72,12 @@ def main():
     parser = argparse.ArgumentParser(
         prog="hive",
         description="Aden Hive - Build and run goal-driven agents",
+    )
+    parser.add_argument(
+        "--version",
+        "-V",
+        action="version",
+        version=f"aden-hive {_get_version()}",
     )
     parser.add_argument(
         "--model",

--- a/core/tests/test_cli_entry_point.py
+++ b/core/tests/test_cli_entry_point.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from framework.cli import _configure_paths
+from framework.cli import _configure_paths, _get_version
 
 
 @pytest.fixture
@@ -57,6 +57,35 @@ class TestConfigurePaths:
     def test_handles_missing_exports_gracefully(self):
         """If exports/ doesn't exist, _configure_paths should not crash."""
         _configure_paths()
+
+
+class TestVersionFlag:
+    """Test --version / -V flag."""
+
+    def test_get_version_returns_string(self):
+        ver = _get_version()
+        assert isinstance(ver, str)
+        assert ver != "unknown"
+
+    def test_version_via_module(self, project_root):
+        result = subprocess.run(
+            [sys.executable, "-m", "framework", "--version"],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root / "core"),
+        )
+        assert result.returncode == 0
+        assert "aden-hive" in result.stdout
+
+    def test_version_short_flag_via_module(self, project_root):
+        result = subprocess.run(
+            [sys.executable, "-m", "framework", "-V"],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root / "core"),
+        )
+        assert result.returncode == 0
+        assert "aden-hive" in result.stdout
 
 
 class TestFrameworkModule:


### PR DESCRIPTION
## Summary
- Adds `--version` / `-V` flag to the `hive` CLI that prints `aden-hive <version>`
- Uses `importlib.metadata.version()` with fallback to reading `pyproject.toml` directly
- Adds 3 unit tests covering the version helper, `--version`, and `-V` flags

Closes #1345

## Test plan
- [x] `hive --version` outputs `aden-hive 0.1.0`
- [x] `hive -V` outputs `aden-hive 0.1.0`
- [x] `python -m framework --version` works identically
- [x] All 3 new tests pass (`TestVersionFlag`)
- [x] `ruff check` passes