### PR TITLE
micro-fix: Added path bootstrap to resolve internal imports #3207

### DIFF
--- a/core/examples/manual_agent.py
+++ b/core/examples/manual_agent.py
@@ -13,7 +13,11 @@ Run with:
 """
 
 import asyncio
+import sys
+from pathlib import Path
 
+# This adds the 'core' directory to the Python path
+sys.path.append(str(Path(__file__).parent.parent))
 from framework.graph import EdgeCondition, EdgeSpec, Goal, GraphSpec, NodeSpec
 from framework.graph.executor import GraphExecutor
 from framework.runtime.core import Runtime


### PR DESCRIPTION


## Description

Brief description of the changes in this PR.

This PR resolves the ModuleNotFoundError reported in issue https://github.com/adenhq/hive/issues/3207. By adding a sys.path bootstrap to the manual_agent.py example, the script can now correctly resolve the internal framework package when executed from the repository root, without requiring the user to manually set their PYTHONPATH.

## Type of Change

[x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #3207

## Changes Made

-Added import sys and from pathlib import Path to the top of core/examples/manual_agent.py.
-Included sys.path.append(str(Path(file).parent.parent)) to dynamically add the core directory to the Python search path during execution.

## Testing

Manual testing was performed on Windows 11 with Python 3.12.3.

-[x] Manual testing performed

-Verification steps: Cloned the repo into a fresh directory, created a virtual environment, installed pydantic, and ran python core/examples/manual_agent.py. The script executed the agent graph successfully and returned the final output: HELLO, ALICE!.

## Checklist

[x] My code follows the project's style guidelines

[x] I have performed a self-review of my code

[x] I have commented my code, particularly in hard-to-understand areas

[x] My changes generate no new warnings

## Screenshots (if applicable)

<img width="589" height="168" alt="ss" src="https://github.com/user-attachments/assets/51ae0c06-a649-4f73-a3b2-839fcae399b7" />
