### PR TITLE
docs: fix Quickstart guide example (replace support_ticket with marketing_agent)

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -159,23 +159,22 @@ $env:PYTHONPATH="core;exports"
 python -m agent_name COMMAND
 ```
 
-### Example: Support Ticket Agent
+
+
+### Example: Marketing Agent (Template)
+
+To verify your installation immediately, you can run the marketing agent template included in the examples.
+
+**Linux / Mac:**
 
 ```bash
-# Validate agent structure
-PYTHONPATH=core:exports python -m your_agent_name validate
+# Run in mock mode
+PYTHONPATH=core:examples/templates python -m marketing_agent run --mock --input '{"topic": "AI", "goal": "write a tweet"}'
 
-# Show agent information
-PYTHONPATH=core:exports python -m your_agent_name info
-
-# Run agent with input
-PYTHONPATH=core:exports python -m your_agent_name run --input '{
-  "task": "Your input here"
-}'
-
-# Run in mock mode (no LLM calls)
-PYTHONPATH=core:exports python -m your_agent_name run --mock --input '{...}'
-```
+**Windows (PowerShell):**
+```powershell
+$env:PYTHONPATH="core;examples\templates"
+python -m marketing_agent run --mock --input '{\"topic\": \"AI\", \"goal\": \"write a tweet\"}'
 
 ## Building New Agents and Run Flow
 


### PR DESCRIPTION
**Summary**
The current Quickstart guide (`enviroment_setup.md`) references `support_ticket_agent` in the `exports/` directory, which does not exist by default in a fresh installation. This causes a `ModuleNotFoundError` for new users trying to verify their setup.

**Changes**
* Updated the "Example" section to use the `marketing_agent` template (which is included in `examples/templates`).
* Included both Bash and PowerShell commands to ensure cross-platform compatibility.

This allows new contributors to successfully run an agent immediately after installation.