### PR TITLE
feat(evaluation): add agent evaluation and adaptiveness framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Agent evaluation framework (`core/framework/evaluation/`)
+  - Runtime evaluation of ExecutionResult against Goal success criteria and constraints
+  - 22-category failure taxonomy with pattern matching and structural analysis
+  - Metrics aggregation with trend detection across runs
+  - Structured reports with evolution recommendations for the Coding Agent
 - Initial project structure
 - React frontend (honeycomb) with Vite and TypeScript
 - Node.js backend (hive) with Express and TypeScript

--- a/core/framework/evaluation/__init__.py
+++ b/core/framework/evaluation/__init__.py
@@ -1,0 +1,21 @@
+"""Agent evaluation and adaptiveness framework."""
+
+from framework.evaluation.evaluator import AgentEvaluator
+from framework.evaluation.failure_classifier import (
+    FailureCategory,
+    FailureClassifier,
+    FailureRecord,
+)
+from framework.evaluation.metrics import EvaluationMetrics, MetricsCollector
+from framework.evaluation.report import EvaluationReport, EvolutionRecommendation
+
+__all__ = [
+    "AgentEvaluator",
+    "EvaluationMetrics",
+    "EvaluationReport",
+    "EvolutionRecommendation",
+    "FailureCategory",
+    "FailureClassifier",
+    "FailureRecord",
+    "MetricsCollector",
+]

--- a/core/framework/evaluation/evaluator.py
+++ b/core/framework/evaluation/evaluator.py
@@ -1,0 +1,354 @@
+"""Agent evaluator -- evaluates ExecutionResult against Goal."""
+
+import logging
+import uuid
+from typing import Any
+
+from framework.evaluation.failure_classifier import (
+    FailureCategory,
+    FailureClassifier,
+    FailureRecord,
+)
+from framework.evaluation.metrics import EvaluationMetrics, MetricsCollector
+from framework.evaluation.report import (
+    EvaluationReport,
+    EvolutionRecommendation,
+    EvolutionStage,
+    RecommendationPriority,
+)
+from framework.graph.goal import Constraint, Goal, SuccessCriterion
+
+logger = logging.getLogger(__name__)
+
+# Rough token pricing per 1K tokens (for cost estimation)
+_MODEL_PRICING: dict[str, dict[str, float]] = {
+    "gpt-4o": {"input": 0.005, "output": 0.015},
+    "gpt-4o-mini": {"input": 0.00015, "output": 0.0006},
+    "claude-3-5-sonnet": {"input": 0.003, "output": 0.015},
+    "claude-haiku-4-5": {"input": 0.001, "output": 0.005},
+    "gemini-1.5-flash": {"input": 0.000075, "output": 0.0003},
+}
+_DEFAULT_COST_PER_1K = 0.002
+
+
+class AgentEvaluator:
+    """Evaluates agent execution results against goals.
+
+    Checks success criteria, validates constraints, classifies failures,
+    computes metrics, and produces an EvaluationReport with evolution
+    recommendations.
+    """
+
+    def __init__(
+        self,
+        classifier: FailureClassifier | None = None,
+        collector: MetricsCollector | None = None,
+    ) -> None:
+        self._classifier = classifier or FailureClassifier()
+        self._collector = collector
+
+    def evaluate(
+        self,
+        execution_result: Any,
+        goal: Goal,
+        *,
+        run_id: str = "",
+        agent_id: str = "",
+        model: str = "",
+    ) -> EvaluationReport:
+        """Evaluate an execution result against a goal."""
+        run_id = run_id or str(uuid.uuid4())[:8]
+
+        criteria_results = self._evaluate_criteria(execution_result, goal)
+        criteria_met = sum(1 for c in criteria_results if c["met"])
+        criteria_total = len(criteria_results)
+
+        constraint_results = self._evaluate_constraints(execution_result, goal)
+        constraint_violations = sum(1 for c in constraint_results if not c["satisfied"])
+
+        failures = self._classifier.classify(execution_result)
+
+        success = getattr(execution_result, "success", False)
+        metrics = EvaluationMetrics(
+            run_id=run_id,
+            agent_id=agent_id,
+            success=success,
+            execution_quality=getattr(execution_result, "execution_quality", "clean"),
+            total_tokens=getattr(execution_result, "total_tokens", 0),
+            total_latency_ms=getattr(execution_result, "total_latency_ms", 0),
+            steps_executed=getattr(execution_result, "steps_executed", 0),
+            total_retries=getattr(execution_result, "total_retries", 0),
+            estimated_cost_usd=self._estimate_cost(execution_result, model),
+            criteria_met=criteria_met,
+            criteria_total=criteria_total,
+            constraint_violations=constraint_violations,
+            failure_count=len(failures),
+            failure_categories={f.category.value: 1 for f in failures},
+        )
+
+        recommendations = self._generate_recommendations(
+            failures, criteria_results, constraint_results, metrics
+        )
+
+        hard_violations = sum(
+            1 for c in constraint_results if not c["satisfied"] and c.get("type") == "hard"
+        )
+        passed = success and criteria_met >= criteria_total * 0.9 and hard_violations == 0
+
+        summary = self._build_summary(passed, criteria_met, criteria_total, failures)
+
+        report = EvaluationReport(
+            run_id=run_id,
+            agent_id=agent_id,
+            goal_id=goal.id,
+            passed=passed,
+            summary=summary,
+            metrics=metrics,
+            failures=failures,
+            criteria_results=criteria_results,
+            constraint_results=constraint_results,
+            recommendations=recommendations,
+        )
+
+        if self._collector is not None:
+            self._collector.record(metrics)
+
+        logger.info(
+            "Evaluation complete: run=%s passed=%s criteria=%d/%d failures=%d",
+            run_id,
+            passed,
+            criteria_met,
+            criteria_total,
+            len(failures),
+        )
+
+        return report
+
+    def _evaluate_criteria(self, result: Any, goal: Goal) -> list[dict[str, Any]]:
+        output = getattr(result, "output", {})
+        success = getattr(result, "success", False)
+        results: list[dict[str, Any]] = []
+
+        for criterion in goal.success_criteria:
+            met = self._check_criterion(criterion, output, success)
+            results.append(
+                {
+                    "id": criterion.id,
+                    "description": criterion.description,
+                    "metric": criterion.metric,
+                    "target": criterion.target,
+                    "weight": criterion.weight,
+                    "met": met,
+                }
+            )
+        return results
+
+    def _check_criterion(
+        self, criterion: SuccessCriterion, output: dict[str, Any], success: bool
+    ) -> bool:
+        metric = criterion.metric
+        target = criterion.target
+
+        if metric == "execution_success":
+            return success
+        if metric == "output_contains":
+            return str(target).lower() in str(output).lower()
+        if metric == "output_equals":
+            return str(output.get(str(target), "")) != ""
+        if metric == "output_exists":
+            return str(target) in output
+        if metric == "llm_judge":
+            # Full LLM judge integration deferred -- optimistic for now
+            return success
+        return success
+
+    def _evaluate_constraints(self, result: Any, goal: Goal) -> list[dict[str, Any]]:
+        total_tokens = getattr(result, "total_tokens", 0)
+        total_latency = getattr(result, "total_latency_ms", 0)
+        results: list[dict[str, Any]] = []
+
+        for constraint in goal.constraints:
+            satisfied = self._check_constraint(constraint, result, total_tokens, total_latency)
+            results.append(
+                {
+                    "id": constraint.id,
+                    "description": constraint.description,
+                    "type": constraint.constraint_type,
+                    "category": constraint.category,
+                    "satisfied": satisfied,
+                }
+            )
+        return results
+
+    def _check_constraint(
+        self,
+        constraint: Constraint,
+        result: Any,
+        total_tokens: int,
+        total_latency: int,
+    ) -> bool:
+        category = constraint.category
+        success = getattr(result, "success", False)
+
+        if category == "cost":
+            try:
+                limit = int(constraint.check) if constraint.check.isdigit() else 100_000
+            except (ValueError, AttributeError):
+                limit = 100_000
+            return total_tokens <= limit
+
+        if category == "time":
+            try:
+                limit = int(constraint.check) if constraint.check.isdigit() else 120_000
+            except (ValueError, AttributeError):
+                limit = 120_000
+            return total_latency <= limit
+
+        if category == "safety":
+            error = getattr(result, "error", "") or ""
+            return "safety" not in error.lower() and "pii" not in error.lower()
+
+        return success
+
+    def _generate_recommendations(
+        self,
+        failures: list[FailureRecord],
+        criteria_results: list[dict[str, Any]],
+        constraint_results: list[dict[str, Any]],
+        metrics: EvaluationMetrics,
+    ) -> list[EvolutionRecommendation]:
+        recs: list[EvolutionRecommendation] = []
+
+        for failure in failures:
+            stage = self._stage_for_failure(failure.category)
+            priority = self._priority_from_severity(failure.severity)
+            recs.append(
+                EvolutionRecommendation(
+                    stage=stage,
+                    priority=priority,
+                    action=failure.remediation_hint or f"Fix {failure.category.value}",
+                    description=failure.message,
+                    target_node=failure.node_id,
+                    failure_category=failure.category,
+                    estimated_effort=self._effort_for_stage(stage),
+                )
+            )
+
+        for criterion in criteria_results:
+            if not criterion["met"]:
+                recs.append(
+                    EvolutionRecommendation(
+                        stage=EvolutionStage.AGENT,
+                        priority=RecommendationPriority.HIGH,
+                        action=f"Fix unmet criterion: {criterion['id']}",
+                        description=(
+                            f"Criterion '{criterion['description']}' "
+                            f"(metric: {criterion['metric']}) was not met."
+                        ),
+                        estimated_effort="medium",
+                    )
+                )
+
+        for constraint in constraint_results:
+            if not constraint["satisfied"]:
+                is_hard = constraint.get("type") == "hard"
+                recs.append(
+                    EvolutionRecommendation(
+                        stage=EvolutionStage.AGENT if is_hard else EvolutionStage.CONFIG,
+                        priority=(
+                            RecommendationPriority.CRITICAL
+                            if is_hard
+                            else RecommendationPriority.MEDIUM
+                        ),
+                        action=f"Fix constraint: {constraint['id']}",
+                        description=constraint["description"],
+                        estimated_effort="medium" if is_hard else "small",
+                    )
+                )
+
+        if metrics.estimated_cost_usd > 1.0:
+            recs.append(
+                EvolutionRecommendation(
+                    stage=EvolutionStage.CONFIG,
+                    priority=RecommendationPriority.MEDIUM,
+                    action="Reduce execution cost",
+                    description=(
+                        f"Execution cost ${metrics.estimated_cost_usd:.4f} is high. "
+                        "Consider prompt compression, caching, or cheaper model."
+                    ),
+                    estimated_effort="small",
+                )
+            )
+
+        priority_order = {
+            RecommendationPriority.CRITICAL: 0,
+            RecommendationPriority.HIGH: 1,
+            RecommendationPriority.MEDIUM: 2,
+            RecommendationPriority.LOW: 3,
+        }
+        recs.sort(key=lambda r: priority_order.get(r.priority, 9))
+        return recs
+
+    def _estimate_cost(self, result: Any, model: str) -> float:
+        tokens = getattr(result, "total_tokens", 0)
+        if tokens == 0:
+            return 0.0
+        cost_per_1k = _DEFAULT_COST_PER_1K
+        for model_name, pricing in _MODEL_PRICING.items():
+            if model_name in model.lower():
+                cost_per_1k = pricing["input"] * 0.6 + pricing["output"] * 0.4
+                break
+        return (tokens / 1000) * cost_per_1k
+
+    @staticmethod
+    def _build_summary(
+        passed: bool,
+        criteria_met: int,
+        criteria_total: int,
+        failures: list[FailureRecord],
+    ) -> str:
+        status = "PASSED" if passed else "FAILED"
+        parts = [f"{status}: {criteria_met}/{criteria_total} criteria met"]
+        if failures:
+            top = failures[0]
+            node_info = f" on {top.node_id}" if top.node_id else ""
+            parts.append(f"{len(failures)} failure(s), top: {top.category.value}{node_info}")
+        return ". ".join(parts) + "."
+
+    @staticmethod
+    def _stage_for_failure(category: FailureCategory) -> EvolutionStage:
+        config_cats = {
+            FailureCategory.LLM_RATE_LIMIT,
+            FailureCategory.LLM_EMPTY_RESPONSE,
+            FailureCategory.RESOURCE_BUDGET_EXHAUSTED,
+            FailureCategory.RESOURCE_CONCURRENCY_LIMIT,
+            FailureCategory.CONSTRAINT_COST_EXCEEDED,
+            FailureCategory.CONSTRAINT_TIME_EXCEEDED,
+        }
+        goal_cats = {
+            FailureCategory.CONSTRAINT_QUALITY_BELOW,
+            FailureCategory.CONSTRAINT_SAFETY_VIOLATION,
+        }
+        if category in config_cats:
+            return EvolutionStage.CONFIG
+        if category in goal_cats:
+            return EvolutionStage.GOAL
+        return EvolutionStage.AGENT
+
+    @staticmethod
+    def _priority_from_severity(severity: str) -> RecommendationPriority:
+        mapping = {
+            "critical": RecommendationPriority.CRITICAL,
+            "high": RecommendationPriority.HIGH,
+            "medium": RecommendationPriority.MEDIUM,
+            "low": RecommendationPriority.LOW,
+        }
+        return mapping.get(severity, RecommendationPriority.MEDIUM)
+
+    @staticmethod
+    def _effort_for_stage(stage: EvolutionStage) -> str:
+        if stage == EvolutionStage.CONFIG:
+            return "small"
+        if stage == EvolutionStage.GOAL:
+            return "large"
+        return "medium"

