### PR TITLE
fix: [Bug]: EventBus.wait_for does not correctly handle

### DIFF
--- a/core/framework/runtime/event_bus.py
+++ b/core/framework/runtime/event_bus.py
@@ -446,7 +446,7 @@ class EventBus:
             if timeout:
                 try:
                     await asyncio.wait_for(event_received.wait(), timeout=timeout)
-                except TimeoutError:
+                except asyncio.TimeoutError:
                     return None
             else:
                 await event_received.wait()


### PR DESCRIPTION
## Summary

This PR addresses failing tests in the repository.

**Issue:** [Bug]: EventBus.wait_for does not correctly handle asyncio timeout exceptions

**Changes:**
```diff
diff --git a/core/framework/runtime/event_bus.py b/core/framework/runtime/event_bus.py
index afe5383..facf3f5 100644
--- a/core/framework/runtime/event_bus.py
+++ b/core/framework/runtime/event_bus.py
@@ -446,11 +446,11 @@ async def handler(event: AgentEvent) -> None:
             if timeout:
                 try:
                     await asyncio.wait_for(event_received.wait(), timeout=timeout)
-                except TimeoutError:
+                except asyncio.TimeoutError:
                     return None
             else:
                 await event_received.wait()
 
             return result
         finally:
-            self.unsubscribe(sub_id)
+            self.unsubscribe(sub_id)
\ No newline at end of file

```

Fixes #2589

---
*This PR was generated by [Sediment](https://github.com/sediment/sediment) - learning from outcomes to improve AI coding.*