### PR TITLE
fix(docs): remove duplicate entry in Edge Protocol docstring

### DIFF
--- a/core/framework/graph/edge.py
+++ b/core/framework/graph/edge.py
@@ -11,7 +11,6 @@ our edges can be created dynamically by a Builder agent based on the goal.
 
 Edge Types:
 - always: Always traverse after source completes
-- always: Always traverse after source completes
 - on_success: Traverse only if source succeeds
 - on_failure: Traverse only if source fails
 - conditional: Traverse based on expression evaluation (SAFE SUBSET ONLY)


### PR DESCRIPTION
## Summary

Removes a duplicate line in the Edge Protocol module docstring.

## Change

**File:** `core/framework/graph/edge.py`

The "Edge Types" list in the module docstring contained a duplicate entry:

```diff
 Edge Types:
 - always: Always traverse after source completes
-- always: Always traverse after source completes
 + on_success: Traverse only if source succeeds
```

Fixes #2717