### PR TITLE
Docs/environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# LLM Providers (set at least one depending on the model used)
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+GEMINI_API_KEY=
+
+# Environment
+ENV=development
+
+# Observability
+ENABLE_TELEMETRY=true

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ cd hive
 ./quickstart.sh
 ```
 
+> 📌 Before running agents, see [Environment Variables Setup](docs/getting-started.md#environment-variables).
+
+
 This sets up:
 - **framework** - Core agent runtime and graph executor (in `core/.venv`)
 - **aden_tools** - MCP tools for agent capabilities (in `tools/.venv`)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -130,6 +130,25 @@ PYTHONPATH=exports uv run python -m my_agent run --input '{
 PYTHONPATH=exports uv run python -m my_agent run --mock --input '{...}'
 ```
 
+## Environment Variables
+
+Hive requires certain environment variables to be set before running agents.
+
+### Required (at least one provider)
+- `OPENAI_API_KEY` – API key for OpenAI models
+- `ANTHROPIC_API_KEY` – API key for Anthropic (Claude) models
+- `GEMINI_API_KEY` – API key for Google Gemini models
+
+> Only one provider key is required, depending on the model used.
+
+### Environment
+- `ENV` – Environment name (e.g., `development`, `production`)
+
+### Notes
+- Do not commit real secrets to version control.
+- Use the provided `.env.example` file as a reference.
+
+
 ## API Keys Setup
 
 For running agents with real LLMs:


### PR DESCRIPTION
### Summary
Improves contributor onboarding by documenting required environment variables and providing an example `.env` file.

### Changes
- Added `.env.example` at the repository root
- Documented environment variables in `docs/getting-started.md`
- Linked environment setup from `README.md`

### Related Issue
Closes #3649
