### PR TITLE
feat(tools): add excel read, write, and info tools for xlsx files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Excel tools** - Added `excel_read`, `excel_write`, and `excel_info` tools for reading and writing Excel (.xlsx) files
 - Initial project structure
 - React frontend (honeycomb) with Vite and TypeScript
 - Node.js backend (hive) with Express and TypeScript

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
   <img src="https://img.shields.io/badge/OpenAI-supported-412991?style=flat-square&logo=openai" alt="OpenAI" />
   <img src="https://img.shields.io/badge/Anthropic-supported-d4a574?style=flat-square" alt="Anthropic" />
   <img src="https://img.shields.io/badge/Google_Gemini-supported-4285F4?style=flat-square&logo=google" alt="Gemini" />
-  <img src="https://img.shields.io/badge/MCP-19_Tools-00ADD8?style=flat-square" alt="MCP" />
+  <img src="https://img.shields.io/badge/MCP-34_Tools-00ADD8?style=flat-square" alt="MCP" />
 </p>
 
 ## Overview
@@ -250,7 +250,8 @@ subgraph Foundation
         e2["Memory STM/LTM"]:::done
         e3["Web Search/Scraper"]:::done
         e4["CSV/PDF"]:::done
-        e5["Excel/Email"]
+        e5["Excel"]:::done
+        e6["Email"]
     end
     subgraph core["Core"]
         f1["Eval System"]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,8 @@ subgraph Foundation
         e2["Memory STM/LTM"]:::done
         e3["Web Search/Scraper"]:::done
         e4["CSV/PDF"]:::done
-        e5["Excel/Email"]
+        e5["Excel"]:::done
+        e6["Email"]
     end
     subgraph core["Core"]
         f1["Eval System"]
@@ -173,7 +174,7 @@ classDef done fill:#9e9e9e,color:#fff,stroke:#757575
     - [x] Web Scraper
     - [x] CSV tools
     - [x] PDF tools
