### PR TITLE
test: skip Windows-incompatible tests (ls, pipe, symlink, Unix paths)

### DIFF
--- a/tools/tests/tools/test_file_system_toolkits.py
+++ b/tools/tests/tools/test_file_system_toolkits.py
@@ -1,6 +1,7 @@
 """Tests for file_system_toolkits tools (FastMCP)."""
 
 import os
+import platform
 from unittest.mock import patch
 
 import pytest
@@ -568,6 +569,10 @@ class TestExecuteCommandTool:
         assert result["success"] is True
         assert "error message" in result.get("stderr", "")
 
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="'ls' command is not available on Windows; use 'dir' instead",
+    )
     def test_execute_command_list_files(
         self, execute_command_fn, mock_workspace, mock_secure_path, tmp_path
     ):
@@ -581,6 +586,10 @@ class TestExecuteCommandTool:
         assert result["return_code"] == 0
         assert "testfile.txt" in result["stdout"]
 
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="Bash pipes ('|') and 'tr' command are not available on Windows; use PowerShell equivalents",
+    )
     def test_execute_command_with_pipe(self, execute_command_fn, mock_workspace, mock_secure_path):
         """Executing a command with pipe works correctly."""
         result = execute_command_fn(command="echo 'hello world' | tr 'a-z' 'A-Z'", **mock_workspace)


### PR DESCRIPTION
## Description

This PR fixes 5 tests that fail on Windows due to OS-level differences. By adding @pytest.mark.skipif(platform.system() == "Windows", ...) decorators, these tests now skip gracefully on Windows while still running on Linux/macOS CI systems.

**Before fix:**  5 failed, 698 passed
**After fix:**  5 skipped, 698 passed

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (no functional changes)

## Related Issues

Improves Windows compatibility for contributors.

## Changes Made

- Added `import platform` to test files
- Skip `test_execute_command_list_files` on Windows (ls command not available)
- Skip `test_execute_command_with_pipe` on Windows (Bash pipes and tr command not available)
- Skip `test_absolute_path_treated_as_relative` on Windows (Unix path semantics differ)
- Skip `test_symlink_within_sandbox_works` on Windows (symlink creation requires admin privileges)
- Skip `test_symlink_escape_detected_with_realpath` on Windows (symlink creation requires admin privileges)

**Files modified:**
- `tools/tests/tools/test_file_system_toolkits.py`
- `tools/tests/tools/test_security.py`

## Testing

All tests were run locally to verify:

- [x] Unit tests pass (`pytest tools/tests/ -v`)
- [x] Test Results: 698 passed, 35 skipped

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Changes are minimal and non-invasive (only skip markers added)
- [x] No dependencies or breaking changes introduced
- [x] My changes generate no new warnings

## Notes

**Why skip instead of refactor?**
Skipping is the standard pytest approach for OS-specific tests. Full functionality is still tested on Linux/macOS CI runners.