### PR TITLE
Docs: Add documentation status indicator to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@
   <img src="https://img.shields.io/badge/MCP-19_Tools-00ADD8?style=flat-square" alt="MCP" />
 </p>
 
+> **Documentation Status**
+>  
+> This README reflects the current structure and capabilities of Hive as of **February 2026**.  
+> As Hive evolves rapidly, some sections may change. Please refer to commit history or open issues for the latest updates.
+
+
 ## Overview
 
 Build reliable, self-improving AI agents without hardcoding workflows. Define your goal through conversation with a coding agent, and the framework generates a node graph with dynamically created connection code. When things break, the framework captures failure data, evolves the agent through the coding agent, and redeploys. Built-in human-in-the-loop nodes, credential management, and real-time monitoring give you control without sacrificing adaptability.


### PR DESCRIPTION
## Description

This PR adds a small documentation status note below the main title of the README to indicate how current the content is as Hive evolves.

This helps set expectations for readers and improves trust when evaluating rapidly changing projects.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #3228

## Changes Made

- Added documentation status indicator below README title

## Testing

- [x] Manual review of README rendering and structure

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have made corresponding changes to the documentation

## Screenshots (if applicable)

N/A – Documentation change
