### PR TITLE
Add policy enforcement layer (guardrails) to agent runtime

### DIFF
--- a/core/framework/__init__.py
+++ b/core/framework/__init__.py
@@ -25,6 +25,7 @@ See `framework.testing` for details.
 from framework.builder.query import BuilderQuery
 from framework.llm import AnthropicProvider, LLMProvider
 from framework.runner import AgentOrchestrator, AgentRunner
+from framework.runner.runner import PolicyConfig
 from framework.runtime.core import Runtime
 from framework.schemas.decision import Decision, DecisionEvaluation, Option, Outcome
 from framework.schemas.run import Problem, Run, RunSummary
@@ -38,6 +39,33 @@ from framework.testing import (
     TestResult,
     TestStorage,
     TestSuiteResult,
+)
+
+# Policy framework (guardrails)
+from framework.policies import (
+    AggregatedDecision,
+    AllowlistMode,
+    BasePolicy,
+    BudgetConfig,
+    BudgetLimitPolicy,
+    BudgetMode,
+    ConfirmationRequiredError,
+    DomainAllowlistPolicy,
+    GuardrailsError,
+    HighRiskToolGatingPolicy,
+    InjectionGuardPolicy,
+    InjectionMode,
+    Policy,
+    PolicyAction,
+    PolicyConfigurationError,
+    PolicyDecision,
+    PolicyEngine,
+    PolicyEvent,
+    PolicyEventType,
+    PolicyRegistrationError,
+    PolicyViolationError,
+    Severity,
+    ToolInterceptor,
 )
 
 __all__ = [
@@ -59,6 +87,7 @@ __all__ = [
     # Runner
     "AgentRunner",
     "AgentOrchestrator",
+    "PolicyConfig",
     # Testing
     "Test",
     "TestResult",
@@ -67,4 +96,28 @@ __all__ = [
     "ApprovalStatus",
     "ErrorCategory",
     "DebugTool",
+    # Policy Framework (Guardrails)
+    "PolicyEngine",
+    "AggregatedDecision",
+    "PolicyEvent",
+    "PolicyEventType",
+    "PolicyDecision",
+    "PolicyAction",
+    "Severity",
+    "Policy",
+    "BasePolicy",
+    "HighRiskToolGatingPolicy",
+    "DomainAllowlistPolicy",
+    "AllowlistMode",
+    "BudgetLimitPolicy",
+    "BudgetConfig",
+    "BudgetMode",
+    "InjectionGuardPolicy",
+    "InjectionMode",
+    "ToolInterceptor",
+    "GuardrailsError",
+    "PolicyViolationError",
+    "PolicyConfigurationError",
+    "PolicyRegistrationError",
+    "ConfirmationRequiredError",
 ]

--- a/core/framework/policies/README.md
+++ b/core/framework/policies/README.md
@@ -1,0 +1,222 @@
+# Hive Guardrails (Policy Engine)
+
+Policy enforcement layer for the Hive agent runtime. Intercepts tool calls during execution and evaluates them against configurable policies before allowing, blocking, or requiring human confirmation.
+
+## How It Works
+
+```
+Agent LLM decides to call a tool
+        |
+        v
+  PolicyEngine.evaluate(TOOL_CALL)
+        |
+   +---------+-----------+----------------+
+   |         |           |                |
+ ALLOW    BLOCK    REQUIRE_CONFIRM     SUGGEST
+   |         |           |                |
+   v         v           v                v
+ Execute   Return     Route to        Log and
+  tool     error     approval_cb      execute
+           result    (HITL)
+```
+
+When a `PolicyEngine` is configured on the `GraphExecutor`, every tool call passes through a policy-aware wrapper that:
+
+1. Creates a `TOOL_CALL` event with the tool name and arguments
+2. Evaluates all registered policies against the event
+3. Acts on the aggregated decision (allow, block, require confirmation, or suggest)
+4. If allowed, executes the tool and evaluates a `TOOL_RESULT` event (post-call)
+5. Records blocked/flagged calls in the Runtime via `report_problem()`
+
+## Quick Start
+
+```python
+from framework import AgentRunner, PolicyConfig
+
+# Configure policies
+config = PolicyConfig(
+    enable_tool_gating=True,          # Block/confirm high-risk tools
+    tool_gating_mode="balanced",       # "permissive", "balanced", "strict"
+
+    enable_domain_allowlist=True,      # Restrict network access
+    allowed_domains=["api.example.com", "*.internal.net"],
+
+    enable_budget_limits=True,         # Enforce resource budgets
+    token_limit=100_000,
+    cost_limit_usd=1.00,
+
+    enable_injection_guard=True,       # Detect prompt injection in tool results
+    injection_mode="balanced",
+)
+
+# Load agent with policies
+runner = AgentRunner.load(
+    "exports/my-agent",
+    policy_config=config,
+)
+
+# Policies are automatically enforced during execution
+result = await runner.run({"input": "value"})
+```
+
+## Built-in Policies
+
+### HighRiskToolGatingPolicy
+
+Evaluates tool names against glob patterns to identify high-risk operations (file deletion, code execution, credential access). Matching tools trigger `REQUIRE_CONFIRM`; safe-pattern matches are allowed.
+
+**Default high-risk patterns:** `*_delete`, `*_remove`, `*execute*`, `*credential*`, `*password*`, `*secret*`, etc.
+
+**Modes via `tool_gating_mode`:**
+| Mode | Behavior for unmatched tools |
+|------|------------------------------|
+| `permissive` | Allow |
+| `balanced` | Require confirmation |
+| `strict` | Block |
+
+### DomainAllowlistPolicy
+
+Controls which domains agents can reach via network tools (`http_request`, `web_scrape`, `api_call`, etc.). Checks URLs in tool arguments against allowlists and blocklists.
+
+**Modes via `domain_allowlist_mode`:**
+| Mode | Behavior for unknown domains |
+|------|------------------------------|
+| `permissive` | Log suggestion, allow |
+| `balanced` | Require confirmation |
+| `strict` | Block |
+
+### BudgetLimitPolicy
+
+Enforces resource budgets on token usage, cost, and execution time. Evaluates `RUN_CONTROL` events emitted by the runtime with current usage metrics.
+
+**Config fields:** `token_limit`, `cost_limit_usd`, `time_limit_seconds`
+
+Soft limits are auto-set at 80% of the hard limit. In `balanced` mode, soft limit triggers a warning; hard limit blocks.
+
+### InjectionGuardPolicy
+
+Detects prompt injection patterns in tool results (post-call evaluation). Flags content that appears to contain instruction-like patterns attempting to manipulate the agent.
+
+**Modes via `injection_mode`:**
+| Mode | Behavior for detected injection |
+|------|--------------------------------|
+| `permissive` | Log suggestion |
+| `balanced` | Require confirmation |
+| `strict` | Block |
+
+## HITL (Human-in-the-Loop) Integration
+
+`REQUIRE_CONFIRM` decisions route through the existing `approval_callback` on `AgentRunner`:
+
+```python
+runner = AgentRunner.load("exports/my-agent", policy_config=config)
+
+def my_approval_handler(info: dict) -> bool:
+    """Called when a policy requires human confirmation."""
+    print(f"Tool: {info['tool_name']}")
+    print(f"Reason: {info['reason']}")
+    print(f"Policy: {info['policy_id']}")
+    return input("Approve? (y/n): ").lower() == "y"
+
+runner.set_approval_callback(my_approval_handler)
+```
+
+If no callback is set, `REQUIRE_CONFIRM` decisions are denied by default.
+
+## Advanced: Direct PolicyEngine Usage
+
+For custom policies or programmatic control, use the `PolicyEngine` directly:
+
+```python
+from framework import PolicyEngine, PolicyConfig
+from framework.policies.builtin.tool_gating import HighRiskToolGatingPolicy
+from framework.graph.executor import GraphExecutor
+
+engine = PolicyEngine(raise_on_block=False)
+engine.register_policy(HighRiskToolGatingPolicy(default_action="confirm"))
+
+executor = GraphExecutor(
+    runtime=runtime,
+    llm=llm,
+    tools=tools,
+    tool_executor=tool_executor,
+    policy_engine=engine,
+)
+```
+
+### Custom Policies
+
+Implement the `Policy` protocol:
+
+```python
+from framework.policies.base import BasePolicy
+from framework.policies.decisions import PolicyDecision, Severity
+from framework.policies.events import PolicyEvent, PolicyEventType
+
+class MyCustomPolicy(BasePolicy):
+    _id = "my-custom-policy"
+    _name = "My Custom Policy"
+    _description = "Blocks calls to deprecated tools"
+    _event_types = [PolicyEventType.TOOL_CALL]
+
+    @property
+    def id(self): return self._id
+    @property
+    def name(self): return self._name
+    @property
+    def description(self): return self._description
+    @property
+    def event_types(self): return self._event_types
+
+    async def evaluate(self, event: PolicyEvent) -> PolicyDecision:
+        tool_name = event.payload.get("tool_name", "")
+        if tool_name.startswith("deprecated_"):
+            return PolicyDecision.block(
+                policy_id=self.id,
+                reason=f"Tool '{tool_name}' is deprecated",
+                severity=Severity.HIGH,
+            )
+        return PolicyDecision.allow(policy_id=self.id)
+
+engine.register_policy(MyCustomPolicy())
+```
+
+## Architecture
+
+```
+runner/runner.py          PolicyConfig → _build_policy_engine() → PolicyEngine
+                                                                      |
+graph/executor.py         GraphExecutor.__init__(policy_engine=...)   |
+                                |                                     |
+                          _wrap_with_policy(tool_executor)            |
+                                |                                     |
+                          policy_executor(tool_use)  ←────── evaluates policies
+                                |
+                          original_executor(tool_use) ← only if allowed
+
+runtime/agent_runtime.py  policy_engine threaded through AgentRuntime
+                                |
+runtime/execution_stream.py     → ExecutionStream → GraphExecutor (per execution)
+```
+
+**Files modified for runtime wiring:**
+- `core/framework/graph/executor.py` — `_wrap_with_policy()`, `policy_engine` param
+- `core/framework/runner/runner.py` — `PolicyConfig`, `_build_policy_engine()`
+- `core/framework/runtime/agent_runtime.py` — `policy_engine` param threaded through
+- `core/framework/runtime/execution_stream.py` — `policy_engine` param forwarded to executor
+- `core/framework/__init__.py` — `PolicyConfig` exported
+
+## Testing
+
+```bash
+# Integration tests (policy + runtime wiring)
+PYTHONPATH=core pytest core/tests/test_policy_integration.py -v
+
+# Standalone policy unit tests
+pytest tests/ -v
+
+# Full Hive suite
+PYTHONPATH=core pytest core/tests/ -v
+```
+
+Current: **285 Hive tests + 90 standalone tests**, all passing.

--- a/core/framework/policies/__init__.py
+++ b/core/framework/policies/__init__.py
@@ -1,0 +1,111 @@
+"""Policy-native guardrails for Aden Hive agent framework.
+
+This package provides a policy-based guardrails system that integrates
+with the Hive agent framework. Policies evaluate agent actions at key
+interception points and return structured decisions.
+
+Key components:
+- PolicyEngine: Orchestrates policy evaluation
+- Policy: Protocol/base class for defining policies
+- PolicyEvent: Events that policies evaluate
+- PolicyDecision: Decisions returned by policies
+- ToolInterceptor: Creates policy events from tool calls
+
+Built-in policies:
+- HighRiskToolGatingPolicy: Require confirmation for high-risk tools
+- DomainAllowlistPolicy: Control allowed network domains
+- BudgetLimitPolicy: Enforce resource budgets
+- InjectionGuardPolicy: Detect prompt injection attempts
+
+Example:
+    from framework.policies import (
+        PolicyEngine,
+        PolicyEvent,
+        PolicyEventType,
+        HighRiskToolGatingPolicy,
+        DomainAllowlistPolicy,
+        BudgetLimitPolicy,
+        InjectionGuardPolicy,
+    )
+
+    # Create engine and register policies
+    engine = PolicyEngine()
+    engine.register_policy(HighRiskToolGatingPolicy())
+    engine.register_policy(DomainAllowlistPolicy())
+    engine.register_policy(BudgetLimitPolicy())
+    engine.register_policy(InjectionGuardPolicy())
+
+    # Create an event
+    event = PolicyEvent.create(
+        event_type=PolicyEventType.TOOL_CALL,
+        payload={"tool_name": "file_delete", "args": {"path": "/tmp/x"}},
+        execution_id="exec-123",
+    )
+
+    # Evaluate
+    result = await engine.evaluate(event)
+    print(f"Action: {result.final_action}")
+"""
+
+from framework.policies.base import BasePolicy, Policy
+from framework.policies.builtin import (
+    AllowlistMode,
+    BudgetConfig,
+    BudgetLimitPolicy,
+    BudgetMode,
+    DomainAllowlistPolicy,
+    HighRiskToolGatingPolicy,
+    InjectionGuardPolicy,
+    InjectionMode,
+)
+from framework.policies.decisions import PolicyAction, PolicyDecision, Severity
+from framework.policies.engine import AggregatedDecision, PolicyEngine
+from framework.policies.events import PolicyEvent, PolicyEventType
+from framework.policies.exceptions import (
+    ConfirmationRequiredError,
+    GuardrailsError,
+    PolicyConfigurationError,
+    PolicyRegistrationError,
+    PolicyViolationError,
+)
+from framework.policies.interceptors import ToolInterceptor
+
+__version__ = "0.1.0"
+
+__all__ = [
+    # Core
+    "PolicyEngine",
+    "AggregatedDecision",
+    # Events
+    "PolicyEvent",
+    "PolicyEventType",
+    # Decisions
+    "PolicyDecision",
+    "PolicyAction",
+    "Severity",
+    # Policies - Base
+    "Policy",
+    "BasePolicy",
+    # Policies - Tool Gating
+    "HighRiskToolGatingPolicy",
+    # Policies - Domain Allowlist
+    "DomainAllowlistPolicy",
+    "AllowlistMode",
+    # Policies - Budget Limits
+    "BudgetLimitPolicy",
+    "BudgetConfig",
+    "BudgetMode",
+    # Policies - Injection Guard
+    "InjectionGuardPolicy",
+    "InjectionMode",
+    # Interceptors
+    "ToolInterceptor",
+    # Exceptions
+    "GuardrailsError",
+    "PolicyViolationError",
+    "PolicyConfigurationError",
+    "PolicyRegistrationError",
+    "ConfirmationRequiredError",
+    # Version
+    "__version__",
+]

--- a/core/framework/policies/base.py
+++ b/core/framework/policies/base.py
@@ -1,0 +1,147 @@
+"""Base policy protocol and abstract class.
+
+Defines the interface that all policies must implement.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Protocol, runtime_checkable
+
+from framework.policies.decisions import PolicyDecision
+from framework.policies.events import PolicyEvent, PolicyEventType
+
+
+@runtime_checkable
+class Policy(Protocol):
+    """Protocol defining the policy interface.
+
+    All policies must implement this protocol to be registered
+    with the PolicyEngine. The protocol defines:
+
+    - id: Unique identifier for the policy
+    - name: Human-readable name
+    - description: What the policy does
+    - event_types: Which events this policy evaluates
+    - evaluate: Async method to evaluate an event
+
+    Example:
+        class MyPolicy:
+            @property
+            def id(self) -> str:
+                return "my-policy"
+
+            @property
+            def name(self) -> str:
+                return "My Custom Policy"
+
+            @property
+            def description(self) -> str:
+                return "Checks for something important"
+
+            @property
+            def event_types(self) -> list[PolicyEventType]:
+                return [PolicyEventType.TOOL_CALL]
+
+            async def evaluate(self, event: PolicyEvent) -> PolicyDecision:
+                return PolicyDecision.allow(self.id)
+    """
+
+    @property
+    def id(self) -> str:
+        """Unique identifier for this policy."""
+        ...
+
+    @property
+    def name(self) -> str:
+        """Human-readable name for this policy."""
+        ...
+
+    @property
+    def description(self) -> str:
+        """Description of what this policy does."""
+        ...
+
+    @property
+    def event_types(self) -> list[PolicyEventType]:
+        """Event types this policy evaluates."""
+        ...
+
+    async def evaluate(self, event: PolicyEvent) -> PolicyDecision:
+        """Evaluate an event and return a decision.
+
+        Args:
+            event: The event to evaluate
+
+        Returns:
+            A PolicyDecision indicating what action to take
+        """
+        ...
+
+
+class BasePolicy(ABC):
+    """Abstract base class for policies.
+
+    Provides a convenient base class with default implementations
+    for common functionality. Subclasses must implement the abstract
+    methods.
+
+    Example:
+        class MyPolicy(BasePolicy):
+            @property
+            def id(self) -> str:
+                return "my-policy"
+
+            @property
+            def name(self) -> str:
+                return "My Policy"
+
+            @property
+            def description(self) -> str:
+                return "Does something useful"
+
+            @property
+            def event_types(self) -> list[PolicyEventType]:
+                return [PolicyEventType.TOOL_CALL]
+
+            async def evaluate(self, event: PolicyEvent) -> PolicyDecision:
+                # Implementation here
+                return PolicyDecision.allow(self.id)
+    """
+
+    @property
+    @abstractmethod
+    def id(self) -> str:
+        """Unique identifier for this policy."""
+        pass
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable name for this policy."""
+        pass
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Description of what this policy does."""
+        pass
+
+    @property
+    @abstractmethod
+    def event_types(self) -> list[PolicyEventType]:
+        """Event types this policy evaluates."""
+        pass
+
+    @abstractmethod
+    async def evaluate(self, event: PolicyEvent) -> PolicyDecision:
+        """Evaluate an event and return a decision.
+
+        Args:
+            event: The event to evaluate
+
+        Returns:
+            A PolicyDecision indicating what action to take
+        """
+        pass
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(id={self.id!r}, name={self.name!r})"

--- a/core/framework/policies/builtin/__init__.py
+++ b/core/framework/policies/builtin/__init__.py
@@ -1,0 +1,31 @@
+"""Built-in policies for common guardrail patterns.
+
+These policies provide out-of-the-box protection for common
+agent safety concerns.
+
+Available policies:
+- HighRiskToolGatingPolicy: Require confirmation for high-risk tools
+- DomainAllowlistPolicy: Control allowed network domains
+- BudgetLimitPolicy: Enforce resource budgets
+- InjectionGuardPolicy: Detect prompt injection attempts
+"""
+
+from framework.policies.builtin.budget_limits import BudgetConfig, BudgetLimitPolicy, BudgetMode
+from framework.policies.builtin.domain_allowlist import AllowlistMode, DomainAllowlistPolicy
+from framework.policies.builtin.injection_guard import InjectionGuardPolicy, InjectionMode
+from framework.policies.builtin.tool_gating import HighRiskToolGatingPolicy
+
+__all__ = [
+    # Tool gating
+    "HighRiskToolGatingPolicy",
+    # Domain allowlist
+    "DomainAllowlistPolicy",
+    "AllowlistMode",
+    # Budget limits
+    "BudgetLimitPolicy",
+    "BudgetConfig",
+    "BudgetMode",
+    # Injection guard
+    "InjectionGuardPolicy",
+    "InjectionMode",
+]

--- a/core/framework/policies/builtin/budget_limits.py
+++ b/core/framework/policies/builtin/budget_limits.py
@@ -1,0 +1,381 @@
+"""Budget limit policy for resource control.
+
+This policy enforces budget limits on token usage, cost, time,
+and execution counts, preventing runaway agent execution.
+"""
+
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+from framework.policies.base import BasePolicy
+from framework.policies.decisions import PolicyDecision, Severity
+from framework.policies.events import PolicyEvent, PolicyEventType
+
+
+class BudgetMode(Enum):
+    """Operating modes for budget enforcement."""
+
+    PERMISSIVE = "permissive"
+    """Warn at thresholds but don't block (SUGGEST only)."""
+
+    BALANCED = "balanced"
+    """Warn at soft limit, block at hard limit."""
+
+    STRICT = "strict"
+    """Block immediately at any limit."""
+
+
+@dataclass
+class BudgetConfig:
+    """Configuration for a single budget limit.
+
+    Attributes:
+        soft_limit: Threshold for warnings (e.g., 80% of hard limit)
+        hard_limit: Threshold for blocking
+        current: Current usage (updated externally)
+        unit: Unit of measurement for display
+    """
+
+    soft_limit: Optional[float] = None
+    hard_limit: Optional[float] = None
+    current: float = 0.0
+    unit: str = ""
+
+    @property
+    def soft_limit_reached(self) -> bool:
+        """Check if soft limit is reached."""
+        if self.soft_limit is None:
+            return False
+        return self.current >= self.soft_limit
+
+    @property
+    def hard_limit_reached(self) -> bool:
+        """Check if hard limit is reached."""
+        if self.hard_limit is None:
+            return False
+        return self.current >= self.hard_limit
+
+    @property
+    def usage_percent(self) -> Optional[float]:
+        """Get usage as percentage of hard limit."""
+        if self.hard_limit is None or self.hard_limit == 0:
+            return None
+        return (self.current / self.hard_limit) * 100
+
+
+@dataclass
+class BudgetLimitPolicy(BasePolicy):
+    """Policy that enforces resource budgets on agent execution.
+
+    This policy tracks and enforces limits on:
+    - Token usage (input + output tokens)
+    - Cost (in dollars or credits)
+    - Time (execution duration)
+    - Tool calls (number of invocations)
+    - LLM calls (number of requests)
+
+    Operating modes:
+    - permissive: Warn at thresholds but don't block
+    - balanced: Warn at soft limit (80%), block at hard limit (100%)
+    - strict: Block immediately at any limit
+
+    The policy evaluates RUN_CONTROL events which should be emitted
+    periodically by the runtime with current usage metrics.
+
+    Attributes:
+        mode: Operating mode (permissive, balanced, strict)
+        token_budget: Token usage limits
+        cost_budget: Cost limits (dollars/credits)
+        time_budget: Execution time limits (seconds)
+        tool_call_budget: Tool invocation limits
+        llm_call_budget: LLM request limits
+
+    Example:
+        policy = BudgetLimitPolicy(
+            mode=BudgetMode.BALANCED,
+            token_budget=BudgetConfig(soft_limit=8000, hard_limit=10000, unit="tokens"),
+            cost_budget=BudgetConfig(soft_limit=0.80, hard_limit=1.00, unit="USD"),
+        )
+        engine.register_policy(policy)
+
+        # Runtime emits periodic updates
+        event = PolicyEvent.create(
+            event_type=PolicyEventType.RUN_CONTROL,
+            payload={
+                "tokens_used": 7500,
+                "cost_usd": 0.75,
+                "elapsed_seconds": 45,
+            },
+            execution_id="exec-123",
+        )
+    """
+
+    mode: BudgetMode = BudgetMode.BALANCED
+    token_budget: BudgetConfig = field(
+        default_factory=lambda: BudgetConfig(
+            soft_limit=80000, hard_limit=100000, unit="tokens"
+        )
+    )
+    cost_budget: BudgetConfig = field(
+        default_factory=lambda: BudgetConfig(
+            soft_limit=0.80, hard_limit=1.00, unit="USD"
+        )
+    )
+    time_budget: BudgetConfig = field(
+        default_factory=lambda: BudgetConfig(
+            soft_limit=240, hard_limit=300, unit="seconds"
+        )
+    )
+    tool_call_budget: BudgetConfig = field(
+        default_factory=lambda: BudgetConfig(
+            soft_limit=80, hard_limit=100, unit="calls"
+        )
+    )
+    llm_call_budget: BudgetConfig = field(
+        default_factory=lambda: BudgetConfig(
+            soft_limit=40, hard_limit=50, unit="calls"
+        )
+    )
+
+    # Internal tracking
+    _start_time: Optional[float] = field(default=None, repr=False)
+
+    # Policy metadata
+    _id: str = "budget-limits"
+    _name: str = "Budget Limits"
+    _description: str = (
+        "Enforces resource budgets on token usage, cost, time, and "
+        "execution counts to prevent runaway agent behavior."
+    )
+
+    def __post_init__(self) -> None:
+        """Initialize start time for time tracking."""
+        if self._start_time is None:
+            self._start_time = time.time()
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    @property
+    def event_types(self) -> list[PolicyEventType]:
+        return [PolicyEventType.RUN_CONTROL, PolicyEventType.TOOL_CALL, PolicyEventType.LLM_REQUEST]
+
+    def _update_from_payload(self, payload: dict) -> None:
+        """Update budget tracking from event payload."""
+        # Token usage
+        if "tokens_used" in payload:
+            self.token_budget.current = payload["tokens_used"]
+        if "input_tokens" in payload and "output_tokens" in payload:
+            self.token_budget.current = payload["input_tokens"] + payload["output_tokens"]
+
+        # Cost
+        if "cost_usd" in payload:
+            self.cost_budget.current = payload["cost_usd"]
+        if "cost" in payload:
+            self.cost_budget.current = payload["cost"]
+
+        # Time
+        if "elapsed_seconds" in payload:
+            self.time_budget.current = payload["elapsed_seconds"]
+        elif self._start_time:
+            self.time_budget.current = time.time() - self._start_time
+
+        # Tool calls
+        if "tool_call_count" in payload:
+            self.tool_call_budget.current = payload["tool_call_count"]
+
+        # LLM calls
+        if "llm_call_count" in payload:
+            self.llm_call_budget.current = payload["llm_call_count"]
+
+    def _check_budgets(
+        self,
+    ) -> tuple[list[tuple[str, BudgetConfig]], list[tuple[str, BudgetConfig]]]:
+        """Check all budgets and return (soft_breached, hard_breached) lists."""
+        budgets = [
+            ("tokens", self.token_budget),
+            ("cost", self.cost_budget),
+            ("time", self.time_budget),
+            ("tool_calls", self.tool_call_budget),
+            ("llm_calls", self.llm_call_budget),
+        ]
+
+        soft_breached = []
+        hard_breached = []
+
+        for name, budget in budgets:
+            if budget.hard_limit_reached:
+                hard_breached.append((name, budget))
+            elif budget.soft_limit_reached:
+                soft_breached.append((name, budget))
+
+        return soft_breached, hard_breached
+
+    def _format_budget_status(self, name: str, budget: BudgetConfig) -> str:
+        """Format a budget status message."""
+        percent = budget.usage_percent
+        if percent is not None:
+            return f"{name}: {budget.current:.1f}/{budget.hard_limit:.1f} {budget.unit} ({percent:.0f}%)"
+        return f"{name}: {budget.current:.1f} {budget.unit}"
+
+    async def evaluate(self, event: PolicyEvent) -> PolicyDecision:
+        """Evaluate resource usage against budget limits.
+
+        Args:
+            event: The event to evaluate (RUN_CONTROL, TOOL_CALL, or LLM_REQUEST)
+
+        Returns:
+            PolicyDecision based on budget status
+        """
+        # Increment counters for relevant events
+        if event.event_type == PolicyEventType.TOOL_CALL:
+            self.tool_call_budget.current += 1
+        elif event.event_type == PolicyEventType.LLM_REQUEST:
+            self.llm_call_budget.current += 1
+
+        # Update from payload if present
+        self._update_from_payload(event.payload)
+
+        # Check all budgets
+        soft_breached, hard_breached = self._check_budgets()
+
+        # Build status messages
+        breach_details = []
+        for name, budget in hard_breached:
+            breach_details.append(self._format_budget_status(name, budget))
+        for name, budget in soft_breached:
+            breach_details.append(self._format_budget_status(name, budget))
+
+        metadata: dict[str, Any] = {
+            "token_usage": self.token_budget.current,
+            "cost_usage": self.cost_budget.current,
+            "time_usage": self.time_budget.current,
+            "tool_call_count": self.tool_call_budget.current,
+            "llm_call_count": self.llm_call_budget.current,
+        }
+
+        # Handle hard limit breaches
+        if hard_breached:
+            names = [name for name, _ in hard_breached]
+
+            if self.mode == BudgetMode.PERMISSIVE:
+                # Even permissive mode warns on hard limits
+                return PolicyDecision.suggest(
+                    policy_id=self.id,
+                    reason=f"Budget exceeded for: {', '.join(names)}. {'; '.join(breach_details)}",
+                    severity=Severity.HIGH,
+                    tags=["budget", "exceeded"] + names,
+                    metadata=metadata,
+                )
+            else:
+                return PolicyDecision.block(
+                    policy_id=self.id,
+                    reason=f"Budget limit reached for: {', '.join(names)}. {'; '.join(breach_details)}",
+                    severity=Severity.CRITICAL,
+                    tags=["budget", "limit-reached"] + names,
+                    metadata=metadata,
+                )
+
+        # Handle soft limit breaches
+        if soft_breached:
+            names = [name for name, _ in soft_breached]
+
+            if self.mode == BudgetMode.STRICT:
+                return PolicyDecision.require_confirm(
+                    policy_id=self.id,
+                    reason=f"Approaching budget limit for: {', '.join(names)}. {'; '.join(breach_details)}",
+                    severity=Severity.MEDIUM,
+                    tags=["budget", "warning"] + names,
+                    metadata=metadata,
+                )
+            else:
+                return PolicyDecision.suggest(
+                    policy_id=self.id,
+                    reason=f"Approaching budget limit for: {', '.join(names)}. {'; '.join(breach_details)}",
+                    severity=Severity.LOW,
+                    tags=["budget", "warning"] + names,
+                    metadata=metadata,
+                )
+
+        # All within limits
+        return PolicyDecision.allow(
+            policy_id=self.id,
+            reason="All budgets within limits",
+            metadata=metadata,
+        )
+
+    def reset(self) -> None:
+        """Reset all budget counters."""
+        self.token_budget.current = 0
+        self.cost_budget.current = 0
+        self.time_budget.current = 0
+        self.tool_call_budget.current = 0
+        self.llm_call_budget.current = 0
+        self._start_time = time.time()
+
+    def set_token_limit(
+        self, hard_limit: float, soft_limit: Optional[float] = None
+    ) -> None:
+        """Set token budget limits."""
+        self.token_budget.hard_limit = hard_limit
+        self.token_budget.soft_limit = soft_limit or (hard_limit * 0.8)
+
+    def set_cost_limit(
+        self, hard_limit: float, soft_limit: Optional[float] = None
+    ) -> None:
+        """Set cost budget limits."""
+        self.cost_budget.hard_limit = hard_limit
+        self.cost_budget.soft_limit = soft_limit or (hard_limit * 0.8)
+
+    def set_time_limit(
+        self, hard_limit: float, soft_limit: Optional[float] = None
+    ) -> None:
+        """Set time budget limits (in seconds)."""
+        self.time_budget.hard_limit = hard_limit
+        self.time_budget.soft_limit = soft_limit or (hard_limit * 0.8)
+
+    def get_usage_summary(self) -> dict[str, Any]:
+        """Get a summary of current usage across all budgets."""
+        return {
+            "tokens": {
+                "current": self.token_budget.current,
+                "soft_limit": self.token_budget.soft_limit,
+                "hard_limit": self.token_budget.hard_limit,
+                "percent": self.token_budget.usage_percent,
+            },
+            "cost": {
+                "current": self.cost_budget.current,
+                "soft_limit": self.cost_budget.soft_limit,
+                "hard_limit": self.cost_budget.hard_limit,
+                "percent": self.cost_budget.usage_percent,
+            },
+            "time": {
+                "current": self.time_budget.current,
+                "soft_limit": self.time_budget.soft_limit,
+                "hard_limit": self.time_budget.hard_limit,
+                "percent": self.time_budget.usage_percent,
+            },
+            "tool_calls": {
+                "current": self.tool_call_budget.current,
+                "soft_limit": self.tool_call_budget.soft_limit,
+                "hard_limit": self.tool_call_budget.hard_limit,
+                "percent": self.tool_call_budget.usage_percent,
+            },
+            "llm_calls": {
+                "current": self.llm_call_budget.current,
+                "soft_limit": self.llm_call_budget.soft_limit,
+                "hard_limit": self.llm_call_budget.hard_limit,
+                "percent": self.llm_call_budget.usage_percent,
+            },
+        }

--- a/core/framework/policies/builtin/domain_allowlist.py
+++ b/core/framework/policies/builtin/domain_allowlist.py
@@ -1,0 +1,308 @@
+"""Domain allowlist policy for network tool calls.
+
+This policy evaluates network-related tool calls and checks
+whether the target domain is allowed, providing defense-in-depth
+against unintended external communications.
+"""
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+from urllib.parse import urlparse
+
+from framework.policies.base import BasePolicy
+from framework.policies.decisions import PolicyDecision, Severity
+from framework.policies.events import PolicyEvent, PolicyEventType
+
+
+class AllowlistMode(Enum):
+    """Operating modes for the domain allowlist."""
+
+    PERMISSIVE = "permissive"
+    """Log unknown domains but allow (SUGGEST)."""
+
+    BALANCED = "balanced"
+    """Require confirmation for unknown domains (REQUIRE_CONFIRM)."""
+
+    STRICT = "strict"
+    """Block unknown domains entirely (BLOCK)."""
+
+
+# Default patterns for network-related tools
+DEFAULT_NETWORK_TOOL_PATTERNS = [
+    r".*http.*",
+    r".*fetch.*",
+    r".*request.*",
+    r".*api.*call.*",
+    r".*url.*",
+    r".*web.*",
+    r".*download.*",
+    r".*upload.*",
+    r".*curl.*",
+    r".*webhook.*",
+]
+
+# Default allowed domains (common safe destinations)
+DEFAULT_ALLOWED_DOMAINS = [
+    # Localhost
+    "localhost",
+    "127.0.0.1",
+    "0.0.0.0",
+    # Common APIs that are generally safe
+    "api.openai.com",
+    "api.anthropic.com",
+    "api.github.com",
+    "raw.githubusercontent.com",
+]
+
+# Default blocked domains (known risky destinations)
+DEFAULT_BLOCKED_DOMAINS = [
+    # Pastebin-like services (potential data exfil)
+    "pastebin.com",
+    "hastebin.com",
+    "ghostbin.com",
+    # File sharing (potential data exfil)
+    "transfer.sh",
+    "file.io",
+    # Request catchers (potential data exfil)
+    "requestbin.com",
+    "webhook.site",
+    "hookbin.com",
+]
+
+
+@dataclass
+class DomainAllowlistPolicy(BasePolicy):
+    """Policy that controls which domains agents can communicate with.
+
+    This policy evaluates network-related tool calls and checks the
+    target URL/domain against allowlists and blocklists.
+
+    Operating modes:
+    - permissive: Log unknown domains but allow (SUGGEST)
+    - balanced: Require confirmation for unknown domains (REQUIRE_CONFIRM)
+    - strict: Block unknown domains entirely (BLOCK)
+
+    Attributes:
+        mode: Operating mode (permissive, balanced, strict)
+        allowed_domains: Domains that are always allowed
+        blocked_domains: Domains that are always blocked
+        network_tool_patterns: Regex patterns to identify network tools
+        check_subdomains: Whether to check parent domains
+
+    Example:
+        policy = DomainAllowlistPolicy(
+            mode=AllowlistMode.BALANCED,
+            allowed_domains=["api.mycompany.com", "*.internal.net"],
+        )
+        engine.register_policy(policy)
+    """
+
+    mode: AllowlistMode = AllowlistMode.PERMISSIVE
+    allowed_domains: list[str] = field(
+        default_factory=lambda: DEFAULT_ALLOWED_DOMAINS.copy()
+    )
+    blocked_domains: list[str] = field(
+        default_factory=lambda: DEFAULT_BLOCKED_DOMAINS.copy()
+    )
+    network_tool_patterns: list[str] = field(
+        default_factory=lambda: DEFAULT_NETWORK_TOOL_PATTERNS.copy()
+    )
+    check_subdomains: bool = True
+
+    # Policy metadata
+    _id: str = "domain-allowlist"
+    _name: str = "Domain Allowlist"
+    _description: str = (
+        "Controls which external domains agents can communicate with, "
+        "providing defense against unintended data exfiltration."
+    )
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    @property
+    def event_types(self) -> list[PolicyEventType]:
+        return [PolicyEventType.TOOL_CALL]
+
+    def _is_network_tool(self, tool_name: str) -> bool:
+        """Check if a tool is network-related."""
+        tool_lower = tool_name.lower()
+        for pattern in self.network_tool_patterns:
+            if re.match(pattern, tool_lower):
+                return True
+        return False
+
+    def _extract_domain(self, payload: dict) -> Optional[str]:
+        """Extract domain from tool call payload."""
+        # Check common parameter names for URLs
+        url_params = ["url", "endpoint", "uri", "href", "target", "destination"]
+
+        args = payload.get("args", {})
+
+        for param in url_params:
+            if param in args:
+                url = args[param]
+                if isinstance(url, str):
+                    try:
+                        parsed = urlparse(url)
+                        if parsed.netloc:
+                            # Remove port if present
+                            return parsed.netloc.split(":")[0].lower()
+                    except Exception:
+                        pass
+
+        # Check if domain is passed directly
+        if "domain" in args:
+            return str(args["domain"]).lower()
+        if "host" in args:
+            return str(args["host"]).lower()
+
+        return None
+
+    def _matches_domain(self, domain: str, pattern: str) -> bool:
+        """Check if a domain matches a pattern (supports wildcards)."""
+        pattern = pattern.lower()
+        domain = domain.lower()
+
+        # Exact match
+        if domain == pattern:
+            return True
+
+        # Wildcard match (*.example.com matches sub.example.com)
+        if pattern.startswith("*."):
+            suffix = pattern[2:]
+            if domain.endswith(suffix) or domain == suffix[1:]:
+                return True
+
+        # Subdomain check
+        if self.check_subdomains:
+            if domain.endswith("." + pattern):
+                return True
+
+        return False
+
+    def _is_allowed(self, domain: str) -> bool:
+        """Check if domain is in the allowlist."""
+        for allowed in self.allowed_domains:
+            if self._matches_domain(domain, allowed):
+                return True
+        return False
+
+    def _is_blocked(self, domain: str) -> bool:
+        """Check if domain is in the blocklist."""
+        for blocked in self.blocked_domains:
+            if self._matches_domain(domain, blocked):
+                return True
+        return False
+
+    async def evaluate(self, event: PolicyEvent) -> PolicyDecision:
+        """Evaluate a tool call for domain restrictions.
+
+        Args:
+            event: The TOOL_CALL event to evaluate
+
+        Returns:
+            PolicyDecision based on domain analysis
+        """
+        tool_name = event.payload.get("tool_name", "")
+
+        # Skip non-network tools
+        if not self._is_network_tool(tool_name):
+            return PolicyDecision.allow(
+                policy_id=self.id,
+                reason=f"Tool '{tool_name}' is not a network tool",
+            )
+
+        # Extract domain from payload
+        domain = self._extract_domain(event.payload)
+
+        if not domain:
+            # Can't determine domain - decide based on mode
+            if self.mode == AllowlistMode.STRICT:
+                return PolicyDecision.require_confirm(
+                    policy_id=self.id,
+                    reason=f"Cannot determine target domain for network tool '{tool_name}'",
+                    severity=Severity.MEDIUM,
+                    tags=["network", "unknown-domain"],
+                    metadata={"tool_name": tool_name},
+                )
+            return PolicyDecision.allow(
+                policy_id=self.id,
+                reason=f"Network tool '{tool_name}' - domain not specified in args",
+                metadata={"tool_name": tool_name},
+            )
+
+        # Check blocklist first (always enforced)
+        if self._is_blocked(domain):
+            return PolicyDecision.block(
+                policy_id=self.id,
+                reason=f"Domain '{domain}' is blocked (potential data exfiltration risk)",
+                severity=Severity.CRITICAL,
+                tags=["network", "blocked-domain", "security"],
+                metadata={"tool_name": tool_name, "domain": domain},
+            )
+
+        # Check allowlist
+        if self._is_allowed(domain):
+            return PolicyDecision.allow(
+                policy_id=self.id,
+                reason=f"Domain '{domain}' is in the allowlist",
+                metadata={"tool_name": tool_name, "domain": domain},
+            )
+
+        # Unknown domain - decide based on mode
+        if self.mode == AllowlistMode.PERMISSIVE:
+            return PolicyDecision.suggest(
+                policy_id=self.id,
+                reason=f"Domain '{domain}' is not in allowlist. Consider adding if trusted.",
+                severity=Severity.LOW,
+                tags=["network", "unknown-domain"],
+                metadata={"tool_name": tool_name, "domain": domain},
+            )
+        elif self.mode == AllowlistMode.BALANCED:
+            return PolicyDecision.require_confirm(
+                policy_id=self.id,
+                reason=f"Domain '{domain}' is not in allowlist. Confirm to proceed.",
+                severity=Severity.MEDIUM,
+                tags=["network", "unknown-domain", "requires-confirmation"],
+                metadata={"tool_name": tool_name, "domain": domain},
+            )
+        else:  # STRICT
+            return PolicyDecision.block(
+                policy_id=self.id,
+                reason=f"Domain '{domain}' is not in allowlist (strict mode)",
+                severity=Severity.HIGH,
+                tags=["network", "blocked-domain"],
+                metadata={"tool_name": tool_name, "domain": domain},
+            )
+
+    def add_allowed_domain(self, domain: str) -> None:
+        """Add a domain to the allowlist."""
+        if domain not in self.allowed_domains:
+            self.allowed_domains.append(domain)
+
+    def add_blocked_domain(self, domain: str) -> None:
+        """Add a domain to the blocklist."""
+        if domain not in self.blocked_domains:
+            self.blocked_domains.append(domain)
+
+    def remove_allowed_domain(self, domain: str) -> None:
+        """Remove a domain from the allowlist."""
+        if domain in self.allowed_domains:
+            self.allowed_domains.remove(domain)
+
+    def remove_blocked_domain(self, domain: str) -> None:
+        """Remove a domain from the blocklist."""
+        if domain in self.blocked_domains:
+            self.blocked_domains.remove(domain)

--- a/core/framework/policies/builtin/injection_guard.py
+++ b/core/framework/policies/builtin/injection_guard.py
@@ -1,0 +1,343 @@
+"""Injection guard policy for detecting prompt injection attempts.
+
+This policy analyzes tool outputs and other untrusted content for
+patterns that may indicate prompt injection attacks, where malicious
+content attempts to hijack agent behavior.
+"""
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+from framework.policies.base import BasePolicy
+from framework.policies.decisions import PolicyDecision, Severity
+from framework.policies.events import PolicyEvent, PolicyEventType
+
+
+class InjectionMode(Enum):
+    """Operating modes for injection detection."""
+
+    PERMISSIVE = "permissive"
+    """Flag suspicious patterns but allow (SUGGEST)."""
+
+    BALANCED = "balanced"
+    """Require confirmation for high-confidence detections."""
+
+    STRICT = "strict"
+    """Block any detected injection patterns."""
+
+
+# Patterns that may indicate prompt injection attempts
+# These are intentionally broad to catch variations
+INJECTION_PATTERNS = [
+    # Direct instruction override attempts
+    (r"ignore\s+(all\s+)?(previous|prior|above)\s+(instructions?|prompts?|rules?)", "instruction_override", Severity.HIGH),
+    (r"disregard\s+(all\s+)?(previous|prior|above)", "instruction_override", Severity.HIGH),
+    (r"forget\s+(everything|all|what)\s+(you|i)\s+(said|told|instructed)", "instruction_override", Severity.HIGH),
+    (r"new\s+instructions?:", "instruction_override", Severity.MEDIUM),
+    (r"system\s*:\s*you\s+are", "role_injection", Severity.HIGH),
+
+    # Role/persona hijacking
+    (r"you\s+are\s+now\s+(a|an|the)", "role_injection", Severity.MEDIUM),
+    (r"act\s+as\s+(a|an|if|though)", "role_injection", Severity.LOW),
+    (r"pretend\s+(to\s+be|you\s+are)", "role_injection", Severity.MEDIUM),
+    (r"from\s+now\s+on,?\s+you", "role_injection", Severity.MEDIUM),
+
+    # Jailbreak attempts
+    (r"developer\s+mode", "jailbreak", Severity.HIGH),
+    (r"dan\s+mode", "jailbreak", Severity.HIGH),
+    (r"jailbreak", "jailbreak", Severity.CRITICAL),
+    (r"bypass\s+(safety|security|filter|restriction)", "jailbreak", Severity.HIGH),
+
+    # Data exfiltration attempts
+    (r"(send|post|upload|transmit)\s+(to|this|the|all)\s+(url|endpoint|server|webhook)", "exfiltration", Severity.HIGH),
+    (r"curl\s+(-X\s+POST|--data)", "exfiltration", Severity.MEDIUM),
+    (r"base64\s+encode", "obfuscation", Severity.LOW),
+
+    # Hidden instruction markers
+    (r"\[INST\]", "hidden_instruction", Severity.MEDIUM),
+    (r"<\|im_start\|>", "hidden_instruction", Severity.MEDIUM),
+    (r"###\s*(Human|Assistant|System):", "hidden_instruction", Severity.MEDIUM),
+    (r"```system", "hidden_instruction", Severity.MEDIUM),
+
+    # Encoded/obfuscated commands
+    (r"eval\s*\(", "code_execution", Severity.HIGH),
+    (r"exec\s*\(", "code_execution", Severity.HIGH),
+    (r"__import__", "code_execution", Severity.HIGH),
+
+    # Privilege escalation
+    (r"sudo\s+", "privilege_escalation", Severity.HIGH),
+    (r"chmod\s+[0-7]{3,4}", "privilege_escalation", Severity.MEDIUM),
+    (r"rm\s+-rf\s+/", "destructive_command", Severity.CRITICAL),
+]
+
+# Benign patterns that might trigger false positives
+FALSE_POSITIVE_CONTEXTS = [
+    r"how\s+to\s+prevent",
+    r"example\s+of",
+    r"what\s+is\s+(a\s+)?prompt\s+injection",
+    r"security\s+(research|testing|audit)",
+    r"documentation",
+    r"tutorial",
+]
+
+
+@dataclass
+class InjectionGuardPolicy(BasePolicy):
+    """Policy that detects potential prompt injection in tool outputs.
+
+    This policy analyzes content from tool results and other untrusted
+    sources for patterns that may indicate prompt injection attacks.
+
+    Operating modes:
+    - permissive: Flag suspicious patterns but allow (SUGGEST)
+    - balanced: Require confirmation for high-confidence detections
+    - strict: Block any detected injection patterns
+
+    The policy labels tool outputs as "data" rather than "instructions"
+    by flagging content that appears to contain instruction-like patterns.
+
+    Attributes:
+        mode: Operating mode (permissive, balanced, strict)
+        custom_patterns: Additional patterns to detect
+        ignore_patterns: Patterns to ignore (reduce false positives)
+        min_severity: Minimum severity to act on
+
+    Example:
+        policy = InjectionGuardPolicy(
+            mode=InjectionMode.BALANCED,
+            custom_patterns=[
+                (r"my_custom_attack", "custom", Severity.HIGH),
+            ],
+        )
+        engine.register_policy(policy)
+    """
+
+    mode: InjectionMode = InjectionMode.PERMISSIVE
+    custom_patterns: list[tuple[str, str, Severity]] = field(default_factory=list)
+    ignore_patterns: list[str] = field(
+        default_factory=lambda: FALSE_POSITIVE_CONTEXTS.copy()
+    )
+    min_severity: Severity = Severity.LOW
+
+    # Policy metadata
+    _id: str = "injection-guard"
+    _name: str = "Injection Guard"
+    _description: str = (
+        "Detects potential prompt injection attempts in tool outputs "
+        "and other untrusted content."
+    )
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    @property
+    def event_types(self) -> list[PolicyEventType]:
+        return [PolicyEventType.TOOL_RESULT]
+
+    def _get_all_patterns(self) -> list[tuple[str, str, Severity]]:
+        """Get all detection patterns including custom ones."""
+        return INJECTION_PATTERNS + self.custom_patterns
+
+    def _extract_content(self, payload: dict) -> str:
+        """Extract text content from tool result payload."""
+        result = payload.get("result", "")
+
+        if isinstance(result, str):
+            return result
+        elif isinstance(result, dict):
+            # Try to extract text from common keys
+            for key in ["text", "content", "body", "output", "data", "message"]:
+                if key in result and isinstance(result[key], str):
+                    return str(result[key])
+            # Fall back to string representation
+            return str(result)
+        elif isinstance(result, list):
+            # Join list items
+            return " ".join(str(item) for item in result)
+        else:
+            return str(result)
+
+    def _is_false_positive_context(self, content: str) -> bool:
+        """Check if content appears to be in a benign context."""
+        content_lower = content.lower()
+        for pattern in self.ignore_patterns:
+            if re.search(pattern, content_lower, re.IGNORECASE):
+                return True
+        return False
+
+    def _severity_value(self, severity: Severity) -> int:
+        """Convert severity to numeric value for comparison."""
+        return {
+            Severity.LOW: 1,
+            Severity.MEDIUM: 2,
+            Severity.HIGH: 3,
+            Severity.CRITICAL: 4,
+        }[severity]
+
+    def _detect_patterns(
+        self, content: str
+    ) -> list[tuple[str, str, Severity, str]]:
+        """Detect injection patterns in content.
+
+        Returns:
+            List of (pattern, category, severity, matched_text) tuples
+        """
+        detections = []
+        content_lower = content.lower()
+
+        for pattern, category, severity in self._get_all_patterns():
+            # Skip if below minimum severity
+            if self._severity_value(severity) < self._severity_value(self.min_severity):
+                continue
+
+            matches = re.finditer(pattern, content_lower, re.IGNORECASE)
+            for match in matches:
+                matched_text = match.group(0)
+                detections.append((pattern, category, severity, matched_text))
+
+        return detections
+
+    async def evaluate(self, event: PolicyEvent) -> PolicyDecision:
+        """Evaluate tool output for injection patterns.
+
+        Args:
+            event: The TOOL_RESULT event to evaluate
+
+        Returns:
+            PolicyDecision based on injection detection
+        """
+        tool_name = event.payload.get("tool_name", "unknown")
+        content = self._extract_content(event.payload)
+
+        if not content:
+            return PolicyDecision.allow(
+                policy_id=self.id,
+                reason="No content to analyze",
+                metadata={"tool_name": tool_name},
+            )
+
+        # Check for false positive context
+        if self._is_false_positive_context(content):
+            return PolicyDecision.allow(
+                policy_id=self.id,
+                reason="Content appears to be in educational/documentation context",
+                metadata={"tool_name": tool_name, "false_positive_context": True},
+            )
+
+        # Detect patterns
+        detections = self._detect_patterns(content)
+
+        if not detections:
+            return PolicyDecision.allow(
+                policy_id=self.id,
+                reason="No injection patterns detected",
+                metadata={"tool_name": tool_name},
+            )
+
+        # Aggregate detections
+        categories = list(set(d[1] for d in detections))
+        # Find max severity using helper to compare enum values
+        max_severity = max(
+            (d[2] for d in detections),
+            key=lambda s: self._severity_value(s)
+        )
+        matched_texts = [d[3][:50] for d in detections[:3]]  # First 3, truncated
+
+        metadata: dict[str, Any] = {
+            "tool_name": tool_name,
+            "detection_count": len(detections),
+            "categories": categories,
+            "max_severity": max_severity.value,
+            "matched_samples": matched_texts,
+        }
+
+        reason = (
+            f"Detected {len(detections)} potential injection pattern(s) "
+            f"in output from '{tool_name}': {', '.join(categories)}"
+        )
+
+        # Decide action based on mode and severity
+        if self.mode == InjectionMode.PERMISSIVE:
+            return PolicyDecision.suggest(
+                policy_id=self.id,
+                reason=reason + ". Review tool output before using.",
+                severity=max_severity,
+                tags=["injection", "security"] + categories,
+                metadata=metadata,
+            )
+
+        elif self.mode == InjectionMode.BALANCED:
+            if max_severity in (Severity.HIGH, Severity.CRITICAL):
+                return PolicyDecision.require_confirm(
+                    policy_id=self.id,
+                    reason=reason + ". Confirm before proceeding.",
+                    severity=max_severity,
+                    tags=["injection", "security", "requires-confirmation"] + categories,
+                    metadata=metadata,
+                )
+            else:
+                return PolicyDecision.suggest(
+                    policy_id=self.id,
+                    reason=reason + ". Low confidence - review if concerned.",
+                    severity=max_severity,
+                    tags=["injection", "security"] + categories,
+                    metadata=metadata,
+                )
+
+        else:  # STRICT
+            if max_severity in (Severity.HIGH, Severity.CRITICAL):
+                return PolicyDecision.block(
+                    policy_id=self.id,
+                    reason=reason + ". Blocked in strict mode.",
+                    severity=max_severity,
+                    tags=["injection", "security", "blocked"] + categories,
+                    metadata=metadata,
+                )
+            else:
+                return PolicyDecision.require_confirm(
+                    policy_id=self.id,
+                    reason=reason + ". Confirm to proceed in strict mode.",
+                    severity=max_severity,
+                    tags=["injection", "security", "requires-confirmation"] + categories,
+                    metadata=metadata,
+                )
+
+    def add_pattern(
+        self, pattern: str, category: str, severity: Severity = Severity.MEDIUM
+    ) -> None:
+        """Add a custom detection pattern.
+
+        Args:
+            pattern: Regex pattern to detect
+            category: Category name for the pattern
+            severity: Severity level for detections
+        """
+        self.custom_patterns.append((pattern, category, severity))
+
+    def add_ignore_pattern(self, pattern: str) -> None:
+        """Add a pattern to reduce false positives.
+
+        Args:
+            pattern: Regex pattern for benign contexts
+        """
+        if pattern not in self.ignore_patterns:
+            self.ignore_patterns.append(pattern)
+
+    def set_min_severity(self, severity: Severity) -> None:
+        """Set minimum severity threshold for detections.
+
+        Args:
+            severity: Minimum severity to report
+        """
+        self.min_severity = severity

--- a/core/framework/policies/builtin/tool_gating.py
+++ b/core/framework/policies/builtin/tool_gating.py
@@ -1,0 +1,279 @@
+"""High-risk tool gating policy.
+
+This policy requires human confirmation before executing tools
+that perform destructive, sensitive, or irreversible actions.
+"""
+
+import fnmatch
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+from framework.policies.base import BasePolicy
+from framework.policies.decisions import PolicyDecision, Severity
+from framework.policies.events import PolicyEvent, PolicyEventType
+
+
+# Default patterns for high-risk tools
+DEFAULT_HIGH_RISK_PATTERNS = [
+    # Destructive operations
+    "*_delete",
+    "*_remove",
+    "*_drop",
+    "*_truncate",
+    "*_destroy",
+    # Write operations
+    "*_write",
+    "*_create",
+    "*_update",
+    "*_modify",
+    "*_set",
+    # Execution
+    "*_execute",
+    "*_run",
+    "*_eval",
+    "shell_*",
+    "bash_*",
+    "exec_*",
+    # Network/communication
+    "*_send",
+    "*_post",
+    "*_email",
+    "*_notify",
+    "*_publish",
+    # Credentials/auth (match both *_credential* and credential_*)
+    "*credential*",
+    "*secret*",
+    "*password*",
+    "token_*",
+    "*_token",
+    "*_key",
+    "key_*",
+    "*auth*",
+    # Specific high-risk tools
+    "file_write",
+    "file_delete",
+    "database_query",
+    "http_request",
+    "subprocess_run",
+]
+
+# Default patterns for always-allowed (safe) tools
+DEFAULT_SAFE_PATTERNS = [
+    "*_read",
+    "*_get",
+    "*_list",
+    "*_search",
+    "*_find",
+    "*_fetch",
+    "*_query",  # Read-only queries
+    "*_describe",
+    "*_info",
+    "*_status",
+    "*_check",
+    "*_validate",
+    "*_parse",
+    "*_format",
+    "*_convert",
+]
+
+
+@dataclass
+class HighRiskToolGatingPolicy(BasePolicy):
+    """Policy that requires confirmation for high-risk tool calls.
+
+    This policy evaluates tool calls against configurable patterns
+    to determine if human confirmation is required. Tools matching
+    high-risk patterns trigger REQUIRE_CONFIRM, while tools matching
+    safe patterns are allowed.
+
+    The policy uses glob-style patterns (fnmatch) for matching tool names.
+
+    Attributes:
+        high_risk_patterns: Patterns that trigger REQUIRE_CONFIRM
+        safe_patterns: Patterns that are always allowed
+        default_action: Action for tools matching neither pattern
+        severity: Severity level for REQUIRE_CONFIRM decisions
+
+    Example:
+        policy = HighRiskToolGatingPolicy(
+            high_risk_patterns=["*_delete", "*_execute"],
+            safe_patterns=["*_read", "*_list"],
+        )
+        engine.register_policy(policy)
+    """
+
+    high_risk_patterns: list[str] = field(
+        default_factory=lambda: DEFAULT_HIGH_RISK_PATTERNS.copy()
+    )
+    safe_patterns: list[str] = field(
+        default_factory=lambda: DEFAULT_SAFE_PATTERNS.copy()
+    )
+    default_action: str = "allow"  # "allow", "confirm", or "block"
+    severity: Severity = Severity.HIGH
+
+    # Policy metadata
+    _id: str = "high-risk-tool-gating"
+    _name: str = "High-Risk Tool Gating"
+    _description: str = (
+        "Requires human confirmation for tools that perform destructive, "
+        "sensitive, or irreversible actions."
+    )
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    @property
+    def event_types(self) -> list[PolicyEventType]:
+        return [PolicyEventType.TOOL_CALL]
+
+    def _matches_pattern(self, tool_name: str, patterns: list[str]) -> bool:
+        """Check if tool name matches any of the given patterns.
+
+        Args:
+            tool_name: The tool name to check
+            patterns: List of glob patterns to match against
+
+        Returns:
+            True if the tool matches any pattern
+        """
+        tool_lower = tool_name.lower()
+        for pattern in patterns:
+            if fnmatch.fnmatch(tool_lower, pattern.lower()):
+                return True
+        return False
+
+    def _get_matching_pattern(
+        self, tool_name: str, patterns: list[str]
+    ) -> Optional[str]:
+        """Get the first pattern that matches the tool name.
+
+        Args:
+            tool_name: The tool name to check
+            patterns: List of glob patterns to match against
+
+        Returns:
+            The first matching pattern, or None
+        """
+        tool_lower = tool_name.lower()
+        for pattern in patterns:
+            if fnmatch.fnmatch(tool_lower, pattern.lower()):
+                return pattern
+        return None
+
+    async def evaluate(self, event: PolicyEvent) -> PolicyDecision:
+        """Evaluate a tool call event.
+
+        Args:
+            event: The TOOL_CALL event to evaluate
+
+        Returns:
+            PolicyDecision indicating ALLOW or REQUIRE_CONFIRM
+        """
+        tool_name = event.payload.get("tool_name", "")
+        args = event.payload.get("args", {})
+
+        # Check safe patterns first (allow-list)
+        if self._matches_pattern(tool_name, self.safe_patterns):
+            return PolicyDecision.allow(
+                policy_id=self.id,
+                reason=f"Tool '{tool_name}' matches safe pattern",
+                metadata={
+                    "tool_name": tool_name,
+                    "matched_pattern": self._get_matching_pattern(
+                        tool_name, self.safe_patterns
+                    ),
+                },
+            )
+
+        # Check high-risk patterns
+        if self._matches_pattern(tool_name, self.high_risk_patterns):
+            matched_pattern = self._get_matching_pattern(
+                tool_name, self.high_risk_patterns
+            )
+            return PolicyDecision.require_confirm(
+                policy_id=self.id,
+                reason=(
+                    f"Tool '{tool_name}' is high-risk (matches '{matched_pattern}'). "
+                    f"Human confirmation required."
+                ),
+                severity=self.severity,
+                tags=["high-risk-tool", "requires-confirmation"],
+                metadata={
+                    "tool_name": tool_name,
+                    "args": args,
+                    "matched_pattern": matched_pattern,
+                },
+            )
+
+        # Default action for unmatched tools
+        if self.default_action == "confirm":
+            return PolicyDecision.require_confirm(
+                policy_id=self.id,
+                reason=(
+                    f"Tool '{tool_name}' requires confirmation "
+                    f"(no explicit safe pattern match)"
+                ),
+                severity=Severity.MEDIUM,
+                tags=["unknown-tool", "requires-confirmation"],
+                metadata={"tool_name": tool_name, "args": args},
+            )
+        elif self.default_action == "block":
+            return PolicyDecision.block(
+                policy_id=self.id,
+                reason=f"Tool '{tool_name}' is not in the allowed list",
+                severity=Severity.HIGH,
+                tags=["blocked-tool"],
+                metadata={"tool_name": tool_name, "args": args},
+            )
+        else:  # default: allow
+            return PolicyDecision.allow(
+                policy_id=self.id,
+                reason=f"Tool '{tool_name}' does not match any high-risk pattern",
+                metadata={"tool_name": tool_name},
+            )
+
+    def add_high_risk_pattern(self, pattern: str) -> None:
+        """Add a pattern to the high-risk list.
+
+        Args:
+            pattern: Glob pattern to add
+        """
+        if pattern not in self.high_risk_patterns:
+            self.high_risk_patterns.append(pattern)
+
+    def add_safe_pattern(self, pattern: str) -> None:
+        """Add a pattern to the safe list.
+
+        Args:
+            pattern: Glob pattern to add
+        """
+        if pattern not in self.safe_patterns:
+            self.safe_patterns.append(pattern)
+
+    def remove_high_risk_pattern(self, pattern: str) -> None:
+        """Remove a pattern from the high-risk list.
+
+        Args:
+            pattern: Glob pattern to remove
+        """
+        if pattern in self.high_risk_patterns:
+            self.high_risk_patterns.remove(pattern)
+
+    def remove_safe_pattern(self, pattern: str) -> None:
+        """Remove a pattern from the safe list.
+
+        Args:
+            pattern: Glob pattern to remove
+        """
+        if pattern in self.safe_patterns:
+            self.safe_patterns.remove(pattern)

--- a/core/framework/policies/decisions.py
+++ b/core/framework/policies/decisions.py
@@ -1,0 +1,211 @@
+"""Policy decision types for the guardrails system.
+
+Decisions represent the outcome of policy evaluation. Each decision
+indicates what action to take and provides context for that action.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Optional
+import uuid
+
+
+class PolicyAction(Enum):
+    """Actions that a policy can return."""
+
+    ALLOW = "allow"
+    """Proceed normally - no policy concerns."""
+
+    SUGGEST = "suggest"
+    """Proceed but attach guidance (e.g., prefer read-only tool)."""
+
+    REQUIRE_CONFIRM = "require_confirm"
+    """Pause execution for human-in-the-loop confirmation."""
+
+    BLOCK = "block"
+    """Stop execution with a structured exception."""
+
+
+class Severity(Enum):
+    """Severity levels for policy decisions."""
+
+    LOW = "low"
+    """Minor concern, informational."""
+
+    MEDIUM = "medium"
+    """Moderate concern, should be reviewed."""
+
+    HIGH = "high"
+    """Significant concern, requires attention."""
+
+    CRITICAL = "critical"
+    """Critical concern, immediate action required."""
+
+
+@dataclass
+class PolicyDecision:
+    """The result of evaluating a policy against an event.
+
+    A decision captures:
+    - What action to take (allow, suggest, require_confirm, block)
+    - Why this decision was made
+    - Metadata for logging, auditing, and handling
+
+    Attributes:
+        action: The action to take
+        reason: Human-readable explanation for the decision
+        policy_id: Identifier of the policy that made this decision
+        severity: How severe the concern is
+        tags: Categorization tags for filtering/analysis
+        suggested_patch: Optional modifications to make the action safe
+        requires_human: Whether human review is required
+        metadata: Additional context for logging/debugging
+        decision_id: Unique identifier for this decision
+        timestamp: When the decision was made
+    """
+
+    action: PolicyAction
+    reason: str
+    policy_id: str
+    severity: Severity = Severity.MEDIUM
+    tags: list[str] = field(default_factory=list)
+    suggested_patch: Optional[dict[str, Any]] = None
+    requires_human: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+    decision_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+    def __post_init__(self) -> None:
+        """Set requires_human based on action if not explicitly set."""
+        if self.action == PolicyAction.REQUIRE_CONFIRM:
+            self.requires_human = True
+
+    @classmethod
+    def allow(
+        cls,
+        policy_id: str,
+        reason: str = "No policy concerns",
+        **kwargs: Any,
+    ) -> "PolicyDecision":
+        """Create an ALLOW decision.
+
+        Args:
+            policy_id: The policy making this decision
+            reason: Why the action is allowed
+            **kwargs: Additional decision attributes
+
+        Returns:
+            A PolicyDecision with ALLOW action
+        """
+        return cls(
+            action=PolicyAction.ALLOW,
+            reason=reason,
+            policy_id=policy_id,
+            severity=Severity.LOW,
+            **kwargs,
+        )
+
+    @classmethod
+    def suggest(
+        cls,
+        policy_id: str,
+        reason: str,
+        suggested_patch: Optional[dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> "PolicyDecision":
+        """Create a SUGGEST decision.
+
+        Args:
+            policy_id: The policy making this decision
+            reason: Why a suggestion is being made
+            suggested_patch: Recommended modifications
+            **kwargs: Additional decision attributes
+
+        Returns:
+            A PolicyDecision with SUGGEST action
+        """
+        return cls(
+            action=PolicyAction.SUGGEST,
+            reason=reason,
+            policy_id=policy_id,
+            severity=kwargs.pop("severity", Severity.LOW),
+            suggested_patch=suggested_patch,
+            **kwargs,
+        )
+
+    @classmethod
+    def require_confirm(
+        cls,
+        policy_id: str,
+        reason: str,
+        severity: Severity = Severity.HIGH,
+        **kwargs: Any,
+    ) -> "PolicyDecision":
+        """Create a REQUIRE_CONFIRM decision.
+
+        Args:
+            policy_id: The policy making this decision
+            reason: Why confirmation is required
+            severity: Severity level (default HIGH)
+            **kwargs: Additional decision attributes
+
+        Returns:
+            A PolicyDecision with REQUIRE_CONFIRM action
+        """
+        return cls(
+            action=PolicyAction.REQUIRE_CONFIRM,
+            reason=reason,
+            policy_id=policy_id,
+            severity=severity,
+            requires_human=True,
+            **kwargs,
+        )
+
+    @classmethod
+    def block(
+        cls,
+        policy_id: str,
+        reason: str,
+        severity: Severity = Severity.CRITICAL,
+        **kwargs: Any,
+    ) -> "PolicyDecision":
+        """Create a BLOCK decision.
+
+        Args:
+            policy_id: The policy making this decision
+            reason: Why the action is blocked
+            severity: Severity level (default CRITICAL)
+            **kwargs: Additional decision attributes
+
+        Returns:
+            A PolicyDecision with BLOCK action
+        """
+        return cls(
+            action=PolicyAction.BLOCK,
+            reason=reason,
+            policy_id=policy_id,
+            severity=severity,
+            **kwargs,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the decision to a dictionary.
+
+        Returns:
+            Dictionary representation suitable for logging/storage
+        """
+        return {
+            "decision_id": self.decision_id,
+            "action": self.action.value,
+            "reason": self.reason,
+            "policy_id": self.policy_id,
+            "severity": self.severity.value,
+            "tags": self.tags,
+            "suggested_patch": self.suggested_patch,
+            "requires_human": self.requires_human,
+            "metadata": self.metadata,
+            "timestamp": self.timestamp,
+        }

--- a/core/framework/policies/engine.py
+++ b/core/framework/policies/engine.py
@@ -1,0 +1,341 @@
+"""Policy engine for orchestrating policy evaluation.
+
+The PolicyEngine is the central component that:
+- Registers and manages policies
+- Routes events to appropriate policies
+- Evaluates policies with short-circuit logic
+- Aggregates decisions and handles conflicts
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+from framework.policies.base import Policy
+from framework.policies.decisions import PolicyAction, PolicyDecision, Severity
+from framework.policies.events import PolicyEvent, PolicyEventType
+from framework.policies.exceptions import (
+    ConfirmationRequiredError,
+    PolicyRegistrationError,
+    PolicyViolationError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AggregatedDecision:
+    """Aggregated result from evaluating multiple policies.
+
+    When multiple policies evaluate an event, their decisions
+    are aggregated into a single result following these rules:
+    - BLOCK wins (short-circuits evaluation)
+    - REQUIRE_CONFIRM is next priority
+    - SUGGEST decisions are collected
+    - ALLOW only if all policies allow
+
+    Attributes:
+        final_action: The resulting action to take
+        decisions: All individual policy decisions
+        blocking_decision: The decision that caused a BLOCK (if any)
+        confirmation_decision: The decision requiring confirmation (if any)
+        suggestions: List of SUGGEST decisions
+    """
+
+    final_action: PolicyAction
+    decisions: list[PolicyDecision]
+    blocking_decision: Optional[PolicyDecision] = None
+    confirmation_decision: Optional[PolicyDecision] = None
+    suggestions: list[PolicyDecision] = field(default_factory=list)
+
+    @property
+    def is_allowed(self) -> bool:
+        """Check if the action is allowed to proceed."""
+        return self.final_action in (PolicyAction.ALLOW, PolicyAction.SUGGEST)
+
+    @property
+    def requires_confirmation(self) -> bool:
+        """Check if human confirmation is required."""
+        return self.final_action == PolicyAction.REQUIRE_CONFIRM
+
+    @property
+    def is_blocked(self) -> bool:
+        """Check if the action is blocked."""
+        return self.final_action == PolicyAction.BLOCK
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dictionary for logging."""
+        return {
+            "final_action": self.final_action.value,
+            "decision_count": len(self.decisions),
+            "blocking_decision": (
+                self.blocking_decision.to_dict()
+                if self.blocking_decision
+                else None
+            ),
+            "confirmation_decision": (
+                self.confirmation_decision.to_dict()
+                if self.confirmation_decision
+                else None
+            ),
+            "suggestion_count": len(self.suggestions),
+        }
+
+
+DecisionCallback = Callable[[PolicyDecision, PolicyEvent], None]
+
+
+class PolicyEngine:
+    """Orchestrates policy evaluation for events.
+
+    The engine manages a collection of policies and evaluates them
+    against events. It supports:
+    - Policy registration by event type
+    - Ordered evaluation with short-circuit on BLOCK
+    - Decision aggregation and conflict resolution
+    - Callbacks for observability
+
+    Example:
+        engine = PolicyEngine()
+        engine.register_policy(HighRiskToolGatingPolicy())
+
+        event = PolicyEvent.create(
+            event_type=PolicyEventType.TOOL_CALL,
+            payload={"tool_name": "file_delete", "args": {"path": "/tmp/x"}},
+            execution_id="exec-123",
+        )
+
+        result = await engine.evaluate(event)
+        if result.is_blocked:
+            raise PolicyViolationError(result.blocking_decision, event)
+    """
+
+    def __init__(
+        self,
+        *,
+        raise_on_block: bool = True,
+        raise_on_confirm: bool = False,
+    ) -> None:
+        """Initialize the PolicyEngine.
+
+        Args:
+            raise_on_block: Raise PolicyViolationError on BLOCK decisions
+            raise_on_confirm: Raise ConfirmationRequiredError on REQUIRE_CONFIRM
+        """
+        self._policies: dict[str, Policy] = {}
+        self._policies_by_event_type: dict[PolicyEventType, list[Policy]] = {
+            event_type: [] for event_type in PolicyEventType
+        }
+        self._decision_callbacks: list[DecisionCallback] = []
+        self._raise_on_block = raise_on_block
+        self._raise_on_confirm = raise_on_confirm
+
+    @property
+    def policies(self) -> dict[str, Policy]:
+        """Get all registered policies by ID."""
+        return self._policies.copy()
+
+    def register_policy(self, policy: Policy) -> None:
+        """Register a policy with the engine.
+
+        Args:
+            policy: The policy to register
+
+        Raises:
+            PolicyRegistrationError: If policy ID is already registered
+        """
+        if policy.id in self._policies:
+            raise PolicyRegistrationError(
+                f"Policy with ID '{policy.id}' is already registered"
+            )
+
+        self._policies[policy.id] = policy
+        for event_type in policy.event_types:
+            self._policies_by_event_type[event_type].append(policy)
+
+        logger.info(
+            "Registered policy",
+            extra={
+                "policy_id": policy.id,
+                "policy_name": policy.name,
+                "event_types": [et.value for et in policy.event_types],
+            },
+        )
+
+    def unregister_policy(self, policy_id: str) -> None:
+        """Unregister a policy from the engine.
+
+        Args:
+            policy_id: The ID of the policy to unregister
+
+        Raises:
+            KeyError: If policy ID is not registered
+        """
+        if policy_id not in self._policies:
+            raise KeyError(f"Policy '{policy_id}' is not registered")
+
+        policy = self._policies.pop(policy_id)
+        for event_type in policy.event_types:
+            self._policies_by_event_type[event_type].remove(policy)
+
+        logger.info(
+            "Unregistered policy",
+            extra={"policy_id": policy_id},
+        )
+
+    def add_decision_callback(self, callback: DecisionCallback) -> None:
+        """Add a callback to be invoked for each decision.
+
+        Callbacks receive the decision and event for logging,
+        metrics, or other observability purposes.
+
+        Args:
+            callback: Function to call with (decision, event)
+        """
+        self._decision_callbacks.append(callback)
+
+    def get_policies_for_event(
+        self, event_type: PolicyEventType
+    ) -> list[Policy]:
+        """Get all policies that handle a given event type.
+
+        Args:
+            event_type: The event type to look up
+
+        Returns:
+            List of policies that handle this event type
+        """
+        return self._policies_by_event_type[event_type].copy()
+
+    async def evaluate(self, event: PolicyEvent) -> AggregatedDecision:
+        """Evaluate all applicable policies against an event.
+
+        Policies are evaluated in registration order. Evaluation
+        short-circuits on BLOCK decisions.
+
+        Args:
+            event: The event to evaluate
+
+        Returns:
+            AggregatedDecision with the combined result
+
+        Raises:
+            PolicyViolationError: If raise_on_block=True and BLOCK decision
+            ConfirmationRequiredError: If raise_on_confirm=True and REQUIRE_CONFIRM
+        """
+        policies = self._policies_by_event_type.get(event.event_type, [])
+
+        if not policies:
+            # No policies for this event type - allow by default
+            return AggregatedDecision(
+                final_action=PolicyAction.ALLOW,
+                decisions=[],
+            )
+
+        decisions: list[PolicyDecision] = []
+        suggestions: list[PolicyDecision] = []
+        blocking_decision: Optional[PolicyDecision] = None
+        confirmation_decision: Optional[PolicyDecision] = None
+
+        for policy in policies:
+            try:
+                decision = await policy.evaluate(event)
+            except Exception as e:
+                logger.error(
+                    "Policy evaluation failed",
+                    extra={
+                        "policy_id": policy.id,
+                        "event_id": event.event_id,
+                        "error": str(e),
+                    },
+                )
+                # Policy errors result in a BLOCK for safety
+                decision = PolicyDecision.block(
+                    policy_id=policy.id,
+                    reason=f"Policy evaluation error: {e}",
+                    severity=Severity.CRITICAL,
+                    metadata={"error": str(e)},
+                )
+
+            decisions.append(decision)
+            self._notify_callbacks(decision, event)
+
+            # Handle decision by action type
+            if decision.action == PolicyAction.BLOCK:
+                blocking_decision = decision
+                # Short-circuit on BLOCK
+                break
+            elif decision.action == PolicyAction.REQUIRE_CONFIRM:
+                if confirmation_decision is None:
+                    confirmation_decision = decision
+            elif decision.action == PolicyAction.SUGGEST:
+                suggestions.append(decision)
+
+        # Determine final action (priority: BLOCK > REQUIRE_CONFIRM > SUGGEST > ALLOW)
+        if blocking_decision:
+            final_action = PolicyAction.BLOCK
+        elif confirmation_decision:
+            final_action = PolicyAction.REQUIRE_CONFIRM
+        elif suggestions:
+            final_action = PolicyAction.SUGGEST
+        else:
+            final_action = PolicyAction.ALLOW
+
+        result = AggregatedDecision(
+            final_action=final_action,
+            decisions=decisions,
+            blocking_decision=blocking_decision,
+            confirmation_decision=confirmation_decision,
+            suggestions=suggestions,
+        )
+
+        logger.debug(
+            "Policy evaluation complete",
+            extra={
+                "event_id": event.event_id,
+                "event_type": event.event_type.value,
+                "final_action": final_action.value,
+                "policy_count": len(policies),
+                "decision_count": len(decisions),
+            },
+        )
+
+        # Raise exceptions if configured
+        if self._raise_on_block and result.is_blocked:
+            assert blocking_decision is not None
+            raise PolicyViolationError(blocking_decision, event)
+
+        if self._raise_on_confirm and result.requires_confirmation:
+            assert confirmation_decision is not None
+            raise ConfirmationRequiredError(confirmation_decision, event)
+
+        return result
+
+    async def evaluate_many(
+        self, events: list[PolicyEvent]
+    ) -> list[AggregatedDecision]:
+        """Evaluate multiple events concurrently.
+
+        Args:
+            events: List of events to evaluate
+
+        Returns:
+            List of AggregatedDecision results in same order
+        """
+        return await asyncio.gather(
+            *[self.evaluate(event) for event in events]
+        )
+
+    def _notify_callbacks(
+        self, decision: PolicyDecision, event: PolicyEvent
+    ) -> None:
+        """Notify all registered callbacks of a decision."""
+        for callback in self._decision_callbacks:
+            try:
+                callback(decision, event)
+            except Exception as e:
+                logger.warning(
+                    "Decision callback failed",
+                    extra={"error": str(e)},
+                )

--- a/core/framework/policies/events.py
+++ b/core/framework/policies/events.py
@@ -1,0 +1,107 @@
+"""Policy event types for the guardrails system.
+
+Events represent actions that policies evaluate. Each event captures
+the context needed to make a policy decision.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Optional
+import uuid
+
+
+class PolicyEventType(Enum):
+    """Types of events that policies can evaluate."""
+
+    LLM_REQUEST = "llm_request"
+    """Before an LLM call - evaluate prompt, context, sensitive data."""
+
+    LLM_RESPONSE = "llm_response"
+    """After an LLM call - evaluate output for unsafe intent, data exfil."""
+
+    TOOL_CALL = "tool_call"
+    """Before a tool call - evaluate tool name, args, permissions."""
+
+    TOOL_RESULT = "tool_result"
+    """After a tool call - evaluate output for injection, provenance."""
+
+    SIDE_EFFECT = "side_effect"
+    """Before external side effects - send, write, mutate, post."""
+
+    RUN_CONTROL = "run_control"
+    """Runtime control events - budget, retry loops, execution limits."""
+
+
+@dataclass
+class PolicyEvent:
+    """An event submitted to the policy engine for evaluation.
+
+    Events are the primary input to policies. Each event captures:
+    - What type of action is being attempted
+    - Context about the execution (IDs, timing)
+    - Payload with action-specific details
+
+    Attributes:
+        event_type: The category of event (tool call, LLM request, etc.)
+        timestamp: ISO-formatted timestamp of when the event occurred
+        execution_id: Unique identifier for the current execution/run
+        payload: Event-specific data (tool name, args, etc.)
+        stream_id: Optional identifier for the agent stream
+        correlation_id: Optional ID for tracking related events
+        event_id: Unique identifier for this specific event
+    """
+
+    event_type: PolicyEventType
+    timestamp: str
+    execution_id: str
+    payload: dict[str, Any]
+    stream_id: Optional[str] = None
+    correlation_id: Optional[str] = None
+    event_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+    @classmethod
+    def create(
+        cls,
+        event_type: PolicyEventType,
+        payload: dict[str, Any],
+        execution_id: str,
+        stream_id: Optional[str] = None,
+        correlation_id: Optional[str] = None,
+    ) -> "PolicyEvent":
+        """Factory method to create an event with automatic timestamp.
+
+        Args:
+            event_type: The type of event
+            payload: Event-specific data
+            execution_id: The current execution ID
+            stream_id: Optional stream identifier
+            correlation_id: Optional correlation ID
+
+        Returns:
+            A new PolicyEvent instance
+        """
+        return cls(
+            event_type=event_type,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            execution_id=execution_id,
+            payload=payload,
+            stream_id=stream_id,
+            correlation_id=correlation_id,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the event to a dictionary.
+
+        Returns:
+            Dictionary representation suitable for logging/storage
+        """
+        return {
+            "event_id": self.event_id,
+            "event_type": self.event_type.value,
+            "timestamp": self.timestamp,
+            "execution_id": self.execution_id,
+            "stream_id": self.stream_id,
+            "correlation_id": self.correlation_id,
+            "payload": self.payload,
+        }

--- a/core/framework/policies/exceptions.py
+++ b/core/framework/policies/exceptions.py
@@ -1,0 +1,146 @@
+"""Exceptions for the guardrails system.
+
+Structured exceptions allow the runtime to handle policy violations
+deterministically (retry, escalate to HITL, degrade model, etc.).
+"""
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from framework.policies.decisions import PolicyDecision
+    from framework.policies.events import PolicyEvent
+
+
+class GuardrailsError(Exception):
+    """Base exception for all guardrails errors."""
+
+    pass
+
+
+class PolicyViolationError(GuardrailsError):
+    """Raised when a policy blocks an action.
+
+    This exception carries the full context of the violation,
+    allowing the runtime to:
+    - Log the violation with full details
+    - Escalate to human-in-the-loop if configured
+    - Retry with modified parameters
+    - Degrade to a safer model/approach
+
+    Attributes:
+        decision: The PolicyDecision that caused the block
+        event: The PolicyEvent that was evaluated
+        message: Human-readable error message
+
+    Example:
+        try:
+            await engine.evaluate(event)
+        except PolicyViolationError as e:
+            logger.error(
+                "Policy violation",
+                policy_id=e.decision.policy_id,
+                reason=e.decision.reason,
+                event_type=e.event.event_type.value,
+            )
+            if e.decision.requires_human:
+                await escalate_to_human(e)
+    """
+
+    def __init__(
+        self,
+        decision: "PolicyDecision",
+        event: "PolicyEvent",
+        message: Optional[str] = None,
+    ) -> None:
+        """Initialize the PolicyViolationError.
+
+        Args:
+            decision: The decision that blocked the action
+            event: The event that was evaluated
+            message: Optional custom message (defaults to decision reason)
+        """
+        self.decision = decision
+        self.event = event
+        super().__init__(message or decision.reason)
+
+    def to_dict(self) -> dict:
+        """Serialize the error for logging/storage.
+
+        Returns:
+            Dictionary with decision and event details
+        """
+        return {
+            "error_type": "PolicyViolationError",
+            "message": str(self),
+            "decision": self.decision.to_dict(),
+            "event": self.event.to_dict(),
+        }
+
+
+class PolicyConfigurationError(GuardrailsError):
+    """Raised when a policy is misconfigured.
+
+    This can happen when:
+    - Required configuration is missing
+    - Configuration values are invalid
+    - Policy dependencies are not met
+    """
+
+    pass
+
+
+class PolicyRegistrationError(GuardrailsError):
+    """Raised when policy registration fails.
+
+    This can happen when:
+    - A policy with the same ID is already registered
+    - The policy doesn't implement the required interface
+    - The policy's event types are invalid
+    """
+
+    pass
+
+
+class ConfirmationRequiredError(GuardrailsError):
+    """Raised when human confirmation is required to proceed.
+
+    This is a non-blocking indication that the action requires
+    human approval before continuing. The runtime should pause
+    and request confirmation.
+
+    Attributes:
+        decision: The PolicyDecision requiring confirmation
+        event: The PolicyEvent that was evaluated
+    """
+
+    def __init__(
+        self,
+        decision: "PolicyDecision",
+        event: "PolicyEvent",
+        message: Optional[str] = None,
+    ) -> None:
+        """Initialize the ConfirmationRequiredError.
+
+        Args:
+            decision: The decision requiring confirmation
+            event: The event that was evaluated
+            message: Optional custom message
+        """
+        self.decision = decision
+        self.event = event
+        super().__init__(
+            message or f"Confirmation required: {decision.reason}"
+        )
+
+    def to_dict(self) -> dict:
+        """Serialize the error for logging/storage.
+
+        Returns:
+            Dictionary with decision and event details
+        """
+        return {
+            "error_type": "ConfirmationRequiredError",
+            "message": str(self),
+            "decision": self.decision.to_dict(),
+            "event": self.event.to_dict(),
+        }

--- a/core/framework/policies/interceptors/__init__.py
+++ b/core/framework/policies/interceptors/__init__.py
@@ -1,0 +1,9 @@
+"""Interceptors for creating policy events from agent actions.
+
+Interceptors sit between the agent runtime and the policy engine,
+creating PolicyEvents from tool calls, LLM requests, and other actions.
+"""
+
+from framework.policies.interceptors.tool import ToolInterceptor
+
+__all__ = ["ToolInterceptor"]

--- a/core/framework/policies/interceptors/tool.py
+++ b/core/framework/policies/interceptors/tool.py
@@ -1,0 +1,224 @@
+"""Tool call interceptor for creating policy events.
+
+The ToolInterceptor creates PolicyEvents from tool calls and results,
+enabling policies to evaluate tool usage.
+"""
+
+from typing import Any, Optional
+
+from framework.policies.decisions import PolicyAction
+from framework.policies.engine import AggregatedDecision, PolicyEngine
+from framework.policies.events import PolicyEvent, PolicyEventType
+from framework.policies.exceptions import ConfirmationRequiredError, PolicyViolationError
+
+
+class ToolInterceptor:
+    """Intercepts tool calls and evaluates them against policies.
+
+    The interceptor creates PolicyEvents from tool calls and submits
+    them to the PolicyEngine for evaluation. It provides methods for
+    both before and after tool execution.
+
+    Example:
+        engine = PolicyEngine()
+        engine.register_policy(HighRiskToolGatingPolicy())
+        interceptor = ToolInterceptor(engine, execution_id="exec-123")
+
+        # Before calling a tool
+        result = await interceptor.before_call("file_delete", {"path": "/tmp/x"})
+        if result.requires_confirmation:
+            # Request human approval
+            approved = await request_human_approval(result.confirmation_decision)
+            if not approved:
+                return
+
+        # Execute the tool
+        tool_result = await execute_tool("file_delete", {"path": "/tmp/x"})
+
+        # After tool execution
+        await interceptor.after_call("file_delete", tool_result)
+    """
+
+    def __init__(
+        self,
+        engine: PolicyEngine,
+        execution_id: str,
+        stream_id: Optional[str] = None,
+    ) -> None:
+        """Initialize the ToolInterceptor.
+
+        Args:
+            engine: The PolicyEngine to use for evaluation
+            execution_id: The current execution ID
+            stream_id: Optional stream identifier
+        """
+        self._engine = engine
+        self._execution_id = execution_id
+        self._stream_id = stream_id
+        self._correlation_counter = 0
+
+    def _next_correlation_id(self) -> str:
+        """Generate the next correlation ID for tracking call pairs."""
+        self._correlation_counter += 1
+        return f"{self._execution_id}:tool:{self._correlation_counter}"
+
+    async def before_call(
+        self,
+        tool_name: str,
+        args: dict[str, Any],
+        *,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> AggregatedDecision:
+        """Evaluate a tool call before execution.
+
+        Creates a TOOL_CALL event and submits it to the policy engine.
+
+        Args:
+            tool_name: Name of the tool being called
+            args: Arguments being passed to the tool
+            metadata: Optional additional context
+
+        Returns:
+            AggregatedDecision from policy evaluation
+
+        Raises:
+            PolicyViolationError: If engine.raise_on_block and BLOCK
+            ConfirmationRequiredError: If engine.raise_on_confirm and REQUIRE_CONFIRM
+        """
+        correlation_id = self._next_correlation_id()
+
+        event = PolicyEvent.create(
+            event_type=PolicyEventType.TOOL_CALL,
+            payload={
+                "tool_name": tool_name,
+                "args": args,
+                "metadata": metadata or {},
+            },
+            execution_id=self._execution_id,
+            stream_id=self._stream_id,
+            correlation_id=correlation_id,
+        )
+
+        return await self._engine.evaluate(event)
+
+    async def after_call(
+        self,
+        tool_name: str,
+        result: Any,
+        *,
+        success: bool = True,
+        error: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
+        correlation_id: Optional[str] = None,
+    ) -> AggregatedDecision:
+        """Evaluate a tool result after execution.
+
+        Creates a TOOL_RESULT event and submits it to the policy engine.
+        This allows policies to detect injection attempts in tool output.
+
+        Args:
+            tool_name: Name of the tool that was called
+            result: The result returned by the tool
+            success: Whether the tool call succeeded
+            error: Error message if the call failed
+            metadata: Optional additional context
+            correlation_id: Optional ID to correlate with before_call
+
+        Returns:
+            AggregatedDecision from policy evaluation
+        """
+        event = PolicyEvent.create(
+            event_type=PolicyEventType.TOOL_RESULT,
+            payload={
+                "tool_name": tool_name,
+                "result": result,
+                "success": success,
+                "error": error,
+                "metadata": metadata or {},
+            },
+            execution_id=self._execution_id,
+            stream_id=self._stream_id,
+            correlation_id=correlation_id,
+        )
+
+        return await self._engine.evaluate(event)
+
+    async def intercept(
+        self,
+        tool_name: str,
+        args: dict[str, Any],
+        execute_fn: Any,  # Callable that executes the tool
+        *,
+        metadata: Optional[dict[str, Any]] = None,
+        on_confirm_required: Optional[Any] = None,  # Callback for confirmation
+    ) -> Any:
+        """Full interception: evaluate before, execute, evaluate after.
+
+        This is a convenience method that handles the full lifecycle
+        of tool interception.
+
+        Args:
+            tool_name: Name of the tool to call
+            args: Arguments for the tool
+            execute_fn: Async function to execute the tool
+            metadata: Optional additional context
+            on_confirm_required: Optional callback for confirmation requests
+
+        Returns:
+            The tool execution result
+
+        Raises:
+            PolicyViolationError: If the tool call is blocked
+            ConfirmationRequiredError: If confirmation is required and no callback
+        """
+        # Evaluate before
+        before_result = await self.before_call(tool_name, args, metadata=metadata)
+
+        # Handle confirmation requirement
+        if before_result.requires_confirmation:
+            if on_confirm_required:
+                approved = await on_confirm_required(
+                    before_result.confirmation_decision
+                )
+                if not approved:
+                    raise PolicyViolationError(
+                        before_result.confirmation_decision,  # type: ignore
+                        PolicyEvent.create(
+                            event_type=PolicyEventType.TOOL_CALL,
+                            payload={"tool_name": tool_name, "args": args},
+                            execution_id=self._execution_id,
+                        ),
+                        message="User denied confirmation",
+                    )
+            else:
+                raise ConfirmationRequiredError(
+                    before_result.confirmation_decision,  # type: ignore
+                    PolicyEvent.create(
+                        event_type=PolicyEventType.TOOL_CALL,
+                        payload={"tool_name": tool_name, "args": args},
+                        execution_id=self._execution_id,
+                    ),
+                )
+
+        # Execute the tool
+        try:
+            result = await execute_fn(tool_name, args)
+            success = True
+            error = None
+        except Exception as e:
+            result = None
+            success = False
+            error = str(e)
+            raise  # Re-raise after recording
+
+        finally:
+            # Evaluate after (even on error)
+            await self.after_call(
+                tool_name,
+                result,
+                success=success,
+                error=error,
+                metadata=metadata,
+            )
+
+        return result

--- a/core/framework/runtime/agent_runtime.py
+++ b/core/framework/runtime/agent_runtime.py
@@ -100,6 +100,7 @@ class AgentRuntime:
         tools: list["Tool"] | None = None,
         tool_executor: Callable | None = None,
         config: AgentRuntimeConfig | None = None,
+        policy_engine: Any | None = None,
     ):
         """
         Initialize agent runtime.
@@ -112,6 +113,7 @@ class AgentRuntime:
             tools: Available tools
             tool_executor: Function to execute tools
             config: Optional runtime configuration
+            policy_engine: Optional PolicyEngine for tool call policy evaluation
         """
         self.graph = graph
         self.goal = goal
@@ -133,6 +135,7 @@ class AgentRuntime:
         self._llm = llm
         self._tools = tools or []
         self._tool_executor = tool_executor
+        self._policy_engine = policy_engine
 
         # Entry points and streams
         self._entry_points: dict[str, EntryPointSpec] = {}
@@ -212,6 +215,7 @@ class AgentRuntime:
                     tool_executor=self._tool_executor,
                     result_retention_max=self._config.execution_result_max,
                     result_retention_ttl_seconds=self._config.execution_result_ttl_seconds,
+                    policy_engine=self._policy_engine,
                 )
                 await stream.start()
                 self._streams[ep_id] = stream
@@ -429,6 +433,7 @@ def create_agent_runtime(
     tools: list["Tool"] | None = None,
     tool_executor: Callable | None = None,
     config: AgentRuntimeConfig | None = None,
+    policy_engine: Any | None = None,
 ) -> AgentRuntime:
     """
     Create and configure an AgentRuntime with entry points.
@@ -444,6 +449,7 @@ def create_agent_runtime(
         tools: Available tools
         tool_executor: Tool executor function
         config: Runtime configuration
+        policy_engine: Optional PolicyEngine for tool call policy evaluation
 
     Returns:
         Configured AgentRuntime (not yet started)
@@ -456,6 +462,7 @@ def create_agent_runtime(
         tools=tools,
         tool_executor=tool_executor,
         config=config,
+        policy_engine=policy_engine,
     )
 
     for spec in entry_points:

--- a/core/framework/runtime/execution_stream.py
+++ b/core/framework/runtime/execution_stream.py
@@ -112,6 +112,7 @@ class ExecutionStream:
         tool_executor: Callable | None = None,
         result_retention_max: int | None = 1000,
         result_retention_ttl_seconds: float | None = None,
+        policy_engine: Any | None = None,
     ):
         """
         Initialize execution stream.
@@ -128,6 +129,7 @@ class ExecutionStream:
             llm: LLM provider for nodes
             tools: Available tools
             tool_executor: Function to execute tools
+            policy_engine: Optional PolicyEngine for tool call policy evaluation
         """
         self.stream_id = stream_id
         self.entry_spec = entry_spec
@@ -142,6 +144,7 @@ class ExecutionStream:
         self._tool_executor = tool_executor
         self._result_retention_max = result_retention_max
         self._result_retention_ttl_seconds = result_retention_ttl_seconds
+        self._policy_engine = policy_engine
 
         # Create stream-scoped runtime
         self._runtime = StreamRuntime(
@@ -320,6 +323,7 @@ class ExecutionStream:
                     llm=self._llm,
                     tools=self._tools,
                     tool_executor=self._tool_executor,
+                    policy_engine=self._policy_engine,
                 )
 
                 # Create modified graph with entry point

--- a/core/tests/test_policy_integration.py
+++ b/core/tests/test_policy_integration.py
@@ -1,0 +1,439 @@
+"""
+Integration tests for PolicyEngine runtime wiring.
+
+These tests verify that policies are evaluated during tool execution
+when a PolicyEngine is configured on the GraphExecutor.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from framework.graph.edge import EdgeSpec, GraphSpec
+from framework.graph.executor import GraphExecutor
+from framework.graph.goal import Goal
+from framework.graph.node import NodeContext, NodeProtocol, NodeResult, NodeSpec
+from framework.llm.provider import ToolResult, ToolUse
+from framework.policies.builtin.tool_gating import HighRiskToolGatingPolicy
+from framework.policies.engine import PolicyEngine
+from framework.runtime.core import Runtime
+
+
+# === Fixtures ===
+
+
+@pytest.fixture
+def runtime(tmp_path):
+    """Create a real Runtime with temp storage."""
+    return Runtime(storage_path=tmp_path / "runtime_storage")
+
+
+@pytest.fixture
+def simple_graph():
+    """Minimal graph with one LLM tool node and a terminal node."""
+    nodes = [
+        NodeSpec(
+            id="tool-node",
+            name="Tool Node",
+            description="Calls a tool",
+            node_type="llm_tool_use",
+            input_keys=["query"],
+            output_keys=["result"],
+            tools=["safe_read", "dangerous_delete"],
+        ),
+    ]
+    edges = []
+    return GraphSpec(
+        id="test-graph",
+        goal_id="test-goal",
+        version="1.0.0",
+        entry_node="tool-node",
+        terminal_nodes=["tool-node"],
+        nodes=nodes,
+        edges=edges,
+        max_steps=5,
+    )
+
+
+@pytest.fixture
+def goal():
+    return Goal(
+        id="test-goal",
+        name="Test Goal",
+        description="Test policy integration",
+    )
+
+
+def _make_tool_executor():
+    """Create a tool executor that records calls and returns success."""
+    calls = []
+
+    def executor(tool_use: ToolUse) -> ToolResult:
+        calls.append(tool_use)
+        return ToolResult(
+            tool_use_id=tool_use.id,
+            content=json.dumps({"status": "ok", "tool": tool_use.name}),
+            is_error=False,
+        )
+
+    return executor, calls
+
+
+# === Tests: PolicyEngine wraps tool executor ===
+
+
+class TestPolicyToolInterception:
+    """Test that the PolicyEngine intercepts tool calls via GraphExecutor."""
+
+    def test_executor_wraps_tool_executor_when_engine_provided(self, runtime):
+        """Verify the tool executor is wrapped when a PolicyEngine is set."""
+        original, _calls = _make_tool_executor()
+        engine = PolicyEngine(raise_on_block=False)
+
+        executor = GraphExecutor(
+            runtime=runtime,
+            tool_executor=original,
+            policy_engine=engine,
+        )
+
+        # The tool_executor should be a different function (the wrapper)
+        assert executor.tool_executor is not original
+
+    def test_executor_preserves_tool_executor_without_engine(self, runtime):
+        """Without a PolicyEngine, the original executor is used directly."""
+        original, _calls = _make_tool_executor()
+
+        executor = GraphExecutor(
+            runtime=runtime,
+            tool_executor=original,
+        )
+
+        assert executor.tool_executor is original
+
+    def test_allowed_tool_call_passes_through(self, runtime):
+        """A tool call allowed by policy should execute normally."""
+        original, calls = _make_tool_executor()
+        engine = PolicyEngine(raise_on_block=False)
+        engine.register_policy(HighRiskToolGatingPolicy())
+
+        executor = GraphExecutor(
+            runtime=runtime,
+            tool_executor=original,
+            policy_engine=engine,
+        )
+
+        # Start a run so runtime has a run context
+        runtime.start_run("test-goal", "test")
+
+        tool_use = ToolUse(id="call_1", name="safe_read", input={"key": "value"})
+        result = executor.tool_executor(tool_use)
+
+        assert not result.is_error
+        assert len(calls) == 1
+        assert calls[0].name == "safe_read"
+
+        runtime.end_run(success=True)
+
+    def test_blocked_tool_call_returns_error(self, runtime):
+        """A tool call blocked by policy should return an error ToolResult."""
+        original, calls = _make_tool_executor()
+
+        # Create engine that blocks on high-risk patterns
+        # HighRiskToolGatingPolicy with default_action="block" blocks unknown tools in strict mode
+        engine = PolicyEngine(raise_on_block=False)
+        policy = HighRiskToolGatingPolicy(default_action="block")
+        engine.register_policy(policy)
+
+        executor = GraphExecutor(
+            runtime=runtime,
+            tool_executor=original,
+            policy_engine=engine,
+        )
+
+        runtime.start_run("test-goal", "test")
+
+        # "file_delete" matches high-risk patterns — will be REQUIRE_CONFIRM or BLOCK
+        tool_use = ToolUse(id="call_2", name="file_delete", input={"path": "/tmp/x"})
+        result = executor.tool_executor(tool_use)
+
+        # The original executor should NOT have been called
+        assert len(calls) == 0
+        assert result.is_error
+        content = json.loads(result.content)
+        assert "error" in content
+
+        runtime.end_run(success=True)
+
+    def test_require_confirm_denied_without_callback(self, runtime):
+        """REQUIRE_CONFIRM without approval callback should deny the call."""
+        original, calls = _make_tool_executor()
+        engine = PolicyEngine(raise_on_block=False, raise_on_confirm=False)
+        engine.register_policy(HighRiskToolGatingPolicy())
+
+        executor = GraphExecutor(
+            runtime=runtime,
+            tool_executor=original,
+            policy_engine=engine,
+            approval_callback=None,
+        )
+
+        runtime.start_run("test-goal", "test")
+
+        # "file_delete" matches high-risk patterns -> REQUIRE_CONFIRM
+        tool_use = ToolUse(id="call_3", name="file_delete", input={"path": "/tmp/x"})
+        result = executor.tool_executor(tool_use)
+
+        # Should be denied since no approval callback
+        assert result.is_error
+        assert len(calls) == 0
+        content = json.loads(result.content)
+        assert "denied" in content.get("error", "").lower() or "blocked" in content.get(
+            "error", ""
+        ).lower()
+
+        runtime.end_run(success=True)
+
+    def test_require_confirm_approved_with_callback(self, runtime):
+        """REQUIRE_CONFIRM with approving callback should allow execution."""
+        original, calls = _make_tool_executor()
+        engine = PolicyEngine(raise_on_block=False, raise_on_confirm=False)
+        engine.register_policy(HighRiskToolGatingPolicy())
+
+        # Approval callback that always approves
+        approve_cb = MagicMock(return_value=True)
+
+        executor = GraphExecutor(
+            runtime=runtime,
+            tool_executor=original,
+            policy_engine=engine,
+            approval_callback=approve_cb,
+        )
+
+        runtime.start_run("test-goal", "test")
+
+        tool_use = ToolUse(id="call_4", name="file_delete", input={"path": "/tmp/x"})
+        result = executor.tool_executor(tool_use)
+
+        # Callback should have been called
+        approve_cb.assert_called_once()
+        call_info = approve_cb.call_args[0][0]
+        assert call_info["type"] == "policy_confirmation"
+        assert call_info["tool_name"] == "file_delete"
+
+        # Tool should have executed
+        assert not result.is_error
+        assert len(calls) == 1
+
+        runtime.end_run(success=True)
+
+    def test_require_confirm_denied_with_callback(self, runtime):
+        """REQUIRE_CONFIRM with denying callback should block execution."""
+        original, calls = _make_tool_executor()
+        engine = PolicyEngine(raise_on_block=False, raise_on_confirm=False)
+        engine.register_policy(HighRiskToolGatingPolicy())
+
+        # Approval callback that always denies
+        deny_cb = MagicMock(return_value=False)
+
+        executor = GraphExecutor(
+            runtime=runtime,
+            tool_executor=original,
+            policy_engine=engine,
+            approval_callback=deny_cb,
+        )
+
+        runtime.start_run("test-goal", "test")
+
+        tool_use = ToolUse(id="call_5", name="file_delete", input={"path": "/tmp/x"})
+        result = executor.tool_executor(tool_use)
+
+        # Should be denied
+        assert result.is_error
+        assert len(calls) == 0
+
+        runtime.end_run(success=True)
+
+    def test_policy_decisions_recorded_in_runtime(self, runtime):
+        """Verify that blocked tool calls create runtime problem reports."""
+        from framework.policies.base import BasePolicy
+        from framework.policies.decisions import PolicyDecision, Severity
+        from framework.policies.events import PolicyEvent, PolicyEventType
+
+        # Create a custom policy that always blocks
+        class AlwaysBlockPolicy(BasePolicy):
+            _id: str = "always-block"
+            _name: str = "Always Block"
+            _description: str = "Blocks everything"
+            _event_types = [PolicyEventType.TOOL_CALL]
+
+            @property
+            def id(self):
+                return self._id
+
+            @property
+            def name(self):
+                return self._name
+
+            @property
+            def description(self):
+                return self._description
+
+            @property
+            def event_types(self):
+                return self._event_types
+
+            async def evaluate(self, event: PolicyEvent) -> PolicyDecision:
+                return PolicyDecision.block(
+                    policy_id=self._id,
+                    reason="Always blocked for testing",
+                    severity=Severity.HIGH,
+                )
+
+        original, _calls = _make_tool_executor()
+        engine = PolicyEngine(raise_on_block=False)
+        engine.register_policy(AlwaysBlockPolicy())
+
+        executor = GraphExecutor(
+            runtime=runtime,
+            tool_executor=original,
+            policy_engine=engine,
+        )
+
+        runtime.start_run("test-goal", "test")
+
+        tool_use = ToolUse(id="call_6", name="file_delete", input={"path": "/tmp"})
+        executor.tool_executor(tool_use)
+
+        # Check that a problem was reported
+        run = runtime.current_run
+        assert run is not None
+        assert len(run.problems) > 0
+        problem = run.problems[0]
+        assert "file_delete" in problem.description
+        assert problem.severity == "warning"
+
+        runtime.end_run(success=True)
+
+    def test_no_policies_registered_allows_everything(self, runtime):
+        """An empty PolicyEngine should allow all tool calls."""
+        original, calls = _make_tool_executor()
+        engine = PolicyEngine(raise_on_block=False)
+        # No policies registered
+
+        executor = GraphExecutor(
+            runtime=runtime,
+            tool_executor=original,
+            policy_engine=engine,
+        )
+
+        runtime.start_run("test-goal", "test")
+
+        tool_use = ToolUse(id="call_7", name="anything_at_all", input={})
+        result = executor.tool_executor(tool_use)
+
+        assert not result.is_error
+        assert len(calls) == 1
+
+        runtime.end_run(success=True)
+
+
+# === Tests: PolicyConfig builds engine correctly ===
+
+
+class TestPolicyConfig:
+    """Test that PolicyConfig correctly builds a PolicyEngine."""
+
+    def test_default_config_disabled(self):
+        """Default PolicyConfig with no policies enabled produces None."""
+        from framework.runner.runner import PolicyConfig
+
+        config = PolicyConfig()
+        # No policies enabled, even though enabled=True
+        # _build_policy_engine should return None since no policies registered
+        from framework.runner.runner import AgentRunner
+
+        # We can't easily test _build_policy_engine without an AgentRunner,
+        # so test the config structure instead
+        assert config.enabled is True
+        assert config.enable_tool_gating is False
+        assert config.enable_domain_allowlist is False
+        assert config.enable_budget_limits is False
+        assert config.enable_injection_guard is False
+
+    def test_config_with_tool_gating(self):
+        """PolicyConfig with tool_gating=True should enable gating policy."""
+        from framework.runner.runner import PolicyConfig
+
+        config = PolicyConfig(
+            enable_tool_gating=True,
+            tool_gating_mode="strict",
+        )
+        assert config.enable_tool_gating is True
+        assert config.tool_gating_mode == "strict"
+
+    def test_config_with_all_policies(self):
+        """PolicyConfig with all policies enabled."""
+        from framework.runner.runner import PolicyConfig
+
+        config = PolicyConfig(
+            enable_tool_gating=True,
+            enable_domain_allowlist=True,
+            allowed_domains=["api.example.com"],
+            enable_budget_limits=True,
+            token_limit=50000,
+            cost_limit_usd=0.50,
+            enable_injection_guard=True,
+        )
+        assert config.enable_tool_gating is True
+        assert config.enable_domain_allowlist is True
+        assert config.allowed_domains == ["api.example.com"]
+        assert config.enable_budget_limits is True
+        assert config.token_limit == 50000
+        assert config.cost_limit_usd == 0.50
+        assert config.enable_injection_guard is True
+
+    def test_policy_config_exported_from_framework(self):
+        """PolicyConfig should be importable from framework."""
+        from framework import PolicyConfig
+
+        config = PolicyConfig(enable_tool_gating=True)
+        assert config.enable_tool_gating is True
+
+
+# === Tests: Post-call evaluation (injection guard) ===
+
+
+class TestPostCallEvaluation:
+    """Test that TOOL_RESULT events are evaluated after tool execution."""
+
+    def test_post_call_evaluation_runs(self, runtime):
+        """Verify post-call evaluation happens even when pre-call allows."""
+        from framework.policies.builtin.injection_guard import (
+            InjectionGuardPolicy,
+            InjectionMode,
+        )
+
+        original, calls = _make_tool_executor()
+        engine = PolicyEngine(raise_on_block=False)
+        engine.register_policy(
+            InjectionGuardPolicy(mode=InjectionMode.PERMISSIVE)
+        )
+
+        executor = GraphExecutor(
+            runtime=runtime,
+            tool_executor=original,
+            policy_engine=engine,
+        )
+
+        runtime.start_run("test-goal", "test")
+
+        # Normal tool call — should pass both pre and post evaluation
+        tool_use = ToolUse(id="call_8", name="read_data", input={"key": "test"})
+        result = executor.tool_executor(tool_use)
+
+        # Should execute successfully
+        assert not result.is_error
+        assert len(calls) == 1
+
+        runtime.end_run(success=True)


### PR DESCRIPTION
 ## Summary
  - Wires PolicyEngine into GraphExecutor to intercept tool calls during execution
  - Four built-in policies: tool gating, domain allowlist, budget limits, injection guard
  - Declarative configuration via PolicyConfig on AgentRunner.load()
  - REQUIRE_CONFIRM decisions route to existing HITL approval_callback
  - 285 tests passing (271 existing + 14 new integration tests)

  ## Files Changed
  - `core/framework/graph/executor.py` — policy-aware tool executor wrapper
  - `core/framework/runner/runner.py` — PolicyConfig, _build_policy_engine()
  - `core/framework/runtime/agent_runtime.py` — policy_engine threaded through
  - `core/framework/runtime/execution_stream.py` — policy_engine forwarded to executor
  - `core/framework/__init__.py` — PolicyConfig exported
  - `core/framework/policies/` — policy engine, 4 built-in policies, README
  - `core/tests/test_policy_integration.py` — 14 integration tests

  ## Test plan
  - [ ] `PYTHONPATH=core pytest core/tests/ -v` (285 pass)
  - [ ] `pytest tests/ -v` (90 standalone pass)
  - [ ] Review PolicyConfig usage in policies/README.md