### PR TITLE
docs: add Email tools to building-agents-construction SKILL.md

### DIFF
--- a/.claude/skills/building-agents-construction/SKILL.md
+++ b/.claude/skills/building-agents-construction/SKILL.md
@@ -359,3 +359,16 @@ Return this exact structure:
 3. **Skipping validation** - Always validate nodes and graph before proceeding
 4. **Not waiting for approval** - Always ask user before major steps
 5. **Displaying this file** - Execute the steps, don't show documentation
+
+---
+
+## REFERENCE: Available Tools - Email
+
+Email tools for sending emails. Requires `RESEND_API_KEY`.
+
+| Tool | Description |
+|------|-------------|
+| `send_email` | Send an email via Resend API |
+| `send_budget_alert_email` | Send a budget alert notification email |
+
+**Note:** Always verify tool availability with `mcp__agent-builder__list_mcp_tools()` before using.


### PR DESCRIPTION
## Description

Add Email tools (`send_email`, `send_budget_alert_email`) to [.claude/skills/building-agents-construction/SKILL.md](cci:7://file:///Users/siketyson/Desktop/aden/.claude/skills/building-agents-construction/SKILL.md:0:0-0:0) for agent discovery.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #2929 

## Changes Made

- Added "REFERENCE: Available Tools - Email" section documenting 2 email tools

## Testing

- [x] Lint passes (documentation only, no code changes)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code