### PR TITLE
feat(runner): add from_file loader

### DIFF
--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -550,6 +550,52 @@ class AgentRunner:
             model=model,
         )
 
+    @classmethod
+    def from_file(
+        cls,
+        path: str | Path,
+        mock_mode: bool = False,
+        storage_path: Path | None = None,
+        model: str = "cerebras/zai-glm-4.7",
+    ) -> "AgentRunner":
+        """
+        Load an agent from an exported agent.json file on disk.
+
+        This is a convenience method for cases where you already have the path
+        to a specific export file. It supports:
+        - passing a directory (will load `<dir>/agent.json`)
+        - Windows-friendly UTF-8 BOM files via `encoding="utf-8-sig"`
+
+        Args:
+            path: Path to `agent.json` or to its containing agent folder
+            mock_mode: If True, use mock LLM responses
+            storage_path: Path for runtime storage (defaults to temp)
+            model: LLM model to use (any LiteLLM-compatible model name)
+
+        Returns:
+            AgentRunner instance ready to run
+        """
+        p = Path(path)
+        agent_json_path = (p / "agent.json") if p.is_dir() else p
+
+        if not agent_json_path.exists():
+            raise FileNotFoundError(
+                f"agent.json not found at {agent_json_path.resolve()}"
+            )
+
+        agent_path = agent_json_path.parent
+        with open(agent_json_path, encoding="utf-8-sig") as f:
+            graph, goal = load_agent_export(f.read())
+
+        return cls(
+            agent_path=agent_path,
+            graph=graph,
+            goal=goal,
+            mock_mode=mock_mode,
+            storage_path=storage_path,
+            model=model,
+        )
+
     def register_tool(
         self,
         name: str,

--- a/core/tests/test_agent_runner_from_file.py
+++ b/core/tests/test_agent_runner_from_file.py
@@ -1,0 +1,86 @@
+import codecs
+import inspect
+import json
+from pathlib import Path
+
+from framework.runner import AgentRunner
+
+
+def _minimal_export() -> dict:
+    return {
+        "agent": {
+            "id": "test-agent",
+            "name": "Test Agent",
+            "version": "1.0.0",
+            "description": "Minimal export for from_file() tests",
+        },
+        "graph": {
+            "id": "test-graph",
+            "goal_id": "test-goal",
+            "version": "1.0.0",
+            "entry_node": "hello",
+            "entry_points": {"start": "hello"},
+            "terminal_nodes": ["hello"],
+            "pause_nodes": [],
+            "nodes": [
+                {
+                    "id": "hello",
+                    "name": "Hello",
+                    "description": "Return a result",
+                    "node_type": "llm_generate",
+                    "input_keys": [],
+                    "output_keys": ["result"],
+                }
+            ],
+            "edges": [],
+            "max_steps": 5,
+            "max_retries_per_node": 1,
+            "description": "",
+        },
+        "goal": {
+            "id": "test-goal",
+            "name": "Test Goal",
+            "description": "Test goal description",
+            "success_criteria": [],
+            "constraints": [],
+        },
+        "required_tools": [],
+        "metadata": {"created_at": "2026-02-10T00:00:00", "node_count": 1, "edge_count": 0},
+    }
+
+
+def test_from_file_loads_export_from_directory(tmp_path: Path) -> None:
+    export = _minimal_export()
+    agent_dir = tmp_path / "my_agent"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "agent.json").write_text(json.dumps(export), encoding="utf-8")
+
+    runner = AgentRunner.from_file(
+        agent_dir,
+        mock_mode=True,
+        storage_path=(tmp_path / "storage"),
+    )
+
+    assert runner.agent_path == agent_dir
+    assert runner.goal.id == "test-goal"
+    assert runner.graph.entry_node == "hello"
+    assert inspect.iscoroutinefunction(runner.run)
+
+
+def test_from_file_handles_utf8_bom(tmp_path: Path) -> None:
+    export = _minimal_export()
+    agent_dir = tmp_path / "my_agent"
+    agent_dir.mkdir(parents=True)
+    agent_json_path = agent_dir / "agent.json"
+
+    raw = json.dumps(export).encode("utf-8")
+    agent_json_path.write_bytes(codecs.BOM_UTF8 + raw)
+
+    runner = AgentRunner.from_file(
+        agent_json_path,
+        mock_mode=True,
+        storage_path=(tmp_path / "storage"),
+    )
+
+    assert runner.agent_path == agent_dir
+    assert runner.goal.id == "test-goal"

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -365,16 +365,18 @@ PYTHONPATH=exports uv run python -m agent_name test --fail-fast
 import pytest
 from framework.runner import AgentRunner
 
-def test_ticket_categorization():
+@pytest.mark.asyncio
+async def test_ticket_categorization():
     """Test that tickets are categorized correctly"""
-    runner = AgentRunner.from_file("exports/my_agent/agent.json")
+    runner = AgentRunner.from_file("exports/my_agent/agent.json", mock_mode=True)
 
-    result = runner.run({
+    execution = await runner.run({
         "ticket_content": "I can't log in to my account"
     })
 
-    assert result["category"] == "authentication"
-    assert result["priority"] in ["high", "medium", "low"]
+    assert execution.success is True
+    assert execution.output.get("category") == "authentication"
+    assert execution.output.get("priority") in ["high", "medium", "low"]
 ```
 
 ---


### PR DESCRIPTION
Fixes #3695

## Summary
- Add AgentRunner.from_file() to load exported agent.json from disk (directory path supported; handles UTF-8 BOM via utf-8-sig).
- Add deterministic tests for export loading + BOM handling.
- Update docs snippet to use async runner.run() with from_file().

## Test plan
cd core
python -m pytest -q tests/test_agent_runner_from_file.py