### PR TITLE
feat: inject runtime datetime into LLM system prompts

### DIFF
--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -20,6 +20,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import UTC
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -1514,6 +1515,8 @@ Do NOT fabricate data or return empty objects."""
 
     def _build_system_prompt(self, ctx: NodeContext) -> str:
         """Build the system prompt."""
+        from datetime import datetime
+
         parts = []
 
         if ctx.node_spec.system_prompt:
@@ -1535,6 +1538,15 @@ Do NOT fabricate data or return empty objects."""
                     pass
 
             parts.append(prompt)
+
+        # Inject current datetime so LLM knows "now"
+        utc_dt = datetime.now(UTC)
+        local_dt = datetime.now().astimezone()
+        local_tz_name = local_dt.tzname() or "Unknown"
+        parts.append("\n## Runtime Context")
+        parts.append(f"- Current Date/Time (UTC): {utc_dt.isoformat()}")
+        parts.append(f"- Local Timezone: {local_tz_name}")
+        parts.append(f"- Current Date/Time (Local): {local_dt.isoformat()}")
 
         if ctx.goal_context:
             parts.append("\n# Goal Context")


### PR DESCRIPTION
Injects runtime datetime into LLM system prompts so agents know "now" instead of hallucinating dates from training data.                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                       
  ## Type of Change                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                       
  - [ ] Bug fix (non-breaking change that fixes an issue)                                                                                                                                                                                                                                              
  - [x] New feature (non-breaking change that adds functionality)                                                                                                                                                                                                                                      
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)                                                                                                                                                                                               
  - [ ] Documentation update                                                                                                                                                                                                                                                                           
  - [ ] Refactoring (no functional changes)                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                       
  ## Related Issues                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                       
  Fixes #3292                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                       
  ## Changes Made                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                       
  - Added datetime injection in `LLMNode._build_system_prompt()`                                                                                                                                                                                                                                       
  - Injects UTC time, local timezone name, and local time                                                                                                                                                                                                                                              
  - All LLM agents now automatically receive runtime context                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                       
  ## Testing                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                       
  - [x] Unit tests pass (`cd core && pytest tests/`)                                                                                                                                                                                                                                                   
  - [x] Lint passes (`cd core && ruff check .`)                                                                                                                                                                                                                                                        
  - [x] Manual testing performed                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                       
  ## Checklist                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                       
  - [x] My code follows the project's style guidelines                                                                                                                                                                                                                                                 
  - [x] I have performed a self-review of my code                                                                                                                                                                                                                                                      
  - [ ] I have commented my code, particularly in hard-to-understand areas                                                                                                                                                                                                                             
  - [ ] I have made corresponding changes to the documentation                                                                                                                                                                                                                                         
  - [x] My changes generate no new warnings                                                                                                                                                                                                                                                            
  - [ ] I have added tests that prove my fix is effective or that my feature works                                                                                                                                                                                                                     
  - [x] New and existing unit tests pass locally with my changes                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                       
  ## Screenshots (if applicable)                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                       
  **What agents see now:**                                                                                                                                                                                                                                                                             
  Runtime Context                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                       
  - Current Date/Time (UTC): 2026-02-02T19:27:36.229466+00:00                                                                                                                                                                                                                                          
  - Local Timezone: PST                                                                                                                                                                                                                                                                                
  - Current Date/Time (Local): 2026-02-02T11:27:36.229469-08:00        