### PR TITLE
fix: race condition deadlock, missing short-circuit eval, unhandled format exceptions

### DIFF
--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -115,11 +115,23 @@ class SafeEvalVisitor(ast.NodeVisitor):
         return True
 
     def visit_BoolOp(self, node: ast.BoolOp) -> Any:
-        values = [self.visit(v) for v in node.values]
+        # Short-circuit evaluation to match Python semantics.
+        # Previously all operands were eagerly evaluated, which broke
+        # guard patterns like: ``x is not None and x.get("key")``
         if isinstance(node.op, ast.And):
-            return all(values)
+            result = True
+            for v in node.values:
+                result = self.visit(v)
+                if not result:
+                    return result
+            return result
         elif isinstance(node.op, ast.Or):
-            return any(values)
+            result = False
+            for v in node.values:
+                result = self.visit(v)
+                if result:
+                    return result
+            return result
         raise ValueError(f"Boolean operator {type(node.op).__name__} is not allowed")
 
     def visit_IfExp(self, node: ast.IfExp) -> Any:


### PR DESCRIPTION
## Summary

Fixes three bugs found during code review:

- **Race condition deadlock in `EventLoopNode._await_user_input()`** — `_input_ready.clear()` was called after the `emit_client_input_requested()` await, creating a window where `inject_event()` could set the flag only for `clear()` to immediately wipe it, causing `wait()` to block forever. Fix: move `clear()` before the emit. (Fixes #4009)

- **Missing short-circuit evaluation in `safe_eval.visit_BoolOp()`** — All operands of `and`/`or` were eagerly evaluated via list comprehension, breaking guard patterns like `x is not None and x.get("key")` which would crash instead of short-circuiting. Fix: iterate operands with early return. (Fixes #4010)

- **Unhandled `TypeError`/`IndexError` in `HybridJudge._format_feedback()`** — Template formatting with `{result[key]}` raises `TypeError` when `result` is not subscriptable, which was not caught, crashing the judge evaluation. Fix: add `TypeError` and `IndexError` to the except clause. (Fixes #4011)

## Test plan

- [x] All 67 existing tests pass (test_event_loop_node: 35, test_event_loop_integration: 17, test_event_loop_wiring: 10, test_graph_executor: 5)
- [ ] Verify `_await_user_input` no longer deadlocks when `inject_event()` arrives during emit
- [ ] Verify edge conditions with guard patterns like `x is not None and x["key"]` work correctly
- [ ] Verify judge rules with non-dict result values don't crash