### PR TITLE
fix: change steps to fix: resolve KeyError in cmd_list by changing steps to nodesnodes in cmd_list to prevent crash

### DIFF
--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -459,7 +459,7 @@ def cmd_list(args: argparse.Namespace) -> int:
             print(f"  {agent['name']}")
             print(f"    Path: {agent['path']}")
             print(f"    Description: {agent['description']}")
-            print(f"    Steps: {agent['steps']}, Tools: {agent['tools']}")
+            print(f"    Steps: {agent['nodes']}, Tools: {agent['tools']}")
             print()
 
     return 0


### PR DESCRIPTION
## Description

Fixed a KeyError in the `list` command. The CLI was trying to access `agent['steps']` which didn't exist in the dictionary, causing a crash on Windows/clean installs.

## Type of Change

- [ X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Found during initial Windows environment setup.

## Changes Made

Changed `agent['steps']` to `agent['nodes']` in `core/framework/runner/cli.py` to match the data structure returned by the runner.

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ X] Manual testing performed

## Checklist

- [X ] My code follows the project's style guidelines
- [X ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
<img width="1920" height="1080" alt="Screenshot (40)" src="https://github.com/user-attachments/assets/4c8852fa-254e-4d9d-af78-8920273fe980" />

Add screenshots to demonstrate UI changes.
