### PR TITLE
fix: validate agent.json on load with clear error messages (#2039)

### DIFF
--- a/core/framework/runner/config_validator.py
+++ b/core/framework/runner/config_validator.py
@@ -1,0 +1,160 @@
+"""
+Validates agent.json configuration at load time.
+
+Catches missing fields, type errors, and structural issues early
+instead of failing at runtime with confusing errors.
+
+Fixes: https://github.com/adenhq/hive/issues/2039
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class AgentConfigError(ValueError):
+    """Raised when agent.json has invalid or missing configuration."""
+
+    def __init__(self, errors: list[str], config_path: str = "agent.json"):
+        self.errors = errors
+        self.config_path = config_path
+        error_list = "\n  - ".join(errors)
+        super().__init__(
+            f"Invalid {config_path}:\n  - {error_list}\n\n"
+            f"See docs/getting-started.md for the required agent.json schema."
+        )
+
+
+# Valid node types — must match GraphExecutor.VALID_NODE_TYPES
+VALID_NODE_TYPES = {
+    "llm_tool_use",
+    "llm_generate",
+    "router",
+    "function",
+    "human_input",
+    "event_loop",
+}
+
+
+def validate_agent_config(config: dict[str, Any], config_path: str = "agent.json") -> None:
+    """
+    Validate an agent configuration dictionary.
+
+    Raises AgentConfigError with all validation errors if the config is invalid.
+    Reports all errors at once for a better developer experience.
+
+    Args:
+        config: The parsed agent.json dictionary
+        config_path: Path to config file (for error messages)
+
+    Raises:
+        AgentConfigError: If any validation checks fail
+    """
+    errors: list[str] = []
+
+    # --- Required top-level fields ---
+    REQUIRED_FIELDS: dict[str, type] = {
+        "id": str,
+        "name": str,
+        "nodes": list,
+        "edges": list,
+        "entry_node": str,
+        "goal": dict,
+    }
+
+    for field_name, expected_type in REQUIRED_FIELDS.items():
+        if field_name not in config:
+            errors.append(f"Missing required field: '{field_name}'")
+        elif not isinstance(config[field_name], expected_type):
+            actual = type(config[field_name]).__name__
+            errors.append(
+                f"Field '{field_name}' must be {expected_type.__name__}, got {actual}"
+            )
+
+    # Stop early if basic structure is broken — further checks depend on these
+    if errors:
+        raise AgentConfigError(errors, config_path)
+
+    # --- Validate nodes ---
+    node_ids: set[str] = set()
+    for i, node in enumerate(config["nodes"]):
+        if not isinstance(node, dict):
+            errors.append(f"nodes[{i}]: must be a dict, got {type(node).__name__}")
+            continue
+
+        node_id = node.get("id")
+
+        if node_id is None:
+            errors.append(f"nodes[{i}]: missing required field 'id'")
+        elif not isinstance(node_id, str):
+            errors.append(
+                f"nodes[{i}]: 'id' must be a string, got {type(node_id).__name__}"
+            )
+        else:
+            if node_id in node_ids:
+                errors.append(f"nodes[{i}]: duplicate node id '{node_id}'")
+            node_ids.add(node_id)
+
+        if "name" not in node:
+            errors.append(f"nodes[{i}]: missing required field 'name'")
+
+        node_type = node.get("node_type")
+        if node_type is None:
+            errors.append(f"nodes[{i}]: missing required field 'node_type'")
+        elif node_type not in VALID_NODE_TYPES:
+            node_label = node_id or f"index {i}"
+            errors.append(
+                f"nodes[{i}] (id='{node_label}'): "
+                f"invalid node_type '{node_type}'. "
+                f"Must be one of: {', '.join(sorted(VALID_NODE_TYPES))}"
+            )
+
+        # llm_tool_use nodes must declare tools
+        if node_type == "llm_tool_use" and not node.get("tools"):
+            node_label = node_id or f"index {i}"
+            errors.append(
+                f"nodes[{i}] (id='{node_label}'): node_type is 'llm_tool_use' "
+                f"but no tools are declared. Either add tools or use 'llm_generate'."
+            )
+
+    # --- Validate entry_node references an existing node ---
+    entry_node = config["entry_node"]
+    if node_ids and entry_node not in node_ids:
+        errors.append(
+            f"entry_node '{entry_node}' does not match any node id. "
+            f"Available node ids: {sorted(node_ids)}"
+        )
+
+    # --- Validate edges ---
+    for i, edge in enumerate(config["edges"]):
+        if not isinstance(edge, dict):
+            errors.append(f"edges[{i}]: must be a dict, got {type(edge).__name__}")
+            continue
+
+        source = edge.get("source")
+        target = edge.get("target")
+
+        if source is None:
+            errors.append(f"edges[{i}]: missing required field 'source'")
+        elif node_ids and source not in node_ids:
+            errors.append(
+                f"edges[{i}]: source '{source}' is not a valid node id. "
+                f"Available: {sorted(node_ids)}"
+            )
+
+        if target is None:
+            errors.append(f"edges[{i}]: missing required field 'target'")
+        elif node_ids and target not in node_ids:
+            errors.append(
+                f"edges[{i}]: target '{target}' is not a valid node id. "
+                f"Available: {sorted(node_ids)}"
+            )
+
+    # --- Validate goal ---
+    goal = config["goal"]
+    for required_goal_field in ("id", "name", "description"):
+        if required_goal_field not in goal:
+            errors.append(f"goal: missing required field '{required_goal_field}'")
+
+    if errors:
+        raise AgentConfigError(errors, config_path)

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -20,6 +20,7 @@ from framework.graph.edge import (
 from framework.graph.executor import ExecutionResult, GraphExecutor
 from framework.graph.node import NodeSpec
 from framework.llm.provider import LLMProvider, Tool
+from framework.runner.config_validator import validate_agent_config
 from framework.runner.tool_registry import ToolRegistry
 
 # Multi-entry-point runtime imports
@@ -449,8 +450,16 @@ class AgentRunner:
         if not agent_json_path.exists():
             raise FileNotFoundError(f"No agent.py or agent.json found in {agent_path}")
 
+        # with open(agent_json_path) as f:
+        #     graph, goal = load_agent_export(f.read())
+
         with open(agent_json_path) as f:
-            graph, goal = load_agent_export(f.read())
+            raw_config = json.load(f)
+
+        # Validate config before processing
+        validate_agent_config(raw_config, config_path=str(agent_json_path))
+
+        graph, goal = load_agent_export(raw_config)
 
         return cls(
             agent_path=agent_path,

--- a/core/tests/test_config_validator.py
+++ b/core/tests/test_config_validator.py
@@ -1,0 +1,271 @@
+"""Tests for agent.json config validation.
+
+Ensures AgentRunner.load() catches invalid configs early with clear errors
+instead of failing at runtime with confusing messages.
+
+Fixes: https://github.com/adenhq/hive/issues/2039
+"""
+
+import pytest
+
+from framework.runner.config_validator import AgentConfigError, validate_agent_config
+
+
+def _minimal_valid_config() -> dict:
+    """Return a minimal valid agent.json config."""
+    return {
+        "id": "test_agent",
+        "name": "Test Agent",
+        "entry_node": "node_1",
+        "nodes": [
+            {
+                "id": "node_1",
+                "name": "Start Node",
+                "node_type": "llm_generate",
+                "input_keys": [],
+                "output_keys": ["result"],
+            }
+        ],
+        "edges": [],
+        "goal": {
+            "id": "goal_1",
+            "name": "Test Goal",
+            "description": "A test goal",
+        },
+    }
+
+
+class TestValidateAgentConfig:
+    """Tests for validate_agent_config."""
+
+    def test_valid_config_passes(self):
+        """A minimal valid config should not raise."""
+        validate_agent_config(_minimal_valid_config())
+
+    def test_valid_config_with_edges(self):
+        """A valid config with edges should not raise."""
+        config = _minimal_valid_config()
+        config["nodes"].append(
+            {
+                "id": "node_2",
+                "name": "End Node",
+                "node_type": "llm_generate",
+                "input_keys": ["result"],
+                "output_keys": ["final"],
+            }
+        )
+        config["edges"] = [{"source": "node_1", "target": "node_2"}]
+        validate_agent_config(config)
+
+    # --- Missing top-level fields ---
+
+    def test_missing_id_raises(self):
+        config = _minimal_valid_config()
+        del config["id"]
+        with pytest.raises(AgentConfigError, match="Missing required field: 'id'"):
+            validate_agent_config(config)
+
+    def test_missing_name_raises(self):
+        config = _minimal_valid_config()
+        del config["name"]
+        with pytest.raises(AgentConfigError, match="Missing required field: 'name'"):
+            validate_agent_config(config)
+
+    def test_missing_nodes_raises(self):
+        config = _minimal_valid_config()
+        del config["nodes"]
+        with pytest.raises(AgentConfigError, match="Missing required field: 'nodes'"):
+            validate_agent_config(config)
+
+    def test_missing_edges_raises(self):
+        config = _minimal_valid_config()
+        del config["edges"]
+        with pytest.raises(AgentConfigError, match="Missing required field: 'edges'"):
+            validate_agent_config(config)
+
+    def test_missing_entry_node_raises(self):
+        config = _minimal_valid_config()
+        del config["entry_node"]
+        with pytest.raises(AgentConfigError, match="Missing required field: 'entry_node'"):
+            validate_agent_config(config)
+
+    def test_missing_goal_raises(self):
+        config = _minimal_valid_config()
+        del config["goal"]
+        with pytest.raises(AgentConfigError, match="Missing required field: 'goal'"):
+            validate_agent_config(config)
+
+    def test_empty_config_raises(self):
+        with pytest.raises(AgentConfigError, match="Missing required field"):
+            validate_agent_config({})
+
+    # --- Wrong types ---
+
+    def test_nodes_wrong_type_raises(self):
+        config = _minimal_valid_config()
+        config["nodes"] = "not_a_list"
+        with pytest.raises(AgentConfigError, match="must be list, got str"):
+            validate_agent_config(config)
+
+    def test_edges_wrong_type_raises(self):
+        config = _minimal_valid_config()
+        config["edges"] = "not_a_list"
+        with pytest.raises(AgentConfigError, match="must be list, got str"):
+            validate_agent_config(config)
+
+    def test_goal_wrong_type_raises(self):
+        config = _minimal_valid_config()
+        config["goal"] = "not_a_dict"
+        with pytest.raises(AgentConfigError, match="must be dict, got str"):
+            validate_agent_config(config)
+
+    # --- Node validation ---
+
+    def test_node_missing_id_raises(self):
+        config = _minimal_valid_config()
+        del config["nodes"][0]["id"]
+        config["entry_node"] = "node_1"  # won't match
+        with pytest.raises(AgentConfigError, match="missing required field 'id'"):
+            validate_agent_config(config)
+
+    def test_node_missing_name_raises(self):
+        config = _minimal_valid_config()
+        del config["nodes"][0]["name"]
+        with pytest.raises(AgentConfigError, match="missing required field 'name'"):
+            validate_agent_config(config)
+
+    def test_node_missing_node_type_raises(self):
+        config = _minimal_valid_config()
+        del config["nodes"][0]["node_type"]
+        with pytest.raises(AgentConfigError, match="missing required field 'node_type'"):
+            validate_agent_config(config)
+
+    def test_node_invalid_node_type_raises(self):
+        config = _minimal_valid_config()
+        config["nodes"][0]["node_type"] = "invalid_type"
+        with pytest.raises(AgentConfigError, match="invalid node_type 'invalid_type'"):
+            validate_agent_config(config)
+
+    def test_node_not_dict_raises(self):
+        config = _minimal_valid_config()
+        config["nodes"] = ["not_a_dict"]
+        with pytest.raises(AgentConfigError, match="must be a dict"):
+            validate_agent_config(config)
+
+    def test_duplicate_node_ids_raises(self):
+        config = _minimal_valid_config()
+        config["nodes"].append(config["nodes"][0].copy())
+        with pytest.raises(AgentConfigError, match="duplicate node id 'node_1'"):
+            validate_agent_config(config)
+
+    def test_llm_tool_use_without_tools_raises(self):
+        config = _minimal_valid_config()
+        config["nodes"][0]["node_type"] = "llm_tool_use"
+        config["nodes"][0].pop("tools", None)
+        with pytest.raises(AgentConfigError, match="no tools are declared"):
+            validate_agent_config(config)
+
+    # --- All valid node types accepted ---
+
+    @pytest.mark.parametrize(
+        "node_type",
+        ["llm_tool_use", "llm_generate", "router", "function", "human_input", "event_loop"],
+    )
+    def test_all_valid_node_types_accepted(self, node_type):
+        config = _minimal_valid_config()
+        config["nodes"][0]["node_type"] = node_type
+        if node_type == "llm_tool_use":
+            config["nodes"][0]["tools"] = ["web_search"]
+        validate_agent_config(config)  # Should not raise
+
+    # --- Entry node validation ---
+
+    def test_entry_node_not_in_nodes_raises(self):
+        config = _minimal_valid_config()
+        config["entry_node"] = "nonexistent_node"
+        with pytest.raises(AgentConfigError, match="does not match any node id"):
+            validate_agent_config(config)
+
+    # --- Edge validation ---
+
+    def test_edge_invalid_source_raises(self):
+        config = _minimal_valid_config()
+        config["edges"] = [{"source": "fake_node", "target": "node_1"}]
+        with pytest.raises(AgentConfigError, match="source 'fake_node' is not a valid node id"):
+            validate_agent_config(config)
+
+    def test_edge_invalid_target_raises(self):
+        config = _minimal_valid_config()
+        config["edges"] = [{"source": "node_1", "target": "fake_node"}]
+        with pytest.raises(AgentConfigError, match="target 'fake_node' is not a valid node id"):
+            validate_agent_config(config)
+
+    def test_edge_missing_source_raises(self):
+        config = _minimal_valid_config()
+        config["edges"] = [{"target": "node_1"}]
+        with pytest.raises(AgentConfigError, match="missing required field 'source'"):
+            validate_agent_config(config)
+
+    def test_edge_missing_target_raises(self):
+        config = _minimal_valid_config()
+        config["edges"] = [{"source": "node_1"}]
+        with pytest.raises(AgentConfigError, match="missing required field 'target'"):
+            validate_agent_config(config)
+
+    def test_edge_not_dict_raises(self):
+        config = _minimal_valid_config()
+        config["edges"] = ["not_a_dict"]
+        with pytest.raises(AgentConfigError, match="must be a dict"):
+            validate_agent_config(config)
+
+    # --- Goal validation ---
+
+    def test_goal_missing_id_raises(self):
+        config = _minimal_valid_config()
+        del config["goal"]["id"]
+        with pytest.raises(AgentConfigError, match="goal: missing required field 'id'"):
+            validate_agent_config(config)
+
+    def test_goal_missing_name_raises(self):
+        config = _minimal_valid_config()
+        del config["goal"]["name"]
+        with pytest.raises(AgentConfigError, match="goal: missing required field 'name'"):
+            validate_agent_config(config)
+
+    def test_goal_missing_description_raises(self):
+        config = _minimal_valid_config()
+        del config["goal"]["description"]
+        with pytest.raises(
+            AgentConfigError, match="goal: missing required field 'description'"
+        ):
+            validate_agent_config(config)
+
+    def test_goal_empty_dict_raises(self):
+        config = _minimal_valid_config()
+        config["goal"] = {}
+        with pytest.raises(AgentConfigError, match="goal: missing required field"):
+            validate_agent_config(config)
+
+    # --- Error reporting ---
+
+    def test_multiple_errors_all_reported(self):
+        """All errors should be collected and reported at once."""
+        config = _minimal_valid_config()
+        config["entry_node"] = "nonexistent"
+        config["goal"] = {}  # missing id, name, description
+
+        with pytest.raises(AgentConfigError) as exc_info:
+            validate_agent_config(config)
+
+        # Should contain multiple errors
+        assert len(exc_info.value.errors) >= 2
+
+    def test_error_message_includes_config_path(self):
+        """Error message should include the config file path."""
+        with pytest.raises(AgentConfigError, match="my/custom/path.json"):
+            validate_agent_config({}, config_path="my/custom/path.json")
+
+    def test_error_message_includes_docs_reference(self):
+        """Error message should point to documentation."""
+        with pytest.raises(AgentConfigError, match="getting-started.md"):
+            validate_agent_config({})


### PR DESCRIPTION
Fixes #2039

AgentRunner.load() now validates agent.json immediately after parsing, catching missing fields, type mismatches, and structural issues before runtime.

## Changes
- **New:** `core/framework/runner/config_validator.py` — validates required fields, node types, edge references, goal structure
- **Modified:** `core/framework/runner/runner.py` — calls validator in load()
- **New:** `core/tests/test_config_validator.py` — 38 test cases, all passing