### PR TITLE
[Feature]: Add Excel Tool for reading/writing .xlsx/.xlsm files #2675

### DIFF
--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -45,6 +45,9 @@ ocr = [
     "pytesseract>=0.3.10",
     "pillow>=10.0.0",
 ]
+excel = [
+    "openpyxl>=3.1.0",
+]
 sql = [
     "duckdb>=1.0.0",
 ]
@@ -53,6 +56,7 @@ all = [
     "pytesseract>=0.3.10",
     "pillow>=10.0.0",
     "duckdb>=1.0.0",
+    "openpyxl>=3.1.0",
 ]
 
 [tool.uv.sources]

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -99,4 +99,8 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 
 [dependency-groups]
-dev = ["ty>=0.0.13", "ruff>=0.14.14"]
+dev = [
+    "ty>=0.0.13",
+    "ruff>=0.14.14",
+    "duckdb>=1.4.4",
+]

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -25,6 +25,7 @@ from .apollo_tool import register_tools as register_apollo
 from .csv_tool import register_tools as register_csv
 from .email_tool import register_tools as register_email
 from .example_tool import register_tools as register_example
+from .excel_tool import register_tools as register_excel
 from .file_system_toolkits.apply_diff import register_tools as register_apply_diff
 from .file_system_toolkits.apply_patch import register_tools as register_apply_patch
 from .file_system_toolkits.data_tools import register_tools as register_data_tools
