### PR TITLE
docs: clarify example agents exports directory usageDocs fix exports link

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -557,7 +557,8 @@ export AGENT_STORAGE_PATH="/custom/storage"
 
 - **Framework Documentation:** [core/README.md](core/README.md)
 - **Tools Documentation:** [tools/README.md](tools/README.md)
-- **Example Agents:** [exports/](./exports)
+- **Example Agents:** Generated locally under the `exports/` directory when you create an agent using `/building-agents-construction`.
+
 - **Agent Building Guide:** [.claude/skills/building-agents-construction/SKILL.md](.claude/skills/building-agents-construction/SKILL.md)
 - **Testing Guide:** [.claude/skills/testing-agent/SKILL.md](.claude/skills/testing-agent/SKILL.md)
 

--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -557,7 +557,7 @@ export AGENT_STORAGE_PATH="/custom/storage"
 
 - **Framework Documentation:** [core/README.md](core/README.md)
 - **Tools Documentation:** [tools/README.md](tools/README.md)
-- **Example Agents:** [exports/](exports/)
+- **Example Agents:** [exports/](./exports)
 - **Agent Building Guide:** [.claude/skills/building-agents-construction/SKILL.md](.claude/skills/building-agents-construction/SKILL.md)
 - **Testing Guide:** [.claude/skills/testing-agent/SKILL.md](.claude/skills/testing-agent/SKILL.md)
 


### PR DESCRIPTION
What:
- Clarified how example agents are created and where they live

Why:
- The `exports/` directory is generated locally and is not tracked in git
- Previous reference caused a broken link and confusion for new contributors

Testing:
- Verified documentation renders correctly and no broken links remain

Fixes #3356

Happy to adjust this if you’d prefer a different wording. Thanks!