### PR TITLE
Fix for Missing dependency resend, in tools specific requirements.txt

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -9,5 +9,6 @@ lxml
 playwright
 playwright-stealth
 requests
+resend
 
 # Note: After installing, run `playwright install` to download browser binaries

--- a/tools/src/aden_tools/tools/csv_tool/csv_tool.py
+++ b/tools/src/aden_tools/tools/csv_tool/csv_tool.py
@@ -34,7 +34,7 @@ def register_tools(mcp: FastMCP) -> None:
         Returns:
             dict with success status, data, and metadata
         """
-        if (offset < 0 or (limit is not None and limit < 0)):
+        if offset < 0 or (limit is not None and limit < 0):
             return {"error": "offset and limit must be non-negative"}
         try:
             secure_path = get_secure_path(path, workspace_id, agent_id, session_id)


### PR DESCRIPTION
## Description

This PR addresses a ``` ModuleNotFoundError ```, by adding the missing resend dependency to the ``` tools/requirements.txt file ```.

A format which was fixed using ruff for the csv_tools.py file.

This ensures the MCP server and associated tools have all necessary libraries available after a standard installation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
The issue number it is solving : #2851 

## Changes Made

- Added ``` resend ``` to requirements.txt

## Testing

Describe the tests you ran to verify your changes:

- [x] cd core && pytest tests/
- [x] cd core && ruff check .

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
<img width="1931" height="940" alt="image" src="https://github.com/user-attachments/assets/ded394ee-3737-4f35-8c89-df1b944d147f" />
