### PR TITLE
feat(tools): add news MCP tools with NewsData and Finlight

### DIFF
--- a/tools/src/aden_tools/credentials/integrations.py
+++ b/tools/src/aden_tools/credentials/integrations.py
@@ -50,4 +50,20 @@ INTEGRATION_CREDENTIALS = {
         credential_id="hubspot",
         credential_key="access_token",
     ),
+    "newsdata": CredentialSpec(
+        env_var="NEWSDATA_API_KEY",
+        tools=["news_search", "news_headlines", "news_by_company"],
+        required=True,
+        startup_required=False,
+        help_url="https://newsdata.io/",
+        description="API key for NewsData.io news search",
+    ),
+    "finlight": CredentialSpec(
+        env_var="FINLIGHT_API_KEY",
+        tools=["news_sentiment"],
+        required=True,
+        startup_required=False,
+        help_url="https://finlight.me/",
+        description="API key for Finlight news sentiment analysis",
+    ),
 }

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -39,6 +39,7 @@ from .file_system_toolkits.replace_file_content import (
 from .file_system_toolkits.view_file import register_tools as register_view_file
 from .file_system_toolkits.write_to_file import register_tools as register_write_to_file
 from .hubspot_tool import register_tools as register_hubspot
+from .news_tool import register_tools as register_news
 from .pdf_read_tool import register_tools as register_pdf_read
 from .web_scrape_tool import register_tools as register_web_scrape
 from .web_search_tool import register_tools as register_web_search
@@ -70,6 +71,7 @@ def register_all_tools(
     # email supports multiple providers (Resend) with auto-detection
     register_email(mcp, credentials=credentials)
     register_hubspot(mcp, credentials=credentials)
+    register_news(mcp, credentials=credentials)
 
     # Register file system toolkits
     register_view_file(mcp)
@@ -114,6 +116,10 @@ def register_all_tools(
         "hubspot_get_deal",
         "hubspot_create_deal",
         "hubspot_update_deal",
+        "news_search",
+        "news_headlines",
+        "news_by_company",
+        "news_sentiment",
     ]
 
 

--- a/tools/src/aden_tools/tools/news_tool/README.md
+++ b/tools/src/aden_tools/tools/news_tool/README.md
@@ -1,0 +1,68 @@
+# News Tool
+
+Search news articles and headlines with optional sentiment analysis.
+
+## Description
+
+Provides structured news results from multiple providers with automatic fallback:
+- **NewsData.io** (primary)
+- **Finlight.me** (optional; required for sentiment)
+
+## Tools
+
+### `news_search`
+Search news articles with filters.
+
+Arguments:
+- `query` (str, required)
+- `from_date` (str, optional, YYYY-MM-DD)
+- `to_date` (str, optional, YYYY-MM-DD)
+- `language` (str, optional, default `en`)
+- `limit` (int, optional, default `10`)
+- `sources` (str, optional)
+- `category` (str, optional)
+- `country` (str, optional)
+
+### `news_headlines`
+Get top headlines by category and country.
+
+Arguments:
+- `category` (str, required)
+- `country` (str, required)
+- `limit` (int, optional, default `10`)
+
+### `news_by_company`
+Get news mentioning a company.
+
+Arguments:
+- `company_name` (str, required)
+- `days_back` (int, optional, default `7`)
+- `limit` (int, optional, default `10`)
+- `language` (str, optional, default `en`)
+
+### `news_sentiment`
+Get news with sentiment analysis (Finlight provider only).
+
+Arguments:
+- `query` (str, required)
+- `from_date` (str, optional, YYYY-MM-DD)
+- `to_date` (str, optional, YYYY-MM-DD)
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `NEWSDATA_API_KEY` | Yes | API key for [NewsData.io](https://newsdata.io/) |
+| `FINLIGHT_API_KEY` | Optional | API key for [Finlight.me](https://finlight.me/) |
+
+## Example Usage
+
+```python
+news_search(query="Series B funding", from_date="2026-02-01", to_date="2026-02-10")
+news_headlines(category="business", country="us")
+news_by_company(company_name="Acme Corp", days_back=7)
+news_sentiment(query="Acme Corp")
+```
+
+
+

--- a/tools/src/aden_tools/tools/news_tool/__init__.py
+++ b/tools/src/aden_tools/tools/news_tool/__init__.py
@@ -1,0 +1,10 @@
+"""
+News Tool - Search and summarize news articles.
+"""
+
+from .news_tool import register_tools
+
+__all__ = ["register_tools"]
+
+
+

--- a/tools/src/aden_tools/tools/news_tool/news_tool.py
+++ b/tools/src/aden_tools/tools/news_tool/news_tool.py
@@ -1,0 +1,520 @@
+"""
+News Tool - Search news using multiple providers.
+
+Supports:
+- NewsData.io (NEWSDATA_API_KEY)
+- Finlight.me (FINLIGHT_API_KEY) for sentiment and optional fallback
+
+Auto-detection: Tries NewsData first, then Finlight.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+from typing import TYPE_CHECKING
+
+import httpx
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialStoreAdapter
+
+NEWSDATA_URL = "https://newsdata.io/api/1/news"
+FINLIGHT_URL = "https://api.finlight.me/v1/news"
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: CredentialStoreAdapter | None = None,
+) -> None:
+    """Register news tools with the MCP server."""
+
+    def _get_credentials() -> dict[str, str | None]:
+        """Get available news credentials."""
+        if credentials is not None:
+            return {
+                "newsdata_api_key": credentials.get("newsdata"),
+                "finlight_api_key": credentials.get("finlight"),
+            }
+        return {
+            "newsdata_api_key": os.getenv("NEWSDATA_API_KEY"),
+            "finlight_api_key": os.getenv("FINLIGHT_API_KEY"),
+        }
+
+    def _normalize_limit(limit: int | None, default: int = 10) -> int:
+        """Normalize limit to a positive integer."""
+        if limit is None:
+            return default
+        return max(limit, 1)
+
+    def _clean_params(params: dict[str, str | int | None]) -> dict[str, str | int]:
+        """Remove None/empty values from request params."""
+        return {key: value for key, value in params.items() if value not in (None, "")}
+
+    def _build_date_range(days_back: int) -> tuple[str, str]:
+        """Build from/to date strings for the past N days."""
+        end_date = date.today()
+        start_date = end_date - timedelta(days=days_back)
+        return start_date.isoformat(), end_date.isoformat()
+
+    def _newsdata_error(response: httpx.Response) -> dict:
+        """Map NewsData API errors to friendly messages."""
+        if response.status_code == 401:
+            return {"error": "Invalid NewsData API key"}
+        if response.status_code == 429:
+            return {"error": "NewsData rate limit exceeded. Try again later."}
+        if response.status_code == 422:
+            return {"error": "Invalid NewsData parameters"}
+        return {"error": f"NewsData request failed: HTTP {response.status_code}"}
+
+    def _finlight_error(response: httpx.Response) -> dict:
+        """Map Finlight API errors to friendly messages."""
+        if response.status_code == 401:
+            return {"error": "Invalid Finlight API key"}
+        if response.status_code == 429:
+            return {"error": "Finlight rate limit exceeded. Try again later."}
+        if response.status_code == 422:
+            return {"error": "Invalid Finlight parameters"}
+        return {"error": f"Finlight request failed: HTTP {response.status_code}"}
+
+    def _format_article(
+        title: str,
+        source: str,
+        published_at: str,
+        url: str,
+        snippet: str,
+        sentiment: str | float | None = None,
+    ) -> dict:
+        """Normalize an article payload."""
+        payload = {
+            "title": title,
+            "source": source,
+            "date": published_at,
+            "url": url,
+            "snippet": snippet,
+        }
+        if sentiment is not None:
+            payload["sentiment"] = sentiment
+        return payload
+
+    def _parse_newsdata_results(data: dict) -> list[dict]:
+        """Parse NewsData results into normalized articles."""
+        raw_results = data.get("results") or []
+        return [
+            _format_article(
+                title=item.get("title", ""),
+                source=item.get("source_id", ""),
+                published_at=item.get("pubDate", ""),
+                url=item.get("link", ""),
+                snippet=item.get("description", ""),
+            )
+            for item in raw_results
+        ]
+
+    def _parse_finlight_results(
+        data: dict,
+        include_sentiment: bool = False,
+    ) -> list[dict]:
+        """Parse Finlight results into normalized articles."""
+        raw_results = data.get("data") or data.get("results") or []
+        results = []
+        for item in raw_results:
+            sentiment_value = None
+            if include_sentiment:
+                sentiment_value = item.get("sentiment") or item.get("sentiment_score")
+            results.append(
+                _format_article(
+                    title=item.get("title", ""),
+                    source=item.get("source", ""),
+                    published_at=item.get("published_at", ""),
+                    url=item.get("url", ""),
+                    snippet=item.get("summary", "") or item.get("description", ""),
+                    sentiment=sentiment_value,
+                )
+            )
+        return results
+
+    def _search_newsdata(
+        query: str | None,
+        from_date: str | None,
+        to_date: str | None,
+        language: str | None,
+        limit: int,
+        sources: str | None,
+        category: str | None,
+        country: str | None,
+        api_key: str,
+    ) -> dict:
+        """Search NewsData API."""
+        params = _clean_params(
+            {
+            "apikey": api_key,
+            "q": query,
+            "from_date": from_date,
+            "to_date": to_date,
+            "language": language,
+            "category": category,
+            "country": country,
+            "size": limit,
+            }
+        )
+        if sources:
+            params["sources"] = sources
+
+        response = httpx.get(NEWSDATA_URL, params=params, timeout=30.0)
+        if response.status_code != 200:
+            return _newsdata_error(response)
+
+        data = response.json()
+        results = _parse_newsdata_results(data)
+        return {
+            "results": results,
+            "total": len(results),
+            "provider": "newsdata",
+        }
+
+    def _search_finlight(
+        query: str | None,
+        from_date: str | None,
+        to_date: str | None,
+        language: str | None,
+        limit: int,
+        sources: str | None,
+        category: str | None,
+        country: str | None,
+        api_key: str,
+        include_sentiment: bool = False,
+    ) -> dict:
+        """Search Finlight API."""
+        params = _clean_params(
+            {
+            "query": query,
+            "from_date": from_date,
+            "to_date": to_date,
+            "language": language,
+            "category": category,
+            "country": country,
+            "limit": limit,
+            }
+        )
+        if sources:
+            params["sources"] = sources
+
+        response = httpx.get(
+            FINLIGHT_URL,
+            params=params,
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=30.0,
+        )
+        if response.status_code != 200:
+            return _finlight_error(response)
+
+        data = response.json()
+        results = _parse_finlight_results(data, include_sentiment=include_sentiment)
+        return {
+            "results": results,
+            "total": len(results),
+            "provider": "finlight",
+        }
+
+    def _run_with_fallback(primary: dict, fallback: dict | None) -> dict:
+        """Return primary result or fallback if primary errors."""
+        if "error" not in primary:
+            return primary
+        if fallback is None or "error" in fallback:
+            if fallback is None:
+                return primary
+            return {
+                "error": "All providers failed",
+                "providers": {"primary": primary, "fallback": fallback},
+            }
+        return fallback
+
+    @mcp.tool()
+    def news_search(
+        query: str,
+        from_date: str | None = None,
+        to_date: str | None = None,
+        language: str | None = "en",
+        limit: int | None = 10,
+        sources: str | None = None,
+        category: str | None = None,
+        country: str | None = None,
+    ) -> dict:
+        """
+        Search news articles with filters.
+
+        Args:
+            query: Search query
+            from_date: Start date (YYYY-MM-DD)
+            to_date: End date (YYYY-MM-DD)
+            language: Language code (e.g., en)
+            limit: Max number of results
+            sources: Optional sources filter
+            category: Optional category filter
+            country: Optional country filter
+
+        Returns:
+            Dict with list of articles and provider metadata.
+        """
+        if not query:
+            return {"error": "Query is required"}
+
+        creds = _get_credentials()
+        newsdata_key = creds["newsdata_api_key"]
+        finlight_key = creds["finlight_api_key"]
+        if not newsdata_key and not finlight_key:
+            return {
+                "error": "No news credentials configured",
+                "help": "Set NEWSDATA_API_KEY or FINLIGHT_API_KEY environment variable",
+            }
+
+        limit_value = _normalize_limit(limit)
+
+        try:
+            primary = (
+                _search_newsdata(
+                    query=query,
+                    from_date=from_date,
+                    to_date=to_date,
+                    language=language,
+                    limit=limit_value,
+                    sources=sources,
+                    category=category,
+                    country=country,
+                    api_key=newsdata_key,
+                )
+                if newsdata_key
+                else {"error": "NewsData credentials not configured"}
+            )
+            fallback = (
+                _search_finlight(
+                    query=query,
+                    from_date=from_date,
+                    to_date=to_date,
+                    language=language,
+                    limit=limit_value,
+                    sources=sources,
+                    category=category,
+                    country=country,
+                    api_key=finlight_key,
+                )
+                if finlight_key
+                else None
+            )
+            result = _run_with_fallback(primary, fallback)
+            result["query"] = query
+            return result
+        except httpx.TimeoutException:
+            return {"error": "News search request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+        except Exception as e:
+            return {"error": f"News search failed: {e}"}
+
+    @mcp.tool()
+    def news_headlines(
+        category: str,
+        country: str,
+        limit: int | None = 10,
+    ) -> dict:
+        """
+        Get top news headlines by category and country.
+
+        Args:
+            category: Category (business, tech, finance, etc.)
+            country: Country code (us, uk, etc.)
+            limit: Max number of results
+
+        Returns:
+            Dict with list of headline articles and provider metadata.
+        """
+        if not category:
+            return {"error": "Category is required"}
+        if not country:
+            return {"error": "Country is required"}
+
+        creds = _get_credentials()
+        newsdata_key = creds["newsdata_api_key"]
+        finlight_key = creds["finlight_api_key"]
+        if not newsdata_key and not finlight_key:
+            return {
+                "error": "No news credentials configured",
+                "help": "Set NEWSDATA_API_KEY or FINLIGHT_API_KEY environment variable",
+            }
+
+        limit_value = _normalize_limit(limit)
+
+        try:
+            primary = (
+                _search_newsdata(
+                    query=None,
+                    from_date=None,
+                    to_date=None,
+                    language=None,
+                    limit=limit_value,
+                    sources=None,
+                    category=category,
+                    country=country,
+                    api_key=newsdata_key,
+                )
+                if newsdata_key
+                else {"error": "NewsData credentials not configured"}
+            )
+            fallback = (
+                _search_finlight(
+                    query=None,
+                    from_date=None,
+                    to_date=None,
+                    language=None,
+                    limit=limit_value,
+                    sources=None,
+                    category=category,
+                    country=country,
+                    api_key=finlight_key,
+                )
+                if finlight_key
+                else None
+            )
+            result = _run_with_fallback(primary, fallback)
+            result["category"] = category
+            result["country"] = country
+            return result
+        except httpx.TimeoutException:
+            return {"error": "News headline request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+        except Exception as e:
+            return {"error": f"News headlines failed: {e}"}
+
+    @mcp.tool()
+    def news_by_company(
+        company_name: str,
+        days_back: int = 7,
+        limit: int | None = 10,
+        language: str | None = "en",
+    ) -> dict:
+        """
+        Get news mentioning a specific company.
+
+        Args:
+            company_name: Company name to search for
+            days_back: Days to look back (default 7)
+            limit: Max number of results
+            language: Language code (e.g., en)
+
+        Returns:
+            Dict with list of articles and provider metadata.
+        """
+        if not company_name:
+            return {"error": "Company name is required"}
+        if days_back < 0:
+            return {"error": "days_back must be 0 or greater"}
+
+        from_date, to_date = _build_date_range(days_back)
+
+        creds = _get_credentials()
+        newsdata_key = creds["newsdata_api_key"]
+        finlight_key = creds["finlight_api_key"]
+        if not newsdata_key and not finlight_key:
+            return {
+                "error": "No news credentials configured",
+                "help": "Set NEWSDATA_API_KEY or FINLIGHT_API_KEY environment variable",
+            }
+
+        limit_value = _normalize_limit(limit)
+        query = f'"{company_name}"'
+
+        try:
+            primary = (
+                _search_newsdata(
+                    query=query,
+                    from_date=from_date,
+                    to_date=to_date,
+                    language=language,
+                    limit=limit_value,
+                    sources=None,
+                    category=None,
+                    country=None,
+                    api_key=newsdata_key,
+                )
+                if newsdata_key
+                else {"error": "NewsData credentials not configured"}
+            )
+            fallback = (
+                _search_finlight(
+                    query=query,
+                    from_date=from_date,
+                    to_date=to_date,
+                    language=language,
+                    limit=limit_value,
+                    sources=None,
+                    category=None,
+                    country=None,
+                    api_key=finlight_key,
+                )
+                if finlight_key
+                else None
+            )
+            result = _run_with_fallback(primary, fallback)
+            result["company_name"] = company_name
+            result["days_back"] = days_back
+            return result
+        except httpx.TimeoutException:
+            return {"error": "Company news request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+        except Exception as e:
+            return {"error": f"Company news failed: {e}"}
+
+    @mcp.tool()
+    def news_sentiment(
+        query: str,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> dict:
+        """
+        Get news with sentiment analysis (Finlight provider).
+
+        Args:
+            query: Search query
+            from_date: Start date (YYYY-MM-DD)
+            to_date: End date (YYYY-MM-DD)
+
+        Returns:
+            Dict with list of sentiment-scored articles.
+        """
+        if not query:
+            return {"error": "Query is required"}
+
+        creds = _get_credentials()
+        finlight_key = creds["finlight_api_key"]
+        if not finlight_key:
+            return {
+                "error": "Finlight credentials not configured",
+                "help": "Set FINLIGHT_API_KEY environment variable",
+            }
+
+        try:
+            result = _search_finlight(
+                query=query,
+                from_date=from_date,
+                to_date=to_date,
+                language=None,
+                limit=_normalize_limit(None),
+                sources=None,
+                category=None,
+                country=None,
+                api_key=finlight_key,
+                include_sentiment=True,
+            )
+            result["query"] = query
+            return result
+        except httpx.TimeoutException:
+            return {"error": "News sentiment request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+        except Exception as e:
+            return {"error": f"News sentiment failed: {e}"}
+

--- a/tools/tests/tools/test_news_tool.py
+++ b/tools/tests/tools/test_news_tool.py
@@ -1,0 +1,143 @@
+"""Tests for news tool with multi-provider support (FastMCP)."""
+
+from datetime import date as real_date
+
+import httpx
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.news_tool import news_tool, register_tools
+
+
+class DummyResponse:
+    """Simple mock response for httpx.get."""
+
+    def __init__(self, status_code: int, payload: dict):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> dict:
+        return self._payload
+
+
+@pytest.fixture
+def news_tools(mcp: FastMCP):
+    """Register and return the news tool functions."""
+    register_tools(mcp)
+    return mcp._tool_manager._tools
+
+
+class TestNewsSearch:
+    """Tests for news_search tool."""
+
+    def test_news_search_newsdata_success(self, news_tools, monkeypatch):
+        """NewsData provider returns normalized results."""
+        monkeypatch.setenv("NEWSDATA_API_KEY", "news-key")
+        monkeypatch.delenv("FINLIGHT_API_KEY", raising=False)
+
+        captured: dict = {}
+
+        def mock_get(url: str, params=None, timeout=30.0, headers=None):
+            captured["url"] = url
+            captured["params"] = params or {}
+            return DummyResponse(
+                200,
+                {
+                    "results": [
+                        {
+                            "title": "Funding Round",
+                            "source_id": "techcrunch",
+                            "pubDate": "2026-02-01",
+                            "link": "https://example.com/article",
+                            "description": "A funding round was announced.",
+                        }
+                    ]
+                },
+            )
+
+        monkeypatch.setattr(httpx, "get", mock_get)
+
+        result = news_tools["news_search"].fn(query="funding")
+
+        assert result["provider"] == "newsdata"
+        assert result["query"] == "funding"
+        assert result["total"] == 1
+        assert captured["params"]["q"] == "funding"
+
+    def test_news_search_falls_back_to_finlight(self, news_tools, monkeypatch):
+        """Fallback to Finlight when NewsData returns an error."""
+        monkeypatch.setenv("NEWSDATA_API_KEY", "news-key")
+        monkeypatch.setenv("FINLIGHT_API_KEY", "finlight-key")
+
+        def mock_get(url: str, params=None, timeout=30.0, headers=None):
+            if "newsdata.io" in url:
+                return DummyResponse(401, {})
+            return DummyResponse(
+                200,
+                {
+                    "data": [
+                        {
+                            "title": "Market Update",
+                            "source": "finlight",
+                            "published_at": "2026-02-02",
+                            "url": "https://example.com/fin",
+                            "summary": "Markets moved today.",
+                        }
+                    ]
+                },
+            )
+
+        monkeypatch.setattr(httpx, "get", mock_get)
+
+        result = news_tools["news_search"].fn(query="markets")
+
+        assert result["provider"] == "finlight"
+        assert result["total"] == 1
+
+
+class TestNewsByCompany:
+    """Tests for news_by_company tool."""
+
+    def test_news_by_company_date_filter(self, news_tools, monkeypatch):
+        """news_by_company builds date filters and quoted company query."""
+        monkeypatch.setenv("NEWSDATA_API_KEY", "news-key")
+        monkeypatch.delenv("FINLIGHT_API_KEY", raising=False)
+
+        class FakeDate(real_date):
+            @classmethod
+            def today(cls) -> real_date:
+                return real_date(2026, 2, 10)
+
+        monkeypatch.setattr(news_tool, "date", FakeDate)
+
+        captured: dict = {}
+
+        def mock_get(url: str, params=None, timeout=30.0, headers=None):
+            captured["params"] = params or {}
+            return DummyResponse(200, {"results": []})
+
+        monkeypatch.setattr(httpx, "get", mock_get)
+
+        result = news_tools["news_by_company"].fn(company_name="Acme", days_back=7)
+
+        assert result["provider"] == "newsdata"
+        assert captured["params"]["from_date"] == "2026-02-03"
+        assert captured["params"]["to_date"] == "2026-02-10"
+        assert captured["params"]["q"] == '"Acme"'
+
+
+class TestNewsSentiment:
+    """Tests for news_sentiment tool."""
+
+    def test_news_sentiment_requires_finlight(self, news_tools, monkeypatch):
+        """news_sentiment returns error when Finlight key missing."""
+        monkeypatch.delenv("FINLIGHT_API_KEY", raising=False)
+        monkeypatch.delenv("NEWSDATA_API_KEY", raising=False)
+
+        result = news_tools["news_sentiment"].fn(query="Acme")
+
+        assert "error" in result
+        assert "Finlight credentials not configured" in result["error"]
+
+
+


### PR DESCRIPTION
## Description

Add news MCP tools to support market intelligence workflows using NewsData as the primary provider, with Finlight as a fallback provider and as the sentiment provider.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #3060

## Changes Made

- Add MCP tools: `news_search`, `news_headlines`, `news_by_company`, `news_sentiment`
- Implement provider strategy: NewsData primary + Finlight fallback (sentiment via Finlight)
- Register credential specs: `NEWSDATA_API_KEY` (query param) and `FINLIGHT_API_KEY` (Authorization header)
- Add unit tests for provider success/fallback behavior and date filtering via `news_by_company`
- Map common provider errors (401/429/422) for both providers

## Testing

- [x] Unit tests pass (`py -3.11 -m pytest tools/tests/tools/test_news_tool.py`)
- [ ] Lint passes (`make check`) (not run)
- [ ] Manual testing performed (not run)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (not needed / no complex logic added)
- [ ] I have made corresponding changes to the documentation (not required for this change)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
<img width="581" height="321" alt="image" src="https://github.com/user-attachments/assets/09c204f2-6acb-4407-9f52-84f0e89029f5" />
