### PR TITLE
feat(runtime): introduce Execution Evidence model for safer failure i…

### DIFF
--- a/core/framework/runtime/evidence.py
+++ b/core/framework/runtime/evidence.py
@@ -1,0 +1,80 @@
+"""
+Execution Evidence Model - Separates execution attempts from observed outcomes.
+
+This module provides a lightweight model for classifying the quality of evidence
+about execution outcomes. In distributed or external tool interactions, execution
+does not imply confirmation - timeouts, retries, or partial failures may produce
+effects outside the system's observation boundary.
+
+The Execution Evidence model enables:
+- Distinguishing "executed" from "confirmed"
+- Future reconciliation for partial failures
+- Evidence-based guardrails and retry policies
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class EvidenceType(str, Enum):
+    """Classification of execution evidence quality."""
+
+    OBSERVED = "observed"  # Saw the result
+    CONFIRMED = "confirmed"  # Verified the effect
+    ASSUMED = "assumed"  # Inferred from context
+    UNKNOWN = "unknown"  # No evidence
+
+
+class ExecutionAttempt(BaseModel):
+    """
+    Records a single execution attempt with evidence classification.
+
+    Separates execution (what we tried) from observation (what we saw)
+    from confirmation (what we verified).
+
+    This enables safer failure interpretation and future reconciliation.
+
+    Example:
+        attempt = ExecutionAttempt(
+            attempt_id="node_1_attempt_2",
+            node_id="api_caller",
+        )
+
+        # ... execute ...
+
+        attempt.finished_at = datetime.now()
+        attempt.observed_result = "Success"
+        attempt.evidence_type = EvidenceType.CONFIRMED
+    """
+
+    attempt_id: str
+    node_id: str
+    step_index: int = 0  # For EventLoopNode iterations
+
+    started_at: datetime = Field(default_factory=datetime.now)
+    finished_at: Optional[datetime] = None
+
+    # What we observed
+    observed_result: Optional[str] = None
+    evidence_type: EvidenceType = EvidenceType.UNKNOWN
+
+    # Error tracking
+    error: Optional[str] = None
+    is_partial: bool = False
+
+    # Metadata
+    retry_of: Optional[str] = None  # attempt_id of previous try
+
+    @property
+    def duration_ms(self) -> int:
+        """Calculate execution duration in milliseconds."""
+        if self.finished_at is None:
+            return 0
+        delta = self.finished_at - self.started_at
+        return int(delta.total_seconds() * 1000)
+
+    model_config = {"extra": "allow"}
+

--- a/core/framework/runtime/runtime_log_schemas.py
+++ b/core/framework/runtime/runtime_log_schemas.py
@@ -11,6 +11,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from framework.runtime.evidence import ExecutionAttempt
+
 # ---------------------------------------------------------------------------
 # Level 3: Tool logs (most granular) — per step within any node
 # ---------------------------------------------------------------------------
@@ -48,6 +50,9 @@ class NodeStepLog(BaseModel):
     error: str = ""  # Error message if step failed
     stacktrace: str = ""  # Full stack trace if exception occurred
     is_partial: bool = False  # True if step didn't complete normally
+    # Execution evidence (optional, backward compatible):
+    execution_attempt: ExecutionAttempt | None = None
+    evidence_quality: str = "unknown"  # Denormalized for easy querying
 
 
 # ---------------------------------------------------------------------------

--- a/core/tests/test_execution_evidence.py
+++ b/core/tests/test_execution_evidence.py
@@ -1,0 +1,333 @@
+"""
+Unit tests for the Execution Evidence model.
+
+Tests cover:
+- EvidenceType enum values
+- ExecutionAttempt creation and properties
+- Duration calculation
+- Integration with NodeStepLog
+- Evidence classification scenarios
+"""
+
+import pytest
+from datetime import datetime, timedelta
+
+from framework.runtime.evidence import ExecutionAttempt, EvidenceType
+from framework.runtime.runtime_log_schemas import NodeStepLog
+
+
+class TestEvidenceType:
+    """Test EvidenceType enum."""
+
+    def test_evidence_types_exist(self):
+        """All evidence types should be defined."""
+        assert EvidenceType.OBSERVED == "observed"
+        assert EvidenceType.CONFIRMED == "confirmed"
+        assert EvidenceType.ASSUMED == "assumed"
+        assert EvidenceType.UNKNOWN == "unknown"
+
+    def test_evidence_type_is_string_enum(self):
+        """EvidenceType should be a string enum."""
+        assert isinstance(EvidenceType.OBSERVED.value, str)
+        assert isinstance(EvidenceType.CONFIRMED.value, str)
+
+
+class TestExecutionAttempt:
+    """Test ExecutionAttempt dataclass."""
+
+    def test_create_minimal_attempt(self):
+        """Should create attempt with minimal fields."""
+        attempt = ExecutionAttempt(
+            attempt_id="test_1",
+            node_id="test_node",
+        )
+
+        assert attempt.attempt_id == "test_1"
+        assert attempt.node_id == "test_node"
+        assert attempt.step_index == 0
+        assert attempt.evidence_type == EvidenceType.UNKNOWN
+        assert attempt.finished_at is None
+
+    def test_create_with_all_fields(self):
+        """Should create attempt with all fields."""
+        start = datetime(2024, 1, 1, 12, 0, 0)
+        end = datetime(2024, 1, 1, 12, 0, 1)
+
+        attempt = ExecutionAttempt(
+            attempt_id="test_1",
+            node_id="test_node",
+            step_index=5,
+            started_at=start,
+            finished_at=end,
+            observed_result="Success",
+            evidence_type=EvidenceType.CONFIRMED,
+            error=None,
+            is_partial=False,
+            retry_of="test_0",
+        )
+
+        assert attempt.step_index == 5
+        assert attempt.observed_result == "Success"
+        assert attempt.evidence_type == EvidenceType.CONFIRMED
+        assert attempt.retry_of == "test_0"
+
+    def test_duration_calculation(self):
+        """Should calculate duration correctly."""
+        start = datetime(2024, 1, 1, 12, 0, 0)
+        end = datetime(2024, 1, 1, 12, 0, 1, 500000)  # 1.5 seconds later
+
+        attempt = ExecutionAttempt(
+            attempt_id="test_1",
+            node_id="test_node",
+            started_at=start,
+            finished_at=end,
+        )
+
+        assert attempt.duration_ms == 1500
+
+    def test_duration_when_not_finished(self):
+        """Should return 0 when execution not finished."""
+        attempt = ExecutionAttempt(
+            attempt_id="test_1",
+            node_id="test_node",
+        )
+
+        assert attempt.duration_ms == 0
+
+    def test_set_evidence_type(self):
+        """Should allow setting evidence type."""
+        attempt = ExecutionAttempt(
+            attempt_id="test_1",
+            node_id="test_node",
+        )
+
+        attempt.evidence_type = EvidenceType.CONFIRMED
+        assert attempt.evidence_type == EvidenceType.CONFIRMED
+
+        attempt.evidence_type = EvidenceType.OBSERVED
+        assert attempt.evidence_type == EvidenceType.OBSERVED
+
+    def test_track_retry_chain(self):
+        """Should track retry relationships."""
+        first_attempt = ExecutionAttempt(
+            attempt_id="test_1",
+            node_id="test_node",
+        )
+
+        retry_attempt = ExecutionAttempt(
+            attempt_id="test_2",
+            node_id="test_node",
+            retry_of="test_1",
+        )
+
+        assert retry_attempt.retry_of == first_attempt.attempt_id
+
+    def test_partial_failure_tracking(self):
+        """Should track partial failures."""
+        attempt = ExecutionAttempt(
+            attempt_id="test_1",
+            node_id="test_node",
+            is_partial=True,
+            error="Validation failed",
+        )
+
+        assert attempt.is_partial is True
+        assert attempt.error == "Validation failed"
+
+    def test_observed_result_storage(self):
+        """Should store observed results."""
+        attempt = ExecutionAttempt(
+            attempt_id="test_1",
+            node_id="api_node",
+            observed_result="{'status': 200, 'data': {...}}",
+        )
+
+        assert "status" in attempt.observed_result
+        assert "200" in attempt.observed_result
+
+
+class TestNodeStepLogIntegration:
+    """Test integration with NodeStepLog."""
+
+    def test_add_execution_attempt_to_step_log(self):
+        """Should attach execution attempt to step log."""
+        attempt = ExecutionAttempt(
+            attempt_id="test_1",
+            node_id="api_node",
+            evidence_type=EvidenceType.CONFIRMED,
+        )
+
+        step_log = NodeStepLog(
+            node_id="api_node",
+            execution_attempt=attempt,
+            evidence_quality="confirmed",
+        )
+
+        assert step_log.execution_attempt == attempt
+        assert step_log.evidence_quality == "confirmed"
+
+    def test_step_log_without_attempt(self):
+        """Should work without execution attempt (backward compat)."""
+        step_log = NodeStepLog(
+            node_id="simple_node",
+        )
+
+        assert step_log.execution_attempt is None
+        assert step_log.evidence_quality == "unknown"
+
+    def test_step_log_with_existing_fields(self):
+        """Should work alongside existing NodeStepLog fields."""
+        attempt = ExecutionAttempt(
+            attempt_id="test_1",
+            node_id="llm_node",
+            evidence_type=EvidenceType.OBSERVED,
+        )
+
+        step_log = NodeStepLog(
+            node_id="llm_node",
+            node_type="llm_tool_use",
+            step_index=0,
+            llm_text="Generated response",
+            input_tokens=100,
+            output_tokens=50,
+            latency_ms=1500,
+            execution_attempt=attempt,
+            evidence_quality="observed",
+        )
+
+        assert step_log.node_type == "llm_tool_use"
+        assert step_log.input_tokens == 100
+        assert step_log.execution_attempt.evidence_type == EvidenceType.OBSERVED
+
+
+class TestEvidenceClassification:
+    """Test evidence classification scenarios."""
+
+    def test_classify_confirmed_success(self):
+        """Successful execution with verification should be CONFIRMED."""
+        attempt = ExecutionAttempt(
+            attempt_id="test_1",
+            node_id="api_node",
+        )
+
+        # Simulate successful verified execution
+        attempt.finished_at = datetime.now()
+        attempt.observed_result = "Success: verified in database"
+        attempt.evidence_type = EvidenceType.CONFIRMED
+
+        assert attempt.evidence_type == EvidenceType.CONFIRMED
+        assert attempt.observed_result is not None
+        assert attempt.error is None
+
+    def test_classify_observed_success(self):
+        """Successful execution without verification should be OBSERVED."""
+        attempt = ExecutionAttempt(
+            attempt_id="test_1",
+            node_id="api_node",
+        )
+
+        # Simulate successful but unverified execution
+        attempt.finished_at = datetime.now()
+        attempt.observed_result = "200 OK"
+        attempt.evidence_type = EvidenceType.OBSERVED
+
+        assert attempt.evidence_type == EvidenceType.OBSERVED
+        assert attempt.observed_result is not None
+
+    def test_classify_timeout_assumed(self):
+        """Timeout with likely success should be ASSUMED."""
+        attempt = ExecutionAttempt(
+            attempt_id="test_1",
+            node_id="slow_api",
+        )
+
+        # Simulate timeout
+        attempt.finished_at = datetime.now()
+        attempt.error = "Timeout after 30s"
+        attempt.evidence_type = EvidenceType.ASSUMED
+
+        assert attempt.evidence_type == EvidenceType.ASSUMED
+        assert "Timeout" in attempt.error
+
+    def test_classify_failure_unknown(self):
+        """Failed execution should be UNKNOWN."""
+        attempt = ExecutionAttempt(
+            attempt_id="test_1",
+            node_id="api_node",
+        )
+
+        # Simulate failure
+        attempt.finished_at = datetime.now()
+        attempt.error = "Network error"
+        attempt.evidence_type = EvidenceType.UNKNOWN
+
+        assert attempt.evidence_type == EvidenceType.UNKNOWN
+        assert attempt.error is not None
+
+    def test_classify_partial_failure(self):
+        """Partial failure should be tracked."""
+        attempt = ExecutionAttempt(
+            attempt_id="test_1",
+            node_id="validation_node",
+        )
+
+        # Simulate partial failure
+        attempt.finished_at = datetime.now()
+        attempt.observed_result = "Partial data returned"
+        attempt.evidence_type = EvidenceType.OBSERVED
+        attempt.is_partial = True
+        attempt.error = "Validation errors in fields: email, phone"
+
+        assert attempt.is_partial is True
+        assert attempt.evidence_type == EvidenceType.OBSERVED
+        assert attempt.error is not None
+
+
+class TestRetryScenarios:
+    """Test retry tracking scenarios."""
+
+    def test_first_attempt_no_retry(self):
+        """First attempt should have no retry_of."""
+        attempt = ExecutionAttempt(
+            attempt_id="node_1_attempt_1",
+            node_id="flaky_api",
+        )
+
+        assert attempt.retry_of is None
+
+    def test_retry_chain(self):
+        """Should track retry chain."""
+        attempts = []
+
+        for i in range(3):
+            attempt = ExecutionAttempt(
+                attempt_id=f"node_1_attempt_{i+1}",
+                node_id="flaky_api",
+                retry_of=f"node_1_attempt_{i}" if i > 0 else None,
+            )
+            attempts.append(attempt)
+
+        assert attempts[0].retry_of is None
+        assert attempts[1].retry_of == "node_1_attempt_1"
+        assert attempts[2].retry_of == "node_1_attempt_2"
+
+    def test_retry_with_different_evidence(self):
+        """Retries may have different evidence types."""
+        first = ExecutionAttempt(
+            attempt_id="attempt_1",
+            node_id="api",
+            evidence_type=EvidenceType.UNKNOWN,
+            error="Timeout",
+        )
+
+        retry = ExecutionAttempt(
+            attempt_id="attempt_2",
+            node_id="api",
+            retry_of="attempt_1",
+            evidence_type=EvidenceType.CONFIRMED,
+            observed_result="Success",
+        )
+
+        assert first.evidence_type == EvidenceType.UNKNOWN
+        assert retry.evidence_type == EvidenceType.CONFIRMED
+        assert retry.retry_of == first.attempt_id

--- a/docs/execution-evidence.md
+++ b/docs/execution-evidence.md
@@ -1,0 +1,83 @@
+# Execution Evidence Model
+
+## Problem
+
+In distributed or external tool interactions, execution does not imply confirmation:
+
+- **Timeouts** may hide partial success
+- **Retries** may succeed outside observation window  
+- **External APIs** may have eventual consistency
+- **Async operations** may complete after timeout
+
+## Solution
+
+The Execution Evidence model separates:
+
+1. **Execution attempt** - what we tried to do
+2. **Observed result** - what we saw happen
+3. **Evidence quality** - how confident we are
+
+## Evidence Types
+
+| Type | Meaning | Example |
+|------|---------|---------|
+| `CONFIRMED` | Verified the effect | API returned 200 + verified in DB |
+| `OBSERVED` | Saw the result | API returned 200 |
+| `ASSUMED` | Inferred from context | Timeout but likely succeeded |
+| `UNKNOWN` | No evidence | Network error |
+
+## Usage
+
+```python
+from framework.runtime.evidence import ExecutionAttempt, EvidenceType
+from datetime import datetime
+
+# Before execution
+attempt = ExecutionAttempt(
+    attempt_id="node_1_attempt_2",
+    node_id="api_caller",
+    started_at=datetime.now(),
+)
+
+# Execute
+result = await call_external_api()
+
+# Classify evidence
+attempt.finished_at = datetime.now()
+attempt.observed_result = str(result)
+
+if result.verified:
+    attempt.evidence_type = EvidenceType.CONFIRMED
+elif result.success:
+    attempt.evidence_type = EvidenceType.OBSERVED
+else:
+    attempt.evidence_type = EvidenceType.UNKNOWN
+```
+
+## Integration with Runtime Logging
+
+The `NodeStepLog` model now includes an optional `execution_attempt` field:
+
+```python
+from framework.runtime.runtime_log_schemas import NodeStepLog
+
+step_log = NodeStepLog(
+    node_id="api_caller",
+    execution_attempt=attempt,
+    evidence_quality=attempt.evidence_type.value,
+)
+```
+
+## Future Work
+
+- **Reconciliation service** - verify assumed successes
+- **Evidence-based retry policies** - retry on low confidence
+- **Guardrails** - block actions with insufficient evidence
+- **Adaptive learning** - improve evidence classification over time
+
+## Design Principles
+
+1. **Backward compatible** - all fields optional
+2. **Zero behavior change** - purely observational
+3. **Minimal overhead** - lightweight dataclass
+4. **Future-proof** - enables reconciliation layer


### PR DESCRIPTION
## Description

Introduces an **Execution Evidence model** to separate execution attempts from observed outcomes.

**This model is intentionally lightweight and does not introduce new runtime behavior.** It only improves how execution outcomes are represented for future reconciliation and guardrails.

### Problem

In distributed or external tool interactions, execution does not imply confirmation:
- Timeouts may hide partial success
- Retries may succeed outside observation window
- External APIs may have eventual consistency

### Solution

Adds [EvidenceType](cci:2://file:///c:/Users/windows10/Downloads/HIVE/hive/core/framework/runtime/evidence.py:21:0-27:39) enum and [ExecutionAttempt](cci:2://file:///c:/Users/windows10/Downloads/HIVE/hive/core/framework/runtime/evidence.py:30:0-78:37) model to classify:
- `CONFIRMED` - verified the effect
- `OBSERVED` - saw the result
- `ASSUMED` - inferred from context
- `UNKNOWN` - no evidence

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- Added [core/framework/runtime/evidence.py](cci:7://file:///c:/Users/windows10/Downloads/HIVE/hive/core/framework/runtime/evidence.py:0:0-0:0) with [EvidenceType](cci:2://file:///c:/Users/windows10/Downloads/HIVE/hive/core/framework/runtime/evidence.py:21:0-27:39) and [ExecutionAttempt](cci:2://file:///c:/Users/windows10/Downloads/HIVE/hive/core/framework/runtime/evidence.py:30:0-78:37)
- Extended [NodeStepLog](cci:2://file:///c:/Users/windows10/Downloads/HIVE/hive/core/framework/runtime/runtime_log_schemas.py:30:0-54:72) with optional [execution_attempt](cci:1://file:///c:/Users/windows10/Downloads/HIVE/hive/core/tests/test_execution_evidence.py:151:4-166:55) field (backward compatible)
- Added [docs/execution-evidence.md](cci:7://file:///c:/Users/windows10/Downloads/HIVE/hive/docs/execution-evidence.md:0:0-0:0) documentation
- Added 21 unit tests with 100% coverage of new code

## Testing

- [x] Unit tests pass (`python -m pytest core/tests/test_execution_evidence.py -v` - 21/21 passing)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes