### PR TITLE
micro-fix: add missing Content-Type header mock in web_scrape tests

### DIFF
--- a/tools/tests/tools/test_web_scrape_tool.py
+++ b/tools/tests/tools/test_web_scrape_tool.py
@@ -64,6 +64,7 @@ class TestWebScrapeToolLinkConversion:
         mock_response.status_code = 200
         mock_response.text = html_content
         mock_response.url = final_url
+        mock_response.headers.get.return_value = "text/html; charset=utf-8"
         return mock_response
 
     @patch("aden_tools.tools.web_scrape_tool.web_scrape_tool.httpx.get")


### PR DESCRIPTION
## Description

 Fix incomplete mock setup in `TestWebScrapeToolLinkConversion` that caused all 7 link conversion tests to fail.    
      
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #2000 

## Changes Made

 Add `mock_response.headers.get.return_value = "text/html; charset=utf-8"` to `_mock_response()` helper                 

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes