### PR TITLE
docs(skills): micro-fix remove hardcoded path in building-agents skill

### DIFF
--- a/.claude/skills/building-agents-construction/SKILL.md
+++ b/.claude/skills/building-agents-construction/SKILL.md
@@ -286,7 +286,7 @@ This returns JSON with all the goal, nodes, edges, and MCP server configurations
 > **Test your agent:**
 >
 > ```bash
-> cd /home/timothy/oss/hive
+> # From the hive project root:
 > PYTHONPATH=exports uv run python -m AGENT_NAME validate
 > PYTHONPATH=exports uv run python -m AGENT_NAME info
 > ```
@@ -298,7 +298,8 @@ This returns JSON with all the goal, nodes, edges, and MCP server configurations
 **RUN validation:**
 
 ```bash
-cd /home/timothy/oss/hive && PYTHONPATH=exports uv run python -m AGENT_NAME validate
+# From the hive project root:
+PYTHONPATH=exports uv run python -m AGENT_NAME validate
 ```
 
 - If valid: Agent is complete!


### PR DESCRIPTION
## Summary
Removes hardcoded `/home/timothy/oss/hive` path that breaks the onboarding workflow for all users.

## Changes
- Replace hardcoded path with generic "from project root" comment
- 2 locations in `.claude/skills/building-agents-construction/SKILL.md`
- 3 insertions, 2 deletions

## Type
- [x] Micro-fix (< 20 lines, no logic changes, docs/skills file)