### PR TITLE
micro-fix: fix typo STIRCT → STRICT in safe_eval.py

### DIFF
--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -145,7 +145,7 @@ class SafeEvalVisitor(ast.NodeVisitor):
 
     def visit_Attribute(self, node: ast.Attribute) -> Any:
         # value.attr
-        # STIRCT CHECK: No access to private attributes (starting with _)
+        # STRICT CHECK: No access to private attributes (starting with _)
         if node.attr.startswith("_"):
             raise ValueError(f"Access to private attribute '{node.attr}' is not allowed")
 


### PR DESCRIPTION
Fixes #4444

Simple typo fix in security comment:
- `STIRCT CHECK` → `STRICT CHECK`

**Changes:**
- 1 line changed in `core/framework/graph/safe_eval.py`
- Documentation/comment fix only
- No functional changes
