### PR TITLE
change from python to python 3 in skill.md of  build constriction

### DIFF
--- a/.claude/skills/building-agents-construction/SKILL.md
+++ b/.claude/skills/building-agents-construction/SKILL.md
@@ -28,7 +28,7 @@ When this skill is loaded, IMMEDIATELY begin executing Step 1. Do not explain wh
 mcp__agent-builder__add_mcp_server(
     name="hive-tools",
     transport="stdio",
-    command="python",
+    command="python3",
     args='["mcp_server.py", "--stdio"]',
     cwd="tools",
     description="Hive tools MCP server"
@@ -284,8 +284,8 @@ This returns JSON with all the goal, nodes, edges, and MCP server configurations
 >
 > ```bash
 > cd /home/timothy/oss/hive
-> PYTHONPATH=core:exports python -m AGENT_NAME validate
-> PYTHONPATH=core:exports python -m AGENT_NAME info
+> PYTHONPATH=core:exports python3 -m AGENT_NAME validate
+> PYTHONPATH=core:exports python3 -m AGENT_NAME info
 > ```
 
 ---
@@ -295,7 +295,7 @@ This returns JSON with all the goal, nodes, edges, and MCP server configurations
 **RUN validation:**
 
 ```bash
-cd /home/timothy/oss/hive && PYTHONPATH=core:exports python -m AGENT_NAME validate
+cd /home/timothy/oss/hive && PYTHONPATH=core:exports python3 -m AGENT_NAME validate
 ```
 
 - If valid: Agent is complete!


### PR DESCRIPTION
## Description

This PR updates agent skill commands to explicitly use `python3` instead of `python`.

On many Linux and WSL environments, the `python` command is not available by default, which causes agent build and validation steps to fail with `python: command not found`. Using `python3` improves cross-platform compatibility without changing behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #3356 

## Changes Made

- Updated agent skill commands to use `python3` instead of `python`
- Ensured agent `validate` and `info` commands work on Linux/WSL environments where `python` is not available
- This change is intentionally scoped to agent build and validation commands (e.g. building-agent-construction), which are executed by Claude Code. Other documentation examples are left unchanged to keep the PR focused and non-breaking.
- 
## Testing


- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)


<img width="1186" height="170" alt="python_3_issue" src="https://github.com/user-attachments/assets/7bf6a91b-6de5-4a2d-9687-07dff1213a93" />
