### PR TITLE
fix(setup): detect Python in conda/venv/pyenv environments

### DIFF
--- a/core/setup_mcp.sh
+++ b/core/setup_mcp.sh
@@ -18,8 +18,28 @@ NC='\033[0m' # No Color
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
 
+# Detect Python respecting active environments
+if [ -n "$VIRTUAL_ENV" ] || [ -n "$CONDA_PREFIX" ] || [ -n "$PYENV_ROOT" ]; then
+    PYTHON_CANDIDATES=("python" "python3")
+else
+    PYTHON_CANDIDATES=("python3" "python")
+fi
+
+PYTHON_CMD=""
+for cmd in "${PYTHON_CANDIDATES[@]}"; do
+    if command -v "$cmd" &> /dev/null; then
+        PYTHON_CMD="$cmd"
+        break
+    fi
+done
+
+if [ -z "$PYTHON_CMD" ]; then
+    echo -e "${RED}Error: Python not found${NC}"
+    exit 1
+fi
+
 echo -e "${YELLOW}Step 1: Installing framework package...${NC}"
-pip install -e . || {
+"$PYTHON_CMD" -m pip install -e . || {
     echo -e "${RED}Failed to install framework package${NC}"
     exit 1
 }
@@ -27,7 +47,7 @@ echo -e "${GREEN}✓ Framework package installed${NC}"
 echo ""
 
 echo -e "${YELLOW}Step 2: Installing MCP dependencies...${NC}"
-pip install mcp fastmcp || {
+"$PYTHON_CMD" -m pip install mcp fastmcp || {
     echo -e "${RED}Failed to install MCP dependencies${NC}"
     exit 1
 }
@@ -59,7 +79,7 @@ fi
 echo ""
 
 echo -e "${YELLOW}Step 4: Testing MCP server...${NC}"
-python -c "from framework.mcp import agent_builder_server; print('✓ MCP server module loads successfully')" || {
+"$PYTHON_CMD" -c "from framework.mcp import agent_builder_server; print('✓ MCP server module loads successfully')" || {
     echo -e "${RED}Failed to import MCP server module${NC}"
     exit 1
 }

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -44,8 +44,15 @@ if ! command -v python &> /dev/null && ! command -v python3 &> /dev/null; then
 fi
 
 # Prefer a Python >= 3.11 if multiple are installed (common on macOS).
+# Respect active environments (conda, venv, pyenv) by checking 'python' first when active
+if [ -n "$VIRTUAL_ENV" ] || [ -n "$CONDA_PREFIX" ] || [ -n "$PYENV_ROOT" ]; then
+    CANDIDATES=(python python3 python3.13 python3.12 python3.11)
+else
+    CANDIDATES=(python3.13 python3.12 python3.11 python3 python)
+fi
+
 PYTHON_CMD=""
-for CANDIDATE in python3.13 python3.12 python3.11 python3 python; do
+for CANDIDATE in "${CANDIDATES[@]}"; do
     if command -v "$CANDIDATE" &> /dev/null; then
         PYTHON_MAJOR=$("$CANDIDATE" -c 'import sys; print(sys.version_info.major)')
         PYTHON_MINOR=$("$CANDIDATE" -c 'import sys; print(sys.version_info.minor)')

--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -26,7 +26,12 @@ REQUIRED_PYTHON_VERSION="3.11"
 IFS='.' read -r PYTHON_MAJOR_VERSION PYTHON_MINOR_VERSION <<< "$REQUIRED_PYTHON_VERSION"
 
 # Available python interpreter (follows sequence)
-POSSIBLE_PYTHONS=("python3" "python" "py")
+# Respect active environments (conda, venv, pyenv) by checking 'python' first when active
+if [ -n "$VIRTUAL_ENV" ] || [ -n "$CONDA_PREFIX" ] || [ -n "$PYENV_ROOT" ]; then
+    POSSIBLE_PYTHONS=("python" "python3" "py")
+else
+    POSSIBLE_PYTHONS=("python3" "python" "py")
+fi
 
 # Default python interpreter (initialized)
 PYTHON_CMD=()


### PR DESCRIPTION
## Description

Fixes Python detection in setup scripts to properly respect conda, venv, and pyenv environments.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #1242 
Fixes #650  
Fixes #1220
Fixes #1262

## Changes Made

- Added environment variable detection for `$VIRTUAL_ENV`, `$CONDA_PREFIX`, `$PYENV_ROOT`
- Prioritize `python` over `python3` when in active environment
- Applied consistently across `scripts/setup-python.sh`, `quickstart.sh`, and `core/setup_mcp.sh`

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`) - N/A (shell scripts only)
- [ ] Lint passes (`cd core && ruff check .`) - N/A (shell scripts only)
- [x] Manual testing performed


**Manual tests:**
- Conda environment (Python 3.11): Correctly detects and uses conda Python
- venv environment: Correctly detects and uses venv Python  
- Old Python (3.9): Fails gracefully with clear version error
- System Python: Uses python3 as fallback


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - N/A (internal script behavior)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works - N/A (shell scripts, manual testing only)
- [ ] New and existing unit tests pass locally with my changes  - N/A (no Python code changed)
