### PR TITLE
docs: add OpenAI Agents SDK comparison and improve template documentation

### DIFF
--- a/docs/articles/README.md
+++ b/docs/articles/README.md
@@ -16,6 +16,7 @@ Educational content comparing AI agent frameworks and exploring the agent develo
 | [Building Production AI Agents](./building-production-ai-agents.md) | Guide | production, deployment, reliability |
 | [Multi-Agent vs Single-Agent](./multi-agent-vs-single-agent-systems.md) | Concept | architecture, design patterns |
 | [AI Agent Observability](./ai-agent-observability-monitoring.md) | Guide | monitoring, observability, debugging |
+| [Aden vs OpenAI Agents SDK](./aden-vs-openai-agents.md) | Comparison | openai, agents sdk, handoffs, guardrails |
 
 ## Purpose
 

--- a/docs/articles/aden-vs-openai-agents.md
+++ b/docs/articles/aden-vs-openai-agents.md
@@ -1,0 +1,345 @@
+# Aden vs OpenAI Agents SDK: A Detailed Comparison
+
+*Comparing self-evolving agent systems with lightweight multi-agent orchestration*
+
+---
+
+OpenAI Agents SDK and Aden both enable multi-agent systems but come from fundamentally different philosophies. OpenAI Agents SDK (the production evolution of Swarm) provides a minimal, Python-native framework for handoff-based agent orchestration. Aden focuses on goal-driven, self-improving agent graphs with built-in production controls.
+
+---
+
+## Overview
+
+| Aspect | OpenAI Agents SDK | Aden |
+|--------|-------------------|------|
+| **Philosophy** | Lightweight multi-agent handoffs | Goal-driven, self-evolving agents |
+| **Architecture** | Agent + Runner with handoff chains | Node-based agent graphs |
+| **Workflow** | Handoff-based delegation | Dynamically generated |
+| **Self-Improvement** | No | Yes |
+| **Human-in-the-Loop** | Tool approval gates | Native intervention points with escalation |
+| **Monitoring** | Built-in tracing + OpenAI dashboard | Full dashboard with cost controls |
+| **License** | MIT | Apache 2.0 |
+
+---
+
+## Philosophy & Approach
+
+### OpenAI Agents SDK
+OpenAI Agents SDK is built on a deliberately small set of primitives: **Agents**, **Handoffs**, **Guardrails**, and **Tracing**. The design philosophy is minimal surface area — enough features to be useful, but few enough concepts to learn quickly. Agents are defined as Python objects with instructions, tools, and handoffs to other agents.
+
+```python
+# OpenAI Agents SDK: Handoff-based multi-agent system
+from agents import Agent, Runner
+
+billing_agent = Agent(
+    name="Billing specialist",
+    instructions="You handle billing questions.",
+    tools=[lookup_invoice, process_refund],
+)
+
+triage_agent = Agent(
+    name="Triage agent",
+    instructions="Route the user to the right specialist.",
+    handoffs=[billing_agent, support_agent],
+)
+
+result = Runner.run_sync(triage_agent, "I need a refund for order #123")
+print(result.final_output)
+```
+
+### Aden
+Aden uses a **coding agent** to generate agent systems from natural language goals. The system creates agents, connections, and evolves based on failures. Rather than manually defining handoff chains, you describe what you want and Aden generates the agent graph.
+
+```python
+# Aden: Goal-driven generation
+goal = """
+Handle customer support requests by:
+1. Triaging incoming questions by category
+2. Routing billing issues to a specialist agent
+3. Escalating complex cases to human reviewers
+4. Learning from resolution patterns to improve routing
+
+When routing fails or customers are unsatisfied:
+- Capture the failure context
+- Adjust routing logic based on patterns
+- Improve specialist agent instructions
+"""
+
+# Aden generates:
+# - Triage agent with learned routing rules
+# - Specialist agents with appropriate tools
+# - Human-in-the-loop escalation checkpoint
+# - Feedback loop for continuous improvement
+```
+
+---
+
+## Feature Comparison
+
+### Agent Definition
+
+| Feature | OpenAI Agents SDK | Aden |
+|---------|-------------------|------|
+| Agent creation | Manual Python objects | Generated from goals |
+| Instructions | Static string or dynamic function | Inferred from requirements |
+| Tools assignment | Manual per agent | Auto-configured |
+| Structured output | Pydantic models, dataclasses, TypedDict | Via goal refinement |
+| Dynamic instructions | `RunContextWrapper` injection | Goal-based abstraction |
+| Customization | High (explicit control) | High (via goal refinement) |
+
+**Verdict:** OpenAI Agents SDK gives precise, explicit control over every agent parameter; Aden reduces boilerplate through goal-driven generation.
+
+### Multi-Agent Coordination
+
+| Feature | OpenAI Agents SDK | Aden |
+|---------|-------------------|------|
+| Primary pattern | Handoffs (peer delegation) | Dynamic goal-based graphs |
+| Secondary pattern | Agents-as-tools (manager pattern) | Node connections with conditions |
+| Communication | Full conversation history transfer | Generated connection code |
+| Conditional routing | Handoff `is_enabled` flag | Edge conditions with expressions |
+| Flexibility | Within handoff/tool patterns | Fully dynamic |
+| Adaptation | Manual updates | Automatic evolution |
+
+**Verdict:** OpenAI Agents SDK excels at clean linear handoff chains; Aden supports more complex graph topologies with conditional edges and feedback loops.
+
+### Safety & Guardrails
+
+| Feature | OpenAI Agents SDK | Aden |
+|---------|-------------------|------|
+| Input validation | Input guardrails with tripwire | Goal-level constraints |
+| Output validation | Output guardrails with tripwire | Success criteria evaluation |
+| Tool-level guards | Input + output tool guardrails | Tool-level policies |
+| Execution mode | Parallel (default) or blocking | Integrated with execution |
+| Failure behavior | Raises typed exceptions | Captured for evolution |
+| Layered approach | Input + output + tool (3 layers) | Constraint-based |
+| Custom guard models | Run cheap/fast models as guards | N/A |
+
+**Verdict:** OpenAI Agents SDK has a more sophisticated guardrails system with its layered tripwire approach (input, output, and tool-level guards that can run in parallel). This is a genuine strength.
+
+### Observability & Tracing
+
+| Feature | OpenAI Agents SDK | Aden |
+|---------|-------------------|------|
+| Built-in tracing | Automatic (agent, LLM, tool, handoff spans) | Full dashboard |
+| Dashboard | OpenAI platform traces UI | Built-in monitoring dashboard |
+| External integrations | 20+ (W&B, Langfuse, Arize, MLflow, etc.) | Growing ecosystem |
+| Cost tracking | Via tracing metadata | Native with budget enforcement |
+| Custom spans | `@trace` decorator, manual spans | Integrated metrics |
+| Sensitive data control | `trace_include_sensitive_data` flag | Configurable |
+
+**Verdict:** OpenAI Agents SDK has broader third-party tracing integrations out of the box; Aden provides deeper built-in cost tracking with budget enforcement.
+
+### Self-Improvement
+
+| Feature | OpenAI Agents SDK | Aden |
+|---------|-------------------|------|
+| Learning from failures | Not built-in | Core feature |
+| Agent evolution | Manual updates | Automatic |
+| Goal-driven generation | No | Yes |
+| Feedback loops | Manual implementation | Built-in edge conditions |
+| Performance adaptation | Manual tuning | Continuous improvement |
+
+**Verdict:** Aden's self-improvement and evolution capabilities are a unique differentiator with no equivalent in OpenAI Agents SDK.
+
+---
+
+## Code Comparison
+
+### Building a Customer Support System
+
+#### OpenAI Agents SDK Approach
+```python
+from agents import Agent, Runner, handoff, input_guardrail
+from agents import GuardrailFunctionOutput, RunContextWrapper
+
+# Safety guardrail
+@input_guardrail
+async def content_filter(
+    ctx: RunContextWrapper, agent: Agent, input: str
+) -> GuardrailFunctionOutput:
+    result = await Runner.run(safety_agent, input)
+    return GuardrailFunctionOutput(
+        output_info=result.final_output,
+        tripwire_triggered=result.final_output.is_unsafe,
+    )
+
+# Specialist agents
+billing_agent = Agent(
+    name="Billing specialist",
+    instructions="Handle billing inquiries. Access invoice and payment tools.",
+    tools=[lookup_invoice, process_refund, check_payment_status],
+)
+
+tech_agent = Agent(
+    name="Technical support",
+    instructions="Resolve technical issues. Access diagnostic tools.",
+    tools=[check_system_status, run_diagnostics, create_ticket],
+)
+
+# Triage agent with handoffs
+triage_agent = Agent(
+    name="Customer support triage",
+    instructions=(
+        "You are the first point of contact. Determine the customer's need "
+        "and route them to the appropriate specialist."
+    ),
+    handoffs=[billing_agent, tech_agent],
+    input_guardrails=[content_filter],
+)
+
+# Run the system
+result = await Runner.run(
+    triage_agent,
+    "I was charged twice for my subscription last month",
+)
+print(result.final_output)
+```
+
+#### Aden Approach
+```python
+# Define goal - system generates the support team
+goal = """
+Create a customer support system that:
+1. Triages incoming requests by category (billing, technical, general)
+2. Routes to specialist agents with appropriate tools
+3. Requires human approval for refunds over $100
+4. Tracks resolution patterns and improves routing
+
+When support interactions fail:
+- Capture the failure context and customer sentiment
+- Identify patterns in misrouted tickets
+- Adjust triage logic and specialist instructions
+- Escalate repeated failures to human reviewers
+"""
+
+# Aden automatically:
+# - Creates triage, billing, and tech specialist nodes
+# - Configures tools per specialist
+# - Sets up HITL checkpoint for high-value refunds
+# - Establishes feedback loop for continuous improvement
+# - Monitors cost per resolution
+# - Evolves routing based on success patterns
+```
+
+---
+
+## Production Considerations
+
+### Deployment
+
+| Aspect | OpenAI Agents SDK | Aden |
+|--------|-------------------|------|
+| Installation | `pip install openai-agents` | Full framework install |
+| Dependencies | Minimal (openai, pydantic, griffe) | Includes runtime + monitoring |
+| Python version | 3.9+ | 3.10+ |
+| Hosting model | Self-hosted (any infrastructure) | Self-hosted |
+| Containerization | Standard Python packaging | Standard Python packaging |
+
+### Sessions & Memory
+
+| Aspect | OpenAI Agents SDK | Aden |
+|--------|-------------------|------|
+| Short-term memory | SQLiteSession, SQLAlchemySession, DaprSession | Built-in state management |
+| Context persistence | Multiple session backends (7+ types) | Graph-level state |
+| Context compaction | Auto-compaction via Responses API | Configurable history limits |
+| Conversation branching | AdvancedSQLiteSession | N/A |
+| Encryption | EncryptedSession with TTL | Configurable |
+| Cloud-hosted state | OpenAI Conversations API | N/A |
+
+### Voice & Realtime
+
+| Aspect | OpenAI Agents SDK | Aden |
+|--------|-------------------|------|
+| Voice pipeline | VoicePipeline (STT -> Agent -> TTS) | Not built-in |
+| Native voice | RealtimeAgent (beta) | Not built-in |
+| Voice activity detection | Server VAD + Semantic VAD | N/A |
+| Voice models | 6 voice options (alloy, echo, etc.) | N/A |
+
+---
+
+## When to Choose OpenAI Agents SDK
+
+OpenAI Agents SDK is the better choice when:
+
+1. **Linear handoff workflows** — Your agents delegate in clean chains (triage -> specialist -> resolution)
+2. **Guardrails are critical** — You need layered input, output, and tool-level safety with tripwire semantics
+3. **Voice agents** — You need voice pipelines or native realtime voice conversations
+4. **Minimal dependencies** — You want a lightweight library, not a full framework
+5. **Tracing ecosystem** — You need integrations with 20+ observability platforms out of the box
+6. **Rapid prototyping** — Few primitives means a short learning curve to get agents running
+
+---
+
+## When to Choose Aden
+
+Aden is the better choice when:
+
+1. **Goals over architecture** — You know what to achieve, not how to wire the agents
+2. **Self-improvement required** — Your system needs to learn from failures and evolve automatically
+3. **Complex graph topologies** — Dynamic conditional routing, feedback loops, and parallel execution
+4. **Production cost controls** — You need native budget enforcement and model degradation policies
+5. **Human oversight with escalation** — Native HITL with configurable escalation policies, not just tool approval gates
+6. **Vendor independence** — Zero lock-in with 100+ LLM providers via LiteLLM
+7. **Continuous improvement** — Want agents that get measurably better over time without manual tuning
+
+---
+
+## Migration Considerations
+
+### OpenAI Agents SDK to Aden
+- Map each `Agent` to a node in Aden's graph with equivalent instructions and tools
+- Convert `handoffs` to `EdgeSpec` connections between nodes
+- Replace `Runner.run()` with Aden's `GraphExecutor` execution model
+- Add failure scenarios and success criteria to enable evolution
+- Guardrail logic can move to Aden's constraint definitions
+- Existing `@function_tool` definitions often transfer directly
+
+### Aden to OpenAI Agents SDK
+- Analyze the generated agent graph and map each node to an `Agent`
+- Convert edge conditions to handoff chains or agents-as-tools patterns
+- Self-improvement loops must be reimplemented manually or removed
+- Budget enforcement requires external implementation
+- HITL checkpoints map to `needs_approval` on tools
+- Set up external monitoring to replace Aden's built-in dashboard
+
+---
+
+## Community & Support
+
+| Aspect | OpenAI Agents SDK | Aden |
+|--------|-------------------|------|
+| GitHub stars | ~18.8k | Growing |
+| Backing | OpenAI | Independent / open-source |
+| Community size | Large (OpenAI ecosystem) | Growing |
+| Documentation | Comprehensive | Growing |
+| Enterprise support | Via OpenAI platform | Community-driven |
+| Third-party ecosystem | Extensive integrations | Integrated platform |
+
+---
+
+## Conclusion
+
+**OpenAI Agents SDK** excels as a lightweight, well-designed orchestration layer for multi-agent handoff workflows. Its guardrails system (layered tripwires across input, output, and tools), extensive tracing integrations, and voice capabilities make it a strong choice for teams that want explicit control with minimal framework overhead. Backed by OpenAI's ecosystem and community, it offers a fast path from prototype to production for handoff-centric use cases.
+
+**Aden** takes a fundamentally different approach: instead of manually wiring agent handoffs, you define goals and let the system generate, execute, and evolve agent graphs. Its unique self-improvement capabilities, built-in cost controls with budget enforcement, and native HITL with escalation make it the stronger choice for production systems that need to get better over time without constant manual intervention.
+
+### Decision Matrix
+
+| Your Situation | Choose |
+|----------------|--------|
+| Clean linear handoff chains | OpenAI Agents SDK |
+| Need agents to improve over time | Aden |
+| Layered guardrails are critical | OpenAI Agents SDK |
+| Voice or realtime agents | OpenAI Agents SDK |
+| Goal-driven generation | Aden |
+| Budget enforcement needed | Aden |
+| Minimal framework overhead | OpenAI Agents SDK |
+| Complex conditional graph flows | Aden |
+| Broad tracing integrations | OpenAI Agents SDK |
+| Vendor independence | Aden |
+| Maximum explicit control | OpenAI Agents SDK |
+| Continuous self-evolution | Aden |
+
+---
+
+*Last updated: February 2025*

