### PR TITLE
docs: clarify test generation responsibility in hive skill

### DIFF
--- a/.claude/skills/hive/SKILL.md
+++ b/.claude/skills/hive/SKILL.md
@@ -197,16 +197,18 @@ exports/agent_name/
 
 ### What This Phase Does
 
-Creates comprehensive test suite:
-- Constraint tests (verify hard requirements)
-- Success criteria tests (measure goal achievement)
-- Edge case tests (handle failures gracefully)
-- Integration tests (end-to-end workflows)
+### What This Phase Does
+
+Guides the creation and execution of a comprehensive test suite:
+- Constraint tests
+- Success criteria tests
+- Edge case tests
+- Integration tests
 
 ### Process
 
 1. **Analyze agent** - Read goal, constraints, success criteria
-2. **Generate tests** - Create pytest files in `exports/agent_name/tests/`
+2. **Generate tests** - The calling agent writes pytest files in `exports/agent_name/tests/` using hive-test guidelines and templates
 3. **User approval** - Review and approve each test
 4. **Run evaluation** - Execute tests and collect results
 5. **Debug failures** - Identify and fix issues


### PR DESCRIPTION
## Description

Clarifies that the hive workflow and hive-test tools provide orchestration,
guidelines, templates, and execution utilities, while test code is written by
the calling agent using the Write tool. This aligns the hive skill documentation
with current behavior.


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

N/A (documentation-only change)

## Changes Made

- Change 1 - Clarified test generation responsibility in `.claude/skills/hive/SKILL.md` to reflect delegation to the `hive-test` skill
- Change 2 - Removed implication in the hive workflow that hive-test tools directly write test code
- Change 3 - Aligned documentation language with existing implementation

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A