### PR TITLE
[Integration] feat(tools): add BigQuery MCP tool for SQL querying and data analysis

### DIFF
--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "litellm>=1.81.0",
     "resend>=2.0.0",
     "framework",
-    "google-cloud-bigquery>=3.0.0",
+    
 ]
 
 [project.optional-dependencies]

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "litellm>=1.81.0",
     "resend>=2.0.0",
     "framework",
+    "google-cloud-bigquery>=3.0.0",
 ]
 
 [project.optional-dependencies]
@@ -51,12 +52,16 @@ excel = [
 sql = [
     "duckdb>=1.0.0",
 ]
+bigquery = [
+    "google-cloud-bigquery>=3.0.0",
+]
 all = [
     "RestrictedPython>=7.0",
     "pytesseract>=0.3.10",
     "pillow>=10.0.0",
     "duckdb>=1.0.0",
     "openpyxl>=3.1.0",
+    "google-cloud-bigquery>=3.0.0",
 ]
 
 [tool.uv.sources]

--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -53,6 +53,7 @@ To add a new credential:
 
 from .apollo import APOLLO_CREDENTIALS
 from .base import CredentialError, CredentialSpec
+from .bigquery import BIGQUERY_CREDENTIALS
 from .browser import get_aden_auth_url, get_aden_setup_url, open_browser
 from .email import EMAIL_CREDENTIALS
 from .gcp_vision import GCP_VISION_CREDENTIALS
@@ -88,6 +89,7 @@ CREDENTIAL_SPECS = {
     **SLACK_CREDENTIALS,
     **SERPAPI_CREDENTIALS,
     **TELEGRAM_CREDENTIALS,
+    **BIGQUERY_CREDENTIALS,
 }
 
 __all__ = [
@@ -124,4 +126,5 @@ __all__ = [
     "APOLLO_CREDENTIALS",
     "SERPAPI_CREDENTIALS",
     "TELEGRAM_CREDENTIALS",
+    "BIGQUERY_CREDENTIALS",
 ]

--- a/tools/src/aden_tools/credentials/bigquery.py
+++ b/tools/src/aden_tools/credentials/bigquery.py
@@ -1,0 +1,28 @@
+"""
+BigQuery tool credentials.
+
+Contains credentials for Google BigQuery data warehouse access.
+"""
+
+from .base import CredentialSpec
+
+BIGQUERY_CREDENTIALS = {
+    "bigquery_credentials": CredentialSpec(
+        env_var="GOOGLE_APPLICATION_CREDENTIALS",
+        tools=["run_bigquery_query", "describe_dataset"],
+        node_types=[],
+        required=False,  # Falls back to ADC if not set
+        startup_required=False,
+        help_url="https://cloud.google.com/bigquery/docs/authentication/service-account-file",
+        description="Path to Google Cloud service account JSON file for BigQuery access",
+    ),
+    "bigquery_project": CredentialSpec(
+        env_var="BIGQUERY_PROJECT_ID",
+        tools=["run_bigquery_query", "describe_dataset"],
+        node_types=[],
+        required=False,  # Can be specified per-call or inferred from credentials
+        startup_required=False,
+        help_url="https://cloud.google.com/resource-manager/docs/creating-managing-projects",
+        description="Default Google Cloud project ID for BigQuery queries",
+    ),
+}

--- a/tools/src/aden_tools/credentials/bigquery.py
+++ b/tools/src/aden_tools/credentials/bigquery.py
@@ -7,22 +7,44 @@ Contains credentials for Google BigQuery data warehouse access.
 from .base import CredentialSpec
 
 BIGQUERY_CREDENTIALS = {
-    "bigquery_credentials": CredentialSpec(
+    "bigquery": CredentialSpec(
         env_var="GOOGLE_APPLICATION_CREDENTIALS",
         tools=["run_bigquery_query", "describe_dataset"],
-        node_types=[],
         required=False,  # Falls back to ADC if not set
         startup_required=False,
         help_url="https://cloud.google.com/bigquery/docs/authentication/service-account-file",
         description="Path to Google Cloud service account JSON file for BigQuery access",
+        # Auth method support
+        aden_supported=False,
+        direct_api_key_supported=True,
+        api_key_instructions="""To set up BigQuery authentication:
+
+Option 1: Service Account (Recommended for production)
+1. Go to Google Cloud Console > IAM & Admin > Service Accounts
+2. Create a service account or select existing one
+3. Grant roles: "BigQuery Data Viewer" and "BigQuery Job User"
+4. Create a JSON key and download it
+5. Set GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json
+
+Option 2: Application Default Credentials (For local development)
+1. Install Google Cloud SDK: https://cloud.google.com/sdk/docs/install
+2. Run: gcloud auth application-default login
+3. Select your project when prompted""",
+        # Credential store mapping
+        credential_id="bigquery",
+        credential_key="service_account_json_path",
     ),
     "bigquery_project": CredentialSpec(
         env_var="BIGQUERY_PROJECT_ID",
         tools=["run_bigquery_query", "describe_dataset"],
-        node_types=[],
-        required=False,  # Can be specified per-call or inferred from credentials
+        required=False,
         startup_required=False,
         help_url="https://cloud.google.com/resource-manager/docs/creating-managing-projects",
         description="Default Google Cloud project ID for BigQuery queries",
+        aden_supported=False,
+        direct_api_key_supported=True,
+        api_key_instructions="Set this to your Google Cloud project ID (e.g., 'my-project-123')",
+        credential_id="bigquery_project",
+        credential_key="project_id",
     ),
 }

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 # Import register_tools from each tool module
 from .apollo_tool import register_tools as register_apollo
+from .bigquery_tool import register_tools as register_bigquery
 from .csv_tool import register_tools as register_csv
 from .email_tool import register_tools as register_email
 from .example_tool import register_tools as register_example
@@ -90,6 +91,7 @@ def register_all_tools(
     register_telegram(mcp, credentials=credentials)
     register_vision(mcp, credentials=credentials)
     register_google_maps(mcp, credentials=credentials)
+    register_bigquery(mcp, credentials=credentials)
 
     # Register file system toolkits
     register_view_file(mcp)
@@ -176,7 +178,6 @@ def register_all_tools(
         "query_runtime_logs",
         "query_runtime_log_details",
         "query_runtime_log_raw",
-        # SerpAPI tools (Google Scholar & Patents)
         "scholar_search",
         "scholar_get_citations",
         "scholar_get_author",
@@ -197,7 +198,6 @@ def register_all_tools(
         "slack_remove_reaction",
         "slack_list_users",
         "slack_upload_file",
-        # Advanced Slack tools
         "slack_search_messages",
         "slack_get_thread_replies",
         "slack_pin_message",
@@ -209,38 +209,28 @@ def register_all_tools(
         "slack_send_dm",
         "slack_get_permalink",
         "slack_send_ephemeral",
-        # Block Kit & Views
         "slack_post_blocks",
         "slack_open_modal",
         "slack_update_home_tab",
-        # Phase 2: User Status & Presence
         "slack_set_status",
         "slack_set_presence",
         "slack_get_presence",
-        # Phase 2: Reminders
         "slack_create_reminder",
         "slack_list_reminders",
         "slack_delete_reminder",
-        # Phase 2: User Groups
         "slack_create_usergroup",
         "slack_update_usergroup_members",
         "slack_list_usergroups",
-        # Phase 2: Emoji
         "slack_list_emoji",
-        # Phase 2: Canvas
         "slack_create_canvas",
         "slack_edit_canvas",
-        # Phase 2: Analytics (AI-Driven)
         "slack_get_messages_for_analysis",
-        # Phase 2: Workflow
         "slack_trigger_workflow",
-        # Phase 3: Critical Power Tools
         "slack_get_conversation_context",
         "slack_find_user_by_email",
         "slack_kick_user_from_channel",
         "slack_delete_file",
         "slack_get_team_stats",
-        # Vision tools
         "vision_detect_labels",
         "vision_detect_text",
         "vision_detect_faces",
@@ -252,13 +242,14 @@ def register_all_tools(
         "vision_safe_search",
         "telegram_send_message",
         "telegram_send_document",
-        # Google Maps tools
         "maps_geocode",
         "maps_reverse_geocode",
         "maps_directions",
         "maps_distance_matrix",
         "maps_place_details",
         "maps_place_search",
+        "run_bigquery_query",
+        "describe_dataset",
     ]
 
 

--- a/tools/src/aden_tools/tools/bigquery_tool/README.md
+++ b/tools/src/aden_tools/tools/bigquery_tool/README.md
@@ -1,0 +1,207 @@
+# BigQuery Tool
+
+Execute SQL queries and explore datasets in Google BigQuery.
+
+## Features
+
+- **`run_bigquery_query`**: Execute read-only SQL queries and return structured results
+- **`describe_dataset`**: List tables and schemas in a dataset for query planning
+
+## Setup
+
+### 1. Install Dependencies
+
+The BigQuery tool requires `google-cloud-bigquery`:
+
+```bash
+pip install google-cloud-bigquery>=3.0.0
+```
+
+### 2. Configure Authentication
+
+Choose one of the following authentication methods:
+
+#### Option A: Service Account (Recommended for Production)
+
+1. Create a service account in Google Cloud Console
+2. Grant the following roles:
+   - `BigQuery Data Viewer` (to read data)
+   - `BigQuery Job User` (to run queries)
+3. Download the JSON key file
+4. Set the environment variable:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account.json"
+```
+
+#### Option B: Application Default Credentials (For Local Development)
+
+```bash
+gcloud auth application-default login
+```
+
+### 3. Set Default Project (Optional)
+
+If your queries don't specify a project, set a default:
+
+```bash
+export BIGQUERY_PROJECT_ID="your-project-id"
+```
+
+## Usage
+
+### Run a Query
+
+```python
+result = run_bigquery_query(
+    sql="SELECT name, COUNT(*) as count FROM `project.dataset.table` GROUP BY name",
+    max_rows=100
+)
+
+if result.get("success"):
+    for row in result["rows"]:
+        print(row)
+    print(f"Bytes processed: {result['bytes_processed']}")
+else:
+    print(f"Error: {result['error']}")
+```
+
+### Describe a Dataset
+
+```python
+result = describe_dataset(
+    dataset_id="my_dataset",
+    project_id="my-project"  # optional if BIGQUERY_PROJECT_ID is set
+)
+
+if result.get("success"):
+    for table in result["tables"]:
+        print(f"Table: {table['table_id']}")
+        print(f"  Rows: {table['row_count']}")
+        for col in table["columns"]:
+            print(f"  - {col['name']}: {col['type']}")
+else:
+    print(f"Error: {result['error']}")
+```
+
+## Safety Features
+
+### Read-Only Enforcement
+
+The tool blocks write operations for safety. The following SQL keywords are rejected:
+
+- `INSERT`
+- `UPDATE`
+- `DELETE`
+- `DROP`
+- `CREATE`
+- `ALTER`
+- `TRUNCATE`
+- `MERGE`
+- `REPLACE`
+
+### Row Limits
+
+- Default limit: 1000 rows
+- Maximum limit: 10,000 rows
+- Results include `query_truncated: true` if more rows exist
+
+### Cost Awareness
+
+Every query result includes `bytes_processed` so you can monitor BigQuery costs.
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GOOGLE_APPLICATION_CREDENTIALS` | No* | Path to service account JSON file |
+| `BIGQUERY_PROJECT_ID` | No | Default project ID for queries |
+
+*Required if not using Application Default Credentials (ADC)
+
+## Error Handling
+
+The tool returns structured error responses with helpful messages:
+
+```python
+# Authentication error
+{
+    "error": "BigQuery authentication failed",
+    "help": "Set GOOGLE_APPLICATION_CREDENTIALS to your service account JSON path, or run 'gcloud auth application-default login' for local development."
+}
+
+# Permission error
+{
+    "error": "BigQuery permission denied: ...",
+    "help": "Ensure your service account has the 'BigQuery Data Viewer' and 'BigQuery Job User' roles."
+}
+
+# Write operation blocked
+{
+    "error": "Write operations are not allowed",
+    "help": "Only SELECT queries are permitted. INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, TRUNCATE, and MERGE are blocked."
+}
+```
+
+## Example Agent Use Cases
+
+### Analytics Copilot
+
+```python
+# Agent receives: "What are the top 10 products by revenue last month?"
+
+# Step 1: Explore the dataset
+describe_dataset("sales_data")
+
+# Step 2: Run the query
+run_bigquery_query("""
+    SELECT product_name, SUM(revenue) as total_revenue
+    FROM `project.sales_data.transactions`
+    WHERE DATE(transaction_date) >= DATE_SUB(CURRENT_DATE(), INTERVAL 1 MONTH)
+    GROUP BY product_name
+    ORDER BY total_revenue DESC
+    LIMIT 10
+""")
+```
+
+### Data Validation Agent
+
+```python
+# Check for data quality issues
+run_bigquery_query("""
+    SELECT 
+        COUNT(*) as total_rows,
+        COUNTIF(email IS NULL) as null_emails,
+        COUNTIF(NOT REGEXP_CONTAINS(email, r'^[^@]+@[^@]+$')) as invalid_emails
+    FROM `project.dataset.users`
+""")
+```
+
+## Extending the Tool
+
+Future enhancements (not in MVP):
+
+- Natural language → SQL generation (use LLM nodes upstream)
+- Write operations (requires additional safety controls)
+- Query dry-run for cost estimation
+- Result caching
+- Pagination support for large results
+
+## Troubleshooting
+
+### "Could not automatically determine credentials"
+
+- Set `GOOGLE_APPLICATION_CREDENTIALS` environment variable, or
+- Run `gcloud auth application-default login`
+
+### "Permission denied"
+
+Ensure your service account has:
+- `roles/bigquery.dataViewer` - to read tables
+- `roles/bigquery.jobUser` - to run queries
+
+### "Dataset not found"
+
+- Check the dataset name is correct
+- Verify the project ID is correct
+- Ensure you have access to the dataset

--- a/tools/src/aden_tools/tools/bigquery_tool/__init__.py
+++ b/tools/src/aden_tools/tools/bigquery_tool/__init__.py
@@ -1,0 +1,9 @@
+"""
+BigQuery Tool - Query and explore Google BigQuery datasets.
+
+Provides MCP tools for executing SQL queries and exploring dataset schemas.
+"""
+
+from .bigquery_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/bigquery_tool/bigquery_tool.py
+++ b/tools/src/aden_tools/tools/bigquery_tool/bigquery_tool.py
@@ -243,7 +243,10 @@ def register_tools(
             }
 
         except ImportError as e:
-            return {"error": str(e)}
+            return {
+                "error": str(e),
+                "help": "Install the dependency by running: pip install google-cloud-bigquery",
+            }
         except Exception as e:
             error_msg = str(e)
 
@@ -358,7 +361,10 @@ def register_tools(
             }
 
         except ImportError as e:
-            return {"error": str(e)}
+            return {
+                "error": str(e),
+                "help": "Install the dependency by running: pip install google-cloud-bigquery",
+            }
         except Exception as e:
             error_msg = str(e)
 

--- a/tools/src/aden_tools/tools/bigquery_tool/bigquery_tool.py
+++ b/tools/src/aden_tools/tools/bigquery_tool/bigquery_tool.py
@@ -1,0 +1,366 @@
+"""
+BigQuery Tool - Execute SQL queries and explore datasets in Google BigQuery.
+
+Supports:
+- Service account authentication via GOOGLE_APPLICATION_CREDENTIALS
+- Application Default Credentials (ADC) fallback
+
+Safety features:
+- Read-only queries only (INSERT, UPDATE, DELETE, etc. are blocked)
+- Configurable row limits to prevent large result sets
+- Bytes processed returned for cost awareness
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import TYPE_CHECKING, Any
+
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialStoreAdapter
+
+
+# SQL keywords that indicate write operations (case-insensitive)
+WRITE_KEYWORDS = [
+    r"\bINSERT\b",
+    r"\bUPDATE\b",
+    r"\bDELETE\b",
+    r"\bDROP\b",
+    r"\bCREATE\b",
+    r"\bALTER\b",
+    r"\bTRUNCATE\b",
+    r"\bMERGE\b",
+    r"\bREPLACE\b",
+]
+
+# Compiled regex pattern for detecting write operations
+WRITE_PATTERN = re.compile("|".join(WRITE_KEYWORDS), re.IGNORECASE)
+
+
+def _is_read_only_query(sql: str) -> bool:
+    """
+    Check if a SQL query is read-only.
+
+    Args:
+        sql: The SQL query string to check
+
+    Returns:
+        True if the query appears to be read-only, False otherwise
+    """
+    # Remove comments (both -- and /* */ style)
+    sql_no_comments = re.sub(r"--.*$", "", sql, flags=re.MULTILINE)
+    sql_no_comments = re.sub(r"/\*.*?\*/", "", sql_no_comments, flags=re.DOTALL)
+
+    # Check for write keywords
+    return not bool(WRITE_PATTERN.search(sql_no_comments))
+
+
+def _format_schema(schema: list) -> list[dict[str, str]]:
+    """Format BigQuery schema fields to simple dictionaries."""
+    return [
+        {
+            "name": field.name,
+            "type": field.field_type,
+            "mode": field.mode,
+        }
+        for field in schema
+    ]
+
+
+def _create_bigquery_client(project_id: str | None = None) -> Any:
+    """
+    Create a BigQuery client with appropriate credentials.
+
+    Args:
+        project_id: Optional project ID override
+
+    Returns:
+        BigQuery client instance
+
+    Raises:
+        ImportError: If google-cloud-bigquery is not installed
+        Exception: If authentication fails
+    """
+    try:
+        from google.cloud import bigquery
+    except ImportError:
+        raise ImportError(
+            "google-cloud-bigquery is required for BigQuery tools. "
+            "Install it with: pip install google-cloud-bigquery"
+        ) from None
+
+    # Create client - will use ADC if GOOGLE_APPLICATION_CREDENTIALS not set
+    if project_id:
+        return bigquery.Client(project=project_id)
+    else:
+        # Let the client infer project from credentials
+        return bigquery.Client()
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: CredentialStoreAdapter | None = None,
+) -> None:
+    """Register BigQuery tools with the MCP server."""
+
+    def _get_credentials() -> dict[str, str | None]:
+        """Get BigQuery credentials from credential store or environment."""
+        if credentials is not None:
+            return {
+                "credentials_path": credentials.get("bigquery_credentials"),
+                "project_id": credentials.get("bigquery_project"),
+            }
+        return {
+            "credentials_path": os.getenv("GOOGLE_APPLICATION_CREDENTIALS"),
+            "project_id": os.getenv("BIGQUERY_PROJECT_ID"),
+        }
+
+    def _get_client(project_id: str | None = None) -> Any:
+        """
+        Get a BigQuery client with credentials resolution.
+
+        Args:
+            project_id: Optional project ID override
+
+        Returns:
+            BigQuery client instance
+        """
+        creds = _get_credentials()
+        effective_project = project_id or creds["project_id"]
+        return _create_bigquery_client(effective_project)
+
+    @mcp.tool()
+    def run_bigquery_query(
+        sql: str,
+        project_id: str | None = None,
+        max_rows: int = 1000,
+    ) -> dict:
+        """
+        Execute a read-only SQL query against Google BigQuery.
+
+        This tool executes SQL queries and returns the results as structured data.
+        Only SELECT queries are allowed - write operations (INSERT, UPDATE, DELETE,
+        DROP, CREATE, ALTER, TRUNCATE, MERGE) are blocked for safety.
+
+        Args:
+            sql: The SQL query to execute. Must be a read-only query.
+            project_id: Google Cloud project ID. Falls back to BIGQUERY_PROJECT_ID
+                       env var or credentials default if not provided.
+            max_rows: Maximum number of rows to return (default: 1000).
+                     Use this to prevent accidentally fetching large result sets.
+
+        Returns:
+            Dict with query results:
+            - success: True if query executed successfully
+            - rows: List of row dictionaries
+            - total_rows: Total number of rows in result
+            - rows_returned: Number of rows actually returned (may be limited)
+            - schema: List of column definitions (name, type, mode)
+            - bytes_processed: Bytes scanned by the query (for cost awareness)
+            - query_truncated: True if results were truncated due to max_rows
+
+            Or error dict with:
+            - error: Error message
+            - help: Optional help text
+
+        Example:
+            >>> run_bigquery_query(
+            ...     sql="SELECT name, COUNT(*) as cnt FROM `project.dataset.users` GROUP BY name",
+            ...     max_rows=100
+            ... )
+            {
+                "success": True,
+                "rows": [{"name": "Alice", "cnt": 42}, ...],
+                "total_rows": 1500,
+                "rows_returned": 100,
+                "schema": [{"name": "name", "type": "STRING", "mode": "NULLABLE"}, ...],
+                "bytes_processed": 1048576,
+                "query_truncated": True
+            }
+        """
+        # Validate SQL is read-only
+        if not _is_read_only_query(sql):
+            return {
+                "error": "Write operations are not allowed",
+                "help": "Only SELECT queries are permitted. "
+                "INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, TRUNCATE, and MERGE are blocked.",
+            }
+
+        # Validate max_rows
+        if max_rows < 1:
+            return {"error": "max_rows must be at least 1"}
+        if max_rows > 10000:
+            return {
+                "error": "max_rows cannot exceed 10000",
+                "help": "For larger result sets, consider using pagination or "
+                "exporting to Cloud Storage.",
+            }
+
+        try:
+            client = _get_client(project_id)
+
+            # Execute query
+            query_job = client.query(sql)
+            results = query_job.result()
+
+            # Get total row count
+            total_rows = results.total_rows
+
+            # Fetch rows up to max_rows
+            rows = []
+            for i, row in enumerate(results):
+                if i >= max_rows:
+                    break
+                rows.append(dict(row.items()))
+
+            query_truncated = total_rows > max_rows if total_rows else False
+
+            return {
+                "success": True,
+                "rows": rows,
+                "total_rows": total_rows,
+                "rows_returned": len(rows),
+                "schema": _format_schema(results.schema),
+                "bytes_processed": query_job.total_bytes_processed or 0,
+                "query_truncated": query_truncated,
+            }
+
+        except ImportError as e:
+            return {"error": str(e)}
+        except Exception as e:
+            error_msg = str(e)
+
+            # Provide helpful messages for common errors
+            if "Could not automatically determine credentials" in error_msg:
+                return {
+                    "error": "BigQuery authentication failed",
+                    "help": "Set GOOGLE_APPLICATION_CREDENTIALS to your service account JSON path, "
+                    "or run 'gcloud auth application-default login' for local development.",
+                }
+            if "Permission" in error_msg and "denied" in error_msg.lower():
+                return {
+                    "error": f"BigQuery permission denied: {error_msg}",
+                    "help": "Ensure your service account has the 'BigQuery Data Viewer' "
+                    "and 'BigQuery Job User' roles.",
+                }
+            if "Not found" in error_msg:
+                return {
+                    "error": f"BigQuery resource not found: {error_msg}",
+                    "help": "Check that the project, dataset, and table names are correct.",
+                }
+
+            return {"error": f"BigQuery query failed: {error_msg}"}
+
+    @mcp.tool()
+    def describe_dataset(
+        dataset_id: str,
+        project_id: str | None = None,
+    ) -> dict:
+        """
+        Describe a BigQuery dataset, listing its tables and their schemas.
+
+        Use this tool to explore dataset structure before writing queries.
+        Returns table names, types, row counts, and column definitions.
+
+        Args:
+            dataset_id: The BigQuery dataset ID to describe (e.g., "my_dataset").
+                       Do not include the project ID prefix.
+            project_id: Google Cloud project ID. Falls back to BIGQUERY_PROJECT_ID
+                       env var or credentials default if not provided.
+
+        Returns:
+            Dict with dataset information:
+            - success: True if operation succeeded
+            - dataset_id: The dataset ID
+            - project_id: The resolved project ID
+            - tables: List of table information, each containing:
+                - table_id: Table name
+                - type: Table type (TABLE, VIEW, EXTERNAL, etc.)
+                - row_count: Number of rows (None for views)
+                - size_bytes: Table size in bytes (None for views)
+                - columns: List of column definitions (name, type, mode)
+
+            Or error dict with:
+            - error: Error message
+            - help: Optional help text
+
+        Example:
+            >>> describe_dataset("my_dataset")
+            {
+                "success": True,
+                "dataset_id": "my_dataset",
+                "project_id": "my-project",
+                "tables": [
+                    {
+                        "table_id": "users",
+                        "type": "TABLE",
+                        "row_count": 50000,
+                        "size_bytes": 10485760,
+                        "columns": [
+                            {"name": "id", "type": "INTEGER", "mode": "REQUIRED"},
+                            {"name": "email", "type": "STRING", "mode": "NULLABLE"}
+                        ]
+                    }
+                ]
+            }
+        """
+        if not dataset_id or not dataset_id.strip():
+            return {"error": "dataset_id is required"}
+
+        try:
+            client = _get_client(project_id)
+
+            # Get dataset reference
+            dataset_ref = client.dataset(dataset_id)
+
+            # List tables in the dataset
+            tables_list = list(client.list_tables(dataset_ref))
+
+            tables_info = []
+            for table_item in tables_list:
+                # Get full table metadata
+                table = client.get_table(table_item.reference)
+
+                table_info = {
+                    "table_id": table.table_id,
+                    "type": table.table_type,
+                    "row_count": table.num_rows,
+                    "size_bytes": table.num_bytes,
+                    "columns": _format_schema(table.schema) if table.schema else [],
+                }
+                tables_info.append(table_info)
+
+            return {
+                "success": True,
+                "dataset_id": dataset_id,
+                "project_id": client.project,
+                "tables": tables_info,
+            }
+
+        except ImportError as e:
+            return {"error": str(e)}
+        except Exception as e:
+            error_msg = str(e)
+
+            if "Could not automatically determine credentials" in error_msg:
+                return {
+                    "error": "BigQuery authentication failed",
+                    "help": "Set GOOGLE_APPLICATION_CREDENTIALS to your service account JSON path, "
+                    "or run 'gcloud auth application-default login' for local development.",
+                }
+            if "Not found" in error_msg:
+                return {
+                    "error": f"Dataset not found: {dataset_id}",
+                    "help": "Check that the dataset exists and you have access to it. "
+                    f"Full error: {error_msg}",
+                }
+            if "Permission" in error_msg and "denied" in error_msg.lower():
+                return {
+                    "error": f"Permission denied for dataset: {dataset_id}",
+                    "help": "Ensure your service account has the 'BigQuery Data Viewer' role.",
+                }
+
+            return {"error": f"Failed to describe dataset: {error_msg}"}

--- a/tools/src/aden_tools/tools/bigquery_tool/bigquery_tool.py
+++ b/tools/src/aden_tools/tools/bigquery_tool/bigquery_tool.py
@@ -242,8 +242,11 @@ def register_tools(
                 "query_truncated": query_truncated,
             }
 
-        except ImportError as e:
-            return {"error": str(e)}
+        except ImportError:
+            return {
+                "error": "google-cloud-bigquery is not installed.",
+                "help": "Install the optional dependency with: pip install google-cloud-bigquery",
+            }
         except Exception as e:
             error_msg = str(e)
 
@@ -357,8 +360,11 @@ def register_tools(
                 "tables": tables_info,
             }
 
-        except ImportError as e:
-            return {"error": str(e)}
+        except ImportError:
+            return {
+                "error": "google-cloud-bigquery is not installed.",
+                "help": "Install the optional dependency with: pip install google-cloud-bigquery",
+            }
         except Exception as e:
             error_msg = str(e)
 

--- a/tools/src/aden_tools/tools/bigquery_tool/bigquery_tool.py
+++ b/tools/src/aden_tools/tools/bigquery_tool/bigquery_tool.py
@@ -242,11 +242,8 @@ def register_tools(
                 "query_truncated": query_truncated,
             }
 
-        except ImportError:
-            return {
-                "error": "google-cloud-bigquery is not installed.",
-                "help": "Install the optional dependency with: pip install google-cloud-bigquery",
-            }
+        except ImportError as e:
+            return {"error": str(e)}
         except Exception as e:
             error_msg = str(e)
 
@@ -360,11 +357,8 @@ def register_tools(
                 "tables": tables_info,
             }
 
-        except ImportError:
-            return {
-                "error": "google-cloud-bigquery is not installed.",
-                "help": "Install the optional dependency with: pip install google-cloud-bigquery",
-            }
+        except ImportError as e:
+            return {"error": str(e)}
         except Exception as e:
             error_msg = str(e)
 

--- a/tools/tests/tools/test_bigquery_tool.py
+++ b/tools/tests/tools/test_bigquery_tool.py
@@ -32,7 +32,7 @@ def mock_credentials():
     """Create mock credentials for testing."""
     return CredentialStoreAdapter.for_testing(
         {
-            "bigquery_credentials": "/path/to/service-account.json",
+            "bigquery": "/path/to/service-account.json",
             "bigquery_project": "test-project",
         }
     )
@@ -392,14 +392,14 @@ class TestCredentialResolution:
         """Should use credentials from CredentialStoreAdapter."""
         mock_creds = CredentialStoreAdapter.for_testing(
             {
-                "bigquery_credentials": "/custom/path/credentials.json",
+                "bigquery": "/custom/path/credentials.json",
                 "bigquery_project": "custom-project",
             }
         )
         register_tools(mcp, credentials=mock_creds)
 
         # Verify credentials are accessible (actual usage tested in other tests)
-        assert mock_creds.get("bigquery_credentials") == "/custom/path/credentials.json"
+        assert mock_creds.get("bigquery") == "/custom/path/credentials.json"
         assert mock_creds.get("bigquery_project") == "custom-project"
 
     def test_falls_back_to_env_vars(self, mcp):

--- a/tools/tests/tools/test_bigquery_tool.py
+++ b/tools/tests/tools/test_bigquery_tool.py
@@ -1,0 +1,432 @@
+"""
+Tests for BigQuery tool.
+
+Tests cover:
+- Query execution with mocked BigQuery client
+- Read-only enforcement (blocking write operations)
+- Row limiting
+- Dataset description
+- Error handling and user-friendly messages
+- Credential resolution
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.credentials import CredentialStoreAdapter
+from aden_tools.tools.bigquery_tool import register_tools
+
+
+@pytest.fixture
+def mcp():
+    """Create a FastMCP instance for testing."""
+    return FastMCP("test-server")
+
+
+@pytest.fixture
+def mock_credentials():
+    """Create mock credentials for testing."""
+    return CredentialStoreAdapter.for_testing(
+        {
+            "bigquery_credentials": "/path/to/service-account.json",
+            "bigquery_project": "test-project",
+        }
+    )
+
+
+@pytest.fixture
+def registered_mcp(mcp, mock_credentials):
+    """Register BigQuery tools with mock credentials."""
+    register_tools(mcp, credentials=mock_credentials)
+    return mcp
+
+
+class TestReadOnlyEnforcement:
+    """Tests for SQL write operation blocking."""
+
+    def test_blocks_insert(self, registered_mcp):
+        """INSERT statements should be blocked."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+        result = tool.fn(sql="INSERT INTO table VALUES (1, 2)")
+        assert "error" in result
+        assert "Write operations are not allowed" in result["error"]
+
+    def test_blocks_update(self, registered_mcp):
+        """UPDATE statements should be blocked."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+        result = tool.fn(sql="UPDATE table SET col = 1")
+        assert "error" in result
+        assert "Write operations are not allowed" in result["error"]
+
+    def test_blocks_delete(self, registered_mcp):
+        """DELETE statements should be blocked."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+        result = tool.fn(sql="DELETE FROM table WHERE id = 1")
+        assert "error" in result
+        assert "Write operations are not allowed" in result["error"]
+
+    def test_blocks_drop(self, registered_mcp):
+        """DROP statements should be blocked."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+        result = tool.fn(sql="DROP TABLE my_table")
+        assert "error" in result
+        assert "Write operations are not allowed" in result["error"]
+
+    def test_blocks_create(self, registered_mcp):
+        """CREATE statements should be blocked."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+        result = tool.fn(sql="CREATE TABLE my_table (id INT)")
+        assert "error" in result
+        assert "Write operations are not allowed" in result["error"]
+
+    def test_blocks_alter(self, registered_mcp):
+        """ALTER statements should be blocked."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+        result = tool.fn(sql="ALTER TABLE my_table ADD COLUMN new_col INT")
+        assert "error" in result
+        assert "Write operations are not allowed" in result["error"]
+
+    def test_blocks_truncate(self, registered_mcp):
+        """TRUNCATE statements should be blocked."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+        result = tool.fn(sql="TRUNCATE TABLE my_table")
+        assert "error" in result
+        assert "Write operations are not allowed" in result["error"]
+
+    def test_blocks_merge(self, registered_mcp):
+        """MERGE statements should be blocked."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+        result = tool.fn(sql="MERGE INTO target USING source ON condition WHEN MATCHED THEN UPDATE")
+        assert "error" in result
+        assert "Write operations are not allowed" in result["error"]
+
+    def test_blocks_case_insensitive(self, registered_mcp):
+        """Write detection should be case-insensitive."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+        result = tool.fn(sql="insert into table values (1)")
+        assert "error" in result
+        assert "Write operations are not allowed" in result["error"]
+
+    def test_allows_select(self, registered_mcp):
+        """SELECT statements should be allowed (will fail on client, not validation)."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+        with patch(
+            "aden_tools.tools.bigquery_tool.bigquery_tool._create_bigquery_client"
+        ) as mock_create_client:
+            # Mock will raise an error, but we're testing that it gets past validation
+            mock_create_client.side_effect = Exception("Mock error")
+            result = tool.fn(sql="SELECT * FROM table")
+            # Should not have the write operation error
+            assert "Write operations are not allowed" not in result.get("error", "")
+
+    def test_allows_select_with_subquery(self, registered_mcp):
+        """Complex SELECT with subqueries should be allowed."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+        with patch(
+            "aden_tools.tools.bigquery_tool.bigquery_tool._create_bigquery_client"
+        ) as mock_create_client:
+            mock_create_client.side_effect = Exception("Mock error")
+            result = tool.fn(
+                sql="""
+                SELECT a.*, b.count
+                FROM (SELECT id, name FROM users) a
+                JOIN (SELECT user_id, COUNT(*) as count FROM orders GROUP BY user_id) b
+                ON a.id = b.user_id
+            """
+            )
+            assert "Write operations are not allowed" not in result.get("error", "")
+
+
+class TestRowLimits:
+    """Tests for row limit validation."""
+
+    def test_rejects_zero_max_rows(self, registered_mcp):
+        """max_rows of 0 should be rejected."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+        result = tool.fn(sql="SELECT 1", max_rows=0)
+        assert "error" in result
+        assert "max_rows must be at least 1" in result["error"]
+
+    def test_rejects_negative_max_rows(self, registered_mcp):
+        """Negative max_rows should be rejected."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+        result = tool.fn(sql="SELECT 1", max_rows=-1)
+        assert "error" in result
+        assert "max_rows must be at least 1" in result["error"]
+
+    def test_rejects_excessive_max_rows(self, registered_mcp):
+        """max_rows over 10000 should be rejected."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+        result = tool.fn(sql="SELECT 1", max_rows=10001)
+        assert "error" in result
+        assert "max_rows cannot exceed 10000" in result["error"]
+
+    def test_accepts_valid_max_rows(self, registered_mcp):
+        """Valid max_rows values should be accepted."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+        with patch(
+            "aden_tools.tools.bigquery_tool.bigquery_tool._create_bigquery_client"
+        ) as mock_create_client:
+            mock_create_client.side_effect = Exception("Mock error")
+            # These should pass validation (will fail on mock client)
+            for max_rows in [1, 100, 1000, 10000]:
+                result = tool.fn(sql="SELECT 1", max_rows=max_rows)
+                assert "max_rows" not in result.get("error", "")
+
+
+class TestQueryExecution:
+    """Tests for successful query execution."""
+
+    def test_successful_query(self, registered_mcp):
+        """Test successful query execution with mocked client."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+
+        with patch(
+            "aden_tools.tools.bigquery_tool.bigquery_tool._create_bigquery_client"
+        ) as mock_create_client:
+            # Set up mock client and query job
+            mock_client = MagicMock()
+            mock_create_client.return_value = mock_client
+
+            mock_query_job = MagicMock()
+            mock_query_job.total_bytes_processed = 1024
+
+            # Mock row results
+            mock_row1 = MagicMock()
+            mock_row1.items.return_value = [("id", 1), ("name", "Alice")]
+            mock_row2 = MagicMock()
+            mock_row2.items.return_value = [("id", 2), ("name", "Bob")]
+
+            mock_results = MagicMock()
+            mock_results.total_rows = 2
+            mock_results.__iter__ = lambda self: iter([mock_row1, mock_row2])
+            mock_results.schema = [
+                MagicMock(name="id", field_type="INTEGER", mode="REQUIRED"),
+                MagicMock(name="name", field_type="STRING", mode="NULLABLE"),
+            ]
+
+            mock_query_job.result.return_value = mock_results
+            mock_client.query.return_value = mock_query_job
+
+            result = tool.fn(sql="SELECT id, name FROM users")
+
+            assert result["success"] is True
+            assert result["rows"] == [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
+            assert result["total_rows"] == 2
+            assert result["rows_returned"] == 2
+            assert result["bytes_processed"] == 1024
+            assert result["query_truncated"] is False
+            assert len(result["schema"]) == 2
+
+    def test_query_truncation(self, registered_mcp):
+        """Test that results are truncated when exceeding max_rows."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+
+        with patch(
+            "aden_tools.tools.bigquery_tool.bigquery_tool._create_bigquery_client"
+        ) as mock_create_client:
+            mock_client = MagicMock()
+            mock_create_client.return_value = mock_client
+
+            mock_query_job = MagicMock()
+            mock_query_job.total_bytes_processed = 2048
+
+            # Create 10 mock rows
+            mock_rows = []
+            for i in range(10):
+                row = MagicMock()
+                row.items.return_value = [("id", i)]
+                mock_rows.append(row)
+
+            mock_results = MagicMock()
+            mock_results.total_rows = 10
+            mock_results.__iter__ = lambda self: iter(mock_rows)
+            mock_results.schema = [MagicMock(name="id", field_type="INTEGER", mode="REQUIRED")]
+
+            mock_query_job.result.return_value = mock_results
+            mock_client.query.return_value = mock_query_job
+
+            # Request only 5 rows
+            result = tool.fn(sql="SELECT id FROM users", max_rows=5)
+
+            assert result["success"] is True
+            assert result["total_rows"] == 10
+            assert result["rows_returned"] == 5
+            assert result["query_truncated"] is True
+            assert len(result["rows"]) == 5
+
+
+class TestDescribeDataset:
+    """Tests for describe_dataset tool."""
+
+    def test_empty_dataset_id(self, registered_mcp):
+        """Empty dataset_id should be rejected."""
+        tool = registered_mcp._tool_manager._tools["describe_dataset"]
+        result = tool.fn(dataset_id="")
+        assert "error" in result
+        assert "dataset_id is required" in result["error"]
+
+    def test_whitespace_dataset_id(self, registered_mcp):
+        """Whitespace-only dataset_id should be rejected."""
+        tool = registered_mcp._tool_manager._tools["describe_dataset"]
+        result = tool.fn(dataset_id="   ")
+        assert "error" in result
+        assert "dataset_id is required" in result["error"]
+
+    def test_successful_describe(self, registered_mcp):
+        """Test successful dataset description with mocked client."""
+        tool = registered_mcp._tool_manager._tools["describe_dataset"]
+
+        with patch(
+            "aden_tools.tools.bigquery_tool.bigquery_tool._create_bigquery_client"
+        ) as mock_create_client:
+            mock_client = MagicMock()
+            mock_client.project = "test-project"
+            mock_create_client.return_value = mock_client
+
+            # Mock table listing
+            mock_table_item = MagicMock()
+            mock_table_item.reference = "test-project.my_dataset.users"
+            mock_client.list_tables.return_value = [mock_table_item]
+
+            # Mock full table details
+            mock_table = MagicMock()
+            mock_table.table_id = "users"
+            mock_table.table_type = "TABLE"
+            mock_table.num_rows = 1000
+            mock_table.num_bytes = 10240
+            mock_table.schema = [
+                MagicMock(name="id", field_type="INTEGER", mode="REQUIRED"),
+                MagicMock(name="email", field_type="STRING", mode="NULLABLE"),
+            ]
+            mock_client.get_table.return_value = mock_table
+
+            result = tool.fn(dataset_id="my_dataset")
+
+            assert result["success"] is True
+            assert result["dataset_id"] == "my_dataset"
+            assert result["project_id"] == "test-project"
+            assert len(result["tables"]) == 1
+            assert result["tables"][0]["table_id"] == "users"
+            assert result["tables"][0]["row_count"] == 1000
+            assert len(result["tables"][0]["columns"]) == 2
+
+
+class TestErrorHandling:
+    """Tests for error handling and user-friendly messages."""
+
+    def test_authentication_error(self, registered_mcp):
+        """Authentication errors should provide helpful messages."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+
+        with patch(
+            "aden_tools.tools.bigquery_tool.bigquery_tool._create_bigquery_client"
+        ) as mock_create_client:
+            mock_create_client.side_effect = Exception(
+                "Could not automatically determine credentials"
+            )
+            result = tool.fn(sql="SELECT 1")
+
+            assert "error" in result
+            assert "authentication failed" in result["error"].lower()
+            assert "help" in result
+            assert "GOOGLE_APPLICATION_CREDENTIALS" in result["help"]
+
+    def test_permission_error(self, registered_mcp):
+        """Permission errors should provide helpful messages."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+
+        with patch(
+            "aden_tools.tools.bigquery_tool.bigquery_tool._create_bigquery_client"
+        ) as mock_create_client:
+            mock_create_client.side_effect = Exception(
+                "Permission denied for table project.dataset.table"
+            )
+            result = tool.fn(sql="SELECT 1")
+
+            assert "error" in result
+            assert "permission denied" in result["error"].lower()
+            assert "help" in result
+            assert "BigQuery Data Viewer" in result["help"]
+
+    def test_not_found_error(self, registered_mcp):
+        """Not found errors should provide helpful messages."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+
+        with patch(
+            "aden_tools.tools.bigquery_tool.bigquery_tool._create_bigquery_client"
+        ) as mock_create_client:
+            mock_create_client.side_effect = Exception(
+                "Not found: Table project.dataset.nonexistent was not found"
+            )
+            result = tool.fn(sql="SELECT 1")
+
+            assert "error" in result
+            assert "not found" in result["error"].lower()
+            assert "help" in result
+
+    def test_dataset_not_found_error(self, registered_mcp):
+        """Dataset not found errors should provide helpful messages."""
+        tool = registered_mcp._tool_manager._tools["describe_dataset"]
+
+        with patch(
+            "aden_tools.tools.bigquery_tool.bigquery_tool._create_bigquery_client"
+        ) as mock_create_client:
+            mock_create_client.side_effect = Exception(
+                "Not found: Dataset project:nonexistent was not found"
+            )
+            result = tool.fn(dataset_id="nonexistent")
+
+            assert "error" in result
+            assert "not found" in result["error"].lower()
+
+
+class TestCredentialResolution:
+    """Tests for credential resolution from different sources."""
+
+    def test_uses_credential_store(self, mcp):
+        """Should use credentials from CredentialStoreAdapter."""
+        mock_creds = CredentialStoreAdapter.for_testing(
+            {
+                "bigquery_credentials": "/custom/path/credentials.json",
+                "bigquery_project": "custom-project",
+            }
+        )
+        register_tools(mcp, credentials=mock_creds)
+
+        # Verify credentials are accessible (actual usage tested in other tests)
+        assert mock_creds.get("bigquery_credentials") == "/custom/path/credentials.json"
+        assert mock_creds.get("bigquery_project") == "custom-project"
+
+    def test_falls_back_to_env_vars(self, mcp):
+        """Should fall back to environment variables when no credential store."""
+        register_tools(mcp, credentials=None)
+
+        # Tool is registered and will use os.getenv internally
+        assert "run_bigquery_query" in mcp._tool_manager._tools
+        assert "describe_dataset" in mcp._tool_manager._tools
+
+
+class TestImportError:
+    """Tests for handling missing google-cloud-bigquery package."""
+
+    def test_import_error_message(self, registered_mcp):
+        """Should provide helpful message when google-cloud-bigquery not installed."""
+        tool = registered_mcp._tool_manager._tools["run_bigquery_query"]
+
+        with patch(
+            "aden_tools.tools.bigquery_tool.bigquery_tool._create_bigquery_client"
+        ) as mock_create_client:
+            mock_create_client.side_effect = ImportError(
+                "google-cloud-bigquery is required for BigQuery tools. "
+                "Install it with: pip install google-cloud-bigquery"
+            )
+            result = tool.fn(sql="SELECT 1")
+
+            assert "error" in result
+            assert "google-cloud-bigquery" in result["error"]
+            assert "pip install" in result["error"]


### PR DESCRIPTION
## Description

Add BigQuery MCP tool enabling Hive agents to query Google BigQuery data warehouses and explore dataset schemas. This integration follows the existing multi-provider pattern (matching email_tool) and is discoverable by the coding agent for building data-driven agents.

**Related to / Parent Issue:** #2805

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Fixes #3067

## Changes Made

### New files
- `tools/src/aden_tools/credentials/bigquery.py` — CredentialSpec for BigQuery authentication
- `tools/src/aden_tools/tools/bigquery_tool/__init__.py` — Package init
- `tools/src/aden_tools/tools/bigquery_tool/bigquery_tool.py` — Two MCP tools: `run_bigquery_query` and `describe_dataset`
- `tools/src/aden_tools/tools/bigquery_tool/README.md` — Usage docs, setup instructions, and examples
- `tools/tests/tools/test_bigquery_tool.py` — 27 unit tests covering validation, query execution, error handling

### Modified files
- `tools/pyproject.toml` — Added `google-cloud-bigquery>=3.0.0` dependency
- `tools/src/aden_tools/credentials/__init__.py` — Registered `BIGQUERY_CREDENTIALS` into `CREDENTIAL_SPECS`
- `tools/src/aden_tools/tools/__init__.py` — Registered BigQuery tools in `register_all_tools()`

## Tools Added

| Tool | Description |
|------|-------------|
| `run_bigquery_query` | Execute read-only SQL queries, return rows + schema + bytes processed |
| `describe_dataset` | List tables and column schemas for query planning |

## Safety Features

- **Read-only enforcement**: Blocks INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, TRUNCATE, MERGE
- **Row limits**: Default 1000, max 10000 to prevent large result sets
- **Cost transparency**: Returns `bytes_processed` with every query

## Authentication

Supports two methods via `CredentialStoreAdapter`:
1. Service account JSON file (`GOOGLE_APPLICATION_CREDENTIALS`)
2. Application Default Credentials (ADC) for local development

## Testing

- [x] Unit tests pass (27 tests) — `pytest tests/tools/test_bigquery_tool.py -v`
- [x] Lint passes — `ruff check .`
- [x] Integration tested with `bigquery-public-data.samples` dataset

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Example Use Cases

**Analytics Copilot Agent** — Natural language → SQL → query BigQuery → return insights
**Data Validation Agent** — Check data quality, null counts, schema compliance
**Business Reporting Agent** — Automated periodic queries for dashboards