### PR TITLE
Update environment-setup.md

### DIFF
--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -442,6 +442,46 @@ This design allows agents in `exports/` to be:
 - Version controlled separately
 - Deployed as standalone packages
 
+
+### When is PYTHONPATH Required?
+
+PYTHONPATH is only required when running agents or scripts that import modules from the `exports/` directory.
+
+This is because:
+- `framework` and `aden_tools` are installed in editable mode and are automatically available in the environment.
+- The `exports/` directory contains user-created agents that are not installed as packages, so Python needs an explicit path to locate them.
+
+#### PYTHONPATH is NOT required when:
+- Importing `framework`
+- Importing `aden_tools`
+- Running commands using the `hive` CLI
+- Verifying installations using `uv run`
+
+Example:
+```bash
+uv run python -c "import framework"
+```
+
+#### PYTHONPATH is required when:
+- Running an agent directly with `python -m`
+- Importing modules located inside the `exports/` directory
+
+Example (Linux/macOS):
+```bash
+PYTHONPATH=exports uv run python -m your_agent_name validate
+```
+
+Example (Windows PowerShell):
+```powershell
+$env:PYTHONPATH="core;exports"
+python -m your_agent_name validate
+```
+
+#### Does `uv run` set PYTHONPATH automatically?
+
+No. `uv run` manages the virtual environment and dependencies, but it does not automatically include the `exports/` directory in the Python module search path. PYTHONPATH must be set manually when running agents directly.
+
+
 ## Development Workflow
 
 ### 1. Setup (Once)


### PR DESCRIPTION
docs: clarify when PYTHONPATH is required vs optional

## Description
Clarified when PYTHONPATH is required vs optional in the environment setup documentation.

Added clearer explanations and examples to help new contributors understand:
- When PYTHONPATH is required
- When it is not required
- Why exports requires PYTHONPATH
- Whether uv run sets PYTHONPATH automatically

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #3842

## Changes Made

- Added a new section explaining when PYTHONPATH is required
- Added examples for Linux/macOS and Windows
- Clarified uv run behavior regarding PYTHONPATH


## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
