### PR TITLE
fix: use public list_tools API

### DIFF
--- a/core/MCP_INTEGRATION_GUIDE.md
+++ b/core/MCP_INTEGRATION_GUIDE.md
@@ -304,7 +304,7 @@ If you get connection errors with STDIO transport:
 If a tool is registered but not found:
 
 1. Verify the server registered successfully (check logs)
-2. List available tools: `runner._tool_registry.get_registered_names()`
+2. List available tools: `runner.list_tools()`
 3. Check tool name spelling in your node configuration
 
 ### HTTP Server Not Responding

--- a/core/examples/mcp_integration_example.py
+++ b/core/examples/mcp_integration_example.py
@@ -33,8 +33,8 @@ async def example_1_programmatic_registration():
     print(f"Registered {num_tools} tools from tools MCP server")
 
     # List all available tools
-    tools = runner._tool_registry.get_tools()
-    print(f"\nAvailable tools: {list(tools.keys())}")
+    tools = runner.list_tools()
+    print(f"\nAvailable tools: {tools}")
 
     # Run the agent with MCP tools available
     result = await runner.run(
@@ -85,8 +85,8 @@ async def example_3_config_file():
     runner = AgentRunner.load(test_agent_path)
 
     # Tools are automatically available
-    tools = runner._tool_registry.get_tools()
-    print(f"Available tools: {list(tools.keys())}")
+    tools = runner.list_tools()
+    print(f"Available tools: {tools}")
 
     # Cleanup
     runner.cleanup()

--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -367,8 +367,9 @@ def cmd_info(args: argparse.Namespace) -> int:
             print(f"  - [{c['type']}] {c['description']}")
         print()
         print(f"Required Tools ({len(info.required_tools)}):")
+        available_tools = set(runner.list_tools())
         for tool in info.required_tools:
-            status = "✓" if runner._tool_registry.has_tool(tool) else "✗"
+            status = "✓" if tool in available_tools else "✗"
             print(f"  {status} {tool}")
         print()
         print(f"Tools Module: {'✓ tools.py found' if info.has_tools_module else '✗ no tools.py'}")

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -369,6 +369,10 @@ class AgentRunner:
         """
         return self._tool_registry.discover_from_module(module_path)
 
+    def list_tools(self) -> list[str]:
+        """List registered tool names."""
+        return self._tool_registry.get_registered_names()
+
     def register_mcp_server(
         self,
         name: str,


### PR DESCRIPTION
## Summary
- add AgentRunner.list_tools as the public tool listing API
- update CLI, docs, and MCP example to avoid private registry access

## Test plan
- not run (docs/examples/CLI wiring only)