### PR TITLE
fix: add missing pydantic dep and clarify example pathing

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ This installs:
 - All required dependencies
 - Claude Code skills for building agents
 
+### Running Examples
+If you encounter a `ModuleNotFoundError` when running examples, ensure your `PYTHONPATH` includes the `core` directory:
+```bash
+export PYTHONPATH=$PYTHONPATH:$(pwd)/core
+python3 core/examples/manual_agent.py
+
 ### Build Your First Agent
 
 ```bash

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -157,7 +157,7 @@ fi
 # Install MCP dependencies (in tools venv)
 echo "  Installing MCP dependencies..."
 TOOLS_PYTHON="$SCRIPT_DIR/tools/.venv/bin/python"
-uv pip install --python "$TOOLS_PYTHON" mcp fastmcp > /dev/null 2>&1
+uv pip install --python "$TOOLS_PYTHON" pydantic mcp fastmcp > /dev/null 2>&1
 echo -e "${GREEN}  ✓ MCP dependencies installed${NC}"
 
 # Fix openai version compatibility (in tools venv)


### PR DESCRIPTION
## Description

This PR resolves the ModuleNotFoundError for pydantic that occurs when running the framework's examples after a fresh installation. It also clarifies the environment configuration required to run manual agents successfully.
## Type of Change

- Bug fix (non-breaking change that fixes an issue)
- Documentation update

## Related Issues

Fixes #2483 

## Changes Made

- Added pydantic to the uv pip install sequence in quickstart.sh.

- Updated README.md with instructions on setting the PYTHONPATH to include the core directory.

- Added a "Running Examples" section to improve developer onboarding.

## Testing

- Manual testing performed: Verified that core/examples/manual_agent.py runs successfully on a clean environment after applying these changes.