### PR TITLE
fix(csv_tool): validate non-negative offset and limit in csv_read

### DIFF
--- a/tools/src/aden_tools/tools/csv_tool/csv_tool.py
+++ b/tools/src/aden_tools/tools/csv_tool/csv_tool.py
@@ -34,6 +34,9 @@ def register_tools(mcp: FastMCP) -> None:
         Returns:
             dict with success status, data, and metadata
         """
+        if offset < 0 or (limit is not None and limit < 0):
+            return {"error": "offset and limit must be non-negative"}
+
         try:
             secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
 

--- a/tools/tests/tools/test_csv_tool.py
+++ b/tools/tests/tools/test_csv_tool.py
@@ -157,6 +157,49 @@ class TestCsvRead:
         # First row should be id=50
         assert result["rows"][0] == {"id": "50", "value": "500"}
 
+    def test_negative_limit(self, csv_tool_fn, basic_csv, tmp_path):
+        """Return error for negative limit."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = csv_tool_fn(
+                path="basic.csv",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                limit=-1,
+            )
+
+        assert "error" in result
+        assert "non-negative" in result["error"].lower()
+
+    def test_negative_offset(self, csv_tool_fn, basic_csv, tmp_path):
+        """Return error for negative offset."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = csv_tool_fn(
+                path="basic.csv",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                offset=-1,
+            )
+
+        assert "error" in result
+        assert "non-negative" in result["error"].lower()
+
+    def test_negative_limit_and_offset(self, csv_tool_fn, basic_csv, tmp_path):
+        """Return error for both negative limit and offset."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = csv_tool_fn(
+                path="basic.csv",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                limit=-5,
+                offset=-10,
+            )
+
+        assert "error" in result
+        assert "non-negative" in result["error"].lower()
+
     def test_file_not_found(self, csv_tool_fn, session_dir, tmp_path):
         """Return error for non-existent file."""
         with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):


### PR DESCRIPTION
  ## Description

  Add input validation to the `csv_read` function to reject negative values for `offset` and `limit` parameters. Previously, passing negative values caused silent incorrect behavior (returning empty results with  
  no error).

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Refactoring (no functional changes)

  ## Related Issues

 (https://github.com/adenhq/hive/issues/3164)

  > **Note:** This bug was previously reported in #1848 and a fix was submitted in PR #1873 (marked as merged on 2026-01-28). However, that fix is not present in the current `main` branch. This PR re-applies the  
  validation.

  ## Changes Made

  - Added validation in `csv_read` to check that `offset >= 0` and `limit >= 0` (when provided)
  - Returns `{"error": "offset and limit must be non-negative"}` when validation fails
  - Added 3 test cases:
    - `test_negative_limit`: Verifies error when limit is negative
    - `test_negative_offset`: Verifies error when offset is negative
    - `test_negative_limit_and_offset`: Verifies error when both are negative

  ## Testing

  - [x] Unit tests pass (`cd tools && pytest tests/tools/test_csv_tool.py -v`)
  - [x] Lint passes (`ruff check`)
  - [x] All 3 new test cases pass

  ## Checklist

  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective
  - [x] New and existing unit tests pass locally with my changes
