### PR TITLE
feat(claude): streamline MCP tool approvals with settings template

### DIFF
--- a/.claude/settings.local.json.example
+++ b/.claude/settings.local.json.example
@@ -1,0 +1,42 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__agent-builder__*",
+      "mcp__tools__*",
+      "Bash(PYTHONPATH=*)",
+      "Bash(MOCK_MODE=*)",
+      "Bash(cd *)",
+      "Bash(uv run *)",
+      "Bash(uv pip *)",
+      "Bash(uv sync)",
+      "Bash(python *)",
+      "Bash(python3 *)",
+      "Bash(pytest *)",
+      "Bash(ruff *)",
+      "Bash(mkdir *)",
+      "Bash(ls *)",
+      "Bash(export *)",
+      "Bash(gh *)",
+      "Skill(agent-workflow)",
+      "Skill(agent-workflow:*)",
+      "Skill(building-agents-construction)",
+      "Skill(building-agents-construction:*)",
+      "Skill(building-agents-core)",
+      "Skill(building-agents-core:*)",
+      "Skill(building-agents-patterns)",
+      "Skill(building-agents-patterns:*)",
+      "Skill(testing-agent)",
+      "Skill(testing-agent:*)",
+      "Skill(setup-credentials)",
+      "Skill(setup-credentials:*)",
+      "Skill(triage-issue)",
+      "Skill(triage-issue:*)",
+      "WebFetch(domain:github.com)"
+    ]
+  },
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": [
+    "agent-builder",
+    "tools"
+  ]
+}

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -765,6 +765,31 @@ fi
 echo ""
 
 # ============================================================
+# Step 8: Configure Claude Code settings
+# ============================================================
+
+echo -e "${YELLOW}⬢${NC} ${BLUE}${BOLD}Step 8: Configuring Claude Code settings...${NC}"
+echo ""
+
+EXAMPLE_SETTINGS="$SCRIPT_DIR/.claude/settings.local.json.example"
+TARGET_SETTINGS="$SCRIPT_DIR/.claude/settings.local.json"
+
+if [ -f "$EXAMPLE_SETTINGS" ]; then
+    MERGE_OUTPUT=$($PYTHON_CMD "$SCRIPT_DIR/scripts/merge_claude_settings.py" \
+        --example "$EXAMPLE_SETTINGS" \
+        --target "$TARGET_SETTINGS" 2>&1) && {
+        echo -e "${GREEN}  ✓ $MERGE_OUTPUT${NC}"
+    } || {
+        echo -e "${YELLOW}  ⚠ Could not merge Claude settings: $MERGE_OUTPUT${NC}"
+        echo -e "${YELLOW}    You can copy .claude/settings.local.json.example manually.${NC}"
+    }
+else
+    echo -e "${YELLOW}  ⚠ No settings template found at $EXAMPLE_SETTINGS${NC}"
+fi
+
+echo ""
+
+# ============================================================
 # Success!
 # ============================================================
 

