### PR TITLE
micro-fix: move pytest from production dependencies to dev extras

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -11,15 +11,15 @@ dependencies = [
     "litellm>=1.81.0",
     "mcp>=1.0.0",
     "fastmcp>=2.0.0",
-    "pytest>=8.0",
-    "pytest-asyncio>=0.23",
-    "pytest-xdist>=3.0",
 ]
 
 [project.optional-dependencies]
 dev = [
     "ruff>=0.1.0",
     "mypy>=1.0",
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "pytest-xdist>=3.0",
 ]
 
 [build-system]

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -32,8 +32,9 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0.0",
-    "pytest-asyncio>=0.21.0",
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "pytest-xdist>=3.0",
 ]
 sandbox = [
     "RestrictedPython>=7.0",


### PR DESCRIPTION
### Summary
This is a small configuration-only change to clean up production dependencies.

### What changed
- Moved pytest, pytest-asyncio, and pytest-xdist from
  [project.dependencies] to [project.optional-dependencies] (dev)

### Why
- Prevents test-only dependencies from being installed in production
- Reduces dependency footprint and security surface

### Scope
- < 20 lines changed
- No logic, API, or database changes
