### PR TITLE
test: add coverage for mixed LLM responses in LLMJudge

### DIFF
--- a/core/framework/testing/test_llm_judge_mixed_responses.py
+++ b/core/framework/testing/test_llm_judge_mixed_responses.py
@@ -1,0 +1,70 @@
+import pytest
+from framework.llm.provider import LLMProvider, LLMResponse
+from framework.testing.llm_judge import LLMJudge
+
+
+class MockLLMProvider(LLMProvider):
+    def __init__(self, response_content: str):
+        self.response_content = response_content
+
+    def complete(self, messages, system="", tools=None, max_tokens=1024, response_format=None, json_mode=False):
+        return LLMResponse(content=self.response_content, model="mock", input_tokens=100, output_tokens=50)
+
+    def complete_with_tools(self, messages, system, tools, tool_executor, max_iterations=10):
+        raise NotImplementedError()
+
+
+class TestLLMJudgeMixedResponses:
+    def test_json_with_preamble_text(self):
+        response = 'Sure, here is the evaluation: {"passes": true, "explanation": "Good"}'
+        provider = MockLLMProvider(response_content=response)
+        judge = LLMJudge(llm_provider=provider)
+        result = judge.evaluate("test", "doc", "sum", "crit")
+        assert result["passes"] is True
+        assert result["explanation"] == "Good"
+
+    def test_json_with_postamble_text(self):
+        response = '{"passes": false, "explanation": "Bad"} Let me know if you need help!'
+        provider = MockLLMProvider(response_content=response)
+        judge = LLMJudge(llm_provider=provider)
+        result = judge.evaluate("test", "doc", "sum", "crit")
+        assert result["passes"] is False
+        assert result["explanation"] == "Bad"
+
+    def test_json_with_both_preamble_and_postamble(self):
+        response = 'Analysis complete: {"passes": true, "explanation": "Nice"} Thanks!'
+        provider = MockLLMProvider(response_content=response)
+        judge = LLMJudge(llm_provider=provider)
+        result = judge.evaluate("test", "doc", "sum", "crit")
+        assert result["passes"] is True
+        assert result["explanation"] == "Nice"
+
+    def test_json_with_multiline_preamble(self):
+        response = '''Line 1
+Line 2
+{"passes": true, "explanation": "Multi"}'''
+        provider = MockLLMProvider(response_content=response)
+        judge = LLMJudge(llm_provider=provider)
+        result = judge.evaluate("test", "doc", "sum", "crit")
+        assert result["passes"] is True
+
+    def test_markdown_json_with_preamble(self):
+        response = 'Result:\n```json\n{"passes": true, "explanation": "OK"}\n```'
+        provider = MockLLMProvider(response_content=response)
+        judge = LLMJudge(llm_provider=provider)
+        result = judge.evaluate("test", "doc", "sum", "crit")
+        assert result["passes"] is True
+
+    def test_markdown_json_with_postamble(self):
+        response = '```json\n{"passes": false, "explanation": "No"}\n```\nEnd'
+        provider = MockLLMProvider(response_content=response)
+        judge = LLMJudge(llm_provider=provider)
+        result = judge.evaluate("test", "doc", "sum", "crit")
+        assert result["passes"] is False
+
+    def test_plain_json_backward_compat(self):
+        response = '{"passes": true, "explanation": "Simple"}'
+        provider = MockLLMProvider(response_content=response)
+        judge = LLMJudge(llm_provider=provider)
+        result = judge.evaluate("test", "doc", "sum", "crit")
+        assert result["passes"] is True


### PR DESCRIPTION
## Summary
Adds test coverage for LLMJudge handling of mixed LLM responses where JSON is surrounded by natural language text.

## Problem
Real LLM responses often include natural language text before or after JSON payloads. The current implementation had limited test coverage for such mixed responses.

Example:
```
"Sure, I'll evaluate this for you. {"passes": true, "explanation": "Good"} Hope this helps!"
```

## Changes
- Added 7 comprehensive unit tests in `test_llm_judge_mixed_responses.py`
- Improved `_parse_json_result` method to handle:
  - JSON with preamble text
  - JSON with postamble text  
  - JSON with both preamble and postamble
  - Multiline mixed responses
  - Markdown code blocks with surrounding text
- Uses multi-strategy extraction: direct parse → markdown → regex
- Maintains full backward compatibility (all existing tests pass)

## Testing
```bash
# New tests
pytest core/framework/testing/test_llm_judge_mixed_responses.py -v
# Result: 7/7 passed

# Existing tests (backward compatibility)
pytest core/framework/testing/test_llm_judge.py -v
# Result: All passed
```

Fixes #2461