### PR TITLE
Apply graph level default for node max_retries

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -485,7 +485,11 @@ class GraphExecutor:
                     )
 
                     # [CORRECTED] Use node_spec.max_retries instead of hardcoded 3
-                    max_retries = getattr(node_spec, "max_retries", 3)
+                    max_retries = (
+                        node_spec.max_retries
+                        if node_spec.max_retries is not None
+                        else graph.max_retries_per_node
+                    )
 
                     # Event loop nodes handle retry internally via judge —
                     # executor retry is catastrophic (retry multiplication)
@@ -1184,7 +1188,11 @@ class GraphExecutor:
                 branch.error = f"Node {branch.node_id} not found in graph"
                 return branch, RuntimeError(branch.error)
 
-            effective_max_retries = node_spec.max_retries
+            effective_max_retries = (
+                node_spec.max_retries
+                if node_spec.max_retries is not None
+                else graph.max_retries_per_node
+            )
             if node_spec.node_type == "event_loop":
                 if effective_max_retries > 1:
                     self.logger.warning(


### PR DESCRIPTION
This PR ensures GraphSpec.max_retries_per_node is respected when a node does not explicitly define max_retries, aligning runtime behavior with graph-level policy expectations.

Testing:
- Repo test command is `make test` (cd core && uv run python -m pytest tests/ -v)
- Since uv was unavailable locally, I ran the relevant tests directly:
  cd core && python3 -m pytest tests/test_executor_max_retries.py -v
- All tests passed (6 passed)
- A warning about missing GlooCache API keys was observed but did not affect test outcomes
