### PR TITLE
fix(examples): ensure UTF-8 stdout on Windows

### DIFF
--- a/core/examples/manual_agent.py
+++ b/core/examples/manual_agent.py
@@ -13,10 +13,16 @@ Run with:
 """
 
 import asyncio
+import sys
 
 from framework.graph import EdgeCondition, EdgeSpec, Goal, GraphSpec, NodeSpec
 from framework.graph.executor import GraphExecutor
 from framework.runtime.core import Runtime
+
+
+# Ensure emoji output works on Windows terminals.
+if sys.platform == "win32" and hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
 
 
 # 1. Define Node Logic (Pure Python Functions)


### PR DESCRIPTION
## Summary
- reconfigure stdout encoding on Windows so emoji output doesn't crash

## Test plan
- not run (example change)