@@ -97,6 +98,7 @@ def register_all_tools(
     register_execute_command(mcp)
     register_data_tools(mcp)
     register_csv(mcp)
+    register_excel(mcp)
 
     return [
         "example_tool",
@@ -122,6 +124,13 @@ def register_all_tools(
         "csv_append",
         "csv_info",
         "csv_sql",
+        "excel_read",
+        "excel_write",
+        "excel_append",
+        "excel_info",
+        "excel_sheet_list",
+        "excel_sql",
+        "excel_search",
         "apollo_enrich_person",
         "apollo_enrich_company",
         "apollo_search_people",

--- a/tools/src/aden_tools/tools/excel_tool/README.md
+++ b/tools/src/aden_tools/tools/excel_tool/README.md
@@ -1,0 +1,361 @@
+# Excel Tool
+
+Read and manipulate Excel files (.xlsx, .xlsm) within the Aden agent framework.
+
+## Installation
+
+The Excel tool requires `openpyxl`. Install it with:
+
+```bash
+pip install openpyxl
+# or
+pip install tools[excel]
+```
+
+## Available Functions
+
+### `excel_read`
+
+Read data from an Excel file.
+
+**Parameters:**
+- `path` (str): Path to the Excel file (relative to session sandbox)
+- `workspace_id` (str): Workspace identifier
+- `agent_id` (str): Agent identifier
+- `session_id` (str): Session identifier
+- `sheet` (str, optional): Sheet name to read (default: active sheet)
+- `limit` (int, optional): Maximum number of rows to return
+- `offset` (int, optional): Number of rows to skip from the beginning
+
+**Returns:**
+```python
+{
+    "success": True,
+    "path": "data.xlsx",
+    "sheet_name": "Sheet1",
+    "columns": ["name", "age", "city"],
+    "column_count": 3,
+    "rows": [
+        {"name": "Alice", "age": 30, "city": "NYC"},
+        {"name": "Bob", "age": 25, "city": "LA"}
+    ],
+    "row_count": 2,
+    "total_rows": 2,
+    "offset": 0,
+    "limit": None
+}
+```
+
+**Example:**
+```python
+# Read all data from the active sheet
+result = excel_read(
+    path="employees.xlsx",
+    workspace_id="ws-123",
+    agent_id="agent-456",
+    session_id="session-789"
+)
+
+# Read specific sheet with pagination
+result = excel_read(
+    path="data.xlsx",
+    workspace_id="ws-123",
+    agent_id="agent-456",
+    session_id="session-789",
+    sheet="Q4 Sales",
+    limit=100,
+    offset=50
+)
+```
+
+### `excel_write`
+
+Write data to a new Excel file.
+
+**Parameters:**
+- `path` (str): Path to the Excel file
+- `workspace_id` (str): Workspace identifier
+- `agent_id` (str): Agent identifier
+- `session_id` (str): Session identifier
+- `columns` (list[str]): List of column names for the header
+- `rows` (list[dict]): List of dictionaries, each representing a row
+- `sheet` (str, optional): Sheet name (default: "Sheet1")
+
+**Returns:**
+```python
+{
+    "success": True,
+    "path": "output.xlsx",
+    "sheet_name": "Sheet1",
+    "columns": ["name", "age"],
+    "column_count": 2,
+    "rows_written": 3
+}
+```
+
+**Example:**
+```python
+result = excel_write(
+    path="output.xlsx",
+    workspace_id="ws-123",
+    agent_id="agent-456",
+    session_id="session-789",
+    columns=["name", "age", "department"],
+    rows=[
+        {"name": "Alice", "age": 30, "department": "Engineering"},
+        {"name": "Bob", "age": 25, "department": "Marketing"}
+    ],
+    sheet="Employees"
+)
+```
+
+### `excel_append`
+
+Append rows to an existing Excel file.
+
+**Parameters:**
+- `path` (str): Path to the Excel file
+- `workspace_id` (str): Workspace identifier
+- `agent_id` (str): Agent identifier
+- `session_id` (str): Session identifier
+- `rows` (list[dict]): List of dictionaries to append
+- `sheet` (str, optional): Sheet name to append to (default: active sheet)
+
+**Returns:**
+```python
+{
+    "success": True,
+    "path": "data.xlsx",
+    "sheet_name": "Sheet1",
+    "rows_appended": 2,
+    "total_rows": 10
+}
+```
+
+**Example:**
+```python
+result = excel_append(
+    path="employees.xlsx",
+    workspace_id="ws-123",
+    agent_id="agent-456",
+    session_id="session-789",
+    rows=[
+        {"name": "Charlie", "age": 35, "department": "Sales"},
+        {"name": "Diana", "age": 28, "department": "HR"}
+    ]
+)
+```
+
+### `excel_info`
+
+Get metadata about an Excel file without reading all data.
+
+**Parameters:**
+- `path` (str): Path to the Excel file
+- `workspace_id` (str): Workspace identifier
+- `agent_id` (str): Agent identifier
+- `session_id` (str): Session identifier
+
+**Returns:**
+```python
+{
+    "success": True,
+    "path": "data.xlsx",
+    "file_size_bytes": 12345,
+    "sheet_count": 3,
+    "sheet_names": ["Employees", "Products", "Summary"],
+    "sheets": [
+        {
+            "name": "Employees",
+            "columns": ["id", "name", "department"],
+            "column_count": 3,
+            "row_count": 100
+        },
+        ...
+    ]
+}
+```
+
+**Example:**
+```python
+result = excel_info(
+    path="report.xlsx",
+    workspace_id="ws-123",
+    agent_id="agent-456",
+    session_id="session-789"
+)
+
+print(f"File has {result['sheet_count']} sheets")
+for sheet in result['sheets']:
+    print(f"  - {sheet['name']}: {sheet['row_count']} rows")
+```
+
+### `excel_sheet_list`
+
+List all sheet names in an Excel file.
+
+**Parameters:**
+- `path` (str): Path to the Excel file
+- `workspace_id` (str): Workspace identifier
+- `agent_id` (str): Agent identifier
+- `session_id` (str): Session identifier
+
+**Returns:**
+```python
+{
+    "success": True,
+    "path": "data.xlsx",
+    "sheet_names": ["Sheet1", "Sheet2", "Summary"],
+    "sheet_count": 3
+}
+```
+
+**Example:**
+```python
+result = excel_sheet_list(
+    path="workbook.xlsx",
+    workspace_id="ws-123",
+    agent_id="agent-456",
+    session_id="session-789"
+)
+
+for sheet in result['sheet_names']:
+    print(f"Found sheet: {sheet}")
+```
+
+### `excel_sql`
+
+Query an Excel file using SQL (powered by DuckDB). Each sheet is available as a table.
+
+**Parameters:**
+- `path` (str): Path to the Excel file
+- `workspace_id` (str): Workspace identifier
+- `agent_id` (str): Agent identifier
+- `session_id` (str): Session identifier
+- `query` (str): SQL query. Use 'data' for the target sheet, or sheet names (with spaces as underscores) to query/join multiple sheets.
+- `sheet` (str, optional): Sheet to use as 'data' table (default: first sheet)
+
+**Returns:**
+```python
+{
+    "success": True,
+    "path": "sales.xlsx",
+    "target_sheet": "Q4",
+    "query": "SELECT * FROM data WHERE amount > 100",
+    "columns": ["product", "amount"],
+    "column_count": 2,
+    "rows": [{"product": "Widget", "amount": 150}],
+    "row_count": 1
+}
+```
+
+**Examples:**
+```python
+# Simple query on default sheet
+result = excel_sql(
+    path="data.xlsx",
+    workspace_id="ws-123",
+    agent_id="agent-456",
+    session_id="session-789",
+    query="SELECT * FROM data WHERE price > 100"
+)
+
+# Aggregate data
+result = excel_sql(
+    path="sales.xlsx",
+    query="SELECT category, SUM(amount) as total FROM data GROUP BY category",
+    ...
+)
+
+# Join multiple sheets (sheets: 'Sales', 'Products')
+result = excel_sql(
+    path="workbook.xlsx",
+    query="SELECT s.*, p.name FROM Sales s JOIN Products p ON s.product_id = p.id",
+    ...
+)
+```
+
+**Note:** Only SELECT queries are allowed for security. Sheet names with spaces become underscores in SQL.
+
+### `excel_search`
+
+Search for values across Excel sheets.
+
+**Parameters:**
+- `path` (str): Path to the Excel file
+- `workspace_id` (str): Workspace identifier
+- `agent_id` (str): Agent identifier
+- `session_id` (str): Session identifier
+- `search_term` (str): Text to search for
+- `sheet` (str, optional): Specific sheet to search (default: all sheets)
+- `case_sensitive` (bool, optional): Whether search is case-sensitive (default: False)
+- `match_type` (str, optional): 'contains', 'exact', 'starts_with', or 'ends_with' (default: 'contains')
+
+**Returns:**
+```python
+{
+    "success": True,
+    "path": "data.xlsx",
+    "search_term": "Alice",
+    "match_type": "contains",
+    "case_sensitive": False,
+    "sheets_searched": ["Sheet1", "Sheet2"],
+    "matches": [
+        {"sheet": "Sheet1", "row": 2, "column": "name", "column_index": 1, "value": "Alice"},
+        {"sheet": "Sheet2", "row": 5, "column": "author", "column_index": 3, "value": "Alice Smith"}
+    ],
+    "match_count": 2
+}
+```
+
+**Example:**
+```python
+# Search for "error" across all sheets (case-insensitive)
+result = excel_search(
+    path="logs.xlsx",
+    workspace_id="ws-123",
+    agent_id="agent-456",
+    session_id="session-789",
+    search_term="error"
+)
+
+# Exact match, case-sensitive, specific sheet
+result = excel_search(
+    path="employees.xlsx",
+    search_term="John",
+    sheet="Active",
+    case_sensitive=True,
+    match_type="exact",
+    ...
+)
+```
+
+## Error Handling
+
+All functions return a dict with an `error` key if something goes wrong:
+
+```python
+{
+    "error": "File not found: missing.xlsx"
+}
+```
+
+Common errors:
+- File not found
+- Invalid file extension (must be .xlsx or .xlsm)
+- Sheet not found (when specifying a sheet that doesn't exist)
+- Empty columns (when writing)
+- Path traversal attempt (security)
+
+## Security
+
+- All file operations are sandboxed within the session directory
+- Path traversal attacks are blocked
+- Files are validated for correct extension before processing
+
+## Supported Formats
+
+- `.xlsx` - Excel 2007+ format (recommended)
+- `.xlsm` - Excel 2007+ with macros
+
+Note: The tool uses `openpyxl` which does not support the older `.xls` format. Convert legacy files to `.xlsx` before use.

--- a/tools/src/aden_tools/tools/excel_tool/__init__.py
+++ b/tools/src/aden_tools/tools/excel_tool/__init__.py
@@ -1,0 +1,5 @@
+"""Excel Tool package."""
+
+from .excel_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/excel_tool/excel_tool.py
+++ b/tools/src/aden_tools/tools/excel_tool/excel_tool.py
@@ -1,0 +1,792 @@
+"""Excel Tool - Read and manipulate Excel files (.xlsx, .xlsm)."""
+
+import os
+from datetime import datetime
+from typing import Any
+
+from fastmcp import FastMCP
+
+from ..file_system_toolkits.security import get_secure_path
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register Excel tools with the MCP server."""
+
+    @mcp.tool()
+    def excel_read(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        sheet: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> dict:
+        """
+        Read an Excel file and return its contents.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+            sheet: Sheet name to read (default: active sheet)
+            limit: Maximum number of rows to return (None = all rows)
+            offset: Number of rows to skip from the beginning (after header)
+
+        Returns:
+            dict with success status, data, and metadata
+        """
+        try:
+            from openpyxl import load_workbook
+        except ImportError:
+            return {
+                "error": (
+                    "openpyxl not installed. Install with: "
+                    "pip install openpyxl  or  pip install tools[excel]"
+                )
+            }
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            if not path.lower().endswith((".xlsx", ".xlsm")):
+                return {"error": "File must have .xlsx or .xlsm extension"}
+
+            # Load workbook in read-only mode for better performance
+            wb = load_workbook(secure_path, read_only=True, data_only=True)
+
+            try:
+                # Get the specified sheet or active sheet
+                if sheet:
+                    if sheet not in wb.sheetnames:
+                        return {
+                            "error": f"Sheet '{sheet}' not found. Available sheets: {wb.sheetnames}"
+                        }
+                    ws = wb[sheet]
+                else:
+                    ws = wb.active
+
+                if ws is None:
+                    return {"error": "Workbook has no active sheet"}
+
+                # Read all rows
+                all_rows = []
+                for row in ws.iter_rows(values_only=True):
+                    # Convert cell values to serializable format
+                    converted_row = [_convert_cell_value(cell) for cell in row]
+                    all_rows.append(converted_row)
+
+                if not all_rows:
+                    return {
+                        "success": True,
+                        "path": path,
+                        "sheet_name": ws.title,
+                        "columns": [],
+                        "column_count": 0,
+                        "rows": [],
+                        "row_count": 0,
+                        "total_rows": 0,
+                        "offset": offset,
+                        "limit": limit,
+                    }
+
+                # First row as headers
+                columns = all_rows[0] if all_rows else []
+                data_rows = all_rows[1:]  # Rows without header
+
+                # Apply offset and limit to data rows
+                total_rows = len(data_rows)
+                if offset > 0:
+                    data_rows = data_rows[offset:]
+                if limit is not None:
+                    data_rows = data_rows[:limit]
+
+                # Convert rows to list of dicts with column names as keys
+                rows_as_dicts = []
+                for row in data_rows:
+                    row_dict = {}
+                    for i, value in enumerate(row):
+                        if i < len(columns) and columns[i]:
+                            col_name = columns[i]
+                        else:
+                            col_name = f"Column_{i + 1}"
+                        row_dict[str(col_name)] = value
+                    rows_as_dicts.append(row_dict)
+
+                # Format column names
+                formatted_columns = [
+                    str(c) if c is not None else f"Column_{i + 1}" for i, c in enumerate(columns)
+                ]
+
+                return {
+                    "success": True,
+                    "path": path,
+                    "sheet_name": ws.title,
+                    "columns": formatted_columns,
+                    "column_count": len(columns),
+                    "rows": rows_as_dicts,
+                    "row_count": len(rows_as_dicts),
+                    "total_rows": total_rows,
+                    "offset": offset,
+                    "limit": limit,
+                }
+
+            finally:
+                wb.close()
+
+        except Exception as e:
+            return {"error": f"Failed to read Excel file: {str(e)}"}
+
+    @mcp.tool()
+    def excel_write(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        columns: list[str],
+        rows: list[dict],
+        sheet: str = "Sheet1",
+    ) -> dict:
+        """
+        Write data to a new Excel file.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+            columns: List of column names for the header
+            rows: List of dictionaries, each representing a row
+            sheet: Name for the sheet (default: "Sheet1")
+
+        Returns:
+            dict with success status and metadata
+        """
+        try:
+            from openpyxl import Workbook
+        except ImportError:
+            return {
+                "error": (
+                    "openpyxl not installed. Install with: "
+                    "pip install openpyxl  or  pip install tools[excel]"
+                )
+            }
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            if not path.lower().endswith((".xlsx", ".xlsm")):
+                return {"error": "File must have .xlsx or .xlsm extension"}
+
+            if not columns:
+                return {"error": "columns cannot be empty"}
+
+            # Create parent directories if needed
+            parent_dir = os.path.dirname(secure_path)
+            if parent_dir:
+                os.makedirs(parent_dir, exist_ok=True)
+
+            # Create new workbook
+            wb = Workbook()
+            ws = wb.active
+            if ws is None:
+                return {"error": "Failed to create worksheet"}
+
+            ws.title = sheet
+
+            # Write header row
+            for col_idx, col_name in enumerate(columns, start=1):
+                ws.cell(row=1, column=col_idx, value=col_name)
+
+            # Write data rows
+            for row_idx, row_data in enumerate(rows, start=2):
+                for col_idx, col_name in enumerate(columns, start=1):
+                    value = row_data.get(col_name, "")
+                    ws.cell(row=row_idx, column=col_idx, value=value)
+
+            # Save workbook
+            wb.save(secure_path)
+            wb.close()
+
+            return {
+                "success": True,
+                "path": path,
+                "sheet_name": sheet,
+                "columns": columns,
+                "column_count": len(columns),
+                "rows_written": len(rows),
+            }
+
+        except Exception as e:
+            return {"error": f"Failed to write Excel file: {str(e)}"}
+
+    @mcp.tool()
+    def excel_append(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        rows: list[dict],
+        sheet: str | None = None,
+    ) -> dict:
+        """
+        Append rows to an existing Excel file.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+            rows: List of dictionaries to append, keys should match existing columns
+            sheet: Sheet name to append to (default: active sheet)
+
+        Returns:
+            dict with success status and metadata
+        """
+        try:
+            from openpyxl import load_workbook
+        except ImportError:
+            return {
+                "error": (
+                    "openpyxl not installed. Install with: "
+                    "pip install openpyxl  or  pip install tools[excel]"
+                )
+            }
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}. Use excel_write to create a new file."}
+
+            if not path.lower().endswith((".xlsx", ".xlsm")):
+                return {"error": "File must have .xlsx or .xlsm extension"}
+
+            if not rows:
+                return {"error": "rows cannot be empty"}
+
+            # Load existing workbook
+            wb = load_workbook(secure_path)
+
+            # Get the specified sheet or active sheet
+            if sheet:
+                if sheet not in wb.sheetnames:
+                    return {
+                        "error": f"Sheet '{sheet}' not found. Available sheets: {wb.sheetnames}"
+                    }
+                ws = wb[sheet]
+            else:
+                ws = wb.active
+
+            if ws is None:
+                return {"error": "Workbook has no active sheet"}
+
+            # Get existing columns from first row
+            columns = []
+            for cell in ws[1]:
+                columns.append(str(cell.value) if cell.value is not None else "")
+
+            if not columns or all(c == "" for c in columns):
+                wb.close()
+                return {"error": "Excel file has no headers in the first row"}
+
+            # Find the next empty row
+            next_row = ws.max_row + 1
+
+            # Append rows
+            for row_data in rows:
+                for col_idx, col_name in enumerate(columns, start=1):
+                    value = row_data.get(col_name, "")
+                    ws.cell(row=next_row, column=col_idx, value=value)
+                next_row += 1
+
+            # Save workbook
+            wb.save(secure_path)
+            wb.close()
+
+            # Get new total row count (excluding header)
+            total_rows = next_row - 2  # -1 for header, -1 because next_row was incremented
+
+            return {
+                "success": True,
+                "path": path,
+                "sheet_name": ws.title,
+                "rows_appended": len(rows),
+                "total_rows": total_rows,
+            }
+
+        except Exception as e:
+            return {"error": f"Failed to append to Excel file: {str(e)}"}
+
+    @mcp.tool()
+    def excel_info(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> dict:
+        """
+        Get metadata about an Excel file without reading all data.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+
+        Returns:
+            dict with file metadata (sheets, columns per sheet, row counts, file size)
+        """
+        try:
+            from openpyxl import load_workbook
+        except ImportError:
+            return {
+                "error": (
+                    "openpyxl not installed. Install with: "
+                    "pip install openpyxl  or  pip install tools[excel]"
+                )
+            }
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            if not path.lower().endswith((".xlsx", ".xlsm")):
+                return {"error": "File must have .xlsx or .xlsm extension"}
+
+            # Get file size
+            file_size = os.path.getsize(secure_path)
+
+            # Load workbook in read-only mode
+            wb = load_workbook(secure_path, read_only=True, data_only=True)
+
+            try:
+                sheets_info = []
+                for sheet_name in wb.sheetnames:
+                    ws = wb[sheet_name]
+
+                    # Get columns from first row
+                    columns = []
+                    first_row = next(ws.iter_rows(min_row=1, max_row=1, values_only=True), None)
+                    if first_row:
+                        columns = [
+                            str(c) if c is not None else f"Column_{i + 1}"
+                            for i, c in enumerate(first_row)
+                        ]
+
+                    # Count rows (excluding header)
+                    row_count = 0
+                    for _ in ws.iter_rows(min_row=2, values_only=True):
+                        row_count += 1
+
+                    sheets_info.append(
+                        {
+                            "name": sheet_name,
+                            "columns": columns,
+                            "column_count": len(columns),
+                            "row_count": row_count,
+                        }
+                    )
+
+                return {
+                    "success": True,
+                    "path": path,
+                    "file_size_bytes": file_size,
+                    "sheet_count": len(wb.sheetnames),
+                    "sheet_names": wb.sheetnames,
+                    "sheets": sheets_info,
+                }
+
+            finally:
+                wb.close()
+
+        except Exception as e:
+            return {"error": f"Failed to get Excel info: {str(e)}"}
+
+    @mcp.tool()
+    def excel_sheet_list(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> dict:
+        """
+        List all sheet names in an Excel file.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+
+        Returns:
+            dict with list of sheet names
+        """
+        try:
+            from openpyxl import load_workbook
+        except ImportError:
+            return {
+                "error": (
+                    "openpyxl not installed. Install with: "
+                    "pip install openpyxl  or  pip install tools[excel]"
+                )
+            }
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            if not path.lower().endswith((".xlsx", ".xlsm")):
+                return {"error": "File must have .xlsx or .xlsm extension"}
+
+            # Load workbook in read-only mode (minimal memory usage)
+            wb = load_workbook(secure_path, read_only=True)
+
+            try:
+                return {
+                    "success": True,
+                    "path": path,
+                    "sheet_names": wb.sheetnames,
+                    "sheet_count": len(wb.sheetnames),
+                }
+            finally:
+                wb.close()
+
+        except Exception as e:
+            return {"error": f"Failed to list sheets: {str(e)}"}
+
+    @mcp.tool()
+    def excel_sql(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        query: str,
+        sheet: str | None = None,
+    ) -> dict:
+        """
+        Query an Excel file using SQL (powered by DuckDB).
+
+        Each sheet is available as a table with its sheet name (spaces replaced
+        with underscores). Use 'data' as alias for the specified/active sheet.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+            query: SQL query. Use 'data' for the target sheet, or sheet names
+                   (with spaces as underscores) to query/join multiple sheets.
+            sheet: Sheet to use as 'data' table (default: first sheet)
+
+        Returns:
+            dict with query results, columns, and row count
+
+        Examples:
+            # Simple query on default sheet
+            query="SELECT * FROM data WHERE price > 100"
+
+            # Aggregate data
+            query="SELECT category, SUM(amount) as total FROM data GROUP BY category"
+
+            # Join multiple sheets (sheet names: 'Sales', 'Products')
+            query="SELECT s.*, p.name FROM Sales s JOIN Products p ON s.product_id = p.id"
+        """
+        try:
+            import duckdb
+        except ImportError:
+            return {
+                "error": (
+                    "DuckDB not installed. Install with: "
+                    "pip install duckdb  or  pip install tools[sql]"
+                )
+            }
+
+        try:
+            from openpyxl import load_workbook
+        except ImportError:
+            return {
+                "error": (
+                    "openpyxl not installed. Install with: "
+                    "pip install openpyxl  or  pip install tools[excel]"
+                )
+            }
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            if not path.lower().endswith((".xlsx", ".xlsm")):
+                return {"error": "File must have .xlsx or .xlsm extension"}
+
+            if not query or not query.strip():
+                return {"error": "query cannot be empty"}
+
+            # Security: only allow SELECT statements
+            query_upper = query.strip().upper()
+            if not query_upper.startswith("SELECT"):
+                return {"error": "Only SELECT queries are allowed for security reasons"}
+
+            # Disallowed keywords
+            disallowed = [
+                "INSERT",
+                "UPDATE",
+                "DELETE",
+                "DROP",
+                "CREATE",
+                "ALTER",
+                "TRUNCATE",
+                "EXEC",
+                "EXECUTE",
+            ]
+            for keyword in disallowed:
+                if keyword in query_upper:
+                    return {"error": f"'{keyword}' is not allowed in queries"}
+
+            # Load workbook
+            wb = load_workbook(secure_path, read_only=True, data_only=True)
+
+            try:
+                # Determine target sheet for 'data' alias
+                if sheet:
+                    if sheet not in wb.sheetnames:
+                        wb.close()
+                        return {"error": f"Sheet '{sheet}' not found. Available: {wb.sheetnames}"}
+                    target_sheet = sheet
+                else:
+                    target_sheet = wb.sheetnames[0]
+
+                # Load all sheets into DuckDB
+                con = duckdb.connect(":memory:")
+
+                for sheet_name in wb.sheetnames:
+                    ws = wb[sheet_name]
+                    rows = list(ws.iter_rows(values_only=True))
+
+                    if not rows:
+                        continue
+
+                    # Headers from first row
+                    headers = [
+                        str(c) if c is not None else f"Column_{i + 1}"
+                        for i, c in enumerate(rows[0])
+                    ]
+
+                    # Data rows
+                    records = []
+                    for row in rows[1:]:
+                        record = {}
+                        for i, val in enumerate(row):
+                            col = headers[i] if i < len(headers) else f"Column_{i + 1}"
+                            record[col] = _convert_cell_value(val)
+                        records.append(record)
+
+                    # Create table (sanitize name: spaces -> underscores)
+                    table_name = sheet_name.replace(" ", "_").replace("-", "_")
+                    if records:
+                        import pandas as pd
+
+                        df = pd.DataFrame(records)
+                        con.register(f"temp_{table_name}", df)
+                        con.execute(
+                            f'CREATE TABLE "{table_name}" AS SELECT * FROM temp_{table_name}'
+                        )
+                    else:
+                        # Empty table
+                        cols_sql = ", ".join(f'"{h}" VARCHAR' for h in headers)
+                        con.execute(f'CREATE TABLE "{table_name}" ({cols_sql})')
+
+                    # Create 'data' alias for target sheet
+                    if sheet_name == target_sheet:
+                        con.execute(f'CREATE VIEW data AS SELECT * FROM "{table_name}"')
+
+                wb.close()
+
+                # Execute query
+                result = con.execute(query)
+                columns = [desc[0] for desc in result.description]
+                rows = result.fetchall()
+                con.close()
+
+                # Convert to dicts
+                rows_as_dicts = [dict(zip(columns, row, strict=False)) for row in rows]
+
+                return {
+                    "success": True,
+                    "path": path,
+                    "target_sheet": target_sheet,
+                    "available_sheets": wb.sheetnames if hasattr(wb, "sheetnames") else [],
+                    "query": query,
+                    "columns": columns,
+                    "column_count": len(columns),
+                    "rows": rows_as_dicts,
+                    "row_count": len(rows_as_dicts),
+                }
+
+            except Exception as e:
+                wb.close()
+                raise e
+
+        except Exception as e:
+            error_msg = str(e)
+            if "Catalog Error" in error_msg or "Table" in error_msg:
+                return {
+                    "error": f"SQL error: {error_msg}. "
+                    "Use 'data' for target sheet or sheet names with underscores."
+                }
+            return {"error": f"Query failed: {error_msg}"}
+
+    @mcp.tool()
+    def excel_search(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        search_term: str,
+        sheet: str | None = None,
+        case_sensitive: bool = False,
+        match_type: str = "contains",
+    ) -> dict:
+        """
+        Search for values across Excel sheets.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+            search_term: Text to search for
+            sheet: Specific sheet to search (default: search all sheets)
+            case_sensitive: Whether search is case-sensitive (default: False)
+            match_type: 'contains', 'exact', 'starts_with', or 'ends_with'
+
+        Returns:
+            dict with list of matches containing sheet, row, column, and value
+        """
+        try:
+            from openpyxl import load_workbook
+        except ImportError:
+            return {
+                "error": (
+                    "openpyxl not installed. Install with: "
+                    "pip install openpyxl  or  pip install tools[excel]"
+                )
+            }
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            if not path.lower().endswith((".xlsx", ".xlsm")):
+                return {"error": "File must have .xlsx or .xlsm extension"}
+
+            if not search_term:
+                return {"error": "search_term cannot be empty"}
+
+            if match_type not in ("contains", "exact", "starts_with", "ends_with"):
+                return {
+                    "error": "match_type must be 'contains', 'exact', 'starts_with', or 'ends_with'"
+                }
+
+            # Prepare search term
+            term = search_term if case_sensitive else search_term.lower()
+
+            # Load workbook
+            wb = load_workbook(secure_path, read_only=True, data_only=True)
+
+            try:
+                sheets_to_search = [sheet] if sheet else wb.sheetnames
+
+                if sheet and sheet not in wb.sheetnames:
+                    return {"error": f"Sheet '{sheet}' not found. Available: {wb.sheetnames}"}
+
+                matches = []
+                for sheet_name in sheets_to_search:
+                    ws = wb[sheet_name]
+
+                    # Get headers for column names
+                    headers = []
+                    first_row = next(ws.iter_rows(min_row=1, max_row=1, values_only=True), None)
+                    if first_row:
+                        headers = [
+                            str(c) if c is not None else f"Column_{i + 1}"
+                            for i, c in enumerate(first_row)
+                        ]
+
+                    # Search all cells
+                    for row_idx, row in enumerate(ws.iter_rows(values_only=True), start=1):
+                        for col_idx, cell_value in enumerate(row):
+                            if cell_value is None:
+                                continue
+
+                            # Convert to string for comparison
+                            cell_str = str(cell_value)
+                            compare_val = cell_str if case_sensitive else cell_str.lower()
+
+                            # Check match
+                            is_match = False
+                            if match_type == "contains":
+                                is_match = term in compare_val
+                            elif match_type == "exact":
+                                is_match = term == compare_val
+                            elif match_type == "starts_with":
+                                is_match = compare_val.startswith(term)
+                            elif match_type == "ends_with":
+                                is_match = compare_val.endswith(term)
+
+                            if is_match:
+                                col_name = (
+                                    headers[col_idx]
+                                    if col_idx < len(headers)
+                                    else f"Column_{col_idx + 1}"
+                                )
+                                matches.append(
+                                    {
+                                        "sheet": sheet_name,
+                                        "row": row_idx,
+                                        "column": col_name,
+                                        "column_index": col_idx + 1,
+                                        "value": _convert_cell_value(cell_value),
+                                    }
+                                )
+
+                return {
+                    "success": True,
+                    "path": path,
+                    "search_term": search_term,
+                    "match_type": match_type,
+                    "case_sensitive": case_sensitive,
+                    "sheets_searched": sheets_to_search,
+                    "matches": matches,
+                    "match_count": len(matches),
+                }
+
+            finally:
+                wb.close()
+
+        except Exception as e:
+            return {"error": f"Search failed: {str(e)}"}
+
+
+def _convert_cell_value(value: Any) -> Any:
+    """Convert Excel cell values to JSON-serializable types."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, (int, float, str, bool)):
+        return value
+    # For any other type, convert to string
+    return str(value)

--- a/tools/tests/tools/test_excel_tool.py
+++ b/tools/tests/tools/test_excel_tool.py
@@ -1,0 +1,1091 @@
+"""Tests for excel_tool - Read and manipulate Excel files (.xlsx, .xlsm)."""
+
+import importlib.util
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastmcp import FastMCP
+
+openpyxl_available = importlib.util.find_spec("openpyxl") is not None
+
+# Skip all tests if openpyxl is not installed
+pytestmark = pytest.mark.skipif(not openpyxl_available, reason="openpyxl not installed")
+
+if openpyxl_available:
+    from openpyxl import Workbook
+
+    from aden_tools.tools.excel_tool.excel_tool import register_tools
+
+# Test IDs for sandbox
+TEST_WORKSPACE_ID = "test-workspace"
+TEST_AGENT_ID = "test-agent"
+TEST_SESSION_ID = "test-session"
+
+
+@pytest.fixture
+def excel_tools(mcp: FastMCP, tmp_path: Path):
+    """Register all Excel tools and return them as a dict."""
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        register_tools(mcp)
+        yield {
+            "excel_read": mcp._tool_manager._tools["excel_read"].fn,
+            "excel_write": mcp._tool_manager._tools["excel_write"].fn,
+            "excel_append": mcp._tool_manager._tools["excel_append"].fn,
+            "excel_info": mcp._tool_manager._tools["excel_info"].fn,
+            "excel_sheet_list": mcp._tool_manager._tools["excel_sheet_list"].fn,
+            "excel_sql": mcp._tool_manager._tools["excel_sql"].fn,
+            "excel_search": mcp._tool_manager._tools["excel_search"].fn,
+        }
+
+
+@pytest.fixture
+def excel_read_fn(excel_tools):
+    """Return excel_read function for backward compatibility."""
+    return excel_tools["excel_read"]
+
+
+@pytest.fixture
+def session_dir(tmp_path: Path) -> Path:
+    """Create and return the session directory within the sandbox."""
+    session_path = tmp_path / TEST_WORKSPACE_ID / TEST_AGENT_ID / TEST_SESSION_ID
+    session_path.mkdir(parents=True, exist_ok=True)
+    return session_path
+
+
+@pytest.fixture
+def basic_xlsx(session_dir: Path) -> Path:
+    """Create a basic Excel file for testing."""
+    xlsx_file = session_dir / "basic.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    # Header row
+    ws.append(["name", "age", "city"])
+    # Data rows
+    ws.append(["Alice", 30, "NYC"])
+    ws.append(["Bob", 25, "LA"])
+    ws.append(["Charlie", 35, "Chicago"])
+    wb.save(xlsx_file)
+    wb.close()
+    return xlsx_file
+
+
+@pytest.fixture
+def multi_sheet_xlsx(session_dir: Path) -> Path:
+    """Create an Excel file with multiple sheets."""
+    xlsx_file = session_dir / "multi_sheet.xlsx"
+    wb = Workbook()
+
+    # First sheet (active)
+    ws1 = wb.active
+    ws1.title = "Employees"
+    ws1.append(["id", "name", "department"])
+    ws1.append([1, "Alice", "Engineering"])
+    ws1.append([2, "Bob", "Marketing"])
+
+    # Second sheet
+    ws2 = wb.create_sheet("Products")
+    ws2.append(["id", "name", "price"])
+    ws2.append([1, "Widget", 99.99])
+    ws2.append([2, "Gadget", 149.99])
+
+    # Third sheet
+    ws3 = wb.create_sheet("Summary")
+    ws3.append(["metric", "value"])
+    ws3.append(["total_employees", 2])
+    ws3.append(["total_products", 2])
+
+    wb.save(xlsx_file)
+    wb.close()
+    return xlsx_file
+
+
+@pytest.fixture
+def large_xlsx(session_dir: Path) -> Path:
+    """Create a larger Excel file for pagination testing."""
+    xlsx_file = session_dir / "large.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Data"
+    ws.append(["id", "value"])
+    for i in range(100):
+        ws.append([i, i * 10])
+    wb.save(xlsx_file)
+    wb.close()
+    return xlsx_file
+
+
+@pytest.fixture
+def empty_xlsx(session_dir: Path) -> Path:
+    """Create an empty Excel file."""
+    xlsx_file = session_dir / "empty.xlsx"
+    wb = Workbook()
+    wb.save(xlsx_file)
+    wb.close()
+    return xlsx_file
+
+
+@pytest.fixture
+def headers_only_xlsx(session_dir: Path) -> Path:
+    """Create an Excel file with only headers."""
+    xlsx_file = session_dir / "headers_only.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["name", "age", "city"])
+    wb.save(xlsx_file)
+    wb.close()
+    return xlsx_file
+
+
+@pytest.fixture
+def xlsx_with_dates(session_dir: Path) -> Path:
+    """Create an Excel file with date values."""
+    xlsx_file = session_dir / "dates.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["name", "created_at"])
+    ws.append(["Alice", datetime(2024, 1, 15, 10, 30, 0)])
+    ws.append(["Bob", datetime(2024, 6, 20, 14, 45, 0)])
+    wb.save(xlsx_file)
+    wb.close()
+    return xlsx_file
+
+
+class TestExcelRead:
+    """Tests for excel_read function."""
+
+    def test_read_basic_xlsx(self, excel_read_fn, basic_xlsx, tmp_path):
+        """Read a basic Excel file successfully."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_read_fn(
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        assert result["columns"] == ["name", "age", "city"]
+        assert result["column_count"] == 3
+        assert result["row_count"] == 3
+        assert result["total_rows"] == 3
+        assert len(result["rows"]) == 3
+        assert result["rows"][0] == {"name": "Alice", "age": 30, "city": "NYC"}
+        assert result["sheet_name"] == "Sheet1"
+
+    def test_read_specific_sheet(self, excel_read_fn, multi_sheet_xlsx, tmp_path):
+        """Read a specific sheet from an Excel file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_read_fn(
+                path="multi_sheet.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                sheet="Products",
+            )
+
+        assert result["success"] is True
+        assert result["sheet_name"] == "Products"
+        assert result["columns"] == ["id", "name", "price"]
+        assert result["row_count"] == 2
+        assert result["rows"][0]["name"] == "Widget"
+
+    def test_read_nonexistent_sheet_error(self, excel_read_fn, multi_sheet_xlsx, tmp_path):
+        """Return error for non-existent sheet."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_read_fn(
+                path="multi_sheet.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                sheet="NonExistent",
+            )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+        assert "Available sheets" in result["error"]
+
+    def test_read_with_limit(self, excel_read_fn, basic_xlsx, tmp_path):
+        """Read Excel with row limit."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_read_fn(
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                limit=2,
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 2
+        assert result["total_rows"] == 3
+        assert result["limit"] == 2
+        assert len(result["rows"]) == 2
+        assert result["rows"][0]["name"] == "Alice"
+        assert result["rows"][1]["name"] == "Bob"
+
+    def test_read_with_offset(self, excel_read_fn, basic_xlsx, tmp_path):
+        """Read Excel with row offset."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_read_fn(
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                offset=1,
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 2
+        assert result["offset"] == 1
+        assert result["rows"][0]["name"] == "Bob"
+        assert result["rows"][1]["name"] == "Charlie"
+
+    def test_read_with_limit_and_offset(self, excel_read_fn, large_xlsx, tmp_path):
+        """Read Excel with both limit and offset (pagination)."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_read_fn(
+                path="large.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                limit=10,
+                offset=50,
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 10
+        assert result["total_rows"] == 100
+        assert result["offset"] == 50
+        assert result["limit"] == 10
+        # First row should be id=50
+        assert result["rows"][0] == {"id": 50, "value": 500}
+
+    def test_file_not_found(self, excel_read_fn, session_dir, tmp_path):
+        """Return error for non-existent file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_read_fn(
+                path="nonexistent.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_non_xlsx_extension(self, excel_read_fn, session_dir, tmp_path):
+        """Return error for non-Excel file extension."""
+        # Create a text file
+        txt_file = session_dir / "data.txt"
+        txt_file.write_text("name,age\nAlice,30\n")
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_read_fn(
+                path="data.txt",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert ".xlsx" in result["error"].lower() or ".xlsm" in result["error"].lower()
+
+    def test_empty_xlsx_file(self, excel_read_fn, empty_xlsx, tmp_path):
+        """Read empty Excel file (returns empty result)."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_read_fn(
+                path="empty.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 0
+        assert result["rows"] == []
+
+    def test_headers_only_xlsx(self, excel_read_fn, headers_only_xlsx, tmp_path):
+        """Read Excel with only headers (no data rows)."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_read_fn(
+                path="headers_only.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        assert result["columns"] == ["name", "age", "city"]
+        assert result["row_count"] == 0
+        assert result["total_rows"] == 0
+        assert result["rows"] == []
+
+    def test_missing_workspace_id(self, excel_read_fn, basic_xlsx, tmp_path):
+        """Return error when workspace_id is missing."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_read_fn(
+                path="basic.xlsx",
+                workspace_id="",
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+
+    def test_missing_agent_id(self, excel_read_fn, basic_xlsx, tmp_path):
+        """Return error when agent_id is missing."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_read_fn(
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id="",
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+
+    def test_missing_session_id(self, excel_read_fn, basic_xlsx, tmp_path):
+        """Return error when session_id is missing."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_read_fn(
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id="",
+            )
+
+        assert "error" in result
+
+    def test_path_traversal_blocked(self, excel_read_fn, session_dir, tmp_path):
+        """Prevent path traversal attacks."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_read_fn(
+                path="../../../etc/passwd.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+
+    def test_offset_beyond_rows(self, excel_read_fn, basic_xlsx, tmp_path):
+        """Offset beyond available rows returns empty result."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_read_fn(
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                offset=100,
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 0
+        assert result["rows"] == []
+        assert result["total_rows"] == 3
+
+    def test_read_with_dates(self, excel_read_fn, xlsx_with_dates, tmp_path):
+        """Read Excel with date values (should serialize to ISO format)."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_read_fn(
+                path="dates.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        # Dates should be serialized as ISO strings
+        assert "2024-01-15" in result["rows"][0]["created_at"]
+
+
+class TestExcelWrite:
+    """Tests for excel_write function."""
+
+    def test_write_new_xlsx(self, excel_tools, session_dir, tmp_path):
+        """Write a new Excel file successfully."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="output.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["name", "age", "city"],
+                rows=[
+                    {"name": "Alice", "age": 30, "city": "NYC"},
+                    {"name": "Bob", "age": 25, "city": "LA"},
+                ],
+            )
+
+        assert result["success"] is True
+        assert result["columns"] == ["name", "age", "city"]
+        assert result["column_count"] == 3
+        assert result["rows_written"] == 2
+        assert result["sheet_name"] == "Sheet1"
+
+        # Verify file exists
+        assert (session_dir / "output.xlsx").exists()
+
+    def test_write_with_custom_sheet_name(self, excel_tools, session_dir, tmp_path):
+        """Write Excel with custom sheet name."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="output.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["id", "value"],
+                rows=[{"id": 1, "value": 100}],
+                sheet="MyData",
+            )
+
+        assert result["success"] is True
+        assert result["sheet_name"] == "MyData"
+
+    def test_write_creates_parent_directories(self, excel_tools, session_dir, tmp_path):
+        """Write creates parent directories if needed."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="subdir/nested/output.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["id"],
+                rows=[{"id": 1}],
+            )
+
+        assert result["success"] is True
+        assert (session_dir / "subdir" / "nested" / "output.xlsx").exists()
+
+    def test_write_empty_columns_error(self, excel_tools, session_dir, tmp_path):
+        """Return error when columns is empty."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="output.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=[],
+                rows=[],
+            )
+
+        assert "error" in result
+        assert "empty" in result["error"].lower()
+
+    def test_write_non_xlsx_extension_error(self, excel_tools, session_dir, tmp_path):
+        """Return error for non-Excel file extension."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="output.txt",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["id"],
+                rows=[],
+            )
+
+        assert "error" in result
+        assert ".xlsx" in result["error"].lower() or ".xlsm" in result["error"].lower()
+
+    def test_write_empty_rows(self, excel_tools, session_dir, tmp_path):
+        """Write Excel with headers but no rows."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="output.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["name", "age"],
+                rows=[],
+            )
+
+        assert result["success"] is True
+        assert result["rows_written"] == 0
+
+
+class TestExcelAppend:
+    """Tests for excel_append function."""
+
+    def test_append_to_existing_xlsx(self, excel_tools, basic_xlsx, tmp_path):
+        """Append rows to an existing Excel file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_append"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                rows=[
+                    {"name": "David", "age": 28, "city": "Seattle"},
+                    {"name": "Eve", "age": 32, "city": "Boston"},
+                ],
+            )
+
+        assert result["success"] is True
+        assert result["rows_appended"] == 2
+        assert result["total_rows"] == 5
+
+    def test_append_to_specific_sheet(self, excel_tools, multi_sheet_xlsx, tmp_path):
+        """Append rows to a specific sheet."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_append"](
+                path="multi_sheet.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                rows=[{"id": 3, "name": "Doohickey", "price": 49.99}],
+                sheet="Products",
+            )
+
+        assert result["success"] is True
+        assert result["sheet_name"] == "Products"
+        assert result["rows_appended"] == 1
+
+    def test_append_file_not_found(self, excel_tools, session_dir, tmp_path):
+        """Return error when file doesn't exist."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_append"](
+                path="nonexistent.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                rows=[{"name": "Alice"}],
+            )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_append_empty_rows_error(self, excel_tools, basic_xlsx, tmp_path):
+        """Return error when rows is empty."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_append"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                rows=[],
+            )
+
+        assert "error" in result
+        assert "empty" in result["error"].lower()
+
+    def test_append_non_xlsx_extension_error(self, excel_tools, session_dir, tmp_path):
+        """Return error for non-Excel file extension."""
+        txt_file = session_dir / "data.txt"
+        txt_file.write_text("name\nAlice\n")
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_append"](
+                path="data.txt",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                rows=[{"name": "Bob"}],
+            )
+
+        assert "error" in result
+        assert ".xlsx" in result["error"].lower() or ".xlsm" in result["error"].lower()
+
+
+class TestExcelInfo:
+    """Tests for excel_info function."""
+
+    def test_get_info_basic_xlsx(self, excel_tools, basic_xlsx, tmp_path):
+        """Get info about a basic Excel file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_info"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        assert result["sheet_count"] == 1
+        assert result["sheet_names"] == ["Sheet1"]
+        assert "file_size_bytes" in result
+        assert result["file_size_bytes"] > 0
+        assert len(result["sheets"]) == 1
+        assert result["sheets"][0]["name"] == "Sheet1"
+        assert result["sheets"][0]["columns"] == ["name", "age", "city"]
+        assert result["sheets"][0]["row_count"] == 3
+
+    def test_get_info_multi_sheet_xlsx(self, excel_tools, multi_sheet_xlsx, tmp_path):
+        """Get info about a multi-sheet Excel file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_info"](
+                path="multi_sheet.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        assert result["sheet_count"] == 3
+        assert "Employees" in result["sheet_names"]
+        assert "Products" in result["sheet_names"]
+        assert "Summary" in result["sheet_names"]
+
+    def test_get_info_file_not_found(self, excel_tools, session_dir, tmp_path):
+        """Return error when file doesn't exist."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_info"](
+                path="nonexistent.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_get_info_non_xlsx_extension_error(self, excel_tools, session_dir, tmp_path):
+        """Return error for non-Excel file extension."""
+        txt_file = session_dir / "data.txt"
+        txt_file.write_text("name\nAlice\n")
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_info"](
+                path="data.txt",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert ".xlsx" in result["error"].lower() or ".xlsm" in result["error"].lower()
+
+
+class TestExcelSheetList:
+    """Tests for excel_sheet_list function."""
+
+    def test_list_sheets_basic(self, excel_tools, basic_xlsx, tmp_path):
+        """List sheets in a basic Excel file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sheet_list"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        assert result["sheet_names"] == ["Sheet1"]
+        assert result["sheet_count"] == 1
+
+    def test_list_sheets_multi_sheet(self, excel_tools, multi_sheet_xlsx, tmp_path):
+        """List sheets in a multi-sheet Excel file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sheet_list"](
+                path="multi_sheet.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        assert result["sheet_count"] == 3
+        assert "Employees" in result["sheet_names"]
+        assert "Products" in result["sheet_names"]
+        assert "Summary" in result["sheet_names"]
+
+    def test_list_sheets_file_not_found(self, excel_tools, session_dir, tmp_path):
+        """Return error when file doesn't exist."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sheet_list"](
+                path="nonexistent.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_list_sheets_non_xlsx_extension_error(self, excel_tools, session_dir, tmp_path):
+        """Return error for non-Excel file extension."""
+        txt_file = session_dir / "data.txt"
+        txt_file.write_text("name\nAlice\n")
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sheet_list"](
+                path="data.txt",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert ".xlsx" in result["error"].lower() or ".xlsm" in result["error"].lower()
+
+
+class TestExcelIntegration:
+    """Integration tests for Excel tools (write + read)."""
+
+    def test_write_then_read(self, excel_tools, session_dir, tmp_path):
+        """Write and then read back the same data."""
+        test_data = [
+            {"name": "Alice", "score": 95},
+            {"name": "Bob", "score": 87},
+            {"name": "Charlie", "score": 92},
+        ]
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            # Write
+            write_result = excel_tools["excel_write"](
+                path="test.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["name", "score"],
+                rows=test_data,
+            )
+            assert write_result["success"] is True
+
+            # Read back
+            read_result = excel_tools["excel_read"](
+                path="test.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert read_result["success"] is True
+        assert read_result["row_count"] == 3
+        assert read_result["rows"][0]["name"] == "Alice"
+        assert read_result["rows"][0]["score"] == 95
+
+    def test_write_append_read(self, excel_tools, session_dir, tmp_path):
+        """Write, append, and then read back all data."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            # Write initial data
+            excel_tools["excel_write"](
+                path="test.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["id", "value"],
+                rows=[{"id": 1, "value": "A"}, {"id": 2, "value": "B"}],
+            )
+
+            # Append more data
+            excel_tools["excel_append"](
+                path="test.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                rows=[{"id": 3, "value": "C"}, {"id": 4, "value": "D"}],
+            )
+
+            # Read back
+            read_result = excel_tools["excel_read"](
+                path="test.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert read_result["success"] is True
+        assert read_result["row_count"] == 4
+        assert read_result["rows"][2]["id"] == 3
+        assert read_result["rows"][3]["value"] == "D"
+
+
+# Check if duckdb is available for SQL tests
+duckdb_available = importlib.util.find_spec("duckdb") is not None
+
+
+@pytest.mark.skipif(not duckdb_available, reason="duckdb not installed")
+class TestExcelSql:
+    """Tests for excel_sql function."""
+
+    def test_sql_basic_query(self, excel_tools, basic_xlsx, tmp_path):
+        """Run basic SQL query on Excel file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sql"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="SELECT * FROM data",
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 3
+        assert "name" in result["columns"]
+
+    def test_sql_with_filter(self, excel_tools, basic_xlsx, tmp_path):
+        """Run SQL query with WHERE clause."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sql"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="SELECT * FROM data WHERE age > 25",
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 2  # Alice (30) and Charlie (35)
+
+    def test_sql_with_aggregation(self, excel_tools, basic_xlsx, tmp_path):
+        """Run SQL query with aggregation."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sql"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="SELECT COUNT(*) as count, AVG(age) as avg_age FROM data",
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 1
+        assert result["rows"][0]["count"] == 3
+
+    def test_sql_specific_sheet(self, excel_tools, multi_sheet_xlsx, tmp_path):
+        """Run SQL query on specific sheet."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sql"](
+                path="multi_sheet.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="SELECT * FROM data WHERE price > 100",
+                sheet="Products",
+            )
+
+        assert result["success"] is True
+        assert result["target_sheet"] == "Products"
+        assert result["row_count"] == 1  # Gadget at 149.99
+
+    def test_sql_join_sheets(self, excel_tools, multi_sheet_xlsx, tmp_path):
+        """Join data across multiple sheets."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sql"](
+                path="multi_sheet.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="SELECT e.name, p.name as product FROM Employees e, Products p",
+            )
+
+        assert result["success"] is True
+        # Cross join: 2 employees x 2 products = 4 rows
+        assert result["row_count"] == 4
+
+    def test_sql_empty_query_error(self, excel_tools, basic_xlsx, tmp_path):
+        """Return error for empty query."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sql"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="",
+            )
+
+        assert "error" in result
+        assert "empty" in result["error"].lower()
+
+    def test_sql_non_select_rejected(self, excel_tools, basic_xlsx, tmp_path):
+        """Reject non-SELECT queries for security."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sql"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="DELETE FROM data",
+            )
+
+        assert "error" in result
+        assert "SELECT" in result["error"]
+
+    def test_sql_file_not_found(self, excel_tools, session_dir, tmp_path):
+        """Return error when file doesn't exist."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sql"](
+                path="nonexistent.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="SELECT * FROM data",
+            )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+
+class TestExcelSearch:
+    """Tests for excel_search function."""
+
+    def test_search_basic_contains(self, excel_tools, basic_xlsx, tmp_path):
+        """Search for text containing a term."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_search"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                search_term="Alice",
+            )
+
+        assert result["success"] is True
+        assert result["match_count"] >= 1
+        assert any(m["value"] == "Alice" for m in result["matches"])
+
+    def test_search_case_insensitive(self, excel_tools, basic_xlsx, tmp_path):
+        """Search is case-insensitive by default."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_search"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                search_term="alice",
+                case_sensitive=False,
+            )
+
+        assert result["success"] is True
+        assert result["match_count"] >= 1
+
+    def test_search_case_sensitive(self, excel_tools, basic_xlsx, tmp_path):
+        """Case-sensitive search."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_search"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                search_term="alice",
+                case_sensitive=True,
+            )
+
+        # "alice" (lowercase) won't match "Alice"
+        assert result["success"] is True
+        assert result["match_count"] == 0
+
+    def test_search_exact_match(self, excel_tools, basic_xlsx, tmp_path):
+        """Search with exact match."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_search"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                search_term="NYC",
+                match_type="exact",
+            )
+
+        assert result["success"] is True
+        assert result["match_count"] == 1
+        assert result["matches"][0]["value"] == "NYC"
+
+    def test_search_starts_with(self, excel_tools, basic_xlsx, tmp_path):
+        """Search with starts_with match."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_search"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                search_term="Ch",
+                match_type="starts_with",
+            )
+
+        assert result["success"] is True
+        # Should match "Charlie" and "Chicago"
+        assert result["match_count"] == 2
+
+    def test_search_across_sheets(self, excel_tools, multi_sheet_xlsx, tmp_path):
+        """Search across all sheets."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_search"](
+                path="multi_sheet.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                search_term="Alice",
+            )
+
+        assert result["success"] is True
+        assert result["match_count"] >= 1
+        # Should search all sheets
+        assert len(result["sheets_searched"]) == 3
+
+    def test_search_specific_sheet(self, excel_tools, multi_sheet_xlsx, tmp_path):
+        """Search in specific sheet only."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_search"](
+                path="multi_sheet.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                search_term="Widget",
+                sheet="Products",
+            )
+
+        assert result["success"] is True
+        assert result["sheets_searched"] == ["Products"]
+        assert result["match_count"] >= 1
+
+    def test_search_no_matches(self, excel_tools, basic_xlsx, tmp_path):
+        """Search returns empty when no matches."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_search"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                search_term="ZZZZNOTFOUND",
+            )
+
+        assert result["success"] is True
+        assert result["match_count"] == 0
+        assert result["matches"] == []
+
+    def test_search_empty_term_error(self, excel_tools, basic_xlsx, tmp_path):
+        """Return error for empty search term."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_search"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                search_term="",
+            )
+
+        assert "error" in result
+        assert "empty" in result["error"].lower()
+
+    def test_search_invalid_match_type(self, excel_tools, basic_xlsx, tmp_path):
+        """Return error for invalid match_type."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_search"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                search_term="test",
+                match_type="invalid",
+            )
+
+        assert "error" in result
+        assert "match_type" in result["error"]
+
+    def test_search_file_not_found(self, excel_tools, session_dir, tmp_path):
+        """Return error when file doesn't exist."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_search"](
+                path="nonexistent.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                search_term="test",
+            )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()

--- a/uv.lock
+++ b/uv.lock
@@ -624,6 +624,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1788,6 +1797,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]
@@ -3116,6 +3137,7 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "duckdb" },
+    { name = "openpyxl" },
     { name = "pillow" },
     { name = "pytesseract" },
     { name = "restrictedpython" },
@@ -3123,6 +3145,9 @@ all = [
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
+]
+excel = [
+    { name = "openpyxl" },
 ]
 ocr = [
     { name = "pillow" },
@@ -3137,6 +3162,7 @@ sql = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "duckdb" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -3152,6 +3178,8 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jsonpath-ng", specifier = ">=1.6.0" },
     { name = "litellm", specifier = ">=1.81.0" },
+    { name = "openpyxl", marker = "extra == 'all'", specifier = ">=3.1.0" },
+    { name = "openpyxl", marker = "extra == 'excel'", specifier = ">=3.1.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pillow", marker = "extra == 'all'", specifier = ">=10.0.0" },
     { name = "pillow", marker = "extra == 'ocr'", specifier = ">=10.0.0" },
@@ -3168,10 +3196,11 @@ requires-dist = [
     { name = "restrictedpython", marker = "extra == 'all'", specifier = ">=7.0" },
     { name = "restrictedpython", marker = "extra == 'sandbox'", specifier = ">=7.0" },
 ]
-provides-extras = ["dev", "sandbox", "ocr", "sql", "all"]
+provides-extras = ["dev", "sandbox", "ocr", "excel", "sql", "all"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "duckdb", specifier = ">=1.4.4" },
     { name = "ruff", specifier = ">=0.14.14" },
     { name = "ty", specifier = ">=0.0.13" },
 ]


### PR DESCRIPTION
## Description

Adds comprehensive Excel spreadsheet tools to the Aden tools library, enabling agents to read, write, query, and search Excel files 

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Fixes #2675 

## Changes Made

### New [excel_tool](cci:7://file:///Users/siketyson/Desktop/aden/tools/src/aden_tools/tools/excel_tool:0:0-0:0) Module

Added 7 tool functions for complete Excel file manipulation:

| Tool | Description |
|------|-------------|
| `excel_read` | Read Excel files with pagination support (limit/offset) |
| `excel_write` | Create new Excel files with custom sheet names |
| `excel_append` | Append rows to existing sheets |
| `excel_info` | Get file metadata (sheets, columns, row counts) |
| `excel_sheet_list` | List all sheet names in a workbook |
| `excel_sql` | Query Excel data with SQL via DuckDB (including multi-sheet joins!) |
| `excel_search` | Search values across sheets with `contains`/`exact`/`starts_with` matching |

### Other Changes

- Added `openpyxl` as optional dependency (`pip install aden-tools[excel]`)
- Updated [__init__.py](cci:7://file:///Users/siketyson/Desktop/aden/tools/src/aden_tools/tools/__init__.py:0:0-0:0) to register Excel tools
- Added Excel tools reference to `building-agents-construction/SKILL.md`

## Testing

- ✅ **56 new unit tests** covering all Excel functions
- ✅ Lint passes (`ruff check . && ruff format .`)
- ✅ Manual testing performed

```bash
# Run tests
pytest tools/tests/tools/test_excel_tool.py -v

# Example output
56 passed in 2.34s