### PR TITLE
fix(docs): broken example agents link in ENVIRONMENT_SETUP.md

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -557,7 +557,7 @@ export AGENT_STORAGE_PATH="/custom/storage"
 
 - **Framework Documentation:** [core/README.md](core/README.md)
 - **Tools Documentation:** [tools/README.md](tools/README.md)
-- **Example Agents:** [exports/](exports/)
+- **Example Agents:** [core/examples/](core/examples/)
 - **Agent Building Guide:** [.claude/skills/building-agents-construction/SKILL.md](.claude/skills/building-agents-construction/SKILL.md)
 - **Testing Guide:** [.claude/skills/testing-agent/SKILL.md](.claude/skills/testing-agent/SKILL.md)
 


### PR DESCRIPTION
## Summary

- Fixes broken `exports/` link in ENVIRONMENT_SETUP.md Additional Resources section
- Points to `core/examples/` which contains the actual example agents

Closes #3320

## Test plan

- [ ] Verify `core/examples/` link resolves on GitHub