### PR TITLE
docs: align ruff lint scope with Makefile and CI

### DIFF
--- a/docs/contributing-lint-setup.md
+++ b/docs/contributing-lint-setup.md
@@ -109,8 +109,8 @@ The `.cursorrules` file at the repo root tells Cursor's AI the project's style r
 Every push and PR to `main` runs the `Lint Python` job in GitHub Actions (`.github/workflows/ci.yml`):
 
 ```
-ruff check   → core/, tools/, exports/
-ruff format  → core/, tools/, exports/ (--check mode, no modifications)
+ruff check   → core/, tools/
+ruff format  → core/, tools/ (--check mode, no modifications)
 ```
 
 Both must pass. If CI fails:


### PR DESCRIPTION
### What does this PR do?

Aligns the linting documentation with the actual behavior defined in the Makefile and CI.

The docs previously stated that `ruff` runs on `core/`, `tools/`, and `exports/`, but the current implementation only runs on `core/` and `tools/`.

### Why?

This removes confusion for contributors following the lint setup instructions and reflects the current intended scope.

### Related issue
Fixes #2438
