### PR TITLE
[micro-fix]: Remove commented-out debug statements and dead code to improve code cleanliness.

### DIFF
--- a/core/framework/graph/flexible_executor.py
+++ b/core/framework/graph/flexible_executor.py
@@ -178,9 +178,6 @@ class FlexibleGraphExecutor:
 
                 # Execute next step (for now, sequential; could be parallel)
                 step = ready_steps[0]
-                # Debug: show ready steps
-                # ready_ids = [s.id for s in ready_steps]
-                # print(f"  [DEBUG] Ready steps: {ready_ids}, executing: {step.id}")
 
                 # APPROVAL CHECK - before execution
                 if step.requires_approval:

--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -1152,12 +1152,6 @@ Keep the same JSON structure but with shorter content values.
                         tokens_used=response.input_tokens + response.output_tokens,
                         latency_ms=latency_ms,
                     )
-                    # JSON extraction failed completely - still strip code blocks
-                    # logger.warning(f"      ⚠ Failed to extract JSON output: {e}")
-                    # stripped_content = self._strip_code_blocks(response.content)
-                    # for key in ctx.node_spec.output_keys:
-                    #     ctx.memory.write(key, stripped_content)
-                    #     output[key] = stripped_content
             else:
                 # For non-llm_generate or single output nodes, write entire response (stripped)
                 stripped_content = self._strip_code_blocks(response.content)

--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -935,7 +935,6 @@ def _select_agent(agents_dir: Path) -> str | None:
         # fixes issue #696, creates an exports folder if it does not exist
         agents_dir.mkdir(parents=True, exist_ok=True)
         print(f"Created directory: {agents_dir}", file=sys.stderr)
-        # return None
 
     agents = []
     for path in agents_dir.iterdir():


### PR DESCRIPTION
## Description
Remove debug and dead commented code that clutters the codebase:

## Type of Change
- [✓ ] Refactoring (no functional changes)

## Related Issues

N/A - This is a micro-fix (commented-out code removal only, <20 lines changed)

## Changes Made

- **node.py**: Remove 5-line commented block that was duplicate dead code (active version exists at lines 1163-1166)
- **flexible_executor.py**: Remove 2-line commented debug print statements
- **cli.py**: Remove 1-line commented `return None` statement (leftover from #696 fix)

**Total: 8 lines removed**

## Testing

Describe the tests you ran to verify your changes:

- [✓] Unit tests pass (`cd core && pytest tests/`)
- [✓] Lint passes (`cd core && ruff check .`)
- [✓] Manual testing performed

## Checklist

- [✓] My code follows the project's style guidelines
- [✓] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [✓] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [✓] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Not applicable (CLI-only change).
