### PR TITLE
feat(artifacts): add interactive agent output protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Hive Artifacts**: Interactive agent output protocol (#3914)
+  - JSON-based protocol for emitting structured UI components (Forms, Markdown)
+  - Schema layer with Pydantic models for Form and Markdown components
+  - TUI renderer in chat_repl.py for detecting and displaying artifacts
+  - Example agent (`artifact_demo`) demonstrating form and markdown artifacts
+  - Comprehensive unit tests for artifact schema validation
 - Initial project structure
 - React frontend (honeycomb) with Vite and TypeScript
 - Node.js backend (hive) with Express and TypeScript

--- a/core/framework/schemas/__init__.py
+++ b/core/framework/schemas/__init__.py
@@ -1,13 +1,32 @@
 """Schema definitions for runtime data."""
 
+from framework.schemas.artifact import (
+    Artifact,
+    ArtifactResponse,
+    ArtifactType,
+    FormComponent,
+    FormField,
+    FormFieldType,
+    MarkdownComponent,
+)
 from framework.schemas.decision import Decision, DecisionEvaluation, Option, Outcome
 from framework.schemas.run import Problem, Run, RunSummary
 
 __all__ = [
+    # Artifact schemas
+    "Artifact",
+    "ArtifactResponse",
+    "ArtifactType",
+    "FormComponent",
+    "FormField",
+    "FormFieldType",
+    "MarkdownComponent",
+    # Decision schemas
     "Decision",
     "Option",
     "Outcome",
     "DecisionEvaluation",
+    # Run schemas
     "Run",
     "RunSummary",
     "Problem",

--- a/core/framework/schemas/artifact.py
+++ b/core/framework/schemas/artifact.py
@@ -1,0 +1,352 @@
+"""
+Artifact Schema - Interactive Agent Output Protocol.
+
+This module defines the schema for Hive Artifacts, a lightweight JSON-based
+protocol that allows agents to emit interactive widgets (Forms, Charts, Mini-Apps)
+directly into the output stream.
+
+Key Concept: The agent emits a structured JSON block (the "Artifact") that
+describes what to render. The client (TUI, Web, or IDE Extension) is responsible
+for rendering it.
+
+Benefits:
+1. Visual & Engaging: Agents generate their own UI on the fly
+2. Lightweight: No extra servers, ports, or state databases
+3. Cloud-Native: In headless environments, the UI is just readable JSON logs
+4. Autonomous: The agent decides when to show a UI
+"""
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class ArtifactType(StrEnum):
+    """Types of interactive components an agent can emit."""
+
+    FORM = "form"
+    MARKDOWN = "markdown"
+    CHART = "chart"  # Future: Phase 2
+    CODE_SANDBOX = "code_sandbox"  # Future: Phase 3
+
+
+class FormFieldType(StrEnum):
+    """Types of form input fields."""
+
+    TEXT = "text"
+    SELECT = "select"
+    CHECKBOX = "checkbox"
+    TEXTAREA = "textarea"
+    NUMBER = "number"
+
+
+class FormField(BaseModel):
+    """Definition of a single form field.
+
+    Examples:
+        Text input:
+            FormField(name="username", type="text", label="Username", required=True)
+
+        Select/dropdown:
+            FormField(
+                name="env",
+                type="select",
+                label="Environment",
+                options=["staging", "production"],
+                default="staging"
+            )
+
+        Checkbox:
+            FormField(
+                name="confirm",
+                type="checkbox",
+                label="I understand the risks"
+            )
+    """
+
+    name: str = Field(description="Field identifier (used as key in response)")
+    type: FormFieldType = Field(description="Type of input field")
+    label: str = Field(description="Human-readable label")
+    options: list[str] = Field(
+        default_factory=list,
+        description="Options for select fields (required if type=select)",
+    )
+    required: bool = Field(default=True, description="Whether field is required")
+    default: str | int | bool | None = Field(
+        default=None, description="Default value for the field"
+    )
+    placeholder: str | None = Field(
+        default=None, description="Placeholder text for input fields"
+    )
+    help_text: str | None = Field(
+        default=None, description="Additional help text for the field"
+    )
+
+    model_config = {"extra": "forbid"}
+
+
+class FormComponent(BaseModel):
+    """Interactive form for structured user input.
+
+    The agent can emit a form to collect structured data from the user.
+    When the user submits the form, the client sends the data back to the
+    agent as a response.
+
+    Example:
+        ```python
+        form = FormComponent(
+            title="Confirm Deployment",
+            description="Select deployment environment and confirm",
+            fields=[
+                FormField(
+                    name="env",
+                    type="select",
+                    label="Environment",
+                    options=["staging", "production"]
+                ),
+                FormField(
+                    name="confirm",
+                    type="checkbox",
+                    label="I understand the risks"
+                ),
+            ],
+            submit_label="Deploy Now"
+        )
+        ```
+
+        User response:
+        ```json
+        {
+            "env": "production",
+            "confirm": true
+        }
+        ```
+    """
+
+    title: str = Field(description="Form title")
+    description: str | None = Field(
+        default=None, description="Optional form description"
+    )
+    fields: list[FormField] = Field(
+        description="List of form fields", min_length=1
+    )
+    submit_label: str = Field(
+        default="Submit", description="Label for submit button"
+    )
+    cancel_label: str | None = Field(
+        default=None, description="Label for cancel button (if cancelable)"
+    )
+
+    model_config = {"extra": "forbid"}
+
+
+class MarkdownComponent(BaseModel):
+    """Rich text content using Markdown.
+
+    The agent can emit markdown for formatted text output including:
+    - Headings, lists, tables
+    - Code blocks with syntax highlighting
+    - Links, images, emphasis
+    - Blockquotes, horizontal rules
+
+    Example:
+        ```python
+        md = MarkdownComponent(
+            content='''
+# Analysis Results
+
+The deployment was successful with the following metrics:
+
+| Metric | Value |
+|--------|-------|
+| Uptime | 99.9% |
+| Errors | 0     |
+
+**Status**: ✓ All systems operational
+            '''
+        )
+        ```
+    """
+
+    content: str = Field(description="Markdown-formatted text content")
+
+    model_config = {"extra": "forbid"}
+
+
+class ChartComponent(BaseModel):
+    """Simple data visualization (Future: Phase 2).
+
+    Placeholder for future chart support (Bar, Line, Pie charts).
+    """
+
+    chart_type: str = Field(description="Type of chart: bar, line, pie")
+    data: dict[str, Any] = Field(description="Chart data")
+    title: str | None = Field(default=None, description="Chart title")
+
+    model_config = {"extra": "forbid"}
+
+
+class CodeSandboxComponent(BaseModel):
+    """Code snippet viewer/editor (Future: Phase 3).
+
+    Placeholder for future code sandbox support.
+    """
+
+    code: str = Field(description="Code content")
+    language: str = Field(description="Programming language")
+    filename: str | None = Field(default=None, description="Optional filename")
+    editable: bool = Field(default=False, description="Whether code is editable")
+
+    model_config = {"extra": "forbid"}
+
+
+class Artifact(BaseModel):
+    """An interactive widget emitted by an agent.
+
+    The agent emits artifacts as structured JSON to stdout. The client
+    (TUI, Web, IDE) detects artifacts by the `type: "artifact"` field
+    and renders them appropriately.
+
+    The "UI is in the Logs" concept: Since the UI definition is stateless
+    JSON, you can "replay" an interaction just by reading the logs.
+
+    Example JSON output:
+        ```json
+        {
+            "type": "artifact",
+            "id": "deployment-form-01",
+            "component": "form",
+            "props": {
+                "title": "Confirm Deployment",
+                "fields": [
+                    {
+                        "name": "env",
+                        "type": "select",
+                        "label": "Environment",
+                        "options": ["staging", "prod"]
+                    }
+                ]
+            }
+        }
+        ```
+
+    Client Response (when user interacts):
+        ```json
+        {
+            "artifact_id": "deployment-form-01",
+            "action": "submit",
+            "data": {
+                "env": "prod"
+            }
+        }
+        ```
+    """
+
+    type: Literal["artifact"] = Field(
+        default="artifact",
+        description="Must be 'artifact' for detection by clients",
+    )
+    id: str = Field(
+        description="Unique identifier for this artifact instance"
+    )
+    component: ArtifactType = Field(
+        description="Type of component to render"
+    )
+    props: FormComponent | MarkdownComponent | ChartComponent | CodeSandboxComponent = Field(
+        description="Component-specific properties",
+        discriminator="__artifact_component_type__",  # Will be set by component type
+    )
+    timestamp: datetime = Field(
+        default_factory=datetime.now,
+        description="When this artifact was emitted",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Optional metadata for client use",
+    )
+
+    model_config = {"extra": "forbid"}
+
+    @classmethod
+    def create_form(
+        cls,
+        id: str,
+        title: str,
+        fields: list[FormField],
+        description: str | None = None,
+        submit_label: str = "Submit",
+    ) -> "Artifact":
+        """Convenience method to create a form artifact.
+
+        Example:
+            ```python
+            artifact = Artifact.create_form(
+                id="deploy-form",
+                title="Deploy Application",
+                fields=[
+                    FormField(name="env", type="select", label="Environment",
+                              options=["staging", "prod"]),
+                ],
+                submit_label="Deploy Now"
+            )
+            print(artifact.model_dump_json())  # Emit to stdout
+            ```
+        """
+        return cls(
+            id=id,
+            component=ArtifactType.FORM,
+            props=FormComponent(
+                title=title,
+                description=description,
+                fields=fields,
+                submit_label=submit_label,
+            ),
+        )
+
+    @classmethod
+    def create_markdown(
+        cls,
+        id: str,
+        content: str,
+    ) -> "Artifact":
+        """Convenience method to create a markdown artifact.
+
+        Example:
+            ```python
+            artifact = Artifact.create_markdown(
+                id="report-md",
+                content="# Report\\n\\nAnalysis complete."
+            )
+            print(artifact.model_dump_json())  # Emit to stdout
+            ```
+        """
+        return cls(
+            id=id,
+            component=ArtifactType.MARKDOWN,
+            props=MarkdownComponent(content=content),
+        )
+
+
+class ArtifactResponse(BaseModel):
+    """User response to an artifact interaction.
+
+    When a user interacts with an artifact (e.g., submits a form),
+    the client sends this response back to the agent.
+    """
+
+    artifact_id: str = Field(description="ID of the artifact being responded to")
+    action: str = Field(
+        description="Action taken: 'submit', 'cancel', 'edit', etc."
+    )
+    data: dict[str, Any] = Field(
+        default_factory=dict,
+        description="User-provided data (e.g., form field values)",
+    )
+    timestamp: datetime = Field(
+        default_factory=datetime.now,
+        description="When the response was generated",
+    )
+
+    model_config = {"extra": "forbid"}

--- a/core/tests/test_artifact_schema.py
+++ b/core/tests/test_artifact_schema.py
@@ -1,0 +1,412 @@
+"""Tests for artifact schema validation and serialization."""
+
+import json
+from datetime import datetime
+
+import pytest
+
+from framework.schemas.artifact import (
+    Artifact,
+    ArtifactResponse,
+    ArtifactType,
+    FormComponent,
+    FormField,
+    FormFieldType,
+    MarkdownComponent,
+)
+
+
+class TestFormField:
+    """Test FormField validation."""
+
+    def test_create_text_field(self):
+        """Test creating a text input field."""
+        field = FormField(
+            name="username",
+            type=FormFieldType.TEXT,
+            label="Username",
+            required=True,
+            placeholder="Enter your username",
+        )
+        assert field.name == "username"
+        assert field.type == FormFieldType.TEXT
+        assert field.required is True
+        assert field.placeholder == "Enter your username"
+
+    def test_create_select_field(self):
+        """Test creating a select/dropdown field."""
+        field = FormField(
+            name="environment",
+            type=FormFieldType.SELECT,
+            label="Environment",
+            options=["staging", "production"],
+            default="staging",
+        )
+        assert field.name == "environment"
+        assert field.type == FormFieldType.SELECT
+        assert field.options == ["staging", "production"]
+        assert field.default == "staging"
+
+    def test_create_checkbox_field(self):
+        """Test creating a checkbox field."""
+        field = FormField(
+            name="confirm",
+            type=FormFieldType.CHECKBOX,
+            label="I agree to terms",
+            default=False,
+        )
+        assert field.name == "confirm"
+        assert field.type == FormFieldType.CHECKBOX
+        assert field.default is False
+
+    def test_field_defaults(self):
+        """Test default values for optional fields."""
+        field = FormField(
+            name="test",
+            type=FormFieldType.TEXT,
+            label="Test",
+        )
+        assert field.required is True  # Default
+        assert field.default is None
+        assert field.placeholder is None
+        assert field.help_text is None
+        assert field.options == []
+
+    def test_field_json_serialization(self):
+        """Test JSON serialization of FormField."""
+        field = FormField(
+            name="env",
+            type=FormFieldType.SELECT,
+            label="Environment",
+            options=["dev", "prod"],
+        )
+        json_data = field.model_dump()
+        assert json_data["name"] == "env"
+        assert json_data["type"] == "select"
+        assert json_data["options"] == ["dev", "prod"]
+
+
+class TestFormComponent:
+    """Test FormComponent validation."""
+
+    def test_create_basic_form(self):
+        """Test creating a basic form."""
+        form = FormComponent(
+            title="User Registration",
+            fields=[
+                FormField(name="name", type=FormFieldType.TEXT, label="Name"),
+                FormField(name="email", type=FormFieldType.TEXT, label="Email"),
+            ],
+        )
+        assert form.title == "User Registration"
+        assert len(form.fields) == 2
+        assert form.submit_label == "Submit"  # Default
+
+    def test_form_with_description(self):
+        """Test form with description."""
+        form = FormComponent(
+            title="Deploy App",
+            description="Select environment and confirm deployment",
+            fields=[
+                FormField(
+                    name="env",
+                    type=FormFieldType.SELECT,
+                    label="Environment",
+                    options=["staging", "prod"],
+                ),
+            ],
+            submit_label="Deploy Now",
+        )
+        assert form.description == "Select environment and confirm deployment"
+        assert form.submit_label == "Deploy Now"
+
+    def test_form_requires_fields(self):
+        """Test that form requires at least one field."""
+        with pytest.raises(ValueError):
+            FormComponent(title="Empty Form", fields=[])
+
+    def test_form_json_serialization(self):
+        """Test JSON serialization of FormComponent."""
+        form = FormComponent(
+            title="Test Form",
+            fields=[
+                FormField(name="field1", type=FormFieldType.TEXT, label="Field 1"),
+            ],
+        )
+        json_data = form.model_dump()
+        assert json_data["title"] == "Test Form"
+        assert len(json_data["fields"]) == 1
+
+
+class TestMarkdownComponent:
+    """Test MarkdownComponent validation."""
+
+    def test_create_markdown(self):
+        """Test creating a markdown component."""
+        md = MarkdownComponent(content="# Hello World\n\nThis is **bold** text.")
+        assert "# Hello World" in md.content
+        assert "**bold**" in md.content
+
+    def test_markdown_with_code_block(self):
+        """Test markdown with code blocks."""
+        md = MarkdownComponent(
+            content="""
+# Code Example
+
+```python
+def hello():
+    print("Hello, World!")
+```
+"""
+        )
+        assert "```python" in md.content
+
+    def test_markdown_json_serialization(self):
+        """Test JSON serialization of MarkdownComponent."""
+        md = MarkdownComponent(content="# Test")
+        json_data = md.model_dump()
+        assert json_data["content"] == "# Test"
+
+
+class TestArtifact:
+    """Test Artifact model."""
+
+    def test_create_form_artifact(self):
+        """Test creating a form artifact."""
+        artifact = Artifact(
+            id="form-001",
+            component=ArtifactType.FORM,
+            props=FormComponent(
+                title="Test Form",
+                fields=[
+                    FormField(name="test", type=FormFieldType.TEXT, label="Test"),
+                ],
+            ),
+        )
+        assert artifact.type == "artifact"
+        assert artifact.id == "form-001"
+        assert artifact.component == ArtifactType.FORM
+        assert isinstance(artifact.props, FormComponent)
+
+    def test_create_markdown_artifact(self):
+        """Test creating a markdown artifact."""
+        artifact = Artifact(
+            id="md-001",
+            component=ArtifactType.MARKDOWN,
+            props=MarkdownComponent(content="# Test"),
+        )
+        assert artifact.id == "md-001"
+        assert artifact.component == ArtifactType.MARKDOWN
+        assert isinstance(artifact.props, MarkdownComponent)
+
+    def test_artifact_has_timestamp(self):
+        """Test that artifact has a timestamp."""
+        artifact = Artifact(
+            id="test",
+            component=ArtifactType.MARKDOWN,
+            props=MarkdownComponent(content="test"),
+        )
+        assert isinstance(artifact.timestamp, datetime)
+
+    def test_artifact_json_serialization(self):
+        """Test full JSON serialization of artifact."""
+        artifact = Artifact(
+            id="deploy-form",
+            component=ArtifactType.FORM,
+            props=FormComponent(
+                title="Deploy",
+                fields=[
+                    FormField(
+                        name="env",
+                        type=FormFieldType.SELECT,
+                        label="Environment",
+                        options=["staging", "prod"],
+                    ),
+                ],
+            ),
+        )
+
+        # Test model_dump (dict)
+        data = artifact.model_dump()
+        assert data["type"] == "artifact"
+        assert data["id"] == "deploy-form"
+        assert data["component"] == "form"
+        assert "props" in data
+
+        # Test model_dump_json (JSON string)
+        json_str = artifact.model_dump_json()
+        parsed = json.loads(json_str)
+        assert parsed["type"] == "artifact"
+        assert parsed["component"] == "form"
+
+    def test_artifact_json_deserialization(self):
+        """Test parsing artifact from JSON."""
+        json_data = {
+            "type": "artifact",
+            "id": "test-form",
+            "component": "form",
+            "props": {
+                "title": "Test",
+                "fields": [
+                    {
+                        "name": "field1",
+                        "type": "text",
+                        "label": "Field 1",
+                        "options": [],
+                        "required": True,
+                        "default": None,
+                        "placeholder": None,
+                        "help_text": None,
+                    }
+                ],
+                "description": None,
+                "submit_label": "Submit",
+                "cancel_label": None,
+            },
+            "timestamp": "2026-02-07T16:00:00",
+            "metadata": {},
+        }
+
+        artifact = Artifact.model_validate(json_data)
+        assert artifact.id == "test-form"
+        assert artifact.component == ArtifactType.FORM
+
+    def test_create_form_convenience_method(self):
+        """Test Artifact.create_form() convenience method."""
+        artifact = Artifact.create_form(
+            id="quick-form",
+            title="Quick Form",
+            fields=[
+                FormField(name="name", type=FormFieldType.TEXT, label="Name"),
+            ],
+            submit_label="Go",
+        )
+        assert artifact.id == "quick-form"
+        assert artifact.component == ArtifactType.FORM
+        assert isinstance(artifact.props, FormComponent)
+        assert artifact.props.title == "Quick Form"
+        assert artifact.props.submit_label == "Go"
+
+    def test_create_markdown_convenience_method(self):
+        """Test Artifact.create_markdown() convenience method."""
+        artifact = Artifact.create_markdown(
+            id="quick-md",
+            content="# Quick Markdown",
+        )
+        assert artifact.id == "quick-md"
+        assert artifact.component == ArtifactType.MARKDOWN
+        assert isinstance(artifact.props, MarkdownComponent)
+        assert artifact.props.content == "# Quick Markdown"
+
+
+class TestArtifactResponse:
+    """Test ArtifactResponse model."""
+
+    def test_create_submit_response(self):
+        """Test creating a form submission response."""
+        response = ArtifactResponse(
+            artifact_id="form-001",
+            action="submit",
+            data={"env": "production", "confirm": True},
+        )
+        assert response.artifact_id == "form-001"
+        assert response.action == "submit"
+        assert response.data["env"] == "production"
+        assert response.data["confirm"] is True
+
+    def test_create_cancel_response(self):
+        """Test creating a cancel response."""
+        response = ArtifactResponse(
+            artifact_id="form-001",
+            action="cancel",
+            data={},
+        )
+        assert response.action == "cancel"
+        assert response.data == {}
+
+    def test_response_json_serialization(self):
+        """Test JSON serialization of response."""
+        response = ArtifactResponse(
+            artifact_id="test",
+            action="submit",
+            data={"key": "value"},
+        )
+        json_data = response.model_dump()
+        assert json_data["artifact_id"] == "test"
+        assert json_data["action"] == "submit"
+        assert json_data["data"]["key"] == "value"
+
+
+class TestArtifactExamples:
+    """Test real-world artifact examples from the issue."""
+
+    def test_deployment_form_example(self):
+        """
+        Test the deployment form example from issue #3914.
+
+        Example from issue:
+        {
+          "type": "artifact",
+          "id": "deployment-form-01",
+          "component": "form",
+          "props": {
+            "title": "Confirm Deployment",
+            "fields": [
+              {"name": "env", "type": "select", "options": ["staging", "prod"]},
+              {"name": "confirm", "type": "checkbox", "label": "I understand the risks"}
+            ]
+          }
+        }
+        """
+        artifact = Artifact.create_form(
+            id="deployment-form-01",
+            title="Confirm Deployment",
+            fields=[
+                FormField(
+                    name="env",
+                    type=FormFieldType.SELECT,
+                    label="Environment",
+                    options=["staging", "prod"],
+                ),
+                FormField(
+                    name="confirm",
+                    type=FormFieldType.CHECKBOX,
+                    label="I understand the risks",
+                ),
+            ],
+        )
+
+        # Verify structure
+        assert artifact.id == "deployment-form-01"
+        json_str = artifact.model_dump_json()
+        parsed = json.loads(json_str)
+
+        assert parsed["type"] == "artifact"
+        assert parsed["component"] == "form"
+        assert len(parsed["props"]["fields"]) == 2
+        assert parsed["props"]["fields"][0]["name"] == "env"
+        assert parsed["props"]["fields"][1]["name"] == "confirm"
+
+    def test_analysis_report_markdown(self):
+        """Test creating an analysis report with markdown."""
+        report = """
+# Analysis Results
+
+The deployment was successful with the following metrics:
+
+| Metric | Value |
+|--------|-------|
+| Uptime | 99.9% |
+| Errors | 0     |
+
+**Status**: ✓ All systems operational
+"""
+        artifact = Artifact.create_markdown(
+            id="report-001",
+            content=report,
+        )
+
+        assert "Analysis Results" in artifact.props.content
+        assert "99.9%" in artifact.props.content
+        json_str = artifact.model_dump_json()
+        assert "Analysis Results" in json_str

--- a/examples/templates/artifact_demo/README.md
+++ b/examples/templates/artifact_demo/README.md
@@ -1,0 +1,54 @@
+# Artifact Demo Agent
+
+This example agent demonstrates the **Hive Artifacts** feature - an interactive agent output protocol that allows agents to emit structured UI components.
+
+## What it Does
+
+The agent showcases two artifact types:
+
+1. **Markdown Artifacts**: Display rich formatted content with headings, tables, and styling
+2. **Form Artifacts**: Collect structured user input with various field types (text, select, checkbox)
+
+## Flow
+
+1. **Welcome**: Displays a markdown artifact with introduction
+2. **Request Info**: Emits a form artifact asking for deployment configuration
+3. **Process**: Receives form submission and processes it
+4. **Results**: Shows formatted results in a markdown artifact
+
+## Running the Agent
+
+```bash
+# Using TUI (recommended to see artifacts)
+hive tui
+
+# Then select "artifact_demo" from the list
+```
+
+## Artifact Protocol
+
+Artifacts are emitted as JSON with the following structure:
+
+```json
+{
+  "type": "artifact",
+  "id": "unique-id",
+  "component": "form" | "markdown",
+  "props": { /* component-specific properties */ }
+}
+```
+
+The TUI detects these JSON blocks and renders them as interactive widgets instead of plain text.
+
+## Benefits
+
+-  **Visual & Engaging**: Agents can create rich UIs on the fly
+- ⚡ **Lightweight**: No servers, just JSON in logs
+-  **Cloud-Native**: Works in headless environments (readable JSON) and interactive clients (rendered widgets)
+-  **Autonomous**: Agent decides when to show UI
+
+## Learn More
+
+- See `core/framework/schemas/artifact.py` for schema definitions
+- See `core/framework/tui/widgets/chat_repl.py` for TUI rendering logic
+- See GitHub Issue #3914 for the full feature proposal

--- a/examples/templates/artifact_demo/agent.json
+++ b/examples/templates/artifact_demo/agent.json
@@ -1,0 +1,14 @@
+{
+    "name": "artifact_demo",
+    "description": "Demonstrates Hive Artifacts with interactive forms and markdown output",
+    "version": "1.0.0",
+    "entry_point": "agent.py",
+    "goal": "artifact_demo",
+    "required_tools": [],
+    "tags": [
+        "demo",
+        "artifacts",
+        "interactive",
+        "ui"
+    ]
+}

--- a/examples/templates/artifact_demo/agent.py
+++ b/examples/templates/artifact_demo/agent.py
@@ -1,0 +1,299 @@
+"""
+Artifact Demo Agent - Demonstrates Hive Artifacts feature.
+
+This agent showcases the interactive agent output protocol by emitting
+form and markdown artifacts instead of plain text.
+"""
+
+import json
+from datetime import datetime
+
+from framework.graph import GraphSpec, Edge, EventLoopNode
+from framework.goal import Goal
+from framework.schemas.artifact import Artifact, FormField, FormFieldType
+
+
+# ============================================================================
+# Goal Definition
+# ============================================================================
+
+goal = Goal(
+    name="Artifact Demo",
+    description="Demonstrate Hive Artifacts with interactive forms and markdown output",
+    success_criteria=[
+        "Agent emits a form artifact for user input",
+        "Agent receives and processes form submission",
+        "Agent emits a markdown artifact with formatted results",
+    ],
+    constraints=[
+        "Use Hive Artifacts protocol (JSON with type='artifact')",
+        "Support both form and markdown components",
+    ],
+)
+
+
+# ============================================================================
+# Node Definitions
+# ============================================================================
+
+welcome_node = EventLoopNode(
+    id="welcome",
+    name="Welcome Message",
+    description="Show welcome message with markdown artifact",
+    input_keys=["user_input"],
+    output_keys=["welcome_message"],
+    client_facing=False,
+)
+
+request_deployment_info = EventLoopNode(
+    id="request_deployment",
+    name="Request Deployment Information",
+    description="Emit a form artifact to collect deployment details from user",
+    input_keys=["welcome_message"],
+    output_keys=["deployment_form"],
+    client_facing=False,
+)
+
+process_deployment = EventLoopNode(
+    id="process_deployment",
+    name="Process Deployment",
+    description="Process the deployment form submission and emit confirmation",
+    input_keys=["deployment_form", "user_response"],
+    output_keys=["deployment_result"],
+    client_facing=True,  # Waits for user input (form submission)
+)
+
+show_results = EventLoopNode(
+    id="show_results",
+    name="Show Results",
+    description="Display deployment results using markdown artifact",
+    input_keys=["deployment_result"],
+    output_keys=["final_report"],
+    client_facing=False,
+)
+
+
+# ============================================================================
+# Graph Structure
+# ============================================================================
+
+nodes = [
+    welcome_node,
+    request_deployment_info,
+    process_deployment,
+    show_results,
+]
+
+edges = [
+    Edge(from_node="welcome", to_node="request_deployment"),
+    Edge(from_node="request_deployment", to_node="process_deployment"),
+    Edge(from_node="process_deployment", to_node="show_results"),
+]
+
+graph = GraphSpec(
+    name="artifact_demo",
+    description="Demo agent for Hive Artifacts",
+    nodes=nodes,
+    edges=edges,
+    entry_node="welcome",
+    terminal_nodes=["show_results"],
+)
+
+
+# ============================================================================
+# Node Implementations
+# ============================================================================
+
+
+async def execute_welcome(context: dict) -> dict:
+    """Show welcome message with markdown artifact."""
+
+    welcome_md = """
+# 🎯 Hive Artifacts Demo
+
+Welcome to the **Hive Artifacts** demonstration!
+
+This agent will showcase the new interactive output protocol by:
+
+1. Displaying this **Markdown** artifact
+2. Emitting a **Form** artifact for you to fill out
+3. Processing your submission
+4. Showing formatted results
+
+Let's get started! 👇
+"""
+
+    artifact = Artifact.create_markdown(
+        id="welcome-md-001",
+        content=welcome_md,
+    )
+
+    # Emit artifact as JSON
+    artifact_json = artifact.model_dump_json()
+
+    return {
+        "welcome_message": artifact_json,
+        "output_string": artifact_json,
+    }
+
+
+async def execute_request_deployment(context: dict) -> dict:
+    """Emit a form artifact to collect deployment information."""
+
+    artifact = Artifact.create_form(
+        id="deployment-form-001",
+        title="Deployment Configuration",
+        description="Please configure your deployment settings below:",
+        fields=[
+            FormField(
+                name="environment",
+                type=FormFieldType.SELECT,
+                label="Target Environment",
+                options=["development", "staging", "production"],
+                default="staging",
+                required=True,
+                help_text="Select the environment to deploy to",
+            ),
+            FormField(
+                name="branch",
+                type=FormFieldType.TEXT,
+                label="Git Branch",
+                default="main",
+                required=True,
+                placeholder="e.g., main, develop, feature/xyz",
+            ),
+            FormField(
+                name="run_tests",
+                type=FormFieldType.CHECKBOX,
+                label="Run tests before deployment",
+                default=True,
+                required=False,
+            ),
+            FormField(
+                name="confirm",
+                type=FormFieldType.CHECKBOX,
+                label="I understand this will deploy to the selected environment",
+                required=True,
+            ),
+        ],
+        submit_label="Deploy Now",
+    )
+
+    artifact_json = artifact.model_dump_json()
+
+    return {
+        "deployment_form": artifact_json,
+        "output_string": artifact_json,
+    }
+
+
+async def execute_process_deployment(context: dict) -> dict:
+    """Process the deployment form submission."""
+
+    # In a real agent, user_response would contain the form data
+    # For this demo, we simulate processing
+
+    user_response = context.get("user_input", "{}")
+
+    try:
+        form_data = (
+            json.loads(user_response)
+            if isinstance(user_response, str)
+            else user_response
+        )
+    except json.JSONDecodeError:
+        form_data = {
+            "environment": "staging",
+            "branch": "main",
+            "run_tests": True,
+            "confirm": True,
+        }
+
+    # Simulate deployment
+    deployment_info = {
+        "environment": form_data.get("environment", "staging"),
+        "branch": form_data.get("branch", "main"),
+        "run_tests": form_data.get("run_tests", True),
+        "timestamp": datetime.now().isoformat(),
+        "status": "success",
+    }
+
+    return {
+        "deployment_result": json.dumps(deployment_info),
+        "output_string": "Processing deployment...",
+    }
+
+
+async def execute_show_results(context: dict) -> dict:
+    """Display deployment results using markdown artifact."""
+
+    deployment_result = context.get("deployment_result", "{}")
+
+    try:
+        result_data = (
+            json.loads(deployment_result)
+            if isinstance(deployment_result, str)
+            else deployment_result
+        )
+    except json.JSONDecodeError:
+        result_data = {"status": "unknown"}
+
+    results_md = f"""
+# ✅ Deployment Complete
+
+Your deployment has been successfully completed!
+
+## Deployment Summary
+
+| Parameter | Value |
+|-----------|-------|
+| Environment | **{result_data.get("environment", "N/A")}** |
+| Branch | `{result_data.get("branch", "N/A")}` |
+| Tests Run | {"Yes ✓" if result_data.get("run_tests") else "No ✗"} |
+| Status | **{result_data.get("status", "unknown").upper()}** |
+| Timestamp | {result_data.get("timestamp", "N/A")} |
+
+---
+
+## Next Steps
+
+1. Monitor the deployment logs
+2. Verify application health checks
+3. Test critical user flows
+4. Roll back if any issues detected
+
+**Thank you for using Hive Artifacts!** 🚀
+"""
+
+    artifact = Artifact.create_markdown(
+        id="results-md-001",
+        content=results_md,
+    )
+
+    artifact_json = artifact.model_dump_json()
+
+    return {
+        "final_report": artifact_json,
+        "output_string": artifact_json,
+    }
+
+
+# Register node executors
+welcome_node.executor = execute_welcome
+request_deployment_info.executor = execute_request_deployment
+process_deployment.executor = execute_process_deployment
+show_results.executor = execute_show_results
+
+
+# ============================================================================
+# Entry Points
+# ============================================================================
+
+# Standard entry point for conversation-style interaction
+entry_points = [
+    {
+        "id": "main",
+        "entry_node": "welcome",
+        "description": "Main entry point - demonstrates artifact protocol",
+    }
+]


### PR DESCRIPTION
This PR implements Phase 1 of Hive Artifacts (#3914) - a lightweight JSON-based protocol that enables agents to emit interactive widgets (Forms, Markdown) directly into the output stream.

Core Concept: Agents emit structured JSON artifacts describing UI components. Clients (TUI, Web, IDE) detect these artifacts and render them as interactive widgets instead of plain text. This "UI is in the Logs" approach makes interactions stateless, replayable, and cloud-native.

Type of Change
 New feature (non-breaking change that adds functionality)
 Documentation update
Related Issues
Relates to #3914

Changes Made
Schema Layer (
core/framework/schemas/artifact.py
)
Added Pydantic models for artifact protocol with Form and Markdown components
Convenience methods: Artifact.create_form() and Artifact.create_markdown()
Full JSON serialization/deserialization support
TUI Integration (
core/framework/tui/widgets/chat_repl.py
)
Extended chat REPL to detect and render artifacts via JSON pattern matching
Text-based form display with JSON response interface
Markdown content rendering with formatting
Testing (
core/tests/test_artifact_schema.py
)
300+ lines of comprehensive unit tests
Coverage for all component types and field validations
Real-world examples from GitHub issue
Example Agent (examples/templates/artifact_demo/)
Complete demonstration showing markdown and form artifacts
Deployment configuration workflow example
Documentation
Updated CHANGELOG.md
Comprehensive README and docstrings
Testing
 Unit tests created (300+ lines)
 Code follows style guidelines
 Documentation updated
 Example agent for manual testing
 Backward compatible
Benefits
- Visual & Engaging: Agents can create rich UIs on the fly
-  Lightweight: No extra servers, just JSON in logs
- Cloud-Native: Works in headless and interactive environments
-  Stateless & Replayable: Complete UI definition in logs
Example Usage :
# Agent emits a form artifact
artifact = Artifact.create_form(
    id="deploy-form",
    title="Deployment Configuration",
    fields=[
        FormField(name="env", type="select", options=["staging", "prod"]),
        FormField(name="confirm", type="checkbox", label="I understand")
    ]
)
print(artifact.model_dump_json())