### PR TITLE
docs: add Google Gemini API key setup instructions

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -83,6 +83,7 @@ For running agents with real LLMs:
 # Add to your shell profile (~/.bashrc, ~/.zshrc, etc.)
 export ANTHROPIC_API_KEY="your-key-here"
 export OPENAI_API_KEY="your-key-here"        # Optional
+export GEMINI_API_KEY="your-key-here"        # Optional, for Gemini models
 export BRAVE_SEARCH_API_KEY="your-key-here"  # Optional, for web search tool
 ```
 
@@ -91,6 +92,7 @@ Get API keys:
 - **Anthropic**: [console.anthropic.com](https://console.anthropic.com/)
 - **OpenAI**: [platform.openai.com](https://platform.openai.com/)
 - **Brave Search**: [brave.com/search/api](https://brave.com/search/api/)
+- **Google Gemini**: [aistudio.google.com](https://aistudio.google.com/apikey)
 
 ### Install Claude Code Skills
 

--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -98,6 +98,8 @@ For running agents with real LLMs:
 
 ```bash
 export ANTHROPIC_API_KEY="your-key-here"
+export OPENAI_API_KEY="your-key-here"        # Optional
+export GEMINI_API_KEY="your-key-here"        # Optional, for Gemini models
 ```
 
 ## Running Agents

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,9 @@ export ANTHROPIC_API_KEY="sk-ant-..."
 # OpenAI (optional, for GPT models via LiteLLM)
 export OPENAI_API_KEY="sk-..."
 
+# Google Gemini (optional, for Gemini models via LiteLLM)
+export GEMINI_API_KEY="..."
+
 # Cerebras (optional, used by output cleaner and some nodes)
 export CEREBRAS_API_KEY="..."
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -138,6 +138,7 @@ For running agents with real LLMs:
 # Add to your shell profile (~/.bashrc, ~/.zshrc, etc.)
 export ANTHROPIC_API_KEY="your-key-here"
 export OPENAI_API_KEY="your-key-here"        # Optional
+export GEMINI_API_KEY="your-key-here"        # Optional, for Gemini models
 export BRAVE_SEARCH_API_KEY="your-key-here"  # Optional, for web search
 ```
 
@@ -145,6 +146,7 @@ Get your API keys:
 - **Anthropic**: [console.anthropic.com](https://console.anthropic.com/)
 - **OpenAI**: [platform.openai.com](https://platform.openai.com/)
 - **Brave Search**: [brave.com/search/api](https://brave.com/search/api/)
+- **Google Gemini**: [aistudio.google.com](https://aistudio.google.com/apikey)
 
 ## Testing Your Agent
 


### PR DESCRIPTION
## Description
Adds Google Gemini API key setup instructions to documentation.
## Type of Change
- [x] Documentation update
## Changes Made
- Added `GEMINI_API_KEY` to setup docs (DEVELOPER.md, ENVIRONMENT_SETUP.md, docs/configuration.md, docs/getting-started.md)
- Added link to Google AI Studio
