### PR TITLE
docs: fix reference to nonexistent support_ticket_agent example

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -358,7 +358,7 @@ Windows:
 
 ```powershell
 $env:PYTHONPATH="core;exports"
-python -m support_ticket_agent validate
+python -m your_agent_name validate
 ```
 
 ### Agent imports fail with "broken installation"


### PR DESCRIPTION
## Summary

- Replaces hardcoded `support_ticket_agent` with generic `your_agent_name` in ENVIRONMENT_SETUP.md PowerShell example
- The `exports/` directory is gitignored so the referenced agent doesn't exist on fresh clones
- Now matches the Linux/macOS example directly above it

Closes #3155

## Test plan

- [ ] Verify the PowerShell example is consistent with the Linux example above it