### PR TITLE
feat: Add SEO audit tool for on-page optimization analysis

### DIFF
--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -40,6 +40,7 @@ from .file_system_toolkits.view_file import register_tools as register_view_file
 from .file_system_toolkits.write_to_file import register_tools as register_write_to_file
 from .hubspot_tool import register_tools as register_hubspot
 from .pdf_read_tool import register_tools as register_pdf_read
+from .seo_tool import register_tools as register_seo
 from .web_scrape_tool import register_tools as register_web_scrape
 from .web_search_tool import register_tools as register_web_search
 
@@ -82,6 +83,9 @@ def register_all_tools(
     register_execute_command(mcp)
     register_csv(mcp)
 
+    # Register SEO audit tool
+    register_seo(mcp)
+
     return [
         "example_tool",
         "web_search",
@@ -114,6 +118,7 @@ def register_all_tools(
         "hubspot_get_deal",
         "hubspot_create_deal",
         "hubspot_update_deal",
+        "analyze_on_page",
     ]
 
 

--- a/tools/src/aden_tools/tools/seo_tool/README.md
+++ b/tools/src/aden_tools/tools/seo_tool/README.md
@@ -1,0 +1,165 @@
+# SEO Audit Tool
+
+Analyze webpages for on-page SEO optimization. This tool provides comprehensive SEO health reports to help agents automate technical marketing tasks.
+
+## Features
+
+- **Title Tag Analysis**: Checks presence, length (30-60 chars optimal), and content
+- **Meta Description Check**: Validates presence and length (120-160 chars optimal)  
+- **Heading Hierarchy**: Analyzes H1-H6 structure and detects hierarchy gaps
+- **Image Alt Text**: Reports coverage percentage and identifies missing alt attributes
+- **Canonical Tag**: Verifies presence and self-referencing status
+- **Meta Robots**: Detects indexing/following directives
+- **Open Graph Tags**: Checks social sharing metadata
+- **Overall Score**: Provides 0-100 score with letter grade (A-F)
+
+## Use Cases
+
+1. **Content Publishing**: Check blog posts for SEO issues before publishing
+2. **Competitor Analysis**: Extract heading structures and keywords from competitor pages
+3. **Periodic Audits**: Detect SEO regressions after website deployments
+4. **Migration Validation**: Verify SEO elements are preserved after site migrations
+
+## Installation
+
+The SEO tool is included in the aden-tools package. Ensure you have the dependencies:
+
+```bash
+pip install httpx beautifulsoup4
+```
+
+## Usage
+
+### As an MCP Tool
+
+When running with the Aden MCP server, the `analyze_on_page` tool is automatically available:
+
+```python
+# The tool is registered automatically when the server starts
+# Agents can call it with:
+result = await mcp.call_tool("analyze_on_page", {"url": "https://example.com"})
+```
+
+### Standalone Usage
+
+```python
+from aden_tools.tools.seo_tool import analyze_on_page
+
+result = analyze_on_page("https://example.com")
+print(f"SEO Score: {result['overall_score']['score']}/100")
+print(f"Grade: {result['overall_score']['grade']}")
+```
+
+## Response Format
+
+```json
+{
+  "url": "https://example.com",
+  "final_url": "https://example.com/",
+  "status_code": 200,
+  "title": {
+    "present": true,
+    "content": "Example Domain",
+    "length": 14,
+    "optimal": false,
+    "issues": ["Too short (14 chars, recommended min 30)"]
+  },
+  "meta_description": {
+    "present": true,
+    "content": "This is an example website...",
+    "length": 150,
+    "optimal": true,
+    "issues": []
+  },
+  "headings": {
+    "structure": {
+      "h1": {"count": 1, "content": ["Example Domain"]},
+      "h2": {"count": 0, "content": []},
+      ...
+    },
+    "h1_count": 1,
+    "total_headings": 1,
+    "issues": []
+  },
+  "images": {
+    "total": 5,
+    "with_alt": 3,
+    "missing_alt_count": 2,
+    "coverage_percent": 60.0,
+    "optimal": false,
+    "issues": ["2 image(s) missing alt attribute"]
+  },
+  "canonical": {
+    "present": true,
+    "href": "https://example.com/",
+    "self_referencing": true,
+    "issues": []
+  },
+  "robots": {
+    "present": false,
+    "indexable": true,
+    "followable": true,
+    "issues": []
+  },
+  "open_graph": {
+    "present": true,
+    "tags": {"og:title": "...", "og:description": "..."},
+    "missing_required": ["og:image"],
+    "issues": ["Missing Open Graph tags: og:image"]
+  },
+  "overall_score": {
+    "score": 75,
+    "grade": "C",
+    "max_score": 100,
+    "issues": ["Title length not optimal (-10)", "2 images with alt text issues (-4)"],
+    "passed": true
+  }
+}
+```
+
+## Scoring Methodology
+
+| Component | Points | Criteria |
+|-----------|--------|----------|
+| Title Tag | 20 | Present and optimal length |
+| Meta Description | 20 | Present and optimal length |
+| H1 Tag | 20 | Exactly one H1 present |
+| Image Alt Text | 20 | All images have alt attributes |
+| Canonical Tag | 10 | Present |
+| Heading Hierarchy | 10 | No gaps in heading levels |
+
+Grades:
+- **A**: 90-100
+- **B**: 80-89  
+- **C**: 70-79
+- **D**: 60-69
+- **F**: Below 60
+
+## Error Handling
+
+The tool returns error responses for common failure cases:
+
+```json
+{"error": "URL cannot be empty"}
+{"error": "URL must start with http:// or https://"}
+{"error": "Request timed out after 30 seconds: https://..."}
+{"error": "HTTP error 404: https://..."}
+{"error": "Failed to fetch URL: Connection refused"}
+```
+
+## Configuration
+
+The tool uses sensible defaults based on SEO best practices:
+
+| Setting | Value |
+|---------|-------|
+| Title Min Length | 30 characters |
+| Title Max Length | 60 characters |
+| Meta Desc Min Length | 120 characters |
+| Meta Desc Max Length | 160 characters |
+| Request Timeout | 30 seconds |
+| User Agent | `AdenSEOBot/1.0` |
+
+## Contributing
+
+See the main [CONTRIBUTING.md](../../../CONTRIBUTING.md) for guidelines on contributing to this tool.

--- a/tools/src/aden_tools/tools/seo_tool/__init__.py
+++ b/tools/src/aden_tools/tools/seo_tool/__init__.py
@@ -1,0 +1,87 @@
+"""
+SEO Audit Tool - Analyze webpages for on-page SEO optimization.
+
+Provides comprehensive SEO health reports including title tags, meta descriptions,
+heading hierarchy, image alt text coverage, and canonical tag verification.
+"""
+
+from .seo_tool import register_tools
+
+__all__ = ["register_tools"]
+
+
+# Standalone usage function
+def analyze_on_page(url: str) -> dict:
+    """
+    Convenience function to analyze SEO without setting up MCP.
+
+    For standalone usage, import and call directly:
+        from aden_tools.tools.seo_tool import analyze_on_page
+        result = analyze_on_page("https://example.com")
+
+    Args:
+        url: The URL of the webpage to analyze
+
+    Returns:
+        Dict with comprehensive SEO health report
+    """
+    import httpx
+    from bs4 import BeautifulSoup
+
+    from .seo_tool import (
+        USER_AGENT,
+        _analyze_canonical,
+        _analyze_headings,
+        _analyze_images,
+        _analyze_meta_description,
+        _analyze_meta_robots,
+        _analyze_open_graph,
+        _analyze_title,
+        _calculate_score,
+    )
+
+    if not url or not url.strip():
+        return {"error": "URL cannot be empty"}
+
+    if not url.startswith(("http://", "https://")):
+        return {"error": "URL must start with http:// or https://"}
+
+    try:
+        response = httpx.get(
+            url,
+            headers={"User-Agent": USER_AGENT},
+            follow_redirects=True,
+            timeout=30.0,
+        )
+        response.raise_for_status()
+    except httpx.TimeoutException:
+        return {"error": f"Request timed out after 30 seconds: {url}"}
+    except httpx.HTTPStatusError as e:
+        return {"error": f"HTTP error {e.response.status_code}: {url}"}
+    except httpx.RequestError as e:
+        return {"error": f"Failed to fetch URL: {e}"}
+
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    title = _analyze_title(soup)
+    meta_desc = _analyze_meta_description(soup)
+    headings = _analyze_headings(soup)
+    images = _analyze_images(soup)
+    canonical = _analyze_canonical(soup, url)
+    robots = _analyze_meta_robots(soup)
+    open_graph = _analyze_open_graph(soup)
+    overall = _calculate_score(title, meta_desc, headings, images, canonical)
+
+    return {
+        "url": url,
+        "final_url": str(response.url),
+        "status_code": response.status_code,
+        "title": title,
+        "meta_description": meta_desc,
+        "headings": headings,
+        "images": images,
+        "canonical": canonical,
+        "robots": robots,
+        "open_graph": open_graph,
+        "overall_score": overall,
+    }

--- a/tools/src/aden_tools/tools/seo_tool/seo_tool.py
+++ b/tools/src/aden_tools/tools/seo_tool/seo_tool.py
@@ -1,0 +1,488 @@
+"""
+SEO Audit Tool - Analyze webpages for on-page SEO optimization.
+
+This tool provides comprehensive SEO health reports for webpages, helping
+agents automate technical marketing tasks and ensure content is optimized
+for search engines.
+
+Use cases:
+- Content agents checking blog posts for SEO issues before publishing
+- Competitor analysis to extract heading structures and keywords
+- Periodic audits to detect SEO regressions after deployments
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from bs4 import BeautifulSoup
+from fastmcp import FastMCP
+
+# SEO best practice limits
+TITLE_MIN_LENGTH = 30
+TITLE_MAX_LENGTH = 60
+META_DESC_MIN_LENGTH = 120
+META_DESC_MAX_LENGTH = 160
+
+# User agent for requests
+USER_AGENT = "AdenSEOBot/1.0 (+https://github.com/adenhq/hive)"
+
+
+def _analyze_title(soup: BeautifulSoup) -> dict[str, Any]:
+    """Analyze the title tag for SEO best practices.
+
+    Args:
+        soup: BeautifulSoup parsed HTML document
+
+    Returns:
+        Dict with title analysis including content, length, and issues
+    """
+    title_tag = soup.find("title")
+    if not title_tag or not title_tag.string:
+        return {
+            "present": False,
+            "content": None,
+            "length": 0,
+            "optimal": False,
+            "issues": ["Missing title tag"],
+        }
+
+    title = title_tag.string.strip()
+    length = len(title)
+
+    issues = []
+    if length < TITLE_MIN_LENGTH:
+        issues.append(f"Too short ({length} chars, recommended min {TITLE_MIN_LENGTH})")
+    if length > TITLE_MAX_LENGTH:
+        issues.append(f"Too long ({length} chars, recommended max {TITLE_MAX_LENGTH})")
+
+    return {
+        "present": True,
+        "content": title,
+        "length": length,
+        "optimal": TITLE_MIN_LENGTH <= length <= TITLE_MAX_LENGTH,
+        "issues": issues,
+    }
+
+
+def _analyze_meta_description(soup: BeautifulSoup) -> dict[str, Any]:
+    """Analyze the meta description tag for SEO best practices.
+
+    Args:
+        soup: BeautifulSoup parsed HTML document
+
+    Returns:
+        Dict with meta description analysis
+    """
+    meta = soup.find("meta", attrs={"name": "description"})
+    if not meta or not meta.get("content"):
+        return {
+            "present": False,
+            "content": None,
+            "length": 0,
+            "optimal": False,
+            "issues": ["Missing meta description"],
+        }
+
+    content = meta["content"].strip()
+    length = len(content)
+
+    issues = []
+    if length < META_DESC_MIN_LENGTH:
+        issues.append(
+            f"Too short ({length} chars, recommended min {META_DESC_MIN_LENGTH})"
+        )
+    if length > META_DESC_MAX_LENGTH:
+        issues.append(
+            f"Too long ({length} chars, recommended max {META_DESC_MAX_LENGTH})"
+        )
+
+    return {
+        "present": True,
+        "content": content,
+        "length": length,
+        "optimal": META_DESC_MIN_LENGTH <= length <= META_DESC_MAX_LENGTH,
+        "issues": issues,
+    }
+
+
+def _analyze_headings(soup: BeautifulSoup) -> dict[str, Any]:
+    """Analyze heading hierarchy H1-H6 for proper structure.
+
+    Args:
+        soup: BeautifulSoup parsed HTML document
+
+    Returns:
+        Dict with heading structure analysis
+    """
+    headings: dict[str, dict[str, Any]] = {}
+    hierarchy: list[dict[str, Any]] = []
+
+    for level in range(1, 7):
+        tag = f"h{level}"
+        found = soup.find_all(tag)
+        headings[tag] = {
+            "count": len(found),
+            "content": [h.get_text(strip=True)[:100] for h in found[:5]],
+        }
+        for h in found:
+            hierarchy.append({"level": level, "text": h.get_text(strip=True)[:100]})
+
+    issues = []
+    if headings["h1"]["count"] == 0:
+        issues.append("Missing H1 tag - every page should have exactly one H1")
+    elif headings["h1"]["count"] > 1:
+        issues.append(
+            f"Multiple H1 tags found ({headings['h1']['count']}) - "
+            "only one H1 recommended per page"
+        )
+
+    # Check for heading hierarchy gaps
+    prev_level = 0
+    for item in hierarchy:
+        if item["level"] > prev_level + 1 and prev_level > 0:
+            issues.append(
+                f"Heading hierarchy gap: H{prev_level} followed by H{item['level']}"
+            )
+            break
+        prev_level = item["level"]
+
+    return {
+        "structure": headings,
+        "hierarchy": hierarchy[:20],
+        "h1_count": headings["h1"]["count"],
+        "total_headings": sum(h["count"] for h in headings.values()),
+        "issues": issues,
+    }
+
+
+def _analyze_images(soup: BeautifulSoup) -> dict[str, Any]:
+    """Analyze image alt text coverage for accessibility and SEO.
+
+    Args:
+        soup: BeautifulSoup parsed HTML document
+
+    Returns:
+        Dict with image analysis including alt text coverage
+    """
+    images = soup.find_all("img")
+    total = len(images)
+
+    if total == 0:
+        return {
+            "total": 0,
+            "with_alt": 0,
+            "missing_alt_count": 0,
+            "coverage_percent": 100.0,
+            "missing_alt_examples": [],
+            "optimal": True,
+            "issues": [],
+        }
+
+    missing_alt = []
+    empty_alt = []
+    for img in images:
+        alt = img.get("alt")
+        src = img.get("src", img.get("data-src", "unknown"))[:100]
+        if alt is None:
+            missing_alt.append(src)
+        elif alt.strip() == "":
+            empty_alt.append(src)
+
+    missing_count = len(missing_alt)
+    with_alt = total - missing_count - len(empty_alt)
+    coverage = (with_alt / total * 100) if total > 0 else 100
+
+    issues = []
+    if missing_count > 0:
+        issues.append(f"{missing_count} image(s) missing alt attribute")
+    if len(empty_alt) > 0:
+        issues.append(f"{len(empty_alt)} image(s) have empty alt attribute")
+
+    return {
+        "total": total,
+        "with_alt": with_alt,
+        "missing_alt_count": missing_count,
+        "empty_alt_count": len(empty_alt),
+        "coverage_percent": round(coverage, 1),
+        "missing_alt_examples": missing_alt[:5],
+        "optimal": missing_count == 0 and len(empty_alt) == 0,
+        "issues": issues,
+    }
+
+
+def _analyze_canonical(soup: BeautifulSoup, url: str) -> dict[str, Any]:
+    """Verify canonical tag presence and correctness.
+
+    Args:
+        soup: BeautifulSoup parsed HTML document
+        url: The URL being analyzed
+
+    Returns:
+        Dict with canonical tag analysis
+    """
+    canonical = soup.find("link", attrs={"rel": "canonical"})
+    if not canonical or not canonical.get("href"):
+        return {
+            "present": False,
+            "href": None,
+            "self_referencing": False,
+            "issues": ["Missing canonical tag - helps prevent duplicate content issues"],
+        }
+
+    href = canonical["href"].strip()
+
+    # Normalize URLs for comparison
+    normalized_url = url.rstrip("/").lower()
+    normalized_href = href.rstrip("/").lower()
+
+    return {
+        "present": True,
+        "href": href,
+        "self_referencing": normalized_href == normalized_url,
+        "issues": [],
+    }
+
+
+def _analyze_meta_robots(soup: BeautifulSoup) -> dict[str, Any]:
+    """Analyze meta robots tag for indexing directives.
+
+    Args:
+        soup: BeautifulSoup parsed HTML document
+
+    Returns:
+        Dict with robots meta tag analysis
+    """
+    robots = soup.find("meta", attrs={"name": "robots"})
+    if not robots or not robots.get("content"):
+        return {
+            "present": False,
+            "content": None,
+            "indexable": True,
+            "followable": True,
+            "issues": [],
+        }
+
+    content = robots["content"].lower()
+    directives = [d.strip() for d in content.split(",")]
+
+    indexable = "noindex" not in directives
+    followable = "nofollow" not in directives
+
+    issues = []
+    if not indexable:
+        issues.append("Page is set to noindex - will not appear in search results")
+    if not followable:
+        issues.append("Page is set to nofollow - links will not be crawled")
+
+    return {
+        "present": True,
+        "content": content,
+        "directives": directives,
+        "indexable": indexable,
+        "followable": followable,
+        "issues": issues,
+    }
+
+
+def _analyze_open_graph(soup: BeautifulSoup) -> dict[str, Any]:
+    """Analyze Open Graph tags for social sharing.
+
+    Args:
+        soup: BeautifulSoup parsed HTML document
+
+    Returns:
+        Dict with Open Graph analysis
+    """
+    og_tags = {}
+    required_tags = ["og:title", "og:description", "og:image", "og:url"]
+
+    for tag in soup.find_all("meta", attrs={"property": True}):
+        prop = tag.get("property", "")
+        if prop.startswith("og:"):
+            og_tags[prop] = tag.get("content", "")
+
+    missing = [tag for tag in required_tags if tag not in og_tags]
+
+    issues = []
+    if missing:
+        issues.append(f"Missing Open Graph tags: {', '.join(missing)}")
+
+    return {
+        "present": len(og_tags) > 0,
+        "tags": og_tags,
+        "missing_required": missing,
+        "issues": issues,
+    }
+
+
+def _calculate_score(
+    title: dict,
+    meta_desc: dict,
+    headings: dict,
+    images: dict,
+    canonical: dict,
+) -> dict[str, Any]:
+    """Calculate overall SEO score based on all factors.
+
+    Args:
+        title: Title analysis result
+        meta_desc: Meta description analysis result
+        headings: Headings analysis result
+        images: Images analysis result
+        canonical: Canonical analysis result
+
+    Returns:
+        Dict with overall score, grade, and summary of issues
+    """
+    score = 100
+    issues = []
+
+    # Title (20 points)
+    if not title["present"]:
+        score -= 20
+        issues.append("Missing title tag (-20)")
+    elif not title["optimal"]:
+        score -= 10
+        issues.append("Title length not optimal (-10)")
+
+    # Meta description (20 points)
+    if not meta_desc["present"]:
+        score -= 20
+        issues.append("Missing meta description (-20)")
+    elif not meta_desc["optimal"]:
+        score -= 10
+        issues.append("Meta description length not optimal (-10)")
+
+    # H1 tag (20 points)
+    h1_count = headings.get("h1_count", 0)
+    if h1_count == 0:
+        score -= 20
+        issues.append("Missing H1 tag (-20)")
+    elif h1_count > 1:
+        score -= 10
+        issues.append(f"Multiple H1 tags: {h1_count} found (-10)")
+
+    # Images alt text (20 points)
+    if not images["optimal"]:
+        missing = images.get("missing_alt_count", 0) + images.get("empty_alt_count", 0)
+        penalty = min(20, missing * 2)
+        score -= penalty
+        if penalty > 0:
+            issues.append(f"{missing} images with alt text issues (-{penalty})")
+
+    # Canonical (10 points)
+    if not canonical["present"]:
+        score -= 10
+        issues.append("Missing canonical tag (-10)")
+
+    # Heading hierarchy (10 points)
+    if headings.get("issues"):
+        for issue in headings["issues"]:
+            if "gap" in issue.lower():
+                score -= 5
+                issues.append("Heading hierarchy issues (-5)")
+                break
+
+    score = max(0, score)
+
+    # Determine grade
+    if score >= 90:
+        grade = "A"
+    elif score >= 80:
+        grade = "B"
+    elif score >= 70:
+        grade = "C"
+    elif score >= 60:
+        grade = "D"
+    else:
+        grade = "F"
+
+    return {
+        "score": score,
+        "grade": grade,
+        "max_score": 100,
+        "issues": issues,
+        "passed": score >= 70,
+    }
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register SEO audit tools with the MCP server.
+
+    Args:
+        mcp: FastMCP server instance
+    """
+
+    @mcp.tool()
+    def analyze_on_page(url: str) -> dict:
+        """
+        Analyze a webpage for on-page SEO health and optimization opportunities.
+
+        Returns a comprehensive SEO health report including:
+        - Title tag analysis (presence, length, content)
+        - Meta description check (presence, length, content)
+        - Heading hierarchy structure (H1-H6)
+        - Image alt text coverage
+        - Canonical tag verification
+        - Meta robots directives
+        - Open Graph tags for social sharing
+        - Overall SEO score and grade
+
+        Args:
+            url: The URL of the webpage to analyze (must be publicly accessible)
+
+        Returns:
+            Dict with comprehensive SEO health report, or error dict on failure
+        """
+        # Validate URL
+        if not url or not url.strip():
+            return {"error": "URL cannot be empty"}
+
+        if not url.startswith(("http://", "https://")):
+            return {"error": "URL must start with http:// or https://"}
+
+        try:
+            response = httpx.get(
+                url,
+                headers={"User-Agent": USER_AGENT},
+                follow_redirects=True,
+                timeout=30.0,
+            )
+            response.raise_for_status()
+        except httpx.TimeoutException:
+            return {"error": f"Request timed out after 30 seconds: {url}"}
+        except httpx.HTTPStatusError as e:
+            return {"error": f"HTTP error {e.response.status_code}: {url}"}
+        except httpx.RequestError as e:
+            return {"error": f"Failed to fetch URL: {e}"}
+
+        # Parse HTML
+        soup = BeautifulSoup(response.text, "html.parser")
+
+        # Run all analyses
+        title = _analyze_title(soup)
+        meta_desc = _analyze_meta_description(soup)
+        headings = _analyze_headings(soup)
+        images = _analyze_images(soup)
+        canonical = _analyze_canonical(soup, url)
+        robots = _analyze_meta_robots(soup)
+        open_graph = _analyze_open_graph(soup)
+
+        # Calculate overall score
+        overall = _calculate_score(title, meta_desc, headings, images, canonical)
+
+        return {
+            "url": url,
+            "final_url": str(response.url),
+            "status_code": response.status_code,
+            "title": title,
+            "meta_description": meta_desc,
+            "headings": headings,
+            "images": images,
+            "canonical": canonical,
+            "robots": robots,
+            "open_graph": open_graph,
+            "overall_score": overall,
+        }

--- a/tools/src/aden_tools/tools/seo_tool/tests/__init__.py
+++ b/tools/src/aden_tools/tools/seo_tool/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for SEO audit tool."""

--- a/tools/src/aden_tools/tools/seo_tool/tests/test_seo_tool.py
+++ b/tools/src/aden_tools/tools/seo_tool/tests/test_seo_tool.py
@@ -1,0 +1,384 @@
+"""
+Unit tests for the SEO Audit Tool.
+
+These tests use mocked HTTP responses to verify SEO analysis functionality
+without making actual network requests.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+from bs4 import BeautifulSoup
+
+from aden_tools.tools.seo_tool.seo_tool import (
+    META_DESC_MAX_LENGTH,
+    META_DESC_MIN_LENGTH,
+    TITLE_MAX_LENGTH,
+    TITLE_MIN_LENGTH,
+    _analyze_canonical,
+    _analyze_headings,
+    _analyze_images,
+    _analyze_meta_description,
+    _analyze_meta_robots,
+    _analyze_open_graph,
+    _analyze_title,
+    _calculate_score,
+)
+
+# Sample HTML fixtures
+MINIMAL_HTML = """
+<!DOCTYPE html>
+<html>
+<head></head>
+<body><p>Hello</p></body>
+</html>
+"""
+
+OPTIMAL_HTML = (
+    "<!DOCTYPE html>\n<html>\n<head>\n"
+    "    <title>This is an optimal title for SEO purposes test</title>\n"
+    '    <meta name="description" content="This is a well-crafted meta '
+    "description that provides detailed and valuable information about "
+    'the page content for search engines.">\n'
+    '    <link rel="canonical" href="https://example.com/page">\n'
+    '    <meta name="robots" content="index, follow">\n'
+    '    <meta property="og:title" content="Page Title">\n'
+    '    <meta property="og:description" content="Page description">\n'
+    '    <meta property="og:image" content="https://example.com/image.jpg">\n'
+    '    <meta property="og:url" content="https://example.com/page">\n'
+    "</head>\n<body>\n"
+    "    <h1>Main Heading</h1>\n"
+    "    <h2>Section 1</h2>\n"
+    "    <p>Content here</p>\n"
+    "    <h2>Section 2</h2>\n"
+    '    <img src="image1.jpg" alt="Descriptive alt text">\n'
+    '    <img src="image2.jpg" alt="Another image description">\n'
+    "</body>\n</html>"
+)
+
+ISSUES_HTML = """
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Short</title>
+    <meta name="description" content="Too short">
+</head>
+<body>
+    <h1>First H1</h1>
+    <h1>Second H1 - Multiple!</h1>
+    <h3>Skipped H2 - Hierarchy Gap</h3>
+    <img src="no-alt.jpg">
+    <img src="empty-alt.jpg" alt="">
+    <img src="good.jpg" alt="Good description">
+</body>
+</html>
+"""
+
+NOINDEX_HTML = (
+    "<!DOCTYPE html>\n<html>\n<head>\n"
+    "    <title>Noindex Page Title Example for Testing SEO</title>\n"
+    '    <meta name="description" content="This page is set to noindex '
+    'so search engines will not index it.">\n'
+    '    <meta name="robots" content="noindex, nofollow">\n'
+    "</head>\n<body>\n"
+    "    <h1>Private Page</h1>\n"
+    "</body>\n</html>"
+)
+
+
+class TestAnalyzeTitle:
+    """Tests for title tag analysis."""
+
+    def test_missing_title(self):
+        soup = BeautifulSoup(MINIMAL_HTML, "html.parser")
+        result = _analyze_title(soup)
+        assert result["present"] is False
+        assert result["content"] is None
+        assert "Missing title tag" in result["issues"]
+
+    def test_short_title(self):
+        soup = BeautifulSoup(ISSUES_HTML, "html.parser")
+        result = _analyze_title(soup)
+        assert result["present"] is True
+        assert result["content"] == "Short"
+        assert result["length"] == 5
+        assert result["optimal"] is False
+        assert any("Too short" in issue for issue in result["issues"])
+
+    def test_optimal_title(self):
+        soup = BeautifulSoup(OPTIMAL_HTML, "html.parser")
+        result = _analyze_title(soup)
+        assert result["present"] is True
+        assert result["optimal"] is True
+        assert TITLE_MIN_LENGTH <= result["length"] <= TITLE_MAX_LENGTH
+        assert len(result["issues"]) == 0
+
+    def test_long_title(self):
+        html = f"<html><head><title>{'x' * 100}</title></head></html>"
+        soup = BeautifulSoup(html, "html.parser")
+        result = _analyze_title(soup)
+        assert result["optimal"] is False
+        assert any("Too long" in issue for issue in result["issues"])
+
+
+class TestAnalyzeMetaDescription:
+    """Tests for meta description analysis."""
+
+    def test_missing_meta_description(self):
+        soup = BeautifulSoup(MINIMAL_HTML, "html.parser")
+        result = _analyze_meta_description(soup)
+        assert result["present"] is False
+        assert "Missing meta description" in result["issues"]
+
+    def test_short_meta_description(self):
+        soup = BeautifulSoup(ISSUES_HTML, "html.parser")
+        result = _analyze_meta_description(soup)
+        assert result["present"] is True
+        assert result["optimal"] is False
+        assert any("Too short" in issue for issue in result["issues"])
+
+    def test_optimal_meta_description(self):
+        soup = BeautifulSoup(OPTIMAL_HTML, "html.parser")
+        result = _analyze_meta_description(soup)
+        assert result["present"] is True
+        assert result["optimal"] is True
+        assert META_DESC_MIN_LENGTH <= result["length"] <= META_DESC_MAX_LENGTH
+
+    def test_long_meta_description(self):
+        html = f'<html><head><meta name="description" content="{"x" * 300}"></head></html>'
+        soup = BeautifulSoup(html, "html.parser")
+        result = _analyze_meta_description(soup)
+        assert result["optimal"] is False
+        assert any("Too long" in issue for issue in result["issues"])
+
+
+class TestAnalyzeHeadings:
+    """Tests for heading structure analysis."""
+
+    def test_no_headings(self):
+        soup = BeautifulSoup(MINIMAL_HTML, "html.parser")
+        result = _analyze_headings(soup)
+        assert result["h1_count"] == 0
+        assert result["total_headings"] == 0
+        assert any("Missing H1" in issue for issue in result["issues"])
+
+    def test_multiple_h1(self):
+        soup = BeautifulSoup(ISSUES_HTML, "html.parser")
+        result = _analyze_headings(soup)
+        assert result["h1_count"] == 2
+        assert any("Multiple H1" in issue for issue in result["issues"])
+
+    def test_heading_hierarchy_gap(self):
+        soup = BeautifulSoup(ISSUES_HTML, "html.parser")
+        result = _analyze_headings(soup)
+        assert any("gap" in issue.lower() for issue in result["issues"])
+
+    def test_proper_hierarchy(self):
+        soup = BeautifulSoup(OPTIMAL_HTML, "html.parser")
+        result = _analyze_headings(soup)
+        assert result["h1_count"] == 1
+        assert not any("gap" in issue.lower() for issue in result["issues"])
+
+
+class TestAnalyzeImages:
+    """Tests for image alt text analysis."""
+
+    def test_no_images(self):
+        soup = BeautifulSoup(MINIMAL_HTML, "html.parser")
+        result = _analyze_images(soup)
+        assert result["total"] == 0
+        assert result["optimal"] is True
+
+    def test_images_with_alt(self):
+        soup = BeautifulSoup(OPTIMAL_HTML, "html.parser")
+        result = _analyze_images(soup)
+        assert result["total"] == 2
+        assert result["with_alt"] == 2
+        assert result["missing_alt_count"] == 0
+        assert result["coverage_percent"] == 100.0
+        assert result["optimal"] is True
+
+    def test_images_missing_alt(self):
+        soup = BeautifulSoup(ISSUES_HTML, "html.parser")
+        result = _analyze_images(soup)
+        assert result["total"] == 3
+        assert result["missing_alt_count"] == 1
+        assert result["empty_alt_count"] == 1
+        assert result["optimal"] is False
+
+
+class TestAnalyzeCanonical:
+    """Tests for canonical tag analysis."""
+
+    def test_missing_canonical(self):
+        soup = BeautifulSoup(MINIMAL_HTML, "html.parser")
+        result = _analyze_canonical(soup, "https://example.com")
+        assert result["present"] is False
+        assert any("Missing canonical" in issue for issue in result["issues"])
+
+    def test_present_canonical(self):
+        soup = BeautifulSoup(OPTIMAL_HTML, "html.parser")
+        result = _analyze_canonical(soup, "https://example.com/page")
+        assert result["present"] is True
+        assert result["href"] == "https://example.com/page"
+        assert result["self_referencing"] is True
+
+    def test_non_self_referencing(self):
+        soup = BeautifulSoup(OPTIMAL_HTML, "html.parser")
+        result = _analyze_canonical(soup, "https://example.com/different")
+        assert result["self_referencing"] is False
+
+
+class TestAnalyzeMetaRobots:
+    """Tests for meta robots analysis."""
+
+    def test_no_robots_tag(self):
+        soup = BeautifulSoup(MINIMAL_HTML, "html.parser")
+        result = _analyze_meta_robots(soup)
+        assert result["present"] is False
+        assert result["indexable"] is True
+        assert result["followable"] is True
+
+    def test_noindex_nofollow(self):
+        soup = BeautifulSoup(NOINDEX_HTML, "html.parser")
+        result = _analyze_meta_robots(soup)
+        assert result["present"] is True
+        assert result["indexable"] is False
+        assert result["followable"] is False
+        assert any("noindex" in issue.lower() for issue in result["issues"])
+
+    def test_index_follow(self):
+        soup = BeautifulSoup(OPTIMAL_HTML, "html.parser")
+        result = _analyze_meta_robots(soup)
+        assert result["present"] is True
+        assert result["indexable"] is True
+        assert result["followable"] is True
+
+
+class TestAnalyzeOpenGraph:
+    """Tests for Open Graph tag analysis."""
+
+    def test_missing_og_tags(self):
+        soup = BeautifulSoup(MINIMAL_HTML, "html.parser")
+        result = _analyze_open_graph(soup)
+        assert result["present"] is False
+        assert len(result["missing_required"]) == 4
+
+    def test_complete_og_tags(self):
+        soup = BeautifulSoup(OPTIMAL_HTML, "html.parser")
+        result = _analyze_open_graph(soup)
+        assert result["present"] is True
+        assert "og:title" in result["tags"]
+        assert "og:description" in result["tags"]
+        assert "og:image" in result["tags"]
+        assert "og:url" in result["tags"]
+        assert len(result["missing_required"]) == 0
+
+
+class TestCalculateScore:
+    """Tests for overall score calculation."""
+
+    def test_perfect_score(self):
+        soup = BeautifulSoup(OPTIMAL_HTML, "html.parser")
+        title = _analyze_title(soup)
+        meta_desc = _analyze_meta_description(soup)
+        headings = _analyze_headings(soup)
+        images = _analyze_images(soup)
+        canonical = _analyze_canonical(soup, "https://example.com/page")
+
+        result = _calculate_score(title, meta_desc, headings, images, canonical)
+        assert result["score"] >= 90
+        assert result["grade"] in ["A", "B"]
+        assert result["passed"] is True
+
+    def test_low_score(self):
+        soup = BeautifulSoup(MINIMAL_HTML, "html.parser")
+        title = _analyze_title(soup)
+        meta_desc = _analyze_meta_description(soup)
+        headings = _analyze_headings(soup)
+        images = _analyze_images(soup)
+        canonical = _analyze_canonical(soup, "https://example.com")
+
+        result = _calculate_score(title, meta_desc, headings, images, canonical)
+        assert result["score"] < 50
+        assert result["grade"] == "F"
+        assert result["passed"] is False
+
+    def test_medium_score_with_issues(self):
+        soup = BeautifulSoup(ISSUES_HTML, "html.parser")
+        title = _analyze_title(soup)
+        meta_desc = _analyze_meta_description(soup)
+        headings = _analyze_headings(soup)
+        images = _analyze_images(soup)
+        canonical = _analyze_canonical(soup, "https://example.com")
+
+        result = _calculate_score(title, meta_desc, headings, images, canonical)
+        assert 0 <= result["score"] <= 100
+        assert result["grade"] in ["A", "B", "C", "D", "F"]
+
+
+class TestIntegration:
+    """Integration tests for the full analyze_on_page function."""
+
+    @patch("aden_tools.tools.seo_tool.seo_tool.httpx.get")
+    def test_analyze_valid_url(self, mock_get):
+        """Test analyzing a valid URL with mocked response."""
+        mock_response = MagicMock()
+        mock_response.text = OPTIMAL_HTML
+        mock_response.status_code = 200
+        mock_response.url = "https://example.com/page"
+        mock_get.return_value = mock_response
+
+        from aden_tools.tools.seo_tool import analyze_on_page as standalone_analyze
+
+        # Use the module-level function
+        result = standalone_analyze("https://example.com/page")
+
+        assert "url" in result
+        assert "title" in result
+        assert "meta_description" in result
+        assert "headings" in result
+        assert "images" in result
+        assert "overall_score" in result
+
+    def test_empty_url(self):
+        """Test that empty URL returns error."""
+        from aden_tools.tools.seo_tool import analyze_on_page
+
+        result = analyze_on_page("")
+        assert "error" in result
+        assert "empty" in result["error"].lower()
+
+    def test_invalid_url_scheme(self):
+        """Test that non-HTTP URL returns error."""
+        from aden_tools.tools.seo_tool import analyze_on_page
+
+        result = analyze_on_page("ftp://example.com")
+        assert "error" in result
+        assert "http" in result["error"].lower()
+
+    @patch("httpx.get")
+    def test_timeout_error(self, mock_get):
+        """Test handling of timeout errors."""
+        mock_get.side_effect = httpx.TimeoutException("Timed out")
+
+        from aden_tools.tools.seo_tool import analyze_on_page
+
+        result = analyze_on_page("https://example.com")
+        assert "error" in result
+        assert "timed out" in result["error"].lower()
+
+    @patch("httpx.get")
+    def test_http_error(self, mock_get):
+        """Test handling of HTTP errors."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_get.side_effect = httpx.HTTPStatusError(
+            "Not Found", request=MagicMock(), response=mock_response
+        )
+
+        from aden_tools.tools.seo_tool import analyze_on_page
+
+        result = analyze_on_page("https://example.com")
+        assert "error" in result
+        assert "404" in result["error"]


### PR DESCRIPTION
## Description


Implements the SEO Audit Tool as requested in issue #2861.

This tool provides comprehensive on-page SEO analysis for webpages, enabling agents to automate technical marketing tasks such as checking blog posts before publishing, competitor analysis, and periodic SEO audits.

## Changes

### New Files
- `tools/src/aden_tools/tools/seo_tool/seo_tool.py` - Main implementation with `analyze_on_page` MCP tool
- `tools/src/aden_tools/tools/seo_tool/__init__.py` - Module exports with standalone convenience function
- `tools/src/aden_tools/tools/seo_tool/README.md` - Documentation with usage examples
- `tools/src/aden_tools/tools/seo_tool/tests/test_seo_tool.py` - 31 unit tests

### Modified Files
- `tools/src/aden_tools/tools/__init__.py` - Register the new SEO tool

## Features

The `analyze_on_page(url)` function returns a comprehensive SEO health report including:

| Analysis | Description |
|----------|-------------|
| Title Tag | Presence, content, length (30-60 chars optimal) |
| Meta Description | Presence, content, length (120-160 chars optimal) |
| Headings | H1-H6 hierarchy structure with gap detection |
| Images | Alt text coverage percentage and missing examples |
| Canonical | Tag presence and self-referencing check |
| Meta Robots | Indexing/following directives detection |
| Open Graph | Social sharing tags validation |
| Overall Score | 0-100 score with letter grade (A-F) |

## Example Response

```json
{
  "url": "https://example.com",
  "overall_score": {
    "score": 85,
    "grade": "B",
    "passed": true,
    "issues": ["Missing canonical tag (-10)"]
  }
}
```

## Testing

- [x] 31 unit tests passing
- [x] Lint clean (ruff)
- [x] All helper functions use mocked HTTP responses

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added for new functionality
- [x] Documentation updated (README.md)
- [x] No breaking changes to existing tools

Closes #2861

