### PR TITLE
Fix race condition in SHARED isolation level

### DIFF
--- a/core/framework/runtime/shared_state.py
+++ b/core/framework/runtime/shared_state.py
@@ -208,8 +208,10 @@ class SharedStateManager:
         if isolation == IsolationLevel.ISOLATED:
             scope = StateScope.EXECUTION
 
-        # SYNCHRONIZED requires locks for stream/global writes
-        if isolation == IsolationLevel.SYNCHRONIZED and scope != StateScope.EXECUTION:
+        #Both SHARED states(SYNCHRONIZED or SHARED) requires locks for stream/global writes 
+        #ISOLATED mode writes directly to execution-private state(no race possible)
+
+        if isolation != IsolationLevel.ISOLATED and scope != StateScope.EXECUTION:
             await self._write_with_lock(key, value, execution_id, stream_id, scope)
         else:
             await self._write_direct(key, value, execution_id, stream_id, scope)


### PR DESCRIPTION
## Description
- Add locks to SHARED mode for stream/global writes
- Only ISOLATED mode uses direct writes
- Prevents concurrent session state corruption

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes: Concurrent writes to shared session state cause data corruption

## Changes Made

- Modified write routing condition in shared_state.py:write() to use _write_with_lock() for both SHARED and SYNCHRONIZED modes
- Only ISOLATED mode and EXECUTION scope writes use _write_direct()

## Testing

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A
