### PR TITLE
docs(fix): correct LLMNode token counting bug

### DIFF
--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -1073,7 +1073,7 @@ Keep the same JSON structure but with shorter content values.
                 decision_id=decision_id,
                 success=True,
                 result=response.content,
-                tokens_used=response.input_tokens + response.output_tokens,
+                tokens_used=total_input_tokens + total_output_tokens,
                 latency_ms=latency_ms,
             )
 
@@ -1148,7 +1148,7 @@ Keep the same JSON structure but with shorter content values.
                             f"Expected keys: {ctx.node_spec.output_keys}"
                         ),
                         output={},
-                        tokens_used=response.input_tokens + response.output_tokens,
+                        tokens_used=total_input_tokens + total_output_tokens,
                         latency_ms=latency_ms,
                     )
                     # JSON extraction failed completely - still strip code blocks
@@ -1167,7 +1167,7 @@ Keep the same JSON structure but with shorter content values.
             return NodeResult(
                 success=True,
                 output=output,
-                tokens_used=response.input_tokens + response.output_tokens,
+                tokens_used=total_input_tokens + total_output_tokens,
                 latency_ms=latency_ms,
             )
 


### PR DESCRIPTION
### Summary
Updated `LLMNode` to use `total_input_tokens` and `total_output_tokens` in the final result, ensuring that tokens from validation retries are correctly counted.

### Fixes
Fixes #4266

### Changes
- Swapped `response.input_tokens` with `total_input_tokens` in `record_outcome` and `NodeResult`.