### PR TITLE
  fix: replace blocking time.sleep with asyncio.sleep in LLM rate-limit retry

### DIFF
--- a/core/framework/llm/anthropic.py
+++ b/core/framework/llm/anthropic.py
@@ -81,6 +81,25 @@ class AnthropicProvider(LLMProvider):
             json_mode=json_mode,
         )
 
+    async def acomplete(
+        self,
+        messages: list[dict[str, Any]],
+        system: str = "",
+        tools: list[Tool] | None = None,
+        max_tokens: int = 1024,
+        response_format: dict[str, Any] | None = None,
+        json_mode: bool = False,
+    ) -> LLMResponse:
+        """Async completion from Claude (via LiteLLM) — does not block the event loop."""
+        return await self._provider.acomplete(
+            messages=messages,
+            system=system,
+            tools=tools,
+            max_tokens=max_tokens,
+            response_format=response_format,
+            json_mode=json_mode,
+        )
+
     def complete_with_tools(
         self,
         messages: list[dict[str, Any]],


### PR DESCRIPTION
 ## Summary
  - `_completion_with_rate_limit_retry` uses `time.sleep()` for exponential backoff, which blocks the entire asyncio event loop during
  rate-limit retries
  - All concurrent operations (parallel node execution, streaming, TUI, HITL timers) freeze for seconds per retry attempt
  - Added `async acomplete()` to `LLMProvider` base class with a thread-executor default fallback
  - Added native async `_acompletion_with_rate_limit_retry` in `LiteLLMProvider` using `litellm.acompletion` + `asyncio.sleep`
  - Added `acomplete()` override in `AnthropicProvider` delegating to the async LiteLLM path
  - Fully backward compatible — sync `complete()` is untouched

**Associated Issue** #4057 