### PR TITLE
feat: add Study Planner sample agent

### DIFF
--- a/examples/templates/study_planner_agent/README.md
+++ b/examples/templates/study_planner_agent/README.md
@@ -1,0 +1,116 @@
+# Tech & AI News Reporter
+
+**Version**: 1.0.0
+**Type**: Multi-node agent
+**Created**: 2026-02-06
+
+## Overview
+
+Research the latest technology and AI news from the web, summarize key stories, and produce a well-organized report for the user to read.
+
+## Architecture
+
+### Execution Flow
+
+```
+intake → research → compile-report
+```
+
+### Nodes (3 total)
+
+1. **intake** (event_loop)
+   - Greet the user and ask if they have specific tech/AI topics to focus on, or if they want a general news roundup.
+   - Writes: `research_brief`
+   - Client-facing: Yes (blocks for user input)
+2. **research** (event_loop)
+   - Search the web for recent tech/AI news articles, scrape the top results, and extract key information including titles, summaries, sources, and topics.
+   - Reads: `research_brief`
+   - Writes: `articles_data`
+   - Tools: `web_search, web_scrape`
+3. **compile-report** (event_loop)
+   - Organize the researched articles into a structured HTML report, save it, and deliver a clickable link to the user.
+   - Reads: `articles_data`
+   - Writes: `report_file`
+   - Tools: `save_data, serve_file_to_user`
+   - Client-facing: Yes (blocks for user input)
+
+### Edges (2 total)
+
+- `intake` → `research` (condition: on_success, priority=1)
+- `research` → `compile-report` (condition: on_success, priority=1)
+
+
+## Goal Criteria
+
+### Success Criteria
+
+**Finds recent, relevant tech/AI news articles** (weight 0.25)
+- Metric: Number of articles sourced
+- Target: 5+ articles
+**Covers diverse topics, not just one story** (weight 0.2)
+- Metric: Distinct topics covered
+- Target: 3+ topics
+**Produces a structured, readable report with sections, summaries, and links** (weight 0.25)
+- Metric: Report has clear sections and summaries
+- Target: Yes
+**Includes source attribution with URLs for every story** (weight 0.15)
+- Metric: Stories with source URLs
+- Target: 100%
+**Delivers the report to the user in a viewable format** (weight 0.15)
+- Metric: User receives a viewable report
+- Target: Yes
+
+### Constraints
+
+**Never fabricate news stories or URLs** (hard)
+- Category: quality
+**Always attribute sources with links** (hard)
+- Category: quality
+**Only include news from the past week** (hard)
+- Category: quality
+
+## Required Tools
+
+- `save_data`
+- `serve_file_to_user`
+- `web_scrape`
+- `web_search`
+
+
+
+
+
+
+
+## Usage
+
+### Basic Usage
+
+```python
+from framework.runner import AgentRunner
+
+# Load the agent
+runner = AgentRunner.load("examples/templates/tech_news_reporter")
+
+# Run with input
+result = await runner.run({"input_key": "value"})
+
+# Access results
+print(result.output)
+print(result.status)
+```
+
+### Input Schema
+
+The agent's entry node `intake` requires:
+
+
+### Output Schema
+
+Terminal nodes: `compile-report`
+
+## Version History
+
+- **1.0.0** (2026-02-06): Initial release
+  - 3 nodes, 2 edges
+  - Goal: Tech & AI News Reporter

--- a/examples/templates/study_planner_agent/__init__.py
+++ b/examples/templates/study_planner_agent/__init__.py
@@ -1,0 +1,21 @@
+"""
+Study Planner Agent - Generates day-wise study schedules based on
+subjects, deadlines, difficulty, and available time.
+"""
+
+from .agent import StudyPlannerAgent, default_agent, goal, nodes, edges
+from .config import RuntimeConfig, AgentMetadata, default_config, metadata
+
+__version__ = "1.0.0"
+
+__all__ = [
+    "StudyPlannerAgent",
+    "default_agent",
+    "goal",
+    "nodes",
+    "edges",
+    "RuntimeConfig",
+    "AgentMetadata",
+    "default_config",
+    "metadata",
+]

