### PR TITLE
docs: add non-developer quick tour for evaluating HiveFix windows unicode emoji

### DIFF
--- a/docs/quick-tour-non-developer.md
+++ b/docs/quick-tour-non-developer.md
@@ -1,0 +1,228 @@
+\# Quick Tour: Evaluate Hive in <15 Minutes (Non-Developer)
+
+
+
+This quick tour is designed for \*\*product managers, operations leaders, architects, and business stakeholders\*\* who want to understand what Hive does and why it’s different — \*without\* diving into setup commands, code, or infrastructure.
+
+
+
+By the end of this page, you should be able to answer:
+
+\- What problem Hive is solving
+
+\- How Hive approaches agent orchestration differently
+
+\- Where humans, monitoring, and cost controls fit into the system
+
+\- Whether Hive is worth a deeper technical evaluation
+
+
+
+---
+
+
+
+\## What You’ll See When You Run Hive
+
+
+
+At a high level, Hive lets teams describe \*\*what outcome they want\*\*, and the system handles \*\*how to achieve it\*\*.
+
+
+
+When Hive runs, the flow looks like this:
+
+
+
+1\. A \*\*natural-language goal\*\* is defined (e.g. “Route support tickets efficiently, escalating edge cases to humans”)
+
+2\. Hive translates that goal into an \*\*agent graph\*\* — a set of connected steps the agent will execute
+
+3\. The agent \*\*executes the graph\*\*, collecting signals from each step
+
+4\. Based on outcomes and feedback, Hive can \*\*adapt\*\* the graph over time
+
+5\. Humans can be inserted at key points for \*\*approval, review, or correction\*\*
+
+6\. Teams monitor execution, outcomes, and \*\*costs\*\* in real time
+
+
+
+The key idea:  
+
+👉 \*You focus on outcomes and guardrails; Hive handles orchestration and adaptation.\*
+
+
+
+---
+
+
+
+\## Example: Support Ticket Routing With Human Approval
+
+
+
+Let’s make this concrete with a simple business scenario.
+
+
+
+\### Business Goal
+
+> “Automatically route incoming support tickets to the right team,  
+
+> but require human approval for high-risk or ambiguous cases.”
+
+
+
+\### How Hive Interprets This
+
+
+
+\*\*1. Goal → Agent Graph\*\*  
+
+Hive converts the goal into an agent graph that might include:
+
+\- Classifying incoming tickets
+
+\- Determining urgency and risk
+
+\- Auto-routing low-risk tickets
+
+\- Pausing for human approval on edge cases
+
+
+
+You don’t design the graph manually — Hive generates and manages it based on the goal.
+
+
+
+\*\*2. Execution With Oversight\*\*  
+
+As tickets flow through the system:
+
+\- Most are handled automatically
+
+\- Certain decisions trigger \*\*human-in-the-loop (HITL)\*\* checkpoints
+
+\- Humans approve, correct, or override when needed
+
+
+
+\*\*3. Adaptation Over Time\*\*  
+
+If patterns change (new ticket types, misclassifications, delays):
+
+\- Hive learns from execution feedback
+
+\- The agent graph can evolve to improve outcomes
+
+
+
+---
+
+
+
+\## Key Concepts in Action
+
+
+
+This example highlights several core Hive concepts:
+
+
+
+\### Goal → Graph
+
+Hive starts from \*intent\*, not predefined workflows.  
+
+Goals are translated into executable agent graphs automatically.
+
+
+
+\### Adaptiveness
+
+Agents aren’t static. Execution results and feedback inform how the system improves over time.
+
+
+
+\### Human-in-the-Loop (HITL)
+
+Humans are first-class participants, not afterthoughts.  
+
+Approval, review, and correction can be built directly into the agent flow.
+
+
+
+\### Observability
+
+Teams can see:
+
+\- What the agent is doing
+
+\- Where decisions are made
+
+\- How outcomes are trending over time
+
+
+
+\### Cost \& Control Surfaces
+
+Hive treats budgets and constraints as explicit controls, not hidden side effects.  
+
+This helps PMs and architects reason about \*\*risk, spend, and governance\*\* early.
+
+
+
+---
+
+
+
+\## How Hive Differs From Other Tools (At a Glance)
+
+
+
+| Dimension | Hive | Temporal / Airflow | LangGraph / CrewAI |
+
+|--------|------|--------------------|--------------------|
+
+| Primary model | Goal-driven agent graphs | Static workflows / DAGs | LLM control flows |
+
+| Adaptiveness | Built-in, continuous | None | Limited |
+
+| HITL support | First-class nodes | External | Ad-hoc |
+
+| Observability | Outcome + decision focused | Ops-focused | Minimal |
+
+| Cost controls | Explicit guardrails | Infrastructure-level | Token-level |
+
+| Best for | Outcome-driven agent systems | Deterministic workflows | Prompt-centric agents |
+
+
+
+---
+
+
+
+\## Next Steps
+
+
+
+If Hive’s approach resonates:
+
+
+
+\- \*\*Product / Ops / Architects:\*\*  
+
+&nbsp; Share this mental model with your engineering team to evaluate fit.
+
+
+
+\- \*\*Developers:\*\*  
+
+&nbsp; Continue to the full \*\*Quick Start\*\* to run Hive locally and explore real agents.
+
+
+
+Hive is designed so \*\*evaluation can happen before implementation\*\* — helping teams decide \*why\* before investing in \*how\*.
+
+
+


### PR DESCRIPTION
## Description

Adds a new **“Quick tour (non-developer)”** document to help PMs, ops leaders, and architects
evaluate Hive’s outcome-driven approach in under 15 minutes, before involving engineering.

The guide focuses on *what and why* (goals → agent graphs → execution → controls),
not setup or CLI usage.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #3174

## Changes Made

- Added `docs/quick-tour-non-developer.md`
- Introduced a concepts-first walkthrough for non-technical evaluators
- Included a concrete business example to demonstrate goal → graph → execution
- Highlighted adaptiveness, HITL, observability, and cost controls from a product perspective

## Testing

- [x] Manual review (documentation only)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if applicable)

N/A — documentation-only change
