### PR TITLE
docs: fix broken Example Agents link in ENVIRONMENT_SETdocs: fix broken Example Agents link in ENVIRONMENT_SETUP.mdUP.md

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -474,7 +474,7 @@ export AGENT_STORAGE_PATH="/custom/storage"
 
 - **Framework Documentation:** [core/README.md](core/README.md)
 - **Tools Documentation:** [tools/README.md](tools/README.md)
-- **Example Agents:** [exports/](exports/)
+- **Example Agents:** [examples/](examples/)
 - **Agent Building Guide:** [.claude/skills/building-agents-construction/SKILL.md](.claude/skills/building-agents-construction/SKILL.md)
 - **Testing Guide:** [.claude/skills/testing-agent/SKILL.md](.claude/skills/testing-agent/SKILL.md)
 


### PR DESCRIPTION
Fixes #3320

## Problem
The "Example Agents (exports/)" link in the "Additional Resources" section of ENVIRONMENT_SETUP.md was returning a 404 because the exports/ folder is gitignored and does not exist in the remote repository.

## Solution
Updated the link to point to the examples/ directory, which was recently added to the repository and contains the relevant example agent material.