### PR TITLE
fix(tui): add multiline input and cross-platform clipboard support

### DIFF
--- a/core/framework/tui/app.py
+++ b/core/framework/tui/app.py
@@ -6,7 +6,7 @@ import time
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal, Vertical
-from textual.widgets import Footer, Input, Label
+from textual.widgets import Footer, Label, TextArea
 
 from framework.runtime.agent_runtime import AgentRuntime
 from framework.runtime.event_bus import AgentEvent, EventType
@@ -180,13 +180,13 @@ class AdenTUI(App):
         scrollbar-color: $primary;
     }
 
-    Input {
+    TextArea {
         background: $surface;
         border: tall $primary;
         margin-top: 1;
     }
 
-    Input:focus {
+    TextArea:focus {
         border: tall $accent;
     }
 
@@ -504,8 +504,8 @@ class AdenTUI(App):
         original_chat_border = chat_widget.styles.border_left
         chat_widget.styles.border_left = ("none", "transparent")
 
-        # Hide all Input widget borders
-        input_widgets = self.query("Input")
+        # Hide all TextArea widget borders
+        input_widgets = self.query("TextArea")
         original_input_borders = []
         for input_widget in input_widgets:
             original_input_borders.append(input_widget.styles.border)
@@ -580,8 +580,8 @@ class AdenTUI(App):
         # Send /sessions command to chat input
         try:
             chat_repl = self.query_one(ChatRepl)
-            chat_input = chat_repl.query_one("#chat-input", Input)
-            chat_input.value = "/sessions"
+            chat_input = chat_repl.query_one("#chat-input", TextArea)
+            chat_input.text = "/sessions"
             # Trigger submission
             self.notify(
                 "💡 Type /sessions in the chat to see all sessions",

--- a/core/framework/tui/app.py
+++ b/core/framework/tui/app.py
@@ -6,7 +6,7 @@ import time
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal, Vertical
-from textual.widgets import Footer, Label, TextArea
+from textual.widgets import Footer, Label
 
 from framework.runtime.agent_runtime import AgentRuntime
 from framework.runtime.event_bus import AgentEvent, EventType
@@ -180,13 +180,13 @@ class AdenTUI(App):
         scrollbar-color: $primary;
     }
 
-    TextArea {
+    ChatTextArea {
         background: $surface;
         border: tall $primary;
         margin-top: 1;
     }
 
-    TextArea:focus {
+    ChatTextArea:focus {
         border: tall $accent;
     }
 
@@ -505,7 +505,7 @@ class AdenTUI(App):
         chat_widget.styles.border_left = ("none", "transparent")
 
         # Hide all TextArea widget borders
-        input_widgets = self.query("TextArea")
+        input_widgets = self.query("ChatTextArea")
         original_input_borders = []
         for input_widget in input_widgets:
             original_input_borders.append(input_widget.styles.border)
@@ -575,19 +575,12 @@ class AdenTUI(App):
                 timeout=5,
             )
 
-    def action_show_sessions(self) -> None:
+    async def action_show_sessions(self) -> None:
         """Show sessions list (bound to Ctrl+R)."""
         # Send /sessions command to chat input
         try:
             chat_repl = self.query_one(ChatRepl)
-            chat_input = chat_repl.query_one("#chat-input", TextArea)
-            chat_input.text = "/sessions"
-            # Trigger submission
-            self.notify(
-                "💡 Type /sessions in the chat to see all sessions",
-                severity="information",
-                timeout=3,
-            )
+            await chat_repl._submit_input("/sessions")
         except Exception:
             self.notify(
                 "Use /sessions command to see all sessions",

--- a/core/framework/tui/widgets/chat_repl.py
+++ b/core/framework/tui/widgets/chat_repl.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from textual.app import ComposeResult
 from textual.containers import Vertical
-from textual.widgets import Input, Label
+from textual.widgets import Label, TextArea
 
 from framework.runtime.agent_runtime import AgentRuntime
 from framework.tui.widgets.selectable_rich_log import SelectableRichLog as RichLog
@@ -56,16 +56,17 @@ class ChatRepl(Vertical):
         display: none;
     }
 
-    ChatRepl > Input {
+    ChatRepl > TextArea {
         width: 100%;
         height: auto;
+        max-height: 7;
         dock: bottom;
         background: $surface;
         border: tall $primary;
         margin-top: 1;
     }
 
-    ChatRepl > Input:focus {
+    ChatRepl > TextArea:focus {
         border: tall $accent;
     }
     """
@@ -108,7 +109,7 @@ class ChatRepl(Vertical):
             min_width=0,
         )
         yield Label("Agent is processing...", id="processing-indicator")
-        yield Input(placeholder="Enter input for agent...", id="chat-input")
+        yield TextArea(id="chat-input", placeholder="Enter input for agent...")
 
     # Regex for file:// URIs that are NOT already inside Rich [link=...] markup
     _FILE_URI_RE = re.compile(r"(?<!\[link=)(file://[^\s)\]>*]+)")
@@ -485,7 +486,7 @@ class ChatRepl(Vertical):
             indicator.display = True
 
             # Update placeholder
-            chat_input = self.query_one("#chat-input", Input)
+            chat_input = self.query_one("#chat-input", TextArea)
             chat_input.placeholder = "Commands: /pause, /sessions (agent resuming...)"
 
             # Trigger execution with resume state
@@ -572,7 +573,7 @@ class ChatRepl(Vertical):
             indicator.display = True
 
             # Update placeholder
-            chat_input = self.query_one("#chat-input", Input)
+            chat_input = self.query_one("#chat-input", TextArea)
             chat_input.placeholder = "Commands: /pause, /sessions (agent recovering...)"
 
             # Trigger execution with checkpoint recovery
@@ -739,9 +740,21 @@ class ChatRepl(Vertical):
             # Silently fail - don't block TUI startup
             pass
 
-    async def on_input_submitted(self, message: Input.Submitted) -> None:
-        """Handle input submission — either start new execution or inject input."""
-        user_input = message.value.strip()
+    async def on_key(self, event) -> None:
+        """Intercept Enter in TextArea to submit; Shift+Enter inserts newline."""
+        focused = self.app.focused
+        if not isinstance(focused, TextArea):
+            return
+        if event.key == "enter" and not event.shift:
+            event.prevent_default()
+            chat_input = self.query_one("#chat-input", TextArea)
+            user_input = chat_input.text.strip()
+            chat_input.clear()
+            if user_input:
+                await self._submit_input(user_input)
+
+    async def _submit_input(self, user_input: str) -> None:
+        """Handle submitted text — either start new execution or inject input."""
         if not user_input:
             return
 
@@ -749,16 +762,14 @@ class ChatRepl(Vertical):
         # Commands work during execution, during client-facing input, anytime
         if user_input.startswith("/"):
             await self._handle_command(user_input)
-            message.input.value = ""
             return
 
         # Client-facing input: route to the waiting node
         if self._waiting_for_input and self._input_node_id:
             self._write_history(f"[bold green]You:[/bold green] {user_input}")
-            message.input.value = ""
 
             # Keep input enabled for commands (but change placeholder)
-            chat_input = self.query_one("#chat-input", Input)
+            chat_input = self.query_one("#chat-input", TextArea)
             chat_input.placeholder = "Commands: /pause, /sessions (agent processing...)"
             self._waiting_for_input = False
 
@@ -785,9 +796,8 @@ class ChatRepl(Vertical):
 
         indicator = self.query_one("#processing-indicator", Label)
 
-        # Append user message and clear input
+        # Append user message
         self._write_history(f"[bold green]You:[/bold green] {user_input}")
-        message.input.value = ""
 
         try:
             # Get entry point
@@ -813,7 +823,7 @@ class ChatRepl(Vertical):
             indicator.display = True
 
             # Keep input enabled for commands during execution
-            chat_input = self.query_one("#chat-input", Input)
+            chat_input = self.query_one("#chat-input", TextArea)
             chat_input.placeholder = "Commands available: /pause, /sessions, /help"
 
             # Submit execution to the dedicated agent loop so blocking
@@ -834,7 +844,7 @@ class ChatRepl(Vertical):
             indicator.display = False
             self._current_exec_id = None
             # Re-enable input on error
-            chat_input = self.query_one("#chat-input", Input)
+            chat_input = self.query_one("#chat-input", TextArea)
             chat_input.disabled = False
             self._write_history(f"[bold red]Error:[/bold red] {e}")
 
@@ -910,7 +920,7 @@ class ChatRepl(Vertical):
         self._pending_ask_question = ""
 
         # Re-enable input
-        chat_input = self.query_one("#chat-input", Input)
+        chat_input = self.query_one("#chat-input", TextArea)
         chat_input.disabled = False
         chat_input.placeholder = "Enter input for agent..."
         chat_input.focus()
@@ -930,7 +940,7 @@ class ChatRepl(Vertical):
         self._input_node_id = None
 
         # Re-enable input
-        chat_input = self.query_one("#chat-input", Input)
+        chat_input = self.query_one("#chat-input", TextArea)
         chat_input.disabled = False
         chat_input.placeholder = "Enter input for agent..."
         chat_input.focus()
@@ -961,7 +971,7 @@ class ChatRepl(Vertical):
         indicator = self.query_one("#processing-indicator", Label)
         indicator.update("Waiting for your input...")
 
-        chat_input = self.query_one("#chat-input", Input)
+        chat_input = self.query_one("#chat-input", TextArea)
         chat_input.disabled = False
         chat_input.placeholder = "Type your response..."
         chat_input.focus()

--- a/core/framework/tui/widgets/selectable_rich_log.py
+++ b/core/framework/tui/widgets/selectable_rich_log.py
@@ -195,12 +195,27 @@ def _copy_to_clipboard(text: str) -> None:
     try:
         if sys.platform == "darwin":
             subprocess.run(["pbcopy"], input=text.encode(), check=True, timeout=5)
-        elif sys.platform.startswith("linux"):
+        elif sys.platform == "win32":
             subprocess.run(
-                ["xclip", "-selection", "clipboard"],
-                input=text.encode(),
+                ["clip.exe"],
+                input=text.encode("utf-16le"),
                 check=True,
                 timeout=5,
             )
+        elif sys.platform.startswith("linux"):
+            try:
+                subprocess.run(
+                    ["xclip", "-selection", "clipboard"],
+                    input=text.encode(),
+                    check=True,
+                    timeout=5,
+                )
+            except (subprocess.SubprocessError, FileNotFoundError):
+                subprocess.run(
+                    ["xsel", "--clipboard", "--input"],
+                    input=text.encode(),
+                    check=True,
+                    timeout=5,
+                )
     except (subprocess.SubprocessError, FileNotFoundError):
         pass


### PR DESCRIPTION
## Description

Fixes #4423

The TUI chat input uses a single-line `Input` widget that drops multiline
pastes and has no newline support. Copy-to-clipboard also fails on some
platforms.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #4423

## Changes Made

- Replace single-line `Input` widget with `TextArea` in chat REPL
  - Enter submits, Shift+Enter inserts a newline
  - Dynamic height (1–5 visible lines, scrolls beyond that)
  - Multiline paste now works correctly
- Add Windows clipboard support (`clip.exe`) in `_copy_to_clipboard`
- Add `xsel` fallback for Linux when `xclip` is not installed
- Update CSS selectors and widget queries in `app.py` to match new widget

## Testing

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

Manual verification:
- Shift+Enter inserts newlines in input box
- Multiline paste preserves all lines with visible cursor
- Ctrl+C copies selected text to clipboard
- Enter submits message and clears input
- Slash commands (/help, /sessions) still work

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes