### PR TITLE
docs(readme): add uv prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 - Python 3.11+ for agent development
 - Claude Code or Cursor for utilizing agent skills
 - uv (Python package manager) is required (used in commands like `uv run`). Install: https://docs.astral.sh/uv/
+- 
 > **Note for Windows Users:** It is strongly recommended to use **WSL (Windows Subsystem for Linux)** or **Git Bash** to run this framework. Some core automation scripts may not execute correctly in standard Command Prompt or PowerShell.
 
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 - Python 3.11+ for agent development
 - Claude Code or Cursor for utilizing agent skills
 - uv (Python package manager) is required (used in commands like `uv run`). Install: https://docs.astral.sh/uv/
-- 
+
 > **Note for Windows Users:** It is strongly recommended to use **WSL (Windows Subsystem for Linux)** or **Git Bash** to run this framework. Some core automation scripts may not execute correctly in standard Command Prompt or PowerShell.
 
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 
 - Python 3.11+ for agent development
 - Claude Code or Cursor for utilizing agent skills
-
+- uv (Python package manager) is required (used in commands like `uv run`). Install: https://docs.astral.sh/uv/
 > **Note for Windows Users:** It is strongly recommended to use **WSL (Windows Subsystem for Linux)** or **Git Bash** to run this framework. Some core automation scripts may not execute correctly in standard Command Prompt or PowerShell.
+
 
 ### Installation
 


### PR DESCRIPTION
## Description
README currently uses `uv run` in commands, but `uv` isn’t listed under prerequisites. This PR adds `uv` as an explicit prerequisite with the official install link to reduce setup friction.

## Type of Change
- [x] Documentation update

## Related Issues
N/A (docs-only update)

## Changes Made
- Added `uv` as a prerequisite since setup/run commands rely on `uv run`.
- Included the official `uv` installation link.

## Testing
- [x] Manual testing performed (documentation-only change)

## Checklist
- [x] I have performed a self-review of my change
- [x] I have made corresponding changes to the documentation
