### PR TITLE
fix(scripts): micro-fix add python3.11 to POSSIBLE_PYTHONS for macOS

### DIFF
--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -26,7 +26,7 @@ REQUIRED_PYTHON_VERSION="3.11"
 IFS='.' read -r PYTHON_MAJOR_VERSION PYTHON_MINOR_VERSION <<< "$REQUIRED_PYTHON_VERSION"
 
 # Available python interpreter (follows sequence)
-POSSIBLE_PYTHONS=("python3" "python" "py")
+POSSIBLE_PYTHONS=("python3.11" "python3" "python" "py")
 
 # Default python interpreter (initialized)
 PYTHON_CMD=()


### PR DESCRIPTION
## Description
On macOS systems using Homebrew, the Python 3.11 interpreter is often installed with the versioned binary name python3.11. The current setup-python.sh script defaults to searching for python3, which can fail during onboarding even if a valid 3.11 installation exists. This PR adds the versioned binary to the search sequence to ensure a smoother setup for Mac developers.

## Type of Change
[x] Bug fix (non-breaking change that fixes an issue)

[x] Documentation update (improves the reliability of the setup script)

## Related Issues
N/A (Identified during initial project onboarding/audit)

## Changes Made
Modified scripts/setup-python.sh to include python3.11 in the POSSIBLE_PYTHONS array.

This allows the script to detect versioned Homebrew installations that aren't globally symlinked to python3.

## Testing
Describe the tests you ran to verify your changes:

[x] Manual testing performed: Successfully ran ./scripts/setup-python.sh on an M1 Mac after the change; confirmed it detected the interpreter and proceeded with uv package installation.

## Checklist
[x] My code follows the project's style guidelines

[x] I have performed a self-review of my code

[x] My changes generate no new warnings

Note: During this fix, I also noted that the root README mentions an exports/ directory and a support_ticket_agent that appear to be missing from the current main branch. I am happy to help update the docs to reflect the core/examples structure once this setup fix is merged.