### PR TITLE
fix(scripts): micro-fix - improve error message when Python version is too old

### DIFF
--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -64,7 +64,7 @@ for cmd in "${POSSIBLE_PYTHONS[@]}"; do
                 echo ""
             fi
         else
-            echo -e "${RED}✗${NC} ${CURRENT_CMD[@]} not found"
+            echo -e "${RED}✗${NC} ${CURRENT_CMD[@]} version too old (requires ${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}+)"
             echo ""
         fi
     fi


### PR DESCRIPTION
## Description
Fixes misleading error message in setup script when Python version is too old.
## Problem
When users have Python < 3.11, the setup script showed "not found" which was confusing since Python IS installed, just outdated.
## Solution
Changed line 67 in `scripts/setup-python.sh` to display:
- **Before**: `✗ python3 not found`
- **After**: `✗ python3 version too old (requires 3.11+)`
## Testing
- ✅ Verified error only shows when Python version < 3.11
- ✅ Logic preserves existing "not found" error for when Python isn't installed (lines 74-86)
## Type of Change
- [x] Bug fix (improves UX)
- [x] Documentation/error message improvement