### PR TITLE
docs: clarify Aden vs Hive naming in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@
 
 Build autonomous, reliable, self-improving AI agents without hardcoding workflows. Define your goal through conversation with a coding agent, and the framework generates a node graph with dynamically created connection code. When things break, the framework captures failure data, evolves the agent through the coding agent, and redeploys. Built-in human-in-the-loop nodes, credential management, and real-time monitoring give you control without sacrificing adaptability.
 
+> **Note:** Hive is an open-source framework and CLI provided by [Aden](https://adenhq.com).
+
 Visit [adenhq.com](https://adenhq.com) for complete documentation, examples, and guides.
 
 https://github.com/user-attachments/assets/846c0cc7-ffd6-47fa-b4b7-495494857a55


### PR DESCRIPTION
## Description

Adds a concise note explaining that Hive is the framework/CLI and Aden is the company providing it. This helps new contributors and evaluators understand the relationship between the two names.

## Type of Change

- [x] Documentation update

## Related Issues

Addresses #4360

## Changes Made

- Added note after Overview section: "Hive is an open-source framework and CLI provided by Aden."
- Linked to adenhq.com for company information
- Single sentence for clarity and brevity

## Why This Helps

New users often encounter both "Hive" and "Aden" in the docs and GitHub org without understanding the distinction. This one-line clarification removes that friction point immediately.
