### PR TITLE
feat(product): Agent Outcome Scorecards — quantify the adaptation loop

### DIFF
--- a/core/framework/builder/scorecard_cli.py
+++ b/core/framework/builder/scorecard_cli.py
@@ -1,0 +1,245 @@
+"""
+CLI commands for Agent Outcome Scorecards.
+
+Registers the `scorecard` subcommand with the main hive CLI.
+Follows the same register_commands() pattern used by
+framework.runner.cli and framework.testing.cli.
+
+Usage:
+    hive scorecard exports/my-agent
+    hive scorecard exports/my-agent --time-window last_7_days
+    hive scorecard exports/my-agent --format json
+    hive scorecard exports/my-agent --compare previous_scorecard.json
+"""
+
+import json
+import sys
+from pathlib import Path
+
+from framework.builder.scorecard_generator import ScorecardGenerator
+from framework.schemas.scorecard import Scorecard
+
+
+def register_scorecard_commands(subparsers) -> None:
+    """Register scorecard commands with the CLI subparsers."""
+    scorecard_parser = subparsers.add_parser(
+        "scorecard",
+        help="Generate an outcome scorecard for an agent",
+        description=(
+            "Analyzes agent run history and produces a structured scorecard "
+            "showing goal achievement, cost trends, adaptation progress, "
+            "and decision confidence."
+        ),
+    )
+
+    scorecard_parser.add_argument(
+        "agent_path",
+        type=str,
+        help="Path to agent export directory (e.g., exports/my-agent)",
+    )
+
+    scorecard_parser.add_argument(
+        "--goal-id",
+        type=str,
+        default=None,
+        help="Goal ID to analyze (auto-detected if only one goal exists)",
+    )
+
+    scorecard_parser.add_argument(
+        "--time-window",
+        type=str,
+        default="all_time",
+        choices=["last_7_days", "last_14_days", "last_30_days", "last_90_days", "all_time"],
+        help="Time window for analysis (default: all_time)",
+    )
+
+    scorecard_parser.add_argument(
+        "--format",
+        type=str,
+        default="table",
+        choices=["table", "json", "markdown"],
+        dest="output_format",
+        help="Output format (default: table)",
+    )
+
+    scorecard_parser.add_argument(
+        "--compare",
+        type=str,
+        default=None,
+        metavar="SCORECARD_JSON",
+        help="Path to a previous scorecard JSON file for before/after comparison",
+    )
+
+    scorecard_parser.add_argument(
+        "--save",
+        type=str,
+        default=None,
+        metavar="OUTPUT_PATH",
+        help="Save scorecard JSON to this path (for later comparison)",
+    )
+
+    scorecard_parser.set_defaults(func=_handle_scorecard)
+
+
+def _handle_scorecard(args) -> int:
+    """Handle the scorecard subcommand."""
+    agent_path = Path(args.agent_path)
+
+    if not agent_path.is_dir():
+        print(f"Error: Agent path '{agent_path}' does not exist or is not a directory.")
+        return 1
+
+    # Find storage path (convention: agent_path/runs/ or agent_path/storage/)
+    storage_path = _find_storage_path(agent_path)
+    if storage_path is None:
+        print(f"Error: No run storage found in '{agent_path}'.")
+        print("Expected a 'runs/' or 'storage/' directory with run data.")
+        return 1
+
+    # Detect agent name from path
+    agent_name = agent_path.name
+
+    # Create generator
+    generator = ScorecardGenerator(storage_path)
+
+    # Auto-detect goal ID if not specified
+    goal_id = args.goal_id
+    if goal_id is None:
+        goal_id = _detect_goal_id(generator)
+        if goal_id is None:
+            print("Error: Could not auto-detect goal ID. Use --goal-id to specify.")
+            return 1
+
+    # Generate scorecard
+    try:
+        scorecard = generator.generate(agent_name, goal_id, args.time_window)
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+
+    # Handle comparison mode
+    if args.compare:
+        compare_path = Path(args.compare)
+        if not compare_path.is_file():
+            print(f"Error: Comparison file '{compare_path}' not found.")
+            return 1
+
+        try:
+            with open(compare_path) as f:
+                before_data = json.load(f)
+            before = Scorecard.model_validate(before_data)
+        except Exception as e:
+            print(f"Error loading comparison scorecard: {e}")
+            return 1
+
+        diff = generator.compare(before, scorecard)
+        _output_diff(diff, args.output_format)
+    else:
+        _output_scorecard(scorecard, args.output_format)
+
+    # Save if requested
+    if args.save:
+        save_path = Path(args.save)
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(save_path, "w") as f:
+            f.write(scorecard.model_dump_json(indent=2))
+        print(f"\nScorecard saved to: {save_path}")
+
+    return 0
+
+
+def _find_storage_path(agent_path: Path) -> Path | None:
+    """Find the run storage directory within an agent export."""
+    candidates = [
+        agent_path / "runs",
+        agent_path / "storage",
+        agent_path / "data" / "runs",
+        agent_path,  # Fall back to agent path itself
+    ]
+    for candidate in candidates:
+        if candidate.is_dir():
+            # Check if it contains run data
+            json_files = list(candidate.glob("*.json"))
+            subdirs = [d for d in candidate.iterdir() if d.is_dir()]
+            if json_files or subdirs:
+                return candidate
+    return None
+
+
+def _detect_goal_id(generator: ScorecardGenerator) -> str | None:
+    """Auto-detect goal ID from storage."""
+    try:
+        goals = generator.storage.list_all_goals()
+        if len(goals) == 1:
+            return goals[0]
+        elif len(goals) > 1:
+            print(f"Multiple goals found: {', '.join(goals)}")
+            print("Use --goal-id to specify which goal to analyze.")
+            return None
+    except Exception:
+        pass
+    return None
+
+
+def _output_scorecard(scorecard: Scorecard, output_format: str) -> None:
+    """Output scorecard in the requested format."""
+    if output_format == "json":
+        print(scorecard.model_dump_json(indent=2))
+    elif output_format == "markdown":
+        print(_scorecard_to_markdown(scorecard))
+    else:
+        print(scorecard.to_table_str())
+
+
+def _output_diff(diff, output_format: str) -> None:
+    """Output scorecard diff in the requested format."""
+    if output_format == "json":
+        print(diff.model_dump_json(indent=2))
+    else:
+        print(diff.to_table_str())
+
+
+def _scorecard_to_markdown(scorecard: Scorecard) -> str:
+    """Convert scorecard to Markdown format."""
+    lines = [
+        f"# Agent Scorecard: {scorecard.agent_name}",
+        "",
+        f"**Goal:** {scorecard.goal_id}  ",
+        f"**Window:** {scorecard.time_window} | **Runs:** {scorecard.runs_analyzed}  ",
+        f"**Generated:** {scorecard.generated_at.strftime('%Y-%m-%d %H:%M')}",
+        "",
+        f"## Overall Health: {scorecard.overall_health}/100 ({scorecard.health_label})",
+        "",
+        f"- **Goal Achievement:** {scorecard.goal_achievement_rate:.1%}",
+        "",
+        "## Criteria Breakdown",
+        "",
+        "| Criterion | Achievement | Trend | Samples |",
+        "|-----------|------------|-------|---------|",
+    ]
+
+    for cs in scorecard.criteria_scores:
+        lines.append(
+            f"| {cs.description} | {cs.achievement_rate:.1%} | {cs.trend} | {cs.sample_size} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Cost",
+            "",
+            f"- **Avg tokens/run:** {scorecard.cost_metrics.avg_tokens_per_run:.0f}",
+            f"- **Total tokens:** {scorecard.cost_metrics.total_spend_tokens}",
+            f"- **Trend:** {scorecard.cost_metrics.cost_trend}",
+            "",
+            "## Adaptation",
+            "",
+            f"- **Graph versions:** {scorecard.adaptation_metrics.total_graph_versions}",
+            f"- **Failures resolved:** {scorecard.adaptation_metrics.failure_modes_resolved}",
+            f"- **Failures remaining:** {scorecard.adaptation_metrics.failure_modes_remaining}",
+            f"- **Avg confidence:** {scorecard.adaptation_metrics.avg_decision_confidence:.2f}",
+            f"- **Confidence trend:** {scorecard.adaptation_metrics.confidence_trend}",
+        ]
+    )
+
+    return "\n".join(lines)

