### PR TITLE
feat(frontend): add simple HTML/CSS/JS dashboard

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,92 @@
+# Hive Dashboard (Frontend)
+
+A simple HTML/CSS/JS dashboard for monitoring Hive agents.
+
+## Features
+
+- Agent status cards with real-time metrics
+- Status filtering (online/degraded/offline)
+- Sparkline charts for request history
+- Activity log
+- Auto-refresh every 30 seconds
+- Responsive design
+
+## Running Locally
+
+No build step required. Just open `index.html` in your browser:
+
+```bash
+# Option 1: Open directly
+open frontend/index.html
+
+# Option 2: Use Python's built-in server
+cd frontend
+python -m http.server 8080
+# Then visit http://localhost:8080
+
+# Option 3: Use Node's http-server
+npx http-server frontend -p 8080
+```
+
+## Current State
+
+This is an MVP using **mock data**. The following features are ready to be connected to real APIs:
+
+### Ready for Integration
+
+1. **Agent List API** - Replace `mockAgents` with fetch from `/api/agents`
+2. **WebSocket Updates** - Connect to real-time agent status stream
+3. **Activity Feed** - Fetch from `/api/activity` endpoint
+
+### Placeholder Functions
+
+See `app.js` for:
+- `fetchAgents()` - Stub for REST API integration
+- `connectWebSocket()` - Stub for real-time updates
+
+## File Structure
+
+```
+frontend/
+├── index.html    # Main HTML structure
+├── styles.css    # All styling (dark theme)
+├── app.js        # JavaScript logic + mock data
+└── README.md     # This file
+```
+
+## Customization
+
+### Adding New Agents
+
+Edit the `mockAgents` array in `app.js`:
+
+```javascript
+{
+    id: 'agent-007',
+    name: 'My New Agent',
+    status: 'online', // online | degraded | offline | unknown
+    metrics: {
+        requestsPerMinute: 50,
+        successRate: 95.0,
+        avgLatency: 200,
+        costToday: 10.00,
+        requestHistory: generateSparklineData()
+    }
+}
+```
+
+### Changing Colors
+
+Edit CSS variables in `styles.css`:
+- Online: `#22c55e` (green)
+- Degraded: `#eab308` (yellow)
+- Offline: `#ef4444` (red)
+- Primary: `#3b82f6` (blue)
+
+## Next Steps
+
+1. [ ] Connect to real agent API endpoint
+2. [ ] Add WebSocket for live updates
+3. [ ] Add agent creation form
+4. [ ] Add cost breakdown charts
+5. [ ] Add agent graph visualization

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,310 @@
+// Hive Dashboard - Simple Frontend
+// This uses mock data for now - can be connected to real APIs later
+
+// Mock data for agents
+const mockAgents = [
+    {
+        id: 'agent-001',
+        name: 'Marketing Agent',
+        status: 'online',
+        metrics: {
+            requestsPerMinute: 45,
+            successRate: 98.5,
+            avgLatency: 230,
+            costToday: 12.50,
+            requestHistory: generateSparklineData()
+        }
+    },
+    {
+        id: 'agent-002',
+        name: 'Knowledge Agent',
+        status: 'online',
+        metrics: {
+            requestsPerMinute: 120,
+            successRate: 99.2,
+            avgLatency: 180,
+            costToday: 28.75,
+            requestHistory: generateSparklineData()
+        }
+    },
+    {
+        id: 'agent-003',
+        name: 'Blog Writer',
+        status: 'degraded',
+        metrics: {
+            requestsPerMinute: 8,
+            successRate: 85.0,
+            avgLatency: 890,
+            costToday: 5.20,
+            requestHistory: generateSparklineData()
+        }
+    },
+    {
+        id: 'agent-004',
+        name: 'SDR Agent',
+        status: 'online',
+        metrics: {
+            requestsPerMinute: 32,
+            successRate: 96.8,
+            avgLatency: 310,
+            costToday: 18.90,
+            requestHistory: generateSparklineData()
+        }
+    },
+    {
+        id: 'agent-005',
+        name: 'Data Analyst',
+        status: 'offline',
+        metrics: {
+            requestsPerMinute: 0,
+            successRate: 0,
+            avgLatency: 0,
+            costToday: 2.10,
+            requestHistory: generateSparklineData(true)
+        }
+    },
+    {
+        id: 'agent-006',
+        name: 'Support Bot',
+        status: 'online',
+        metrics: {
+            requestsPerMinute: 78,
+            successRate: 97.5,
+            avgLatency: 145,
+            costToday: 22.30,
+            requestHistory: generateSparklineData()
+        }
+    }
+];
+
+// Mock activity data
+const mockActivity = [
+    { type: 'success', message: 'Marketing Agent completed campaign analysis', time: '2 min ago' },
+    { type: 'info', message: 'Knowledge Agent indexed 150 new documents', time: '5 min ago' },
+    { type: 'warning', message: 'Blog Writer experiencing high latency', time: '8 min ago' },
+    { type: 'success', message: 'SDR Agent sent 45 outreach emails', time: '12 min ago' },
+    { type: 'error', message: 'Data Analyst went offline - connection timeout', time: '15 min ago' },
+    { type: 'info', message: 'Support Bot resolved 23 tickets', time: '20 min ago' },
+    { type: 'success', message: 'System backup completed successfully', time: '1 hour ago' }
+];
+
+// Generate random sparkline data
+function generateSparklineData(offline = false) {
+    const data = [];
+    for (let i = 0; i < 20; i++) {
+        if (offline && i > 15) {
+            data.push(0);
+        } else {
+            data.push(Math.floor(Math.random() * 80) + 20);
+        }
+    }
+    return data;
+}
+
+// State
+let currentFilter = 'all';
+let agents = [...mockAgents];
+
+// DOM Elements
+const agentsGrid = document.getElementById('agents-grid');
+const activityLog = document.getElementById('activity-log');
+const statusFilter = document.getElementById('status-filter');
+const refreshBtn = document.getElementById('refresh-btn');
+const lastUpdated = document.getElementById('last-updated');
+
+// Initialize
+document.addEventListener('DOMContentLoaded', () => {
+    renderAgents();
+    renderActivity();
+    updateStats();
+    updateTimestamp();
+
+    // Event listeners
+    statusFilter.addEventListener('change', handleFilterChange);
+    refreshBtn.addEventListener('click', handleRefresh);
+
+    // Auto-refresh every 30 seconds
+    setInterval(() => {
+        simulateDataUpdate();
+        renderAgents();
+        updateStats();
+        updateTimestamp();
+    }, 30000);
+});
+
+// Render agent cards
+function renderAgents() {
+    const filteredAgents = currentFilter === 'all'
+        ? agents
+        : agents.filter(a => a.status === currentFilter);
+
+    if (filteredAgents.length === 0) {
+        agentsGrid.innerHTML = `
+            <div class="empty-state">
+                <h3>No agents found</h3>
+                <p>No agents match the current filter.</p>
+            </div>
+        `;
+        return;
+    }
+
+    agentsGrid.innerHTML = filteredAgents.map(agent => createAgentCard(agent)).join('');
+}
+
+// Create agent card HTML
+function createAgentCard(agent) {
+    const maxValue = Math.max(...agent.metrics.requestHistory);
+    const sparklineBars = agent.metrics.requestHistory
+        .map(value => {
+            const height = maxValue > 0 ? (value / maxValue) * 100 : 0;
+            return `<div class="sparkline-bar" style="height: ${height}%" title="${value} req"></div>`;
+        })
+        .join('');
+
+    return `
+        <div class="agent-card">
+            <div class="agent-header">
+                <div>
+                    <div class="agent-name">${agent.name}</div>
+                    <div class="agent-id">${agent.id}</div>
+                </div>
+                <span class="status-badge ${agent.status}">${agent.status}</span>
+            </div>
+            <div class="agent-metrics">
+                <div class="metric">
+                    <div class="metric-value">${agent.metrics.requestsPerMinute}</div>
+                    <div class="metric-label">Req/min</div>
+                </div>
+                <div class="metric">
+                    <div class="metric-value">${agent.metrics.successRate}%</div>
+                    <div class="metric-label">Success</div>
+                </div>
+                <div class="metric">
+                    <div class="metric-value">${agent.metrics.avgLatency}ms</div>
+                    <div class="metric-label">Latency</div>
+                </div>
+                <div class="metric">
+                    <div class="metric-value">$${agent.metrics.costToday.toFixed(2)}</div>
+                    <div class="metric-label">Cost Today</div>
+                </div>
+            </div>
+            <div class="sparkline">
+                <div class="sparkline-label">Requests (last 20 min)</div>
+                <div class="sparkline-chart">
+                    ${sparklineBars}
+                </div>
+            </div>
+        </div>
+    `;
+}
+
+// Render activity log
+function renderActivity() {
+    const icons = {
+        success: '✓',
+        warning: '⚠',
+        error: '✕',
+        info: 'ℹ'
+    };
+
+    activityLog.innerHTML = mockActivity.map(item => `
+        <div class="activity-item">
+            <div class="activity-icon ${item.type}">${icons[item.type]}</div>
+            <div class="activity-content">
+                <div class="activity-message">${item.message}</div>
+                <div class="activity-time">${item.time}</div>
+            </div>
+        </div>
+    `).join('');
+}
+
+// Update stats bar
+function updateStats() {
+    const total = agents.length;
+    const online = agents.filter(a => a.status === 'online').length;
+    const degraded = agents.filter(a => a.status === 'degraded').length;
+    const offline = agents.filter(a => a.status === 'offline').length;
+    const totalCost = agents.reduce((sum, a) => sum + a.metrics.costToday, 0);
+
+    document.getElementById('total-agents').textContent = total;
+    document.getElementById('online-count').textContent = online;
+    document.getElementById('degraded-count').textContent = degraded;
+    document.getElementById('offline-count').textContent = offline;
+    document.getElementById('total-cost').textContent = `$${totalCost.toFixed(2)}`;
+}
+
+// Update timestamp
+function updateTimestamp() {
+    const now = new Date();
+    lastUpdated.textContent = `Last updated: ${now.toLocaleTimeString()}`;
+}
+
+// Handle filter change
+function handleFilterChange(e) {
+    currentFilter = e.target.value;
+    renderAgents();
+}
+
+// Handle refresh
+function handleRefresh() {
+    refreshBtn.textContent = 'Refreshing...';
+    refreshBtn.disabled = true;
+
+    setTimeout(() => {
+        simulateDataUpdate();
+        renderAgents();
+        updateStats();
+        updateTimestamp();
+        refreshBtn.textContent = 'Refresh';
+        refreshBtn.disabled = false;
+    }, 500);
+}
+
+// Simulate data updates (for demo purposes)
+function simulateDataUpdate() {
+    agents = agents.map(agent => {
+        // Randomly update metrics slightly
+        const newMetrics = { ...agent.metrics };
+
+        if (agent.status !== 'offline') {
+            newMetrics.requestsPerMinute = Math.max(0, agent.metrics.requestsPerMinute + Math.floor(Math.random() * 20) - 10);
+            newMetrics.successRate = Math.min(100, Math.max(80, agent.metrics.successRate + (Math.random() * 2 - 1)));
+            newMetrics.avgLatency = Math.max(50, agent.metrics.avgLatency + Math.floor(Math.random() * 50) - 25);
+            newMetrics.costToday = agent.metrics.costToday + (Math.random() * 0.5);
+
+            // Shift sparkline data
+            newMetrics.requestHistory = [
+                ...agent.metrics.requestHistory.slice(1),
+                Math.floor(Math.random() * 80) + 20
+            ];
+        }
+
+        return { ...agent, metrics: newMetrics };
+    });
+}
+
+// Future: Connect to real API
+async function fetchAgents() {
+    try {
+        // Replace with real API endpoint when available
+        // const response = await fetch('/api/agents');
+        // const data = await response.json();
+        // agents = data;
+        // renderAgents();
+        // updateStats();
+        console.log('API fetch would happen here');
+    } catch (error) {
+        console.error('Failed to fetch agents:', error);
+    }
+}
+
+// Future: WebSocket connection for real-time updates
+function connectWebSocket() {
+    // Replace with real WebSocket endpoint when available
+    // const ws = new WebSocket('ws://localhost:4001/ws');
+    // ws.onmessage = (event) => {
+    //     const data = JSON.parse(event.data);
+    //     updateAgentData(data);
+    // };
+    console.log('WebSocket connection would happen here');
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hive Dashboard</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>Hive Dashboard</h1>
+        <p class="subtitle">Agent Monitoring & Management</p>
+    </header>
+
+    <main>
+        <section class="stats-bar">
+            <div class="stat">
+                <span class="stat-value" id="total-agents">0</span>
+                <span class="stat-label">Total Agents</span>
+            </div>
+            <div class="stat">
+                <span class="stat-value online" id="online-count">0</span>
+                <span class="stat-label">Online</span>
+            </div>
+            <div class="stat">
+                <span class="stat-value degraded" id="degraded-count">0</span>
+                <span class="stat-label">Degraded</span>
+            </div>
+            <div class="stat">
+                <span class="stat-value offline" id="offline-count">0</span>
+                <span class="stat-label">Offline</span>
+            </div>
+            <div class="stat">
+                <span class="stat-value" id="total-cost">$0.00</span>
+                <span class="stat-label">Cost Today</span>
+            </div>
+        </section>
+
+        <section class="agents-section">
+            <div class="section-header">
+                <h2>Agents</h2>
+                <div class="controls">
+                    <select id="status-filter">
+                        <option value="all">All Status</option>
+                        <option value="online">Online</option>
+                        <option value="degraded">Degraded</option>
+                        <option value="offline">Offline</option>
+                    </select>
+                    <button id="refresh-btn">Refresh</button>
+                </div>
+            </div>
+            <div class="agents-grid" id="agents-grid">
+                <!-- Agent cards will be inserted here -->
+            </div>
+        </section>
+
+        <section class="activity-section">
+            <h2>Recent Activity</h2>
+            <div class="activity-log" id="activity-log">
+                <!-- Activity items will be inserted here -->
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <p>Hive Agent Framework &bull; <span id="last-updated">Never</span></p>
+    </footer>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,384 @@
+/* Reset and base styles */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #738cc8;
+    color: #e2e8f0;
+    min-height: 100vh;
+    line-height: 1.6;
+}
+
+/* Header */
+header {
+    background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+    padding: 24px 32px;
+    border-bottom: 1px solid #334155;
+}
+
+header h1 {
+    font-size: 24px;
+    font-weight: 600;
+    color: #f8fafc;
+}
+
+header .subtitle {
+    color: #94a3b8;
+    font-size: 14px;
+    margin-top: 4px;
+}
+
+/* Main content */
+main {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 24px;
+}
+
+/* Stats bar */
+.stats-bar {
+    display: flex;
+    gap: 16px;
+    margin-bottom: 32px;
+    flex-wrap: wrap;
+}
+
+.stat {
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 12px;
+    padding: 20px 24px;
+    flex: 1;
+    min-width: 150px;
+    text-align: center;
+}
+
+.stat-value {
+    display: block;
+    font-size: 32px;
+    font-weight: 700;
+    color: #f8fafc;
+    margin-bottom: 4px;
+}
+
+.stat-value.online { color: #22c55e; }
+.stat-value.degraded { color: #eab308; }
+.stat-value.offline { color: #ef4444; }
+
+.stat-label {
+    font-size: 13px;
+    color: #94a3b8;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+/* Section styles */
+.agents-section, .activity-section {
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 12px;
+    padding: 24px;
+    margin-bottom: 24px;
+}
+
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+.section-header h2 {
+    font-size: 18px;
+    font-weight: 600;
+}
+
+.controls {
+    display: flex;
+    gap: 12px;
+}
+
+select, button {
+    background: #334155;
+    border: 1px solid #475569;
+    color: #e2e8f0;
+    padding: 8px 16px;
+    border-radius: 6px;
+    font-size: 14px;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+select:hover, button:hover {
+    background: #475569;
+    border-color: #64748b;
+}
+
+button {
+    background: #3b82f6;
+    border-color: #3b82f6;
+}
+
+button:hover {
+    background: #2563eb;
+    border-color: #2563eb;
+}
+
+/* Agents grid */
+.agents-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 16px;
+}
+
+/* Agent card */
+.agent-card {
+    background: #0f172a;
+    border: 1px solid #334155;
+    border-radius: 10px;
+    padding: 20px;
+    transition: all 0.2s;
+}
+
+.agent-card:hover {
+    border-color: #3b82f6;
+    transform: translateY(-2px);
+}
+
+.agent-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 16px;
+}
+
+.agent-name {
+    font-size: 16px;
+    font-weight: 600;
+    color: #f8fafc;
+}
+
+.agent-id {
+    font-size: 12px;
+    color: #64748b;
+    margin-top: 2px;
+}
+
+.status-badge {
+    padding: 4px 10px;
+    border-radius: 20px;
+    font-size: 12px;
+    font-weight: 500;
+    text-transform: capitalize;
+}
+
+.status-badge.online {
+    background: rgba(34, 197, 94, 0.15);
+    color: #22c55e;
+}
+
+.status-badge.degraded {
+    background: rgba(234, 179, 8, 0.15);
+    color: #eab308;
+}
+
+.status-badge.offline {
+    background: rgba(239, 68, 68, 0.15);
+    color: #ef4444;
+}
+
+.status-badge.unknown {
+    background: rgba(148, 163, 184, 0.15);
+    color: #94a3b8;
+}
+
+.agent-metrics {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+}
+
+.metric {
+    background: #1e293b;
+    padding: 12px;
+    border-radius: 6px;
+}
+
+.metric-value {
+    font-size: 18px;
+    font-weight: 600;
+    color: #f8fafc;
+}
+
+.metric-label {
+    font-size: 11px;
+    color: #64748b;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+/* Sparkline */
+.sparkline {
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px solid #334155;
+}
+
+.sparkline-label {
+    font-size: 11px;
+    color: #64748b;
+    margin-bottom: 8px;
+}
+
+.sparkline-chart {
+    height: 40px;
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+}
+
+.sparkline-bar {
+    flex: 1;
+    background: #3b82f6;
+    border-radius: 2px 2px 0 0;
+    min-height: 2px;
+    transition: height 0.3s;
+}
+
+.sparkline-bar:hover {
+    background: #60a5fa;
+}
+
+/* Activity log */
+.activity-log {
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.activity-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px 0;
+    border-bottom: 1px solid #334155;
+}
+
+.activity-item:last-child {
+    border-bottom: none;
+}
+
+.activity-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    flex-shrink: 0;
+}
+
+.activity-icon.success {
+    background: rgba(34, 197, 94, 0.15);
+    color: #22c55e;
+}
+
+.activity-icon.warning {
+    background: rgba(234, 179, 8, 0.15);
+    color: #eab308;
+}
+
+.activity-icon.error {
+    background: rgba(239, 68, 68, 0.15);
+    color: #ef4444;
+}
+
+.activity-icon.info {
+    background: rgba(59, 130, 246, 0.15);
+    color: #3b82f6;
+}
+
+.activity-content {
+    flex: 1;
+}
+
+.activity-message {
+    font-size: 14px;
+    color: #e2e8f0;
+}
+
+.activity-time {
+    font-size: 12px;
+    color: #64748b;
+    margin-top: 2px;
+}
+
+/* Footer */
+footer {
+    text-align: center;
+    padding: 24px;
+    color: #64748b;
+    font-size: 13px;
+}
+
+/* Loading state */
+.loading {
+    text-align: center;
+    padding: 40px;
+    color: #64748b;
+}
+
+.loading::after {
+    content: '';
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    border: 2px solid #334155;
+    border-top-color: #3b82f6;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin-left: 10px;
+    vertical-align: middle;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+/* Empty state */
+.empty-state {
+    text-align: center;
+    padding: 60px 20px;
+    color: #64748b;
+}
+
+.empty-state h3 {
+    font-size: 18px;
+    margin-bottom: 8px;
+    color: #94a3b8;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .stats-bar {
+        flex-direction: column;
+    }
+
+    .stat {
+        min-width: 100%;
+    }
+
+    .section-header {
+        flex-direction: column;
+        gap: 12px;
+        align-items: flex-start;
+    }
+
+    .agents-grid {
+        grid-template-columns: 1fr;
+    }
+}


### PR DESCRIPTION
## Summary
- Add lightweight frontend dashboard for agent monitoring
- No build step required - pure HTML/CSS/JS
- Uses mock data with stubs ready for API integration

## Features
- Agent status cards with metrics (req/min, success rate, latency, cost)
- Sparkline charts for request history visualization
- Status filtering (online/degraded/offline)
- Activity log with recent events
- Auto-refresh every 30 seconds
- Responsive design for mobile
- Dark theme

## Files Added
```
frontend/
├── index.html    # Main HTML structure
├── styles.css    # Dark theme styling
├── app.js        # JavaScript logic + mock data
└── README.md     # Documentation
```

## Running Locally
```bash
cd frontend
python -m http.server 8080
# Visit http://localhost:8080
```

## Ready for Integration
The code includes placeholder functions for:
- `fetchAgents()` - REST API connection
- `connectWebSocket()` - Real-time updates

## Test plan
- [x] Open index.html in browser
- [x] Verify agent cards display with metrics
- [x] Test status filter dropdown
- [x] Verify sparkline charts render
- [x] Test refresh button
- [x] Check responsive layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)