### PR TITLE
feat: implement AgentRunner.from_file and handle UTF-8-sig for Windows

### DIFF
--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -375,6 +375,39 @@ class AgentRunner:
         return module
 
     @classmethod
+    def from_file(
+        cls,
+        path: str | Path,
+        mock_mode: bool = False,
+        storage_path: Path | None = None,
+        model: str | None = None,
+        enable_tui: bool = False,
+    ) -> "AgentRunner":
+        """
+        Creates an AgentRunner instance directly from an agent.json file.
+        """
+        path = Path(path)
+        if not path.exists():
+            raise FileNotFoundError(f"Agent file not found at: {path}")
+
+        # Read the file as a raw string (handle BOM with utf-8-sig)
+        with open(path, encoding="utf-8-sig") as f:
+            raw_json_data = f.read()
+
+        # load_agent_export is designed to take a string and do the parsing
+        graph, goal = load_agent_export(raw_json_data)
+
+        return cls(
+            agent_path=path.parent,
+            graph=graph,
+            goal=goal,
+            mock_mode=mock_mode,
+            storage_path=storage_path,
+            model=model,
+            enable_tui=enable_tui,
+        )
+
+    @classmethod
     def load(
         cls,
         agent_path: str | Path,


### PR DESCRIPTION
## Description
Implemented the missing `AgentRunner.from_file()` class method. Previously, the class only supported `load()`, but documentation suggested `from_file()` for manual agent initialization, leading to an `AttributeError`. 

This also addresses encoding issues for Windows users by using `utf-8-sig` to handle PowerShell BOM characters.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Related Issues
Fixes #3695

## Changes Made
- Added `@classmethod from_file` to `AgentRunner` in `core/framework/runner/runner.py`.
- Updated file reading to use `utf-8-sig` encoding to handle Windows PowerShell BOM characters.
- Utilized the existing `load_agent_export` helper to ensure consistent parsing of `GraphSpec` and `Goal` objects.

## Testing
- [x] Manual testing performed
  - Reproduced the `AttributeError` using a standalone script on Windows 11.
  - Verified fix; confirmed `agent.json` (wrapped in a `graph` key) loads correctly and prints "Success!".
  - Verified Pydantic validation handles the schema correctly once fields (`id`, `name`, `description`) were aligned.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings