### PR TITLE
feat(tools): add read-only sqlite database tool

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -75,6 +75,8 @@ python mcp_server.py
 | `web_search`           | Search the web (Google or Brave, auto-detected) |
 | `web_scrape`           | Scrape and extract content from webpages       |
 | `pdf_read`             | Read and extract text from PDF files           |
+| `db_info`              | Inspect SQLite schemas (read-only)             |
+| `db_query`             | Run read-only SQLite queries                   |
 
 ## Project Structure
 

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 # Import register_tools from each tool module
 from .csv_tool import register_tools as register_csv
+from .database_tool import register_tools as register_database
 from .email_tool import register_tools as register_email
 from .example_tool import register_tools as register_example
 from .file_system_toolkits.apply_diff import register_tools as register_apply_diff
@@ -81,6 +82,7 @@ def register_all_tools(
     register_grep_search(mcp)
     register_execute_command(mcp)
     register_csv(mcp)
+    register_database(mcp)
 
     return [
         "example_tool",
@@ -100,6 +102,8 @@ def register_all_tools(
         "csv_append",
         "csv_info",
         "csv_sql",
+        "db_info",
+        "db_query",
         "send_email",
         "send_budget_alert_email",
         "hubspot_search_contacts",

--- a/tools/src/aden_tools/tools/database_tool/__init__.py
+++ b/tools/src/aden_tools/tools/database_tool/__init__.py
@@ -1,0 +1,3 @@
+from .database_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/database_tool/database_tool.py
+++ b/tools/src/aden_tools/tools/database_tool/database_tool.py
@@ -1,0 +1,114 @@
+"""Database Tool - Secure read-only SQLite access."""
+
+from __future__ import annotations
+
+import os
+import re
+import sqlite3
+
+from fastmcp import FastMCP
+
+from ..file_system_toolkits.security import get_secure_path
+
+FORBIDDEN_SQL = re.compile(
+    r"\b(attach|detach|pragma|alter|insert|update|delete|drop|create|replace)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_read_only_query(query: str) -> bool:
+    stripped = query.strip().strip(";")
+    if not stripped:
+        return False
+    if FORBIDDEN_SQL.search(stripped):
+        return False
+    return stripped.lower().startswith("select") or stripped.lower().startswith("with")
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register database tools with the MCP server."""
+
+    @mcp.tool()
+    def db_info(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> dict:
+        """Return table and column metadata for a SQLite database."""
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            conn = sqlite3.connect(f"file:{secure_path}?mode=ro", uri=True)
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+            )
+            tables = [row[0] for row in cursor.fetchall()]
+            table_info = {}
+            for table in tables:
+                cursor.execute(f"PRAGMA table_info('{table}')")
+                table_info[table] = [
+                    {
+                        "name": col[1],
+                        "type": col[2],
+                        "not_null": bool(col[3]),
+                        "default": col[4],
+                        "primary_key": bool(col[5]),
+                    }
+                    for col in cursor.fetchall()
+                ]
+
+            return {
+                "success": True,
+                "path": path,
+                "tables": tables,
+                "table_count": len(tables),
+                "schema": table_info,
+            }
+        except sqlite3.Error as exc:
+            return {"error": f"Database error: {str(exc)}"}
+        except Exception as exc:
+            return {"error": f"Failed to inspect database: {str(exc)}"}
+
+    @mcp.tool()
+    def db_query(
+        path: str,
+        query: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        limit: int = 1000,
+    ) -> dict:
+        """Execute a read-only SQL query against a SQLite database."""
+        if limit <= 0:
+            return {"error": "limit must be greater than zero"}
+
+        if not _is_read_only_query(query):
+            return {"error": "Only SELECT queries are allowed"}
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            conn = sqlite3.connect(f"file:{secure_path}?mode=ro", uri=True)
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+            wrapped_query = f"SELECT * FROM ({query.strip().strip(';')}) LIMIT ?"
+            cursor.execute(wrapped_query, (limit,))
+            rows = [dict(row) for row in cursor.fetchall()]
+
+            return {
+                "success": True,
+                "path": path,
+                "row_count": len(rows),
+                "rows": rows,
+                "limit": limit,
+            }
+        except sqlite3.Error as exc:
+            return {"error": f"Database error: {str(exc)}"}
+        except Exception as exc:
+            return {"error": f"Failed to execute query: {str(exc)}"}

--- a/tools/tests/tools/test_database_tool.py
+++ b/tools/tests/tools/test_database_tool.py
@@ -1,0 +1,86 @@
+"""Tests for database_tool - Read-only SQLite access."""
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.database_tool.database_tool import register_tools
+
+TEST_WORKSPACE_ID = "test-workspace"
+TEST_AGENT_ID = "test-agent"
+TEST_SESSION_ID = "test-session"
+
+
+@pytest.fixture
+def db_tools(mcp: FastMCP, tmp_path: Path):
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        register_tools(mcp)
+        yield {
+            "db_info": mcp._tool_manager._tools["db_info"].fn,
+            "db_query": mcp._tool_manager._tools["db_query"].fn,
+        }
+
+
+@pytest.fixture
+def session_dir(tmp_path: Path) -> Path:
+    session_path = tmp_path / TEST_WORKSPACE_ID / TEST_AGENT_ID / TEST_SESSION_ID
+    session_path.mkdir(parents=True, exist_ok=True)
+    return session_path
+
+
+@pytest.fixture
+def sample_db(session_dir: Path) -> Path:
+    db_path = session_dir / "sample.db"
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+    cursor.execute("INSERT INTO users (name) VALUES ('Alice'), ('Bob')")
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def test_db_info_lists_tables(db_tools, sample_db, tmp_path):
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        result = db_tools["db_info"](
+            path="sample.db",
+            workspace_id=TEST_WORKSPACE_ID,
+            agent_id=TEST_AGENT_ID,
+            session_id=TEST_SESSION_ID,
+        )
+
+    assert result["success"] is True
+    assert "users" in result["tables"]
+    assert result["table_count"] == 1
+
+
+def test_db_query_select(db_tools, sample_db, tmp_path):
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        result = db_tools["db_query"](
+            path="sample.db",
+            query="SELECT name FROM users ORDER BY id",
+            workspace_id=TEST_WORKSPACE_ID,
+            agent_id=TEST_AGENT_ID,
+            session_id=TEST_SESSION_ID,
+        )
+
+    assert result["success"] is True
+    assert result["row_count"] == 2
+    assert result["rows"][0]["name"] == "Alice"
+
+
+def test_db_query_rejects_non_select(db_tools, sample_db, tmp_path):
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        result = db_tools["db_query"](
+            path="sample.db",
+            query="DELETE FROM users",
+            workspace_id=TEST_WORKSPACE_ID,
+            agent_id=TEST_AGENT_ID,
+            session_id=TEST_SESSION_ID,
+        )
+
+    assert "error" in result
+    assert "select" in result["error"].lower()


### PR DESCRIPTION
## Summary
- add db_info and db_query tools for read-only SQLite access
- register new tools and document them in the tools README
- include unit tests covering common cases

## Test plan
- not run (tests added)