### PR TITLE
docs(path): Align Agent Storage Path to .hive/agents/{agent_name}/

### DIFF
--- a/.claude/skills/hive-create/SKILL.md
+++ b/.claude/skills/hive-create/SKILL.md
@@ -507,7 +507,7 @@ EventLoopNodes are **auto-created** by `GraphExecutor` at runtime. Both direct `
 from framework.graph.executor import GraphExecutor
 from framework.runtime.core import Runtime
 
-storage_path = Path.home() / ".hive" / "my_agent"
+storage_path = Path.home() / ".hive" / "agents" / "my_agent"
 storage_path.mkdir(parents=True, exist_ok=True)
 runtime = Runtime(storage_path)
 

--- a/.claude/skills/hive-create/examples/deep_research_agent/__main__.py
+++ b/.claude/skills/hive-create/examples/deep_research_agent/__main__.py
@@ -90,7 +90,7 @@ def tui(mock, verbose, debug):
         agent._event_bus = EventBus()
         agent._tool_registry = ToolRegistry()
 
-        storage_path = Path.home() / ".hive" / "deep_research_agent"
+        storage_path = Path.home() / ".hive" / "agents" / "deep_research_agent"
         storage_path.mkdir(parents=True, exist_ok=True)
 
         mcp_config_path = Path(__file__).parent / "mcp_servers.json"

--- a/.claude/skills/hive-create/examples/deep_research_agent/agent.py
+++ b/.claude/skills/hive-create/examples/deep_research_agent/agent.py
@@ -177,7 +177,7 @@ class DeepResearchAgent:
         """Set up the executor with all components."""
         from pathlib import Path
 
-        storage_path = Path.home() / ".hive" / "deep_research_agent"
+        storage_path = Path.home() / ".hive" / "agents" / "deep_research_agent"
         storage_path.mkdir(parents=True, exist_ok=True)
 
         self._event_bus = EventBus()

--- a/.claude/skills/hive-debugger/SKILL.md
+++ b/.claude/skills/hive-debugger/SKILL.md
@@ -34,7 +34,7 @@ Before using this skill, ensure:
 1. You have an exported agent in `exports/{agent_name}/`
 2. The agent has been run at least once (logs exist)
 3. Runtime logging is enabled (default in Hive framework)
-4. You have access to the agent's working directory at `~/.hive/{agent_name}/`
+4. You have access to the agent's working directory at `~/.hive/agents/{agent_name}/`
 
 ---
 
@@ -51,7 +51,7 @@ Before using this skill, ensure:
    - Confirm the agent exists in `exports/{agent_name}/`
 
 2. **Determine agent working directory:**
-   - Calculate: `~/.hive/{agent_name}/`
+   - Calculate: `~/.hive/agents/{agent_name}/`
    - Verify this directory exists and contains session logs
 
 3. **Read agent configuration:**
@@ -532,7 +532,7 @@ max_node_visits=3  # Prevent getting stuck
    **Check if issue is resolved:**
    ```
    query_runtime_logs(
-       agent_work_dir="~/.hive/{agent_name}",
+       agent_work_dir="~/.hive/agents/{agent_name}",
        status="needs_attention",
        limit=5
    )
