### PR TITLE
docs: add minimal Python-only quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,33 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 - **[Report Issues](https://github.com/adenhq/hive/issues)** - Bug reports and feature requests
 
 ## Quick Start
+### Python only quick start
+This section provides a minimal Python-only example to help new contributors
+quickly get started with Hive without additional tooling.
+
+#### Prerequisites
+- Python 3.9+
+- Git
+
+#### Installation
+```bash
+git clone https://github.com/adenhq/hive.git
+cd hive
+pip install -e .
+```
+
+#### Minimal Example
+Create a file named `example_agent.py` locally with the following content:
+# NOTE: This is a minimal illustrative example.
+# Refer to the examples directory for exact imports and advanced usage.
+```
+agent = Agent(
+    name="hello_agent",
+    goal="Print hello world"
+)
+
+agent.run()
+```
 
 ### Prerequisites
 


### PR DESCRIPTION
This PR adds a minimal Python-only quick start section to help new contributors
get started with Hive using only Python.

Fixes #2135