--- a/core/framework/builder/scorecard_generator.py
+++ b/core/framework/builder/scorecard_generator.py
@@ -1,0 +1,472 @@
+"""
+Scorecard Generator - Transforms raw run data into structured outcome scorecards.
+
+Uses BuilderQuery (patterns, failures) and FileStorage (run data) to compute
+rolling metrics across configurable time windows.
+
+Health score weighting:
+    40% goal achievement rate
+    25% cost efficiency trend
+    20% adaptation progress (failure resolution)
+    15% decision confidence
+"""
+
+from collections import defaultdict
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from framework.builder.query import BuilderQuery
+from framework.schemas.run import Run, RunStatus
+from framework.schemas.scorecard import (
+    AdaptationMetrics,
+    CostMetrics,
+    CriterionScore,
+    Scorecard,
+    ScorecardDiff,
+)
+from framework.storage.backend import FileStorage
+
+
+# Time window parsing
+_WINDOW_DELTAS = {
+    "last_7_days": timedelta(days=7),
+    "last_14_days": timedelta(days=14),
+    "last_30_days": timedelta(days=30),
+    "last_90_days": timedelta(days=90),
+    "all_time": None,  # No cutoff
+}
+
+
+class ScorecardGenerator:
+    """
+    Generates outcome scorecards from agent run history.
+
+    Wraps BuilderQuery and FileStorage to produce Scorecard instances
+    that can be serialized to JSON, rendered as tables, or compared
+    to previous scorecards for before/after analysis.
+
+    Usage:
+        generator = ScorecardGenerator("/path/to/storage")
+        scorecard = generator.generate("my_agent", "goal_001", "last_7_days")
+        print(scorecard.to_table_str())
+        print(scorecard.model_dump_json(indent=2))
+    """
+
+    def __init__(self, storage_path: str | Path):
+        self.query = BuilderQuery(str(storage_path))
+        self.storage = FileStorage(str(storage_path))
+
+    def generate(
+        self,
+        agent_name: str,
+        goal_id: str,
+        time_window: str = "all_time",
+    ) -> Scorecard:
+        """
+        Generate a scorecard from run data.
+
+        Args:
+            agent_name: Human-readable agent identifier.
+            goal_id: The goal ID to analyze runs for.
+            time_window: Analysis window (e.g., 'last_7_days', 'all_time').
+
+        Returns:
+            A Scorecard instance with computed metrics.
+
+        Raises:
+            ValueError: If no runs found for the given goal and window.
+        """
+        runs = self._get_runs_in_window(goal_id, time_window)
+        if not runs:
+            raise ValueError(
+                f"No runs found for goal '{goal_id}' in window '{time_window}'"
+            )
+
+        patterns = self.query.find_patterns(goal_id)
+
+        criteria_scores = self._score_criteria(runs)
+        cost_metrics = self._compute_cost_metrics(runs)
+        adaptation_metrics = self._compute_adaptation_metrics(runs, goal_id)
+
+        # Use pattern analysis for goal achievement rate if available
+        goal_achievement_rate = (
+            patterns.success_rate if patterns else self._compute_achievement_rate(runs)
+        )
+
+        overall_health = self._compute_health(
+            goal_achievement_rate, cost_metrics, adaptation_metrics
+        )
+
+        return Scorecard(
+            agent_name=agent_name,
+            goal_id=goal_id,
+            generated_at=datetime.now(),
+            time_window=time_window,
+            runs_analyzed=len(runs),
+            overall_health=overall_health,
+            goal_achievement_rate=goal_achievement_rate,
+            criteria_scores=criteria_scores,
+            cost_metrics=cost_metrics,
+            adaptation_metrics=adaptation_metrics,
+        )
+
+    def compare(self, before: Scorecard, after: Scorecard) -> ScorecardDiff:
+        """
+        Compare two scorecards to show improvement or regression.
+
+        Args:
+            before: The earlier scorecard.
+            after: The later scorecard.
+
+        Returns:
+            A ScorecardDiff with deltas, improvements, and regressions.
+        """
+        achievement_delta = after.goal_achievement_rate - before.goal_achievement_rate
+        cost_delta = (
+            after.cost_metrics.avg_tokens_per_run - before.cost_metrics.avg_tokens_per_run
+        )
+        health_delta = after.overall_health - before.overall_health
+
+        improvements = []
+        regressions = []
+
+        # Achievement
+        if achievement_delta > 0.01:
+            improvements.append(
+                f"Goal achievement improved by {achievement_delta:.1%}"
+            )
+        elif achievement_delta < -0.01:
+            regressions.append(
+                f"Goal achievement declined by {abs(achievement_delta):.1%}"
+            )
+
+        # Cost
+        if cost_delta < -10:
+            improvements.append(
+                f"Avg tokens per run decreased by {abs(cost_delta):.0f}"
+            )
+        elif cost_delta > 10:
+            regressions.append(
+                f"Avg tokens per run increased by {cost_delta:.0f}"
+            )
+
+        # Confidence
+        conf_delta = (
+            after.adaptation_metrics.avg_decision_confidence
+            - before.adaptation_metrics.avg_decision_confidence
+        )
+        if conf_delta > 0.02:
+            improvements.append(
+                f"Decision confidence improved by {conf_delta:.2f}"
+            )
+        elif conf_delta < -0.02:
+            regressions.append(
+                f"Decision confidence declined by {abs(conf_delta):.2f}"
+            )
+
+        # Failure resolution
+        resolved_delta = (
+            after.adaptation_metrics.failure_modes_resolved
+            - before.adaptation_metrics.failure_modes_resolved
+        )
+        if resolved_delta > 0:
+            improvements.append(
+                f"{resolved_delta} additional failure mode(s) resolved"
+            )
+
+        # Per-criterion comparison
+        before_criteria = {cs.criterion_id: cs for cs in before.criteria_scores}
+        for cs_after in after.criteria_scores:
+            cs_before = before_criteria.get(cs_after.criterion_id)
+            if cs_before:
+                delta = cs_after.achievement_rate - cs_before.achievement_rate
+                if delta > 0.05:
+                    improvements.append(
+                        f"Criterion '{cs_after.description}' improved by {delta:.1%}"
+                    )
+                elif delta < -0.05:
+                    regressions.append(
+                        f"Criterion '{cs_after.description}' declined by {abs(delta):.1%}"
+                    )
+
+        return ScorecardDiff(
+            before=before,
+            after=after,
+            achievement_delta=achievement_delta,
+            cost_delta=cost_delta,
+            health_delta=health_delta,
+            improvements=improvements,
+            regressions=regressions,
+        )
+
+    # === PRIVATE METHODS ===
+
+    def _get_runs_in_window(
+        self, goal_id: str, time_window: str
+    ) -> list[Run]:
+        """Retrieve runs within the specified time window."""
+        run_ids = self.storage.get_runs_by_goal(goal_id)
+        runs = []
+        cutoff = self._get_cutoff(time_window)
+
+        for run_id in run_ids:
+            run = self.storage.load_run(run_id)
+            if run is None:
+                continue
+            # Filter by time window
+            if cutoff and run.started_at < cutoff:
+                continue
+            runs.append(run)
+
+        # Sort chronologically
+        runs.sort(key=lambda r: r.started_at)
+        return runs
+
+    def _get_cutoff(self, time_window: str) -> datetime | None:
+        """Convert time window string to a cutoff datetime."""
+        delta = _WINDOW_DELTAS.get(time_window)
+        if delta is None:
+            return None
+        return datetime.now() - delta
+
+    def _compute_achievement_rate(self, runs: list[Run]) -> float:
+        """Compute goal achievement rate from run statuses."""
+        if not runs:
+            return 0.0
+        completed = sum(1 for r in runs if r.status == RunStatus.COMPLETED)
+        return completed / len(runs)
+
+    def _score_criteria(self, runs: list[Run]) -> list[CriterionScore]:
+        """
+        Score each success criterion across runs.
+
+        Examines each run's decisions and outcomes to determine
+        which criteria were met, then computes achievement rates
+        and trends.
+        """
+        if not runs:
+            return []
+
+        # Collect all unique criterion IDs from the goals
+        # Since we're analyzing runs for a single goal, criteria should be consistent
+        criterion_results: dict[str, list[bool]] = defaultdict(list)
+        criterion_descriptions: dict[str, str] = {}
+
+        for run in runs:
+            # Check if the run's output_data contains criterion results
+            criteria_met = run.output_data.get("criteria_met", {})
+            for crit_id, was_met in criteria_met.items():
+                criterion_results[crit_id].append(bool(was_met))
+
+            # Also check if goal success criteria descriptions are available
+            criteria_desc = run.output_data.get("criteria_descriptions", {})
+            criterion_descriptions.update(criteria_desc)
+
+        scores = []
+        for crit_id, results in criterion_results.items():
+            if not results:
+                continue
+
+            achievement_rate = sum(results) / len(results)
+            trend = self._compute_trend(results)
+            description = criterion_descriptions.get(crit_id, crit_id)
+
+            scores.append(
+                CriterionScore(
+                    criterion_id=crit_id,
+                    description=description,
+                    achievement_rate=achievement_rate,
+                    trend=trend,
+                    sample_size=len(results),
+                )
+            )
+
+        return scores
+
+    def _compute_cost_metrics(self, runs: list[Run]) -> CostMetrics:
+        """Aggregate cost (token usage) data from runs."""
+        if not runs:
+            return CostMetrics(
+                total_spend_tokens=0,
+                avg_tokens_per_run=0.0,
+                cost_trend="stable",
+                cheapest_run_tokens=0,
+                most_expensive_run_tokens=0,
+            )
+
+        token_counts = [r.metrics.total_tokens for r in runs]
+        total = sum(token_counts)
+        avg = total / len(token_counts)
+
+        # Compute cost trend from first half vs second half
+        cost_trend = self._compute_trend(token_counts, lower_is_better=True)
+
+        return CostMetrics(
+            total_spend_tokens=total,
+            avg_tokens_per_run=avg,
+            cost_trend=cost_trend,
+            cheapest_run_tokens=min(token_counts) if token_counts else 0,
+            most_expensive_run_tokens=max(token_counts) if token_counts else 0,
+        )
+
+    def _compute_adaptation_metrics(
+        self, runs: list[Run], goal_id: str
+    ) -> AdaptationMetrics:
+        """
+        Track evolution and improvement signals.
+
+        Counts distinct graph versions, resolved vs remaining failure modes,
+        and tracks decision confidence trends.
+        """
+        if not runs:
+            return AdaptationMetrics(
+                total_graph_versions=1,
+                failure_modes_resolved=0,
+                failure_modes_remaining=0,
+                avg_decision_confidence=0.0,
+                confidence_trend="stable",
+            )
+
+        # Track unique graph versions (approximated by distinct node sets)
+        node_sets: set[frozenset[str]] = set()
+        for run in runs:
+            node_set = frozenset(run.metrics.nodes_executed)
+            if node_set:
+                node_sets.add(node_set)
+        total_graph_versions = max(len(node_sets), 1)
+
+        # Track failure modes: errors that appeared early but stopped later
+        midpoint = len(runs) // 2
+        if midpoint > 0:
+            early_runs = runs[:midpoint]
+            late_runs = runs[midpoint:]
+
+            early_errors: set[str] = set()
+            for run in early_runs:
+                for problem in run.problems:
+                    if problem.root_cause:
+                        early_errors.add(problem.root_cause)
+
+            late_errors: set[str] = set()
+            for run in late_runs:
+                for problem in run.problems:
+                    if problem.root_cause:
+                        late_errors.add(problem.root_cause)
+
+            resolved = early_errors - late_errors
+            remaining = late_errors
+        else:
+            resolved = set()
+            remaining = set()
+            for run in runs:
+                for problem in run.problems:
+                    if problem.root_cause:
+                        remaining.add(problem.root_cause)
+
+        # Decision confidence
+        all_confidences: list[float] = []
+        for run in runs:
+            for decision in run.decisions:
+                if decision.evaluation and decision.evaluation.confidence is not None:
+                    all_confidences.append(decision.evaluation.confidence)
+
+        avg_confidence = (
+            sum(all_confidences) / len(all_confidences)
+            if all_confidences
+            else 0.0
+        )
+        confidence_trend = (
+            self._compute_trend(all_confidences)
+            if len(all_confidences) >= 4
+            else "stable"
+        )
+
+        return AdaptationMetrics(
+            total_graph_versions=total_graph_versions,
+            failure_modes_resolved=len(resolved),
+            failure_modes_remaining=len(remaining),
+            avg_decision_confidence=min(avg_confidence, 1.0),
+            confidence_trend=confidence_trend,
+        )
+
+    def _compute_health(
+        self,
+        achievement_rate: float,
+        cost_metrics: CostMetrics,
+        adaptation_metrics: AdaptationMetrics,
+    ) -> int:
+        """
+        Compute composite health score (0-100).
+
+        Weighting:
+            40% goal achievement rate
+            25% cost efficiency (trend-based)
+            20% adaptation progress (resolved / total failure modes)
+            15% decision confidence
+        """
+        # Achievement component (0-40)
+        achievement_score = achievement_rate * 40
+
+        # Cost component (0-25): based on trend direction
+        cost_trend_scores = {"decreasing": 25, "stable": 15, "increasing": 5}
+        cost_score = cost_trend_scores.get(cost_metrics.cost_trend, 15)
+
+        # Adaptation component (0-20): ratio of resolved failure modes
+        total_failures = (
+            adaptation_metrics.failure_modes_resolved
+            + adaptation_metrics.failure_modes_remaining
+        )
+        if total_failures > 0:
+            resolution_rate = adaptation_metrics.failure_modes_resolved / total_failures
+            adaptation_score = resolution_rate * 20
+        else:
+            # No failures at all = healthy
+            adaptation_score = 20
+
+        # Confidence component (0-15)
+        confidence_score = adaptation_metrics.avg_decision_confidence * 15
+
+        total = achievement_score + cost_score + adaptation_score + confidence_score
+        return max(0, min(100, int(round(total))))
+
+    def _compute_trend(
+        self,
+        values: list[float | bool | int],
+        lower_is_better: bool = False,
+    ) -> str:
+        """
+        Compute trend direction from a sequence of values.
+
+        Splits into first half vs second half and compares means.
+        A 5% threshold is used to distinguish 'improving' from 'stable'.
+        """
+        if len(values) < 4:
+            return "stable"
+
+        # Convert bools to floats
+        float_values = [float(v) for v in values]
+
+        midpoint = len(float_values) // 2
+        first_half_mean = sum(float_values[:midpoint]) / midpoint
+        second_half_mean = sum(float_values[midpoint:]) / (len(float_values) - midpoint)
+
+        if first_half_mean == 0:
+            return "stable"
+
+        change_pct = (second_half_mean - first_half_mean) / abs(first_half_mean)
+
+        threshold = 0.05  # 5% change required to register as a trend
+
+        if lower_is_better:
+            if change_pct < -threshold:
+                return "improving"
+            elif change_pct > threshold:
+                return "declining"
+        else:
+            if change_pct > threshold:
+                return "improving"
+            elif change_pct < -threshold:
+                return "declining"
+
+        return "stable"

