### PR TITLE
docs: add Web tools to building-agents-construction SKILL.md

### DIFF
--- a/.claude/skills/building-agents-construction/SKILL.md
+++ b/.claude/skills/building-agents-construction/SKILL.md
@@ -359,3 +359,17 @@ Return this exact structure:
 3. **Skipping validation** - Always validate nodes and graph before proceeding
 4. **Not waiting for approval** - Always ask user before major steps
 5. **Displaying this file** - Execute the steps, don't show documentation
+
+---
+
+## REFERENCE: Available Tools - Web
+
+Web tools for searching, scraping, and reading online content.
+
+| Tool | Description |
+|------|-------------|
+| `web_search` | Search the web (Brave/Google). Requires API key. |
+| `web_scrape` | Scrape webpage content and convert to markdown |
+| `pdf_read` | Read and extract text from PDF files |
+
+**Note:** Always verify tool availability with `mcp__agent-builder__list_mcp_tools()` before using.


### PR DESCRIPTION
## Description

Add Web tools (`web_search`, `web_scrape`, `pdf_read`) to [.claude/skills/building-agents-construction/SKILL.md](cci:7://file:///Users/siketyson/Desktop/aden/.claude/skills/building-agents-construction/SKILL.md:0:0-0:0) for agent discovery.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #2928 

## Changes Made

- Added "REFERENCE: Available Tools - Web" section documenting 3 web tools

## Testing

- [x] Lint passes (documentation only, no code changes)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code