### PR TITLE
fix(storage): add file locking to prevent race condition in _update_index

### DIFF
--- a/core/framework/credentials/storage.py
+++ b/core/framework/credentials/storage.py
@@ -10,6 +10,7 @@ This module provides abstract and concrete storage implementations:
 
 from __future__ import annotations
 
+import fcntl
 import json
 import logging
 import os
@@ -223,13 +224,19 @@ class EncryptedFileStorage(CredentialStorage):
         return False
 
     def list_all(self) -> list[str]:
-        """List all credential IDs."""
+        """List all credential IDs with file locking for read consistency."""
         index_path = self.base_path / "metadata" / "index.json"
         if not index_path.exists():
             return []
-        with open(index_path, encoding="utf-8-sig") as f:
-            index = json.load(f)
-        return list(index.get("credentials", {}).keys())
+        lock_path = self.base_path / "metadata" / ".index.lock"
+        with open(lock_path, "a") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_SH)
+            try:
+                with open(index_path, encoding="utf-8-sig") as f:
+                    index = json.load(f)
+                return list(index.get("credentials", {}).keys())
+            finally:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
 
     def exists(self, credential_id: str) -> bool:
         """Check if credential exists."""
@@ -264,27 +271,33 @@ class EncryptedFileStorage(CredentialStorage):
         operation: str,
         credential_type: str | None = None,
     ) -> None:
-        """Update the metadata index."""
+        """Update the metadata index with file locking for concurrency safety."""
         index_path = self.base_path / "metadata" / "index.json"
+        lock_path = self.base_path / "metadata" / ".index.lock"
 
-        if index_path.exists():
-            with open(index_path, encoding="utf-8-sig") as f:
-                index = json.load(f)
-        else:
-            index = {"credentials": {}, "version": "1.0"}
+        with open(lock_path, "a") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            try:
+                if index_path.exists():
+                    with open(index_path, encoding="utf-8-sig") as f:
+                        index = json.load(f)
+                else:
+                    index = {"credentials": {}, "version": "1.0"}
 
-        if operation == "save":
-            index["credentials"][credential_id] = {
-                "updated_at": datetime.now(UTC).isoformat(),
-                "type": credential_type,
-            }
-        elif operation == "delete":
-            index["credentials"].pop(credential_id, None)
+                if operation == "save":
+                    index["credentials"][credential_id] = {
+                        "updated_at": datetime.now(UTC).isoformat(),
+                        "type": credential_type,
+                    }
+                elif operation == "delete":
+                    index["credentials"].pop(credential_id, None)
 
-        index["last_modified"] = datetime.now(UTC).isoformat()
+                index["last_modified"] = datetime.now(UTC).isoformat()
 
-        with open(index_path, "w", encoding="utf-8") as f:
-            json.dump(index, f, indent=2)
+                with open(index_path, "w", encoding="utf-8") as f:
+                    json.dump(index, f, indent=2)
+            finally:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
 
 
 class EnvVarStorage(CredentialStorage):

--- a/core/framework/credentials/storage.py
+++ b/core/framework/credentials/storage.py
@@ -10,7 +10,6 @@ This module provides abstract and concrete storage implementations:
 
 from __future__ import annotations
 
-import fcntl
 import json
 import logging
 import os
@@ -225,6 +224,8 @@ class EncryptedFileStorage(CredentialStorage):
 
     def list_all(self) -> list[str]:
         """List all credential IDs with file locking for read consistency."""
+        import fcntl
+
         index_path = self.base_path / "metadata" / "index.json"
         if not index_path.exists():
             return []
@@ -272,6 +273,8 @@ class EncryptedFileStorage(CredentialStorage):
         credential_type: str | None = None,
     ) -> None:
         """Update the metadata index with file locking for concurrency safety."""
+        import fcntl
+
         index_path = self.base_path / "metadata" / "index.json"
         lock_path = self.base_path / "metadata" / ".index.lock"
 

--- a/core/framework/credentials/tests/test_credential_store.py
+++ b/core/framework/credentials/tests/test_credential_store.py
@@ -703,5 +703,208 @@ class TestOAuth2Module:
             )
 
 