--- a/examples/templates/study_planner_agent/__main__.py
+++ b/examples/templates/study_planner_agent/__main__.py
@@ -1,0 +1,148 @@
+"""
+CLI entry point for Study Planner Agent.
+
+Uses AgentRuntime for multi-entrypoint support.
+"""
+
+import asyncio
+import json
+import logging
+import sys
+import click
+
+from .agent import default_agent, StudyPlannerAgent
+
+
+def setup_logging(verbose=False, debug=False):
+    """Configure logging for execution visibility."""
+    if debug:
+        level, fmt = logging.DEBUG, "%(asctime)s %(name)s: %(message)s"
+    elif verbose:
+        level, fmt = logging.INFO, "%(message)s"
+    else:
+        level, fmt = logging.WARNING, "%(levelname)s: %(message)s"
+    logging.basicConfig(level=level, format=fmt, stream=sys.stderr)
+    logging.getLogger("framework").setLevel(level)
+
+
+@click.group()
+@click.version_option(version="1.0.0")
+def cli():
+    """Study Planner Agent - Generate structured study schedules."""
+    pass
+
+
+@cli.command()
+@click.option("--quiet", "-q", is_flag=True, help="Only output result JSON")
+@click.option("--verbose", "-v", is_flag=True, help="Show execution details")
+@click.option("--debug", is_flag=True, help="Show debug logging")
+def run(quiet, verbose, debug):
+    """Execute the study planner agent."""
+    if not quiet:
+        setup_logging(verbose=verbose, debug=debug)
+
+    context = {}
+
+    result = asyncio.run(default_agent.run(context))
+
+    output_data = {
+        "success": result.success,
+        "steps_executed": result.steps_executed,
+        "output": result.output,
+    }
+    if result.error:
+        output_data["error"] = result.error
+
+    click.echo(json.dumps(output_data, indent=2, default=str))
+    sys.exit(0 if result.success else 1)
+
+
+@cli.command()
+@click.option("--json", "output_json", is_flag=True)
+def info(output_json):
+    """Show agent information."""
+    info_data = default_agent.info()
+    if output_json:
+        click.echo(json.dumps(info_data, indent=2))
+    else:
+        click.echo(f"Agent: {info_data['name']}")
+        click.echo(f"Version: {info_data['version']}")
+        click.echo(f"Description: {info_data['description']}")
+        click.echo(f"\nNodes: {', '.join(info_data['nodes'])}")
+        click.echo(f"Entry: {info_data['entry_node']}")
+        click.echo(f"Terminal: {', '.join(info_data['terminal_nodes'])}")
+
+
+@cli.command()
+def validate():
+    """Validate agent structure."""
+    validation = default_agent.validate()
+    if validation["valid"]:
+        click.echo("Agent is valid")
+        if validation["warnings"]:
+            for warning in validation["warnings"]:
+                click.echo(f"  WARNING: {warning}")
+    else:
+        click.echo("Agent has errors:")
+        for error in validation["errors"]:
+            click.echo(f"  ERROR: {error}")
+    sys.exit(0 if validation["valid"] else 1)
+
+
+@cli.command()
+@click.option("--verbose", "-v", is_flag=True)
+def shell(verbose):
+    """Interactive study planner session."""
+    asyncio.run(_interactive_shell(verbose))
+
+
+async def _interactive_shell(verbose=False):
+    """Async interactive shell."""
+    setup_logging(verbose=verbose)
+
+    click.echo("=== Study Planner Agent ===")
+    click.echo("Enter your subjects, deadlines, and daily study time.")
+    click.echo("Type 'quit' to exit.\n")
+
+    agent = StudyPlannerAgent()
+    await agent.start()
+
+    try:
+        while True:
+            try:
+                user_input = await asyncio.get_event_loop().run_in_executor(
+                    None, input, "Study> "
+                )
+                if user_input.lower() in ["quit", "exit", "q"]:
+                    click.echo("Goodbye!")
+                    break
+
+                context = {"input": user_input}
+
+                result = await agent.trigger_and_wait("start", context)
+
+                if result is None:
+                    click.echo("\n[Execution timed out]\n")
+                    continue
+
+                if result.success:
+                    click.echo("\nGenerated Study Plan:\n")
+                    click.echo(str(result.output))
+                    click.echo()
+                else:
+                    click.echo(f"\nFailed: {result.error}\n")
+
+            except KeyboardInterrupt:
+                click.echo("\nGoodbye!")
+                break
+            except Exception as e:
+                click.echo(f"Error: {e}", err=True)
+                import traceback
+
+                traceback.print_exc()
+    finally:
+        await agent.stop()
+
+
+if __name__ == "__main__":
+    cli()

