### PR TITLE
fix: add warning when Google search results capped at 10

### DIFF
--- a/tools/src/aden_tools/tools/web_search_tool/web_search_tool.py
+++ b/tools/src/aden_tools/tools/web_search_tool/web_search_tool.py
@@ -74,11 +74,11 @@ def register_tools(
             "total": len(results),
             "provider": "google",
         }
-        
+
         # Warn if results were capped due to API limit
         if num_results > 10:
             result["warning"] = f"Google API limited results to 10 (requested {num_results})"
-        
+
         return result
 
     def _search_brave(

--- a/tools/src/aden_tools/tools/web_search_tool/web_search_tool.py
+++ b/tools/src/aden_tools/tools/web_search_tool/web_search_tool.py
@@ -68,12 +68,18 @@ def register_tools(
                 }
             )
 
-        return {
+        result = {
             "query": query,
             "results": results,
             "total": len(results),
             "provider": "google",
         }
+        
+        # Warn if results were capped due to API limit
+        if num_results > 10:
+            result["warning"] = f"Google API limited results to 10 (requested {num_results})"
+        
+        return result
 
     def _search_brave(
         query: str,


### PR DESCRIPTION
Closes #2102

## Summary
Adds a warning to the response when Google search API caps results at 10.

## Changes
- Added `warning` field to result when `num_results > 10`
- Warning message: "Google API limited results to 10 (requested {num_results})"

## Why?
Google Custom Search API has a hard limit of 10 results per request. Previously, requests for more results were silently capped without informing the user.

## Example
```python
result = web_search(query="test", num_results=15, provider="google")
# Returns: {
#   "query": "test",
#   "results": [...],  # 10 items
#   "total": 10,
#   "provider": "google",
#   "warning": "Google API limited results to 10 (requested 15)"
# }
```

## Testing
✅ Requests ≤10: No warning
✅ Requests >10: Warning added to response