### PR TITLE
fix(config): surface configuration.json parse/read errors

### DIFF
--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -19,16 +19,24 @@ from framework.graph.edge import DEFAULT_MAX_TOKENS
 
 HIVE_CONFIG_FILE = Path.home() / ".hive" / "configuration.json"
 
-
 def get_hive_config() -> dict[str, Any]:
     """Load hive configuration from ~/.hive/configuration.json."""
     if not HIVE_CONFIG_FILE.exists():
         return {}
+
     try:
         with open(HIVE_CONFIG_FILE, encoding="utf-8-sig") as f:
             return json.load(f)
-    except (json.JSONDecodeError, OSError):
-        return {}
+    except json.JSONDecodeError as e:
+        raise ValueError(
+            f"Invalid JSON in Hive configuration file: {HIVE_CONFIG_FILE}\n"
+            f"JSON error: {e}"
+        ) from e
+    except OSError as e:
+        raise OSError(
+            f"Failed to read Hive configuration file: {HIVE_CONFIG_FILE}\n"
+            f"OS error: {e}"
+        ) from e
 
 
 # ---------------------------------------------------------------------------

--- a/core/framework/testing/test_config.py
+++ b/core/framework/testing/test_config.py
@@ -1,0 +1,33 @@
+import json
+import pytest
+from pathlib import Path
+
+from framework.config import get_hive_config, HIVE_CONFIG_FILE
+
+
+def test_invalid_json_config_raises(monkeypatch, tmp_path):
+    bad_config = tmp_path / "configuration.json"
+    bad_config.write_text('{ "llm": "x", }')
+
+    monkeypatch.setattr(
+        "framework.config.HIVE_CONFIG_FILE",
+        bad_config,
+    )
+
+    with pytest.raises(ValueError) as exc:
+        get_hive_config()
+
+    msg = str(exc.value)
+    assert "Invalid JSON in Hive configuration file" in msg
+    assert str(bad_config) in msg
+
+
+def test_missing_config_returns_empty(monkeypatch):
+    fake_path = Path("/tmp/does_not_exist.json")
+
+    monkeypatch.setattr(
+        "framework.config.HIVE_CONFIG_FILE",
+        fake_path,
+    )
+
+    assert get_hive_config() == {}


### PR DESCRIPTION
Previously invalid or unreadable configuration.json was silently ignored and an empty config was returned.

Now parsing and read errors fail fast with a clear message, while preserving the original exception. Includes unit tests for invalid and missing config.

## Description

Brief description of the changes in this PR.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #4531

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.