### PR TITLE
Fix: Register function nodes from agent's tools.py at runtime

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE_function_nodes_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE_function_nodes_fix.md
@@ -1,0 +1,46 @@
+# Fix: Register function nodes from agent's tools.py at runtime
+
+## Issue
+
+Fixes the runtime failure when running exported agents that use **function** nodes. Without this fix, execution fails with:
+
+- `RuntimeError: Function node 'X' not registered. Register with node_registry.`
+- or `'function' object has no attribute 'validate_input'` if a raw callable is passed.
+
+**Issue:** [#function-nodes-not-registered-at-runtime](../issues/function-nodes-not-registered-at-runtime.md)
+
+## Summary
+
+The runner only used the agent’s `tools.py` for **LLM tools** (via `ToolRegistry`). It never built a **function node registry** for graph nodes with `node_type == "function"`, so `GraphExecutor` had no implementation for those nodes and failed when it reached them.
+
+This PR:
+
+1. **Runner** – Adds `_build_function_node_registry()` that loads the agent’s `tools.py`, finds every graph node with `node_type == "function"`, resolves `node_spec.function` to a callable in that module, wraps it in `FunctionNode`, and returns `node_id -> FunctionNode(callable)`.
+2. **Runner** – Uses that registry when creating the executor (legacy path) and when creating the agent runtime (multi-entry-point path).
+3. **AgentRuntime / ExecutionStream** – Threads an optional `node_registry` through `create_agent_runtime`, `AgentRuntime`, and `ExecutionStream` so multi-entry-point runs get the same function-node implementations.
+
+## Changes
+
+| Area | Change |
+|------|--------|
+| `core/framework/runner/runner.py` | Add `_build_function_node_registry()`; pass `node_registry` into `GraphExecutor` and `create_agent_runtime()`. |
+| `core/framework/runtime/agent_runtime.py` | Add `node_registry` to `AgentRuntime.__init__` and `create_agent_runtime()`; pass to `ExecutionStream`. |
+| `core/framework/runtime/execution_stream.py` | Add `node_registry` to `ExecutionStream.__init__`; pass to `GraphExecutor`. |
+
+## Reproduction / verification
+
+1. Create an export with function nodes (e.g. `core/exports/greeting-agent/` with `agent.json` + `tools.py` containing `greet` and `uppercase` as in the issue).
+2. Run:  
+   `python -m framework run exports/greeting-agent --input '{"name": "Alice"}' --quiet`
+3. **Before fix:** Fails with `RuntimeError` or `'function' object has no attribute 'validate_input'`.
+4. **After fix:** Succeeds with `"success": true` and `"output": { "final_greeting": "HELLO, ALICE!" }`.
+
+All existing tests pass (`pytest tests/ framework/runtime/tests/`).
+
+## Checklist
+
+- [x] Issue documented with reproduction steps
+- [x] Fix implemented (runner + runtime threading)
+- [x] Legacy single-entry and multi-entry paths both use the registry
+- [x] All 229 tests pass
+- [x] Manual run of exported function-node agent succeeds

--- a/core/framework/runtime/agent_runtime.py
+++ b/core/framework/runtime/agent_runtime.py
@@ -96,6 +96,7 @@ class AgentRuntime:
         tools: list["Tool"] | None = None,
         tool_executor: Callable | None = None,
         config: AgentRuntimeConfig | None = None,
+        node_registry: dict[str, Any] | None = None,
     ):
         """
         Initialize agent runtime.
@@ -108,6 +109,7 @@ class AgentRuntime:
             tools: Available tools
             tool_executor: Function to execute tools
             config: Optional runtime configuration
+            node_registry: Optional node_id -> implementation for function nodes
         """
         self.graph = graph
         self.goal = goal
@@ -129,6 +131,7 @@ class AgentRuntime:
         self._llm = llm
         self._tools = tools or []
         self._tool_executor = tool_executor
+        self._node_registry = node_registry or {}
 
         # Entry points and streams
         self._entry_points: dict[str, EntryPointSpec] = {}
@@ -206,6 +209,7 @@ class AgentRuntime:
                     llm=self._llm,
                     tools=self._tools,
                     tool_executor=self._tool_executor,
+                    node_registry=self._node_registry,
                 )
                 await stream.start()
                 self._streams[ep_id] = stream
@@ -420,6 +424,7 @@ def create_agent_runtime(
     tools: list["Tool"] | None = None,
     tool_executor: Callable | None = None,
     config: AgentRuntimeConfig | None = None,
+    node_registry: dict[str, Any] | None = None,
 ) -> AgentRuntime:
     """
     Create and configure an AgentRuntime with entry points.
@@ -435,6 +440,7 @@ def create_agent_runtime(
         tools: Available tools
         tool_executor: Tool executor function
         config: Runtime configuration
+        node_registry: Optional node_id -> implementation for function nodes
 
     Returns:
         Configured AgentRuntime (not yet started)
@@ -447,6 +453,7 @@ def create_agent_runtime(
         tools=tools,
         tool_executor=tool_executor,
         config=config,
+        node_registry=node_registry,
     )
 
     for spec in entry_points:

--- a/core/framework/runtime/execution_stream.py
+++ b/core/framework/runtime/execution_stream.py
@@ -105,6 +105,7 @@ class ExecutionStream:
         llm: "LLMProvider | None" = None,
         tools: list["Tool"] | None = None,
         tool_executor: Callable | None = None,
+        node_registry: dict[str, Any] | None = None,
     ):
         """
         Initialize execution stream.