@@ -542,7 +542,7 @@ max_node_visits=3  # Prevent getting stuck
    **Verify specific node behavior:**
    ```
    query_runtime_log_details(
-       agent_work_dir="~/.hive/{agent_name}",
+       agent_work_dir="~/.hive/agents/{agent_name}",
        run_id="{new_run_id}",
        node_id="{fixed_node_id}"
    )
@@ -671,7 +671,7 @@ You: "I'll help debug the twitter_outreach agent. Let me gather context..."
 Context:
 - Agent: twitter_outreach
 - Goal: twitter-outreach-multi-loop
-- Working Dir: ~/.hive/twitter_outreach
+- Working Dir: ~/.hive/agents/twitter_outreach
 - Success Criteria: ["Successfully send 5 personalized outreach messages"]
 - Constraints: ["Must verify handle exists", "Must personalize message"]
 - Nodes: intake-collector, profile-analyzer, message-composer, outreach-sender
@@ -834,12 +834,12 @@ Your agent should now work correctly!"
 ## Storage Locations Reference
 
 **New unified storage (default):**
-- Logs: `~/.hive/{agent_name}/sessions/session_YYYYMMDD_HHMMSS_{uuid}/logs/`
-- State: `~/.hive/{agent_name}/sessions/{session_id}/state.json`
-- Conversations: `~/.hive/{agent_name}/sessions/{session_id}/conversations/`
+- Logs: `~/.hive/agents/{agent_name}/sessions/session_YYYYMMDD_HHMMSS_{uuid}/logs/`
+- State: `~/.hive/agents/{agent_name}/sessions/{session_id}/state.json`
+- Conversations: `~/.hive/agents/{agent_name}/sessions/{session_id}/conversations/`
 
 **Old storage (deprecated, still supported):**
-- Logs: `~/.hive/{agent_name}/runtime_logs/runs/{run_id}/`
+- Logs: `~/.hive/agents/{agent_name}/runtime_logs/runs/{run_id}/`
 
 The MCP tools automatically check both locations.
 

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -308,9 +308,9 @@ class AgentRunner:
             self._storage_path = storage_path
             self._temp_dir = None
         else:
-            # Use persistent storage in ~/.hive by default
+            # Use persistent storage in ~/.hive/agents/{agent_name}/ per RUNTIME_LOGGING.md spec
             home = Path.home()
-            default_storage = home / ".hive" / "storage" / agent_path.name
+            default_storage = home / ".hive" / "agents" / agent_path.name
             default_storage.mkdir(parents=True, exist_ok=True)
             self._storage_path = default_storage
             self._temp_dir = None
@@ -395,7 +395,7 @@ class AgentRunner:
         Args:
             agent_path: Path to agent folder
             mock_mode: If True, use mock LLM responses
-            storage_path: Path for runtime storage (defaults to ~/.hive/storage/{name})
+            storage_path: Path for runtime storage (defaults to ~/.hive/agents/{name})
             model: LLM model to use (reads from agent's default_config if None)
             enable_tui: If True, forces use of AgentRuntime with EventBus
 

--- a/core/framework/runtime/RUNTIME_LOGGING.md
+++ b/core/framework/runtime/RUNTIME_LOGGING.md
@@ -19,7 +19,7 @@ This layered approach enables efficient debugging: start with L1 to identify pro
 **Default since 2026-02-06**
 
 ```
-~/.hive/{agent_name}/
+~/.hive/agents/{agent_name}/
 └── sessions/
     └── session_YYYYMMDD_HHMMSS_{uuid}/
         ├── state.json           # Session state and metadata
@@ -42,7 +42,7 @@ This layered approach enables efficient debugging: start with L1 to identify pro
 **Read-only for backward compatibility**
 
 ```
-~/.hive/{agent_name}/
+~/.hive/agents/{agent_name}/
 ├── runtime_logs/
 │   └── runs/
 │       └── {run_id}/
@@ -215,7 +215,7 @@ Three MCP tools provide access to the logging system:
 
 ```python
 query_runtime_logs(
-    agent_work_dir: str,        # e.g., "~/.hive/twitter_outreach"
+    agent_work_dir: str,        # e.g., "~/.hive/agents/twitter_outreach"
     status: str = "",           # "needs_attention", "success", "failure", "degraded"
     limit: int = 20
 ) -> dict  # {"runs": [...], "total": int}
@@ -362,14 +362,14 @@ query_runtime_log_raw(agent_work_dir, run_id)
 ```python
 # 1. Find problematic runs (L1)
 result = query_runtime_logs(
-    agent_work_dir="~/.hive/twitter_outreach",
+    agent_work_dir="~/.hive/agents/twitter_outreach",
     status="needs_attention"
 )
 run_id = result["runs"][0]["run_id"]
 
 # 2. Identify failing nodes (L2)
 details = query_runtime_log_details(
-    agent_work_dir="~/.hive/twitter_outreach",
+    agent_work_dir="~/.hive/agents/twitter_outreach",
     run_id=run_id,
     needs_attention_only=True
 )
@@ -377,7 +377,7 @@ problem_node = details["nodes"][0]["node_id"]
 
 # 3. Analyze root cause (L3)
 raw = query_runtime_log_raw(
-    agent_work_dir="~/.hive/twitter_outreach",
+    agent_work_dir="~/.hive/agents/twitter_outreach",
     run_id=run_id,
     node_id=problem_node
 )
@@ -390,12 +390,12 @@ raw = query_runtime_log_raw(
 
 ```python
 # Get recent runs
