### PR TITLE
micro-fix: Fix schema validation to fail when jsonschema library is not installed

### DIFF
--- a/core/framework/graph/validator.py
+++ b/core/framework/graph/validator.py
@@ -259,8 +259,10 @@ class OutputValidator:
         try:
             import jsonschema
         except ImportError:
-            logger.warning("jsonschema not installed, skipping schema validation")
-            return ValidationResult(success=True, errors=[])
+            return ValidationResult(
+                success=False,
+                errors=["jsonschema library not installed - cannot validate schema"],
+            )
 
         errors = []
         validator = jsonschema.Draft7Validator(schema)

--- a/core/framework/runner/mcp_client.py
+++ b/core/framework/runner/mcp_client.py
@@ -457,8 +457,7 @@ class MCPClient:
             if self._loop.is_running():
                 try:
                     cleanup_future = asyncio.run_coroutine_threadsafe(
-                        self._cleanup_stdio_async(),
-                        self._loop
+                        self._cleanup_stdio_async(), self._loop
                     )
                     cleanup_future.result(timeout=self._CLEANUP_TIMEOUT)
                     cleanup_attempted = True


### PR DESCRIPTION
Fixes #2576

## Changes
- Changed `validate_schema()` to return `success=False` when jsonschema is not installed
- Added clear error message: "jsonschema library not installed - cannot validate schema"
- Removed misleading warning log that suggested validation was skipped successfully

## Impact
- Prevents silent validation failures
- Invalid data is now properly rejected instead of passing through
- Users get clear feedback when required dependencies are missing
- Aligns with "fail fast" principle - validation failures are explicit

## Testing
- ✅ Lint checks passed
- ✅ Format checks passed
- ✅ All validator tests passed (13 tests)