### PR TITLE
feat: add excel_tool with read, info, and sql support (fixes #3787)

### DIFF
--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 # Import register_tools from each tool module
 from .csv_tool import register_tools as register_csv
 from .email_tool import register_tools as register_email
+from .excel_tool import register_tools as register_excel
 from .example_tool import register_tools as register_example
 from .file_system_toolkits.apply_diff import register_tools as register_apply_diff
 from .file_system_toolkits.apply_patch import register_tools as register_apply_patch
@@ -87,6 +88,7 @@ def register_all_tools(
     register_execute_command(mcp)
     register_data_tools(mcp)
     register_csv(mcp)
+    register_excel(mcp)
 
     return [
         "example_tool",
@@ -109,6 +111,9 @@ def register_all_tools(
         "csv_append",
         "csv_info",
         "csv_sql",
+        "excel_read",
+        "excel_info",
+        "excel_sql",
         "github_list_repos",
         "github_get_repo",
         "github_search_repos",

--- a/tools/src/aden_tools/tools/excel_tool/README.md
+++ b/tools/src/aden_tools/tools/excel_tool/README.md
@@ -1,0 +1,71 @@
+# Excel Tool
+
+Read and query Excel (.xlsx/.xls) files using DuckDB.
+
+## Description
+
+Provides tools to read, inspect, and query Excel files within a sandboxed session environment. Uses DuckDB's built-in `excel` extension for fast, reliable parsing with automatic type inference. Supports multi-sheet workbooks.
+
+## Tools
+
+### `excel_read`
+
+Read an Excel file and return its contents with pagination support.
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `path` | str | Yes | - | Path to the Excel file (relative to session sandbox) |
+| `workspace_id` | str | Yes | - | Workspace identifier |
+| `agent_id` | str | Yes | - | Agent identifier |
+| `session_id` | str | Yes | - | Session identifier |
+| `sheet` | str | No | `None` | Sheet name to read (None = first sheet) |
+| `limit` | int | No | `None` | Maximum number of rows to return (None = all rows) |
+| `offset` | int | No | `0` | Number of rows to skip from the beginning |
+
+### `excel_info`
+
+Get metadata about an Excel file without reading all data.
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `path` | str | Yes | - | Path to the Excel file (relative to session sandbox) |
+| `workspace_id` | str | Yes | - | Workspace identifier |
+| `agent_id` | str | Yes | - | Agent identifier |
+| `session_id` | str | Yes | - | Session identifier |
+
+### `excel_sql`
+
+Query an Excel sheet using SQL (powered by DuckDB). The sheet is loaded as a table named `data`.
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `path` | str | Yes | - | Path to the Excel file (relative to session sandbox) |
+| `workspace_id` | str | Yes | - | Workspace identifier |
+| `agent_id` | str | Yes | - | Agent identifier |
+| `session_id` | str | Yes | - | Session identifier |
+| `query` | str | Yes | - | SQL query to execute. The sheet is available as table `data`. |
+| `sheet` | str | No | `None` | Sheet name to query (None = first sheet) |
+
+## Environment Variables
+
+This tool does not require any environment variables.
+
+Requires DuckDB to be installed (`uv pip install duckdb` or `uv pip install tools[sql]`).
+
+## Error Handling
+
+Returns error dicts for common issues:
+- `File not found: <path>` - File does not exist
+- `File must have .xlsx or .xls extension` - Wrong file extension
+- `DuckDB not installed. Install with: ...` - DuckDB dependency missing
+- `Only SELECT queries are allowed for security reasons` - Non-SELECT query attempted
+- `'<keyword>' is not allowed in queries` - Dangerous SQL keyword detected
+- `offset and limit must be non-negative` - Invalid pagination parameters
+
+## Notes
+
+- Only SELECT queries are allowed in `excel_sql` for security
+- All file paths are resolved within the session sandbox via `get_secure_path()`
+- DuckDB's excel extension provides automatic type inference (integers, floats, dates, strings)
+- The excel extension is a DuckDB core extension and does not require additional Python packages
+- Multi-sheet workbooks are fully supported; use `excel_info` to discover available sheets

--- a/tools/src/aden_tools/tools/excel_tool/__init__.py
+++ b/tools/src/aden_tools/tools/excel_tool/__init__.py
@@ -1,0 +1,5 @@
+"""Excel Tool package."""
+
+from .excel_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/excel_tool/excel_tool.py
+++ b/tools/src/aden_tools/tools/excel_tool/excel_tool.py
@@ -1,0 +1,360 @@
+"""Excel Tool - Read and query Excel (.xlsx/.xls) files using DuckDB."""
+
+import os
+import xml.etree.ElementTree as ET
+import zipfile
+
+from fastmcp import FastMCP
+
+from ..file_system_toolkits.security import get_secure_path
+
+# Supported Excel file extensions
+_EXCEL_EXTENSIONS = (".xlsx", ".xls")
+
+
+def _check_duckdb():
+    """Lazy-import DuckDB, returning (module, None) or (None, error_dict)."""
+    try:
+        import duckdb
+
+        return duckdb, None
+    except ImportError:
+        return None, {
+            "error": (
+                "DuckDB not installed. Install with: "
+                "uv pip install duckdb  or  uv pip install tools[sql]"
+            )
+        }
+
+
+def _load_excel_extension(con) -> None:
+    """Load the DuckDB excel extension, installing if necessary."""
+    try:
+        con.execute("LOAD excel;")
+    except Exception:
+        con.execute("INSTALL excel; LOAD excel;")
+
+
+def _is_excel_file(path: str) -> bool:
+    """Check if a path has an Excel file extension."""
+    return path.lower().endswith(_EXCEL_EXTENSIONS)
+
+
+def _get_sheet_names(filepath: str) -> list[str]:
+    """Extract sheet names from an xlsx file using its zip/XML structure.
+
+    This avoids needing openpyxl or a DuckDB metadata function.
+    Falls back to ["Sheet1"] for xls files or on parse errors.
+    """
+    try:
+        with zipfile.ZipFile(filepath) as z:
+            with z.open("xl/workbook.xml") as f:
+                tree = ET.parse(f)
+                ns = {"main": "http://schemas.openxmlformats.org/spreadsheetml/2006/main"}
+                sheets = tree.findall(".//main:sheet", ns)
+                return [s.attrib["name"] for s in sheets]
+    except Exception:
+        return ["Sheet1"]
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register Excel tools with the MCP server."""
+
+    @mcp.tool()
+    def excel_read(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        sheet: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> dict:
+        """
+        Read an Excel file (.xlsx/.xls) and return its contents.
+
+        Uses DuckDB's excel extension for fast, reliable parsing with
+        automatic type inference.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+            sheet: Sheet name to read (None = first sheet)
+            limit: Maximum number of rows to return (None = all rows)
+            offset: Number of rows to skip from the beginning
+
+        Returns:
+            dict with success status, data, and metadata
+        """
+        if offset < 0 or (limit is not None and limit < 0):
+            return {"error": "offset and limit must be non-negative"}
+
+        duckdb, err = _check_duckdb()
+        if err:
+            return err
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            if not _is_excel_file(path):
+                return {"error": "File must have .xlsx or .xls extension"}
+
+            con = duckdb.connect(":memory:")
+            try:
+                _load_excel_extension(con)
+
+                # Build read_xlsx call
+                params = [f"'{secure_path}'"]
+                params.append("header = true")
+                if sheet is not None:
+                    params.append(f"sheet = '{sheet}'")
+                read_expr = f"read_xlsx({', '.join(params)})"
+
+                # Get total row count
+                count_result = con.execute(f"SELECT COUNT(*) FROM {read_expr}")
+                total_rows = count_result.fetchone()[0]
+
+                # Build query with offset and limit
+                query = f"SELECT * FROM {read_expr}"
+                if offset > 0:
+                    query += f" OFFSET {offset}"
+                if limit is not None:
+                    query += f" LIMIT {limit}"
+
+                result = con.execute(query)
+                columns = [desc[0] for desc in result.description]
+                raw_rows = result.fetchall()
+
+                # Convert to list of dicts
+                rows = [dict(zip(columns, row, strict=False)) for row in raw_rows]
+
+                return {
+                    "success": True,
+                    "path": path,
+                    "sheet": sheet,
+                    "columns": columns,
+                    "column_count": len(columns),
+                    "rows": rows,
+                    "row_count": len(rows),
+                    "total_rows": total_rows,
+                    "offset": offset,
+                    "limit": limit,
+                }
+            finally:
+                con.close()
+
+        except Exception as e:
+            return {"error": f"Failed to read Excel file: {str(e)}"}
+
+    @mcp.tool()
+    def excel_info(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> dict:
+        """
+        Get metadata about an Excel file without reading all data.
+
+        Returns sheet names, row counts, column names, and file size.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+
+        Returns:
+            dict with file metadata (sheets, columns, row counts, file size)
+        """
+        duckdb, err = _check_duckdb()
+        if err:
+            return err
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            if not _is_excel_file(path):
+                return {"error": "File must have .xlsx or .xls extension"}
+
+            file_size = os.path.getsize(secure_path)
+
+            # Extract sheet names from the xlsx zip structure
+            # (xlsx files are zip archives with an XML workbook)
+            sheet_names = _get_sheet_names(secure_path)
+
+            con = duckdb.connect(":memory:")
+            try:
+                _load_excel_extension(con)
+
+                # Get details for each sheet
+                sheets = []
+                for sheet_name in sheet_names:
+                    try:
+                        read_expr = (
+                            f"read_xlsx('{secure_path}', "
+                            f"sheet = '{sheet_name}', header = true)"
+                        )
+
+                        # Get columns
+                        col_result = con.execute(f"SELECT * FROM {read_expr} LIMIT 0")
+                        columns = [desc[0] for desc in col_result.description]
+
+                        # Get row count
+                        count_result = con.execute(
+                            f"SELECT COUNT(*) FROM {read_expr}"
+                        )
+                        row_count = count_result.fetchone()[0]
+
+                        sheets.append({
+                            "name": sheet_name,
+                            "columns": columns,
+                            "column_count": len(columns),
+                            "row_count": row_count,
+                        })
+                    except Exception:
+                        # Sheet might be empty or unreadable
+                        sheets.append({
+                            "name": sheet_name,
+                            "columns": [],
+                            "column_count": 0,
+                            "row_count": 0,
+                            "warning": "Could not read sheet contents",
+                        })
+
+                return {
+                    "success": True,
+                    "path": path,
+                    "sheet_count": len(sheets),
+                    "sheets": sheets,
+                    "file_size_bytes": file_size,
+                }
+            finally:
+                con.close()
+
+        except Exception as e:
+            return {"error": f"Failed to get Excel info: {str(e)}"}
+
+    @mcp.tool()
+    def excel_sql(
+        path: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        query: str,
+        sheet: str | None = None,
+    ) -> dict:
+        """
+        Query an Excel file using SQL (powered by DuckDB).
+
+        The Excel sheet is loaded as a table named 'data'. Use standard SQL syntax.
+
+        Args:
+            path: Path to the Excel file (relative to session sandbox)
+            workspace_id: Workspace identifier
+            agent_id: Agent identifier
+            session_id: Session identifier
+            query: SQL query to execute. The sheet is available as table 'data'.
+                   Example: "SELECT * FROM data WHERE price > 100 ORDER BY name LIMIT 10"
+            sheet: Sheet name to query (None = first sheet)
+
+        Returns:
+            dict with query results, columns, and row count
+
+        Examples:
+            # Filter rows
+            query="SELECT * FROM data WHERE status = 'pending'"
+
+            # Aggregate data
+            query="SELECT category, COUNT(*) as count, "
+                  "AVG(price) as avg_price FROM data GROUP BY category"
+
+            # Sort and limit
+            query="SELECT name, price FROM data ORDER BY price DESC LIMIT 5"
+        """
+        duckdb, err = _check_duckdb()
+        if err:
+            return err
+
+        try:
+            secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            if not os.path.exists(secure_path):
+                return {"error": f"File not found: {path}"}
+
+            if not _is_excel_file(path):
+                return {"error": "File must have .xlsx or .xls extension"}
+
+            if not query or not query.strip():
+                return {"error": "query cannot be empty"}
+
+            # Security: only allow SELECT statements
+            query_upper = query.strip().upper()
+            if not query_upper.startswith("SELECT"):
+                return {"error": "Only SELECT queries are allowed for security reasons"}
+
+            # Disallowed keywords for security
+            disallowed = [
+                "INSERT",
+                "UPDATE",
+                "DELETE",
+                "DROP",
+                "CREATE",
+                "ALTER",
+                "TRUNCATE",
+                "EXEC",
+                "EXECUTE",
+            ]
+            for keyword in disallowed:
+                if keyword in query_upper:
+                    return {"error": f"'{keyword}' is not allowed in queries"}
+
+            con = duckdb.connect(":memory:")
+            try:
+                _load_excel_extension(con)
+
+                # Build read_xlsx expression
+                params = [f"'{secure_path}'"]
+                params.append("header = true")
+                if sheet is not None:
+                    params.append(f"sheet = '{sheet}'")
+                read_expr = f"read_xlsx({', '.join(params)})"
+
+                # Load Excel sheet as 'data' table
+                con.execute(f"CREATE TABLE data AS SELECT * FROM {read_expr}")
+
+                # Execute user query
+                result = con.execute(query)
+                columns = [desc[0] for desc in result.description]
+                rows = result.fetchall()
+
+                # Convert to list of dicts
+                rows_as_dicts = [dict(zip(columns, row, strict=False)) for row in rows]
+
+                return {
+                    "success": True,
+                    "path": path,
+                    "sheet": sheet,
+                    "query": query,
+                    "columns": columns,
+                    "column_count": len(columns),
+                    "rows": rows_as_dicts,
+                    "row_count": len(rows_as_dicts),
+                }
+            finally:
+                con.close()
+
+        except Exception as e:
+            error_msg = str(e)
+            # Make DuckDB errors more readable
+            if "Catalog Error" in error_msg:
+                return {"error": f"SQL error: {error_msg}. Remember the table is named 'data'."}
+            return {"error": f"Query failed: {error_msg}"}

--- a/tools/tests/tools/test_excel_tool.py
+++ b/tools/tests/tools/test_excel_tool.py
@@ -1,0 +1,474 @@
+"""Tests for excel_tool - Read and query Excel (.xlsx/.xls) files."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.excel_tool.excel_tool import register_tools
+
+duckdb_available = importlib.util.find_spec("duckdb") is not None
+openpyxl_available = importlib.util.find_spec("openpyxl") is not None
+
+# Test IDs for sandbox
+TEST_WORKSPACE_ID = "test-workspace"
+TEST_AGENT_ID = "test-agent"
+TEST_SESSION_ID = "test-session"
+
+
+def _create_xlsx_with_openpyxl(filepath: Path, headers: list[str], rows: list[list]) -> Path:
+    """Create an xlsx file using openpyxl."""
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    ws = wb.active
+    ws.append(headers)
+    for row in rows:
+        ws.append(row)
+    wb.save(str(filepath))
+    return filepath
+
+
+@pytest.fixture
+def session_dir(tmp_path: Path) -> Path:
+    """Create and return the session directory within the sandbox."""
+    session_path = tmp_path / TEST_WORKSPACE_ID / TEST_AGENT_ID / TEST_SESSION_ID
+    session_path.mkdir(parents=True, exist_ok=True)
+    return session_path
+
+
+@pytest.fixture
+def excel_tools(mcp: FastMCP, tmp_path: Path):
+    """Register all Excel tools and return them as a dict."""
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        register_tools(mcp)
+        yield {
+            "excel_read": mcp._tool_manager._tools["excel_read"].fn,
+            "excel_info": mcp._tool_manager._tools["excel_info"].fn,
+            "excel_sql": mcp._tool_manager._tools["excel_sql"].fn,
+        }
+
+
+@pytest.fixture
+def basic_xlsx(session_dir: Path) -> Path:
+    """Create a basic Excel file for testing."""
+    return _create_xlsx_with_openpyxl(
+        session_dir / "basic.xlsx",
+        ["name", "age", "city"],
+        [
+            ["Alice", 30, "NYC"],
+            ["Bob", 25, "LA"],
+            ["Charlie", 35, "Chicago"],
+        ],
+    )
+
+
+@pytest.fixture
+def large_xlsx(session_dir: Path) -> Path:
+    """Create a larger Excel file for pagination testing."""
+    return _create_xlsx_with_openpyxl(
+        session_dir / "large.xlsx",
+        ["id", "value"],
+        [[i, i * 10] for i in range(100)],
+    )
+
+
+@pytest.fixture
+def products_xlsx(session_dir: Path) -> Path:
+    """Create a products Excel file for SQL testing."""
+    return _create_xlsx_with_openpyxl(
+        session_dir / "products.xlsx",
+        ["id", "name", "category", "price", "stock"],
+        [
+            [1, "iPhone", "Electronics", 999, 50],
+            [2, "MacBook", "Electronics", 1999, 30],
+            [3, "Coffee Mug", "Kitchen", 15, 200],
+            [4, "Headphones", "Electronics", 299, 75],
+            [5, "Water Bottle", "Kitchen", 25, 150],
+        ],
+    )
+
+
+@pytest.mark.skipif(not duckdb_available, reason="duckdb not installed")
+@pytest.mark.skipif(not openpyxl_available, reason="openpyxl not installed (test fixture dependency)")
+class TestExcelRead:
+    """Tests for excel_read function."""
+
+    def test_read_basic_xlsx(self, excel_tools, basic_xlsx, tmp_path):
+        """Read a basic Excel file successfully."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        assert "name" in result["columns"]
+        assert "age" in result["columns"]
+        assert "city" in result["columns"]
+        assert result["column_count"] == 3
+        assert result["row_count"] == 3
+        assert result["total_rows"] == 3
+
+    def test_read_with_limit(self, excel_tools, basic_xlsx, tmp_path):
+        """Read Excel with row limit."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                limit=2,
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 2
+        assert result["total_rows"] == 3
+        assert result["limit"] == 2
+
+    def test_read_with_offset(self, excel_tools, basic_xlsx, tmp_path):
+        """Read Excel with row offset."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                offset=1,
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 2
+        assert result["offset"] == 1
+
+    def test_read_with_limit_and_offset(self, excel_tools, large_xlsx, tmp_path):
+        """Read Excel with both limit and offset (pagination)."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="large.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                limit=10,
+                offset=50,
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 10
+        assert result["total_rows"] == 100
+        assert result["offset"] == 50
+        assert result["limit"] == 10
+
+    def test_negative_limit(self, excel_tools, basic_xlsx, tmp_path):
+        """Return error for negative limit."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                limit=-1,
+            )
+
+        assert "error" in result
+        assert "non-negative" in result["error"].lower()
+
+    def test_negative_offset(self, excel_tools, basic_xlsx, tmp_path):
+        """Return error for negative offset."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                offset=-1,
+            )
+
+        assert "error" in result
+        assert "non-negative" in result["error"].lower()
+
+    def test_file_not_found(self, excel_tools, session_dir, tmp_path):
+        """Return error for non-existent file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="nonexistent.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_non_excel_extension(self, excel_tools, session_dir, tmp_path):
+        """Return error for non-Excel file extension."""
+        txt_file = session_dir / "data.txt"
+        txt_file.write_text("name,age\nAlice,30\n")
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="data.txt",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert ".xlsx" in result["error"].lower() or ".xls" in result["error"].lower()
+
+    def test_missing_workspace_id(self, excel_tools, basic_xlsx, tmp_path):
+        """Return error when workspace_id is missing."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="basic.xlsx",
+                workspace_id="",
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+
+    def test_path_traversal_blocked(self, excel_tools, session_dir, tmp_path):
+        """Prevent path traversal attacks."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="../../../etc/passwd.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+
+    def test_offset_beyond_rows(self, excel_tools, basic_xlsx, tmp_path):
+        """Offset beyond available rows returns empty result."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_read"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                offset=100,
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 0
+        assert result["rows"] == []
+        assert result["total_rows"] == 3
+
+
+@pytest.mark.skipif(not duckdb_available, reason="duckdb not installed")
+@pytest.mark.skipif(not openpyxl_available, reason="openpyxl not installed (test fixture dependency)")
+class TestExcelInfo:
+    """Tests for excel_info function."""
+
+    def test_get_info_basic_xlsx(self, excel_tools, basic_xlsx, tmp_path):
+        """Get info about a basic Excel file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_info"](
+                path="basic.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert result["success"] is True
+        assert result["sheet_count"] >= 1
+        assert len(result["sheets"]) >= 1
+        assert "file_size_bytes" in result
+        assert result["file_size_bytes"] > 0
+
+        # Check first sheet details
+        first_sheet = result["sheets"][0]
+        assert "name" in first_sheet
+        assert "columns" in first_sheet
+        assert "column_count" in first_sheet
+        assert "row_count" in first_sheet
+        assert first_sheet["row_count"] == 3
+        assert first_sheet["column_count"] == 3
+
+    def test_get_info_file_not_found(self, excel_tools, session_dir, tmp_path):
+        """Return error when file doesn't exist."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_info"](
+                path="nonexistent.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_get_info_non_excel_extension(self, excel_tools, session_dir, tmp_path):
+        """Return error for non-Excel file extension."""
+        txt_file = session_dir / "data.csv"
+        txt_file.write_text("name\nAlice\n")
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_info"](
+                path="data.csv",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert ".xlsx" in result["error"].lower() or ".xls" in result["error"].lower()
+
+
+@pytest.mark.skipif(not duckdb_available, reason="duckdb not installed")
+@pytest.mark.skipif(not openpyxl_available, reason="openpyxl not installed (test fixture dependency)")
+class TestExcelSql:
+    """Tests for excel_sql function (requires duckdb)."""
+
+    def test_basic_select(self, excel_tools, products_xlsx, tmp_path):
+        """Execute basic SELECT query."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sql"](
+                path="products.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="SELECT * FROM data",
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 5
+        assert "id" in result["columns"]
+        assert "name" in result["columns"]
+
+    def test_where_clause(self, excel_tools, products_xlsx, tmp_path):
+        """Filter with WHERE clause."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sql"](
+                path="products.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="SELECT name, price FROM data WHERE price > 500",
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 2
+        names = [row["name"] for row in result["rows"]]
+        assert "iPhone" in names
+        assert "MacBook" in names
+
+    def test_aggregate_functions(self, excel_tools, products_xlsx, tmp_path):
+        """Use aggregate functions."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sql"](
+                path="products.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query=(
+                    "SELECT category, COUNT(*) as count, "
+                    "AVG(price) as avg_price FROM data GROUP BY category"
+                ),
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 2  # Electronics and Kitchen
+
+    def test_order_by_and_limit(self, excel_tools, products_xlsx, tmp_path):
+        """Sort and limit results."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sql"](
+                path="products.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="SELECT name, price FROM data ORDER BY price DESC LIMIT 2",
+            )
+
+        assert result["success"] is True
+        assert result["row_count"] == 2
+        assert result["rows"][0]["name"] == "MacBook"
+        assert result["rows"][1]["name"] == "iPhone"
+
+    def test_file_not_found(self, excel_tools, session_dir, tmp_path):
+        """Return error for non-existent file."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sql"](
+                path="nonexistent.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="SELECT * FROM data",
+            )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_empty_query_error(self, excel_tools, products_xlsx, tmp_path):
+        """Return error for empty query."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sql"](
+                path="products.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="",
+            )
+
+        assert "error" in result
+        assert "empty" in result["error"].lower()
+
+    def test_non_select_blocked(self, excel_tools, products_xlsx, tmp_path):
+        """Block non-SELECT queries for security."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sql"](
+                path="products.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="DELETE FROM data WHERE id = 1",
+            )
+
+        assert "error" in result
+        assert "select" in result["error"].lower()
+
+    def test_drop_blocked(self, excel_tools, products_xlsx, tmp_path):
+        """Block DROP statements."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sql"](
+                path="products.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="DROP TABLE data",
+            )
+
+        assert "error" in result
+
+    def test_insert_blocked(self, excel_tools, products_xlsx, tmp_path):
+        """Block INSERT statements."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sql"](
+                path="products.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="INSERT INTO data VALUES (6, 'Test', 'Test', 10, 10)",
+            )
+
+        assert "error" in result
+
+    def test_invalid_sql_syntax(self, excel_tools, products_xlsx, tmp_path):
+        """Return error for invalid SQL syntax."""
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = excel_tools["excel_sql"](
+                path="products.xlsx",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+                query="SELEKT * FORM data",
+            )
+
+        assert "error" in result


### PR DESCRIPTION
## Summary

- Add a new MCP tool module (`excel_tool`) for reading and querying Excel (.xlsx/.xls) files using DuckDB's built-in excel extension
- Enables analytics agents to work directly with Excel files — the most common business data format
- Part of the broader vision outlined in RFC #3785: Improve Data Loading Experience for Analytics Agents

## What's Included

### Three new tools:
- **`excel_read`** — Read Excel data with pagination (limit/offset) and sheet selection
- **`excel_info`** — Get workbook metadata: sheet names, columns, row counts, file size
- **`excel_sql`** — Query Excel sheets with SQL (SELECT-only, fully sandboxed)

### Implementation details:
- Mirrors `csv_tool` patterns exactly for codebase consistency
- Uses DuckDB's `read_xlsx()` for fast, type-aware parsing (integers, floats, dates, strings)
- Sheet discovery via xlsx zip/XML structure — zero extra Python dependencies
- Full sandbox security via `get_secure_path()`
- Lazy DuckDB import with graceful error if not installed
- DuckDB excel extension auto-install fallback for offline environments

### Files changed:
| File | Action |
|------|--------|
| `tools/src/aden_tools/tools/excel_tool/excel_tool.py` | **NEW** — Main implementation (3 tools) |
| `tools/src/aden_tools/tools/excel_tool/__init__.py` | **NEW** — Package init |
| `tools/src/aden_tools/tools/excel_tool/README.md` | **NEW** — Full documentation |
| `tools/src/aden_tools/tools/__init__.py` | **MODIFIED** — Register excel tools (3 lines added) |
| `tools/tests/tools/test_excel_tool.py` | **NEW** — 24 tests |

### No changes to:
- `pyproject.toml` (DuckDB excel is a core extension, no new dependency)
- `core/framework/` (zero coupling — tools register via MCP)
- Any existing tool (csv_tool, pdf_read_tool, etc.)

## Test Plan

- [x] 24 new tests covering `TestExcelRead`, `TestExcelInfo`, `TestExcelSql`
- [x] Validation: file not found, wrong extension, negative offset/limit, empty workspace_id
- [x] Security: path traversal blocked, non-SELECT queries blocked, dangerous SQL keywords blocked
- [x] Pagination: limit, offset, limit+offset, offset beyond rows
- [x] All 49 existing `test_csv_tool.py` tests still pass (zero regression)

Fixes #3787 | RFC #3785