### PR TITLE
docs: fix .env.example references in tools README

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -16,10 +16,10 @@ uv pip install -e "tools[dev]"
 
 ## Environment Setup
 
-Some tools require API keys to function. Copy the example file and add your credentials:
+Some tools require API keys to function. Credentials are managed through the encrypted credential store at `~/.hive/credentials`, which is configured automatically during initial setup:
 
 ```bash
-cp .env.example .env
+./quickstart.sh
 ```
 
 | Variable               | Required For                  | Get Key                                                 |
@@ -31,14 +31,14 @@ cp .env.example .env
 
 > **Note:** `web_search` supports multiple providers. Set either Brave OR Google credentials. Brave is preferred for backward compatibility.
 
-Alternatively, export as environment variables:
+Alternatively, export credentials as environment variables:
 
 ```bash
 export ANTHROPIC_API_KEY=your-key-here
 export BRAVE_SEARCH_API_KEY=your-key-here
 ```
 
-See [.env.example](.env.example) for details.
+See the [credentials module](src/aden_tools/credentials/) for details on how credentials are resolved.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- Updated tools/README.md to remove references to nonexistent .env.example file
- The file does not exist in the tools/ directory
- Updated setup instructions to reflect current credential management process

Closes #4494

## Test plan
- [ ] tools/README.md renders correctly
- [ ] Setup instructions are accurate