### PR TITLE
[micro-fix] Prevent MCP client from initialize if MCP stdio hangs

### DIFF
--- a/core/framework/loader/mcp_client.py
+++ b/core/framework/loader/mcp_client.py
@@ -245,6 +245,11 @@ class MCPClient:
 
             # Wait for connection to be ready
             connection_ready.wait(timeout=10)
+            if not connection_ready.is_set():
+                raise RuntimeError(
+                    "Timed out waiting for MCP stdio connection to initialize "
+                    f"(command={self.config.command}, args={self.config.args})"
+                )
             if connection_error:
                 raise connection_error[0]
 

--- a/core/tests/test_mcp_client.py
+++ b/core/tests/test_mcp_client.py
@@ -1,5 +1,8 @@
 """Unit tests for MCP client transport and reconnect behavior."""
 
+import asyncio
+import sys
+import types
 from types import SimpleNamespace
 
 import httpx
@@ -226,3 +229,104 @@ def test_call_tool_http_preserves_runtime_error_wrapping(monkeypatch):
     assert "Failed to call tool via HTTP" in str(exc_info.value)
     assert exc_info.value.__cause__ is connect_error
     assert reconnects == []
+
+
+def test_connect_stdio_times_out_when_not_ready(monkeypatch):
+    mcp = types.ModuleType("mcp")
+    mcp_client = types.ModuleType("mcp.client")
+    mcp_client_stdio = types.ModuleType("mcp.client.stdio")
+
+    class StdioServerParameters:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class ClientSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def initialize(self):
+            return None
+
+    class NeverEnterContext:
+        async def __aenter__(self):
+            await asyncio.Future()  # Simulate a hung handshake
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    def stdio_client(_params):
+        return NeverEnterContext()
+
+    mcp.StdioServerParameters = StdioServerParameters
+    mcp.ClientSession = ClientSession
+    mcp_client_stdio.stdio_client = stdio_client
+
+    monkeypatch.setitem(sys.modules, "mcp", mcp)
+    monkeypatch.setitem(sys.modules, "mcp.client", mcp_client)
+    monkeypatch.setitem(sys.modules, "mcp.client.stdio", mcp_client_stdio)
+
+    # Make the event loop start succeed, but the connection-ready event never set.
+    class FakeEvent:
+        _count = 0
+
+        def __init__(self):
+            type(self)._count += 1
+            self._idx = type(self)._count
+            self._set = False
+
+        def set(self):
+            self._set = True
+
+        def wait(self, timeout=None):
+            # First event (loop_started) reports ready immediately.
+            # Second event (connection_ready) never becomes ready.
+            return self._idx == 1
+
+        def is_set(self):
+            return self._set if self._idx == 1 else False
+
+    class FakeLoop:
+        def create_task(self, coro):
+            # Avoid "coroutine was never awaited" warnings.
+            coro.close()
+            return None
+
+        def run_forever(self):
+            return None
+
+    def fake_new_event_loop():
+        return FakeLoop()
+
+    def fake_set_event_loop(_loop):
+        return None
+
+    class FakeThread:
+        def __init__(self, target, daemon=None):
+            self._target = target
+            self._alive = False
+
+        def start(self):
+            self._alive = True
+            self._target()
+            self._alive = False
+
+        def is_alive(self):
+            return self._alive
+
+        def join(self, timeout=None):
+            return None
+
+    monkeypatch.setattr("threading.Event", FakeEvent)
+    monkeypatch.setattr("threading.Thread", FakeThread)
+    monkeypatch.setattr("asyncio.new_event_loop", fake_new_event_loop)
+    monkeypatch.setattr("asyncio.set_event_loop", fake_set_event_loop)
+
+    monkeypatch.setattr(MCPClient, "_discover_tools", lambda _self: None)
+
+    client = MCPClient(MCPServerConfig(name="demo", transport="stdio", command="dummy"))
+
+    with pytest.raises(RuntimeError, match="Timed out waiting for MCP stdio connection"):
+        client.connect()


### PR DESCRIPTION
## Description

Fix MCP stdio connect to fail fast when the session never initializes, and add a unit test covering the timeout path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #2806

## Changes Made

- Add timeout check after connection_ready.wait() in STDIO connect
- Return a clear error when the stdio session never becomes ready
- Add unit test to validate the timeout behavior

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MCP STDIO connections now detect and report timeout errors with clear, detailed messages when a connection fails to establish within the configured timeframe.
* **Tests**
  * Added a unit test covering the STDIO connection timeout path to ensure the timeout is raised and reported as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aden-hive/hive/pull/3104)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->