### PR TITLE
feat(graph): add Mermaid diagram export for agent graphs

### DIFF
--- a/core/framework/graph/edge.py
+++ b/core/framework/graph/edge.py
@@ -667,3 +667,14 @@ class GraphSpec(BaseModel):
                             seen_keys[key] = node_id
 
         return errors
+
+    def to_mermaid(self) -> str:
+        """Export this graph to a Mermaid flowchart diagram string.
+
+        Returns:
+            A string containing valid Mermaid flowchart syntax suitable for
+            rendering in GitHub, markdown viewers, or Mermaid-compatible tools.
+        """
+        from framework.graph.mermaid import to_mermaid
+
+        return to_mermaid(self)

--- a/core/framework/graph/mermaid.py
+++ b/core/framework/graph/mermaid.py
@@ -1,0 +1,152 @@
+"""
+Mermaid Diagram Exporter - Export agent graphs to Mermaid.js syntax.
+
+Converts a GraphSpec into a Mermaid flowchart diagram string that renders
+natively in GitHub, markdown viewers, and documentation tools.
+
+Usage:
+    from framework.graph.mermaid import to_mermaid
+
+    diagram = to_mermaid(graph_spec)
+    print(diagram)
+
+    # Or via GraphSpec convenience method:
+    diagram = graph_spec.to_mermaid()
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+from framework.graph.edge import EdgeCondition
+
+if TYPE_CHECKING:
+    from framework.graph.edge import EdgeSpec, GraphSpec
+
+# Mermaid node shapes by node_type: (left_delimiter, right_delimiter)
+_NODE_SHAPES: dict[str, tuple[str, str]] = {
+    "event_loop": ("(", ")"),
+    "llm_tool_use": ("(", ")"),
+    "llm_generate": ("(", ")"),
+    "function": ("[[", "]]"),
+    "router": ("{", "}"),
+    "human_input": ("([", "])"),
+}
+
+_DEFAULT_SHAPE = ("(", ")")
+
+
+def _sanitize_id(node_id: str) -> str:
+    """Sanitize a node ID for Mermaid compatibility.
+
+    Mermaid node IDs must contain only alphanumeric characters and underscores.
+    """
+    sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", node_id)
+    if sanitized and sanitized[0].isdigit():
+        sanitized = f"_{sanitized}"
+    return sanitized
+
+
+def _escape_label(text: str) -> str:
+    """Escape characters that conflict with Mermaid syntax."""
+    return text.replace('"', "'").replace("|", "/")
+
+
+def _node_display_name(node: Any) -> str:
+    """Get a human-readable display name for a node."""
+    return node.name if node.name else node.id
+
+
+def _edge_label(edge: EdgeSpec) -> str:
+    """Generate a Mermaid edge label based on the edge condition type."""
+    if edge.condition == EdgeCondition.ALWAYS:
+        return ""
+    if edge.condition == EdgeCondition.ON_SUCCESS:
+        return "Success"
+    if edge.condition == EdgeCondition.ON_FAILURE:
+        return "Failure"
+    if edge.condition == EdgeCondition.CONDITIONAL:
+        return _escape_label(edge.condition_expr) if edge.condition_expr else "Conditional"
+    if edge.condition == EdgeCondition.LLM_DECIDE:
+        return _escape_label(edge.description) if edge.description else "LLM Decision"
+    return ""
+
+
+def _topo_order(graph: GraphSpec) -> list[str]:
+    """BFS traversal from entry_node, appending unreachable nodes at the end."""
+    visited: list[str] = []
+    seen: set[str] = set()
+    queue = [graph.entry_node]
+    while queue:
+        nid = queue.pop(0)
+        if nid in seen:
+            continue
+        seen.add(nid)
+        visited.append(nid)
+        for edge in graph.get_outgoing_edges(nid):
+            if edge.target not in seen:
+                queue.append(edge.target)
+    for node in graph.nodes:
+        if node.id not in seen:
+            visited.append(node.id)
+    return visited
+
+
+def to_mermaid(graph: GraphSpec) -> str:
+    """Export a GraphSpec to a Mermaid flowchart diagram string.
+
+    Args:
+        graph: The GraphSpec to convert.
+
+    Returns:
+        A string containing valid Mermaid flowchart syntax suitable for
+        rendering in GitHub, markdown viewers, or Mermaid-compatible tools.
+
+    Example output::
+
+        graph TD
+            _start_((Start)) --> research
+            research("Research Agent")
+            writer("Writer Agent")
+            research -->|"Success"| writer
+    """
+    lines: list[str] = ["graph TD"]
+
+    node_map: dict[str, Any] = {node.id: node for node in graph.nodes}
+    terminal_set = set(graph.terminal_nodes or [])
+    ordered = _topo_order(graph)
+
+    # Define nodes with shapes
+    for node_id in ordered:
+        node = node_map.get(node_id)
+        if not node:
+            continue
+        safe_id = _sanitize_id(node_id)
+        name = _escape_label(_node_display_name(node))
+        node_type = getattr(node, "node_type", "event_loop")
+        left, right = _NODE_SHAPES.get(node_type, _DEFAULT_SHAPE)
+        lines.append(f'    {safe_id}{left}"{name}"{right}')
+
+    # Start marker pointing to entry node
+    entry_safe = _sanitize_id(graph.entry_node)
+    lines.append(f"    _start_((Start)) --> {entry_safe}")
+
+    # Edges
+    for node_id in ordered:
+        for edge in graph.get_outgoing_edges(node_id):
+            src = _sanitize_id(edge.source)
+            tgt = _sanitize_id(edge.target)
+            label = _edge_label(edge)
+            if label:
+                lines.append(f'    {src} -->|"{label}"| {tgt}')
+            else:
+                lines.append(f"    {src} --> {tgt}")
+
+    # Style terminal nodes
+    terminal_ids = [_sanitize_id(nid) for nid in terminal_set if nid in node_map]
+    if terminal_ids:
+        lines.append("    classDef terminal stroke-width:4px")
+        lines.append(f"    class {','.join(terminal_ids)} terminal")
+
+    return "\n".join(lines) + "\n"

--- a/core/tests/test_mermaid_export.py
+++ b/core/tests/test_mermaid_export.py
@@ -1,0 +1,356 @@
+"""
+Tests for Mermaid diagram export from GraphSpec.
+"""
+
+from framework.graph.edge import EdgeCondition, EdgeSpec, GraphSpec
+from framework.graph.mermaid import _sanitize_id, to_mermaid
+from framework.graph.node import NodeSpec
+
+
+def _make_node(node_id: str, name: str = "", node_type: str = "event_loop") -> NodeSpec:
+    """Helper to create a minimal NodeSpec."""
+    return NodeSpec(
+        id=node_id,
+        name=name or node_id,
+        description=f"Test node {node_id}",
+        node_type=node_type,
+    )
+
+
+def _make_edge(
+    edge_id: str,
+    source: str,
+    target: str,
+    condition: EdgeCondition = EdgeCondition.ALWAYS,
+    condition_expr: str | None = None,
+    description: str = "",
+) -> EdgeSpec:
+    """Helper to create a minimal EdgeSpec."""
+    return EdgeSpec(
+        id=edge_id,
+        source=source,
+        target=target,
+        condition=condition,
+        condition_expr=condition_expr,
+        description=description,
+    )
+
+
+# -- Linear graph --
+
+
+def test_linear_graph():
+    """A -> B -> C produces correct Mermaid output."""
+    graph = GraphSpec(
+        id="linear",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["c"],
+        nodes=[_make_node("a", "A"), _make_node("b", "B"), _make_node("c", "C")],
+        edges=[
+            _make_edge("e1", "a", "b"),
+            _make_edge("e2", "b", "c"),
+        ],
+    )
+
+    result = to_mermaid(graph)
+
+    assert "graph TD" in result
+    assert "_start_((Start)) --> a" in result
+    assert "a --> b" in result
+    assert "b --> c" in result
+
+
+def test_linear_graph_via_method():
+    """GraphSpec.to_mermaid() delegates to the standalone function."""
+    graph = GraphSpec(
+        id="linear",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["c"],
+        nodes=[_make_node("a", "A"), _make_node("b", "B"), _make_node("c", "C")],
+        edges=[
+            _make_edge("e1", "a", "b"),
+            _make_edge("e2", "b", "c"),
+        ],
+    )
+
+    assert graph.to_mermaid() == to_mermaid(graph)
+
+
+# -- Edge conditions --
+
+
+def test_on_success_edge():
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["b"],
+        nodes=[_make_node("a"), _make_node("b")],
+        edges=[_make_edge("e1", "a", "b", EdgeCondition.ON_SUCCESS)],
+    )
+
+    result = to_mermaid(graph)
+    assert '-->|"Success"|' in result
+
+
+def test_on_failure_edge():
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["b"],
+        nodes=[_make_node("a"), _make_node("b")],
+        edges=[_make_edge("e1", "a", "b", EdgeCondition.ON_FAILURE)],
+    )
+
+    result = to_mermaid(graph)
+    assert '-->|"Failure"|' in result
+
+
+def test_conditional_edge_with_expr():
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["b"],
+        nodes=[_make_node("a"), _make_node("b")],
+        edges=[
+            _make_edge(
+                "e1", "a", "b", EdgeCondition.CONDITIONAL, condition_expr="output.confidence > 0.8"
+            )
+        ],
+    )
+
+    result = to_mermaid(graph)
+    assert "output.confidence > 0.8" in result
+
+
+def test_conditional_edge_without_expr():
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["b"],
+        nodes=[_make_node("a"), _make_node("b")],
+        edges=[_make_edge("e1", "a", "b", EdgeCondition.CONDITIONAL)],
+    )
+
+    result = to_mermaid(graph)
+    assert "Conditional" in result
+
+
+def test_llm_decide_edge_with_description():
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["b"],
+        nodes=[_make_node("a"), _make_node("b")],
+        edges=[
+            _make_edge(
+                "e1",
+                "a",
+                "b",
+                EdgeCondition.LLM_DECIDE,
+                description="Only if results need refinement",
+            )
+        ],
+    )
+
+    result = to_mermaid(graph)
+    assert "Only if results need refinement" in result
+
+
+def test_llm_decide_edge_without_description():
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["b"],
+        nodes=[_make_node("a"), _make_node("b")],
+        edges=[_make_edge("e1", "a", "b", EdgeCondition.LLM_DECIDE)],
+    )
+
+    result = to_mermaid(graph)
+    assert "LLM Decision" in result
+
+
+# -- Fan-out and fan-in --
+
+
+def test_fan_out():
+    """One node branching to multiple targets."""
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["b", "c"],
+        nodes=[_make_node("a"), _make_node("b"), _make_node("c")],
+        edges=[
+            _make_edge("e1", "a", "b", EdgeCondition.ON_SUCCESS),
+            _make_edge("e2", "a", "c", EdgeCondition.ON_FAILURE),
+        ],
+    )
+
+    result = to_mermaid(graph)
+    assert 'a -->|"Success"| b' in result
+    assert 'a -->|"Failure"| c' in result
+
+
+def test_fan_in():
+    """Multiple sources converging to one target."""
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["c"],
+        nodes=[_make_node("a"), _make_node("b"), _make_node("c")],
+        edges=[
+            _make_edge("e1", "a", "b"),
+            _make_edge("e2", "a", "c"),
+            _make_edge("e3", "b", "c"),
+        ],
+    )
+
+    result = to_mermaid(graph)
+    assert "a --> c" in result
+    assert "b --> c" in result
+
+
+# -- Feedback loops (cycles) --
+
+
+def test_feedback_loop():
+    """Cycles render without infinite recursion."""
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["c"],
+        nodes=[_make_node("a"), _make_node("b"), _make_node("c")],
+        edges=[
+            _make_edge("e1", "a", "b", EdgeCondition.ON_SUCCESS),
+            _make_edge("e2", "b", "a", EdgeCondition.ON_FAILURE),  # feedback loop
+            _make_edge("e3", "b", "c", EdgeCondition.ON_SUCCESS),
+        ],
+    )
+
+    result = to_mermaid(graph)
+    assert 'b -->|"Failure"| a' in result
+    assert 'b -->|"Success"| c' in result
+
+
+# -- Node types and shapes --
+
+
+def test_node_type_shapes():
+    """Different node types get correct Mermaid shapes."""
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="llm",
+        terminal_nodes=["human"],
+        nodes=[
+            _make_node("llm", "LLM Node", "event_loop"),
+            _make_node("func", "Function Node", "function"),
+            _make_node("route", "Router Node", "router"),
+            _make_node("human", "Human Input", "human_input"),
+        ],
+        edges=[
+            _make_edge("e1", "llm", "func"),
+            _make_edge("e2", "func", "route"),
+            _make_edge("e3", "route", "human"),
+        ],
+    )
+
+    result = to_mermaid(graph)
+    assert 'llm("LLM Node")' in result
+    assert 'func[["Function Node"]]' in result
+    assert 'route{"Router Node"}' in result
+    assert 'human(["Human Input"])' in result
+
+
+# -- Terminal nodes --
+
+
+def test_terminal_nodes_get_style():
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["b"],
+        nodes=[_make_node("a"), _make_node("b")],
+        edges=[_make_edge("e1", "a", "b")],
+    )
+
+    result = to_mermaid(graph)
+    assert "classDef terminal stroke-width:4px" in result
+    assert "class b terminal" in result
+
+
+# -- Entry node --
+
+
+def test_entry_node_has_start_arrow():
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="first",
+        terminal_nodes=["first"],
+        nodes=[_make_node("first")],
+        edges=[],
+    )
+
+    result = to_mermaid(graph)
+    assert "_start_((Start)) --> first" in result
+
+
+# -- ID sanitization --
+
+
+def test_sanitize_id_special_characters():
+    assert _sanitize_id("my-node") == "my_node"
+    assert _sanitize_id("node.name") == "node_name"
+    assert _sanitize_id("node with spaces") == "node_with_spaces"
+    assert _sanitize_id("123start") == "_123start"
+    assert _sanitize_id("already_valid") == "already_valid"
+
+
+def test_node_ids_with_special_chars():
+    """Node IDs with special characters are sanitized in the output."""
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="my-node",
+        terminal_nodes=["end-node"],
+        nodes=[_make_node("my-node", "My Node"), _make_node("end-node", "End Node")],
+        edges=[_make_edge("e1", "my-node", "end-node")],
+    )
+
+    result = to_mermaid(graph)
+    assert "my_node" in result
+    assert "end_node" in result
+    # Original IDs with hyphens should not appear as Mermaid IDs
+    assert "my-node" not in result.split('"')[0]  # not outside quoted labels
+
+
+# -- Empty edges --
+
+
+def test_graph_with_no_edges():
+    """A graph with nodes but no edges still renders nodes."""
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="solo",
+        terminal_nodes=["solo"],
+        nodes=[_make_node("solo", "Solo Node")],
+        edges=[],
+    )
+
+    result = to_mermaid(graph)
+    assert "graph TD" in result
+    assert 'solo("Solo Node")' in result
+    assert "_start_((Start)) --> solo" in result


### PR DESCRIPTION
## Summary
- Adds `to_mermaid()` function in `core/framework/graph/mermaid.py` to export `GraphSpec` as Mermaid.js flowchart syntax
- Adds `GraphSpec.to_mermaid()` convenience method
- Renders natively in GitHub markdown, docs, and Mermaid-compatible tools

## What it does
- Maps node types to Mermaid shapes (event_loop → rounded rect, function → subroutine, router → diamond, human_input → stadium)
- Handles all 5 edge conditions as labeled arrows (ALWAYS, ON_SUCCESS, ON_FAILURE, CONDITIONAL with expression, LLM_DECIDE with description)
- Entry node gets a Start marker, terminal nodes get distinct styling
- BFS topological ordering (same pattern as `graph_view.py`)
- ID sanitization for Mermaid compatibility

## Example output
```mermaid
graph TD
    research("Research Agent")
    writer("Writer Agent")
    review(["Human Review"])
    _start_((Start)) --> research
    research -->|"Success"| writer
    writer --> review
    classDef terminal stroke-width:4px
    class review terminal
