### PR TITLE
micro-fix: Initialize dotenv in CLI entry points (Fixes #2048)

### DIFF
--- a/core/framework/__main__.py
+++ b/core/framework/__main__.py
@@ -1,3 +1,6 @@
+from dotenv import load_dotenv
+load_dotenv()
+
 """Allow running as python -m framework"""
 
 from framework.cli import main

--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -1,3 +1,6 @@
+from dotenv import load_dotenv
+load_dotenv()
+
 """
 Command-line interface for Goal Agent.
 


### PR DESCRIPTION
## Summary
Fixes a startup crash where environment variables were missing because `.env` was not loaded early enough.

## Fixes
Resolves #2048

## Changes
* Added `load_dotenv()` to `core/framework/cli.py` and `core/framework/__main__.py`.
* Ensures env vars are available before config initialization.