--- a/core/framework/evaluation/failure_classifier.py
+++ b/core/framework/evaluation/failure_classifier.py
@@ -1,0 +1,314 @@
+"""Extended failure classification for runtime agent evaluation."""
+
+import re
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class FailureCategory(StrEnum):
+    """Failure taxonomy for runtime evaluation.
+
+    Categories map to remediation strategies in the evolution loop.
+    """
+
+    # LLM failures
+    LLM_HALLUCINATION = "llm_hallucination"
+    LLM_RATE_LIMIT = "llm_rate_limit"
+    LLM_CONTENT_FILTER = "llm_content_filter"
+    LLM_INVALID_OUTPUT = "llm_invalid_output"
+    LLM_EMPTY_RESPONSE = "llm_empty_response"
+    LLM_CONTEXT_OVERFLOW = "llm_context_overflow"
+
+    # Tool failures
+    TOOL_API_ERROR = "tool_api_error"
+    TOOL_TIMEOUT = "tool_timeout"
+    TOOL_INVALID_RESPONSE = "tool_invalid_response"
+    TOOL_AUTH_FAILURE = "tool_auth_failure"
+    TOOL_NOT_FOUND = "tool_not_found"
+
+    # Graph/logic failures
+    GRAPH_DEAD_END = "graph_dead_end"
+    GRAPH_INFINITE_LOOP = "graph_infinite_loop"
+    GRAPH_MISSING_OUTPUT = "graph_missing_output"
+    GRAPH_VALIDATION_ERROR = "graph_validation_error"
+
+    # Constraint violations
+    CONSTRAINT_COST_EXCEEDED = "constraint_cost_exceeded"
+    CONSTRAINT_TIME_EXCEEDED = "constraint_time_exceeded"
+    CONSTRAINT_QUALITY_BELOW = "constraint_quality_below"
+    CONSTRAINT_SAFETY_VIOLATION = "constraint_safety_violation"
+
+    # Resource failures
+    RESOURCE_BUDGET_EXHAUSTED = "resource_budget_exhausted"
+    RESOURCE_MEMORY_EXCEEDED = "resource_memory_exceeded"
+    RESOURCE_CONCURRENCY_LIMIT = "resource_concurrency_limit"
+
+    UNKNOWN = "unknown"
+
+
+class FailureRecord(BaseModel):
+    """Structured record of a classified failure."""
+
+    category: FailureCategory
+    severity: str
+    node_id: str | None = None
+    message: str
+    context: dict[str, Any] = Field(default_factory=dict)
+    remediation_hint: str = ""
+    timestamp: datetime = Field(default_factory=datetime.now)
+
+    model_config = {"extra": "allow"}
+
+    @property
+    def is_retriable(self) -> bool:
+        retriable = {
+            FailureCategory.LLM_RATE_LIMIT,
+            FailureCategory.LLM_EMPTY_RESPONSE,
+            FailureCategory.TOOL_TIMEOUT,
+            FailureCategory.TOOL_API_ERROR,
+            FailureCategory.RESOURCE_CONCURRENCY_LIMIT,
+        }
+        return self.category in retriable
+
+    @property
+    def requires_graph_change(self) -> bool:
+        graph_change = {
+            FailureCategory.GRAPH_DEAD_END,
+            FailureCategory.GRAPH_INFINITE_LOOP,
+            FailureCategory.GRAPH_MISSING_OUTPUT,
+            FailureCategory.LLM_HALLUCINATION,
+            FailureCategory.CONSTRAINT_QUALITY_BELOW,
+        }
+        return self.category in graph_change
+
+
+# Pattern tables for classification
+
+_LLM_PATTERNS: list[tuple[str, FailureCategory]] = [
+    (r"rate.?limit|429|too many requests", FailureCategory.LLM_RATE_LIMIT),
+    (r"content.?filter|safety|blocked|moderation", FailureCategory.LLM_CONTENT_FILTER),
+    (r"empty.?response|no.?content|empty.?stream", FailureCategory.LLM_EMPTY_RESPONSE),
+    (r"context.?(length|window|overflow)|too.?many.?tokens", FailureCategory.LLM_CONTEXT_OVERFLOW),
+    (r"hallucin|fabricat|made.?up|not.?grounded", FailureCategory.LLM_HALLUCINATION),
+    (r"invalid.?json|parse.?error|malformed.?output", FailureCategory.LLM_INVALID_OUTPUT),
+]
+
+_TOOL_PATTERNS: list[tuple[str, FailureCategory]] = [
+    (r"timeout|timed?.?out|deadline.?exceeded", FailureCategory.TOOL_TIMEOUT),
+    (r"auth|unauthorized|403|401|forbidden", FailureCategory.TOOL_AUTH_FAILURE),
+    (r"tool.?not.?found|unknown.?tool|no.?such.?tool", FailureCategory.TOOL_NOT_FOUND),
+    (r"api.?error|500|502|503|service.?unavailable", FailureCategory.TOOL_API_ERROR),
+    (r"invalid.?response|unexpected.?format", FailureCategory.TOOL_INVALID_RESPONSE),
+]
+
+_GRAPH_PATTERNS: list[tuple[str, FailureCategory]] = [
+    (r"dead.?end|no.?next.?node|terminal.?without", FailureCategory.GRAPH_DEAD_END),
+    (r"infinite.?loop|max.?visits|cycle.?detect", FailureCategory.GRAPH_INFINITE_LOOP),
+    (r"missing.?output|required.?key|output.?not.?set", FailureCategory.GRAPH_MISSING_OUTPUT),
+    (r"validation.?error|schema.?mismatch|pydantic", FailureCategory.GRAPH_VALIDATION_ERROR),
+]
+
+_CONSTRAINT_PATTERNS: list[tuple[str, FailureCategory]] = [
+    (r"budget|cost.?exceed|spending.?limit", FailureCategory.CONSTRAINT_COST_EXCEEDED),
+    (r"time.?exceed|too.?slow|latency.?exceed", FailureCategory.CONSTRAINT_TIME_EXCEEDED),
+    (r"quality.?below|accuracy.?below|score.?too.?low", FailureCategory.CONSTRAINT_QUALITY_BELOW),
+    (r"safety|pii|sensitive.?data|violation", FailureCategory.CONSTRAINT_SAFETY_VIOLATION),
+]
+
+_RESOURCE_PATTERNS: list[tuple[str, FailureCategory]] = [
+    (r"budget.?exhaust|no.?budget|funds.?depleted", FailureCategory.RESOURCE_BUDGET_EXHAUSTED),
+    (r"memory.?exceed|oom|out.?of.?memory", FailureCategory.RESOURCE_MEMORY_EXCEEDED),
+    (r"concurrency|too.?many.?agents|parallel.?limit", FailureCategory.RESOURCE_CONCURRENCY_LIMIT),
+]
+
+_ALL_PATTERN_GROUPS = [
+    _CONSTRAINT_PATTERNS,
+    _RESOURCE_PATTERNS,
+    _LLM_PATTERNS,
+    _TOOL_PATTERNS,
+    _GRAPH_PATTERNS,
+]
+
+_SEVERITY_MAP: dict[FailureCategory, str] = {
+    FailureCategory.CONSTRAINT_SAFETY_VIOLATION: "critical",
+    FailureCategory.RESOURCE_BUDGET_EXHAUSTED: "critical",
+    FailureCategory.LLM_HALLUCINATION: "high",
+    FailureCategory.GRAPH_INFINITE_LOOP: "high",
+    FailureCategory.GRAPH_DEAD_END: "high",
+    FailureCategory.CONSTRAINT_COST_EXCEEDED: "high",
+    FailureCategory.TOOL_AUTH_FAILURE: "high",
+    FailureCategory.LLM_RATE_LIMIT: "low",
+    FailureCategory.LLM_EMPTY_RESPONSE: "low",
+    FailureCategory.TOOL_TIMEOUT: "low",
+}
+
+_HINT_MAP: dict[FailureCategory, str] = {
+    FailureCategory.LLM_HALLUCINATION: "Add output validation or grounding check after LLM calls.",
+    FailureCategory.LLM_RATE_LIMIT: "Add fallback provider or increase retry backoff.",
+    FailureCategory.LLM_CONTENT_FILTER: "Review system prompt; add input sanitization.",
+    FailureCategory.LLM_INVALID_OUTPUT: "Add structured output schema or output parsing node.",
+    FailureCategory.LLM_EMPTY_RESPONSE: "Retry with different model or check token budget.",
+    FailureCategory.LLM_CONTEXT_OVERFLOW: "Implement context compression or split into sub-tasks.",
+    FailureCategory.TOOL_API_ERROR: "Add retry with exponential backoff; check endpoint health.",
+    FailureCategory.TOOL_TIMEOUT: "Increase timeout or add circuit breaker.",
+    FailureCategory.TOOL_INVALID_RESPONSE: "Add response validation and fallback parsing.",
+    FailureCategory.TOOL_AUTH_FAILURE: "Refresh credentials or check API key validity.",
+    FailureCategory.TOOL_NOT_FOUND: "Register the required tool in mcp_servers.json.",
+    FailureCategory.GRAPH_DEAD_END: "Add fallback edge or terminal node for unhandled paths.",
+    FailureCategory.GRAPH_INFINITE_LOOP: "Add max_node_visits constraint or convergence check.",
+    FailureCategory.GRAPH_MISSING_OUTPUT: "Ensure required output keys are set before terminal.",
+    FailureCategory.GRAPH_VALIDATION_ERROR: "Fix Pydantic schema or node output shape.",
+    FailureCategory.CONSTRAINT_COST_EXCEEDED: "Enable budget-based model degradation.",
+    FailureCategory.CONSTRAINT_TIME_EXCEEDED: "Parallelize nodes or use faster models.",
+    FailureCategory.CONSTRAINT_QUALITY_BELOW: "Upgrade model or improve prompts.",
+    FailureCategory.CONSTRAINT_SAFETY_VIOLATION: "Add PII detection and content moderation.",
+    FailureCategory.RESOURCE_BUDGET_EXHAUSTED: "Increase daily budget or add degradation policy.",
+    FailureCategory.RESOURCE_MEMORY_EXCEEDED: "Implement memory pruning.",
+    FailureCategory.RESOURCE_CONCURRENCY_LIMIT: "Queue requests or scale agent instances.",
+}
+
+
+class FailureClassifier:
+    """Classify execution failures into actionable categories.
+
+    Two-pass approach: structural analysis of ExecutionResult fields,
+    then pattern matching on error messages.
+    """
+
+    def __init__(self) -> None:
+        self._compiled: list[tuple[re.Pattern[str], FailureCategory]] = []
+        for group in _ALL_PATTERN_GROUPS:
+            for pattern_str, category in group:
+                self._compiled.append((re.compile(pattern_str, re.IGNORECASE), category))
+
+    def classify(self, execution_result: Any) -> list[FailureRecord]:
+        """Classify all failures in an ExecutionResult."""
+        records: list[FailureRecord] = []
+
+        records.extend(self._check_structural(execution_result))
+
+        error_text = self._extract_error_text(execution_result)
+        if error_text:
+            records.extend(self._match_patterns(error_text))
+
+        records = self._deduplicate(records)
+
+        success = getattr(execution_result, "success", True)
+        if not success and not records:
+            records.append(
+                FailureRecord(
+                    category=FailureCategory.UNKNOWN,
+                    severity="medium",
+                    message=(
+                        getattr(execution_result, "error", "Unknown failure") or "Unknown failure"
+                    ),
+                    remediation_hint="Manual investigation required.",
+                )
+            )
+
+        return records
+
+    def classify_error(self, error_message: str, node_id: str | None = None) -> FailureRecord:
+        """Classify a single error string."""
+        for pattern, category in self._compiled:
+            if pattern.search(error_message):
+                return FailureRecord(
+                    category=category,
+                    severity=_SEVERITY_MAP.get(category, "medium"),
+                    node_id=node_id,
+                    message=error_message[:500],
+                    remediation_hint=_HINT_MAP.get(category, "Manual investigation required."),
+                )
+        return FailureRecord(
+            category=FailureCategory.UNKNOWN,
+            severity="medium",
+            node_id=node_id,
+            message=error_message[:500],
+            remediation_hint="Manual investigation required.",
+        )
+
+    def _check_structural(self, result: Any) -> list[FailureRecord]:
+        records: list[FailureRecord] = []
+
+        quality = getattr(result, "execution_quality", "clean")
+        if quality == "failed":
+            for node_id in getattr(result, "nodes_with_failures", []):
+                retry_count = getattr(result, "retry_details", {}).get(node_id, 0)
+                records.append(
+                    FailureRecord(
+                        category=FailureCategory.GRAPH_VALIDATION_ERROR,
+                        severity="high",
+                        node_id=node_id,
+                        message=f"Node '{node_id}' failed after {retry_count} retries",
+                        context={"retries": retry_count},
+                        remediation_hint="Review node implementation or add error handling.",
+                    )
+                )
+
+        total_tokens = getattr(result, "total_tokens", 0)
+        if total_tokens > 100_000:
+            records.append(
+                FailureRecord(
+                    category=FailureCategory.CONSTRAINT_COST_EXCEEDED,
+                    severity="medium",
+                    message=f"High token usage: {total_tokens:,} tokens",
+                    context={"total_tokens": total_tokens},
+                    remediation_hint="Consider prompt compression or model degradation.",
+                )
+            )
+
+        total_latency = getattr(result, "total_latency_ms", 0)
+        if total_latency > 120_000:
+            records.append(
+                FailureRecord(
+                    category=FailureCategory.CONSTRAINT_TIME_EXCEEDED,
+                    severity="medium",
+                    message=f"High latency: {total_latency:,}ms",
+                    context={"total_latency_ms": total_latency},
+                    remediation_hint="Consider parallelizing nodes or reducing LLM calls.",
+                )
+            )
+
+        return records
+
+    def _extract_error_text(self, result: Any) -> str:
+        parts: list[str] = []
+        error = getattr(result, "error", None)
+        if error:
+            parts.append(str(error))
+        output = getattr(result, "output", {})
+        if isinstance(output, dict) and "error" in output:
+            parts.append(str(output["error"]))
+        return " ".join(parts)
+
+    def _match_patterns(self, error_text: str) -> list[FailureRecord]:
+        records: list[FailureRecord] = []
+        seen: set[FailureCategory] = set()
+        for pattern, category in self._compiled:
+            if category in seen:
+                continue
+            if pattern.search(error_text):
+                seen.add(category)
+                records.append(
+                    FailureRecord(
+                        category=category,
+                        severity=_SEVERITY_MAP.get(category, "medium"),
+                        message=error_text[:500],
+                        remediation_hint=_HINT_MAP.get(category, "Manual investigation required."),
+                    )
+                )
+        return records
+
+    def _deduplicate(self, records: list[FailureRecord]) -> list[FailureRecord]:
+        severity_order = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+        best: dict[FailureCategory, FailureRecord] = {}
+        for r in records:
+            existing = best.get(r.category)
+            if existing is None or severity_order.get(r.severity, 9) < severity_order.get(
+                existing.severity, 9
+            ):
+                best[r.category] = r
+        return list(best.values())

