### PR TITLE
ci: improve pip cache key for core deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+          cache-dependency-path: |
+            core/requirements.txt
+            core/requirements-dev.txt
+            core/pyproject.toml
 
       - name: Install dependencies
         run: |
@@ -53,6 +57,10 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+          cache-dependency-path: |
+            core/requirements.txt
+            core/requirements-dev.txt
+            core/pyproject.toml
 
       - name: Install dependencies
         run: |
@@ -77,6 +85,10 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+          cache-dependency-path: |
+            core/requirements.txt
+            core/requirements-dev.txt
+            core/pyproject.toml
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary\n- Add cache-dependency-path for core dependency files in CI\n- Improves pip cache hit rate when core requirements change\n\n## Testing\n- Not run (workflow change only)\n\nFixes #2647