-    - [ ] Excel tools
+    - [x] Excel tools
     - [ ] Email Tools
     - [ ] Recipe for "Add your own tools"
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,7 +109,7 @@ MCP (Model Context Protocol) servers are configured in `.mcp.json` at the projec
 }
 ```
 
-The tools MCP server exposes tools including web search, PDF reading, CSV processing, and file system operations.
+The tools MCP server exposes tools including web search, PDF reading, CSV and Excel processing, and file system operations.
 
 ## Storage
 

--- a/docs/i18n/hi.md
+++ b/docs/i18n/hi.md
@@ -31,7 +31,7 @@
   <img src="https://img.shields.io/badge/OpenAI-supported-412991?style=flat-square&logo=openai" alt="OpenAI" />
   <img src="https://img.shields.io/badge/Anthropic-supported-d4a574?style=flat-square" alt="Anthropic" />
   <img src="https://img.shields.io/badge/Google_Gemini-supported-4285F4?style=flat-square&logo=google" alt="Gemini" />
-  <img src="https://img.shields.io/badge/MCP-19_Tools-00ADD8?style=flat-square" alt="MCP" />
+  <img src="https://img.shields.io/badge/MCP-34_Tools-00ADD8?style=flat-square" alt="MCP" />
 </p>
 
 # अवलोकन (Overview)

--- a/tools/README.md
+++ b/tools/README.md
@@ -75,6 +75,15 @@ python mcp_server.py
 | `web_search`           | Search the web (Google or Brave, auto-detected) |
 | `web_scrape`           | Scrape and extract content from webpages       |
 | `pdf_read`             | Read and extract text from PDF files           |
+| `csv_read`             | Read CSV files with pagination support         |
+| `csv_write`            | Write data to CSV files                        |
+| `csv_append`           | Append rows to existing CSV files              |
+| `csv_info`             | Get metadata about CSV files                   |
+| `csv_sql`              | Query CSV files using SQL (DuckDB)             |
+| `excel_read`           | Read Excel (.xlsx) files with sheet selection  |
+| `excel_write`          | Write data to Excel (.xlsx) files              |
+| `excel_info`           | Get metadata about Excel files                 |
+| `send_email`           | Send emails via Resend provider                |
 
 ## Project Structure
 
@@ -85,6 +94,9 @@ tools/
 │   ├── credentials/         # Credential management
 │   └── tools/               # Tool implementations
 │       ├── example_tool/
+│       ├── csv_tool/          # CSV processing tools
+│       ├── email_tool/        # Email sending tools
+│       ├── excel_tool/        # Excel (.xlsx) processing tools
 │       ├── file_system_toolkits/  # File operation tools
 │       │   ├── view_file.py
 │       │   ├── write_to_file.py
@@ -94,6 +106,7 @@ tools/
 │       │   ├── apply_patch.py
 │       │   ├── grep_search.py
 │       │   └── execute_command_tool.py
+│       ├── hubspot_tool/      # HubSpot CRM integration
 │       ├── web_search_tool/
 │       ├── web_scrape_tool/
 │       └── pdf_read_tool/

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -47,11 +47,15 @@ ocr = [
 sql = [
     "duckdb>=1.0.0",
 ]
+excel = [
+    "openpyxl>=3.1.0",
+]
 all = [
     "RestrictedPython>=7.0",
     "pytesseract>=0.3.10",
     "pillow>=10.0.0",
     "duckdb>=1.0.0",
+    "openpyxl>=3.1.0",
 ]
 
 [build-system]

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 from .csv_tool import register_tools as register_csv
 from .email_tool import register_tools as register_email
 from .example_tool import register_tools as register_example
+from .excel_tool import register_tools as register_excel
 from .file_system_toolkits.apply_diff import register_tools as register_apply_diff
 from .file_system_toolkits.apply_patch import register_tools as register_apply_patch
 from .file_system_toolkits.execute_command_tool import (
@@ -81,6 +82,7 @@ def register_all_tools(
     register_grep_search(mcp)
     register_execute_command(mcp)
     register_csv(mcp)
+    register_excel(mcp)
 
     return [
         "example_tool",
@@ -100,6 +102,9 @@ def register_all_tools(
         "csv_append",
         "csv_info",
         "csv_sql",
+        "excel_read",
+        "excel_write",
+        "excel_info",
         "send_email",
         "send_budget_alert_email",
         "hubspot_search_contacts",

--- a/tools/src/aden_tools/tools/excel_tool/README.md
+++ b/tools/src/aden_tools/tools/excel_tool/README.md
@@ -1,0 +1,188 @@
+# Excel Tool
+
+Read and write Excel (.xlsx) spreadsheet files.
+
+## Overview
+
+The Excel tool provides functionality to read, write, and inspect Excel files within the agent sandbox. It supports:
+
+- Reading data from specific sheets or the active sheet
+- Writing data to new Excel files with custom columns
+- Getting metadata about Excel files (sheet names, dimensions, etc.)
+- Pagination support for large files
+
+## Tools
+
+### excel_read
+
+Read an Excel file and return its contents.
+
+**When to use:**
+- Extracting data from Excel spreadsheets
+- Processing tabular data in .xlsx format
+- Reading specific sheets from multi-sheet workbooks
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | string | Yes | Path to the Excel file (relative to session sandbox) |
+| `workspace_id` | string | Yes | Workspace identifier |
+| `agent_id` | string | Yes | Agent identifier |
+| `session_id` | string | Yes | Session identifier |
+| `sheet_name` | string | No | Name of the sheet to read (default: first/active sheet) |
+| `limit` | integer | No | Maximum number of rows to return |
+| `offset` | integer | No | Number of rows to skip from the beginning |
+
+**Returns:**
+- `success`: Boolean indicating if operation succeeded
+- `sheet_name`: Name of the sheet that was read
+- `columns`: List of column headers
+- `rows`: List of row data as dictionaries
+- `row_count`: Number of rows returned
+- `total_rows`: Total rows in the sheet
+- `error`: Error message if operation failed
+
+**Example:**
+```python
+# Read all data from first sheet
+result = excel_read(
+    path="sales_data.xlsx",
+    workspace_id="ws1",
+    agent_id="agent1",
+    session_id="sess1"
+)
+
+# Read specific sheet with pagination
+result = excel_read(
+    path="sales_data.xlsx",
+    sheet_name="Q1 Sales",
+    offset=100,
+    limit=50,
+    workspace_id="ws1",
+    agent_id="agent1",
+    session_id="sess1"
+)
+```
+
+### excel_write
+
+Write data to a new Excel (.xlsx) file.
+
+**When to use:**
+- Creating Excel reports from processed data
+- Exporting data in spreadsheet format
+- Generating multi-sheet workbooks
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | string | Yes | Path to the Excel file (relative to session sandbox) |
+| `workspace_id` | string | Yes | Workspace identifier |
+| `agent_id` | string | Yes | Agent identifier |
+| `session_id` | string | Yes | Session identifier |
+| `columns` | list[string] | Yes | List of column names for the header row |
+| `rows` | list[dict] | Yes | List of dictionaries, each representing a row |
+| `sheet_name` | string | No | Name for the sheet (default: "Sheet1") |
+
+**Returns:**
+- `success`: Boolean indicating if operation succeeded
+- `sheet_name`: Name of the created sheet
+- `columns`: List of column headers
+- `rows_written`: Number of rows written
+- `error`: Error message if operation failed
+
+**Example:**
+```python
+result = excel_write(
+    path="output.xlsx",
+    workspace_id="ws1",
+    agent_id="agent1",
+    session_id="sess1",
+    columns=["Name", "Age", "City"],
+    rows=[
+        {"Name": "Alice", "Age": 30, "City": "NYC"},
+        {"Name": "Bob", "Age": 25, "City": "LA"}
+    ],
+    sheet_name="Customers"
+)
+```
+
+### excel_info
+
+Get metadata about an Excel file without reading all data.
+
+**When to use:**
+- Checking file structure before processing
+- Listing available sheets in a workbook
+- Getting row/column counts for planning
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | string | Yes | Path to the Excel file (relative to session sandbox) |
+| `workspace_id` | string | Yes | Workspace identifier |
+| `agent_id` | string | Yes | Agent identifier |
+| `session_id` | string | Yes | Session identifier |
+
+**Returns:**
+- `success`: Boolean indicating if operation succeeded
+- `sheet_names`: List of all sheet names in the workbook
+- `active_sheet`: Name of the currently active sheet
+- `columns`: List of column headers from the active sheet
+- `column_count`: Number of columns
+- `total_rows`: Total number of data rows
+- `file_size_bytes`: Size of the file in bytes
+- `error`: Error message if operation failed
+
+**Example:**
+```python
+result = excel_info(
+    path="data.xlsx",
+    workspace_id="ws1",
+    agent_id="agent1",
+    session_id="sess1"
+)
+# Returns sheet names, column headers, and row counts
+```
+
+## Dependencies
+
+This tool requires `openpyxl`:
+
+```bash
+pip install openpyxl
+```
+
+Or install with the excel extra:
+
+```bash
+pip install tools[excel]
+```
+
+## Error Handling
+
+All tools return error dictionaries with descriptive messages:
+
+- File not found errors
+- Invalid file extensions (must be .xlsx)
+- Missing required parameters
+- Missing dependencies (openpyxl not installed)
+- Sheet not found errors
+- File access outside sandbox (security error)
+
+## Security
+
+- All file paths are resolved within the session sandbox
+- Path traversal attempts are blocked
+- Only .xlsx files are supported
+- Files must be within the workspace/agent/session directory structure
+
+## Limitations
+
+- Only .xlsx format is supported (not .xls or .ods)
+- Formula values are read as calculated results, not formulas
+- Very large files (>100MB) may require increased memory
+- Cell formatting is not preserved when writing

--- a/tools/src/aden_tools/tools/excel_tool/__init__.py
+++ b/tools/src/aden_tools/tools/excel_tool/__init__.py
@@ -1,0 +1,5 @@
+"""Excel Tool package."""
+
+from .excel_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/excel_tool/excel_tool.py
+++ b/tools/src/aden_tools/tools/excel_tool/excel_tool.py
@@ -1,0 +1,349 @@
+"""Excel Tool - Read and manipulate Excel (.xlsx) files."""
+
+import os
+from typing import Any
+
+from fastmcp import FastMCP
+
+from ..file_system_toolkits.security import get_secure_path
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register Excel tools with the MCP server."""
+
+    @mcp.tool()
+    def excel_read(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        sheet_name: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> dict:
+        """
+        Read an Excel file and return its contents.
+
+        Use this when you need to extract data from Excel spreadsheets (.xlsx files).
+        Supports reading specific sheets by name, pagination with limit/offset.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+            sheet_name: Name of the sheet to read (default: first sheet)
+            limit: Maximum number of rows to return (None = all rows)
+            offset: Number of rows to skip from the beginning (default: 0)
+
+        Returns:
+            dict with success status, data, and metadata including:
+            - sheet_name: Name of the sheet read
+            - columns: List of column headers
+            - rows: List of row data as dictionaries
+            - row_count: Number of rows returned
+            - total_rows: Total rows in the sheet
+
+        Examples:
+            # Read all data from first sheet
+            excel_read(path="data.xlsx", workspace_id="ws1", agent_id="agent1", session_id="sess1")
+
+            # Read specific sheet
+            excel_read(path="data.xlsx", sheet_name="Sales", ...)
+
+            # Paginate results (skip 100 rows, return next 50)
+            excel_read(path="data.xlsx", offset=100, limit=50, ...)
+        """
+        if offset < 0 or (limit is not None and limit < 0):
+            return {"error": "offset and limit must be non-negative"}
+
+        try:
+            import openpyxl
+        except ImportError:
+            return {
+                "error": (
+                    "openpyxl not installed. Install with: "
+                    "pip install openpyxl  or  pip install tools[excel]"
+                )
+            }
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            if not path.lower().endswith(".xlsx"):
+                return {"error": "File must have .xlsx extension"}
+
+            # Load workbook
+            wb = openpyxl.load_workbook(secure_path, read_only=True, data_only=True)
+
+            # Get sheet
+            if sheet_name:
+                if sheet_name not in wb.sheetnames:
+                    return {
+                        "error": f"Sheet '{sheet_name}' not found. "
+                        f"Available sheets: {', '.join(wb.sheetnames)}"
+                    }
+                ws = wb[sheet_name]
+            else:
+                ws = wb.active
+                sheet_name = ws.title
+
+            # Get headers from first row
+            rows_iter = ws.iter_rows(values_only=True)
+            try:
+                headers = next(rows_iter)
+            except StopIteration:
+                return {"error": "Excel file is empty or has no headers"}
+
+            # Filter out None headers (can happen with empty columns)
+            columns = [str(h) if h is not None else f"Column_{i}" for i, h in enumerate(headers)]
+
+            # Apply offset and limit
+            rows = []
+            row_idx = 0
+            for row_data in rows_iter:
+                if row_idx < offset:
+                    row_idx += 1
+                    continue
+                if limit is not None and len(rows) >= limit:
+                    break
+
+                # Create row dict, handling None values
+                row_dict = {}
+                for i, cell_value in enumerate(row_data):
+                    if i < len(columns):
+                        # Convert value to string for consistency
+                        if cell_value is not None:
+                            row_dict[columns[i]] = str(cell_value)
+                        else:
+                            row_dict[columns[i]] = ""
+
+                # Only include rows that have at least one non-empty value
+                if any(row_dict.values()):
+                    rows.append(row_dict)
+
+                row_idx += 1
+
+            # Count total rows (approximate from iterator)
+            total_rows = row_idx - offset + len(rows) if limit is None else row_idx
+
+            wb.close()
+
+            return {
+                "success": True,
+                "path": path,
+                "sheet_name": sheet_name,
+                "columns": columns,
+                "column_count": len(columns),
+                "rows": rows,
+                "row_count": len(rows),
+                "total_rows": total_rows,
+                "offset": offset,
+                "limit": limit,
+            }
+
+        except Exception as e:
+            return {"error": f"Failed to read Excel: {str(e)}"}
+
+    @mcp.tool()
+    def excel_write(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        columns: list[str],
+        rows: list[dict],
+        sheet_name: str = "Sheet1",
+    ) -> dict:
+        """
+        Write data to a new Excel (.xlsx) file.
+
+        Use this when you need to create Excel spreadsheets from data.
+        Creates a new .xlsx file with the specified columns and rows.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+            columns: List of column names for the header row
+            rows: List of dictionaries, each representing a row
+            sheet_name: Name for the sheet (default: "Sheet1")
+
+        Returns:
+            dict with success status and metadata including:
+            - sheet_name: Name of the created sheet
+            - columns: List of column headers
+            - rows_written: Number of rows written
+
+        Examples:
+            # Create simple Excel file
+            excel_write(
+                path="output.xlsx",
+                columns=["Name", "Age", "City"],
+                rows=[
+                    {"Name": "Alice", "Age": 30, "City": "NYC"},
+                    {"Name": "Bob", "Age": 25, "City": "LA"}
+                ],
+                ...
+            )
+
+            # Create with custom sheet name
+            excel_write(path="sales.xlsx", sheet_name="Q1 Sales", ...)
+        """
+        try:
+            import openpyxl
+        except ImportError:
+            return {
+                "error": (
+                    "openpyxl not installed. Install with: "
+                    "pip install openpyxl  or  pip install tools[excel]"
+                )
+            }
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            if not path.lower().endswith(".xlsx"):
+                return {"error": "File must have .xlsx extension"}
+
+            if not columns:
+                return {"error": "columns cannot be empty"}
+
+            # Create parent directories if needed
+            parent_dir = os.path.dirname(secure_path)
+            if parent_dir:
+                os.makedirs(parent_dir, exist_ok=True)
+
+            # Create workbook
+            wb = openpyxl.Workbook()
+            ws = wb.active
+            ws.title = sheet_name
+
+            # Write headers
+            for col_idx, col_name in enumerate(columns, start=1):
+                ws.cell(row=1, column=col_idx, value=col_name)
+
+            # Write data rows
+            for row_idx, row_data in enumerate(rows, start=2):
+                for col_idx, col_name in enumerate(columns, start=1):
+                    value = row_data.get(col_name, "")
+                    # Handle different data types
+                    if value is None:
+                        cell_value = ""
+                    elif isinstance(value, (int, float, bool)):
+                        cell_value = value
+                    else:
+                        cell_value = str(value)
+                    ws.cell(row=row_idx, column=col_idx, value=cell_value)
+
+            # Save workbook
+            wb.save(secure_path)
+            wb.close()
+
+            return {
+                "success": True,
+                "path": path,
+                "sheet_name": sheet_name,
+                "columns": columns,
+                "column_count": len(columns),
+                "rows_written": len(rows),
+            }
+
+        except Exception as e:
+            return {"error": f"Failed to write Excel: {str(e)}"}
+
+    @mcp.tool()
+    def excel_info(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> dict:
+        """
+        Get metadata about an Excel file without reading all data.
+
+        Use this to check file structure, sheet names, and row/column counts
+        before reading the full file.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+
+        Returns:
+            dict with file metadata including:
+            - sheet_names: List of all sheet names in the workbook
+            - active_sheet: Name of the currently active sheet
+            - columns: List of column headers from the active sheet
+            - column_count: Number of columns
+            - total_rows: Total number of data rows (approximate for large files)
+            - file_size_bytes: Size of the file in bytes
+
+        Examples:
+            # Check file structure before reading
+            excel_info(path="data.xlsx", ...)
+            # Returns: sheet names, column headers, row counts
+        """
+        try:
+            import openpyxl
+        except ImportError:
+            return {
+                "error": (
+                    "openpyxl not installed. Install with: "
+                    "pip install openpyxl  or  pip install tools[excel]"
+                )
+            }
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            if not path.lower().endswith(".xlsx"):
+                return {"error": "File must have .xlsx extension"}
+
+            # Get file size
+            file_size = os.path.getsize(secure_path)
+
+            # Load workbook in read-only mode for efficiency
+            wb = openpyxl.load_workbook(secure_path, read_only=True, data_only=True)
+
+            sheet_names = wb.sheetnames
+            active_sheet = wb.active.title
+
+            # Get headers and count rows from active sheet
+            ws = wb.active
+            rows_iter = ws.iter_rows(values_only=True)
+
+            try:
+                headers = next(rows_iter)
+                columns = [
+                    str(h) if h is not None else f"Column_{i}" for i, h in enumerate(headers)
+                ]
+            except StopIteration:
+                columns = []
+
+            # Count total rows (approximate)
+            total_rows = sum(1 for _ in rows_iter)
+
+            wb.close()
+
+            return {
+                "success": True,
+                "path": path,
+                "sheet_names": sheet_names,
+                "active_sheet": active_sheet,
+                "columns": columns,
+                "column_count": len(columns),
+                "total_rows": total_rows,
+                "file_size_bytes": file_size,
+            }
+
+        except Exception as e:
+            return {"error": f"Failed to get Excel info: {str(e)}"}

--- a/tools/tests/tools/test_excel_tool.py
+++ b/tools/tests/tools/test_excel_tool.py
@@ -1,0 +1,729 @@
+"""Tests for excel_tool - Read and manipulate Excel files."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.excel_tool.excel_tool import register_tools
+
+openpyxl_available = importlib.util.find_spec("openpyxl") is not None
+
+# Test IDs for sandbox
+TEST_WORKSPACE_ID = "test-workspace"
+TEST_AGENT_ID = "test-agent"
+TEST_SESSION_ID = "test-session"
+
+
+@pytest.fixture
+def excel_tools(mcp: FastMCP, tmp_path: Path):
+    """Register all Excel tools and return them as a dict."""
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        register_tools(mcp)
+        yield {
+            "excel_read": mcp._tool_manager._tools["excel_read"].fn,
+            "excel_write": mcp._tool_manager._tools["excel_write"].fn,
+            "excel_info": mcp._tool_manager._tools["excel_info"].fn,
+        }
+
+
+@pytest.fixture
+def excel_tool_fn(excel_tools):
+    """Return excel_read function for backward compatibility."""
+    return excel_tools["excel_read"]
+
+
+@pytest.fixture
+def session_dir(tmp_path: Path) -> Path:
+    """Create and return the session directory within the sandbox."""
+    session_path = tmp_path / TEST_WORKSPACE_ID / TEST_AGENT_ID / TEST_SESSION_ID
+    session_path.mkdir(parents=True, exist_ok=True)
+    return session_path
+
+
+@pytest.fixture
+def basic_excel(session_dir: Path) -> Path:
+    """Create a basic Excel file for testing."""
+    pytest.importorskip("openpyxl")
+    from openpyxl import Workbook
+
+    excel_file = session_dir / "basic.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Data"
+
+    # Write headers
+    ws["A1"] = "name"
+    ws["B1"] = "age"
+    ws["C1"] = "city"
+
+    # Write data
+    ws["A2"] = "Alice"
+    ws["B2"] = 30
+    ws["C2"] = "NYC"
+
+    ws["A3"] = "Bob"
+    ws["B3"] = 25
+    ws["C3"] = "LA"
+
+    ws["A4"] = "Charlie"
+    ws["B4"] = 35
+    ws["C4"] = "Chicago"
+
+    wb.save(excel_file)
+    wb.close()
+    return excel_file
+
+
+@pytest.fixture
+def large_excel(session_dir: Path) -> Path:
+    """Create a larger Excel file for pagination testing."""
+    pytest.importorskip("openpyxl")
+    from openpyxl import Workbook
+
+    excel_file = session_dir / "large.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "LargeData"
+
+    # Write headers
+    ws["A1"] = "id"
+    ws["B1"] = "value"
+
+    # Write 100 rows
+    for i in range(100):
+        ws.cell(row=i + 2, column=1, value=i)
+        ws.cell(row=i + 2, column=2, value=i * 10)
+
+    wb.save(excel_file)
+    wb.close()
+    return excel_file
+
+
+@pytest.fixture
+def multi_sheet_excel(session_dir: Path) -> Path:
+    """Create an Excel file with multiple sheets."""
+    pytest.importorskip("openpyxl")
+    from openpyxl import Workbook
+
+    excel_file = session_dir / "multi_sheet.xlsx"
+    wb = Workbook()
+
+    # First sheet
+    ws1 = wb.active
+    ws1.title = "Sheet1"
+    ws1["A1"] = "col1"
+    ws1["A2"] = "data1"
+
+    # Second sheet
+    ws2 = wb.create_sheet("Sheet2")
+    ws2["A1"] = "col2"
+    ws2["A2"] = "data2"
+
+    # Third sheet
+    ws3 = wb.create_sheet("Sales")
+    ws3["A1"] = "product"
+    ws3["B1"] = "revenue"
+    ws3["A2"] = "Widget"
+    ws3["B2"] = 1000
+
+    wb.save(excel_file)
+    wb.close()
+    return excel_file
+
+
+@pytest.fixture
+def empty_excel(session_dir: Path) -> Path:
+    """Create an empty Excel file (no data, just headers)."""
+    pytest.importorskip("openpyxl")
+    from openpyxl import Workbook
+
+    excel_file = session_dir / "empty.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Empty"
+
+    # Only headers, no data
+    ws["A1"] = "name"
+    ws["B1"] = "value"
+
+    wb.save(excel_file)
+    wb.close()
+    return excel_file
+
+
+@pytest.mark.skipif(not openpyxl_available, reason="openpyxl not installed")
+class TestExcelRead:
+    """Tests for excel_read function."""
+
+    def test_read_basic_excel(self, excel_tool_fn, basic_excel, tmp_path):
+        """Read a basic Excel file successfully."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tool_fn(
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        assert result["sheet_name"] == "Data"
+        assert result["columns"] == ["name", "age", "city"]
+        assert result["column_count"] == 3
+        assert result["row_count"] == 3
+        assert len(result["rows"]) == 3
+        assert result["rows"][0] == {"name": "Alice", "age": "30", "city": "NYC"}
+
+    def test_read_with_limit(self, excel_tool_fn, basic_excel, tmp_path):
+        """Read Excel with row limit."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tool_fn(
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                limit=2,
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 2
+        assert result["limit"] == 2
+        assert len(result["rows"]) == 2
+        assert result["rows"][0]["name"] == "Alice"
+        assert result["rows"][1]["name"] == "Bob"
+
+    def test_read_with_offset(self, excel_tool_fn, basic_excel, tmp_path):
+        """Read Excel with row offset."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tool_fn(
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                offset=1,
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 2
+        assert result["offset"] == 1
+        assert result["rows"][0]["name"] == "Bob"
+        assert result["rows"][1]["name"] == "Charlie"
+
+    def test_read_with_limit_and_offset(self, excel_tool_fn, large_excel, tmp_path):
+        """Read Excel with both limit and offset (pagination)."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tool_fn(
+                path="large.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                limit=10,
+                offset=50,
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 10
+        assert result["offset"] == 50
+        assert result["limit"] == 10
+        # First row should be id=50
+        assert result["rows"][0] == {"id": "50", "value": "500"}
+
+    def test_negative_limit(self, excel_tool_fn, basic_excel, tmp_path):
+        """Return error for negative limit."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tool_fn(
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                limit=-1,
+            )
+
+        assert "error" in result
+        assert "non-negative" in result["error"].lower()
+
+    def test_negative_offset(self, excel_tool_fn, basic_excel, tmp_path):
+        """Return error for negative offset."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tool_fn(
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                offset=-1,
+            )
+
+        assert "error" in result
+        assert "non-negative" in result["error"].lower()
+
+    def test_file_not_found(self, excel_tool_fn, session_dir, tmp_path):
+        """Return error for non-existent file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tool_fn(
+                path="nonexistent.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_non_xlsx_extension(self, excel_tool_fn, session_dir, tmp_path):
+        """Return error for non-Excel file extension."""
+        # Create a text file
+        txt_file = session_dir / "data.txt"
+        txt_file.write_text("name,age\nAlice,30\n")
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tool_fn(
+                path="data.txt",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert ".xlsx" in result["error"].lower()
+
+    def test_read_specific_sheet(self, excel_tool_fn, multi_sheet_excel, tmp_path):
+        """Read a specific sheet by name."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tool_fn(
+                path="multi_sheet.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                sheet_name="Sales",
+            )
+
+        assert result["success"] is True
+        assert result["sheet_name"] == "Sales"
+        assert result["columns"] == ["product", "revenue"]
+        assert result["rows"][0] == {"product": "Widget", "revenue": "1000"}
+
+    def test_read_invalid_sheet_name(self, excel_tool_fn, multi_sheet_excel, tmp_path):
+        """Return error for invalid sheet name."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tool_fn(
+                path="multi_sheet.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                sheet_name="NonExistent",
+            )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_missing_workspace_id(self, excel_tool_fn, basic_excel, tmp_path):
+        """Return error when workspace_id is missing."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tool_fn(
+                path="basic.xlsx",
+                workspace_id="",
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+
+    def test_missing_agent_id(self, excel_tool_fn, basic_excel, tmp_path):
+        """Return error when agent_id is missing."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tool_fn(
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id="",
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+
+    def test_missing_session_id(self, excel_tool_fn, basic_excel, tmp_path):
+        """Return error when session_id is missing."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tool_fn(
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id="",
+            )
+
+        assert "error" in result
+
+    def test_read_unicode_content(self, excel_tool_fn, session_dir, tmp_path):
+        """Read Excel with Unicode content."""
+        from openpyxl import Workbook
+
+        excel_file = session_dir / "unicode.xlsx"
+        wb = Workbook()
+        ws = wb.active
+        ws["A1"] = "名前"
+        ws["B1"] = "年齢"
+        ws["C1"] = "都市"
+        ws["A2"] = "太郎"
+        ws["B2"] = 30
+        ws["C2"] = "東京"
+        ws["A3"] = "Alice"
+        ws["B3"] = 25
+        ws["C3"] = "北京"
+        wb.save(excel_file)
+        wb.close()
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tool_fn(
+                path="unicode.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        assert result["columns"] == ["名前", "年齢", "都市"]
+        assert result["rows"][0]["名前"] == "太郎"
+        assert result["rows"][0]["都市"] == "東京"
+
+    def test_path_traversal_blocked(self, excel_tool_fn, session_dir, tmp_path):
+        """Prevent path traversal attacks."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tool_fn(
+                path="../../../etc/passwd",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+
+    def test_offset_beyond_rows(self, excel_tool_fn, basic_excel, tmp_path):
+        """Offset beyond available rows returns empty result."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tool_fn(
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                offset=100,
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 0
+        assert result["rows"] == []
+
+
+@pytest.mark.skipif(not openpyxl_available, reason="openpyxl not installed")
+class TestExcelWrite:
+    """Tests for excel_write function."""
+
+    def test_write_new_excel(self, excel_tools, session_dir, tmp_path):
+        """Write a new Excel file successfully."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="output.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["name", "age", "city"],
+                rows=[
+                    {"name": "Alice", "age": "30", "city": "NYC"},
+                    {"name": "Bob", "age": "25", "city": "LA"},
+                ],
+            )
+
+        assert result["success"] is True
+        assert result["sheet_name"] == "Sheet1"
+        assert result["columns"] == ["name", "age", "city"]
+        assert result["column_count"] == 3
+        assert result["rows_written"] == 2
+
+        # Verify file was created
+        excel_file = session_dir / "output.xlsx"
+        assert excel_file.exists()
+
+    def test_write_creates_parent_directories(self, excel_tools, session_dir, tmp_path):
+        """Write creates parent directories if needed."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="subdir/nested/output.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["id"],
+                rows=[{"id": "1"}],
+            )
+
+        assert result["success"] is True
+        assert (session_dir / "subdir" / "nested" / "output.xlsx").exists()
+
+    def test_write_empty_columns_error(self, excel_tools, session_dir, tmp_path):
+        """Return error when columns is empty."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="output.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=[],
+                rows=[],
+            )
+
+        assert "error" in result
+        assert "empty" in result["error"].lower()
+
+    def test_write_non_xlsx_extension_error(self, excel_tools, session_dir, tmp_path):
+        """Return error for non-Excel file extension."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="output.xls",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["id"],
+                rows=[],
+            )
+
+        assert "error" in result
+        assert ".xlsx" in result["error"].lower()
+
+    def test_write_filters_extra_columns(self, excel_tools, session_dir, tmp_path):
+        """Extra columns in rows are filtered out."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="output.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["name"],
+                rows=[{"name": "Alice", "extra": "ignored"}],
+            )
+
+        assert result["success"] is True
+
+        # Verify by reading back
+        excel_file = session_dir / "output.xlsx"
+        assert excel_file.exists()
+
+    def test_write_empty_rows(self, excel_tools, session_dir, tmp_path):
+        """Write Excel with headers but no rows."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="output.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["name", "age"],
+                rows=[],
+            )
+
+        assert result["success"] is True
+        assert result["rows_written"] == 0
+
+        excel_file = session_dir / "output.xlsx"
+        assert excel_file.exists()
+
+    def test_write_custom_sheet_name(self, excel_tools, session_dir, tmp_path):
+        """Write Excel with custom sheet name."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="output.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["id"],
+                rows=[{"id": "1"}],
+                sheet_name="CustomSheet",
+            )
+
+        assert result["success"] is True
+        assert result["sheet_name"] == "CustomSheet"
+
+    def test_write_unicode_content(self, excel_tools, session_dir, tmp_path):
+        """Write Excel with Unicode content."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="unicode.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["名前", "都市"],
+                rows=[{"名前": "太郎", "都市": "東京"}],
+            )
+
+        assert result["success"] is True
+
+        excel_file = session_dir / "unicode.xlsx"
+        assert excel_file.exists()
+
+    def test_write_numeric_and_boolean_values(self, excel_tools, session_dir, tmp_path):
+        """Write Excel with numeric and boolean values."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="output.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["id", "price", "active"],
+                rows=[
+                    {"id": 1, "price": 99.99, "active": True},
+                    {"id": 2, "price": 149.5, "active": False},
+                ],
+            )
+
+        assert result["success"] is True
+        assert result["rows_written"] == 2
+
+
+@pytest.mark.skipif(not openpyxl_available, reason="openpyxl not installed")
+class TestExcelInfo:
+    """Tests for excel_info function."""
+
+    def test_get_info_basic_excel(self, excel_tools, basic_excel, tmp_path):
+        """Get info about a basic Excel file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_info"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        assert result["sheet_names"] == ["Data"]
+        assert result["active_sheet"] == "Data"
+        assert result["columns"] == ["name", "age", "city"]
+        assert result["column_count"] == 3
+        assert result["total_rows"] == 3
+        assert "file_size_bytes" in result
+        assert result["file_size_bytes"] > 0
+
+    def test_get_info_multi_sheet(self, excel_tools, multi_sheet_excel, tmp_path):
+        """Get info about multi-sheet Excel file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_info"](
+                path="multi_sheet.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        assert "Sheet1" in result["sheet_names"]
+        assert "Sheet2" in result["sheet_names"]
+        assert "Sales" in result["sheet_names"]
+        assert result["active_sheet"] == "Sheet1"
+
+    def test_get_info_large_excel(self, excel_tools, large_excel, tmp_path):
+        """Get info about a large Excel file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_info"](
+                path="large.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        assert result["total_rows"] == 100
+        assert result["columns"] == ["id", "value"]
+
+    def test_get_info_file_not_found(self, excel_tools, session_dir, tmp_path):
+        """Return error when file doesn't exist."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_info"](
+                path="nonexistent.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_get_info_empty_excel(self, excel_tools, empty_excel, tmp_path):
+        """Get info about Excel with only headers."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_info"](
+                path="empty.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        assert result["columns"] == ["name", "value"]
+        assert result["total_rows"] == 0
+
+    def test_get_info_non_xlsx_extension_error(self, excel_tools, session_dir, tmp_path):
+        """Return error for non-Excel file extension."""
+        txt_file = session_dir / "data.txt"
+        txt_file.write_text("name\nAlice\n")
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_info"](
+                path="data.txt",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert ".xlsx" in result["error"].lower()
+
+
+class TestExcelImportError:
+    """Tests for handling missing openpyxl dependency."""
+
+    def test_read_without_openpyxl(self, mcp: FastMCP, tmp_path: Path, monkeypatch):
+        """Return error when openpyxl is not installed for read."""
+        # Mock openpyxl as not available
+        monkeypatch.setattr(
+            "aden_tools.tools.excel_tool.excel_tool.importlib.util.find_spec",
+            lambda x: None if x == "openpyxl" else True,
+        )
+
+        # Reload the module to pick up the mocked import
+        import importlib
+        from aden_tools.tools import excel_tool as excel_module
+
+        importlib.reload(excel_module)
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            register_tools(mcp)
+            excel_read_fn = mcp._tool_manager._tools["excel_read"].fn
+
+            result = excel_read_fn(
+                path="test.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert "openpyxl" in result["error"].lower()
+
+    def test_write_without_openpyxl(self, mcp: FastMCP, tmp_path: Path, monkeypatch):
+        """Return error when openpyxl is not installed for write."""
+        # Remove openpyxl from import
+        monkeypatch.setattr(
+            "builtins.__import__",
+            lambda name, *args, **kwargs: None if name == "openpyxl" else __builtins__[name],
+        )
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            register_tools(mcp)
+            excel_write_fn = mcp._tool_manager._tools["excel_write"].fn
+
+            result = excel_write_fn(
+                path="test.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["id"],
+                rows=[],
+            )
+
+        assert "error" in result
+        assert "openpyxl" in result["error"].lower()


### PR DESCRIPTION
Implement excel_read, excel_write, and excel_info MCP tools for processing Excel (.xlsx) spreadsheets within the agent sandbox.

Features:
- Read Excel files with sheet selection and pagination support
- Write data to new Excel files with custom columns
- Get metadata (sheet names, dimensions, file size) without reading full data
- Unicode and multi-sheet workbook support
- Security sandbox integration with path validation

Also includes:
- Comprehensive test suite (30+ test cases)
- Complete README documentation with examples
- Updated pyproject.toml with openpyxl dependency
- Registered tools in tools/__init__.py
- Updated ROADMAP.md to mark Excel tools complete
- Updated CHANGELOG.md with new feature entry
- Updated main README with correct tool count (34 tools)

Relates to roadmap item: Excel tools under Infrastructure Tools
