### PR TITLE
  micro-fix(runner): validate required keys in agent.json at load time                                                     

### DIFF
--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -109,6 +109,14 @@ def load_agent_export(data: str | dict) -> tuple[GraphSpec, Goal]:
     if isinstance(data, str):
         data = json.loads(data)
 
+    # Validate required keys
+    if "graph" not in data:
+        raise ValueError("Invalid agent.json: missing 'graph' key")
+    if not data["graph"].get("entry_node"):
+        raise ValueError("Invalid agent.json: missing 'entry_node'")
+    if not data["graph"].get("nodes"):
+        raise ValueError("Invalid agent.json: 'nodes' cannot be empty")
+
     # Extract graph and goal
     graph_data = data.get("graph", {})
     goal_data = data.get("goal", {})


### PR DESCRIPTION
## Description

Add validation in `load_agent_export()` to check required keys (`graph`, `entry_node`, `nodes`) before creating the graph. This provides clear error messages at load time instead of confusing runtime errors.     
  
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #2039 

## Changes Made

  - Add validation for `graph` key exists                                                                                  
  - Add validation for `entry_node` is not empty                                                                           
  - Add validation for `nodes` is not empty    

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes