### PR TITLE
fix(config): handle explicit null for max_tokens in configuration.json

### DIFF
--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -46,7 +46,10 @@ def get_preferred_model() -> str:
 
 def get_max_tokens() -> int:
     """Return the configured max_tokens, falling back to DEFAULT_MAX_TOKENS."""
-    return get_hive_config().get("llm", {}).get("max_tokens", DEFAULT_MAX_TOKENS)
+    value = get_hive_config().get("llm", {}).get("max_tokens")
+    if value is None:
+        return DEFAULT_MAX_TOKENS
+    return int(value)
 
 
 def get_api_key() -> str | None:

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -8,10 +8,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from framework.config import get_hive_config, get_preferred_model
+from framework.config import get_hive_config, get_max_tokens, get_preferred_model
 from framework.graph import Goal
 from framework.graph.edge import (
-    DEFAULT_MAX_TOKENS,
     AsyncEntryPointSpec,
     EdgeCondition,
     EdgeSpec,
@@ -500,8 +499,7 @@ class AgentRunner:
             if agent_config and hasattr(agent_config, "max_tokens"):
                 max_tokens = agent_config.max_tokens
             else:
-                hive_config = get_hive_config()
-                max_tokens = hive_config.get("llm", {}).get("max_tokens", DEFAULT_MAX_TOKENS)
+                max_tokens = get_max_tokens()
 
             # Read intro_message from agent metadata (shown on TUI load)
             agent_metadata = getattr(agent_module, "metadata", None)


### PR DESCRIPTION
**Author:** Konstantinos Foskolakis — Full Stack Web Engineer

## Problem

Setting `"max_tokens": null` in `~/.hive/configuration.json` crashes agent loading with a Pydantic `ValidationError` because `None` propagates to `GraphSpec.max_tokens` (typed as `int`).

Users may set `null` to mean "use the default" — a common JSON convention — but the code treats it as a valid value.

## Root cause

`dict.get("max_tokens", DEFAULT_MAX_TOKENS)` only applies the fallback when the key is **missing**, not when its value is `None`. The same bug existed in both `config.py` and `runner.py`.

## Solution

- `config.py`: Explicit `None` check — return `DEFAULT_MAX_TOKENS` when the value is `None`, cast to `int` otherwise.
- `runner.py`: Replace duplicated inline lookup with a call to `get_max_tokens()` (the centralised helper that now handles `None` correctly). Removed the now-unused `DEFAULT_MAX_TOKENS` import.

## Impact / Compatibility

- No behavior change for users with valid `int` values or missing keys.
- Users with `"max_tokens": null` now get the default (8192) instead of a crash.
- No API changes.

## Validation

- Config and runner tests pass
- Full suite: 688 passed, 51 skipped, 0 failures
- Lint clean (ruff check + ruff format)

## Risk level

**LOW** — Purely defensive; only changes behavior for the `null` edge case (which previously crashed).
