### PR TITLE
[docs] Clarify quickstart PATH and venv location - Fixes #3729

### DIFF
--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -21,6 +21,19 @@ This will:
 - Fix package compatibility issues (openai + litellm)
 - Verify all installations
 
+- > **Note:** If `uv` is not found after installation, you may need to add `~/.local/bin` to your PATH:
+> 
+> ```bash
+> # Add to your shell profile (~/.bashrc, ~/.zshrc, etc.)
+> export PATH="$HOME/.local/bin:$PATH"
+> ```
+> 
+> Or reload your shell:
+> 
+> ```bash
+> source ~/.local/bin/env
+> ```
+
 ## Windows Setup
 
 Windows users should use **WSL (Windows Subsystem for Linux)** to set up and run agents.
@@ -368,6 +381,8 @@ The project uses **separate virtual environments** for `core` and `tools` packag
 ### How It Works
 
 When you run `./quickstart.sh` or `uv sync` in each directory:
+
+> **Note:** When running `./quickstart.sh`, a single root `.venv/` directory is created in the project root, not separate `core/.venv/` and `tools/.venv/` directories. The separate virtual environments mentioned below apply when manually setting up each package.
 
 1. **core/.venv/** - Contains the `framework` package and its dependencies (anthropic, litellm, mcp, etc.)
 2. **tools/.venv/** - Contains the `aden_tools` package and its dependencies (beautifulsoup4, pandas, etc.)


### PR DESCRIPTION
Fixes #3729

This PR improves the onboarding experience by:

1. PATH Setup Clarification: Added instructions for adding ~/.local/bin to PATH when uv is not found after quickstart installation, including shell profile examples and reload commands.

2. Virtual Environment Location : Clarified that quickstart.sh creates a single root .venv/ directory, not separate core/.venv and tools/.venv directories as the previous documentation suggested.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