--- a/core/framework/evaluation/metrics.py
+++ b/core/framework/evaluation/metrics.py
@@ -1,0 +1,152 @@
+"""Metrics collection and aggregation for agent evaluation."""
+
+from __future__ import annotations
+
+import statistics
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class EvaluationMetrics(BaseModel):
+    """Metrics snapshot from a single agent execution."""
+
+    run_id: str = ""
+    agent_id: str = ""
+    success: bool = False
+    execution_quality: str = "clean"
+
+    total_tokens: int = 0
+    total_latency_ms: int = 0
+    steps_executed: int = 0
+    total_retries: int = 0
+
+    estimated_cost_usd: float = 0.0
+
+    criteria_met: int = 0
+    criteria_total: int = 0
+    constraint_violations: int = 0
+    failure_count: int = 0
+    failure_categories: dict[str, int] = Field(default_factory=dict)
+
+    timestamp: datetime = Field(default_factory=datetime.now)
+
+    model_config = {"extra": "allow"}
+
+    @property
+    def criteria_pass_rate(self) -> float:
+        if self.criteria_total == 0:
+            return 0.0
+        return self.criteria_met / self.criteria_total
+
+    @property
+    def avg_latency_per_step_ms(self) -> float:
+        if self.steps_executed == 0:
+            return 0.0
+        return self.total_latency_ms / self.steps_executed
+
+    @property
+    def tokens_per_step(self) -> float:
+        if self.steps_executed == 0:
+            return 0.0
+        return self.total_tokens / self.steps_executed
+
+    def to_summary_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "success": self.success,
+            "quality": self.execution_quality,
+            "criteria": f"{self.criteria_met}/{self.criteria_total}",
+            "tokens": self.total_tokens,
+            "latency_ms": self.total_latency_ms,
+            "cost_usd": f"${self.estimated_cost_usd:.4f}",
+            "retries": self.total_retries,
+            "failures": self.failure_count,
+        }
+
+
+class MetricsCollector:
+    """Accumulates EvaluationMetrics across runs and computes aggregates.
+
+    In-memory for now. Production should persist to TimescaleDB or similar.
+    """
+
+    def __init__(self, agent_id: str = "") -> None:
+        self.agent_id = agent_id
+        self._snapshots: list[EvaluationMetrics] = []
+
+    def record(self, metrics: EvaluationMetrics) -> None:
+        self._snapshots.append(metrics)
+
+    @property
+    def count(self) -> int:
+        return len(self._snapshots)
+
+    @property
+    def snapshots(self) -> list[EvaluationMetrics]:
+        return list(self._snapshots)
+
+    def clear(self) -> None:
+        self._snapshots.clear()
+
+    def aggregate(self) -> dict[str, Any]:
+        """Compute aggregate stats over all recorded snapshots."""
+        if not self._snapshots:
+            return {"total_runs": 0}
+
+        n = len(self._snapshots)
+        successes = [s for s in self._snapshots if s.success]
+        latencies = [s.total_latency_ms for s in self._snapshots]
+        tokens = [s.total_tokens for s in self._snapshots]
+        costs = [s.estimated_cost_usd for s in self._snapshots]
+        pass_rates = [s.criteria_pass_rate for s in self._snapshots]
+        retries = [s.total_retries for s in self._snapshots]
+
+        quality_dist: dict[str, int] = {}
+        for s in self._snapshots:
+            quality_dist[s.execution_quality] = quality_dist.get(s.execution_quality, 0) + 1
+
+        cat_totals: dict[str, int] = {}
+        for s in self._snapshots:
+            for cat, count in s.failure_categories.items():
+                cat_totals[cat] = cat_totals.get(cat, 0) + count
+
+        return {
+            "agent_id": self.agent_id,
+            "total_runs": n,
+            "success_rate": len(successes) / n,
+            "avg_latency_ms": statistics.mean(latencies) if latencies else 0,
+            "p95_latency_ms": (
+                sorted(latencies)[int(n * 0.95)] if n >= 2 else (latencies[0] if latencies else 0)
+            ),
+            "avg_tokens": statistics.mean(tokens) if tokens else 0,
+            "total_tokens": sum(tokens),
+            "avg_cost_usd": statistics.mean(costs) if costs else 0.0,
+            "total_cost_usd": sum(costs),
+            "avg_criteria_pass_rate": statistics.mean(pass_rates) if pass_rates else 0.0,
+            "avg_retries": statistics.mean(retries) if retries else 0,
+            "failure_category_totals": cat_totals,
+            "quality_distribution": quality_dist,
+            "trend": self._compute_trend(),
+        }
+
+    def _compute_trend(self) -> str:
+        """Compare first-half vs second-half success rate."""
+        n = len(self._snapshots)
+        if n < 4:
+            return "insufficient_data"
+
+        mid = n // 2
+        first_rate = sum(1 for s in self._snapshots[:mid] if s.success) / mid
+        second_rate = sum(1 for s in self._snapshots[mid:] if s.success) / (n - mid)
+
+        diff = second_rate - first_rate
+        if diff > 0.1:
+            return "improving"
+        if diff < -0.1:
+            return "degrading"
+        return "stable"
+
+    def get_recent(self, n: int = 10) -> list[EvaluationMetrics]:
+        return self._snapshots[-n:]

