### PR TITLE
docs: add Windows setup note

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ This installs:
 - All required dependencies
 - Claude Code skills for building agents
 
+
+### Windows users note
+
+If you are running Hive on Windows, the setup script must be executed using Git Bash. PowerShell and Command Prompt cannot run `.sh` files. First install Git for Windows from https://git-scm.com/downloads, then open Git Bash and clone the repository using `git clone https://github.com/adenhq/hive.git` followed by `cd hive`. Before running the setup, make the script executable with `chmod +x quickstart.sh`, then start the installation using `./quickstart.sh`. If running `./quickstart.sh` opens a “Choose an app” dialog, it means Git Bash is not being used. Once the script completes, all required dependencies should be installed and the environment will be ready.
+
+
+
+
 ### Build Your First Agent
 
 ```bash


### PR DESCRIPTION
## Description

Added a Windows setup note explaining how to run quickstart.sh using Git Bash, to help Windows users avoid the “choose an app” issue during installation.

## Type of Change

- [x] Documentation update

## Changes Made

- Added Windows Git Bash setup instructions to README.

## Testing

- [x] Manual verification of setup steps on Windows

