### PR TITLE
feat(tools): add image_tool (resize/compress/convert/metadata)

### DIFF
--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -43,6 +43,7 @@ from .pdf_read_tool import register_tools as register_pdf_read
 from .web_scrape_tool import register_tools as register_web_scrape
 from .web_search_tool import register_tools as register_web_search
 
+from .image_tools.image_tool import register_tools as register_image
 
 def register_all_tools(
     mcp: FastMCP,
@@ -82,6 +83,9 @@ def register_all_tools(
     register_execute_command(mcp)
     register_csv(mcp)
 
+    # Register image tools
+    register_image(mcp)
+
     return [
         "example_tool",
         "web_search",
@@ -114,6 +118,11 @@ def register_all_tools(
         "hubspot_get_deal",
         "hubspot_create_deal",
         "hubspot_update_deal",
+        
+        "image_resize",
+        "image_compress",
+        "image_convert",
+        "image_metadata",
     ]
 
 

--- a/tools/src/aden_tools/tools/image_tools/README.md
+++ b/tools/src/aden_tools/tools/image_tools/README.md
@@ -1,0 +1,48 @@
+# image_tools
+
+A small, safe, pure‑Python MCP toolset providing basic image utilities for agents.
+
+## Summary
+Provides four tools for common image tasks: resizing, compression, format conversion, and metadata extraction. Designed to be memory conscious and easy to register with a FastMCP server.
+
+## Features
+- image_resize — Resize images (optionally maintain aspect ratio).
+- image_compress — Compress JPEG/PNG/WebP with a simple quality mapping.
+- image_convert — Convert between common formats (png, jpg/jpeg, webp, bmp, gif).
+- image_metadata — Read format, mode, size, file size and optional EXIF.
+
+## Installation
+Requires Pillow (BSD-3). Install:
+```
+pip install "Pillow>=10.0.0"
+```
+
+## Usage (register with MCP)
+```py
+from fastmcp import FastMCP
+from aden_tools.tools.image_tools import register_tools
+
+mcp = FastMCP("server")
+register_tools(mcp)
+```
+
+## Tool signatures (examples)
+- image_resize(image_path: str, width: int, height: int, maintain_aspect_ratio: bool = True, output_path: str | None = None) -> dict
+- image_compress(image_path: str, quality: int = 75, output_path: str | None = None) -> dict
+- image_convert(image_path: str, target_format: str, output_path: str | None = None) -> dict
+- image_metadata(image_path: str, include_exif: bool = True) -> dict
+
+Each tool returns a dict with either a "success": True and result fields, or an "error" key with a message.
+
+## Notes / Limitations
+- Expects trusted file paths; follow-up work will integrate sandboxing/session helpers.
+- GIF/animated images: only the first frame is handled; animation preservation is out of scope.
+- Tests include a permission-denial case that is skipped on Windows (chmod behavior differs).
+- File size capped for safety (10 MB by default).
+
+## Tests
+Tests live at: tools/tests/tools/test_image_tool.py  
+Run locally:
+```
+python -m pytest tools/tests/tools/test_image_tool.py -q
+```

--- a/tools/src/aden_tools/tools/image_tools/__init__.py
+++ b/tools/src/aden_tools/tools/image_tools/__init__.py
@@ -1,0 +1,5 @@
+
+
+from .image_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/image_tools/image_tool.py
+++ b/tools/src/aden_tools/tools/image_tools/image_tool.py
@@ -1,0 +1,472 @@
+"""
+Image Tool - Resize, compress, convert, and extract metadata from images.
+
+Uses Pillow for image processing operations.
+"""
+
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fastmcp import FastMCP
+
+try:
+    from PIL import Image
+    from PIL import UnidentifiedImageError
+    from PIL.ExifTags import TAGS
+    PILLOW_AVAILABLE = True
+except ImportError:
+    PILLOW_AVAILABLE = False
+
+
+
+# Constants
+MAX_FILE_SIZE_MB = 10
+SUPPORTED_FORMATS = {"jpg", "jpeg", "png", "webp", "bmp", "gif"}
+
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register Image tools with the MCP server."""
+
+
+    # Early return if Pillow not available
+    if not PILLOW_AVAILABLE:
+        @mcp.tool()
+        def image_resize(image_path: str, width: int, height: int) -> dict:
+            """Pillow not installed."""
+            return {
+                "error": "Pillow not installed. Install with: pip install Pillow>=10.0.0"
+            }
+        @mcp.tool()
+        def image_compress(image_path: str, quality: int = 75) -> dict:
+            """Pillow not installed."""
+            return {
+                "error": "Pillow not installed. Install with: pip install Pillow>=10.0.0"
+            }
+        
+        @mcp.tool()
+        def image_convert(image_path: str, target_format: str) -> dict:
+            """Pillow not installed."""
+            return {
+                "error": "Pillow not installed. Install with: pip install Pillow>=10.0.0"
+            }
+        
+        @mcp.tool()
+        def image_metadata(image_path: str) -> dict:
+            """Pillow not installed."""
+            return {
+                "error": "Pillow not installed. Install with: pip install Pillow>=10.0.0"
+            }
+        
+        return
+        
+
+    # Helper function for validation
+    def _validate_image_file(image_path: str) -> dict | Path:
+        """
+        Validate image file and return Path if valid, error dict otherwise.
+        
+        Args:
+            image_path: Path to image file
+            
+        Returns:
+            Path object if valid, error dict otherwise
+        """
+        try:
+            path = Path(image_path).resolve()
+            
+            # Check existence
+            if not path.exists():
+                return {"error": f"Image file not found: {image_path}"}
+            
+            if not path.is_file():
+                return {"error": f"Not a file: {image_path}"}
+            
+            # Validate extension
+            if path.suffix.lower().lstrip(".") not in SUPPORTED_FORMATS:
+                formats_str = ", ".join(sorted(SUPPORTED_FORMATS))
+                return {
+                    "error": f"Unsupported image format: {path.suffix}. Supported formats: {formats_str}"
+                }
+            
+            # Check file size (max 10MB)
+            size_mb = path.stat().st_size / (1024 * 1024)
+            if size_mb > MAX_FILE_SIZE_MB:
+                return {
+                    "error": f"Image too large: {size_mb:.1f}MB "
+                            f"(max {MAX_FILE_SIZE_MB}MB for memory safety)"
+                }
+            
+            return path
+            
+        except PermissionError:
+            return {"error": f"Permission denied: {image_path}"}
+        except Exception as e:
+            return {"error": f"Failed to validate image: {str(e)}"}
+
+
+
+    @mcp.tool()
+    def image_resize(
+        image_path: str,
+        width: int,
+        height: int,
+        maintain_aspect_ratio: bool = True,
+        output_path: str | None = None,
+    ) -> dict:
+        """
+        Resize an image to specified dimensions.
+        
+        Resizes images for thumbnails, web optimization, or standardized outputs.
+        Optionally maintains aspect ratio to prevent distortion.
+        
+        Args:
+            image_path: Path to the image file (absolute or relative)
+            width: Target width in pixels (must be positive)
+            height: Target height in pixels (must be positive)
+            maintain_aspect_ratio: Keep original aspect ratio (default: True)
+            output_path: Optional path to save resized image (auto-generated if None)
+        
+        Returns:
+            Dict with resize results:
+            - success: True if successful
+            - path: Original file path
+            - output_path: Path to resized image
+            - original_size: [width, height] before resize
+            - new_size: [width, height] after resize
+            - file_size_kb: Output file size in KB
+            
+            Or error dict if failed:
+            - error: Error message
+        """
+        
+        # 1. Validate inputs
+        validation = _validate_image_file(image_path)
+        if isinstance(validation, dict):      # detect error 
+            return validation
+        
+        path = validation
+        
+        if width <= 0 or height <= 0:
+            return {"error": "Width and height must be positive integers."}
+        if width > 10000 or height > 10000:
+            return {"error": "Width and height must be less than 10,000 pixels for memory safety."}
+        
+        # 2. Open image
+        try:
+            with Image.open(path) as img:
+                original_size = img.size     # (width, height)
+
+                # 3. Resize image
+                if maintain_aspect_ratio:
+                    img.thumbnail((width, height), Image.Resampling.LANCZOS)
+                    resized_img = img
+                else:
+                    resized_img = img.resize((width, height), Image.Resampling.LANCZOS)
+
+                # 4. Save resized image
+                out_path = Path(output_path) if output_path is not None else path.with_name(f"{path.stem}_resized{path.suffix}")
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                resized_img.save(out_path)
+
+                # Get file size
+                file_size_kb = round(out_path.stat().st_size / 1024, 2)
+ 
+                 # 5. Return result
+                return {
+                    "success": True,
+                    "path": str(path),
+                    "output_path": str(out_path),
+                    "original_size": list(original_size),
+                    "new_size": list(resized_img.size),
+                    "file_size_kb": file_size_kb,
+                }
+        except UnidentifiedImageError:
+            return {"error": f"Cannot identify image file: {image_path}"}
+        except PermissionError:
+            return {"error": f"Permission denied: {image_path}"}
+        except Exception as e:
+            return {"error": f"Failed to resize image: {str(e)}"}
+        
+        
+    @mcp.tool()
+    def image_compress(
+        image_path: str,        # Path to the image file to compress
+        quality: int = 75,      # Compression quality (1-95, higher is better quality)
+        output_path: str | None = None,  # Optional path to save the compressed image
+    ) -> dict:
+        """
+        Compress image file size by adjusting quality.
+        
+        Reduces file size while maintaining visual quality. Supports JPEG, PNG, and WebP.
+        JPEG/WebP: quality directly controls compression. PNG: quality mapped to compression level.
+        
+        Args:
+            image_path: Path to the image file (absolute or relative)
+            quality: Compression quality (10-95, higher = better quality, default: 75)
+            output_path: Optional path to save compressed image (auto-generated if None)
+        
+        Returns:
+            Dict with compression results:
+            - success: True if successful
+            - path: Original file path
+            - output_path: Path to compressed image
+            - original_kb: Original file size in KB
+            - compressed_kb: Compressed file size in KB
+            - reduction_percent: Percentage reduction in file size
+            
+            Or error dict if failed:
+            - error: Error message
+        """
+
+        # Validate file
+        validation = _validate_image_file(image_path)
+        if isinstance(validation, dict):
+            return validation
+        
+        path = validation
+
+
+        
+        # Validate quality
+        if not (10 <= quality <= 95):
+            return {"error": "Quality must be between 10 and 95"}
+        
+        try:
+            with Image.open(path) as img:
+                
+                if output_path is None:
+                    output_path = str(path.with_name(
+                        f"{path.stem}_compressed{path.suffix}"
+                    ))
+
+                # Get format
+                fmt = (img.format or path.suffix.lstrip(".")).lower()
+
+                # Determine output path
+                out_path = Path(output_path) if output_path is not None else path.with_name(f"{path.stem}_compressed{path.suffix}")
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+
+                # Compress based on format
+                if fmt in ("jpg", "jpeg"):
+                    # Convert RGBA to RGB for JPEG (no alpha channel)
+                    if img.mode in ("RGBA", "LA", "P"):
+                        rgb_img = Image.new("RGB", img.size, (255, 255, 255))
+                        if img.mode == "P":
+                            img = img.convert("RGBA")
+                        rgb_img.paste(img, mask=img.split()[-1] if img.mode in ("RGBA", "LA") else None)
+                        img = rgb_img
+                    img.save(out_path, "JPEG", quality=quality, optimize=True)
+
+                elif fmt == "png":
+                    # Map quality (10-95) to compress_level (9-0)
+                    # Higher quality = lower compression level
+                    compress_level = max(0, min(9, int((95 - quality) / 10)))
+                    img.save(out_path, "PNG", optimize=True, compress_level=compress_level)
+
+                elif fmt == "webp":
+                    img.save(out_path, "WEBP", quality=quality, method=6)
+
+                else:
+                    # For other formats, just save with optimize
+                    img.save(out_path, img.format, optimize=True)
+            # Calculate sizes
+            original_kb = round(path.stat().st_size / 1024, 2)
+            compressed_kb = round(out_path.stat().st_size / 1024, 2)
+            reduction = round(((original_kb - compressed_kb) / original_kb) * 100, 2) if original_kb > 0 else 0.0
+            return {
+                "success": True,
+                "input_path": str(image_path),
+                "output_path": str(out_path),
+                "original_kb": original_kb,
+                "compressed_kb": compressed_kb,
+                "reduction_percent": reduction,
+            }
+        except UnidentifiedImageError:
+            return {"error": f"Cannot identify image file: {image_path}"}
+        except PermissionError:
+            return {"error": f"Permission denied: {image_path}"}
+        except Exception as e:
+            return {"error": f"Failed to compress image: {str(e)}"}
+        
+
+    @mcp.tool()
+    def image_convert(
+        image_path: str,
+        target_format: str,
+        output_path: str | None = None,
+    ) -> dict:
+        """
+        Convert image to a different format.
+        
+        Converts between PNG, JPG, WebP, and other common formats.
+        Useful for web optimization (e.g., PNG → WebP) or compatibility (e.g., WebP → JPG).
+        
+        Args:
+            image_path: Path to the image file (absolute or relative)
+            target_format: Target format (png, jpg, jpeg, webp, bmp, gif)
+            output_path: Optional path to save converted image (auto-generated if None)
+        
+        Returns:
+            Dict with conversion results:
+            - success: True if successful
+            - input_path: Original file path
+            - output_path: Path to converted image
+            - original_format: Original image format
+            - new_format: Target image format
+            - file_size_kb: Output file size in KB
+            
+            Or error dict if failed:
+            - error: Error message
+        """
+
+        # Validate file
+        validation = _validate_image_file(image_path)
+        if isinstance(validation, dict):
+            return validation
+        
+        path = validation
+        
+        # Validate target format
+        target_format = target_format.lower().lstrip(".")
+        if target_format not in SUPPORTED_FORMATS:
+            formats_str = ", ".join(sorted(f.lstrip(".") for f in SUPPORTED_FORMATS))
+            return {
+                "error": f"Unsupported target format: {target_format}. "
+                        f"Supported: {formats_str}"
+            }
+        
+        try:
+            with Image.open(path) as img:
+                original_format = img.format or path.suffix.lstrip(".")
+
+                # Determine output path
+                out_path = Path(output_path) if output_path is not None else path.with_suffix(f".{target_format}")
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+
+                # Handle format-specific conversions
+                if target_format in ("jpg", "jpeg"):
+                    # Convert RGBA to RGB for JPEG
+                    if img.mode in ("RGBA", "LA", "P"):
+                        rgb_img = Image.new("RGB", img.size, (255, 255, 255))
+                        if img.mode == "P":
+                            img = img.convert("RGBA")
+                        rgb_img.paste(img, mask=img.split()[-1] if img.mode in ("RGBA", "LA") else None)
+                        img = rgb_img
+                    img.save(out_path, "JPEG", quality=85, optimize=True)
+                    
+                elif target_format == "png":
+                    img.save(out_path, "PNG", optimize=True)
+                    
+                elif target_format == "webp":
+                    img.save(out_path, "WEBP", quality=85, method=6)
+                    
+                else:
+                    # For other formats
+                    img.save(out_path, target_format.upper())
+            
+            # Get file size
+            file_size_kb = round(out_path.stat().st_size / 1024, 2)
+            
+            return {
+                "success": True,
+                "path": str(path),
+                "output_path": str(out_path),
+                "original_format": original_format,
+                "new_format": target_format,
+                "file_size_kb": file_size_kb,
+            }
+            
+        except UnidentifiedImageError:
+            return {"error": f"Cannot identify image file: {image_path}"}
+        except PermissionError:
+            return {"error": f"Permission denied: {image_path}"}
+        except Exception as e:
+            return {"error": f"Failed to convert image: {str(e)}"}
+
+                
+
+
+    @mcp.tool()
+    def image_metadata(
+        image_path: str,
+        include_exif: bool = True,
+    ) -> dict:
+        """
+        Extract image metadata and EXIF information.
+        
+        Returns basic metadata (format, dimensions, file size) and optionally EXIF data
+        (camera info, GPS coordinates, timestamps) if available.
+        
+        Args:
+            image_path: Path to the image file (absolute or relative)
+            include_exif: Include EXIF data if available (default: True)
+        
+        Returns:
+            Dict with metadata:
+            - success: True if successful
+            - path: Image path
+            - format: Image format (JPEG, PNG, etc.)
+            - mode: Color mode (RGB, RGBA, etc.)
+            - size: [width, height] in pixels
+            - file_size_kb: File size in KB
+            - exif: EXIF data dict (if include_exif=True and available)
+            
+            Or error dict if failed:
+            - error: Error message
+        """
+        # Validate file
+        validation = _validate_image_file(image_path)
+        if isinstance(validation, dict):
+            return validation
+        
+        path = validation
+        
+        try:
+            with Image.open(path) as img:
+                # Basic metadata
+                file_size_kb = round(path.stat().st_size / 1024, 2)
+                
+                result: dict[str, Any] = {
+                    "success": True,
+                    "path": str(path),
+                    "format": img.format,
+                    "mode": img.mode,
+                    "size": list(img.size),  # [width, height]
+                    "file_size_kb": file_size_kb,
+                }
+
+                # Add PIL info dict (format-specific metadata)
+                if img.info:
+                    result["info"] = {k: str(v) for k, v in img.info.items()}
+
+                # Extract EXIF data if requested
+                if include_exif:
+                    try:
+                        exif_data = img.getexif()
+                        if exif_data:
+                            exif_dict = {}
+                            for tag_id, value in exif_data.items():
+                                tag_name = TAGS.get(tag_id, f"Tag{tag_id}")
+                                # Convert value to string for JSON safety
+                                exif_dict[tag_name] = str(value)
+                            
+                            if exif_dict:
+                                result["exif"] = exif_dict
+                    except Exception:
+                        # Silently skip EXIF if not available or error
+                        pass
+                
+                return result
+                
+        except UnidentifiedImageError:
+            return {"error": f"Cannot identify image file: {image_path}"}
+        except PermissionError:
+            return {"error": f"Permission denied: {image_path}"}
+        except Exception as e:
+            return {"error": f"Failed to read image metadata: {str(e)}"}
+
+

--- a/tools/tests/tools/test_image_tool.py
+++ b/tools/tests/tools/test_image_tool.py
@@ -1,0 +1,215 @@
+"""Tests for image_tool (FastMCP)."""
+
+from pathlib import Path
+import pytest
+import sys
+
+from fastmcp import FastMCP
+
+# Import module & register_tools always so tests can monkeypatch PIL availability
+from aden_tools.tools.image_tools import image_tool as image_tool_mod
+from aden_tools.tools.image_tools.image_tool import register_tools
+
+# Detect Pillow availability (for creating sample images); tests can simulate absence via monkeypatch
+try:
+    from PIL import Image  # type: ignore
+    PILLOW_AVAILABLE = True
+except Exception:
+    PILLOW_AVAILABLE = False
+
+
+@pytest.fixture
+def mcp() -> FastMCP:
+    """Create a fresh FastMCP instance for testing."""
+    return FastMCP("test-server")
+
+
+@pytest.fixture
+def image_tools(mcp: FastMCP):
+    """Register image tools and return mapping of tool functions."""
+    if not PILLOW_AVAILABLE:
+        pytest.skip("Pillow not installed")
+    register_tools(mcp)
+    return {
+        "resize": mcp._tool_manager._tools["image_resize"].fn,
+        "compress": mcp._tool_manager._tools["image_compress"].fn,
+        "convert": mcp._tool_manager._tools["image_convert"].fn,
+        "metadata": mcp._tool_manager._tools["image_metadata"].fn,
+    }
+
+
+@pytest.fixture
+def sample_png(tmp_path: Path) -> Path:
+    """Create a simple PNG image."""
+    if not PILLOW_AVAILABLE:
+        pytest.skip("Pillow not installed")
+    p = tmp_path / "sample.png"
+    Image.new("RGB", (100, 100), color="red").save(p, "PNG")
+    return p
+
+
+@pytest.fixture
+def sample_jpeg(tmp_path: Path) -> Path:
+    """Create a simple JPEG image."""
+    if not PILLOW_AVAILABLE:
+        pytest.skip("Pillow not installed")
+    p = tmp_path / "sample.jpg"
+    Image.new("RGB", (200, 200), color="blue").save(p, "JPEG", quality=85)
+    return p
+
+
+@pytest.fixture
+def sample_rgba(tmp_path: Path) -> Path:
+    """Create an RGBA PNG (transparent) image."""
+    if not PILLOW_AVAILABLE:
+        pytest.skip("Pillow not installed")
+    p = tmp_path / "sample_rgba.png"
+    Image.new("RGBA", (150, 150), color=(255, 0, 0, 128)).save(p, "PNG")
+    return p
+
+
+# -----------------------
+# image_resize tests
+# -----------------------
+class TestImageResize:
+    def test_resize_file_not_found(self, image_tools, tmp_path: Path):
+        res = image_tools["resize"](image_path=str(tmp_path / "missing.png"), width=50, height=50)
+        assert "error" in res
+        assert "not found" in res["error"].lower()
+
+    def test_resize_invalid_extension(self, image_tools, tmp_path: Path):
+        txt = tmp_path / "t.txt"
+        txt.write_text("not an image")
+        res = image_tools["resize"](image_path=str(txt), width=50, height=50)
+        assert "error" in res
+        assert "unsupported" in res["error"].lower()
+
+    def test_resize_basic(self, image_tools, sample_png: Path, tmp_path: Path):
+        out = tmp_path / "out.png"
+        res = image_tools["resize"](
+            image_path=str(sample_png), width=50, height=50, maintain_aspect_ratio=False, output_path=str(out)
+        )
+        assert res.get("success") is True
+        assert Path(res["output_path"]).exists()
+        assert res["original_size"] == [100, 100]
+        assert res["new_size"] == [50, 50]
+
+    def test_resize_maintain_aspect(self, image_tools, sample_png: Path):
+        res = image_tools["resize"](image_path=str(sample_png), width=200, height=50, maintain_aspect_ratio=True)
+        assert res.get("success") is True
+        # original is 100x100, constrained height -> new_size should be <= (200,50)
+        w, h = res["new_size"]
+        assert h <= 50 and w <= 200
+
+    def test_resize_dimension_validation(self, image_tools, sample_png: Path):
+        res = image_tools["resize"](image_path=str(sample_png), width=0, height=100)
+        assert "error" in res
+        assert "positive" in res["error"].lower()
+
+
+# -----------------------
+# image_compress tests
+# -----------------------
+class TestImageCompress:
+    def test_compress_file_not_found(self, image_tools, tmp_path: Path):
+        res = image_tools["compress"](image_path=str(tmp_path / "missing.jpg"), quality=75)
+        assert "error" in res
+
+    def test_compress_quality_validation(self, image_tools, sample_jpeg: Path):
+        res = image_tools["compress"](image_path=str(sample_jpeg), quality=5)
+        assert "error" in res
+        assert "quality" in res["error"].lower()
+
+        res2 = image_tools["compress"](image_path=str(sample_jpeg), quality=100)
+        assert "error" in res2
+
+    def test_compress_jpeg_reduces_size(self, image_tools, sample_jpeg: Path, tmp_path: Path):
+        original_kb = round(sample_jpeg.stat().st_size / 1024, 2)
+        out = tmp_path / "compressed.jpg"
+        res = image_tools["compress"](image_path=str(sample_jpeg), quality=30, output_path=str(out))
+        assert res.get("success") is True
+        assert Path(res["output_path"]).exists()
+        compressed_kb = res["compressed_kb"]
+        # allow small variance
+        assert compressed_kb <= original_kb + 1.0
+
+    def test_compress_png_outputs_file(self, image_tools, sample_png: Path, tmp_path: Path):
+        out = tmp_path / "compressed.png"
+        res = image_tools["compress"](image_path=str(sample_png), quality=75, output_path=str(out))
+        assert res.get("success") is True
+        assert Path(res["output_path"]).exists()
+
+
+# -----------------------
+# image_convert tests
+# -----------------------
+class TestImageConvert:
+    def test_convert_file_not_found(self, image_tools, tmp_path: Path):
+        res = image_tools["convert"](image_path=str(tmp_path / "missing.png"), target_format="jpg")
+        assert "error" in res
+
+    def test_convert_unsupported_format(self, image_tools, sample_png: Path):
+        res = image_tools["convert"](image_path=str(sample_png), target_format="tiff")
+        assert "error" in res
+        assert "unsupported" in res["error"].lower()
+
+    def test_convert_png_to_jpg_and_back(self, image_tools, sample_png: Path, tmp_path: Path):
+        out_jpg = tmp_path / "to.jpg"
+        res1 = image_tools["convert"](image_path=str(sample_png), target_format="jpg", output_path=str(out_jpg))
+        assert res1.get("success") is True
+        assert Path(res1["output_path"]).exists()
+        out_png = tmp_path / "back.png"
+        res2 = image_tools["convert"](image_path=str(out_jpg), target_format="png", output_path=str(out_png))
+        assert res2.get("success") is True
+        assert Path(res2["output_path"]).exists()
+
+    def test_convert_to_webp(self, image_tools, sample_png: Path, tmp_path: Path):
+        out_webp = tmp_path / "img.webp"
+        res = image_tools["convert"](image_path=str(sample_png), target_format="webp", output_path=str(out_webp))
+        assert res.get("success") is True
+        assert Path(res["output_path"]).suffix.lower() == ".webp"
+
+
+# -----------------------
+# image_metadata tests
+# -----------------------
+class TestImageMetadata:
+    def test_metadata_file_not_found(self, image_tools, tmp_path: Path):
+        res = image_tools["metadata"](image_path=str(tmp_path / "missing.png"))
+        assert "error" in res
+
+    def test_metadata_basic(self, image_tools, sample_png: Path):
+        res = image_tools["metadata"](image_path=str(sample_png), include_exif=False)
+        assert res.get("success") is True
+        assert res["format"].upper() in {"PNG", "JPEG"}
+        assert res["size"] == [100, 100]
+        assert res["file_size_kb"] > 0
+
+    def test_metadata_exif_no_crash(self, image_tools, sample_jpeg: Path):
+        res = image_tools["metadata"](image_path=str(sample_jpeg), include_exif=True)
+        assert res.get("success") is True
+
+    def test_metadata_rgba(self, image_tools, sample_rgba: Path):
+        res = image_tools["metadata"](image_path=str(sample_rgba))
+        assert res.get("success") is True
+        assert res["mode"] in ("RGBA", "RGB")
+
+# -----------------------
+# edge cases
+# -----------------------
+class TestEdgeCases:
+    def test_corrupted_file(self, image_tools, tmp_path: Path):
+        corrupted = tmp_path / "bad.png"
+        corrupted.write_bytes(b"not a png")
+        res = image_tools["metadata"](image_path=str(corrupted))
+        assert "error" in res
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="chmod-based permission denial is not reliable on Windows")
+    def test_permission_error(self, image_tools, sample_png: Path):
+        # Make file unreadable (may require OS support)
+        sample_png.chmod(0o000)
+        try:
+            res = image_tools["metadata"](image_path=str(sample_png))
+            assert "error" in res
+        finally:
+            sample_png.chmod(0o644)


### PR DESCRIPTION
Summary
---
Add a new MCP tool `image_tool` that provides safe, pure-Python image utilities for agents:
- image_resize — resize images (maintain aspect option)
- image_compress — compress JPEG/PNG/WebP with quality mapping
- image_convert — convert between common formats (png, jpg, webp, ...)
- image_metadata — read format, mode, size and optional EXIF

This PR includes:
- Implementation: tools/src/aden_tools/tools/image_tool/image_tool.py
- README: tools/src/aden_tools/tools/image_tool/README.md
- Tests: tools/tests/tools/test_image_tool.py
- Registration update: tools/src/aden_tools/tools/__init__.py (registers new tools)

Why
---
Agents currently cannot perform common image preprocessing tasks. These utilities enable agents to:
- Optimize images for web publishing
- Produce thumbnails / standardized assets
- Convert formats inside automation pipelines
- Extract metadata for asset management

Notes / Known limitations
---
- Dependency: Pillow (BSD-3). Install with `pip install Pillow>=10.0.0`.
- The tool currently expects trusted file paths. I plan a follow-up PR to integrate the repo's session sandbox (get_secure_path) and workspace/session parameters to align with other file tools.
- The test that simulates permission denial using chmod is skipped on Windows because Windows does not reliably enforce chmod(0o000) the same way as Unix; tests handle that via skip.
- GIF/animated images: current behaviour uses the first frame; animated preservation is out of scope for this PR.


Related
---
- Parent issue: #2805
- This implements: #3260

Requesting review from: @Hundao, @bryanadenhq, @austin931114