### PR TITLE
[micro-fix] chore(logging): add debug logging for parse_response failures

### DIFF
--- a/core/framework/graph/hitl.py
+++ b/core/framework/graph/hitl.py
@@ -5,9 +5,12 @@ This module defines the formal structure for pause/resume interactions
 where agents need to gather input from humans.
 """
 
+import logging
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 class HITLInputType(str, Enum):
@@ -212,7 +215,8 @@ Example format:
                 parsed = json.loads(json_match.group())
                 response.answers = parsed
 
-        except Exception:
+        except Exception as e:
+            logger.warning(f"Haiku parsing failed: {e}. Using fallback.")
             # Fallback: use raw input for first question
             if request.questions:
                 response.answers[request.questions[0].id] = raw_input


### PR DESCRIPTION
## Description

This PR adds logging to the `parse_response` function in the `core/framework/graph/hitl.py` module to assist with debugging when Haiku parsing fails or fallback methods are triggered.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Related Issues
Fixes[ #3021](https://github.com/adenhq/hive/issues/3021)

### Changes:
1. Import Python's `logging` module.
2. Add a logger warning to catch exceptions in Haiku parsing and indicate fallback usage.

### Rationale:
- Helps identify potential issues during parsing, especially in multi-question scenarios.
- Assists in debugging edge cases where responses might not be parsed correctly.