### PR TITLE
docs(setup): clarify agent generation and exports directory

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -104,6 +104,14 @@ export ANTHROPIC_API_KEY="your-key-here"
 
 All agent commands must be run from the project root with `PYTHONPATH` set:
 
+**Note:**
+This repository does not include pre-built agent packages by default.
+
+The `exports/` directory is created when:
+- building agents using Claude Code (`./quickstart.sh`), or
+- manually creating agent packages following the documented structure.
+
+
 ```bash
 # From /hive/ directory
 PYTHONPATH=core:exports python -m agent_name COMMAND


### PR DESCRIPTION
## Description

Clarifies the agent development workflow by explaining that agent packages under `exports/` are not included by default and are generated via Claude Code or created manually. This prevents confusion when running example agent commands during setup.


## Type of Change

- [x] Documentation update


## Changes Made

- Clarified that `exports/` is not present by default


## Testing

Describe the tests you ran to verify your changes:

- Verified setup instructions on Ubuntu 24.04 (WSL2), Python 3.12

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have made corresponding documentation changes