--- a/examples/templates/README.md
+++ b/examples/templates/README.md
@@ -21,18 +21,20 @@ template_name/
 
 ```bash
 # 1. Copy to your exports directory
-cp -r examples/templates/marketing_agent exports/my_marketing_agent
+cp -r examples/templates/deep_research_agent exports/my_research_agent
 
 # 2. Update the module references in __main__.py and __init__.py
 
 # 3. Customize goal, nodes, edges, and prompts
 
 # 4. Run it
-uv run python -m exports.my_marketing_agent --input '{"product_description": "..."}'
+uv run python -m exports.my_research_agent run --topic "your research topic"
 ```
 
 ## Available templates
 
-| Template | Description |
-|----------|-------------|
-| [marketing_agent](marketing_agent/) | Multi-channel marketing content generator with audience analysis, content generation, and editorial review nodes |
+| Template | Nodes | Description |
+|----------|:-----:|-------------|
+| [deep_research_agent](deep_research_agent/) | 4 | Research any topic through multi-source search with user review checkpoints and a feedback loop for iterative deepening. Produces a cited HTML report. |
+| [tech_news_reporter](tech_news_reporter/) | 3 | Scan the web for recent tech/AI news, summarize key stories, and deliver a structured HTML report. |
+| [twitter_outreach](twitter_outreach/) | 4 | Research a target's Twitter/X profile and craft a personalized outreach email with human approval before sending. |

