### PR TITLE
feat(utils): add proper __init__.py exports for utils module

### DIFF
--- a/core/framework/utils/__init__.py
+++ b/core/framework/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility functions for the Hive framework."""
+
+from framework.utils.io import atomic_write
+
+__all__ = ["atomic_write"]


### PR DESCRIPTION
## Summary
Add module docstring and exports to the empty `core/framework/utils/__init__.py` file for consistency with other framework modules.

Fixes #3297 

## Changes
- Add module docstring
- Export `atomic_write` function from `framework.utils.io`
- Define `__all__` for explicit public API

## Before
```python
# Empty file
```

## After
```
"""Utility functions for the Hive framework."""

from framework.utils.io import atomic_write

__all__ = ["atomic_write"]
```