### PR TITLE
docs(readme): add Contributing link to Quick Links section

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Use Hive when you need:
 - **[Changelog](https://github.com/adenhq/hive/releases)** - Latest updates and releases
 - **[Roadmap](docs/roadmap.md)** - Upcoming features and plans
 - **[Report Issues](https://github.com/adenhq/hive/issues)** - Bug reports and feature requests
+- **[Contributing](CONTRIBUTING.md)** - How to contribute and submit PRs
 
 ## Quick Start
 


### PR DESCRIPTION
Adds a link to CONTRIBUTING.md in the README Quick Links section so new contributors can find contribution guidelines (issue assignment, commit convention, PR process).
