### PR TITLE
docs(quickstart): add beginner guidance after running quickstart.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 
 ## Quick Start
 
+## Beginner Tip: What Happens After quickstart.sh?
+
+After running `./quickstart.sh`, no GitHub changes are created.
+This step only sets up your local environment.
+
+Next recommended steps:
+1. Review the generated environments
+2. Build your first agent using Claude Code or Cursor
+3. Run a sample agent to verify execution
+4. Modify documentation or examples before opening a PR
+
+
 ## Prerequisites
 
 - Python 3.11+ for agent development


### PR DESCRIPTION
Added a beginner tip section explaining the steps after running quickstart.sh.

### What changed
- Added a short beginner-focused tip explaining what to do after running `./quickstart.sh`
- Clarifies next steps for first-time users to validate setup and avoid confusion

### Why
New users may successfully run `quickstart.sh` but be unsure how to confirm the setup or proceed next. This small documentation update reduces onboarding friction.

### Scope
- Documentation-only change
- No logic or behavior changes
