### PR TITLE
Fix/4464 code quality security hardening

### DIFF
--- a/core/demos/event_loop_wss_demo.py
+++ b/core/demos/event_loop_wss_demo.py
@@ -35,8 +35,8 @@ sys.path.insert(0, str(_HIVE_DIR))  # core.framework.* (for aden_tools imports)
 import os  # noqa: E402
 
 from aden_tools.credentials import CREDENTIAL_SPECS, CredentialStoreAdapter  # noqa: E402
-from core.framework.credentials import CredentialStore  # noqa: E402
 
+from framework.credentials import CredentialStore  # noqa: E402
 from framework.credentials.storage import (  # noqa: E402
     CompositeStorage,
     EncryptedFileStorage,

--- a/core/demos/github_outreach_demo.py
+++ b/core/demos/github_outreach_demo.py
@@ -53,8 +53,8 @@ sys.path.insert(0, str(_HIVE_DIR / "tools" / "src"))
 sys.path.insert(0, str(_HIVE_DIR))
 
 from aden_tools.credentials import CREDENTIAL_SPECS, CredentialStoreAdapter  # noqa: E402
-from core.framework.credentials import CredentialStore  # noqa: E402
 
+from framework.credentials import CredentialStore  # noqa: E402
 from framework.credentials.storage import (  # noqa: E402
     CompositeStorage,
     EncryptedFileStorage,
@@ -751,7 +751,7 @@ EDGES = [
 GRAPH = GraphSpec(
     id="github_outreach_pipeline",
     goal_id="outreach_goal",
-    name="GitHub Outreach Pipeline",
+    description="GitHub Outreach Pipeline",
     entry_node="intake",
     nodes=list(NODE_SPECS.values()),
     edges=EDGES,

--- a/core/demos/handoff_demo.py
+++ b/core/demos/handoff_demo.py
@@ -36,8 +36,8 @@ sys.path.insert(0, str(_HIVE_DIR / "tools" / "src"))  # aden_tools.*
 sys.path.insert(0, str(_HIVE_DIR))  # core.framework.* (for aden_tools imports)
 
 from aden_tools.credentials import CREDENTIAL_SPECS, CredentialStoreAdapter  # noqa: E402
-from core.framework.credentials import CredentialStore  # noqa: E402
 
+from framework.credentials import CredentialStore  # noqa: E402
 from framework.credentials.storage import (  # noqa: E402
     CompositeStorage,
     EncryptedFileStorage,

--- a/core/demos/org_demo.py
+++ b/core/demos/org_demo.py
@@ -40,8 +40,8 @@ sys.path.insert(0, str(_HIVE_DIR))
 import os  # noqa: E402
 
 from aden_tools.credentials import CREDENTIAL_SPECS, CredentialStoreAdapter  # noqa: E402
-from core.framework.credentials import CredentialStore  # noqa: E402
 
+from framework.credentials import CredentialStore  # noqa: E402
 from framework.credentials.storage import (  # noqa: E402
     CompositeStorage,
     EncryptedFileStorage,

--- a/core/framework/credentials/aden/client.py
+++ b/core/framework/credentials/aden/client.py
@@ -32,7 +32,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 import httpx
@@ -434,7 +434,7 @@ class AdenCredentialClient:
                 json={
                     "operation": operation,
                     "status": status,
-                    "timestamp": datetime.utcnow().isoformat() + "Z",
+                    "timestamp": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
                     "metadata": metadata or {},
                 },
             )

--- a/core/framework/credentials/provider.py
+++ b/core/framework/credentials/provider.py
@@ -59,7 +59,7 @@ class CredentialProvider(ABC):
 
         Examples: 'static', 'oauth2', 'my_custom_auth'
         """
-        pass
+        ...
 
     @property
     @abstractmethod
@@ -70,7 +70,7 @@ class CredentialProvider(ABC):
         Returns:
             List of CredentialType enums this provider supports
         """
-        pass
+        ...
 
     @abstractmethod
     def refresh(self, credential: CredentialObject) -> CredentialObject:
@@ -92,7 +92,7 @@ class CredentialProvider(ABC):
         Raises:
             CredentialRefreshError: If refresh fails
         """
-        pass
+        ...
 
     @abstractmethod
     def validate(self, credential: CredentialObject) -> bool:
@@ -110,7 +110,7 @@ class CredentialProvider(ABC):
         Returns:
             True if credential is valid, False otherwise
         """
-        pass
+        ...
 
     def should_refresh(self, credential: CredentialObject) -> bool:
         """

--- a/core/framework/credentials/storage.py
+++ b/core/framework/credentials/storage.py
@@ -41,7 +41,7 @@ class CredentialStorage(ABC):
         Args:
             credential: The credential object to save
         """
-        pass
+        ...
 
     @abstractmethod
     def load(self, credential_id: str) -> CredentialObject | None:
@@ -54,7 +54,7 @@ class CredentialStorage(ABC):
         Returns:
             CredentialObject if found, None otherwise
         """
-        pass
+        ...
 
     @abstractmethod
     def delete(self, credential_id: str) -> bool:
@@ -67,7 +67,7 @@ class CredentialStorage(ABC):
         Returns:
             True if the credential existed and was deleted, False otherwise
         """
-        pass
+        ...
 
     @abstractmethod
     def list_all(self) -> list[str]:
@@ -77,7 +77,7 @@ class CredentialStorage(ABC):
         Returns:
             List of credential IDs
         """
-        pass
+        ...
 
     @abstractmethod
     def exists(self, credential_id: str) -> bool:
@@ -90,7 +90,7 @@ class CredentialStorage(ABC):
         Returns:
             True if credential exists, False otherwise
         """
-        pass
+        ...
 
 
 class EncryptedFileStorage(CredentialStorage):

--- a/core/framework/credentials/tests/test_credential_store.py
+++ b/core/framework/credentials/tests/test_credential_store.py
@@ -345,7 +345,7 @@ class TestCompositeStorage:
 
         storage = CompositeStorage(primary, [fallback])
         cred = storage.load("test")
-
+        assert cred is not None
         # Should get from primary
         assert cred.get_key("k") == "primary"
 
@@ -361,7 +361,7 @@ class TestCompositeStorage:
 
         storage = CompositeStorage(primary, [fallback])
         cred = storage.load("test")
-
+        assert cred is not None
         assert cred.get_key("k") == "fallback"
 
     def test_write_to_primary_only(self):
@@ -599,6 +599,7 @@ class TestCredentialStore:
         store.register_usage(spec)
 
         errors = store.validate_for_usage("test")
+        assert len(errors) > 0
         assert "api_key" in errors[0]
 
     def test_caching(self):

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 tui = ["textual>=0.75.0"]
+vault = ["hvac"]
 
 [project.scripts]
 hive = "framework.cli:main"

--- a/core/tests/test_event_loop_integration.py
+++ b/core/tests/test_event_loop_integration.py
@@ -349,7 +349,7 @@ async def test_event_loop_node_in_graph(runtime):
     graph = GraphSpec(
         id="test_graph",
         goal_id="test_goal",
-        name="Test Graph",
+        description="Test Graph",
         entry_node="el_node",
         nodes=[node_spec],
         edges=[],
@@ -810,7 +810,7 @@ async def test_event_loop_no_executor_retry(runtime):
     graph = GraphSpec(
         id="test_graph",
         goal_id="test_goal",
-        name="Test Graph",
+        description="Test Graph",
         entry_node="el_fail",
         nodes=[node_spec],
         edges=[],
@@ -882,7 +882,7 @@ async def test_context_handoff_between_nodes(runtime):
     graph = GraphSpec(
         id="handoff_graph",
         goal_id="test_goal",
-        name="Handoff Graph",
+        description="Handoff Graph",
         entry_node="enrichment",
         nodes=[enrichment_spec, strategy_spec],
         edges=[
@@ -1062,7 +1062,7 @@ async def test_mixed_node_graph(runtime):
     graph = GraphSpec(
         id="pipeline_graph",
         goal_id="test_goal",
-        name="Pipeline Graph",
+        description="Pipeline Graph",
         entry_node="load",
         nodes=[load_spec, process_spec, format_spec],
         edges=[
@@ -1146,7 +1146,7 @@ async def test_fan_out_rejects_overlapping_output_keys(runtime):
     graph = GraphSpec(
         id="fanout_graph",
         goal_id="test_goal",
-        name="Fan Out Graph",
+        description="Fan Out Graph",
         entry_node="source",
         nodes=[source_spec, branch_a_spec, branch_b_spec],
         edges=[

--- a/core/tests/test_event_loop_wiring.py
+++ b/core/tests/test_event_loop_wiring.py
@@ -156,7 +156,7 @@ async def test_event_loop_max_retries_forced_zero(runtime):
     graph = GraphSpec(
         id="test_graph",
         goal_id="test_goal",
-        name="Test Graph",
+        description="Test Graph",
         entry_node="el_fail",
         nodes=[node_spec],
         edges=[],
@@ -191,7 +191,7 @@ async def test_event_loop_max_retries_zero_no_warning(runtime, caplog):
     graph = GraphSpec(
         id="test_graph",
         goal_id="test_goal",
-        name="Test Graph",
+        description="Test Graph",
         entry_node="el_zero",
         nodes=[node_spec],
         edges=[],
@@ -228,7 +228,7 @@ async def test_event_loop_max_retries_positive_logs_warning(runtime, caplog):
     graph = GraphSpec(
         id="test_graph",
         goal_id="test_goal",
-        name="Test Graph",
+        description="Test Graph",
         entry_node="el_warn",
         nodes=[node_spec],
         edges=[],

--- a/core/tests/test_executor_feedback_edges.py
+++ b/core/tests/test_executor_feedback_edges.py
@@ -117,7 +117,7 @@ async def test_visit_limit_skips_node(runtime, goal):
     graph = GraphSpec(
         id="cycle_graph",
         goal_id="g1",
-        name="Cycle Graph",
+        description="Cycle Graph",
         entry_node="a",
         nodes=[node_a, node_b],
         edges=[
@@ -175,7 +175,7 @@ async def test_visit_limit_allows_multiple(runtime, goal):
     graph = GraphSpec(
         id="cycle_graph",
         goal_id="g1",
-        name="Cycle Graph",
+        description="Cycle Graph",
         entry_node="a",
         nodes=[node_a, node_b],
         edges=[
@@ -231,7 +231,7 @@ async def test_visit_limit_zero_unlimited(runtime, goal):
     graph = GraphSpec(
         id="cycle_graph",
         goal_id="g1",
-        name="Cycle Graph",
+        description="Cycle Graph",
         entry_node="a",
         nodes=[node_a, node_b],
         edges=[
@@ -297,7 +297,7 @@ async def test_conditional_feedback_edge(runtime, goal):
     graph = GraphSpec(
         id="feedback_graph",
         goal_id="g1",
-        name="Feedback Graph",
+        description="Feedback Graph",
         entry_node="director",
         nodes=[director, writer, output_node],
         edges=[
@@ -392,7 +392,7 @@ async def test_conditional_feedback_false(runtime, goal):
     graph = GraphSpec(
         id="feedback_graph",
         goal_id="g1",
-        name="Feedback Graph",
+        description="Feedback Graph",
         entry_node="director",
         nodes=[director, writer, output_node],
         edges=[
@@ -473,7 +473,7 @@ async def test_visit_counts_in_result(runtime, goal):
     graph = GraphSpec(
         id="linear_graph",
         goal_id="g1",
-        name="Linear Graph",
+        description="Linear Graph",
         entry_node="a",
         nodes=[node_a, node_b],
         edges=[
@@ -531,7 +531,7 @@ async def test_conditional_priority_prevents_fanout(runtime, goal):
     graph = GraphSpec(
         id="priority_graph",
         goal_id="g1",
-        name="Priority Graph",
+        description="Priority Graph",
         entry_node="writer",
         nodes=[writer, output_node, director],
         edges=[

--- a/core/tests/test_executor_max_retries.py
+++ b/core/tests/test_executor_max_retries.py
@@ -87,7 +87,7 @@ async def test_executor_respects_custom_max_retries_high(runtime):
     graph = GraphSpec(
         id="test_graph",
         goal_id="test_goal",
-        name="Test Graph",
+        description="Test Graph",
         entry_node="flaky_node",
         nodes=[node_spec],
         edges=[],
@@ -131,7 +131,7 @@ async def test_executor_respects_custom_max_retries_low(runtime):
     graph = GraphSpec(
         id="test_graph",
         goal_id="test_goal",
-        name="Test Graph",
+        description="Test Graph",
         entry_node="fragile_node",
         nodes=[node_spec],
         edges=[],
@@ -174,7 +174,7 @@ async def test_executor_respects_default_max_retries(runtime):
     graph = GraphSpec(
         id="test_graph",
         goal_id="test_goal",
-        name="Test Graph",
+        description="Test Graph",
         entry_node="default_node",
         nodes=[node_spec],
         edges=[],
@@ -219,7 +219,7 @@ async def test_executor_max_retries_two_succeeds_on_second(runtime):
     graph = GraphSpec(
         id="test_graph",
         goal_id="test_goal",
-        name="Test Graph",
+        description="Test Graph",
         entry_node="two_retry_node",
         nodes=[node_spec],
         edges=[],

--- a/core/tests/test_fanout.py
+++ b/core/tests/test_fanout.py
@@ -149,7 +149,7 @@ def _make_fanout_graph(
     return GraphSpec(
         id="fanout_graph",
         goal_id="g1",
-        name="Fanout Graph",
+        description="Fanout Graph",
         entry_node="source",
         nodes=nodes,
         edges=edges,
@@ -408,7 +408,7 @@ async def test_single_edge_no_parallel_overhead(runtime, goal):
     graph = GraphSpec(
         id="seq_graph",
         goal_id="g1",
-        name="Sequential",
+        description="Sequential",
         entry_node="n1",
         nodes=[n1, n2],
         edges=[EdgeSpec(id="e1", source="n1", target="n2", condition=EdgeCondition.ON_SUCCESS)],

--- a/core/tests/test_on_failure_edges.py
+++ b/core/tests/test_on_failure_edges.py
@@ -120,7 +120,7 @@ async def test_on_failure_edge_followed_after_max_retries(runtime, goal):
     graph = GraphSpec(
         id="test_graph",
         goal_id="test_goal",
-        name="Test Graph",
+        description="Test Graph",
         entry_node="failing",
         nodes=nodes,
         edges=edges,
@@ -165,7 +165,7 @@ async def test_no_on_failure_edge_still_terminates(runtime, goal):
     graph = GraphSpec(
         id="test_graph",
         goal_id="test_goal",
-        name="Test Graph",
+        description="Test Graph",
         entry_node="failing",
         nodes=[nodes[0]],
         edges=[],
@@ -230,7 +230,7 @@ async def test_on_failure_edge_not_followed_on_success(runtime, goal):
     graph = GraphSpec(
         id="test_graph",
         goal_id="test_goal",
-        name="Test Graph",
+        description="Test Graph",
         entry_node="working",
         nodes=nodes,
         edges=edges,
@@ -286,7 +286,7 @@ async def test_on_failure_edge_with_zero_retries(runtime, goal):
     graph = GraphSpec(
         id="test_graph",
         goal_id="test_goal",
-        name="Test Graph",
+        description="Test Graph",
         entry_node="fragile",
         nodes=nodes,
         edges=edges,
@@ -342,7 +342,7 @@ async def test_on_failure_handler_appears_in_path(runtime, goal):
     graph = GraphSpec(
         id="test_graph",
         goal_id="test_goal",
-        name="Test Graph",
+        description="Test Graph",
         entry_node="failing",
         nodes=nodes,
         edges=edges,

--- a/docs/articles/building-production-ai-agents.md
+++ b/docs/articles/building-production-ai-agents.md
@@ -385,7 +385,7 @@ def sanitize_output(result):
 ```python
 async def audit_log(event):
     log_entry = {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(UTC).isoformat(),
         "event_type": event.type,
         "agent_id": event.agent_id,
         "user_id": event.user_id,

--- a/uv.lock
+++ b/uv.lock
@@ -774,6 +774,9 @@ dependencies = [
 tui = [
     { name = "textual" },
 ]
+vault = [
+    { name = "hvac" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -786,6 +789,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.40.0" },
     { name = "fastmcp", specifier = ">=2.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "hvac", marker = "extra == 'vault'" },
     { name = "litellm", specifier = ">=1.81.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -796,7 +800,7 @@ requires-dist = [
     { name = "textual", marker = "extra == 'tui'", specifier = ">=0.75.0" },
     { name = "tools", editable = "tools" },
 ]
-provides-extras = ["tui"]
+provides-extras = ["tui", "vault"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1064,6 +1068,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/3f/352efd52136bfd8aa9280c6d4a445869226ae2ccd49ddad4f62e90cfd168/huggingface_hub-1.3.7.tar.gz", hash = "sha256:5f86cd48f27131cdbf2882699cbdf7a67dd4cbe89a81edfdc31211f42e4a5fd1", size = 627537, upload-time = "2026-02-02T10:40:10.61Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/89/bfbfde252d649fae8d5f09b14a2870e5672ed160c1a6629301b3e5302621/huggingface_hub-1.3.7-py3-none-any.whl", hash = "sha256:8155ce937038fa3d0cb4347d752708079bc85e6d9eb441afb44c84bcf48620d2", size = 536728, upload-time = "2026-02-02T10:40:08.274Z" },
+]
+
+[[package]]
+name = "hvac"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/57/b46c397fb3842cfb02a44609aa834c887f38dd75f290c2fc5a34da4b2fee/hvac-2.4.0.tar.gz", hash = "sha256:e0056ad9064e7923e874e6769015b032580b639e29246f5ab1044f7959c1c7e0", size = 332543, upload-time = "2025-10-30T12:57:47.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/33/71e45a6bd6875f44a26f99da31c63b6840123e88bedf2c0b1ce429b8be12/hvac-2.4.0-py3-none-any.whl", hash = "sha256:008db5efd8c2f77bd37d2368ea5f713edceae1c65f11fd608393179478649e0f", size = 155921, upload-time = "2025-10-30T12:57:46.253Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Addresses code quality and security hardening from static analysis: deprecated datetime API, wrong demo import paths, undeclared GraphSpec field, missing optional dependency, PEP 484 abstract methods, and type-safety in credential store tests.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #4464

## Changes Made

- Replace `datetime.utcnow()` with `datetime.now(UTC)` in code and docs (Python 3.12+)
- Fix demo import paths from `core.framework.credentials` to `framework.credentials` (org_demo, handoff_demo, event_loop_wss_demo, github_outreach_demo)
- Use declared `description=` instead of undeclared `name=` for all `GraphSpec` instantiations in tests and demos
- Add `hvac` as optional dependency under `[project.optional-dependencies]` as `vault = ["hvac"]`
- Use `...` instead of `pass` in abstract methods in `storage.py` and `provider.py` (PEP 484)
- Add None checks in credential store tests (e.g. after `storage.load`, and `len(errors) > 0` before `errors[0]` in `test_validate_for_usage_missing_key`)

## Testing

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A