### PR TITLE
docs(getting-started): clarify project root and agent name for run commands

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -114,6 +114,8 @@ hive/
 
 ## Running an Agent
 
+Run these commands from the project root (the `hive/` directory). Replace `my_agent` with your agent's package name (the folder name under `exports/`).
+
 ```bash
 # Validate agent structure
 PYTHONPATH=core:exports python -m my_agent validate


### PR DESCRIPTION
## Description

Clarify in getting-started that agent run commands must be run from the project root (the `hive/` directory) and that `my_agent` is a placeholder for the agent package name (the folder under `exports/`). Reduces ModuleNotFoundError and copy-paste confusion for first-time users.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Docs-only change per [CONTRIBUTING.md](https://github.com/adenhq/hive/blob/main/CONTRIBUTING.md#exceptions-no-assignment-needed) (no issue required).

## Changes Made

- Added one short paragraph before the "Running an Agent" code block in `docs/getting-started.md` stating: (1) run commands from project root, (2) replace `my_agent` with your agent's package name (folder under `exports/`).

## Testing

- [x] No code changes; docs only.
- [x] Lint passes (`make check`).
- [x] Read-through to ensure wording is clear.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (this PR is docs-only)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally (N/A — documentation only)