### PR TITLE
fix(ci): pre-existing test failures and ruff format issue on main

### DIFF
--- a/core/framework/runner/mcp_client.py
+++ b/core/framework/runner/mcp_client.py
@@ -457,8 +457,7 @@ class MCPClient:
             if self._loop.is_running():
                 try:
                     cleanup_future = asyncio.run_coroutine_threadsafe(
-                        self._cleanup_stdio_async(),
-                        self._loop
+                        self._cleanup_stdio_async(), self._loop
                     )
                     cleanup_future.result(timeout=self._CLEANUP_TIMEOUT)
                     cleanup_attempted = True

--- a/tools/tests/tools/test_web_scrape_tool.py
+++ b/tools/tests/tools/test_web_scrape_tool.py
@@ -64,6 +64,7 @@ class TestWebScrapeToolLinkConversion:
         mock_response.status_code = 200
         mock_response.text = html_content
         mock_response.url = final_url
+        mock_response.headers = {"content-type": "text/html; charset=utf-8"}
         return mock_response
 
     @patch("aden_tools.tools.web_scrape_tool.web_scrape_tool.httpx.get")


### PR DESCRIPTION
## Description

Fix two pre-existing CI failures on `main` that are unrelated to any open PR.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #2609

## Changes Made

- `tools/tests/tools/test_web_scrape_tool.py` — Added missing `content-type` header to `_mock_response` helper. The scrape tool checks `Content-Type` to skip non-HTML responses, so all 7 `TestWebScrapeToolLinkConversion` tests were failing with `Skipping non-HTML content (Content-Type: <MagicMock ...>)`.
- `core/framework/runner/mcp_client.py` — Applied `ruff format` to fix formatting that did not pass `ruff format --check`.

## Testing

- [x] Unit tests pass — all 13 `test_web_scrape_tool.py` tests now pass (7 were failing before)
- [x] Lint passes — `ruff check` and `ruff format --check` both clean
- [x] Manual testing performed — verified failures on upstream/main at `b10d617`, confirmed fix resolves both issues

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes