### PR TITLE
Make LLM credentials and test templates provider-agnostic

### DIFF
--- a/core/MCP_BUILDER_TOOLS_GUIDE.md
+++ b/core/MCP_BUILDER_TOOLS_GUIDE.md
@@ -410,4 +410,5 @@ If credentials are missing, you'll receive a response like:
 | ------------ | ---------------------- | ----------------------------------------------------- |
 | `web_search` | `BRAVE_SEARCH_API_KEY` | [brave.com/search/api](https://brave.com/search/api/) |
 
-Note: The MCP server itself requires `ANTHROPIC_API_KEY` at startup for LLM operations.
+Note: MCP servers can start without LLM API keys. You only need an LLM provider key when
+executing LLM-dependent nodes/tools (or running real agent tests).

--- a/tools/README.md
+++ b/tools/README.md
@@ -24,7 +24,10 @@ cp .env.example .env
 
 | Variable               | Required For                  | Get Key                                                 |
 | ---------------------- | ----------------------------- | ------------------------------------------------------- |
-| `ANTHROPIC_API_KEY`    | MCP server startup, LLM nodes | [console.anthropic.com](https://console.anthropic.com/) |
+| `OPENAI_API_KEY`       | LLM calls (OpenAI)            | [platform.openai.com](https://platform.openai.com/api-keys) |
+| `ANTHROPIC_API_KEY`    | LLM calls (Anthropic)         | [console.anthropic.com](https://console.anthropic.com/) |
+| `GROQ_API_KEY`         | LLM calls (Groq)              | [console.groq.com](https://console.groq.com/keys)       |
+| `CEREBRAS_API_KEY`     | LLM calls (Cerebras)          | [cloud.cerebras.ai](https://cloud.cerebras.ai/)         |
 | `BRAVE_SEARCH_API_KEY` | `web_search` tool (Brave)     | [brave.com/search/api](https://brave.com/search/api/)   |
 | `GOOGLE_API_KEY`       | `web_search` tool (Google)    | [console.cloud.google.com](https://console.cloud.google.com/) |
 | `GOOGLE_CSE_ID`        | `web_search` tool (Google)    | [programmablesearchengine.google.com](https://programmablesearchengine.google.com/) |

--- a/tools/mcp_server.py
+++ b/tools/mcp_server.py
@@ -16,13 +16,14 @@ Usage:
 
 Environment Variables:
     MCP_PORT              - Server port (default: 4001)
-    ANTHROPIC_API_KEY     - Required at startup for testing/LLM nodes
+    LLM provider API keys - Optional at startup; required only when using LLM-dependent tools/nodes
+                           (e.g., OPENAI_API_KEY / ANTHROPIC_API_KEY / GROQ_API_KEY / CEREBRAS_API_KEY)
     BRAVE_SEARCH_API_KEY  - Required for web_search tool (validated at agent load time)
 
 Note:
     Two-tier credential validation:
-    - Tier 1 (startup): ANTHROPIC_API_KEY must be set before server starts
-    - Tier 2 (agent load): Tool credentials validated when agent is loaded
+    - Tier 1 (startup): Only credentials marked startup_required=True are enforced at startup
+    - Tier 2 (tool use): Tool credentials are validated when a tool is called
     See aden_tools.credentials for details.
 """
 

--- a/tools/src/aden_tools/credentials/llm.py
+++ b/tools/src/aden_tools/credentials/llm.py
@@ -12,10 +12,9 @@ LLM_CREDENTIALS = {
         tools=[],
         node_types=["llm_generate", "llm_tool_use"],
         required=False,  # Not required - agents can use other providers via LiteLLM
-        startup_required=False,  # MCP server doesn't need LLM credentials
+        startup_required=False,  # MCP servers don't require LLM credentials at startup
         help_url="https://console.anthropic.com/settings/keys",
         description="API key for Anthropic Claude models",
-        # Auth method support
         direct_api_key_supported=True,
         api_key_instructions="""To get an Anthropic API key:
 1. Go to https://console.anthropic.com/settings/keys
@@ -24,21 +23,67 @@ LLM_CREDENTIALS = {
 4. Give your key a descriptive name (e.g., "Hive Agent")
 5. Copy the API key (starts with sk-ant-)
 6. Store it securely - you won't be able to see the full key again!""",
-        # Health check configuration
         health_check_endpoint="https://api.anthropic.com/v1/messages",
         health_check_method="POST",
-        # Credential store mapping
         credential_id="anthropic",
         credential_key="api_key",
     ),
-    # Future LLM providers:
-    # "openai": CredentialSpec(
-    #     env_var="OPENAI_API_KEY",
-    #     tools=[],
-    #     node_types=["openai_generate"],
-    #     required=False,
-    #     startup_required=False,
-    #     help_url="https://platform.openai.com/api-keys",
-    #     description="API key for OpenAI models",
-    # ),
+    "openai": CredentialSpec(
+        env_var="OPENAI_API_KEY",
+        tools=[],
+        node_types=["llm_generate", "llm_tool_use"],
+        required=False,
+        startup_required=False,
+        help_url="https://platform.openai.com/api-keys",
+        description="API key for OpenAI models (used via LiteLLM)",
+        direct_api_key_supported=True,
+        api_key_instructions="""To get an OpenAI API key:
+1. Go to https://platform.openai.com/api-keys
+2. Sign in or create an OpenAI account
+3. Click "Create new secret key"
+4. Copy the key (starts with sk-)
+5. Store it securely - you won't be able to see the full key again!""",
+        health_check_endpoint="https://api.openai.com/v1/models",
+        health_check_method="GET",
+        credential_id="openai",
+        credential_key="api_key",
+    ),
+    "cerebras": CredentialSpec(
+        env_var="CEREBRAS_API_KEY",
+        tools=[],
+        node_types=["llm_generate", "llm_tool_use"],
+        required=False,
+        startup_required=False,
+        help_url="https://cloud.cerebras.ai/",
+        description="API key for Cerebras models (often used for fast/cheap inference via LiteLLM)",
+        direct_api_key_supported=True,
+        api_key_instructions="""To get a Cerebras API key:
+1. Go to https://cloud.cerebras.ai/
+2. Sign in or create an account
+3. Create an API key in your account settings
+4. Copy the key and store it securely""",
+        health_check_endpoint="https://api.cerebras.ai/v1/models",
+        health_check_method="GET",
+        credential_id="cerebras",
+        credential_key="api_key",
+    ),
+    "groq": CredentialSpec(
+        env_var="GROQ_API_KEY",
+        tools=[],
+        node_types=["llm_generate", "llm_tool_use"],
+        required=False,
+        startup_required=False,
+        help_url="https://console.groq.com/keys",
+        description="API key for Groq models (fast inference via LiteLLM)",
+        direct_api_key_supported=True,
+        api_key_instructions="""To get a Groq API key:
+1. Go to https://console.groq.com/keys
+2. Sign in or create an account
+3. Create a new API key
+4. Copy the key and store it securely""",
+        health_check_endpoint="https://api.groq.com/openai/v1/models",
+        health_check_method="GET",
+        credential_id="groq",
+        credential_key="api_key",
+    ),
 }


### PR DESCRIPTION
## Summary
- Add first-class LLM credential specs for OpenAI, Groq, and Cerebras (in addition to Anthropic).
- Update pytest test scaffolding to accept any configured LLM provider key.
- Align MCP/tools documentation with existing provider-agnostic runtime behavior.

## Why
Hive supports multiple LLM providers via LiteLLM, but credential specs and test templates still implied Anthropic was required.
This caused onboarding confusion and unnecessary test blocking for users on other providers.

Note: This PR does not change quickstart onboarding or provider selection behavior.

## Test Plan
- Ran `pytest -q` in `tools/` (286 passed, 12 skipped)
- Verified MCP server starts without any LLM API keys
- Verified credentials resolve correctly with only `OPENAI_API_KEY` set
- Confirmed test templates skip only when no provider key is present
- Confirmed `quickstart.sh` behavior unchanged