--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -82,6 +82,11 @@ def main():
 
     register_testing_commands(subparsers)
 
+    # Register scorecard commands (scorecard)
+    from framework.builder.scorecard_cli import register_scorecard_commands
+
+    register_scorecard_commands(subparsers)
+
     args = parser.parse_args()
 
     if hasattr(args, "func"):

--- a/core/framework/schemas/scorecard.py
+++ b/core/framework/schemas/scorecard.py
@@ -1,0 +1,246 @@
+"""
+Scorecard Schema - Quantifying agent adaptation over time.
+
+Scorecards transform internal runtime metrics (OutcomeAggregator progress,
+BuilderQuery patterns, RunMetrics success rates) into a structured,
+user-facing report that answers: "Is my agent getting better?"
+
+This serves three product goals:
+1. Enterprise POC-to-contract conversion (quantifiable proof of value)
+2. Community benchmarking (template quality comparison)
+3. Developer feedback (where to invest optimization effort)
+"""
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field, computed_field
+
+
+class CriterionScore(BaseModel):
+    """
+    Achievement score for a single success criterion across runs.
+
+    Computed by tracking how often each SuccessCriterion.met == True
+    across the analyzed run window, with trend detection.
+    """
+
+    criterion_id: str
+    description: str
+    achievement_rate: float = Field(
+        ge=0.0, le=1.0, description="Fraction of runs where this criterion was met"
+    )
+    trend: str = Field(
+        description="Direction of change: 'improving', 'stable', or 'declining'"
+    )
+    sample_size: int = Field(ge=0, description="Number of runs this score is based on")
+
+    model_config = {"extra": "allow"}
+
+
+class CostMetrics(BaseModel):
+    """
+    Cost tracking across runs.
+
+    Derived from RunMetrics.total_tokens and configurable per-token pricing.
+    Enables the question: "Is my agent getting cheaper to run?"
+    """
+
+    total_spend_tokens: int = Field(ge=0, description="Total tokens consumed across all runs")
+    avg_tokens_per_run: float = Field(ge=0.0, description="Average tokens per run")
+    cost_trend: str = Field(
+        description="Direction of change: 'decreasing', 'stable', or 'increasing'"
+    )
+    cheapest_run_tokens: int = Field(ge=0, description="Tokens in most efficient run")
+    most_expensive_run_tokens: int = Field(ge=0, description="Tokens in least efficient run")
+
+    model_config = {"extra": "allow"}
+
+
+class AdaptationMetrics(BaseModel):
+    """
+    Metrics about the self-improvement loop.
+
+    Tracks how the agent evolves: how many graph evolutions occurred,
+    how many distinct failure modes were resolved, and whether decision
+    confidence is trending upward.
+    """
+
+    total_graph_versions: int = Field(
+        ge=1, description="Number of distinct agent graph versions observed"
+    )
+    failure_modes_resolved: int = Field(
+        ge=0, description="Distinct failure patterns that stopped recurring"
+    )
+    failure_modes_remaining: int = Field(
+        ge=0, description="Distinct failure patterns still occurring"
+    )
+    avg_decision_confidence: float = Field(
+        ge=0.0, le=1.0, description="Mean confidence across all decisions"
+    )
+    confidence_trend: str = Field(
+        description="Direction of change: 'improving', 'stable', or 'declining'"
+    )
+
+    model_config = {"extra": "allow"}
+
+
+class Scorecard(BaseModel):
+    """
+    Complete outcome scorecard for an agent.
+
+    This is the user-facing artifact that quantifies the adaptation loop.
+    It aggregates data from BuilderQuery (patterns, failures), RunMetrics
+    (success rates, tokens), and OutcomeAggregator (criterion progress)
+    into a single, exportable report.
+
+    The overall_health score (0-100) is a weighted composite:
+    - 40% goal achievement rate
+    - 25% cost efficiency trend
+    - 20% adaptation progress
+    - 15% decision confidence
+    """
+
+    agent_name: str
+    goal_id: str
+    generated_at: datetime = Field(default_factory=datetime.now)
+    time_window: str = Field(
+        description="Analysis window: 'last_7_days', 'last_30_days', 'all_time'"
+    )
+    runs_analyzed: int = Field(ge=0)
+
+    # Composite health
+    overall_health: int = Field(ge=0, le=100, description="Weighted health score (0-100)")
+
+    # Goal performance
+    goal_achievement_rate: float = Field(
+        ge=0.0, le=1.0, description="Fraction of runs that achieved the goal"
+    )
+
+    # Detailed breakdowns
+    criteria_scores: list[CriterionScore] = Field(default_factory=list)
+    cost_metrics: CostMetrics
+    adaptation_metrics: AdaptationMetrics
+
+    model_config = {"extra": "allow"}
+
+    @computed_field
+    @property
+    def health_label(self) -> str:
+        """Human-readable health status."""
+        if self.overall_health >= 80:
+            return "healthy"
+        elif self.overall_health >= 50:
+            return "needs_attention"
+        else:
+            return "critical"
+
+    def to_table_str(self) -> str:
+        """Format scorecard as a readable table for terminal output."""
+        lines = [
+            f"{'=' * 60}",
+            f"  AGENT SCORECARD: {self.agent_name}",
+            f"  Goal: {self.goal_id}",
+            f"  Window: {self.time_window} | Runs: {self.runs_analyzed}",
+            f"  Generated: {self.generated_at.strftime('%Y-%m-%d %H:%M')}",
+            f"{'=' * 60}",
+            "",
+            f"  OVERALL HEALTH: {self.overall_health}/100 ({self.health_label.upper()})",
+            f"  Goal Achievement: {self.goal_achievement_rate:.1%}",
+            "",
+            "  CRITERIA BREAKDOWN:",
+        ]
+
+        for cs in self.criteria_scores:
+            trend_icon = {"improving": "+", "stable": "=", "declining": "-"}.get(
+                cs.trend, "?"
+            )
+            lines.append(
+                f"    [{trend_icon}] {cs.description}: "
+                f"{cs.achievement_rate:.1%} (n={cs.sample_size})"
+            )
+
+        lines.extend(
+            [
+                "",
+                "  COST:",
+                f"    Avg tokens/run: {self.cost_metrics.avg_tokens_per_run:.0f}",
+                f"    Total tokens: {self.cost_metrics.total_spend_tokens}",
+                f"    Trend: {self.cost_metrics.cost_trend}",
+                "",
+                "  ADAPTATION:",
+                f"    Graph versions: {self.adaptation_metrics.total_graph_versions}",
+                f"    Failures resolved: {self.adaptation_metrics.failure_modes_resolved}",
+                f"    Failures remaining: {self.adaptation_metrics.failure_modes_remaining}",
+                f"    Avg confidence: {self.adaptation_metrics.avg_decision_confidence:.2f}",
+                f"    Confidence trend: {self.adaptation_metrics.confidence_trend}",
+                "",
+                f"{'=' * 60}",
+            ]
+        )
+
+        return "\n".join(lines)
+
+
+class ScorecardDiff(BaseModel):
+    """
+    Comparison between two scorecards.
+
+    Enables before/after analysis: "After evolution X, the agent improved
+    goal achievement by 15% and reduced cost by 22%."
+    """
+
+    before: Scorecard
+    after: Scorecard
+    achievement_delta: float = Field(
+        description="Change in goal achievement rate (positive = better)"
+    )
+    cost_delta: float = Field(
+        description="Change in avg tokens per run (negative = cheaper)"
+    )
+    health_delta: int = Field(
+        description="Change in overall health score (positive = better)"
+    )
+    improvements: list[str] = Field(
+        default_factory=list, description="List of metrics that improved"
+    )
+    regressions: list[str] = Field(
+        default_factory=list, description="List of metrics that regressed"
+    )
+
+    model_config = {"extra": "allow"}
+
+    def to_table_str(self) -> str:
+        """Format comparison as a readable diff table."""
+        lines = [
+            f"{'=' * 60}",
+            f"  SCORECARD COMPARISON",
+            f"  Before: {self.before.generated_at.strftime('%Y-%m-%d')} | "
+            f"After: {self.after.generated_at.strftime('%Y-%m-%d')}",
+            f"{'=' * 60}",
+            "",
+            f"  Health: {self.before.overall_health} -> {self.after.overall_health} "
+            f"({'+'if self.health_delta >= 0 else ''}{self.health_delta})",
+            f"  Achievement: {self.before.goal_achievement_rate:.1%} -> "
+            f"{self.after.goal_achievement_rate:.1%} "
+            f"({'+'if self.achievement_delta >= 0 else ''}{self.achievement_delta:.1%})",
+            f"  Avg tokens: {self.before.cost_metrics.avg_tokens_per_run:.0f} -> "
+            f"{self.after.cost_metrics.avg_tokens_per_run:.0f} "
+            f"({'+'if self.cost_delta >= 0 else ''}{self.cost_delta:.0f})",
+        ]
+
+        if self.improvements:
+            lines.append("")
+            lines.append("  IMPROVEMENTS:")
+            for imp in self.improvements:
+                lines.append(f"    [+] {imp}")
+
+        if self.regressions:
+            lines.append("")
+            lines.append("  REGRESSIONS:")
+            for reg in self.regressions:
+                lines.append(f"    [-] {reg}")
+
+        lines.append(f"\n{'=' * 60}")
+
+        return "\n".join(lines)

