### PR TITLE
docs: fix Example Agents link in ENVIRONMENT_SETUP.md (#3320)

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -557,7 +557,7 @@ export AGENT_STORAGE_PATH="/custom/storage"
 
 - **Framework Documentation:** [core/README.md](core/README.md)
 - **Tools Documentation:** [tools/README.md](tools/README.md)
-- **Example Agents:** [exports/](exports/)
+- **Example Agents:** [examples/README.md](examples/README.md)
 - **Agent Building Guide:** [.claude/skills/building-agents-construction/SKILL.md](.claude/skills/building-agents-construction/SKILL.md)
 - **Testing Guide:** [.claude/skills/testing-agent/SKILL.md](.claude/skills/testing-agent/SKILL.md)
 


### PR DESCRIPTION
## Description

Fixed the 404 bug for Example Agents link in ENVIRONMENT_SETUP.md by pointing it to the correct folder `examples/`. 
Verified that the subfolders `recipes/` and `templates/` exist and README.md is present. 

This resolves issue #3320.
