### PR TITLE
Replace eval() with safe_eval() in NodeProtocol documentation

### DIFF
--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -583,6 +583,8 @@ class NodeProtocol(ABC):
     3. Register with the executor
 
     Example:
+        from framework.graph.safe_eval import safe_eval
+
         class CalculatorNode(NodeProtocol):
             async def execute(self, ctx: NodeContext) -> NodeResult:
                 expression = ctx.input_data.get("expression")
@@ -596,7 +598,7 @@ class NodeProtocol(ABC):
                 )
 
                 # Do the work
-                result = eval(expression)
+                result = safe_eval(expression, context={"x": 10, "y": 20})
 
                 # Record outcome
                 ctx.runtime.record_outcome(decision_id, success=True, result=result)


### PR DESCRIPTION
## Description

The NodeProtocol documentation example was demonstrating unsafe use of eval() on user input, which could teach developers to implement code injection vulnerabilities.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #3576

## Changes Made

Changes:
- Replace eval(expression) with safe_eval(expression, context={...})
- Add import statement for safe_eval in the example

This aligns the documentation with the framework's existing safe_eval utility
that properly validates expressions using AST parsing.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
