### PR TITLE
Add SME Credit Risk Agent with scorecard

### DIFF
--- a/examples/templates/credit_risk_agent/agent.py
+++ b/examples/templates/credit_risk_agent/agent.py
@@ -1,0 +1,98 @@
+"""An AI agent that analyzes SME companies and evaluates their credit risk, including probability of default, financial strength, and lending recommendation."""
+
+from framework.graph import EdgeSpec, EdgeCondition, Goal, SuccessCriterion
+from framework.graph.edge import GraphSpec
+
+from .config import default_config, metadata
+from .nodes import (
+    intake_node,
+    financial_analysis_node,
+    risk_assessment_node,
+    credit_decision_node,
+)
+
+# Goal definition
+goal = Goal(
+    id="sme-credit-risk-assessment",
+    name="SME Credit Risk Assessment",
+    description=(
+        "Evaluate SME credit applications by analyzing financial data, cash flows, "
+        "risk factors, and mitigants in order to estimate probability of default "
+	"and issue a lending recommendation."
+    ),
+    success_criteria=[
+        SuccessCriterion(
+            id="risk-identification",
+            description="All material credit risk factors are identified and explained",
+            metric="risk_coverage",
+            target="high",
+            weight=0.3,
+        ),
+        SuccessCriterion(
+            id="repayment-capacity",
+            description="Cash flow and repayment capacity are correctly assessed and supports debt repayment",
+            metric="dscr_accuracy",
+            target=">=1.1",
+            weight=0.3,
+        ),
+        SuccessCriterion(
+            id="decision-quality",
+            description="Credit decision is justified and consistent with risk profile",
+            metric="decision_consistency",
+            target="high",
+            weight=0.4,
+        ),
+    )
+
+# Node list
+nodes = [
+    intake_node,
+    financial_analysis_node,
+    risk_assessment_node,
+    credit_decision_node,
+]
+
+# Edge definitions
+edges = [
+    # intake -> financial_analysis
+    EdgeSpec(
+        id="intake-to-financial",
+        source="intake",
+        target="financial_analysis",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    # financial_analysis -> risk_assessment
+    EdgeSpec(
+        id="financial-to-risk",
+        source="financial_analysis",
+        target="risk_assessment",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    # risk_assessment -> credit_decision
+    EdgeSpec(
+        id="risk-to-decision",
+        source="risk_assessment",
+        target="credit_decision",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+]
+
+# Graph configuration
+entry_node = "intake"
+entry_points = {"start": "intake"}
+terminal_nodes = ["credit_decision"]
+pause_nodes = []
+
+
+class CreditRiskAgent:
+    """
+    Credit Risk Agent — 4-node pipeline with user checkpoints.
+
+    Flow: intake -> financial_analysis -> risk_assessment -> credit_decision
+
+    """
+
+    pass

--- a/examples/templates/credit_risk_agent/config.py
+++ b/examples/templates/credit_risk_agent/config.py
@@ -1,0 +1,46 @@
+"""Runtime configuration."""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+def _load_preferred_model() -> str:
+    """Load preferred model from ~/.hive/configuration.json."""
+    config_path = Path.home() / ".hive" / "configuration.json"
+    if config_path.exists():
+        try:
+            with open(config_path) as f:
+                config = json.load(f)
+            llm = config.get("llm", {})
+            if llm.get("provider") and llm.get("model"):
+                return f"{llm['provider']}/{llm['model']}"
+        except Exception:
+            pass
+    return "anthropic/claude-sonnet-4-20250514"
+
+
+@dataclass
+class RuntimeConfig:
+    model: str = field(default_factory=_load_preferred_model)
+    temperature: float = 0.7
+    max_tokens: int = 40000
+    api_key: str | None = None
+    api_base: str | None = None
+
+
+default_config = RuntimeConfig()
+
+
+@dataclass
+class AgentMetadata:
+    name: str = "SME Credit Risk Agent"
+    version: str = "1.0.0"
+    description: str = (
+        "Deterministic, explainable credit risk assessment agent for SME lending. "
+        "Evaluates repayment capacity, leverage, business stability, data quality, "
+        "and credit history to issue a lending recommendation."
+    )
+
+
+metadata = AgentMetadata()

--- a/examples/templates/credit_risk_agent/nodes/__init__.py
+++ b/examples/templates/credit_risk_agent/nodes/__init__.py
@@ -1,0 +1,15 @@
+"""
+Node definitions for SME Credit Risk Agent.
+"""
+
+from .intake import intake_node
+from .financial_analysis import financial_analysis_node
+from .risk_assessment import risk_assessment_node
+from .credit_decision_node import credit_decision_node
+
+__all__ = [
+    "intake_node",
+    "financial_analysis_node",
+    "risk_assessment_node",
+    "credit_decision_node",
+]

--- a/examples/templates/credit_risk_agent/nodes/credit_decision_node.py
+++ b/examples/templates/credit_risk_agent/nodes/credit_decision_node.py
@@ -1,0 +1,175 @@
+"""
+Credit Decision Node
+
+Evaluates SME credit applications using a deterministic, explainable
+scorecard calibrated for LATAM SME lending.
+
+Outputs:
+- credit_score (0–100)
+- risk_level
+- probability_of_default (range)
+- decision
+- score_breakdown
+"""
+
+from framework.graph import Node, NodeResult
+
+
+credit_decision_node = Node(
+    id="credit_decision",
+    name="Credit Decision",
+    description="Applies a deterministic scorecard to issue a credit decision",
+    client_facing=True,
+)
+
+
+@credit_decision_node.run
+def run(input_data: dict, context: dict) -> NodeResult:
+    """
+    Expected input_data:
+    {
+        "monthly_cash_flow": float,
+        "existing_debt": float,
+        "dscr": float,
+        "years_in_operation": int,
+        "data_sources": list[str],
+        "past_defaults": bool
+    }
+    """
+
+    # -------------------------
+    # Input extraction
+    # -------------------------
+    monthly_cash_flow = input_data["monthly_cash_flow"]
+    existing_debt = input_data["existing_debt"]
+    dscr = input_data["dscr"]
+    years_in_operation = input_data["years_in_operation"]
+    data_sources = set(input_data.get("data_sources", []))
+    past_defaults = input_data["past_defaults"]
+
+    score = 0
+
+    # ======================================================
+    # 1. Repayment Capacity (DSCR) — max 40 pts
+    # ======================================================
+    if dscr >= 1.5:
+        repayment_points = 40
+    elif dscr >= 1.3:
+        repayment_points = 32
+    elif dscr >= 1.1:
+        repayment_points = 24
+    elif dscr >= 1.0:
+        repayment_points = 12
+    else:
+        repayment_points = 0
+
+    score += repayment_points
+
+    # ======================================================
+    # 2. Business Stability (Years in Operation) — max 20 pts
+    # ======================================================
+    if years_in_operation >= 5:
+        stability_points = 20
+    elif years_in_operation >= 3:
+        stability_points = 15
+    elif years_in_operation >= 1:
+        stability_points = 8
+    else:
+        stability_points = 0
+
+    score += stability_points
+
+    # ======================================================
+    # 3. Leverage (Debt / Monthly Cash Flow) — max 15 pts
+    # LATAM-calibrated thresholds
+    # ======================================================
+    if monthly_cash_flow > 0:
+        debt_months = existing_debt / monthly_cash_flow
+    else:
+        debt_months = float("inf")
+
+    if monthly_cash_flow <= 0:
+        leverage_points = 0
+    elif debt_months < 12:
+        leverage_points = 15
+    elif debt_months <= 18:
+        leverage_points = 10
+    else:
+        leverage_points = 5
+
+    score += leverage_points
+
+    # ======================================================
+    # 4. Data Quality — max 15 pts
+    # ======================================================
+    if {"bank_statements", "pos_sales", "utility_payments"}.issubset(data_sources):
+        data_quality_points = 15
+    elif {"bank_statements", "pos_sales"}.issubset(data_sources):
+        data_quality_points = 12
+    elif "bank_statements" in data_sources:
+        data_quality_points = 8
+    elif len(data_sources) > 0:
+        data_quality_points = 4
+    else:
+        data_quality_points = 0
+
+    score += data_quality_points
+
+    data_quality_assessment = {
+        "sources_provided": list(data_sources),
+        "points": data_quality_points,
+    }
+
+    # ======================================================
+    # 5. Credit History — max 10 pts
+    # ======================================================
+    history_points = 10 if not past_defaults else 0
+    score += history_points
+
+    # ======================================================
+    # Score Breakdown
+    # ======================================================
+    score_breakdown = {
+        "repayment_capacity": repayment_points,
+        "business_stability": stability_points,
+        "leverage": leverage_points,
+        "data_quality": data_quality_points,
+        "credit_history": history_points,
+    }
+
+    # ======================================================
+    # Decision Logic
+    # ======================================================
+    if dscr < 1.0:
+        decision = "Reject"
+        risk_level = "High"
+        pd_range = ">15%"
+    elif score >= 80:
+        decision = "Approve"
+        risk_level = "Low"
+        pd_range = "1–3%"
+    elif score >= 65:
+        decision = "Conditional Approval"
+        risk_level = "Medium"
+        pd_range = "4–8%"
+    else:
+        decision = "Reject"
+        risk_level = "High"
+        pd_range = ">15%"
+
+    # ======================================================
+    # Output
+    # ======================================================
+    return NodeResult(
+        success=True,
+        output={
+            "credit_score": score,
+            "risk_level": risk_level,
+            "probability_of_default": pd_range,
+            "decision": decision,
+            "score_breakdown": score_breakdown,
+            "data_quality": data_quality_assessment,
+        },
+    )
+
+


### PR DESCRIPTION
Fixes #4134 

**Summary**

This PR introduces a new SME Credit Risk Agent template under examples/templates/credit_risk_agent.

The agent demonstrates how Hive can be used to build a deterministic, explainable credit decisioning workflow, inspired by real-world SME lending practices in LATAM.

**What’s included**

- A 4-node credit risk pipeline:

    1. Intake
    2. Financial analysis
    3. Risk assessment
    4. Credit decision

- A fully deterministic scorecard-based credit decision node
- Transparent score breakdown and decision logic
- No LLM dependence for the final credit decision (fully explainable)



**Credit decision methodology:**

The credit decision is based on a 0–100 score composed of:

- Repayment capacity (DSCR) — up to 40 pts
- Business stability (years in operation) — up to 20 pts
- Leverage (debt / monthly cash flow) — up to 15 pts
- Data quality / source coverage — up to 15 pts
- Credit history (past defaults) — up to 10 pts


**Decision rules:**

- Automatic rejection if DSCR < 1.0
- Approval, conditional approval, or rejection based on total score
- Risk level and PD range derived from score bands


**Calibration Notes (LATAM reality):**

Some thresholds (like leverage measured in months of cash flow) are intentionally calibrated for LATAM SME realities, where:

- Informality is higher
- Financial statements are often partial
- Cash-flow-based underwriting is more common than balance-sheet-based models


**Why this is useful for Hive**

- Provides a production-oriented example with other type of agents
- Shows how Hive can support: Fintech, Credit underwriting, Risk decisioning
- Demonstrates explainability and auditability, which are critical in regulated environments
- 


Happy to iterate based on feedback.