### PR TITLE
Clarify supported criterion evaluation and progress semantics

### DIFF
--- a/core/framework/graph/goal.py
+++ b/core/framework/graph/goal.py
@@ -44,6 +44,12 @@ class SuccessCriterion(BaseModel):
     metric: str = Field(
         description="How to measure: 'output_contains', 'output_equals', 'llm_judge', 'custom'"
     )
+    # NEW: runtime evaluation type (separate from metric)
+    type: str = Field(
+        default="success_rate",
+        description="Runtime evaluation type, e.g. 'success_rate'"
+    )
+    
     target: Any = Field(description="The target value or condition")
     weight: float = Field(default=1.0, ge=0.0, le=1.0, description="Relative importance (0-1)")
     met: bool = False

--- a/core/framework/graph/goal.py
+++ b/core/framework/graph/goal.py
@@ -46,10 +46,9 @@ class SuccessCriterion(BaseModel):
     )
     # NEW: runtime evaluation type (separate from metric)
     type: str = Field(
-        default="success_rate",
-        description="Runtime evaluation type, e.g. 'success_rate'"
+        default="success_rate", description="Runtime evaluation type, e.g. 'success_rate'"
     )
-    
+
     target: Any = Field(description="The target value or condition")
     weight: float = Field(default=1.0, ge=0.0, le=1.0, description="Relative importance (0-1)")
     met: bool = False

--- a/core/framework/runtime/outcome_aggregator.py
+++ b/core/framework/runtime/outcome_aggregator.py
@@ -312,10 +312,10 @@ class OutcomeAggregator:
 
     async def _evaluate_criterion(self, criterion: Any) -> CriterionStatus:
         """
-        Evaluate a single success criterion.
+            Evaluate a single success criterion.
 
-        This is a heuristic evaluation based on decision outcomes.
-        More sophisticated evaluation can be added per criterion type.
+            This is a heuristic evaluation based on decision outcomes.
+            More sophisticated evaluation can be added per criterion type.
         """
         status = CriterionStatus(
             criterion_id=criterion.id,
@@ -324,6 +324,11 @@ class OutcomeAggregator:
             progress=0.0,
             evidence=[],
         )
+
+        # Guard: only apply this heuristic to success-rate criteria
+        criterion_type = getattr(criterion, "type", "success_rate")
+        if criterion_type != "success_rate":
+            return status
 
         # Get relevant decisions (those mentioning this criterion or related intents)
         relevant_decisions = [
@@ -348,7 +353,6 @@ class OutcomeAggregator:
             # Add evidence
             for d in relevant_decisions[:5]:  # Limit evidence
                 if d.outcome:
-                    # Add more explicit evidence for observability
                     evidence = (
                         f"decision_id={d.decision.id}, "
                         f"intent={d.decision.intent}, "
@@ -363,7 +367,6 @@ class OutcomeAggregator:
                 target_value = float(target.rstrip("%")) / 100
                 status.met = status.progress >= target_value
             else:
-                # For non-percentage targets, consider met if progress > 0.8
                 status.met = status.progress >= 0.8
         except (ValueError, AttributeError):
             status.met = status.progress >= 0.8

--- a/core/framework/runtime/outcome_aggregator.py
+++ b/core/framework/runtime/outcome_aggregator.py
@@ -366,6 +366,7 @@ class OutcomeAggregator:
                 target_value = float(target.rstrip("%")) / 100
                 status.met = status.progress >= target_value
             else:
+                # For non-percentage targets, consider met if progress > 0.8
                 status.met = status.progress >= 0.8
         except (ValueError, AttributeError):
             status.met = status.progress >= 0.8

--- a/core/framework/runtime/outcome_aggregator.py
+++ b/core/framework/runtime/outcome_aggregator.py
@@ -312,10 +312,9 @@ class OutcomeAggregator:
 
     async def _evaluate_criterion(self, criterion: Any) -> CriterionStatus:
         """
-            Evaluate a single success criterion.
-
-            This is a heuristic evaluation based on decision outcomes.
-            More sophisticated evaluation can be added per criterion type.
+        Evaluate a single success criterion.
+        This is a heuristic evaluation based on decision outcomes.
+        More sophisticated evaluation can be added per criterion type.
         """
         status = CriterionStatus(
             criterion_id=criterion.id,

--- a/core/framework/runtime/outcome_aggregator.py
+++ b/core/framework/runtime/outcome_aggregator.py
@@ -325,12 +325,6 @@ class OutcomeAggregator:
             evidence=[],
         )
 
-        # 🔹 NEW: Explicitly guard supported evaluation behavior
-        # Currently, only success-rate–based evaluation is supported.
-        criterion_type = getattr(criterion, "type", None)
-        if criterion_type is not None and criterion_type != "success_rate":
-            return status
-
         # Get relevant decisions (those mentioning this criterion or related intents)
         relevant_decisions = [
             d
@@ -348,14 +342,13 @@ class OutcomeAggregator:
         if outcomes:
             success_count = sum(1 for o in outcomes if o.success)
 
-            # 🔹 NEW: Explicitly document progress semantics
             # Progress is computed as raw success rate of decision outcomes.
             status.progress = success_count / len(outcomes)
 
             # Add evidence
             for d in relevant_decisions[:5]:  # Limit evidence
                 if d.outcome:
-                    # 🔹 NEW: More explicit evidence for observability
+                    # Add more explicit evidence for observability
                     evidence = (
                         f"decision_id={d.decision.id}, "
                         f"intent={d.decision.intent}, "


### PR DESCRIPTION
## Description

This PR makes the evaluation behavior of `OutcomeAggregator._evaluate_criterion` explicit by gating evaluation to supported criterion types only.

Previously, all success criteria were implicitly treated as success-rate based, which could lead to misleading `progress` and `met` values for unsupported or future criterion types. This change ensures that only `success_rate` criteria are evaluated, while others return a neutral, un-met status until proper evaluators are implemented.

This improves clarity, correctness, and observability of the evaluation system without introducing breaking changes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #3955

Related to the broader evaluation system RFC (#3900), but scoped specifically to Phase 1 criterion evaluation semantics.

## Changes Made

- Explicitly gate criterion evaluation to `success_rate` type
- Default untyped criteria to `success_rate` for backward compatibility
- Prevent unsupported criterion types from being implicitly evaluated
- Improve evaluation evidence clarity by including decision ID and result

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (not required for this change)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective (follow-up work)
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
N/A