### PR TITLE
feat(tools): add text body, reply-to and headers support to email tool

### DIFF
--- a/tools/src/aden_tools/tools/email_tool/README.md
+++ b/tools/src/aden_tools/tools/email_tool/README.md
@@ -10,9 +10,14 @@ Send a general-purpose email.
 **Parameters:**
 - `to` (str | list[str]) - Recipient email address(es)
 - `subject` (str) - Email subject line
-- `html` (str) - Email body as HTML
+- `html` (str, optional) - Email body as HTML (optional if `text` is provided)
+- `text` (str, optional) - Email body as plain text (optional if `html` is provided)
 - `from_email` (str, optional) - Sender address. Falls back to `EMAIL_FROM` env var
-- `provider` ("auto" | "resend", optional) - Provider to use (default: "auto")
+- `provider` ("auto" | "resend" | "gmail", optional) - Provider to use (default: "auto")
+- `cc` (str | list[str], optional) - CC recipient(s)
+- `bcc` (str | list[str], optional) - BCC recipient(s)
+- `reply_to` (str | list[str], optional) - Reply-to address(es)
+- `headers` (dict[str, str], optional) - Custom email headers
 
 ### `send_budget_alert_email`
 Send a formatted budget alert notification.


### PR DESCRIPTION
## Description

Added text body, reply-to and headers support to the email tool; updated validation, tests and docs.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #3836

## Changes Made

- Added text, reply_to and headers support to email tool (Resend + Gmail)
- Updated validation to require at least one body type (html or text)
- Added tests and updated email tool README

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`pytest tests/tools/test_email_tool.py` (venv))
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

Notes: Core test suite had 3 failures in `tests/test_litellm_streaming.py` (real API streaming tests) likely env/credential related.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

NA
