### PR TITLE
Fix: Resume from pause continues from next node instead of entry

### DIFF
--- a/core/framework/graph/edge.py
+++ b/core/framework/graph/edge.py
@@ -469,6 +469,11 @@ class GraphSpec(BaseModel):
         if not session_state:
             return self.entry_node
 
+        # If resuming and we have the next node to run (stored when pausing), use it
+        next_node = session_state.get("next_node")
+        if next_node and self.get_node(next_node):
+            return next_node
+
         # Check if resuming from a pause node
         paused_at = session_state.get("paused_at")
         if paused_at and paused_at in self.pause_nodes:

--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -333,11 +333,24 @@ class GraphExecutor:
                 if node_spec.id in graph.pause_nodes:
                     self.logger.info("💾 Saving session state after pause node")
                     saved_memory = memory.read_all()
+                    # Compute next node so resume continues from there instead of entry_node
+                    next_node_id = (
+                        result.next_node
+                        if result.next_node
+                        else self._follow_edges(
+                            graph=graph,
+                            goal=goal,
+                            current_node_id=current_node_id,
+                            current_node_spec=node_spec,
+                            result=result,
+                            memory=memory,
+                        )
+                    )
                     session_state_out = {
                         "paused_at": node_spec.id,
                         "resume_from": f"{node_spec.id}_resume",  # Resume key
                         "memory": saved_memory,
-                        "next_node": None,  # Will resume from entry point
+                        "next_node": next_node_id,  # Resume from this node (None if no edge)
                     }
 
                     self.runtime.end_run(


### PR DESCRIPTION
## Summary

When an agent run **pauses** at a HITL/pause node and the user **resumes** with the saved `session_state`, execution now continues from the **node after the pause** instead of restarting from the entry node.

**Fixes #3109**  
**Related:** #328 (Execution Breaks after pausing for human approval) — this implements the fix for the GraphExecutor path.

## Changes

- **`core/framework/graph/executor.py`**: When saving session state after a pause node, compute the next node (`result.next_node` or `_follow_edges(...)`) and store it in `session_state_out["next_node"]`.
- **`core/framework/graph/edge.py`**: In `get_entry_point(session_state)`, if `session_state.get("next_node")` is set and is a valid node id, return it so the executor starts from that node when resuming.

## Behavior

- **Before:** `get_entry_point(session_state)` fell back to `entry_node` when no `entry_points` resume key was defined, so resume restarted from the beginning with memory restored.
- **After:** The executor stores the next node when pausing; `get_entry_point` returns it when resuming, so execution continues after the pause.

Made with [Cursor](https://cursor.com)