### PR TITLE
fix: code quality improvements and security hardening

### DIFF
--- a/core/PR_CHANGES.md
+++ b/core/PR_CHANGES.md
@@ -1,0 +1,109 @@
+# Code Quality Improvements and Security Hardening
+
+This PR addresses multiple code quality issues identified through static analysis and security scanning.
+
+## Summary
+
+- Fix deprecated `datetime.utcnow()` usage (Python 3.12+ deprecation)
+- Correct import paths in demo files
+- Add `hvac` as optional dependency for HashiCorp Vault
+- Improve type safety with None checks
+- Follow PEP 484 conventions for abstract methods
+- Add security annotations for sandboxed code execution
+
+## Changes
+
+### 1. Deprecated API Fix
+**File:** `core/framework/credentials/aden/client.py`
+- Replace `datetime.utcnow()` with `datetime.now(UTC)`
+- Python 3.12+ deprecates `utcnow()` in favor of timezone-aware datetimes
+
+### 2. Import Path Corrections
+**Files:** `core/demos/*.py`
+- Fix `core.framework.credentials` → `framework.credentials`
+- Imports now resolve correctly with the path setup
+- Auto-formatted to comply with isort rules
+
+### 3. GraphSpec API Fix
+**File:** `core/demos/github_outreach_demo.py`
+- Replace undeclared `name` parameter with `description`
+- Uses the actual declared field in `GraphSpec`
+
+### 4. Optional Dependency
+**File:** `core/pyproject.toml`
+- Add `hvac>=2.0.0` as optional dependency under `[vault]`
+- Install with: `pip install framework[vault]`
+
+### 5. Abstract Method Conventions
+**Files:** `core/framework/credentials/storage.py`, `core/framework/credentials/provider.py`
+- Replace `pass` with `...` (ellipsis) in abstract methods
+- Follows PEP 484 type annotation conventions
+
+### 6. Type Safety Improvements
+**File:** `core/framework/credentials/tests/test_credential_store.py`
+- Add `assert cred is not None` before accessing `.get_key()`
+- Prevents type checker warnings about potentially None values
+
+### 7. Security Annotations
+**File:** `core/framework/graph/code_sandbox.py`
+- Add `# nosec B102` for intentional `exec()` usage
+- Add `# nosec B307` for intentional `eval()` usage
+- Both are in sandboxed environment with restricted builtins, timeouts, and memory limits
+
+## Security Scan Results
+
+### Bandit Security Scanner
+```
+Run metrics:
+  Total lines of code: 33,083
+  Total issues (by severity):
+    High: 0
+    Medium: 0 (2 acknowledged with nosec)
+    Low: 313 (informational - subprocess usage, etc.)
+
+  Files skipped: 0
+  Issues skipped via nosec: 2
+```
+
+The 2 Medium severity issues were for `exec()` and `eval()` usage in the code sandbox. These are:
+- **Intentional**: The sandbox is designed to execute dynamic code
+- **Mitigated**: Restricted builtins whitelist, timeout enforcement, memory limits, namespace isolation
+- **Documented**: Security measures are documented in the module docstring
+
+### Low Severity Findings (Informational)
+Low severity findings are primarily:
+- Subprocess calls (expected for tool execution)
+- Assert statements in tests
+- Try-except-pass patterns in cleanup code
+
+These are acceptable patterns for this codebase.
+
+## Testing
+
+```bash
+# All tests pass
+$ cd core && uv run pytest tests/ -v
+================ 683 passed, 51 skipped, 228 warnings in 19.49s ================
+
+# Linter passes
+$ uv run ruff check .
+All checks passed!
+```
+
+## Test Plan
+
+- [x] Run `uv run pytest tests/` - All 683 tests pass
+- [x] Run `uv run ruff check .` - No linting errors
+- [x] Run `uv run bandit -r core/framework -ll` - No High/Medium issues
+- [x] Verify demo files import correctly
+- [x] Verify credential store functionality unchanged
+
+## Notes for Reviewers
+
+1. **Strix Security Scanner**: Could not run due to Docker daemon connectivity issues. Used Bandit as alternative.
+2. **Low severity findings**: Not addressed as they are acceptable patterns (subprocess, assertions, cleanup handlers)
+3. **Breaking changes**: None - all changes are backward compatible
+
+---
+
+🤖 Generated with [Claude Code](https://claude.ai/code)

--- a/core/demos/event_loop_wss_demo.py
+++ b/core/demos/event_loop_wss_demo.py
@@ -35,8 +35,8 @@ sys.path.insert(0, str(_HIVE_DIR))  # core.framework.* (for aden_tools imports)
 import os  # noqa: E402
 
 from aden_tools.credentials import CREDENTIAL_SPECS, CredentialStoreAdapter  # noqa: E402
-from core.framework.credentials import CredentialStore  # noqa: E402
 
+from framework.credentials import CredentialStore  # noqa: E402
 from framework.credentials.storage import (  # noqa: E402
     CompositeStorage,
     EncryptedFileStorage,

--- a/core/demos/github_outreach_demo.py
+++ b/core/demos/github_outreach_demo.py
@@ -53,8 +53,8 @@ sys.path.insert(0, str(_HIVE_DIR / "tools" / "src"))
 sys.path.insert(0, str(_HIVE_DIR))
 
 from aden_tools.credentials import CREDENTIAL_SPECS, CredentialStoreAdapter  # noqa: E402
-from core.framework.credentials import CredentialStore  # noqa: E402
 
+from framework.credentials import CredentialStore  # noqa: E402
 from framework.credentials.storage import (  # noqa: E402
     CompositeStorage,
     EncryptedFileStorage,
@@ -751,7 +751,7 @@ EDGES = [
 GRAPH = GraphSpec(
     id="github_outreach_pipeline",
     goal_id="outreach_goal",
-    name="GitHub Outreach Pipeline",
+    description="GitHub Outreach Pipeline",
     entry_node="intake",
     nodes=list(NODE_SPECS.values()),
     edges=EDGES,

--- a/core/demos/handoff_demo.py
+++ b/core/demos/handoff_demo.py
@@ -36,8 +36,8 @@ sys.path.insert(0, str(_HIVE_DIR / "tools" / "src"))  # aden_tools.*
 sys.path.insert(0, str(_HIVE_DIR))  # core.framework.* (for aden_tools imports)
 
 from aden_tools.credentials import CREDENTIAL_SPECS, CredentialStoreAdapter  # noqa: E402
-from core.framework.credentials import CredentialStore  # noqa: E402
 
+from framework.credentials import CredentialStore  # noqa: E402
 from framework.credentials.storage import (  # noqa: E402
     CompositeStorage,
     EncryptedFileStorage,

--- a/core/demos/org_demo.py
+++ b/core/demos/org_demo.py
@@ -40,8 +40,8 @@ sys.path.insert(0, str(_HIVE_DIR))
 import os  # noqa: E402
 
 from aden_tools.credentials import CREDENTIAL_SPECS, CredentialStoreAdapter  # noqa: E402
-from core.framework.credentials import CredentialStore  # noqa: E402
 
+from framework.credentials import CredentialStore  # noqa: E402
 from framework.credentials.storage import (  # noqa: E402
     CompositeStorage,
     EncryptedFileStorage,

--- a/core/framework/credentials/aden/client.py
+++ b/core/framework/credentials/aden/client.py
@@ -32,7 +32,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 import httpx
@@ -434,7 +434,7 @@ class AdenCredentialClient:
                 json={
                     "operation": operation,
                     "status": status,
-                    "timestamp": datetime.utcnow().isoformat() + "Z",
+                    "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
                     "metadata": metadata or {},
                 },
             )

--- a/core/framework/credentials/provider.py
+++ b/core/framework/credentials/provider.py
@@ -59,7 +59,7 @@ class CredentialProvider(ABC):
 
         Examples: 'static', 'oauth2', 'my_custom_auth'
         """
-        pass
+        ...
 
     @property
     @abstractmethod
@@ -70,7 +70,7 @@ class CredentialProvider(ABC):
         Returns:
             List of CredentialType enums this provider supports
         """
-        pass
+        ...
 
     @abstractmethod
     def refresh(self, credential: CredentialObject) -> CredentialObject:
@@ -92,7 +92,7 @@ class CredentialProvider(ABC):
         Raises:
             CredentialRefreshError: If refresh fails
         """
-        pass
+        ...
 
     @abstractmethod
     def validate(self, credential: CredentialObject) -> bool:
@@ -110,7 +110,7 @@ class CredentialProvider(ABC):
         Returns:
             True if credential is valid, False otherwise
         """
-        pass
+        ...
 
     def should_refresh(self, credential: CredentialObject) -> bool:
         """

--- a/core/framework/credentials/storage.py
+++ b/core/framework/credentials/storage.py
@@ -41,7 +41,7 @@ class CredentialStorage(ABC):
         Args:
             credential: The credential object to save
         """
-        pass
+        ...
 
     @abstractmethod
     def load(self, credential_id: str) -> CredentialObject | None:
@@ -54,7 +54,7 @@ class CredentialStorage(ABC):
         Returns:
             CredentialObject if found, None otherwise
         """
-        pass
+        ...
 
     @abstractmethod
     def delete(self, credential_id: str) -> bool:
@@ -67,7 +67,7 @@ class CredentialStorage(ABC):
         Returns:
             True if the credential existed and was deleted, False otherwise
         """
-        pass
+        ...
 
     @abstractmethod
     def list_all(self) -> list[str]:
@@ -77,7 +77,7 @@ class CredentialStorage(ABC):
         Returns:
             List of credential IDs
         """
-        pass
+        ...
 
     @abstractmethod
     def exists(self, credential_id: str) -> bool:
@@ -90,7 +90,7 @@ class CredentialStorage(ABC):
         Returns:
             True if credential exists, False otherwise
         """
-        pass
+        ...
 
 
 class EncryptedFileStorage(CredentialStorage):

--- a/core/framework/credentials/tests/test_credential_store.py
+++ b/core/framework/credentials/tests/test_credential_store.py
@@ -347,6 +347,7 @@ class TestCompositeStorage:
         cred = storage.load("test")
 
         # Should get from primary
+        assert cred is not None
         assert cred.get_key("k") == "primary"
 
     def test_fallback_when_not_in_primary(self):
@@ -362,6 +363,7 @@ class TestCompositeStorage:
         storage = CompositeStorage(primary, [fallback])
         cred = storage.load("test")
 
+        assert cred is not None
         assert cred.get_key("k") == "fallback"
 
     def test_write_to_primary_only(self):

--- a/core/framework/graph/code_sandbox.py
+++ b/core/framework/graph/code_sandbox.py
@@ -288,7 +288,7 @@ class CodeSandbox:
             with self._timeout_context(self.timeout_seconds):
                 # Compile and execute
                 compiled = compile(code, "<sandbox>", "exec")
-                exec(compiled, namespace)
+                exec(compiled, namespace)  # nosec B102 - intentional sandboxed execution with restricted builtins
 
             execution_time_ms = int((time.time() - start_time) * 1000)
 
@@ -358,7 +358,7 @@ class CodeSandbox:
 
         try:
             with self._timeout_context(self.timeout_seconds):
-                result = eval(expression, namespace)
+                result = eval(expression, namespace)  # nosec B307 - intentional sandboxed eval with restricted builtins
 
             return SandboxResult(success=True, result=result)
 

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 tui = ["textual>=0.75.0"]
+vault = ["hvac>=2.0.0"]
 
 [project.scripts]
 hive = "framework.cli:main"

--- a/uv.lock
+++ b/uv.lock
@@ -774,6 +774,9 @@ dependencies = [
 tui = [
     { name = "textual" },
 ]
+vault = [
+    { name = "hvac" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -786,6 +789,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.40.0" },
     { name = "fastmcp", specifier = ">=2.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "hvac", marker = "extra == 'vault'", specifier = ">=2.0.0" },
     { name = "litellm", specifier = ">=1.81.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -796,7 +800,7 @@ requires-dist = [
     { name = "textual", marker = "extra == 'tui'", specifier = ">=0.75.0" },
     { name = "tools", editable = "tools" },
 ]
-provides-extras = ["tui"]
+provides-extras = ["tui", "vault"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1064,6 +1068,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/3f/352efd52136bfd8aa9280c6d4a445869226ae2ccd49ddad4f62e90cfd168/huggingface_hub-1.3.7.tar.gz", hash = "sha256:5f86cd48f27131cdbf2882699cbdf7a67dd4cbe89a81edfdc31211f42e4a5fd1", size = 627537, upload-time = "2026-02-02T10:40:10.61Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/89/bfbfde252d649fae8d5f09b14a2870e5672ed160c1a6629301b3e5302621/huggingface_hub-1.3.7-py3-none-any.whl", hash = "sha256:8155ce937038fa3d0cb4347d752708079bc85e6d9eb441afb44c84bcf48620d2", size = 536728, upload-time = "2026-02-02T10:40:08.274Z" },
+]
+
+[[package]]
+name = "hvac"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/57/b46c397fb3842cfb02a44609aa834c887f38dd75f290c2fc5a34da4b2fee/hvac-2.4.0.tar.gz", hash = "sha256:e0056ad9064e7923e874e6769015b032580b639e29246f5ab1044f7959c1c7e0", size = 332543, upload-time = "2025-10-30T12:57:47.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/33/71e45a6bd6875f44a26f99da31c63b6840123e88bedf2c0b1ce429b8be12/hvac-2.4.0-py3-none-any.whl", hash = "sha256:008db5efd8c2f77bd37d2368ea5f713edceae1c65f11fd608393179478649e0f", size = 155921, upload-time = "2025-10-30T12:57:46.253Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #4464

## Summary

- Fix deprecated `datetime.utcnow()` usage (Python 3.12+ deprecation)
- Correct import paths in demo files (`core.framework.credentials` → `framework.credentials`)
- Add `hvac` as optional dependency for HashiCorp Vault support
- Improve type safety with None checks in tests
- Follow PEP 484 conventions for abstract methods (`pass` → `...`)
- Add security annotations for sandboxed code execution

## Test plan

- [x] Run `uv run pytest tests/` - All 683 tests pass
- [x] Run `uv run ruff check .` - No linting errors
- [x] Run `uv run bandit -r core/framework -ll` - No High/Medium security issues
- [x] Verify demo files import correctly

## Security Scan Results (Bandit)

| Severity | Count |
|----------|-------|
| High | 0 |
| Medium | 0 (2 acknowledged with nosec) |
| Low | 313 (informational) |
| Lines scanned | 33,083 |

🤖 Generated with [Claude Code](https://claude.ai/code)