### PR TITLE
Fix web scrape tool handling of missing Content-Type

### DIFF
--- a/tools/src/aden_tools/tools/web_scrape_tool/web_scrape_tool.py
+++ b/tools/src/aden_tools/tools/web_scrape_tool/web_scrape_tool.py
@@ -153,7 +153,7 @@ def register_tools(mcp: FastMCP) -> None:
 
             if response.status_code != 200:
                 return {"error": f"HTTP {response.status_code}: Failed to fetch URL"}
-
+            """
             # Check content type
             content_type = response.headers.get("content-type", "").lower()
             if not any(t in content_type for t in ["text/html", "application/xhtml+xml"]):
@@ -161,6 +161,22 @@ def register_tools(mcp: FastMCP) -> None:
                     "error": f"Skipping non-HTML content (Content-Type: {content_type})",
                     "url": url,
                     "skipped": True,
+                }
+"""
+            content_type = response.headers.get("content-type")
+
+            # Normalize safely
+            if isinstance(content_type, str):
+                content_type = content_type.lower()
+            else:
+                content_type = None
+
+            # Only skip if header exists AND explicitly non-HTML
+            if content_type and "text/html" not in content_type:
+                return {
+                    "error": f"Skipping non-HTML content (Content-Type: {content_type})",
+                    "skipped": True,
+                    "url": url,
                 }
 
             # Parse HTML


### PR DESCRIPTION
Fixes #<2804>
## What does this PR do?
Fixes an issue where the web scrape tool incorrectly skipped valid HTML
responses when the Content-Type header was missing or mocked.

## Why is this needed?
Several tests in TestWebScrapeToolLinkConversion were failing because
the tool assumed Content-Type would always be present and a string.
This change makes the behavior more defensive and aligns with real-world HTTP responses.

## Tests
- Ran pytest in tools/
- 
<img width="904" 
<img width="900" height="442" alt="Screenshot_20260131_021047" src="https://github.com/user-attachments/assets/42662146-1912-4ec4-a53b-a689eb5c6cc3" />

<img width="931" height="827" alt="Screenshot_20260131_020914" src="https://github.com/user-attachments/assets/b157823d-488e-47e0-b35e-9546690c605b" />



