### PR TITLE
docs: clarify Aden vs Hive naming

### DIFF
--- a/.claude/skills/hive-patterns/SKILL.md
+++ b/.claude/skills/hive-patterns/SKILL.md
@@ -383,3 +383,8 @@ When agent is complete, transition to testing phase:
 ---
 
 **Remember: Agent is actively constructed, visible the whole time. No hidden state. No surprise exports. Just transparent, incremental file building.**
+## Simple Explanation for Beginners
+
+This document describes common patterns used to build AI agents in Hive.
+In simple terms, these patterns help agents move step by step through tasks
+in a transparent and predictable way, without hidden or confusing behavior.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to Aden Agent Framework
 
-Thank you for your interest in contributing to the Aden Agent Framework! This document provides guidelines and information for contributors. We’re especially looking for help building tools, integrations([check #2805](https://github.com/adenhq/hive/issues/2805)), and example agents for the framework. If you’re interested in extending its functionality, this is the perfect place to start. 
+Thank you for your interest in contributing to Hive (the Aden Hive Agent Framework)!
+ This document provides guidelines and information for contributors. We’re especially looking for help building tools, integrations([check #2805](https://github.com/adenhq/hive/issues/2805)), and example agents for the framework. If you’re interested in extending its functionality, this is the perfect place to start. 
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 </p>
 
 ## Overview
+**Naming:** Hive is the agent framework and CLI (this repository). Aden is the company that develops Hive. The formal name is **Aden Hive Agent Framework**.
 
 Build autonomous, reliable, self-improving AI agents without hardcoding workflows. Define your goal through conversation with a coding agent, and the framework generates a node graph with dynamically created connection code. When things break, the framework captures failure data, evolves the agent through the coding agent, and redeploys. Built-in human-in-the-loop nodes, credential management, and real-time monitoring give you control without sacrificing adaptability.
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,22 @@ This sets up:
 - **credential store** - Encrypted API key storage (`~/.hive/credentials`)
 - **LLM provider** - Interactive default model configuration
 - All required Python dependencies with `uv`
+### Try it first
+
+See Hive in action with a template agent (no building required):
+
+```bash
+# Run a research agent
+hive run examples/templates/deep_research_agent --input '{"topic": "AI agents in 2025"}'
+
+# Or browse and run interactively
+hive tui
+
 
 ### Build Your First Agent
+```md
+Your agents go in `exports/`. You can copy a template from `examples/templates/`
+to get started, or build one using the skills above.
 
 ```bash
 # Build an agent using Claude Code

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,7 @@
 # Getting Started
 
-This guide will help you set up the Aden Agent Framework and build your first agent.
+This guide will help you set up Hive (the Aden Hive Agent Framework) and build your first agent.
+
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
Clarifies the relationship between Hive (framework/CLI) and Aden (company) to reduce confusion for new contributors and evaluators.

## Changes
- README: Added naming clarification
- CONTRIBUTING: Updated intro wording
- docs/getting-started.md: Clarified Hive naming

Fixes #4360 

