### PR TITLE
docs(contributing): fix duplicate step numbers and add tools test command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,8 @@ You may submit PRs without prior assignment for:
    make check    # Lint and format checks (ruff check + ruff format --check on core/ and tools/)
    make test     # Core tests (cd core && pytest tests/ -v)
    ```
-6. Commit your changes following our commit conventions
-7. Push to your fork and submit a Pull Request
+8. Commit your changes following our commit conventions
+9. Push to your fork and submit a Pull Request
 
 ## Development Setup
 
@@ -144,6 +144,9 @@ make test
 
 # Or run tests directly
 cd core && pytest tests/ -v
+
+# Run tools package tests (when contributing to tools/)
+cd tools && uv run pytest tests/ -v
 
 # Run tests for a specific agent
 PYTHONPATH=exports uv run python -m agent_name test


### PR DESCRIPTION
## Description

Fix CONTRIBUTING.md numbering and add tools test command for contributors working on the tools package.

## Type of Change

- [x] Documentation update

## Changes Made

- Fix Getting Started steps 6/7 duplicated; renumber to 8 and 9
- Add command to run tools package tests: \cd tools && uv run pytest tests/ -v\

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code