### PR TITLE
fix(core): add cache invalidation to save_run_sync [micro-fix]

### DIFF
--- a/core/framework/storage/concurrent.py
+++ b/core/framework/storage/concurrent.py
@@ -424,7 +424,9 @@ class ConcurrentStorage:
 
     def save_run_sync(self, run: Run) -> None:
         """Synchronous save (uses base storage directly with lock)."""
-        # Use threading lock for sync operations
+        # Invalidate caches to prevent stale reads (matches async behavior)
+        self._cache.pop(f"run:{run.id}", None)
+        self._cache.pop(f"summary:{run.id}", None)
         self._base_storage.save_run(run)
 
     def load_run_sync(self, run_id: str) -> Run | None:


### PR DESCRIPTION
## Summary
Adds cache invalidation to `save_run_sync()` for consistency with async version.
## Problem
`save_run_sync()` doesn't invalidate caches unlike the async `save_run()`, which cause stale reads when mixing sync and async operations.
## Solution
Add cache invalidation matching the async version's behavior.
## Files Changed
- `core/framework/storage/concurrent.py`
## Testing
- [x] Matches existing async behavior pattern
- [x] Prevents potential stale cache reads