### PR TITLE
[integration] feat(tools): add Google Calendar integration

### DIFF
--- a/.claude/skills/hive-credentials/SKILL.md
+++ b/.claude/skills/hive-credentials/SKILL.md
@@ -508,7 +508,7 @@ All credential specs are defined in `tools/src/aden_tools/credentials/`:
 | `llm.py`          | LLM Providers | `anthropic`                                   | No             |
 | `search.py`       | Search Tools  | `brave_search`, `google_search`, `google_cse` | No             |
 | `email.py`        | Email         | `resend`                                      | No             |
-| `integrations.py` | Integrations  | `github`, `hubspot`                           | No / Yes       |
+| `integrations.py` | Integrations  | `github`, `hubspot`, `google_calendar_oauth`  | No / Yes       |
 
 **Note:** Additional LLM providers (Cerebras, Groq, OpenAI) are handled by LiteLLM via environment
 variables (`CEREBRAS_API_KEY`, `GROQ_API_KEY`, `OPENAI_API_KEY`) but are not yet in CREDENTIAL_SPECS.

--- a/tools/README.md
+++ b/tools/README.md
@@ -76,6 +76,14 @@ python mcp_server.py
 | `web_scrape`           | Scrape and extract content from webpages       |
 | `pdf_read`             | Read and extract text from PDF files           |
 | `get_current_time`     | Get current date/time with timezone support    |
+| `calendar_list_calendars` | List all accessible calendars               |
+| `calendar_list_events` | List events from a calendar                    |
+| `calendar_get_event`   | Get details of a specific event                |
+| `calendar_create_event`| Create a new calendar event                    |
+| `calendar_update_event`| Update an existing calendar event              |
+| `calendar_delete_event`| Delete a calendar event                        |
+| `calendar_get_calendar`| Get calendar metadata                          |
+| `calendar_check_availability` | Check free/busy status for attendees    |
 
 ## Project Structure
 
@@ -98,7 +106,8 @@ tools/
 │       ├── web_search_tool/
 │       ├── web_scrape_tool/
 │       ├── pdf_read_tool/
-│       └── time_tool/
+│       ├── time_tool/
+│       └── calendar_tool/
 ├── tests/                   # Test suite
 ├── mcp_server.py            # MCP server entry point
 ├── README.md

--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -58,6 +58,7 @@ from .browser import get_aden_auth_url, get_aden_setup_url, open_browser
 from .email import EMAIL_CREDENTIALS
 from .gcp_vision import GCP_VISION_CREDENTIALS
 from .github import GITHUB_CREDENTIALS
+from .google_calendar import GOOGLE_CALENDAR_CREDENTIALS
 from .google_maps import GOOGLE_MAPS_CREDENTIALS
 from .health_check import HealthCheckResult, check_credential_health
 from .hubspot import HUBSPOT_CREDENTIALS