--- a/examples/templates/deep_research_agent/README.md
+++ b/examples/templates/deep_research_agent/README.md
@@ -1,0 +1,197 @@
+# Deep Research Agent
+
+**Version**: 1.0.0
+**Type**: Multi-node agent with feedback loop
+**Created**: 2026-02-06
+
+## Overview
+
+Research any topic by searching diverse sources, analyzing findings, and producing a cited report — with user checkpoints to guide direction. The agent features a feedback loop between review and research, allowing iterative deepening until the user is satisfied with the coverage and quality of findings.
+
+## Business Value
+
+- **Research automation** — Reduces hours of manual web research into a single guided session, freeing analysts to focus on synthesis and decision-making
+- **Quality assurance** — Built-in review checkpoint ensures findings meet user expectations before report generation, preventing wasted effort on misaligned research
+- **Iterative deepening** — Feedback loop between review and research allows progressive refinement without restarting, matching how expert researchers work
+- **Citation compliance** — Every factual claim requires source attribution, producing reports that meet academic and professional standards out of the box
+- **Reusable pattern** — The intake-research-review-report architecture with conditional feedback loop serves as a foundation for any investigation workflow
+
+## Architecture
+
+### Execution Flow
+
+```
+intake → research → review → report
+                      ↓  ↑
+                  feedback loop
+              (if needs more research)
+```
+
+### Nodes (4 total)
+
+1. **intake** (`event_loop`)
+   - Discuss the research topic with the user, clarify scope, and confirm direction
+   - Reads: `topic`
+   - Writes: `research_brief`
+   - Tools: none
+   - Client-facing: Yes
+
+2. **research** (`event_loop`)
+   - Search the web, fetch source content, and compile findings
+   - Reads: `research_brief`, `feedback`
+   - Writes: `findings`, `sources`, `gaps`
+   - Tools: `web_search`, `web_scrape`, `load_data`, `save_data`, `list_data_files`
+   - Client-facing: No
+   - Max visits: 3
+
+3. **review** (`event_loop`)
+   - Present findings to user and decide whether to research more or write the report
+   - Reads: `findings`, `sources`, `gaps`, `research_brief`
+   - Writes: `needs_more_research`, `feedback`
+   - Tools: none
+   - Client-facing: Yes
+   - Max visits: 3
+
+4. **report** (`event_loop`)
+   - Write a cited HTML report from the findings and present it to the user
+   - Reads: `findings`, `sources`, `research_brief`
+   - Writes: `delivery_status`
+   - Tools: `save_data`, `serve_file_to_user`, `load_data`, `list_data_files`
+   - Client-facing: Yes
+
+### Edges (4 total)
+
+- `intake` → `research` (condition: `on_success`, priority 1)
+- `research` → `review` (condition: `on_success`, priority 1)
+- `review` → `research` (condition: `needs_more_research == True`, priority 1) — feedback loop
+- `review` → `report` (condition: `needs_more_research == False`, priority 2)
+
+## Goal Criteria
+
+### Success Criteria
+
+**Source diversity** (weight 0.25)
+- Metric: `source_count`
+- Target: >= 5 diverse, authoritative sources
+
+**Citation coverage** (weight 0.25)
+- Metric: `citation_coverage`
+- Target: 100% — every factual claim cites its source
+
+**User satisfaction** (weight 0.25)
+- Metric: `user_approval`
+- Target: User reviews findings before report generation
+
+**Report completeness** (weight 0.25)
+- Metric: `question_coverage`
+- Target: 90% — final report answers the original research questions
+
+### Constraints
+
+- **No hallucination** (quality/accuracy) — Only include information found in fetched sources
+- **Source attribution** (quality/accuracy) — Every claim must cite its source with a numbered reference
+- **User checkpoint** (functional/interaction) — Present findings to the user before writing the final report
+
+## Required Tools
+
+The agent uses tools provided by the Hive MCP server:
+
+- `web_search` — Search the web with diverse queries across different angles
+- `web_scrape` — Fetch and extract content from promising source URLs
+- `save_data` — Persist research findings and the final HTML report
+- `load_data` — Retrieve previously saved research data
+- `list_data_files` — Browse saved data files
+- `serve_file_to_user` — Deliver the final report as a clickable link
+
+## Usage
+
+```bash
+# Validate the agent structure
+PYTHONPATH=core:exports uv run python -m deep_research_agent validate
+
+# Show agent info
+PYTHONPATH=core:exports uv run python -m deep_research_agent info
+
+# Run research on a topic
+PYTHONPATH=core:exports uv run python -m deep_research_agent run --topic "quantum computing breakthroughs 2025"
+
+# Launch the TUI for interactive research
+PYTHONPATH=core:exports uv run python -m deep_research_agent tui
+
+# Interactive shell
+PYTHONPATH=core:exports uv run python -m deep_research_agent shell
+```
+
+### Programmatic Usage
+
+```python
+import asyncio
+from deep_research_agent import DeepResearchAgent
+
+async def main():
+    agent = DeepResearchAgent()
+    result = await agent.run({"topic": "impact of AI on healthcare diagnostics"})
+    if result.success:
+        print("Research complete:", result.output)
+    else:
+        print("Failed:", result.error)
+
+asyncio.run(main())
+```
+
+## Customization Guide
+
+### Adjusting Research Depth
+
+Modify the `max_node_visits` on `research_node` and `review_node` in `nodes/__init__.py` to control how many feedback iterations are allowed. The default is 3 visits each.
+
+### Changing the Model
+
+Edit `config.py` to change the default model. The agent reads from `~/.hive/configuration.json` if available, falling back to `anthropic/claude-sonnet-4-20250514`.
+
+### Adding Custom Tools
+
+Add tool names to the `tools` list in any `NodeSpec` in `nodes/__init__.py`. Register the corresponding tool implementations in your MCP server or tool registry.
+
+### Modifying Report Format
+
+Edit the `report_node` system prompt in `nodes/__init__.py` to change the HTML structure, styling, or report sections. The default produces a self-contained HTML document with executive summary, table of contents, themed findings, and numbered references.
+
+### Adding New Nodes
+
+Define a new `NodeSpec` in `nodes/__init__.py`, add it to the `nodes` list in `agent.py`, and create `EdgeSpec` entries to connect it to the graph. For example, add a fact-checking node between `review` and `report` for additional verification.
+
+## Example Output
+
+A successful run produces:
+- An interactive intake session where the research scope is clarified
+- Multiple rounds of web research with 5+ authoritative sources
+- A user review checkpoint with a summary of findings and gaps
+- A self-contained HTML report with:
+  - Executive summary
+  - Table of contents
+  - Themed findings with `[n]` citation links
+  - Analysis and synthesis section
+  - Numbered references with clickable URLs
+
+## MCP Server Configuration
+
+The agent connects to the Hive tools MCP server. Configuration from `mcp_servers.json`:
+
+```json
+{
+  "hive-tools": {
+    "transport": "stdio",
+    "command": "uv",
+    "args": ["run", "python", "mcp_server.py", "--stdio"],
+    "cwd": "../../../tools",
+    "description": "Hive tools MCP server providing web_search, web_scrape, and write_to_file"
+  }
+}
+```
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0.0 | 2026-02-06 | Initial release with 4-node research pipeline and feedback loop |

