### PR TITLE
refactor(csv_read): optimize csv_read tools from two read to one read

### DIFF
--- a/tools/src/aden_tools/tools/csv_tool/csv_tool.py
+++ b/tools/src/aden_tools/tools/csv_tool/csv_tool.py
@@ -45,7 +45,10 @@ def register_tools(mcp: FastMCP) -> None:
             if not path.lower().endswith(".csv"):
                 return {"error": "File must have .csv extension"}
 
-            # Read CSV
+            # Optimized: Read once and count rows in the same pass
+            rows = []
+            total_rows = 0
+            
             with open(secure_path, encoding="utf-8", newline="") as f:
                 reader = csv.DictReader(f)
 
@@ -57,16 +60,11 @@ def register_tools(mcp: FastMCP) -> None:
                 # Apply offset and limit
                 rows = []
                 for i, row in enumerate(reader):
+                    total_rows += 1  # rows counter
                     if i < offset:
                         continue
-                    if limit is not None and len(rows) >= limit:
-                        break
-                    rows.append(row)
-
-            # Get total row count (re-read for accurate count)
-            with open(secure_path, encoding="utf-8", newline="") as f:
-                reader = csv.reader(f)
-                total_rows = sum(1 for row in reader if any(row)) - 1
+                    if limit is None or len(rows) < limit:
+                        rows.append(row)
 
             return {
                 "success": True,


### PR DESCRIPTION
micro-fix: Optimized CSV reading by counting rows in a single pass and removing redundant file read.

## Description

Updated the current implementation of the csv_read tool in aden_tools as it is inefficient for large datasets and contains a subtle counting bug for complex CSV files. - 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Related Issues

Fixes #1737 
## Changes Made

- Initialize total_rows = 0 and increment it while iterating through the csv.DictReader.
- Handle offset and limit logic within the same loop.
- Remove the second with open block entirely.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

<img width="287" height="68" alt="Screenshot 2026-01-28 at 12 18 21" src="https://github.com/user-attachments/assets/849ef9e7-269b-40ee-aa45-cb439318977a" />
<img width="451" height="207" alt="Screenshot 2026-01-28 at 12 19 46" src="https://github.com/user-attachments/assets/7992e6a1-5ab0-41e8-8ebd-4dfb7b8e3b52" />