### PR TITLE
fix(tools): handle Windows cross-drive path validation [micro-fix]

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/security.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/security.py
@@ -22,8 +22,12 @@ def get_secure_path(path: str, workspace_id: str, agent_id: str, session_id: str
         final_path = os.path.abspath(os.path.join(session_dir, path))
 
     # Verify path is within session_dir
-    common_prefix = os.path.commonpath([final_path, session_dir])
-    if common_prefix != session_dir:
-        raise ValueError(f"Access denied: Path '{path}' is outside the session sandbox.")
+    try:
+        common_prefix = os.path.commonpath([final_path, session_dir])
+        if common_prefix != session_dir:
+            raise ValueError(f"Access denied: Path '{path}' is outside the session sandbox.")
+    except ValueError:
+        # Catches both commonpath failure (different drives on Windows) and our explicit raise
+        raise ValueError(f"Access denied: Path '{path}' is outside the session sandbox.") from None
 
     return final_path


### PR DESCRIPTION
## Summary
Fixes crash on Windows when paths are on different drives.
## Problem
`os.path.commonpath()` raises `ValueError` when comparing paths on different drives (e.g., `C:\` vs `D:\`). This causes an unhandled exception instead of a proper access denied error.
## Solution
Wrap `commonpath()` in try-except and convert to access denied error.
## Files Changed
- `tools/src/aden_tools/tools/file_system_toolkits/security.py`
## Testing
- [x] Windows-specific edge case
- [x] Converts crash to proper error handling
