### PR TITLE
feat(contributing): add guidance for non-code contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,33 @@ You may submit PRs without prior assignment for:
   | Typos & Documentation & Linting | Refactoring for "clean code" |
   | No logic/API/DB changes | New features (even tiny ones) |
 
+## How You Can Contribute
+
+Hive welcomes contributions beyond code. Here are ways to get involved based on your background:
+
+### Documentation
+
+- Improve or add guides, tutorials, and examples
+- Fix typos, broken links, or unclear instructions
+- Translate documentation (see `docs/i18n/`)
+- No dev environment setup needed — edit files directly on GitHub
+
+### Design & UX
+
+- Create diagrams explaining agent architecture or workflows
+- Design UI mockups for the observability dashboard
+- Improve the visual presentation of documentation
+- Propose UX improvements for CLI tools and setup flows
+
+### Product & Project Management
+
+- Help triage and label open issues
+- Write clear reproduction steps for bug reports
+- Draft feature proposals with user stories and acceptance criteria
+- Provide feedback on the roadmap (see [ROADMAP.md](ROADMAP.md))
+
+> **Tip:** Non-code contributions don't require a local dev setup. You can fork the repo, edit files on GitHub, and submit a PR directly.
+
 ## Getting Started
 
 1. Fork the repository


### PR DESCRIPTION
## Summary

- Adds a "How You Can Contribute" section to `CONTRIBUTING.md` for designers, PMs, and documentation contributors
- Covers three areas: Documentation, Design & UX, and Product & Project Management
- Placed before the technical "Getting Started" section so non-code contributors see their options first

Related to #1847

Closes #3215

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm ROADMAP.md and docs/i18n/ links resolve
- [ ] Check section placement flows logically in the document