### PR TITLE
fix(graph): prevent memory keys from shadowing reserved context in edge conditions

### DIFF
--- a/core/tests/test_edge_context_shadowing.py
+++ b/core/tests/test_edge_context_shadowing.py
@@ -1,0 +1,83 @@
+"""Tests for edge condition context-key precedence.
+
+Verifies that memory keys cannot shadow reserved context keys
+(output, result, true, false) during conditional-edge evaluation.
+"""
+
+from framework.graph.edge import EdgeCondition, EdgeSpec
+
+
+class TestConditionContextShadowing:
+    """Memory keys must not overwrite reserved context variables."""
+
+    def test_memory_result_does_not_shadow_output_result(self):
+        """A memory key 'result' must not override output.get('result')."""
+        edge = EdgeSpec(
+            id="e1",
+            source="a",
+            target="b",
+            condition=EdgeCondition.CONDITIONAL,
+            condition_expr="result == 'current'",
+        )
+        output = {"result": "current"}
+        memory = {"result": "stale_memory_value"}
+
+        # 'result' in the context should be output.get("result"),
+        # not the memory value.
+        assert edge._evaluate_condition(output, memory) is True
+
+    def test_memory_output_does_not_shadow_output_dict(self):
+        """A memory key named 'output' must not replace the output dict."""
+        edge = EdgeSpec(
+            id="e2",
+            source="a",
+            target="b",
+            condition=EdgeCondition.CONDITIONAL,
+            condition_expr='output.get("status") == "done"',
+        )
+        output = {"status": "done"}
+        memory = {"output": "some_string"}
+
+        assert edge._evaluate_condition(output, memory) is True
+
+    def test_memory_true_does_not_shadow_boolean(self):
+        """A memory key named 'true' must not replace the boolean True."""
+        edge = EdgeSpec(
+            id="e3",
+            source="a",
+            target="b",
+            condition=EdgeCondition.CONDITIONAL,
+            condition_expr="true",
+        )
+        output = {}
+        memory = {"true": 0}  # Would be falsy if it shadowed
+
+        assert edge._evaluate_condition(output, memory) is True
+
+    def test_memory_false_does_not_shadow_boolean(self):
+        """A memory key named 'false' must not replace the boolean False."""
+        edge = EdgeSpec(
+            id="e4",
+            source="a",
+            target="b",
+            condition=EdgeCondition.CONDITIONAL,
+            condition_expr="false",
+        )
+        output = {}
+        memory = {"false": 1}  # Would be truthy if it shadowed
+
+        assert edge._evaluate_condition(output, memory) is False
+
+    def test_non_reserved_memory_keys_still_accessible(self):
+        """Normal (non-reserved) memory keys should still be directly accessible."""
+        edge = EdgeSpec(
+            id="e5",
+            source="a",
+            target="b",
+            condition=EdgeCondition.CONDITIONAL,
+            condition_expr="confidence > 0.5",
+        )
+        output = {}
+        memory = {"confidence": 0.9}
+
+        assert edge._evaluate_condition(output, memory) is True


### PR DESCRIPTION
**Author:** Konstantinos Foskolakis — Full Stack Web Engineer

## Problem

Conditional edge evaluation in `_evaluate_condition()` silently produces wrong routing decisions when shared memory contains keys that clash with reserved context names (`result`, `output`, `true`, `false`).

Since `result` is an extremely common output key, any agent with a conditional edge expression like `result == "done"` will evaluate against a stale memory value instead of the current node's output — sending execution down the wrong path with no error or warning.

Additionally, the `EdgeSpec` docstring shows `output.confidence < 0.8` as an example, but `output` is a plain `dict` — dot notation raises `AttributeError`, which the exception handler silently catches and returns `False`.

## Root cause

The context dict was built with `**memory` unpacked **after** the reserved keys. In Python, later keys in a `{**a, "key": val, **b}` literal overwrite earlier ones, so `**memory` overwrote `result`, `output`, `true`, and `false` whenever those names appeared in shared memory.

## Solution

Move `**memory` to the **first** position in the dict literal so reserved keys always take precedence:

```python
context = {
    **memory,           # placed first — cannot shadow reserved keys below
    "output": output,
    "memory": memory,
    "result": output.get("result"),
    "true": True,
    "false": False,
}
```

Also fixed the docstring example to use correct dict-access syntax: `output.get("confidence", 0) < 0.8`.

## Impact / Compatibility

- **Behavior change**: Memory keys named `result`, `output`, `true`, or `false` can no longer shadow the reserved context values. Any existing condition expressions that *relied* on the shadowing were getting incorrect results anyway, so this is a correctness fix.
- No API changes. No new dependencies.

## Validation

- 5 new tests in `test_edge_context_shadowing.py` — all pass
- All 25 existing edge/conditional tests pass
- Full suite: 688 passed, 51 skipped, 0 failures
- Lint clean (ruff check + ruff format)

## Risk level

**MED** — Changes core condition evaluation semantics, but the previous behavior was objectively wrong (memory overwriting output). The fix restores the intended invariant. Tests cover all reserved key names.
