### PR TITLE
SECURITY: remove pow() and disable __builtins__ to prevent DoS

### DIFF
--- a/core/framework/graph/code_sandbox.py
+++ b/core/framework/graph/code_sandbox.py
@@ -1,3 +1,4 @@
+
 """
 Code Sandbox for Safe Execution of Dynamic Code.
 
@@ -11,7 +12,6 @@ Security measures:
 3. Memory limits (via resource module on Unix)
 4. Namespace isolation
 """
-
 import ast
 import signal
 import sys
@@ -22,6 +22,7 @@ from typing import Any
 # Safe builtins whitelist
 SAFE_BUILTINS = {
     # Basic types
+    "__builtins__": {},
     "True": True,
     "False": False,
     "None": None,
@@ -56,7 +57,7 @@ SAFE_BUILTINS = {
     "next": next,
     "oct": oct,
     "ord": ord,
-    "pow": pow,
+    # "pow": pow,
     "range": range,
     "repr": repr,
     "reversed": reversed,

--- a/tests/test_code_sandbox.py
+++ b/tests/test_code_sandbox.py
@@ -1,0 +1,26 @@
+import sys
+import os
+
+# Get the absolute path to the 'core' folder
+# 1. Get current folder (tests/)
+current_dir = os.path.dirname(os.path.abspath(__file__))
+# 2. Get parent folder (hive/)
+repo_root = os.path.dirname(current_dir)
+# 3. Target the 'core' folder (hive/core/)
+core_path = os.path.join(repo_root, "core")
+
+# Add 'core' to sys.path so Python can find 'framework'
+sys.path.insert(0, core_path)
+
+import pytest
+# Now this import will work because we are pointing to 'core'
+from framework.graph.code_sandbox import safe_exec
+
+def test_pow_is_not_available():
+    """
+    Regression test for SECURITY issue #2686:
+    pow() should not be available in SAFE_BUILTINS to prevent DoS.
+    """
+    # Attempting to use pow() should raise a NameError (because it's removed)
+    with pytest.raises(NameError):
+        safe_exec("pow(2, 100000000)")


### PR DESCRIPTION
## Description
Fixes security vulnerability #2686 (Resource Exhaustion DoS via pow()).

## Changes
- Removed `pow()` from `SAFE_BUILTINS` in `core/framework/graph/code_sandbox.py`.
- Added `"__builtins__": {}` to prevent auto-restoration of built-in functions.
- Added regression test `tests/test_code_sandbox.py` to ensure `pow()` remains inaccessible.

## Verification
- Ran `pytest tests/test_code_sandbox.py` locally on Windows.
- Test passes: `pow(2, 100000000)` correctly raises `NameError`.
