### PR TITLE
fix(mcp): guard loop state checks

### DIFF
--- a/core/framework/builder/workflow.py
+++ b/core/framework/builder/workflow.py
@@ -386,7 +386,7 @@ class GraphBuilder:
             if not any(e.target == node.id for e in self.session.edges):
                 entry_candidates.append(node.id)
 
-        if len(entry_candidates) == 0 and self.session.nodes:
+        if not entry_candidates and self.session.nodes:
             errors.append("No entry node found (all nodes have incoming edges)")
         elif len(entry_candidates) > 1:
             warnings.append(f"Multiple entry candidates: {entry_candidates}. Specify one.")

--- a/core/framework/runner/mcp_client.py
+++ b/core/framework/runner/mcp_client.py
@@ -87,7 +87,7 @@ class MCPClient:
         # If we have a persistent loop (for STDIO), use it
         if self._loop is not None:
             # Check if loop is running AND not closed
-            if self._loop.is_running() and not self._loop.is_closed():
+            if not self._loop.is_closed() and self._loop.is_running():
                 future = asyncio.run_coroutine_threadsafe(coro, self._loop)
                 return future.result()
             # else: fall through to the standard approach below


### PR DESCRIPTION
## Summary
- check event loop closed state before querying running state
- use idiomatic empty list check for entry candidates

## Test plan
- not run (low-risk change)