### PR TITLE
Link "Building Tools" guide and add Architecture Overview

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ You may submit PRs without prior assignment for:
 ./quickstart.sh
 ```
 
+> **Tip:** planning to build a new tool? Check out our [Building Tools Guide](tools/BUILDING_TOOLS.md) for a step-by-step walkthrough.
+
 > **Windows Users:**  
 > If you are on native Windows, it is recommended to use **WSL (Windows Subsystem for Linux)**.  
 > Alternatively, make sure to run PowerShell or Git Bash with Python 3.11+ installed, and disable "App Execution Aliases" in Windows settings.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Aden Agent Framework
 
-Thank you for your interest in contributing to the Aden Agent Framework! This document provides guidelines and information for contributors. We’re especially looking for help building tools, integrations([check #2805](https://github.com/adenhq/hive/issues/2805)), and example agents for the framework. If you’re interested in extending its functionality, this is the perfect place to start. 
+Thank you for your interest in contributing to the Aden Agent Framework! This document provides guidelines and information for contributors. We’re especially looking for help building tools (see [Building Tools Guide](tools/BUILDING_TOOLS.md)), integrations([check #2805](https://github.com/adenhq/hive/issues/2805)), and example agents for the framework. If you’re interested in extending its functionality, this is the perfect place to start. 
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Use Hive when you need:
 - **[Self-Hosting Guide](https://docs.adenhq.com/getting-started/quickstart)** - Deploy Hive on your infrastructure
 - **[Changelog](https://github.com/adenhq/hive/releases)** - Latest updates and releases
 - **[Roadmap](docs/roadmap.md)** - Upcoming features and plans
+- **[Building Tools](tools/BUILDING_TOOLS.md)** - Guide for creating custom tools
 - **[Report Issues](https://github.com/adenhq/hive/issues)** - Bug reports and feature requests
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ classDef done fill:#9e9e9e,color:#fff,stroke:#757575
 
 ## Contributing
 
-We welcome contributions from the community! We’re especially looking for help building tools, integrations, and example agents for the framework ([check #2805](https://github.com/adenhq/hive/issues/2805)). If you’re interested in extending its functionality, this is the perfect place to start. Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+We welcome contributions from the community! We’re especially looking for help building tools (see [Building Tools Guide](tools/BUILDING_TOOLS.md)), integrations([check #2805](https://github.com/adenhq/hive/issues/2805)). If you’re interested in extending its functionality, this is the perfect place to start. Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 **Important:** Please get assigned to an issue before submitting a PR. Comment on an issue to claim it, and a maintainer will assign you. Issues with reproducible steps and proposals are prioritized. This helps prevent duplicate work.
 

--- a/docs/architecture/overview.mermaid
+++ b/docs/architecture/overview.mermaid
@@ -1,0 +1,24 @@
+graph TD
+    User([User]) -->|Run Agent| Runner[Agent Runner]
+
+    subgraph "Agent Runtime"
+        Runner -->|Load| Graph[Agent Graph]
+        Graph -->|Start| Node1[Node: Plan]
+        Node1 -->|Next| Node2[Node: Execute]
+
+        Node2 -->|Use Tool| Tools[Tool Registry]
+        Tools -->|Call| Tool1[Excel Tool]
+        Tools -->|Call| Tool2[Image Gen Tool]
+        Tool1 -->|Result| Memory[(Shared Memory)]
+        Tool2 -->|Result| Memory
+
+        Memory -->|Read Context| Node2
+    end
+
+    Node2 -->|Output| Runner
+    Runner -->|Display| User
+
+    style User fill:#f9f,stroke:#333
+    style Runner fill:#bbf,stroke:#333
+    style Graph fill:#bfb,stroke:#333
+    style Memory fill:#fbb,stroke:#333

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -175,7 +175,7 @@ classDef done fill:#9e9e9e,color:#fff,stroke:#757575
     - [x] PDF tools
     - [ ] Excel tools
     - [ ] Email Tools
-    - [ ] Recipe for "Add your own tools"
+    - [x] Recipe for "Add your own tools"
 
 ### Memory & File System
 - [x] DB for long-term persistent memory (Filesystem as durable scratchpad pattern)


### PR DESCRIPTION
## Description
This PR improves the discoverability of the `tools/BUILDING_TOOLS.md` guide by linking it from the root `README.md` and `CONTRIBUTING.md`. It also updates the roadmap to reflect that the "Add your own tools" recipe exists.

## Changes
- [x] Linked `tools/BUILDING_TOOLS.md` in `README.md`
- [x] Linked `tools/BUILDING_TOOLS.md` in `CONTRIBUTING.md`
- [x] Updated `docs/roadmap.md`
- [x] Added `docs/architecture/overview.mermaid` (Architecture Diagram)

## Related Issue
Fixes #(Issue Number from Step 1)