--- a/scripts/merge_claude_settings.py
+++ b/scripts/merge_claude_settings.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Merge Claude Code settings from an example template into a user's local settings.
+
+Ensures every contributor has the project-required MCP tool approvals while
+preserving any personal entries they have already added.
+
+Usage:
+    python scripts/merge_claude_settings.py --example <path> --target <path>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+
+def merge_settings(example_path: Path, target_path: Path) -> dict:
+    """Merge example settings into the target settings file.
+
+    Args:
+        example_path: Path to the ``.example`` template (must exist).
+        target_path: Path to the user's ``settings.local.json``.  Created from
+            the example when absent.
+
+    Returns:
+        A dict with ``"action"`` (``"created"`` or ``"merged"``),
+        ``"new_entries"`` (list of permission strings that were added), and
+        ``"target"`` (the final resolved path).
+
+    Raises:
+        FileNotFoundError: If *example_path* does not exist.
+        json.JSONDecodeError: If either file contains invalid JSON.
+    """
+    if not example_path.exists():
+        raise FileNotFoundError(f"Example file not found: {example_path}")
+
+    example_text = example_path.read_text(encoding="utf-8")
+    example = json.loads(example_text)
+
+    if not target_path.exists():
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(example_path, target_path)
+        return {
+            "action": "created",
+            "new_entries": example.get("permissions", {}).get("allow", []),
+            "target": str(target_path),
+        }
+
+    target_text = target_path.read_text(encoding="utf-8")
+    target = json.loads(target_text)
+
+    # --- permissions.allow merge ---
+    if "permissions" not in target:
+        target["permissions"] = {}
+    if "allow" not in target["permissions"]:
+        target["permissions"]["allow"] = []
+
+    example_allow: list[str] = example.get("permissions", {}).get("allow", [])
+    target_allow: list[str] = target["permissions"]["allow"]
+
+    existing_set = set(target_allow)
+    new_entries = [e for e in example_allow if e not in existing_set]
+
+    # Example entries first, then user-only entries (preserving relative order).
+    example_set = set(example_allow)
+    user_only = [e for e in target_allow if e not in example_set]
+    target["permissions"]["allow"] = example_allow + user_only
+
+    # --- top-level keys: fill missing, never overwrite ---
+    for key, value in example.items():
+        if key == "permissions":
+            continue
+        if key not in target:
+            target[key] = value
+
+    target_path.write_text(json.dumps(target, indent=2) + "\n", encoding="utf-8")
+
+    return {
+        "action": "merged",
+        "new_entries": new_entries,
+        "target": str(target_path),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry-point.
+
+    Returns:
+        Exit code: 0 on success, 1 on error.
+    """
+    parser = argparse.ArgumentParser(
+        description="Merge Claude Code settings from example into local target."
+    )
+    parser.add_argument(
+        "--example",
+        required=True,
+        type=Path,
+        help="Path to the .example settings template.",
+    )
+    parser.add_argument(
+        "--target",
+        required=True,
+        type=Path,
+        help="Path to the user's settings.local.json.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        result = merge_settings(args.example, args.target)
+    except (FileNotFoundError, json.JSONDecodeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    if result["action"] == "created":
+        print(f"Created {result['target']} from example template.")
+    else:
+        n = len(result["new_entries"])
+        if n:
+            print(f"Merged {n} new permission(s) into {result['target']}.")
+            for entry in result["new_entries"]:
+                print(f"  + {entry}")
+        else:
+            print(f"{result['target']} is already up to date.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_merge_claude_settings.py
+++ b/scripts/tests/test_merge_claude_settings.py
@@ -1,0 +1,447 @@
+"""Tests for scripts/merge_claude_settings.py."""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the merge script as a module (scripts/ is not a package).
+# ---------------------------------------------------------------------------
+_SCRIPT_PATH = Path(__file__).resolve().parent.parent / "merge_claude_settings.py"
+_spec = importlib.util.spec_from_file_location("merge_claude_settings", _SCRIPT_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+merge_settings = _mod.merge_settings
+main = _mod.main
+
+# Path to the real example file shipped in the repo.
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+REAL_EXAMPLE = REPO_ROOT / ".claude" / "settings.local.json.example"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+EXAMPLE_CONTENT = {
+    "permissions": {
+        "allow": [
+            "mcp__agent-builder__*",
+            "mcp__tools__*",
+            "Bash(uv run *)",
+        ]
+    },
+    "enableAllProjectMcpServers": True,
+    "enabledMcpjsonServers": ["agent-builder", "tools"],
+}
+
+
+def _write_json(path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _read_json(path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# ===================================================================
+# Unit tests – fresh install
+# ===================================================================
+
+
+class TestFreshInstall:
+    """Verify behaviour when no target file exists yet."""
+
+    def test_creates_target_from_example(self, tmp_path):
+        """Target should be a copy of the example file."""
+        example = tmp_path / "example.json"
+        target = tmp_path / "target.json"
+        _write_json(example, EXAMPLE_CONTENT)
+
+        result = merge_settings(example, target)
+
+        assert result["action"] == "created"
+        assert target.exists()
+        assert _read_json(target) == EXAMPLE_CONTENT
+
+    def test_creates_parent_directories(self, tmp_path):
+        """Missing parent directories should be created automatically."""
+        example = tmp_path / "example.json"
+        target = tmp_path / "deep" / "nested" / "target.json"
+        _write_json(example, EXAMPLE_CONTENT)
+
+        merge_settings(example, target)
+
+        assert target.exists()
+
+
+# ===================================================================
+# Unit tests – merging existing
+# ===================================================================
+
+
+class TestMergeExisting:
+    """Verify merge logic when the target file already exists."""
+
+    def test_adds_new_entries(self, tmp_path):
+        """New example entries must appear in the merged target."""
+        example = tmp_path / "example.json"
+        target = tmp_path / "target.json"
+        _write_json(example, EXAMPLE_CONTENT)
+        _write_json(target, {"permissions": {"allow": ["Bash(uv run *)"]}})
+
+        result = merge_settings(example, target)
+
+        merged = _read_json(target)
+        assert "mcp__agent-builder__*" in merged["permissions"]["allow"]
+        assert "mcp__tools__*" in merged["permissions"]["allow"]
+        assert result["action"] == "merged"
+        assert len(result["new_entries"]) == 2
+
+    def test_deduplicates(self, tmp_path):
+        """Overlapping entries must not be duplicated."""
+        example = tmp_path / "example.json"
+        target = tmp_path / "target.json"
+        _write_json(example, EXAMPLE_CONTENT)
+        _write_json(
+            target,
+            {"permissions": {"allow": ["mcp__agent-builder__*", "Bash(uv run *)"]}},
+        )
+
+        merge_settings(example, target)
+
+        merged = _read_json(target)
+        allow = merged["permissions"]["allow"]
+        assert allow.count("mcp__agent-builder__*") == 1
+        assert allow.count("Bash(uv run *)") == 1
+
+    def test_preserves_user_entries(self, tmp_path):
+        """Personal entries already in the target must be kept."""
+        example = tmp_path / "example.json"
+        target = tmp_path / "target.json"
+        _write_json(example, EXAMPLE_CONTENT)
+        _write_json(
+            target,
+            {"permissions": {"allow": ["Bash(my-custom-script *)"]}},
+        )
+
+        merge_settings(example, target)
+
+        merged = _read_json(target)
+        assert "Bash(my-custom-script *)" in merged["permissions"]["allow"]
+
+    def test_example_entries_ordered_first(self, tmp_path):
+        """Project entries should appear before personal entries."""
+        example = tmp_path / "example.json"
+        target = tmp_path / "target.json"
+        _write_json(example, EXAMPLE_CONTENT)
+        _write_json(
+            target,
+            {"permissions": {"allow": ["Bash(my-custom-script *)"]}},
+        )
+
+        merge_settings(example, target)
+
+        merged = _read_json(target)
+        allow = merged["permissions"]["allow"]
+        # All example entries come first, user entry is last.
+        assert allow[-1] == "Bash(my-custom-script *)"
+        assert (
+            allow[: len(EXAMPLE_CONTENT["permissions"]["allow"])]
+            == EXAMPLE_CONTENT["permissions"]["allow"]
+        )
+
+
+# ===================================================================
+# Unit tests – top-level key merge
+# ===================================================================
+
+
+class TestTopLevelKeyMerge:
+    """Verify that top-level keys are filled but never overwritten."""
+
+    def test_fills_missing_keys(self, tmp_path):
+        """Missing top-level keys should be filled from the example."""
+        example = tmp_path / "example.json"
+        target = tmp_path / "target.json"
+        _write_json(example, EXAMPLE_CONTENT)
+        _write_json(target, {"permissions": {"allow": []}})
+
+        merge_settings(example, target)
+
+        merged = _read_json(target)
+        assert merged["enableAllProjectMcpServers"] is True
+        assert merged["enabledMcpjsonServers"] == ["agent-builder", "tools"]
+
+    def test_does_not_overwrite_existing_keys(self, tmp_path):
+        """Existing top-level keys must not be overwritten by example values."""
+        example = tmp_path / "example.json"
+        target = tmp_path / "target.json"
+        _write_json(example, EXAMPLE_CONTENT)
+        _write_json(
+            target,
+            {
+                "permissions": {"allow": []},
+                "enableAllProjectMcpServers": False,
+                "enabledMcpjsonServers": ["custom-server"],
+            },
+        )
+
+        merge_settings(example, target)
+
+        merged = _read_json(target)
+        assert merged["enableAllProjectMcpServers"] is False
+        assert merged["enabledMcpjsonServers"] == ["custom-server"]
+
+
+# ===================================================================
+# Unit tests – error handling
+# ===================================================================
+
+
+class TestErrorHandling:
+    """Verify correct exceptions for invalid inputs."""
+
+    def test_missing_example_raises(self, tmp_path):
+        """A missing example file must raise FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            merge_settings(tmp_path / "missing.json", tmp_path / "target.json")
+
+    def test_malformed_example_raises(self, tmp_path):
+        """Invalid JSON in the example must raise JSONDecodeError."""
+        example = tmp_path / "example.json"
+        example.write_text("{bad json", encoding="utf-8")
+
+        with pytest.raises(json.JSONDecodeError):
+            merge_settings(example, tmp_path / "target.json")
+
+    def test_malformed_target_raises(self, tmp_path):
+        """Invalid JSON in the target must raise JSONDecodeError."""
+        example = tmp_path / "example.json"
+        target = tmp_path / "target.json"
+        _write_json(example, EXAMPLE_CONTENT)
+        target.write_text("{bad json", encoding="utf-8")
+
+        with pytest.raises(json.JSONDecodeError):
+            merge_settings(example, target)
+
+    def test_missing_permissions_key_in_target(self, tmp_path):
+        """A target with no 'permissions' key should get one created."""
+        example = tmp_path / "example.json"
+        target = tmp_path / "target.json"
+        _write_json(example, EXAMPLE_CONTENT)
+        _write_json(target, {"someOtherKey": True})
+
+        merge_settings(example, target)
+
+        merged = _read_json(target)
+        assert "permissions" in merged
+        assert merged["permissions"]["allow"] == EXAMPLE_CONTENT["permissions"]["allow"]
+
+    def test_missing_allow_key_in_target(self, tmp_path):
+        """A target with 'permissions' but no 'allow' should get 'allow' created and keep 'deny'."""
+        example = tmp_path / "example.json"
+        target = tmp_path / "target.json"
+        _write_json(example, EXAMPLE_CONTENT)
+        _write_json(target, {"permissions": {"deny": ["Bash(rm *)"]}})
+
+        merge_settings(example, target)
+
+        merged = _read_json(target)
+        assert merged["permissions"]["allow"] == EXAMPLE_CONTENT["permissions"]["allow"]
+        assert merged["permissions"]["deny"] == ["Bash(rm *)"]
+
+
+# ===================================================================
+# Idempotency
+# ===================================================================
+
+
+class TestIdempotency:
+    """Verify that running merge twice produces identical output."""
+
+    def test_idempotent(self, tmp_path):
+        """Two consecutive merges must produce the same file content."""
+        example = tmp_path / "example.json"
+        target = tmp_path / "target.json"
+        _write_json(example, EXAMPLE_CONTENT)
+        _write_json(
+            target,
+            {"permissions": {"allow": ["Bash(my-custom-script *)"]}},
+        )
+
+        merge_settings(example, target)
+        first_pass = target.read_text(encoding="utf-8")
+
+        merge_settings(example, target)
+        second_pass = target.read_text(encoding="utf-8")
+
+        assert first_pass == second_pass
+
+
+# ===================================================================
+# CLI tests (subprocess)
+# ===================================================================
+
+
+class TestCLI:
+    """Verify the command-line interface via subprocess."""
+
+    def test_cli_fresh_install(self, tmp_path):
+        """CLI should exit 0 and print 'Created' for a fresh install."""
+        example = tmp_path / "example.json"
+        target = tmp_path / "target.json"
+        _write_json(example, EXAMPLE_CONTENT)
+
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(_SCRIPT_PATH),
+                "--example",
+                str(example),
+                "--target",
+                str(target),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert proc.returncode == 0
+        assert "Created" in proc.stdout
+
+    def test_cli_merge(self, tmp_path):
+        """CLI should exit 0 and report new entries when merging."""
+        example = tmp_path / "example.json"
+        target = tmp_path / "target.json"
+        _write_json(example, EXAMPLE_CONTENT)
+        _write_json(target, {"permissions": {"allow": ["Bash(uv run *)"]}})
+
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(_SCRIPT_PATH),
+                "--example",
+                str(example),
+                "--target",
+                str(target),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert proc.returncode == 0
+        assert "Merged" in proc.stdout
+
+    def test_cli_missing_example(self, tmp_path):
+        """CLI should exit 1 and print 'Error' when example is missing."""
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(_SCRIPT_PATH),
+                "--example",
+                str(tmp_path / "missing.json"),
+                "--target",
+                str(tmp_path / "target.json"),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert proc.returncode == 1
+        assert "Error" in proc.stderr
+
+
+# ===================================================================
+# End-to-end integration
+# ===================================================================
+
+
+class TestEndToEnd:
+    """Integration tests exercising realistic scenarios."""
+
+    def test_full_onboarding_flow(self, tmp_path):
+        """Simulate fresh onboarding: create → verify → re-merge → idempotent."""
+        example = tmp_path / "example.json"
+        target = tmp_path / ".claude" / "settings.local.json"
+        _write_json(example, EXAMPLE_CONTENT)
+
+        # First merge – creates target
+        result = merge_settings(example, target)
+        assert result["action"] == "created"
+
+        merged = _read_json(target)
+        assert merged["permissions"]["allow"] == EXAMPLE_CONTENT["permissions"]["allow"]
+        assert merged["enableAllProjectMcpServers"] is True
+        assert merged["enabledMcpjsonServers"] == ["agent-builder", "tools"]
+
+        # Second merge – idempotent
+        result2 = merge_settings(example, target)
+        assert result2["action"] == "merged"
+        assert len(result2["new_entries"]) == 0
+        assert _read_json(target) == merged
+
+    def test_existing_contributor_preserves_custom(self, tmp_path):
+        """Contributor already has custom settings: merge adds project entries, keeps theirs."""
+        example = tmp_path / "example.json"
+        target = tmp_path / "target.json"
+        _write_json(example, EXAMPLE_CONTENT)
+        _write_json(
+            target,
+            {
+                "permissions": {
+                    "allow": ["Bash(my-custom *)", "Bash(npm test *)"],
+                    "deny": ["Bash(rm -rf *)"],
+                },
+                "customUserKey": 42,
+            },
+        )
+
+        merge_settings(example, target)
+
+        merged = _read_json(target)
+        # Personal entries preserved
+        assert "Bash(my-custom *)" in merged["permissions"]["allow"]
+        assert "Bash(npm test *)" in merged["permissions"]["allow"]
+        assert merged["permissions"]["deny"] == ["Bash(rm -rf *)"]
+        assert merged["customUserKey"] == 42
+        # Project entries added
+        for entry in EXAMPLE_CONTENT["permissions"]["allow"]:
+            assert entry in merged["permissions"]["allow"]
+
+    def test_example_file_is_valid(self):
+        """The real .claude/settings.local.json.example in the repo must be valid."""
+        assert REAL_EXAMPLE.exists(), f"Example file missing: {REAL_EXAMPLE}"
+        data = json.loads(REAL_EXAMPLE.read_text(encoding="utf-8"))
+        assert "permissions" in data
+        assert "allow" in data["permissions"]
+        allow = data["permissions"]["allow"]
+        # Spot-check critical patterns — MCP wildcards
+        assert any("mcp__agent-builder__" in e for e in allow)
+        assert any("mcp__tools__" in e for e in allow)
+        # Bash commands from agent generation flow
+        assert any("Bash(PYTHONPATH=" in e for e in allow)
+        assert any("Bash(MOCK_MODE=" in e for e in allow)
+        assert any("Bash(cd " in e for e in allow)
+        assert any("Bash(uv run" in e for e in allow)
+        assert any("Bash(uv pip" in e for e in allow)
+        assert any("Bash(python3" in e for e in allow)
+        assert any("Bash(pytest" in e for e in allow)
+        assert any("Bash(ruff" in e for e in allow)
+        assert any("Bash(mkdir" in e for e in allow)
+        assert any("Bash(ls" in e for e in allow)
+        assert any("Bash(export" in e for e in allow)
+        assert any("Bash(gh" in e for e in allow)
+        # All skills used in the workflow
+        assert any("Skill(agent-workflow)" in e for e in allow)
+        assert any("Skill(building-agents-construction)" in e for e in allow)
+        assert any("Skill(building-agents-core)" in e for e in allow)
+        assert any("Skill(building-agents-patterns)" in e for e in allow)
+        assert any("Skill(testing-agent)" in e for e in allow)
+        assert any("Skill(setup-credentials)" in e for e in allow)
+        assert any("Skill(triage-issue)" in e for e in allow)
+        # Top-level config
+        assert data.get("enableAllProjectMcpServers") is True
+        assert "agent-builder" in data.get("enabledMcpjsonServers", [])


### PR DESCRIPTION
## Description

Contributors experience "approval fatigue" — every MCP tool call and bash command
in Claude Code requires manual approval. The current `.claude/settings.local.json`
is tracked by git and contains personal cruft (e.g., a hardcoded git commit message
from someone's Excel tool work).

This PR replaces the tracked file with a `.example` template and a merge script that
preserves personal contributor settings while ensuring everyone has the project-required
auto-approvals.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Fixes #4258

## Changes Made

- Add `.claude/settings.local.json.example` — canonical template with 31 auto-approval
  entries covering all MCP tools (`agent-builder`, `tools`), bash commands (`PYTHONPATH`,
  `MOCK_MODE`, `cd`, `uv`, `python`, `pytest`, `ruff`, `mkdir`, `ls`, `export`, `gh`),
  all 7 skills, and `WebFetch(domain:github.com)`
- Add `scripts/merge_claude_settings.py` — pure-stdlib merge script that copies on fresh
  install, deduplicates and preserves personal entries on merge, and fills missing
  top-level keys without overwriting existing values
- Integrate merge step into `quickstart.sh` after verification (non-fatal — failure
  shows a warning, doesn't block onboarding)
- Untrack `.claude/settings.local.json` (`git rm --cached`) and add it to `.gitignore`
- Add `scripts/tests/test_merge_claude_settings.py` — 20 test cases across 8 classes

## Testing

- [x] 20/20 unit tests pass (`uv run pytest scripts/tests/ -v`)
- [x] Lint passes (`ruff check scripts/`)
- [x] Format passes (`ruff format --check scripts/`)
- [x] 259 existing tools tests pass — no regressions
- [x] Manual E2E: fresh install, idempotent re-merge, existing contributor merge

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes