### PR TITLE
fix(docs): correct pytest command in DEVELOPER.md

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -509,7 +509,7 @@ chore(deps): update React to 18.2.0
 
 1. Create a feature branch from `main`
 2. Make your changes with clear commits
-3. Run tests locally: `PYTHONPATH=core:exports python -m pytest`
+3. Run tests locally: `PYTHONPATH=core:exports pytest`
 4. Run linting: `black --check .`
 5. Push and create a PR
 6. Fill out the PR template


### PR DESCRIPTION
Fixes #2879

## Problem
The Git Workflow section in DEVELOPER.md instructed contributors to run tests using:
```
PYTHONPATH=core:exports python -m pytest
```

This command is incorrect and may fail because pytest is typically run directly, not via `python -m`.

## Solution
Changed the command to:
```
PYTHONPATH=core:exports pytest
```

This is the standard way to run pytest and works correctly when pytest is installed in the environment.