### PR TITLE
fix: add module entrypoint for python -m core

### DIFF
--- a/core/__main__.py
+++ b/core/__main__.py
@@ -1,0 +1,26 @@
+"""
+Allow `python -m core` to work by forwarding to the Hive CLI.
+
+Hive's core package imports `framework` as a top-level package, so we add
+the `core/` directory to sys.path to make `framework/` importable.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    core_dir = Path(__file__).resolve().parent  # .../hive/core
+    sys.path.insert(0, str(core_dir))
+
+    # `framework` lives at core/framework
+    from framework.cli import main as cli_main
+
+    return int(cli_main() or 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Description

This PR fixes an issue where running Hive as a module via `python -m core` fails because the package does not define a `core.__main__` entrypoint.

It adds a `core/__main__.py` file that forwards execution to the existing Hive CLI while ensuring the internal `framework` package can be resolved at runtime.

This enables the standard Python module execution pattern and improves developer experience and CLI consistency.

## Type of Change

- [ X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #4325

## Changes Made

- Added `core/__main__.py` to enable execution via `python -m core`
- Inserted `core/` into `sys.path` so the `framework` package resolves correctly
- Forwarded execution to the existing Hive CLI entrypoint

## Testing

Describe the tests you ran to verify your changes:

Manual testing performed:

- Verified `uv run python -m core --help` now displays CLI help output
- Confirmed previous error (`No module named core.__main__`) is resolved

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ X] Manual testing performed

## Checklist

- [ X] My code follows the project's style guidelines
- [X ] I have performed a self-review of my code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
