### PR TITLE
fix(docs): correct test command in DEVELOPER.md

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -509,7 +509,7 @@ chore(deps): update React to 18.2.0
 
 1. Create a feature branch from `main`
 2. Make your changes with clear commits
-3. Run tests locally: `PYTHONPATH=core:exports python -m pytest`
+3. Run tests locally: `PYTHONPATH=core:exports pytest`
 4. Run linting: `black --check .`
 5. Push and create a PR
 6. Fill out the PR template


### PR DESCRIPTION
## Summary

Fixes the incorrect test command in `DEVELOPER.md` Git Workflow section.

## Change

**Before:**
```bash
PYTHONPATH=core:exports python -m pytest
```

**After:**
```bash
PYTHONPATH=core:exports pytest
```

## Why

The original command `python -m pytest` may fail because:
- pytest is not intended to be executed via `python -m pytest` in this project setup
- Running `pytest` directly is the standard approach when pytest is installed in the environment

This fixes contributor confusion when following the documentation.

Fixes #2879