### PR TITLE
feat(tools): add parquet tool support

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -75,6 +75,9 @@ python mcp_server.py
 | `web_search`           | Search the web (Google or Brave, auto-detected) |
 | `web_scrape`           | Scrape and extract content from webpages       |
 | `pdf_read`             | Read and extract text from PDF files           |
+| `parquet_read`         | Read parquet files with filters/grouping       |
+| `parquet_write`        | Write parquet files                            |
+| `parquet_info`         | Inspect parquet metadata                       |
 
 ## Project Structure
 

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -39,6 +39,7 @@ from .file_system_toolkits.replace_file_content import (
 from .file_system_toolkits.view_file import register_tools as register_view_file
 from .file_system_toolkits.write_to_file import register_tools as register_write_to_file
 from .hubspot_tool import register_tools as register_hubspot
+from .parquet_tool import register_tools as register_parquet
 from .pdf_read_tool import register_tools as register_pdf_read
 from .web_scrape_tool import register_tools as register_web_scrape
 from .web_search_tool import register_tools as register_web_search
@@ -81,6 +82,7 @@ def register_all_tools(
     register_grep_search(mcp)
     register_execute_command(mcp)
     register_csv(mcp)
+    register_parquet(mcp)
 
     return [
         "example_tool",
@@ -100,6 +102,9 @@ def register_all_tools(
         "csv_append",
         "csv_info",
         "csv_sql",
+        "parquet_read",
+        "parquet_write",
+        "parquet_info",
         "send_email",
         "send_budget_alert_email",
         "hubspot_search_contacts",

--- a/tools/src/aden_tools/tools/parquet_tool/__init__.py
+++ b/tools/src/aden_tools/tools/parquet_tool/__init__.py
@@ -1,0 +1,3 @@
+from .parquet_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/parquet_tool/parquet_tool.py
+++ b/tools/src/aden_tools/tools/parquet_tool/parquet_tool.py
@@ -1,0 +1,283 @@
+"""Parquet Tool - Read and query Parquet files."""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+
+from fastmcp import FastMCP
+
+from ..file_system_toolkits.security import get_secure_path
+
+ALLOWED_OPERATORS = {"=", "!=", ">", "<", ">=", "<=", "in", "like"}
+ALLOWED_AGGREGATES = {"count", "sum", "avg", "min", "max"}
+ALLOWED_ORDER = {"asc", "desc"}
+IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _validate_identifier(name: str) -> bool:
+    return bool(IDENTIFIER_RE.match(name))
+
+
+def _error_invalid_identifier(name: str) -> dict:
+    return {"error": f"Invalid column name: {name}"}
+
+
+def _require_duckdb() -> tuple[object | None, dict | None]:
+    try:
+        import duckdb
+
+        return duckdb, None
+    except ImportError:
+        return None, {"error": "duckdb is required for parquet tools"}
+
+
+def _build_query(
+    table_expr: str,
+    selected_columns: list[str] | None,
+    filters: list[dict] | None,
+    group_by: list[str] | None,
+    order_by: list[dict] | None,
+    limit: int | None,
+    offset: int,
+    aggregates: list[dict] | None,
+) -> tuple[str, list[Any]] | tuple[None, dict]:
+    params: list[Any] = []
+
+    if selected_columns:
+        for col in selected_columns:
+            if not _validate_identifier(col):
+                return None, _error_invalid_identifier(col)
+
+    if group_by:
+        for col in group_by:
+            if not _validate_identifier(col):
+                return None, _error_invalid_identifier(col)
+
+    select_parts: list[str] = []
+    if group_by:
+        select_parts.extend(group_by)
+        if aggregates:
+            for agg in aggregates:
+                column = agg.get("column")
+                func = str(agg.get("op", "")).lower()
+                alias = agg.get("alias")
+                if not column or not _validate_identifier(column):
+                    return None, _error_invalid_identifier(str(column))
+                if func not in ALLOWED_AGGREGATES:
+                    return None, {"error": f"Unsupported aggregate: {func}"}
+                expr = f"{func}({column})"
+                if alias:
+                    if not _validate_identifier(alias):
+                        return None, _error_invalid_identifier(str(alias))
+                    expr = f"{expr} AS {alias}"
+                select_parts.append(expr)
+        else:
+            select_parts = group_by
+    elif selected_columns:
+        select_parts = selected_columns
+    else:
+        select_parts = ["*"]
+
+    where_parts: list[str] = []
+    if filters:
+        for condition in filters:
+            column = condition.get("column")
+            op = str(condition.get("op", "")).lower()
+            value = condition.get("value")
+            if not column or not _validate_identifier(column):
+                return None, _error_invalid_identifier(str(column))
+            if op not in ALLOWED_OPERATORS:
+                return None, {"error": f"Unsupported operator: {op}"}
+            if op == "in":
+                if not isinstance(value, list) or not value:
+                    return None, {"error": "IN operator requires a non-empty list value"}
+                placeholders = ", ".join(["?"] * len(value))
+                where_parts.append(f"{column} IN ({placeholders})")
+                params.extend(value)
+            else:
+                where_parts.append(f"{column} {op} ?")
+                params.append(value)
+
+    order_parts: list[str] = []
+    if order_by:
+        for entry in order_by:
+            column = entry.get("column")
+            direction = str(entry.get("direction", "asc")).lower()
+            if not column or not _validate_identifier(column):
+                return None, _error_invalid_identifier(str(column))
+            if direction not in ALLOWED_ORDER:
+                return None, {"error": f"Unsupported order direction: {direction}"}
+            order_parts.append(f"{column} {direction.upper()}")
+
+    query = f"SELECT {', '.join(select_parts)} FROM {table_expr}"
+
+    if where_parts:
+        query += " WHERE " + " AND ".join(where_parts)
+    if group_by:
+        query += " GROUP BY " + ", ".join(group_by)
+    if order_parts:
+        query += " ORDER BY " + ", ".join(order_parts)
+    if limit is not None:
+        query += " LIMIT ?"
+        params.append(limit)
+    if offset:
+        query += " OFFSET ?"
+        params.append(offset)
+
+    return query, params
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register parquet tools with the MCP server."""
+
+    @mcp.tool()
+    def parquet_read(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        limit: int | None = None,
+        offset: int = 0,
+        selected_columns: list[str] | None = None,
+        filters: list[dict] | None = None,
+        group_by: list[str] | None = None,
+        order_by: list[dict] | None = None,
+        aggregates: list[dict] | None = None,
+    ) -> dict:
+        """
+        Read a Parquet file and return its contents.
+
+        Supports filters, group by, and ordering via structured parameters.
+        """
+        if offset < 0 or (limit is not None and limit < 0):
+            return {"error": "offset and limit must be non-negative"}
+
+        if not path.lower().endswith(".parquet"):
+            return {"error": "File must have .parquet extension"}
+
+        duckdb, error = _require_duckdb()
+        if error:
+            return error
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            table_expr = "read_parquet(?)"
+            query, params_or_error = _build_query(
+                table_expr=table_expr,
+                selected_columns=selected_columns,
+                filters=filters,
+                group_by=group_by,
+                order_by=order_by,
+                limit=limit,
+                offset=offset,
+                aggregates=aggregates,
+            )
+            if not query:
+                return params_or_error
+
+            params = [secure_path, *params_or_error]
+
+            conn = duckdb.connect()
+            result = conn.execute(query, params).fetchdf()
+            rows = result.to_dict(orient="records")
+            columns = list(result.columns)
+
+            total_rows = conn.execute("SELECT COUNT(*) FROM read_parquet(?)", [secure_path]).fetchone()[0]
+
+            return {
+                "success": True,
+                "path": path,
+                "columns": columns,
+                "column_count": len(columns),
+                "rows": rows,
+                "row_count": len(rows),
+                "total_rows": total_rows,
+                "offset": offset,
+                "limit": limit,
+            }
+        except Exception as exc:
+            return {"error": f"Failed to read parquet: {str(exc)}"}
+
+    @mcp.tool()
+    def parquet_write(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        columns: list[str],
+        rows: list[dict],
+    ) -> dict:
+        """Write data to a Parquet file."""
+        if not path.lower().endswith(".parquet"):
+            return {"error": "File must have .parquet extension"}
+
+        if not columns:
+            return {"error": "columns cannot be empty"}
+
+        duckdb, error = _require_duckdb()
+        if error:
+            return error
+
+        try:
+            import pandas as pd
+
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+            parent_dir = os.path.dirname(secure_path)
+            if parent_dir:
+                os.makedirs(parent_dir, exist_ok=True)
+
+            df = pd.DataFrame(rows, columns=columns)
+            conn = duckdb.connect()
+            conn.register("data_df", df)
+            conn.execute("COPY data_df TO ? (FORMAT PARQUET)", [secure_path])
+
+            return {
+                "success": True,
+                "path": path,
+                "columns": columns,
+                "column_count": len(columns),
+                "rows_written": len(df),
+            }
+        except Exception as exc:
+            return {"error": f"Failed to write parquet: {str(exc)}"}
+
+    @mcp.tool()
+    def parquet_info(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> dict:
+        """Return metadata about a Parquet file."""
+        if not path.lower().endswith(".parquet"):
+            return {"error": "File must have .parquet extension"}
+
+        duckdb, error = _require_duckdb()
+        if error:
+            return error
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            conn = duckdb.connect()
+            describe = conn.execute("DESCRIBE SELECT * FROM read_parquet(?)", [secure_path]).fetchall()
+            columns = [row[0] for row in describe]
+            total_rows = conn.execute("SELECT COUNT(*) FROM read_parquet(?)", [secure_path]).fetchone()[0]
+
+            return {
+                "success": True,
+                "path": path,
+                "columns": columns,
+                "column_count": len(columns),
+                "total_rows": total_rows,
+                "file_size": os.path.getsize(secure_path),
+            }
+        except Exception as exc:
+            return {"error": f"Failed to read parquet info: {str(exc)}"}

--- a/tools/tests/tools/test_parquet_tool.py
+++ b/tools/tests/tools/test_parquet_tool.py
@@ -1,0 +1,163 @@
+"""Tests for parquet_tool - Read and query Parquet files."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.parquet_tool.parquet_tool import register_tools
+
+duckdb_available = importlib.util.find_spec("duckdb") is not None
+
+TEST_WORKSPACE_ID = "test-workspace"
+TEST_AGENT_ID = "test-agent"
+TEST_SESSION_ID = "test-session"
+
+
+@pytest.fixture
+def parquet_tools(mcp: FastMCP, tmp_path: Path):
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        register_tools(mcp)
+        yield {
+            "parquet_read": mcp._tool_manager._tools["parquet_read"].fn,
+            "parquet_write": mcp._tool_manager._tools["parquet_write"].fn,
+            "parquet_info": mcp._tool_manager._tools["parquet_info"].fn,
+        }
+
+
+@pytest.fixture
+def session_dir(tmp_path: Path) -> Path:
+    session_path = tmp_path / TEST_WORKSPACE_ID / TEST_AGENT_ID / TEST_SESSION_ID
+    session_path.mkdir(parents=True, exist_ok=True)
+    return session_path
+
+
+@pytest.fixture
+def basic_parquet(session_dir: Path):
+    if not duckdb_available:
+        pytest.skip("duckdb not installed")
+
+    import duckdb
+
+    parquet_file = session_dir / "basic.parquet"
+    conn = duckdb.connect()
+    conn.execute(
+        "CREATE TABLE data AS SELECT * FROM (VALUES (1, 'Alice', 30), (2, 'Bob', 25),"
+        " (3, 'Charlie', 35)) AS t(id, name, age)"
+    )
+    conn.execute("COPY data TO ? (FORMAT PARQUET)", [str(parquet_file)])
+    return parquet_file
+
+
+def test_parquet_read_basic(parquet_tools, basic_parquet, tmp_path):
+    if not duckdb_available:
+        pytest.skip("duckdb not installed")
+
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        result = parquet_tools["parquet_read"](
+            path="basic.parquet",
+            workspace_id=TEST_WORKSPACE_ID,
+            agent_id=TEST_AGENT_ID,
+            session_id=TEST_SESSION_ID,
+        )
+
+    assert result["success"] is True
+    assert result["column_count"] == 3
+    assert result["row_count"] == 3
+    assert result["total_rows"] == 3
+
+
+def test_parquet_read_with_filters(parquet_tools, basic_parquet, tmp_path):
+    if not duckdb_available:
+        pytest.skip("duckdb not installed")
+
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        result = parquet_tools["parquet_read"](
+            path="basic.parquet",
+            workspace_id=TEST_WORKSPACE_ID,
+            agent_id=TEST_AGENT_ID,
+            session_id=TEST_SESSION_ID,
+            filters=[{"column": "age", "op": ">", "value": 30}],
+        )
+
+    assert result["success"] is True
+    assert result["row_count"] == 1
+    assert result["rows"][0]["name"] == "Charlie"
+
+
+def test_parquet_read_group_by(parquet_tools, basic_parquet, tmp_path):
+    if not duckdb_available:
+        pytest.skip("duckdb not installed")
+
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        result = parquet_tools["parquet_read"](
+            path="basic.parquet",
+            workspace_id=TEST_WORKSPACE_ID,
+            agent_id=TEST_AGENT_ID,
+            session_id=TEST_SESSION_ID,
+            group_by=["age"],
+            aggregates=[{"column": "id", "op": "count", "alias": "count_id"}],
+            order_by=[{"column": "age", "direction": "desc"}],
+        )
+
+    assert result["success"] is True
+    assert result["rows"][0]["count_id"] == 1
+
+
+def test_parquet_info(parquet_tools, basic_parquet, tmp_path):
+    if not duckdb_available:
+        pytest.skip("duckdb not installed")
+
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        result = parquet_tools["parquet_info"](
+            path="basic.parquet",
+            workspace_id=TEST_WORKSPACE_ID,
+            agent_id=TEST_AGENT_ID,
+            session_id=TEST_SESSION_ID,
+        )
+
+    assert result["success"] is True
+    assert result["column_count"] == 3
+    assert result["total_rows"] == 3
+
+
+def test_parquet_write_and_read(parquet_tools, session_dir, tmp_path):
+    if not duckdb_available:
+        pytest.skip("duckdb not installed")
+
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        write_result = parquet_tools["parquet_write"](
+            path="written.parquet",
+            workspace_id=TEST_WORKSPACE_ID,
+            agent_id=TEST_AGENT_ID,
+            session_id=TEST_SESSION_ID,
+            columns=["id", "name"],
+            rows=[{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}],
+        )
+
+        assert write_result["success"] is True
+
+        read_result = parquet_tools["parquet_read"](
+            path="written.parquet",
+            workspace_id=TEST_WORKSPACE_ID,
+            agent_id=TEST_AGENT_ID,
+            session_id=TEST_SESSION_ID,
+        )
+
+    assert read_result["success"] is True
+    assert read_result["row_count"] == 2
+
+
+def test_parquet_extension_required(parquet_tools, session_dir, tmp_path):
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        result = parquet_tools["parquet_read"](
+            path="data.txt",
+            workspace_id=TEST_WORKSPACE_ID,
+            agent_id=TEST_AGENT_ID,
+            session_id=TEST_SESSION_ID,
+        )
+
+    assert "error" in result
+    assert ".parquet" in result["error"]


### PR DESCRIPTION
## Summary
- add parquet read/write/info tools with structured filters and grouping support
- register parquet tools in tool registry and document in tools README
- add tests for parquet tool behaviors

## Test plan
- not run (requires duckdb)