### PR TITLE
feat(tools): Implement Calendly integration

### DIFF
--- a/.agent/workflows/calendly_integration.md
+++ b/.agent/workflows/calendly_integration.md
@@ -1,0 +1,15 @@
+---
+description: Implement Calendly integration
+---
+1. Ensure we are on the main branch and up to date.
+// turbo
+2. Create and checkout a new branch 'calendly-integration' resetted to main.
+3. Create the directory structure for `tools/src/aden_tools/tools/calendly_tool`.
+4. Implement the Calendly client and tool functions in `tools/src/aden_tools/tools/calendly_tool/__init__.py`.
+   - Implement `get_current_user` to get user URI.
+   - Implement `list_event_types` to get available event types.
+   - Implement `create_scheduling_link` to generate a booking link.
+   - Use `aden_tools.credentials` for API key management.
+5. Create unit tests in `tools/tests/tools/test_calendly_tool.py`.
+6. Run the tests to verify implementation.
+7. Add documentation to `tools/README.md`.

--- a/pr-calendly-integration.md
+++ b/pr-calendly-integration.md
@@ -1,0 +1,21 @@
+Implement Calendly Integration
+
+# Description
+Implements Calendly integration for the Hive agent framework to enable automated scheduling workflows.
+
+## Features
+- List available event types for a user
+- Create single-use scheduling links
+- Integration with credential management system
+- MCP tool registration
+
+## Tools Added
+- `calendly_list_event_types`: Lists available meeting types
+- `calendly_create_scheduling_link`: Generates booking URLs
+
+## Testing
+- Unit tests added in `tools/tests/tools/test_calendly_tool.py`
+- Verified using `pytest` in `agents` environment
+
+## Related Issue
+- Addresses issue #2930

