### PR TITLE
fix(credentials): correctly resolve integration_id in AdenCredentialResponse.from_dict

### DIFF
--- a/core/framework/credentials/aden/client.py
+++ b/core/framework/credentials/aden/client.py
@@ -139,18 +139,15 @@ class AdenCredentialResponse:
     metadata: dict[str, Any] = field(default_factory=dict)
     """Additional integration-specific metadata."""
 
-
     @classmethod
     def from_dict(
         cls, data: dict[str, Any], integration_id: str | None = None
-    ) -> "AdenCredentialResponse":
+    ) -> AdenCredentialResponse:
         """Create from API response dictionary or normalized credential dict."""
 
         expires_at = None
         if data.get("expires_at"):
-            expires_at = datetime.fromisoformat(
-                data["expires_at"].replace("Z", "+00:00")
-            )
+            expires_at = datetime.fromisoformat(data["expires_at"].replace("Z", "+00:00"))
 
         resolved_integration_id = (
             integration_id
@@ -159,10 +156,7 @@ class AdenCredentialResponse:
             or data.get("provider", "")
         )
 
-        resolved_integration_type = (
-            data.get("integration_type")
-            or data.get("provider", "")
-            )
+        resolved_integration_type = data.get("integration_type") or data.get("provider", "")
         metadata = data.get("metadata")
         if metadata is None and data.get("email"):
             metadata = {"email": data.get("email")}
@@ -178,7 +172,6 @@ class AdenCredentialResponse:
             scopes=data.get("scopes", []),
             metadata=metadata,
         )
-
 
 
 @dataclass

--- a/core/framework/credentials/aden/client.py
+++ b/core/framework/credentials/aden/client.py
@@ -139,24 +139,46 @@ class AdenCredentialResponse:
     metadata: dict[str, Any] = field(default_factory=dict)
     """Additional integration-specific metadata."""
 
+
     @classmethod
     def from_dict(
         cls, data: dict[str, Any], integration_id: str | None = None
-    ) -> AdenCredentialResponse:
-        """Create from API response dictionary."""
+    ) -> "AdenCredentialResponse":
+        """Create from API response dictionary or normalized credential dict."""
+
         expires_at = None
         if data.get("expires_at"):
-            expires_at = datetime.fromisoformat(data["expires_at"].replace("Z", "+00:00"))
+            expires_at = datetime.fromisoformat(
+                data["expires_at"].replace("Z", "+00:00")
+            )
+
+        resolved_integration_id = (
+            integration_id
+            or data.get("integration_id")
+            or data.get("alias")
+            or data.get("provider", "")
+        )
+
+        resolved_integration_type = (
+            data.get("integration_type")
+            or data.get("provider", "")
+            )
+        metadata = data.get("metadata")
+        if metadata is None and data.get("email"):
+            metadata = {"email": data.get("email")}
+        if metadata is None:
+            metadata = {}
 
         return cls(
-            integration_id=integration_id or data.get("alias", data.get("provider", "")),
-            integration_type=data.get("provider", ""),
+            integration_id=resolved_integration_id,
+            integration_type=resolved_integration_type,
             access_token=data["access_token"],
             token_type=data.get("token_type", "Bearer"),
             expires_at=expires_at,
             scopes=data.get("scopes", []),
-            metadata={"email": data.get("email")} if data.get("email") else {},
+            metadata=metadata,
         )
+
 
 
 @dataclass


### PR DESCRIPTION
## Description

Fixes an issue where `AdenCredentialResponse.from_dict` ignored `integration_id` and `metadata` fields present in normalized credential responses, resulting in empty `integration_id` values and dropped metadata.
This change makes `from_dict` robust across both Aden API responses and
internal normalized credential dictionaries.

## Type of Change

- [x] Bug fix (non-breaking change)

## Related Issues

Fixes #3379

## Changes Made

- Correctly resolve `integration_id` with a clear precedence order
- Respect `integration_type` when explicitly provided
- Preserve full `metadata` payload instead of silently dropping it
- Align type annotations with Ruff expectations

## Testing

- [x] Unit tests pass (`PYTHONPATH=. python -m pytest core/framework/credentials/aden/tests`)
- [x] Lint passes (`ruff check core/framework/credentials/aden/client.py`)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Existing and new tests pass locally
