### PR TITLE
Refactor circular type definitions in edge.py for improved type safety

### DIFF
--- a/core/framework/graph/edge.py
+++ b/core/framework/graph/edge.py
@@ -22,12 +22,17 @@ allowing the LLM to evaluate whether proceeding along an edge makes sense
 given the current goal, context, and execution state.
 """
 
+from __future__ import annotations
+
 from enum import Enum
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
 from framework.graph.safe_eval import safe_eval
+
+if TYPE_CHECKING:
+    from framework.graph.node import NodeSpec
 
 
 class EdgeCondition(str, Enum):
@@ -397,7 +402,7 @@ class GraphSpec(BaseModel):
     )
 
     # Components
-    nodes: list[Any] = Field(  # NodeSpec, but avoiding circular import
+    nodes: list[NodeSpec] = Field(
         default_factory=list, description="All node specifications"
     )
     edges: list[EdgeSpec] = Field(default_factory=list, description="All edge specifications")


### PR DESCRIPTION
## Summary

Resolves #2907 by refactoring circular type definitions in `core/framework/graph/edge.py`.

## Changes

- Added `from __future__ import annotations` for postponed evaluation (PEP 563)
- Imported `NodeSpec` under `TYPE_CHECKING` guard to avoid runtime circular import
- Updated `GraphSpec.nodes` type annotation from `list[Any]` to `list[NodeSpec]`

## Impact

This eliminates the circular import between `edge.py` and `node.py` while enabling proper type checking. Static analyzers like mypy and pyright can now verify the graph structure, and IDEs will provide autocomplete for node properties.

Fixes #2907