### PR TITLE
docs(core): remove duplicate entry in Edge Protocol docstring

### DIFF
--- a/core/framework/graph/edge.py
+++ b/core/framework/graph/edge.py
@@ -11,7 +11,6 @@ our edges can be created dynamically by a Builder agent based on the goal.
 
 Edge Types:
 - always: Always traverse after source completes
-- always: Always traverse after source completes
 - on_success: Traverse only if source succeeds
 - on_failure: Traverse only if source fails
 - conditional: Traverse based on expression evaluation (SAFE SUBSET ONLY)


### PR DESCRIPTION
Fixes #2717\n\n## Problem\nThe module-level docstring in `core/framework/graph/edge.py` contained a duplicate entry in the "Edge Types" list:\n\n```python\nEdge Types:\n- always: Always traverse after source completes\n- always: Always traverse after source completes  # <-- Duplicate\n- on_success: Traverse only if source succeeds\n```\n\n## Solution\nRemoved the duplicate line.