### PR TITLE
nodeConversation Class

### DIFF
--- a/core/framework/graph/__init__.py
+++ b/core/framework/graph/__init__.py
@@ -1,6 +1,7 @@
 """Graph structures: Goals, Nodes, Edges, and Flexible Execution."""
 
 from framework.graph.code_sandbox import CodeSandbox, safe_eval, safe_exec
+from framework.graph.conversation import ConversationStore, Message, NodeConversation
 from framework.graph.edge import EdgeCondition, EdgeSpec, GraphSpec
 from framework.graph.executor import GraphExecutor
 from framework.graph.flexible_executor import ExecutorConfig, FlexibleGraphExecutor
@@ -72,4 +73,8 @@ __all__ = [
     "CodeSandbox",
     "safe_exec",
     "safe_eval",
+    # Conversation
+    "NodeConversation",
+    "ConversationStore",
+    "Message",
 ]

--- a/core/framework/graph/conversation.py
+++ b/core/framework/graph/conversation.py
@@ -1,0 +1,426 @@
+"""NodeConversation: Message history management for graph nodes."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Literal, Protocol, runtime_checkable
+
+
+@dataclass
+class Message:
+    """A single message in a conversation.
+
+    Attributes:
+        seq: Monotonic sequence number.
+        role: One of "user", "assistant", or "tool".
+        content: Message text.
+        tool_use_id: Internal tool-use identifier (output as ``tool_call_id`` in LLM dicts).
+        tool_calls: OpenAI-format tool call list for assistant messages.
+        is_error: When True and role is "tool", ``to_llm_dict`` prepends "ERROR: " to content.
+    """
+
+    seq: int
+    role: Literal["user", "assistant", "tool"]
+    content: str
+    tool_use_id: str | None = None
+    tool_calls: list[dict[str, Any]] | None = None
+    is_error: bool = False
+
+    def to_llm_dict(self) -> dict[str, Any]:
+        """Convert to OpenAI-format message dict."""
+        if self.role == "user":
+            return {"role": "user", "content": self.content}
+
+        if self.role == "assistant":
+            d: dict[str, Any] = {"role": "assistant", "content": self.content}
+            if self.tool_calls:
+                d["tool_calls"] = self.tool_calls
+            return d
+
+        # role == "tool"
+        content = f"ERROR: {self.content}" if self.is_error else self.content
+        return {
+            "role": "tool",
+            "tool_call_id": self.tool_use_id,
+            "content": content,
+        }
+
+    def to_storage_dict(self) -> dict[str, Any]:
+        """Serialize all fields for persistence.  Omits None/default-False fields."""
+        d: dict[str, Any] = {
+            "seq": self.seq,
+            "role": self.role,
+            "content": self.content,
+        }
+        if self.tool_use_id is not None:
+            d["tool_use_id"] = self.tool_use_id
+        if self.tool_calls is not None:
+            d["tool_calls"] = self.tool_calls
+        if self.is_error:
+            d["is_error"] = self.is_error
+        return d
+
+    @classmethod
+    def from_storage_dict(cls, data: dict[str, Any]) -> Message:
+        """Deserialize from a storage dict."""
+        return cls(
+            seq=data["seq"],
+            role=data["role"],
+            content=data["content"],
+            tool_use_id=data.get("tool_use_id"),
+            tool_calls=data.get("tool_calls"),
+            is_error=data.get("is_error", False),
+        )
+
+
+# ---------------------------------------------------------------------------
+# ConversationStore protocol (Phase 2)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class ConversationStore(Protocol):
+    """Protocol for conversation persistence backends."""
+
+    async def write_part(self, seq: int, data: dict[str, Any]) -> None: ...
+
+    async def read_parts(self) -> list[dict[str, Any]]: ...
+
+    async def write_meta(self, data: dict[str, Any]) -> None: ...
+
+    async def read_meta(self) -> dict[str, Any] | None: ...
+
+    async def write_cursor(self, data: dict[str, Any]) -> None: ...
+
+    async def read_cursor(self) -> dict[str, Any] | None: ...
+
+    async def delete_parts_before(self, seq: int) -> None: ...
+
+    async def close(self) -> None: ...
+
+    async def destroy(self) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# NodeConversation
+# ---------------------------------------------------------------------------
+
+
+class NodeConversation:
+    """Message history for a graph node with optional write-through persistence.
+
+    When *store* is ``None`` the conversation works purely in-memory.
+    When a :class:`ConversationStore` is supplied every mutation is
+    persisted via write-through (meta is lazily written on the first
+    ``_persist`` call).
+    """
+
+    def __init__(
+        self,
+        system_prompt: str = "",
+        max_history_tokens: int = 32000,
+        compaction_threshold: float = 0.8,
+        output_keys: list[str] | None = None,
+        store: ConversationStore | None = None,
+    ) -> None:
+        self._system_prompt = system_prompt
+        self._max_history_tokens = max_history_tokens
+        self._compaction_threshold = compaction_threshold
+        self._output_keys = output_keys
+        self._store = store
+        self._messages: list[Message] = []
+        self._next_seq: int = 0
+        self._meta_persisted: bool = False
+
+    # --- Properties --------------------------------------------------------
+
+    @property
+    def system_prompt(self) -> str:
+        return self._system_prompt
+
+    @property
+    def messages(self) -> list[Message]:
+        """Return a defensive copy of the message list."""
+        return list(self._messages)
+
+    @property
+    def turn_count(self) -> int:
+        """Number of conversational turns (one turn = one user message)."""
+        return sum(1 for m in self._messages if m.role == "user")
+
+    @property
+    def message_count(self) -> int:
+        """Total number of messages (all roles)."""
+        return len(self._messages)
+
+    @property
+    def next_seq(self) -> int:
+        return self._next_seq
+
+    # --- Add messages ------------------------------------------------------
+
+    async def add_user_message(self, content: str) -> Message:
+        msg = Message(seq=self._next_seq, role="user", content=content)
+        self._messages.append(msg)
+        self._next_seq += 1
+        await self._persist(msg)
+        return msg
+
+    async def add_assistant_message(
+        self,
+        content: str,
+        tool_calls: list[dict[str, Any]] | None = None,
+    ) -> Message:
+        msg = Message(
+            seq=self._next_seq,
+            role="assistant",
+            content=content,
+            tool_calls=tool_calls,
+        )
+        self._messages.append(msg)
+        self._next_seq += 1
+        await self._persist(msg)
+        return msg
+
+    async def add_tool_result(
+        self,
+        tool_use_id: str,
+        content: str,
+        is_error: bool = False,
+    ) -> Message:
+        msg = Message(
+            seq=self._next_seq,
+            role="tool",
+            content=content,
+            tool_use_id=tool_use_id,
+            is_error=is_error,
+        )
+        self._messages.append(msg)
+        self._next_seq += 1
+        await self._persist(msg)
+        return msg
+
+    # --- Query -------------------------------------------------------------
+
+    def to_llm_messages(self) -> list[dict[str, Any]]:
+        """Return messages as OpenAI-format dicts (system prompt excluded)."""
+        return [m.to_llm_dict() for m in self._messages]
+
+    def estimate_tokens(self) -> int:
+        """Rough token estimate: total characters / 4."""
+        total_chars = sum(len(m.content) for m in self._messages)
+        return total_chars // 4
+
+    def needs_compaction(self) -> bool:
+        return self.estimate_tokens() >= self._max_history_tokens * self._compaction_threshold
+
+    # --- Output-key extraction ---------------------------------------------
+
+    def _extract_protected_values(self, messages: list[Message]) -> dict[str, str]:
+        """Scan assistant messages for output_key values before compaction.
+
+        Iterates most-recent-first. Once a key is found, it's skipped for
+        older messages (latest value wins).
+        """
+        if not self._output_keys:
+            return {}
+
+        found: dict[str, str] = {}
+        remaining_keys = set(self._output_keys)
+
+        for msg in reversed(messages):
+            if msg.role != "assistant" or not remaining_keys:
+                continue
+
+            for key in list(remaining_keys):
+                value = self._try_extract_key(msg.content, key)
+                if value is not None:
+                    found[key] = value
+                    remaining_keys.discard(key)
+
+        return found
+
+    def _try_extract_key(self, content: str, key: str) -> str | None:
+        """Try 4 strategies to extract a key's value from message content."""
+        from framework.graph.node import find_json_object
+
+        # 1. Whole message is JSON
+        try:
+            parsed = json.loads(content)
+            if isinstance(parsed, dict) and key in parsed:
+                val = parsed[key]
+                return json.dumps(val) if not isinstance(val, str) else val
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+        # 2. Embedded JSON via find_json_object
+        json_str = find_json_object(content)
+        if json_str:
+            try:
+                parsed = json.loads(json_str)
+                if isinstance(parsed, dict) and key in parsed:
+                    val = parsed[key]
+                    return json.dumps(val) if not isinstance(val, str) else val
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        # 3. Colon format: key: value
+        match = re.search(rf'\b{re.escape(key)}\s*:\s*(.+)', content)
+        if match:
+            return match.group(1).strip()
+
+        # 4. Equals format: key = value
+        match = re.search(rf'\b{re.escape(key)}\s*=\s*(.+)', content)
+        if match:
+            return match.group(1).strip()
+
+        return None
+
+    # --- Lifecycle ---------------------------------------------------------
+
+    async def compact(self, summary: str, keep_recent: int = 2) -> None:
+        """Replace old messages with a summary, optionally keeping recent ones.
+
+        Args:
+            summary: Caller-provided summary text.
+            keep_recent: Number of recent messages to preserve (default 2).
+                         Clamped to [0, len(messages) - 1].
+        """
+        if not self._messages:
+            return
+
+        # Clamp: must discard at least 1 message
+        keep_recent = max(0, min(keep_recent, len(self._messages) - 1))
+
+        if keep_recent > 0:
+            old_messages = self._messages[:-keep_recent]
+            recent_messages = self._messages[-keep_recent:]
+        else:
+            old_messages = self._messages
+            recent_messages = []
+
+        # Extract protected values from messages being discarded
+        if self._output_keys:
+            protected = self._extract_protected_values(old_messages)
+            if protected:
+                lines = ["PRESERVED VALUES (do not lose these):"]
+                for k, v in protected.items():
+                    lines.append(f"- {k}: {v}")
+                lines.append("")
+                lines.append("CONVERSATION SUMMARY:")
+                lines.append(summary)
+                summary = "\n".join(lines)
+
+        # Determine summary seq
+        if recent_messages:
+            summary_seq = recent_messages[0].seq - 1
+        else:
+            summary_seq = self._next_seq
+            self._next_seq += 1
+
+        summary_msg = Message(seq=summary_seq, role="user", content=summary)
+
+        # Persist
+        if self._store:
+            delete_before = recent_messages[0].seq if recent_messages else self._next_seq
+            await self._store.delete_parts_before(delete_before)
+            await self._store.write_part(summary_msg.seq, summary_msg.to_storage_dict())
+            await self._store.write_cursor({"next_seq": self._next_seq})
+
+        self._messages = [summary_msg] + recent_messages
+
+    async def clear(self) -> None:
+        """Remove all messages, keep system prompt, preserve ``_next_seq``."""
+        if self._store:
+            await self._store.delete_parts_before(self._next_seq)
+            await self._store.write_cursor({"next_seq": self._next_seq})
+        self._messages.clear()
+
+    def export_summary(self) -> str:
+        """Structured summary with [STATS], [CONFIG], [RECENT_MESSAGES] sections."""
+        prompt_preview = (
+            self._system_prompt[:80] + "..."
+            if len(self._system_prompt) > 80
+            else self._system_prompt
+        )
+
+        lines = [
+            "[STATS]",
+            f"turns: {self.turn_count}",
+            f"messages: {self.message_count}",
+            f"estimated_tokens: {self.estimate_tokens()}",
+            "",
+            "[CONFIG]",
+            f"system_prompt: {prompt_preview!r}",
+        ]
+
+        if self._output_keys:
+            lines.append(f"output_keys: {', '.join(self._output_keys)}")
+
+        lines.append("")
+        lines.append("[RECENT_MESSAGES]")
+        for m in self._messages[-5:]:
+            preview = m.content[:60] + "..." if len(m.content) > 60 else m.content
+            lines.append(f"  [{m.role}] {preview}")
+
+        return "\n".join(lines)
+
+    # --- Persistence internals ---------------------------------------------
+
+    async def _persist(self, message: Message) -> None:
+        """Write-through a single message.  No-op when store is None."""
+        if self._store is None:
+            return
+        if not self._meta_persisted:
+            await self._persist_meta()
+        await self._store.write_part(message.seq, message.to_storage_dict())
+        await self._store.write_cursor({"next_seq": self._next_seq})
+
+    async def _persist_meta(self) -> None:
+        """Lazily write conversation metadata to the store (called once)."""
+        if self._store is None:
+            return
+        await self._store.write_meta(
+            {
+                "system_prompt": self._system_prompt,
+                "max_history_tokens": self._max_history_tokens,
+                "compaction_threshold": self._compaction_threshold,
+                "output_keys": self._output_keys,
+            }
+        )
+        self._meta_persisted = True
+
+    # --- Restore -----------------------------------------------------------
+
+    @classmethod
+    async def restore(cls, store: ConversationStore) -> NodeConversation | None:
+        """Reconstruct a NodeConversation from a store.
+
+        Returns ``None`` if the store contains no metadata (i.e. the
+        conversation was never persisted).
+        """
+        meta = await store.read_meta()
+        if meta is None:
+            return None
+
+        conv = cls(
+            system_prompt=meta.get("system_prompt", ""),
+            max_history_tokens=meta.get("max_history_tokens", 32000),
+            compaction_threshold=meta.get("compaction_threshold", 0.8),
+            output_keys=meta.get("output_keys"),
+            store=store,
+        )
+        conv._meta_persisted = True
+
+        parts = await store.read_parts()
+        conv._messages = [Message.from_storage_dict(p) for p in parts]
+
+        cursor = await store.read_cursor()
+        if cursor:
+            conv._next_seq = cursor["next_seq"]
+        elif conv._messages:
+            conv._next_seq = conv._messages[-1].seq + 1
+
+        return conv