--- a/examples/templates/tech_news_reporter/README.md
+++ b/examples/templates/tech_news_reporter/README.md
@@ -114,3 +114,18 @@ Terminal nodes: `compile-report`
 - **1.0.0** (2026-02-06): Initial release
   - 3 nodes, 2 edges
   - Goal: Tech & AI News Reporter
+
+## Business Value
+
+- **Stay current** — Automates the daily ritual of scanning dozens of tech news sites, delivering a curated briefing in minutes instead of hours
+- **Team awareness** — Produces shareable HTML reports that keep entire teams aligned on industry developments without everyone doing independent research
+- **Focus filtering** — The intake conversation lets users narrow scope to specific topics (e.g., "AI regulation" or "semiconductor supply chain"), avoiding information overload
+- **Source quality** — Prioritizes authoritative sources and enforces URL attribution, so readers can verify claims and explore further
+- **Reusable pattern** — The linear intake-research-report pipeline serves as a starting point for any web-to-report workflow (market research, competitor analysis, trend monitoring)
+
+## Customization Guide
+
+- **Change news sources** — Edit the `research` node system prompt in `nodes/__init__.py` to prioritize specific publications, RSS feeds, or domains (e.g., restrict to `.gov` sites for policy news)
+- **Adjust article count** — Modify the success criteria target in `agent.py` to require more or fewer articles per report (default is 5+)
+- **Modify report format** — Edit the `compile-report` node system prompt to change the HTML layout, add sections like "Editor's Pick" or "Trending Topics", or switch to Markdown output
+- **Add an analysis node** — Insert a new `NodeSpec` between `research` and `compile-report` that summarizes trends, identifies themes across articles, or scores stories by relevance to the user's interests