-runs = query_runtime_logs("~/.hive/my_agent", limit=10)
+runs = query_runtime_logs("~/.hive/agents/my_agent", limit=10)
 
 # For each run, check specific node
 for run in runs["runs"]:
     node_details = query_runtime_log_details(
-        "~/.hive/my_agent",
+        "~/.hive/agents/my_agent",
         run["run_id"],
         node_id="problematic-node"
     )
@@ -411,7 +411,7 @@ import time
 
 while True:
     result = query_runtime_logs(
-        agent_work_dir="~/.hive/my_agent",
+        agent_work_dir="~/.hive/agents/my_agent",
         status="needs_attention",
         limit=1
     )
@@ -574,10 +574,10 @@ The system automatically handles both old and new formats:
 
 ```python
 # MCP tools check both locations automatically
-result = query_runtime_logs("~/.hive/old_agent")
+result = query_runtime_logs("~/.hive/agents/old_agent")
 # Returns logs from both:
-# - ~/.hive/old_agent/runtime_logs/runs/*/
-# - ~/.hive/old_agent/sessions/session_*/logs/
+# - ~/.hive/agents/old_agent/runtime_logs/runs/*/
+# - ~/.hive/agents/old_agent/sessions/session_*/logs/
 ```
 
 ### Deprecation Warnings
@@ -636,9 +636,9 @@ Typical session with 5 nodes, 20 steps:
 **Symptom:** MCP tools return empty results
 
 **Check:**
-1. Verify storage path exists: `~/.hive/{agent_name}/`
-2. Check session directories: `ls ~/.hive/{agent_name}/sessions/`
-3. Verify logs directory exists: `ls ~/.hive/{agent_name}/sessions/session_*/logs/`
+1. Verify storage path exists: `~/.hive/agents/{agent_name}/`
+2. Check session directories: `ls ~/.hive/agents/{agent_name}/sessions/`
+3. Verify logs directory exists: `ls ~/.hive/agents/{agent_name}/sessions/session_*/logs/`
 4. Check file permissions
 
 ### Issue: Corrupt JSONL files
