### PR TITLE
feat(tools): add Salesforce integration

### DIFF
--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -46,6 +46,7 @@ from .runtime_logs_tool import register_tools as register_runtime_logs
 from .slack_tool import register_tools as register_slack
 from .web_scrape_tool import register_tools as register_web_scrape
 from .web_search_tool import register_tools as register_web_search
+from .salesforce_tool import register_tools as register_salesforce
 
 
 def register_all_tools(
@@ -77,6 +78,7 @@ def register_all_tools(
     register_email(mcp, credentials=credentials)
     register_hubspot(mcp, credentials=credentials)
     register_slack(mcp, credentials=credentials)
+    register_salesforce(mcp, credentials=credentials)
 
     # Register file system toolkits
     register_view_file(mcp)
@@ -203,6 +205,12 @@ def register_all_tools(
         "slack_kick_user_from_channel",
         "slack_delete_file",
         "slack_get_team_stats",
+        # Salesforce tools
+        "salesforce_soql_query",
+        "salesforce_get_record",
+        "salesforce_create_record",
+        "salesforce_update_record",
+        "salesforce_get_limits",
     ]
 
 

--- a/tools/src/aden_tools/tools/salesforce_tool/README.md
+++ b/tools/src/aden_tools/tools/salesforce_tool/README.md
@@ -1,0 +1,116 @@
+# Salesforce Tool
+
+Interact with Salesforce data via the REST API. This tool allows the Aden agent framework to query, create, update, and manage Salesforce records.
+
+## Installation
+
+The Salesforce tool uses `httpx` which is already included in the base dependencies. No additional installation required.
+
+## Setup
+
+You need a Salesforce Connected App and an OAuth Access Token to use this tool.
+
+### Getting Credentials
+
+1.  **Log in to Salesforce Setup.**
+2.  Go to **Apps > App Manager**.
+3.  Click **New Connected App**.
+4.  Enable OAuth Settings and select the `api` and `refresh_token` scopes.
+5.  Save and note your **Consumer Key** and **Consumer Secret**.
+6.  Use these credentials to generate an Access Token via the Salesforce OAuth flow (e.g., Device Flow or Web Server Flow).
+
+### Configuration
+
+Set the following environment variables:
+
+```bash
+export SALESFORCE_ACCESS_TOKEN=your_access_token_here
+export SALESFORCE_INSTANCE_URL=https://your-domain.my.salesforce.com
+```
+
+Or configure via the credential store (recommended for production).
+
+## Available Functions
+
+### `salesforce_soql_query`
+
+Execute a SOQL query to search or retrieve data from Salesforce.
+
+**Parameters:**
+- `query` (str): The SOQL query string (e.g., `SELECT Id, Name, Email FROM Contact WHERE Email LIKE '%@example.com%'`)
+- `access_token` (str, optional): Override access token.
+- `instance_url` (str, optional): Override instance URL.
+
+**Returns:**
+A string summary of the query results, including the total number of records found and a list of the top records.
+
+**Example:**
+```python
+salesforce_soql_query("SELECT Id, Name, StageName FROM Opportunity WHERE IsClosed = false")
+```
+
+### `salesforce_get_record`
+
+Retrieve a single record from Salesforce by ID.
+
+**Parameters:**
+- `sobject` (str): The API name of the object (e.g., "Account", "Contact").
+- `record_id` (str): The 15 or 18 character Salesforce ID.
+- `fields` (list[str], optional): specific fields to retrieve.
+
+**Returns:**
+A string representation of the record data.
+
+**Example:**
+```python
+salesforce_get_record("Account", "001xxxxxxxxxxxx", fields=["Name", "BillingCity"])
+```
+
+### `salesforce_create_record`
+
+Create a new record in Salesforce.
+
+**Parameters:**
+- `sobject` (str): The API name of the object.
+- `data` (dict): A dictionary of field API names and values.
+
+**Returns:**
+Success message with the new record ID, or an error message.
+
+**Example:**
+```python
+salesforce_create_record("Lead", {"FirstName": "John", "LastName": "Doe", "Company": "Acme Corp"})
+```
+
+### `salesforce_update_record`
+
+Update an existing record in Salesforce.
+
+**Parameters:**
+- `sobject` (str): The API name of the object.
+- `record_id` (str): The ID of the record to update.
+- `data` (dict): A dictionary of fields to update.
+
+**Returns:**
+Success message or error message.
+
+**Example:**
+```python
+salesforce_update_record("Contact", "003xxxxxxxxxxxx", {"Title": "VP of Sales"})
+```
+
+### `salesforce_get_limits`
+
+Check API usage limits for the Salesforce organization.
+
+**Returns:**
+A string summary of API usage (e.g., `API Usage: {'Max': 15000, 'Remaining': 14500}`).
+
+**Example:**
+```python
+salesforce_get_limits()
+```
+
+## Error Handling
+
+All functions return a descriptive string starting with "Error: ..." or containing specific error details if the API call fails (e.g., invalid query, record not found, permission denied).

--- a/tools/src/aden_tools/tools/salesforce_tool/__init__.py
+++ b/tools/src/aden_tools/tools/salesforce_tool/__init__.py
@@ -1,0 +1,3 @@
+from .salesforce_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/salesforce_tool/salesforce_tool.py
+++ b/tools/src/aden_tools/tools/salesforce_tool/salesforce_tool.py
@@ -1,0 +1,331 @@
+"""
+Salesforce Tool - Interact with Salesforce data via the REST API.
+
+Supports:
+- OAuth2 Access Tokens (SALESFORCE_ACCESS_TOKEN)
+- Instance URL (SALESFORCE_INSTANCE_URL)
+
+API Reference: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_what_is_rest_api.htm
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialStoreAdapter
+
+# Default API version if not specified
+DEFAULT_API_VERSION = "v60.0"
+
+
+class _SalesforceClient:
+    """Internal client wrapping Salesforce REST API calls."""
+
+    def __init__(
+        self, access_token: str, instance_url: str, api_version: str = DEFAULT_API_VERSION
+    ):
+        self._access_token = access_token
+        self._instance_url = instance_url.rstrip("/")
+        self._api_version = api_version
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._access_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    @property
+    def _base_url(self) -> str:
+        return f"{self._instance_url}/services/data/{self._api_version}"
+
+    def _handle_response(self, response: httpx.Response) -> Any:
+        """Handle Salesforce API response format."""
+        if response.status_code == 204:
+            return {"success": True}
+
+        try:
+            data = response.json()
+        except Exception:
+            # If JSON parsing fails but status is error, return error
+            if response.status_code >= 400:
+                return {
+                    "error": f"HTTP error {response.status_code}: {response.text}",
+                    "status_code": response.status_code,
+                }
+            return {"success": True, "text": response.text}
+
+        # Check for Salesforce error array format
+        if (
+            isinstance(data, list)
+            and len(data) > 0
+            and isinstance(data[0], dict)
+            and "errorCode" in data[0]
+        ):
+            return {"error": data[0]["message"], "code": data[0]["errorCode"]}
+
+        # Check for error object format
+        if isinstance(data, dict) and "error" in data:
+            return {"error": data.get("error_description", data["error"])}
+
+        if response.status_code >= 400:
+            return {
+                "error": f"HTTP error {response.status_code}",
+                "details": data,
+                "status_code": response.status_code,
+            }
+
+        return data
+
+    def query(self, query_string: str) -> dict[str, Any]:
+        """Execute a SOQL query."""
+        response = httpx.get(
+            f"{self._base_url}/query",
+            headers=self._headers,
+            params={"q": query_string},
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def get_record(
+        self, sobject: str, record_id: str, fields: list[str] | None = None
+    ) -> dict[str, Any]:
+        """Retrieve a specific record by ID."""
+        params = {}
+        if fields:
+            params["fields"] = ",".join(fields)
+
+        response = httpx.get(
+            f"{self._base_url}/sobjects/{sobject}/{record_id}",
+            headers=self._headers,
+            params=params,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def create_record(self, sobject: str, data: dict[str, Any]) -> dict[str, Any]:
+        """Create a new record."""
+        response = httpx.post(
+            f"{self._base_url}/sobjects/{sobject}",
+            headers=self._headers,
+            json=data,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def update_record(self, sobject: str, record_id: str, data: dict[str, Any]) -> dict[str, Any]:
+        """Update an existing record."""
+        response = httpx.patch(
+            f"{self._base_url}/sobjects/{sobject}/{record_id}",
+            headers=self._headers,
+            json=data,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def delete_record(self, sobject: str, record_id: str) -> dict[str, Any]:
+        """Delete a record."""
+        response = httpx.delete(
+            f"{self._base_url}/sobjects/{sobject}/{record_id}",
+            headers=self._headers,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def get_limits(self) -> dict[str, Any]:
+        """Check API usage limits."""
+        response = httpx.get(
+            f"{self._base_url}/limits",
+            headers=self._headers,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+
+# -----------------------------------------------------------------------------
+# Tool Definitions
+# -----------------------------------------------------------------------------
+
+
+def register_tools(mcp: FastMCP, credential_store: CredentialStoreAdapter | None = None) -> None:
+    """Register Salesforce tools with the MCP server."""
+
+    def _get_client(
+        user_access_token: str | None = None, user_instance_url: str | None = None
+    ) -> _SalesforceClient:
+        # 1. Try passed arguments (e.g. from agent input)
+        # 2. Try environment variables
+        token = user_access_token or os.environ.get("SALESFORCE_ACCESS_TOKEN")
+        instance_url = user_instance_url or os.environ.get("SALESFORCE_INSTANCE_URL")
+
+        # 3. Try Credential Store if available
+        if (not token or not instance_url) and credential_store:
+            # Basic lookup naming convention 'salesforce'
+            creds = credential_store.get_credential("salesforce")
+            if creds:
+                token = token or creds.get("access_token")
+                instance_url = instance_url or creds.get("instance_url")
+
+        if not token:
+            raise ValueError(
+                "Salesforce Access Token is required. Set SALESFORCE_ACCESS_TOKEN env var."
+            )
+        if not instance_url:
+            raise ValueError(
+                "Salesforce Instance URL is required. Set SALESFORCE_INSTANCE_URL env var."
+            )
+
+        return _SalesforceClient(token, instance_url)
+
+    @mcp.tool()
+    def salesforce_soql_query(
+        query: str, access_token: str | None = None, instance_url: str | None = None
+    ) -> str:
+        """Execute a SOQL query to search or retrieve data from Salesforce.
+
+        Args:
+            query: The SOQL query string
+                   (e.g., "SELECT Id, Name, Email FROM Contact WHERE Email LIKE '%@example.com%'")
+            access_token: Optional access token override
+            instance_url: Optional instance URL override
+        """
+        try:
+            client = _get_client(access_token, instance_url)
+            result = client.query(query)
+
+            if "error" in result:
+                return f"Error executing query: {result['error']}"
+
+            records = result.get("records", [])
+            total_size = result.get("totalSize", 0)
+
+            # Simple string representation for agent consumption
+            # We strip out the messy 'attributes' metadata field from records to keep it clean
+            clean_records = []
+            for record in records:
+                if "attributes" in record:
+                    del record["attributes"]
+                clean_records.append(record)
+
+            return f"Found {total_size} records. Top results:\n{clean_records}"
+
+        except Exception as e:
+            return f"Error: {str(e)}"
+
+    @mcp.tool()
+    def salesforce_get_record(
+        sobject: str,
+        record_id: str,
+        fields: list[str] | None = None,
+        access_token: str | None = None,
+        instance_url: str | None = None,
+    ) -> str:
+        """Retrieve a single record from Salesforce by ID.
+
+        Args:
+            sobject: The API name of the object (e.g., "Account", "Contact", "CustomObject__c")
+            record_id: The 15 or 18 character Salesforce ID
+            fields: Optional list of specific fields to retrieve (defaults to all)
+            access_token: Optional access token override
+            instance_url: Optional instance URL override
+        """
+        try:
+            client = _get_client(access_token, instance_url)
+            result = client.get_record(sobject, record_id, fields)
+
+            if "error" in result:
+                return f"Error retrieving record: {result['error']}"
+
+            if "attributes" in result:
+                del result["attributes"]
+
+            return str(result)
+
+        except Exception as e:
+            return f"Error: {str(e)}"
+
+    @mcp.tool()
+    def salesforce_create_record(
+        sobject: str,
+        data: dict[str, Any],
+        access_token: str | None = None,
+        instance_url: str | None = None,
+    ) -> str:
+        """Create a new record in Salesforce.
+
+        Args:
+            sobject: The API name of the object (e.g., "Lead", "Case")
+            data: A dictionary of field API names and values to set
+            access_token: Optional access token override
+            instance_url: Optional instance URL override
+        """
+        try:
+            client = _get_client(access_token, instance_url)
+            result = client.create_record(sobject, data)
+
+            if "error" in result:
+                return f"Error creating record: {result['error']}"
+
+            return f"Successfully created record. ID: {result.get('id')}"
+
+        except Exception as e:
+            return f"Error: {str(e)}"
+
+    @mcp.tool()
+    def salesforce_update_record(
+        sobject: str,
+        record_id: str,
+        data: dict[str, Any],
+        access_token: str | None = None,
+        instance_url: str | None = None,
+    ) -> str:
+        """Update an existing record in Salesforce.
+
+        Args:
+            sobject: The API name of the object
+            record_id: The ID of the record to update
+            data: A dictionary of fields to update
+            access_token: Optional access token override
+            instance_url: Optional instance URL override
+        """
+        try:
+            client = _get_client(access_token, instance_url)
+            result = client.update_record(sobject, record_id, data)
+
+            if "error" in result:
+                return f"Error updating record: {result['error']}"
+
+            return "Successfully updated record."
+
+        except Exception as e:
+            return f"Error: {str(e)}"
+
+    @mcp.tool()
+    def salesforce_get_limits(
+        access_token: str | None = None, instance_url: str | None = None
+    ) -> str:
+        """Check API usage limits for the Salesforce organization.
+
+        Args:
+            access_token: Optional access token override
+            instance_url: Optional instance URL override
+        """
+        try:
+            client = _get_client(access_token, instance_url)
+            result = client.get_limits()
+
+            if "error" in result:
+                return f"Error fetching limits: {result['error']}"
+
+            # Extract just the DailyApiRequests for brevity, or return full dict str
+            api_usage = result.get("DailyApiRequests", {})
+            return f"API Usage: {api_usage}"
+
+        except Exception as e:
+            return f"Error: {str(e)}"

--- a/tools/tests/tools/test_salesforce_tool.py
+++ b/tools/tests/tools/test_salesforce_tool.py
@@ -1,0 +1,194 @@
+"""Tests for salesforce_tool."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.salesforce_tool.salesforce_tool import register_tools
+
+
+@pytest.fixture
+def mcp():
+    """Create a FastMCP instance."""
+    mcp = FastMCP("test-server")
+    register_tools(mcp)
+    return mcp
+
+
+@pytest.fixture
+def tool_manager(mcp):
+    """Retrieve the tool manager from the MCP server."""
+    # FastMCP stores tools in its internal _tool_manager._tools dictionary
+    return mcp._tool_manager
+
+
+@pytest.fixture
+def mock_httpx_client():
+    """Mock request call."""
+    with patch("httpx.get") as mock_get, \
+         patch("httpx.post") as mock_post, \
+         patch("httpx.patch") as mock_patch, \
+         patch("httpx.delete") as mock_delete:
+        yield {
+            "get": mock_get,
+            "post": mock_post,
+            "patch": mock_patch,
+            "delete": mock_delete,
+        }
+
+
+def test_missing_credentials_error(tool_manager):
+    """Test error when credentials are missing."""
+    tool = tool_manager._tools["salesforce_soql_query"].fn
+    result = tool(query="SELECT Id FROM Account")
+    assert "Salesforce Access Token is required" in result
+
+
+def test_salesforce_soql_query(tool_manager, mock_httpx_client):
+    """Test SOQL query execution."""
+    tool = tool_manager._tools["salesforce_soql_query"].fn
+    mock_get = mock_httpx_client["get"]
+
+    # Mock successful response
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "totalSize": 1,
+        "done": True,
+        "records": [
+            {
+                "attributes": {"type": "Account", "url": "/..."},
+                "Id": "001...",
+                "Name": "Test Account"
+            }
+        ]
+    }
+    mock_get.return_value = mock_response
+
+    result = tool(
+        query="SELECT Id, Name FROM Account",
+        access_token="fake_token",
+        instance_url="https://test.salesforce.com"
+    )
+
+    # Verify call arguments
+    mock_get.assert_called_once()
+    args, kwargs = mock_get.call_args
+    assert "https://test.salesforce.com/services/data/v60.0/query" in args[0]
+    assert kwargs["params"]["q"] == "SELECT Id, Name FROM Account"
+
+    # Verify result logic (stripping attributes)
+    assert "Found 1 records" in result
+    assert "Test Account" in result
+    assert "attributes" not in result
+
+
+def test_salesforce_soql_query_error(tool_manager, mock_httpx_client):
+    """Test SOQL query with API error."""
+    tool = tool_manager._tools["salesforce_soql_query"].fn
+    mock_get = mock_httpx_client["get"]
+
+    # Mock error response
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 400
+    mock_response.json.return_value = [{"message": "Invalid query", "errorCode": "MALFORMED_QUERY"}]
+    mock_get.return_value = mock_response
+
+    result = tool(
+        query="SELECT Invalid FROM Account",
+        access_token="fake_token",
+        instance_url="https://test.salesforce.com"
+    )
+
+    assert "Error executing query" in result
+    assert "Invalid query" in result
+
+
+def test_salesforce_get_record(tool_manager, mock_httpx_client):
+    """Test getting a record."""
+    tool = tool_manager._tools["salesforce_get_record"].fn
+    mock_get = mock_httpx_client["get"]
+
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "attributes": {"type": "Account", "url": "..."},
+        "Id": "001...",
+        "Name": "Test Account"
+    }
+    mock_get.return_value = mock_response
+
+    result = tool(
+        sobject="Account",
+        record_id="001...",
+        access_token="fake_token",
+        instance_url="https://test.salesforce.com"
+    )
+
+    assert "Test Account" in result
+    assert "attributes" not in result
+
+
+def test_salesforce_create_record(tool_manager, mock_httpx_client):
+    """Test creating a record."""
+    tool = tool_manager._tools["salesforce_create_record"].fn
+    mock_post = mock_httpx_client["post"]
+
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 201
+    mock_response.json.return_value = {"id": "001...", "success": True, "errors": []}
+    mock_post.return_value = mock_response
+
+    result = tool(
+        sobject="Account",
+        data={"Name": "New Account"},
+        access_token="fake_token",
+        instance_url="https://test.salesforce.com"
+    )
+
+    assert "Successfully created record" in result
+    assert "001..." in result
+
+
+def test_salesforce_update_record(tool_manager, mock_httpx_client):
+    """Test updating a record."""
+    tool = tool_manager._tools["salesforce_update_record"].fn
+    mock_patch = mock_httpx_client["patch"]
+
+    # 204 No Content is typical for update success
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 204
+    mock_patch.return_value = mock_response
+
+    result = tool(
+        sobject="Account",
+        record_id="001...",
+        data={"Name": "Updated Name"},
+        access_token="fake_token",
+        instance_url="https://test.salesforce.com"
+    )
+
+    assert "Successfully updated record" in result
+
+
+def test_salesforce_get_limits(tool_manager, mock_httpx_client):
+    """Test fetching API limits."""
+    tool = tool_manager._tools["salesforce_get_limits"].fn
+    mock_get = mock_httpx_client["get"]
+
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "DailyApiRequests": {"Max": 15000, "Remaining": 14999}
+    }
+    mock_get.return_value = mock_response
+
+    result = tool(
+        access_token="fake_token",
+        instance_url="https://test.salesforce.com"
+    )
+
+    assert "API Usage" in result
+    assert "Remaining': 14999" in result


### PR DESCRIPTION
Fixes #4334
## Overview
This PR introduces a new integration with Salesforce, enabling agents to interact with CRM data directly.

## Features Added
- New Tool: `salesforce_tool` package under `tools/src/aden_tools/tools/`
- Core Functions:
  - salesforce_soql_query: Execute SOQL queries
  - salesforce_get_record: Retrieve record by ID
  - salesforce_create_record: Create new records
  - salesforce_update_record: Update existing records
  - salesforce_get_limits: Check API usage limits
- Includes error handling for API failures
- Added unit tests for all major functions
- Added README with setup and usage instructions

## Verification
- Implemented new tool module
- Registered tool in tools registry
- Added unit tests
- Tested locally with pytest
- Lint check passed

This improves Hive's integration capabilities and adds support for CRM-based workflows.