--- a/examples/templates/twitter_outreach/README.md
+++ b/examples/templates/twitter_outreach/README.md
@@ -55,3 +55,18 @@ intake → research → draft-review → send
 - **Approval Required** — Never sends without explicit user approval
 - **Tone** — Professional, authentic, conversational
 - **Privacy** — Only uses publicly available information
+
+## Business Value
+
+- **Personalized outreach** — Each email references the recipient's actual interests, recent posts, and bio, moving beyond generic templates that get ignored
+- **Time savings** — Automates the research-draft-review cycle that typically takes 20-30 minutes per recipient down to a single guided session
+- **Higher response rates** — Personalization based on real social signals consistently outperforms batch email approaches, driving meaningful engagement
+- **Approval workflow** — Human-in-the-loop review at the draft stage ensures every message meets your standards before sending, preventing embarrassing mistakes
+- **Reusable pattern** — The research-to-personalized-action pipeline adapts to LinkedIn outreach, partnership proposals, investor emails, or any scenario where context-aware communication matters
+
+## Customization Guide
+
+- **Change data source** — Swap Twitter/X research for LinkedIn, GitHub, or company websites by editing the `research` node system prompt and tools in `nodes/__init__.py`
+- **Email provider** — Replace the `send_email` tool with your preferred email service (SendGrid, Mailgun, SMTP) by updating the tool implementation in your MCP server
+- **Tone adjustment** — Edit the `draft-review` node system prompt to match your communication style (formal, casual, technical) or add brand voice guidelines
+- **Multi-recipient** — Extend the intake node to accept a list of handles and loop the research-draft-send pipeline, creating a batch outreach workflow with per-recipient personalization