@@ -661,7 +661,7 @@ query_runtime_log_details(agent_work_dir, run_id)
 **Solution:**
 ```bash
 # Archive old sessions
-cd ~/.hive/{agent_name}/sessions/
+cd ~/.hive/agents/{agent_name}/sessions/
 find . -name "session_2025*" -type d -exec tar -czf archive.tar.gz {} +
 rm -rf session_2025*
 

--- a/core/framework/storage/session_store.py
+++ b/core/framework/storage/session_store.py
@@ -37,7 +37,7 @@ class SessionStore:
         Initialize session store.
 
         Args:
-            base_path: Base path for storage (e.g., ~/.hive/twitter_outreach)
+            base_path: Base path for storage (e.g., ~/.hive/agents/twitter_outreach)
         """
         self.base_path = Path(base_path)
         self.sessions_dir = self.base_path / "sessions"

--- a/examples/templates/deep_research_agent/__main__.py
+++ b/examples/templates/deep_research_agent/__main__.py
@@ -88,7 +88,7 @@ def tui(verbose, debug):
         agent._event_bus = EventBus()
         agent._tool_registry = ToolRegistry()
 
-        storage_path = Path.home() / ".hive" / "deep_research_agent"
+        storage_path = Path.home() / ".hive" / "agents" / "deep_research_agent"
         storage_path.mkdir(parents=True, exist_ok=True)
 
         mcp_config_path = Path(__file__).parent / "mcp_servers.json"

--- a/examples/templates/deep_research_agent/agent.py
+++ b/examples/templates/deep_research_agent/agent.py
@@ -177,7 +177,7 @@ class DeepResearchAgent:
         """Set up the executor with all components."""
         from pathlib import Path
 
-        storage_path = Path.home() / ".hive" / "deep_research_agent"
+        storage_path = Path.home() / ".hive" / "agents" / "deep_research_agent"
         storage_path.mkdir(parents=True, exist_ok=True)
 
         self._event_bus = EventBus()

--- a/examples/templates/tech_news_reporter/__main__.py
+++ b/examples/templates/tech_news_reporter/__main__.py
@@ -86,7 +86,7 @@ def tui(verbose, debug):
         agent._event_bus = EventBus()
         agent._tool_registry = ToolRegistry()
 
-        storage_path = Path.home() / ".hive" / "tech_news_reporter"
+        storage_path = Path.home() / ".hive" / "agents" / "tech_news_reporter"
         storage_path.mkdir(parents=True, exist_ok=True)
 
         mcp_config_path = Path(__file__).parent / "mcp_servers.json"


### PR DESCRIPTION

Standardizes agent session storage to use `~/.hive/agents/{agent_name}/` across all execution paths (hive CLI, standalone agent TUI, and direct execution). This aligns with the RUNTIME_LOGGING.md specification and provides cleaner separation between agent data and global configuration.

## Problem

Previously, there were inconsistent storage paths:

| Execution Method | Storage Path |
|------------------|--------------|
| `hive` CLI | `~/.hive/storage/{agent_name}/` |
| Standalone agent TUI | `~/.hive/{agent_name}/` |
| RUNTIME_LOGGING.md spec | `~/.hive/{agent_name}/` |

This caused confusion when debugging agents - logs would appear in different locations depending on how the agent was launched.

Additionally, the flat `~/.hive/{agent_name}/` structure mixed agent session data with global config files:

```
~/.hive/
├── configuration.json    # Global config
├── credentials/          # Credential store
├── workdir/              # Temp work
├── twitter_outreach/     # Agent data (mixed with config!)
├── deep_research_agent/  # Agent data (mixed with config!)
└── ...
```

## Solution

Standardize all paths to `~/.hive/agents/{agent_name}/`:

```
~/.hive/
├── configuration.json    # Global config (unchanged)
├── credentials/          # Credential store (unchanged)
├── workdir/              # Temp work (unchanged)
└── agents/               # All agent session data
    ├── twitter_outreach/
    │   └── sessions/
    │       └── session_YYYYMMDD_HHMMSS_{uuid}/
    │           ├── state.json
    │           ├── logs/
    │           ├── conversations/
    │           └── data/
    ├── deep_research_agent/
    └── ...
```

Benefits:
- Clean separation between agent data and global config
- Easy to list all agents: `ls ~/.hive/agents/`
- Easy to backup/delete all agent data without touching config
- Scales better as agent count grows
- Single source of truth for where to find agent logs

## Changes

### Core Framework
- **`core/framework/runner/runner.py`**: Updated default storage path from `~/.hive/storage/{name}` to `~/.hive/agents/{name}`

### Documentation
- **`core/framework/runtime/RUNTIME_LOGGING.md`**: Updated all path references and examples
- **`core/framework/storage/session_store.py`**: Updated docstring example

### Skills
- **`.claude/skills/hive-debugger/SKILL.md`**: Updated working directory references
- **`.claude/skills/hive-create/SKILL.md`**: Updated storage path example

### Example Agents
- **`examples/templates/deep_research_agent/__main__.py`**
- **`examples/templates/deep_research_agent/agent.py`**
- **`examples/templates/tech_news_reporter/__main__.py`**
- **`.claude/skills/hive-create/examples/deep_research_agent/__main__.py`**
- **`.claude/skills/hive-create/examples/deep_research_agent/agent.py`**

## Migration

Existing agent data in old locations (`~/.hive/storage/` or `~/.hive/{agent_name}/`) will remain accessible for reading but new sessions will be written to `~/.hive/agents/{agent_name}/`.

To migrate existing data (optional):
```bash
# Move from old storage/ location
mv ~/.hive/storage/* ~/.hive/agents/

# Move any agents at top level
mv ~/.hive/my_agent ~/.hive/agents/my_agent
```

## Testing

All existing tests pass:
```
pytest core/tests/ -x -q
# 100% passed with expected deprecation warnings
```

## Breaking Changes

None. This is a path change for new sessions only. Existing logs remain readable from their current locations.
