### PR TITLE
fix(llm): validate API key format in LiteLLMProvider to fail fast on malformed keys

### DIFF
--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -323,6 +323,9 @@ class LiteLLMProvider(LLMProvider):
             api_base: Custom API base URL (for proxies or local deployments)
             **kwargs: Additional arguments passed to litellm.completion()
         """
+        if api_key is not None:
+            self._validate_api_key(api_key)
+
         self.model = model
         self.api_key = api_key
         self.api_base = api_base or self._default_api_base_for_model(model)
@@ -343,6 +346,33 @@ class LiteLLMProvider(LLMProvider):
         # correctly marks codex models with mode="responses", so we do NOT
         # override the mode.  The responses_api_bridge in litellm handles
         # converting Chat Completions requests to Responses API format.
+
+    def _validate_api_key(self, api_key: str) -> None:
+        """Validate API key format to fail fast on common configuration errors."""
+        # 1. Check for empty or whitespace-only strings
+        if not api_key or not api_key.strip():
+            raise ValueError("API key cannot be empty or whitespace-only")
+
+        # 2. Check for any ASCII control characters (0x00-0x1F and DEL 0x7F)
+        # This catches newlines, tabs, NUL bytes, and other invisible chars
+        # that often slip in from file reads or copy-pasting
+        if any(ord(c) < 32 or ord(c) == 127 for c in api_key):
+            raise ValueError(
+                "API key contains invalid control characters. "
+                "Please check your configuration or .env file."
+            )
+
+        # 3. Check for accidentally quoted keys (e.g., '"sk-..."')
+        # Strip whitespace first to catch padded cases like ' "sk-..." '
+        # This is a common .env parsing error
+        stripped = api_key.strip()
+        if (stripped.startswith('"') and stripped.endswith('"')) or (
+            stripped.startswith("'") and stripped.endswith("'")
+        ):
+            raise ValueError(
+                "API key appears to be quoted inside the string value. "
+                "Please remove the surrounding quotes."
+            )
 
     @staticmethod
     def _default_api_base_for_model(model: str) -> str | None:

--- a/core/tests/test_litellm_provider.py
+++ b/core/tests/test_litellm_provider.py
@@ -79,6 +79,51 @@ class TestLiteLLMProviderInit:
             provider = LiteLLMProvider(model="ollama/llama3")
             assert provider.model == "ollama/llama3"
 
+    def test_init_with_malformed_key_whitespace(self):
+        """Test that whitespace-only API keys raise ValueError."""
+        with pytest.raises(ValueError, match="cannot be empty or whitespace-only"):
+            LiteLLMProvider(api_key="   ")
+
+        with pytest.raises(ValueError, match="cannot be empty or whitespace-only"):
+            LiteLLMProvider(api_key="")
+
+    def test_init_with_malformed_key_control_chars(self):
+        """Test that API keys with any control characters raise ValueError."""
+        # Newline / carriage return
+        with pytest.raises(ValueError, match="invalid control characters"):
+            LiteLLMProvider(api_key="sk-proj-1234\n")
+
+        with pytest.raises(ValueError, match="invalid control characters"):
+            LiteLLMProvider(api_key="sk-proj-1234\r")
+
+        # Tab
+        with pytest.raises(ValueError, match="invalid control characters"):
+            LiteLLMProvider(api_key="sk-proj-1234\t")
+
+        # NUL byte
+        with pytest.raises(ValueError, match="invalid control characters"):
+            LiteLLMProvider(api_key="sk-proj-1234\x00")
+
+        # DEL (0x7F)
+        with pytest.raises(ValueError, match="invalid control characters"):
+            LiteLLMProvider(api_key="sk-proj-1234\x7f")
+
+    def test_init_with_malformed_key_quotes(self):
+        """Test that accidentally quoted API keys raise ValueError."""
+        # Exact quote wrapping
+        with pytest.raises(ValueError, match="quoted"):
+            LiteLLMProvider(api_key='"sk-proj-1234"')
+
+        with pytest.raises(ValueError, match="quoted"):
+            LiteLLMProvider(api_key="'sk-proj-1234'")
+
+        # Whitespace-padded quotes
+        with pytest.raises(ValueError, match="quoted"):
+            LiteLLMProvider(api_key=' "sk-proj-1234" ')
+
+        with pytest.raises(ValueError, match="quoted"):
+            LiteLLMProvider(api_key=" 'sk-proj-1234' ")
+
 
 class TestLiteLLMProviderComplete:
     """Test LiteLLMProvider.complete() method."""


### PR DESCRIPTION
Fixes #1133

## What
Adds `_validate_api_key()` to `LiteLLMProvider.__init__()` to reject malformed API keys at initialization instead of failing later at runtime with unclear auth errors.

## Validation checks
1. Empty or whitespace-only keys
2. Keys containing ASCII control characters (`0x00–0x1F`, `0x7F`)  
   - covered examples: newline, carriage return, tab, NUL, DEL
3. Accidentally quoted keys, including whitespace-padded quotes

## Impact
Applies to all providers that use `LiteLLMProvider` (OpenAI, Anthropic, Gemini, DeepSeek, Mistral, etc.).

## Tests
Added 3 tests under `TestLiteLLMProviderInit`:
- `test_init_with_malformed_key_whitespace`
- `test_init_with_malformed_key_control_chars`
- `test_init_with_malformed_key_quotes`

Validation run:
- `make check` ✅
- `make test` ✅ (`686 passed, 71 skipped`)
