### PR TITLE
docs: add missing README for Deep Research Agent

### DIFF
--- a/examples/templates/deep_research_agent/README.md
+++ b/examples/templates/deep_research_agent/README.md
@@ -1,0 +1,22 @@
+# Deep Research Agent
+
+A template agent designed to perform comprehensive research on a specific topic and generate a structured report.
+
+## Usage
+
+Run the agent using the following command:
+
+### Linux / Mac
+```bash
+PYTHONPATH=core:examples/templates python -m deep_research_agent run --mock --topic "Artificial Intelligence"
+
+### Windows
+```powershell
+$env:PYTHONPATH="core;examples\templates"
+python -m deep_research_agent run --mock --topic "Artificial Intelligence"
+
+## Options
+
+- `-t, --topic`: The research topic (required).
+- `--mock`: Run without calling real LLM APIs (simulated execution).
+- `--help`: Show all available options.


### PR DESCRIPTION
The `deep_research_agent` template was missing a `README.md` file.
I added documentation explaining how to run it on Linux/Mac and Windows, documenting the correct flags (`--topic`).

*Submitted under the Documentation/Fast-track exception.*