--- a/core/framework/evaluation/report.py
+++ b/core/framework/evaluation/report.py
@@ -1,0 +1,132 @@
+"""Evaluation reports and evolution recommendations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from framework.evaluation.failure_classifier import FailureCategory, FailureRecord
+from framework.evaluation.metrics import EvaluationMetrics
+
+
+class EvolutionStage(StrEnum):
+    """Which stage of the Goal > Agent > Eval loop to revisit."""
+
+    GOAL = "goal"
+    AGENT = "agent"
+    EVAL = "eval"
+    CONFIG = "config"
+    NONE = "none"
+
+
+class RecommendationPriority(StrEnum):
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class EvolutionRecommendation(BaseModel):
+    """A single actionable recommendation for improving the agent."""
+
+    stage: EvolutionStage
+    priority: RecommendationPriority
+    action: str
+    description: str
+    target_node: str | None = None
+    failure_category: FailureCategory | None = None
+    estimated_effort: str = "small"
+
+    model_config = {"extra": "allow"}
+
+
+class EvaluationReport(BaseModel):
+    """Complete evaluation report for a single agent execution."""
+
+    run_id: str = ""
+    agent_id: str = ""
+    goal_id: str = ""
+
+    passed: bool = False
+    summary: str = ""
+
+    metrics: EvaluationMetrics = Field(default_factory=EvaluationMetrics)
+    failures: list[FailureRecord] = Field(default_factory=list)
+    criteria_results: list[dict[str, Any]] = Field(default_factory=list)
+    constraint_results: list[dict[str, Any]] = Field(default_factory=list)
+    recommendations: list[EvolutionRecommendation] = Field(default_factory=list)
+
+    timestamp: datetime = Field(default_factory=datetime.now)
+
+    model_config = {"extra": "allow"}
+
+    @property
+    def has_critical_failures(self) -> bool:
+        return any(f.severity == "critical" for f in self.failures)
+
+    @property
+    def requires_graph_evolution(self) -> bool:
+        return any(f.requires_graph_change for f in self.failures)
+
+    @property
+    def top_recommendation(self) -> EvolutionRecommendation | None:
+        if not self.recommendations:
+            return None
+        return self.recommendations[0]
+
+    def to_summary_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "passed": self.passed,
+            "summary": self.summary,
+            "criteria": f"{self.metrics.criteria_met}/{self.metrics.criteria_total}",
+            "failures": len(self.failures),
+            "recommendations": len(self.recommendations),
+            "top_action": self.top_recommendation.action if self.top_recommendation else None,
+            "metrics": self.metrics.to_summary_dict(),
+        }
+
+    def to_coding_agent_prompt(self) -> str:
+        """Format as a prompt the Coding Agent can consume to evolve the graph."""
+        lines = [
+            "# Agent Evaluation Report",
+            "",
+            f"Result: {'PASSED' if self.passed else 'FAILED'}",
+            f"Summary: {self.summary}",
+            "",
+            "## Metrics",
+            f"- Tokens: {self.metrics.total_tokens:,}",
+            f"- Latency: {self.metrics.total_latency_ms:,}ms",
+            f"- Cost: ${self.metrics.estimated_cost_usd:.4f}",
+            f"- Criteria: {self.metrics.criteria_met}/{self.metrics.criteria_total}",
+            f"- Retries: {self.metrics.total_retries}",
+            "",
+        ]
+
+        if self.failures:
+            lines.append("## Failures")
+            for f in self.failures:
+                node_info = f" (node: {f.node_id})" if f.node_id else ""
+                lines.append(f"- [{f.severity.upper()}] {f.category.value}{node_info}: {f.message}")
+            lines.append("")
+
+        if self.criteria_results:
+            lines.append("## Success Criteria")
+            for cr in self.criteria_results:
+                status = "PASS" if cr.get("met") else "FAIL"
+                lines.append(f"- [{status}] {cr.get('description', cr.get('id', '?'))}")
+            lines.append("")
+
+        if self.recommendations:
+            lines.append("## Recommended Actions")
+            for i, rec in enumerate(self.recommendations, 1):
+                lines.append(f"{i}. [{rec.priority.value.upper()}] {rec.action}")
+                target = rec.target_node or "general"
+                lines.append(f"   Stage: {rec.stage.value} | Target: {target}")
+                lines.append(f"   {rec.description}")
+            lines.append("")
+
+        return "\n".join(lines)

--- a/core/tests/test_evaluation.py
+++ b/core/tests/test_evaluation.py
@@ -1,0 +1,580 @@
+"""Tests for the evaluation framework."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from framework.evaluation.evaluator import AgentEvaluator
+from framework.evaluation.failure_classifier import (
+    FailureCategory,
+    FailureClassifier,
+    FailureRecord,
+)
+from framework.evaluation.metrics import EvaluationMetrics, MetricsCollector
+from framework.evaluation.report import (
+    EvaluationReport,
+    EvolutionRecommendation,
+    EvolutionStage,
+    RecommendationPriority,
+)
+from framework.graph.goal import Constraint, Goal, SuccessCriterion
+
+
+@dataclass
+class FakeExecutionResult:
+    success: bool = True
+    output: dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
+    steps_executed: int = 3
+    total_tokens: int = 1000
+    total_latency_ms: int = 2000
+    path: list[str] = field(default_factory=lambda: ["node-a", "node-b", "node-c"])
+    total_retries: int = 0
+    nodes_with_failures: list[str] = field(default_factory=list)
+    retry_details: dict[str, int] = field(default_factory=dict)
+    had_partial_failures: bool = False
+    execution_quality: str = "clean"
+    node_visit_counts: dict[str, int] = field(default_factory=dict)
+
+
+def _make_goal(**overrides: Any) -> Goal:
+    defaults: dict[str, Any] = {
+        "id": "test-goal",
+        "name": "Test Goal",
+        "description": "A goal for testing.",
+        "success_criteria": [
+            SuccessCriterion(
+                id="sc-1",
+                description="Execution must succeed",
+                metric="execution_success",
+                target=True,
+                weight=1.0,
+            ),
+        ],
+        "constraints": [],
+    }
+    defaults.update(overrides)
+    return Goal(**defaults)
+
+
+class TestFailureClassifier:
+    def setup_method(self) -> None:
+        self.classifier = FailureClassifier()
+
+    def test_classify_rate_limit(self) -> None:
+        result = FakeExecutionResult(success=False, error="429 Too Many Requests")
+        records = self.classifier.classify(result)
+        categories = {r.category for r in records}
+        assert FailureCategory.LLM_RATE_LIMIT in categories
+
+    def test_classify_timeout(self) -> None:
+        result = FakeExecutionResult(success=False, error="Request timed out after 30s")
+        records = self.classifier.classify(result)
+        categories = {r.category for r in records}
+        assert FailureCategory.TOOL_TIMEOUT in categories
+
+    def test_classify_auth_failure(self) -> None:
+        result = FakeExecutionResult(success=False, error="401 Unauthorized - invalid API key")
+        records = self.classifier.classify(result)
+        categories = {r.category for r in records}
+        assert FailureCategory.TOOL_AUTH_FAILURE in categories
+
+    def test_classify_content_filter(self) -> None:
+        result = FakeExecutionResult(success=False, error="Content filter triggered: safety block")
+        records = self.classifier.classify(result)
+        categories = {r.category for r in records}
+        assert FailureCategory.LLM_CONTENT_FILTER in categories
+
+    def test_classify_empty_response(self) -> None:
+        result = FakeExecutionResult(success=False, error="Empty response from model")
+        records = self.classifier.classify(result)
+        categories = {r.category for r in records}
+        assert FailureCategory.LLM_EMPTY_RESPONSE in categories
+
+    def test_classify_context_overflow(self) -> None:
+        result = FakeExecutionResult(
+            success=False, error="Context window overflow: too many tokens"
+        )
+        records = self.classifier.classify(result)
+        categories = {r.category for r in records}
+        assert FailureCategory.LLM_CONTEXT_OVERFLOW in categories
+
+    def test_classify_hallucination(self) -> None:
+        result = FakeExecutionResult(success=False, error="Output not grounded in source data")
+        records = self.classifier.classify(result)
+        categories = {r.category for r in records}
+        assert FailureCategory.LLM_HALLUCINATION in categories
+
+    def test_classify_budget_exceeded(self) -> None:
+        result = FakeExecutionResult(
+            success=False, error="Budget exhausted: spending limit reached"
+        )
+        records = self.classifier.classify(result)
+        categories = {r.category for r in records}
+        assert FailureCategory.CONSTRAINT_COST_EXCEEDED in categories
+
+    def test_classify_dead_end(self) -> None:
+        result = FakeExecutionResult(success=False, error="Dead end: no next node for output")
+        records = self.classifier.classify(result)
+        categories = {r.category for r in records}
+        assert FailureCategory.GRAPH_DEAD_END in categories
+
+    def test_classify_infinite_loop(self) -> None:
+        result = FakeExecutionResult(success=False, error="Max visits exceeded, cycle detected")
+        records = self.classifier.classify(result)
+        categories = {r.category for r in records}
+        assert FailureCategory.GRAPH_INFINITE_LOOP in categories
+
+    def test_classify_safety_violation(self) -> None:
+        result = FakeExecutionResult(success=False, error="PII detected: sensitive data in output")
+        records = self.classifier.classify(result)
+        categories = {r.category for r in records}
+        assert FailureCategory.CONSTRAINT_SAFETY_VIOLATION in categories
+
+    def test_structural_high_tokens(self) -> None:
+        result = FakeExecutionResult(success=True, total_tokens=200_000)
+        records = self.classifier.classify(result)
+        categories = {r.category for r in records}
+        assert FailureCategory.CONSTRAINT_COST_EXCEEDED in categories
+
+    def test_structural_high_latency(self) -> None:
+        result = FakeExecutionResult(success=True, total_latency_ms=150_000)
+        records = self.classifier.classify(result)
+        categories = {r.category for r in records}
+        assert FailureCategory.CONSTRAINT_TIME_EXCEEDED in categories
+
+    def test_structural_failed_nodes(self) -> None:
+        result = FakeExecutionResult(
+            success=False,
+            execution_quality="failed",
+            nodes_with_failures=["node-x"],
+            retry_details={"node-x": 3},
+            error="node-x failed",
+        )
+        records = self.classifier.classify(result)
+        node_ids = {r.node_id for r in records if r.node_id}
+        assert "node-x" in node_ids
+
+    def test_clean_success_returns_empty(self) -> None:
+        result = FakeExecutionResult(success=True)
+        records = self.classifier.classify(result)
+        assert records == []
+
+    def test_unknown_failure(self) -> None:
+        result = FakeExecutionResult(success=False, error="Something weird happened")
+        records = self.classifier.classify(result)
+        assert len(records) >= 1
+        assert records[-1].category == FailureCategory.UNKNOWN
+
+    def test_classify_error_string(self) -> None:
+        record = self.classifier.classify_error("Rate limit exceeded", node_id="n1")
+        assert record.category == FailureCategory.LLM_RATE_LIMIT
+        assert record.node_id == "n1"
+
+    def test_deduplication(self) -> None:
+        result = FakeExecutionResult(
+            success=False,
+            error="rate limit rate limit rate limit",
+        )
+        records = self.classifier.classify(result)
+        cats = [r.category for r in records]
+        assert cats.count(FailureCategory.LLM_RATE_LIMIT) <= 1
+
+
+class TestFailureRecord:
+    def test_retriable(self) -> None:
+        r = FailureRecord(
+            category=FailureCategory.LLM_RATE_LIMIT,
+            severity="low",
+            message="rate limited",
+        )
+        assert r.is_retriable is True
+
+    def test_not_retriable(self) -> None:
+        r = FailureRecord(
+            category=FailureCategory.LLM_HALLUCINATION,
+            severity="high",
+            message="hallucinated",
+        )
+        assert r.is_retriable is False
+
+    def test_requires_graph_change(self) -> None:
+        r = FailureRecord(
+            category=FailureCategory.GRAPH_DEAD_END,
+            severity="high",
+            message="dead end",
+        )
+        assert r.requires_graph_change is True
+
+    def test_no_graph_change_needed(self) -> None:
+        r = FailureRecord(
+            category=FailureCategory.TOOL_TIMEOUT,
+            severity="low",
+            message="timeout",
+        )
+        assert r.requires_graph_change is False
+
+
+class TestMetricsCollector:
+    def test_record_and_count(self) -> None:
+        collector = MetricsCollector(agent_id="test")
+        collector.record(EvaluationMetrics(success=True, total_tokens=100))
+        collector.record(EvaluationMetrics(success=False, total_tokens=200))
+        assert collector.count == 2
+
+    def test_aggregate_success_rate(self) -> None:
+        collector = MetricsCollector()
+        for success in [True, True, False, True]:
+            collector.record(EvaluationMetrics(success=success))
+        agg = collector.aggregate()
+        assert agg["success_rate"] == 0.75
+
+    def test_aggregate_empty(self) -> None:
+        collector = MetricsCollector()
+        agg = collector.aggregate()
+        assert agg["total_runs"] == 0
+
+    def test_aggregate_tokens_and_cost(self) -> None:
+        collector = MetricsCollector()
+        collector.record(EvaluationMetrics(total_tokens=1000, estimated_cost_usd=0.01))
+        collector.record(EvaluationMetrics(total_tokens=2000, estimated_cost_usd=0.02))
+        agg = collector.aggregate()
+        assert agg["total_tokens"] == 3000
+        assert agg["total_cost_usd"] == pytest.approx(0.03)
+
+    def test_trend_improving(self) -> None:
+        collector = MetricsCollector()
+        for _ in range(5):
+            collector.record(EvaluationMetrics(success=False))
+        for _ in range(5):
+            collector.record(EvaluationMetrics(success=True))
+        agg = collector.aggregate()
+        assert agg["trend"] == "improving"
+
+    def test_trend_degrading(self) -> None:
+        collector = MetricsCollector()
+        for _ in range(5):
+            collector.record(EvaluationMetrics(success=True))
+        for _ in range(5):
+            collector.record(EvaluationMetrics(success=False))
+        agg = collector.aggregate()
+        assert agg["trend"] == "degrading"
+
+    def test_trend_stable(self) -> None:
+        collector = MetricsCollector()
+        for _ in range(10):
+            collector.record(EvaluationMetrics(success=True))
+        agg = collector.aggregate()
+        assert agg["trend"] == "stable"
+
+    def test_trend_insufficient_data(self) -> None:
+        collector = MetricsCollector()
+        collector.record(EvaluationMetrics(success=True))
+        agg = collector.aggregate()
+        assert agg["trend"] == "insufficient_data"
+
+    def test_get_recent(self) -> None:
+        collector = MetricsCollector()
+        for i in range(20):
+            collector.record(EvaluationMetrics(run_id=str(i)))
+        recent = collector.get_recent(5)
+        assert len(recent) == 5
+        assert recent[0].run_id == "15"
+
+    def test_clear(self) -> None:
+        collector = MetricsCollector()
+        collector.record(EvaluationMetrics())
+        collector.clear()
+        assert collector.count == 0
+
+
+class TestEvaluationMetrics:
+    def test_criteria_pass_rate(self) -> None:
+        m = EvaluationMetrics(criteria_met=3, criteria_total=4)
+        assert m.criteria_pass_rate == 0.75
+
+    def test_criteria_pass_rate_zero(self) -> None:
+        m = EvaluationMetrics(criteria_met=0, criteria_total=0)
+        assert m.criteria_pass_rate == 0.0
+
+    def test_avg_latency_per_step(self) -> None:
+        m = EvaluationMetrics(total_latency_ms=6000, steps_executed=3)
+        assert m.avg_latency_per_step_ms == 2000.0
+
+    def test_tokens_per_step(self) -> None:
+        m = EvaluationMetrics(total_tokens=3000, steps_executed=3)
+        assert m.tokens_per_step == 1000.0
+
+    def test_to_summary_dict(self) -> None:
+        m = EvaluationMetrics(run_id="r1", success=True, total_tokens=500)
+        d = m.to_summary_dict()
+        assert d["run_id"] == "r1"
+        assert d["success"] is True
+
+
+class TestAgentEvaluator:
+    def setup_method(self) -> None:
+        self.evaluator = AgentEvaluator()
+
+    def test_passing_evaluation(self) -> None:
+        result = FakeExecutionResult(success=True)
+        goal = _make_goal()
+        report = self.evaluator.evaluate(result, goal)
+        assert report.passed is True
+        assert report.metrics.criteria_met == 1
+        assert len(report.failures) == 0
+
+    def test_failing_evaluation(self) -> None:
+        result = FakeExecutionResult(
+            success=False, error="Rate limit exceeded", execution_quality="failed"
+        )
+        goal = _make_goal()
+        report = self.evaluator.evaluate(result, goal)
+        assert report.passed is False
+        assert len(report.failures) > 0
+        assert len(report.recommendations) > 0
+
+    def test_criteria_output_contains(self) -> None:
+        result = FakeExecutionResult(
+            success=True,
+            output={"report": "The weather in San Francisco is sunny"},
+        )
+        goal = _make_goal(
+            success_criteria=[
+                SuccessCriterion(
+                    id="has-weather",
+                    description="Output contains weather info",
+                    metric="output_contains",
+                    target="weather",
+                    weight=1.0,
+                ),
+            ]
+        )
+        report = self.evaluator.evaluate(result, goal)
+        assert report.passed is True
+        assert report.metrics.criteria_met == 1
+
+    def test_criteria_output_contains_fail(self) -> None:
+        result = FakeExecutionResult(
+            success=True,
+            output={"report": "No relevant data found"},
+        )
+        goal = _make_goal(
+            success_criteria=[
+                SuccessCriterion(
+                    id="has-weather",
+                    description="Must mention weather",
+                    metric="output_contains",
+                    target="weather",
+                    weight=1.0,
+                ),
+            ]
+        )
+        report = self.evaluator.evaluate(result, goal)
+        assert report.metrics.criteria_met == 0
+
+    def test_criteria_output_exists(self) -> None:
+        result = FakeExecutionResult(
+            success=True,
+            output={"summary": "Some summary text"},
+        )
+        goal = _make_goal(
+            success_criteria=[
+                SuccessCriterion(
+                    id="has-summary",
+                    description="Output has summary key",
+                    metric="output_exists",
+                    target="summary",
+                    weight=1.0,
+                ),
+            ]
+        )
+        report = self.evaluator.evaluate(result, goal)
+        assert report.metrics.criteria_met == 1
+
+    def test_hard_constraint_violation_fails(self) -> None:
+        result = FakeExecutionResult(
+            success=True,
+            error="PII detected in output: safety violation",
+        )
+        goal = _make_goal(
+            constraints=[
+                Constraint(
+                    id="no-pii",
+                    description="Must not expose PII",
+                    constraint_type="hard",
+                    category="safety",
+                ),
+            ]
+        )
+        report = self.evaluator.evaluate(result, goal)
+        assert report.passed is False
+
+    def test_soft_constraint_violation_can_pass(self) -> None:
+        result = FakeExecutionResult(success=True, total_tokens=200_000)
+        goal = _make_goal(
+            constraints=[
+                Constraint(
+                    id="token-budget",
+                    description="Prefer under 50k tokens",
+                    constraint_type="soft",
+                    category="cost",
+                    check="50000",
+                ),
+            ]
+        )
+        report = self.evaluator.evaluate(result, goal)
+        assert report.passed is True
+        violated = [c for c in report.constraint_results if not c["satisfied"]]
+        assert len(violated) == 1
+
+    def test_recommendations_sorted_by_priority(self) -> None:
+        result = FakeExecutionResult(
+            success=False,
+            error="Rate limit and dead end no next node",
+            execution_quality="failed",
+        )
+        goal = _make_goal()
+        report = self.evaluator.evaluate(result, goal)
+        if len(report.recommendations) >= 2:
+            priorities = [r.priority for r in report.recommendations]
+            priority_order = {
+                RecommendationPriority.CRITICAL: 0,
+                RecommendationPriority.HIGH: 1,
+                RecommendationPriority.MEDIUM: 2,
+                RecommendationPriority.LOW: 3,
+            }
+            values = [priority_order[p] for p in priorities]
+            assert values == sorted(values)
+
+    def test_metrics_collector_integration(self) -> None:
+        collector = MetricsCollector(agent_id="test")
+        evaluator = AgentEvaluator(collector=collector)
+        for success in [True, True, False]:
+            result = FakeExecutionResult(success=success)
+            goal = _make_goal()
+            evaluator.evaluate(result, goal, agent_id="test")
+        assert collector.count == 3
+        agg = collector.aggregate()
+        assert agg["total_runs"] == 3
+
+    def test_cost_estimation(self) -> None:
+        result = FakeExecutionResult(success=True, total_tokens=10_000)
+        goal = _make_goal()
+        report = self.evaluator.evaluate(result, goal, model="gpt-4o")
+        assert report.metrics.estimated_cost_usd > 0
+
+    def test_run_id_auto_generated(self) -> None:
+        result = FakeExecutionResult(success=True)
+        goal = _make_goal()
+        report = self.evaluator.evaluate(result, goal)
+        assert report.run_id != ""
+        assert len(report.run_id) == 8
+
+
+class TestEvaluationReport:
+    def test_has_critical_failures(self) -> None:
+        report = EvaluationReport(
+            failures=[
+                FailureRecord(
+                    category=FailureCategory.CONSTRAINT_SAFETY_VIOLATION,
+                    severity="critical",
+                    message="PII exposed",
+                )
+            ]
+        )
+        assert report.has_critical_failures is True
+
+    def test_no_critical_failures(self) -> None:
+        report = EvaluationReport(
+            failures=[
+                FailureRecord(
+                    category=FailureCategory.TOOL_TIMEOUT,
+                    severity="low",
+                    message="timeout",
+                )
+            ]
+        )
+        assert report.has_critical_failures is False
+
+    def test_requires_graph_evolution(self) -> None:
+        report = EvaluationReport(
+            failures=[
+                FailureRecord(
+                    category=FailureCategory.GRAPH_DEAD_END,
+                    severity="high",
+                    message="dead end",
+                )
+            ]
+        )
+        assert report.requires_graph_evolution is True
+
+    def test_top_recommendation(self) -> None:
+        report = EvaluationReport(
+            recommendations=[
+                EvolutionRecommendation(
+                    stage=EvolutionStage.AGENT,
+                    priority=RecommendationPriority.HIGH,
+                    action="Fix dead end",
+                    description="Add fallback edge",
+                ),
+            ]
+        )
+        assert report.top_recommendation is not None
+        assert report.top_recommendation.action == "Fix dead end"
+
+    def test_to_summary_dict(self) -> None:
+        report = EvaluationReport(run_id="r1", passed=True, summary="All good")
+        d = report.to_summary_dict()
+        assert d["passed"] is True
+        assert d["run_id"] == "r1"
+
+    def test_to_coding_agent_prompt(self) -> None:
+        report = EvaluationReport(
+            passed=False,
+            summary="1/2 criteria met",
+            metrics=EvaluationMetrics(
+                total_tokens=5000,
+                total_latency_ms=3000,
+                criteria_met=1,
+                criteria_total=2,
+            ),
+            failures=[
+                FailureRecord(
+                    category=FailureCategory.LLM_HALLUCINATION,
+                    severity="high",
+                    message="Output not grounded",
+                )
+            ],
+            recommendations=[
+                EvolutionRecommendation(
+                    stage=EvolutionStage.AGENT,
+                    priority=RecommendationPriority.HIGH,
+                    action="Add grounding check",
+                    description="Validate LLM output against sources",
+                ),
+            ],
+        )
+        prompt = report.to_coding_agent_prompt()
+        assert "FAILED" in prompt
+        assert "hallucination" in prompt.lower()
+        assert "Add grounding check" in prompt
+        assert "## Recommended Actions" in prompt
+
+
+class TestEvolutionRecommendation:
+    def test_fields(self) -> None:
+        rec = EvolutionRecommendation(
+            stage=EvolutionStage.AGENT,
+            priority=RecommendationPriority.HIGH,
+            action="Add validator",
+            description="Add output validation node",
+            target_node="research-node",
+            failure_category=FailureCategory.LLM_INVALID_OUTPUT,
+        )
+        assert rec.stage == EvolutionStage.AGENT
+        assert rec.target_node == "research-node"
+        assert rec.estimated_effort == "small"


