### PR TITLE
docs: add HubSpot tools to building-agents-construction SKILL.md

### DIFF
--- a/.claude/skills/building-agents-construction/SKILL.md
+++ b/.claude/skills/building-agents-construction/SKILL.md
@@ -359,3 +359,35 @@ Return this exact structure:
 3. **Skipping validation** - Always validate nodes and graph before proceeding
 4. **Not waiting for approval** - Always ask user before major steps
 5. **Displaying this file** - Execute the steps, don't show documentation
+
+---
+
+## REFERENCE: Available Tools - HubSpot CRM
+
+HubSpot CRM tools for contacts, companies, and deals management. Requires `HUBSPOT_ACCESS_TOKEN`.
+
+### Contacts
+| Tool | Description |
+|------|-------------|
+| `hubspot_search_contacts` | Search contacts by query |
+| `hubspot_get_contact` | Get contact by ID |
+| `hubspot_create_contact` | Create a new contact |
+| `hubspot_update_contact` | Update existing contact |
+
+### Companies
+| Tool | Description |
+|------|-------------|
+| `hubspot_search_companies` | Search companies by query |
+| `hubspot_get_company` | Get company by ID |
+| `hubspot_create_company` | Create a new company |
+| `hubspot_update_company` | Update existing company |
+
+### Deals
+| Tool | Description |
+|------|-------------|
+| `hubspot_search_deals` | Search deals by query |
+| `hubspot_get_deal` | Get deal by ID |
+| `hubspot_create_deal` | Create a new deal |
+| `hubspot_update_deal` | Update existing deal |
+
+**Note:** Always verify tool availability with `mcp__agent-builder__list_mcp_tools()` before using.


### PR DESCRIPTION
## Description

Add HubSpot CRM tools (12 tools for contacts, companies, deals) to [.claude/skills/building-agents-construction/SKILL.md](cci:7://file:///Users/siketyson/Desktop/aden/.claude/skills/building-agents-construction/SKILL.md:0:0-0:0) for agent discovery.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #2927 

## Changes Made

- Added "REFERENCE: Available Tools - HubSpot CRM" section with 3 sub-sections (Contacts, Companies, Deals)

## Testing

- [x] Lint passes (documentation only, no code changes)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code