### PR TITLE
ci: migrate CI and release workflows from pip/requirements-dev.txt to uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,13 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v4
+
       - name: Install dependencies
         run: |
-          cd core
-          pip install -e .
-          pip install -r requirements-dev.txt
+          uv sync --group dev  
+          uv pip install -e core 
 
       - name: Ruff lint
         run: |
@@ -54,11 +56,13 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v4
+
       - name: Install dependencies
         run: |
-          cd core
-          pip install -e .
-          pip install -r requirements-dev.txt
+          uv sync --group dev
+          uv pip install -e core
 
       - name: Run tests
         run: |
@@ -99,11 +103,13 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v4
+
       - name: Install dependencies
         run: |
-          cd core
-          pip install -e .
-          pip install -r requirements-dev.txt
+          uv sync --group dev  
+          uv pip install -e core
 
       - name: Validate exported agents
         run: |
@@ -126,7 +132,7 @@ jobs:
           for agent_dir in "${agent_dirs[@]}"; do
             if [ -f "$agent_dir/agent.json" ]; then
               echo "Validating $agent_dir"
-              python -c "import json; json.load(open('$agent_dir/agent.json'))"
+              python3 -c "import json; json.load(open('$agent_dir/agent.json'))"
               validated=$((validated + 1))
             fi
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,13 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v4
+
       - name: Install dependencies
         run: |
-          cd core
-          pip install -e .
-          pip install -r requirements-dev.txt
+          uv sync --group dev
+          uv pip install -e core
 
       - name: Run tests
         run: |


### PR DESCRIPTION
### Summary
This PR fixes CI and release workflow failures caused by the removed `requirements-dev.txt` file.  
All references to `requirements-dev.txt` in CI and release jobs have been replaced with `uv` commands, following the existing `test-tools` job pattern.

### Changes
- `.github/workflows/ci.yml`
  - Replaced `pip install -r requirements-dev.txt` with `uv sync --group dev` and `uv pip install -e core`.
- `.github/workflows/release.yml`
  - Replaced `pip install -r requirements-dev.txt` with `uv sync --group dev` and `uv pip install -e core`.

### Testing
- All CI steps (lint, test, validate) have been tested locally using Python3 and `uv`.
- Core and tools tests pass with `pytest`.

### Notes
- No behavioral changes; only dependency installation method updated for CI compatibility.
- This resolves issue #3363.
