### PR TITLE
feat(core): allow disabling output validation for long content via No…

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -263,7 +263,7 @@ class GraphExecutor:
                         validation = self.validator.validate_all(
                             output=result.output,
                             expected_keys=node_spec.output_keys,
-                            check_hallucination=True,
+                            check_hallucination=node_spec.validate_output,
                         )
                         if not validation.success:
                             self.logger.error(f"   ✗ Output validation failed: {validation.error}")


### PR DESCRIPTION
## Description

This PR introduces a `validate_output` flag to `NodeSpec` to allow agents to generate long content (e.g., blog posts, code files) without crashing.

Previously, `SharedMemory` forced a strict validation check that raised a `MemoryWriteError` for any string over 5000 characters that looked like code. This made it impossible to build "Writer" or "Analyzer" agents for large files.

## Type of Change

- New feature (non-breaking change that adds functionality)

## Related Issues

Fixes #2625 

## Changes Made

- `core/framework/graph/node.py`:
   - Added `validate_output: bool = True` to `NodeSpec`.
   - Updated `LLMNode.execute` to pass this flag during `memory.write()`.

- `core/framework/graph/executor.py`:
   - Updated `GraphExecutor` to pass `node_spec.validate_output` to the `validator`.

## Testing

Describe the tests you ran to verify your changes:

- Manual testing performed

**Verification Procedure**: I created a test script with two scenarios using a Mock LLM returning 7,800 characters of code:

1. Default Node (`validate_output=True`): correctly failed with `MemoryWriteError` (hallucination check).
2. Loose Node (`validate_output=False`): correctly succeeded and wrote the 7,800 characters to memory.

<img width="1565" height="379" alt="Screenshot from 2026-01-30 17-21-21" src="https://github.com/user-attachments/assets/9e7ac258-69e1-462e-8a4d-4ef9b07cfca3" />

## Checklist

- My code follows the project's style guidelines
- I have performed a self-review of my code
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works

