### PR TITLE
fix(safe_eval): raise ValueError on dict unpacking [micro-fix]

### DIFF
--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -83,10 +83,16 @@ class SafeEvalVisitor(ast.NodeVisitor):
         return tuple(self.visit(elt) for elt in node.elts)
 
     def visit_Dict(self, node: ast.Dict) -> dict:
+        # Check for dict unpacking (**expr) which appears as None keys in AST
+        # Silent skipping of unpacking is a security/data integrity issue
+        if any(k is None for k in node.keys):
+            raise ValueError(
+                "Dict unpacking (**expr) is not allowed in safe evaluations. "
+                "Flatten the dict manually or use individual key access."
+            )
         return {
             self.visit(k): self.visit(v)
             for k, v in zip(node.keys, node.values, strict=False)
-            if k is not None
         }
 
     # --- Operations ---


### PR DESCRIPTION
## Summary
Fixes #2538

This PR addresses a silent failure mode in `safe_eval.py` where dictionary unpacking (e.g., `{**kwargs}`) was being ignored without warning.

**Problem:** Previously, `visit_Dict` checked `if k is not None` to filter out unpacking nodes. This resulted in silent data loss (`safe_eval("{'a': 1, **others}")` returned `{'a': 1}` silently).

**Solution:** Updated `visit_Dict` to explicitly check for unpacking (`None` keys) and raise a `ValueError`. It is safer to fail explicitly than to return partial data silently.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan
Verified locally:
- `{**{'b': 2}}` → correctly raises `ValueError`
- `{'a': 1, 'b': 2}` → works as expected (no regression)
- `{**context_var}` → correctly raises `ValueError`