### PR TITLE
fix: remove pow from SAFE_BUILTINS to prevent resource exhaustion DoS…

### DIFF
--- a/core/framework/graph/code_sandbox.py
+++ b/core/framework/graph/code_sandbox.py
@@ -56,7 +56,7 @@ SAFE_BUILTINS = {
     "next": next,
     "oct": oct,
     "ord": ord,
-    "pow": pow,
+    # pow intentionally excluded - enables resource exhaustion DoS (see issue #2686)
     "range": range,
     "repr": repr,
     "reversed": reversed,


### PR DESCRIPTION
## Description

Removes `pow` from `SAFE_BUILTINS` to prevent resource exhaustion DoS attacks.

`pow(10, 10**8)` allocates gigabytes instantly, crashing before any timeout fires.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #2686

## Changes Made

- Removed `pow` from `SAFE_BUILTINS` whitelist (line 59)
- Added comment explaining exclusion

## Note for Maintainers

Requesting assignment to #2686. This is a 1-line security fix — happy to have it reviewed despite the bot auto-close.
