### PR TITLE
chore(micro-fix): fix debug logging level in graph executor

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -368,7 +368,7 @@ class GraphExecutor:
             # Check if resuming from paused_at (session state resume)
             paused_at = session_state.get("paused_at") if session_state else None
             node_ids = [n.id for n in graph.nodes]
-            self.logger.info(f"🔍 Debug: paused_at={paused_at}, available node IDs={node_ids}")
+            self.logger.debug(f"paused_at={paused_at}, available node IDs={node_ids}")
 
             if paused_at and graph.get_node(paused_at) is not None:
                 # Resume from paused_at node directly (works for any node, not just pause_nodes)


### PR DESCRIPTION
## Type: Micro-fix

This PR adjusts a debug logging statement to use the appropriate logging level.

### Changes
- Changed `logger.info()` to `logger.debug()` in `core/framework/graph/executor.py:371`
- Removed redundant "🔍 Debug:" prefix from log message
- **Total lines changed: 1**

### Why This Qualifies as a Micro-fix
✅ < 20 lines changed (only 1 line)  
✅ No logic, API, or database changes  
✅ Linting/cleanup category (logging best practices)  
✅ Zero risk of breaking changes  

Per [CONTRIBUTING.md](https://github.com/adenhq/hive/blob/main/CONTRIBUTING.md#exceptions-no-assignment-needed), micro-fixes can be submitted without prior issue assignment.

### Problem
Debug-level information was appearing in production logs at INFO level, adding noise to log output.

### Solution
Use the appropriate `debug` logging level so the message only appears when debug logging is explicitly enabled.

### Testing
- ✅ `ruff check` passes (linting) - all files clean
- ✅ `ruff format --check` passes (formatting) - 239 files already formatted
- ✅ `pytest tests/` passes - **683 tests passed**, 0 failed

### Checklist
- [x] Follow conventional commit format
- [x] Changes limited to < 20 lines
- [x] No functional changes
- [x] Lint and tests pass
- [x] Marked as `micro-fix` for fast-track review

[micro-fix,code-quality,logging,chore]
