### PR TITLE
Fix: GraphExecutor exception handler preserves partial output and metrics

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -423,7 +423,10 @@ class GraphExecutor:
             return ExecutionResult(
                 success=False,
                 error=str(e),
+                output=memory.read_all(),
                 steps_executed=steps,
+                total_tokens=total_tokens,
+                total_latency_ms=total_latency,
                 path=path,
             )
 


### PR DESCRIPTION
## Summary

When an uncaught exception occurs during graph execution, the executor's generic `except Exception` block now returns `ExecutionResult` with `output=memory.read_all()` and `total_tokens` / `total_latency_ms`, so callers get partial state and accurate metrics instead of empty output and zeros.

**Fixes #3110**

## Changes

- `core/framework/graph/executor.py`: In the `except Exception` block in `execute()`, add `output=memory.read_all()`, `total_tokens=total_tokens`, `total_latency_ms=total_latency` to the returned `ExecutionResult`.

## Consistency

Other failure paths in the same method (max retries exceeded, invalid graph, etc.) already pass these fields; the exception path is now aligned.

Made with [Cursor](https://cursor.com)