### PR TITLE
Fix delete_parts_before() crash on non-numeric filenames

### DIFF
--- a/core/framework/storage/conversation_store.py
+++ b/core/framework/storage/conversation_store.py
@@ -94,6 +94,8 @@ class FileConversationStore:
             if not self._parts_dir.exists():
                 return
             for f in self._parts_dir.glob("*.json"):
+                if not f.stem.isdigit():
+                    continue
                 file_seq = int(f.stem)
                 if file_seq < seq:
                     f.unlink()


### PR DESCRIPTION
## Summary
- Added `isdigit()` guard in `delete_parts_before()` to skip non-numeric filenames before calling `int(f.stem)`
- Prevents `ValueError` when unexpected files (editor temps, OS metadata) exist in the conversation parts directory

## Test plan
- [ ] Verify non-numeric JSON files in parts/ directory no longer cause crashes
- [ ] Verify numeric part files are still correctly deleted

Fixes #4111

> Automated fix by buildingvibes