### PR TITLE
fix(llm): support Llama 3.2 tool calls and dedicated Ollama setup

### DIFF
--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -603,7 +603,11 @@ class AgentRunner:
             else:
                 # Fall back to environment variable
                 api_key_env = self._get_api_key_env_var(self.model)
-                if api_key_env and os.environ.get(api_key_env):
+
+                if api_key_env is None:
+                    # No key required (e.g. Ollama)
+                    self._llm = LiteLLMProvider(model=self.model)
+                elif os.environ.get(api_key_env):
                     self._llm = LiteLLMProvider(model=self.model)
                 else:
                     # Fall back to credential store

--- a/uv.lock
+++ b/uv.lock
@@ -754,7 +754,7 @@ wheels = [
 
 [[package]]
 name = "framework"
-version = "0.1.0"
+version = "0.4.2"
 source = { editable = "core" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Description
This PR addresses several issues related to Ollama support:
1. **Llama 3.2 Tool Call Fallback**: Smaller models like Llama 3.2 often output tool calls as raw JSON text in the message content. This PR adds a fallback mechanism in LiteLLMProvider to parse these JSON blocks.
2. **No-Auth Provider Support**: Updated AgentRunner to correctly initialize LiteLLMProvider for models that do not require an API key (e.g., local Ollama).
3. **Dedicated Ollama Setup**: Enhanced quickstart.sh with a specialized Ollama flow including:
   - Service existence and status verification.
   - Interactive model selection from locally installed models.
   - Optimized model listing to minimize command calls.
   - Exact model matching to prevent false positives.

Fixes #4222