### PR TITLE
Feature/aden sync by provider

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -32,9 +32,13 @@
       "mcp__agent-builder__verify_credentials",
       "Bash(PYTHONPATH=/home/timothy/oss/hive/core:/home/timothy/oss/hive/exports python:*)",
       "Bash(PYTHONPATH=core:exports:tools/src python -m hubspot_input:*)",
-      "mcp__agent-builder__export_graph"
+      "mcp__agent-builder__export_graph",
+      "Bash(python3:*)"
     ]
   },
-  "enabledMcpjsonServers": ["agent-builder", "tools"],
-  "enableAllProjectMcpServers": true
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": [
+    "agent-builder",
+    "tools"
+  ]
 }


### PR DESCRIPTION
# Hardening & Aden Credential Sync

fixes #3243

## Summary

- Hardened EventLoopNode compaction to handle context budget overruns
- Integrated Aden OAuth credential sync into the event loop demo
- Fixed a bug where Aden-synced credentials were unreachable by provider name

## Changes

### Tiered Compaction (conversation.py, event_loop_node.py)

The original compaction logic had a single threshold check at the start of each loop iteration. Several edge cases could blow past the context budget:

- A single tool result exceeding the remaining budget
- Multiple large tool results accumulated in one turn
- The LLM API returning before compaction fires

Added a layered defense:

| Layer | Where | What |
|-------|-------|------|
| Post-turn check | After each `_run_single_turn` | Catches tool-result bloat immediately |
| Tiered aggressiveness | `_compact_tiered()` | 80–100%: normal (keep 4), 100–120%: aggressive (keep 2), 120%+: emergency (keep 1, static summary) |
| Pre-send guard | Before every `ctx.llm.stream()` | Last-resort compaction when usage ≥ 100% |
| API token feedback | After `FinishEvent` | `update_token_count(input_tokens)` replaces chars/4 estimate with actual API count |

### Aden Credential Sync (event_loop_wss_demo.py)

Updated demo 1 to sync OAuth tokens from the Aden server on startup when `ADEN_API_KEY` is set. Falls back to local `CompositeStorage` (encrypted + env var) when Aden is unavailable.

### Provider Index Bug Fix (aden/storage.py)

Aden stores credentials with base64 hash IDs (e.g., `aHVic3BvdDp0ZXN0OjEzNjExOjExNTI1`) while the credential adapter looks up by logical name (`hubspot`). After sync, lookups failed with 400s from the Aden API and fell back to stale env var tokens.

**Root cause**: `AdenCachedStorage.load("hubspot")` did a direct ID lookup, found a stale env var credential, and never checked for the Aden-synced one stored under the hash ID.

**Fix**: Added a `_provider_index` (provider name → hash ID) to `AdenCachedStorage`, populated during `save()` from the `_integration_type` key. The index is checked **before** direct lookup so Aden-synced credentials take priority.

```
load("hubspot")
  → _provider_index["hubspot"] → "aHVic3BvdDp0ZXN0OjEzNjExOjExNTI1"
  → _load_by_id(hash) → fresh Aden credential
```

### Tests

| File | Tests Added |
|------|-------------|
| `test_node_conversation.py` | `test_update_token_count_overrides_estimate`, `test_compact_resets_token_count`, `test_clear_resets_token_count`, `test_usage_ratio`, `test_usage_ratio_zero_budget`, `test_needs_compaction_with_actual_tokens` |
| `test_aden_sync.py` | `test_save_indexes_provider`, `test_load_by_provider_name`, `test_load_by_direct_id_still_works`, `test_exists_by_provider_name`, `test_rebuild_provider_index`, `test_save_without_integration_type_no_index` |

## Files Changed

| File | Change |
|------|--------|
| `core/framework/graph/conversation.py` | Added `_last_api_input_tokens`, `update_token_count()`, `usage_ratio()` |
| `core/framework/graph/event_loop_node.py` | Added `_compact_tiered()`, post-turn compaction, pre-send guard, token feedback |
| `core/framework/credentials/aden/storage.py` | Added `_provider_index`, `_index_provider()`, `rebuild_provider_index()`; refactored `load()` + `_load_by_id()` |
| `core/framework/credentials/aden/tests/test_aden_sync.py` | 6 new provider-index tests |
| `core/tests/test_node_conversation.py` | 6 new compaction/token tests |
| `core/demos/event_loop_wss_demo.py` | Aden sync on startup with local fallback |

## Test Plan

- [x] Run `pytest core/tests/test_node_conversation.py` — compaction + token tracking tests
- [x] Run `pytest core/framework/credentials/aden/tests/test_aden_sync.py` — provider index tests
- [x] Run `python core/demos/event_loop_wss_demo.py` with `ADEN_API_KEY` set — verify `Loaded credential 'hubspot' via provider index` in logs
- [x] Run demo without `ADEN_API_KEY` — verify graceful fallback to env vars
