### PR TITLE
fix: use python3 in agent skill commands for Linux/WSL (#3356)

### DIFF
--- a/.claude/skills/agent-workflow/SKILL.md
+++ b/.claude/skills/agent-workflow/SKILL.md
@@ -342,7 +342,7 @@ agent-workflow (meta-skill)
 - Check node IDs match between nodes/__init__.py and agent.py
 - Verify all edges reference valid node IDs
 - Ensure entry_node exists in nodes list
-- Run: `PYTHONPATH=core:exports python -m agent_name validate`
+- Run: `PYTHONPATH=core:exports python3 -m agent_name validate`
 
 ### "Agent has structure but won't run"
 
@@ -368,7 +368,7 @@ Run these checks:
 ls exports/my_agent/agent.py
 
 # Check if it validates
-PYTHONPATH=core:exports python -m my_agent validate
+PYTHONPATH=core:exports python3 -m my_agent validate
 
 # Check if tests exist
 ls exports/my_agent/tests/

--- a/.claude/skills/agent-workflow/examples/file-monitor-example.md
+++ b/.claude/skills/agent-workflow/examples/file-monitor-example.md
@@ -75,10 +75,10 @@ initialize → list → identify → check
 ### Step 5: Finalize
 
 ```bash
-$ PYTHONPATH=core:exports python -m file_monitor_agent validate
+$ PYTHONPATH=core:exports python3 -m file_monitor_agent validate
 ✓ Agent is valid
 
-$ PYTHONPATH=core:exports python -m file_monitor_agent info
+$ PYTHONPATH=core:exports python3 -m file_monitor_agent info
 Agent: File Monitor & Copy Agent
 Nodes: 7
 Edges: 8
@@ -162,7 +162,7 @@ test_edge_cases.py::test_large_files              PASSED
 ./RUN_AGENT.sh
 
 # Or manually
-PYTHONPATH=core:exports:tools/src python -m file_monitor_agent run
+PYTHONPATH=core:exports:tools/src python3 -m file_monitor_agent run
 ```
 
 **Capabilities:**

--- a/.claude/skills/building-agents-construction/SKILL.md
+++ b/.claude/skills/building-agents-construction/SKILL.md
@@ -28,7 +28,7 @@ When this skill is loaded, IMMEDIATELY begin executing Step 1. Do not explain wh
 mcp__agent-builder__add_mcp_server(
     name="hive-tools",
     transport="stdio",
-    command="python",
+    command="python3",
     args='["mcp_server.py", "--stdio"]',
     cwd="tools",
     description="Hive tools MCP server"
@@ -284,8 +284,8 @@ This returns JSON with all the goal, nodes, edges, and MCP server configurations
 >
 > ```bash
 > cd /home/timothy/oss/hive
-> PYTHONPATH=core:exports python -m AGENT_NAME validate
-> PYTHONPATH=core:exports python -m AGENT_NAME info
+> PYTHONPATH=core:exports python3 -m AGENT_NAME validate
+> PYTHONPATH=core:exports python3 -m AGENT_NAME info
 > ```
 
 ---
@@ -295,7 +295,7 @@ This returns JSON with all the goal, nodes, edges, and MCP server configurations
 **RUN validation:**
 
 ```bash
-cd /home/timothy/oss/hive && PYTHONPATH=core:exports python -m AGENT_NAME validate
+cd /home/timothy/oss/hive && PYTHONPATH=core:exports python3 -m AGENT_NAME validate
 ```
 
 - If valid: Agent is complete!

--- a/.claude/skills/building-agents-construction/examples/online_research_agent/README.md
+++ b/.claude/skills/building-agents-construction/examples/online_research_agent/README.md
@@ -18,16 +18,16 @@ Deep-dive research agent that searches 10+ sources and produces comprehensive na
 
 ```bash
 # Show agent info
-python -m online_research_agent info
+python3 -m online_research_agent info
 
 # Validate structure
-python -m online_research_agent validate
+python3 -m online_research_agent validate
 
 # Run research on a topic
-python -m online_research_agent run --topic "impact of AI on healthcare"
+python3 -m online_research_agent run --topic "impact of AI on healthcare"
 
 # Interactive shell
-python -m online_research_agent shell
+python3 -m online_research_agent shell
 ```
 
 ### Python API

--- a/.claude/skills/building-agents-construction/examples/online_research_agent/mcp_servers.json
+++ b/.claude/skills/building-agents-construction/examples/online_research_agent/mcp_servers.json
@@ -1,7 +1,7 @@
 {
   "hive-tools": {
     "transport": "stdio",
-    "command": "python",
+    "command": "python3",
     "args": ["mcp_server.py", "--stdio"],
     "cwd": "../../tools",
     "description": "Hive tools MCP server providing web_search, web_scrape, and write_to_file"

--- a/.claude/skills/building-agents-core/SKILL.md
+++ b/.claude/skills/building-agents-core/SKILL.md
@@ -141,7 +141,7 @@ Tools are provided by MCP servers. Never assume a tool exists - always discover 
 mcp__agent-builder__add_mcp_server(
     name="tools",
     transport="stdio",
-    command="python",
+    command="python3",
     args='["mcp_server.py", "--stdio"]',
     cwd="../tools"
 )

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "agent-builder": {
-      "command": "python",
+      "command": "python3",
       "args": ["-m", "framework.mcp.agent_builder_server"],
       "cwd": "core",
       "env": {
@@ -9,7 +9,7 @@
       }
     },
     "tools": {
-      "command": "python",
+      "command": "python3",
       "args": ["mcp_server.py", "--stdio"],
       "cwd": "tools",
       "env": {

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "agent-builder": {
-      "command": ".venv/bin/python",
+      "command": ".venv/bin/python3",
       "args": ["-m", "framework.mcp.agent_builder_server"],
       "cwd": "core",
       "env": {
@@ -9,7 +9,7 @@
       }
     },
     "tools": {
-      "command": ".venv/bin/python",
+      "command": ".venv/bin/python3",
       "args": ["mcp_server.py", "--stdio"],
       "cwd": "tools",
       "env": {

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -51,7 +51,7 @@ Ensure you have installed:
 Verify installation:
 
 ```bash
-python --version    # Should be 3.11+
+python3 --version    # Should be 3.11+
 uv --version        # Should be latest
 git --version       # Any recent version
 ```
@@ -111,12 +111,12 @@ This installs agent-related Claude Code skills:
 
 ```bash
 # Verify package imports
-python -c "import framework; print('✓ framework OK')"
-python -c "import aden_tools; print('✓ aden_tools OK')"
-python -c "import litellm; print('✓ litellm OK')"
+python3 -c "import framework; print('✓ framework OK')"
+python3 -c "import aden_tools; print('✓ aden_tools OK')"
+python3 -c "import litellm; print('✓ litellm OK')"
 
 # Run an agent (after building one via /building-agents-construction)
-PYTHONPATH=core:exports python -m your_agent_name validate
+PYTHONPATH=core:exports python3 -m your_agent_name validate
 ```
 
 ---
@@ -256,7 +256,7 @@ claude> /testing-agent
 4. **Validate the Agent**
 
    ```bash
-   PYTHONPATH=core:exports python -m your_agent_name validate
+   PYTHONPATH=core:exports python3 -m your_agent_name validate
    ```
 
 5. **Test the Agent**
@@ -302,19 +302,19 @@ If you prefer to build agents manually:
 
 ```bash
 # Validate agent structure
-PYTHONPATH=core:exports python -m agent_name validate
+PYTHONPATH=core:exports python3 -m agent_name validate
 
 # Show agent information
-PYTHONPATH=core:exports python -m agent_name info
+PYTHONPATH=core:exports python3 -m agent_name info
 
 # Run agent with input
-PYTHONPATH=core:exports python -m agent_name run --input '{
+PYTHONPATH=core:exports python3 -m agent_name run --input '{
   "ticket_content": "My login is broken",
   "customer_id": "CUST-123"
 }'
 
 # Run in mock mode (no LLM calls)
-PYTHONPATH=core:exports python -m agent_name run --mock --input '{...}'
+PYTHONPATH=core:exports python3 -m agent_name run --mock --input '{...}'
 ```
 
 ---
@@ -338,17 +338,17 @@ This generates and runs:
 
 ```bash
 # Run all tests for an agent
-PYTHONPATH=core:exports python -m agent_name test
+PYTHONPATH=core:exports python3 -m agent_name test
 
 # Run specific test type
-PYTHONPATH=core:exports python -m agent_name test --type constraint
-PYTHONPATH=core:exports python -m agent_name test --type success
+PYTHONPATH=core:exports python3 -m agent_name test --type constraint
+PYTHONPATH=core:exports python3 -m agent_name test --type success
 
 # Run with parallel execution
-PYTHONPATH=core:exports python -m agent_name test --parallel 4
+PYTHONPATH=core:exports python3 -m agent_name test --parallel 4
 
 # Fail fast (stop on first failure)
-PYTHONPATH=core:exports python -m agent_name test --fail-fast
+PYTHONPATH=core:exports python3 -m agent_name test --fail-fast
 ```
 
 ### Writing Custom Tests
@@ -596,7 +596,7 @@ def my_custom_tool(param1: str, param2: int) -> Dict[str, Any]:
 {
   "tools": {
     "transport": "stdio",
-    "command": "python",
+    "command": "python3",
     "args": ["-m", "aden_tools.mcp_server"],
     "cwd": "tools/",
     "description": "File system and web tools"
@@ -635,10 +635,10 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 # Run with verbose output
-PYTHONPATH=core:exports python -m agent_name run --input '{...}' --verbose
+PYTHONPATH=core:exports python3 -m agent_name run --input '{...}' --verbose
 
 # Use mock mode to test without LLM calls
-PYTHONPATH=core:exports python -m agent_name run --mock --input '{...}'
+PYTHONPATH=core:exports python3 -m agent_name run --mock --input '{...}'
 ```
 
 ---

--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -149,7 +149,7 @@ All agent commands must be run from the project root with `PYTHONPATH` set:
 
 ```bash
 # From /hive/ directory
-PYTHONPATH=core:exports python -m agent_name COMMAND
+PYTHONPATH=core:exports python3 -m agent_name COMMAND
 ```
 
 Windows (PowerShell):
@@ -163,18 +163,18 @@ python -m agent_name COMMAND
 
 ```bash
 # Validate agent structure
-PYTHONPATH=core:exports python -m your_agent_name validate
+PYTHONPATH=core:exports python3 -m your_agent_name validate
 
 # Show agent information
-PYTHONPATH=core:exports python -m your_agent_name info
+PYTHONPATH=core:exports python3 -m your_agent_name info
 
 # Run agent with input
-PYTHONPATH=core:exports python -m your_agent_name run --input '{
+PYTHONPATH=core:exports python3 -m your_agent_name run --input '{
   "task": "Your input here"
 }'
 
 # Run in mock mode (no LLM calls)
-PYTHONPATH=core:exports python -m your_agent_name run --mock --input '{...}'
+PYTHONPATH=core:exports python3 -m your_agent_name run --mock --input '{...}'
 ```
 
 ## Building New Agents and Run Flow
@@ -293,7 +293,7 @@ Always activate the venv before running agents:
 
 ```bash
 source .venv/bin/activate
-PYTHONPATH=core:exports python -m your_agent_name demo
+PYTHONPATH=core:exports python3 -m your_agent_name demo
 ```
 
 ### PowerShell: “running scripts is disabled on this system”
@@ -351,7 +351,7 @@ pip install --upgrade "openai>=1.0.0"
 Linux/macOS:
 
 ```bash
-PYTHONPATH=core:exports python -m your_agent_name validate
+PYTHONPATH=core:exports python3 -m your_agent_name validate
 ```
 
 Windows:
@@ -495,7 +495,7 @@ Enter goal: "Build an agent that processes customer support tickets"
 ### 3. Validate Agent
 
 ```bash
-PYTHONPATH=core:exports python -m your_agent_name validate
+PYTHONPATH=core:exports python3 -m your_agent_name validate
 ```
 
 ### 4. Test Agent
@@ -507,7 +507,7 @@ claude> /testing-agent
 ### 5. Run Agent
 
 ```bash
-PYTHONPATH=core:exports python -m your_agent_name run --input '{...}'
+PYTHONPATH=core:exports python3 -m your_agent_name run --input '{...}'
 ```
 
 ## IDE Setup

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ claude> /building-agents-construction
 claude> /testing-agent
 
 # Run your agent
-PYTHONPATH=core:exports python -m your_agent_name run --input '{...}'
+PYTHONPATH=core:exports python3 -m your_agent_name run --input '{...}'
 ```
 
 **[📖 Complete Setup Guide](ENVIRONMENT_SETUP.md)** - Detailed instructions for agent development

--- a/core/examples/manual_agent.py
+++ b/core/examples/manual_agent.py
@@ -9,7 +9,7 @@ for understanding the core runtime loop:
 Setup -> Graph definition -> Execution -> Result
 
 Run with:
-    PYTHONPATH=core python core/examples/manual_agent.py
+    PYTHONPATH=core python3 core/examples/manual_agent.py
 """
 
 import asyncio

--- a/core/examples/mcp_integration_example.py
+++ b/core/examples/mcp_integration_example.py
@@ -25,7 +25,7 @@ async def example_1_programmatic_registration():
     num_tools = runner.register_mcp_server(
         name="tools",
         transport="stdio",
-        command="python",
+        command="python3",
         args=["-m", "aden_tools.mcp_server", "--stdio"],
         cwd="../tools",
     )
@@ -156,7 +156,7 @@ async def example_4_custom_agent_with_mcp_tools():
     runner.register_mcp_server(
         name="tools",
         transport="stdio",
-        command="python",
+        command="python3",
         args=["-m", "aden_tools.mcp_server", "--stdio"],
         cwd="../tools",
     )

--- a/core/examples/mcp_servers.json
+++ b/core/examples/mcp_servers.json
@@ -4,7 +4,7 @@
       "name": "tools",
       "description": "Aden tools including web search, file operations, and PDF reading",
       "transport": "stdio",
-      "command": "python",
+      "command": "python3",
       "args": ["mcp_server.py", "--stdio"],
       "cwd": "../tools",
       "env": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -184,7 +184,7 @@ $env:ANTHROPIC_API_KEY = "sk-ant-..."
 Run from the project root with PYTHONPATH:
 
 ```bash
-PYTHONPATH=core:exports python -m my_agent validate
+PYTHONPATH=core:exports python3 -m my_agent validate
 ```
 
 See [Environment Setup](../ENVIRONMENT_SETUP.md) for detailed installation instructions.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ cd hive
 ./quickstart.sh
 
 # 3. Verify installation (optional, quickstart.sh already verifies)
-python -c "import framework; import aden_tools; print('✓ Setup complete')"
+python3 -c "import framework; import aden_tools; print('✓ Setup complete')"
 ```
 
 ## Building Your First Agent
@@ -55,7 +55,7 @@ cd exports/my_agent
 # Create agent.json, tools.py, README.md (see DEVELOPER.md for structure)
 
 # Validate the agent
-PYTHONPATH=core:exports python -m my_agent validate
+PYTHONPATH=core:exports python3 -m my_agent validate
 ```
 
 ### Option 3: Manual Code-First (Minimal Example)
@@ -67,7 +67,7 @@ If you prefer to start with code rather than CLI wizards, check out the manual a
 cat core/examples/manual_agent.py
 
 # Run it (no API keys required)
-PYTHONPATH=core python core/examples/manual_agent.py
+PYTHONPATH=core python3 core/examples/manual_agent.py
 ```
 
 This demonstrates the core runtime loop using pure Python functions, skipping the complexity of LLM setup and file-based configuration.
@@ -116,18 +116,18 @@ hive/
 
 ```bash
 # Validate agent structure
-PYTHONPATH=core:exports python -m my_agent validate
+PYTHONPATH=core:exports python3 -m my_agent validate
 
 # Show agent information
-PYTHONPATH=core:exports python -m my_agent info
+PYTHONPATH=core:exports python3 -m my_agent info
 
 # Run agent with input
-PYTHONPATH=core:exports python -m my_agent run --input '{
+PYTHONPATH=core:exports python3 -m my_agent run --input '{
   "task": "Your input here"
 }'
 
 # Run in mock mode (no LLM calls)
-PYTHONPATH=core:exports python -m my_agent run --mock --input '{...}'
+PYTHONPATH=core:exports python3 -m my_agent run --mock --input '{...}'
 ```
 
 ## API Keys Setup
@@ -153,11 +153,11 @@ Get your API keys:
 claude> /testing-agent
 
 # Or manually
-PYTHONPATH=core:exports python -m my_agent test
+PYTHONPATH=core:exports python3 -m my_agent test
 
 # Run with specific test type
-PYTHONPATH=core:exports python -m my_agent test --type constraint
-PYTHONPATH=core:exports python -m my_agent test --type success
+PYTHONPATH=core:exports python3 -m my_agent test --type constraint
+PYTHONPATH=core:exports python3 -m my_agent test --type success
 ```
 
 ## Next Steps
@@ -193,7 +193,7 @@ pip install -e .
 echo $ANTHROPIC_API_KEY
 
 # Run in mock mode to test without API
-PYTHONPATH=core:exports python -m my_agent run --mock --input '{...}'
+PYTHONPATH=core:exports python3 -m my_agent run --mock --input '{...}'
 ```
 
 ### Package Installation Issues

--- a/docs/i18n/es.md
+++ b/docs/i18n/es.md
@@ -95,7 +95,7 @@ claude> /building-agents-construction
 claude> /testing-agent
 
 # Ejecutar tu agente
-PYTHONPATH=core:exports python -m your_agent_name run --input '{...}'
+PYTHONPATH=core:exports python3 -m your_agent_name run --input '{...}'
 ```
 
 **[📖 Guía de Configuración Completa](ENVIRONMENT_SETUP.md)** - Instrucciones detalladas para desarrollo de agentes
@@ -241,7 +241,7 @@ claude> /building-agents-construction
 claude> /testing-agent
 
 # Ejecutar agentes
-PYTHONPATH=core:exports python -m agent_name run --input '{...}'
+PYTHONPATH=core:exports python3 -m agent_name run --input '{...}'
 ```
 
 Consulta [ENVIRONMENT_SETUP.md](ENVIRONMENT_SETUP.md) para instrucciones de configuración completas.

--- a/docs/i18n/hi.md
+++ b/docs/i18n/hi.md
@@ -104,7 +104,7 @@ claude> /building-agents-construction
 claude> /testing-agent
 
 # अपने एजेंट को चलाएँ
-PYTHONPATH=core:exports python -m your_agent_name run --input '{...}'
+PYTHONPATH=core:exports python3 -m your_agent_name run --input '{...}'
 ```
 
 **[📖 पूर्ण कॉन्फ़िगरेशन गाइड](ENVIRONMENT_SETUP.md)** - एजेंट विकास के लिए विस्तृत निर्देश
@@ -250,7 +250,7 @@ claude> /building-agents-construction
 claude> /testing-agent
 
 # एजेंट चलाएँ
-PYTHONPATH=core:exports python -m agent_name run --input '{...}'
+PYTHONPATH=core:exports python3 -m agent_name run --input '{...}'
 ```
 
 पूरी कॉन्फ़िगरेशन निर्देशों के लिए ENVIRONMENT_SETUP.md देखें।

--- a/docs/i18n/ja.md
+++ b/docs/i18n/ja.md
@@ -97,7 +97,7 @@ claude> /building-agents-construction
 claude> /testing-agent
 
 # エージェントを実行
-PYTHONPATH=core:exports python -m your_agent_name run --input '{...}'
+PYTHONPATH=core:exports python3 -m your_agent_name run --input '{...}'
 ```
 
 **[📖 完全セットアップガイド](ENVIRONMENT_SETUP.md)** - エージェント開発の詳細な手順
@@ -243,7 +243,7 @@ claude> /building-agents-construction
 claude> /testing-agent
 
 # エージェントを実行
-PYTHONPATH=core:exports python -m agent_name run --input '{...}'
+PYTHONPATH=core:exports python3 -m agent_name run --input '{...}'
 ```
 
 完全なセットアップ手順については、[ENVIRONMENT_SETUP.md](ENVIRONMENT_SETUP.md)を参照してください。

--- a/docs/i18n/ko.md
+++ b/docs/i18n/ko.md
@@ -97,7 +97,7 @@ claude> /building-agents
 claude> /testing-agent
 
 # 에이전트 실행
-PYTHONPATH=core:exports python -m your_agent_name run --input '{...}'
+PYTHONPATH=core:exports python3 -m your_agent_name run --input '{...}'
 ```
 
 **[📖 전체 설정 가이드](ENVIRONMENT_SETUP.md)** - 에이전트 개발을 위한 상세한 설명
@@ -254,7 +254,7 @@ claude> /building-agents
 claude> /testing-agent
 
 # 에이전트 실행
-PYTHONPATH=core:exports python -m agent_name run --input '{...}'
+PYTHONPATH=core:exports python3 -m agent_name run --input '{...}'
 ```
 
 전체 설정 방법은 [ENVIRONMENT_SETUP.md](ENVIRONMENT_SETUP.md) 를 참고하세요.

--- a/docs/i18n/pt.md
+++ b/docs/i18n/pt.md
@@ -97,7 +97,7 @@ claude> /building-agents-construction
 claude> /testing-agent
 
 # Executar seu agente
-PYTHONPATH=core:exports python -m your_agent_name run --input '{...}'
+PYTHONPATH=core:exports python3 -m your_agent_name run --input '{...}'
 ```
 
 **[📖 Guia Completo de Configuração](ENVIRONMENT_SETUP.md)** - Instruções detalhadas para desenvolvimento de agentes
@@ -243,7 +243,7 @@ claude> /building-agents-construction
 claude> /testing-agent
 
 # Executar agentes
-PYTHONPATH=core:exports python -m agent_name run --input '{...}'
+PYTHONPATH=core:exports python3 -m agent_name run --input '{...}'
 ```
 
 Consulte [ENVIRONMENT_SETUP.md](ENVIRONMENT_SETUP.md) para instruções completas de configuração.

--- a/docs/i18n/ru.md
+++ b/docs/i18n/ru.md
@@ -97,7 +97,7 @@ claude> /building-agents-construction
 claude> /testing-agent
 
 # Запустить агента
-PYTHONPATH=core:exports python -m your_agent_name run --input '{...}'
+PYTHONPATH=core:exports python3 -m your_agent_name run --input '{...}'
 ```
 
 **[📖 Полное руководство по настройке](ENVIRONMENT_SETUP.md)** - Подробные инструкции для разработки агентов
@@ -243,7 +243,7 @@ claude> /building-agents-construction
 claude> /testing-agent
 
 # Запустить агентов
-PYTHONPATH=core:exports python -m agent_name run --input '{...}'
+PYTHONPATH=core:exports python3 -m agent_name run --input '{...}'
 ```
 
 Обратитесь к [ENVIRONMENT_SETUP.md](ENVIRONMENT_SETUP.md) для полных инструкций по настройке.

--- a/docs/i18n/zh-CN.md
+++ b/docs/i18n/zh-CN.md
@@ -97,7 +97,7 @@ claude> /building-agents-construction
 claude> /testing-agent
 
 # 运行您的智能体
-PYTHONPATH=core:exports python -m your_agent_name run --input '{...}'
+PYTHONPATH=core:exports python3 -m your_agent_name run --input '{...}'
 ```
 
 **[📖 完整设置指南](ENVIRONMENT_SETUP.md)** - 智能体开发的详细说明
@@ -243,7 +243,7 @@ claude> /building-agents-construction
 claude> /testing-agent
 
 # 运行智能体
-PYTHONPATH=core:exports python -m agent_name run --input '{...}'
+PYTHONPATH=core:exports python3 -m agent_name run --input '{...}'
 ```
 
 完整设置说明请参阅 [ENVIRONMENT_SETUP.md](ENVIRONMENT_SETUP.md)。

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,7 +31,7 @@ cp -r examples/templates/marketing_agent exports/my_agent
 # 2. Edit the goal, nodes, and edges in agent.py and nodes/__init__.py
 
 # 3. Run it
-PYTHONPATH=core python -m exports.my_agent --help
+PYTHONPATH=core python3 -m exports.my_agent --help
 ```
 
 ## How to use a recipe

--- a/examples/templates/README.md
+++ b/examples/templates/README.md
@@ -28,7 +28,7 @@ cp -r examples/templates/marketing_agent exports/my_marketing_agent
 # 3. Customize goal, nodes, edges, and prompts
 
 # 4. Run it
-PYTHONPATH=core python -m exports.my_marketing_agent --input '{"product_description": "..."}'
+PYTHONPATH=core python3 -m exports.my_marketing_agent --input '{"product_description": "..."}'
 ```
 
 ## Available templates

--- a/examples/templates/marketing_agent/README.md
+++ b/examples/templates/marketing_agent/README.md
@@ -25,10 +25,10 @@ A multi-channel marketing content generator. Given a product and audience, this 
 
 ```bash
 # From the repo root
-PYTHONPATH=core python -m examples.templates.marketing_agent
+PYTHONPATH=core python3 -m examples.templates.marketing_agent
 
 # With custom input
-PYTHONPATH=core python -m examples.templates.marketing_agent --input '{
+PYTHONPATH=core python3 -m examples.templates.marketing_agent --input '{
   "product_description": "A fitness tracking app",
   "target_audience": "Health-conscious millennials",
   "brand_voice": "Energetic and motivational",

--- a/tools/README.md
+++ b/tools/README.md
@@ -56,7 +56,7 @@ mcp.run()
 Or run directly:
 
 ```bash
-python mcp_server.py
+python3 mcp_server.py
 ```
 
 ## Available Tools


### PR DESCRIPTION
### Summary
Replaced `python` with `python3` in agent skill build, validation, and run commands to support environments 
where `python` is not available by default (e.g., Ubuntu 22.04, WSL).

### Changes
- Updated docs: getting-started.md, configuration.md, README.md, ENVIRONMENT_SETUP.md
- Updated quickstart.sh where necessary
- Ensures agent commands work out of the box on Linux/WSL

### Related Issue
Fixes #3356
