### PR TITLE
fix: silent exit when selecting non-Anthropic LLM provider

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -60,7 +60,8 @@ prompt_choice() {
     while true; do
         read -r -p "Enter choice (1-${#options[@]}): " choice
         if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#options[@]}" ]; then
-            return $((choice - 1))
+            PROMPT_CHOICE=$((choice - 1))
+            return 0
         fi
         echo -e "${RED}Invalid choice. Please enter 1-${#options[@]}${NC}"
     done
@@ -507,7 +508,7 @@ if [ -z "$SELECTED_PROVIDER_ID" ]; then
         "Groq - Fast, free tier" \
         "Cerebras - Fast, free tier" \
         "Skip for now"
-    choice=$?
+     choice=$PROMPT_CHOICE
 
     case $choice in
         0)


### PR DESCRIPTION
Fixes #3051

## Description
`quickstart.sh` exits silently when selecting any LLM provider except Anthropic (option 1). The `prompt_choice` function used return codes to pass selections. Combined with `set -e`, non-zero returns (options 2-6) caused immediate script exit.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
Fixes #3051

## Changes Made
- Changed `prompt_choice` function to use global variable `PROMPT_CHOICE` instead of return code
- Function now always returns 0 (success) to avoid triggering `set -e`
- Updated call site to read from `$PROMPT_CHOICE` instead of `$?`

## Testing
- [x] Manual testing performed

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings