### PR TITLE
fix: [Bug]: FlexibleGraphExecutor.execute_plan() mutate

### DIFF
--- a/core/framework/graph/flexible_executor.py
+++ b/core/framework/graph/flexible_executor.py
@@ -138,7 +138,8 @@ class FlexibleGraphExecutor:
         Returns:
             PlanExecutionResult with status and feedback
         """
-        context = context or {}
+        # Create a copy to avoid mutating the caller's context dictionary
+        context = dict(context) if context else {}
         context.update(plan.context)  # Merge plan's accumulated context
 
         # Start run


### PR DESCRIPTION
## Summary

This PR addresses failing tests in the repository.

**Issue:** [Bug]: FlexibleGraphExecutor.execute_plan() mutates input context dictionary

**Changes:**
```diff
diff --git a/core/framework/graph/flexible_executor.py b/core/framework/graph/flexible_executor.py
index c3a5659..f2fc2c0 100644
--- a/core/framework/graph/flexible_executor.py
+++ b/core/framework/graph/flexible_executor.py
@@ -138,7 +138,8 @@ async def execute_plan(
         Returns:
             PlanExecutionResult with status and feedback
         """
-        context = context or {}
+        # Create a copy to avoid mutating the caller's context dictionary
+        context = dict(context) if context else {}
         context.update(plan.context)  # Merge plan's accumulated context
 
         # Start run
@@ -549,4 +550,4 @@ async def execute_plan(
         tools=tools,
         tool_executor=tool_executor,
     )
-    return await executor.execute_plan(plan, goal, context)
+    return await executor.execute_plan(plan, goal, context)
\ No newline at end of file

```

Fixes #2541

---
*This PR was generated by [Sediment](https://github.com/sediment/sediment) - learning from outcomes to improve AI coding.*