### PR TITLE
feat(observability): Lifecycle hook system with OTel integration and pluggable exporters

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -598,7 +598,9 @@ class GraphExecutor:
                 try:
                     await self._hooks.on_node_start(
                         NodeStartEvent(
-                            run_id=self.runtime._current_run.id if self.runtime._current_run else "",
+                            run_id=(
+                                self.runtime._current_run.id if self.runtime._current_run else ""
+                            ),
                             node_id=node_spec.id,
                             node_name=node_spec.name,
                             node_type=node_spec.node_type,

--- a/core/framework/observability/__init__.py
+++ b/core/framework/observability/__init__.py
@@ -1,23 +1,54 @@
 """
-Observability module for automatic trace correlation and structured logging.
+Observability module for automatic trace correlation, structured logging,
+and lifecycle hooks.
 
 This module provides zero-friction observability:
 - Automatic trace context propagation via ContextVar
 - Structured JSON logging for production
 - Human-readable logging for development
+- Lifecycle hooks for monitoring and telemetry
 - No manual ID passing required
 """
 
+from framework.observability.config import ObservabilityConfig
+from framework.observability.hooks import (
+    CompositeHooks,
+    NoOpHooks,
+    ObservabilityHooks,
+)
 from framework.observability.logging import (
     clear_trace_context,
     configure_logging,
     get_trace_context,
     set_trace_context,
 )
+from framework.observability.types import (
+    DecisionEvent,
+    NodeCompleteEvent,
+    NodeErrorEvent,
+    NodeStartEvent,
+    RunCompleteEvent,
+    RunStartEvent,
+    ToolCallEvent,
+)
 
 __all__ = [
+    # Logging
     "configure_logging",
     "get_trace_context",
     "set_trace_context",
     "clear_trace_context",
+    # Hooks
+    "ObservabilityHooks",
+    "NoOpHooks",
+    "CompositeHooks",
+    "ObservabilityConfig",
+    # Event types
+    "RunStartEvent",
+    "NodeStartEvent",
+    "NodeCompleteEvent",
+    "NodeErrorEvent",
+    "DecisionEvent",
+    "ToolCallEvent",
+    "RunCompleteEvent",
 ]

--- a/core/framework/observability/config.py
+++ b/core/framework/observability/config.py
@@ -1,0 +1,51 @@
+"""Configuration for the observability subsystem.
+
+Usage::
+
+    config = ObservabilityConfig(
+        enabled=True,
+        hooks=[ConsoleExporter(), PrometheusExporter(port=9090)],
+        sample_rate=1.0,
+    )
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from framework.observability.hooks import ObservabilityHooks
+
+
+@dataclass
+class ObservabilityConfig:
+    """Configuration for observability.
+
+    Attributes:
+        enabled: Master switch. When False, no hooks are called.
+        hooks: List of hook implementations to receive events.
+               Multiple hooks are wrapped in a CompositeHooks automatically.
+        sample_rate: Fraction of runs to instrument (0.0–1.0).
+                     1.0 = every run, 0.1 = 10% of runs.
+                     Useful for high-throughput production to reduce overhead.
+    """
+
+    enabled: bool = True
+    hooks: list[ObservabilityHooks] = field(default_factory=list)
+    sample_rate: float = 1.0
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.sample_rate <= 1.0:
+            msg = f"sample_rate must be between 0.0 and 1.0, got {self.sample_rate}"
+            raise ValueError(msg)
+
+    def should_sample(self) -> bool:
+        """Determine whether a given run should be instrumented."""
+        if not self.enabled:
+            return False
+        if self.sample_rate >= 1.0:
+            return True
+        import random
+
+        return random.random() < self.sample_rate

--- a/core/framework/observability/exporters/__init__.py
+++ b/core/framework/observability/exporters/__init__.py
@@ -1,0 +1,9 @@
+"""Built-in observability exporters.
+
+All exporters implement ``ObservabilityHooks`` and can be composed via
+``CompositeHooks`` to run multiple simultaneously.
+
+Available exporters:
+- ``ConsoleExporter``  — pretty-printed real-time output for development
+- ``FileExporter``     — JSON Lines for local analysis
+"""

--- a/core/framework/observability/exporters/console.py
+++ b/core/framework/observability/exporters/console.py
@@ -1,0 +1,144 @@
+"""Console exporter — pretty-printed real-time observability for development.
+
+Outputs lifecycle events in a structured, colorized format to stderr
+for easy debugging during local development.
+
+Usage::
+
+    from framework.observability.exporters.console import ConsoleExporter
+    from framework.observability.hooks import CompositeHooks
+
+    runtime = Runtime(
+        storage_path="./logs",
+        observability_hooks=ConsoleExporter(),
+    )
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from typing import TextIO
+
+from framework.observability.types import (
+    DecisionEvent,
+    NodeCompleteEvent,
+    NodeErrorEvent,
+    NodeStartEvent,
+    RunCompleteEvent,
+    RunStartEvent,
+    ToolCallEvent,
+)
+
+# ANSI color codes
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+_GREEN = "\033[32m"
+_YELLOW = "\033[33m"
+_RED = "\033[31m"
+_BLUE = "\033[34m"
+_CYAN = "\033[36m"
+_MAGENTA = "\033[35m"
+
+
+class ConsoleExporter:
+    """Pretty-prints observability events to the console.
+
+    Args:
+        stream: Output stream (default: stderr)
+        verbose: If True, include extra detail like reasoning and input data
+        color: If True, use ANSI colors (default: True)
+    """
+
+    def __init__(
+        self,
+        stream: TextIO | None = None,
+        verbose: bool = False,
+        color: bool = True,
+    ) -> None:
+        self._stream = stream or sys.stderr
+        self._verbose = verbose
+        self._color = color
+
+    def _ts(self) -> str:
+        return datetime.now().strftime("%H:%M:%S.%f")[:-3]
+
+    def _c(self, code: str, text: str) -> str:
+        if not self._color:
+            return text
+        return f"{code}{text}{_RESET}"
+
+    def _write(self, line: str) -> None:
+        self._stream.write(line + "\n")
+        self._stream.flush()
+
+    async def on_run_start(self, event: RunStartEvent) -> None:
+        self._write(
+            f"{self._c(_DIM, self._ts())} "
+            f"{self._c(_BOLD + _BLUE, '[RUN]')} "
+            f"Started: {self._c(_BOLD, event.goal_id)} "
+            f"{self._c(_DIM, f'(run={event.run_id})')}"
+        )
+
+    async def on_run_complete(self, event: RunCompleteEvent) -> None:
+        status_color = _GREEN if event.status == "success" else _RED
+        self._write(
+            f"{self._c(_DIM, self._ts())} "
+            f"{self._c(_BOLD + _BLUE, '[RUN]')} "
+            f"Completed: {self._c(status_color, event.status.upper())} "
+            f"{self._c(_DIM, f'({event.duration_ms}ms)')}"
+        )
+
+    async def on_node_start(self, event: NodeStartEvent) -> None:
+        self._write(
+            f"{self._c(_DIM, self._ts())} "
+            f"{self._c(_CYAN, '[NODE]')} "
+            f"{self._c(_BOLD, event.node_name)}: "
+            f"Executing {self._c(_DIM, f'({event.node_type})')}"
+        )
+
+    async def on_node_complete(self, event: NodeCompleteEvent) -> None:
+        if event.success:
+            self._write(
+                f"{self._c(_DIM, self._ts())} "
+                f"{self._c(_GREEN, '[NODE]')} "
+                f"{self._c(_BOLD, event.node_name)}: "
+                f"{self._c(_GREEN, '✓ Success')} "
+                f"{self._c(_DIM, f'({event.latency_ms}ms, {event.tokens_used} tokens)')}"
+            )
+        else:
+            self._write(
+                f"{self._c(_DIM, self._ts())} "
+                f"{self._c(_RED, '[NODE]')} "
+                f"{self._c(_BOLD, event.node_name)}: "
+                f"{self._c(_RED, '✗ Failed')} "
+                f"{self._c(_DIM, f'({event.latency_ms}ms)')}"
+            )
+
+    async def on_node_error(self, event: NodeErrorEvent) -> None:
+        self._write(
+            f"{self._c(_DIM, self._ts())} "
+            f"{self._c(_RED, '[ERROR]')} "
+            f"{self._c(_BOLD, event.node_name)}: "
+            f"{self._c(_RED, event.error)}"
+        )
+
+    async def on_decision_made(self, event: DecisionEvent) -> None:
+        line = (
+            f"{self._c(_DIM, self._ts())} "
+            f"{self._c(_MAGENTA, '[DECISION]')} "
+            f"{event.intent} → {self._c(_BOLD, event.chosen)}"
+        )
+        if self._verbose:
+            line += f" {self._c(_DIM, f'(reason: {event.reasoning})')}"
+        self._write(line)
+
+    async def on_tool_call(self, event: ToolCallEvent) -> None:
+        status = self._c(_RED, "✗") if event.is_error else self._c(_GREEN, "✓")
+        self._write(
+            f"{self._c(_DIM, self._ts())} "
+            f"{self._c(_YELLOW, '[TOOL]')} "
+            f"{event.tool_name} {status} "
+            f"{self._c(_DIM, f'({event.latency_ms}ms)')}"
+        )

--- a/core/framework/observability/exporters/file.py
+++ b/core/framework/observability/exporters/file.py
@@ -56,71 +56,92 @@ class FileExporter:
                 f.write(line + "\n")
 
     async def on_run_start(self, event: RunStartEvent) -> None:
-        self._write_event("run_start", {
-            "run_id": event.run_id,
-            "goal_id": event.goal_id,
-            "input_data": event.input_data,
-            "timestamp": event.timestamp,
-        })
+        self._write_event(
+            "run_start",
+            {
+                "run_id": event.run_id,
+                "goal_id": event.goal_id,
+                "input_data": event.input_data,
+                "timestamp": event.timestamp,
+            },
+        )
 
     async def on_run_complete(self, event: RunCompleteEvent) -> None:
-        self._write_event("run_complete", {
-            "run_id": event.run_id,
-            "status": event.status,
-            "duration_ms": event.duration_ms,
-            "total_nodes_executed": event.total_nodes_executed,
-            "total_tokens": event.total_tokens,
-            "timestamp": event.timestamp,
-        })
+        self._write_event(
+            "run_complete",
+            {
+                "run_id": event.run_id,
+                "status": event.status,
+                "duration_ms": event.duration_ms,
+                "total_nodes_executed": event.total_nodes_executed,
+                "total_tokens": event.total_tokens,
+                "timestamp": event.timestamp,
+            },
+        )
 
     async def on_node_start(self, event: NodeStartEvent) -> None:
-        self._write_event("node_start", {
-            "run_id": event.run_id,
-            "node_id": event.node_id,
-            "node_name": event.node_name,
-            "node_type": event.node_type,
-            "timestamp": event.timestamp,
-        })
+        self._write_event(
+            "node_start",
+            {
+                "run_id": event.run_id,
+                "node_id": event.node_id,
+                "node_name": event.node_name,
+                "node_type": event.node_type,
+                "timestamp": event.timestamp,
+            },
+        )
 
     async def on_node_complete(self, event: NodeCompleteEvent) -> None:
-        self._write_event("node_complete", {
-            "run_id": event.run_id,
-            "node_id": event.node_id,
-            "node_name": event.node_name,
-            "success": event.success,
-            "latency_ms": event.latency_ms,
-            "tokens_used": event.tokens_used,
-            "timestamp": event.timestamp,
-        })
+        self._write_event(
+            "node_complete",
+            {
+                "run_id": event.run_id,
+                "node_id": event.node_id,
+                "node_name": event.node_name,
+                "success": event.success,
+                "latency_ms": event.latency_ms,
+                "tokens_used": event.tokens_used,
+                "timestamp": event.timestamp,
+            },
+        )
 
     async def on_node_error(self, event: NodeErrorEvent) -> None:
-        self._write_event("node_error", {
-            "run_id": event.run_id,
-            "node_id": event.node_id,
-            "node_name": event.node_name,
-            "error": event.error,
-            "stacktrace": event.stacktrace,
-            "timestamp": event.timestamp,
-        })
+        self._write_event(
+            "node_error",
+            {
+                "run_id": event.run_id,
+                "node_id": event.node_id,
+                "node_name": event.node_name,
+                "error": event.error,
+                "stacktrace": event.stacktrace,
+                "timestamp": event.timestamp,
+            },
+        )
 
     async def on_decision_made(self, event: DecisionEvent) -> None:
-        self._write_event("decision", {
-            "run_id": event.run_id,
-            "decision_id": event.decision_id,
-            "node_id": event.node_id,
-            "intent": event.intent,
-            "chosen": event.chosen,
-            "reasoning": event.reasoning,
-            "options_count": event.options_count,
-            "timestamp": event.timestamp,
-        })
+        self._write_event(
+            "decision",
+            {
+                "run_id": event.run_id,
+                "decision_id": event.decision_id,
+                "node_id": event.node_id,
+                "intent": event.intent,
+                "chosen": event.chosen,
+                "reasoning": event.reasoning,
+                "options_count": event.options_count,
+                "timestamp": event.timestamp,
+            },
+        )
 
     async def on_tool_call(self, event: ToolCallEvent) -> None:
-        self._write_event("tool_call", {
-            "run_id": event.run_id,
-            "node_id": event.node_id,
-            "tool_name": event.tool_name,
-            "is_error": event.is_error,
-            "latency_ms": event.latency_ms,
-            "timestamp": event.timestamp,
-        })
+        self._write_event(
+            "tool_call",
+            {
+                "run_id": event.run_id,
+                "node_id": event.node_id,
+                "tool_name": event.tool_name,
+                "is_error": event.is_error,
+                "latency_ms": event.latency_ms,
+                "timestamp": event.timestamp,
+            },
+        )

--- a/core/framework/observability/exporters/file.py
+++ b/core/framework/observability/exporters/file.py
@@ -1,0 +1,126 @@
+"""File exporter — JSON Lines format for local analysis.
+
+Writes one JSON object per event to a ``.jsonl`` file, suitable for
+ingestion by log analysis tools or custom dashboards.
+
+Usage::
+
+    from framework.observability.exporters.file import FileExporter
+
+    runtime = Runtime(
+        storage_path="./logs",
+        observability_hooks=FileExporter(path="./events.jsonl"),
+    )
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from pathlib import Path
+from typing import Any
+
+from framework.observability.types import (
+    DecisionEvent,
+    NodeCompleteEvent,
+    NodeErrorEvent,
+    NodeStartEvent,
+    RunCompleteEvent,
+    RunStartEvent,
+    ToolCallEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class FileExporter:
+    """Appends lifecycle events as JSON Lines to a file.
+
+    Thread-safe — uses a lock for concurrent writes.
+
+    Args:
+        path: Path to the JSONL output file (created if missing)
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+
+    def _write_event(self, event_type: str, data: dict[str, Any]) -> None:
+        record = {"event_type": event_type, **data}
+        line = json.dumps(record, default=str)
+        with self._lock:
+            with self._path.open("a") as f:
+                f.write(line + "\n")
+
+    async def on_run_start(self, event: RunStartEvent) -> None:
+        self._write_event("run_start", {
+            "run_id": event.run_id,
+            "goal_id": event.goal_id,
+            "input_data": event.input_data,
+            "timestamp": event.timestamp,
+        })
+
+    async def on_run_complete(self, event: RunCompleteEvent) -> None:
+        self._write_event("run_complete", {
+            "run_id": event.run_id,
+            "status": event.status,
+            "duration_ms": event.duration_ms,
+            "total_nodes_executed": event.total_nodes_executed,
+            "total_tokens": event.total_tokens,
+            "timestamp": event.timestamp,
+        })
+
+    async def on_node_start(self, event: NodeStartEvent) -> None:
+        self._write_event("node_start", {
+            "run_id": event.run_id,
+            "node_id": event.node_id,
+            "node_name": event.node_name,
+            "node_type": event.node_type,
+            "timestamp": event.timestamp,
+        })
+
+    async def on_node_complete(self, event: NodeCompleteEvent) -> None:
+        self._write_event("node_complete", {
+            "run_id": event.run_id,
+            "node_id": event.node_id,
+            "node_name": event.node_name,
+            "success": event.success,
+            "latency_ms": event.latency_ms,
+            "tokens_used": event.tokens_used,
+            "timestamp": event.timestamp,
+        })
+
+    async def on_node_error(self, event: NodeErrorEvent) -> None:
+        self._write_event("node_error", {
+            "run_id": event.run_id,
+            "node_id": event.node_id,
+            "node_name": event.node_name,
+            "error": event.error,
+            "stacktrace": event.stacktrace,
+            "timestamp": event.timestamp,
+        })
+
+    async def on_decision_made(self, event: DecisionEvent) -> None:
+        self._write_event("decision", {
+            "run_id": event.run_id,
+            "decision_id": event.decision_id,
+            "node_id": event.node_id,
+            "intent": event.intent,
+            "chosen": event.chosen,
+            "reasoning": event.reasoning,
+            "options_count": event.options_count,
+            "timestamp": event.timestamp,
+        })
+
+    async def on_tool_call(self, event: ToolCallEvent) -> None:
+        self._write_event("tool_call", {
+            "run_id": event.run_id,
+            "node_id": event.node_id,
+            "tool_name": event.tool_name,
+            "is_error": event.is_error,
+            "latency_ms": event.latency_ms,
+            "timestamp": event.timestamp,
+        })

--- a/core/framework/observability/exporters/prometheus.py
+++ b/core/framework/observability/exporters/prometheus.py
@@ -118,17 +118,15 @@ class PrometheusExporter:
         pass  # No metric on start — measured on complete
 
     async def on_node_complete(self, event: NodeCompleteEvent) -> None:
-        self._node_duration.labels(
-            node_id=event.node_id, node_type=event.node_type
-        ).observe(event.latency_ms / 1000.0)
+        self._node_duration.labels(node_id=event.node_id, node_type=event.node_type).observe(
+            event.latency_ms / 1000.0
+        )
 
         if event.tokens_used:
             self._tokens_total.labels(node_id=event.node_id).inc(event.tokens_used)
 
     async def on_node_error(self, event: NodeErrorEvent) -> None:
-        self._node_errors_total.labels(
-            node_id=event.node_id, node_type=event.node_type
-        ).inc()
+        self._node_errors_total.labels(node_id=event.node_id, node_type=event.node_type).inc()
 
     async def on_decision_made(self, event: DecisionEvent) -> None:
         self._decisions_total.inc()

--- a/core/framework/observability/exporters/prometheus.py
+++ b/core/framework/observability/exporters/prometheus.py
@@ -1,0 +1,140 @@
+"""Prometheus metrics exporter.
+
+Exposes Hive agent metrics at a configurable HTTP endpoint for
+Prometheus scraping.
+
+Requires the ``observability`` optional dependency group::
+
+    pip install framework[observability]
+
+Usage::
+
+    from framework.observability.exporters.prometheus import PrometheusExporter
+
+    exporter = PrometheusExporter(port=9090)
+    # Metrics available at http://localhost:9090/metrics
+
+    runtime = Runtime(
+        storage_path="./logs",
+        observability_hooks=exporter,
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+
+try:
+    from prometheus_client import Counter, Histogram, start_http_server
+
+    HAS_PROMETHEUS = True
+except ImportError:
+    HAS_PROMETHEUS = False
+
+from framework.observability.types import (
+    DecisionEvent,
+    NodeCompleteEvent,
+    NodeErrorEvent,
+    NodeStartEvent,
+    RunCompleteEvent,
+    RunStartEvent,
+    ToolCallEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PrometheusExporter:
+    """Exports Hive agent metrics to Prometheus.
+
+    Metrics exposed:
+    - ``hive_agent_runs_total`` — counter of runs by status
+    - ``hive_node_duration_seconds`` — histogram of node latencies
+    - ``hive_node_errors_total`` — counter of node errors
+    - ``hive_llm_tokens_total`` — counter of tokens used
+    - ``hive_decisions_total`` — counter of decisions made
+    - ``hive_tool_calls_total`` — counter of tool calls
+
+    Args:
+        port: HTTP port for the metrics endpoint (default: 9090)
+        start_server: If True, starts the HTTP server on init (default: True)
+    """
+
+    def __init__(self, port: int = 9090, start_server: bool = True) -> None:
+        if not HAS_PROMETHEUS:
+            raise ImportError(
+                "prometheus-client is required for PrometheusExporter. "
+                "Install with: pip install prometheus-client"
+            )
+
+        # Counters
+        self._runs_total = Counter(
+            "hive_agent_runs_total",
+            "Total number of agent runs",
+            ["status"],
+        )
+        self._node_errors_total = Counter(
+            "hive_node_errors_total",
+            "Total number of node errors",
+            ["node_id", "node_type"],
+        )
+        self._tokens_total = Counter(
+            "hive_llm_tokens_total",
+            "Total LLM tokens used",
+            ["node_id"],
+        )
+        self._decisions_total = Counter(
+            "hive_decisions_total",
+            "Total decisions made",
+        )
+        self._tool_calls_total = Counter(
+            "hive_tool_calls_total",
+            "Total tool calls",
+            ["tool_name", "is_error"],
+        )
+
+        # Histograms
+        self._node_duration = Histogram(
+            "hive_node_duration_seconds",
+            "Node execution duration in seconds",
+            ["node_id", "node_type"],
+            buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0),
+        )
+
+        if start_server:
+            try:
+                start_http_server(port)
+                logger.info("Prometheus metrics server started on port %d", port)
+            except OSError as e:
+                logger.warning("Could not start Prometheus server on port %d: %s", port, e)
+
+    async def on_run_start(self, event: RunStartEvent) -> None:
+        pass  # No metric on start — counted on complete
+
+    async def on_run_complete(self, event: RunCompleteEvent) -> None:
+        self._runs_total.labels(status=event.status).inc()
+
+    async def on_node_start(self, event: NodeStartEvent) -> None:
+        pass  # No metric on start — measured on complete
+
+    async def on_node_complete(self, event: NodeCompleteEvent) -> None:
+        self._node_duration.labels(
+            node_id=event.node_id, node_type=event.node_type
+        ).observe(event.latency_ms / 1000.0)
+
+        if event.tokens_used:
+            self._tokens_total.labels(node_id=event.node_id).inc(event.tokens_used)
+
+    async def on_node_error(self, event: NodeErrorEvent) -> None:
+        self._node_errors_total.labels(
+            node_id=event.node_id, node_type=event.node_type
+        ).inc()
+
+    async def on_decision_made(self, event: DecisionEvent) -> None:
+        self._decisions_total.inc()
+
+    async def on_tool_call(self, event: ToolCallEvent) -> None:
+        self._tool_calls_total.labels(
+            tool_name=event.tool_name,
+            is_error=str(event.is_error).lower(),
+        ).inc()

--- a/core/framework/observability/hooks.py
+++ b/core/framework/observability/hooks.py
@@ -1,0 +1,163 @@
+"""Observability hooks for agent lifecycle monitoring.
+
+ObservabilityHooks defines the contract for observing agent execution.
+Implementations receive events at key lifecycle points without modifying
+the core execution path.
+
+Built-in implementations:
+- NoOpHooks: Zero-overhead default (all methods are no-ops)
+- CompositeHooks: Fans out to multiple hook implementations
+
+Usage::
+
+    # Custom monitoring
+    class MyHooks(ObservabilityHooks):
+        async def on_node_start(self, event: NodeStartEvent) -> None:
+            print(f"Node {event.node_id} starting")
+
+    runtime = Runtime(
+        storage_path="./logs",
+        observability_hooks=MyHooks(),
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol, runtime_checkable
+
+from framework.observability.types import (
+    DecisionEvent,
+    NodeCompleteEvent,
+    NodeErrorEvent,
+    NodeStartEvent,
+    RunCompleteEvent,
+    RunStartEvent,
+    ToolCallEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class ObservabilityHooks(Protocol):
+    """Protocol for lifecycle event observers.
+
+    All methods are async to support non-blocking I/O (e.g., sending
+    metrics to a remote backend). Implementations MUST NOT raise —
+    hook failures should be logged and swallowed to avoid disrupting
+    agent execution.
+    """
+
+    async def on_run_start(self, event: RunStartEvent) -> None:
+        """Called when a graph run begins."""
+        ...
+
+    async def on_node_start(self, event: NodeStartEvent) -> None:
+        """Called when a node begins execution."""
+        ...
+
+    async def on_node_complete(self, event: NodeCompleteEvent) -> None:
+        """Called when a node finishes (success or failure)."""
+        ...
+
+    async def on_node_error(self, event: NodeErrorEvent) -> None:
+        """Called when a node raises an exception."""
+        ...
+
+    async def on_decision_made(self, event: DecisionEvent) -> None:
+        """Called when the agent records a decision via Runtime.decide()."""
+        ...
+
+    async def on_tool_call(self, event: ToolCallEvent) -> None:
+        """Called when a tool is invoked during node execution."""
+        ...
+
+    async def on_run_complete(self, event: RunCompleteEvent) -> None:
+        """Called when a graph run finishes."""
+        ...
+
+
+class NoOpHooks:
+    """Zero-overhead default implementation.
+
+    All methods are synchronous no-ops. Because the protocol methods
+    are async, calling code uses ``await``, but Python's ``await`` on
+    a regular method that returns ``None`` is essentially free.
+    """
+
+    async def on_run_start(self, event: RunStartEvent) -> None:
+        pass
+
+    async def on_node_start(self, event: NodeStartEvent) -> None:
+        pass
+
+    async def on_node_complete(self, event: NodeCompleteEvent) -> None:
+        pass
+
+    async def on_node_error(self, event: NodeErrorEvent) -> None:
+        pass
+
+    async def on_decision_made(self, event: DecisionEvent) -> None:
+        pass
+
+    async def on_tool_call(self, event: ToolCallEvent) -> None:
+        pass
+
+    async def on_run_complete(self, event: RunCompleteEvent) -> None:
+        pass
+
+
+class CompositeHooks:
+    """Fans out events to multiple hook implementations.
+
+    Useful for running multiple exporters simultaneously, e.g.
+    console + Prometheus + OTLP.
+
+    Exceptions in individual hooks are caught and logged — one failing
+    hook does not prevent others from receiving the event.
+
+    Usage::
+
+        hooks = CompositeHooks([
+            ConsoleExporter(),
+            PrometheusExporter(port=9090),
+        ])
+    """
+
+    def __init__(self, hooks: list[ObservabilityHooks]) -> None:
+        self._hooks = hooks
+
+    async def _dispatch(self, method_name: str, event: object) -> None:
+        """Dispatch an event to all registered hooks."""
+        for hook in self._hooks:
+            try:
+                method = getattr(hook, method_name)
+                await method(event)
+            except Exception:
+                logger.exception(
+                    "Observability hook %s.%s failed (non-fatal)",
+                    type(hook).__name__,
+                    method_name,
+                )
+
+    async def on_run_start(self, event: RunStartEvent) -> None:
+        await self._dispatch("on_run_start", event)
+
+    async def on_node_start(self, event: NodeStartEvent) -> None:
+        await self._dispatch("on_node_start", event)
+
+    async def on_node_complete(self, event: NodeCompleteEvent) -> None:
+        await self._dispatch("on_node_complete", event)
+
+    async def on_node_error(self, event: NodeErrorEvent) -> None:
+        await self._dispatch("on_node_error", event)
+
+    async def on_decision_made(self, event: DecisionEvent) -> None:
+        await self._dispatch("on_decision_made", event)
+
+    async def on_tool_call(self, event: ToolCallEvent) -> None:
+        await self._dispatch("on_tool_call", event)
+
+    async def on_run_complete(self, event: RunCompleteEvent) -> None:
+        await self._dispatch("on_run_complete", event)

--- a/core/framework/observability/semantic_conventions.py
+++ b/core/framework/observability/semantic_conventions.py
@@ -1,0 +1,54 @@
+"""Semantic conventions for Hive agent observability.
+
+Follows OpenTelemetry GenAI semantic conventions where applicable,
+with Hive-specific extensions prefixed ``hive.``.
+
+See: https://opentelemetry.io/docs/specs/semconv/gen-ai/
+"""
+
+# -- Span names --
+SPAN_AGENT_RUN = "agent.run"
+SPAN_NODE_EXECUTE = "node.execute"
+SPAN_TOOL_CALL = "tool.call"
+
+# -- Resource attributes --
+ATTR_FRAMEWORK_NAME = "agent.framework.name"
+ATTR_FRAMEWORK_VERSION = "agent.framework.version"
+FRAMEWORK_NAME = "hive"
+
+# -- Run attributes --
+ATTR_RUN_ID = "hive.run.id"
+ATTR_GOAL_ID = "hive.goal.id"
+ATTR_RUN_STATUS = "hive.run.status"
+ATTR_RUN_DURATION_MS = "hive.run.duration_ms"
+
+# -- Node attributes --
+ATTR_NODE_ID = "hive.node.id"
+ATTR_NODE_NAME = "hive.node.name"
+ATTR_NODE_TYPE = "hive.node.type"
+ATTR_NODE_LATENCY_MS = "hive.node.latency_ms"
+ATTR_NODE_SUCCESS = "hive.node.success"
+
+# -- LLM / token attributes (aligned with OTel GenAI semconv) --
+ATTR_LLM_TOKENS_INPUT = "gen_ai.usage.input_tokens"
+ATTR_LLM_TOKENS_OUTPUT = "gen_ai.usage.output_tokens"
+ATTR_LLM_TOKENS_TOTAL = "gen_ai.usage.total_tokens"
+
+# -- Decision attributes --
+ATTR_DECISION_ID = "hive.decision.id"
+ATTR_DECISION_INTENT = "hive.decision.intent"
+ATTR_DECISION_CHOSEN = "hive.decision.chosen"
+ATTR_DECISION_OPTIONS_COUNT = "hive.decision.options_count"
+
+# -- Tool attributes --
+ATTR_TOOL_NAME = "hive.tool.name"
+ATTR_TOOL_IS_ERROR = "hive.tool.is_error"
+ATTR_TOOL_LATENCY_MS = "hive.tool.latency_ms"
+
+# -- Metric names --
+METRIC_RUNS_TOTAL = "hive.agent.runs.total"
+METRIC_NODE_DURATION = "hive.node.duration"
+METRIC_TOKENS_USED = "hive.llm.tokens.used"
+METRIC_DECISIONS_TOTAL = "hive.decisions.total"
+METRIC_TOOL_CALLS_TOTAL = "hive.tool.calls.total"
+METRIC_NODE_ERRORS_TOTAL = "hive.node.errors.total"

--- a/core/framework/observability/telemetry_manager.py
+++ b/core/framework/observability/telemetry_manager.py
@@ -35,8 +35,7 @@ import threading
 from typing import Any
 
 try:
-    from opentelemetry import context as otel_context
-    from opentelemetry import trace
+    from opentelemetry import context as otel_context, trace
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.trace import StatusCode
 

--- a/core/framework/observability/telemetry_manager.py
+++ b/core/framework/observability/telemetry_manager.py
@@ -1,0 +1,244 @@
+"""OpenTelemetry-backed implementation of ObservabilityHooks.
+
+``TelemetryManager`` translates lifecycle events into OTel spans and metrics.
+Each agent run becomes a root span, each node becomes a child span, and
+counters/histograms track key operational metrics.
+
+Requires the ``observability`` optional dependency group::
+
+    pip install framework[observability]
+
+If OpenTelemetry is not installed, importing this module raises
+``ImportError`` — callers should gate usage behind a try/except or
+the ``ObservabilityConfig.enabled`` flag.
+
+Usage::
+
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+
+    manager = TelemetryManager(tracer_provider=provider)
+
+    runtime = Runtime(
+        storage_path="./logs",
+        observability_hooks=manager,
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+
+try:
+    from opentelemetry import context as otel_context
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.trace import StatusCode
+
+    HAS_OTEL = True
+except ImportError:
+    HAS_OTEL = False
+
+from framework.observability import semantic_conventions as sc
+from framework.observability.types import (
+    DecisionEvent,
+    NodeCompleteEvent,
+    NodeErrorEvent,
+    NodeStartEvent,
+    RunCompleteEvent,
+    RunStartEvent,
+    ToolCallEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TelemetryManager:
+    """Maps ObservabilityHooks events to OpenTelemetry spans and metrics.
+
+    Lifecycle mapping:
+    - ``on_run_start``   → starts root span ``agent.run``
+    - ``on_node_start``  → starts child span ``node.execute``
+    - ``on_node_complete`` → closes child span with OK status
+    - ``on_node_error``  → closes child span with ERROR status
+    - ``on_run_complete`` → closes root span
+
+    All spans carry Hive semantic convention attributes.
+    """
+
+    def __init__(
+        self,
+        tracer_provider: Any | None = None,
+        service_name: str = "hive-agent",
+    ) -> None:
+        if not HAS_OTEL:
+            raise ImportError(
+                "OpenTelemetry packages are required for TelemetryManager. "
+                "Install with: pip install opentelemetry-api opentelemetry-sdk"
+            )
+
+        if tracer_provider is None:
+            tracer_provider = TracerProvider()
+
+        self._tracer = trace.get_tracer(
+            instrumenting_module_name="framework.observability",
+            tracer_provider=tracer_provider,
+        )
+        self._service_name = service_name
+
+        # Active span tracking: run_id → span, (run_id, node_id) → span
+        self._lock = threading.Lock()
+        self._run_spans: dict[str, trace.Span] = {}
+        self._node_spans: dict[tuple[str, str], trace.Span] = {}
+        self._run_contexts: dict[str, Any] = {}
+
+    # -- Run lifecycle --
+
+    async def on_run_start(self, event: RunStartEvent) -> None:
+        span = self._tracer.start_span(
+            name=sc.SPAN_AGENT_RUN,
+            attributes={
+                sc.ATTR_FRAMEWORK_NAME: sc.FRAMEWORK_NAME,
+                sc.ATTR_RUN_ID: event.run_id,
+                sc.ATTR_GOAL_ID: event.goal_id,
+            },
+        )
+        ctx = trace.set_span_in_context(span)
+        token = otel_context.attach(ctx)
+        with self._lock:
+            self._run_spans[event.run_id] = span
+            self._run_contexts[event.run_id] = (ctx, token)
+
+    async def on_run_complete(self, event: RunCompleteEvent) -> None:
+        with self._lock:
+            span = self._run_spans.pop(event.run_id, None)
+            ctx_data = self._run_contexts.pop(event.run_id, None)
+        if span is None:
+            return
+
+        span.set_attribute(sc.ATTR_RUN_STATUS, event.status)
+        span.set_attribute(sc.ATTR_RUN_DURATION_MS, event.duration_ms)
+
+        if event.status == "success":
+            span.set_status(StatusCode.OK)
+        else:
+            span.set_status(StatusCode.ERROR, event.status)
+
+        span.end()
+
+        if ctx_data:
+            _, token = ctx_data
+            otel_context.detach(token)
+
+    # -- Node lifecycle --
+
+    async def on_node_start(self, event: NodeStartEvent) -> None:
+        with self._lock:
+            parent_ctx_data = self._run_contexts.get(event.run_id)
+        parent_ctx = parent_ctx_data[0] if parent_ctx_data else None
+
+        span = self._tracer.start_span(
+            name=f"{sc.SPAN_NODE_EXECUTE}.{event.node_id}",
+            context=parent_ctx,
+            attributes={
+                sc.ATTR_NODE_ID: event.node_id,
+                sc.ATTR_NODE_NAME: event.node_name,
+                sc.ATTR_NODE_TYPE: event.node_type,
+            },
+        )
+        with self._lock:
+            self._node_spans[(event.run_id, event.node_id)] = span
+
+    async def on_node_complete(self, event: NodeCompleteEvent) -> None:
+        with self._lock:
+            span = self._node_spans.pop((event.run_id, event.node_id), None)
+        if span is None:
+            return
+
+        span.set_attribute(sc.ATTR_NODE_SUCCESS, event.success)
+        span.set_attribute(sc.ATTR_NODE_LATENCY_MS, event.latency_ms)
+        if event.tokens_used:
+            span.set_attribute(sc.ATTR_LLM_TOKENS_TOTAL, event.tokens_used)
+        if event.input_tokens:
+            span.set_attribute(sc.ATTR_LLM_TOKENS_INPUT, event.input_tokens)
+        if event.output_tokens:
+            span.set_attribute(sc.ATTR_LLM_TOKENS_OUTPUT, event.output_tokens)
+
+        if event.success:
+            span.set_status(StatusCode.OK)
+        else:
+            span.set_status(StatusCode.ERROR, "Node execution failed")
+
+        span.end()
+
+    async def on_node_error(self, event: NodeErrorEvent) -> None:
+        with self._lock:
+            span = self._node_spans.get((event.run_id, event.node_id))
+        if span is None:
+            return
+
+        span.set_status(StatusCode.ERROR, event.error)
+        span.record_exception(
+            Exception(event.error),
+            attributes={"exception.stacktrace": event.stacktrace} if event.stacktrace else {},
+        )
+        # Don't end span here — on_node_complete will do it
+
+    # -- Decision + Tool (lightweight: add events to parent span) --
+
+    async def on_decision_made(self, event: DecisionEvent) -> None:
+        span = self._run_spans.get(event.run_id)
+        if span is None:
+            return
+
+        span.add_event(
+            "decision",
+            attributes={
+                sc.ATTR_DECISION_ID: event.decision_id,
+                sc.ATTR_DECISION_INTENT: event.intent,
+                sc.ATTR_DECISION_CHOSEN: event.chosen,
+                sc.ATTR_DECISION_OPTIONS_COUNT: event.options_count,
+            },
+        )
+
+    async def on_tool_call(self, event: ToolCallEvent) -> None:
+        # Add as event to the node span (or run span if node not found)
+        span = self._node_spans.get((event.run_id, event.node_id))
+        if span is None:
+            span = self._run_spans.get(event.run_id)
+        if span is None:
+            return
+
+        span.add_event(
+            "tool_call",
+            attributes={
+                sc.ATTR_TOOL_NAME: event.tool_name,
+                sc.ATTR_TOOL_IS_ERROR: event.is_error,
+                sc.ATTR_TOOL_LATENCY_MS: event.latency_ms,
+            },
+        )
+
+    # -- Cleanup --
+
+    def shutdown(self) -> None:
+        """End all active spans. Call on process shutdown to prevent leaks."""
+        with self._lock:
+            for span in self._node_spans.values():
+                span.set_status(StatusCode.ERROR, "shutdown: span not completed")
+                span.end()
+            self._node_spans.clear()
+
+            for span in self._run_spans.values():
+                span.set_status(StatusCode.ERROR, "shutdown: run not completed")
+                span.end()
+            self._run_spans.clear()
+
+            for ctx_data in self._run_contexts.values():
+                _, token = ctx_data
+                otel_context.detach(token)
+            self._run_contexts.clear()

--- a/core/framework/observability/types.py
+++ b/core/framework/observability/types.py
@@ -1,0 +1,101 @@
+"""Event types for the observability hook system.
+
+Each event dataclass captures the data passed to an ObservabilityHooks method.
+These provide a stable contract for exporters and custom hooks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RunStartEvent:
+    """Emitted when a graph run begins."""
+
+    run_id: str
+    goal_id: str
+    input_data: dict[str, Any] = field(default_factory=dict)
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+
+@dataclass(frozen=True)
+class NodeStartEvent:
+    """Emitted when a node begins execution."""
+
+    run_id: str
+    node_id: str
+    node_name: str
+    node_type: str
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+
+@dataclass(frozen=True)
+class NodeCompleteEvent:
+    """Emitted when a node finishes successfully."""
+
+    run_id: str
+    node_id: str
+    node_name: str
+    node_type: str
+    success: bool
+    latency_ms: int = 0
+    tokens_used: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+
+@dataclass(frozen=True)
+class NodeErrorEvent:
+    """Emitted when a node fails with an error."""
+
+    run_id: str
+    node_id: str
+    node_name: str
+    node_type: str
+    error: str
+    stacktrace: str = ""
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+
+@dataclass(frozen=True)
+class DecisionEvent:
+    """Emitted when the agent records a decision."""
+
+    run_id: str
+    decision_id: str
+    node_id: str
+    intent: str
+    chosen: str
+    reasoning: str
+    options_count: int = 0
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+
+@dataclass(frozen=True)
+class ToolCallEvent:
+    """Emitted when a tool is invoked during node execution."""
+
+    run_id: str
+    node_id: str
+    tool_name: str
+    tool_input: dict[str, Any] = field(default_factory=dict)
+    result: str = ""
+    is_error: bool = False
+    latency_ms: int = 0
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+
+@dataclass(frozen=True)
+class RunCompleteEvent:
+    """Emitted when a graph run finishes."""
+
+    run_id: str
+    status: str  # "success" | "failure" | "degraded"
+    duration_ms: int = 0
+    total_nodes_executed: int = 0
+    total_tokens: int = 0
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())

--- a/core/framework/runtime/core.py
+++ b/core/framework/runtime/core.py
@@ -92,9 +92,7 @@ class Runtime:
             return
         exc = task.exception()
         if exc is not None:
-            logger.debug(
-                "Observability hook failed (non-fatal): %s", exc, exc_info=exc
-            )
+            logger.debug("Observability hook failed (non-fatal): %s", exc, exc_info=exc)
 
     # === RUN LIFECYCLE ===
 
@@ -135,9 +133,7 @@ class Runtime:
         # Emit observability hook
         self._emit_hook_safe(
             self._hooks.on_run_start(
-                RunStartEvent(
-                    run_id=run_id, goal_id=goal_id, input_data=input_data or {}
-                )
+                RunStartEvent(run_id=run_id, goal_id=goal_id, input_data=input_data or {})
             )
         )
 

--- a/core/framework/runtime/runtime_log_schemas.py
+++ b/core/framework/runtime/runtime_log_schemas.py
@@ -44,8 +44,8 @@ class NodeStepLog(BaseModel):
     input_tokens: int = 0
     output_tokens: int = 0
     latency_ms: int = 0
-    # EventLoopNode only:
-    verdict: str = ""  # "ACCEPT"|"RETRY"|"ESCALATE"|"CONTINUE"
+    # EventLoopNode verdicts + lifecycle events:
+    verdict: str = ""  # "ACCEPT"|"RETRY"|"ESCALATE"|"CONTINUE"|"NODE_STARTED"
     verdict_feedback: str = ""
     # Error tracking:
     error: str = ""  # Error message if step failed

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -20,6 +20,13 @@ dependencies = [
 
 [project.optional-dependencies]
 tui = ["textual>=0.75.0"]
+observability = [
+    "opentelemetry-api>=1.20.0",
+    "opentelemetry-sdk>=1.20.0",
+    "opentelemetry-exporter-otlp>=1.20.0",
+    "opentelemetry-exporter-prometheus>=0.50b0",
+    "prometheus-client>=0.20.0",
+]
 
 [project.scripts]
 hive = "framework.cli:main"

--- a/core/tests/test_hooks.py
+++ b/core/tests/test_hooks.py
@@ -9,8 +9,7 @@ Tests cover:
 
 from __future__ import annotations
 
-import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -29,7 +28,6 @@ from framework.observability.types import (
     RunStartEvent,
     ToolCallEvent,
 )
-
 
 # ---------------------------------------------------------------------------
 # Event type tests
@@ -142,14 +140,10 @@ class TestNoOpHooks:
             NodeStartEvent(run_id="r", node_id="n", node_name="N", node_type="t")
         )
         await hooks.on_node_complete(
-            NodeCompleteEvent(
-                run_id="r", node_id="n", node_name="N", node_type="t", success=True
-            )
+            NodeCompleteEvent(run_id="r", node_id="n", node_name="N", node_type="t", success=True)
         )
         await hooks.on_node_error(
-            NodeErrorEvent(
-                run_id="r", node_id="n", node_name="N", node_type="t", error="err"
-            )
+            NodeErrorEvent(run_id="r", node_id="n", node_name="N", node_type="t", error="err")
         )
         await hooks.on_decision_made(
             DecisionEvent(
@@ -161,9 +155,7 @@ class TestNoOpHooks:
                 reasoning="r",
             )
         )
-        await hooks.on_tool_call(
-            ToolCallEvent(run_id="r", node_id="n", tool_name="t")
-        )
+        await hooks.on_tool_call(ToolCallEvent(run_id="r", node_id="n", tool_name="t"))
         await hooks.on_run_complete(RunCompleteEvent(run_id="r", status="success"))
 
     def test_satisfies_protocol(self):
@@ -219,14 +211,10 @@ class TestCompositeHooks:
             NodeStartEvent(run_id="r", node_id="n", node_name="N", node_type="t")
         )
         await composite.on_node_complete(
-            NodeCompleteEvent(
-                run_id="r", node_id="n", node_name="N", node_type="t", success=True
-            )
+            NodeCompleteEvent(run_id="r", node_id="n", node_name="N", node_type="t", success=True)
         )
         await composite.on_node_error(
-            NodeErrorEvent(
-                run_id="r", node_id="n", node_name="N", node_type="t", error="e"
-            )
+            NodeErrorEvent(run_id="r", node_id="n", node_name="N", node_type="t", error="e")
         )
         await composite.on_decision_made(
             DecisionEvent(
@@ -238,9 +226,7 @@ class TestCompositeHooks:
                 reasoning="r",
             )
         )
-        await composite.on_tool_call(
-            ToolCallEvent(run_id="r", node_id="n", tool_name="t")
-        )
+        await composite.on_tool_call(ToolCallEvent(run_id="r", node_id="n", tool_name="t"))
         await composite.on_run_complete(RunCompleteEvent(run_id="r", status="success"))
 
         # All 7 methods should have been called

--- a/core/tests/test_hooks.py
+++ b/core/tests/test_hooks.py
@@ -1,0 +1,368 @@
+"""Tests for the observability hook system.
+
+Tests cover:
+- NoOpHooks zero-overhead behavior
+- CompositeHooks fan-out and error isolation
+- ObservabilityConfig validation
+- Event dataclass construction
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from framework.observability.config import ObservabilityConfig
+from framework.observability.hooks import (
+    CompositeHooks,
+    NoOpHooks,
+    ObservabilityHooks,
+)
+from framework.observability.types import (
+    DecisionEvent,
+    NodeCompleteEvent,
+    NodeErrorEvent,
+    NodeStartEvent,
+    RunCompleteEvent,
+    RunStartEvent,
+    ToolCallEvent,
+)
+
+
+# ---------------------------------------------------------------------------
+# Event type tests
+# ---------------------------------------------------------------------------
+
+
+class TestEventTypes:
+    def test_run_start_event_defaults(self):
+        event = RunStartEvent(run_id="run-1", goal_id="goal-1")
+        assert event.run_id == "run-1"
+        assert event.goal_id == "goal-1"
+        assert event.input_data == {}
+        assert event.timestamp  # auto-generated
+
+    def test_node_start_event(self):
+        event = NodeStartEvent(
+            run_id="run-1",
+            node_id="node-1",
+            node_name="Search",
+            node_type="event_loop",
+        )
+        assert event.node_id == "node-1"
+        assert event.node_name == "Search"
+        assert event.node_type == "event_loop"
+
+    def test_node_complete_event_with_metrics(self):
+        event = NodeCompleteEvent(
+            run_id="run-1",
+            node_id="node-1",
+            node_name="Search",
+            node_type="event_loop",
+            success=True,
+            latency_ms=1500,
+            tokens_used=300,
+            input_tokens=200,
+            output_tokens=100,
+        )
+        assert event.success is True
+        assert event.latency_ms == 1500
+        assert event.tokens_used == 300
+
+    def test_node_error_event(self):
+        event = NodeErrorEvent(
+            run_id="run-1",
+            node_id="node-1",
+            node_name="Broken",
+            node_type="function",
+            error="Connection timeout",
+            stacktrace="Traceback...",
+        )
+        assert event.error == "Connection timeout"
+        assert event.stacktrace == "Traceback..."
+
+    def test_decision_event(self):
+        event = DecisionEvent(
+            run_id="run-1",
+            decision_id="dec-1",
+            node_id="node-1",
+            intent="Choose search strategy",
+            chosen="web_search",
+            reasoning="Most relevant",
+            options_count=3,
+        )
+        assert event.chosen == "web_search"
+        assert event.options_count == 3
+
+    def test_tool_call_event(self):
+        event = ToolCallEvent(
+            run_id="run-1",
+            node_id="node-1",
+            tool_name="web_search",
+            tool_input={"query": "test"},
+            result="Found 3 results",
+            is_error=False,
+            latency_ms=500,
+        )
+        assert event.tool_name == "web_search"
+        assert event.is_error is False
+
+    def test_run_complete_event(self):
+        event = RunCompleteEvent(
+            run_id="run-1",
+            status="success",
+            duration_ms=5000,
+            total_nodes_executed=3,
+            total_tokens=1500,
+        )
+        assert event.status == "success"
+        assert event.duration_ms == 5000
+
+    def test_events_are_frozen(self):
+        """Event dataclasses should be immutable."""
+        event = RunStartEvent(run_id="run-1", goal_id="goal-1")
+        with pytest.raises(AttributeError):
+            event.run_id = "changed"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# NoOpHooks tests
+# ---------------------------------------------------------------------------
+
+
+class TestNoOpHooks:
+    @pytest.mark.asyncio
+    async def test_all_methods_are_callable(self):
+        """NoOpHooks should accept all event types without error."""
+        hooks = NoOpHooks()
+        await hooks.on_run_start(RunStartEvent(run_id="r", goal_id="g"))
+        await hooks.on_node_start(
+            NodeStartEvent(run_id="r", node_id="n", node_name="N", node_type="t")
+        )
+        await hooks.on_node_complete(
+            NodeCompleteEvent(
+                run_id="r", node_id="n", node_name="N", node_type="t", success=True
+            )
+        )
+        await hooks.on_node_error(
+            NodeErrorEvent(
+                run_id="r", node_id="n", node_name="N", node_type="t", error="err"
+            )
+        )
+        await hooks.on_decision_made(
+            DecisionEvent(
+                run_id="r",
+                decision_id="d",
+                node_id="n",
+                intent="i",
+                chosen="c",
+                reasoning="r",
+            )
+        )
+        await hooks.on_tool_call(
+            ToolCallEvent(run_id="r", node_id="n", tool_name="t")
+        )
+        await hooks.on_run_complete(RunCompleteEvent(run_id="r", status="success"))
+
+    def test_satisfies_protocol(self):
+        """NoOpHooks should be recognized as an ObservabilityHooks instance."""
+        hooks = NoOpHooks()
+        assert isinstance(hooks, ObservabilityHooks)
+
+
+# ---------------------------------------------------------------------------
+# CompositeHooks tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompositeHooks:
+    @pytest.mark.asyncio
+    async def test_dispatches_to_all_hooks(self):
+        """CompositeHooks should call every registered hook."""
+        hook_a = AsyncMock(spec=NoOpHooks)
+        hook_b = AsyncMock(spec=NoOpHooks)
+
+        composite = CompositeHooks([hook_a, hook_b])
+
+        event = RunStartEvent(run_id="run-1", goal_id="goal-1")
+        await composite.on_run_start(event)
+
+        hook_a.on_run_start.assert_awaited_once_with(event)
+        hook_b.on_run_start.assert_awaited_once_with(event)
+
+    @pytest.mark.asyncio
+    async def test_error_isolation(self):
+        """One failing hook should not prevent others from receiving events."""
+        hook_good = AsyncMock(spec=NoOpHooks)
+        hook_bad = AsyncMock(spec=NoOpHooks)
+        hook_bad.on_run_start.side_effect = RuntimeError("hook crashed")
+
+        composite = CompositeHooks([hook_bad, hook_good])
+
+        event = RunStartEvent(run_id="run-1", goal_id="goal-1")
+        # Should not raise
+        await composite.on_run_start(event)
+
+        # The good hook should still be called
+        hook_good.on_run_start.assert_awaited_once_with(event)
+
+    @pytest.mark.asyncio
+    async def test_all_event_types_dispatched(self):
+        """CompositeHooks should dispatch all 7 event types."""
+        hook = AsyncMock(spec=NoOpHooks)
+        composite = CompositeHooks([hook])
+
+        await composite.on_run_start(RunStartEvent(run_id="r", goal_id="g"))
+        await composite.on_node_start(
+            NodeStartEvent(run_id="r", node_id="n", node_name="N", node_type="t")
+        )
+        await composite.on_node_complete(
+            NodeCompleteEvent(
+                run_id="r", node_id="n", node_name="N", node_type="t", success=True
+            )
+        )
+        await composite.on_node_error(
+            NodeErrorEvent(
+                run_id="r", node_id="n", node_name="N", node_type="t", error="e"
+            )
+        )
+        await composite.on_decision_made(
+            DecisionEvent(
+                run_id="r",
+                decision_id="d",
+                node_id="n",
+                intent="i",
+                chosen="c",
+                reasoning="r",
+            )
+        )
+        await composite.on_tool_call(
+            ToolCallEvent(run_id="r", node_id="n", tool_name="t")
+        )
+        await composite.on_run_complete(RunCompleteEvent(run_id="r", status="success"))
+
+        # All 7 methods should have been called
+        assert hook.on_run_start.await_count == 1
+        assert hook.on_node_start.await_count == 1
+        assert hook.on_node_complete.await_count == 1
+        assert hook.on_node_error.await_count == 1
+        assert hook.on_decision_made.await_count == 1
+        assert hook.on_tool_call.await_count == 1
+        assert hook.on_run_complete.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_hooks_list(self):
+        """CompositeHooks with no hooks should be a no-op."""
+        composite = CompositeHooks([])
+        # Should not raise
+        await composite.on_run_start(RunStartEvent(run_id="r", goal_id="g"))
+
+
+# ---------------------------------------------------------------------------
+# ObservabilityConfig tests
+# ---------------------------------------------------------------------------
+
+
+class TestObservabilityConfig:
+    def test_default_config(self):
+        config = ObservabilityConfig()
+        assert config.enabled is True
+        assert config.hooks == []
+        assert config.sample_rate == 1.0
+
+    def test_invalid_sample_rate_raises(self):
+        with pytest.raises(ValueError, match="sample_rate"):
+            ObservabilityConfig(sample_rate=1.5)
+        with pytest.raises(ValueError, match="sample_rate"):
+            ObservabilityConfig(sample_rate=-0.1)
+
+    def test_should_sample_disabled(self):
+        config = ObservabilityConfig(enabled=False)
+        assert config.should_sample() is False
+
+    def test_should_sample_full_rate(self):
+        config = ObservabilityConfig(enabled=True, sample_rate=1.0)
+        # Must always be True at 100% rate
+        for _ in range(100):
+            assert config.should_sample() is True
+
+    def test_should_sample_zero_rate(self):
+        config = ObservabilityConfig(enabled=True, sample_rate=0.0)
+        # Must always be False at 0% rate
+        for _ in range(100):
+            assert config.should_sample() is False
+
+    def test_should_sample_partial_rate(self):
+        """At 50% sample rate, some should be True and some False."""
+        config = ObservabilityConfig(enabled=True, sample_rate=0.5)
+        results = [config.should_sample() for _ in range(1000)]
+        # Very unlikely all True or all False at 50%
+        assert any(results)
+        assert not all(results)
+
+
+# ---------------------------------------------------------------------------
+# Custom hook implementation test
+# ---------------------------------------------------------------------------
+
+
+class TestCustomHookImplementation:
+    @pytest.mark.asyncio
+    async def test_custom_hook_receives_events(self):
+        """A user-defined hook implementation should receive all events."""
+
+        class EventCollector:
+            """Collects events for testing."""
+
+            def __init__(self):
+                self.events: list = []
+
+            async def on_run_start(self, event: RunStartEvent) -> None:
+                self.events.append(("run_start", event))
+
+            async def on_node_start(self, event: NodeStartEvent) -> None:
+                self.events.append(("node_start", event))
+
+            async def on_node_complete(self, event: NodeCompleteEvent) -> None:
+                self.events.append(("node_complete", event))
+
+            async def on_node_error(self, event: NodeErrorEvent) -> None:
+                self.events.append(("node_error", event))
+
+            async def on_decision_made(self, event: DecisionEvent) -> None:
+                self.events.append(("decision", event))
+
+            async def on_tool_call(self, event: ToolCallEvent) -> None:
+                self.events.append(("tool_call", event))
+
+            async def on_run_complete(self, event: RunCompleteEvent) -> None:
+                self.events.append(("run_complete", event))
+
+        collector = EventCollector()
+
+        # Simulate a run lifecycle
+        await collector.on_run_start(RunStartEvent(run_id="r1", goal_id="g1"))
+        await collector.on_node_start(
+            NodeStartEvent(run_id="r1", node_id="n1", node_name="Search", node_type="event_loop")
+        )
+        await collector.on_node_complete(
+            NodeCompleteEvent(
+                run_id="r1",
+                node_id="n1",
+                node_name="Search",
+                node_type="event_loop",
+                success=True,
+                latency_ms=1000,
+            )
+        )
+        await collector.on_run_complete(
+            RunCompleteEvent(run_id="r1", status="success", duration_ms=1000)
+        )
+
+        assert len(collector.events) == 4
+        assert collector.events[0][0] == "run_start"
+        assert collector.events[1][0] == "node_start"
+        assert collector.events[2][0] == "node_complete"
+        assert collector.events[3][0] == "run_complete"

--- a/uv.lock
+++ b/uv.lock
@@ -5,9 +5,12 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
 [manifest]
@@ -771,6 +774,13 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+observability = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-exporter-prometheus" },
+    { name = "opentelemetry-sdk" },
+    { name = "prometheus-client" },
+]
 tui = [
     { name = "textual" },
 ]
@@ -788,6 +798,11 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "litellm", specifier = ">=1.81.0" },
     { name = "mcp", specifier = ">=1.0.0" },
+    { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.20.0" },
+    { name = "opentelemetry-exporter-otlp", marker = "extra == 'observability'", specifier = ">=1.20.0" },
+    { name = "opentelemetry-exporter-prometheus", marker = "extra == 'observability'", specifier = ">=0.50b0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'observability'", specifier = ">=1.20.0" },
+    { name = "prometheus-client", marker = "extra == 'observability'", specifier = ">=0.20.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
@@ -796,7 +811,7 @@ requires-dist = [
     { name = "textual", marker = "extra == 'tui'", specifier = ">=0.75.0" },
     { name = "tools", editable = "tools" },
 ]
-provides-extras = ["tui"]
+provides-extras = ["tui", "observability"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -919,6 +934,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.72.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/7b/adfd75544c415c487b33061fe7ae526165241c1ea133f9a9125a56b39fd8/googleapis_common_protos-1.72.0.tar.gz", hash = "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5", size = 147433, upload-time = "2025-11-06T18:29:24.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ab/09169d5a4612a5f92490806649ac8d41e3ec9129c636754575b3553f4ea4/googleapis_common_protos-1.72.0-py3-none-any.whl", hash = "sha256:4299c5a82d5ae1a9702ada957347726b167f9f8d1fc352477702a1e851ff4038", size = 297515, upload-time = "2025-11-06T18:29:13.14Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -968,6 +995,57 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/97/43/8bf0ffa3d498eeee4c58c212a3905dd6146c01c8dc0b0a046481ca29b18c/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ed6b402bc74d6557a705e197d47f9063733091ed6357b3de33619d8a8d93ac53", size = 1614917, upload-time = "2026-01-23T16:04:26.276Z" },
     { url = "https://files.pythonhosted.org/packages/89/90/a3be7a5f378fc6e84abe4dcfb2ba32b07786861172e502388b4c90000d1b/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:59913f1e5ada20fde795ba906916aea25d442abcc0593fba7e26c92b7ad76249", size = 1676092, upload-time = "2026-01-23T15:33:52.176Z" },
     { url = "https://files.pythonhosted.org/packages/e1/2b/98c7f93e6db9977aaee07eb1e51ca63bd5f779b900d362791d3252e60558/greenlet-3.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:301860987846c24cb8964bdec0e31a96ad4a2a801b41b4ef40963c1b44f33451", size = 233181, upload-time = "2026-01-23T15:33:00.29Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.78.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", size = 12852416, upload-time = "2026-02-06T09:57:18.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/c7/d0b780a29b0837bf4ca9580904dfb275c1fc321ded7897d620af7047ec57/grpcio-1.78.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:2777b783f6c13b92bd7b716667452c329eefd646bfb3f2e9dabea2e05dbd34f6", size = 5951525, upload-time = "2026-02-06T09:55:01.989Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b1/96920bf2ee61df85a9503cb6f733fe711c0ff321a5a697d791b075673281/grpcio-1.78.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:9dca934f24c732750389ce49d638069c3892ad065df86cb465b3fa3012b70c9e", size = 11830418, upload-time = "2026-02-06T09:55:04.462Z" },
+    { url = "https://files.pythonhosted.org/packages/83/0c/7c1528f098aeb75a97de2bae18c530f56959fb7ad6c882db45d9884d6edc/grpcio-1.78.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:459ab414b35f4496138d0ecd735fed26f1318af5e52cb1efbc82a09f0d5aa911", size = 6524477, upload-time = "2026-02-06T09:55:07.111Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/52/e7c1f3688f949058e19a011c4e0dec973da3d0ae5e033909677f967ae1f4/grpcio-1.78.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:082653eecbdf290e6e3e2c276ab2c54b9e7c299e07f4221872380312d8cf395e", size = 7198266, upload-time = "2026-02-06T09:55:10.016Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/61/8ac32517c1e856677282c34f2e7812d6c328fa02b8f4067ab80e77fdc9c9/grpcio-1.78.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:85f93781028ec63f383f6bc90db785a016319c561cc11151fbb7b34e0d012303", size = 6730552, upload-time = "2026-02-06T09:55:12.207Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/98/b8ee0158199250220734f620b12e4a345955ac7329cfd908d0bf0fda77f0/grpcio-1.78.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f12857d24d98441af6a1d5c87442d624411db486f7ba12550b07788f74b67b04", size = 7304296, upload-time = "2026-02-06T09:55:15.044Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/0f/7b72762e0d8840b58032a56fdbd02b78fc645b9fa993d71abf04edbc54f4/grpcio-1.78.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5397fff416b79e4b284959642a4e95ac4b0f1ece82c9993658e0e477d40551ec", size = 8288298, upload-time = "2026-02-06T09:55:17.276Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ae/ae4ce56bc5bb5caa3a486d60f5f6083ac3469228faa734362487176c15c5/grpcio-1.78.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:fbe6e89c7ffb48518384068321621b2a69cab509f58e40e4399fdd378fa6d074", size = 7730953, upload-time = "2026-02-06T09:55:19.545Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/6e/8052e3a28eb6a820c372b2eb4b5e32d195c661e137d3eca94d534a4cfd8a/grpcio-1.78.0-cp311-cp311-win32.whl", hash = "sha256:6092beabe1966a3229f599d7088b38dfc8ffa1608b5b5cdda31e591e6500f856", size = 4076503, upload-time = "2026-02-06T09:55:21.521Z" },
+    { url = "https://files.pythonhosted.org/packages/08/62/f22c98c5265dfad327251fa2f840b591b1df5f5e15d88b19c18c86965b27/grpcio-1.78.0-cp311-cp311-win_amd64.whl", hash = "sha256:1afa62af6e23f88629f2b29ec9e52ec7c65a7176c1e0a83292b93c76ca882558", size = 4799767, upload-time = "2026-02-06T09:55:24.107Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f4/7384ed0178203d6074446b3c4f46c90a22ddf7ae0b3aee521627f54cfc2a/grpcio-1.78.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:f9ab915a267fc47c7e88c387a3a28325b58c898e23d4995f765728f4e3dedb97", size = 5913985, upload-time = "2026-02-06T09:55:26.832Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ed/be1caa25f06594463f685b3790b320f18aea49b33166f4141bfdc2bfb236/grpcio-1.78.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3f8904a8165ab21e07e58bf3e30a73f4dffc7a1e0dbc32d51c61b5360d26f43e", size = 11811853, upload-time = "2026-02-06T09:55:29.224Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a7/f06d151afc4e64b7e3cc3e872d331d011c279aaab02831e40a81c691fb65/grpcio-1.78.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:859b13906ce098c0b493af92142ad051bf64c7870fa58a123911c88606714996", size = 6475766, upload-time = "2026-02-06T09:55:31.825Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a8/4482922da832ec0082d0f2cc3a10976d84a7424707f25780b82814aafc0a/grpcio-1.78.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b2342d87af32790f934a79c3112641e7b27d63c261b8b4395350dad43eff1dc7", size = 7170027, upload-time = "2026-02-06T09:55:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bf/f4a3b9693e35d25b24b0b39fa46d7d8a3c439e0a3036c3451764678fec20/grpcio-1.78.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:12a771591ae40bc65ba67048fa52ef4f0e6db8279e595fd349f9dfddeef571f9", size = 6690766, upload-time = "2026-02-06T09:55:36.902Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/521875265cc99fe5ad4c5a17010018085cae2810a928bf15ebe7d8bcd9cc/grpcio-1.78.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:185dea0d5260cbb2d224c507bf2a5444d5abbb1fa3594c1ed7e4c709d5eb8383", size = 7266161, upload-time = "2026-02-06T09:55:39.824Z" },
+    { url = "https://files.pythonhosted.org/packages/05/86/296a82844fd40a4ad4a95f100b55044b4f817dece732bf686aea1a284147/grpcio-1.78.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:51b13f9aed9d59ee389ad666b8c2214cc87b5de258fa712f9ab05f922e3896c6", size = 8253303, upload-time = "2026-02-06T09:55:42.353Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e4/ea3c0caf5468537f27ad5aab92b681ed7cc0ef5f8c9196d3fd42c8c2286b/grpcio-1.78.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd5f135b1bd58ab088930b3c613455796dfa0393626a6972663ccdda5b4ac6ce", size = 7698222, upload-time = "2026-02-06T09:55:44.629Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/47/7f05f81e4bb6b831e93271fb12fd52ba7b319b5402cbc101d588f435df00/grpcio-1.78.0-cp312-cp312-win32.whl", hash = "sha256:94309f498bcc07e5a7d16089ab984d42ad96af1d94b5a4eb966a266d9fcabf68", size = 4066123, upload-time = "2026-02-06T09:55:47.644Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/e7/d6914822c88aa2974dbbd10903d801a28a19ce9cd8bad7e694cbbcf61528/grpcio-1.78.0-cp312-cp312-win_amd64.whl", hash = "sha256:9566fe4ababbb2610c39190791e5b829869351d14369603702e890ef3ad2d06e", size = 4797657, upload-time = "2026-02-06T09:55:49.86Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a9/8f75894993895f361ed8636cd9237f4ab39ef87fd30db17467235ed1c045/grpcio-1.78.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:ce3a90455492bf8bfa38e56fbbe1dbd4f872a3d8eeaf7337dc3b1c8aa28c271b", size = 5920143, upload-time = "2026-02-06T09:55:52.035Z" },
+    { url = "https://files.pythonhosted.org/packages/55/06/0b78408e938ac424100100fd081189451b472236e8a3a1f6500390dc4954/grpcio-1.78.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:2bf5e2e163b356978b23652c4818ce4759d40f4712ee9ec5a83c4be6f8c23a3a", size = 11803926, upload-time = "2026-02-06T09:55:55.494Z" },
+    { url = "https://files.pythonhosted.org/packages/88/93/b59fe7832ff6ae3c78b813ea43dac60e295fa03606d14d89d2e0ec29f4f3/grpcio-1.78.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8f2ac84905d12918e4e55a16da17939eb63e433dc11b677267c35568aa63fc84", size = 6478628, upload-time = "2026-02-06T09:55:58.533Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/df/e67e3734527f9926b7d9c0dde6cd998d1d26850c3ed8eeec81297967ac67/grpcio-1.78.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b58f37edab4a3881bc6c9bca52670610e0c9ca14e2ea3cf9debf185b870457fb", size = 7173574, upload-time = "2026-02-06T09:56:01.786Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/cc03fffb07bfba982a9ec097b164e8835546980aec25ecfa5f9c1a47e022/grpcio-1.78.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:735e38e176a88ce41840c21bb49098ab66177c64c82426e24e0082500cc68af5", size = 6692639, upload-time = "2026-02-06T09:56:04.529Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9a/289c32e301b85bdb67d7ec68b752155e674ee3ba2173a1858f118e399ef3/grpcio-1.78.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2045397e63a7a0ee7957c25f7dbb36ddc110e0cfb418403d110c0a7a68a844e9", size = 7268838, upload-time = "2026-02-06T09:56:08.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/79/1be93f32add280461fa4773880196572563e9c8510861ac2da0ea0f892b6/grpcio-1.78.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a9f136fbafe7ccf4ac7e8e0c28b31066e810be52d6e344ef954a3a70234e1702", size = 8251878, upload-time = "2026-02-06T09:56:10.914Z" },
+    { url = "https://files.pythonhosted.org/packages/65/65/793f8e95296ab92e4164593674ae6291b204bb5f67f9d4a711489cd30ffa/grpcio-1.78.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:748b6138585379c737adc08aeffd21222abbda1a86a0dca2a39682feb9196c20", size = 7695412, upload-time = "2026-02-06T09:56:13.593Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9f/1e233fe697ecc82845942c2822ed06bb522e70d6771c28d5528e4c50f6a4/grpcio-1.78.0-cp313-cp313-win32.whl", hash = "sha256:271c73e6e5676afe4fc52907686670c7cea22ab2310b76a59b678403ed40d670", size = 4064899, upload-time = "2026-02-06T09:56:15.601Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/27/d86b89e36de8a951501fb06a0f38df19853210f341d0b28f83f4aa0ffa08/grpcio-1.78.0-cp313-cp313-win_amd64.whl", hash = "sha256:f2d4e43ee362adfc05994ed479334d5a451ab7bc3f3fee1b796b8ca66895acb4", size = 4797393, upload-time = "2026-02-06T09:56:17.882Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f2/b56e43e3c968bfe822fa6ce5bca10d5c723aa40875b48791ce1029bb78c7/grpcio-1.78.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:e87cbc002b6f440482b3519e36e1313eb5443e9e9e73d6a52d43bd2004fcfd8e", size = 5920591, upload-time = "2026-02-06T09:56:20.758Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/81/1f3b65bd30c334167bfa8b0d23300a44e2725ce39bba5b76a2460d85f745/grpcio-1.78.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:c41bc64626db62e72afec66b0c8a0da76491510015417c127bfc53b2fe6d7f7f", size = 11813685, upload-time = "2026-02-06T09:56:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/1c/bbe2f8216a5bd3036119c544d63c2e592bdf4a8ec6e4a1867592f4586b26/grpcio-1.78.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8dfffba826efcf366b1e3ccc37e67afe676f290e13a3b48d31a46739f80a8724", size = 6487803, upload-time = "2026-02-06T09:56:27.367Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5c/a6b2419723ea7ddce6308259a55e8e7593d88464ce8db9f4aa857aba96fa/grpcio-1.78.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:74be1268d1439eaaf552c698cdb11cd594f0c49295ae6bb72c34ee31abbe611b", size = 7173206, upload-time = "2026-02-06T09:56:29.876Z" },
+    { url = "https://files.pythonhosted.org/packages/df/1e/b8801345629a415ea7e26c83d75eb5dbe91b07ffe5210cc517348a8d4218/grpcio-1.78.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be63c88b32e6c0f1429f1398ca5c09bc64b0d80950c8bb7807d7d7fb36fb84c7", size = 6693826, upload-time = "2026-02-06T09:56:32.305Z" },
+    { url = "https://files.pythonhosted.org/packages/34/84/0de28eac0377742679a510784f049738a80424b17287739fc47d63c2439e/grpcio-1.78.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3c586ac70e855c721bda8f548d38c3ca66ac791dc49b66a8281a1f99db85e452", size = 7277897, upload-time = "2026-02-06T09:56:34.915Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/9c/ad8685cfe20559a9edb66f735afdcb2b7d3de69b13666fdfc542e1916ebd/grpcio-1.78.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:35eb275bf1751d2ffbd8f57cdbc46058e857cf3971041521b78b7db94bdaf127", size = 8252404, upload-time = "2026-02-06T09:56:37.553Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/05/33a7a4985586f27e1de4803887c417ec7ced145ebd069bc38a9607059e2b/grpcio-1.78.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:207db540302c884b8848036b80db352a832b99dfdf41db1eb554c2c2c7800f65", size = 7696837, upload-time = "2026-02-06T09:56:40.173Z" },
+    { url = "https://files.pythonhosted.org/packages/73/77/7382241caf88729b106e49e7d18e3116216c778e6a7e833826eb96de22f7/grpcio-1.78.0-cp314-cp314-win32.whl", hash = "sha256:57bab6deef2f4f1ca76cc04565df38dc5713ae6c17de690721bdf30cb1e0545c", size = 4142439, upload-time = "2026-02-06T09:56:43.258Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b2/b096ccce418882fbfda4f7496f9357aaa9a5af1896a9a7f60d9f2b275a06/grpcio-1.78.0-cp314-cp314-win_amd64.whl", hash = "sha256:dce09d6116df20a96acfdbf85e4866258c3758180e8c49845d6ba8248b6d0bbb", size = 4929852, upload-time = "2026-02-06T09:56:45.885Z" },
 ]
 
 [[package]]
@@ -1804,6 +1882,120 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-otlp"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/9c/3ab1db90f32da200dba332658f2bbe602369e3d19f6aba394031a42635be/opentelemetry_exporter_otlp-1.39.1.tar.gz", hash = "sha256:7cf7470e9fd0060c8a38a23e4f695ac686c06a48ad97f8d4867bc9b420180b9c", size = 6147, upload-time = "2025-12-11T13:32:40.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/6c/bdc82a066e6fb1dcf9e8cc8d4e026358fe0f8690700cc6369a6bf9bd17a7/opentelemetry_exporter_otlp-1.39.1-py3-none-any.whl", hash = "sha256:68ae69775291f04f000eb4b698ff16ff685fdebe5cb52871bc4e87938a7b00fe", size = 7019, upload-time = "2025-12-11T13:32:19.387Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/9d/22d241b66f7bbde88a3bfa6847a351d2c46b84de23e71222c6aae25c7050/opentelemetry_exporter_otlp_proto_common-1.39.1.tar.gz", hash = "sha256:763370d4737a59741c89a67b50f9e39271639ee4afc999dadfe768541c027464", size = 20409, upload-time = "2025-12-11T13:32:40.885Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/02/ffc3e143d89a27ac21fd557365b98bd0653b98de8a101151d5805b5d4c33/opentelemetry_exporter_otlp_proto_common-1.39.1-py3-none-any.whl", hash = "sha256:08f8a5862d64cc3435105686d0216c1365dc5701f86844a8cd56597d0c764fde", size = 18366, upload-time = "2025-12-11T13:32:20.2Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/48/b329fed2c610c2c32c9366d9dc597202c9d1e58e631c137ba15248d8850f/opentelemetry_exporter_otlp_proto_grpc-1.39.1.tar.gz", hash = "sha256:772eb1c9287485d625e4dbe9c879898e5253fea111d9181140f51291b5fec3ad", size = 24650, upload-time = "2025-12-11T13:32:41.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/a3/cc9b66575bd6597b98b886a2067eea2693408d2d5f39dad9ab7fc264f5f3/opentelemetry_exporter_otlp_proto_grpc-1.39.1-py3-none-any.whl", hash = "sha256:fa1c136a05c7e9b4c09f739469cbdb927ea20b34088ab1d959a849b5cc589c18", size = 19766, upload-time = "2025-12-11T13:32:21.027Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/04/2a08fa9c0214ae38880df01e8bfae12b067ec0793446578575e5080d6545/opentelemetry_exporter_otlp_proto_http-1.39.1.tar.gz", hash = "sha256:31bdab9745c709ce90a49a0624c2bd445d31a28ba34275951a6a362d16a0b9cb", size = 17288, upload-time = "2025-12-11T13:32:42.029Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/f1/b27d3e2e003cd9a3592c43d099d2ed8d0a947c15281bf8463a256db0b46c/opentelemetry_exporter_otlp_proto_http-1.39.1-py3-none-any.whl", hash = "sha256:d9f5207183dd752a412c4cd564ca8875ececba13be6e9c6c370ffb752fd59985", size = 19641, upload-time = "2025-12-11T13:32:22.248Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-prometheus"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "prometheus-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/39/7dafa6fff210737267bed35a8855b6ac7399b9e582b8cf1f25f842517012/opentelemetry_exporter_prometheus-0.60b1.tar.gz", hash = "sha256:a4011b46906323f71724649d301b4dc188aaa068852e814f4df38cc76eac616b", size = 14976, upload-time = "2025-12-11T13:32:42.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/0d/4be6bf5477a3eb3d917d2f17d3c0b6720cd6cb97898444a61d43cc983f5c/opentelemetry_exporter_prometheus-0.60b1-py3-none-any.whl", hash = "sha256:49f59178de4f4590e3cef0b8b95cf6e071aae70e1f060566df5546fad773b8fd", size = 13019, upload-time = "2025-12-11T13:32:23.974Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/1d/f25d76d8260c156c40c97c9ed4511ec0f9ce353f8108ca6e7561f82a06b2/opentelemetry_proto-1.39.1.tar.gz", hash = "sha256:6c8e05144fc0d3ed4d22c2289c6b126e03bcd0e6a7da0f16cedd2e1c2772e2c8", size = 46152, upload-time = "2025-12-11T13:32:48.681Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/95/b40c96a7b5203005a0b03d8ce8cd212ff23f1793d5ba289c87a097571b18/opentelemetry_proto-1.39.1-py3-none-any.whl", hash = "sha256:22cdc78efd3b3765d09e68bfbd010d4fc254c9818afd0b6b423387d9dee46007", size = 72535, upload-time = "2025-12-11T13:32:33.866Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/c76080c9ba07e1e8235d24cdcc4d125ef7aa3edf23eb4e497c2e50889adc/opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6", size = 171460, upload-time = "2025-12-11T13:32:49.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/98/e91cf858f203d86f4eccdf763dcf01cf03f1dae80c3750f7e635bfa206b6/opentelemetry_sdk-1.39.1-py3-none-any.whl", hash = "sha256:4d5482c478513ecb0a5d938dcc61394e647066e0cc2676bee9f3af3f3f45f01c", size = 132565, upload-time = "2025-12-11T13:32:35.069Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2141,6 +2333,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/25/7c72c307aafc96fa87062aa6291d9f7c94836e43214d43722e86037aac02/protobuf-6.33.5.tar.gz", hash = "sha256:6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c", size = 444465, upload-time = "2026-01-29T21:51:33.494Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/79/af92d0a8369732b027e6d6084251dd8e782c685c72da161bd4a2e00fbabb/protobuf-6.33.5-cp310-abi3-win32.whl", hash = "sha256:d71b040839446bac0f4d162e758bea99c8251161dae9d0983a3b88dee345153b", size = 425769, upload-time = "2026-01-29T21:51:21.751Z" },
+    { url = "https://files.pythonhosted.org/packages/55/75/bb9bc917d10e9ee13dee8607eb9ab963b7cf8be607c46e7862c748aa2af7/protobuf-6.33.5-cp310-abi3-win_amd64.whl", hash = "sha256:3093804752167bcab3998bec9f1048baae6e29505adaf1afd14a37bddede533c", size = 437118, upload-time = "2026-01-29T21:51:24.022Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/6b/e48dfc1191bc5b52950246275bf4089773e91cb5ba3592621723cdddca62/protobuf-6.33.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:a5cb85982d95d906df1e2210e58f8e4f1e3cdc088e52c921a041f9c9a0386de5", size = 427766, upload-time = "2026-01-29T21:51:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b1/c79468184310de09d75095ed1314b839eb2f72df71097db9d1404a1b2717/protobuf-6.33.5-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:9b71e0281f36f179d00cbcb119cb19dec4d14a81393e5ea220f64b286173e190", size = 324638, upload-time = "2026-01-29T21:51:26.423Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
+    { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Adds a comprehensive observability framework to Hive with lifecycle hooks,
OpenTelemetry integration, and pluggable exporters. Zero overhead when disabled
(NoOpHooks default). Addresses #2051, #2158, #2156.

## What Changed

### Phase 1 — Core Hook System
- [ObservabilityHooks](cci:2://file:///home/somansh/dev/hive/core/framework/observability/hooks.py:41:0-77:11) protocol with 7 async lifecycle methods
- [NoOpHooks](cci:2://file:///home/somansh/dev/hive/core/framework/observability/hooks.py:80:0-107:12) (zero-cost default) and [CompositeHooks](cci:2://file:///home/somansh/dev/hive/core/framework/observability/hooks.py:110:0-162:54) (fan-out)
- 7 frozen event dataclasses in [observability/types.py](cci:7://file:///home/somansh/dev/hive/core/framework/observability/types.py:0:0-0:0)
- [ObservabilityConfig](cci:2://file:///home/somansh/dev/hive/core/framework/observability/config.py:20:0-50:49) with sampling support
- [Runtime](cci:2://file:///home/somansh/dev/hive/core/framework/runtime/core.py:28:0-469:9) emits: [on_run_start](cci:1://file:///home/somansh/dev/hive/core/framework/observability/hooks.py:143:4-144:51), [on_decision_made](cci:1://file:///home/somansh/dev/hive/core/framework/observability/hooks.py:155:4-156:55), [on_run_complete](cci:1://file:///home/somansh/dev/hive/core/framework/observability/hooks.py:161:4-162:54)
- [GraphExecutor](cci:2://file:///home/somansh/dev/hive/core/framework/graph/executor.py:111:0-1777:9) emits: [on_node_start](cci:1://file:///home/somansh/dev/hive/core/framework/observability/telemetry_manager.py:139:4-154:66), [on_node_complete](cci:1://file:///home/somansh/dev/hive/core/framework/observability/telemetry_manager.py:156:4-176:18), [on_node_error](cci:1://file:///home/somansh/dev/hive/core/framework/observability/exporters/file.py:95:4-103:10)

### Phase 2 — OpenTelemetry Integration
- [TelemetryManager](cci:2://file:///home/somansh/dev/hive/core/framework/observability/telemetry_manager.py:60:0-243:38) maps hooks → OTel spans (run=root, nodes=children)
- [semantic_conventions.py](cci:7://file:///home/somansh/dev/hive/core/framework/observability/semantic_conventions.py:0:0-0:0) aligned with OTel GenAI semconv
- Thread-safe span tracking with [shutdown()](cci:1://file:///home/somansh/dev/hive/core/framework/observability/telemetry_manager.py:227:4-243:38) cleanup
- Added `[observability]` optional dependency group in [pyproject.toml](cci:7://file:///home/somansh/dev/hive/pyproject.toml:0:0-0:0)

### Phase 3 — Pluggable Exporters
- [ConsoleExporter](cci:2://file:///home/somansh/dev/hive/core/framework/observability/exporters/console.py:44:0-143:9) — ANSI-colorized real-time output for dev
- [FileExporter](cci:2://file:///home/somansh/dev/hive/core/framework/observability/exporters/file.py:36:0-125:10) — thread-safe JSON Lines
- [PrometheusExporter](cci:2://file:///home/somansh/dev/hive/core/framework/observability/exporters/prometheus.py:46:0-139:15) — counters + histograms at `:9090/metrics`

## Files Changed
| Status | File |
|--------|------|
| NEW | [core/framework/observability/hooks.py](cci:7://file:///home/somansh/dev/hive/core/framework/observability/hooks.py:0:0-0:0) |
| NEW | [core/framework/observability/types.py](cci:7://file:///home/somansh/dev/hive/core/framework/observability/types.py:0:0-0:0) |
| NEW | [core/framework/observability/config.py](cci:7://file:///home/somansh/dev/hive/core/framework/observability/config.py:0:0-0:0) |
| NEW | [core/framework/observability/semantic_conventions.py](cci:7://file:///home/somansh/dev/hive/core/framework/observability/semantic_conventions.py:0:0-0:0) |
| NEW | [core/framework/observability/telemetry_manager.py](cci:7://file:///home/somansh/dev/hive/core/framework/observability/telemetry_manager.py:0:0-0:0) |
| NEW | [core/framework/observability/exporters/__init__.py](cci:7://file:///home/somansh/dev/hive/core/framework/observability/exporters/__init__.py:0:0-0:0) |
| NEW | [core/framework/observability/exporters/console.py](cci:7://file:///home/somansh/dev/hive/core/framework/observability/exporters/console.py:0:0-0:0) |
| NEW | [core/framework/observability/exporters/file.py](cci:7://file:///home/somansh/dev/hive/core/framework/observability/exporters/file.py:0:0-0:0) |
| NEW | [core/framework/observability/exporters/prometheus.py](cci:7://file:///home/somansh/dev/hive/core/framework/observability/exporters/prometheus.py:0:0-0:0) |
| NEW | [core/tests/test_hooks.py](cci:7://file:///home/somansh/dev/hive/core/tests/test_hooks.py:0:0-0:0) |
| MOD | [core/framework/observability/__init__.py](cci:7://file:///home/somansh/dev/hive/core/framework/observability/__init__.py:0:0-0:0) |
| MOD | [core/framework/runtime/core.py](cci:7://file:///home/somansh/dev/hive/core/framework/runtime/core.py:0:0-0:0) |
| MOD | [core/framework/graph/executor.py](cci:7://file:///home/somansh/dev/hive/core/framework/graph/executor.py:0:0-0:0) |
| MOD | [core/pyproject.toml](cci:7://file:///home/somansh/dev/hive/core/pyproject.toml:0:0-0:0) |

## Testing
- 57 tests passing (`pytest core/tests/test_hooks.py core/tests/test_runtime_logger.py`)
- Covers: event types, NoOpHooks, CompositeHooks error isolation, config validation

## Usage
```python
from framework.observability.hooks import CompositeHooks
from framework.observability.exporters.console import ConsoleExporter
from framework.observability.exporters.file import FileExporter

hooks = CompositeHooks([
    ConsoleExporter(verbose=True),
    FileExporter(path="./events.jsonl"),
])
runtime = Runtime(storage_path="./logs", observability_hooks=hooks)