### PR TITLE
feat: Add uv version check and auto-upgrade logic for versions older than 0.4.0 micro-fix

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -171,6 +171,27 @@ fi
 
 UV_VERSION=$(uv --version)
 echo -e "${GREEN}  ✓ uv detected: $UV_VERSION${NC}"
+
+# Check minimum uv version (workspace support requires >= 0.4.0)
+UV_VER_NUM=$(echo "$UV_VERSION" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+UV_MAJOR=$(echo "$UV_VER_NUM" | cut -d. -f1)
+UV_MINOR=$(echo "$UV_VER_NUM" | cut -d. -f2)
+MIN_UV_MAJOR=0
+MIN_UV_MINOR=4
+
+if [ "$UV_MAJOR" -lt "$MIN_UV_MAJOR" ] || \
+   ([ "$UV_MAJOR" -eq "$MIN_UV_MAJOR" ] && [ "$UV_MINOR" -lt "$MIN_UV_MINOR" ]); then
+    echo -e "${YELLOW}  ⚠ uv $UV_VER_NUM is too old (need >= 0.4.0). Upgrading...${NC}"
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    export PATH="$HOME/.local/bin:$PATH"
+    if ! command -v uv &> /dev/null; then
+        echo -e "${RED}  ✗ uv upgrade failed. Please upgrade manually: https://astral.sh/uv/${NC}"
+        exit 1
+    fi
+    UV_VERSION=$(uv --version)
+    echo -e "${GREEN}  ✓ uv upgraded: $UV_VERSION${NC}"
+fi
+
 echo ""
 
 # ============================================================


### PR DESCRIPTION
## Description

`quickstart.sh` fails at "Installing workspace packages..." for users with `uv` versions older than 0.4.0. The script checks for `uv` presence but not its version. Since the project uses `[tool.uv.workspace]` and `uv sync`, which require workspace support (added in `uv ~0.4.0`), old versions silently fail.

This PR adds a minimum version check (`>= 0.4.0`) after `uv` detection and auto-upgrades via the official installer if the version is too old.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes [#(issue number:4440)](https://github.com/adenhq/hive/issues/4440)

## Changes Made

- Added `uv` version parsing after detection (extracts semver from `uv --version` output)
- Added version comparison against minimum required `0.4.0`
- Auto-upgrades `uv` via `curl -LsSf https://astral.sh/uv/install.sh | sh` if version is too old
- Added error handling if the upgrade itself fails

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

**Version parsing verification:**
```bash
# Old version (should trigger upgrade)
$ echo "uv 0.1.24" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1
0.1.24  # Correctly parsed, 0.1 < 0.4 → triggers upgrade

# Current version (should pass through)
$ echo "uv 0.10.2 (a788db7e5 2026-02-10)" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1
0.10.2  # Correctly parsed, 0.10 >= 0.4 → no upgrade needed
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A