### PR DESCRIPTION
Closes #4233

## What this does

Adds a runtime evaluation module that assesses ExecutionResult against Goal definitions. This is the missing piece in the adaptiveness loop -- right now the Coding Agent generates worker graphs but has no structured feedback on how they performed.

## Changes

New module at core/framework/evaluation/ with four components:

**AgentEvaluator** - takes an ExecutionResult and a Goal, checks each SuccessCriterion and Constraint, classifies any failures, computes metrics, and produces an EvaluationReport. A run passes if execution succeeded, 90%+ criteria are met, and no hard constraints are violated.

**FailureClassifier** - 22-category taxonomy covering LLM failures (hallucination, rate limits, content filter, context overflow), tool failures (timeout, auth, not found), graph issues (dead ends, infinite loops, missing outputs), constraint violations (cost, time, quality, safety), and resource limits. Two-pass classification: structural checks on ExecutionResult fields, then regex pattern matching on error messages. Each failure gets a severity, remediation hint, and properties like is_retriable and requires_graph_change.

**MetricsCollector** - accumulates EvaluationMetrics across runs. Computes aggregates (success rate, p95 latency, total cost, avg criteria pass rate) and detects trends by comparing first-half vs second-half success rates.

**EvaluationReport** - bundles everything into a report with evolution recommendations. Each recommendation maps to an EvolutionStage (Goal/Agent/Eval/Config) so the Coding Agent knows which part of the loop to revisit. Includes a to_coding_agent_prompt() method that formats the report as a prompt the Coding Agent can consume directly.

## Tests

55 unit tests covering all components. All passing, linting and formatting clean.

## How to test

\\\ash
cd core
uv run python -m pytest tests/test_evaluation.py -v
uv run ruff check framework/evaluation/
\\\

Made with [Cursor](https://cursor.com)