### PR TITLE
Add zero-compute example agent for first-run experience

### DIFF
--- a/examples/goal_breakdown_agent/Readme.md
+++ b/examples/goal_breakdown_agent/Readme.md
@@ -1,0 +1,20 @@
+### Summary
+This PR improves Hive’s first-run experience by adding a minimal, zero-compute
+example agent that runs without LLMs, tools, or API keys.
+
+### Motivation
+After setup, new users currently do not have a runnable agent example without
+configuring LLMs or tools. This introduces unnecessary cognitive and computational
+overhead early in the experience.
+
+### What’s included
+- `goal_breakdown_agent` under `exports/`
+  - Deterministic output
+  - No external dependencies
+  - Instant execution
+- (Optional) Documentation clarification for first-run usage
+
+### Impact
+- Faster first success for new users
+- Reduced compute and setup requirements
+- Better accessibility for low-resource environments

--- a/examples/goal_breakdown_agent/__main__.py
+++ b/examples/goal_breakdown_agent/__main__.py
@@ -1,0 +1,43 @@
+import json
+import argparse
+
+
+def validate():
+    print("✓ goal_breakdown_agent validated successfully")
+
+
+def run(input_data: dict):
+    goal = input_data.get("goal", "").strip()
+
+    if not goal:
+        raise ValueError("Input must contain a non-empty 'goal' field")
+
+    breakdown = {
+        "goal": goal,
+        "milestones": [
+            "Clarify problem and success criteria",
+            "Break goal into core components",
+            "Identify dependencies and constraints",
+            "Prioritize tasks by impact",
+            "Define a simple execution sequence",
+        ],
+    }
+
+    print(json.dumps(breakdown, indent=2))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=["validate", "run"])
+    parser.add_argument("--input", type=str, required=False)
+
+    args = parser.parse_args()
+
+    if args.command == "validate":
+        validate()
+
+    elif args.command == "run":
+        if not args.input:
+            raise ValueError("--input JSON is required")
+
+        run(json.loads(args.input))


### PR DESCRIPTION
### Summary
This PR improves Hive’s first-run experience by adding a minimal, zero-compute
example agent that runs without LLMs, tools, or API keys.

### Motivation
After setup, new users currently do not have a runnable agent example without
configuring LLMs or tools. This introduces unnecessary cognitive and computational
overhead early in the experience.

### What’s included
- `goal_breakdown_agent` under `exports/`
  - Deterministic output
  - No external dependencies
  - Instant execution
- (Optional) Documentation clarification for first-run usage

### Impact
- Faster first success for new users
- Reduced compute and setup requirements
- Better accessibility for low-resource environments

### Issue
Fixes: #2596