--- a/core/framework/graph/conversation.py
+++ b/core/framework/graph/conversation.py
@@ -267,12 +267,12 @@ class NodeConversation:
                 pass
 
         # 3. Colon format: key: value
-        match = re.search(rf'\b{re.escape(key)}\s*:\s*(.+)', content)
+        match = re.search(rf"\b{re.escape(key)}\s*:\s*(.+)", content)
         if match:
             return match.group(1).strip()
 
         # 4. Equals format: key = value
-        match = re.search(rf'\b{re.escape(key)}\s*=\s*(.+)', content)
+        match = re.search(rf"\b{re.escape(key)}\s*=\s*(.+)", content)
         if match:
             return match.group(1).strip()
 

--- a/core/framework/storage/__init__.py
+++ b/core/framework/storage/__init__.py
@@ -1,5 +1,6 @@
 """Storage backends for runtime data."""
 
 from framework.storage.backend import FileStorage
+from framework.storage.conversation_store import FileConversationStore
 
-__all__ = ["FileStorage"]
+__all__ = ["FileStorage", "FileConversationStore"]

--- a/core/framework/storage/conversation_store.py
+++ b/core/framework/storage/conversation_store.py
@@ -1,0 +1,113 @@
+"""File-per-part ConversationStore implementation.
+
+Each conversation part is stored as a separate JSON file under a
+``parts/`` subdirectory.  Meta and cursor are stored as ``meta.json``
+and ``cursor.json`` in the base directory.
+
+Directory layout::
+
+    {base_path}/
+        meta.json
+        cursor.json
+        parts/
+            0000000000.json
+            0000000001.json
+            ...
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+class FileConversationStore:
+    """File-per-part ConversationStore.
+
+    Uses one JSON file per message part, with ``pathlib.Path`` for
+    cross-platform path handling and ``asyncio.to_thread`` for
+    non-blocking I/O.
+    """
+
+    def __init__(self, base_path: str | Path) -> None:
+        self._base = Path(base_path)
+        self._parts_dir = self._base / "parts"
+
+    # --- sync helpers --------------------------------------------------------
+
+    def _write_json(self, path: Path, data: dict) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    def _read_json(self, path: Path) -> dict | None:
+        if not path.exists():
+            return None
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, ValueError):
+            return None
+
+    # --- async wrapper -------------------------------------------------------
+
+    async def _run(self, fn, *args):
+        return await asyncio.to_thread(fn, *args)
+
+    # --- ConversationStore interface -----------------------------------------
+
+    async def write_part(self, seq: int, data: dict[str, Any]) -> None:
+        path = self._parts_dir / f"{seq:010d}.json"
+        await self._run(self._write_json, path, data)
+
+    async def read_parts(self) -> list[dict[str, Any]]:
+        def _read_all() -> list[dict[str, Any]]:
+            if not self._parts_dir.exists():
+                return []
+            files = sorted(self._parts_dir.glob("*.json"))
+            parts = []
+            for f in files:
+                data = self._read_json(f)
+                if data is not None:
+                    parts.append(data)
+            return parts
+
+        return await self._run(_read_all)
+
+    async def write_meta(self, data: dict[str, Any]) -> None:
+        await self._run(self._write_json, self._base / "meta.json", data)
+
+    async def read_meta(self) -> dict[str, Any] | None:
+        return await self._run(self._read_json, self._base / "meta.json")
+
+    async def write_cursor(self, data: dict[str, Any]) -> None:
+        await self._run(self._write_json, self._base / "cursor.json", data)
+
+    async def read_cursor(self) -> dict[str, Any] | None:
+        return await self._run(self._read_json, self._base / "cursor.json")
+
+    async def delete_parts_before(self, seq: int) -> None:
+        def _delete() -> None:
+            if not self._parts_dir.exists():
+                return
+            for f in self._parts_dir.glob("*.json"):
+                file_seq = int(f.stem)
+                if file_seq < seq:
+                    f.unlink()
+
+        await self._run(_delete)
+
+    async def close(self) -> None:
+        """No-op — no persistent handles for file-per-part storage."""
+        pass
+
+    async def destroy(self) -> None:
+        """Delete the entire base directory and all persisted data."""
+        def _destroy() -> None:
+            if self._base.exists():
+                shutil.rmtree(self._base)
+
+        await self._run(_destroy)

--- a/core/framework/storage/conversation_store.py
+++ b/core/framework/storage/conversation_store.py
@@ -47,7 +47,7 @@ class FileConversationStore:
         if not path.exists():
             return None
         try:
-            with open(path, "r", encoding="utf-8") as f:
+            with open(path, encoding="utf-8") as f:
                 return json.load(f)
         except (json.JSONDecodeError, ValueError):
             return None
@@ -106,6 +106,7 @@ class FileConversationStore:
 
     async def destroy(self) -> None:
         """Delete the entire base directory and all persisted data."""
+
         def _destroy() -> None:
             if self._base.exists():
                 shutil.rmtree(self._base)

--- a/core/tests/test_node_conversation.py
+++ b/core/tests/test_node_conversation.py
@@ -1,0 +1,565 @@
+"""Tests for NodeConversation, Message, ConversationStore, and FileConversationStore."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from framework.graph.conversation import Message, NodeConversation
+from framework.storage.conversation_store import FileConversationStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class MockConversationStore:
+    """In-memory dict-based store for testing."""
+
+    def __init__(self) -> None:
+        self._parts: dict[int, dict] = {}
+        self._meta: dict | None = None
+        self._cursor: dict | None = None
+
+    async def write_part(self, seq: int, data: dict[str, Any]) -> None:
+        self._parts[seq] = data
+
+    async def read_parts(self) -> list[dict[str, Any]]:
+        return [self._parts[k] for k in sorted(self._parts)]
+
+    async def write_meta(self, data: dict[str, Any]) -> None:
+        self._meta = data
+
+    async def read_meta(self) -> dict[str, Any] | None:
+        return self._meta
+
+    async def write_cursor(self, data: dict[str, Any]) -> None:
+        self._cursor = data
+
+    async def read_cursor(self) -> dict[str, Any] | None:
+        return self._cursor
+
+    async def delete_parts_before(self, seq: int) -> None:
+        self._parts = {k: v for k, v in self._parts.items() if k >= seq}
+
+    async def close(self) -> None:
+        pass
+
+    async def destroy(self) -> None:
+        pass
+
+
+SAMPLE_TOOL_CALLS = [
+    {
+        "id": "call_1",
+        "type": "function",
+        "function": {"name": "get_weather", "arguments": '{"city":"SF"}'},
+    }
+]
+
+
+# ===================================================================
+# Message serialization
+# ===================================================================
+
+
+class TestMessage:
+    def test_user_and_assistant_to_llm_dict(self):
+        """User and assistant (no tools) produce simple role+content dicts."""
+        assert Message(seq=0, role="user", content="hi").to_llm_dict() == {
+            "role": "user",
+            "content": "hi",
+        }
+        assert Message(seq=0, role="assistant", content="hello").to_llm_dict() == {
+            "role": "assistant",
+            "content": "hello",
+        }
+
+    def test_assistant_to_llm_dict_with_tools(self):
+        m = Message(seq=0, role="assistant", content="", tool_calls=SAMPLE_TOOL_CALLS)
+        d = m.to_llm_dict()
+        assert d["role"] == "assistant"
+        assert d["tool_calls"] == SAMPLE_TOOL_CALLS
+
+    def test_tool_to_llm_dict(self):
+        m = Message(seq=0, role="tool", content="sunny", tool_use_id="call_1")
+        d = m.to_llm_dict()
+        assert d == {"role": "tool", "tool_call_id": "call_1", "content": "sunny"}
+
+    def test_tool_error_to_llm_dict(self):
+        m = Message(
+            seq=0, role="tool", content="not found", tool_use_id="call_1", is_error=True
+        )
+        d = m.to_llm_dict()
+        assert d["content"] == "ERROR: not found"
+        assert d["tool_call_id"] == "call_1"
+
+    def test_storage_roundtrip(self):
+        m = Message(seq=5, role="assistant", content="ok", tool_calls=SAMPLE_TOOL_CALLS)
+        restored = Message.from_storage_dict(m.to_storage_dict())
+        assert restored.seq == m.seq
+        assert restored.role == m.role
+        assert restored.content == m.content
+        assert restored.tool_calls == m.tool_calls
+
+    def test_storage_dict_edge_cases(self):
+        """is_error is preserved; None/False fields are omitted."""
+        m = Message(seq=1, role="tool", content="fail", tool_use_id="c1", is_error=True)
+        d = m.to_storage_dict()
+        assert d["is_error"] is True
+        assert Message.from_storage_dict(d).is_error is True
+
+        d2 = Message(seq=0, role="user", content="hi").to_storage_dict()
+        assert "tool_use_id" not in d2
+        assert "tool_calls" not in d2
+        assert "is_error" not in d2
+
+
+# ===================================================================
+# NodeConversation (in-memory)
+# ===================================================================
+
+
+class TestNodeConversation:
+    @pytest.mark.asyncio
+    async def test_multi_turn_build_and_export(self):
+        conv = NodeConversation(system_prompt="You are helpful.")
+        await conv.add_user_message("hello")
+        await conv.add_assistant_message("hi there")
+        await conv.add_user_message("weather?")
+        await conv.add_assistant_message("", tool_calls=SAMPLE_TOOL_CALLS)
+        await conv.add_tool_result("call_1", "sunny")
+        await conv.add_assistant_message("It's sunny!")
+
+        assert conv.turn_count == 2
+        assert conv.message_count == 6
+        llm = conv.to_llm_messages()
+        assert len(llm) == 6
+        assert llm[0]["role"] == "user"
+        assert llm[3]["tool_calls"] == SAMPLE_TOOL_CALLS
+
+        summary = conv.export_summary()
+        assert "turns: 2" in summary
+        assert "messages: 6" in summary
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_excluded_from_messages(self):
+        conv = NodeConversation(system_prompt="secret")
+        await conv.add_user_message("hi")
+        llm = conv.to_llm_messages()
+        assert len(llm) == 1
+        assert all("secret" not in str(m) for m in llm)
+
+    @pytest.mark.asyncio
+    async def test_turn_and_seq_counting(self):
+        """turn_count tracks user messages; next_seq increments on every add."""
+        conv = NodeConversation()
+        assert conv.turn_count == 0
+        assert conv.next_seq == 0
+        await conv.add_user_message("a")
+        assert conv.turn_count == 1
+        assert conv.next_seq == 1
+        await conv.add_assistant_message("b")
+        assert conv.turn_count == 1
+        assert conv.next_seq == 2
+
+    @pytest.mark.asyncio
+    async def test_token_estimation(self):
+        conv = NodeConversation()
+        await conv.add_user_message("a" * 400)
+        assert conv.estimate_tokens() == 100
+
+    @pytest.mark.asyncio
+    async def test_needs_compaction(self):
+        conv = NodeConversation(max_history_tokens=100, compaction_threshold=0.8)
+        await conv.add_user_message("x" * 320)
+        assert conv.needs_compaction() is True
+
+    @pytest.mark.asyncio
+    async def test_compact_replaces_with_summary(self):
+        """keep_recent=0 replaces all messages; empty conversation is a no-op."""
+        conv = NodeConversation()
+        await conv.compact("summary")
+        assert conv.turn_count == 0
+
+        conv2 = NodeConversation()
+        await conv2.add_user_message("one")
+        await conv2.add_assistant_message("two")
+        seq_before = conv2.next_seq
+
+        await conv2.compact("summary of conversation", keep_recent=0)
+
+        assert conv2.turn_count == 1
+        assert conv2.message_count == 1
+        assert conv2.messages[0].content == "summary of conversation"
+        assert conv2.messages[0].role == "user"
+        assert conv2.messages[0].seq == seq_before
+        assert conv2.next_seq == seq_before + 1
+
+    @pytest.mark.asyncio
+    async def test_compact_keep_recent_default(self):
+        """Default keep_recent=2 keeps last 2 messages."""
+        conv = NodeConversation()
+        await conv.add_user_message("m1")
+        await conv.add_assistant_message("m2")
+        await conv.add_user_message("m3")
+        await conv.add_assistant_message("m4")
+        await conv.add_user_message("m5")
+        await conv.add_assistant_message("m6")
+
+        await conv.compact("summary of early conversation")
+
+        assert conv.message_count == 3
+        assert conv.messages[0].content == "summary of early conversation"
+        assert conv.messages[0].role == "user"
+        assert conv.messages[1].content == "m5"
+        assert conv.messages[2].content == "m6"
+
+    @pytest.mark.asyncio
+    async def test_compact_keep_recent_clamped(self):
+        """keep_recent larger than len-1 gets clamped."""
+        conv = NodeConversation()
+        await conv.add_user_message("a")
+        await conv.add_assistant_message("b")
+
+        await conv.compact("summary", keep_recent=5)
+
+        assert conv.message_count == 2
+        assert conv.messages[0].content == "summary"
+        assert conv.messages[1].content == "b"
+
+    @pytest.mark.asyncio
+    async def test_compact_preserves_output_keys(self):
+        """PRESERVED VALUES block appears in summary when output_keys match."""
+        conv = NodeConversation(output_keys=["score", "status"])
+        await conv.add_user_message("process this")
+        await conv.add_assistant_message("score: 87")
+        await conv.add_assistant_message("status = complete")
+        await conv.add_user_message("next question")
+
+        await conv.compact("conversation summary", keep_recent=1)
+
+        summary_content = conv.messages[0].content
+        assert "PRESERVED VALUES" in summary_content
+        assert "score: 87" in summary_content
+        assert "status: complete" in summary_content
+        assert "CONVERSATION SUMMARY:" in summary_content
+        assert "conversation summary" in summary_content
+
+    @pytest.mark.asyncio
+    async def test_compact_seq_arithmetic_with_keep_recent(self):
+        """Summary seq = recent[0].seq - 1 when keeping recent messages."""
+        conv = NodeConversation()
+        await conv.add_user_message("m1")      # seq=0
+        await conv.add_assistant_message("m2")  # seq=1
+        await conv.add_user_message("m3")       # seq=2
+        await conv.add_assistant_message("m4")  # seq=3
+
+        await conv.compact("summary", keep_recent=2)
+
+        assert conv.messages[0].seq == 1  # summary
+        assert conv.messages[1].seq == 2  # m3
+        assert conv.messages[2].seq == 3  # m4
+        assert conv.next_seq == 4
+
+    @pytest.mark.asyncio
+    async def test_clear(self):
+        """Clear removes messages, keeps system prompt, preserves next_seq."""
+        conv = NodeConversation(system_prompt="keep me")
+        await conv.add_user_message("a")
+        await conv.add_user_message("b")
+        seq_before = conv.next_seq
+        await conv.clear()
+        assert conv.turn_count == 0
+        assert conv.system_prompt == "keep me"
+        assert conv.next_seq == seq_before
+
+    @pytest.mark.asyncio
+    async def test_export_summary(self):
+        conv = NodeConversation(system_prompt="Be helpful")
+        await conv.add_user_message("q1")
+        await conv.add_assistant_message("a1")
+        s = conv.export_summary()
+        assert "[STATS]" in s
+        assert "turns: 1" in s
+        assert "messages: 2" in s
+        assert "[CONFIG]" in s
+        assert "Be helpful" in s
+        assert "[RECENT_MESSAGES]" in s
+        assert "[user]" in s
+        assert "[assistant]" in s
+
+    @pytest.mark.asyncio
+    async def test_export_summary_output_keys(self):
+        """output_keys appear in CONFIG when set, absent when None."""
+        conv = NodeConversation(
+            system_prompt="test",
+            output_keys=["confirmed_meetings", "lead_score"],
+        )
+        await conv.add_user_message("hi")
+        assert "output_keys: confirmed_meetings, lead_score" in conv.export_summary()
+
+        conv2 = NodeConversation(system_prompt="test")
+        await conv2.add_user_message("hi")
+        assert "output_keys" not in conv2.export_summary()
+
+
+# ===================================================================
+# Output-key extraction
+# ===================================================================
+
+
+class TestExtractProtectedValues:
+    @pytest.mark.asyncio
+    async def test_extract_colon_format(self):
+        conv = NodeConversation(output_keys=["score"])
+        await conv.add_assistant_message("The score: 87")
+        assert conv._extract_protected_values(conv.messages) == {"score": "87"}
+
+    @pytest.mark.asyncio
+    async def test_extract_json_format(self):
+        conv = NodeConversation(output_keys=["meetings"])
+        await conv.add_assistant_message('{"meetings": ["standup", "retro"]}')
+        assert conv._extract_protected_values(conv.messages) == {
+            "meetings": '["standup", "retro"]'
+        }
+
+    @pytest.mark.asyncio
+    async def test_extract_equals_format(self):
+        conv = NodeConversation(output_keys=["status"])
+        await conv.add_assistant_message("status = done")
+        assert conv._extract_protected_values(conv.messages) == {"status": "done"}
+
+    @pytest.mark.asyncio
+    async def test_extract_most_recent_wins(self):
+        conv = NodeConversation(output_keys=["score"])
+        await conv.add_assistant_message("score: 50")
+        await conv.add_assistant_message("score: 99")
+        assert conv._extract_protected_values(conv.messages) == {"score": "99"}
+
+    @pytest.mark.asyncio
+    async def test_extract_embedded_json(self):
+        conv = NodeConversation(output_keys=["lead_score"])
+        await conv.add_assistant_message(
+            'Based on my analysis, here are the results: {"lead_score": 87, "status": "hot"}'
+        )
+        assert conv._extract_protected_values(conv.messages) == {"lead_score": "87"}
+
+    @pytest.mark.asyncio
+    async def test_extract_no_match_cases(self):
+        """No extraction: user messages, no output_keys, key not found."""
+        conv = NodeConversation(output_keys=["score"])
+        await conv.add_user_message("score: 42")
+        assert conv._extract_protected_values(conv.messages) == {}
+
+        conv2 = NodeConversation(output_keys=None)
+        await conv2.add_assistant_message("score: 42")
+        assert conv2._extract_protected_values(conv2.messages) == {}
+
+        conv3 = NodeConversation(output_keys=["missing_key"])
+        await conv3.add_assistant_message("nothing relevant here")
+        assert conv3._extract_protected_values(conv3.messages) == {}
+
+
+# ===================================================================
+# Persistence (MockConversationStore)
+# ===================================================================
+
+
+class TestPersistence:
+    @pytest.mark.asyncio
+    async def test_write_through_each_add(self):
+        store = MockConversationStore()
+        conv = NodeConversation(store=store)
+        await conv.add_user_message("a")
+        await conv.add_assistant_message("b")
+        parts = await store.read_parts()
+        assert len(parts) == 2
+        assert parts[0]["content"] == "a"
+        assert parts[1]["content"] == "b"
+
+    @pytest.mark.asyncio
+    async def test_meta_and_cursor_persistence(self):
+        """Meta is lazily written on first add; cursor updated on each add."""
+        store = MockConversationStore()
+        conv = NodeConversation(system_prompt="sys", store=store)
+        assert store._meta is None
+        await conv.add_user_message("trigger")
+        assert store._meta is not None
+        assert store._meta["system_prompt"] == "sys"
+        assert store._cursor == {"next_seq": 1}
+        await conv.add_user_message("b")
+        assert store._cursor == {"next_seq": 2}
+
+    @pytest.mark.asyncio
+    async def test_restore_from_store(self):
+        """Restore reconstructs conversation; empty store returns None."""
+        store = MockConversationStore()
+        assert await NodeConversation.restore(store) is None
+
+        conv = NodeConversation(system_prompt="hello", max_history_tokens=500, store=store)
+        await conv.add_user_message("u1")
+        await conv.add_assistant_message("a1")
+
+        restored = await NodeConversation.restore(store)
+        assert restored is not None
+        assert restored.system_prompt == "hello"
+        assert restored.turn_count == 1
+        assert restored.message_count == 2
+        assert restored.next_seq == 2
+        assert restored.messages[0].content == "u1"
+
+    @pytest.mark.asyncio
+    async def test_restore_preserves_tool_messages(self):
+        store = MockConversationStore()
+        conv = NodeConversation(store=store)
+        await conv.add_assistant_message("", tool_calls=SAMPLE_TOOL_CALLS)
+        await conv.add_tool_result("call_1", "result", is_error=True)
+
+        restored = await NodeConversation.restore(store)
+        assert restored is not None
+        msgs = restored.messages
+        assert msgs[0].tool_calls == SAMPLE_TOOL_CALLS
+        assert msgs[1].tool_use_id == "call_1"
+        assert msgs[1].is_error is True
+
+    @pytest.mark.asyncio
+    async def test_compact_deletes_old_parts(self):
+        store = MockConversationStore()
+        conv = NodeConversation(store=store)
+        await conv.add_user_message("a")
+        await conv.add_user_message("b")
+        assert len(store._parts) == 2
+
+        await conv.compact("summary", keep_recent=0)
+        assert len(store._parts) == 1
+        remaining = list(store._parts.values())
+        assert remaining[0]["content"] == "summary"
+
+    @pytest.mark.asyncio
+    async def test_compact_then_restore(self):
+        """Compact with keep_recent persists correctly and restores."""
+        store = MockConversationStore()
+        conv = NodeConversation(system_prompt="sp", store=store)
+        await conv.add_user_message("m1")
+        await conv.add_assistant_message("m2")
+        await conv.add_user_message("m3")
+        await conv.add_assistant_message("m4")
+
+        await conv.compact("early summary", keep_recent=2)
+
+        restored = await NodeConversation.restore(store)
+        assert restored is not None
+        assert restored.message_count == 3
+        assert restored.messages[0].content == "early summary"
+        assert restored.messages[1].content == "m3"
+        assert restored.messages[2].content == "m4"
+
+    @pytest.mark.asyncio
+    async def test_clear_deletes_store_parts(self):
+        store = MockConversationStore()
+        conv = NodeConversation(store=store)
+        await conv.add_user_message("a")
+        await conv.add_user_message("b")
+        await conv.clear()
+        assert len(store._parts) == 0
+
+
+# ===================================================================
+# FileConversationStore
+# ===================================================================
+
+
+class TestFileConversationStore:
+    @pytest.mark.asyncio
+    async def test_meta_and_cursor_crud(self, tmp_path):
+        """Write/read meta and cursor; empty reads return None."""
+        store = FileConversationStore(tmp_path / "conv")
+        assert await store.read_meta() is None
+        await store.write_meta({"system_prompt": "hi"})
+        assert await store.read_meta() == {"system_prompt": "hi"}
+
+        await store.write_cursor({"next_seq": 5})
+        assert await store.read_cursor() == {"next_seq": 5}
+
+    @pytest.mark.asyncio
+    async def test_write_and_read_parts_in_order(self, tmp_path):
+        store = FileConversationStore(tmp_path / "conv")
+        await store.write_part(2, {"seq": 2, "content": "second"})
+        await store.write_part(0, {"seq": 0, "content": "first"})
+        await store.write_part(1, {"seq": 1, "content": "middle"})
+        parts = await store.read_parts()
+        assert [p["seq"] for p in parts] == [0, 1, 2]
+
+    @pytest.mark.asyncio
+    async def test_delete_parts_before(self, tmp_path):
+        store = FileConversationStore(tmp_path / "conv")
+        for i in range(5):
+            await store.write_part(i, {"seq": i})
+        await store.delete_parts_before(3)
+        parts = await store.read_parts()
+        assert [p["seq"] for p in parts] == [3, 4]
+
+    @pytest.mark.asyncio
+    async def test_idempotent_write_part(self, tmp_path):
+        store = FileConversationStore(tmp_path / "conv")
+        await store.write_part(0, {"seq": 0, "v": 1})
+        await store.write_part(0, {"seq": 0, "v": 2})
+        parts = await store.read_parts()
+        assert len(parts) == 1
+        assert parts[0]["v"] == 2
+
+    @pytest.mark.asyncio
+    async def test_integration_with_node_conversation(self, tmp_path):
+        """Full round-trip: create -> add messages -> restore from file store."""
+        store = FileConversationStore(tmp_path / "conv")
+        conv = NodeConversation(system_prompt="test", store=store)
+        await conv.add_user_message("u1")
+        await conv.add_assistant_message("a1", tool_calls=SAMPLE_TOOL_CALLS)
+        await conv.add_tool_result("call_1", "r1", is_error=True)
+
+        restored = await NodeConversation.restore(store)
+        assert restored is not None
+        assert restored.system_prompt == "test"
+        assert restored.turn_count == 1
+        assert restored.message_count == 3
+        assert restored.next_seq == 3
+        msgs = restored.messages
+        assert msgs[0].content == "u1"
+        assert msgs[1].tool_calls == SAMPLE_TOOL_CALLS
+        assert msgs[2].is_error is True
+
+        llm = restored.to_llm_messages()
+        assert llm[2]["content"] == "ERROR: r1"
+
+    @pytest.mark.asyncio
+    async def test_corrupt_part_skipped_on_read(self, tmp_path):
+        """A corrupt JSON part file is skipped, not fatal to restore."""
+        store = FileConversationStore(tmp_path / "conv")
+        await store.write_part(0, {"seq": 0, "content": "ok"})
+        await store.write_part(1, {"seq": 1, "content": "good"})
+
+        # Simulate crash mid-write: corrupt part 0
+        corrupt_path = tmp_path / "conv" / "parts" / "0000000000.json"
+        corrupt_path.write_text("{truncated", encoding="utf-8")
+
+        parts = await store.read_parts()
+        assert len(parts) == 1
+        assert parts[0]["seq"] == 1
+
+    @pytest.mark.asyncio
+    async def test_directory_structure(self, tmp_path):
+        """Verify meta.json, cursor.json, and parts/*.json files exist after writes."""
+        store = FileConversationStore(tmp_path / "conv")
+        await store.write_meta({"system_prompt": "hi"})
+        await store.write_cursor({"next_seq": 2})
+        await store.write_part(0, {"seq": 0, "content": "first"})
+        await store.write_part(1, {"seq": 1, "content": "second"})
+
+        base = tmp_path / "conv"
+        assert (base / "meta.json").exists()
+        assert (base / "cursor.json").exists()
+        assert (base / "parts" / "0000000000.json").exists()
+        assert (base / "parts" / "0000000001.json").exists()

