### PR TITLE
feat(runtime): add opt-in support for function nodes via explicit registration

### DIFF
--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -1613,9 +1613,21 @@ class FunctionNode(NodeProtocol):
             # Write to output keys
             output = {}
             if ctx.node_spec.output_keys:
-                key = ctx.node_spec.output_keys[0]
-                output[key] = result
-                ctx.memory.write(key, result)
+                if isinstance(result, dict):
+                    # Map dict fields to output keys when possible
+                    for key in ctx.node_spec.output_keys:
+                        if key in result:
+                            value = result[key]
+                        elif len(ctx.node_spec.output_keys) == 1:
+                            value = result
+                        else:
+                            value = None
+                        output[key] = value
+                        ctx.memory.write(key, value)
+                else:
+                    key = ctx.node_spec.output_keys[0]
+                    output[key] = result
+                    ctx.memory.write(key, result)
             else:
                 output = {"result": result}
 

--- a/core/framework/runtime/execution_stream.py
+++ b/core/framework/runtime/execution_stream.py
@@ -110,6 +110,7 @@ class ExecutionStream:
         llm: "LLMProvider | None" = None,
         tools: list["Tool"] | None = None,
         tool_executor: Callable | None = None,
+        node_registry: dict[str, Any] | None = None,
         result_retention_max: int | None = 1000,
         result_retention_ttl_seconds: float | None = None,
     ):
@@ -128,6 +129,7 @@ class ExecutionStream:
             llm: LLM provider for nodes
             tools: Available tools
             tool_executor: Function to execute tools
+            node_registry: Optional custom node implementations by ID
         """
         self.stream_id = stream_id
         self.entry_spec = entry_spec
@@ -140,6 +142,7 @@ class ExecutionStream:
         self._llm = llm
         self._tools = tools or []
         self._tool_executor = tool_executor
+        self._node_registry: dict[str, Any] = dict(node_registry or {})
         self._result_retention_max = result_retention_max
         self._result_retention_ttl_seconds = result_retention_ttl_seconds
 
@@ -320,6 +323,7 @@ class ExecutionStream:
                     llm=self._llm,
                     tools=self._tools,
                     tool_executor=self._tool_executor,
+                    node_registry=self._node_registry,
                 )
 
                 # Create modified graph with entry point


### PR DESCRIPTION
Fixes #2602

## Summary
This PR adds opt-in support for function-based nodes in `AgentRuntime` by explicitly
registering function nodes and propagating a node registry through
`ExecutionStream → GraphExecutor`.

This allows agents to execute deterministic Python logic as part of a graph
without invoking an LLM.

## Problem
While running Hive end-to-end locally, function nodes fail with:

> `Function node 'X' not registered`

because `ExecutionStream` does not currently pass a node registry into
`GraphExecutor`. This prevents deterministic validation or preprocessing steps
from running correctly, especially in agents with multiple entry points.

## Solution
- Add explicit function node registration support in `AgentRuntime`
- Propagate the node registry through `ExecutionStream` into `GraphExecutor`
- Enable deterministic, non-LLM execution paths inside agent graphs

## What’s included
- Runtime support for registering and executing function-based nodes
- Tests covering function node registration and multi-output handling
- Minor development configuration cleanup

## Scope & compatibility
- Fully backward-compatible
- Opt-in only
- No changes to existing agents or default execution paths

This change is intentionally scoped to fixing the runtime execution path for
function nodes. Happy to adjust naming, structure, or scope based on feedback.