### PR TITLE
fix: replace private _tool_registry usage with public list_tools API

### DIFF
--- a/core/MCP_INTEGRATION_GUIDE.md
+++ b/core/MCP_INTEGRATION_GUIDE.md
@@ -304,7 +304,7 @@ If you get connection errors with STDIO transport:
 If a tool is registered but not found:
 
 1. Verify the server registered successfully (check logs)
-2. List available tools: `runner._tool_registry.get_registered_names()`
+2. List available tools: `runner.list_tools()`
 3. Check tool name spelling in your node configuration
 
 ### HTTP Server Not Responding

--- a/core/examples/mcp_integration_example.py
+++ b/core/examples/mcp_integration_example.py
@@ -33,7 +33,7 @@ async def example_1_programmatic_registration():
     print(f"Registered {num_tools} tools from tools MCP server")
 
     # List all available tools
-    tools = runner._tool_registry.get_tools()
+    tools = runner.list_tools()
     print(f"\nAvailable tools: {list(tools.keys())}")
 
     # Run the agent with MCP tools available

--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -366,9 +366,12 @@ def cmd_info(args: argparse.Namespace) -> int:
         for c in info.constraints:
             print(f"  - [{c['type']}] {c['description']}")
         print()
+
+        tools = runner.list_tools()
+
         print(f"Required Tools ({len(info.required_tools)}):")
         for tool in info.required_tools:
-            status = "✓" if runner._tool_registry.has_tool(tool) else "✗"
+            status = "✓" if tool in tools else "✗"
             print(f"  {status} {tool}")
         print()
         print(f"Tools Module: {'✓ tools.py found' if info.has_tools_module else '✗ no tools.py'}")


### PR DESCRIPTION
- Add and use AgentRunner.list_tools() for tool inspection
- Update MCP integration example to avoid private internals
- Update CLI and MCP integration guide to reference public API

Fixes #2490

## Description

This PR removes usage of the private `_tool_registry` attribute from MCP-related examples and CLI code.

It introduces and standardizes the use of a public `AgentRunner.list_tools()` API for tool inspection, improving encapsulation, forward compatibility, and example correctness.

## Type of Change

- [ x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #2490

## Changes Made

- Added and used `AgentRunner.list_tools()` as the public API for tool inspection
- Updated MCP integration example to avoid private `_tool_registry` access
- Updated CLI output to rely on public tool listing
- Updated MCP integration guide to reference the public API

## Testing

Describe the tests you ran to verify your changes:

- Verified changes are limited to examples, CLI output, and documentation
- No behavioral changes to runtime execution paths
- Relying on CI for validation

## Checklist

- [ x] My code follows the project's style guidelines
- [x ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A
