### PR TITLE
fix: [Bug]: ExecutionStream.wait_for_completion does no

### DIFF
--- a/core/framework/runtime/execution_stream.py
+++ b/core/framework/runtime/execution_stream.py
@@ -457,7 +457,7 @@ class ExecutionStream:
             self._prune_execution_results()
             return self._execution_results.get(execution_id)
 
-        except TimeoutError:
+        except asyncio.TimeoutError:
             return None
 
     def get_result(self, execution_id: str) -> ExecutionResult | None:


### PR DESCRIPTION
## Summary

This PR addresses failing tests in the repository.

**Issue:** [Bug]: ExecutionStream.wait_for_completion does not correctly handle asyncio timeout exceptions

**Changes:**
```diff
diff --git a/core/framework/runtime/execution_stream.py b/core/framework/runtime/execution_stream.py
index aed3f77..36d3671 100644
--- a/core/framework/runtime/execution_stream.py
+++ b/core/framework/runtime/execution_stream.py
@@ -457,7 +457,7 @@ async def wait_for_completion(
             self._prune_execution_results()
             return self._execution_results.get(execution_id)
 
-        except TimeoutError:
+        except asyncio.TimeoutError:
             return None
 
     def get_result(self, execution_id: str) -> ExecutionResult | None:
@@ -514,4 +514,4 @@ def get_stats(self) -> dict:
             "status_counts": statuses,
             "max_concurrent": self.entry_spec.max_concurrent,
             "available_slots": available_slots,
-        }
+        }
\ No newline at end of file

```

Fixes #2590

---
*This PR was generated by [Sediment](https://github.com/erikcw/sediment) - learning from outcomes to improve AI coding.*