### PR TITLE
fix(runtime): validate and create storage path on init

### DIFF
--- a/core/framework/runtime/core.py
+++ b/core/framework/runtime/core.py
@@ -56,6 +56,12 @@ class Runtime:
     """
 
     def __init__(self, storage_path: str | Path):
+        # Validate and create storage path if needed
+        path = Path(storage_path) if isinstance(storage_path, str) else storage_path
+        if not path.exists():
+            logger.warning(f"Storage path does not exist, creating: {path}")
+            path.mkdir(parents=True, exist_ok=True)
+
         self.storage = FileStorage(storage_path)
         self._current_run: Run | None = None
         self._current_node: str = "unknown"


### PR DESCRIPTION
## Description
Fixes the bug where `Runtime` accepts a nonexistent storage path without validation, leading to silent failures when trying to save data later.

Fixes #1870

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Added path validation in `Runtime.__init__()`
- Logs a warning when the storage directory doesn't exist
- Auto-creates the directory with `parents=True` to prevent downstream errors
- Implements **Option 3** from the issue discussion (explicit, safe, informative)

## Before
```python
runtime = Runtime(Path('nonexistent'))  # Silently accepts
# ... later fails when trying to save
```

## After
```python
runtime = Runtime(Path('nonexistent'))
# WARNING: Storage path does not exist, creating: nonexistent
# Directory is created, saves work correctly
```

## Testing
- [x] Manual testing with nonexistent paths
- [x] Manual testing with existing paths
- [x] Lint passes (`ruff check`)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings