### PR TITLE
Fix flaky async tests on Windows by replacing sleep-based waits

### DIFF
--- a/core/tests/test_concurrent_storage.py
+++ b/core/tests/test_concurrent_storage.py
@@ -85,12 +85,21 @@ async def test_batched_write_cache_consistency(tmp_path: Path):
         assert cache_key not in storage._cache, (
             "Cache should not be updated before batch is flushed"
         )
+        import time
+
+        async def wait_until(predicate, timeout=2.0, interval=0.02):
+            start = time.monotonic()
+            while time.monotonic() - start < timeout:
+                if predicate():
+                    return
+                await asyncio.sleep(interval)
+            raise AssertionError("Timed out waiting for condition")
 
         # Wait for batch to flush (poll instead of fixed sleep for CI reliability)
         for _ in range(500):  # 500 * 0.01s = 5s max
             if cache_key in storage._cache:
                 break
-            await asyncio.sleep(0.01)
+            await wait_until(lambda: cache_key in storage._cache, timeout=2.0)
 
         # After batch flush, cache should contain the run
         assert cache_key in storage._cache, "Cache should be updated after batch flush"


### PR DESCRIPTION
## Description

This PR fixes flaky async tests on Windows CI by replacing time-based sleeps
(e.g. `asyncio.sleep(0.1)`) with deterministic condition-based waiting.

The failures were caused by platform-dependent async scheduling differences
between Linux and Windows, which led to assertions running before async side
effects (such as event handlers or batched cache flushes) had completed.

This change improves test reliability across platforms without modifying any
production logic.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #3470

## Changes Made

- Replaced fixed `asyncio.sleep(0.1)` calls used for synchronization in async
  tests with deterministic `wait_until(...)` conditions.
- Ensured async event handlers and background batch flushes complete before
  assertions are evaluated.
- Replaced sleep-based task yielding with `asyncio.sleep(0)` where only event
  loop yielding was required.
- Reformatted affected test files using `ruff format` to satisfy CI formatting
  checks.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed (verified CI on both Windows and Linux runners)


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A
