### PR TITLE
fix: resolve Windows compatibility issues and credential mapping bugs

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -13,6 +13,20 @@ This guide covers everything you need to know to develop with the Aden Agent Fra
 7. [Git Workflow](#git-workflow)
 8. [Common Tasks](#common-tasks)
 9. [Troubleshooting](#troubleshooting)
+10. [Windows Development](#windows-development)
+
+---
+
+## Windows Development
+
+### Environment Setup
+- Use PowerShell for running scripts and tests.
+- Symlinks require Developer Mode or Admin privileges. Tests using symlinks are skipped otherwise.
+
+### Test Considerations
+- Pipes (`|`) and some shell commands (`ls`, `grep`) behave differently or are missing on Windows.
+- Path separators are `\` instead of `/`.
+- Absolute paths include drive letters (e.g., `C:\User\...`).
 
 ---
 

--- a/core/framework/credentials/aden/client.py
+++ b/core/framework/credentials/aden/client.py
@@ -148,14 +148,21 @@ class AdenCredentialResponse:
         if data.get("expires_at"):
             expires_at = datetime.fromisoformat(data["expires_at"].replace("Z", "+00:00"))
 
+        metadata = data.get("metadata", {}).copy()
+        if data.get("email"):
+            metadata["email"] = data["email"]
+
         return cls(
-            integration_id=integration_id or data.get("alias", data.get("provider", "")),
-            integration_type=data.get("provider", ""),
+            integration_id=integration_id
+            or data.get("integration_id")
+            or data.get("alias")
+            or data.get("provider", ""),
+            integration_type=data.get("integration_type") or data.get("provider", ""),
             access_token=data["access_token"],
             token_type=data.get("token_type", "Bearer"),
             expires_at=expires_at,
             scopes=data.get("scopes", []),
-            metadata={"email": data.get("email")} if data.get("email") else {},
+            metadata=metadata,
         )
 
 

--- a/tools/src/aden_tools/tools/file_system_toolkits/security.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/security.py
@@ -16,7 +16,7 @@ def get_secure_path(path: str, workspace_id: str, agent_id: str, session_id: str
     # Resolve absolute path
     if os.path.isabs(path):
         # Treat absolute paths as relative to the session root if they start with /
-        rel_path = path.lstrip(os.sep)
+        rel_path = path.lstrip(os.sep + "/")
         final_path = os.path.abspath(os.path.join(session_dir, rel_path))
     else:
         final_path = os.path.abspath(os.path.join(session_dir, path))

--- a/tools/tests/tools/test_file_system_toolkits.py
+++ b/tools/tests/tools/test_file_system_toolkits.py
@@ -1,6 +1,7 @@
 """Tests for file_system_toolkits tools (FastMCP)."""
 
 import os
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -575,12 +576,14 @@ class TestExecuteCommandTool:
         # Create a test file
         (tmp_path / "testfile.txt").write_text("content")
 
-        result = execute_command_fn(command=f"ls {tmp_path}", **mock_workspace)
+        cmd = f"dir {tmp_path}" if sys.platform == "win32" else f"ls {tmp_path}"
+        result = execute_command_fn(command=cmd, **mock_workspace)
 
         assert result["success"] is True
         assert result["return_code"] == 0
         assert "testfile.txt" in result["stdout"]
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Pipes/tr not standard on Windows cmd")
     def test_execute_command_with_pipe(self, execute_command_fn, mock_workspace, mock_secure_path):
         """Executing a command with pipe works correctly."""
         result = execute_command_fn(command="echo 'hello world' | tr 'a-z' 'A-Z'", **mock_workspace)

--- a/tools/tests/tools/test_security.py
+++ b/tools/tests/tools/test_security.py
@@ -4,6 +4,7 @@ import os
 from unittest.mock import patch
 
 import pytest
+import sys
 
 
 class TestGetSecurePath:
@@ -228,6 +229,9 @@ class TestGetSecurePath:
         expected = self.workspaces_dir / "test-workspace" / "test-agent" / "test-session"
         assert result == str(expected)
 
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="Symlinks require admin privileges on Windows"
+    )
     def test_symlink_within_sandbox_works(self, ids):
         """Symlinks that stay within the sandbox are allowed."""
         from aden_tools.tools.file_system_toolkits.security import get_secure_path
@@ -247,6 +251,9 @@ class TestGetSecurePath:
 
         assert result == str(symlink_path)
 
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="Symlinks require admin privileges on Windows"
+    )
     def test_symlink_escape_detected_with_realpath(self, ids):
         """Symlinks pointing outside sandbox can be detected using realpath.
 


### PR DESCRIPTION
Fixes #3403

## Problem
Running the test suite on Windows (Python 3.11) caused 7 failures:
- 2 cross‑platform issues (path handling and credential mapping)
- 5 Windows‑specific compatibility problems (commands and symlink behavior)

## Changes
- Security: Updated `get_secure_path()` in `security.py` to strip both `/` and `os.sep` to handle Windows absolute paths safely.
- Credentials: Fixed `AdenCredentialResponse.from_dict()` to correctly read `integration_id` and preserve existing `metadata`.
- Tests: Added cross‑platform command handling in file system tests (`dir` on Windows, `ls` elsewhere).
- Tests: Skipped Windows‑incompatible tests (symlinks that require admin, pipe commands not standard in cmd/PowerShell).
- Docs: Added a **Windows Development** section to `DEVELOPER.md` with setup notes and caveats. [file:48]

## Testing
- `pytest tools/tests/ -v` → 256 passed, 15 skipped
- `pytest core/framework/credentials/aden/tests/test_aden_sync.py -v` → 30 passed
