### PR TITLE
Fix MockLLMProvider to fully implement complete_with_tools

### DIFF
--- a/core/tests/test_llm_judge.py
+++ b/core/tests/test_llm_judge.py
@@ -26,6 +26,7 @@ class MockLLMProvider(LLMProvider):
     def __init__(self, response_content: str = '{"passes": true, "explanation": "Test passed"}'):
         self.response_content = response_content
         self.complete_calls = []
+        self.complete_with_tools_calls = []
 
     def complete(
         self,
@@ -52,7 +53,23 @@ class MockLLMProvider(LLMProvider):
         )
 
     def complete_with_tools(self, messages, system, tools, tool_executor, max_iterations=10):
-        raise NotImplementedError("Tool use not needed for judge tests")
+        self.complete_with_tools_calls.append(
+            {
+                "messages": messages,
+                "system": system,
+                "tools": tools,
+                "tool_executor": tool_executor,
+                "max_iterations": max_iterations,
+            }
+        )
+
+        return LLMResponse(
+            content='{"passes": true, "explanation": "Tool execution completed"}',
+            model="mock-model",
+            input_tokens=200,
+            output_tokens=150,
+        )
+
 
 
 # ============================================================================


### PR DESCRIPTION
## Description

This PR fixes an incomplete mock implementation in `MockLLMProvider` where
`complete_with_tools` previously raised `NotImplementedError`.

The mock now fully implements the `LLMProvider` interface with minimal,
test-safe behavior, preserving interface substitutability and preventing
future failures in tool-enabled scenarios.

## Type of Change

-  Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #3621

## Changes Made

- Implemented a mock `complete_with_tools` method in `MockLLMProvider`
- Added call tracking for `complete_with_tools` to support future assertions
- Returned a deterministic `LLMResponse` to keep tests stable and predictable

## Testing

The following tests were run locally:

-  Unit tests pass (`pytest core/tests/test_llm_judge.py`)

## Checklist

-  My code follows the project's style guidelines
-  I have performed a self-review of my code
-  My changes generate no new warnings
-  New and existing unit tests pass locally with my changes
