### PR TITLE
feat(cli): add usage examples to all --help subcommands

### DIFF
--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import json
 import sys
+import textwrap
 from pathlib import Path
 
 
@@ -15,6 +16,13 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         "run",
         help="Run an exported agent",
         description="Execute an exported agent with the given input.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent("""\
+            examples:
+              %(prog)s exports/my_agent --input '{"query": "hello"}'
+              %(prog)s exports/my_agent --input-file request.json --verbose
+              %(prog)s exports/my_agent --mock --input '{"test": true}'
+        """),
     )
     run_parser.add_argument(
         "agent_path",
@@ -63,6 +71,12 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         "info",
         help="Show agent information",
         description="Display details about an exported agent.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent("""\
+            examples:
+              %(prog)s exports/my_agent
+              %(prog)s exports/my_agent --json
+        """),
     )
     info_parser.add_argument(
         "agent_path",
@@ -81,6 +95,11 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         "validate",
         help="Validate an exported agent",
         description="Check that an exported agent is valid and runnable.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent("""\
+            examples:
+              %(prog)s exports/my_agent
+        """),
     )
     validate_parser.add_argument(
         "agent_path",
@@ -94,6 +113,12 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         "list",
         help="List available agents",
         description="List all exported agents in a directory.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent("""\
+            examples:
+              %(prog)s
+              %(prog)s /path/to/agents
+        """),
     )
     list_parser.add_argument(
         "directory",
@@ -109,6 +134,13 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         "dispatch",
         help="Dispatch request to multiple agents",
         description="Route a request to the best agent(s) using the orchestrator.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent("""\
+            examples:
+              %(prog)s --input '{"query": "summarize sales"}'
+              %(prog)s exports/ --input '{"task": "review"}' --agents agent_a agent_b
+              %(prog)s --input '{"data": [1,2]}' --intent "analyze trends" --quiet
+        """),
     )
     dispatch_parser.add_argument(
         "agents_dir",
@@ -149,6 +181,13 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         "shell",
         help="Interactive agent session",
         description="Start an interactive REPL session with agents.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent("""\
+            examples:
+              %(prog)s exports/my_agent
+              %(prog)s --multi
+              %(prog)s exports/my_agent --no-approve
+        """),
     )
     shell_parser.add_argument(
         "agent_path",

--- a/core/framework/testing/cli.py
+++ b/core/framework/testing/cli.py
@@ -12,6 +12,7 @@ import argparse
 import ast
 import os
 import subprocess
+import textwrap
 from pathlib import Path
 
 
@@ -22,6 +23,13 @@ def register_testing_commands(subparsers: argparse._SubParsersAction) -> None:
     run_parser = subparsers.add_parser(
         "test-run",
         help="Run tests for an agent",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent("""\
+            examples:
+              %(prog)s exports/my_agent --goal main
+              %(prog)s exports/my_agent --goal main --type constraint --fail-fast
+              %(prog)s exports/my_agent --goal main --parallel 4
+        """),
     )
     run_parser.add_argument(
         "agent_path",
@@ -57,6 +65,12 @@ def register_testing_commands(subparsers: argparse._SubParsersAction) -> None:
     debug_parser = subparsers.add_parser(
         "test-debug",
         help="Debug a failed test by re-running with verbose output",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent("""\
+            examples:
+              %(prog)s exports/my_agent test_constraint_max_tokens
+              %(prog)s exports/my_agent test_success_responds --goal main
+        """),
     )
     debug_parser.add_argument(
         "agent_path",
@@ -78,6 +92,12 @@ def register_testing_commands(subparsers: argparse._SubParsersAction) -> None:
     list_parser = subparsers.add_parser(
         "test-list",
         help="List tests for an agent by scanning test files",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent("""\
+            examples:
+              %(prog)s exports/my_agent
+              %(prog)s exports/my_agent --type constraint
+        """),
     )
     list_parser.add_argument(
         "agent_path",
@@ -95,6 +115,11 @@ def register_testing_commands(subparsers: argparse._SubParsersAction) -> None:
     stats_parser = subparsers.add_parser(
         "test-stats",
         help="Show test statistics for an agent",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent("""\
+            examples:
+              %(prog)s exports/my_agent
+        """),
     )
     stats_parser.add_argument(
         "agent_path",

--- a/core/tests/test_cli_entry_point.py
+++ b/core/tests/test_cli_entry_point.py
@@ -63,8 +63,16 @@ class TestHelpExamples:
     """Test that all subcommands include usage examples in --help."""
 
     SUBCOMMANDS = [
-        "run", "info", "validate", "list", "dispatch", "shell",
-        "test-run", "test-debug", "test-list", "test-stats",
+        "run",
+        "info",
+        "validate",
+        "list",
+        "dispatch",
+        "shell",
+        "test-run",
+        "test-debug",
+        "test-list",
+        "test-stats",
     ]
 
     @pytest.mark.parametrize("subcommand", SUBCOMMANDS)

--- a/core/tests/test_cli_entry_point.py
+++ b/core/tests/test_cli_entry_point.py
@@ -59,6 +59,28 @@ class TestConfigurePaths:
         _configure_paths()
 
 
+class TestHelpExamples:
+    """Test that all subcommands include usage examples in --help."""
+
+    SUBCOMMANDS = [
+        "run", "info", "validate", "list", "dispatch", "shell",
+        "test-run", "test-debug", "test-list", "test-stats",
+    ]
+
+    @pytest.mark.parametrize("subcommand", SUBCOMMANDS)
+    def test_subcommand_has_examples(self, project_root, subcommand):
+        result = subprocess.run(
+            [sys.executable, "-m", "framework", subcommand, "--help"],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root / "core"),
+        )
+        assert result.returncode == 0
+        assert "examples:" in result.stdout.lower(), (
+            f"'{subcommand} --help' is missing an examples section"
+        )
+
+
 class TestFrameworkModule:
     """Test ``python -m framework`` invocation (the underlying module)."""
 


### PR DESCRIPTION
## Summary
- Adds `epilog` with practical usage examples to all 10 CLI subcommands (`run`, `info`, `validate`, `list`, `dispatch`, `shell`, `test-run`, `test-debug`, `test-list`, `test-stats`)
- Uses `RawDescriptionHelpFormatter` to preserve example formatting
- Adds parametrized test covering all 10 subcommands

Closes #1340

## Test plan
- [x] All 10 subcommands show `examples:` section in `--help` output
- [x] Parametrized test `TestHelpExamples` passes (10/10)
- [x] `ruff check` passes on both modified files