### PR TITLE
fix: preserve partial output and metrics on GraphExecutor exception

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -615,7 +615,10 @@ class GraphExecutor:
             return ExecutionResult(
                 success=False,
                 error=str(e),
+                output=memory.read_all(),
                 steps_executed=steps,
+                total_tokens=total_tokens,
+                total_latency_ms=total_latency,
                 path=path,
                 total_retries=total_retries_count,
                 nodes_with_failures=nodes_failed,


### PR DESCRIPTION
## Description

Preserves partial execution output and accumulated metrics when an unhandled exception occurs during graph execution.

Previously, the generic exception handler in `GraphExecutor.execute()` returned an `ExecutionResult` with default values, discarding partial output stored in memory and resetting token and latency metrics to zero. This change aligns the exception path with other failure paths that already preserve partial execution state.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #3110

## Changes Made

- Updated the generic exception handler in `GraphExecutor.execute()` to include:
  - `output=memory.read_all()`
  - accumulated `total_tokens`
  - accumulated `total_latency_ms`
- Ensured behavior is consistent with other existing failure paths

## Testing

The following verification steps were performed:

- [x] Unit tests pass (`pytest core/tests/test_graph_executor.py`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed (reproduced exception during graph execution and verified partial output and metrics are preserved)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (not required for this change)
- [ ] I have made corresponding changes to the documentation (not required)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (existing coverage sufficient)
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable.
