### PR TITLE
fix(ci): migrate remaining CI jobs from pip to uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,23 +21,22 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
 
       - name: Install dependencies
-        run: |
-          cd core
-          pip install -e .
-          pip install -r requirements-dev.txt
+        run: uv sync --project core --group dev
 
       - name: Ruff lint
         run: |
-          ruff check core/
-          ruff check tools/
+          uv run --project core ruff check core/
+          uv run --project core ruff check tools/
 
       - name: Ruff format
         run: |
-          ruff format --check core/
-          ruff format --check tools/
+          uv run --project core ruff format --check core/
+          uv run --project core ruff format --check tools/
 
   test:
     name: Test Python Framework
@@ -52,18 +51,19 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
 
       - name: Install dependencies
         run: |
           cd core
-          pip install -e .
-          pip install -r requirements-dev.txt
+          uv sync
 
       - name: Run tests
         run: |
           cd core
-          pytest tests/ -v
+          uv run pytest tests/ -v
 
   test-tools:
     name: Test Tools
@@ -97,13 +97,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
 
       - name: Install dependencies
         run: |
           cd core
-          pip install -e .
-          pip install -r requirements-dev.txt
+          uv sync
 
       - name: Validate exported agents
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,18 +21,19 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
 
       - name: Install dependencies
         run: |
           cd core
-          pip install -e .
-          pip install -r requirements-dev.txt
+          uv sync
 
       - name: Run tests
         run: |
           cd core
-          pytest tests/ -v
+          uv run pytest tests/ -v
 
       - name: Generate changelog
         id: changelog


### PR DESCRIPTION
## Description

Migrate remaining CI jobs from pip to uv. The `requirements-dev.txt` file was deleted during the uv migration but CI workflows still referenced it, breaking lint, test, and validate jobs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #3363

## Changes Made

- Replaced `pip install -e . && pip install -r requirements-dev.txt` with `uv sync` in ci.yml (lint, test, validate jobs)
- Replaced the same in release.yml (release job)
- Added `astral-sh/setup-uv@v4` step to all affected jobs
- Used `--project core` in lint job to keep paths clean from repo root
- Removed `cache: 'pip'` from setup-python where no longer needed

## Testing

- [ ] CI passes on this PR (lint, test, test-tools, validate)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code