### PR TITLE
Fix HITLQuestion validation for SELECTION/STRUCTURED

### DIFF
--- a/core/framework/graph/hitl.py
+++ b/core/framework/graph/hitl.py
@@ -37,6 +37,17 @@ class HITLQuestion:
     # Metadata
     required: bool = True
     help_text: str = ""
+    def __post_init__(self):
+    if self.input_type == HITLInputType.SELECTION and not self.options:
+        raise ValueError(
+            "HITLQuestion with input_type=SELECTION must define non-empty options."
+        )
+    elif self.input_type == HITLInputType.STRUCTURED and not self.fields:
+        raise ValueError(
+            "HITLQuestion with input_type=STRUCTURED must define non-empty fields."
+        )
+
+
 
 
 @dataclass


### PR DESCRIPTION
Fixes #3023

Adds dataclass validation to `HITLQuestion` to prevent invalid configurations:
- SELECTION requires non-empty `options`
- STRUCTURED requires non-empty `fields`

Raises clear `ValueError` messages during initialization.