--- a/core/tests/test_scorecard.py
+++ b/core/tests/test_scorecard.py
@@ -1,0 +1,461 @@
+"""
+Tests for Agent Outcome Scorecards.
+
+Tests cover:
+1. Schema validation (Scorecard, CriterionScore, CostMetrics, etc.)
+2. ScorecardGenerator logic with mock run data
+3. Health score computation and weighting
+4. Trend detection algorithm
+5. ScorecardDiff comparison
+6. Edge cases (zero runs, single run, all failures, all successes)
+"""
+
+import json
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from framework.schemas.scorecard import (
+    AdaptationMetrics,
+    CostMetrics,
+    CriterionScore,
+    Scorecard,
+    ScorecardDiff,
+)
+from framework.builder.scorecard_generator import ScorecardGenerator
+
+
+# === FIXTURES ===
+
+
+def make_mock_run(
+    run_id: str,
+    goal_id: str = "goal_001",
+    status: str = "completed",
+    total_tokens: int = 1000,
+    total_decisions: int = 5,
+    successful_decisions: int = 4,
+    failed_decisions: int = 1,
+    nodes_executed: list[str] | None = None,
+    problems: list | None = None,
+    started_at: datetime | None = None,
+    output_data: dict | None = None,
+):
+    """Create a mock Run object for testing."""
+    run = MagicMock()
+    run.id = run_id
+    run.goal_id = goal_id
+    run.status = MagicMock()
+    run.status.value = status
+    run.status.__eq__ = lambda self, other: self.value == (other.value if hasattr(other, 'value') else other)
+
+    # Make status comparison work with RunStatus enum
+    if status == "completed":
+        from framework.schemas.run import RunStatus
+        run.status = RunStatus.COMPLETED
+    elif status == "failed":
+        from framework.schemas.run import RunStatus
+        run.status = RunStatus.FAILED
+
+    run.started_at = started_at or datetime.now()
+    run.completed_at = run.started_at + timedelta(seconds=30)
+
+    # Metrics
+    run.metrics = MagicMock()
+    run.metrics.total_tokens = total_tokens
+    run.metrics.total_decisions = total_decisions
+    run.metrics.successful_decisions = successful_decisions
+    run.metrics.failed_decisions = failed_decisions
+    run.metrics.success_rate = (
+        successful_decisions / total_decisions if total_decisions > 0 else 0.0
+    )
+    run.metrics.nodes_executed = nodes_executed or ["node_a", "node_b", "node_c"]
+
+    # Problems
+    run.problems = problems or []
+
+    # Decisions (with confidence)
+    run.decisions = []
+    for i in range(total_decisions):
+        dec = MagicMock()
+        dec.evaluation = MagicMock()
+        dec.evaluation.confidence = 0.8 + (i * 0.02)
+        dec.was_successful = i < successful_decisions
+        dec.outcome = MagicMock()
+        dec.outcome.error = None if dec.was_successful else "test error"
+        run.decisions.append(dec)
+
+    # Output data
+    run.output_data = output_data or {}
+
+    return run
+
+
+# === SCHEMA TESTS ===
+
+
+class TestCriterionScore:
+    def test_valid_creation(self):
+        cs = CriterionScore(
+            criterion_id="crit_001",
+            description="Output contains required fields",
+            achievement_rate=0.85,
+            trend="improving",
+            sample_size=10,
+        )
+        assert cs.achievement_rate == 0.85
+        assert cs.trend == "improving"
+
+    def test_achievement_rate_bounds(self):
+        with pytest.raises(Exception):
+            CriterionScore(
+                criterion_id="crit_001",
+                description="test",
+                achievement_rate=1.5,  # > 1.0
+                trend="stable",
+                sample_size=5,
+            )
+
+
+class TestCostMetrics:
+    def test_valid_creation(self):
+        cm = CostMetrics(
+            total_spend_tokens=5000,
+            avg_tokens_per_run=1000.0,
+            cost_trend="decreasing",
+            cheapest_run_tokens=500,
+            most_expensive_run_tokens=2000,
+        )
+        assert cm.total_spend_tokens == 5000
+        assert cm.cost_trend == "decreasing"
+
+
+class TestScorecard:
+    def test_health_label_healthy(self):
+        sc = Scorecard(
+            agent_name="test_agent",
+            goal_id="goal_001",
+            time_window="all_time",
+            runs_analyzed=10,
+            overall_health=85,
+            goal_achievement_rate=0.9,
+            criteria_scores=[],
+            cost_metrics=CostMetrics(
+                total_spend_tokens=10000,
+                avg_tokens_per_run=1000.0,
+                cost_trend="stable",
+                cheapest_run_tokens=500,
+                most_expensive_run_tokens=1500,
+            ),
+            adaptation_metrics=AdaptationMetrics(
+                total_graph_versions=3,
+                failure_modes_resolved=2,
+                failure_modes_remaining=1,
+                avg_decision_confidence=0.85,
+                confidence_trend="improving",
+            ),
+        )
+        assert sc.health_label == "healthy"
+
+    def test_health_label_needs_attention(self):
+        sc = Scorecard(
+            agent_name="test_agent",
+            goal_id="goal_001",
+            time_window="all_time",
+            runs_analyzed=10,
+            overall_health=60,
+            goal_achievement_rate=0.6,
+            criteria_scores=[],
+            cost_metrics=CostMetrics(
+                total_spend_tokens=10000,
+                avg_tokens_per_run=1000.0,
+                cost_trend="stable",
+                cheapest_run_tokens=500,
+                most_expensive_run_tokens=1500,
+            ),
+            adaptation_metrics=AdaptationMetrics(
+                total_graph_versions=2,
+                failure_modes_resolved=0,
+                failure_modes_remaining=3,
+                avg_decision_confidence=0.5,
+                confidence_trend="declining",
+            ),
+        )
+        assert sc.health_label == "needs_attention"
+
+    def test_health_label_critical(self):
+        sc = Scorecard(
+            agent_name="test_agent",
+            goal_id="goal_001",
+            time_window="all_time",
+            runs_analyzed=10,
+            overall_health=30,
+            goal_achievement_rate=0.2,
+            criteria_scores=[],
+            cost_metrics=CostMetrics(
+                total_spend_tokens=50000,
+                avg_tokens_per_run=5000.0,
+                cost_trend="increasing",
+                cheapest_run_tokens=3000,
+                most_expensive_run_tokens=8000,
+            ),
+            adaptation_metrics=AdaptationMetrics(
+                total_graph_versions=1,
+                failure_modes_resolved=0,
+                failure_modes_remaining=5,
+                avg_decision_confidence=0.3,
+                confidence_trend="declining",
+            ),
+        )
+        assert sc.health_label == "critical"
+
+    def test_json_serialization(self):
+        sc = Scorecard(
+            agent_name="test_agent",
+            goal_id="goal_001",
+            time_window="all_time",
+            runs_analyzed=5,
+            overall_health=75,
+            goal_achievement_rate=0.8,
+            criteria_scores=[
+                CriterionScore(
+                    criterion_id="c1",
+                    description="Test criterion",
+                    achievement_rate=0.8,
+                    trend="improving",
+                    sample_size=5,
+                )
+            ],
+            cost_metrics=CostMetrics(
+                total_spend_tokens=5000,
+                avg_tokens_per_run=1000.0,
+                cost_trend="stable",
+                cheapest_run_tokens=500,
+                most_expensive_run_tokens=1500,
+            ),
+            adaptation_metrics=AdaptationMetrics(
+                total_graph_versions=2,
+                failure_modes_resolved=1,
+                failure_modes_remaining=1,
+                avg_decision_confidence=0.75,
+                confidence_trend="stable",
+            ),
+        )
+        json_str = sc.model_dump_json(indent=2)
+        parsed = json.loads(json_str)
+        assert parsed["agent_name"] == "test_agent"
+        assert parsed["health_label"] == "needs_attention"
+
+    def test_table_output(self):
+        sc = Scorecard(
+            agent_name="test_agent",
+            goal_id="goal_001",
+            time_window="last_7_days",
+            runs_analyzed=10,
+            overall_health=85,
+            goal_achievement_rate=0.9,
+            criteria_scores=[],
+            cost_metrics=CostMetrics(
+                total_spend_tokens=10000,
+                avg_tokens_per_run=1000.0,
+                cost_trend="decreasing",
+                cheapest_run_tokens=500,
+                most_expensive_run_tokens=1500,
+            ),
+            adaptation_metrics=AdaptationMetrics(
+                total_graph_versions=3,
+                failure_modes_resolved=2,
+                failure_modes_remaining=0,
+                avg_decision_confidence=0.85,
+                confidence_trend="improving",
+            ),
+        )
+        table = sc.to_table_str()
+        assert "test_agent" in table
+        assert "HEALTHY" in table
+        assert "90.0%" in table
+
+
+# === GENERATOR TESTS ===
+
+
+class TestScorecardGenerator:
+    @patch("framework.builder.scorecard_generator.FileStorage")
+    @patch("framework.builder.scorecard_generator.BuilderQuery")
+    def test_generate_basic(self, MockQuery, MockStorage):
+        """Test basic scorecard generation with mock runs."""
+        # Setup mocks
+        mock_storage = MockStorage.return_value
+        mock_query = MockQuery.return_value
+
+        runs = [
+            make_mock_run(f"run_{i}", status="completed" if i < 8 else "failed")
+            for i in range(10)
+        ]
+
+        mock_storage.get_runs_by_goal.return_value = [r.id for r in runs]
+        mock_storage.load_run.side_effect = lambda rid: next(
+            (r for r in runs if r.id == rid), None
+        )
+
+        # Pattern analysis mock
+        mock_patterns = MagicMock()
+        mock_patterns.success_rate = 0.8
+        mock_query.find_patterns.return_value = mock_patterns
+
+        generator = ScorecardGenerator("/fake/path")
+        generator.query = mock_query
+        generator.storage = mock_storage
+
+        scorecard = generator.generate("test_agent", "goal_001")
+
+        assert scorecard.agent_name == "test_agent"
+        assert scorecard.goal_id == "goal_001"
+        assert scorecard.runs_analyzed == 10
+        assert scorecard.goal_achievement_rate == 0.8
+
+    @patch("framework.builder.scorecard_generator.FileStorage")
+    @patch("framework.builder.scorecard_generator.BuilderQuery")
+    def test_generate_no_runs_raises(self, MockQuery, MockStorage):
+        """Test that generating with no runs raises ValueError."""
+        mock_storage = MockStorage.return_value
+        mock_storage.get_runs_by_goal.return_value = []
+
+        generator = ScorecardGenerator("/fake/path")
+        generator.storage = mock_storage
+
+        with pytest.raises(ValueError, match="No runs found"):
+            generator.generate("test_agent", "goal_001")
+
+
+class TestTrendDetection:
+    def test_improving_trend(self):
+        generator = ScorecardGenerator.__new__(ScorecardGenerator)
+        values = [0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.85, 0.9]
+        assert generator._compute_trend(values) == "improving"
+
+    def test_declining_trend(self):
+        generator = ScorecardGenerator.__new__(ScorecardGenerator)
+        values = [0.9, 0.85, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3]
+        assert generator._compute_trend(values) == "declining"
+
+    def test_stable_trend(self):
+        generator = ScorecardGenerator.__new__(ScorecardGenerator)
+        values = [0.7, 0.72, 0.68, 0.71, 0.69, 0.70, 0.71, 0.70]
+        assert generator._compute_trend(values) == "stable"
+
+    def test_too_few_values(self):
+        generator = ScorecardGenerator.__new__(ScorecardGenerator)
+        values = [0.5, 0.9]
+        assert generator._compute_trend(values) == "stable"
+
+    def test_cost_trend_lower_is_better(self):
+        generator = ScorecardGenerator.__new__(ScorecardGenerator)
+        values = [1000, 900, 800, 700, 600, 500, 400, 300]
+        assert generator._compute_trend(values, lower_is_better=True) == "improving"
+
+
+class TestHealthComputation:
+    def test_perfect_health(self):
+        generator = ScorecardGenerator.__new__(ScorecardGenerator)
+        health = generator._compute_health(
+            achievement_rate=1.0,
+            cost_metrics=CostMetrics(
+                total_spend_tokens=1000,
+                avg_tokens_per_run=100,
+                cost_trend="decreasing",
+                cheapest_run_tokens=50,
+                most_expensive_run_tokens=200,
+            ),
+            adaptation_metrics=AdaptationMetrics(
+                total_graph_versions=3,
+                failure_modes_resolved=5,
+                failure_modes_remaining=0,
+                avg_decision_confidence=1.0,
+                confidence_trend="improving",
+            ),
+        )
+        assert health == 100
+
+    def test_worst_health(self):
+        generator = ScorecardGenerator.__new__(ScorecardGenerator)
+        health = generator._compute_health(
+            achievement_rate=0.0,
+            cost_metrics=CostMetrics(
+                total_spend_tokens=100000,
+                avg_tokens_per_run=10000,
+                cost_trend="increasing",
+                cheapest_run_tokens=8000,
+                most_expensive_run_tokens=15000,
+            ),
+            adaptation_metrics=AdaptationMetrics(
+                total_graph_versions=1,
+                failure_modes_resolved=0,
+                failure_modes_remaining=10,
+                avg_decision_confidence=0.0,
+                confidence_trend="declining",
+            ),
+        )
+        assert health == 5  # Only gets 5 from cost_score (increasing)
+
+
+class TestScorecardComparison:
+    def test_improvement_detected(self):
+        generator = ScorecardGenerator.__new__(ScorecardGenerator)
+
+        before = Scorecard(
+            agent_name="test",
+            goal_id="g1",
+            time_window="all_time",
+            runs_analyzed=5,
+            overall_health=50,
+            goal_achievement_rate=0.5,
+            criteria_scores=[],
+            cost_metrics=CostMetrics(
+                total_spend_tokens=5000,
+                avg_tokens_per_run=1000,
+                cost_trend="stable",
+                cheapest_run_tokens=500,
+                most_expensive_run_tokens=1500,
+            ),
+            adaptation_metrics=AdaptationMetrics(
+                total_graph_versions=1,
+                failure_modes_resolved=0,
+                failure_modes_remaining=3,
+                avg_decision_confidence=0.6,
+                confidence_trend="stable",
+            ),
+        )
+
+        after = Scorecard(
+            agent_name="test",
+            goal_id="g1",
+            time_window="all_time",
+            runs_analyzed=10,
+            overall_health=80,
+            goal_achievement_rate=0.85,
+            criteria_scores=[],
+            cost_metrics=CostMetrics(
+                total_spend_tokens=8000,
+                avg_tokens_per_run=800,
+                cost_trend="decreasing",
+                cheapest_run_tokens=400,
+                most_expensive_run_tokens=1200,
+            ),
+            adaptation_metrics=AdaptationMetrics(
+                total_graph_versions=3,
+                failure_modes_resolved=2,
+                failure_modes_remaining=1,
+                avg_decision_confidence=0.85,
+                confidence_trend="improving",
+            ),
+        )
+
+        diff = generator.compare(before, after)
+
+        assert diff.health_delta == 30
+        assert diff.achievement_delta == pytest.approx(0.35)
+        assert diff.cost_delta == pytest.approx(-200)
+        assert len(diff.improvements) > 0
+        assert any("achievement" in imp.lower() for imp in diff.improvements)


