### PR TITLE
Remove hardcoded Anthropic dependency from LLMJudge

### DIFF
--- a/core/framework/testing/llm_judge.py
+++ b/core/framework/testing/llm_judge.py
@@ -1,12 +1,11 @@
 """
 LLM-based judge for semantic evaluation of test results.
-Refactored to be provider-agnostic while maintaining 100% backward compatibility.
+Provider-agnostic by design.
 """
 
 from __future__ import annotations
 
 import json
-import os
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -16,44 +15,12 @@ if TYPE_CHECKING:
 class LLMJudge:
     """
     LLM-based judge for semantic evaluation of test results.
-    Automatically detects available providers (OpenAI/Anthropic) if none injected.
+
+    An LLMProvider must be injected explicitly.
     """
 
     def __init__(self, llm_provider: LLMProvider | None = None):
-        """Initialize the LLM judge."""
         self._provider = llm_provider
-        self._client = None  # Fallback Anthropic client (lazy-loaded for tests)
-
-    def _get_client(self):
-        """
-        Lazy-load the Anthropic client.
-        REQUIRED: Kept for backward compatibility with existing unit tests.
-        """
-        if self._client is None:
-            try:
-                import anthropic
-
-                self._client = anthropic.Anthropic()
-            except ImportError as err:
-                raise RuntimeError("anthropic package required for LLM judge") from err
-        return self._client
-
-    def _get_fallback_provider(self) -> LLMProvider | None:
-        """
-        Auto-detects available API keys and returns the appropriate provider.
-        Priority: OpenAI -> Anthropic.
-        """
-        if os.environ.get("OPENAI_API_KEY"):
-            from framework.llm.openai import OpenAIProvider
-
-            return OpenAIProvider(model="gpt-4o-mini")
-
-        if os.environ.get("ANTHROPIC_API_KEY"):
-            from framework.llm.anthropic import AnthropicProvider
-
-            return AnthropicProvider(model="claude-3-haiku-20240307")
-
-        return None
 
     def evaluate(
         self,
@@ -63,6 +30,9 @@ class LLMJudge:
         criteria: str,
     ) -> dict[str, Any]:
         """Evaluate whether a summary meets a constraint."""
+        if not self._provider:
+            raise RuntimeError("LLMProvider must be provided to LLMJudge")
+
         prompt = f"""You are evaluating whether a summary meets a specific constraint.
 
 CONSTRAINT: {constraint}
@@ -77,24 +47,8 @@ SUMMARY TO EVALUATE:
 Respond with JSON: {{"passes": true/false, "explanation": "..."}}"""
 
         try:
-            # 1. Use injected provider
-            if self._provider:
-                active_provider = self._provider
-            # 2. Check if _get_client was MOCKED (legacy tests) or use Agnostic Fallback
-            elif hasattr(self._get_client, "return_value") or not self._get_fallback_provider():
-                client = self._get_client()
-                response = client.messages.create(
-                    model="claude-haiku-4-5-20251001",
-                    max_tokens=500,
-                    messages=[{"role": "user", "content": prompt}],
-                )
-                return self._parse_json_result(response.content[0].text.strip())
-            else:
-                active_provider = self._get_fallback_provider()
-
-            response = active_provider.complete(
+            response = self._provider.complete(
                 messages=[{"role": "user", "content": prompt}],
-                system="",  # Empty to satisfy legacy test expectations
                 max_tokens=500,
                 json_mode=True,
             )
@@ -104,16 +58,16 @@ Respond with JSON: {{"passes": true/false, "explanation": "..."}}"""
             return {"passes": False, "explanation": f"LLM judge error: {e}"}
 
     def _parse_json_result(self, text: str) -> dict[str, Any]:
-        """Robustly parse JSON output even if LLM adds markdown or chatter."""
+        """Parse JSON output from the LLM."""
         try:
             if "```" in text:
                 text = text.split("```")[1].replace("json", "").strip()
 
-            result = json.loads(text.strip())
+            result = json.loads(text)
             return {
                 "passes": bool(result.get("passes", False)),
                 "explanation": result.get("explanation", "No explanation provided"),
             }
+
         except Exception as e:
-            # Must include 'LLM judge error' for specific unit tests to pass
             raise ValueError(f"LLM judge error: Failed to parse JSON: {e}") from e


### PR DESCRIPTION
## Description

Fixes #1135

Removes hardcoded Anthropic SDK usage from LLMJudge and enforces explicit
LLMProvider injection to maintain provider-agnostic architecture.

No other files modified.
