### PR TITLE
fix(storage): add file locking to prevent race condition in _update_index

### DIFF
--- a/core/framework/credentials/storage.py
+++ b/core/framework/credentials/storage.py
@@ -263,27 +263,35 @@ class EncryptedFileStorage(CredentialStorage):
         operation: str,
         credential_type: str | None = None,
     ) -> None:
-        """Update the metadata index."""
+        """Update the metadata index with file locking for concurrency safety."""
+        import fcntl
+
         index_path = self.base_path / "metadata" / "index.json"
+        lock_path = self.base_path / "metadata" / ".index.lock"
 
-        if index_path.exists():
-            with open(index_path) as f:
-                index = json.load(f)
-        else:
-            index = {"credentials": {}, "version": "1.0"}
+        with open(lock_path, "w") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            try:
+                if index_path.exists():
+                    with open(index_path) as f:
+                        index = json.load(f)
+                else:
+                    index = {"credentials": {}, "version": "1.0"}
 
-        if operation == "save":
-            index["credentials"][credential_id] = {
-                "updated_at": datetime.now(UTC).isoformat(),
-                "type": credential_type,
-            }
-        elif operation == "delete":
-            index["credentials"].pop(credential_id, None)
+                if operation == "save":
+                    index["credentials"][credential_id] = {
+                        "updated_at": datetime.now(UTC).isoformat(),
+                        "type": credential_type,
+                    }
+                elif operation == "delete":
+                    index["credentials"].pop(credential_id, None)
 
-        index["last_modified"] = datetime.now(UTC).isoformat()
+                index["last_modified"] = datetime.now(UTC).isoformat()
 
-        with open(index_path, "w") as f:
-            json.dump(index, f, indent=2)
+                with open(index_path, "w") as f:
+                    json.dump(index, f, indent=2)
+            finally:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
 
 
 class EnvVarStorage(CredentialStorage):


### PR DESCRIPTION
## Summary
- Add file locking (fcntl.flock) to _update_index method
- Use `.index.lock` file for coordination between concurrent operations
- Prevent silent credential loss during concurrent saves/deletes

## Test plan
- [x] Verify 20 concurrent saves preserve all credentials (was losing ~50%)
- [x] Verify 50 concurrent saves under stress test
- [x] Verify concurrent save/delete operations remain consistent
- [x] Verify lock file is created
- [x] All 68 tests passing

Fixes #3451