### PR TITLE
micro-fix: Replace deprecated datetime.utcnow() with datetime.now(UTC)

### DIFF
--- a/core/framework/credentials/aden/client.py
+++ b/core/framework/credentials/aden/client.py
@@ -32,7 +32,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 import httpx
@@ -417,7 +417,7 @@ class AdenCredentialClient:
                 json={
                     "operation": operation,
                     "status": status,
-                    "timestamp": datetime.utcnow().isoformat() + "Z",
+                    "timestamp": datetime.now(UTC).isoformat(),
                     "metadata": metadata or {},
                 },
             )

--- a/core/framework/runner/mcp_client.py
+++ b/core/framework/runner/mcp_client.py
@@ -457,8 +457,7 @@ class MCPClient:
             if self._loop.is_running():
                 try:
                     cleanup_future = asyncio.run_coroutine_threadsafe(
-                        self._cleanup_stdio_async(),
-                        self._loop
+                        self._cleanup_stdio_async(), self._loop
                     )
                     cleanup_future.result(timeout=self._CLEANUP_TIMEOUT)
                     cleanup_attempted = True


### PR DESCRIPTION
Fixes #2545

## Changes
- Updated import in `AdenCredentialClient` to include `UTC` from `datetime`
- Replaced deprecated `datetime.utcnow().isoformat() + "Z"` with timezone-aware `datetime.now(UTC).isoformat()`

## Impact
- Eliminates Python 3.12+ deprecation warning
- Produces timezone-aware timestamps (`+00:00` instead of naive `Z` suffix)
- Aligns with the rest of the credentials module which already uses `datetime.now(UTC)`

## Testing
- ✅ Lint checks passed
- ✅ Format checks passed  
- ✅ Import verified - no deprecation warnings
- ✅ Timestamp format compatibility confirmed