--- a/tools/README.md
+++ b/tools/README.md
@@ -27,7 +27,9 @@ cp .env.example .env
 | `ANTHROPIC_API_KEY`    | MCP server startup, LLM nodes | [console.anthropic.com](https://console.anthropic.com/) |
 | `BRAVE_SEARCH_API_KEY` | `web_search` tool (Brave)     | [brave.com/search/api](https://brave.com/search/api/)   |
 | `GOOGLE_API_KEY`       | `web_search` tool (Google)    | [console.cloud.google.com](https://console.cloud.google.com/) |
+| `GOOGLE_API_KEY`       | `web_search` tool (Google)    | [console.cloud.google.com](https://console.cloud.google.com/) |
 | `GOOGLE_CSE_ID`        | `web_search` tool (Google)    | [programmablesearchengine.google.com](https://programmablesearchengine.google.com/) |
+| `CALENDLY_API_KEY`     | `calendly` tools              | [calendly.com/integrations/api_webhooks](https://calendly.com/integrations/api_webhooks) |
 
 > **Note:** `web_search` supports multiple providers. Set either Brave OR Google credentials. Brave is preferred for backward compatibility.
 
@@ -75,6 +77,7 @@ python mcp_server.py
 | `web_search`           | Search the web (Google or Brave, auto-detected) |
 | `web_scrape`           | Scrape and extract content from webpages       |
 | `pdf_read`             | Read and extract text from PDF files           |
+| `calendly`             | List event types and create scheduling links   |
 
 ## Project Structure
 

--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -47,6 +47,7 @@ To add a new credential:
 """
 
 from .base import CredentialError, CredentialManager, CredentialSpec
+from .calendly import CALENDLY_CREDENTIALS
 from .llm import LLM_CREDENTIALS
 from .search import SEARCH_CREDENTIALS
 from .store_adapter import CredentialStoreAdapter
@@ -55,6 +56,7 @@ from .store_adapter import CredentialStoreAdapter
 CREDENTIAL_SPECS = {
     **LLM_CREDENTIALS,
     **SEARCH_CREDENTIALS,
+    **CALENDLY_CREDENTIALS,
 }
 
 __all__ = [
@@ -69,4 +71,5 @@ __all__ = [
     # Category registries (for direct access if needed)
     "LLM_CREDENTIALS",
     "SEARCH_CREDENTIALS",
+    "CALENDLY_CREDENTIALS",
 ]

--- a/tools/src/aden_tools/credentials/calendly.py
+++ b/tools/src/aden_tools/credentials/calendly.py
@@ -1,0 +1,17 @@
+"""
+Calendly credentials.
+"""
+
+from .base import CredentialSpec
+
+CALENDLY_CREDENTIALS = {
+    "calendly_api_key": CredentialSpec(
+        env_var="CALENDLY_API_KEY",
+        tools=["calendly_list_event_types", "calendly_create_scheduling_link"],
+        node_types=[],
+        required=False,
+        startup_required=False,
+        help_url="https://calendly.com/integrations/api_webhooks",
+        description="Personal Access Token for Calendly API",
+    ),
+}

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from aden_tools.credentials import CredentialManager
 
 # Import register_tools from each tool module
+from .calendly_tool import register_tools as register_calendly
 from .csv_tool import register_tools as register_csv
 from .example_tool import register_tools as register_example
 from .file_system_toolkits.apply_diff import register_tools as register_apply_diff
@@ -74,6 +75,9 @@ def register_all_tools(
     register_grep_search(mcp)
     register_execute_command(mcp)
     register_csv(mcp)
+    
+    # Register Calendly tools
+    register_calendly(mcp, credentials=credentials)
 
     return [
         "example_tool",
@@ -93,6 +97,9 @@ def register_all_tools(
         "csv_append",
         "csv_info",
         "csv_sql",
+        # Calendly tools
+        "calendly_list_event_types",
+        "calendly_create_scheduling_link",
     ]
 
 

--- a/tools/src/aden_tools/tools/calendly_tool/__init__.py
+++ b/tools/src/aden_tools/tools/calendly_tool/__init__.py
@@ -1,0 +1,136 @@
+import logging
+import httpx
+from typing import Any, Optional
+from fastmcp import Context, FastMCP
+
+logger = logging.getLogger(__name__)
+
+CALENDLY_API_BASE = "https://api.calendly.com"
+
+def get_calendly_headers(api_key: str) -> dict:
+    """Return headers for Calendly API."""
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json"
+    }
+
+def get_current_user(api_key: str) -> dict:
+    """Get the current authenticated user's information."""
+    url = f"{CALENDLY_API_BASE}/users/me"
+    with httpx.Client() as client:
+        response = client.get(url, headers=get_calendly_headers(api_key))
+        response.raise_for_status()
+        return response.json()["resource"]
+
+def list_event_types(api_key: str, user_uri: Optional[str] = None) -> list[dict]:
+    """
+    List available event types for the user.
+    If user_uri is not provided, it fetches the current user's URI first.
+    """
+    with httpx.Client() as client:
+        if not user_uri:
+            # We can't reuse the client strictly easily across functions without refactoring, 
+            # so we'll just call the function which makes its own client.
+            # Or better, let's keep it simple.
+            user = get_current_user(api_key)
+            user_uri = user["uri"]
+
+        url = f"{CALENDLY_API_BASE}/event_types"
+        params = {"user": user_uri}
+        
+        response = client.get(url, headers=get_calendly_headers(api_key), params=params)
+        response.raise_for_status()
+        # Calendly returns a "collection" list
+        return response.json().get("collection", [])
+
+def create_scheduling_link(
+    api_key: str, 
+    event_type_uri: str, 
+    max_event_count: int = 1
+) -> str:
+    """
+    Create a single-use scheduling link for a specific event type.
+    Note: Calendly API for scheduling links is via 'scheduling_links'.
+    """
+    url = f"{CALENDLY_API_BASE}/scheduling_links"
+    payload = {
+        "max_event_count": max_event_count,
+        "owner": event_type_uri,
+        "owner_type": "EventType"
+    }
+    
+    with httpx.Client() as client:
+        response = client.post(url, headers=get_calendly_headers(api_key), json=payload)
+        response.raise_for_status()
+        return response.json()["resource"]["booking_url"]
+
+def register_tools(mcp: FastMCP, credentials=None):
+    """Register Calendly tools with the MCP server."""
+
+    @mcp.tool(
+        name="calendly_list_event_types",
+        description="List all available event types (meeting types) for the Calendly user."
+    )
+    def calendly_list_event_types(ctx: Context = None) -> str:
+        """
+        List event types to choose which one to book.
+        Returns a formatted string of event types with their names and URIs.
+        """
+        if credentials:
+            try:
+                credentials.validate_for_tools(["calendly_list_event_types"])
+                api_key = credentials.get("calendly_api_key")
+            except Exception as e:
+                return f"Error: Missing credentials. {str(e)}"
+        else:
+            return "Error: Credential manager not provided."
+
+        try:
+            event_types = list_event_types(api_key)
+            if not event_types:
+                return "No event types found."
+            
+            # Format nicely for the LLM
+            result = ["Found the following event types:"]
+            for et in event_types:
+                active_status = " (Active)" if et.get("active") else " (Inactive)"
+                result.append(f"- Name: {et.get('name')}{active_status}")
+                result.append(f"  URI: {et.get('uri')}")
+                result.append(f"  Slug: {et.get('slug')}")
+                result.append(f"  Description: {et.get('description_plain', 'N/A')[:100]}...")
+                result.append("---")
+            return "\n".join(result)
+            
+        except httpx.HTTPError as e:
+            return f"Calendly API Error: {str(e)}"
+        except Exception as e:
+            return f"Error creating scheduling link: {str(e)}"
+
+    @mcp.tool(
+        name="calendly_create_scheduling_link",
+        description="Create a single-use booking link for a specific event type."
+    )
+    def calendly_create_scheduling_link(event_type_uri: str, ctx: Context = None) -> str:
+        """
+        Create a booking link.
+        
+        Args:
+            event_type_uri: The full URI of the event type (e.g., returned by list_event_types).
+        """
+        if credentials:
+            try:
+                credentials.validate_for_tools(["calendly_create_scheduling_link"])
+                api_key = credentials.get("calendly_api_key")
+            except Exception as e:
+                return f"Error: Missing credentials. {str(e)}"
+        else:
+            return "Error: Credential manager not provided."
+
+        try:
+            link = create_scheduling_link(api_key, event_type_uri)
+            return f"Successfully created booking link: {link}"
+            
+        except httpx.HTTPError as e:
+            return f"Calendly API Error: {str(e)}"
+        except Exception as e:
+            return f"Error creating scheduling link: {str(e)}"

--- a/tools/tests/tools/test_calendly_tool.py
+++ b/tools/tests/tools/test_calendly_tool.py
@@ -1,0 +1,113 @@
+import pytest
+from unittest.mock import Mock, patch
+import httpx
+from aden_tools.tools.calendly_tool import (
+    get_calendly_headers,
+    get_current_user,
+    list_event_types,
+    create_scheduling_link
+)
+
+@pytest.fixture
+def mock_api_key():
+    return "test-api-key"
+
+@pytest.fixture
+def mock_user_uri():
+    return "https://api.calendly.com/users/USER_UUID"
+
+@pytest.fixture
+def mock_event_type_uri():
+    return "https://api.calendly.com/event_types/EVENT_UUID"
+
+def test_get_calendly_headers(mock_api_key):
+    headers = get_calendly_headers(mock_api_key)
+    assert headers["Authorization"] == f"Bearer {mock_api_key}"
+    assert headers["Content-Type"] == "application/json"
+
+@patch('httpx.Client.get')
+def test_get_current_user(mock_get, mock_api_key, mock_user_uri):
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "resource": {
+            "uri": mock_user_uri,
+            "name": "Test User"
+        }
+    }
+    mock_response.raise_for_status.return_value = None
+    mock_get.return_value = mock_response
+
+    user = get_current_user(mock_api_key)
+    
+    assert user["uri"] == mock_user_uri
+    mock_get.assert_called_once_with(
+        "https://api.calendly.com/users/me",
+        headers={"Authorization": f"Bearer {mock_api_key}", "Content-Type": "application/json"}
+    )
+
+@patch('httpx.Client.get')
+def test_list_event_types(mock_get, mock_api_key, mock_user_uri):
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "collection": [
+            {"uri": "uri1", "name": "Event 1"},
+            {"uri": "uri2", "name": "Event 2"}
+        ]
+    }
+    mock_response.raise_for_status.return_value = None
+    mock_get.return_value = mock_response
+
+    # Test with user_uri provided
+    event_types = list_event_types(mock_api_key, user_uri=mock_user_uri)
+    
+    assert len(event_types) == 2
+    mock_get.assert_called_once_with(
+        "https://api.calendly.com/event_types",
+        headers=get_calendly_headers(mock_api_key),
+        params={"user": mock_user_uri}
+    )
+
+@patch('aden_tools.tools.calendly_tool.get_current_user')
+@patch('httpx.Client.get')
+def test_list_event_types_no_user_uri(mock_get, mock_get_user, mock_api_key, mock_user_uri):
+    # Mock getting current user
+    mock_get_user.return_value = {"uri": mock_user_uri}
+    
+    # Mock list response
+    mock_response = Mock()
+    mock_response.json.return_value = {"collection": []}
+    mock_get.return_value = mock_response
+
+    list_event_types(mock_api_key)
+    
+    # Verify get_current_user was called
+    mock_get_user.assert_called_once_with(mock_api_key)
+    
+    # Verify list event types called with fetched user uri
+    mock_get.assert_called_once()
+    assert mock_get.call_args[1]['params']['user'] == mock_user_uri
+
+@patch('httpx.Client.post')
+def test_create_scheduling_link(mock_post, mock_api_key, mock_event_type_uri):
+    expected_link = "https://calendly.com/booking/link"
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "resource": {
+            "booking_url": expected_link
+        }
+    }
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
+    link = create_scheduling_link(mock_api_key, mock_event_type_uri)
+    
+    assert link == expected_link
+    mock_post.assert_called_once_with(
+        "https://api.calendly.com/scheduling_links",
+        headers=get_calendly_headers(mock_api_key),
+        json={
+            "max_event_count": 1,
+            "owner": mock_event_type_uri,
+            "owner_type": "EventType"
+        }
+    )


### PR DESCRIPTION
# Description
Implements Calendly integration for the Hive agent framework to enable automated scheduling workflows.

## Features
- List available event types for a user
- Create single-use scheduling links
- Integration with credential management system
- MCP tool registration

## Tools Added
- `calendly_list_event_types`: Lists available meeting types
- `calendly_create_scheduling_link`: Generates booking URLs

## Testing
- Unit tests added in `tools/tests/tools/test_calendly_tool.py`
- Verified using `pytest` in `agents` environment

## Related Issue
- Resolve #2930
