### PR TITLE
fix(examples): add core path bootstrap

### DIFF
--- a/core/examples/manual_agent.py
+++ b/core/examples/manual_agent.py
@@ -13,6 +13,12 @@ Run with:
 """
 
 import asyncio
+import sys
+from pathlib import Path
+
+CORE_DIR = Path(__file__).resolve().parents[1]
+if str(CORE_DIR) not in sys.path:
+    sys.path.insert(0, str(CORE_DIR))
 
 from framework.graph import EdgeCondition, EdgeSpec, Goal, GraphSpec, NodeSpec
 from framework.graph.executor import GraphExecutor


### PR DESCRIPTION
## Summary
- add a core path bootstrap so manual_agent can import framework without PYTHONPATH

## Test plan
- not run (example change)