### PR TITLE
fix: move pytest to dev dependencies in core/pyproject.toml #2388

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -11,15 +11,15 @@ dependencies = [
     "litellm>=1.81.0",
     "mcp>=1.0.0",
     "fastmcp>=2.0.0",
-    "pytest>=8.0",
-    "pytest-asyncio>=0.23",
-    "pytest-xdist>=3.0",
 ]
 
 [project.optional-dependencies]
 dev = [
     "ruff>=0.1.0",
     "mypy>=1.0",
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "pytest-xdist>=3.0",
 ]
 
 [build-system]


### PR DESCRIPTION
## Description
This PR fixes the issue where `pytest` and related testing dependencies were listed as production dependencies in `core/pyproject.toml`.
## Problem
- `pytest`, `pytest-asyncio`, and `pytest-xdist` were in the main `[project.dependencies]` section
- This caused unnecessary packages to be installed in production environments
- Increased production dependency footprint and potential security surface area
## Solution
- Moved all pytest-related dependencies to `[project.optional-dependencies]` under the `dev` extra
- Production installs: `pip install ./core` (no pytest)
- Development installs: `pip install ./core[dev]` (includes pytest)
## Changes
- Modified `core/pyproject.toml`:
  - Removed `pytest>=8.0`, `pytest-asyncio>=0.23`, `pytest-xdist>=3.0` from main dependencies
  - Added them to `dev` optional dependencies
## Testing
- Verified that the pyproject.toml syntax is correct
- No functional changes to code, only dependency organization

Fixes #2388