### PR TITLE
Fix incorrect MCP test generation description in hive-test skill

### DIFF
--- a/.claude/skills/hive-test/SKILL.md
+++ b/.claude/skills/hive-test/SKILL.md
@@ -1191,4 +1191,6 @@ MOCK_MODE=1 pytest exports/your_agent/tests/ -v
 
 ---
 
-**MCP tools generate tests, write them to Python files, and run them via pytest.**
+**MCP tools provide test guidelines and execute tests, but do NOT generate test code.**
+Claude writes tests directly to Python files using the Write tool based on returned templates.
+


### PR DESCRIPTION
Clarifies that generate_*_tests return guidelines/templates and that the calling agent writes test code directly. Aligns docs with current behavior.

## Description

Clarifies that generate_*_tests MCP tools return guidelines and templates only, and that the calling agent writes test code directly using the Write tool. This aligns the hive-test skill documentation with the current implementation.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)


## Changes Made

- Change 1 - Corrected an incorrect statement in .claude/skills/hive-test/SKILL.md that implied MCP tools generate and write test code. 
- Change 2 - Clarified the division of responsibility between MCP tools (guidelines/execution) and the calling agent (test generation)


## Testing

Manual documentation review for accuracy and consistency with current MCP tool behavior


## Checklist

- [ ] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
N/A