### PR TITLE
feat(hubspot): add native HubSpot CRM integration (contacts, companies, deals)

### DIFF
--- a/tools/src/aden_tools/credentials/integrations.py
+++ b/tools/src/aden_tools/credentials/integrations.py
@@ -63,6 +63,7 @@ INTEGRATION_CREDENTIALS = {
             "hubspot_get_deal",
             "hubspot_create_deal",
             "hubspot_update_deal",
+            "hubspot_update_deal_stage",
             "hubspot_get_contact_by_email",
         ],
         required=True,

--- a/tools/src/aden_tools/credentials/integrations.py
+++ b/tools/src/aden_tools/credentials/integrations.py
@@ -1,0 +1,95 @@
+"""
+Integration credentials.
+
+Contains credentials for third-party service integrations (HubSpot, etc.).
+"""
+
+from .base import CredentialSpec
+
+INTEGRATION_CREDENTIALS = {
+    "github": CredentialSpec(
+        env_var="GITHUB_TOKEN",
+        tools=[
+            "github_list_repos",
+            "github_get_repo",
+            "github_search_repos",
+            "github_list_issues",
+            "github_get_issue",
+            "github_create_issue",
+            "github_update_issue",
+            "github_list_pull_requests",
+            "github_get_pull_request",
+            "github_create_pull_request",
+            "github_search_code",
+            "github_list_branches",
+            "github_get_branch",
+        ],
+        required=True,
+        startup_required=False,
+        help_url="https://github.com/settings/tokens",
+        description="GitHub Personal Access Token (classic)",
+        # Auth method support
+        aden_supported=False,
+        direct_api_key_supported=True,
+        api_key_instructions="""To get a GitHub Personal Access Token:
+1. Go to GitHub Settings > Developer settings > Personal access tokens
+2. Click "Generate new token" > "Generate new token (classic)"
+3. Give your token a descriptive name (e.g., "Hive Agent")
+4. Select the following scopes:
+   - repo (Full control of private repositories)
+   - read:org (Read org and team membership - optional)
+   - user (Read user profile data - optional)
+5. Click "Generate token" and copy the token (starts with ghp_)
+6. Store it securely - you won't be able to see it again!""",
+        # Health check configuration
+        health_check_endpoint="https://api.github.com/user",
+        health_check_method="GET",
+        # Credential store mapping
+        credential_id="github",
+        credential_key="access_token",
+    ),
+    "hubspot": CredentialSpec(
+        env_var="HUBSPOT_ACCESS_TOKEN",
+        tools=[
+            "hubspot_search_contacts",
+            "hubspot_get_contact",
+            "hubspot_create_contact",
+            "hubspot_update_contact",
+            "hubspot_search_companies",
+            "hubspot_get_company",
+            "hubspot_create_company",
+            "hubspot_update_company",
+            "hubspot_search_deals",
+            "hubspot_get_deal",
+            "hubspot_create_deal",
+            "hubspot_update_deal",
+            "hubspot_get_contact_by_email",
+        ],
+        required=True,
+        startup_required=False,
+        help_url="https://developers.hubspot.com/docs/api/private-apps",
+        description="HubSpot access token (Private App or OAuth2)",
+        # Auth method support
+        aden_supported=True,
+        aden_provider_name="hubspot",
+        direct_api_key_supported=True,
+        api_key_instructions="""To get a HubSpot Private App token:
+1. Go to HubSpot Settings > Integrations > Private Apps
+2. Click "Create a private app"
+3. Name your app (e.g., "Hive Agent")
+4. Go to the "Scopes" tab and enable:
+   - crm.objects.contacts.read
+   - crm.objects.contacts.write
+   - crm.objects.companies.read
+   - crm.objects.companies.write
+   - crm.objects.deals.read
+   - crm.objects.deals.write
+5. Click "Create app" and copy the access token""",
+        # Health check configuration
+        health_check_endpoint="https://api.hubapi.com/crm/v3/objects/contacts?limit=1",
+        health_check_method="GET",
+        # Credential store mapping
+        credential_id="hubspot",
+        credential_key="access_token",
+    ),
+}


### PR DESCRIPTION
## Description

This PR adds a native HubSpot CRM integration to the Aden Agent Framework, enabling Hive agents to securely interact with HubSpot contacts and deals using HubSpot’s official APIs.

The integration supports both Private App tokens and OAuth 2.0 authentication, allowing agents to fetch, create, and update CRM records. This removes the need for manual syncing or external scripts and unlocks automated sales and customer workflows inside Hive.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Fixes #2805
Fixes #2848
(Expand agent capabilities by adding more integrations/tools)

## Changes Made

Added HubSpot CRM MCP tool with full Contacts, Companies, and Deals support

- List/search records
- Get contact by ID and by email
- Create and update contacts, companies, and deals
- Update deal stage helper


 ### Implemented HubSpot OAuth2 provider with pre-configured endpoints and CRM scopes
### Added credential integration for HubSpot (env var + credential store support)
### Implemented pagination support for search endpoints

### Added comprehensive unit tests covering:

- Client behavior and error handling
- MCP tool registration
- Contact, company, and deal operations
- OAuth2 provider configuration and validation

## Testing

-  Unit tests pass
``` Run
pytest tools/src/aden_tools/tools/hubspot_tool/tests/test_hubspot_tool.py -v
```
-  OAuth2 provider tests pass
-  Credential spec tests pass
-  Manual verification of tool registration and error handling

## Checklist

- [ ] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.


In addition to the HubSpot CRM integration introduced in this PR, I also addressed and aligned the implementation with learnings from related work and discussions in:

PR: https://github.com/adenhq/hive/pull/1846

Issue: https://github.com/adenhq/hive/issues/1488

These helped ensure the integration follows existing patterns around tool registration, credentials, and error handling.

What this PR adds (at a glance)

- HubSpot CRM – Contacts and Deals Management
- List and search contacts and deals (with pagination support)
- Get contact by ID or email
- Create and update contacts and deals
- Update deal stage
- Credential-store and environment-variable support

If there’s anything you’d like me to change—naming, scope, structure, or test coverage—please let me know and I’ll be happy to revise it quickly.

Thanks for reviewing! 

 @bryanadenhq @RichardTang-Aden @austin931114 @vincentjiang777 @TimothyZhang7

hey @RichardTang-Aden This PR replaces #3910, which I closed earlier while cleaning up branches.
The implementation remains the same, with minor refinements and rebasing on the latest main branch.

Apologies for any confusion.