### PR TITLE
docs(getting-started): fix project structure tree for tools and mcp_server location

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -93,12 +93,12 @@ hive/
 │   └── pyproject.toml      # Package metadata
 │
 ├── tools/                  # MCP Tools Package
+│   ├── mcp_server.py       # MCP server entry point
 │   └── src/aden_tools/     # Tools for agent capabilities
-│       ├── tools/          # Individual tool implementations
-│       │   ├── web_search_tool/
-│       │   ├── web_scrape_tool/
-│       │   └── file_system_toolkits/
-│       └── mcp_server.py   # HTTP MCP server
+│       └── tools/          # Individual tool implementations
+│           ├── web_search_tool/
+│           ├── web_scrape_tool/
+│           └── file_system_toolkits/
 │
 ├── exports/                # Agent Packages (user-generated, not in repo)
 │   └── your_agent/         # Your agents created via /hive


### PR DESCRIPTION
Updates the project structure in getting-started.md so mcp_server.py is shown under tools/ instead of tools/src/aden_tools/.