@@ -86,6 +87,7 @@ CREDENTIAL_SPECS = {
     **GITHUB_CREDENTIALS,
     **GOOGLE_MAPS_CREDENTIALS,
     **HUBSPOT_CREDENTIALS,
+    **GOOGLE_CALENDAR_CREDENTIALS,
     **SLACK_CREDENTIALS,
     **SERPAPI_CREDENTIALS,
     **TELEGRAM_CREDENTIALS,
@@ -122,6 +124,7 @@ __all__ = [
     "GITHUB_CREDENTIALS",
     "GOOGLE_MAPS_CREDENTIALS",
     "HUBSPOT_CREDENTIALS",
+    "GOOGLE_CALENDAR_CREDENTIALS",
     "SLACK_CREDENTIALS",
     "APOLLO_CREDENTIALS",
     "SERPAPI_CREDENTIALS",

--- a/tools/src/aden_tools/credentials/google_calendar.py
+++ b/tools/src/aden_tools/credentials/google_calendar.py
@@ -1,0 +1,42 @@
+"""
+Google Calendar tool credentials.
+
+Contains credentials for Google Calendar integration.
+"""
+
+from .base import CredentialSpec
+
+GOOGLE_CALENDAR_CREDENTIALS = {
+    "google_calendar_oauth": CredentialSpec(
+        env_var="GOOGLE_CALENDAR_OAUTH_TOKEN",
+        tools=[
+            "calendar_list_events",
+            "calendar_get_event",
+            "calendar_create_event",
+            "calendar_update_event",
+            "calendar_delete_event",
+            "calendar_list_calendars",
+            "calendar_get_calendar",
+            "calendar_check_availability",
+        ],
+        required=True,
+        startup_required=False,
+        help_url="https://console.cloud.google.com/apis/credentials",
+        description="Google Calendar OAuth2 credentials (via Aden or direct setup)",
+        # Auth method support
+        aden_supported=True,
+        aden_provider_name="google-calendar",
+        direct_api_key_supported=False,
+        api_key_instructions=(
+            "To set up Google Calendar credentials directly:\n"
+            "1. Go to https://developers.google.com/oauthplayground/\n"
+            "2. Select 'Google Calendar API v3' scopes\n"
+            "3. Authorize and get an access token\n"
+            "4. Set GOOGLE_CALENDAR_OAUTH_TOKEN environment variable\n"
+            "Note: Tokens expire after ~1 hour. Use Aden OAuth for auto-refresh."
+        ),
+        # Credential store mapping
+        credential_id="google_calendar_oauth",
+        credential_key="access_token",
+    ),
+}

--- a/tools/src/aden_tools/credentials/google_calendar.py
+++ b/tools/src/aden_tools/credentials/google_calendar.py
@@ -8,7 +8,7 @@ from .base import CredentialSpec
 
 GOOGLE_CALENDAR_CREDENTIALS = {
     "google_calendar_oauth": CredentialSpec(
-        env_var="GOOGLE_CALENDAR_OAUTH_TOKEN",
+        env_var="GOOGLE_CALENDAR_ACCESS_TOKEN",
         tools=[
             "calendar_list_events",
             "calendar_get_event",
@@ -19,22 +19,19 @@ GOOGLE_CALENDAR_CREDENTIALS = {
             "calendar_get_calendar",
             "calendar_check_availability",
         ],
-        required=True,
+        node_types=[],
+        required=False,
         startup_required=False,
-        help_url="https://console.cloud.google.com/apis/credentials",
-        description="Google Calendar OAuth2 credentials (via Aden or direct setup)",
+        help_url="https://hive.adenhq.com",
+        description="Google Calendar OAuth2 access token (via Aden) - used for Google Calendar",
         # Auth method support
         aden_supported=True,
         aden_provider_name="google-calendar",
         direct_api_key_supported=False,
-        api_key_instructions=(
-            "To set up Google Calendar credentials directly:\n"
-            "1. Go to https://developers.google.com/oauthplayground/\n"
-            "2. Select 'Google Calendar API v3' scopes\n"
-            "3. Authorize and get an access token\n"
-            "4. Set GOOGLE_CALENDAR_OAUTH_TOKEN environment variable\n"
-            "Note: Tokens expire after ~1 hour. Use Aden OAuth for auto-refresh."
-        ),
+        api_key_instructions="Google Calendar OAuth requires OAuth2. Connect via hive.adenhq.com",
+        # Health check configuration
+        health_check_endpoint="https://www.googleapis.com/calendar/v3/users/me/calendarList",
+        health_check_method="GET",
         # Credential store mapping
         credential_id="google_calendar_oauth",
         credential_key="access_token",

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 # Import register_tools from each tool module
 from .apollo_tool import register_tools as register_apollo
 from .bigquery_tool import register_tools as register_bigquery
+from .calendar_tool import register_tools as register_calendar
 from .csv_tool import register_tools as register_csv
 from .email_tool import register_tools as register_email
 from .example_tool import register_tools as register_example
@@ -92,6 +93,7 @@ def register_all_tools(
     register_news(mcp, credentials=credentials)
     register_apollo(mcp, credentials=credentials)
     register_serpapi(mcp, credentials=credentials)
+    register_calendar(mcp, credentials=credentials)
     register_slack(mcp, credentials=credentials)
     register_telegram(mcp, credentials=credentials)
     register_vision(mcp, credentials=credentials)
@@ -195,6 +197,14 @@ def register_all_tools(
         "scholar_get_author",
         "patents_search",
         "patents_get_details",
+        "calendar_list_events",
+        "calendar_get_event",
+        "calendar_create_event",
+        "calendar_update_event",
+        "calendar_delete_event",
+        "calendar_list_calendars",
+        "calendar_get_calendar",
+        "calendar_check_availability",
         "slack_send_message",
         "slack_list_channels",
         "slack_get_channel_history",

--- a/tools/src/aden_tools/tools/calendar_tool/README.md
+++ b/tools/src/aden_tools/tools/calendar_tool/README.md
@@ -1,0 +1,265 @@
+# Google Calendar Tool
+
+A tool for managing Google Calendar events, checking availability, and coordinating schedules.
+
+## Features
+
+- **Events**: Create, read, update, and delete calendar events
+- **Calendars**: List and access user's calendars
+- **Availability**: Check free/busy times for smart scheduling
+- **Attendees**: Add participants and send meeting invites
+
+## Setup
+
+### Option A: Aden OAuth (Recommended)
+
+Use Aden's managed OAuth flow for automatic token refresh:
+
+1. Set `aden_provider_name="google-calendar"` in your agent's credential spec
+2. Aden handles the OAuth flow and token refresh automatically
+
+### Option B: Direct Token (Testing)
+
+For quick testing, get a token from the [Google OAuth Playground](https://developers.google.com/oauthplayground/):
+
+1. Go to OAuth Playground
+2. Select "Google Calendar API v3" scopes
+3. Authorize and get an access token
+4. Set the environment variable:
+
+```bash
+export GOOGLE_CALENDAR_OAUTH_TOKEN="your-access-token"
+```
+
+**Note:** Access tokens from OAuth Playground expire after ~1 hour. For production, use Aden OAuth.
+
+## Authentication
+
+This tool uses OAuth 2.0 for authentication with Google Calendar API.
+
+**Default scope:**
+- `https://www.googleapis.com/auth/calendar` - Full read/write access to calendars and events
+
+**Alternative (read-only):**
+- `https://www.googleapis.com/auth/calendar.readonly` - Read-only access
+
+## Tools
+
+### calendar_list_events
+
+List upcoming calendar events.
+
+**Parameters:**
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| calendar_id | str | No | "primary" | Calendar ID or "primary" for main calendar |
+| time_min | str | No | now | Start time (ISO 8601 format) |
+| time_max | str | No | None | End time (ISO 8601 format) |
+| max_results | int | No | 10 | Maximum events to return (1-2500) |
+| query | str | No | None | Free text search terms |
+
+**Example:**
+```python
+calendar_list_events(
+    calendar_id="primary",
+    time_min="2024-01-15T00:00:00Z",
+    time_max="2024-01-22T00:00:00Z",
+    max_results=20
+)
+```
+
+### calendar_get_event
+
+Get details of a specific event.
+
+**Parameters:**
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| event_id | str | Yes | - | The event ID |
+| calendar_id | str | No | "primary" | Calendar ID |
+
+### calendar_create_event
+
+Create a new calendar event.
+
+**Parameters:**
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| summary | str | Yes | - | Event title |
+| start_time | str | Yes | - | Start time (ISO 8601). For all-day events: "YYYY-MM-DD" |
+| end_time | str | Yes | - | End time (ISO 8601). For all-day events: "YYYY-MM-DD" (exclusive) |
+| calendar_id | str | No | "primary" | Calendar ID |
+| description | str | No | None | Event description |
+| location | str | No | None | Event location |
+| attendees | list[str] | No | None | List of attendee emails |
+| send_notifications | bool | No | True | Send invite emails to attendees |
+| timezone | str | No | None | IANA timezone (e.g., "America/New_York"). Ignored for all-day events. |
+| all_day | bool | No | False | Create an all-day event (uses date-only start/end) |
+
+**Note:** When attendees are provided, a Google Meet link is automatically generated.
+
+**Example (timed event):**
+```python
+calendar_create_event(
+    summary="Team Standup",
+    start_time="2024-01-15T09:00:00",
+    end_time="2024-01-15T09:30:00",
+    timezone="America/New_York",
+    attendees=["alice@example.com", "bob@example.com"],
+    description="Daily sync meeting"
+)
+```
+
+**Example (all-day event):**
+```python
+calendar_create_event(
+    summary="Company Holiday",
+    start_time="2024-12-25",
+    end_time="2024-12-26",  # end date is exclusive
+    all_day=True
+)
+```
+
+### calendar_update_event
+
+Update an existing event. Only provided fields are changed (uses PATCH).
+
+**Parameters:**
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| event_id | str | Yes | - | The event ID to update |
+| calendar_id | str | No | "primary" | Calendar ID |
+| summary | str | No | None | New event title |
+| start_time | str | No | None | New start time. For all-day: "YYYY-MM-DD" |
+| end_time | str | No | None | New end time. For all-day: "YYYY-MM-DD" |
+| description | str | No | None | New description |
+| location | str | No | None | New location |
+| attendees | list[str] | No | None | Updated attendee list |
+| send_notifications | bool | No | True | Send update emails |
+| timezone | str | No | None | IANA timezone (e.g., "America/New_York"). Ignored for all-day. |
+| all_day | bool | No | False | Convert to all-day event (requires start_time + end_time) |
+| add_meet_link | bool | No | False | Add a Google Meet link to the event |
+
+### calendar_delete_event
+
+Delete a calendar event.
+
+**Parameters:**
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| event_id | str | Yes | - | The event ID to delete |
+| calendar_id | str | No | "primary" | Calendar ID |
+| send_notifications | bool | No | True | Send cancellation emails |
+
+### calendar_list_calendars
+
+List all calendars accessible to the user.
+
+**Parameters:**
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| max_results | int | No | 100 | Maximum calendars to return |
+
+### calendar_get_calendar
+
+Get details of a specific calendar.
+
+**Parameters:**
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| calendar_id | str | Yes | - | The calendar ID |
+
+### calendar_check_availability
+
+Check free/busy status for scheduling.
+
+**Parameters:**
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| time_min | str | Yes | - | Start of time range (ISO 8601) |
+| time_max | str | Yes | - | End of time range (ISO 8601) |
+| calendars | list[str] | No | ["primary"] | Calendar IDs to check |
+| timezone | str | No | "UTC" | Timezone for the query |
+
+**Example:**
+```python
+calendar_check_availability(
+    time_min="2024-01-15T00:00:00Z",
+    time_max="2024-01-16T00:00:00Z",
+    calendars=["primary", "team-calendar@group.calendar.google.com"]
+)
+```
+
+**Response:**
+```json
+{
+    "time_min": "2024-01-15T00:00:00Z",
+    "time_max": "2024-01-16T00:00:00Z",
+    "calendars": {
+        "primary": {
+            "busy": [
+                {"start": "2024-01-15T09:00:00Z", "end": "2024-01-15T10:00:00Z"},
+                {"start": "2024-01-15T14:00:00Z", "end": "2024-01-15T15:00:00Z"}
+            ]
+        }
+    }
+}
+```
+
+## Error Handling
+
+All tools return a dict with either success data or an error:
+
+**Success:**
+```json
+{
+    "id": "event123",
+    "summary": "Team Meeting",
+    "start": {"dateTime": "2024-01-15T09:00:00Z"},
+    "end": {"dateTime": "2024-01-15T10:00:00Z"}
+}
+```
+
+**Error:**
+```json
+{
+    "error": "Calendar credentials not configured",
+    "help": "Set GOOGLE_CALENDAR_OAUTH_TOKEN environment variable"
+}
+```
+
+## Common Use Cases
+
+### Schedule a meeting with availability check
+```python
+# 1. Check when everyone is free
+availability = calendar_check_availability(
+    time_min="2024-01-15T00:00:00Z",
+    time_max="2024-01-19T00:00:00Z"
+)
+
+# 2. Create the meeting at a free slot
+event = calendar_create_event(
+    summary="Project Review",
+    start_time="2024-01-16T14:00:00Z",
+    end_time="2024-01-16T15:00:00Z",
+    attendees=["team@example.com"]
+)
+```
+
+### Get today's agenda
+```python
+from datetime import datetime, timedelta
+
+today = datetime.now().replace(hour=0, minute=0, second=0)
+tomorrow = today + timedelta(days=1)
+
+events = calendar_list_events(
+    time_min=today.isoformat() + "Z",
+    time_max=tomorrow.isoformat() + "Z"
+)
+```
+
+## API Reference
+
+This tool uses the [Google Calendar API v3](https://developers.google.com/calendar/api/v3/reference).

--- a/tools/src/aden_tools/tools/calendar_tool/README.md
+++ b/tools/src/aden_tools/tools/calendar_tool/README.md
@@ -28,7 +28,7 @@ For quick testing, get a token from the [Google OAuth Playground](https://develo
 4. Set the environment variable:
 
 ```bash
-export GOOGLE_CALENDAR_OAUTH_TOKEN="your-access-token"
+export GOOGLE_CALENDAR_ACCESS_TOKEN="your-access-token"
 ```
 
 **Note:** Access tokens from OAuth Playground expire after ~1 hour. For production, use Aden OAuth.
@@ -224,7 +224,7 @@ All tools return a dict with either success data or an error:
 ```json
 {
     "error": "Calendar credentials not configured",
-    "help": "Set GOOGLE_CALENDAR_OAUTH_TOKEN environment variable"
+    "help": "Set GOOGLE_CALENDAR_ACCESS_TOKEN environment variable"
 }
 ```
 

--- a/tools/src/aden_tools/tools/calendar_tool/__init__.py
+++ b/tools/src/aden_tools/tools/calendar_tool/__init__.py
@@ -1,0 +1,5 @@
+"""Google Calendar Tool package."""
+
+from .calendar_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/calendar_tool/calendar_tool.py
+++ b/tools/src/aden_tools/tools/calendar_tool/calendar_tool.py
@@ -8,7 +8,7 @@ Supports:
 
 Requires OAuth 2.0 credentials:
 - Aden: Use aden_provider_name="google-calendar" for managed OAuth (recommended)
-- Direct: Set GOOGLE_CALENDAR_OAUTH_TOKEN with token from OAuth Playground
+- Direct: Set GOOGLE_CALENDAR_ACCESS_TOKEN with token from OAuth Playground
 """
 
 from __future__ import annotations
@@ -85,7 +85,7 @@ def register_tools(
             return credentials.get("google_calendar_oauth")
 
         # Fall back to environment variable
-        return os.getenv("GOOGLE_CALENDAR_OAUTH_TOKEN")
+        return os.getenv("GOOGLE_CALENDAR_ACCESS_TOKEN")
 
     def _get_headers() -> dict[str, str]:
         """Get authorization headers for API requests.
@@ -106,7 +106,7 @@ def register_tools(
         if not token:
             return {
                 "error": "Calendar credentials not configured",
-                "help": "Set GOOGLE_CALENDAR_OAUTH_TOKEN environment variable",
+                "help": "Set GOOGLE_CALENDAR_ACCESS_TOKEN environment variable",
             }
         return None
 

--- a/tools/src/aden_tools/tools/calendar_tool/calendar_tool.py
+++ b/tools/src/aden_tools/tools/calendar_tool/calendar_tool.py
@@ -1,0 +1,810 @@
+"""
+Google Calendar Tool - Manage calendar events and check availability.
+
+Supports:
+- Event CRUD operations (list, get, create, update, delete)
+- Calendar listing and details
+- Free/busy availability checks
+
+Requires OAuth 2.0 credentials:
+- Aden: Use aden_provider_name="google-calendar" for managed OAuth (recommended)
+- Direct: Set GOOGLE_CALENDAR_OAUTH_TOKEN with token from OAuth Playground
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from urllib.parse import quote
+from zoneinfo import available_timezones
+
+import httpx
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from framework.credentials.oauth2 import TokenLifecycleManager
+
+    from aden_tools.credentials import CredentialStoreAdapter
+
+logger = logging.getLogger(__name__)
+
+# Google Calendar API base URL
+CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3"
+
+
+def _create_lifecycle_manager(
+    credentials: CredentialStoreAdapter,
+) -> TokenLifecycleManager | None:
+    """
+    Create a TokenLifecycleManager for automatic token refresh.
+
+    Currently returns None because token refresh is handled server-side by Aden's
+    OAuth infrastructure. When using Aden OAuth, tokens are refreshed automatically
+    before they expire. For direct API access (testing), use a short-lived token
+    from the OAuth Playground - these tokens expire after ~1 hour.
+
+    This function exists as a hook for future local token refresh if needed.
+    """
+    return None
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: CredentialStoreAdapter | None = None,
+) -> None:
+    """Register Google Calendar tools with the MCP server."""
+
+    # Create lifecycle manager for auto-refresh (if possible)
+    lifecycle_manager: TokenLifecycleManager | None = None
+    if credentials is not None:
+        lifecycle_manager = _create_lifecycle_manager(credentials)
+        if lifecycle_manager:
+            logger.info("Google Calendar OAuth auto-refresh enabled")
+
+    def _get_token() -> str | None:
+        """
+        Get OAuth token, refreshing if needed.
+
+        Priority:
+        1. TokenLifecycleManager (auto-refresh) if available
+        2. CredentialStoreAdapter (includes env var fallback)
+        3. Environment variable (direct fallback if no adapter)
+        """
+        # Try lifecycle manager first (handles auto-refresh)
+        if lifecycle_manager is not None:
+            token = lifecycle_manager.sync_get_valid_token()
+            if token is not None:
+                return token.access_token
+
+        # Fall back to credential store adapter
+        if credentials is not None:
+            return credentials.get("google_calendar_oauth")
+
+        # Fall back to environment variable
+        return os.getenv("GOOGLE_CALENDAR_OAUTH_TOKEN")
+
+    def _get_headers() -> dict[str, str]:
+        """Get authorization headers for API requests.
+
+        Note: Callers must use _check_credentials() first to ensure token exists.
+        """
+        token = _get_token()
+        if token is None:
+            token = ""  # Will fail auth but prevents "Bearer None" in logs
+        return {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+
+    def _check_credentials() -> dict | None:
+        """Check if credentials are configured. Returns error dict if not."""
+        token = _get_token()
+        if not token:
+            return {
+                "error": "Calendar credentials not configured",
+                "help": "Set GOOGLE_CALENDAR_OAUTH_TOKEN environment variable",
+            }
+        return None
+
+    def _encode_id(id_value: str) -> str:
+        """URL-encode a calendar or event ID for safe use in URLs."""
+        return quote(id_value, safe="")
+
+    def _sanitize_error(e: Exception) -> str:
+        """Sanitize exception message to avoid leaking sensitive data like tokens."""
+        msg = str(e)
+        # httpx.RequestError can include headers with Bearer token
+        # Only return the error type and a safe portion of the message
+        if "Bearer" in msg or "Authorization" in msg:
+            return f"{type(e).__name__}: Request failed (details redacted for security)"
+        # Truncate long messages that might contain sensitive data
+        if len(msg) > 200:
+            return f"{type(e).__name__}: {msg[:200]}..."
+        return msg
+
+    # Pre-compute valid timezones once
+    _VALID_TIMEZONES = available_timezones()
+
+    # Pattern for date-only strings (YYYY-MM-DD)
+    _DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+    def _validate_timezone(tz: str) -> dict | None:
+        """Validate a timezone string. Returns error dict if invalid, None if valid."""
+        if tz not in _VALID_TIMEZONES:
+            return {"error": f"Invalid timezone '{tz}'. Use IANA format (e.g., 'America/New_York')"}
+        return None
+
+    def _handle_response(response: httpx.Response) -> dict:
+        """Handle API response and return appropriate result."""
+        if response.status_code == 401:
+            # If we have a lifecycle manager, the token should have auto-refreshed
+            # If we still get 401, the refresh token is likely invalid
+            if lifecycle_manager is not None:
+                return {
+                    "error": "OAuth token expired and refresh failed",
+                    "help": "Re-authenticate via Aden or get a new token from OAuth Playground",
+                }
+            return {
+                "error": "Invalid or expired OAuth token",
+                "help": "Get a new token from https://developers.google.com/oauthplayground/",
+            }
+        elif response.status_code == 403:
+            return {
+                "error": "Access denied. Check calendar permissions.",
+                "help": "Ensure the OAuth token has calendar.events scope",
+            }
+        elif response.status_code == 404:
+            return {"error": "Resource not found"}
+        elif response.status_code == 429:
+            return {"error": "Rate limit exceeded. Try again later."}
+        elif response.status_code >= 400:
+            try:
+                error_data = response.json()
+                message = error_data.get("error", {}).get("message", "Unknown error")
+                return {"error": f"API error: {message}"}
+            except Exception:
+                return {"error": f"API request failed: HTTP {response.status_code}"}
+        return response.json()
+
+    @mcp.tool()
+    def calendar_list_events(
+        calendar_id: str = "primary",
+        time_min: str | None = None,
+        time_max: str | None = None,
+        max_results: int = 10,
+        query: str | None = None,
+        # Tracking parameters (injected by framework, ignored by tool)
+        workspace_id: str | None = None,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> dict:
+        """
+        List upcoming calendar events.
+
+        Args:
+            calendar_id: Calendar ID or "primary" for main calendar
+            time_min: Start time filter (ISO 8601 format, e.g., "2024-01-15T00:00:00Z")
+            time_max: End time filter (ISO 8601 format)
+            max_results: Maximum events to return (1-2500, default 10)
+            query: Free text search terms to filter events
+            workspace_id: Tracking parameter (injected by framework)
+            agent_id: Tracking parameter (injected by framework)
+            session_id: Tracking parameter (injected by framework)
+
+        Returns:
+            Dict with list of events or error message
+        """
+        cred_error = _check_credentials()
+        if cred_error:
+            return cred_error
+
+        if max_results < 1 or max_results > 2500:
+            return {"error": "max_results must be between 1 and 2500"}
+
+        # Default time_min to now if not provided
+        if time_min is None:
+            time_min = datetime.now(UTC).isoformat()
+
+        params: dict = {
+            "maxResults": max_results,
+            "singleEvents": "true",
+            "orderBy": "startTime",
+            "timeMin": time_min,
+        }
+
+        if time_max:
+            params["timeMax"] = time_max
+        if query:
+            params["q"] = query
+
+        try:
+            response = httpx.get(
+                f"{CALENDAR_API_BASE}/calendars/{_encode_id(calendar_id)}/events",
+                headers=_get_headers(),
+                params=params,
+                timeout=30.0,
+            )
+            result = _handle_response(response)
+
+            if "error" in result:
+                return result
+
+            # Format events for cleaner output
+            events = []
+            for item in result.get("items", []):
+                start = item.get("start", {})
+                end = item.get("end", {})
+                event_data = {
+                    "id": item.get("id"),
+                    "summary": item.get("summary", "(No title)"),
+                    "start": start.get("dateTime") or start.get("date"),
+                    "end": end.get("dateTime") or end.get("date"),
+                    "location": item.get("location"),
+                    "status": item.get("status"),
+                    "html_link": item.get("htmlLink"),
+                    "description": item.get("description"),
+                    "hangoutLink": item.get("hangoutLink"),
+                }
+                if item.get("attendees"):
+                    event_data["attendees"] = [a.get("email") for a in item["attendees"]]
+                events.append(event_data)
+
+            return {
+                "calendar_id": calendar_id,
+                "events": events,
+                "total": len(events),
+            }
+
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {_sanitize_error(e)}"}
+
+    @mcp.tool()
+    def calendar_get_event(
+        event_id: str,
+        calendar_id: str = "primary",
+        # Tracking parameters (injected by framework, ignored by tool)
+        workspace_id: str | None = None,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> dict:
+        """
+        Get details of a specific calendar event.
+
+        Args:
+            event_id: The event ID to retrieve
+            calendar_id: Calendar ID or "primary" for main calendar
+            workspace_id: Tracking parameter (injected by framework)
+            agent_id: Tracking parameter (injected by framework)
+            session_id: Tracking parameter (injected by framework)
+
+        Returns:
+            Dict with event details or error message
+        """
+        cred_error = _check_credentials()
+        if cred_error:
+            return cred_error
+
+        if not event_id:
+            return {"error": "event_id is required"}
+
+        try:
+            response = httpx.get(
+                f"{CALENDAR_API_BASE}/calendars/{_encode_id(calendar_id)}/events/{_encode_id(event_id)}",
+                headers=_get_headers(),
+                timeout=30.0,
+            )
+            return _handle_response(response)
+
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {_sanitize_error(e)}"}
+
+    @mcp.tool()
+    def calendar_create_event(
+        summary: str,
+        start_time: str,
+        end_time: str,
+        calendar_id: str = "primary",
+        description: str | None = None,
+        location: str | None = None,
+        attendees: list[str] | None = None,
+        send_notifications: bool = True,
+        timezone: str | None = None,
+        all_day: bool = False,
+        # Tracking parameters (injected by framework, ignored by tool)
+        workspace_id: str | None = None,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> dict:
+        """
+        Create a new calendar event.
+
+        Args:
+            summary: Event title
+            start_time: Start time (ISO 8601 format, e.g., "2024-01-15T09:00:00").
+                For all-day events use date-only format: "2024-01-15"
+            end_time: End time (ISO 8601 format).
+                For all-day events use date-only format: "2024-01-16"
+                (end date is exclusive — a 1-day event on Jan 15 uses end "2024-01-16")
+            calendar_id: Calendar ID or "primary" for main calendar
+            description: Event description/notes
+            location: Event location (address or room name)
+            attendees: List of attendee email addresses
+            send_notifications: Whether to send email invites to attendees
+            timezone: Timezone for the event (e.g., "America/New_York"). Ignored for all-day events.
+            all_day: If True, creates an all-day event using date-only start/end
+            workspace_id: Tracking parameter (injected by framework)
+            agent_id: Tracking parameter (injected by framework)
+            session_id: Tracking parameter (injected by framework)
+
+        Returns:
+            Dict with created event details or error message
+        """
+        cred_error = _check_credentials()
+        if cred_error:
+            return cred_error
+
+        if not summary:
+            return {"error": "summary is required"}
+        if not start_time:
+            return {"error": "start_time is required"}
+        if not end_time:
+            return {"error": "end_time is required"}
+
+        # Validate timezone if provided
+        if timezone and not all_day:
+            tz_error = _validate_timezone(timezone)
+            if tz_error:
+                return tz_error
+
+        # Build event body
+        if all_day:
+            # Validate date-only format for all-day events
+            if not _DATE_ONLY_RE.match(start_time):
+                return {
+                    "error": "all-day events require date-only format for start_time (YYYY-MM-DD)"
+                }
+            if not _DATE_ONLY_RE.match(end_time):
+                return {
+                    "error": "all-day events require date-only format for end_time (YYYY-MM-DD)"
+                }
+            event_body: dict = {
+                "summary": summary,
+                "start": {"date": start_time},
+                "end": {"date": end_time},
+            }
+        else:
+            event_body = {
+                "summary": summary,
+                "start": {"dateTime": start_time},
+                "end": {"dateTime": end_time},
+            }
+            if timezone:
+                event_body["start"]["timeZone"] = timezone
+                event_body["end"]["timeZone"] = timezone
+
+        if description is not None:
+            event_body["description"] = description
+        if location is not None:
+            event_body["location"] = location
+        if attendees:
+            event_body["attendees"] = [{"email": email} for email in attendees]
+            # Auto-generate Google Meet link when attendees are present
+            event_body["conferenceData"] = {
+                "createRequest": {
+                    "requestId": f"meet-{uuid.uuid4().hex[:12]}",
+                    "conferenceSolutionKey": {"type": "hangoutsMeet"},
+                }
+            }
+
+        params: dict = {"sendUpdates": "all" if send_notifications else "none"}
+        # Enable conference data support for Meet link generation
+        if attendees:
+            params["conferenceDataVersion"] = 1
+
+        try:
+            response = httpx.post(
+                f"{CALENDAR_API_BASE}/calendars/{_encode_id(calendar_id)}/events",
+                headers=_get_headers(),
+                json=event_body,
+                params=params,
+                timeout=30.0,
+            )
+            return _handle_response(response)
+
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {_sanitize_error(e)}"}
+
+    @mcp.tool()
+    def calendar_update_event(
+        event_id: str,
+        calendar_id: str = "primary",
+        summary: str | None = None,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        description: str | None = None,
+        location: str | None = None,
+        attendees: list[str] | None = None,
+        remove_attendees: list[str] | None = None,
+        send_notifications: bool = True,
+        timezone: str | None = None,
+        all_day: bool = False,
+        add_meet_link: bool = False,
+        # Tracking parameters (injected by framework, ignored by tool)
+        workspace_id: str | None = None,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> dict:
+        """
+        Update an existing calendar event. Only provided fields are changed.
+
+        Args:
+            event_id: The event ID to update
+            calendar_id: Calendar ID or "primary" for main calendar
+            summary: New event title (None to keep existing)
+            start_time: New start time (ISO 8601 format).
+                For all-day events use date-only format: "2024-01-15"
+            end_time: New end time (ISO 8601 format).
+                For all-day events use date-only format: "2024-01-16"
+            description: New description
+            location: New location
+            attendees: Updated list of attendee emails (replaces existing)
+            remove_attendees: List of attendee emails to remove from the event
+            send_notifications: Whether to send update emails
+            timezone: Timezone for the event (e.g., "America/New_York"). Ignored for all-day events.
+            all_day: If True and start_time/end_time are provided, converts to all-day event
+            add_meet_link: If True, adds a Google Meet link to the event
+            workspace_id: Tracking parameter (injected by framework)
+            agent_id: Tracking parameter (injected by framework)
+            session_id: Tracking parameter (injected by framework)
+
+        Returns:
+            Dict with updated event details or error message
+        """
+        cred_error = _check_credentials()
+        if cred_error:
+            return cred_error
+
+        if not event_id:
+            return {"error": "event_id is required"}
+
+        # Validate timezone if provided
+        if timezone and not all_day:
+            tz_error = _validate_timezone(timezone)
+            if tz_error:
+                return tz_error
+
+        # Build partial body with only provided fields (PATCH semantics)
+        patch_body: dict = {}
+
+        if summary is not None:
+            patch_body["summary"] = summary
+        if description is not None:
+            patch_body["description"] = description
+        if location is not None:
+            patch_body["location"] = location
+
+        if remove_attendees is not None:
+            # Fetch current event to get attendee list
+            try:
+                get_response = httpx.get(
+                    f"{CALENDAR_API_BASE}/calendars/{_encode_id(calendar_id)}/events/{_encode_id(event_id)}",
+                    headers=_get_headers(),
+                    timeout=30.0,
+                )
+                event_data = _handle_response(get_response)
+                if "error" in event_data:
+                    return event_data
+            except httpx.TimeoutException:
+                return {"error": "Request timed out while fetching event"}
+            except httpx.RequestError as e:
+                return {"error": f"Network error: {_sanitize_error(e)}"}
+
+            current_attendees = event_data.get("attendees", [])
+            remove_set = {e.lower() for e in remove_attendees}
+            remaining = [
+                a for a in current_attendees if a.get("email", "").lower() not in remove_set
+            ]
+            patch_body["attendees"] = remaining
+        elif attendees is not None:
+            patch_body["attendees"] = [{"email": email} for email in attendees]
+
+        if add_meet_link:
+            patch_body["conferenceData"] = {
+                "createRequest": {
+                    "requestId": f"meet-{uuid.uuid4().hex[:12]}",
+                    "conferenceSolutionKey": {"type": "hangoutsMeet"},
+                }
+            }
+
+        if start_time is not None:
+            if all_day:
+                if not _DATE_ONLY_RE.match(start_time):
+                    return {
+                        "error": (
+                            "all-day events require date-only format for start_time (YYYY-MM-DD)"
+                        )
+                    }
+                patch_body["start"] = {"date": start_time}
+            else:
+                patch_body["start"] = {"dateTime": start_time}
+                if timezone:
+                    patch_body["start"]["timeZone"] = timezone
+
+        if end_time is not None:
+            if all_day:
+                if not _DATE_ONLY_RE.match(end_time):
+                    return {
+                        "error": (
+                            "all-day events require date-only format for end_time (YYYY-MM-DD)"
+                        )
+                    }
+                patch_body["end"] = {"date": end_time}
+            else:
+                patch_body["end"] = {"dateTime": end_time}
+                if timezone:
+                    patch_body["end"]["timeZone"] = timezone
+
+        if not patch_body:
+            return {"error": "No fields to update. Provide at least one field to change."}
+
+        params: dict = {"sendUpdates": "all" if send_notifications else "none"}
+        # Enable conference data support only when modifying conference data
+        if add_meet_link or attendees is not None or remove_attendees is not None:
+            params["conferenceDataVersion"] = 1
+
+        try:
+            response = httpx.patch(
+                f"{CALENDAR_API_BASE}/calendars/{_encode_id(calendar_id)}/events/{_encode_id(event_id)}",
+                headers=_get_headers(),
+                json=patch_body,
+                params=params,
+                timeout=30.0,
+            )
+            return _handle_response(response)
+
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {_sanitize_error(e)}"}
+
+    @mcp.tool()
+    def calendar_delete_event(
+        event_id: str,
+        calendar_id: str = "primary",
+        send_notifications: bool = True,
+        # Tracking parameters (injected by framework, ignored by tool)
+        workspace_id: str | None = None,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> dict:
+        """
+        Delete a calendar event.
+
+        Args:
+            event_id: The event ID to delete
+            calendar_id: Calendar ID or "primary" for main calendar
+            send_notifications: Whether to send cancellation emails to attendees
+            workspace_id: Tracking parameter (injected by framework)
+            agent_id: Tracking parameter (injected by framework)
+            session_id: Tracking parameter (injected by framework)
+
+        Returns:
+            Dict with success status or error message
+        """
+        cred_error = _check_credentials()
+        if cred_error:
+            return cred_error
+
+        if not event_id:
+            return {"error": "event_id is required"}
+
+        params = {"sendUpdates": "all" if send_notifications else "none"}
+
+        try:
+            response = httpx.delete(
+                f"{CALENDAR_API_BASE}/calendars/{_encode_id(calendar_id)}/events/{_encode_id(event_id)}",
+                headers=_get_headers(),
+                params=params,
+                timeout=30.0,
+            )
+
+            if response.status_code == 204:
+                return {"success": True, "message": f"Event {event_id} deleted"}
+
+            return _handle_response(response)
+
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {_sanitize_error(e)}"}
+
+    @mcp.tool()
+    def calendar_list_calendars(
+        max_results: int = 100,
+        # Tracking parameters (injected by framework, ignored by tool)
+        workspace_id: str | None = None,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> dict:
+        """
+        List all calendars accessible to the user.
+
+        Args:
+            max_results: Maximum number of calendars to return (1-250)
+            workspace_id: Tracking parameter (injected by framework)
+            agent_id: Tracking parameter (injected by framework)
+            session_id: Tracking parameter (injected by framework)
+
+        Returns:
+            Dict with list of calendars or error message
+        """
+        cred_error = _check_credentials()
+        if cred_error:
+            return cred_error
+
+        if max_results < 1 or max_results > 250:
+            return {"error": "max_results must be between 1 and 250"}
+
+        try:
+            response = httpx.get(
+                f"{CALENDAR_API_BASE}/users/me/calendarList",
+                headers=_get_headers(),
+                params={"maxResults": max_results},
+                timeout=30.0,
+            )
+            result = _handle_response(response)
+
+            if "error" in result:
+                return result
+
+            calendars = []
+            for item in result.get("items", []):
+                calendars.append(
+                    {
+                        "id": item.get("id"),
+                        "summary": item.get("summary"),
+                        "description": item.get("description"),
+                        "primary": item.get("primary", False),
+                        "access_role": item.get("accessRole"),
+                        "background_color": item.get("backgroundColor"),
+                    }
+                )
+
+            return {
+                "calendars": calendars,
+                "total": len(calendars),
+            }
+
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {_sanitize_error(e)}"}
+
+    @mcp.tool()
+    def calendar_get_calendar(
+        calendar_id: str,
+        # Tracking parameters (injected by framework, ignored by tool)
+        workspace_id: str | None = None,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> dict:
+        """
+        Get details of a specific calendar.
+
+        Args:
+            calendar_id: The calendar ID to retrieve
+            workspace_id: Tracking parameter (injected by framework)
+            agent_id: Tracking parameter (injected by framework)
+            session_id: Tracking parameter (injected by framework)
+
+        Returns:
+            Dict with calendar details or error message
+        """
+        cred_error = _check_credentials()
+        if cred_error:
+            return cred_error
+
+        if not calendar_id:
+            return {"error": "calendar_id is required"}
+
+        try:
+            response = httpx.get(
+                f"{CALENDAR_API_BASE}/calendars/{_encode_id(calendar_id)}",
+                headers=_get_headers(),
+                timeout=30.0,
+            )
+            return _handle_response(response)
+
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {_sanitize_error(e)}"}
+
+    @mcp.tool()
+    def calendar_check_availability(
+        time_min: str,
+        time_max: str,
+        calendars: list[str] | None = None,
+        timezone: str = "UTC",
+        # Tracking parameters (injected by framework, ignored by tool)
+        workspace_id: str | None = None,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> dict:
+        """
+        Check free/busy availability for scheduling.
+
+        Args:
+            time_min: Start of time range (ISO 8601 format)
+            time_max: End of time range (ISO 8601 format)
+            calendars: List of calendar IDs to check (defaults to ["primary"])
+            timezone: Timezone for the query (e.g., "America/New_York")
+            workspace_id: Tracking parameter (injected by framework)
+            agent_id: Tracking parameter (injected by framework)
+            session_id: Tracking parameter (injected by framework)
+
+        Returns:
+            Dict with busy periods for each calendar or error message
+        """
+        cred_error = _check_credentials()
+        if cred_error:
+            return cred_error
+
+        if not time_min:
+            return {"error": "time_min is required"}
+        if not time_max:
+            return {"error": "time_max is required"}
+
+        if calendars is None:
+            calendars = ["primary"]
+
+        request_body = {
+            "timeMin": time_min,
+            "timeMax": time_max,
+            "timeZone": timezone,
+            "items": [{"id": cal_id} for cal_id in calendars],
+        }
+
+        try:
+            response = httpx.post(
+                f"{CALENDAR_API_BASE}/freeBusy",
+                headers=_get_headers(),
+                json=request_body,
+                timeout=30.0,
+            )
+            result = _handle_response(response)
+
+            if "error" in result:
+                return result
+
+            # Format the response for easier consumption
+            formatted_calendars = {}
+            for cal_id, cal_data in result.get("calendars", {}).items():
+                if "errors" in cal_data:
+                    formatted_calendars[cal_id] = {
+                        "error": cal_data["errors"][0].get("reason", "Unknown error")
+                    }
+                else:
+                    formatted_calendars[cal_id] = {"busy": cal_data.get("busy", [])}
+
+            return {
+                "time_min": time_min,
+                "time_max": time_max,
+                "timezone": timezone,
+                "calendars": formatted_calendars,
+            }
+
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {_sanitize_error(e)}"}

--- a/tools/tests/tools/test_calendar_tool.py
+++ b/tools/tests/tools/test_calendar_tool.py
@@ -39,18 +39,18 @@ class TestCredentialErrors:
 
     def test_list_events_no_credentials(self, calendar_tools, monkeypatch):
         """list_events without credentials returns helpful error."""
-        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("GOOGLE_CALENDAR_ACCESS_TOKEN", raising=False)
 
         result = calendar_tools["list_events"]()
 
         assert "error" in result
         assert "Calendar credentials not configured" in result["error"]
         assert "help" in result
-        assert "GOOGLE_CALENDAR_OAUTH_TOKEN" in result["help"]
+        assert "GOOGLE_CALENDAR_ACCESS_TOKEN" in result["help"]
 
     def test_get_event_no_credentials(self, calendar_tools, monkeypatch):
         """get_event without credentials returns helpful error."""
-        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("GOOGLE_CALENDAR_ACCESS_TOKEN", raising=False)
 
         result = calendar_tools["get_event"](event_id="test-event-id")
 
@@ -59,7 +59,7 @@ class TestCredentialErrors:
 
     def test_create_event_no_credentials(self, calendar_tools, monkeypatch):
         """create_event without credentials returns helpful error."""
-        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("GOOGLE_CALENDAR_ACCESS_TOKEN", raising=False)
 
         result = calendar_tools["create_event"](
             summary="Test Event",
@@ -72,7 +72,7 @@ class TestCredentialErrors:
 
     def test_update_event_no_credentials(self, calendar_tools, monkeypatch):
         """update_event without credentials returns helpful error."""
-        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("GOOGLE_CALENDAR_ACCESS_TOKEN", raising=False)
 
         result = calendar_tools["update_event"](event_id="test-event-id")
 
@@ -81,7 +81,7 @@ class TestCredentialErrors:
 
     def test_delete_event_no_credentials(self, calendar_tools, monkeypatch):
         """delete_event without credentials returns helpful error."""
-        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("GOOGLE_CALENDAR_ACCESS_TOKEN", raising=False)
 
         result = calendar_tools["delete_event"](event_id="test-event-id")
 
@@ -90,7 +90,7 @@ class TestCredentialErrors:
 
     def test_list_calendars_no_credentials(self, calendar_tools, monkeypatch):
         """list_calendars without credentials returns helpful error."""
-        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("GOOGLE_CALENDAR_ACCESS_TOKEN", raising=False)
 
         result = calendar_tools["list_calendars"]()
 
@@ -99,7 +99,7 @@ class TestCredentialErrors:
 
     def test_get_calendar_no_credentials(self, calendar_tools, monkeypatch):
         """get_calendar without credentials returns helpful error."""
-        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("GOOGLE_CALENDAR_ACCESS_TOKEN", raising=False)
 
         result = calendar_tools["get_calendar"](calendar_id="primary")
 
@@ -108,7 +108,7 @@ class TestCredentialErrors:
 
     def test_check_availability_no_credentials(self, calendar_tools, monkeypatch):
         """check_availability without credentials returns helpful error."""
-        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("GOOGLE_CALENDAR_ACCESS_TOKEN", raising=False)
 
         result = calendar_tools["check_availability"](
             time_min="2024-01-15T00:00:00Z",
@@ -124,7 +124,7 @@ class TestParameterValidation:
 
     def test_list_events_max_results_too_low(self, calendar_tools, monkeypatch):
         """max_results below 1 returns error."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         result = calendar_tools["list_events"](max_results=0)
 
@@ -133,7 +133,7 @@ class TestParameterValidation:
 
     def test_list_events_max_results_too_high(self, calendar_tools, monkeypatch):
         """max_results above 2500 returns error."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         result = calendar_tools["list_events"](max_results=2501)
 
@@ -142,7 +142,7 @@ class TestParameterValidation:
 
     def test_get_event_missing_event_id(self, calendar_tools, monkeypatch):
         """get_event without event_id returns error."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         result = calendar_tools["get_event"](event_id="")
 
@@ -151,7 +151,7 @@ class TestParameterValidation:
 
     def test_create_event_missing_summary(self, calendar_tools, monkeypatch):
         """create_event without summary returns error."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         result = calendar_tools["create_event"](
             summary="",
@@ -164,7 +164,7 @@ class TestParameterValidation:
 
     def test_create_event_missing_start_time(self, calendar_tools, monkeypatch):
         """create_event without start_time returns error."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         result = calendar_tools["create_event"](
             summary="Test Event",
@@ -177,7 +177,7 @@ class TestParameterValidation:
 
     def test_create_event_missing_end_time(self, calendar_tools, monkeypatch):
         """create_event without end_time returns error."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         result = calendar_tools["create_event"](
             summary="Test Event",
@@ -190,7 +190,7 @@ class TestParameterValidation:
 
     def test_update_event_missing_event_id(self, calendar_tools, monkeypatch):
         """update_event without event_id returns error."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         result = calendar_tools["update_event"](event_id="")
 
@@ -199,7 +199,7 @@ class TestParameterValidation:
 
     def test_delete_event_missing_event_id(self, calendar_tools, monkeypatch):
         """delete_event without event_id returns error."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         result = calendar_tools["delete_event"](event_id="")
 
@@ -208,7 +208,7 @@ class TestParameterValidation:
 
     def test_list_calendars_max_results_too_high(self, calendar_tools, monkeypatch):
         """list_calendars max_results above 250 returns error."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         result = calendar_tools["list_calendars"](max_results=251)
 
@@ -217,7 +217,7 @@ class TestParameterValidation:
 
     def test_get_calendar_missing_calendar_id(self, calendar_tools, monkeypatch):
         """get_calendar without calendar_id returns error."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         result = calendar_tools["get_calendar"](calendar_id="")
 
@@ -226,7 +226,7 @@ class TestParameterValidation:
 
     def test_check_availability_missing_time_min(self, calendar_tools, monkeypatch):
         """check_availability without time_min returns error."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         result = calendar_tools["check_availability"](
             time_min="",
@@ -238,7 +238,7 @@ class TestParameterValidation:
 
     def test_check_availability_missing_time_max(self, calendar_tools, monkeypatch):
         """check_availability without time_max returns error."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         result = calendar_tools["check_availability"](
             time_min="2024-01-15T00:00:00Z",
@@ -255,7 +255,7 @@ class TestMockedAPIResponses:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
     def test_list_events_success(self, mock_get, calendar_tools, monkeypatch):
         """list_events returns formatted events on success."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_get.return_value = _mock_response(
             200,
@@ -286,7 +286,7 @@ class TestMockedAPIResponses:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
     def test_list_events_empty(self, mock_get, calendar_tools, monkeypatch):
         """list_events handles empty calendar."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_get.return_value = _mock_response(200, {"items": []})
 
@@ -299,7 +299,7 @@ class TestMockedAPIResponses:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
     def test_create_event_success(self, mock_post, calendar_tools, monkeypatch):
         """create_event returns created event details."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_post.return_value = _mock_response(
             200,
@@ -324,7 +324,7 @@ class TestMockedAPIResponses:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.delete")
     def test_delete_event_success(self, mock_delete, calendar_tools, monkeypatch):
         """delete_event returns success message."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_delete.return_value = _mock_response(204)
 
@@ -336,7 +336,7 @@ class TestMockedAPIResponses:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
     def test_list_calendars_success(self, mock_get, calendar_tools, monkeypatch):
         """list_calendars returns formatted calendar list."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_get.return_value = _mock_response(
             200,
@@ -368,7 +368,7 @@ class TestMockedAPIResponses:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
     def test_check_availability_success(self, mock_post, calendar_tools, monkeypatch):
         """check_availability returns busy periods."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_post.return_value = _mock_response(
             200,
@@ -398,7 +398,7 @@ class TestMockedAPIResponses:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
     def test_unauthorized_returns_error(self, mock_get, calendar_tools, monkeypatch):
         """401 response returns appropriate error."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "invalid-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "invalid-token")
 
         mock_get.return_value = _mock_response(401, {"error": {"message": "Invalid credentials"}})
 
@@ -410,7 +410,7 @@ class TestMockedAPIResponses:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
     def test_rate_limit_returns_error(self, mock_get, calendar_tools, monkeypatch):
         """429 response returns rate limit error."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_get.return_value = _mock_response(429)
 
@@ -422,7 +422,7 @@ class TestMockedAPIResponses:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
     def test_not_found_returns_error(self, mock_get, calendar_tools, monkeypatch):
         """404 response returns not found error."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_get.return_value = _mock_response(404)
 
@@ -441,7 +441,7 @@ class TestCredentialManager:
         from aden_tools.credentials import CredentialStoreAdapter
 
         # Don't set env var - only use credential store adapter
-        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("GOOGLE_CALENDAR_ACCESS_TOKEN", raising=False)
 
         # Create credential store adapter with test token
         creds = CredentialStoreAdapter.for_testing({"google_calendar_oauth": "test-oauth-token"})
@@ -465,7 +465,7 @@ class TestTokenRefresh:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
     def test_expired_token_returns_helpful_error(self, mock_get, calendar_tools, monkeypatch):
         """401 response with simple token suggests re-authorization."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "expired-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "expired-token")
 
         mock_get.return_value = _mock_response(401, {"error": {"message": "Token expired"}})
 
@@ -489,7 +489,7 @@ class TestTokenRefresh:
         from aden_tools.credentials import CredentialStoreAdapter
 
         # Clear env var
-        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("GOOGLE_CALENDAR_ACCESS_TOKEN", raising=False)
         monkeypatch.delenv("GOOGLE_OAUTH_CLIENT_ID", raising=False)
         monkeypatch.delenv("GOOGLE_OAUTH_CLIENT_SECRET", raising=False)
 
@@ -532,7 +532,7 @@ class TestTokenRefresh:
 
         from aden_tools.credentials import CredentialStoreAdapter
 
-        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("GOOGLE_CALENDAR_ACCESS_TOKEN", raising=False)
 
         # Create store with only access_token (no refresh_token)
         store = CredentialStore.for_testing(
@@ -558,7 +558,7 @@ class TestTokenRefresh:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
     def test_graceful_degradation_on_refresh_failure(self, mock_get, calendar_tools, monkeypatch):
         """If token refresh fails, returns helpful error message."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "invalid-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "invalid-token")
 
         # Simulate 401 (expired token that couldn't be refreshed)
         mock_get.return_value = _mock_response(401, {"error": {"message": "Invalid credentials"}})
@@ -578,7 +578,7 @@ class TestUpdateEventPatch:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.patch")
     def test_update_event_patch_success(self, mock_patch, calendar_tools, monkeypatch):
         """update_event uses PATCH and returns updated event."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_patch.return_value = _mock_response(
             200,
@@ -605,7 +605,7 @@ class TestUpdateEventPatch:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.patch")
     def test_update_event_partial_fields(self, mock_patch, calendar_tools, monkeypatch):
         """update_event sends only provided fields in PATCH body."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_patch.return_value = _mock_response(
             200,
@@ -632,7 +632,7 @@ class TestUpdateEventPatch:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.patch")
     def test_update_event_with_timezone(self, mock_patch, calendar_tools, monkeypatch):
         """update_event includes timezone in start/end when provided."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_patch.return_value = _mock_response(200, {"id": "event123"})
 
@@ -655,7 +655,7 @@ class TestAllDayEvents:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
     def test_create_all_day_event(self, mock_post, calendar_tools, monkeypatch):
         """create_event with all_day=True uses date field."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_post.return_value = _mock_response(
             200,
@@ -684,7 +684,7 @@ class TestAllDayEvents:
 
     def test_create_all_day_event_invalid_start_format(self, calendar_tools, monkeypatch):
         """create_event with all_day=True rejects non-date start_time."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         result = calendar_tools["create_event"](
             summary="Bad Event",
@@ -699,7 +699,7 @@ class TestAllDayEvents:
 
     def test_create_all_day_event_invalid_end_format(self, calendar_tools, monkeypatch):
         """create_event with all_day=True rejects non-date end_time."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         result = calendar_tools["create_event"](
             summary="Bad Event",
@@ -715,7 +715,7 @@ class TestAllDayEvents:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.patch")
     def test_update_to_all_day_event(self, mock_patch, calendar_tools, monkeypatch):
         """update_event can convert timed event to all-day."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_patch.return_value = _mock_response(
             200,
@@ -744,7 +744,7 @@ class TestTimezoneValidation:
 
     def test_invalid_timezone_create_event(self, calendar_tools, monkeypatch):
         """create_event rejects invalid timezone."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         result = calendar_tools["create_event"](
             summary="Test",
@@ -761,7 +761,7 @@ class TestTimezoneValidation:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
     def test_valid_timezone_passes(self, mock_post, calendar_tools, monkeypatch):
         """create_event accepts valid timezone."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_post.return_value = _mock_response(200, {"id": "event123"})
 
@@ -778,7 +778,7 @@ class TestTimezoneValidation:
 
     def test_invalid_timezone_update_event(self, calendar_tools, monkeypatch):
         """update_event rejects invalid timezone."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         result = calendar_tools["update_event"](
             event_id="event123",
@@ -792,7 +792,7 @@ class TestTimezoneValidation:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
     def test_all_day_event_ignores_timezone(self, mock_post, calendar_tools, monkeypatch):
         """create_event with all_day=True skips timezone validation."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_post.return_value = _mock_response(200, {"id": "allday1"})
 
@@ -814,7 +814,7 @@ class TestCreateEventWithAttendees:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
     def test_create_event_with_attendees(self, mock_post, calendar_tools, monkeypatch):
         """create_event includes attendees in request body."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_post.return_value = _mock_response(
             200,
@@ -850,7 +850,7 @@ class TestCreateEventWithAttendees:
         self, mock_post, calendar_tools, monkeypatch
     ):
         """create_event with attendees auto-generates conferenceData with unique requestId."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_post.return_value = _mock_response(200, {"id": "event123"})
 
@@ -876,7 +876,7 @@ class TestCreateEventWithAttendees:
         self, mock_post, calendar_tools, monkeypatch
     ):
         """create_event with attendees includes conferenceDataVersion=1 in query params."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_post.return_value = _mock_response(200, {"id": "event123"})
 
@@ -895,7 +895,7 @@ class TestCreateEventWithAttendees:
         self, mock_post, calendar_tools, monkeypatch
     ):
         """create_event without attendees does not add conferenceData."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_post.return_value = _mock_response(200, {"id": "event123"})
 
@@ -919,7 +919,7 @@ class TestListEventsOutputFields:
         self, mock_get, calendar_tools, monkeypatch
     ):
         """list_events output includes description and hangoutLink fields."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_get.return_value = _mock_response(
             200,
@@ -947,7 +947,7 @@ class TestListEventsOutputFields:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
     def test_list_events_includes_attendees(self, mock_get, calendar_tools, monkeypatch):
         """list_events output includes attendee emails when present."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_get.return_value = _mock_response(
             200,
@@ -976,7 +976,7 @@ class TestListEventsOutputFields:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
     def test_list_events_no_attendees_omits_field(self, mock_get, calendar_tools, monkeypatch):
         """list_events without attendees omits the attendees field."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_get.return_value = _mock_response(
             200,
@@ -1000,7 +1000,7 @@ class TestListEventsOutputFields:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
     def test_list_events_max_results_2500_accepted(self, mock_get, calendar_tools, monkeypatch):
         """list_events accepts max_results=2500 (the API maximum)."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_get.return_value = _mock_response(200, {"items": []})
 
@@ -1016,7 +1016,7 @@ class TestIsNotNoneBehavior:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
     def test_create_event_empty_description_included(self, mock_post, calendar_tools, monkeypatch):
         """create_event with description='' includes it in body (not None check)."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_post.return_value = _mock_response(200, {"id": "event123"})
 
@@ -1034,7 +1034,7 @@ class TestIsNotNoneBehavior:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
     def test_create_event_empty_location_included(self, mock_post, calendar_tools, monkeypatch):
         """create_event with location='' includes it in body (not None check)."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_post.return_value = _mock_response(200, {"id": "event123"})
 
@@ -1052,7 +1052,7 @@ class TestIsNotNoneBehavior:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
     def test_create_event_none_description_excluded(self, mock_post, calendar_tools, monkeypatch):
         """create_event with description=None does not include it in body."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_post.return_value = _mock_response(200, {"id": "event123"})
 
@@ -1072,7 +1072,7 @@ class TestEmptyPatchGuard:
 
     def test_update_event_no_fields_returns_error(self, calendar_tools, monkeypatch):
         """update_event with no fields to change returns error instead of empty PATCH."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         result = calendar_tools["update_event"](event_id="event123")
 
@@ -1087,7 +1087,7 @@ class TestRemoveAttendees:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
     def test_remove_single_attendee(self, mock_get, mock_patch, calendar_tools, monkeypatch):
         """remove_attendees removes specified email and keeps the rest."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         # GET returns current event with 3 attendees
         mock_get.return_value = _mock_response(
@@ -1135,7 +1135,7 @@ class TestRemoveAttendees:
         self, mock_get, mock_patch, calendar_tools, monkeypatch
     ):
         """remove_attendees matching is case-insensitive."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_get.return_value = _mock_response(
             200,
@@ -1163,7 +1163,7 @@ class TestRemoveAttendees:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
     def test_remove_multiple_attendees(self, mock_get, mock_patch, calendar_tools, monkeypatch):
         """remove_attendees can remove multiple emails at once."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_get.return_value = _mock_response(
             200,
@@ -1193,7 +1193,7 @@ class TestRemoveAttendees:
         self, mock_get, mock_patch, calendar_tools, monkeypatch
     ):
         """remove_attendees on event with no attendees sends empty list."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_get.return_value = _mock_response(
             200,
@@ -1215,7 +1215,7 @@ class TestRemoveAttendees:
         self, mock_get, mock_patch, calendar_tools, monkeypatch
     ):
         """remove_attendees triggers conferenceDataVersion=1 in query params."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_get.return_value = _mock_response(
             200,
@@ -1237,7 +1237,7 @@ class TestRemoveAttendees:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
     def test_remove_attendees_get_fails_returns_error(self, mock_get, calendar_tools, monkeypatch):
         """remove_attendees returns error if GET to fetch event fails."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_get.return_value = _mock_response(404)
 
@@ -1256,7 +1256,7 @@ class TestUpdateMeetLink:
     @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.patch")
     def test_update_event_add_meet_link(self, mock_patch, calendar_tools, monkeypatch):
         """update_event with add_meet_link=True includes conferenceData."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_patch.return_value = _mock_response(
             200,
@@ -1286,7 +1286,7 @@ class TestUpdateMeetLink:
         self, mock_patch, calendar_tools, monkeypatch
     ):
         """update_event without add_meet_link does not add conferenceData."""
-        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ACCESS_TOKEN", "test-token")
 
         mock_patch.return_value = _mock_response(200, {"id": "event123", "summary": "Updated"})
 

--- a/tools/tests/tools/test_calendar_tool.py
+++ b/tools/tests/tools/test_calendar_tool.py
@@ -1,0 +1,1302 @@
+"""Tests for Google Calendar tools (FastMCP)."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.calendar_tool import register_tools
+
+
+@pytest.fixture
+def calendar_tools(mcp: FastMCP):
+    """Register and return calendar tool functions."""
+    register_tools(mcp)
+    tools = mcp._tool_manager._tools
+    return {
+        "list_events": tools["calendar_list_events"].fn,
+        "get_event": tools["calendar_get_event"].fn,
+        "create_event": tools["calendar_create_event"].fn,
+        "update_event": tools["calendar_update_event"].fn,
+        "delete_event": tools["calendar_delete_event"].fn,
+        "list_calendars": tools["calendar_list_calendars"].fn,
+        "get_calendar": tools["calendar_get_calendar"].fn,
+        "check_availability": tools["calendar_check_availability"].fn,
+    }
+
+
+def _mock_response(status_code: int = 200, json_data: dict | None = None) -> MagicMock:
+    """Create a mock httpx.Response."""
+    mock = MagicMock(spec=httpx.Response)
+    mock.status_code = status_code
+    mock.json.return_value = json_data or {}
+    return mock
+
+
+class TestCredentialErrors:
+    """Tests for missing credentials handling."""
+
+    def test_list_events_no_credentials(self, calendar_tools, monkeypatch):
+        """list_events without credentials returns helpful error."""
+        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+
+        result = calendar_tools["list_events"]()
+
+        assert "error" in result
+        assert "Calendar credentials not configured" in result["error"]
+        assert "help" in result
+        assert "GOOGLE_CALENDAR_OAUTH_TOKEN" in result["help"]
+
+    def test_get_event_no_credentials(self, calendar_tools, monkeypatch):
+        """get_event without credentials returns helpful error."""
+        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+
+        result = calendar_tools["get_event"](event_id="test-event-id")
+
+        assert "error" in result
+        assert "Calendar credentials not configured" in result["error"]
+
+    def test_create_event_no_credentials(self, calendar_tools, monkeypatch):
+        """create_event without credentials returns helpful error."""
+        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+
+        result = calendar_tools["create_event"](
+            summary="Test Event",
+            start_time="2024-01-15T09:00:00Z",
+            end_time="2024-01-15T10:00:00Z",
+        )
+
+        assert "error" in result
+        assert "Calendar credentials not configured" in result["error"]
+
+    def test_update_event_no_credentials(self, calendar_tools, monkeypatch):
+        """update_event without credentials returns helpful error."""
+        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+
+        result = calendar_tools["update_event"](event_id="test-event-id")
+
+        assert "error" in result
+        assert "Calendar credentials not configured" in result["error"]
+
+    def test_delete_event_no_credentials(self, calendar_tools, monkeypatch):
+        """delete_event without credentials returns helpful error."""
+        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+
+        result = calendar_tools["delete_event"](event_id="test-event-id")
+
+        assert "error" in result
+        assert "Calendar credentials not configured" in result["error"]
+
+    def test_list_calendars_no_credentials(self, calendar_tools, monkeypatch):
+        """list_calendars without credentials returns helpful error."""
+        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+
+        result = calendar_tools["list_calendars"]()
+
+        assert "error" in result
+        assert "Calendar credentials not configured" in result["error"]
+
+    def test_get_calendar_no_credentials(self, calendar_tools, monkeypatch):
+        """get_calendar without credentials returns helpful error."""
+        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+
+        result = calendar_tools["get_calendar"](calendar_id="primary")
+
+        assert "error" in result
+        assert "Calendar credentials not configured" in result["error"]
+
+    def test_check_availability_no_credentials(self, calendar_tools, monkeypatch):
+        """check_availability without credentials returns helpful error."""
+        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+
+        result = calendar_tools["check_availability"](
+            time_min="2024-01-15T00:00:00Z",
+            time_max="2024-01-16T00:00:00Z",
+        )
+
+        assert "error" in result
+        assert "Calendar credentials not configured" in result["error"]
+
+
+class TestParameterValidation:
+    """Tests for parameter validation."""
+
+    def test_list_events_max_results_too_low(self, calendar_tools, monkeypatch):
+        """max_results below 1 returns error."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        result = calendar_tools["list_events"](max_results=0)
+
+        assert "error" in result
+        assert "max_results" in result["error"]
+
+    def test_list_events_max_results_too_high(self, calendar_tools, monkeypatch):
+        """max_results above 2500 returns error."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        result = calendar_tools["list_events"](max_results=2501)
+
+        assert "error" in result
+        assert "max_results" in result["error"]
+
+    def test_get_event_missing_event_id(self, calendar_tools, monkeypatch):
+        """get_event without event_id returns error."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        result = calendar_tools["get_event"](event_id="")
+
+        assert "error" in result
+        assert "event_id" in result["error"]
+
+    def test_create_event_missing_summary(self, calendar_tools, monkeypatch):
+        """create_event without summary returns error."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        result = calendar_tools["create_event"](
+            summary="",
+            start_time="2024-01-15T09:00:00Z",
+            end_time="2024-01-15T10:00:00Z",
+        )
+
+        assert "error" in result
+        assert "summary" in result["error"]
+
+    def test_create_event_missing_start_time(self, calendar_tools, monkeypatch):
+        """create_event without start_time returns error."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        result = calendar_tools["create_event"](
+            summary="Test Event",
+            start_time="",
+            end_time="2024-01-15T10:00:00Z",
+        )
+
+        assert "error" in result
+        assert "start_time" in result["error"]
+
+    def test_create_event_missing_end_time(self, calendar_tools, monkeypatch):
+        """create_event without end_time returns error."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        result = calendar_tools["create_event"](
+            summary="Test Event",
+            start_time="2024-01-15T09:00:00Z",
+            end_time="",
+        )
+
+        assert "error" in result
+        assert "end_time" in result["error"]
+
+    def test_update_event_missing_event_id(self, calendar_tools, monkeypatch):
+        """update_event without event_id returns error."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        result = calendar_tools["update_event"](event_id="")
+
+        assert "error" in result
+        assert "event_id" in result["error"]
+
+    def test_delete_event_missing_event_id(self, calendar_tools, monkeypatch):
+        """delete_event without event_id returns error."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        result = calendar_tools["delete_event"](event_id="")
+
+        assert "error" in result
+        assert "event_id" in result["error"]
+
+    def test_list_calendars_max_results_too_high(self, calendar_tools, monkeypatch):
+        """list_calendars max_results above 250 returns error."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        result = calendar_tools["list_calendars"](max_results=251)
+
+        assert "error" in result
+        assert "max_results" in result["error"]
+
+    def test_get_calendar_missing_calendar_id(self, calendar_tools, monkeypatch):
+        """get_calendar without calendar_id returns error."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        result = calendar_tools["get_calendar"](calendar_id="")
+
+        assert "error" in result
+        assert "calendar_id" in result["error"]
+
+    def test_check_availability_missing_time_min(self, calendar_tools, monkeypatch):
+        """check_availability without time_min returns error."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        result = calendar_tools["check_availability"](
+            time_min="",
+            time_max="2024-01-16T00:00:00Z",
+        )
+
+        assert "error" in result
+        assert "time_min" in result["error"]
+
+    def test_check_availability_missing_time_max(self, calendar_tools, monkeypatch):
+        """check_availability without time_max returns error."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        result = calendar_tools["check_availability"](
+            time_min="2024-01-15T00:00:00Z",
+            time_max="",
+        )
+
+        assert "error" in result
+        assert "time_max" in result["error"]
+
+
+class TestMockedAPIResponses:
+    """Tests with mocked API responses."""
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_list_events_success(self, mock_get, calendar_tools, monkeypatch):
+        """list_events returns formatted events on success."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_get.return_value = _mock_response(
+            200,
+            {
+                "items": [
+                    {
+                        "id": "event1",
+                        "summary": "Team Meeting",
+                        "start": {"dateTime": "2024-01-15T09:00:00Z"},
+                        "end": {"dateTime": "2024-01-15T10:00:00Z"},
+                        "status": "confirmed",
+                        "htmlLink": "https://calendar.google.com/event?eid=xxx",
+                    }
+                ]
+            },
+        )
+
+        result = calendar_tools["list_events"](
+            time_min="2024-01-15T00:00:00Z",
+            max_results=10,
+        )
+
+        assert "events" in result
+        assert len(result["events"]) == 1
+        assert result["events"][0]["summary"] == "Team Meeting"
+        assert result["total"] == 1
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_list_events_empty(self, mock_get, calendar_tools, monkeypatch):
+        """list_events handles empty calendar."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_get.return_value = _mock_response(200, {"items": []})
+
+        result = calendar_tools["list_events"](time_min="2024-01-15T00:00:00Z")
+
+        assert "events" in result
+        assert len(result["events"]) == 0
+        assert result["total"] == 0
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
+    def test_create_event_success(self, mock_post, calendar_tools, monkeypatch):
+        """create_event returns created event details."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_post.return_value = _mock_response(
+            200,
+            {
+                "id": "new-event-id",
+                "summary": "New Event",
+                "start": {"dateTime": "2024-01-15T09:00:00Z"},
+                "end": {"dateTime": "2024-01-15T10:00:00Z"},
+                "status": "confirmed",
+            },
+        )
+
+        result = calendar_tools["create_event"](
+            summary="New Event",
+            start_time="2024-01-15T09:00:00Z",
+            end_time="2024-01-15T10:00:00Z",
+        )
+
+        assert "id" in result
+        assert result["summary"] == "New Event"
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.delete")
+    def test_delete_event_success(self, mock_delete, calendar_tools, monkeypatch):
+        """delete_event returns success message."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_delete.return_value = _mock_response(204)
+
+        result = calendar_tools["delete_event"](event_id="event123")
+
+        assert result["success"] is True
+        assert "event123" in result["message"]
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_list_calendars_success(self, mock_get, calendar_tools, monkeypatch):
+        """list_calendars returns formatted calendar list."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_get.return_value = _mock_response(
+            200,
+            {
+                "items": [
+                    {
+                        "id": "primary",
+                        "summary": "My Calendar",
+                        "primary": True,
+                        "accessRole": "owner",
+                    },
+                    {
+                        "id": "team@group.calendar.google.com",
+                        "summary": "Team Calendar",
+                        "primary": False,
+                        "accessRole": "reader",
+                    },
+                ]
+            },
+        )
+
+        result = calendar_tools["list_calendars"]()
+
+        assert "calendars" in result
+        assert len(result["calendars"]) == 2
+        assert result["calendars"][0]["primary"] is True
+        assert result["total"] == 2
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
+    def test_check_availability_success(self, mock_post, calendar_tools, monkeypatch):
+        """check_availability returns busy periods."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_post.return_value = _mock_response(
+            200,
+            {
+                "calendars": {
+                    "primary": {
+                        "busy": [
+                            {
+                                "start": "2024-01-15T09:00:00Z",
+                                "end": "2024-01-15T10:00:00Z",
+                            }
+                        ]
+                    }
+                }
+            },
+        )
+
+        result = calendar_tools["check_availability"](
+            time_min="2024-01-15T00:00:00Z",
+            time_max="2024-01-16T00:00:00Z",
+        )
+
+        assert "calendars" in result
+        assert "primary" in result["calendars"]
+        assert len(result["calendars"]["primary"]["busy"]) == 1
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_unauthorized_returns_error(self, mock_get, calendar_tools, monkeypatch):
+        """401 response returns appropriate error."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "invalid-token")
+
+        mock_get.return_value = _mock_response(401, {"error": {"message": "Invalid credentials"}})
+
+        result = calendar_tools["list_events"](time_min="2024-01-15T00:00:00Z")
+
+        assert "error" in result
+        assert "Invalid or expired OAuth token" in result["error"]
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_rate_limit_returns_error(self, mock_get, calendar_tools, monkeypatch):
+        """429 response returns rate limit error."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_get.return_value = _mock_response(429)
+
+        result = calendar_tools["list_events"](time_min="2024-01-15T00:00:00Z")
+
+        assert "error" in result
+        assert "Rate limit" in result["error"]
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_not_found_returns_error(self, mock_get, calendar_tools, monkeypatch):
+        """404 response returns not found error."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_get.return_value = _mock_response(404)
+
+        result = calendar_tools["get_event"](event_id="nonexistent")
+
+        assert "error" in result
+        assert "not found" in result["error"]
+
+
+class TestCredentialManager:
+    """Tests for CredentialManager integration."""
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_uses_credential_store_adapter_when_provided(self, mock_get, mcp, monkeypatch):
+        """Tool uses CredentialStoreAdapter when provided."""
+        from aden_tools.credentials import CredentialStoreAdapter
+
+        # Don't set env var - only use credential store adapter
+        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+
+        # Create credential store adapter with test token
+        creds = CredentialStoreAdapter.for_testing({"google_calendar_oauth": "test-oauth-token"})
+        register_tools(mcp, credentials=creds)
+
+        list_events_fn = mcp._tool_manager._tools["calendar_list_events"].fn
+
+        # Mock the API call to verify credentials work
+        mock_get.return_value = _mock_response(200, {"items": []})
+
+        result = list_events_fn()
+
+        # Should NOT get credential error since manager has the token
+        assert "Calendar credentials not configured" not in result.get("error", "")
+        assert "events" in result
+
+
+class TestTokenRefresh:
+    """Tests for OAuth token refresh functionality."""
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_expired_token_returns_helpful_error(self, mock_get, calendar_tools, monkeypatch):
+        """401 response with simple token suggests re-authorization."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "expired-token")
+
+        mock_get.return_value = _mock_response(401, {"error": {"message": "Token expired"}})
+
+        result = calendar_tools["list_events"](time_min="2024-01-15T00:00:00Z")
+
+        assert "error" in result
+        assert "expired" in result["error"].lower() or "invalid" in result["error"].lower()
+        assert "help" in result
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool._create_lifecycle_manager")
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_auto_refresh_uses_lifecycle_manager(
+        self, mock_get, mock_create_lifecycle, mcp, monkeypatch
+    ):
+        """Token auto-refresh uses TokenLifecycleManager when available."""
+        pytest.importorskip("framework.credentials", reason="Requires framework.credentials module")
+        from unittest.mock import MagicMock
+
+        from framework.credentials import CredentialStore
+
+        from aden_tools.credentials import CredentialStoreAdapter
+
+        # Clear env var
+        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("GOOGLE_OAUTH_CLIENT_ID", raising=False)
+        monkeypatch.delenv("GOOGLE_OAUTH_CLIENT_SECRET", raising=False)
+
+        # Create mock lifecycle manager
+        mock_lifecycle = MagicMock()
+        mock_token = MagicMock()
+        mock_token.access_token = "refreshed-token"
+        mock_lifecycle.sync_get_valid_token.return_value = mock_token
+        mock_create_lifecycle.return_value = mock_lifecycle
+
+        # Create credential store with OAuth tokens
+        store = CredentialStore.for_testing(
+            {
+                "google_calendar_oauth": {
+                    "access_token": "old-token",
+                    "refresh_token": "test-refresh-token",
+                }
+            }
+        )
+        creds = CredentialStoreAdapter(store)
+
+        register_tools(mcp, credentials=creds)
+
+        list_events_fn = mcp._tool_manager._tools["calendar_list_events"].fn
+
+        # Mock successful API response
+        mock_get.return_value = _mock_response(200, {"items": []})
+
+        result = list_events_fn()
+
+        # Should have used lifecycle manager for token
+        assert mock_lifecycle.sync_get_valid_token.called
+        assert "events" in result
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_no_lifecycle_manager_without_refresh_token(self, mock_get, mcp, monkeypatch):
+        """Lifecycle manager not created without refresh_token."""
+        pytest.importorskip("framework.credentials", reason="Requires framework.credentials module")
+        from framework.credentials import CredentialStore
+
+        from aden_tools.credentials import CredentialStoreAdapter
+
+        monkeypatch.delenv("GOOGLE_CALENDAR_OAUTH_TOKEN", raising=False)
+
+        # Create store with only access_token (no refresh_token)
+        store = CredentialStore.for_testing(
+            {
+                "google_calendar_oauth": {
+                    "access_token": "simple-token",
+                }
+            }
+        )
+        creds = CredentialStoreAdapter(store)
+
+        register_tools(mcp, credentials=creds)
+
+        list_events_fn = mcp._tool_manager._tools["calendar_list_events"].fn
+
+        mock_get.return_value = _mock_response(200, {"items": []})
+
+        result = list_events_fn()
+
+        # Should work using simple token
+        assert "events" in result
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_graceful_degradation_on_refresh_failure(self, mock_get, calendar_tools, monkeypatch):
+        """If token refresh fails, returns helpful error message."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "invalid-token")
+
+        # Simulate 401 (expired token that couldn't be refreshed)
+        mock_get.return_value = _mock_response(401, {"error": {"message": "Invalid credentials"}})
+
+        result = calendar_tools["list_events"](time_min="2024-01-15T00:00:00Z")
+
+        # Should get error with helpful message
+        assert "error" in result
+        assert "help" in result
+        # Should suggest re-authorization
+        assert "setup" in result["help"].lower() or "token" in result["help"].lower()
+
+
+class TestUpdateEventPatch:
+    """Tests for PATCH-based update_event."""
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.patch")
+    def test_update_event_patch_success(self, mock_patch, calendar_tools, monkeypatch):
+        """update_event uses PATCH and returns updated event."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_patch.return_value = _mock_response(
+            200,
+            {
+                "id": "event123",
+                "summary": "Updated Title",
+                "start": {"dateTime": "2024-01-15T09:00:00Z"},
+                "end": {"dateTime": "2024-01-15T10:00:00Z"},
+                "status": "confirmed",
+            },
+        )
+
+        result = calendar_tools["update_event"](
+            event_id="event123",
+            summary="Updated Title",
+        )
+
+        assert result["summary"] == "Updated Title"
+        # Verify PATCH was called (not GET+PUT)
+        mock_patch.assert_called_once()
+        call_kwargs = mock_patch.call_args
+        assert call_kwargs[1]["json"] == {"summary": "Updated Title"}
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.patch")
+    def test_update_event_partial_fields(self, mock_patch, calendar_tools, monkeypatch):
+        """update_event sends only provided fields in PATCH body."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_patch.return_value = _mock_response(
+            200,
+            {
+                "id": "event123",
+                "summary": "Existing",
+                "description": "New desc",
+                "location": "New place",
+            },
+        )
+
+        result = calendar_tools["update_event"](
+            event_id="event123",
+            description="New desc",
+            location="New place",
+        )
+
+        assert "error" not in result
+        call_kwargs = mock_patch.call_args
+        body = call_kwargs[1]["json"]
+        assert body == {"description": "New desc", "location": "New place"}
+        assert "summary" not in body
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.patch")
+    def test_update_event_with_timezone(self, mock_patch, calendar_tools, monkeypatch):
+        """update_event includes timezone in start/end when provided."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_patch.return_value = _mock_response(200, {"id": "event123"})
+
+        result = calendar_tools["update_event"](
+            event_id="event123",
+            start_time="2024-01-15T09:00:00",
+            end_time="2024-01-15T10:00:00",
+            timezone="America/New_York",
+        )
+
+        assert "error" not in result
+        body = mock_patch.call_args[1]["json"]
+        assert body["start"]["timeZone"] == "America/New_York"
+        assert body["end"]["timeZone"] == "America/New_York"
+
+
+class TestAllDayEvents:
+    """Tests for all-day event support."""
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
+    def test_create_all_day_event(self, mock_post, calendar_tools, monkeypatch):
+        """create_event with all_day=True uses date field."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_post.return_value = _mock_response(
+            200,
+            {
+                "id": "allday1",
+                "summary": "Birthday",
+                "start": {"date": "2024-06-15"},
+                "end": {"date": "2024-06-16"},
+            },
+        )
+
+        result = calendar_tools["create_event"](
+            summary="Birthday",
+            start_time="2024-06-15",
+            end_time="2024-06-16",
+            all_day=True,
+        )
+
+        assert "error" not in result
+        assert result["id"] == "allday1"
+        body = mock_post.call_args[1]["json"]
+        assert "date" in body["start"]
+        assert "dateTime" not in body["start"]
+        assert body["start"]["date"] == "2024-06-15"
+        assert body["end"]["date"] == "2024-06-16"
+
+    def test_create_all_day_event_invalid_start_format(self, calendar_tools, monkeypatch):
+        """create_event with all_day=True rejects non-date start_time."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        result = calendar_tools["create_event"](
+            summary="Bad Event",
+            start_time="2024-01-15T09:00:00Z",
+            end_time="2024-01-16",
+            all_day=True,
+        )
+
+        assert "error" in result
+        assert "date-only format" in result["error"]
+        assert "start_time" in result["error"]
+
+    def test_create_all_day_event_invalid_end_format(self, calendar_tools, monkeypatch):
+        """create_event with all_day=True rejects non-date end_time."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        result = calendar_tools["create_event"](
+            summary="Bad Event",
+            start_time="2024-01-15",
+            end_time="2024-01-15T10:00:00Z",
+            all_day=True,
+        )
+
+        assert "error" in result
+        assert "date-only format" in result["error"]
+        assert "end_time" in result["error"]
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.patch")
+    def test_update_to_all_day_event(self, mock_patch, calendar_tools, monkeypatch):
+        """update_event can convert timed event to all-day."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_patch.return_value = _mock_response(
+            200,
+            {
+                "id": "event123",
+                "start": {"date": "2024-01-15"},
+                "end": {"date": "2024-01-16"},
+            },
+        )
+
+        result = calendar_tools["update_event"](
+            event_id="event123",
+            start_time="2024-01-15",
+            end_time="2024-01-16",
+            all_day=True,
+        )
+
+        assert "error" not in result
+        body = mock_patch.call_args[1]["json"]
+        assert body["start"] == {"date": "2024-01-15"}
+        assert body["end"] == {"date": "2024-01-16"}
+
+
+class TestTimezoneValidation:
+    """Tests for timezone validation."""
+
+    def test_invalid_timezone_create_event(self, calendar_tools, monkeypatch):
+        """create_event rejects invalid timezone."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        result = calendar_tools["create_event"](
+            summary="Test",
+            start_time="2024-01-15T09:00:00",
+            end_time="2024-01-15T10:00:00",
+            timezone="Not/A_Timezone",
+        )
+
+        assert "error" in result
+        assert "Invalid timezone" in result["error"]
+        assert "Not/A_Timezone" in result["error"]
+        assert "IANA format" in result["error"]
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
+    def test_valid_timezone_passes(self, mock_post, calendar_tools, monkeypatch):
+        """create_event accepts valid timezone."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_post.return_value = _mock_response(200, {"id": "event123"})
+
+        result = calendar_tools["create_event"](
+            summary="Test",
+            start_time="2024-01-15T09:00:00",
+            end_time="2024-01-15T10:00:00",
+            timezone="America/New_York",
+        )
+
+        assert "error" not in result
+        body = mock_post.call_args[1]["json"]
+        assert body["start"]["timeZone"] == "America/New_York"
+
+    def test_invalid_timezone_update_event(self, calendar_tools, monkeypatch):
+        """update_event rejects invalid timezone."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        result = calendar_tools["update_event"](
+            event_id="event123",
+            start_time="2024-01-15T09:00:00",
+            timezone="Fake/Zone",
+        )
+
+        assert "error" in result
+        assert "Invalid timezone" in result["error"]
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
+    def test_all_day_event_ignores_timezone(self, mock_post, calendar_tools, monkeypatch):
+        """create_event with all_day=True skips timezone validation."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_post.return_value = _mock_response(200, {"id": "allday1"})
+
+        # Even with an invalid timezone, all_day should not validate it
+        result = calendar_tools["create_event"](
+            summary="Birthday",
+            start_time="2024-06-15",
+            end_time="2024-06-16",
+            timezone="Not/A_Timezone",
+            all_day=True,
+        )
+
+        assert "error" not in result
+
+
+class TestCreateEventWithAttendees:
+    """Tests for create_event with attendees."""
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
+    def test_create_event_with_attendees(self, mock_post, calendar_tools, monkeypatch):
+        """create_event includes attendees in request body."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_post.return_value = _mock_response(
+            200,
+            {
+                "id": "event123",
+                "summary": "Team Meeting",
+                "attendees": [
+                    {"email": "alice@example.com"},
+                    {"email": "bob@example.com"},
+                ],
+            },
+        )
+
+        result = calendar_tools["create_event"](
+            summary="Team Meeting",
+            start_time="2024-01-15T09:00:00Z",
+            end_time="2024-01-15T10:00:00Z",
+            attendees=["alice@example.com", "bob@example.com"],
+        )
+
+        assert "error" not in result
+        body = mock_post.call_args[1]["json"]
+        assert body["attendees"] == [
+            {"email": "alice@example.com"},
+            {"email": "bob@example.com"},
+        ]
+        # Verify sendUpdates is "all" by default
+        params = mock_post.call_args[1]["params"]
+        assert params["sendUpdates"] == "all"
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
+    def test_create_event_with_attendees_includes_conference_data(
+        self, mock_post, calendar_tools, monkeypatch
+    ):
+        """create_event with attendees auto-generates conferenceData with unique requestId."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_post.return_value = _mock_response(200, {"id": "event123"})
+
+        calendar_tools["create_event"](
+            summary="Meeting",
+            start_time="2024-01-15T09:00:00Z",
+            end_time="2024-01-15T10:00:00Z",
+            attendees=["alice@example.com"],
+        )
+
+        body = mock_post.call_args[1]["json"]
+        assert "conferenceData" in body
+        conf = body["conferenceData"]
+        assert "createRequest" in conf
+        assert conf["createRequest"]["conferenceSolutionKey"]["type"] == "hangoutsMeet"
+        # requestId should start with "meet-" and have a unique hex suffix
+        request_id = conf["createRequest"]["requestId"]
+        assert request_id.startswith("meet-")
+        assert len(request_id) > len("meet-")
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
+    def test_create_event_with_attendees_sets_conference_data_version(
+        self, mock_post, calendar_tools, monkeypatch
+    ):
+        """create_event with attendees includes conferenceDataVersion=1 in query params."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_post.return_value = _mock_response(200, {"id": "event123"})
+
+        calendar_tools["create_event"](
+            summary="Meeting",
+            start_time="2024-01-15T09:00:00Z",
+            end_time="2024-01-15T10:00:00Z",
+            attendees=["alice@example.com"],
+        )
+
+        params = mock_post.call_args[1]["params"]
+        assert params["conferenceDataVersion"] == 1
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
+    def test_create_event_without_attendees_no_conference_data(
+        self, mock_post, calendar_tools, monkeypatch
+    ):
+        """create_event without attendees does not add conferenceData."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_post.return_value = _mock_response(200, {"id": "event123"})
+
+        calendar_tools["create_event"](
+            summary="Solo Event",
+            start_time="2024-01-15T09:00:00Z",
+            end_time="2024-01-15T10:00:00Z",
+        )
+
+        body = mock_post.call_args[1]["json"]
+        assert "conferenceData" not in body
+        params = mock_post.call_args[1]["params"]
+        assert "conferenceDataVersion" not in params
+
+
+class TestListEventsOutputFields:
+    """Tests for list_events output field coverage."""
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_list_events_includes_description_and_hangout_link(
+        self, mock_get, calendar_tools, monkeypatch
+    ):
+        """list_events output includes description and hangoutLink fields."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_get.return_value = _mock_response(
+            200,
+            {
+                "items": [
+                    {
+                        "id": "event1",
+                        "summary": "Meeting",
+                        "start": {"dateTime": "2024-01-15T09:00:00Z"},
+                        "end": {"dateTime": "2024-01-15T10:00:00Z"},
+                        "status": "confirmed",
+                        "description": "Discuss Q1 goals",
+                        "hangoutLink": "https://meet.google.com/abc-defg-hij",
+                    }
+                ]
+            },
+        )
+
+        result = calendar_tools["list_events"](time_min="2024-01-15T00:00:00Z")
+
+        event = result["events"][0]
+        assert event["description"] == "Discuss Q1 goals"
+        assert event["hangoutLink"] == "https://meet.google.com/abc-defg-hij"
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_list_events_includes_attendees(self, mock_get, calendar_tools, monkeypatch):
+        """list_events output includes attendee emails when present."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_get.return_value = _mock_response(
+            200,
+            {
+                "items": [
+                    {
+                        "id": "event1",
+                        "summary": "Team Sync",
+                        "start": {"dateTime": "2024-01-15T09:00:00Z"},
+                        "end": {"dateTime": "2024-01-15T10:00:00Z"},
+                        "attendees": [
+                            {"email": "alice@example.com", "responseStatus": "accepted"},
+                            {"email": "bob@example.com", "responseStatus": "needsAction"},
+                        ],
+                    }
+                ]
+            },
+        )
+
+        result = calendar_tools["list_events"](time_min="2024-01-15T00:00:00Z")
+
+        event = result["events"][0]
+        assert "attendees" in event
+        assert event["attendees"] == ["alice@example.com", "bob@example.com"]
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_list_events_no_attendees_omits_field(self, mock_get, calendar_tools, monkeypatch):
+        """list_events without attendees omits the attendees field."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_get.return_value = _mock_response(
+            200,
+            {
+                "items": [
+                    {
+                        "id": "event1",
+                        "summary": "Solo Focus",
+                        "start": {"dateTime": "2024-01-15T09:00:00Z"},
+                        "end": {"dateTime": "2024-01-15T10:00:00Z"},
+                    }
+                ]
+            },
+        )
+
+        result = calendar_tools["list_events"](time_min="2024-01-15T00:00:00Z")
+
+        event = result["events"][0]
+        assert "attendees" not in event
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_list_events_max_results_2500_accepted(self, mock_get, calendar_tools, monkeypatch):
+        """list_events accepts max_results=2500 (the API maximum)."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_get.return_value = _mock_response(200, {"items": []})
+
+        result = calendar_tools["list_events"](max_results=2500)
+
+        assert "error" not in result
+        assert result["total"] == 0
+
+
+class TestIsNotNoneBehavior:
+    """Tests for 'is not None' checks allowing empty strings."""
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
+    def test_create_event_empty_description_included(self, mock_post, calendar_tools, monkeypatch):
+        """create_event with description='' includes it in body (not None check)."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_post.return_value = _mock_response(200, {"id": "event123"})
+
+        calendar_tools["create_event"](
+            summary="Test",
+            start_time="2024-01-15T09:00:00Z",
+            end_time="2024-01-15T10:00:00Z",
+            description="",
+        )
+
+        body = mock_post.call_args[1]["json"]
+        assert "description" in body
+        assert body["description"] == ""
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
+    def test_create_event_empty_location_included(self, mock_post, calendar_tools, monkeypatch):
+        """create_event with location='' includes it in body (not None check)."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_post.return_value = _mock_response(200, {"id": "event123"})
+
+        calendar_tools["create_event"](
+            summary="Test",
+            start_time="2024-01-15T09:00:00Z",
+            end_time="2024-01-15T10:00:00Z",
+            location="",
+        )
+
+        body = mock_post.call_args[1]["json"]
+        assert "location" in body
+        assert body["location"] == ""
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.post")
+    def test_create_event_none_description_excluded(self, mock_post, calendar_tools, monkeypatch):
+        """create_event with description=None does not include it in body."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_post.return_value = _mock_response(200, {"id": "event123"})
+
+        calendar_tools["create_event"](
+            summary="Test",
+            start_time="2024-01-15T09:00:00Z",
+            end_time="2024-01-15T10:00:00Z",
+        )
+
+        body = mock_post.call_args[1]["json"]
+        assert "description" not in body
+        assert "location" not in body
+
+
+class TestEmptyPatchGuard:
+    """Tests for empty PATCH body guard on update."""
+
+    def test_update_event_no_fields_returns_error(self, calendar_tools, monkeypatch):
+        """update_event with no fields to change returns error instead of empty PATCH."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        result = calendar_tools["update_event"](event_id="event123")
+
+        assert "error" in result
+        assert "No fields to update" in result["error"]
+
+
+class TestRemoveAttendees:
+    """Tests for remove_attendees on update_event."""
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.patch")
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_remove_single_attendee(self, mock_get, mock_patch, calendar_tools, monkeypatch):
+        """remove_attendees removes specified email and keeps the rest."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        # GET returns current event with 3 attendees
+        mock_get.return_value = _mock_response(
+            200,
+            {
+                "id": "event123",
+                "summary": "Stand Up",
+                "attendees": [
+                    {"email": "alice@example.com", "responseStatus": "accepted"},
+                    {"email": "bob@example.com", "responseStatus": "accepted"},
+                    {"email": "charlie@example.com", "responseStatus": "needsAction"},
+                ],
+            },
+        )
+        mock_patch.return_value = _mock_response(
+            200,
+            {
+                "id": "event123",
+                "summary": "Stand Up",
+                "attendees": [
+                    {"email": "alice@example.com"},
+                    {"email": "charlie@example.com"},
+                ],
+            },
+        )
+
+        result = calendar_tools["update_event"](
+            event_id="event123",
+            remove_attendees=["bob@example.com"],
+        )
+
+        assert "error" not in result
+        # Verify GET was called to fetch current event
+        mock_get.assert_called_once()
+        # Verify PATCH body has bob removed
+        body = mock_patch.call_args[1]["json"]
+        attendee_emails = [a["email"] for a in body["attendees"]]
+        assert "bob@example.com" not in attendee_emails
+        assert "alice@example.com" in attendee_emails
+        assert "charlie@example.com" in attendee_emails
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.patch")
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_remove_attendees_case_insensitive(
+        self, mock_get, mock_patch, calendar_tools, monkeypatch
+    ):
+        """remove_attendees matching is case-insensitive."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_get.return_value = _mock_response(
+            200,
+            {
+                "id": "event123",
+                "attendees": [
+                    {"email": "Alice@Example.com"},
+                    {"email": "bob@example.com"},
+                ],
+            },
+        )
+        mock_patch.return_value = _mock_response(200, {"id": "event123"})
+
+        calendar_tools["update_event"](
+            event_id="event123",
+            remove_attendees=["alice@example.com"],
+        )
+
+        body = mock_patch.call_args[1]["json"]
+        attendee_emails = [a["email"] for a in body["attendees"]]
+        assert "Alice@Example.com" not in attendee_emails
+        assert "bob@example.com" in attendee_emails
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.patch")
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_remove_multiple_attendees(self, mock_get, mock_patch, calendar_tools, monkeypatch):
+        """remove_attendees can remove multiple emails at once."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_get.return_value = _mock_response(
+            200,
+            {
+                "id": "event123",
+                "attendees": [
+                    {"email": "alice@example.com"},
+                    {"email": "bob@example.com"},
+                    {"email": "charlie@example.com"},
+                ],
+            },
+        )
+        mock_patch.return_value = _mock_response(200, {"id": "event123"})
+
+        calendar_tools["update_event"](
+            event_id="event123",
+            remove_attendees=["alice@example.com", "charlie@example.com"],
+        )
+
+        body = mock_patch.call_args[1]["json"]
+        attendee_emails = [a["email"] for a in body["attendees"]]
+        assert attendee_emails == ["bob@example.com"]
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.patch")
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_remove_attendees_from_event_with_no_attendees(
+        self, mock_get, mock_patch, calendar_tools, monkeypatch
+    ):
+        """remove_attendees on event with no attendees sends empty list."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_get.return_value = _mock_response(
+            200,
+            {"id": "event123", "summary": "Solo Event"},
+        )
+        mock_patch.return_value = _mock_response(200, {"id": "event123"})
+
+        calendar_tools["update_event"](
+            event_id="event123",
+            remove_attendees=["nobody@example.com"],
+        )
+
+        body = mock_patch.call_args[1]["json"]
+        assert body["attendees"] == []
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.patch")
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_remove_attendees_sets_conference_data_version(
+        self, mock_get, mock_patch, calendar_tools, monkeypatch
+    ):
+        """remove_attendees triggers conferenceDataVersion=1 in query params."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_get.return_value = _mock_response(
+            200,
+            {
+                "id": "event123",
+                "attendees": [{"email": "alice@example.com"}],
+            },
+        )
+        mock_patch.return_value = _mock_response(200, {"id": "event123"})
+
+        calendar_tools["update_event"](
+            event_id="event123",
+            remove_attendees=["alice@example.com"],
+        )
+
+        params = mock_patch.call_args[1]["params"]
+        assert params["conferenceDataVersion"] == 1
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.get")
+    def test_remove_attendees_get_fails_returns_error(self, mock_get, calendar_tools, monkeypatch):
+        """remove_attendees returns error if GET to fetch event fails."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_get.return_value = _mock_response(404)
+
+        result = calendar_tools["update_event"](
+            event_id="event123",
+            remove_attendees=["alice@example.com"],
+        )
+
+        assert "error" in result
+        assert "not found" in result["error"]
+
+
+class TestUpdateMeetLink:
+    """Tests for add_meet_link on update_event."""
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.patch")
+    def test_update_event_add_meet_link(self, mock_patch, calendar_tools, monkeypatch):
+        """update_event with add_meet_link=True includes conferenceData."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_patch.return_value = _mock_response(
+            200,
+            {
+                "id": "event123",
+                "hangoutLink": "https://meet.google.com/abc-defg-hij",
+            },
+        )
+
+        result = calendar_tools["update_event"](
+            event_id="event123",
+            add_meet_link=True,
+        )
+
+        assert "error" not in result
+        body = mock_patch.call_args[1]["json"]
+        assert "conferenceData" in body
+        conf = body["conferenceData"]
+        assert conf["createRequest"]["conferenceSolutionKey"]["type"] == "hangoutsMeet"
+        assert conf["createRequest"]["requestId"].startswith("meet-")
+        # conferenceDataVersion must be 1 for Meet link creation
+        params = mock_patch.call_args[1]["params"]
+        assert params["conferenceDataVersion"] == 1
+
+    @patch("aden_tools.tools.calendar_tool.calendar_tool.httpx.patch")
+    def test_update_event_without_meet_link_no_conference_data(
+        self, mock_patch, calendar_tools, monkeypatch
+    ):
+        """update_event without add_meet_link does not add conferenceData."""
+        monkeypatch.setenv("GOOGLE_CALENDAR_OAUTH_TOKEN", "test-token")
+
+        mock_patch.return_value = _mock_response(200, {"id": "event123", "summary": "Updated"})
+
+        calendar_tools["update_event"](
+            event_id="event123",
+            summary="Updated",
+        )
+
+        body = mock_patch.call_args[1]["json"]
+        assert "conferenceData" not in body
+        # conferenceDataVersion should NOT be set for simple updates
+        params = mock_patch.call_args[1]["params"]
+        assert "conferenceDataVersion" not in params


