### PR TITLE
Fix incorrect submission email in quizzes documentation

### DIFF
--- a/docs/quizzes/README.md
+++ b/docs/quizzes/README.md
@@ -40,7 +40,7 @@ Welcome to the Aden Engineering Challenges! These quizzes are designed for stude
 After completing challenges, submit your work by:
 
 1. Creating a GitHub Gist with your answers
-2. Emailing the link to `careers@adenhq.com` with subject: `[Engineering Challenge] Your Name - Track Name`
+2. Emailing the link to `contact@adenhq.com` with subject: `[Engineering Challenge] Your Name - Track Name`
 3. Include your GitHub username in the email
 
 ## Getting Help


### PR DESCRIPTION
## Description

Fixes an incorrect submission email in the quizzes documentation.

The email listed under Submission Guidelines was outdated and has been updated to the correct contact address.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #<issue-number>  
<!-- If no issue exists yet, you can remove this line or write "N/A" -->

## Changes Made

- Updated submission email from `careers@aden.com` to `contact@adenhq.com`
- No other documentation or code changes

## Testing

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

Manual verification:
- Confirmed the correct email appears under Submission Guidelines in `docs/quizzes/README.md`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A)
- [ ] New and existing unit tests pass locally with my changes (N/A)

## Screenshots (if applicable)

N/A
