### PR TITLE
Add Input Type Validation in HITLQuestion Initialization

### DIFF
--- a/core/framework/graph/hitl.py
+++ b/core/framework/graph/hitl.py
@@ -22,7 +22,13 @@ class HITLInputType(StrEnum):
 
 @dataclass
 class HITLQuestion:
-    """A single question to ask the human."""
+    """
+    A single question to ask the human.
+
+    Validates configuration upon initialization:
+    - If input_type is SELECTION, 'options' must be provided.
+    - If input_type is STRUCTURED, 'fields' must be provided.
+    """
 
     id: str
     question: str
@@ -37,6 +43,14 @@ class HITLQuestion:
     # Metadata
     required: bool = True
     help_text: str = ""
+
+    def __post_init__(self):
+        """Validate input type configuration."""
+        if self.input_type == HITLInputType.SELECTION and not self.options:
+            raise ValueError("The 'options' field must be provided for SELECTION input types.")
+
+        if self.input_type == HITLInputType.STRUCTURED and not self.fields:
+            raise ValueError("The 'fields' field must be provided for STRUCTURED input types.")
 
 
 @dataclass

--- a/core/tests/test_hitl_validation.py
+++ b/core/tests/test_hitl_validation.py
@@ -1,0 +1,62 @@
+import pytest
+from framework.graph.hitl import HITLQuestion, HITLInputType
+
+def test_valid_free_text():
+    """Test creating a valid free text question."""
+    q = HITLQuestion(id="q1", question="What is your name?", input_type=HITLInputType.FREE_TEXT)
+    assert q.id == "q1"
+    assert q.question == "What is your name?"
+
+def test_valid_selection():
+    """Test creating a valid selection question."""
+    q = HITLQuestion(
+        id="q2",
+        question="Select a color",
+        input_type=HITLInputType.SELECTION,
+        options=["Red", "Blue"]
+    )
+    assert q.options == ["Red", "Blue"]
+
+def test_invalid_selection():
+    """Test creating a selection question without options raises ValueError."""
+    with pytest.raises(ValueError, match="The 'options' field must be provided for SELECTION input types."):
+        HITLQuestion(
+            id="q3",
+            question="Select a color",
+            input_type=HITLInputType.SELECTION
+        )
+    # Also test empty list
+    with pytest.raises(ValueError, match="The 'options' field must be provided for SELECTION input types."):
+        HITLQuestion(
+            id="q3b",
+            question="Select a color",
+            input_type=HITLInputType.SELECTION,
+            options=[]
+        )
+
+def test_valid_structured():
+    """Test creating a valid structured question."""
+    q = HITLQuestion(
+        id="q4",
+        question="Provide details",
+        input_type=HITLInputType.STRUCTURED,
+        fields={"name": "Your name", "age": "Your age"}
+    )
+    assert q.fields == {"name": "Your name", "age": "Your age"}
+
+def test_invalid_structured():
+    """Test creating a structured question without fields raises ValueError."""
+    with pytest.raises(ValueError, match="The 'fields' field must be provided for STRUCTURED input types."):
+        HITLQuestion(
+            id="q5",
+            question="Provide details",
+            input_type=HITLInputType.STRUCTURED
+        )
+    # Also test empty dict
+    with pytest.raises(ValueError, match="The 'fields' field must be provided for STRUCTURED input types."):
+        HITLQuestion(
+            id="q5b",
+            question="Provide details",
+            input_type=HITLInputType.STRUCTURED,
+            fields={}
+        )


### PR DESCRIPTION
## Description
This PR addresses issue #3023 by adding validation logic to the `HITLQuestion` class. It ensures that:
- Questions of type `SELECTION` must have non-empty `options`.
- Questions of type `STRUCTURED` must have non-empty `fields`.

This prevents runtime errors and confusing UI states caused by improperly configured questions.

## Changes
- Modified `core/framework/graph/hitl.py`: Added `__post_init__` method to `HITLQuestion` dataclass.
- Created `core/tests/test_hitl_validation.py`: Added comprehensive unit tests for valid and invalid configurations.
- Updated documentation string for `HITLQuestion`.

## Validation
- Ran new unit tests: Passed.
- Verified backward compatibility: No existing code uses `HITLQuestion` in a way that would break (no usages found in core).

Resolves #3023

---

_Pull request created with Google Antigravity_