### PR TITLE
docs(evolution): clarify what is automated today vs. human-initiated

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Yes! Hive supports local models through LiteLLM. Simply use the model name forma
 
 **Q: What makes Hive different from other agent frameworks?**
 
-Hive generates your entire agent system from natural language goals using a coding agent—you don't hardcode workflows or manually define graphs. When agents fail, the framework automatically captures failure data, [evolves the agent graph](docs/key_concepts/evolution.md), and redeploys. This self-improving loop is unique to Aden.
+Hive generates your entire agent system from natural language goals using a coding agent—you don't hardcode workflows or manually define graphs. When agents fail, the framework automatically captures failure data and structures it for [evolution](docs/key_concepts/evolution.md). A coding agent or developer then uses that diagnosis to improve and redeploy the agent. This adaptive loop—where failure data directly drives the next version—is unique to Aden. See [Evolution: What Is Automated Today](docs/key_concepts/evolution.md#what-is-automated-today-vs-what-requires-human-action) for details on the current state.
 
 **Q: Is Hive open-source?**
 

--- a/docs/key_concepts/evolution.md
+++ b/docs/key_concepts/evolution.md
@@ -47,3 +47,23 @@ Evolution can change almost anything about an agent:
 Evolution depends on good data. The runtime captures every decision an agent makes: what it was trying to do, what options it considered, what it chose, and what happened as a result. This isn't overhead — it's the signal that makes evolution possible.
 
 Without decision logging, failure analysis is guesswork. With it, the coding agent can trace a failure back to its root cause and make a targeted fix rather than a blind change.
+
+## What Is Automated Today vs. What Requires Human Action
+
+The evolution concept describes Hive's long-term architecture. In the current open-source release, some stages are fully automated and some require a developer or coding agent to initiate.
+
+| Stage | Status | What Happens |
+|---|---|---|
+| **Execute** | Automated | Worker agents run, produce sessions, decisions, and metrics. |
+| **Evaluate** | Automated | The framework checks outcomes against goal success criteria and constraints. |
+| **Diagnose** | Automated | Structured failure data — which node failed, why, and the full decision log — is captured automatically. |
+| **Regenerate** | Human / Coding Agent | A developer or coding agent (e.g., Claude Code, Cursor) reviews the diagnosis and modifies the agent graph. This step is not yet a fully autonomous loop in OSS. |
+| **Redeploy** | Human / Coding Agent | The updated agent is redeployed by the developer or through the coding agent's workflow. |
+
+### What "self-improving" means in practice
+
+- **The framework is self-observing**: it automatically captures every decision, failure, metric, and evaluation result during execution.
+- **The framework is builder-friendly**: it structures failure data so that a coding agent or developer can make targeted fixes rather than guessing.
+- **The regeneration step currently requires a coding agent or developer**: there is no fully autonomous "fail → mutate graph → redeploy" loop running without human involvement in the OSS release.
+
+As the project matures, the goal is to close this loop further — see the [roadmap](../roadmap.md) for planned work on full adaptiveness.


### PR DESCRIPTION
Fixes #3642

## Summary

- Adds a **"What Is Automated Today vs. What Requires Human Action"** section to `docs/key_concepts/evolution.md` with a stage-by-stage table (Execute, Evaluate, Diagnose = automated; Regenerate, Redeploy = human/coding-agent)
- Adds a **"What self-improving means in practice"** subsection clarifying that the framework is self-observing and builder-friendly, but the regeneration step currently requires a coding agent or developer
- Updates the **README FAQ** ("What makes Hive different?") to accurately describe the adaptive loop and link to the new clarification section

## Motivation

The current docs and README use terms like "self-improving" and "self-evolving" without clarifying that the OSS release does not include a fully autonomous fail-mutate-redeploy loop. This creates an expectation mismatch for new users evaluating the framework. The roadmap itself marks "Adaptiveness" as a planned (not done) item.

## Validation

- `make check` (ruff lint + format): **all passed** (153 + 88 files)
- `pytest tests/ -v`: **683 passed, 51 skipped, 0 failures**
- Docs-only change, no logic affected

## Notes

- Kept the tone factual and forward-looking (links to the roadmap)
- Did not change any architecture or marketing claims in articles/ -- scoped to the core README FAQ and the key_concepts evolution doc
- 22 lines added, 2 lines changed
