### PR TITLE
[micro-fix] Fix silent exception handling in model config loader

### DIFF
--- a/.claude/skills/building-agents-construction/examples/online_research_agent/config.py
+++ b/.claude/skills/building-agents-construction/examples/online_research_agent/config.py
@@ -1,23 +1,54 @@
 """Runtime configuration."""
-
 import json
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def _load_preferred_model() -> str:
     """Load preferred model from ~/.hive/configuration.json."""
+    default_model = "anthropic/claude-sonnet-4-20250514"
     config_path = Path.home() / ".hive" / "configuration.json"
-    if config_path.exists():
-        try:
-            with open(config_path) as f:
-                config = json.load(f)
-            llm = config.get("llm", {})
-            if llm.get("provider") and llm.get("model"):
-                return f"{llm['provider']}/{llm['model']}"
-        except Exception:
-            pass
-    return "anthropic/claude-sonnet-4-20250514"
+    
+    if not config_path.exists():
+        return default_model
+    
+    try:
+        with open(config_path) as f:
+            config = json.load(f)
+        
+        llm = config.get("llm", {})
+        
+        if llm.get("provider") and llm.get("model"):
+            return f"{llm['provider']}/{llm['model']}"
+        else:
+            logger.warning(
+                "Configuration file %s is missing 'llm.provider' or 'llm.model'. "
+                "Falling back to default model: %s",
+                config_path, default_model
+            )
+    except json.JSONDecodeError as e:
+        logger.error(
+            "Invalid JSON in configuration file %s at line %d, column %d: %s. "
+            "Falling back to default model: %s",
+            config_path, e.lineno, e.colno, e.msg, default_model
+        )
+    except (IOError, OSError) as e:
+        logger.error(
+            "Error reading configuration file %s: %s. "
+            "Falling back to default model: %s",
+            config_path, e, default_model
+        )
+    except Exception as e:
+        logger.exception(
+            "Unexpected error loading configuration from %s: %s. "
+            "Falling back to default model: %s",
+            config_path, e, default_model
+        )
+    
+    return default_model
 
 
 @dataclass


### PR DESCRIPTION
## Description

This PR fixes a silent exception handling issue in the model configuration loader that could lead to debugging difficulties when users have issues with their `~/.hive/configuration.json` file.

## Problem

The current implementation in `_load_preferred_model()` uses a bare `except Exception: pass` block when loading the model configuration. This silently swallows all errors, making it impossible to debug configuration issues.

**Current code:**
```python
try:
    with open(config_path) as f:
        config = json.load(f)
    llm = config.get("llm", {})
    if llm.get("provider") and llm.get("model"):
        return f"{llm['provider']}/{llm['model']}"
except Exception:
    pass  # ❌ Silent failure
```

**Issues with this approach:**
- Malformed JSON fails silently with no user feedback
- File I/O errors (permissions, disk issues) are invisible
- Missing configuration keys go unnoticed
- Users have no way to know why their custom model isn't being used
- Violates Python's "explicit is better than implicit" principle
- Flagged by Bandit security scanner (B110)

## Solution

Replace silent exception handling with proper error logging and specific exception handling:
```python
import logging

logger = logging.getLogger(__name__)

try:
    with open(config_path) as f:
        config = json.load(f)
    
    llm = config.get("llm", {})
    
    if llm.get("provider") and llm.get("model"):
        return f"{llm['provider']}/{llm['model']}"
    else:
        logger.warning(
            "Configuration file %s is missing 'llm.provider' or 'llm.model'. "
            "Falling back to default model: %s",
            config_path, default_model
        )
except json.JSONDecodeError as e:
    logger.error(
        "Invalid JSON in configuration file %s at line %d, column %d: %s. "
        "Falling back to default model: %s",
        config_path, e.lineno, e.colno, e.msg, default_model
    )
except (IOError, OSError) as e:
    logger.error(
        "Error reading configuration file %s: %s. "
        "Falling back to default model: %s",
        config_path, e, default_model
    )
```

## Benefits

1. **Better Developer Experience:** Clear error messages when configuration fails
2.  **Easier Debugging:** Developers can see exactly what went wrong (file path, line number, error type)
3.  **Production Visibility:** Configuration issues are logged and can be monitored
4.  **Security:** Follows security best practices, resolves Bandit warning
5.  **Maintainability:** Future developers can understand failure modes
6.  **Backward Compatible:** Still falls back to default model on any error

## Example Error Messages

### Before (Silent):
```bash
# User has typo in JSON
$ cat ~/.hive/configuration.json
{"llm": {"provider": "openai", "model": "gpt-4"}  # Missing closing brace
$ python my_script.py
# No error, silently uses default model, user confused
```

### After (Clear Feedback):
```bash
$ python my_script.py
ERROR: Invalid JSON in configuration file /home/user/.hive/configuration.json at line 1, column 46: Expecting ',' delimiter. Falling back to default model: anthropic/claude-sonnet-4-20250514
```

## Testing

Tested scenarios:
-  Valid configuration file → Works correctly
-  Malformed JSON → Clear error with line/column number
-  Missing keys → Warning message with what's missing
-  File permission errors → Clear I/O error message
-  File doesn't exist → Silent fallback (expected behavior)
-  Unexpected errors → Logged with full traceback

## Related Issues

- Addresses Bandit security warning **B110** (Try-Except-Pass)
- Related to **CWE-703**: Improper Check or Handling of Exceptional Conditions
- Improves observability and debugging experience

## Checklist

- [x] Code follows project style guidelines
- [x] Error messages are clear and actionable
- [x] Maintains backward compatibility
- [x] Security best practices followed
- [x] No breaking changes
- [x] Added logging import
- [x] Specific exception handling for different error types

---

**Note:** This is a low-risk change that maintains existing behavior while adding critical visibility into failure modes. The function still returns the default model on any error, ensuring backward compatibility.