### PR TITLE
fix(safe_eval): raise ValueError on dict unpacking instead of silent …

### DIFF
--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -83,10 +83,16 @@ class SafeEvalVisitor(ast.NodeVisitor):
         return tuple(self.visit(elt) for elt in node.elts)
 
     def visit_Dict(self, node: ast.Dict) -> dict:
+        # Check for dict unpacking (**expr) which appears as None keys in AST
+        # Silent skipping of unpacking is a security/data integrity issue
+        if any(k is None for k in node.keys):
+            raise ValueError(
+                "Dict unpacking (**expr) is not allowed in safe evaluations. "
+                "Flatten the dict manually or use individual key access."
+            )
         return {
             self.visit(k): self.visit(v)
             for k, v in zip(node.keys, node.values, strict=False)
-            if k is not None
         }
 
     # --- Operations ---


### PR DESCRIPTION
## Description
This PR addresses a silent failure mode in `safe_eval.py` where dictionary unpacking (e.g., `{**kwargs}`) was being ignored without warning.

**Problem:** Previously, `visit_Dict` checked `if k is not None` to filter out unpacking nodes. This resulted in silent data loss (`safe_eval("{'a': 1, **others}")` returned `{'a': 1}`), which creates ambiguity and data integrity issues.

**Solution:** Updated `visit_Dict` to explicitly check for unpacking (`None` keys) and raise a `ValueError`. This aligns with security best practices to fail loudly rather than silently dropping data.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related Issues
Fixes #2538

## Changes Made
- Modified `visit_Dict` in `core/framework/graph/safe_eval.py`
- Replaced silent filtering of `None` keys with explicit `ValueError`
- Added informative error message for users to explain why unpacking is blocked

## Testing
Verified locally with manual AST test cases:
- [x] `{**{'b': 2}}` -> correctly raises `ValueError` (caught silent failure)
- [x] `{'a': 1, 'b': 2}` -> works as expected (no regression)
- [x] `{**context_var}` -> correctly raises `ValueError`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings