### PR TITLE
docs(developer): clarify venv activation before make check/test

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -509,6 +509,20 @@ docs(readme): update installation instructions
 chore(deps): update React to 18.2.0
 ```
 
+
+### Running Local Checks and Tests
+
+The repository includes Makefile targets used by CI and maintainers.
+
+After running `./quickstart.sh`, activate the framework virtual environment before running checks or tests:
+
+```bash
+source core/.venv/bin/activate
+make check
+make test
+```
+Tools such as ruff are installed inside the virtual environment and may not be available unless the environment is activated.
+
 ### Pull Request Process
 
 1. Create a feature branch from `main`


### PR DESCRIPTION
This PR clarifies that the framework virtual environment (core/.venv) should be activated before running make check and make test, since tools like ruff are installed within the venv.

This helps new contributors run local checks successfully before opening a PR.
