### PR TITLE
Add typed response model for create_session MCP tool

### DIFF
--- a/core/framework/mcp/agent_builder_server.py
+++ b/core/framework/mcp/agent_builder_server.py
@@ -40,6 +40,8 @@ from framework.testing.prompts import (  # noqa: E402
 )
 from framework.utils.io import atomic_write  # noqa: E402
 
+from framework.schemas.agent_builder import CreateSessionResponse
+
 # Initialize MCP server
 mcp = FastMCP("agent-builder")
 
@@ -200,19 +202,21 @@ def get_session() -> BuildSession:
 
 
 @mcp.tool()
-def create_session(name: Annotated[str, "Name for the agent being built"]) -> str:
+def create_session(
+    name: Annotated[str, "Name for the agent being built"],
+) -> CreateSessionResponse:
     """Create a new agent building session. Call this first before building an agent."""
     global _session
     _session = BuildSession(name)
     _save_session(_session)  # Auto-save
-    return json.dumps(
-        {
-            "session_id": _session.id,
-            "name": name,
-            "status": "created",
-            "persisted": True,
-        }
+
+    return CreateSessionResponse(
+        session_id=_session.id,
+        name=name,
+        status="created",
+        persisted=True,
     )
+
 
 
 @mcp.tool()

--- a/core/framework/schemas/agent_builder.py
+++ b/core/framework/schemas/agent_builder.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class CreateSessionResponse(BaseModel):
+    session_id: str
+    name: str
+    status: str
+    persisted: bool


### PR DESCRIPTION
## Description

Adds a typed Pydantic response model for the create_session MCP tool.
This change improves type safety and establishes a clear pattern for incrementally typing MCP tool endpoints without modifying existing behavior.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #4179 

## Changes Made

- Added a `CreateSessionResponse` Pydantic model under `core/framework/schemas`
- Updated the `create_session` MCP tool to return a typed response instead of a raw JSON string
- No changes to tool behavior, validation, or session logic

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

### Manual verification:

- Verified no import or runtime errors
- Confirmed returned structure matches previous JSON payload

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
