### PR TITLE
docs: add local LLM setup guide for Windows users

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,47 @@ You may submit PRs without prior assignment for:
   | Typos & Documentation & Linting | Refactoring for "clean code" |
   | No logic/API/DB changes | New features (even tiny ones) |
 
+## Good First Contributions
+
+Not sure where to start? Here are some beginner-friendly ways to contribute:
+
+### Recommended Entry Points
+
+- **Documentation fixes** — Fix typos, clarify instructions, or fill in missing docs. These don't require issue assignment (see [Exceptions](#exceptions-no-assignment-needed)).
+- **Example agents** — Add or improve example agents in `exports/`. Great for learning the framework while contributing.
+- **Issue triage** — Help label and reproduce reported bugs. Clear reproduction steps make issues easier to fix.
+- **Test coverage** — Add tests for untested code paths in `core/` or `tools/`.
+- **Integrations and tools** — Build new MCP tools. See [#2805](https://github.com/adenhq/hive/issues/2805) for the integration wishlist.
+
+### Running Checks Locally
+
+Before submitting any PR, make sure your changes pass:
+
+```bash
+make check    # Lint and format checks
+make test     # Run core tests
+```
+
+This catches most issues before CI runs and speeds up the review process.
+
+### Understanding Labels
+
+When browsing issues, these labels help you find the right fit:
+
+| Label | Meaning |
+|-------|---------|
+| `good first issue` | Suitable for newcomers — limited scope, clear requirements |
+| `help wanted` | Maintainers are actively looking for contributors |
+| `bug` | Something is broken and needs fixing |
+| `enhancement` | A new feature or improvement |
+| `documentation` | Docs-related changes |
+| `integrations` | New tool or service integrations |
+| `backlog` | Acknowledged but not yet prioritized |
+
+> **Tip:** Filter issues by [`good first issue`](https://github.com/adenhq/hive/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) or [`help wanted`](https://github.com/adenhq/hive/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) to find work suited to your experience level.
+
+---
+
 ## Getting Started
 
 1. Fork the repository

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Hive supports 100+ LLM providers through LiteLLM integration, including OpenAI (
 
 **Q: Can I use Hive with local AI models like Ollama?**
 
-Yes! Hive supports local models through LiteLLM. Simply use the model name format `ollama/model-name` (e.g., `ollama/llama3`, `ollama/mistral`) and ensure Ollama is running locally.
+Yes! Hive supports local models through LiteLLM. Simply use the model name format `ollama/model-name` (e.g., `ollama/llama3`, `ollama/mistral`) and ensure Ollama is running locally. See the [Local LLM Setup Guide for Windows](docs/local-llm-windows-setup.md) for detailed instructions.
 
 **Q: What makes Hive different from other agent frameworks?**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -167,7 +167,8 @@ PYTHONPATH=exports uv run python -m my_agent test --type success
 1. **TUI Dashboard**: Run `hive tui` to explore agents interactively
 2. **Detailed Setup**: See [environment-setup.md](./environment-setup.md)
 3. **Developer Guide**: See [developer-guide.md](./developer-guide.md)
-4. **Build Agents**: Use `/hive` skill in Claude Code
+4. **Local LLMs**: See [Local LLM Setup for Windows](local-llm-windows-setup.md)
+5. **Build Agents**: Use `/hive` skill in Claude Code
 5. **Custom Tools**: Learn to integrate MCP servers
 6. **Join Community**: [Discord](https://discord.com/invite/MXE49hrKDk)
 

--- a/docs/local-llm-windows-setup.md
+++ b/docs/local-llm-windows-setup.md
@@ -1,0 +1,193 @@
+# Using Local LLMs with Hive on Windows
+
+Guide for running Hive with local language models (Ollama) on Windows. No API keys or cloud services required.
+
+## Prerequisites
+
+- Python 3.11+ installed
+- Hive set up and running (see [Environment Setup](../ENVIRONMENT_SETUP.md))
+- One of: WSL, PowerShell, or Git Bash
+
+## Installing Ollama
+
+1. Download Ollama from [ollama.com/download](https://ollama.com/download/windows)
+2. Run the installer
+3. Verify installation:
+
+```powershell
+ollama --version
+```
+
+Ollama runs as a background service on `http://localhost:11434` after installation.
+
+## Pulling a Model
+
+Download a model before using it with Hive:
+
+```powershell
+# Pull a model (runs once, downloads to local storage)
+ollama pull llama3
+ollama pull mistral
+
+# List downloaded models
+ollama list
+
+# Verify a model works
+ollama run llama3 "Hello, world"
+```
+
+### Recommended Models for Getting Started
+
+| Model | Size | Notes |
+|-------|------|-------|
+| `llama3` | ~4.7 GB | Good general-purpose model |
+| `mistral` | ~4.1 GB | Fast, good for code tasks |
+| `phi3` | ~2.3 GB | Smaller, runs on less RAM |
+| `codellama` | ~3.8 GB | Optimized for code generation |
+
+> **Note:** Larger models need more RAM. 8 GB RAM minimum for 7B parameter models, 16 GB+ recommended for 13B+.
+
+## Configuring Hive to Use Ollama
+
+### Option 1: Set Model in Agent Config
+
+In your agent's `config.py` (`exports/your_agent/config.py`):
+
+```python
+CONFIG = {
+    "model": "ollama/llama3",  # Use ollama/ prefix + model name
+    "max_tokens": 4096,
+    "temperature": 0.7,
+}
+```
+
+### Option 2: Override via Environment Variable
+
+If the agent supports model override via environment:
+
+PowerShell:
+```powershell
+$env:AGENT_MODEL="ollama/llama3"
+```
+
+WSL / Git Bash:
+```bash
+export AGENT_MODEL="ollama/llama3"
+```
+
+### Running an Agent with Ollama
+
+Make sure Ollama is running, then:
+
+PowerShell:
+```powershell
+$env:PYTHONPATH="core;exports"
+python -m your_agent_name run --input '{"task": "Your input here"}'
+```
+
+WSL / Git Bash:
+```bash
+PYTHONPATH=core:exports python -m your_agent_name run --input '{"task": "Your input here"}'
+```
+
+No API key is needed — Hive's LiteLLM integration detects the `ollama/` prefix and connects to your local Ollama server automatically.
+
+## Using a Custom Ollama Host
+
+If Ollama runs on a different machine or port, set the base URL:
+
+PowerShell:
+```powershell
+$env:OLLAMA_API_BASE="http://192.168.1.100:11434"
+```
+
+WSL / Git Bash:
+```bash
+export OLLAMA_API_BASE="http://192.168.1.100:11434"
+```
+
+## Optional: Hugging Face Models via LiteLLM
+
+LiteLLM also supports Hugging Face Inference API:
+
+1. Get an API token from [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens)
+2. Set the environment variable:
+
+PowerShell:
+```powershell
+$env:HUGGINGFACE_API_KEY="hf_..."
+```
+
+WSL / Git Bash:
+```bash
+export HUGGINGFACE_API_KEY="hf_..."
+```
+
+3. Use the model in your agent config:
+```python
+CONFIG = {
+    "model": "huggingface/meta-llama/Llama-3-8B-Instruct",
+}
+```
+
+See [LiteLLM Hugging Face docs](https://docs.litellm.ai/docs/providers/huggingface) for supported models.
+
+## Troubleshooting
+
+### Ollama not responding
+
+```powershell
+# Check if Ollama is running
+ollama list
+
+# If not running, start it
+ollama serve
+```
+
+On Windows, Ollama usually starts automatically as a system service. If it doesn't, launch it from the Start menu or run `ollama serve` in a terminal.
+
+### Connection refused errors
+
+Verify Ollama is listening:
+
+```powershell
+curl http://localhost:11434/api/tags
+```
+
+If using WSL, note that `localhost` inside WSL may not reach the Windows host. Use the Windows host IP instead:
+
+```bash
+# Find your Windows host IP from WSL
+cat /etc/resolv.conf | grep nameserver
+# Use that IP:
+export OLLAMA_API_BASE="http://<windows-ip>:11434"
+```
+
+### Model not found
+
+```powershell
+# List available models
+ollama list
+
+# Pull the model if missing
+ollama pull llama3
+```
+
+### Out of memory
+
+- Close other applications to free RAM
+- Use a smaller model (e.g., `phi3` instead of `llama3`)
+- Check model requirements with `ollama show llama3`
+
+### Slow responses
+
+- Local inference speed depends on your hardware (CPU/GPU)
+- GPU acceleration requires compatible NVIDIA GPU with CUDA
+- For CPU-only systems, smaller models (phi3, tinyllama) respond faster
+
+## Further Reading
+
+- [Ollama documentation](https://ollama.com/)
+- [LiteLLM providers](https://docs.litellm.ai/docs/providers)
+- [Hive Configuration Guide](configuration.md)
+- [Hive Environment Setup](../ENVIRONMENT_SETUP.md)


### PR DESCRIPTION
## Summary

- Adds `docs/local-llm-windows-setup.md` covering Ollama installation, model setup, Hive configuration, and troubleshooting for Windows users
- Updates README FAQ with a link to the new guide
- Adds a cross-reference in `docs/getting-started.md` under Next Steps

Closes #3208

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm all external links resolve (Ollama, LiteLLM, Hugging Face)
- [ ] Check internal cross-references from README and getting-started.md