### PR TITLE
docs: add CSV tools to building-agents-construction SKILL.md

### DIFF
--- a/.claude/skills/building-agents-construction/SKILL.md
+++ b/.claude/skills/building-agents-construction/SKILL.md
@@ -359,3 +359,19 @@ Return this exact structure:
 3. **Skipping validation** - Always validate nodes and graph before proceeding
 4. **Not waiting for approval** - Always ask user before major steps
 5. **Displaying this file** - Execute the steps, don't show documentation
+
+---
+
+## REFERENCE: Available Tools - CSV
+
+CSV tools for reading, writing, and querying CSV files.
+
+| Tool | Description |
+|------|-------------|
+| `csv_read` | Read data from CSV files with pagination |
+| `csv_write` | Create new CSV files |
+| `csv_append` | Append rows to existing CSV files |
+| `csv_info` | Get file metadata (columns, row count) |
+| `csv_sql` | Query CSV files with SQL (DuckDB) |
+
+**Note:** Always verify tool availability with `mcp__agent-builder__list_mcp_tools()` before using.


### PR DESCRIPTION
## Description

Add CSV tools (`csv_read`, `csv_write`, `csv_append`, `csv_info`, `csv_sql`) to [.claude/skills/building-agents-construction/SKILL.md](cci:7://file:///Users/siketyson/Desktop/aden/.claude/skills/building-agents-construction/SKILL.md:0:0-0:0) for agent discovery.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #2926 

## Changes Made

- Added "REFERENCE: Available Tools - CSV" section documenting 5 CSV tools

## Testing

- [x] Lint passes (documentation only, no code changes)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code