--- a/core/tests/test_node_conversation.py
+++ b/core/tests/test_node_conversation.py
@@ -9,7 +9,6 @@ import pytest
 from framework.graph.conversation import Message, NodeConversation
 from framework.storage.conversation_store import FileConversationStore
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -89,9 +88,7 @@ class TestMessage:
         assert d == {"role": "tool", "tool_call_id": "call_1", "content": "sunny"}
 
     def test_tool_error_to_llm_dict(self):
-        m = Message(
-            seq=0, role="tool", content="not found", tool_use_id="call_1", is_error=True
-        )
+        m = Message(seq=0, role="tool", content="not found", tool_use_id="call_1", is_error=True)
         d = m.to_llm_dict()
         assert d["content"] == "ERROR: not found"
         assert d["tool_call_id"] == "call_1"
@@ -252,9 +249,9 @@ class TestNodeConversation:
     async def test_compact_seq_arithmetic_with_keep_recent(self):
         """Summary seq = recent[0].seq - 1 when keeping recent messages."""
         conv = NodeConversation()
-        await conv.add_user_message("m1")      # seq=0
+        await conv.add_user_message("m1")  # seq=0
         await conv.add_assistant_message("m2")  # seq=1
-        await conv.add_user_message("m3")       # seq=2
+        await conv.add_user_message("m3")  # seq=2
         await conv.add_assistant_message("m4")  # seq=3
 
         await conv.compact("summary", keep_recent=2)
@@ -322,9 +319,7 @@ class TestExtractProtectedValues:
     async def test_extract_json_format(self):
         conv = NodeConversation(output_keys=["meetings"])
         await conv.add_assistant_message('{"meetings": ["standup", "retro"]}')
-        assert conv._extract_protected_values(conv.messages) == {
-            "meetings": '["standup", "retro"]'
-        }
+        assert conv._extract_protected_values(conv.messages) == {"meetings": '["standup", "retro"]'}
 
     @pytest.mark.asyncio
     async def test_extract_equals_format(self):


### PR DESCRIPTION
## Description

Create a NodeConversation class that manages multi-turn conversation history for event loop nodes. Supports write-through persistence via an optional ConversationStore protocol, output-key-aware compaction, and restoration from durable state.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #2512

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes