### PR TITLE
fix: remove unused tools from root .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -4,11 +4,6 @@
       "command": "uv",
       "args": ["run", "-m", "framework.mcp.agent_builder_server"],
       "cwd": "core"
-    },
-    "tools": {
-      "command": "uv",
-      "args": ["run", "mcp_server.py", "--stdio"],
-      "cwd": "tools"
     }
   }
 }


### PR DESCRIPTION
## Description

Tools MCP are currently not used by the coding agent yet incldued in the root mcp json. To reduce confusion, deleting it from the project

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #4375