### PR TITLE
docs: remove references to nonexistent CHANGELOG.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,8 +99,7 @@ docs(readme): update installation instructions
 2. Update documentation if needed
 3. Add tests for new functionality
 4. Ensure `make check` and `make test` pass
-5. Update the CHANGELOG.md if applicable
-6. Request review from maintainers
+5. Request review from maintainers
 
 ### PR Title Format
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -219,7 +219,6 @@ hive/                                    # Repository root
 ├── quickstart.sh                        # Interactive setup wizard
 ├── README.md                            # Project overview
 ├── CONTRIBUTING.md                      # Contribution guidelines
-├── CHANGELOG.md                         # Version history
 ├── LICENSE                              # Apache 2.0 License
 ├── docs/CODE_OF_CONDUCT.md              # Community guidelines
 └── SECURITY.md                          # Security policy


### PR DESCRIPTION
## Summary
- Removed CHANGELOG.md reference from CONTRIBUTING.md contribution checklist
- Removed CHANGELOG.md from project structure tree in developer-guide.md
- The file does not exist in the repo; GitHub Releases is used for version history

Closes #4493

## Test plan
- [ ] CONTRIBUTING.md renders correctly
- [ ] developer-guide.md project structure tree is accurate