### PR DESCRIPTION
## Summary

- **New: Aden vs OpenAI Agents SDK comparison article** — Comprehensive comparison covering agent definition, multi-agent coordination, guardrails, observability, self-improvement, code examples, and production considerations. Honest about where OpenAI Agents SDK wins (layered tripwire guardrails, 20+ tracing integrations, voice/RealtimeAgent, community size) and where Aden wins (self-improvement/evolution, goal-driven generation, budget enforcement, HITL with escalation, vendor independence).

- **New: deep_research_agent README** — The most sophisticated template (4-node pipeline with conditional feedback loop) had no documentation. Added architecture diagrams, goal criteria from agent.py, node specs from nodes/__init__.py, usage instructions, business value section, and customization guide.

- **Improved: tech_news_reporter and twitter_outreach READMEs** — Added Business Value and Customization Guide sections to both existing template READMEs, converting them from technical reference into adoption-ready documentation.

- **Fixed: templates index** — Replaced stale table (listed only marketing_agent which does not exist) with accurate entries for all 3 actual templates.

## Why these changes matter

**OpenAI Agents SDK is the most important missing comparison.** With ~18.8k GitHub stars and OpenAI distribution, it is the framework developers compare against first. Every other major competitor (CrewAI, LangChain, AutoGen) already has a comparison article — OpenAI was the gap.

**Template docs matter for adoption.** Templates are the fastest path from evaluating to using — but undocumented templates are invisible. The deep_research_agent is the most advanced template (feedback loops, 4 success criteria, 3 constraints) yet had zero documentation. Business Value sections convert evaluators into users by showing ROI. Customization Guides reduce drop-off from users who think the template does not fit their use case.

## Related issues

- Closes #3883 (Documentation gaps in template READMEs)
- Related to #3881 (First-time contributor experience)
- Related to #3882 (README navigation improvements)
- Related to #3900 (RFC: Agent Evaluation System — the eval work identified while writing the self-improvement comparison sections)

## Test plan

- [ ] All internal markdown links resolve correctly
- [ ] Comparison article follows the exact structure of existing articles (aden-vs-crewai.md)
- [ ] deep_research_agent README accurately reflects agent.py and nodes/__init__.py
- [ ] Templates index matches actual directory contents (3 templates, not 1)
- [ ] No broken relative paths in any modified file