--- a/examples/templates/study_planner_agent/agent.json
+++ b/examples/templates/study_planner_agent/agent.json
@@ -1,0 +1,220 @@
+{
+  "agent": {
+    "id": "tech_news_reporter",
+    "name": "Tech & AI News Reporter",
+    "version": "1.0.0",
+    "description": "Research the latest technology and AI news from the web, summarize key stories, and produce a well-organized report for the user to read."
+  },
+  "graph": {
+    "id": "tech_news_reporter-graph",
+    "goal_id": "tech-news-report",
+    "version": "1.0.0",
+    "entry_node": "intake",
+    "entry_points": {
+      "start": "intake"
+    },
+    "pause_nodes": [],
+    "terminal_nodes": [
+      "compile-report"
+    ],
+    "nodes": [
+      {
+        "id": "intake",
+        "name": "Intake",
+        "description": "Greet the user and ask if they have specific tech/AI topics to focus on, or if they want a general news roundup.",
+        "node_type": "event_loop",
+        "input_keys": [],
+        "output_keys": [
+          "research_brief"
+        ],
+        "nullable_output_keys": [],
+        "input_schema": {},
+        "output_schema": {},
+        "system_prompt": "You are the intake assistant for a Tech & AI News Reporter agent.\n\n**STEP 1 — Greet and ask the user:**\nGreet the user and ask what kind of tech/AI news they're interested in today. Offer options like:\n- General tech & AI roundup (covers everything notable)\n- Specific topics (e.g., LLMs, robotics, startups, cybersecurity, semiconductors)\n- A particular company or product\n\nKeep it brief and friendly. If the user already stated a preference in their initial message, acknowledge it.\n\nAfter your greeting, call ask_user() to wait for the user's response.\n\n**STEP 2 — After the user responds, call set_output:**\n- set_output(\"research_brief\", \"<a clear, concise description of what to search for based on the user's preferences>\")\n\nIf the user just wants a general roundup, set: \"General tech and AI news roundup covering the most notable stories from the past week\"",
+        "tools": [],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 1,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": true
+      },
+      {
+        "id": "research",
+        "name": "Research",
+        "description": "Search the web for recent tech/AI news articles, scrape the top results, and extract key information including titles, summaries, sources, and topics.",
+        "node_type": "event_loop",
+        "input_keys": [
+          "research_brief"
+        ],
+        "output_keys": [
+          "articles_data"
+        ],
+        "nullable_output_keys": [],
+        "input_schema": {},
+        "output_schema": {},
+        "system_prompt": "You are a news researcher for a Tech & AI News Reporter agent.\n\nYour task: Find and summarize recent tech/AI news based on the research_brief.\n\n**Instructions:**\n1. Use web_search to find recent tech and AI news articles. Run multiple searches with different queries to get diverse coverage (e.g., \"latest AI news this week\", \"tech industry news today\", topic-specific queries from the brief).\n2. Pick the 5-10 most interesting and significant articles from the search results.\n3. Use web_scrape on each selected article to get the full content.\n4. For each article, extract: title, source name, URL, publication date, a 2-3 sentence summary, and the main topic category.\n\n**Output format:**\nUse set_output(\"articles_data\", <JSON string>) with this structure:\n```json\n{\n  \"articles\": [\n    {\n      \"title\": \"Article Title\",\n      \"source\": \"Source Name\",\n      \"url\": \"https://...\",\n      \"date\": \"2026-02-05\",\n      \"summary\": \"2-3 sentence summary of the key points.\",\n      \"topic\": \"AI / Semiconductors / Startups / etc.\"\n    }\n  ],\n  \"search_date\": \"2026-02-06\",\n  \"topics_covered\": [\"AI\", \"Semiconductors\", \"...\"]\n}\n```\n\n**Rules:**\n- Only include REAL articles with REAL URLs you found via search. Never fabricate.\n- Focus on news from the past week.\n- Aim for at least 3 distinct topic categories.\n- Keep summaries factual and concise.",
+        "tools": [
+          "web_search",
+          "web_scrape"
+        ],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 1,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": false
+      },
+      {
+        "id": "compile-report",
+        "name": "Compile Report",
+        "description": "Organize the researched articles into a structured HTML report, save it, and deliver a clickable link to the user.",
+        "node_type": "event_loop",
+        "input_keys": [
+          "articles_data"
+        ],
+        "output_keys": [
+          "report_file"
+        ],
+        "nullable_output_keys": [],
+        "input_schema": {},
+        "output_schema": {},
+        "system_prompt": "You are the report compiler for a Tech & AI News Reporter agent.\n\nYour task: Turn the articles_data into a polished, readable HTML report and deliver it to the user.\n\n**Instructions:**\n1. Parse the articles_data JSON to get the list of articles.\n2. Generate a well-structured HTML report with:\n   - A header with the report title and date\n   - A table of contents / summary section listing topics covered\n   - Articles grouped by topic category\n   - For each article: title (linked to source URL), source name, date, and summary\n   - Clean, readable styling (inline CSS)\n3. Use save_data to save the HTML report as \"tech_news_report.html\".\n4. Use serve_file_to_user to get a clickable link for the user.\n\n**STEP 1 — Respond to the user (text only, NO tool calls):**\nPresent a brief text summary of the report highlights — how many articles, what topics are covered, and a few headline highlights. Tell the user you're generating their full report now.\n\n**STEP 2 — After presenting the summary, save and serve the report:**\n- save_data(filename=\"tech_news_report.html\", data=<html_content>, data_dir=<data_dir>)\n- serve_file_to_user(filename=\"tech_news_report.html\", data_dir=<data_dir>, label=\"Tech & AI News Report\", open_in_browser=True)\n- set_output(\"report_file\", \"tech_news_report.html\")\n\nThe report will auto-open in the user's default browser. Let them know the report has been opened.",
+        "tools": [
+          "save_data",
+          "serve_file_to_user"
+        ],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 1,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": false
+      }
+    ],
+    "edges": [
+      {
+        "id": "intake-to-research",
+        "source": "intake",
+        "target": "research",
+        "condition": "on_success",
+        "condition_expr": null,
+        "priority": 1,
+        "input_mapping": {}
+      },
+      {
+        "id": "research-to-compile-report",
+        "source": "research",
+        "target": "compile-report",
+        "condition": "on_success",
+        "condition_expr": null,
+        "priority": 1,
+        "input_mapping": {}
+      }
+    ],
+    "max_steps": 100,
+    "max_retries_per_node": 3,
+    "description": "Research the latest technology and AI news from the web, summarize key stories, and produce a well-organized report for the user to read.",
+    "created_at": "2026-02-06T08:42:51.476802"
+  },
+  "goal": {
+    "id": "tech-news-report",
+    "name": "Tech & AI News Reporter",
+    "description": "Research the latest technology and AI news from the web, summarize key stories, and produce a well-organized report for the user to read.",
+    "status": "draft",
+    "success_criteria": [
+      {
+        "id": "sc-find-articles",
+        "description": "Finds recent, relevant tech/AI news articles",
+        "metric": "Number of articles sourced",
+        "target": "5+ articles",
+        "weight": 0.25,
+        "met": false
+      },
+      {
+        "id": "sc-diverse-topics",
+        "description": "Covers diverse topics, not just one story",
+        "metric": "Distinct topics covered",
+        "target": "3+ topics",
+        "weight": 0.2,
+        "met": false
+      },
+      {
+        "id": "sc-structured-report",
+        "description": "Produces a structured, readable report with sections, summaries, and links",
+        "metric": "Report has clear sections and summaries",
+        "target": "Yes",
+        "weight": 0.25,
+        "met": false
+      },
+      {
+        "id": "sc-source-attribution",
+        "description": "Includes source attribution with URLs for every story",
+        "metric": "Stories with source URLs",
+        "target": "100%",
+        "weight": 0.15,
+        "met": false
+      },
+      {
+        "id": "sc-deliver-report",
+        "description": "Delivers the report to the user in a viewable format",
+        "metric": "User receives a viewable report",
+        "target": "Yes",
+        "weight": 0.15,
+        "met": false
+      }
+    ],
+    "constraints": [
+      {
+        "id": "c-no-fabrication",
+        "description": "Never fabricate news stories or URLs",
+        "constraint_type": "hard",
+        "category": "quality",
+        "check": ""
+      },
+      {
+        "id": "c-source-attribution",
+        "description": "Always attribute sources with links",
+        "constraint_type": "hard",
+        "category": "quality",
+        "check": ""
+      },
+      {
+        "id": "c-recent-news",
+        "description": "Only include news from the past week",
+        "constraint_type": "hard",
+        "category": "quality",
+        "check": ""
+      }
+    ],
+    "context": {},
+    "required_capabilities": [],
+    "input_schema": {},
+    "output_schema": {},
+    "version": "1.0.0",
+    "parent_version": null,
+    "evolution_reason": null,
+    "created_at": "2026-02-06 08:39:00.123362",
+    "updated_at": "2026-02-06 08:39:00.123364"
+  },
+  "required_tools": [
+    "web_scrape",
+    "save_data",
+    "serve_file_to_user",
+    "web_search"
+  ],
+  "metadata": {
+    "created_at": "2026-02-06T08:42:51.476862",
+    "node_count": 3,
+    "edge_count": 2
+  }
+}

