### PR TITLE
fix(aden): read integration_id/integration_type from data dict in fro…

### DIFF
--- a/core/framework/credentials/aden/client.py
+++ b/core/framework/credentials/aden/client.py
@@ -149,13 +149,16 @@ class AdenCredentialResponse:
             expires_at = datetime.fromisoformat(data["expires_at"].replace("Z", "+00:00"))
 
         return cls(
-            integration_id=integration_id or data.get("alias", data.get("provider", "")),
-            integration_type=data.get("provider", ""),
+            integration_id=integration_id
+            or data.get("integration_id", data.get("alias", data.get("provider", ""))),
+            integration_type=data.get("integration_type", data.get("provider", "")),
             access_token=data["access_token"],
             token_type=data.get("token_type", "Bearer"),
             expires_at=expires_at,
             scopes=data.get("scopes", []),
-            metadata={"email": data.get("email")} if data.get("email") else {},
+            metadata=data.get("metadata", {}) if data.get("metadata") else (
+                {"email": data.get("email")} if data.get("email") else {}
+            ),
         )
 
 


### PR DESCRIPTION
## Description

Fixed `AdenCredentialResponse.from_dict` to correctly read `integration_id` and 
`integration_type` fields from the input dictionary, with proper fallback to legacy keys for backward compatibility.

## Type of Change

- [✓] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #3379

## Changes Made

- Updated `from_dict` to read `integration_id` from data dict with fallback chain: parameter → `integration_id` key → `alias` key → `provider` key
- Updated `from_dict` to read `integration_type` from data dict with fallback: `integration_type` key → `provider` key
- Fixed `metadata` handling to preserve explicit metadata dict when present in the input

## Testing

Describe the tests you ran to verify your changes:

- [✓] Unit tests pass (`cd core && pytest tests/`)
- [✓] Manual testing performed

## Checklist

- [✓] My code follows the project's style guidelines
- [✓] I have performed a self-review of my code
- [✓] I have commented my code, particularly in hard-to-understand areas
- [✓] My changes generate no new warnings
- [✓] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A - Backend-only change.