+class TestEncryptedFileStorageRaceConditionFix:
+    """Tests for race condition fix in _update_index."""
+
+    @pytest.fixture
+    def temp_dir(self):
+        """Create a temporary directory for tests."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    @pytest.fixture
+    def storage(self, temp_dir):
+        """Create EncryptedFileStorage for tests."""
+        return EncryptedFileStorage(temp_dir)
+
+    def test_concurrent_saves_no_credential_loss(self, temp_dir):
+        """Test that concurrent saves do not lose credentials."""
+        import threading
+
+        storage = EncryptedFileStorage(temp_dir)
+        num_threads = 20
+        results = {"saved": [], "errors": []}
+
+        def save_credential(thread_id):
+            try:
+                cred = CredentialObject(
+                    id=f"cred_{thread_id}",
+                    credential_type=CredentialType.API_KEY,
+                    keys={
+                        "api_key": CredentialKey(
+                            name="api_key", value=SecretStr(f"key_{thread_id}")
+                        )
+                    },
+                )
+                storage.save(cred)
+                results["saved"].append(thread_id)
+            except Exception as e:
+                results["errors"].append((thread_id, str(e)))
+
+        threads = [threading.Thread(target=save_credential, args=(i,)) for i in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(results["errors"]) == 0
+        assert len(results["saved"]) == num_threads
+        assert len(storage.list_all()) == num_threads
+
+    def test_concurrent_save_and_delete_consistency(self, temp_dir):
+        """Test that concurrent save and delete operations remain consistent."""
+        import threading
+
+        storage = EncryptedFileStorage(temp_dir)
+
+        for i in range(10):
+            cred = CredentialObject(
+                id=f"cred_{i}",
+                credential_type=CredentialType.API_KEY,
+                keys={"api_key": CredentialKey(name="api_key", value=SecretStr(f"key_{i}"))},
+            )
+            storage.save(cred)
+
+        results = {"saves": 0, "deletes": 0}
+        lock = threading.Lock()
+
+        def save_new(thread_id):
+            cred = CredentialObject(
+                id=f"new_cred_{thread_id}",
+                credential_type=CredentialType.API_KEY,
+                keys={
+                    "api_key": CredentialKey(
+                        name="api_key", value=SecretStr(f"new_key_{thread_id}")
+                    )
+                },
+            )
+            storage.save(cred)
+            with lock:
+                results["saves"] += 1
+
+        def delete_existing(cred_id):
+            storage.delete(cred_id)
+            with lock:
+                results["deletes"] += 1
+
+        threads = []
+        for i in range(5):
+            threads.append(threading.Thread(target=save_new, args=(i,)))
+            threads.append(threading.Thread(target=delete_existing, args=(f"cred_{i}",)))
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert results["saves"] == 5
+        assert results["deletes"] == 5
+        assert len(storage.list_all()) == 10
+
+    def test_lock_file_created(self, storage, temp_dir):
+        """Test that lock file is created during index update."""
+        cred = CredentialObject(
+            id="test_cred",
+            credential_type=CredentialType.API_KEY,
+            keys={"api_key": CredentialKey(name="api_key", value=SecretStr("test_key"))},
+        )
+        storage.save(cred)
+
+        lock_path = temp_dir / "metadata" / ".index.lock"
+        assert lock_path.exists()
+
+    def test_high_concurrency_stress(self, temp_dir):
+        """Test with high concurrency to verify robustness."""
+        import threading
+
+        storage = EncryptedFileStorage(temp_dir)
+        num_threads = 50
+        saved = []
+        lock = threading.Lock()
+
+        def save_credential(thread_id):
+            cred = CredentialObject(
+                id=f"stress_cred_{thread_id}",
+                credential_type=CredentialType.API_KEY,
+                keys={
+                    "api_key": CredentialKey(name="api_key", value=SecretStr(f"key_{thread_id}"))
+                },
+            )
+            storage.save(cred)
+            with lock:
+                saved.append(thread_id)
+
+        threads = [threading.Thread(target=save_credential, args=(i,)) for i in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(saved) == num_threads
+        assert len(storage.list_all()) == num_threads
+
+    def test_end_to_end_concurrent_workflow(self, temp_dir):
+        """Test full concurrent workflow with saves and deletes."""
+        import threading
+
+        storage = EncryptedFileStorage(temp_dir)
+        num_credentials = 30
+        save_results = []
+        save_lock = threading.Lock()
+
+        def save_cred(i):
+            cred = CredentialObject(
+                id=f"e2e_cred_{i}",
+                credential_type=CredentialType.API_KEY,
+                keys={"api_key": CredentialKey(name="api_key", value=SecretStr(f"secret_{i}"))},
+            )
+            storage.save(cred)
+            with save_lock:
+                save_results.append(i)
+
+        save_threads = [
+            threading.Thread(target=save_cred, args=(i,)) for i in range(num_credentials)
+        ]
+        for t in save_threads:
+            t.start()
+        for t in save_threads:
+            t.join()
+
+        assert len(save_results) == num_credentials
+        assert len(storage.list_all()) == num_credentials
+
+        for i in range(num_credentials):
+            loaded = storage.load(f"e2e_cred_{i}")
+            assert loaded is not None
+            assert loaded.get_key("api_key") == f"secret_{i}"
+
+        delete_count = num_credentials // 2
+        delete_results = []
+        delete_lock = threading.Lock()
+
+        def delete_cred(i):
+            storage.delete(f"e2e_cred_{i}")
+            with delete_lock:
+                delete_results.append(i)
+
+        delete_threads = [
+            threading.Thread(target=delete_cred, args=(i,)) for i in range(delete_count)
+        ]
+        for t in delete_threads:
+            t.start()
+        for t in delete_threads:
+            t.join()
+
+        assert len(delete_results) == delete_count
+        assert len(storage.list_all()) == num_credentials - delete_count
+
+        for i in range(delete_count):
+            assert storage.load(f"e2e_cred_{i}") is None
+        for i in range(delete_count, num_credentials):
+            loaded = storage.load(f"e2e_cred_{i}")
+            assert loaded is not None
+            assert loaded.get_key("api_key") == f"secret_{i}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Add file locking to `_update_index` and `list_all` for concurrency safety
- Use `fcntl.flock` with exclusive lock (LOCK_EX) for writes and shared lock (LOCK_SH) for reads
- Use `.index.lock` file with append mode for coordination
- Prevent silent credential loss during concurrent saves/deletes

## Changes since last review
Rebased to latest main and addressed all review feedback from @RichardTang-Aden:
1. ✅ Removed Windows `msvcrt` codepath — using `fcntl` directly (WSL required for Windows)
2. ✅ Added file locking to `list_all()` with `LOCK_SH` for read consistency
3. ✅ Changed lock file mode from `"w"` to `"a"` to avoid truncation
4. ✅ Preserved upstream's `utf-8-sig` encoding changes

## Test plan
- [x] 20 concurrent saves preserve all credentials (was losing ~50%)
- [x] 50 concurrent saves under stress test
- [x] Concurrent save/delete operations remain consistent
- [x] Lock file is created
- [x] All 68 tests passing

Fixes #3451

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced credential storage reliability by improving data consistency guarantees during concurrent operations.

* **Tests**
  * Added comprehensive test coverage validating concurrent credential operation scenarios, including parallel saves, mixed save and delete workflows, and end-to-end integrity verification across storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->