### PR TITLE
fix(executor): pre-init node_spec and guard parallel None.name

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -427,6 +427,7 @@ class GraphExecutor:
                 data_dir=str(self._storage_path / "data"),
             )
 
+        node_spec = None  # Pre-initialise so the except handler never hits UnboundLocalError
         try:
             while steps < graph.max_steps:
                 steps += 1
@@ -1652,7 +1653,9 @@ class GraphExecutor:
 
         # Handle failures based on config
         if failed_branches:
-            failed_names = [graph.get_node(b.node_id).name for b in failed_branches]
+            failed_names = [
+                n.name if (n := graph.get_node(b.node_id)) else b.node_id for b in failed_branches
+            ]
             if self._parallel_config.on_branch_failure == "fail_all":
                 raise RuntimeError(f"Parallel execution failed: branches {failed_names} failed")
             elif self._parallel_config.on_branch_failure == "continue_others":

--- a/core/tests/test_executor_exception_safety.py
+++ b/core/tests/test_executor_exception_safety.py
@@ -1,0 +1,253 @@
+"""
+Regression tests for executor exception-safety fixes.
+
+Covers:
+  - node_spec pre-initialisation so the except handler never
+    raises UnboundLocalError (issue #4514, finding 1).
+  - Parallel branch failure reporting gracefully falls back
+    to node_id when graph.get_node() returns None (issue #4514, finding 2).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from framework.graph.edge import GraphSpec
+from framework.graph.executor import GraphExecutor
+from framework.graph.goal import Goal
+from framework.graph.node import NodeResult, NodeSpec
+
+# ---- Shared helpers (mirror existing test_graph_executor.py) ----
+
+
+class DummyRuntime:
+    """Minimal runtime stub that records calls for assertions."""
+
+    def __init__(self):
+        self.problems: list[dict] = []
+        self.ended = False
+
+    def start_run(self, **kwargs):
+        return "run-1"
+
+    def end_run(self, **kwargs):
+        self.ended = True
+
+    def report_problem(self, **kwargs):
+        self.problems.append(kwargs)
+
+
+class SuccessNode:
+    def validate_input(self, ctx):
+        return []
+
+    async def execute(self, ctx):
+        return NodeResult(
+            success=True,
+            output={"result": 42},
+            tokens_used=1,
+            latency_ms=1,
+        )
+
+
+class FailingNode:
+    def validate_input(self, ctx):
+        return []
+
+    async def execute(self, ctx):
+        return NodeResult(
+            success=False,
+            error="branch-boom",
+            output={},
+            tokens_used=0,
+            latency_ms=0,
+        )
+
+
+# ── Finding 1: node_spec unbound in except handler ──────────────
+
+
+@pytest.mark.asyncio
+async def test_exception_before_node_spec_does_not_cause_unbound_error():
+    """
+    If graph.get_node() raises inside the try block (before node_spec is
+    assigned on the current iteration), the except handler must still work
+    — it should NOT raise UnboundLocalError.
+
+    Before the fix, `node_spec` was first assigned inside the while-loop;
+    an exception before that line left it undefined, causing the except
+    handler to crash with UnboundLocalError and mask the real error.
+    """
+    runtime = DummyRuntime()
+
+    graph = GraphSpec(
+        id="graph-unbound",
+        goal_id="g-unbound",
+        nodes=[
+            NodeSpec(
+                id="n1",
+                name="node1",
+                description="test node",
+                node_type="llm_generate",
+                input_keys=[],
+                output_keys=["result"],
+                max_retries=0,
+            )
+        ],
+        edges=[],
+        entry_node="n1",
+    )
+
+    executor = GraphExecutor(
+        runtime=runtime,
+        node_registry={"n1": SuccessNode()},
+    )
+
+    goal = Goal(id="g-unbound", name="unbound-test", description="unbound node_spec test")
+
+    # Patch get_node so it works normally during graph.validate() but raises
+    # *inside* the executor's try block (simulating corruption/race).  The
+    # simple graph triggers exactly 1 get_node call during validate(), so we
+    # let the first call through and raise on all subsequent ones.
+    original_get_node = graph.get_node
+    call_count = 0
+
+    def raise_after_validation(node_id: str):
+        nonlocal call_count
+        call_count += 1
+        if call_count > 1:
+            raise ValueError("simulated get_node failure")
+        return original_get_node(node_id)
+
+    with patch.object(graph, "get_node", side_effect=raise_after_validation):
+        result = await executor.execute(graph=graph, goal=goal)
+
+    # The executor should surface the *original* ValueError, not UnboundLocalError
+    assert result.success is False
+    assert "simulated get_node failure" in (result.error or "")
+
+    # Runtime should have been notified of the problem
+    assert runtime.ended is True
+    assert len(runtime.problems) == 1
+    assert "simulated get_node failure" in runtime.problems[0]["description"]
+
+
+@pytest.mark.asyncio
+async def test_exception_handler_logs_node_when_node_spec_assigned():
+    """
+    When node_spec IS assigned before the exception, the except handler
+    should still work correctly (the pre-init doesn't break existing paths).
+    """
+    runtime = DummyRuntime()
+
+    class CrashingNode:
+        """Node whose execute() raises an unexpected exception."""
+
+        def validate_input(self, ctx):
+            return []
+
+        async def execute(self, ctx):
+            raise RuntimeError("unexpected node crash")
+
+    graph = GraphSpec(
+        id="graph-crash",
+        goal_id="g-crash",
+        nodes=[
+            NodeSpec(
+                id="n1",
+                name="crasher",
+                description="crashing node",
+                node_type="llm_generate",
+                input_keys=[],
+                output_keys=["result"],
+                max_retries=0,
+            )
+        ],
+        edges=[],
+        entry_node="n1",
+    )
+
+    executor = GraphExecutor(
+        runtime=runtime,
+        node_registry={"n1": CrashingNode()},
+    )
+
+    goal = Goal(id="g-crash", name="crash-test", description="node crash test")
+    result = await executor.execute(graph=graph, goal=goal)
+
+    assert result.success is False
+    assert "unexpected node crash" in (result.error or "")
+    assert runtime.ended is True
+
+
+# ── Finding 2: parallel branch failure with get_node() returning None ─
+
+
+@pytest.mark.asyncio
+async def test_parallel_branch_failure_none_node_uses_fallback_name():
+    """
+    When a parallel branch fails and graph.get_node(branch.node_id) returns
+    None, the error message should fall back to using the raw node_id instead
+    of crashing with AttributeError: 'NoneType' has no attribute 'name'.
+    """
+
+    graph = GraphSpec(
+        id="graph-par",
+        goal_id="g-par",
+        nodes=[
+            NodeSpec(
+                id="fan-out",
+                name="fan-out-node",
+                description="fan-out node",
+                node_type="llm_generate",
+                input_keys=[],
+                output_keys=["result"],
+                parallel_branches=[
+                    {"branch_id": "b1", "node_id": "branch-1"},
+                    {"branch_id": "b2", "node_id": "branch-2"},
+                ],
+                max_retries=0,
+            ),
+            NodeSpec(
+                id="branch-1",
+                name="branch-one",
+                description="succeeding branch",
+                node_type="llm_generate",
+                input_keys=[],
+                output_keys=["result"],
+                max_retries=0,
+            ),
+            NodeSpec(
+                id="branch-2",
+                name="branch-two",
+                description="failing branch",
+                node_type="llm_generate",
+                input_keys=[],
+                output_keys=["result"],
+                max_retries=0,
+            ),
+        ],
+        edges=[],
+        entry_node="fan-out",
+    )
+
+    # Directly test the walrus-operator list comprehension used in
+    # _execute_parallel_branches for failed-branch name resolution.
+    # We simulate the pattern without the full parallel execution wiring:
+    #   n.name if (n := graph.get_node(node_id)) else node_id
+    # where "ghost-node" is NOT in the graph → fallback to raw node_id.
+
+    fake_branches = [
+        SimpleNamespace(node_id="ghost-node"),  # no NodeSpec in graph
+        SimpleNamespace(node_id="branch-1"),  # has NodeSpec
+    ]
+
+    failed_names = [
+        n.name if (n := graph.get_node(b.node_id)) else b.node_id for b in fake_branches
+    ]
+
+    # ghost-node should fallback to its ID; branch-1 should resolve to its name
+    assert failed_names == ["ghost-node", "branch-one"]


### PR DESCRIPTION
## Summary

Fixes two related exception-safety bugs in `GraphExecutor` that can cascade to produce triple-fault error masking.

### Bug 1 — `UnboundLocalError` masks real exceptions

`node_spec` was first assigned inside the `while` loop at `graph.get_node(current_node_id)`. If any exception occurred before that line (e.g. during pause/checkpoint logic on the first iteration), the `except Exception` handler referenced `node_spec` — which didn't exist yet — causing `UnboundLocalError` to mask the real error.

**Fix:** Pre-initialise `node_spec = None` before the `try` block. The handler already checks `if node_spec is not None:`, so a `None` pre-init is safe and correct.

### Bug 2 — `AttributeError` on parallel branch failure reporting

In `_execute_parallel_branches`, the list comprehension `graph.get_node(b.node_id).name` crashes with `AttributeError: 'NoneType' has no attribute 'name'` when `get_node()` returns `None` for an invalid branch node ID.

**Fix:** Use a walrus-operator guard that falls back to the raw `node_id` string when the node is not found.

### Cascade scenario

These two bugs can cascade: Bug 2's `AttributeError` propagates to Bug 1's handler, which then raises `UnboundLocalError` — a triple-fault that completely obscures the original parallel execution failure.

## Testing

- `test_exception_before_node_spec_does_not_cause_unbound_error` — patches `get_node()` to raise inside the try block; verifies the original error surfaces instead of `UnboundLocalError`.
- `test_exception_handler_logs_node_when_node_spec_assigned` — verifies the pre-init doesn't break the normal path where `node_spec` IS assigned before the exception.
- `test_parallel_branch_failure_none_node_uses_fallback_name` — verifies the walrus-operator guard falls back to `node_id` when `get_node()` returns `None`.

All 3 new tests pass. All 5 existing `test_graph_executor.py` tests pass.

Fixes #4514
