### PR TITLE
micro-fix(tools): view_file truncation respects max_size

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/view_file/view_file.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/view_file/view_file.py
@@ -59,9 +59,11 @@ def register_tools(mcp: FastMCP) -> None:
             with open(secure_path, encoding=encoding) as f:
                 content = f.read()
 
+            TRUNCATION_MSG = "\n\n[... Content truncated due to size limit ...]"
+            truncation_msg_size = len(TRUNCATION_MSG.encode(encoding))
             if len(content.encode(encoding)) > max_size:
-                content = content[:max_size]
-                content += "\n\n[... Content truncated due to size limit ...]"
+                truncate_at = max(0, max_size - truncation_msg_size)
+                content = content[:truncate_at] + TRUNCATION_MSG
 
             return {
                 "success": True,


### PR DESCRIPTION
  ## Description                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                       
  Fix `view_file` tool truncation that causes output to exceed the configured `max_size` by reserving space for the truncation message before truncating content.                                                                                                                                      
                                                                                                                                                                                                                                                                                                       
  ## Type of Change                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                       
  - [x] Bug fix (non-breaking change that fixes an issue)                                                                                                                                                                                                                                              
  - [ ] New feature (non-breaking change that adds functionality)                                                                                                                                                                                                                                      
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)                                                                                                                                                                                               
  - [ ] Documentation update                                                                                                                                                                                                                                                                           
  - [ ] Refactoring (no functional changes)                                                                                                                                                                                                                                                            

  Fixes #2725                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                       
  ## Changes Made                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                       
  - Reserve space for truncation message before truncating content                                                                                                                                                                                                                                     
  - Use `max(0, ...)` to handle edge case where `max_size` is smaller than truncation message itself                                                                                                                                                                                                   
  - Ensures final output never exceeds configured `max_size`                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                       
  ## Testing                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                       
  Describe the tests you ran to verify your changes:                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                       
  - [x] Unit tests pass (`cd core && pytest tests/`)                                                                                                                                                                                                                                                   
  - [x] Lint passes (`cd core && ruff check .`)                                                                                                                                                                                                                                                        
  - [x] Manual testing performed                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                       
  ## Checklist                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                       
  - [x] My code follows the project's style guidelines                                                                                                                                                                                                                                                 
  - [x] I have performed a self-review of my code                                                                                                                                                                                                                                                      
  - [ ] I have commented my code, particularly in hard-to-understand areas                                                                                                                                                                                                                             
  - [ ] I have made corresponding changes to the documentation                                                                                                                                                                                                                                         
  - [x] My changes generate no new warnings                                                                                                                                                                                                                                                            
  - [ ] I have added tests that prove my fix is effective or that my feature works                                                                                                                                                                                                                     
  - [x] New and existing unit tests pass locally with my changes                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                       
  ## Screenshots (if applicable)                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                       
  N/A                                                                                                                                                                                                                                                                                                  
                                                             