### PR TITLE
docs: add tech news reporter IO example

### DIFF
--- a/examples/templates/tech_news_reporter/README.md
+++ b/examples/templates/tech_news_reporter/README.md
@@ -93,7 +93,14 @@ from framework.runner import AgentRunner
 runner = AgentRunner.load("examples/templates/tech_news_reporter")
 
 # Run with input
-result = await runner.run({"query": "General tech and AI roundup for the past week."})
+# Start the run (agent will pause to ask the user for a focus area)
+result = await runner.run({})
+
+# Resume after the intake node asks its question
+result = await runner.run(
+    {"query": "General tech and AI roundup for the past week."},
+    session_state=result.session_state,
+)
 
 # Access results
 print(result.output)
@@ -102,7 +109,7 @@ print(result.status)
 
 ### Example Input/Output
 
-Example input passed to the entry point:
+Example input passed when resuming after the intake prompt:
 
 ```python
 {"query": "Focus on LLMs and robotics, plus any major AI product launches."}

--- a/examples/templates/tech_news_reporter/README.md
+++ b/examples/templates/tech_news_reporter/README.md
@@ -93,11 +93,27 @@ from framework.runner import AgentRunner
 runner = AgentRunner.load("examples/templates/tech_news_reporter")
 
 # Run with input
-result = await runner.run({"input_key": "value"})
+result = await runner.run({"query": "General tech and AI roundup for the past week."})
 
 # Access results
 print(result.output)
 print(result.status)
+```
+
+### Example Input/Output
+
+Example input passed to the entry point:
+
+```python
+{"query": "Focus on LLMs and robotics, plus any major AI product launches."}
+```
+
+Example output shape after the report is generated:
+
+```json
+{
+  "report_file": "tech_news_report.html"
+}
 ```
 
 ### Input Schema


### PR DESCRIPTION
## Description

Add a minimal input/output example to the tech_news_reporter template README and replace the placeholder input key with the real `query` shape so users see how to run the agent and what to expect.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #4477

## Changes Made

- Add example input/output snippet under Usage
- Replace placeholder input key with `query`
- Clarify expected output shape for the report file

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A