### PR TITLE
fix(tests): update credential group test for X integration

### DIFF
--- a/tools/tests/test_credentials.py
+++ b/tools/tests/test_credentials.py
@@ -477,10 +477,23 @@ class TestSpecCompleteness:
         assert google_cse.credential_group == "google_custom_search"
         assert google_search.credential_group == google_cse.credential_group
 
+    def test_x_credentials_share_credential_group(self):
+        """All X credentials share the same credential_group 'x'."""
+        x_cred_names = [n for n in CREDENTIAL_SPECS if n.startswith("x_")]
+        assert len(x_cred_names) >= 1, "Expected at least one X credential"
+        for name in x_cred_names:
+            assert CREDENTIAL_SPECS[name].credential_group == "x", (
+                f"X credential '{name}' has unexpected credential_group="
+                f"'{CREDENTIAL_SPECS[name].credential_group}'"
+            )
+
     def test_credential_group_default_empty(self):
         """Specs without a group have empty credential_group."""
+        grouped = {"google_search", "google_cse"} | {
+            n for n, s in CREDENTIAL_SPECS.items() if s.credential_group == "x"
+        }
         for name, spec in CREDENTIAL_SPECS.items():
-            if name not in ("google_search", "google_cse"):
+            if name not in grouped:
                 assert spec.credential_group == "", (
                     f"Credential '{name}' has unexpected credential_group='{spec.credential_group}'"
                 )


### PR DESCRIPTION
Fixes #2598 
## Summary
- Add `test_x_credentials_share_credential_group` to verify all X credentials share the `x` credential group
- Update `test_credential_group_default_empty` to account for X credentials alongside existing Google exceptions
- Fixes the failing `TestSpecCompleteness::test_credential_group_default_empty` test

## Test plan
- [x] All 790 tests pass (`uv run pytest tests/ -v`)
- [x] Ruff lint clean
- [x] Ruff format clean