### PR TITLE
fix(skills): update MockLLMProvider schema to resolve validation warnings in Online Research Agent 

### DIFF
--- a/.claude/skills/building-agents-construction/examples/online_research_agent/agent.py
+++ b/.claude/skills/building-agents-construction/examples/online_research_agent/agent.py
@@ -16,11 +16,50 @@ class MockLLMProvider:
         self.model = "mock-model"
 
     def complete(self, messages, system="", tools=None, **kwargs):
+        # We construct a "Super JSON" that satisfies ALL nodes in the graph.
+        # This prevents validation errors no matter which node is running.
         
-        mock_content = '{"category": "general", "priority": "medium", "queries": ["mock query"], "topic": "AI Agents", "subtopics": ["Agents"], "reasoning": "This is a mock response."}'
+        super_mock_content = {
+            # Keys for 'parse-query' node
+            "category": "general", 
+            "priority": "medium", 
+            "queries": ["mock search query"], 
+            "topic": "AI Agents", 
+            "subtopics": ["LLMs", "Autonomous Agents"], 
+            "reasoning": "Mock reasoning",
+            
+            # Keys for 'search-sources' & 'fetch-content' nodes
+            "research_focus": "Overview of AI Agents",
+            "source_urls": ["https://example.com/ai-study"],
+            "fetched_sources": [
+                {"url": "https://example.com/ai-study", "content": "AI agents are autonomous systems..."}
+            ],
+            
+            # Keys for 'evaluate-sources' node
+            "key_aspects": ["Autonomy", "Reasoning"],
+            "ranked_sources": ["https://example.com/ai-study"],
+            "source_analysis": {"https://example.com/ai-study": "Highly relevant"},
+            
+            # Keys for 'synthesize-findings' node
+            "key_findings": ["Agents can plan", "Agents use tools"],
+            "themes": ["Automation", "AGI"],
+            
+            # Keys for 'write-report' & 'save-report' nodes
+            "report_content": "# AI Agents Report\n\nAI agents are cool.",
+            "source_citations": ["(Author, 2025)"],
+            "references": ["https://example.com/ai-study"],
+            "final_report": "# AI Agents Report\n\nAI agents are cool.",
+            "file_path": "/tmp/mock_report.md",
+            
+            # Generic keys
+            "quality_score": 100,
+            "issues": []
+        }
         
+        # Return as a proper LLMResponse object
+        import json
         return LLMResponse(
-            content=mock_content,
+            content=json.dumps(super_mock_content),
             model="mock-model"
         )
 


### PR DESCRIPTION
## Description

This PR resolves the ```Output validation failed``` warnings that appear when running the ```online_research_agent``` in mock mode.

Previously, the ```MockLLMProvider``` returned a generic JSON response that lacked specific keys required by downstream nodes (e.g., ```fetch-content``` requires ```source_urls```, ```write-report``` requires ```citations```). While the agent would complete execution, the logs were cluttered with validation errors and "Cleaning failed" messages.

This change updates the ```MockLLMProvider``` to return a comprehensive "super-schema" that satisfies the input requirements of all nodes in the agent graph.
## Type of Change

- Bug fix (non-breaking change that fixes an issue)


## Related Issues

Fixes #1223 

## Changes Made

- Updated ```MockLLMProvider.complete``` in ```agent.py``` to return a fully populated JSON object.
- Added missing keys required by the graph schema:
  - ```research_focus```
  - ```source_urls``` & ```fetched_sources```
  - ```key_aspects``` & ```source_analysis```
  - ```ranked_sources```
  - ```key_findings``` & ```themes```
  - ```report_content```, ```source_citations```, & ```references```
  - ```final_report```
 - Ensured the ```LLMResponse``` object wraps the JSON string correctly.

## Testing

- Manual testing performed

Manual Verification: Ran the agent in mock mode:
```bash
PYTHONPATH=core:exports python3 -m online_research_agent run --topic "AI" --mock
```

## Result
- Execution completed with ```"success": true.```

- Logs are clean of Output validation failed warnings.

- "Haiku formatting failed" warnings may still appear (expected without API key), but schema validation now passes.


## Screenshots (if applicable)

<img width="1593" height="642" alt="image" src="https://github.com/user-attachments/assets/b79c0bcd-5edb-4047-acba-9624373c9ce3" />
