### PR TITLE
feat(tools): add Excel read/write tools for aden_tools

### DIFF
--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -47,11 +47,15 @@ ocr = [
 sql = [
     "duckdb>=1.0.0",
 ]
+excel = [
+    "openpyxl>=3.1.0",
+]
 all = [
     "RestrictedPython>=7.0",
     "pytesseract>=0.3.10",
     "pillow>=10.0.0",
     "duckdb>=1.0.0",
+    "openpyxl>=3.1.0",
 ]
 
 [build-system]

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 # Import register_tools from each tool module
 from .csv_tool import register_tools as register_csv
 from .email_tool import register_tools as register_email
+from .excel_tool import register_tools as register_excel
 from .example_tool import register_tools as register_example
 from .file_system_toolkits.apply_diff import register_tools as register_apply_diff
 from .file_system_toolkits.apply_patch import register_tools as register_apply_patch
@@ -63,6 +64,7 @@ def register_all_tools(
     register_example(mcp)
     register_web_scrape(mcp)
     register_pdf_read(mcp)
+    register_excel(mcp)
 
     # Tools that need credentials (pass credentials if provided)
     # web_search supports multiple providers (Google, Brave) with auto-detection
@@ -100,6 +102,11 @@ def register_all_tools(
         "csv_append",
         "csv_info",
         "csv_sql",
+        "excel_read",
+        "excel_write",
+        "excel_append",
+        "excel_info",
+        "excel_list_sheets",
         "send_email",
         "send_budget_alert_email",
         "hubspot_search_contacts",

--- a/tools/src/aden_tools/tools/excel_tool/README.md
+++ b/tools/src/aden_tools/tools/excel_tool/README.md
@@ -1,0 +1,171 @@
+# Excel Tool
+
+Read and write Excel (.xlsx) files using pandas.
+
+## Description
+
+Provides comprehensive Excel file manipulation capabilities for agents, including reading, writing, appending data, and inspecting file metadata. Uses `pandas` for robust DataFrame-based operations with `openpyxl` as the Excel engine for maximum compatibility.
+
+## Tools
+
+### excel_read
+
+Read data from an Excel file with pagination support.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| path | string | Yes | Path to the Excel file |
+| workspace_id | string | Yes | Workspace identifier |
+| agent_id | string | Yes | Agent identifier |
+| session_id | string | Yes | Session identifier |
+| sheet_name | string/int | No | Sheet name or index (default: first sheet) |
+| limit | int | No | Maximum rows to return |
+| offset | int | No | Rows to skip (default: 0) |
+| include_empty_rows | bool | No | Include empty rows (default: false) |
+
+### excel_write
+
+Create a new Excel file with specified data.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| path | string | Yes | Path for the new Excel file |
+| workspace_id | string | Yes | Workspace identifier |
+| agent_id | string | Yes | Agent identifier |
+| session_id | string | Yes | Session identifier |
+| columns | list[str] | Yes | Column names for header row |
+| rows | list[dict] | Yes | Data rows as dictionaries |
+| sheet_name | string | No | Sheet name (default: "Sheet1") |
+
+### excel_append
+
+Append rows to an existing Excel file.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| path | string | Yes | Path to existing Excel file |
+| workspace_id | string | Yes | Workspace identifier |
+| agent_id | string | Yes | Agent identifier |
+| session_id | string | Yes | Session identifier |
+| rows | list[dict] | Yes | Rows to append |
+| sheet_name | string | No | Sheet to append to (default: first) |
+
+### excel_info
+
+Get metadata about an Excel file without reading all data.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| path | string | Yes | Path to the Excel file |
+| workspace_id | string | Yes | Workspace identifier |
+| agent_id | string | Yes | Agent identifier |
+| session_id | string | Yes | Session identifier |
+
+### excel_list_sheets
+
+List all sheet names in an Excel file.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| path | string | Yes | Path to the Excel file |
+| workspace_id | string | Yes | Workspace identifier |
+| agent_id | string | Yes | Agent identifier |
+| session_id | string | Yes | Session identifier |
+
+## Installation
+
+The Excel tools require `openpyxl` as Pandas Excel engine:
+
+```bash
+# Install as optional dependency
+pip install aden-tools[excel]
+
+# Or install openpyxl directly
+pip install openpyxl
+```
+
+## Error Handling
+
+All tools return error dictionaries on failure:
+
+| Error Case | Response |
+|------------|----------|
+| File not found | `{"error": "File not found: path"}` |
+| Invalid extension | `{"error": "File must have an Excel extension..."}` |
+| Sheet not found | `{"error": "Sheet 'name' not found..."}` |
+| openpyxl missing | `{"error": "openpyxl not installed..."}` |
+| Empty columns | `{"error": "columns cannot be empty"}` |
+| Empty rows (append) | `{"error": "rows cannot be empty"}` |
+
+## Example Usage
+
+### Reading Excel Data
+
+```python
+# Read first 10 rows from default sheet
+result = excel_read(
+    path="data.xlsx",
+    workspace_id="ws-123",
+    agent_id="agent-456",
+    session_id="sess-789",
+    limit=10
+)
+
+# Read specific sheet
+result = excel_read(
+    path="report.xlsx",
+    workspace_id="ws-123",
+    agent_id="agent-456",
+    session_id="sess-789",
+    sheet_name="Sales Data"
+)
+```
+
+### Writing Excel Data
+
+```python
+result = excel_write(
+    path="output.xlsx",
+    workspace_id="ws-123",
+    agent_id="agent-456",
+    session_id="sess-789",
+    columns=["Name", "Age", "City"],
+    rows=[
+        {"Name": "Alice", "Age": 30, "City": "NYC"},
+        {"Name": "Bob", "Age": 25, "City": "LA"}
+    ],
+    sheet_name="Employees"
+)
+```
+
+### Appending Data
+
+```python
+result = excel_append(
+    path="log.xlsx",
+    workspace_id="ws-123",
+    agent_id="agent-456",
+    session_id="sess-789",
+    rows=[{"Date": "2024-01-15", "Event": "Login"}]
+)
+```
+
+### Getting File Info
+
+```python
+result = excel_info(
+    path="report.xlsx",
+    workspace_id="ws-123",
+    agent_id="agent-456",
+    session_id="sess-789"
+)
+# Returns: sheet_count, sheet_names, sheets (with columns/row counts), file_size_bytes
+```
+
+## Notes
+
+- Uses pandas with openpyxl engine for reliable .xlsx support
+- Datetime values are serialized to ISO 8601 format
+- NaN values are converted to None (null in JSON)
+- First row is always treated as headers
+- Multi-sheet files are fully supported

--- a/tools/src/aden_tools/tools/excel_tool/__init__.py
+++ b/tools/src/aden_tools/tools/excel_tool/__init__.py
@@ -1,0 +1,5 @@
+"""Excel tool for reading and writing Excel files."""
+
+from .excel_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/excel_tool/excel_tool.py
+++ b/tools/src/aden_tools/tools/excel_tool/excel_tool.py
@@ -1,0 +1,547 @@
+"""
+Excel Tool - Read and write Excel (.xlsx) files using pandas.
+
+Uses pandas for robust Excel file manipulation, providing functionality
+to read, write, and append data to Excel spreadsheets.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from fastmcp import FastMCP
+
+from ..file_system_toolkits.security import get_secure_path
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register Excel tools with the MCP server."""
+
+    def _check_openpyxl() -> dict | None:
+        """
+        Check if openpyxl is installed (required by pandas for Excel support).
+
+        Returns:
+            None if openpyxl is available, error dict otherwise.
+        """
+        try:
+            import openpyxl  # noqa: F401
+
+            return None
+        except ImportError:
+            return {
+                "error": (
+                    "openpyxl not installed (required for Excel support). "
+                    "Install with: pip install openpyxl  or  pip install tools[excel]"
+                )
+            }
+
+    def _validate_excel_extension(path: str) -> dict | None:
+        """
+        Validate that the file has an Excel extension.
+
+        Args:
+            path: File path to validate.
+
+        Returns:
+            None if valid, error dict otherwise.
+        """
+        valid_extensions = (".xlsx", ".xlsm", ".xltx", ".xltm")
+        if not path.lower().endswith(valid_extensions):
+            return {"error": f"File must have an Excel extension ({', '.join(valid_extensions)})"}
+        return None
+
+    @mcp.tool()
+    def excel_read(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        sheet_name: str | int | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+        include_empty_rows: bool = False,
+    ) -> dict:
+        """
+        Read data from an Excel (.xlsx) file using pandas.
+
+        Reads the specified sheet (or first sheet by default) and returns
+        the data as a list of dictionaries where keys are column headers.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+            sheet_name: Name or index of the sheet to read (None = first sheet)
+            limit: Maximum number of rows to return (None = all rows)
+            offset: Number of rows to skip from the beginning
+            include_empty_rows: Whether to include rows with all NaN/empty values
+
+        Returns:
+            dict with success status, data, and metadata including:
+            - columns: list of column names from the header row
+            - rows: list of dictionaries representing each row
+            - sheet_names: list of all available sheet names
+            - active_sheet: name of the sheet that was read
+        """
+        import pandas as pd
+
+        # Check if openpyxl is installed
+        import_error = _check_openpyxl()
+        if import_error:
+            return import_error
+
+        # Validate inputs
+        if offset < 0 or (limit is not None and limit < 0):
+            return {"error": "offset and limit must be non-negative"}
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            # Check if file exists
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            # Validate extension
+            ext_error = _validate_excel_extension(path)
+            if ext_error:
+                return ext_error
+
+            # Get all sheet names first
+            excel_file = pd.ExcelFile(secure_path, engine="openpyxl")
+            sheet_names = excel_file.sheet_names
+
+            # Determine which sheet to read
+            if sheet_name is not None:
+                if isinstance(sheet_name, str) and sheet_name not in sheet_names:
+                    return {
+                        "error": f"Sheet '{sheet_name}' not found. Available sheets: {sheet_names}"
+                    }
+                active_sheet = (
+                    sheet_name if isinstance(sheet_name, str) else sheet_names[sheet_name]
+                )
+            else:
+                active_sheet = sheet_names[0]
+
+            # Read the sheet into a DataFrame
+            df = pd.read_excel(
+                excel_file,
+                sheet_name=active_sheet,
+                engine="openpyxl",
+            )
+
+            excel_file.close()
+
+            # Get column names
+            columns = df.columns.tolist()
+            # Convert column names to strings (handle numeric column names)
+            columns = [str(col) for col in columns]
+            df.columns = columns
+
+            # Store total rows before any filtering
+            total_rows = len(df)
+
+            # Filter out empty rows if configured
+            if not include_empty_rows:
+                df = df.dropna(how="all")
+
+            # Apply offset
+            if offset > 0:
+                df = df.iloc[offset:]
+
+            # Apply limit
+            if limit is not None:
+                df = df.head(limit)
+
+            # Convert DataFrame to list of dicts with proper serialization
+            rows = []
+            for _, row in df.iterrows():
+                row_dict = {}
+                for col in columns:
+                    value = row[col]
+                    row_dict[col] = _serialize_value(value)
+                rows.append(row_dict)
+
+            return {
+                "success": True,
+                "path": path,
+                "columns": columns,
+                "column_count": len(columns),
+                "rows": rows,
+                "row_count": len(rows),
+                "total_rows": total_rows,
+                "sheet_names": sheet_names,
+                "active_sheet": active_sheet,
+                "offset": offset,
+                "limit": limit,
+            }
+
+        except Exception as e:
+            return {"error": f"Failed to read Excel file: {str(e)}"}
+
+    @mcp.tool()
+    def excel_write(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        columns: list[str],
+        rows: list[dict],
+        sheet_name: str = "Sheet1",
+    ) -> dict:
+        """
+        Write data to a new Excel (.xlsx) file using pandas.
+
+        Creates a new Excel file with the specified columns and rows.
+        If the file already exists, it will be overwritten.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+            columns: List of column names for the header row
+            rows: List of dictionaries, each representing a row of data
+            sheet_name: Name of the sheet to create (default: "Sheet1")
+
+        Returns:
+            dict with success status and metadata
+        """
+        import pandas as pd
+
+        # Check if openpyxl is installed
+        import_error = _check_openpyxl()
+        if import_error:
+            return import_error
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            # Validate extension
+            ext_error = _validate_excel_extension(path)
+            if ext_error:
+                return ext_error
+
+            # Validate columns
+            if not columns:
+                return {"error": "columns cannot be empty"}
+
+            # Create parent directories if needed
+            parent_dir = os.path.dirname(secure_path)
+            if parent_dir:
+                os.makedirs(parent_dir, exist_ok=True)
+
+            # Create DataFrame from rows
+            # Filter rows to only include specified columns
+            filtered_rows = []
+            for row in rows:
+                filtered_row = {col: row.get(col) for col in columns}
+                filtered_rows.append(filtered_row)
+
+            df = pd.DataFrame(filtered_rows, columns=columns)
+
+            # Write to Excel
+            df.to_excel(
+                secure_path,
+                sheet_name=sheet_name,
+                index=False,
+                engine="openpyxl",
+            )
+
+            return {
+                "success": True,
+                "path": path,
+                "columns": columns,
+                "column_count": len(columns),
+                "rows_written": len(rows),
+                "sheet_name": sheet_name,
+            }
+
+        except Exception as e:
+            return {"error": f"Failed to write Excel file: {str(e)}"}
+
+    @mcp.tool()
+    def excel_append(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        rows: list[dict],
+        sheet_name: str | None = None,
+    ) -> dict:
+        """
+        Append rows to an existing Excel (.xlsx) file using pandas.
+
+        Adds new rows to the end of the specified sheet's data.
+        The rows should have keys matching the existing column headers.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+            rows: List of dictionaries to append, keys should match existing columns
+            sheet_name: Name of the sheet to append to (None = first sheet)
+
+        Returns:
+            dict with success status and metadata
+        """
+        import pandas as pd
+
+        # Check if openpyxl is installed
+        import_error = _check_openpyxl()
+        if import_error:
+            return import_error
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            # Check if file exists
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}. Use excel_write to create a new file."}
+
+            # Validate extension
+            ext_error = _validate_excel_extension(path)
+            if ext_error:
+                return ext_error
+
+            # Validate rows
+            if not rows:
+                return {"error": "rows cannot be empty"}
+
+            # Load existing file
+            excel_file = pd.ExcelFile(secure_path, engine="openpyxl")
+            sheet_names = excel_file.sheet_names
+
+            # Determine which sheet to use
+            if sheet_name is not None:
+                if sheet_name not in sheet_names:
+                    return {
+                        "error": f"Sheet '{sheet_name}' not found. Available sheets: {sheet_names}"
+                    }
+                target_sheet = sheet_name
+            else:
+                target_sheet = sheet_names[0]
+
+            # Read existing data
+            existing_df = pd.read_excel(
+                excel_file,
+                sheet_name=target_sheet,
+                engine="openpyxl",
+            )
+            excel_file.close()
+
+            # Get existing columns
+            columns = existing_df.columns.tolist()
+            columns = [str(col) for col in columns]
+
+            if not columns:
+                return {"error": "Cannot append to file without headers"}
+
+            # Filter new rows to only include existing columns
+            filtered_rows = []
+            for row in rows:
+                filtered_row = {col: row.get(col) for col in columns}
+                filtered_rows.append(filtered_row)
+
+            # Create DataFrame for new rows
+            new_df = pd.DataFrame(filtered_rows, columns=columns)
+
+            # Concatenate with existing data
+            combined_df = pd.concat([existing_df, new_df], ignore_index=True)
+
+            # Write back to file
+            combined_df.to_excel(
+                secure_path,
+                sheet_name=target_sheet,
+                index=False,
+                engine="openpyxl",
+            )
+
+            return {
+                "success": True,
+                "path": path,
+                "rows_appended": len(rows),
+                "total_rows": len(combined_df),
+                "sheet_name": target_sheet,
+            }
+
+        except Exception as e:
+            return {"error": f"Failed to append to Excel file: {str(e)}"}
+
+    @mcp.tool()
+    def excel_info(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> dict:
+        """
+        Get metadata about an Excel file without reading all data.
+
+        Returns information about the workbook including sheet names,
+        column headers, row counts, and file size.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+
+        Returns:
+            dict with file metadata including sheets info
+        """
+        import pandas as pd
+
+        # Check if openpyxl is installed
+        import_error = _check_openpyxl()
+        if import_error:
+            return import_error
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            # Check if file exists
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            # Validate extension
+            ext_error = _validate_excel_extension(path)
+            if ext_error:
+                return ext_error
+
+            # Get file size
+            file_size = os.path.getsize(secure_path)
+
+            # Load Excel file
+            excel_file = pd.ExcelFile(secure_path, engine="openpyxl")
+            sheet_names = excel_file.sheet_names
+
+            # Get info for each sheet
+            sheets_info = []
+            for sheet in sheet_names:
+                df = pd.read_excel(excel_file, sheet_name=sheet, engine="openpyxl")
+                columns = [str(col) for col in df.columns.tolist()]
+
+                sheets_info.append(
+                    {
+                        "name": sheet,
+                        "columns": columns,
+                        "column_count": len(columns),
+                        "row_count": len(df),
+                    }
+                )
+
+            excel_file.close()
+
+            return {
+                "success": True,
+                "path": path,
+                "sheet_count": len(sheet_names),
+                "sheet_names": sheet_names,
+                "sheets": sheets_info,
+                "file_size_bytes": file_size,
+            }
+
+        except Exception as e:
+            return {"error": f"Failed to get Excel info: {str(e)}"}
+
+    @mcp.tool()
+    def excel_list_sheets(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> dict:
+        """
+        List all sheet names in an Excel file.
+
+        Quick method to see available sheets without loading full metadata.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+
+        Returns:
+            dict with list of sheet names
+        """
+        import pandas as pd
+
+        # Check if openpyxl is installed
+        import_error = _check_openpyxl()
+        if import_error:
+            return import_error
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            # Check if file exists
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            # Validate extension
+            ext_error = _validate_excel_extension(path)
+            if ext_error:
+                return ext_error
+
+            # Get sheet names using pandas ExcelFile
+            excel_file = pd.ExcelFile(secure_path, engine="openpyxl")
+            sheet_names = excel_file.sheet_names
+            excel_file.close()
+
+            return {
+                "success": True,
+                "path": path,
+                "sheet_names": sheet_names,
+                "sheet_count": len(sheet_names),
+            }
+
+        except Exception as e:
+            return {"error": f"Failed to list sheets: {str(e)}"}
+
+
+def _serialize_value(value: Any) -> Any:
+    """
+    Convert a value to JSON-serializable format.
+
+    Handles NaN, datetime objects, and other pandas/Excel data types.
+
+    Args:
+        value: The value to serialize.
+
+    Returns:
+        A JSON-serializable value.
+    """
+    import pandas as pd
+
+    # Handle NaN/None
+    if pd.isna(value):
+        return None
+
+    # Handle datetime objects
+    from datetime import date, datetime, time
+
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, time):
+        return value.isoformat()
+
+    # Handle numpy types
+    try:
+        import numpy as np
+
+        if isinstance(value, (np.integer, np.floating)):
+            return value.item()  # Convert to Python native type
+        if isinstance(value, np.ndarray):
+            return value.tolist()
+    except ImportError:
+        pass
+
+    # Return as-is for other types
+    return value

--- a/tools/tests/tools/test_excel_tool.py
+++ b/tools/tests/tools/test_excel_tool.py
@@ -1,0 +1,614 @@
+"""Tests for excel_tool - Read and manipulate Excel files using pandas."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.excel_tool.excel_tool import register_tools
+
+# Skip all tests if openpyxl is not installed
+pytest.importorskip("openpyxl", reason="openpyxl required for Excel tests")
+
+# Test IDs for sandbox
+TEST_WORKSPACE_ID = "test-workspace"
+TEST_AGENT_ID = "test-agent"
+TEST_SESSION_ID = "test-session"
+
+
+@pytest.fixture
+def mcp() -> FastMCP:
+    """Create a fresh FastMCP instance for testing."""
+    return FastMCP("test-server")
+
+
+@pytest.fixture
+def excel_tools(mcp: FastMCP, tmp_path: Path):
+    """Register all Excel tools and return them as a dict."""
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        register_tools(mcp)
+        yield {
+            "excel_read": mcp._tool_manager._tools["excel_read"].fn,
+            "excel_write": mcp._tool_manager._tools["excel_write"].fn,
+            "excel_append": mcp._tool_manager._tools["excel_append"].fn,
+            "excel_info": mcp._tool_manager._tools["excel_info"].fn,
+            "excel_list_sheets": mcp._tool_manager._tools["excel_list_sheets"].fn,
+        }
+
+
+@pytest.fixture
+def session_dir(tmp_path: Path) -> Path:
+    """Create and return the session directory within the sandbox."""
+    session_path = tmp_path / TEST_WORKSPACE_ID / TEST_AGENT_ID / TEST_SESSION_ID
+    session_path.mkdir(parents=True, exist_ok=True)
+    return session_path
+
+
+@pytest.fixture
+def basic_excel(session_dir: Path) -> Path:
+    """Create a basic Excel file for testing using pandas."""
+    excel_file = session_dir / "basic.xlsx"
+    df = pd.DataFrame({
+        "Name": ["Alice", "Bob", "Charlie"],
+        "Age": [30, 25, 35],
+        "City": ["NYC", "LA", "Chicago"],
+    })
+    df.to_excel(excel_file, index=False, engine="openpyxl")
+    return excel_file
+
+
+@pytest.fixture
+def multi_sheet_excel(session_dir: Path) -> Path:
+    """Create an Excel file with multiple sheets using pandas."""
+    excel_file = session_dir / "multi_sheet.xlsx"
+    
+    # Create two DataFrames
+    df_sales = pd.DataFrame({
+        "Product": ["Widget", "Gadget"],
+        "Quantity": [100, 50],
+        "Price": [9.99, 19.99],
+    })
+    df_inventory = pd.DataFrame({
+        "Item": ["Widget", "Gadget"],
+        "Stock": [500, 200],
+    })
+    
+    # Write to Excel with multiple sheets
+    with pd.ExcelWriter(excel_file, engine="openpyxl") as writer:
+        df_sales.to_excel(writer, sheet_name="Sales", index=False)
+        df_inventory.to_excel(writer, sheet_name="Inventory", index=False)
+    
+    return excel_file
+
+
+@pytest.fixture
+def large_excel(session_dir: Path) -> Path:
+    """Create a larger Excel file for pagination testing."""
+    excel_file = session_dir / "large.xlsx"
+    df = pd.DataFrame({
+        "id": list(range(100)),
+        "value": [i * 10 for i in range(100)],
+    })
+    df.to_excel(excel_file, index=False, engine="openpyxl")
+    return excel_file
+
+
+class TestExcelRead:
+    """Tests for excel_read function."""
+
+    def test_read_basic_excel(self, excel_tools, basic_excel, tmp_path):
+        """Read a basic Excel file successfully."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        assert result["columns"] == ["Name", "Age", "City"]
+        assert result["column_count"] == 3
+        assert result["row_count"] == 3
+        assert result["total_rows"] == 3
+        assert len(result["rows"]) == 3
+        assert result["rows"][0]["Name"] == "Alice"
+        assert result["rows"][0]["Age"] == 30
+
+    def test_read_with_limit(self, excel_tools, basic_excel, tmp_path):
+        """Read Excel with row limit."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                limit=2,
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 2
+        assert result["limit"] == 2
+        assert len(result["rows"]) == 2
+        assert result["rows"][0]["Name"] == "Alice"
+        assert result["rows"][1]["Name"] == "Bob"
+
+    def test_read_with_offset(self, excel_tools, basic_excel, tmp_path):
+        """Read Excel with row offset."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                offset=1,
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 2
+        assert result["offset"] == 1
+        assert result["rows"][0]["Name"] == "Bob"
+        assert result["rows"][1]["Name"] == "Charlie"
+
+    def test_read_with_limit_and_offset(self, excel_tools, large_excel, tmp_path):
+        """Read Excel with both limit and offset (pagination)."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="large.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                limit=10,
+                offset=50,
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 10
+        assert result["total_rows"] == 100
+        assert result["offset"] == 50
+        assert result["limit"] == 10
+        # First row should be id=50
+        assert result["rows"][0]["id"] == 50
+        assert result["rows"][0]["value"] == 500
+
+    def test_negative_limit(self, excel_tools, basic_excel, tmp_path):
+        """Return error for negative limit."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                limit=-1,
+            )
+
+        assert "error" in result
+        assert "non-negative" in result["error"].lower()
+
+    def test_negative_offset(self, excel_tools, basic_excel, tmp_path):
+        """Return error for negative offset."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                offset=-1,
+            )
+
+        assert "error" in result
+        assert "non-negative" in result["error"].lower()
+
+    def test_file_not_found(self, excel_tools, session_dir, tmp_path):
+        """Return error for non-existent file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="nonexistent.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_non_excel_extension(self, excel_tools, session_dir, tmp_path):
+        """Return error for non-Excel file extension."""
+        # Create a text file
+        txt_file = session_dir / "data.txt"
+        txt_file.write_text("name,age\nAlice,30\n")
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="data.txt",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert "extension" in result["error"].lower()
+
+    def test_read_specific_sheet(self, excel_tools, multi_sheet_excel, tmp_path):
+        """Read specific sheet by name."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="multi_sheet.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                sheet_name="Inventory",
+            )
+
+        assert result["success"] is True
+        assert result["active_sheet"] == "Inventory"
+        assert result["columns"] == ["Item", "Stock"]
+        assert result["row_count"] == 2
+
+    def test_read_invalid_sheet_name(self, excel_tools, basic_excel, tmp_path):
+        """Return error for non-existent sheet."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                sheet_name="NonExistent",
+            )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_offset_beyond_rows(self, excel_tools, basic_excel, tmp_path):
+        """Offset beyond available rows returns empty result."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                offset=100,
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 0
+        assert result["rows"] == []
+        assert result["total_rows"] == 3
+
+
+class TestExcelWrite:
+    """Tests for excel_write function."""
+
+    def test_write_new_excel(self, excel_tools, session_dir, tmp_path):
+        """Write a new Excel file successfully."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="output.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["name", "age", "city"],
+                rows=[
+                    {"name": "Alice", "age": 30, "city": "NYC"},
+                    {"name": "Bob", "age": 25, "city": "LA"},
+                ],
+            )
+
+        assert result["success"] is True
+        assert result["columns"] == ["name", "age", "city"]
+        assert result["column_count"] == 3
+        assert result["rows_written"] == 2
+        assert result["sheet_name"] == "Sheet1"
+
+        # Verify file content
+        df = pd.read_excel(session_dir / "output.xlsx", engine="openpyxl")
+        assert list(df.columns) == ["name", "age", "city"]
+        assert len(df) == 2
+        assert df.iloc[0]["name"] == "Alice"
+
+    def test_write_custom_sheet_name(self, excel_tools, session_dir, tmp_path):
+        """Write with custom sheet name."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="output.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["Product"],
+                rows=[{"Product": "Widget"}],
+                sheet_name="Products",
+            )
+
+        assert result["success"] is True
+        assert result["sheet_name"] == "Products"
+
+        # Verify sheet name
+        excel_file = pd.ExcelFile(session_dir / "output.xlsx", engine="openpyxl")
+        assert "Products" in excel_file.sheet_names
+        excel_file.close()
+
+    def test_write_creates_parent_directories(self, excel_tools, session_dir, tmp_path):
+        """Write creates parent directories if needed."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="subdir/nested/output.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["id"],
+                rows=[{"id": 1}],
+            )
+
+        assert result["success"] is True
+        assert (session_dir / "subdir" / "nested" / "output.xlsx").exists()
+
+    def test_write_empty_columns_error(self, excel_tools, session_dir, tmp_path):
+        """Return error when columns is empty."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="output.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=[],
+                rows=[],
+            )
+
+        assert "error" in result
+        assert "empty" in result["error"].lower()
+
+    def test_write_non_excel_extension_error(self, excel_tools, session_dir, tmp_path):
+        """Return error for non-Excel file extension."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="output.csv",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["id"],
+                rows=[],
+            )
+
+        assert "error" in result
+        assert "extension" in result["error"].lower()
+
+    def test_write_filters_extra_columns(self, excel_tools, session_dir, tmp_path):
+        """Extra columns in rows are filtered out."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="output.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["name"],
+                rows=[{"name": "Alice", "extra": "ignored"}],
+            )
+
+        assert result["success"] is True
+
+        df = pd.read_excel(session_dir / "output.xlsx", engine="openpyxl")
+        assert "extra" not in df.columns
+
+    def test_write_empty_rows(self, excel_tools, session_dir, tmp_path):
+        """Write Excel with headers but no rows."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_write"](
+                path="output.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                columns=["name", "age"],
+                rows=[],
+            )
+
+        assert result["success"] is True
+        assert result["rows_written"] == 0
+
+        df = pd.read_excel(session_dir / "output.xlsx", engine="openpyxl")
+        assert list(df.columns) == ["name", "age"]
+        assert len(df) == 0
+
+
+class TestExcelAppend:
+    """Tests for excel_append function."""
+
+    def test_append_to_existing_excel(self, excel_tools, basic_excel, tmp_path):
+        """Append rows to an existing Excel file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_append"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                rows=[
+                    {"Name": "David", "Age": 28, "City": "Seattle"},
+                    {"Name": "Eve", "Age": 32, "City": "Boston"},
+                ],
+            )
+
+        assert result["success"] is True
+        assert result["rows_appended"] == 2
+        assert result["total_rows"] == 5
+
+    def test_append_file_not_found(self, excel_tools, session_dir, tmp_path):
+        """Return error when file doesn't exist."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_append"](
+                path="nonexistent.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                rows=[{"Name": "Alice"}],
+            )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_append_empty_rows_error(self, excel_tools, basic_excel, tmp_path):
+        """Return error when rows is empty."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_append"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                rows=[],
+            )
+
+        assert "error" in result
+        assert "empty" in result["error"].lower()
+
+    def test_append_filters_extra_columns(self, excel_tools, basic_excel, session_dir, tmp_path):
+        """Extra columns in rows are filtered out based on existing headers."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_append"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                rows=[{"Name": "David", "Age": 28, "City": "Seattle", "extra": "ignored"}],
+            )
+
+        assert result["success"] is True
+
+        df = pd.read_excel(session_dir / "basic.xlsx", engine="openpyxl")
+        assert "extra" not in df.columns
+        assert "David" in df["Name"].values
+
+
+class TestExcelInfo:
+    """Tests for excel_info function."""
+
+    def test_get_info_basic_excel(self, excel_tools, basic_excel, tmp_path):
+        """Get info about a basic Excel file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_info"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        assert result["sheet_count"] == 1
+        assert "file_size_bytes" in result
+        assert result["file_size_bytes"] > 0
+        assert len(result["sheets"]) == 1
+        assert result["sheets"][0]["columns"] == ["Name", "Age", "City"]
+        assert result["sheets"][0]["row_count"] == 3
+
+    def test_get_info_multi_sheet(self, excel_tools, multi_sheet_excel, tmp_path):
+        """Get info about multi-sheet Excel file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_info"](
+                path="multi_sheet.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        assert result["sheet_count"] == 2
+        assert "Sales" in result["sheet_names"]
+        assert "Inventory" in result["sheet_names"]
+
+    def test_get_info_file_not_found(self, excel_tools, session_dir, tmp_path):
+        """Return error when file doesn't exist."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_info"](
+                path="nonexistent.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+
+class TestExcelListSheets:
+    """Tests for excel_list_sheets function."""
+
+    def test_list_sheets_basic(self, excel_tools, multi_sheet_excel, tmp_path):
+        """List sheets in an Excel file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_list_sheets"](
+                path="multi_sheet.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        assert result["sheet_count"] == 2
+        assert "Sales" in result["sheet_names"]
+        assert "Inventory" in result["sheet_names"]
+
+    def test_list_sheets_file_not_found(self, excel_tools, session_dir, tmp_path):
+        """Return error when file doesn't exist."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_list_sheets"](
+                path="nonexistent.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+
+class TestExcelDatetimeSerialization:
+    """Tests for datetime and special value serialization."""
+
+    def test_datetime_values_serialized(self, excel_tools, session_dir, tmp_path):
+        """Datetime values are serialized to ISO format."""
+        from datetime import datetime
+
+        # Create Excel file with datetime values
+        excel_file = session_dir / "dates.xlsx"
+        df = pd.DataFrame({
+            "Date": [datetime(2024, 1, 15, 10, 30, 0)],
+            "Value": [100],
+        })
+        df.to_excel(excel_file, index=False, engine="openpyxl")
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="dates.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        # Datetime should be converted to ISO string
+        assert "2024-01-15" in result["rows"][0]["Date"]
+
+    def test_nan_values_serialized_as_none(self, excel_tools, session_dir, tmp_path):
+        """NaN values are serialized as None."""
+        import numpy as np
+
+        # Create Excel file with NaN values
+        excel_file = session_dir / "with_nan.xlsx"
+        df = pd.DataFrame({
+            "Name": ["Alice", None, "Charlie"],
+            "Age": [30, np.nan, 35],
+        })
+        df.to_excel(excel_file, index=False, engine="openpyxl")
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="with_nan.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                include_empty_rows=True,
+            )
+
+        assert result["success"] is True
+        # NaN values should be None
+        assert result["rows"][1]["Name"] is None
+        assert result["rows"][1]["Age"] is None


### PR DESCRIPTION
## Description

Adds Excel tools to `tools/src/aden_tools/tools/`, addressing the need for Excel file manipulation capabilities in the agent framework.

Closes #3131 

## Type of Change

### New Tools Added

| Tool | Description |
|------|-------------|
| `excel_read` | Read data from Excel files with pagination support |
| `excel_write` | Create new Excel files with specified data |
| `excel_append` | Append rows to existing Excel files |
| `excel_info` | Get file metadata (sheets, columns, row counts) |
| `excel_list_sheets` | Quick listing of available sheets |

### Features

- Uses **pandas** with **openpyxl** engine for robust Excel support
- Follows existing patterns from `csv_tool` and `pdf_read_tool`
- Proper JSON serialization (handles datetime, NaN values)
- Multi-sheet support with sheet selection
- Pagination via `limit`/`offset` parameters
- Security sandbox integration
- 
### Files Added/Modified

- `tools/src/aden_tools/tools/excel_tool/` - New tool package
- `tools/src/aden_tools/tools/__init__.py` - Register excel tools
- `tools/pyproject.toml` - Add openpyxl optional dependency
- `tools/tests/tools/test_excel_tool.py` - 29 comprehensive tests

## Related Issues

Fixes #(issue number)
#3131 

## Testing

All 29 tests pass:
```bash
pytest tests/tools/test_excel_tool.py -v
# 29 passed

## Screenshots (if applicable)

<img width="1853" height="974" alt="image" src="https://github.com/user-attachments/assets/29ea3d16-e7c8-4efe-9618-24f74cbb2164" />


Add screenshots to demonstrate UI changes.
