### PR TITLE
fix: improve "no agents found" error messages with actionable next steps

### DIFF
--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -7,6 +7,23 @@ import sys
 from pathlib import Path
 
 
+def _no_agents_hint(directory: str | Path | None = None) -> str:
+    """Return a helpful hint message when no agents are found."""
+    if directory:
+        header = f"No agents found in {directory}"
+    else:
+        header = "No agents found in exports/ or examples/templates/"
+    return (
+        f"{header}\n"
+        "\n"
+        "To get started:\n"
+        "  Copy a template:    cp -r examples/templates/deep_research_agent exports/my_agent\n"
+        "  Run minimal demo:   uv run python core/examples/manual_agent.py\n"
+        "  Build with Claude:  claude /hive\n"
+        "  See docs:           docs/getting-started.md\n"
+    )
+
+
 def register_commands(subparsers: argparse._SubParsersAction) -> None:
     """Register runner commands with the main CLI."""
 
@@ -710,7 +727,7 @@ def cmd_list(args: argparse.Namespace) -> int:
     directory = Path(args.directory)
     if not directory.exists():
         # FIX: Handle missing directory gracefully on fresh install
-        print(f"No agents found in {directory}")
+        print(_no_agents_hint(directory))
         return 0
 
     agents = []
@@ -740,7 +757,7 @@ def cmd_list(args: argparse.Namespace) -> int:
                 )
 
     if not agents:
-        print(f"No agents found in {directory}")
+        print(_no_agents_hint(directory))
         return 0
 
     print(f"Agents in {directory}:\n")
@@ -793,7 +810,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
                 agent_paths.append((path.name, path))
 
     if not agent_paths:
-        print(f"No agents found in {agents_dir}", file=sys.stderr)
+        print(_no_agents_hint(agents_dir), file=sys.stderr)
         return 1
 
     # Register agents
@@ -1241,7 +1258,7 @@ def cmd_tui(args: argparse.Namespace) -> int:
     has_examples = _has_agents(examples_dir)
 
     if not has_exports and not has_examples:
-        print("No agents found in exports/ or examples/templates/", file=sys.stderr)
+        print(_no_agents_hint(), file=sys.stderr)
         return 1
 
     # Determine which directory to browse
@@ -1449,7 +1466,7 @@ def _select_agent(agents_dir: Path) -> str | None:
             agents.append(path)
 
     if not agents:
-        print(f"No agents found in {agents_dir}", file=sys.stderr)
+        print(_no_agents_hint(agents_dir), file=sys.stderr)
         return None
 
     # Pagination setup
@@ -1588,7 +1605,7 @@ def _interactive_multi(agents_dir: Path) -> int:
                 print(f"Warning: Failed to register {path.name}: {e}")
 
     if agent_count == 0:
-        print(f"No agents found in {agents_dir}", file=sys.stderr)
+        print(_no_agents_hint(agents_dir), file=sys.stderr)
         return 1
 
     print(f"\n{'=' * 60}")


### PR DESCRIPTION
## What

Improved all 6 "No agents found" error messages across `hive list`, `hive tui`, `hive shell`, `hive dispatch`, and `hive eval` to include actionable next steps for new users.

## Why

On a fresh install, running `hive list` or `hive tui` with an empty `exports/` directory shows a bare error like `No agents found in exports/`. This is a dead end — especially for users who don't have Claude Code and want to build agents manually. There's no indication of what to do next, where to find examples, or how to get started.

## Changes

**1 file changed:** `core/framework/runner/cli.py` (+23, −6)

- Added a `_no_agents_hint()` helper function that generates a consistent, helpful message with 4 clear next steps
- Replaced all 6 bare "No agents found" error messages with the new helper:
  - `cmd_list` (2 locations: missing directory + empty directory)
  - `cmd_dispatch` (empty agents directory)
  - `cmd_tui` (no agents in exports/ or examples/)
  - `_select_agent` (used by `hive shell`)
  - `_interactive_multi` (multi-agent mode)

## Before / After

**Before:** `No agents found in exports/`

**After:**

No agents found in exports/

To get started:
  Copy a template:    cp -r examples/templates/deep_research_agent exports/my_agent
  Run minimal demo:   uv run python core/examples/manual_agent.py
  Build with Claude:  claude /hive
  See docs:           docs/getting-started.md

## How to test

1. See the improved message (point to any empty/nonexistent directory): `./hive list /tmp/empty`
2. Verify existing tests still pass: `uv run python -m pytest core/tests/test_cli_entry_point.py -v`

All 9 existing CLI tests pass with no changes needed.

## Context

I discovered this pain point while onboarding as a new contributor — I set up the project with `./quickstart.sh`, configured OpenAI as my LLM provider, and ran `hive list` only to hit the bare error with no guidance. The fix is intentionally small and self-contained: one helper function, one file, consistent messaging across all CLI commands.