### PR TITLE
docs: add minimal 'Hello World' agent path for first-run onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,28 @@ This sets up:
 - **aden_tools** - MCP tools for agent capabilities (in `tools/.venv`)
 - All required Python dependencies
 
+### Hello World Agent (60 seconds)
+
+Run a minimal agent end-to-end with observable output:
+
+```bash
+# From the repo root
+
+# If you ran ./quickstart.sh, just run:
+uv run python core/examples/manual_agent.py
+
+# If you did not run setup yet, use PYTHONPATH fallback:
+cd core && uv pip install -e . && cd -
+PYTHONPATH=core python core/examples/manual_agent.py
+```
+
+What you'll see:
+- Define nodes (`greet`, `uppercase`), wire an edge
+- Instantiate `Runtime` and `GraphExecutor`
+- Execute with input → get final output (uppercase greeting)
+
+See the full example in [core/examples/manual_agent.py](core/examples/manual_agent.py).
+
 ### Build Your First Agent
 
 ```bash

--- a/core/examples/manual_agent.py
+++ b/core/examples/manual_agent.py
@@ -6,10 +6,12 @@ without using the Claude Code CLI or external LLM APIs.
 
 It uses 'function' nodes to define logic in pure Python, making it perfect
 for understanding the core runtime loop:
-Setup -> Graph definition -> Execution -> Result
+Input → Nodes → Edge → Execution → Output
 
 Run with:
     uv run python core/examples/manual_agent.py
+    # or if setup hasn't been run yet:
+    PYTHONPATH=core python core/examples/manual_agent.py
 """
 
 import asyncio

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,6 +25,26 @@ cd hive
 uv run python -c "import framework; import aden_tools; print('✓ Setup complete')"
 ```
 
+## Hello World Agent (Minimal Path)
+
+Run a minimal agent end-to-end in under a minute:
+
+```bash
+# With setup complete via quickstart.sh
+uv run python core/examples/manual_agent.py
+
+# If setup isn't done yet, use PYTHONPATH fallback
+cd core && uv pip install -e . && cd -
+PYTHONPATH=core python core/examples/manual_agent.py
+```
+
+This demonstrates the full loop using pure Python functions:
+- Define nodes (`greet`, `uppercase`) and an edge
+- Instantiate `Runtime` and `GraphExecutor`
+- Execute with input → get final output (uppercase greeting)
+
+See the example at [core/examples/manual_agent.py](../core/examples/manual_agent.py).
+
 ## Building Your First Agent
 
 ### Option 1: Using Claude Code Skills (Recommended)

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,6 +22,21 @@ Use templates when you want to:
 - Start from a known-good structure instead of from scratch
 - See how all the pieces (goal, nodes, edges, config, CLI) fit together in real code
 
+## Minimal "Hello World" Agent
+
+Prefer a quick, code-first example you can run immediately?
+
+```bash
+# From the repo root
+uv run python core/examples/manual_agent.py
+
+# If setup isn't done yet
+cd core && uv pip install -e . && cd -
+PYTHONPATH=core python core/examples/manual_agent.py
+```
+
+This uses pure Python function nodes and a single edge to map input → action → output. See [core/examples/manual_agent.py](../core/examples/manual_agent.py) for the full example.
+
 ## How to use a template
 
 ```bash


### PR DESCRIPTION
Fixes #3751 - adds runnable Hello World example to README, getting-started docs, and examples README.