### PR TITLE
feat: add comprehensive Excel tool for file manipulation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,7 @@ subgraph Foundation
         e2["Memory STM/LTM"]:::done
         e3["Web Search/Scraper"]:::done
         e4["CSV/PDF"]:::done
-        e5["Excel/Email"]
+        e5["Excel/Email"]:::done
     end
     subgraph core["Core"]
         f1["Eval System"]
@@ -173,7 +173,7 @@ classDef done fill:#9e9e9e,color:#fff,stroke:#757575
     - [x] Web Scraper
     - [x] CSV tools
     - [x] PDF tools
-    - [ ] Excel tools
+    - [x] Excel tools
     - [ ] Email Tools
     - [ ] Recipe for "Add your own tools"
 

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -42,6 +42,7 @@ from .hubspot_tool import register_tools as register_hubspot
 from .pdf_read_tool import register_tools as register_pdf_read
 from .web_scrape_tool import register_tools as register_web_scrape
 from .web_search_tool import register_tools as register_web_search
+from .excel_tool import register_tools as register_excel
 
 
 def register_all_tools(
@@ -81,6 +82,7 @@ def register_all_tools(
     register_grep_search(mcp)
     register_execute_command(mcp)
     register_csv(mcp)
+    register_excel(mcp)
 
     return [
         "example_tool",
@@ -114,6 +116,12 @@ def register_all_tools(
         "hubspot_get_deal",
         "hubspot_create_deal",
         "hubspot_update_deal",
+        "excel_read",
+        "excel_write",
+        "excel_append",
+        "excel_info",
+        "excel_sheet_list",
+        "excel_to_csv",
     ]
 
 

--- a/tools/src/aden_tools/tools/excel_tool/README.md
+++ b/tools/src/aden_tools/tools/excel_tool/README.md
@@ -1,0 +1,256 @@
+# Excel Tool
+
+Read and manipulate Excel files (.xlsx, .xlsm, .xls) for agents.
+
+## Features
+
+- Read Excel files with pagination and sheet selection
+- Write new Excel workbooks
+- Append rows to existing files
+- Get file metadata (sheets, columns, row counts)
+- List all sheets in a workbook
+- Convert Excel sheets to CSV format
+
+## Tools
+
+### `excel_read`
+
+Read an Excel file and return its contents.
+
+**Arguments:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | `str` | Yes | Path to Excel file (relative to session sandbox) |
+| `workspace_id` | `str` | Yes | Workspace identifier |
+| `agent_id` | `str` | Yes | Agent identifier |
+| `session_id` | `str` | Yes | Session identifier |
+| `sheet_name` | `str` | No | Sheet to read (default: first sheet) |
+| `limit` | `int` | No | Max rows to return (default: all) |
+| `offset` | `int` | No | Rows to skip from beginning (default: 0) |
+
+**Returns:**
+```json
+{
+  "success": true,
+  "path": "data/report.xlsx",
+  "sheet_name": "Sales",
+  "columns": ["Date", "Amount", "Customer"],
+  "column_count": 3,
+  "rows": [
+    {"Date": "2024-01-01", "Amount": 100, "Customer": "Acme Corp"},
+    {"Date": "2024-01-02", "Amount": 200, "Customer": "Tech Inc"}
+  ],
+  "row_count": 2,
+  "total_rows": 100,
+  "offset": 0,
+  "limit": null
+}
+```
+
+### `excel_write`
+
+Write data to a new Excel file.
+
+**Arguments:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | `str` | Yes | Path for new Excel file |
+| `workspace_id` | `str` | Yes | Workspace identifier |
+| `agent_id` | `str` | Yes | Agent identifier |
+| `session_id` | `str` | Yes | Session identifier |
+| `columns` | `list[str]` | Yes | Column names for header |
+| `rows` | `list[dict]` | Yes | Data rows as dictionaries |
+| `sheet_name` | `str` | No | Sheet name (default: "Sheet1") |
+
+**Returns:**
+```json
+{
+  "success": true,
+  "path": "output/results.xlsx",
+  "sheet_name": "Sheet1",
+  "columns": ["Name", "Score"],
+  "column_count": 2,
+  "rows_written": 50
+}
+```
+
+### `excel_append`
+
+Append rows to an existing Excel file.
+
+**Arguments:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | `str` | Yes | Path to existing Excel file |
+| `workspace_id` | `str` | Yes | Workspace identifier |
+| `agent_id` | `str` | Yes | Agent identifier |
+| `session_id` | `str` | Yes | Session identifier |
+| `rows` | `list[dict]` | Yes | Rows to append (keys match existing columns) |
+| `sheet_name` | `str` | No | Sheet to append to (default: first sheet) |
+
+**Returns:**
+```json
+{
+  "success": true,
+  "path": "data/sales.xlsx",
+  "sheet_name": "Q1",
+  "rows_appended": 10,
+  "total_rows": 110
+}
+```
+
+### `excel_info`
+
+Get metadata about an Excel file without reading all data.
+
+**Arguments:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | `str` | Yes | Path to Excel file |
+| `workspace_id` | `str` | Yes | Workspace identifier |
+| `agent_id` | `str` | Yes | Agent identifier |
+| `session_id` | `str` | Yes | Session identifier |
+
+**Returns:**
+```json
+{
+  "success": true,
+  "path": "data/report.xlsx",
+  "file_size_bytes": 45678,
+  "sheet_count": 3,
+  "sheets": [
+    {
+      "sheet_name": "Sales",
+      "columns": ["Date", "Amount"],
+      "column_count": 2,
+      "total_rows": 100
+    },
+    {
+      "sheet_name": "Costs",
+      "columns": ["Date", "Expense"],
+      "column_count": 2,
+      "total_rows": 75
+    }
+  ]
+}
+```
+
+### `excel_sheet_list`
+
+List all sheet names in an Excel workbook.
+
+**Arguments:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | `str` | Yes | Path to Excel file |
+| `workspace_id` | `str` | Yes | Workspace identifier |
+| `agent_id` | `str` | Yes | Agent identifier |
+| `session_id` | `str` | Yes | Session identifier |
+
+**Returns:**
+```json
+{
+  "success": true,
+  "path": "data/report.xlsx",
+  "sheets": ["Sales", "Costs", "Summary"],
+  "sheet_count": 3
+}
+```
+
+### `excel_to_csv`
+
+Convert an Excel sheet to CSV format.
+
+**Arguments:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | `str` | Yes | Path to Excel file |
+| `workspace_id` | `str` | Yes | Workspace identifier |
+| `agent_id` | `str` | Yes | Agent identifier |
+| `session_id` | `str` | Yes | Session identifier |
+| `output_path` | `str` | Yes | Path for output CSV file |
+| `sheet_name` | `str` | No | Sheet to convert (default: first sheet) |
+
+**Returns:**
+```json
+{
+  "success": true,
+  "input_path": "data/report.xlsx",
+  "output_path": "data/report.csv",
+  "sheet_name": "Sales",
+  "rows_written": 100
+}
+```
+
+## Dependencies
+
+- `openpyxl` - For reading and writing .xlsx and .xlsm files
+
+Install with:
+```bash
+pip install openpyxl
+```
+
+## Use Cases
+
+- **Report Processing**: Read Excel reports from external systems
+- **Data Export**: Generate Excel files for stakeholders
+- **Workflow Automation**: Automate data entry involving spreadsheets
+- **Format Conversion**: Convert between Excel and CSV formats
+- **Multi-Sheet Operations**: Work with complex workbooks containing multiple sheets
+
+## Error Handling
+
+All tools return error dictionaries instead of raising exceptions:
+
+```json
+{
+  "error": "File not found: data/missing.xlsx"
+}
+```
+
+Common error cases:
+- File not found
+- Invalid file extension
+- Missing openpyxl dependency
+- Sheet not found in workbook
+- Empty files or invalid data
+
+## Security
+
+All file paths are validated through `get_secure_path()` to ensure files are within the session sandbox and prevent path traversal attacks.
+
+## Example Agent Usage
+
+```python
+# Read Excel data
+result = excel_read(
+    path="reports/sales_2024.xlsx",
+    workspace_id="ws_123",
+    agent_id="agent_456",
+    session_id="session_789",
+    sheet_name="Q1"
+)
+
+# Write processed data
+excel_write(
+    path="output/summary.xlsx",
+    workspace_id="ws_123",
+    agent_id="agent_456",
+    session_id="session_789",
+    columns=["Product", "Total"],
+    rows=[
+        {"Product": "Widget", "Total": 1000},
+        {"Product": "Gadget", "Total": 1500}
+    ]
+)
+
+# Convert to CSV for further processing
+excel_to_csv(
+    path="output/summary.xlsx",
+    workspace_id="ws_123",
+    agent_id="agent_456",
+    session_id="session_789",
+    output_path="output/summary.csv"
+)
+```

--- a/tools/src/aden_tools/tools/excel_tool/__init__.py
+++ b/tools/src/aden_tools/tools/excel_tool/__init__.py
@@ -1,0 +1,3 @@
+from .excel_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/excel_tool/excel_tool.py
+++ b/tools/src/aden_tools/tools/excel_tool/excel_tool.py
@@ -1,0 +1,517 @@
+"""Excel Tool - Read and manipulate Excel files (.xlsx, .xlsm, .xls)."""
+
+import csv
+import os
+
+from fastmcp import FastMCP
+
+from ..file_system_toolkits.security import get_secure_path
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register Excel tools with the MCP server."""
+
+    @mcp.tool()
+    def excel_read(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        sheet_name: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> dict:
+        """
+        Read an Excel file and return its contents.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+            sheet_name: Name of the sheet to read (None = first sheet)
+            limit: Maximum number of rows to return (None = all rows)
+            offset: Number of rows to skip from the beginning (after header)
+
+        Returns:
+            dict with success status, data, and metadata
+        """
+        if offset < 0 or (limit is not None and limit < 0):
+            return {"error": "offset and limit must be non-negative"}
+
+        try:
+            import openpyxl
+        except ImportError:
+            return {
+                "error": ("openpyxl not installed. Install with: pip install openpyxl")
+            }
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            if not path.lower().endswith((".xlsx", ".xlsm", ".xls")):
+                return {"error": "File must have .xlsx, .xlsm, or .xls extension"}
+
+            # Load workbook
+            wb = openpyxl.load_workbook(secure_path, read_only=True, data_only=True)
+
+            # Get the sheet
+            if sheet_name:
+                if sheet_name not in wb.sheetnames:
+                    wb.close()
+                    return {
+                        "error": f"Sheet '{sheet_name}' not found. "
+                        f"Available sheets: {wb.sheetnames}"
+                    }
+                ws = wb[sheet_name]
+            else:
+                ws = wb.active
+                sheet_name = ws.title
+
+            # Get all rows
+            rows_iter = ws.iter_rows(values_only=True)
+
+            # First row is header
+            header_row = next(rows_iter, None)
+            if not header_row:
+                wb.close()
+                return {"error": "Excel file is empty (no header row)"}
+
+            # Clean header (convert None to empty string)
+            columns = [str(col) if col is not None else "" for col in header_row]
+
+            # Read data rows with offset and limit
+            rows = []
+            row_num = 0
+            for row_values in rows_iter:
+                # Skip offset rows
+                if row_num < offset:
+                    row_num += 1
+                    continue
+
+                # Check limit
+                if limit is not None and len(rows) >= limit:
+                    break
+
+                # Convert row to dict
+                row_dict = {}
+                for i, col_name in enumerate(columns):
+                    value = row_values[i] if i < len(row_values) else None
+                    # Convert None to empty string for consistency
+                    row_dict[col_name] = value if value is not None else ""
+
+                rows.append(row_dict)
+                row_num += 1
+
+            # Count total rows (excluding header)
+            total_rows = ws.max_row - 1 if ws.max_row else 0
+
+            wb.close()
+
+            return {
+                "success": True,
+                "path": path,
+                "sheet_name": sheet_name,
+                "columns": columns,
+                "column_count": len(columns),
+                "rows": rows,
+                "row_count": len(rows),
+                "total_rows": total_rows,
+                "offset": offset,
+                "limit": limit,
+            }
+
+        except Exception as e:
+            return {"error": f"Failed to read Excel file: {str(e)}"}
+
+    @mcp.tool()
+    def excel_write(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        columns: list[str],
+        rows: list[dict],
+        sheet_name: str = "Sheet1",
+    ) -> dict:
+        """
+        Write data to a new Excel file.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+            columns: List of column names for the header
+            rows: List of dictionaries, each representing a row
+            sheet_name: Name of the sheet to create (default: "Sheet1")
+
+        Returns:
+            dict with success status and metadata
+        """
+        try:
+            import openpyxl
+        except ImportError:
+            return {
+                "error": ("openpyxl not installed. Install with: pip install openpyxl")
+            }
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            if not path.lower().endswith((".xlsx", ".xlsm")):
+                return {"error": "File must have .xlsx or .xlsm extension"}
+
+            if not columns:
+                return {"error": "columns cannot be empty"}
+
+            # Create parent directories if needed
+            parent_dir = os.path.dirname(secure_path)
+            if parent_dir:
+                os.makedirs(parent_dir, exist_ok=True)
+
+            # Create workbook and worksheet
+            wb = openpyxl.Workbook()
+            ws = wb.active
+            ws.title = sheet_name
+
+            # Write header
+            ws.append(columns)
+
+            # Write data rows
+            for row in rows:
+                # Extract values in column order
+                row_values = [row.get(col, "") for col in columns]
+                ws.append(row_values)
+
+            # Save workbook
+            wb.save(secure_path)
+            wb.close()
+
+            return {
+                "success": True,
+                "path": path,
+                "sheet_name": sheet_name,
+                "columns": columns,
+                "column_count": len(columns),
+                "rows_written": len(rows),
+            }
+
+        except Exception as e:
+            return {"error": f"Failed to write Excel file: {str(e)}"}
+
+    @mcp.tool()
+    def excel_append(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        rows: list[dict],
+        sheet_name: str | None = None,
+    ) -> dict:
+        """
+        Append rows to an existing Excel file.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+            rows: List of dictionaries to append, keys should match existing columns
+            sheet_name: Name of the sheet to append to (None = first sheet)
+
+        Returns:
+            dict with success status and metadata
+        """
+        try:
+            import openpyxl
+        except ImportError:
+            return {
+                "error": ("openpyxl not installed. Install with: pip install openpyxl")
+            }
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            if not os.path.exists(secure_path):
+                return {
+                    "error": f"File not found: {path}. Use excel_write to create a new file."
+                }
+
+            if not path.lower().endswith((".xlsx", ".xlsm")):
+                return {"error": "File must have .xlsx or .xlsm extension"}
+
+            if not rows:
+                return {"error": "rows cannot be empty"}
+
+            # Load workbook
+            wb = openpyxl.load_workbook(secure_path)
+
+            # Get the sheet
+            if sheet_name:
+                if sheet_name not in wb.sheetnames:
+                    wb.close()
+                    return {
+                        "error": f"Sheet '{sheet_name}' not found. "
+                        f"Available sheets: {wb.sheetnames}"
+                    }
+                ws = wb[sheet_name]
+            else:
+                ws = wb.active
+                sheet_name = ws.title
+
+            # Read existing columns from first row
+            first_row = next(ws.iter_rows(min_row=1, max_row=1, values_only=True))
+            columns = [str(col) if col is not None else "" for col in first_row]
+
+            # Append new rows
+            for row in rows:
+                row_values = [row.get(col, "") for col in columns]
+                ws.append(row_values)
+
+            # Get new total row count (excluding header)
+            total_rows = ws.max_row - 1 if ws.max_row else 0
+
+            # Save workbook
+            wb.save(secure_path)
+            wb.close()
+
+            return {
+                "success": True,
+                "path": path,
+                "sheet_name": sheet_name,
+                "rows_appended": len(rows),
+                "total_rows": total_rows,
+            }
+
+        except Exception as e:
+            return {"error": f"Failed to append to Excel file: {str(e)}"}
+
+    @mcp.tool()
+    def excel_info(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> dict:
+        """
+        Get metadata about an Excel file without reading all data.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+
+        Returns:
+            dict with file metadata (sheets, columns per sheet, row counts, file size)
+        """
+        try:
+            import openpyxl
+        except ImportError:
+            return {
+                "error": ("openpyxl not installed. Install with: pip install openpyxl")
+            }
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            if not path.lower().endswith((".xlsx", ".xlsm", ".xls")):
+                return {"error": "File must have .xlsx, .xlsm, or .xls extension"}
+
+            # Get file size
+            file_size = os.path.getsize(secure_path)
+
+            # Load workbook (read-only for efficiency)
+            wb = openpyxl.load_workbook(secure_path, read_only=True, data_only=True)
+
+            # Collect info for each sheet
+            sheets_info = []
+            for sheet_name in wb.sheetnames:
+                ws = wb[sheet_name]
+
+                # Get header row
+                first_row = next(
+                    ws.iter_rows(min_row=1, max_row=1, values_only=True), None
+                )
+                if first_row:
+                    columns = [str(col) if col is not None else "" for col in first_row]
+                else:
+                    columns = []
+
+                # Get row count (excluding header)
+                total_rows = ws.max_row - 1 if ws.max_row else 0
+
+                sheets_info.append(
+                    {
+                        "sheet_name": sheet_name,
+                        "columns": columns,
+                        "column_count": len(columns),
+                        "total_rows": total_rows,
+                    }
+                )
+
+            wb.close()
+
+            return {
+                "success": True,
+                "path": path,
+                "file_size_bytes": file_size,
+                "sheet_count": len(sheets_info),
+                "sheets": sheets_info,
+            }
+
+        except Exception as e:
+            return {"error": f"Failed to get Excel file info: {str(e)}"}
+
+    @mcp.tool()
+    def excel_sheet_list(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> dict:
+        """
+        List all sheet names in an Excel workbook.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+
+        Returns:
+            dict with list of sheet names
+        """
+        try:
+            import openpyxl
+        except ImportError:
+            return {
+                "error": ("openpyxl not installed. Install with: pip install openpyxl")
+            }
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            if not path.lower().endswith((".xlsx", ".xlsm", ".xls")):
+                return {"error": "File must have .xlsx, .xlsm, or .xls extension"}
+
+            # Load workbook (read-only for efficiency)
+            wb = openpyxl.load_workbook(secure_path, read_only=True)
+
+            sheet_names = wb.sheetnames
+
+            wb.close()
+
+            return {
+                "success": True,
+                "path": path,
+                "sheets": sheet_names,
+                "sheet_count": len(sheet_names),
+            }
+
+        except Exception as e:
+            return {"error": f"Failed to list Excel sheets: {str(e)}"}
+
+    @mcp.tool()
+    def excel_to_csv(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        output_path: str,
+        sheet_name: str | None = None,
+    ) -> dict:
+        """
+        Convert an Excel sheet to CSV format.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+            output_path: Path for the output CSV file (relative to session sandbox)
+            sheet_name: Name of the sheet to convert (None = first sheet)
+
+        Returns:
+            dict with success status and metadata
+        """
+        try:
+            import openpyxl
+        except ImportError:
+            return {
+                "error": ("openpyxl not installed. Install with: pip install openpyxl")
+            }
+
+        try:
+            secure_input_path = get_secure_path(
+                path, workspace_id, agent_id, session_id
+            )
+            secure_output_path = get_secure_path(
+                output_path, workspace_id, agent_id, session_id
+            )
+
+            if not os.path.exists(secure_input_path):
+                return {"error": f"Input file not found: {path}"}
+
+            if not path.lower().endswith((".xlsx", ".xlsm", ".xls")):
+                return {"error": "Input file must have .xlsx, .xlsm, or .xls extension"}
+
+            if not output_path.lower().endswith(".csv"):
+                return {"error": "Output file must have .csv extension"}
+
+            # Load workbook
+            wb = openpyxl.load_workbook(
+                secure_input_path, read_only=True, data_only=True
+            )
+
+            # Get the sheet
+            if sheet_name:
+                if sheet_name not in wb.sheetnames:
+                    wb.close()
+                    return {
+                        "error": f"Sheet '{sheet_name}' not found. "
+                        f"Available sheets: {wb.sheetnames}"
+                    }
+                ws = wb[sheet_name]
+            else:
+                ws = wb.active
+                sheet_name = ws.title
+
+            # Create output directory if needed
+            output_dir = os.path.dirname(secure_output_path)
+            if output_dir:
+                os.makedirs(output_dir, exist_ok=True)
+
+            # Write to CSV
+            with open(secure_output_path, "w", encoding="utf-8", newline="") as f:
+                writer = csv.writer(f)
+                for row in ws.iter_rows(values_only=True):
+                    # Convert None to empty string
+                    cleaned_row = [cell if cell is not None else "" for cell in row]
+                    writer.writerow(cleaned_row)
+
+            # Count rows written (excluding header)
+            rows_written = ws.max_row - 1 if ws.max_row else 0
+
+            wb.close()
+
+            return {
+                "success": True,
+                "input_path": path,
+                "output_path": output_path,
+                "sheet_name": sheet_name,
+                "rows_written": rows_written,
+            }
+
+        except Exception as e:
+            return {"error": f"Failed to convert Excel to CSV: {str(e)}"}

--- a/tools/tests/tools/test_excel_tool.py
+++ b/tools/tests/tools/test_excel_tool.py
@@ -1,6 +1,5 @@
 """Tests for Excel tool."""
 
-import os
 import tempfile
 from pathlib import Path
 

--- a/tools/tests/tools/test_excel_tool.py
+++ b/tools/tests/tools/test_excel_tool.py
@@ -1,0 +1,300 @@
+"""Tests for Excel tool."""
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.excel_tool import register_tools
+
+
+@pytest.fixture
+def mcp():
+    """Create a FastMCP instance with Excel tools registered."""
+    server = FastMCP("test")
+    register_tools(server)
+    return server
+
+
+@pytest.fixture
+def test_workspace():
+    """Create a temporary test workspace."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Set up workspace structure
+        workspace_id = "test_workspace"
+        agent_id = "test_agent"
+        session_id = "test_session"
+
+        workspace_path = Path(tmpdir) / workspace_id / agent_id / session_id
+        workspace_path.mkdir(parents=True, exist_ok=True)
+
+        yield {
+            "tmpdir": tmpdir,
+            "workspace_id": workspace_id,
+            "agent_id": agent_id,
+            "session_id": session_id,
+        }
+
+
+def test_excel_write_basic(mcp, test_workspace):
+    """Test writing a basic Excel file."""
+    tool_fn = mcp._tool_manager._tools["excel_write"].fn
+
+    result = tool_fn(
+        path="test.xlsx",
+        workspace_id=test_workspace["workspace_id"],
+        agent_id=test_workspace["agent_id"],
+        session_id=test_workspace["session_id"],
+        columns=["Name", "Age", "City"],
+        rows=[
+            {"Name": "Alice", "Age": 30, "City": "NYC"},
+            {"Name": "Bob", "Age": 25, "City": "LA"},
+        ],
+    )
+
+    assert result["success"] is True
+    assert result["rows_written"] == 2
+    assert result["column_count"] == 3
+
+
+def test_excel_read_basic(mcp, test_workspace):
+    """Test reading an Excel file."""
+    # First write a file
+    write_fn = mcp._tool_manager._tools["excel_write"].fn
+    write_fn(
+        path="test_read.xlsx",
+        workspace_id=test_workspace["workspace_id"],
+        agent_id=test_workspace["agent_id"],
+        session_id=test_workspace["session_id"],
+        columns=["Product", "Price"],
+        rows=[
+            {"Product": "Widget", "Price": 10},
+            {"Product": "Gadget", "Price": 20},
+            {"Product": "Gizmo", "Price": 30},
+        ],
+    )
+
+    # Now read it
+    read_fn = mcp._tool_manager._tools["excel_read"].fn
+    result = read_fn(
+        path="test_read.xlsx",
+        workspace_id=test_workspace["workspace_id"],
+        agent_id=test_workspace["agent_id"],
+        session_id=test_workspace["session_id"],
+    )
+
+    assert result["success"] is True
+    assert result["row_count"] == 3
+    assert len(result["columns"]) == 2
+    assert result["rows"][0]["Product"] == "Widget"
+
+
+def test_excel_read_with_limit_offset(mcp, test_workspace):
+    """Test reading with pagination (limit and offset)."""
+    # Write a file with multiple rows
+    write_fn = mcp._tool_manager._tools["excel_write"].fn
+    rows = [{"ID": i, "Value": f"Item{i}"} for i in range(10)]
+    write_fn(
+        path="test_pagination.xlsx",
+        workspace_id=test_workspace["workspace_id"],
+        agent_id=test_workspace["agent_id"],
+        session_id=test_workspace["session_id"],
+        columns=["ID", "Value"],
+        rows=rows,
+    )
+
+    # Read with offset=2 and limit=3
+    read_fn = mcp._tool_manager._tools["excel_read"].fn
+    result = read_fn(
+        path="test_pagination.xlsx",
+        workspace_id=test_workspace["workspace_id"],
+        agent_id=test_workspace["agent_id"],
+        session_id=test_workspace["session_id"],
+        offset=2,
+        limit=3,
+    )
+
+    assert result["success"] is True
+    assert result["row_count"] == 3
+    assert result["offset"] == 2
+    assert result["rows"][0]["ID"] == 2
+
+
+def test_excel_append(mcp, test_workspace):
+    """Test appending rows to an existing file."""
+    # Create initial file
+    write_fn = mcp._tool_manager._tools["excel_write"].fn
+    write_fn(
+        path="test_append.xlsx",
+        workspace_id=test_workspace["workspace_id"],
+        agent_id=test_workspace["agent_id"],
+        session_id=test_workspace["session_id"],
+        columns=["Name", "Score"],
+        rows=[{"Name": "Alice", "Score": 95}],
+    )
+
+    # Append more rows
+    append_fn = mcp._tool_manager._tools["excel_append"].fn
+    result = append_fn(
+        path="test_append.xlsx",
+        workspace_id=test_workspace["workspace_id"],
+        agent_id=test_workspace["agent_id"],
+        session_id=test_workspace["session_id"],
+        rows=[
+            {"Name": "Bob", "Score": 87},
+            {"Name": "Charlie", "Score": 92},
+        ],
+    )
+
+    assert result["success"] is True
+    assert result["rows_appended"] == 2
+    assert result["total_rows"] == 3
+
+
+def test_excel_info(mcp, test_workspace):
+    """Test getting Excel file metadata."""
+    # Create a file
+    write_fn = mcp._tool_manager._tools["excel_write"].fn
+    write_fn(
+        path="test_info.xlsx",
+        workspace_id=test_workspace["workspace_id"],
+        agent_id=test_workspace["agent_id"],
+        session_id=test_workspace["session_id"],
+        columns=["A", "B", "C"],
+        rows=[{"A": 1, "B": 2, "C": 3}] * 5,
+    )
+
+    # Get info
+    info_fn = mcp._tool_manager._tools["excel_info"].fn
+    result = info_fn(
+        path="test_info.xlsx",
+        workspace_id=test_workspace["workspace_id"],
+        agent_id=test_workspace["agent_id"],
+        session_id=test_workspace["session_id"],
+    )
+
+    assert result["success"] is True
+    assert result["sheet_count"] == 1
+    assert result["sheets"][0]["column_count"] == 3
+    assert result["sheets"][0]["total_rows"] == 5
+
+
+def test_excel_sheet_list(mcp, test_workspace):
+    """Test listing sheets in a workbook."""
+    # Create file with default sheet
+    write_fn = mcp._tool_manager._tools["excel_write"].fn
+    write_fn(
+        path="test_sheets.xlsx",
+        workspace_id=test_workspace["workspace_id"],
+        agent_id=test_workspace["agent_id"],
+        session_id=test_workspace["session_id"],
+        columns=["X"],
+        rows=[{"X": 1}],
+        sheet_name="CustomSheet",
+    )
+
+    # List sheets
+    list_fn = mcp._tool_manager._tools["excel_sheet_list"].fn
+    result = list_fn(
+        path="test_sheets.xlsx",
+        workspace_id=test_workspace["workspace_id"],
+        agent_id=test_workspace["agent_id"],
+        session_id=test_workspace["session_id"],
+    )
+
+    assert result["success"] is True
+    assert "CustomSheet" in result["sheets"]
+    assert result["sheet_count"] == 1
+
+
+def test_excel_to_csv(mcp, test_workspace):
+    """Test converting Excel to CSV."""
+    # Create Excel file
+    write_fn = mcp._tool_manager._tools["excel_write"].fn
+    write_fn(
+        path="test_convert.xlsx",
+        workspace_id=test_workspace["workspace_id"],
+        agent_id=test_workspace["agent_id"],
+        session_id=test_workspace["session_id"],
+        columns=["Name", "Value"],
+        rows=[
+            {"Name": "Item1", "Value": 100},
+            {"Name": "Item2", "Value": 200},
+        ],
+    )
+
+    # Convert to CSV
+    convert_fn = mcp._tool_manager._tools["excel_to_csv"].fn
+    result = convert_fn(
+        path="test_convert.xlsx",
+        workspace_id=test_workspace["workspace_id"],
+        agent_id=test_workspace["agent_id"],
+        session_id=test_workspace["session_id"],
+        output_path="test_convert.csv",
+    )
+
+    assert result["success"] is True
+    assert result["rows_written"] == 2
+
+
+def test_excel_file_not_found(mcp, test_workspace):
+    """Test error handling for non-existent file."""
+    read_fn = mcp._tool_manager._tools["excel_read"].fn
+    result = read_fn(
+        path="nonexistent.xlsx",
+        workspace_id=test_workspace["workspace_id"],
+        agent_id=test_workspace["agent_id"],
+        session_id=test_workspace["session_id"],
+    )
+
+    assert "error" in result
+    assert "not found" in result["error"].lower()
+
+
+def test_excel_invalid_extension(mcp, test_workspace):
+    """Test error handling for invalid file extension."""
+    write_fn = mcp._tool_manager._tools["excel_write"].fn
+    result = write_fn(
+        path="test.txt",
+        workspace_id=test_workspace["workspace_id"],
+        agent_id=test_workspace["agent_id"],
+        session_id=test_workspace["session_id"],
+        columns=["A"],
+        rows=[{"A": 1}],
+    )
+
+    assert "error" in result
+    assert "extension" in result["error"].lower()
+
+
+def test_excel_empty_columns(mcp, test_workspace):
+    """Test error handling for empty columns."""
+    write_fn = mcp._tool_manager._tools["excel_write"].fn
+    result = write_fn(
+        path="test_empty.xlsx",
+        workspace_id=test_workspace["workspace_id"],
+        agent_id=test_workspace["agent_id"],
+        session_id=test_workspace["session_id"],
+        columns=[],
+        rows=[],
+    )
+
+    assert "error" in result
+    assert "cannot be empty" in result["error"].lower()
+
+
+def test_excel_negative_offset_limit(mcp, test_workspace):
+    """Test error handling for negative offset/limit."""
+    read_fn = mcp._tool_manager._tools["excel_read"].fn
+    result = read_fn(
+        path="test.xlsx",
+        workspace_id=test_workspace["workspace_id"],
+        agent_id=test_workspace["agent_id"],
+        session_id=test_workspace["session_id"],
+        offset=-1,
+    )
+
+    assert "error" in result
+    assert "non-negative" in result["error"].lower()


### PR DESCRIPTION
## Related Issues
Part of the Foundation roadmap for "Essential Tools".

## Changes Made
- Implemented `excel_tool.py` providing a comprehensive suite of tools for Excel file manipulation:
    - `excel_read`: Read Excel files with support for sheet selection, limit, and offset.
    - `excel_write`: Create new Excel files from JSON/dictionary data.
    - `excel_append`: Append new rows to existing Excel sheets.
    - `excel_info`: Retrieve workbook metadata (sheets, column names, row counts).
    - `excel_sheet_list`: List all available sheets in a workbook.
    - `excel_to_csv`: Direct conversion of Excel sheets to CSV format.
- Added comprehensive unit tests in `test_excel_tool.py` covering all functions and error cases.
- Updated `ROADMAP.md` to mark Excel tools as completed in the Foundation phase.

## Testing
Verified the implementation using the provided test suite:
- [x] Unit tests pass (`pytest tools/tests/tools/test_excel_tool.py`)
- [x] Manual verification of file creation and reading in the local environment.
- [x] Error handling verified for invalid file extensions and missing dependencies.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas