### PR TITLE
docs: clarify Aden vs Hive naming across docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@
   <img src="https://img.shields.io/badge/Google_Gemini-supported-4285F4?style=flat-square&logo=google" alt="Gemini" />
 </p>
 
+
+**Aden** is the company and platform; **Hive** is the open-source agent framework at its core. This repo contains Hive.
+
 ## Overview
 
 Build autonomous, reliable, self-improving AI agents without hardcoding workflows. Define your goal through conversation with a coding agent, and the framework generates a node graph with dynamically created connection code. When things break, the framework captures failure data, evolves the agent through the coding agent, and redeploys. Built-in human-in-the-loop nodes, credential management, and real-time monitoring give you control without sacrificing adaptability.


### PR DESCRIPTION
## Summary
- Added a one-line clarification in the README explaining that Aden is the company/platform and Hive is the open-source framework
- Helps new contributors and evaluators understand the naming distinction

Closes #4360

## Test plan
- [ ] README renders correctly on GitHub
- [ ] Clarification is accurate and concise