### PR TITLE
docs: add Next Steps After Setup section to clarify onboarding (#2047)

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -21,6 +21,40 @@ This will:
 - Fix package compatibility issues (openai + litellm)
 - Verify all installations
 
+## Next Steps After Setup
+
+After successfully running `./quickstart.sh` or manual setup, you're ready to build and run agents.
+
+### Is Claude Code Required?
+Claude Code CLI is **recommended but not required**.  
+It provides interactive skills (`/building-agents`, `/testing-agent`) that make agent creation easier.  
+If you have an Anthropic API key, you can use Claude to build agents quickly.  
+
+If you don’t want to use Claude (e.g., no API key or prefer manual setup), you can still build agents manually.
+
+### Minimal Manual Path (No Claude Needed)
+1. Create the `exports/` directory if it does not exist:
+   ```bash
+   mkdir -p exports/my_agent
+   ```
+
+
+Add your agent code inside exports/my_agent/ (e.g., init.py, agent.py, README.md).
+
+Validate your agent:
+
+```bash
+PYTHONPATH=core:exports python -m my_agent validate
+```
+What Success Looks Like
+
+A new folder appears under exports/ (e.g., exports/support_ticket_agent/).
+
+Running validate or info prints agent details without errors.
+
+You can run the agent with --input or --mock mode.
+
+
 ## Alpine Linux Setup
 
 If you are using Alpine Linux (e.g., inside a Docker container), you must install system dependencies and use a virtual environment before running the setup script:

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ claude> /testing-agent
 PYTHONPATH=core:exports python -m your_agent_name run --input '{...}'
 ```
 
+
 **[📖 Complete Setup Guide](ENVIRONMENT_SETUP.md)** - Detailed instructions for agent development
 
 ### Cursor IDE Support


### PR DESCRIPTION
## Description

This PR improves onboarding clarity by documenting what users should do **after** running `quickstart.sh`, especially for those who choose not to use Claude Code.

It adds a clear, minimal manual workflow for creating, validating, and running agents, reducing confusion for first-time contributors.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #2047

## Changes Made

- Added a **Next Steps After Setup** section to the environment setup docs
- Clarified that Claude Code is recommended but optional
- Documented a minimal manual path for building and validating agents
- Improved structure and readability for new users

## Testing

- [x] Manual testing performed  
  - Verified documentation flow
  - Confirmed commands and paths are accurate

## Checklist

- [x] My changes follow the project's documentation style
- [x] I have performed a self-review of my changes
- [x] I have made corresponding documentation updates
- [x] My changes introduce no new warnings

## Screenshots (if applicable)

N/A – documentation-only changes
