### PR TITLE
fix(ci): apply ruff format to csv_tool.py

### DIFF
--- a/tools/src/aden_tools/tools/csv_tool/csv_tool.py
+++ b/tools/src/aden_tools/tools/csv_tool/csv_tool.py
@@ -34,7 +34,7 @@ def register_tools(mcp: FastMCP) -> None:
         Returns:
             dict with success status, data, and metadata
         """
-        if (offset < 0 or (limit is not None and limit < 0)):
+        if offset < 0 or (limit is not None and limit < 0):
             return {"error": "offset and limit must be non-negative"}
         try:
             secure_path = get_secure_path(path, workspace_id, agent_id, session_id)


### PR DESCRIPTION
## Description

Fix `ruff format --check` failure on main branch caused by redundant outer parentheses in csv_tool.py, introduced by #1873.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #2908

## Changes Made

- Applied `ruff format` to `tools/src/aden_tools/tools/csv_tool/csv_tool.py`

## Testing

- [x] Lint passes (`ruff check tools/`)
- [x] Format passes (`ruff format --check tools/`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings