### PR TITLE
micro-fix: change debug logging to appropriate level in executor.py

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -368,7 +368,7 @@ class GraphExecutor:
             # Check if resuming from paused_at (session state resume)
             paused_at = session_state.get("paused_at") if session_state else None
             node_ids = [n.id for n in graph.nodes]
-            self.logger.info(f"🔍 Debug: paused_at={paused_at}, available node IDs={node_ids}")
+            self.logger.debug(f"paused_at={paused_at}, available node IDs={node_ids}")
 
             if paused_at and graph.get_node(paused_at) is not None:
                 # Resume from paused_at node directly (works for any node, not just pause_nodes)


### PR DESCRIPTION
## Description

Changes logger.info() with debug prefix to logger.debug() for session state resume information in the graph executor. This prevents debug-level information from appearing in production logs at INFO level.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Addresses #4377

## Changes Made

- Changed `logger.info(f"🔍 Debug: ...")` to `logger.debug(f"...")`
- Removed redundant debug prefix
- Follows Python logging best practices
- Single line change, zero behavioral impact

## Testing

- ✅ Verified log output only appears with debug logging enabled
- ✅ No functional changes to execution flow
- ✅ Production logs remain clean at INFO level

## Why This Is a Micro-fix

✅ Single line change  
✅ No logic or behavior modification  
✅ Follows Python logging best practices  
✅ Zero risk of breaking changes

Per contribution guidelines, micro-fixes can proceed without prior assignment.