### PR DESCRIPTION
## Summary
- Introduces a structured scorecard system that quantifies agent performance across runs
- Adds `hive scorecard` CLI command with table, JSON, and Markdown output formats
- Enables before/after comparison to visualize improvement from agent evolution
- Provides the enterprise proof-of-value artifact needed for POC-to-contract conversion

Closes #4036

## What Changed

### New: `core/framework/schemas/scorecard.py`
Pydantic schemas for the scorecard data model:
- `CriterionScore` — per-criterion achievement rate with trend detection
- `CostMetrics` — token usage tracking with cost trends
- `AdaptationMetrics` — graph evolution count, failure resolution rate, confidence trends
- `Scorecard` — composite model with weighted health score (0-100) and computed health label
- `ScorecardDiff` — before/after comparison with labeled improvements and regressions

### New: `core/framework/builder/scorecard_generator.py`
Generator that consumes existing `BuilderQuery` patterns and `FileStorage` run data:
- Rolling time window support (7d, 14d, 30d, 90d, all_time)
- Health score computation: 40% achievement, 25% cost efficiency, 20% adaptation, 15% confidence
- Trend detection via first-half vs second-half mean comparison (5% threshold)
- Failure mode resolution tracking (errors present in early runs but absent in later runs)

### New: `core/framework/builder/scorecard_cli.py`
CLI registration following the `register_commands()` pattern:
- `hive scorecard <agent_path>` — full scorecard
- `hive scorecard <agent_path> --time-window last_7_days` — windowed analysis
- `hive scorecard <agent_path> --format json` — programmatic export
- `hive scorecard <agent_path> --compare old.json` — before/after diff

### Modified: `core/framework/cli.py`
Added import and registration of scorecard commands (2-line change).

### New: `core/tests/test_scorecard.py`
Comprehensive tests covering schema validation, generator logic, trend detection, health computation, and comparison accuracy.

## Test plan
- [ ] Run `make check` — linting passes
- [ ] Run `make test` — all tests pass including new test_scorecard.py
- [ ] Manual: `hive scorecard exports/<agent>` produces formatted table output
- [ ] Manual: `hive scorecard <agent> --format json` produces valid JSON
- [ ] Manual: `hive scorecard <agent> --compare old.json` shows diffs

## Why this matters

Today, Hive's adaptation loop works but is invisible. An enterprise buyer running a POC has no artifact to show their CTO that says "this agent improved from 62% to 89% achievement over 14 days." Scorecards create that artifact — transforming Hive's differentiator from an abstract promise into a measurable reality.