### PR TITLE
feat(tools): Add Discord Notification Tool

### DIFF
--- a/tools/src/aden_tools/tools/discord_tool/discord_actions.py
+++ b/tools/src/aden_tools/tools/discord_tool/discord_actions.py
@@ -1,0 +1,27 @@
+import requests
+from fastmcp import FastMCP
+
+def register_tools(mcp: FastMCP) -> None:
+    
+    @mcp.tool()
+    def send_discord_message(webhook_url: str, message: str) -> str:
+        """
+        Sends a notification to a Discord channel via Webhook.
+        Args:
+            webhook_url: The discord webhook link.
+            message: The text you want to send.
+        """
+        if not webhook_url:
+            return "Error: Webhook URL is missing."
+
+        try:
+            payload = {"content": message}
+            response = requests.post(webhook_url, json=payload)
+            
+            if response.status_code in [200, 204]:
+                return "Success: Message sent to Discord!"
+            else:
+                return f"Failed: Discord returned status {response.status_code}"
+                
+        except Exception as e:
+            return f"Error: {str(e)}"


### PR DESCRIPTION
## Description
This PR adds a new `discord_tool` to the `aden_tools` package. It enables agents to send notification messages to Discord channels via Webhooks.

## Changes
- Added `discord_tool/discord_actions.py` with `send_discord_message` function.
- Registered the new tool in `tools/__init__.py`.
- Implemented using the `FastMCP` pattern as recommended.

## Testing
- Validated locally by creating a test script and sending a message to a private Discord server.
- Confirmed success status (204) handling.

## Related Issue
Closes #[Insert your Issue Number here if you have one]
