### PR TITLE
feat(cli): add memory inspect command for viewing agent run data

### DIFF
--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -9,6 +9,11 @@ Usage:
     hive dispatch exports/ --input '{"key": "value"}'
     hive shell exports/my-agent
 
+Memory inspection commands:
+    hive memory inspect <agent> [run_id]
+    hive memory list <agent>
+    hive memory stats <agent>
+
 Testing commands:
     hive test-run <agent_path> --goal <goal_id>
     hive test-debug <goal_id> <test_id>
@@ -74,6 +79,16 @@ def main():
     from framework.testing.cli import register_testing_commands
 
     register_testing_commands(subparsers)
+
+    # Register cost tracking commands (costs)
+    from framework.costs.cli import register_cost_commands
+
+    register_cost_commands(subparsers)
+
+    # Register memory inspection commands (memory)
+    from framework.memory.cli import register_memory_commands
+
+    register_memory_commands(subparsers)
 
     args = parser.parse_args()
 

--- a/core/framework/memory/__init__.py
+++ b/core/framework/memory/__init__.py
@@ -1,0 +1,5 @@
+"""Memory inspection module for viewing agent run data and SharedMemory state."""
+
+from framework.memory.inspector import MemoryInspector
+
+__all__ = ["MemoryInspector"]

--- a/core/framework/memory/cli.py
+++ b/core/framework/memory/cli.py
@@ -1,0 +1,253 @@
+"""CLI commands for memory inspection."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from framework.memory.inspector import MemoryInspector
+from framework.schemas.run import RunStatus
+
+
+def register_memory_commands(subparsers: argparse._SubParsersAction) -> None:
+    """Register memory inspection commands with the main CLI."""
+
+    # memory command with subcommands
+    memory_parser = subparsers.add_parser(
+        "memory",
+        help="Inspect agent memory and run data",
+        description="View SharedMemory state and execution data from agent runs.",
+    )
+    
+    memory_subparsers = memory_parser.add_subparsers(dest="memory_command", required=True)
+    
+    # memory inspect <agent> [run_id]
+    inspect_parser = memory_subparsers.add_parser(
+        "inspect",
+        help="Inspect memory state for a specific run",
+        description="View the final SharedMemory state and metadata for an agent run.",
+    )
+    inspect_parser.add_argument(
+        "agent",
+        type=str,
+        help="Agent name (folder name in exports/ or storage path)",
+    )
+    inspect_parser.add_argument(
+        "run_id",
+        type=str,
+        nargs="?",
+        help="Run ID to inspect (defaults to most recent run)",
+    )
+    inspect_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    inspect_parser.add_argument(
+        "--storage-path",
+        type=str,
+        help="Custom storage path (default: ~/.hive/storage/{agent})",
+    )
+    inspect_parser.set_defaults(func=cmd_memory_inspect)
+    
+    # memory list <agent>
+    list_parser = memory_subparsers.add_parser(
+        "list",
+        help="List all runs for an agent",
+        description="Show all run history for an agent with summaries.",
+    )
+    list_parser.add_argument(
+        "agent",
+        type=str,
+        help="Agent name (folder name in exports/ or storage path)",
+    )
+    list_parser.add_argument(
+        "--status",
+        type=str,
+        choices=["running", "completed", "failed"],
+        help="Filter by run status",
+    )
+    list_parser.add_argument(
+        "--limit",
+        type=int,
+        help="Maximum number of runs to show (most recent first)",
+    )
+    list_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    list_parser.add_argument(
+        "--storage-path",
+        type=str,
+        help="Custom storage path (default: ~/.hive/storage/{agent})",
+    )
+    list_parser.set_defaults(func=cmd_memory_list)
+    
+    # memory stats <agent>
+    stats_parser = memory_subparsers.add_parser(
+        "stats",
+        help="Show statistics for an agent",
+        description="Display run statistics and storage information.",
+    )
+    stats_parser.add_argument(
+        "agent",
+        type=str,
+        help="Agent name (folder name in exports/ or storage path)",
+    )
+    stats_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    stats_parser.add_argument(
+        "--storage-path",
+        type=str,
+        help="Custom storage path (default: ~/.hive/storage/{agent})",
+    )
+    stats_parser.set_defaults(func=cmd_memory_stats)
+
+
+def cmd_memory_inspect(args: argparse.Namespace) -> int:
+    """Inspect memory state for a specific run."""
+    try:
+        storage_path = Path(args.storage_path) if args.storage_path else None
+        inspector = MemoryInspector(args.agent, storage_path)
+        
+        output = inspector.format_memory_output(args.run_id, json_format=args.json)
+        print(output)
+        
+        return 0
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"Error inspecting memory: {e}", file=sys.stderr)
+        return 1
+
+
+def cmd_memory_list(args: argparse.Namespace) -> int:
+    """List all runs for an agent."""
+    try:
+        storage_path = Path(args.storage_path) if args.storage_path else None
+        inspector = MemoryInspector(args.agent, storage_path)
+        
+        # Parse status filter
+        status_filter = None
+        if args.status:
+            status_map = {
+                "running": RunStatus.RUNNING,
+                "completed": RunStatus.COMPLETED,
+                "failed": RunStatus.FAILED,
+            }
+            status_filter = status_map[args.status]
+        
+        summaries = inspector.list_runs(status=status_filter, limit=args.limit)
+        
+        if not summaries:
+            print(f"No runs found for agent: {args.agent}")
+            return 0
+        
+        if args.json:
+            output = []
+            for summary in summaries:
+                output.append({
+                    "run_id": summary.run_id,
+                    "goal_id": summary.goal_id,
+                    "status": summary.status.value,
+                    "duration_ms": summary.duration_ms,
+                    "decision_count": summary.decision_count,
+                    "success_rate": summary.success_rate,
+                    "problem_count": summary.problem_count,
+                    "narrative": summary.narrative,
+                })
+            print(json.dumps(output, indent=2))
+        else:
+            print("=" * 100)
+            print(f"Run History - {args.agent}")
+            print("=" * 100)
+            print()
+            
+            for summary in summaries:
+                status_symbol = {
+                    RunStatus.COMPLETED: "✓",
+                    RunStatus.FAILED: "✗",
+                    RunStatus.RUNNING: "⟳",
+                }
+                symbol = status_symbol.get(summary.status, "?")
+                
+                print(f"{symbol} {summary.run_id}")
+                print(f"  Status: {summary.status.value}")
+                print(f"  Duration: {summary.duration_ms}ms")
+                print(f"  Decisions: {summary.decision_count} ({summary.success_rate:.1%} successful)")
+                if summary.problem_count > 0:
+                    print(f"  Problems: {summary.problem_count}")
+                if summary.narrative:
+                    narrative_short = summary.narrative[:80] + "..." if len(summary.narrative) > 80 else summary.narrative
+                    print(f"  Narrative: {narrative_short}")
+                print()
+            
+            print("=" * 100)
+            print(f"Total runs: {len(summaries)}")
+            if args.status:
+                print(f"Filter: {args.status}")
+            if args.limit:
+                print(f"(Showing most recent {args.limit})")
+            print()
+        
+        return 0
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"Error listing runs: {e}", file=sys.stderr)
+        return 1
+
+
+def cmd_memory_stats(args: argparse.Namespace) -> int:
+    """Show statistics for an agent."""
+    try:
+        storage_path = Path(args.storage_path) if args.storage_path else None
+        inspector = MemoryInspector(args.agent, storage_path)
+        
+        stats = inspector.get_stats()
+        
+        if args.json:
+            print(json.dumps(stats, indent=2))
+        else:
+            print("=" * 70)
+            print(f"Agent Statistics - {stats['agent']}")
+            print("=" * 70)
+            print()
+            print(f"Total Runs: {stats['total_runs']}")
+            print(f"  Completed: {stats['completed']}")
+            print(f"  Failed: {stats['failed']}")
+            print(f"  Running: {stats['running']}")
+            print()
+            if stats['most_recent_run']:
+                print(f"Most Recent Run: {stats['most_recent_run']}")
+                print(f"  Status: {stats['most_recent_status']}")
+            print()
+            print(f"Storage Path: {stats['storage_path']}")
+            print()
+            print("=" * 70)
+            print("Usage:")
+            print("=" * 70)
+            print()
+            print(f"  # Inspect most recent run:")
+            print(f"  hive memory inspect {args.agent}")
+            print()
+            print(f"  # Inspect specific run:")
+            print(f"  hive memory inspect {args.agent} <run_id>")
+            print()
+            print(f"  # List all runs:")
+            print(f"  hive memory list {args.agent}")
+            print()
+        
+        return 0
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"Error getting stats: {e}", file=sys.stderr)
+        return 1

--- a/core/framework/memory/inspector.py
+++ b/core/framework/memory/inspector.py
@@ -1,0 +1,263 @@
+"""Inspector for analyzing agent run memory and execution data."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from framework.schemas.run import Run, RunStatus, RunSummary
+from framework.storage.backend import FileStorage
+
+
+class MemoryInspector:
+    """
+    Inspector for viewing agent run data and SharedMemory state.
+    
+    Provides access to the final SharedMemory state (output_data) and
+    run metadata from persistent storage at ~/.hive/storage/{agent}/runs/.
+    """
+
+    def __init__(self, agent_name: str, storage_path: Path | None = None):
+        """
+        Initialize memory inspector for an agent.
+        
+        Args:
+            agent_name: Name of the agent (folder name in exports/ or storage/)
+            storage_path: Optional custom storage path. Defaults to ~/.hive/storage/{agent_name}
+        """
+        self.agent_name = agent_name
+        
+        if storage_path:
+            self.storage_path = Path(storage_path)
+        else:
+            home = Path.home()
+            self.storage_path = home / ".hive" / "storage" / agent_name
+        
+        if not self.storage_path.exists():
+            raise FileNotFoundError(
+                f"Storage path does not exist: {self.storage_path}\n"
+                f"Run the agent first to create run history: hive run exports/{agent_name} --input '{{...}}'"
+            )
+        
+        self.storage = FileStorage(self.storage_path)
+    
+    def list_runs(self, status: RunStatus | None = None, limit: int | None = None) -> list[RunSummary]:
+        """
+        List all runs for this agent.
+        
+        Args:
+            status: Optional filter by status (RUNNING, COMPLETED, FAILED)
+            limit: Maximum number of runs to return (most recent first)
+        
+        Returns:
+            List of RunSummary objects
+        """
+        if status:
+            run_ids = self.storage.get_runs_by_status(status)
+        else:
+            run_ids = self.storage.list_all_runs()
+        
+        summaries = []
+        for run_id in run_ids:
+            summary = self.storage.load_summary(run_id)
+            if summary:
+                summaries.append(summary)
+        
+        # Sort by run_id (which includes timestamp) descending
+        summaries.sort(key=lambda s: s.run_id, reverse=True)
+        
+        if limit:
+            summaries = summaries[:limit]
+        
+        return summaries
+    
+    def get_run(self, run_id: str | None = None) -> Run | None:
+        """
+        Get full run data including SharedMemory state.
+        
+        Args:
+            run_id: Run ID to fetch. If None, fetches the most recent run.
+        
+        Returns:
+            Full Run object with output_data (SharedMemory) and metadata
+        """
+        if run_id is None:
+            # Get most recent run
+            all_runs = self.storage.list_all_runs()
+            if not all_runs:
+                return None
+            all_runs.sort(reverse=True)  # Sort by timestamp descending
+            run_id = all_runs[0]
+        
+        return self.storage.load_run(run_id)
+    
+    def get_memory_state(self, run_id: str | None = None) -> dict[str, Any] | None:
+        """
+        Get the final SharedMemory state (output_data) for a run.
+        
+        This is the key-value store that accumulated node outputs during
+        graph execution. Only the final state is stored, not per-node states.
+        
+        Args:
+            run_id: Run ID to fetch. If None, fetches the most recent run.
+        
+        Returns:
+            Dictionary containing the SharedMemory key-value pairs
+        """
+        run = self.get_run(run_id)
+        if run:
+            return run.output_data
+        return None
+    
+    def get_run_metadata(self, run_id: str | None = None) -> dict[str, Any] | None:
+        """
+        Get run metadata (status, decisions, metrics, execution path).
+        
+        Args:
+            run_id: Run ID to fetch. If None, fetches the most recent run.
+        
+        Returns:
+            Dictionary containing run metadata
+        """
+        run = self.get_run(run_id)
+        if not run:
+            return None
+        
+        return {
+            "run_id": run.id,
+            "goal_id": run.goal_id,
+            "goal_description": run.goal_description,
+            "status": run.status.value,
+            "started_at": run.started_at.isoformat(),
+            "completed_at": run.completed_at.isoformat() if run.completed_at else None,
+            "duration_ms": run.duration_ms,
+            "narrative": run.narrative,
+            "metrics": {
+                "total_decisions": run.metrics.total_decisions,
+                "successful_decisions": run.metrics.successful_decisions,
+                "failed_decisions": run.metrics.failed_decisions,
+                "total_tokens": run.metrics.total_tokens,
+                "total_latency_ms": run.metrics.total_latency_ms,
+                "nodes_executed": run.metrics.nodes_executed,
+            },
+            "execution_path": run.metrics.nodes_executed,
+            "decision_count": len(run.decisions),
+            "problem_count": len(run.problems),
+        }
+    
+    def get_stats(self) -> dict[str, Any]:
+        """
+        Get statistics about agent runs.
+        
+        Returns:
+            Dictionary with run statistics
+        """
+        all_runs = self.storage.list_all_runs()
+        
+        if not all_runs:
+            return {
+                "agent": self.agent_name,
+                "total_runs": 0,
+                "storage_path": str(self.storage_path),
+            }
+        
+        # Load all summaries for stats
+        summaries = []
+        for run_id in all_runs:
+            summary = self.storage.load_summary(run_id)
+            if summary:
+                summaries.append(summary)
+        
+        # Calculate stats
+        completed = len([s for s in summaries if s.status == RunStatus.COMPLETED])
+        failed = len([s for s in summaries if s.status == RunStatus.FAILED])
+        running = len([s for s in summaries if s.status == RunStatus.RUNNING])
+        
+        # Get most recent run
+        summaries.sort(key=lambda s: s.run_id, reverse=True)
+        most_recent = summaries[0] if summaries else None
+        
+        return {
+            "agent": self.agent_name,
+            "total_runs": len(all_runs),
+            "completed": completed,
+            "failed": failed,
+            "running": running,
+            "storage_path": str(self.storage_path),
+            "most_recent_run": most_recent.run_id if most_recent else None,
+            "most_recent_status": most_recent.status.value if most_recent else None,
+        }
+    
+    def format_memory_output(self, run_id: str | None = None, json_format: bool = False) -> str:
+        """
+        Format memory state and metadata for display.
+        
+        Args:
+            run_id: Run ID to format. If None, uses most recent run.
+            json_format: If True, return JSON string. Otherwise, human-readable.
+        
+        Returns:
+            Formatted string
+        """
+        run = self.get_run(run_id)
+        if not run:
+            return "No runs found. Run the agent first to create run history."
+        
+        output = {
+            "run_id": run.id,
+            "status": run.status.value,
+            "duration_ms": run.duration_ms,
+            "memory_state": run.output_data,
+            "metadata": {
+                "goal_description": run.goal_description,
+                "narrative": run.narrative,
+                "execution_path": run.metrics.nodes_executed,
+                "total_decisions": run.metrics.total_decisions,
+                "successful_decisions": run.metrics.successful_decisions,
+                "failed_decisions": run.metrics.failed_decisions,
+                "problem_count": len(run.problems),
+            },
+        }
+        
+        if json_format:
+            return json.dumps(output, indent=2)
+        
+        # Human-readable format
+        lines = []
+        lines.append("=" * 80)
+        lines.append(f"Agent Memory State - {self.agent_name}")
+        lines.append("=" * 80)
+        lines.append("")
+        lines.append(f"Run ID: {run.id}")
+        lines.append(f"Status: {run.status.value}")
+        lines.append(f"Duration: {run.duration_ms}ms")
+        lines.append("")
+        lines.append("Goal:")
+        lines.append(f"  {run.goal_description}")
+        lines.append("")
+        lines.append("Execution Path:")
+        for node in run.metrics.nodes_executed:
+            lines.append(f"  → {node}")
+        lines.append("")
+        lines.append("SharedMemory State (Final):")
+        if run.output_data:
+            for key, value in run.output_data.items():
+                value_str = json.dumps(value) if not isinstance(value, str) else value
+                if len(value_str) > 100:
+                    value_str = value_str[:97] + "..."
+                lines.append(f"  {key}: {value_str}")
+        else:
+            lines.append("  (empty)")
+        lines.append("")
+        lines.append("Metrics:")
+        lines.append(f"  Decisions: {run.metrics.successful_decisions}/{run.metrics.total_decisions} successful")
+        lines.append(f"  Total Tokens: {run.metrics.total_tokens:,}")
+        lines.append(f"  Total Latency: {run.metrics.total_latency_ms}ms")
+        lines.append(f"  Problems: {len(run.problems)}")
+        lines.append("")
+        if run.narrative:
+            lines.append("Narrative:")
+            lines.append(f"  {run.narrative}")
+            lines.append("")
+        lines.append("=" * 80)
+        
+        return "\n".join(lines)


### PR DESCRIPTION
Implements memory inspection CLI command to view SharedMemory state and run metadata from agent execution history.

Features:
- hive memory inspect <agent> [run_id] - View memory state and metadata
- hive memory list <agent> - List all runs with summaries
- hive memory stats <agent> - Show run statistics

Uses FileStorage.load_run(), list_all_runs(), and load_summary() to access persisted run data from ~/.hive/storage/{agent}/runs/.

Surfaces run.output_data (final SharedMemory state) plus run metadata including status, decisions, metrics, and execution path.

Resolves #3010

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
