### PR TITLE
docs: improve Windows + WSL setup with uv fallback and common mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,50 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 - **[Report Issues](https://github.com/adenhq/hive/issues)** - Bug reports and feature requests
 
 ## Quick Start
+### Windows (WSL) Setup Notes
+### Manual Setup (uv-based Fallback)
+### Common Setup Mistakes
+
+- Running setup commands in **PowerShell instead of WSL**.  
+  All `source`, `python3`, `uv`, and virtual environment commands must be run
+  inside the **Ubuntu (WSL) terminal**.
+
+- Mixing Windows and Linux paths (e.g. `/mnt/c/...` vs `~/hive`).  
+  Prefer working inside the Linux home directory (`~/hive`) to avoid
+  permission and performance issues.
+
+- Assuming `pip install -r requirements.txt` is required.  
+  Hive uses multiple Python packages with isolated virtual environments,
+  and dependencies are installed via `quickstart.sh` or `uv`.
+
+- Interrupting setup without restarting the environment.  
+  After interrupting setup, ensure you activate the correct virtual environment:
+  ```bash
+  source core/.venv/bin/activate
+
+
+On some systems, `quickstart.sh` may hang during dependency installation,
+particularly while upgrading `pip` inside WSL environments.
+
+If this happens, you can safely interrupt the script and complete the setup manually
+using `uv`, which is faster and more reliable.
+
+#### Core framework setup
+```bash
+cd ~/hive/core
+~/.local/bin/uv venv .venv --python python3.12
+~/.local/bin/uv pip install -e .
+
+
+If you are running Aden Hive on **Windows using WSL (Ubuntu)**:
+
+- Run all setup commands inside the **Ubuntu terminal**, not PowerShell.
+- Do not mix Windows and Linux commands (`source`, `python3`, `uv`).
+- The `quickstart.sh` script may appear to hang during `pip` upgrades on some systems.
+
+If the setup appears stuck for several minutes, it is safe to interrupt it with `Ctrl+C`
+and continue using the manual setup instructions below.
+
 
 ### Prerequisites
 


### PR DESCRIPTION
  
Fixes #3356


This PR improves the Windows + WSL onboarding experience by documenting
a known quickstart.sh hang issue and providing a reliable uv-based
manual setup fallback.

While setting up Hive on Windows using WSL, the quickstart wizard can
appear to stall during dependency installation (e.g. during pip
upgrades). This PR captures that failure mode and documents a clear,
repeatable workaround that allows contributors to complete setup
without restarting from scratch.

Changes include:
- A Windows + WSL setup note clarifying that all setup commands must be
  run inside the Ubuntu (WSL) terminal, not PowerShell
- A manual uv-based setup fallback that can be used when quickstart.sh
  hangs or is interrupted
- A shorter, clearer Quick Start flow that reduces ambiguity for new
  contributors
- A "Common Setup Mistakes" section based on real setup issues
  encountered during local development

All changes are documentation-only and do not affect runtime behavior.
They are based on real setup failures and debugging steps taken during
a fresh Windows + WSL install.

These improvements should significantly reduce friction for Windows
users, lower repeated setup questions, and make first-time
contributions easier and more reliable.
