### PR TITLE
fix: use venv locations to verify installation

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -593,9 +593,9 @@ echo ""
 
 ERRORS=0
 
-# Test imports
+# Test imports (CORE_PYTHON and TOOLS_PYTHON set in Step 3)
 echo -n "  ⬡ framework... "
-if $PYTHON_CMD -c "import framework" > /dev/null 2>&1; then
+if [ -f "$CORE_PYTHON" ] && $CORE_PYTHON -c "import framework" > /dev/null 2>&1; then
     echo -e "${GREEN}ok${NC}"
 else
     echo -e "${RED}failed${NC}"
@@ -603,7 +603,7 @@ else
 fi
 
 echo -n "  ⬡ aden_tools... "
-if $PYTHON_CMD -c "import aden_tools" > /dev/null 2>&1; then
+if [ -f "$TOOLS_PYTHON" ] && $TOOLS_PYTHON -c "import aden_tools" > /dev/null 2>&1; then
     echo -e "${GREEN}ok${NC}"
 else
     echo -e "${RED}failed${NC}"
@@ -611,7 +611,7 @@ else
 fi
 
 echo -n "  ⬡ litellm... "
-if $PYTHON_CMD -c "import litellm" > /dev/null 2>&1; then
+if [ -f "$CORE_PYTHON" ] && $CORE_PYTHON -c "import litellm" > /dev/null 2>&1; then
     echo -e "${GREEN}ok${NC}"
 else
     echo -e "${YELLOW}--${NC}"


### PR DESCRIPTION
## Description

The quickstart script incorrectly uses system Python to verify installations in "Step 4: Verify setup". Core and tools have separate venvs and those venvs should be used for the verification checks.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #3333 

## Changes Made

- In Step 4 "Verify installation", use `CORE_PYTHON` (core venv) for `framework` and `litellm` import checks instead of `$PYTHON_CMD`.
- In Step 4, use `TOOLS_PYTHON` (tools venv) for `aden_tools` import check instead of `$PYTHON_CMD`.
- Reuse `CORE_PYTHON` and `TOOLS_PYTHON` already set in Step 3; add a short comment in Step 4 that these variables come from Step 3.

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed (run `./quickstart.sh` through Step 4; framework and aden_tools verification now pass)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A