### PR TITLE
 fix: silent exit when selecting non-Anthropic LLM provider

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -60,7 +60,8 @@ prompt_choice() {
     while true; do
         read -r -p "Enter choice (1-${#options[@]}): " choice
         if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#options[@]}" ]; then
-            return $((choice - 1))
+            PROMPT_CHOICE=$((choice - 1))
+            return 0
         fi
         echo -e "${RED}Invalid choice. Please enter 1-${#options[@]}${NC}"
     done
@@ -507,7 +508,7 @@ if [ -z "$SELECTED_PROVIDER_ID" ]; then
         "Groq - Fast, free tier" \
         "Cerebras - Fast, free tier" \
         "Skip for now"
-    choice=$?
+     choice=$PROMPT_CHOICE
 
     case $choice in
         0)


### PR DESCRIPTION
Fixes #3051
   
   ## Bug Description
   `quickstart.sh` exits silently when selecting any LLM provider except Anthropic (option 1).
   
   ## Root Cause
   The `prompt_choice` function uses `return $((choice - 1))`. Combined with `set -e`, any non-zero return is treated as an error causing script exit.
   
   ## Fix
   Use a global variable `PROMPT_CHOICE` instead of return codes.