### PR DESCRIPTION
  ## Type of Change                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                       
  - [ ] Bug fix (non-breaking change that fixes an issue)                                                                                                                                                                                                                                              
  - [x] New feature (non-breaking change that adds functionality)                                                                                                                                                                                                                                      
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] Documentation update
  - [ ] Refactoring (no functional changes)

  ## Related Issues

  Fixes #2817
### Calendar Tool (`tools/src/aden_tools/tools/calendar_tool/`)
  - Added `calendar_tool` with 8 endpoints (list/get/create/update/delete events, list/get calendars, check availability)
  - Auto-generates Google Meet links when attendees are present (`conferenceDataVersion=1`)
  - Supports all-day events, timezone validation (IANA), and `add_meet_link` on update
  - Added `remove_attendees` parameter to `calendar_update_event` — fetches current event via GET, removes specified emails, PATCHes with remaining attendees (case-insensitive matching)
  - Empty PATCH body guard prevents wasted API quota on no-op updates
  - `conferenceDataVersion` only set when modifying conference data (not on every update)
  - `max_results` raised to 2500 to match Google Calendar API maximum
  - Uses `is not None` checks to allow empty strings for clearing fields via PATCH
  - Implemented URL parameter encoding and token sanitization for security

  ### Health Checks & Credentials
  - Added `GoogleCalendarHealthChecker` to validate OAuth tokens before agent execution
  - Added credential spec in `google_calendar.py` following per-file pattern
  - Updated `hive-credentials` SKILL.md with calendar credential reference

  ## Testing

  ## Testing

  - [x] Calendar tool tests pass — **65 tests** (`pytest tests/tools/test_calendar_tool.py -v`)
  - [x] Health check tests pass — **27 tests** (`pytest tests/test_health_checks.py -v`)
  - [x] All tools tests pass — **725 passed** (`pytest tools/tests/ -v`)
  - [x] All core tests pass — **701 passed** (`pytest core/tests/ -v`)
  - [x] Lint and format pass (`ruff check` + `ruff format`)
  - [x] Manual testing performed with live Google Calendar API
  
  ## Checklist

  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes

  ## Screenshots (if applicable)

  N/A - backend tool, no UI changes