### PR TITLE
fix(bug): add duplicate tool registry name check and logging (#2540)

### DIFF
--- a/core/framework/runner/tool_registry.py
+++ b/core/framework/runner/tool_registry.py
@@ -51,7 +51,17 @@ class ToolRegistry:
             name: Tool name (must match tool.name)
             tool: Tool definition
             executor: Function that takes tool input dict and returns result
+
+        Note:
+            If a tool with the same name is already registered, a warning is logged
+            and the new tool is skipped to prevent silent overwrites.
         """
+        if name in self._tools:
+            existing_desc = self._tools[name].tool.description
+            logger.warning(
+                f"Tool '{name}' already registered, skipping duplicate. Existing: {existing_desc}"
+            )
+            return
         self._tools[name] = RegisteredTool(tool=tool, executor=executor)
 
     def register_function(


### PR DESCRIPTION
 Fix silent overwrite behavior in ToolRegistry.register() by adding duplicate detection. When a tool with the same name is already registered, the method now logs a warning and skips the duplicate instead of silently overwriting the existing tool.
                                                                                                                                                                                                                     
  Type of Change

  - Bug fix (non-breaking change that fixes an issue)
  - New feature (non-breaking change that adds functionality)
  - Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - Documentation update
  - Refactoring (no functional changes)

  Related Issues

  Fixes #2540

  Changes Made

  - Added duplicate name check in ToolRegistry.register() before adding tools
  - Log warning message with existing tool's description when duplicate detected
  - Skip registration of duplicate tools to preserve the original
  - Updated docstring to document the new behavior

  Testing

  - Lint passes (cd core && ruff check .)
  - Manual testing performed

  Checklist

  - My code follows the project's style guidelines
  - I have performed a self-review of my code
  - I have commented my code, particularly in hard-to-understand areas
  - I have made corresponding changes to the documentation
  - My changes generate no new warnings

  Screenshots (if applicable)

  N/A - No UI changes.