--- a/examples/templates/study_planner_agent/agent.py
+++ b/examples/templates/study_planner_agent/agent.py
@@ -1,0 +1,252 @@
+"""Agent graph construction for Study Planner Agent."""
+
+from framework.graph import EdgeSpec, EdgeCondition, Goal, SuccessCriterion, Constraint
+from framework.graph.edge import GraphSpec
+from framework.graph.executor import ExecutionResult, GraphExecutor
+from framework.runtime.event_bus import EventBus
+from framework.runtime.core import Runtime
+from framework.llm import LiteLLMProvider
+from framework.runner.tool_registry import ToolRegistry
+
+from .config import default_config, metadata
+from .nodes import (
+    intake_node,
+    research_node,
+    compile_report_node,
+)
+
+# Goal definition
+goal = Goal(
+    id="study-planner",
+    name="Study Planner Agent",
+    description=(
+        "Create a structured daily study plan based on subjects, deadlines, "
+        "difficulty, and available study hours."
+    ),
+    success_criteria=[
+        SuccessCriterion(
+            id="sc-plan-generated",
+            description="Generates a day-wise study plan",
+            metric="plan_generated",
+            target="true",
+            weight=0.4,
+        ),
+        SuccessCriterion(
+            id="sc-prioritized-subjects",
+            description="Prioritizes subjects based on deadlines",
+            metric="subjects_prioritized",
+            target="true",
+            weight=0.3,
+        ),
+        SuccessCriterion(
+            id="sc-balanced-schedule",
+            description="Creates a balanced and realistic schedule",
+            metric="schedule_balanced",
+            target="true",
+            weight=0.3,
+        ),
+    ],
+    constraints=[
+        Constraint(
+            id="c-realistic-hours",
+            description="Do not assign more study hours than available per day",
+            constraint_type="hard",
+            category="quality",
+        ),
+        Constraint(
+            id="c-clear-output",
+            description="Output must be a clear day-by-day schedule",
+            constraint_type="hard",
+            category="format",
+        ),
+    ],
+)
+
+# Node list
+nodes = [
+    intake_node,
+    research_node,
+    compile_report_node,
+]
+
+# Edge definitions
+edges = [
+    EdgeSpec(
+        id="intake-to-research",
+        source="intake",
+        target="research",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="research-to-compile-report",
+        source="research",
+        target="compile-report",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+]
+
+# Graph configuration
+entry_node = "intake"
+entry_points = {"start": "intake"}
+pause_nodes = []
+terminal_nodes = ["compile-report"]
+
+
+class StudyPlannerAgent:
+    """
+    Study Planner Agent — 3-node pipeline.
+
+    Flow: intake -> research -> compile-report
+    """
+
+    def __init__(self, config=None):
+        self.config = config or default_config
+        self.goal = goal
+        self.nodes = nodes
+        self.edges = edges
+        self.entry_node = entry_node
+        self.entry_points = entry_points
+        self.pause_nodes = pause_nodes
+        self.terminal_nodes = terminal_nodes
+        self._executor: GraphExecutor | None = None
+        self._graph: GraphSpec | None = None
+        self._event_bus: EventBus | None = None
+        self._tool_registry: ToolRegistry | None = None
+
+    def _build_graph(self) -> GraphSpec:
+        """Build the GraphSpec."""
+        return GraphSpec(
+            id="study-planner-graph",
+            goal_id=self.goal.id,
+            version="1.0.0",
+            entry_node=self.entry_node,
+            entry_points=self.entry_points,
+            terminal_nodes=self.terminal_nodes,
+            pause_nodes=self.pause_nodes,
+            nodes=self.nodes,
+            edges=self.edges,
+            default_model=self.config.model,
+            max_tokens=self.config.max_tokens,
+            loop_config={
+                "max_iterations": 50,
+                "max_tool_calls_per_turn": 10,
+                "max_history_tokens": 32000,
+            },
+        )
+
+    def _setup(self) -> GraphExecutor:
+        """Set up the executor with all components."""
+        from pathlib import Path
+
+        storage_path = Path.home() / ".hive" / "study_planner_agent"
+        storage_path.mkdir(parents=True, exist_ok=True)
+
+        self._event_bus = EventBus()
+        self._tool_registry = ToolRegistry()
+
+        mcp_config_path = Path(__file__).parent / "mcp_servers.json"
+        if mcp_config_path.exists():
+            self._tool_registry.load_mcp_config(mcp_config_path)
+
+        llm = LiteLLMProvider(
+            model=self.config.model,
+            api_key=self.config.api_key,
+            api_base=self.config.api_base,
+        )
+
+        tool_executor = self._tool_registry.get_executor()
+        tools = list(self._tool_registry.get_tools().values())
+
+        self._graph = self._build_graph()
+        runtime = Runtime(storage_path)
+
+        self._executor = GraphExecutor(
+            runtime=runtime,
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor,
+            event_bus=self._event_bus,
+            storage_path=storage_path,
+            loop_config=self._graph.loop_config,
+        )
+
+        return self._executor
+
+    async def start(self) -> None:
+        """Set up the agent."""
+        if self._executor is None:
+            self._setup()
+
+    async def stop(self) -> None:
+        """Clean up resources."""
+        self._executor = None
+        self._event_bus = None
+
+    async def trigger_and_wait(
+        self,
+        entry_point: str,
+        input_data: dict,
+        timeout: float | None = None,
+        session_state: dict | None = None,
+    ) -> ExecutionResult | None:
+        """Execute the graph and wait for completion."""
+        if self._executor is None:
+            raise RuntimeError("Agent not started. Call start() first.")
+        if self._graph is None:
+            raise RuntimeError("Graph not built. Call start() first.")
+
+        return await self._executor.execute(
+            graph=self._graph,
+            goal=self.goal,
+            input_data=input_data,
+            session_state=session_state,
+        )
+
+    async def run(self, context: dict, session_state=None) -> ExecutionResult:
+        """Run the agent."""
+        await self.start()
+        try:
+            result = await self.trigger_and_wait(
+                "start", context, session_state=session_state
+            )
+            return result or ExecutionResult(success=False, error="Execution timeout")
+        finally:
+            await self.stop()
+
+    def info(self):
+        """Get agent information."""
+        return {
+            "name": metadata.name,
+            "version": metadata.version,
+            "description": metadata.description,
+            "goal": {
+                "name": self.goal.name,
+                "description": self.goal.description,
+            },
+            "nodes": [n.id for n in self.nodes],
+            "edges": [e.id for e in self.edges],
+        }
+
+    def validate(self):
+        """Validate agent structure."""
+        errors = []
+        warnings = []
+
+        node_ids = {node.id for node in self.nodes}
+        for edge in self.edges:
+            if edge.source not in node_ids:
+                errors.append(f"Edge {edge.id}: source '{edge.source}' not found")
+            if edge.target not in node_ids:
+                errors.append(f"Edge {edge.id}: target '{edge.target}' not found")
+
+        return {
+            "valid": len(errors) == 0,
+            "errors": errors,
+            "warnings": warnings,
+        }
+
+
+# Create default instance
+default_agent = StudyPlannerAgent()

--- a/examples/templates/study_planner_agent/config.py
+++ b/examples/templates/study_planner_agent/config.py
@@ -1,0 +1,46 @@
+"""Runtime configuration."""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+def _load_preferred_model() -> str:
+    """Load preferred model from ~/.hive/configuration.json."""
+    config_path = Path.home() / ".hive" / "configuration.json"
+    if config_path.exists():
+        try:
+            with open(config_path) as f:
+                config = json.load(f)
+            llm = config.get("llm", {})
+            if llm.get("provider") and llm.get("model"):
+                return f"{llm['provider']}/{llm['model']}"
+        except Exception:
+            pass
+    return "anthropic/claude-sonnet-4-20250514"
+
+
+@dataclass
+class RuntimeConfig:
+    model: str = field(default_factory=_load_preferred_model)
+    temperature: float = 0.7
+    max_tokens: int = 40000
+    api_key: str | None = None
+    api_base: str | None = None
+
+
+default_config = RuntimeConfig()
+
+
+@dataclass
+class AgentMetadata:
+    name: str = "Tech & AI News Reporter"
+    version: str = "1.0.0"
+    description: str = (
+        "Research the latest technology and AI news from the web, "
+        "summarize key stories, and produce a well-organized report "
+        "for the user to read."
+    )
+
+
+metadata = AgentMetadata()

--- a/examples/templates/study_planner_agent/mcp_servers.json
+++ b/examples/templates/study_planner_agent/mcp_servers.json
@@ -1,0 +1,9 @@
+{
+  "hive-tools": {
+    "transport": "stdio",
+    "command": "uv",
+    "args": ["run", "python", "mcp_server.py", "--stdio"],
+    "cwd": "../../../tools",
+    "description": "Hive tools MCP server providing web_search, web_scrape, save_data, and serve_file_to_user"
+  }
+}

--- a/examples/templates/study_planner_agent/nodes/__init__.py
+++ b/examples/templates/study_planner_agent/nodes/__init__.py
@@ -1,0 +1,76 @@
+"""Node definitions for Study Planner Agent."""
+
+from framework.graph import NodeSpec
+
+
+# -------------------------
+# Intake Node
+# -------------------------
+intake_node = NodeSpec(
+    id="intake",
+    name="Intake",
+    description="Collect study requirements from the user",
+    node_type="llm_generate",
+    system_prompt=(
+        "You are a study planning assistant.\n"
+        "Your job is to understand the user's study requirements.\n"
+        "Extract the following from the user input:\n"
+        "- Subjects\n"
+        "- Deadlines or exam dates\n"
+        "- Difficulty level (if mentioned)\n"
+        "- Daily available study hours\n\n"
+        "Return the extracted information in a structured summary."
+    ),
+    client_facing=True,
+)
+
+# -------------------------
+# Research Node
+# -------------------------
+research_node = NodeSpec(
+    id="research",
+    name="Prioritize Subjects",
+    description="Analyze and prioritize subjects",
+    node_type="llm_generate",
+    system_prompt=(
+        "You are an academic planning assistant.\n"
+        "Based on the subjects, deadlines, and difficulty levels:\n"
+        "- Prioritize subjects by urgency and difficulty.\n"
+        "- Decide how much time should be allocated to each subject.\n"
+        "- Ensure the total time per day does not exceed available hours.\n\n"
+        "Return a prioritized subject list with suggested daily time allocation."
+    ),
+)
+
+# -------------------------
+# Compile Plan Node
+# -------------------------
+compile_report_node = NodeSpec(
+    id="compile-report",
+    name="Generate Study Plan",
+    description="Create the final study schedule",
+    node_type="llm_generate",
+    system_prompt=(
+        "You are a study planner.\n"
+        "Create a clear day-by-day study schedule.\n\n"
+        "Rules:\n"
+        "- Follow the subject priorities.\n"
+        "- Do not exceed available daily study hours.\n"
+        "- Balance subjects across days.\n"
+        "- Keep the plan realistic and simple.\n\n"
+        "Output format:\n"
+        "Day 1:\n"
+        "- Subject A: 2 hours\n"
+        "- Subject B: 1 hour\n\n"
+        "Day 2:\n"
+        "- Subject C: 2 hours\n"
+        "- Subject A: 1 hour\n"
+    ),
+    terminal=True,
+)
+
+__all__ = [
+    "intake_node",
+    "research_node",
+    "compile_report_node",
+]


### PR DESCRIPTION
Fixes #4355

Adds a beginner-friendly Study Planner agent to the templates.

Use case:
Students can provide subjects, deadlines, and available daily hours.
The agent generates a structured day-wise study plan.

Features:
- Intake node to collect study details
- Planning node to prioritize subjects
- Schedule node to produce day-wise plan

This serves as a simple productivity-focused sample agent for new Hive users.
