### PR TITLE
Fix Web Scrape Tool Test Mock to Return Proper Content-Type Header `micro-fix`

### DIFF
--- a/tools/tests/tools/test_web_scrape_tool.py
+++ b/tools/tests/tools/test_web_scrape_tool.py
@@ -64,6 +64,13 @@ class TestWebScrapeToolLinkConversion:
         mock_response.status_code = 200
         mock_response.text = html_content
         mock_response.url = final_url
+
+        # Mock headers.get() to return proper Content-Type for HTML
+        mock_response.headers = MagicMock()
+        mock_response.headers.get = MagicMock(
+            side_effect=lambda key, default="": "text/html; charset=utf-8"
+            if key.lower() == "content-type" else default
+        )
         return mock_response
 
     @patch("aden_tools.tools.web_scrape_tool.web_scrape_tool.httpx.get")


### PR DESCRIPTION
## Overview

This PR fixes 7 failing tests in `TestWebScrapeToolLinkConversion` by properly mocking the `httpx` response headers in the test helper.

**Branch:** `fix/web-scrape-test-mock`
**Base Commit:** `774911b` (Isolated fix, excludes recent feature additions)

Fixes #2000

## Problem

The `_mock_response` helper method in `test_web_scrape_tool.py` was not properly mocking the `httpx` response headers. When the web scrape tool checked the Content-Type:

```python
content_type = response.headers.get("content-type", "").lower()
```

The mock returned a `MagicMock` object instead of a string. Calling `.lower()` on a `MagicMock` returns another `MagicMock`, which never matched `"text/html"`, causing all link conversion tests to fail with:

```
Error: Skipping non-HTML content (Content-Type: <MagicMock ...>)
```

## Solution

Updated the `_mock_response` helper to properly mock `headers.get()` using `side_effect`:

```python
def _mock_response(self, html_content, final_url="https://example.com/page"):
    mock_response = MagicMock()
    mock_response.status_code = 200
    mock_response.text = html_content
    mock_response.url = final_url
    # Mock headers.get() to return proper Content-Type for HTML
    mock_response.headers = MagicMock()
    mock_response.headers.get = MagicMock(
        side_effect=lambda key, default="": "text/html; charset=utf-8" 
        if key.lower() == "content-type" else default
    )
    return mock_response
```

## Changes

| File | Changes |
|------|---------|
| `tools/tests/tools/test_web_scrape_tool.py` | Fixed `_mock_response` helper to properly mock headers |

## Tests Fixed

All 7 previously failing tests now pass:

| Test | Status |
|------|--------|
| `test_relative_links_converted_to_absolute` | ✅ Fixed |
| `test_root_relative_links_converted` | ✅ Fixed |
| `test_absolute_links_unchanged` | ✅ Fixed |
| `test_links_after_redirects` | ✅ Fixed |
| `test_fragment_links_preserved` | ✅ Fixed |
| `test_query_parameters_preserved` | ✅ Fixed |
| `test_empty_href_skipped` | ✅ Fixed |

## Test Results

### Before Fix
```
241 passed, 7 failed
```

### After Fix
```
248 passed in 35.13s
```

## Root Cause Analysis

The issue was in how Python's `unittest.mock.MagicMock` handles attribute access:

1. `mock_response.headers` returns a new `MagicMock`
2. `.get("content-type", "")` on that `MagicMock` returns another `MagicMock`
3. `.lower()` on that returns yet another `MagicMock`
4. The check `"text/html" in content_type` always fails because `content_type` is a `MagicMock`, not a string

The fix explicitly configures `headers.get()` to return the expected string value when called with `"content-type"`.

## Checklist

- [x] Fix addresses the root cause
- [x] All previously failing tests now pass
- [x] Full test suite passes (248 tests)
- [x] No changes to production code (test-only fix)
- [x] Docstring updated to explain the mock behavior
- [x] Branch is isolated from recent feature commits (clean history)

## Related

- Fixes #2000 - Web Scrape Tool Link Conversion Tests Failing
