### PR TITLE
feat(tools): add json_read tool for JSON file parsing with JSONPath support

### DIFF
--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -42,6 +42,7 @@ from .file_system_toolkits.view_file import register_tools as register_view_file
 from .file_system_toolkits.write_to_file import register_tools as register_write_to_file
 from .github_tool import register_tools as register_github
 from .hubspot_tool import register_tools as register_hubspot
+from .json_read_tool import register_tools as register_json_read
 from .pdf_read_tool import register_tools as register_pdf_read
 from .runtime_logs_tool import register_tools as register_runtime_logs
 from .slack_tool import register_tools as register_slack
@@ -68,6 +69,7 @@ def register_all_tools(
     register_example(mcp)
     register_web_scrape(mcp)
     register_pdf_read(mcp)
+    register_json_read(mcp)
     register_runtime_logs(mcp)
 
     # Tools that need credentials (pass credentials if provided)
@@ -97,6 +99,7 @@ def register_all_tools(
         "web_search",
         "web_scrape",
         "pdf_read",
+        "json_read",
         "view_file",
         "write_to_file",
         "list_dir",

--- a/tools/src/aden_tools/tools/json_read_tool/README.md
+++ b/tools/src/aden_tools/tools/json_read_tool/README.md
@@ -1,0 +1,37 @@
+# JSON Read Tool
+
+Read and parse JSON files with optional JSONPath extraction.
+
+## Description
+
+Returns parsed JSON content. Use for reading config files (package.json, tsconfig.json), API responses, or any structured JSON data. Supports JSONPath for extracting specific subsets.
+
+## Arguments
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `file_path` | str | Yes | - | Path to the JSON file (absolute or relative) |
+| `jsonpath` | str | No | `None` | Optional JSONPath expression (e.g. `$.users[*].name`, `$.dependencies`) |
+| `max_content_length` | int | No | `1000000` | Max file size in bytes (1KB-10MB) |
+
+## Environment Variables
+
+This tool does not require any environment variables.
+
+## Error Handling
+
+Returns error dicts for common issues:
+- `JSON file not found: <path>` - File does not exist
+- `Not a file: <path>` - Path points to a directory
+- `Not a JSON file (expected .json): <path>` - Wrong file extension
+- `File too large: <size> bytes` - Exceeds max_content_length
+- `Invalid JSON: <details>` - Malformed JSON syntax
+- `Invalid JSONPath '<expr>': <details>` - Malformed JSONPath expression
+- `Permission denied: <path>` - No read access to file
+
+## JSONPath Examples
+
+- `$` - Entire document
+- `$.dependencies` - Field "dependencies"
+- `$.users[*].name` - All "name" values from users array
+- `$..email` - All email fields recursively

--- a/tools/src/aden_tools/tools/json_read_tool/__init__.py
+++ b/tools/src/aden_tools/tools/json_read_tool/__init__.py
@@ -1,0 +1,5 @@
+"""JSON Read Tool - Parse and extract data from JSON files."""
+
+from .json_read_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/json_read_tool/json_read_tool.py
+++ b/tools/src/aden_tools/tools/json_read_tool/json_read_tool.py
@@ -1,0 +1,99 @@
+"""
+JSON Read Tool - Parse and extract data from JSON files.
+
+Reads JSON files, optionally applies JSONPath expressions to extract
+specific subsets. Use for config files, package.json, API responses, etc.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from fastmcp import FastMCP
+from jsonpath_ng import parse as jsonpath_parse
+from jsonpath_ng.exceptions import JsonPathParserError
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register JSON read tools with the MCP server."""
+
+    @mcp.tool()
+    def json_read(
+        file_path: str,
+        jsonpath: str | None = None,
+        max_content_length: int = 1_000_000,
+    ) -> dict:
+        """
+        Read and parse a JSON file, optionally extracting data with JSONPath.
+
+        Returns parsed JSON content. Use for reading config files (package.json,
+        tsconfig.json), API responses, or any structured JSON data.
+
+        Args:
+            file_path: Path to the JSON file (absolute or relative)
+            jsonpath: Optional JSONPath expression to extract a subset
+                (e.g., '$.users[*].name', '$.dependencies')
+            max_content_length: Maximum file size in bytes (1KB-10MB, for safety)
+
+        Returns:
+            Dict with parsed content and metadata, or error dict
+        """
+        try:
+            path = Path(file_path).resolve()
+
+            if not path.exists():
+                return {"error": f"JSON file not found: {file_path}"}
+
+            if not path.is_file():
+                return {"error": f"Not a file: {file_path}"}
+
+            ext = path.suffix.lower()
+            if ext != ".json":
+                return {"error": f"Not a JSON file (expected .json): {file_path}"}
+
+            file_size = path.stat().st_size
+            max_content_length = max(1024, min(max_content_length, 10_000_000))
+
+            if file_size > max_content_length:
+                return {
+                    "error": (
+                        f"File too large: {file_size} bytes. "
+                        f"max_content_length={max_content_length}. Increase max_content_length if needed."
+                    ),
+                }
+
+            with open(path, encoding="utf-8") as f:
+                data: Any = json.load(f)
+
+            result: dict[str, Any] = {
+                "path": str(path),
+                "name": path.name,
+                "file_size_bytes": file_size,
+            }
+
+            if jsonpath:
+                try:
+                    expr = jsonpath_parse(jsonpath)
+                    matches = [m.value for m in expr.find(data)]
+                    if len(matches) == 1:
+                        result["content"] = matches[0]
+                        result["jsonpath"] = jsonpath
+                    else:
+                        result["content"] = matches
+                        result["jsonpath"] = jsonpath
+                        result["match_count"] = len(matches)
+                except JsonPathParserError as e:
+                    return {"error": f"Invalid JSONPath '{jsonpath}': {e!s}"}
+            else:
+                result["content"] = data
+
+            return result
+
+        except json.JSONDecodeError as e:
+            return {"error": f"Invalid JSON: {e!s}"}
+        except PermissionError:
+            return {"error": f"Permission denied: {file_path}"}
+        except Exception as e:
+            return {"error": f"Failed to read JSON: {e!s}"}

--- a/tools/tests/tools/test_json_read_tool.py
+++ b/tools/tests/tools/test_json_read_tool.py
@@ -1,0 +1,121 @@
+"""Tests for json_read tool (FastMCP)."""
+
+from pathlib import Path
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.json_read_tool import register_tools
+
+
+@pytest.fixture
+def json_read_fn(mcp: FastMCP):
+    """Register and return the json_read tool function."""
+    register_tools(mcp)
+    return mcp._tool_manager._tools["json_read"].fn
+
+
+class TestJsonReadTool:
+    """Tests for json_read tool."""
+
+    def test_read_json_file_not_found(self, json_read_fn, tmp_path: Path):
+        """Reading non-existent JSON returns error."""
+        result = json_read_fn(file_path=str(tmp_path / "missing.json"))
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_read_json_invalid_extension(self, json_read_fn, tmp_path: Path):
+        """Reading non-JSON file returns error."""
+        txt_file = tmp_path / "test.txt"
+        txt_file.write_text('{"a": 1}')
+
+        result = json_read_fn(file_path=str(txt_file))
+
+        assert "error" in result
+        assert "not a json" in result["error"].lower()
+
+    def test_read_json_directory(self, json_read_fn, tmp_path: Path):
+        """Reading a directory returns error."""
+        result = json_read_fn(file_path=str(tmp_path))
+
+        assert "error" in result
+        assert "not a file" in result["error"].lower()
+
+    def test_read_valid_json(self, json_read_fn, sample_json: Path):
+        """Read and parse valid JSON file."""
+        result = json_read_fn(file_path=str(sample_json))
+
+        assert "error" not in result
+        assert result["content"]["users"][0]["name"] == "Alice"
+        assert result["content"]["users"][1]["age"] == 25
+        assert "path" in result
+        assert "name" in result
+
+    def test_read_json_with_jsonpath(self, json_read_fn, sample_json: Path):
+        """Extract data using JSONPath expression."""
+        result = json_read_fn(
+            file_path=str(sample_json),
+            jsonpath="$.users[*].name",
+        )
+
+        assert "error" not in result
+        assert result["content"] == ["Alice", "Bob"]
+        assert result["jsonpath"] == "$.users[*].name"
+        assert result["match_count"] == 2
+
+    def test_read_json_jsonpath_single_match(self, json_read_fn, tmp_path: Path):
+        """JSONPath with single match returns value directly."""
+        json_file = tmp_path / "test.json"
+        json_file.write_text('{"version": "1.0.0", "name": "my-app"}')
+
+        result = json_read_fn(
+            file_path=str(json_file),
+            jsonpath="$.version",
+        )
+
+        assert "error" not in result
+        assert result["content"] == "1.0.0"
+
+    def test_read_json_invalid_jsonpath(self, json_read_fn, sample_json: Path):
+        """Invalid JSONPath returns error."""
+        result = json_read_fn(
+            file_path=str(sample_json),
+            jsonpath="invalid[path",
+        )
+
+        assert "error" in result
+        assert "jsonpath" in result["error"].lower()
+
+    def test_read_json_invalid_syntax(self, json_read_fn, tmp_path: Path):
+        """Invalid JSON syntax returns error."""
+        json_file = tmp_path / "bad.json"
+        json_file.write_text("{ invalid json }")
+
+        result = json_read_fn(file_path=str(json_file))
+
+        assert "error" in result
+        assert "invalid json" in result["error"].lower()
+
+    def test_max_content_length_respected(self, json_read_fn, tmp_path: Path):
+        """File exceeding max_content_length returns error."""
+        json_file = tmp_path / "large.json"
+        json_file.write_text('{"data": "' + "x" * 2000 + '"}')
+
+        result = json_read_fn(
+            file_path=str(json_file),
+            max_content_length=1000,
+        )
+
+        assert "error" in result
+        assert "too large" in result["error"].lower()
+
+    def test_max_content_length_clamped(self, json_read_fn, sample_json: Path):
+        """max_content_length outside range is clamped."""
+        result = json_read_fn(
+            file_path=str(sample_json),
+            max_content_length=500,
+        )
+
+        assert "error" not in result
+        assert "content" in result


### PR DESCRIPTION
## Description

Adds a new `json_read` tool for parsing and extracting data from JSON files. Supports optional JSONPath queries for targeted field extraction. Suitable for reading configuration files, package manifests, and structured API responses.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Added `json_read_tool` module under `tools/src/aden_tools/tools/`
- Implemented `json_read` tool with optional JSONPath support via jsonpath-ng
- Registered the tool in `register_all_tools` and export list
- Added 10 unit tests covering validation, parsing, JSONPath, and error handling
- Added README documentation for the tool

## Testing

- [x] Unit tests pass (`cd tools && uv run pytest tests/tools/test_json_read_tool.py -v`)
- [x] Spec conformance tests pass
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A – No UI changes.