### PR TITLE
Docs: clarify expected outcome after quickstart setupdocs: clarify success signal after quickstart setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ cd hive
 # Run quickstart setup
 ./quickstart.sh
 ```
+If the setup completes successfully, you should see confirmation output for environment setup and be able to run `hive tui` to launch the interactive dashboard.
 
 This sets up:
 


### PR DESCRIPTION
Small documentation clarification to help first-time users understand when the quickstart setup has completed successfully.
Docs-only change.
