### PR TITLE
[micro-fix] chore: remove unnecessary pass statements from exception classes

### DIFF
--- a/core/framework/credentials/aden/client.py
+++ b/core/framework/credentials/aden/client.py
@@ -43,19 +43,13 @@ logger = logging.getLogger(__name__)
 class AdenClientError(Exception):
     """Base exception for Aden client errors."""
 
-    pass
-
 
 class AdenAuthenticationError(AdenClientError):
     """Raised when API key is invalid or revoked."""
 
-    pass
-
 
 class AdenNotFoundError(AdenClientError):
     """Raised when integration is not found."""
-
-    pass
 
 
 class AdenRefreshError(AdenClientError):

--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -224,8 +224,6 @@ class NodeSpec(BaseModel):
 class MemoryWriteError(Exception):
     """Raised when an invalid value is written to memory."""
 
-    pass
-
 
 @dataclass
 class SharedMemory:


### PR DESCRIPTION
## Description
Removes unnecessary `pass` statements from 4 exception class definitions. In Python, docstrings alone are sufficient class bodies, making `pass` redundant. This fixes 4 PIE790 ruff violations with zero functional impact.

## Type of Change
- [x] Refactoring (no functional changes)

## Changes Made
- Removed `pass` from [AdenClientError](cci:2://file:///c:/Users/Nihil/Desktop/projects/hive/core/framework/credentials/aden/client.py:42:0-43:48) in [core/framework/credentials/aden/client.py](cci:7://file:///c:/Users/Nihil/Desktop/projects/hive/core/framework/credentials/aden/client.py:0:0-0:0)
- Removed `pass` from [AdenAuthenticationError](cci:2://file:///c:/Users/Nihil/Desktop/projects/hive/core/framework/credentials/aden/client.py:46:0-47:52) in [core/framework/credentials/aden/client.py](cci:7://file:///c:/Users/Nihil/Desktop/projects/hive/core/framework/credentials/aden/client.py:0:0-0:0)
- Removed `pass` from [AdenNotFoundError](cci:2://file:///c:/Users/Nihil/Desktop/projects/hive/core/framework/credentials/aden/client.py:50:0-51:47) in [core/framework/credentials/aden/client.py](cci:7://file:///c:/Users/Nihil/Desktop/projects/hive/core/framework/credentials/aden/client.py:0:0-0:0)
- Removed `pass` from [MemoryWriteError](cci:2://file:///c:/Users/Nihil/Desktop/projects/hive/core/framework/graph/node.py:223:0-224:60) in [core/framework/graph/node.py](cci:7://file:///c:/Users/Nihil/Desktop/projects/hive/core/framework/graph/node.py:0:0-0:0)

## Testing
- [x] Python syntax validation passes (`py_compile`)
- [x] Ruff linting passes on modified files
- [x] Exception classes import and instantiate correctly
- [x] No new test failures introduced (existing failures unrelated)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Existing unit tests are unaffected by my changes