### PR TITLE
fix: hardening hive cli setup

### DIFF
--- a/examples/templates/deep_research_agent/mcp_servers.json
+++ b/examples/templates/deep_research_agent/mcp_servers.json
@@ -3,7 +3,7 @@
     "transport": "stdio",
     "command": "python",
     "args": ["mcp_server.py", "--stdio"],
-    "cwd": "../../tools",
+    "cwd": "../../../tools",
     "description": "Hive tools MCP server providing web_search, web_scrape, and write_to_file"
   }
 }

--- a/examples/templates/twitter_outreach/mcp_servers.json
+++ b/examples/templates/twitter_outreach/mcp_servers.json
@@ -3,7 +3,7 @@
     "transport": "stdio",
     "command": "python",
     "args": ["mcp_server.py", "--stdio"],
-    "cwd": "../../tools",
+    "cwd": "../../../tools",
     "description": "Hive tools MCP server providing web_search, web_scrape, and send_email"
   }
 }

--- a/hive
+++ b/hive
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Wrapper script for the Hive CLI.
+# Uses uv to run the hive command in the project's virtual environment.
+#
+# Usage:
+#   ./hive tui           - Launch interactive agent dashboard
+#   ./hive run <agent>   - Run an agent
+#   ./hive --help        - Show all commands
+#
+
+set -e
+
+# Resolve symlinks to find the real script location
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    # Handle relative symlinks
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+# Verify user is running from the hive project directory
+USER_CWD="$(pwd)"
+if [ "$USER_CWD" != "$SCRIPT_DIR" ]; then
+    echo "Error: hive must be run from the project directory." >&2
+    echo "" >&2
+    echo "  Current directory: $USER_CWD" >&2
+    echo "  Expected directory: $SCRIPT_DIR" >&2
+    echo "" >&2
+    echo "Run: cd $SCRIPT_DIR" >&2
+    exit 1
+fi
+
+cd "$SCRIPT_DIR"
+
+# Verify this is a valid Hive project directory
+if [ ! -f "$SCRIPT_DIR/pyproject.toml" ] || [ ! -d "$SCRIPT_DIR/core" ]; then
+    echo "Error: Not a valid Hive project directory: $SCRIPT_DIR" >&2
+    echo "" >&2
+    echo "The hive CLI must be run from a Hive project root." >&2
+    echo "Expected files: pyproject.toml, core/" >&2
+    exit 1
+fi
+
+if [ ! -d "$SCRIPT_DIR/.venv" ]; then
+    echo "Error: Virtual environment not found." >&2
+    echo "" >&2
+    echo "Run ./quickstart.sh first to set up the project." >&2
+    exit 1
+fi
+
+# Ensure uv is in PATH (common install locations)
+export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+
+if ! command -v uv &> /dev/null; then
+    echo "Error: uv is not installed. Run ./quickstart.sh first." >&2
+    exit 1
+fi
+
+exec uv run hive "$@"

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -710,6 +710,38 @@ if [ $ERRORS -gt 0 ]; then
 fi
 
 # ============================================================
+# Step 7: Install hive CLI globally
+# ============================================================
+
+echo -e "${YELLOW}⬢${NC} ${BLUE}${BOLD}Step 7: Installing hive CLI...${NC}"
+echo ""
+
+# Ensure ~/.local/bin exists and is in PATH
+mkdir -p "$HOME/.local/bin"
+
+# Create/update symlink
+HIVE_SCRIPT="$SCRIPT_DIR/hive"
+HIVE_LINK="$HOME/.local/bin/hive"
+
+if [ -L "$HIVE_LINK" ] || [ -e "$HIVE_LINK" ]; then
+    rm -f "$HIVE_LINK"
+fi
+
+ln -s "$HIVE_SCRIPT" "$HIVE_LINK"
+echo -e "${GREEN}  ✓ hive CLI installed to ~/.local/bin/hive${NC}"
+
+# Check if ~/.local/bin is in PATH
+if echo "$PATH" | grep -q "$HOME/.local/bin"; then
+    echo -e "${GREEN}  ✓ ~/.local/bin is in PATH${NC}"
+else
+    echo -e "${YELLOW}  ⚠ Add ~/.local/bin to your PATH:${NC}"
+    echo -e "     ${DIM}echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.bashrc${NC}"
+    echo -e "     ${DIM}source ~/.bashrc${NC}"
+fi
+
+echo ""
+
+# ============================================================
 # Success!
 # ============================================================
 


### PR DESCRIPTION
closes #3869

Symlink resolution - 

The hive script follows symlinks to find the real project directory
`~/.local/bin symlink - quickstart.sh creates ~/.local/bin/hive` → project's hive script

PATH handling - Warns user if `~/.local/bin` isn't in PATH

uv integration - Uses uv run so no venv activation needed
After running ./quickstart.sh, users can simply type hive tui from the project root.