@@ -121,6 +122,7 @@ class ExecutionStream:
             llm: LLM provider for nodes
             tools: Available tools
             tool_executor: Function to execute tools
+            node_registry: Optional node_id -> implementation for function nodes
         """
         self.stream_id = stream_id
         self.entry_spec = entry_spec
@@ -133,6 +135,7 @@ class ExecutionStream:
         self._llm = llm
         self._tools = tools or []
         self._tool_executor = tool_executor
+        self._node_registry = node_registry or {}
 
         # Create stream-scoped runtime
         self._runtime = StreamRuntime(
@@ -283,6 +286,7 @@ class ExecutionStream:
                     llm=self._llm,
                     tools=self._tools,
                     tool_executor=self._tool_executor,
+                    node_registry=self._node_registry,
                 )
 
                 # Create modified graph with entry point

--- a/issues/function-nodes-fix-pr-body.md
+++ b/issues/function-nodes-fix-pr-body.md
@@ -1,0 +1,34 @@
+# PR body (copy when opening the PR)
+
+## Description
+
+Fixes runtime failure when running exported agents that use **function** nodes. The runner now builds a function-node registry from the agent's `tools.py` and passes it to the executor (legacy and multi-entry-point), so function-type nodes execute instead of raising "Function node 'X' not registered".
+
+## Type of Change
+
+- [x] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+
+## Related Issues
+
+Fixes #3107
+
+## Changes Made
+
+- **runner.py**: Add `_build_function_node_registry()` to load agent's `tools.py` and build `node_id -> FunctionNode(callable)` for graph nodes with `node_type == "function"`. Pass that registry into `GraphExecutor` (legacy) and into `create_agent_runtime()` (multi-entry-point).
+- **agent_runtime.py**: Add optional `node_registry` to `AgentRuntime.__init__` and `create_agent_runtime()`; pass it to `ExecutionStream`.
+- **execution_stream.py**: Add optional `node_registry` to `ExecutionStream.__init__`; pass it to `GraphExecutor` when creating the executor per execution.
+
+## Testing
+
+- [x] Unit tests pass: `cd core && pytest tests/ framework/runtime/tests/` (229 passed)
+- [x] Manual: Created `exports/greeting-agent` (agent.json + tools.py with greet/uppercase), ran `python -m framework run exports/greeting-agent --input '{"name": "Alice"}' --quiet` → success, output `"final_greeting": "HELLO, ALICE!"`
+
+## Checklist
+
+- [x] My code follows the project's style guidelines
+- [x] I have performed a self-review of my code
+- [x] New and existing unit tests pass locally with my changes

--- a/issues/function-nodes-not-registered-at-runtime.md
+++ b/issues/function-nodes-not-registered-at-runtime.md
@@ -1,0 +1,142 @@
+# Issue: Function nodes not registered at runtime when running exported agents
+
+## Summary
+
+When running an exported agent that uses **function** nodes (graph nodes with `node_type: "function"` and a `function` name pointing to a callable), the runner never registers those callables with the executor. Execution fails when it reaches a function node with:
+
+```
+RuntimeError: Function node 'greeter' not registered. Register with node_registry.
+```
+
+or, if a raw callable is passed without wrapping:
+
+```
+'function' object has no attribute 'validate_input'
+```
+
+## Why this is valuable
+
+- **Supported workflow is broken:** The framework documents and supports `node_type: "function"` and provides `FunctionNode`; the manual agent example uses function nodes. Exporting such an agent and running it via the CLI/runner is a natural path, but it always fails. Fixing this makes exported agents with function nodes actually runnable.
+- **High impact, contained fix:** Any exported agent that uses function nodes fails at runtime (complete failure, not a minor bug). The fix is scoped to the runner and runtime plumbing—no API break, no new surface area—so the payoff for maintainers and contributors is strong.
+
+## Reproduction
+
+### Prerequisites
+
+- Python 3.11+, framework installed (`cd core && pip install -e . && pip install -r requirements-dev.txt`).
+- No API keys required for a function-only agent.
+
+### Steps
+
+1. **Create an exported agent with function nodes**
+
+   Create directory `core/exports/greeting-agent/` with:
+
+   **`agent.json`**:
+
+   ```json
+   {
+     "graph": {
+       "id": "greeting-agent",
+       "goal_id": "greet-user",
+       "version": "1.0.0",
+       "entry_node": "greeter",
+       "terminal_nodes": ["uppercaser"],
+       "nodes": [
+         {
+           "id": "greeter",
+           "name": "Greeter",
+           "description": "Generates a simple greeting",
+           "node_type": "function",
+           "function": "greet",
+           "input_keys": ["name"],
+           "output_keys": ["greeting"]
+         },
+         {
+           "id": "uppercaser",
+           "name": "Uppercaser",
+           "description": "Converts greeting to uppercase",
+           "node_type": "function",
+           "function": "uppercase",
+           "input_keys": ["greeting"],
+           "output_keys": ["final_greeting"]
+         }
+       ],
+       "edges": [
+         {
+           "id": "greet-to-upper",
+           "source": "greeter",
+           "target": "uppercaser",
+           "condition": "on_success"
+         }
+       ]
+     },
+     "goal": {
+       "id": "greet-user",
+       "name": "Greet User",
+       "description": "Generate a friendly uppercase greeting",
+       "success_criteria": [{"id": "sc1", "description": "Greeting produced", "metric": "custom", "target": "any", "weight": 1.0}],
+       "constraints": []
+     }
+   }
+   ```
+
+   **`tools.py`**:
+
+   ```python
+   def greet(name: str) -> str:
+       """Generate a simple greeting."""
+       return f"Hello, {name}!"
+
+   def uppercase(greeting: str) -> str:
+       """Convert text to uppercase."""
+       return greeting.upper()
+   ```
+
+2. **Run the agent via CLI**
+
+   From `core/`:
+
+   ```bash
+   python -m framework run exports/greeting-agent --input '{"name": "Alice"}'
+   ```
+
+### Actual behavior
+
+- Execution fails when the executor tries to run the first function node (`greeter`).
+- **Without fix:** `RuntimeError: Function node 'greeter' not registered. Register with node_registry.`
+- **If raw callable is passed:** `'function' object has no attribute 'validate_input'` (executor expects a `NodeProtocol` implementation).
+
+### Expected behavior
+
+- The runner should discover function nodes from the graph, load the callables from the agent’s `tools.py` by name (`node_spec.function`), and register them with the executor’s `node_registry` (wrapped as `FunctionNode`).
+- Running the same command should succeed and produce output such as:
+  `"success": true`, `"output": { "final_greeting": "HELLO, ALICE!" }`.
+
+## Root cause
+
+- The runner loads `tools.py` only for **LLM tools** (via `ToolRegistry.discover_from_module`). It does not build a **function node registry** (node_id → implementation) for graph nodes with `node_type == "function"`.
+- `GraphExecutor` is created with default `node_registry={}`, so it has no implementation for function nodes and either raises at `_get_node_implementation` or fails when treating a raw callable as a `NodeProtocol`.
+- Multi-entry-point agents (`AgentRuntime` / `ExecutionStream`) also create `GraphExecutor` without a node registry, so the same failure occurs there.
+
+## Affected code (before fix)
+
+- **`core/framework/runner/runner.py`**
+  - `_setup_legacy_executor()`: creates `GraphExecutor` without `node_registry`.
+  - `_setup_agent_runtime()`: calls `create_agent_runtime()` with no function-node registry.
+- **`core/framework/runtime/agent_runtime.py`**
+  - `AgentRuntime` and `create_agent_runtime()` do not accept or pass a node registry.
+- **`core/framework/runtime/execution_stream.py`**
+  - `ExecutionStream` creates `GraphExecutor` without `node_registry`.
+
+## Fix
+
+See PR that implements:
+
+1. Runner: `_build_function_node_registry()` to load `tools.py` and build node_id → `FunctionNode(callable)` for function-type nodes.
+2. Runner: pass that registry into `GraphExecutor` (legacy) and into `create_agent_runtime()` (multi-entry-point).
+3. AgentRuntime / create_agent_runtime / ExecutionStream: thread `node_registry` through and pass it into `GraphExecutor`.
+
+## Status
+
+Fixed in branch (PR linked below).


### PR DESCRIPTION
# PR body (copy when opening the PR)

## Description

Fixes runtime failure when running exported agents that use **function** nodes. The runner now builds a function-node registry from the agent's `tools.py` and passes it to the executor (legacy and multi-entry-point), so function-type nodes execute instead of raising "Function node 'X' not registered".

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #3107

## Changes Made

- **runner.py**: Add `_build_function_node_registry()` to load agent's `tools.py` and build `node_id -> FunctionNode(callable)` for graph nodes with `node_type == "function"`. Pass that registry into `GraphExecutor` (legacy) and into `create_agent_runtime()` (multi-entry-point).
- **agent_runtime.py**: Add optional `node_registry` to `AgentRuntime.__init__` and `create_agent_runtime()`; pass it to `ExecutionStream`.
- **execution_stream.py**: Add optional `node_registry` to `ExecutionStream.__init__`; pass it to `GraphExecutor` when creating the executor per execution.

## Testing

- [x] Unit tests pass: `cd core && pytest tests/ framework/runtime/tests/` (229 passed)
- [x] Manual: Created `exports/greeting-agent` (agent.json + tools.py with greet/uppercase), ran `python -m framework run exports/greeting-agent --input '{"name": "Alice"}' --quiet` → success, output `"final_greeting": "HELLO, ALICE!"`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
