### PR TITLE
feat(cli): add memory management CLI commands

### DIFF
--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -14,6 +14,11 @@ Testing commands:
     hive test-debug <goal_id> <test_id>
     hive test-list <goal_id>
     hive test-stats <goal_id>
+
+Memory commands:
+    hive memory list [agent_path]
+    hive memory inspect <agent_path> [--run-id <run_id>]
+    hive memory stats [agent_path]
 """
 
 import argparse
@@ -74,6 +79,11 @@ def main():
     from framework.testing.cli import register_testing_commands
 
     register_testing_commands(subparsers)
+
+    # Register memory commands (memory list, memory inspect, memory stats)
+    from framework.memory.cli import register_memory_commands
+
+    register_memory_commands(subparsers)
 
     args = parser.parse_args()
 

--- a/core/framework/memory/__init__.py
+++ b/core/framework/memory/__init__.py
@@ -1,0 +1,1 @@
+"""Memory management utilities for Hive agents."""

--- a/core/framework/memory/cli.py
+++ b/core/framework/memory/cli.py
@@ -1,0 +1,318 @@
+"""CLI commands for memory management."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from framework.storage.backend import FileStorage
+
+
+def register_memory_commands(subparsers: argparse._SubParsersAction) -> None:
+    """Register memory management commands with the main CLI."""
+
+    # Create 'memory' subcommand group
+    memory_parser = subparsers.add_parser(
+        "memory",
+        help="Memory management commands",
+        description="Inspect and manage agent run memory.",
+    )
+    memory_subparsers = memory_parser.add_subparsers(dest="memory_command", required=True)
+
+    # memory list command
+    list_parser = memory_subparsers.add_parser(
+        "list",
+        help="List stored agent runs",
+        description="Display a list of all stored agent runs from memory.",
+    )
+    list_parser.add_argument(
+        "agent_path",
+        type=str,
+        nargs="?",
+        help="Path to agent (e.g., exports/my-agent) or agent name",
+    )
+    list_parser.add_argument(
+        "--status",
+        "-s",
+        type=str,
+        choices=["completed", "failed", "running", "stuck", "cancelled"],
+        help="Filter by run status",
+    )
+    list_parser.add_argument(
+        "--goal",
+        "-g",
+        type=str,
+        help="Filter by goal ID",
+    )
+    list_parser.add_argument(
+        "--limit",
+        "-n",
+        type=int,
+        default=20,
+        help="Maximum number of runs to display (default: 20)",
+    )
+    list_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    list_parser.set_defaults(func=cmd_list)
+
+    # memory inspect command
+    inspect_parser = memory_subparsers.add_parser(
+        "inspect",
+        help="Inspect agent memory from runs",
+        description="View memory state and details from an agent run.",
+    )
+    inspect_parser.add_argument(
+        "agent_path",
+        type=str,
+        help="Path to agent (e.g., exports/my-agent) or agent name",
+    )
+    inspect_parser.add_argument(
+        "--run-id",
+        type=str,
+        help="Specific run ID to inspect (defaults to last run)",
+    )
+    inspect_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    inspect_parser.set_defaults(func=cmd_inspect)
+
+    # memory stats command
+    stats_parser = memory_subparsers.add_parser(
+        "stats",
+        help="Show memory statistics",
+        description="Display statistics about stored agent runs.",
+    )
+    stats_parser.add_argument(
+        "agent_path",
+        type=str,
+        nargs="?",
+        help="Path to agent (e.g., exports/my-agent) or agent name",
+    )
+    stats_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    stats_parser.set_defaults(func=cmd_stats)
+
+
+
+def _get_storage_path(agent_path: str | None) -> Path:
+    """
+    Get the storage path for an agent.
+
+    Args:
+        agent_path: Agent path (e.g., 'exports/my-agent'), agent name, or None to infer
+
+    Returns:
+        Path to storage directory
+    """
+    if agent_path:
+        # Handle paths like 'exports/my-agent' or just 'my-agent'
+        path = Path(agent_path)
+        agent_name = path.name  # Extract the agent name from path
+        return Path.home() / ".hive" / "storage" / agent_name
+
+    # Try to infer from current directory
+    cwd = Path.cwd()
+    exports_dir = cwd.parent if cwd.parent.name == "exports" else None
+    if exports_dir and (exports_dir / cwd.name / "agent.json").exists():
+        return Path.home() / ".hive" / "storage" / cwd.name
+
+    # No agent specified and couldn't infer
+    print("Error: Could not determine agent. Provide agent path as argument.", file=sys.stderr)
+    sys.exit(1)
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    """List stored agent runs."""
+    storage_path = _get_storage_path(args.agent_path)
+
+    if not storage_path.exists():
+        print(f"No memory found at {storage_path}", file=sys.stderr)
+        return 1
+
+    storage = FileStorage(storage_path)
+
+    # Get run IDs
+    if args.status:
+        run_ids = storage.get_runs_by_status(args.status)
+    elif args.goal:
+        run_ids = storage.get_runs_by_goal(args.goal)
+    else:
+        run_ids = storage.list_all_runs()
+
+    # Apply limit
+    run_ids = run_ids[: args.limit]
+
+    # Load summaries
+    summaries = []
+    for run_id in run_ids:
+        summary = storage.load_summary(run_id)
+        if summary:
+            summaries.append(summary)
+
+    if args.json:
+        print(json.dumps([s.model_dump(mode="json") for s in summaries], indent=2))
+        return 0
+
+    # Human-readable output
+    if not summaries:
+        print("No runs found.")
+        return 0
+
+    print(f"Found {len(summaries)} run(s):\n")
+    for s in summaries:
+        status_color = {
+            "completed": "✓",
+            "failed": "✗",
+            "running": "→",
+            "stuck": "⊗",
+            "cancelled": "⊘",
+        }.get(s.status.value if hasattr(s.status, "value") else s.status, "?")
+        print(f"{status_color} {s.run_id}")
+        print(f"  Goal: {s.goal_id}")
+        print(f"  Status: {s.status.value if hasattr(s.status, 'value') else s.status}")
+        print(f"  Duration: {s.duration_ms}ms")
+        print(f"  Decisions: {s.decision_count} (success rate: {s.success_rate:.1%})")
+        if s.problem_count > 0:
+            print(f"  Problems: {s.problem_count}")
+        print()
+
+    return 0
+
+
+def cmd_inspect(args: argparse.Namespace) -> int:
+    """Inspect a specific run."""
+    storage_path = _get_storage_path(args.agent_path)
+
+    if not storage_path.exists():
+        print(f"No memory found at {storage_path}", file=sys.stderr)
+        return 1
+
+    storage = FileStorage(storage_path)
+
+    # Determine run_id: use provided or get last run
+    # Note: argparse converts --run-id to run_id attribute
+    run_id = args.run_id if hasattr(args, "run_id") else None
+    if not run_id:
+        # Get the most recent run
+        all_runs = storage.list_all_runs()
+        if not all_runs:
+            print("No runs found.", file=sys.stderr)
+            return 1
+        run_id = all_runs[-1]  # Assuming list is sorted, take last
+
+    run = storage.load_run(run_id)
+
+    if not run:
+        print(f"Run {run_id} not found.", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(run.model_dump_json(indent=2))
+        return 0
+
+    # Human-readable output
+    print(f"Run: {run.id}")
+    print(f"Goal: {run.goal_id} - {run.goal_description}")
+    print(f"Status: {run.status.value}")
+    print(f"Started: {run.started_at}")
+    print(f"Completed: {run.completed_at or 'N/A'}")
+    print(f"Duration: {run.duration_ms}ms")
+
+    # Display input data (what was passed to the agent)
+    if run.input_data:
+        print("\nInput Data:")
+        for key, value in run.input_data.items():
+            if isinstance(value, (list, dict)):
+                if len(str(value)) < 100:
+                    value_str = json.dumps(value, indent=2)
+                else:
+                    value_str = f"{type(value).__name__} with {len(value)} items"
+            else:
+                value_str = str(value)[:200]
+            print(f"  {key}: {value_str}")
+
+    print("\nMetrics:")
+    print(f"  Decisions: {run.metrics.total_decisions}")
+    print(f"  Successful: {run.metrics.successful_decisions}")
+    print(f"  Failed: {run.metrics.failed_decisions}")
+    print(f"  Nodes executed: {len(run.metrics.nodes_executed)}")
+
+    # Display memory state (run.output_data = final SharedMemory state)
+    if run.output_data:
+        print("\nMemory State:")
+        for key, value in run.output_data.items():
+            # Format value for display
+            if isinstance(value, (list, dict)):
+                if len(str(value)) < 100:
+                    value_str = json.dumps(value, indent=2)
+                else:
+                    value_str = f"{type(value).__name__} with {len(value)} items"
+            else:
+                value_str = str(value)[:200]  # Truncate long strings
+            print(f"  {key}: {value_str}")
+        print(f"\nTotal keys: {len(run.output_data)}")
+    else:
+        print("\nMemory State: (empty)")
+
+    if run.decisions:
+        print(f"\nDecisions ({len(run.decisions)}):")
+        for i, decision in enumerate(run.decisions[:5], 1):
+            print(f"  {i}. [{decision.node_id}] {decision.intent}")
+            print(f"     Chosen: {decision.chosen}")
+            if decision.outcome:
+                outcome_status = "✓" if decision.outcome.success else "✗"
+                print(f"     Outcome: {outcome_status} {decision.outcome.summary}")
+
+        if len(run.decisions) > 5:
+            print(f"  ... and {len(run.decisions) - 5} more")
+
+    return 0
+
+
+def cmd_stats(args: argparse.Namespace) -> int:
+    """Show memory statistics."""
+    storage_path = _get_storage_path(args.agent_path)
+
+    if not storage_path.exists():
+        print(f"No memory found at {storage_path}", file=sys.stderr)
+        return 1
+
+    storage = FileStorage(storage_path)
+    stats = storage.get_stats()
+
+    # Count by status
+    status_counts = {}
+    for status in ["completed", "failed", "running", "stuck", "cancelled"]:
+        status_counts[status] = len(storage.get_runs_by_status(status))
+
+    if args.json:
+        output = {
+            **stats,
+            "by_status": status_counts,
+        }
+        print(json.dumps(output, indent=2))
+        return 0
+
+    # Human-readable output
+    print("Memory Statistics")
+    print(f"Storage: {stats['storage_path']}")
+    print(f"\nTotal runs: {stats['total_runs']}")
+    print(f"Total goals: {stats['total_goals']}")
+    print("\nBy status:")
+    print(f"  Completed: {status_counts['completed']}")
+    print(f"  Failed: {status_counts['failed']}")
+    print(f"  Running: {status_counts['running']}")
+    print(f"  Stuck: {status_counts['stuck']}")
+    print(f"  Cancelled: {status_counts['cancelled']}")
+
+    return 0
+
+

--- a/core/framework/memory/cli.py
+++ b/core/framework/memory/cli.py
@@ -139,6 +139,11 @@ def cmd_list(args: argparse.Namespace) -> int:
 
     storage = FileStorage(storage_path)
 
+    # Validate limit
+    if args.limit < 1:
+        print("Error: limit must be a positive number", file=sys.stderr)
+        return 1
+
     # Get run IDs
     if args.status:
         run_ids = storage.get_runs_by_status(args.status)

--- a/core/tests/test_memory_cli.py
+++ b/core/tests/test_memory_cli.py
@@ -1,0 +1,465 @@
+"""Tests for memory CLI commands."""
+
+import json
+from argparse import Namespace
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from framework.memory.cli import _get_storage_path, cmd_inspect, cmd_list, cmd_stats
+from framework.schemas.decision import Decision, Outcome
+from framework.schemas.run import Run, RunMetrics, RunStatus, RunSummary
+
+
+@pytest.fixture
+def mock_run():
+    """Create a mock Run object with test data."""
+    return Run(
+        id="run_20260131_123456",
+        goal_id="test-goal",
+        goal_description="Test goal for searching AI news",
+        status=RunStatus.COMPLETED,
+        started_at=datetime(2026, 1, 31, 12, 34, 56),
+        completed_at=datetime(2026, 1, 31, 12, 35, 56),
+        duration_ms=60000,
+        input_data={"query": "test query"},
+        output_data={
+            "query": "latest AI news",
+            "search_results": [{"title": "AI Breakthrough", "url": "https://example.com"}],
+            "summary": "Recent AI developments include major breakthroughs in LLMs.",
+        },
+        metrics=RunMetrics(
+            total_decisions=5,
+            successful_decisions=4,
+            failed_decisions=1,
+            nodes_executed=["search_node", "summarize_node"],
+        ),
+        decisions=[
+            Decision(
+                id="dec1",
+                node_id="search_node",
+                intent="Search for AI news",
+                chosen="web_search",
+                outcome=Outcome(
+                    success=True,
+                    summary="Found 10 relevant articles",
+                ),
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def mock_run_empty_memory():
+    """Create a mock Run with empty output_data."""
+    return Run(
+        id="run_empty",
+        goal_id="test-goal",
+        goal_description="Test goal",
+        status=RunStatus.COMPLETED,
+        started_at=datetime(2026, 1, 31, 12, 34, 56),
+        completed_at=datetime(2026, 1, 31, 12, 35, 56),
+        duration_ms=1000,
+        output_data={},
+        metrics=RunMetrics(),
+    )
+
+
+@pytest.fixture
+def mock_summary():
+    """Create a mock RunSummary."""
+    return RunSummary(
+        run_id="run_20260131_123456",
+        goal_id="test-goal",
+        status=RunStatus.COMPLETED,
+        duration_ms=60000,
+        decision_count=5,
+        success_rate=0.8,
+        problem_count=0,
+        narrative="Test run completed successfully",
+        started_at=datetime(2026, 1, 31, 12, 34, 56),
+    )
+
+
+def test_inspect_with_run_id(mock_run, capsys, tmp_path):
+    """Test inspecting a specific run by ID."""
+    args = Namespace(
+        agent_path="exports/test-agent",
+        run_id="run_20260131_123456",
+        json=False,
+    )
+
+    storage_path = tmp_path / "storage"
+    storage_path.mkdir()
+
+    with patch("framework.memory.cli._get_storage_path") as mock_get_path:
+        mock_get_path.return_value = storage_path
+
+        with patch("framework.memory.cli.FileStorage") as MockStorage:
+            mock_storage = MockStorage.return_value
+            mock_storage.load_run.return_value = mock_run
+
+            result = cmd_inspect(args)
+
+            assert result == 0
+            mock_storage.load_run.assert_called_once_with("run_20260131_123456")
+
+            captured = capsys.readouterr()
+            assert "run_20260131_123456" in captured.out
+            assert "test-goal" in captured.out
+            assert "completed" in captured.out.lower()
+
+            # CRITICAL: Verify Memory State is displayed
+            assert "Memory State:" in captured.out
+            assert "query: latest AI news" in captured.out
+            assert "search_results" in captured.out
+            assert "summary: Recent AI developments" in captured.out
+            assert "Total keys: 3" in captured.out
+
+
+def test_inspect_without_run_id_defaults_to_last(mock_run, capsys, tmp_path):
+    """Test inspecting last run when no run_id provided."""
+    args = Namespace(
+        agent_path="exports/test-agent",
+        run_id=None,
+        json=False,
+    )
+
+    storage_path = tmp_path / "storage"
+    storage_path.mkdir()
+
+    with patch("framework.memory.cli._get_storage_path") as mock_get_path:
+        mock_get_path.return_value = storage_path
+
+        with patch("framework.memory.cli.FileStorage") as MockStorage:
+            mock_storage = MockStorage.return_value
+            mock_storage.list_all_runs.return_value = ["run_older", "run_20260131_123456"]
+            mock_storage.load_run.return_value = mock_run
+
+            result = cmd_inspect(args)
+
+            assert result == 0
+            mock_storage.list_all_runs.assert_called_once()
+            mock_storage.load_run.assert_called_once_with("run_20260131_123456")
+
+            captured = capsys.readouterr()
+            assert "Memory State:" in captured.out
+
+
+def test_inspect_json_output(mock_run, capsys, tmp_path):
+    """Test JSON output format."""
+    args = Namespace(
+        agent_path="exports/test-agent",
+        run_id="run_20260131_123456",
+        json=True,
+    )
+
+    storage_path = tmp_path / "storage"
+    storage_path.mkdir()
+
+    with patch("framework.memory.cli._get_storage_path") as mock_get_path:
+        mock_get_path.return_value = storage_path
+
+        with patch("framework.memory.cli.FileStorage") as MockStorage:
+            mock_storage = MockStorage.return_value
+            mock_storage.load_run.return_value = mock_run
+
+            result = cmd_inspect(args)
+
+            assert result == 0
+
+            captured = capsys.readouterr()
+            output = json.loads(captured.out)
+
+            assert output["id"] == "run_20260131_123456"
+            assert output["goal_id"] == "test-goal"
+            assert output["status"] == "completed"
+
+            # CRITICAL: Verify output_data (memory) is in JSON
+            assert "output_data" in output
+            assert output["output_data"]["query"] == "latest AI news"
+            assert "search_results" in output["output_data"]
+            assert "summary" in output["output_data"]
+
+
+def test_inspect_empty_memory(mock_run_empty_memory, capsys, tmp_path):
+    """Test inspecting run with empty memory state."""
+    args = Namespace(
+        agent_path="exports/test-agent",
+        run_id="run_empty",
+        json=False,
+    )
+
+    storage_path = tmp_path / "storage"
+    storage_path.mkdir()
+
+    with patch("framework.memory.cli._get_storage_path") as mock_get_path:
+        mock_get_path.return_value = storage_path
+
+        with patch("framework.memory.cli.FileStorage") as MockStorage:
+            mock_storage = MockStorage.return_value
+            mock_storage.load_run.return_value = mock_run_empty_memory
+
+            result = cmd_inspect(args)
+
+            assert result == 0
+
+            captured = capsys.readouterr()
+            assert "Memory State: (empty)" in captured.out
+
+
+def test_inspect_storage_not_found(capsys, tmp_path):
+    """Test error when storage path doesn't exist."""
+    args = Namespace(
+        agent_path="exports/nonexistent-agent",
+        run_id="run_123",
+        json=False,
+    )
+
+    storage_path = tmp_path / "nonexistent"
+
+    with patch("framework.memory.cli._get_storage_path") as mock_get_path:
+        mock_get_path.return_value = storage_path
+
+        result = cmd_inspect(args)
+
+        assert result == 1
+
+        captured = capsys.readouterr()
+        assert "No memory found" in captured.err
+
+
+def test_inspect_no_runs_found(capsys, tmp_path):
+    """Test error when no runs exist and no run_id provided."""
+    args = Namespace(
+        agent_path="exports/test-agent",
+        run_id=None,
+        json=False,
+    )
+
+    storage_path = tmp_path / "storage"
+    storage_path.mkdir()
+
+    with patch("framework.memory.cli._get_storage_path") as mock_get_path:
+        mock_get_path.return_value = storage_path
+
+        with patch("framework.memory.cli.FileStorage") as MockStorage:
+            mock_storage = MockStorage.return_value
+            mock_storage.list_all_runs.return_value = []
+
+            result = cmd_inspect(args)
+
+            assert result == 1
+
+            captured = capsys.readouterr()
+            assert "No runs found" in captured.err
+
+
+def test_inspect_run_not_found(capsys, tmp_path):
+    """Test error when specific run doesn't exist."""
+    args = Namespace(
+        agent_path="exports/test-agent",
+        run_id="run_nonexistent",
+        json=False,
+    )
+
+    storage_path = tmp_path / "storage"
+    storage_path.mkdir()
+
+    with patch("framework.memory.cli._get_storage_path") as mock_get_path:
+        mock_get_path.return_value = storage_path
+
+        with patch("framework.memory.cli.FileStorage") as MockStorage:
+            mock_storage = MockStorage.return_value
+            mock_storage.load_run.return_value = None
+
+            result = cmd_inspect(args)
+
+            assert result == 1
+
+            captured = capsys.readouterr()
+            assert "run_nonexistent not found" in captured.err
+
+
+def test_get_storage_path_with_agent_path():
+    """Test extracting agent name from path."""
+    path = _get_storage_path("exports/my-agent")
+    assert path == Path.home() / ".hive" / "storage" / "my-agent"
+
+    path = _get_storage_path("my-agent")
+    assert path == Path.home() / ".hive" / "storage" / "my-agent"
+
+
+def test_get_storage_path_no_agent_exits():
+    """Test that missing agent path causes exit."""
+    with patch("framework.memory.cli.Path.cwd") as mock_cwd:
+        mock_cwd.return_value = Path("/some/random/path")
+
+        with pytest.raises(SystemExit) as exc_info:
+            _get_storage_path(None)
+
+        assert exc_info.value.code == 1
+
+
+def test_list_runs(mock_summary, capsys, tmp_path):
+    """Test listing runs."""
+    args = Namespace(
+        agent_path="exports/test-agent",
+        status=None,
+        goal=None,
+        limit=20,
+        json=False,
+    )
+
+    storage_path = tmp_path / "storage"
+    storage_path.mkdir()
+
+    with patch("framework.memory.cli._get_storage_path") as mock_get_path:
+        mock_get_path.return_value = storage_path
+
+        with patch("framework.memory.cli.FileStorage") as MockStorage:
+            mock_storage = MockStorage.return_value
+            mock_storage.list_all_runs.return_value = ["run_20260131_123456"]
+            mock_storage.load_summary.return_value = mock_summary
+
+            result = cmd_list(args)
+
+            assert result == 0
+
+            captured = capsys.readouterr()
+            assert "Found 1 run(s)" in captured.out
+            assert "run_20260131_123456" in captured.out
+            assert "test-goal" in captured.out
+
+
+def test_list_runs_with_status_filter(mock_summary, capsys, tmp_path):
+    """Test listing runs filtered by status."""
+    args = Namespace(
+        agent_path="exports/test-agent",
+        status="completed",
+        goal=None,
+        limit=20,
+        json=False,
+    )
+
+    storage_path = tmp_path / "storage"
+    storage_path.mkdir()
+
+    with patch("framework.memory.cli._get_storage_path") as mock_get_path:
+        mock_get_path.return_value = storage_path
+
+        with patch("framework.memory.cli.FileStorage") as MockStorage:
+            mock_storage = MockStorage.return_value
+            mock_storage.get_runs_by_status.return_value = ["run_20260131_123456"]
+            mock_storage.load_summary.return_value = mock_summary
+
+            result = cmd_list(args)
+
+            assert result == 0
+            mock_storage.get_runs_by_status.assert_called_once_with("completed")
+
+
+def test_list_runs_json_output(mock_summary, capsys, tmp_path):
+    """Test listing runs with JSON output."""
+    args = Namespace(
+        agent_path="exports/test-agent",
+        status=None,
+        goal=None,
+        limit=20,
+        json=True,
+    )
+
+    storage_path = tmp_path / "storage"
+    storage_path.mkdir()
+
+    with patch("framework.memory.cli._get_storage_path") as mock_get_path:
+        mock_get_path.return_value = storage_path
+
+        with patch("framework.memory.cli.FileStorage") as MockStorage:
+            mock_storage = MockStorage.return_value
+            mock_storage.list_all_runs.return_value = ["run_20260131_123456"]
+            mock_storage.load_summary.return_value = mock_summary
+
+            result = cmd_list(args)
+
+            assert result == 0
+
+            captured = capsys.readouterr()
+            output = json.loads(captured.out)
+            assert isinstance(output, list)
+            assert len(output) == 1
+
+
+def test_stats(capsys, tmp_path):
+    """Test statistics display."""
+    args = Namespace(
+        agent_path="exports/test-agent",
+        json=False,
+    )
+
+    storage_path = tmp_path / "storage"
+    storage_path.mkdir()
+
+    with patch("framework.memory.cli._get_storage_path") as mock_get_path:
+        mock_get_path.return_value = storage_path
+
+        with patch("framework.memory.cli.FileStorage") as MockStorage:
+            mock_storage = MockStorage.return_value
+            mock_storage.get_stats.return_value = {
+                "total_runs": 10,
+                "total_goals": 3,
+                "storage_path": str(storage_path),
+            }
+            mock_storage.get_runs_by_status.side_effect = lambda status: {
+                "completed": ["run1", "run2"],
+                "failed": ["run3"],
+                "running": [],
+                "stuck": [],
+                "cancelled": [],
+            }.get(status, [])
+
+            result = cmd_stats(args)
+
+            assert result == 0
+
+            captured = capsys.readouterr()
+            assert "Memory Statistics" in captured.out
+            assert "Total runs: 10" in captured.out
+            assert "Total goals: 3" in captured.out
+            assert "Completed: 2" in captured.out
+            assert "Failed: 1" in captured.out
+
+
+def test_stats_json_output(capsys, tmp_path):
+    """Test statistics with JSON output."""
+    args = Namespace(
+        agent_path="exports/test-agent",
+        json=True,
+    )
+
+    storage_path = tmp_path / "storage"
+    storage_path.mkdir()
+
+    with patch("framework.memory.cli._get_storage_path") as mock_get_path:
+        mock_get_path.return_value = storage_path
+
+        with patch("framework.memory.cli.FileStorage") as MockStorage:
+            mock_storage = MockStorage.return_value
+            mock_storage.get_stats.return_value = {
+                "total_runs": 10,
+                "total_goals": 3,
+                "storage_path": str(storage_path),
+            }
+            mock_storage.get_runs_by_status.return_value = []
+
+            result = cmd_stats(args)
+
+            assert result == 0
+
+            captured = capsys.readouterr()
+            output = json.loads(captured.out)
+            assert output["total_runs"] == 10
+            assert output["total_goals"] == 3
+            assert "by_status" in output

--- a/core/tests/test_memory_cli.py
+++ b/core/tests/test_memory_cli.py
@@ -392,6 +392,30 @@ def test_list_runs_json_output(mock_summary, capsys, tmp_path):
             assert len(output) == 1
 
 
+def test_list_runs_negative_limit(capsys, tmp_path):
+    """Test that negative limit returns error."""
+    args = Namespace(
+        agent_path="exports/test-agent",
+        status=None,
+        goal=None,
+        limit=-5,
+        json=False,
+    )
+
+    storage_path = tmp_path / "storage"
+    storage_path.mkdir()
+
+    with patch("framework.memory.cli._get_storage_path") as mock_get_path:
+        mock_get_path.return_value = storage_path
+
+        result = cmd_list(args)
+
+        assert result == 1
+
+        captured = capsys.readouterr()
+        assert "limit must be a positive number" in captured.err
+
+
 def test_stats(capsys, tmp_path):
     """Test statistics display."""
     args = Namespace(


### PR DESCRIPTION
  ## Description 
  Implements CLI tools for memory management as specified in issue #3010. Added hive memory inspect command that displays run.output_data (final
  SharedMemory state) as required by maintainer, plus bonus list and stats commands following the pattern of existing test-* commands.

  Type of Change

  - Bug fix (non-breaking change that fixes an issue)
  - New feature (non-breaking change that adds functionality)
  - Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - Documentation update
  - Refactoring (no functional changes)

  Related Issues

  Fixes #3010

  Changes Made

  - Added hive memory inspect command to view agent memory state
  - Added hive memory list command to list stored runs
  - Added hive memory stats command to show aggregate statistics
  - Displays run.output_data (final SharedMemory state) per maintainer requirement
  - Added 14 comprehensive tests covering all commands and error cases

  Testing

  Describe the tests you ran to verify your changes:

  - Unit tests pass (cd core && pytest tests/)
  - Lint passes (cd core && ruff check .)
  - Manual testing performed

  Checklist

  - My code follows the project's style guidelines
  - I have performed a self-review of my code
  - I have commented my code, particularly in hard-to-understand areas
  - I have made corresponding changes to the documentation
  - My changes generate no new warnings
  - I have added tests that prove my fix is effective or that my feature works
  - New and existing unit tests pass locally with my changes

  Screenshots (if applicable)

  N/A - CLI feature, no UI changes.