### PR TITLE
fix(cli): correct KeyError in list command

### DIFF
--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -459,7 +459,7 @@ def cmd_list(args: argparse.Namespace) -> int:
             print(f"  {agent['name']}")
             print(f"    Path: {agent['path']}")
             print(f"    Description: {agent['description']}")
-            print(f"    Steps: {agent['steps']}, Tools: {agent['tools']}")
+            print(f"    Steps: {agent['nodes']}, Tools: {agent['tools']}")
             print()
 
     return 0

--- a/scripts/setup-python.sh
+++ b/scripts/setup-python.sh
@@ -64,7 +64,7 @@ for cmd in "${POSSIBLE_PYTHONS[@]}"; do
                 echo ""
             fi
         else
-            echo -e "${RED}✗${NC} ${CURRENT_CMD[@]} not found"
+            echo -e "${RED}✗${NC} ${CURRENT_CMD[@]} version too old (requires ${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}+)"
             echo ""
         fi
     fi


### PR DESCRIPTION
## Description
Fixes critical KeyError crash in the `list` command when displaying agent information.
## Problem
The `framework list` command crashed with `KeyError: 'steps'` because:
- Line 437 creates a dict with key `'nodes'`: `"nodes": info.node_count`
- Line 462 tried to access `agent['steps']` which doesn't exist
## Solution
Changed line 462 to use the correct key `'nodes'` that matches the dictionary structure created on line 437.
```diff
- print(f"    Steps: {agent['steps']}, Tools: {agent['tools']}")
+ print(f"    Steps: {agent['nodes']}, Tools: {agent['tools']}")