### PR TITLE
Fix/powershell syntax error

### DIFF
--- a/quickstart.ps1
+++ b/quickstart.ps1
@@ -501,7 +501,7 @@ if (-not $SelectedProviderId) {
             if ($apiKey) {
                 # Persist as a User-level environment variable (survives reboots)
                 [System.Environment]::SetEnvironmentVariable($SelectedEnvVar, $apiKey, "User")
-                $env:$SelectedEnvVar = $apiKey
+
                 # Also set in current session
                 Set-Item -Path "Env:\$SelectedEnvVar" -Value $apiKey
                 Write-Host ""

--- a/quickstart.ps1
+++ b/quickstart.ps1
@@ -501,7 +501,6 @@ if (-not $SelectedProviderId) {
             if ($apiKey) {
                 # Persist as a User-level environment variable (survives reboots)
                 [System.Environment]::SetEnvironmentVariable($SelectedEnvVar, $apiKey, "User")
-
                 # Also set in current session
                 Set-Item -Path "Env:\$SelectedEnvVar" -Value $apiKey
                 Write-Host ""


### PR DESCRIPTION
## Description

This PR resolves a `ParserError` in `quickstart.ps1` that prevented the setup script from executing on Windows machines. The error was caused by an invalid dynamic variable reference syntax in PowerShell.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #4434 

## Changes Made

- Removed the invalid syntax `$env:$SelectedEnvVar = $apiKey` on line 504.
- Ensured session-level environment variable assignment is handled by the existing `Set-Item` cmdlet on line 505.
- Fixed the PowerShell ParserError that blocked script execution upon startup.

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed: Verified that the setup script now parses correctly and the hive welcome page is reached correctly.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A - Fixes a terminal-level script execution error.
