### PR TITLE
feat(debugging): add production agent debugger with multi-provider RAG

### DIFF
--- a/core/framework/debugging/__init__.py
+++ b/core/framework/debugging/__init__.py
@@ -1,0 +1,25 @@
+"""
+Debugging and trace analysis tools for Hive agents.
+
+This module provides functionality for:
+- Indexing and querying agent execution traces
+- Semantic search over execution history
+- Root cause analysis for failures
+- Performance profiling and optimization
+"""
+
+from framework.debugging.index_store import IndexStore
+from framework.debugging.trace_embedder import TraceEmbedder
+from framework.debugging.trace_index import TraceIndex
+from framework.debugging.trace_indexer import TraceIndexer
+from framework.debugging.trace_rag import TraceRAG
+from framework.debugging.trace_vector_store import TraceVectorStore
+
+__all__ = [
+    "TraceIndex",
+    "IndexStore",
+    "TraceIndexer",
+    "TraceEmbedder",
+    "TraceVectorStore",
+    "TraceRAG",
+]

--- a/core/framework/debugging/cli.py
+++ b/core/framework/debugging/cli.py
@@ -1,0 +1,342 @@
+"""
+CLI tool for trace debugging and analysis.
+
+Provides commands for:
+- Indexing agent execution traces
+- Building vector index for semantic search
+- Querying traces with natural language
+- Analyzing patterns (failures, performance, etc.)
+
+Usage:
+    python -m framework.debugging.cli index <agent_path>
+    python -m framework.debugging.cli build-vector-index <agent_path>
+    python -m framework.debugging.cli query <agent_path> "find failed runs"
+    python -m framework.debugging.cli analyze <agent_path> --pattern failures
+"""
+
+import asyncio
+from pathlib import Path
+from typing import Literal
+
+import click
+
+from framework.debugging.index_store import IndexStore
+from framework.debugging.trace_embedder import TraceEmbedder
+from framework.debugging.trace_indexer import TraceIndexer
+from framework.debugging.trace_rag import TraceRAG
+from framework.debugging.trace_vector_store import TraceVectorStore
+
+
+@click.group()
+def cli():
+    """Hive Trace Debugger - Analyze agent execution traces."""
+    pass
+
+
+@cli.command()
+@click.argument("agent_path", type=click.Path(exists=True, path_type=Path))
+def index(agent_path: Path):
+    """Index all traces from agent sessions.
+
+    Scans session directories, reads L1/L2/L3 logs, and builds searchable index.
+
+    Example:
+        python -m framework.debugging.cli index ~/.hive/agents/sales_agent
+    """
+
+    async def _index():
+        click.echo(f"Indexing traces from: {agent_path}")
+
+        indexer = TraceIndexer(agent_path)
+        store = IndexStore(base_path=agent_path)
+
+        # Load existing index
+        await store.load()
+        click.echo(f"Existing index: {len(store.index)} traces")
+
+        # Index all sessions
+        stats = await indexer.index_all_sessions(store)
+
+        # Save updated index
+        await store.save()
+
+        click.echo("\n✓ Indexing complete!")
+        click.echo(f"  Indexed: {stats['indexed']}")
+        click.echo(f"  Skipped: {stats['skipped']}")
+        click.echo(f"  Errors: {stats['errors']}")
+        click.echo(f"  Total traces: {len(store.index)}")
+
+    asyncio.run(_index())
+
+
+@cli.command()
+@click.argument("agent_path", type=click.Path(exists=True, path_type=Path))
+@click.option("--dimension", default=384, help="Embedding dimension")
+def build_vector_index(agent_path: Path, dimension: int):
+    """Build vector index for semantic search.
+
+    Reads trace index, generates embeddings, and builds FAISS index.
+
+    Example:
+        python -m framework.debugging.cli build-vector-index ~/.hive/agents/sales_agent
+    """
+
+    async def _build():
+        click.echo(f"Building vector index for: {agent_path}")
+
+        # Load trace index
+        store = IndexStore(base_path=agent_path)
+        await store.load()
+
+        traces = store.list_all()
+        if not traces:
+            click.echo("✗ No traces found. Run 'index' command first.")
+            return
+
+        click.echo(f"Found {len(traces)} traces")
+
+        # Initialize embedder and vector store
+        click.echo("Initializing embedder (downloading model if needed)...")
+        embedder = TraceEmbedder()
+
+        vector_store = TraceVectorStore(
+            storage_path=agent_path / ".vector_index", dimension=dimension
+        )
+        await vector_store.initialize()
+
+        # Generate embeddings in batches
+        click.echo("Generating embeddings...")
+        with click.progressbar(length=len(traces)) as bar:
+            batch_size = 10
+            for i in range(0, len(traces), batch_size):
+                batch = traces[i : i + batch_size]
+                embeddings = await embedder.embed_traces(batch)
+                await vector_store.add_traces(batch, embeddings)
+                bar.update(len(batch))
+
+        # Save vector index
+        click.echo("Saving vector index...")
+        await vector_store.save()
+
+        click.echo(f"\n✓ Vector index built: {vector_store.size()} traces")
+
+    asyncio.run(_build())
+
+
+@cli.command()
+@click.argument("agent_path", type=click.Path(exists=True, path_type=Path))
+@click.argument("question")
+@click.option("--k", default=5, help="Number of traces to retrieve")
+@click.option("--no-context", is_flag=True, help="Hide retrieved traces")
+@click.option(
+    "--provider",
+    type=click.Choice(["openai", "anthropic", "google"]),
+    help="LLM provider (auto-detects if not specified)",
+)
+@click.option("--model", help="Model name (uses provider default if not specified)")
+def query(
+    agent_path: Path,
+    question: str,
+    k: int,
+    no_context: bool,
+    provider: str | None,
+    model: str | None,
+):
+    """Query traces using natural language.
+
+    Uses RAG (Retrieval-Augmented Generation) to answer questions about traces.
+    Supports OpenAI, Anthropic (Claude), and Google (Gemini) via LangChain.
+
+    Environment Variables:
+        HIVE_LLM_PROVIDER: Default provider (openai|anthropic|google)
+        OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY: API keys
+
+    Examples:
+        python -m framework.debugging.cli query ~/.hive/agents/sales_agent "Why?"
+        python -m framework.debugging.cli query ... --provider openai
+        python -m framework.debugging.cli query ... --provider anthropic --model claude-3-opus
+        python -m framework.debugging.cli query ... --provider google --model gemini-1.5-pro
+    """
+
+    async def _query():
+        # Check if vector index exists
+        vector_path = agent_path / ".vector_index"
+        if not vector_path.exists():
+            click.echo("✗ Vector index not found. Run 'build-vector-index' first.")
+            return
+
+        # Initialize components
+        embedder = TraceEmbedder()
+        vector_store = TraceVectorStore(storage_path=vector_path)
+        await vector_store.initialize()
+
+        if vector_store.size() == 0:
+            click.echo("✗ Vector index is empty. Run 'build-vector-index' first.")
+            return
+
+        # Create RAG engine with provider
+        try:
+            rag = TraceRAG(embedder, vector_store, provider=provider, model=model)  # type: ignore
+        except (ValueError, ImportError) as e:
+            click.echo(f"✗ LLM initialization failed: {e}")
+            return
+
+        # Query
+        click.echo(f"Querying: {question}\n")
+        result = await rag.query(question, k=k, include_context=not no_context)
+
+        # Display answer
+        click.echo("Answer:")
+        click.echo("-" * 80)
+        click.echo(result["answer"])
+        click.echo("-" * 80)
+
+        # Display retrieved traces if requested
+        if not no_context and "traces" in result:
+            click.echo(f"\nRetrieved Traces ({len(result['traces'])}):")
+            for i, trace in enumerate(result["traces"], 1):
+                click.echo(f"\n{i}. {trace.run_id}")
+                click.echo(f"   Status: {trace.status}")
+                click.echo(f"   Agent: {trace.agent_id}")
+                click.echo(f"   Latency: {trace.total_latency_ms}ms")
+                click.echo(f"   Tokens: {trace.total_tokens}")
+                if trace.error_message:
+                    click.echo(f"   Error: {trace.error_message}")
+
+    asyncio.run(_query())
+
+
+@cli.command()
+@click.argument("agent_path", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--pattern",
+    type=click.Choice(["failures", "performance", "retry_patterns", "error_clusters"]),
+    required=True,
+    help="Pattern type to analyze",
+)
+@click.option("--limit", default=10, help="Number of traces to analyze")
+@click.option(
+    "--provider",
+    type=click.Choice(["openai", "anthropic", "google"]),
+    help="LLM provider (auto-detects if not specified)",
+)
+@click.option("--model", help="Model name (uses provider default if not specified)")
+def analyze(
+    agent_path: Path,
+    pattern: Literal["failures", "performance", "retry_patterns", "error_clusters"],
+    limit: int,
+    provider: str | None,
+    model: str | None,
+):
+    """Analyze patterns across traces.
+
+    Supports OpenAI, Anthropic (Claude), and Google (Gemini) via LangChain.
+
+    Environment Variables:
+        HIVE_LLM_PROVIDER: Default provider (openai|anthropic|google)
+        OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY: API keys
+
+    Examples:
+        python -m framework.debugging.cli analyze ~/.hive/agents/sales_agent --pattern failures
+        python -m framework.debugging.cli analyze ... --pattern failures --provider openai
+        python -m framework.debugging.cli analyze ... --pattern performance --provider google
+    """
+
+    async def _analyze():
+        # Check if vector index exists
+        vector_path = agent_path / ".vector_index"
+        if not vector_path.exists():
+            click.echo("✗ Vector index not found. Run 'build-vector-index' first.")
+            return
+
+        # Initialize components
+        embedder = TraceEmbedder()
+        vector_store = TraceVectorStore(storage_path=vector_path)
+        await vector_store.initialize()
+
+        if vector_store.size() == 0:
+            click.echo("✗ Vector index is empty.")
+            return
+
+        # Create RAG engine with provider
+        try:
+            rag = TraceRAG(embedder, vector_store, provider=provider, model=model)  # type: ignore
+        except (ValueError, ImportError) as e:
+            click.echo(f"✗ LLM initialization failed: {e}")
+            return
+
+        # Analyze pattern
+        click.echo(f"Analyzing {pattern} patterns (limit={limit})...\n")
+        analysis = await rag.analyze_pattern(pattern, limit=limit)
+
+        # Display analysis
+        click.echo("Analysis:")
+        click.echo("=" * 80)
+        click.echo(analysis)
+        click.echo("=" * 80)
+
+    asyncio.run(_analyze())
+
+
+@cli.command()
+@click.argument("agent_path", type=click.Path(exists=True, path_type=Path))
+def stats(agent_path: Path):
+    """Show statistics about indexed traces.
+
+    Example:
+        python -m framework.debugging.cli stats ~/.hive/agents/sales_agent
+    """
+
+    async def _stats():
+        # Load trace index
+        store = IndexStore(base_path=agent_path)
+        await store.load()
+
+        traces = store.list_all()
+
+        if not traces:
+            click.echo("No traces found.")
+            return
+
+        # Calculate statistics
+        total = len(traces)
+        success = sum(1 for t in traces if t.status == "success")
+        failure = sum(1 for t in traces if t.status == "failure")
+        degraded = sum(1 for t in traces if t.status == "degraded")
+
+        avg_latency = sum(t.total_latency_ms for t in traces) / total
+        avg_tokens = sum(t.total_tokens for t in traces) / total
+
+        # Display statistics
+        click.echo(f"Trace Statistics for: {agent_path}")
+        click.echo("=" * 80)
+        click.echo(f"Total Traces: {total}")
+        click.echo(f"  Success: {success} ({success / total * 100:.1f}%)")
+        click.echo(f"  Failure: {failure} ({failure / total * 100:.1f}%)")
+        click.echo(f"  Degraded: {degraded} ({degraded / total * 100:.1f}%)")
+        click.echo(f"\nAverage Latency: {avg_latency:.0f}ms")
+        click.echo(f"Average Tokens: {avg_tokens:.0f}")
+
+        # Most common errors
+        errors = [t.error_message for t in traces if t.error_message]
+        if errors:
+            click.echo("\nMost Common Errors:")
+            from collections import Counter
+
+            for error, count in Counter(errors).most_common(5):
+                click.echo(f"  {count}x: {error[:60]}...")
+
+        # Check vector index
+        vector_path = agent_path / ".vector_index"
+        if vector_path.exists():
+            vector_store = TraceVectorStore(storage_path=vector_path)
+            await vector_store.initialize()
+            click.echo(f"\nVector Index: {vector_store.size()} traces indexed")
+        else:
+            click.echo("\nVector Index: Not built")
+
+    asyncio.run(_stats())
+
+
+if __name__ == "__main__":
+    cli()

--- a/core/framework/debugging/index_store.py
+++ b/core/framework/debugging/index_store.py
@@ -1,0 +1,141 @@
+"""
+IndexStore: File-based storage for trace indexes.
+
+Follows Hive patterns:
+- Async I/O with asyncio.to_thread()
+- atomic_write() for persistence
+- JSON serialization
+- Non-fatal error handling
+
+Reference: core/framework/storage/session_store.py
+"""
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+
+from framework.debugging.trace_index import TraceIndex
+from framework.utils.io import atomic_write
+
+logger = logging.getLogger(__name__)
+
+
+class IndexStore:
+    """
+    File-based storage for trace indexes.
+
+    Follows Hive patterns:
+    - Async I/O with asyncio.to_thread()
+    - atomic_write() for crash-safe persistence
+    - JSON-only serialization
+    - Non-fatal error handling (logs, doesn't raise)
+
+    Reference: framework/storage/session_store.py
+    """
+
+    def __init__(self, base_path: Path | None = None):
+        """
+        Initialize index store.
+
+        Args:
+            base_path: Base directory for storage.
+                      Defaults to ~/.hive/agents
+        """
+        if base_path is None:
+            base_path = Path.home() / ".hive" / "agents"
+
+        self.base_path = Path(base_path)
+        self.index_file = self.base_path / ".trace_index.json"
+        self.index: dict[str, TraceIndex] = {}
+
+    async def load(self) -> None:
+        """
+        Load index from disk.
+
+        Follows Hive pattern: Use asyncio.to_thread for blocking I/O
+        Reference: framework/storage/session_store.py lines 91-98
+        """
+
+        def _load() -> dict[str, TraceIndex]:
+            """Blocking load operation."""
+            if not self.index_file.exists():
+                return {}
+
+            try:
+                with open(self.index_file) as f:
+                    data = json.load(f)
+
+                # Deserialize to TraceIndex objects
+                return {run_id: TraceIndex.model_validate(entry) for run_id, entry in data.items()}
+            except Exception:
+                # Non-fatal error handling (Hive pattern)
+                logger.exception("Failed to load trace index from %s (non-fatal)", self.index_file)
+                return {}
+
+        # Use asyncio.to_thread for blocking I/O (Hive pattern)
+        self.index = await asyncio.to_thread(_load)
+        logger.info(f"Loaded {len(self.index)} traces from index")
+
+    async def save(self) -> None:
+        """
+        Save index to disk.
+
+        Follows Hive patterns:
+        - asyncio.to_thread for blocking I/O
+        - atomic_write for crash-safe writes
+        - Non-fatal error handling
+
+        Reference: framework/storage/session_store.py lines 91-98
+        """
+
+        def _save() -> None:
+            """Blocking save operation."""
+            # Ensure directory exists
+            self.index_file.parent.mkdir(parents=True, exist_ok=True)
+
+            # Serialize to dict
+            data = {run_id: trace.model_dump(mode="json") for run_id, trace in self.index.items()}
+
+            # Use atomic_write (Hive pattern)
+            # Reference: framework/utils/io.py lines 6-18
+            with atomic_write(self.index_file, mode="w") as f:
+                json.dump(data, f, indent=2, default=str)
+
+        try:
+            await asyncio.to_thread(_save)
+            logger.info(f"Saved {len(self.index)} traces to index")
+        except Exception:
+            # Non-fatal error handling (Hive pattern)
+            # Reference: framework/runtime/runtime_logger.py lines 300-304
+            logger.exception("Failed to save trace index to %s (non-fatal)", self.index_file)
+
+    def add(self, trace: TraceIndex) -> None:
+        """
+        Add trace to in-memory index.
+
+        Args:
+            trace: TraceIndex to add
+        """
+        self.index[trace.run_id] = trace
+
+    def get(self, run_id: str) -> TraceIndex | None:
+        """
+        Get trace by run_id.
+
+        Args:
+            run_id: Run identifier
+
+        Returns:
+            TraceIndex if found, None otherwise
+        """
+        return self.index.get(run_id)
+
+    def list_all(self) -> list[TraceIndex]:
+        """
+        List all traces in index.
+
+        Returns:
+            List of all TraceIndex objects
+        """
+        return list(self.index.values())

--- a/core/framework/debugging/llm_provider.py
+++ b/core/framework/debugging/llm_provider.py
@@ -1,0 +1,187 @@
+"""
+LLM Provider Factory for multi-provider support.
+
+Supports OpenAI, Anthropic (Claude), and Google (Gemini) via LangChain.
+Provider selection via environment variable or explicit configuration.
+
+Follows Hive patterns:
+- Environment-based configuration
+- Type safety
+- Non-fatal error handling
+"""
+
+import logging
+import os
+from typing import Literal
+
+from langchain_core.language_models.chat_models import BaseChatModel
+
+logger = logging.getLogger(__name__)
+
+LLMProvider = Literal["openai", "anthropic", "google"]
+
+
+def create_llm(
+    provider: LLMProvider | None = None,
+    model: str | None = None,
+    api_key: str | None = None,
+    temperature: float = 0.0,
+) -> BaseChatModel:
+    """
+    Create LangChain chat model for specified provider.
+
+    Provider priority:
+    1. Explicit provider parameter
+    2. HIVE_LLM_PROVIDER environment variable
+    3. Auto-detect based on available API keys
+
+    Args:
+        provider: LLM provider ("openai", "anthropic", or "google")
+        model: Model name (uses provider default if None)
+        api_key: API key (uses environment variable if None)
+        temperature: Sampling temperature (default 0.0 for deterministic)
+
+    Returns:
+        Configured LangChain chat model
+
+    Raises:
+        ValueError: If provider is invalid or API key is missing
+        ImportError: If required LangChain integration is not installed
+
+    Environment Variables:
+        HIVE_LLM_PROVIDER: Default provider (openai|anthropic|google)
+        OPENAI_API_KEY: OpenAI API key
+        ANTHROPIC_API_KEY: Anthropic API key
+        GOOGLE_API_KEY: Google API key
+
+    Example:
+        # Auto-detect provider
+        llm = create_llm()
+
+        # Explicit provider
+        llm = create_llm(provider="openai", model="gpt-4")
+        llm = create_llm(provider="anthropic", model="claude-3-5-sonnet-20241022")
+        llm = create_llm(provider="google", model="gemini-1.5-pro")
+    """
+    # Determine provider
+    if provider is None:
+        provider = _detect_provider()
+
+    # Validate provider
+    if provider not in ["openai", "anthropic", "google"]:
+        raise ValueError(f"Invalid provider: {provider}. Must be one of: openai, anthropic, google")
+
+    # Create provider-specific LLM
+    if provider == "openai":
+        return _create_openai(model, api_key, temperature)
+    elif provider == "anthropic":
+        return _create_anthropic(model, api_key, temperature)
+    elif provider == "google":
+        return _create_google(model, api_key, temperature)
+
+    raise ValueError(f"Unsupported provider: {provider}")
+
+
+def _detect_provider() -> LLMProvider:
+    """
+    Auto-detect LLM provider based on environment.
+
+    Priority:
+    1. HIVE_LLM_PROVIDER env var
+    2. First available API key (openai -> anthropic -> google)
+
+    Returns:
+        Detected provider name
+
+    Raises:
+        ValueError: If no provider can be detected
+    """
+    # Check explicit env var
+    env_provider = os.getenv("HIVE_LLM_PROVIDER")
+    if env_provider:
+        logger.info("Using provider from HIVE_LLM_PROVIDER: %s", env_provider)
+        return env_provider.lower()  # type: ignore
+
+    # Auto-detect based on API keys
+    if os.getenv("OPENAI_API_KEY"):
+        logger.info("Auto-detected OpenAI provider (OPENAI_API_KEY found)")
+        return "openai"
+    elif os.getenv("ANTHROPIC_API_KEY"):
+        logger.info("Auto-detected Anthropic provider (ANTHROPIC_API_KEY found)")
+        return "anthropic"
+    elif os.getenv("GOOGLE_API_KEY"):
+        logger.info("Auto-detected Google provider (GOOGLE_API_KEY found)")
+        return "google"
+
+    raise ValueError(
+        "No LLM provider configured. Set one of:\n"
+        "  - HIVE_LLM_PROVIDER=openai|anthropic|google\n"
+        "  - OPENAI_API_KEY=sk-...\n"
+        "  - ANTHROPIC_API_KEY=sk-ant-...\n"
+        "  - GOOGLE_API_KEY=..."
+    )
+
+
+def _create_openai(model: str | None, api_key: str | None, temperature: float) -> BaseChatModel:
+    """Create OpenAI chat model."""
+    try:
+        from langchain_openai import ChatOpenAI
+    except ImportError as e:
+        raise ImportError("OpenAI provider requires: pip install langchain-openai") from e
+
+    # Default model
+    if model is None:
+        model = "gpt-4"
+        logger.debug("Using default OpenAI model: %s", model)
+
+    # Get API key
+    final_api_key = api_key or os.getenv("OPENAI_API_KEY")
+    if not final_api_key:
+        raise ValueError("OpenAI API key required. Set OPENAI_API_KEY environment variable.")
+
+    logger.info("Creating OpenAI chat model: %s", model)
+    return ChatOpenAI(model=model, api_key=final_api_key, temperature=temperature)
+
+
+def _create_anthropic(model: str | None, api_key: str | None, temperature: float) -> BaseChatModel:
+    """Create Anthropic chat model."""
+    try:
+        from langchain_anthropic import ChatAnthropic
+    except ImportError as e:
+        raise ImportError("Anthropic provider requires: pip install langchain-anthropic") from e
+
+    # Default model
+    if model is None:
+        model = "claude-3-5-sonnet-20241022"
+        logger.debug("Using default Anthropic model: %s", model)
+
+    # Get API key
+    final_api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
+    if not final_api_key:
+        raise ValueError("Anthropic API key required. Set ANTHROPIC_API_KEY environment variable.")
+
+    logger.info("Creating Anthropic chat model: %s", model)
+    return ChatAnthropic(model=model, anthropic_api_key=final_api_key, temperature=temperature)
+
+
+def _create_google(model: str | None, api_key: str | None, temperature: float) -> BaseChatModel:
+    """Create Google Gemini chat model."""
+    try:
+        from langchain_google_genai import ChatGoogleGenerativeAI
+    except ImportError as e:
+        raise ImportError("Google provider requires: pip install langchain-google-genai") from e
+
+    # Default model
+    if model is None:
+        model = "gemini-1.5-pro"
+        logger.debug("Using default Google model: %s", model)
+
+    # Get API key
+    final_api_key = api_key or os.getenv("GOOGLE_API_KEY")
+    if not final_api_key:
+        raise ValueError("Google API key required. Set GOOGLE_API_KEY environment variable.")
+
+    logger.info("Creating Google chat model: %s", model)
+    return ChatGoogleGenerativeAI(
+        model=model, google_api_key=final_api_key, temperature=temperature
+    )

--- a/core/framework/debugging/tests/conftest.py
+++ b/core/framework/debugging/tests/conftest.py
@@ -1,0 +1,56 @@
+"""
+Shared fixtures for debugging tests.
+
+Follows Hive pattern: Fixtures in conftest.py for reuse
+Reference: tools/tests/conftest.py
+"""
+
+from datetime import datetime
+
+import pytest
+
+from framework.debugging.trace_index import TraceIndex
+
+
+@pytest.fixture
+def sample_trace() -> TraceIndex:
+    """Create a sample successful TraceIndex for testing."""
+    return TraceIndex(
+        run_id="test_run_abc123",
+        agent_id="test_agent",
+        session_id="session_20260212_120000_xyz",
+        status="success",
+        execution_quality="clean",
+        total_latency_ms=1500,
+        total_input_tokens=500,
+        total_output_tokens=1000,
+        node_count=3,
+        timestamp=datetime(2026, 2, 12, 12, 0, 0),
+        summary_path="/fake/path/summary.json",
+        details_path="/fake/path/details.jsonl",
+        tool_logs_path="/fake/path/tool_logs.jsonl",
+        node_ids=["intake", "process", "output"],
+    )
+
+
+@pytest.fixture
+def failed_trace() -> TraceIndex:
+    """Create a sample failed TraceIndex for testing."""
+    return TraceIndex(
+        run_id="test_run_def456",
+        agent_id="another_agent",
+        session_id="session_20260212_130000_abc",
+        status="failure",
+        execution_quality="failed",
+        total_latency_ms=3000,
+        total_input_tokens=1000,
+        total_output_tokens=500,
+        node_count=5,
+        error_message="Timeout in web_search",
+        failed_node_id="research",
+        timestamp=datetime(2026, 2, 12, 13, 0, 0),
+        summary_path="/fake/path2/summary.json",
+        details_path="/fake/path2/details.jsonl",
+        tool_logs_path="/fake/path2/tool_logs.jsonl",
+        node_ids=["intake", "research", "analyze", "review", "output"],
+    )

--- a/core/framework/debugging/tests/test_e2e_workflow.py
+++ b/core/framework/debugging/tests/test_e2e_workflow.py
@@ -1,0 +1,453 @@
+"""
+End-to-end integration test for trace debugging workflow.
+
+Tests the complete workflow:
+1. Create mock session logs
+2. Index traces
+3. Build vector index
+4. Query with RAG
+5. Analyze patterns
+
+This demonstrates the full user experience.
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from framework.debugging.index_store import IndexStore
+from framework.debugging.trace_embedder import TraceEmbedder
+from framework.debugging.trace_indexer import TraceIndexer
+from framework.debugging.trace_rag import TraceRAG
+from framework.debugging.trace_vector_store import TraceVectorStore
+
+
+def create_mock_session_with_logs(
+    agent_path: Path,
+    session_id: str,
+    run_id: str,
+    status: str = "success",
+    with_error: bool = False,
+):
+    """Create a complete mock session with L1/L2/L3 logs."""
+    import json
+    from datetime import datetime
+
+    session_dir = agent_path / "sessions" / session_id
+    logs_dir = session_dir / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    # L1: summary.json
+    summary = {
+        "run_id": run_id,
+        "agent_id": "sales_agent",
+        "goal_id": "outreach_campaign",
+        "status": status,
+        "total_nodes_executed": 3,
+        "node_path": ["intake", "research", "outreach"],
+        "total_input_tokens": 2000,
+        "total_output_tokens": 3000,
+        "needs_attention": with_error,
+        "attention_reasons": ["high_retry_count"] if with_error else [],
+        "started_at": datetime.now().isoformat(),
+        "duration_ms": 8000 if with_error else 5000,
+        "execution_quality": "degraded" if with_error else "clean",
+    }
+
+    with open(logs_dir / "summary.json", "w") as f:
+        json.dump(summary, f, indent=2)
+
+    # L2: details.jsonl
+    details = [
+        {
+            "node_id": "intake",
+            "node_name": "Intake Collector",
+            "node_type": "event_loop",
+            "success": True,
+            "error": None,
+            "total_steps": 2,
+            "tokens_used": 1000,
+            "input_tokens": 400,
+            "output_tokens": 600,
+            "latency_ms": 1500,
+            "exit_status": "success",
+            "retry_count": 0,
+        },
+        {
+            "node_id": "research",
+            "node_name": "Research Node",
+            "node_type": "event_loop",
+            "success": not with_error,
+            "error": "Timeout in web_search" if with_error else None,
+            "total_steps": 8 if with_error else 3,
+            "tokens_used": 2500,
+            "input_tokens": 1000,
+            "output_tokens": 1500,
+            "latency_ms": 5000 if with_error else 2500,
+            "exit_status": "escalate" if with_error else "success",
+            "retry_count": 6 if with_error else 0,
+        },
+        {
+            "node_id": "outreach",
+            "node_name": "Outreach Node",
+            "node_type": "event_loop",
+            "success": True,
+            "error": None,
+            "total_steps": 2,
+            "tokens_used": 1500,
+            "input_tokens": 600,
+            "output_tokens": 900,
+            "latency_ms": 1500,
+            "exit_status": "success",
+            "retry_count": 0,
+        },
+    ]
+
+    with open(logs_dir / "details.jsonl", "w") as f:
+        for detail in details:
+            f.write(json.dumps(detail) + "\n")
+
+    # L3: tool_logs.jsonl
+    steps = [
+        {
+            "node_id": "intake",
+            "step_index": 0,
+            "llm_text": "Collecting lead information",
+            "tool_calls": [],
+            "input_tokens": 200,
+            "output_tokens": 300,
+            "latency_ms": 750,
+            "verdict": "ACCEPT",
+        },
+        {
+            "node_id": "research",
+            "step_index": 0,
+            "llm_text": "Searching for company info",
+            "tool_calls": [],
+            "input_tokens": 500,
+            "output_tokens": 750,
+            "latency_ms": 1200,
+            "verdict": "RETRY" if with_error else "ACCEPT",
+        },
+    ]
+
+    with open(logs_dir / "tool_logs.jsonl", "w") as f:
+        for step in steps:
+            f.write(json.dumps(step) + "\n")
+
+
+class MockEmbeddings:
+    """Mock embeddings for testing."""
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [[0.1 + i * 0.01] * 384 for i in range(len(texts))]
+
+    def embed_query(self, text: str) -> list[float]:
+        return [0.1] * 384
+
+
+class TestEndToEndWorkflow:
+    """Test complete debugging workflow from start to finish."""
+
+    @pytest.mark.asyncio
+    async def test_complete_workflow(self, tmp_path: Path):
+        """
+        Complete workflow: Create sessions → Index → Build vectors → Query
+
+        This is the full user experience.
+        """
+        # ====================================================================
+        # SETUP: Create mock agent with sessions
+        # ====================================================================
+        agent_path = tmp_path / "agents" / "sales_agent"
+
+        # Create 3 sessions: 2 successful, 1 failed
+        create_mock_session_with_logs(
+            agent_path,
+            session_id="session_20260212_100000_abc",
+            run_id="session_20260212_100000_abc",
+            status="success",
+            with_error=False,
+        )
+
+        create_mock_session_with_logs(
+            agent_path,
+            session_id="session_20260212_110000_def",
+            run_id="session_20260212_110000_def",
+            status="success",
+            with_error=False,
+        )
+
+        create_mock_session_with_logs(
+            agent_path,
+            session_id="session_20260212_120000_ghi",
+            run_id="session_20260212_120000_ghi",
+            status="failure",
+            with_error=True,
+        )
+
+        # ====================================================================
+        # STEP 1: Index Traces
+        # ====================================================================
+        indexer = TraceIndexer(agent_path)
+        store = IndexStore(base_path=agent_path)
+
+        stats = await indexer.index_all_sessions(store)
+
+        # Verify indexing
+        assert stats["indexed"] == 3
+        assert stats["skipped"] == 0
+        assert len(store.index) == 3
+
+        # Verify trace content
+        traces = store.list_all()
+        success_traces = [t for t in traces if t.status == "success"]
+        failed_traces = [t for t in traces if t.status == "failure"]
+
+        assert len(success_traces) == 2
+        assert len(failed_traces) == 1
+        assert failed_traces[0].error_message == "Timeout in web_search"
+
+        # Save index
+        await store.save()
+
+        # ====================================================================
+        # STEP 2: Build Vector Index
+        # ====================================================================
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+        vector_store = TraceVectorStore(storage_path=agent_path / ".vector_index", dimension=384)
+        await vector_store.initialize()
+
+        # Generate embeddings and add to vector store
+        embeddings = await embedder.embed_traces(traces)
+        await vector_store.add_traces(traces, embeddings)
+
+        # Verify vector index
+        assert vector_store.size() == 3
+
+        # Save vector index
+        await vector_store.save()
+
+        # ====================================================================
+        # STEP 3: Query with RAG
+        # ====================================================================
+        # Create mock LLM
+        mock_llm = Mock()
+        mock_llm.ainvoke = AsyncMock()
+
+        # Mock response
+        class MockResponse:
+            content = (
+                "Based on the traces, 1 run failed due to a timeout in the "
+                "web_search tool during the research node. The run had 6 retry "
+                "attempts before escalating. The other 2 runs were successful "
+                "with clean execution."
+            )
+
+        mock_llm.ainvoke.return_value = MockResponse()
+
+        rag = TraceRAG(embedder, vector_store, llm=mock_llm)
+
+        # Query: "Why did runs fail?"
+        result = await rag.query("Why did runs fail?", k=3)
+
+        # Verify query results
+        assert "answer" in result
+        assert "timeout" in result["answer"].lower()
+        assert "traces" in result
+        assert len(result["traces"]) == 3
+
+        # Verify LLM was called with proper context
+        assert mock_llm.ainvoke.called
+        call_args = mock_llm.ainvoke.call_args[0][0]
+        assert len(call_args) == 2  # System + Human message
+        assert "web_search" in str(call_args)
+
+        # ====================================================================
+        # STEP 4: Pattern Analysis
+        # ====================================================================
+        # Analyze failure patterns
+        mock_llm.ainvoke.return_value.content = (
+            "Failure Pattern Analysis:\n"
+            "- 33% failure rate (1 of 3 runs)\n"
+            "- Root cause: Timeout in web_search tool\n"
+            "- High retry count (6 attempts) indicates persistent issue\n"
+            "- Recommendation: Check web_search timeout settings"
+        )
+
+        analysis = await rag.analyze_pattern("failures", limit=5)
+
+        # Verify analysis
+        assert "timeout" in analysis.lower()
+        assert "web_search" in analysis.lower()
+
+        # ====================================================================
+        # STEP 5: Find Similar Failures
+        # ====================================================================
+        failed_trace = failed_traces[0]
+        similar = await rag.find_similar_failures(failed_trace, k=2)
+
+        # Should not include the reference trace itself
+        assert all(t.run_id != failed_trace.run_id for t, _ in similar)
+
+        # ====================================================================
+        # STEP 6: Reload and Query Again (Persistence Test)
+        # ====================================================================
+        # Create new instances (simulating new session)
+        store2 = IndexStore(base_path=agent_path)
+        await store2.load()
+
+        vector_store2 = TraceVectorStore(storage_path=agent_path / ".vector_index")
+        await vector_store2.initialize()
+
+        # Verify persistence
+        assert len(store2.index) == 3
+        assert vector_store2.size() == 3
+
+        # Query again
+        rag2 = TraceRAG(embedder, vector_store2, llm=mock_llm)
+        result2 = await rag2.query("What was the success rate?", k=3)
+
+        assert "answer" in result2
+        assert len(result2["traces"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_incremental_indexing(self, tmp_path: Path):
+        """Test adding new sessions incrementally."""
+        agent_path = tmp_path / "agents" / "test_agent"
+
+        # Index initial session
+        create_mock_session_with_logs(
+            agent_path, session_id="session_1", run_id="session_1", status="success"
+        )
+
+        indexer = TraceIndexer(agent_path)
+        store = IndexStore(base_path=agent_path)
+
+        stats = await indexer.index_all_sessions(store)
+        assert stats["indexed"] == 1
+        await store.save()
+
+        # Add new session
+        create_mock_session_with_logs(
+            agent_path,
+            session_id="session_2",
+            run_id="session_2",
+            status="failure",
+            with_error=True,
+        )
+
+        # Re-index (should pick up new session)
+        store2 = IndexStore(base_path=agent_path)
+        await store2.load()
+        assert len(store2.index) == 1  # Old session still there
+
+        stats2 = await indexer.index_all_sessions(store2)
+        assert stats2["indexed"] == 2  # Now has both
+        assert len(store2.index) == 2
+
+    @pytest.mark.asyncio
+    async def test_search_similarity(self, tmp_path: Path):
+        """Test semantic search finds similar traces."""
+        agent_path = tmp_path / "agents" / "test_agent"
+
+        # Create sessions with different characteristics
+        # Session 1: Success with low latency
+        create_mock_session_with_logs(agent_path, "session_fast", "session_fast", "success", False)
+
+        # Session 2: Failure with timeout
+        create_mock_session_with_logs(
+            agent_path, "session_timeout", "session_timeout", "failure", True
+        )
+
+        # Index and build vectors
+        indexer = TraceIndexer(agent_path)
+        store = IndexStore(base_path=agent_path)
+        await indexer.index_all_sessions(store)
+
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+        vector_store = TraceVectorStore(storage_path=agent_path / ".vector_index", dimension=384)
+        await vector_store.initialize()
+
+        traces = store.list_all()
+        embeddings = await embedder.embed_traces(traces)
+        await vector_store.add_traces(traces, embeddings)
+
+        # Search for "timeout error"
+        query_embedding = await embedder.embed_query("timeout error")
+        results = await vector_store.search(query_embedding, k=2)
+
+        # Should find both traces, sorted by similarity
+        assert len(results) == 2
+        # Results are (trace, distance) tuples
+        assert all(isinstance(t[0].run_id, str) for t in results)
+        assert all(isinstance(t[1], float) for t in results)
+
+        # Distances should be sorted (closest first)
+        distances = [dist for _, dist in results]
+        assert distances == sorted(distances)
+
+
+class TestWorkflowErrorHandling:
+    """Test error handling in the workflow."""
+
+    @pytest.mark.asyncio
+    async def test_handle_missing_logs(self, tmp_path: Path):
+        """Workflow handles sessions with missing logs gracefully."""
+        agent_path = tmp_path / "agents" / "test_agent"
+
+        # Create session without logs
+        session_dir = agent_path / "sessions" / "session_incomplete"
+        session_dir.mkdir(parents=True)
+
+        # Index (should skip incomplete session)
+        indexer = TraceIndexer(agent_path)
+        store = IndexStore(base_path=agent_path)
+
+        stats = await indexer.index_all_sessions(store)
+
+        assert stats["indexed"] == 0
+        assert stats["skipped"] == 1
+
+    @pytest.mark.asyncio
+    async def test_handle_corrupted_logs(self, tmp_path: Path):
+        """Workflow handles corrupted logs gracefully."""
+        agent_path = tmp_path / "agents" / "test_agent"
+
+        # Create session with corrupted logs
+        session_dir = agent_path / "sessions" / "session_corrupt"
+        logs_dir = session_dir / "logs"
+        logs_dir.mkdir(parents=True)
+
+        # Write invalid JSON
+        with open(logs_dir / "summary.json", "w") as f:
+            f.write("{ invalid json")
+
+        # Index (should skip corrupted session)
+        indexer = TraceIndexer(agent_path)
+        store = IndexStore(base_path=agent_path)
+
+        stats = await indexer.index_all_sessions(store)
+
+        # Should be skipped due to parse error
+        assert stats["skipped"] == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_vector_index_query(self, tmp_path: Path):
+        """Querying empty vector index returns helpful message."""
+        agent_path = tmp_path / "agents" / "test_agent"
+
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+        vector_store = TraceVectorStore(storage_path=agent_path / ".vector_index", dimension=384)
+        await vector_store.initialize()
+
+        mock_llm = Mock()
+        mock_llm.ainvoke = AsyncMock()
+
+        rag = TraceRAG(embedder, vector_store, llm=mock_llm)
+
+        result = await rag.query("find failures", k=5)
+
+        assert "No traces found" in result["answer"]
+        assert result.get("traces", []) == []

--- a/core/framework/debugging/tests/test_index_store.py
+++ b/core/framework/debugging/tests/test_index_store.py
@@ -1,0 +1,423 @@
+"""
+Tests for IndexStore async file storage.
+
+Follows Hive patterns:
+- pytest with @pytest.mark.asyncio
+- tmp_path fixture for file operations
+- Test classes grouping related tests
+- Descriptive test names and docstrings
+
+Reference: core/tests/test_concurrent_storage.py
+"""
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from framework.debugging.index_store import IndexStore
+from framework.debugging.trace_index import TraceIndex
+
+
+class TestIndexStoreInitialization:
+    """Test IndexStore initialization patterns."""
+
+    def test_default_path_initialization(self):
+        """IndexStore defaults to ~/.hive/agents path."""
+        store = IndexStore()
+
+        expected_base = Path.home() / ".hive" / "agents"
+        assert store.base_path == expected_base
+        assert store.index_file == expected_base / ".trace_index.json"
+        assert store.index == {}
+
+    def test_custom_path_initialization(self, tmp_path: Path):
+        """IndexStore accepts custom base path."""
+        custom_path = tmp_path / "custom" / "path"
+        store = IndexStore(base_path=custom_path)
+
+        assert store.base_path == custom_path
+        assert store.index_file == custom_path / ".trace_index.json"
+        assert store.index == {}
+
+
+class TestIndexStoreLoad:
+    """Test async load operations."""
+
+    @pytest.mark.asyncio
+    async def test_load_empty_index(self, tmp_path: Path):
+        """Loading non-existent index returns empty dict."""
+        store = IndexStore(base_path=tmp_path)
+
+        await store.load()
+
+        assert store.index == {}
+        assert len(store.index) == 0
+
+    @pytest.mark.asyncio
+    async def test_load_existing_index(self, tmp_path: Path):
+        """Loading existing index deserializes TraceIndex objects."""
+        # Create index file manually
+        index_file = tmp_path / ".trace_index.json"
+        index_file.parent.mkdir(parents=True, exist_ok=True)
+
+        data = {
+            "run_123": {
+                "run_id": "run_123",
+                "agent_id": "test_agent",
+                "session_id": "session_xyz",
+                "status": "success",
+                "total_latency_ms": 1000,
+                "summary_path": "/path/summary.json",
+                "details_path": "/path/details.jsonl",
+                "tool_logs_path": "/path/tool_logs.jsonl",
+                "timestamp": "2026-02-12T12:00:00",
+            }
+        }
+
+        with open(index_file, "w") as f:
+            json.dump(data, f)
+
+        store = IndexStore(base_path=tmp_path)
+        await store.load()
+
+        assert len(store.index) == 1
+        assert "run_123" in store.index
+
+        trace = store.index["run_123"]
+        assert isinstance(trace, TraceIndex)
+        assert trace.run_id == "run_123"
+        assert trace.agent_id == "test_agent"
+        assert trace.total_latency_ms == 1000
+
+    @pytest.mark.asyncio
+    async def test_load_multiple_traces(self, tmp_path: Path):
+        """Loading index with multiple traces deserializes all."""
+        index_file = tmp_path / ".trace_index.json"
+        index_file.parent.mkdir(parents=True, exist_ok=True)
+
+        data = {
+            "run_1": {
+                "run_id": "run_1",
+                "agent_id": "agent_1",
+                "session_id": "session_1",
+                "status": "success",
+                "summary_path": "/path/summary.json",
+                "details_path": "/path/details.jsonl",
+                "tool_logs_path": "/path/tool_logs.jsonl",
+            },
+            "run_2": {
+                "run_id": "run_2",
+                "agent_id": "agent_2",
+                "session_id": "session_2",
+                "status": "failure",
+                "summary_path": "/path/summary.json",
+                "details_path": "/path/details.jsonl",
+                "tool_logs_path": "/path/tool_logs.jsonl",
+            },
+        }
+
+        with open(index_file, "w") as f:
+            json.dump(data, f)
+
+        store = IndexStore(base_path=tmp_path)
+        await store.load()
+
+        assert len(store.index) == 2
+        assert all(isinstance(t, TraceIndex) for t in store.index.values())
+
+    @pytest.mark.asyncio
+    async def test_load_corrupted_index_non_fatal(self, tmp_path: Path):
+        """Loading corrupted index logs error but doesn't raise."""
+        index_file = tmp_path / ".trace_index.json"
+        index_file.parent.mkdir(parents=True, exist_ok=True)
+
+        # Write invalid JSON
+        with open(index_file, "w") as f:
+            f.write("{ invalid json")
+
+        store = IndexStore(base_path=tmp_path)
+
+        # Should not raise exception (non-fatal error handling)
+        await store.load()
+
+        # Index should be empty after failed load
+        assert store.index == {}
+
+
+class TestIndexStoreSave:
+    """Test async save operations."""
+
+    @pytest.mark.asyncio
+    async def test_save_empty_index(self, tmp_path: Path):
+        """Saving empty index creates empty JSON file."""
+        store = IndexStore(base_path=tmp_path)
+
+        await store.save()
+
+        assert store.index_file.exists()
+        with open(store.index_file) as f:
+            data = json.load(f)
+
+        assert data == {}
+
+    @pytest.mark.asyncio
+    async def test_save_single_trace(self, tmp_path: Path, sample_trace: TraceIndex):
+        """Saving single trace serializes to JSON correctly."""
+        store = IndexStore(base_path=tmp_path)
+        store.add(sample_trace)
+
+        await store.save()
+
+        assert store.index_file.exists()
+        with open(store.index_file) as f:
+            data = json.load(f)
+
+        assert len(data) == 1
+        assert sample_trace.run_id in data
+        assert data[sample_trace.run_id]["agent_id"] == sample_trace.agent_id
+        assert data[sample_trace.run_id]["status"] == sample_trace.status
+
+    @pytest.mark.asyncio
+    async def test_save_multiple_traces(
+        self, tmp_path: Path, sample_trace: TraceIndex, failed_trace: TraceIndex
+    ):
+        """Saving multiple traces serializes all."""
+        store = IndexStore(base_path=tmp_path)
+        store.add(sample_trace)
+        store.add(failed_trace)
+
+        await store.save()
+
+        with open(store.index_file) as f:
+            data = json.load(f)
+
+        assert len(data) == 2
+        assert sample_trace.run_id in data
+        assert failed_trace.run_id in data
+
+    @pytest.mark.asyncio
+    async def test_save_creates_directory(self, tmp_path: Path, sample_trace: TraceIndex):
+        """Saving creates parent directories if needed."""
+        nested_path = tmp_path / "deep" / "nested" / "path"
+        store = IndexStore(base_path=nested_path)
+        store.add(sample_trace)
+
+        await store.save()
+
+        assert store.index_file.exists()
+        assert store.index_file.parent.exists()
+
+    @pytest.mark.asyncio
+    async def test_save_uses_atomic_write(self, tmp_path: Path, sample_trace: TraceIndex):
+        """Saving uses atomic_write for crash safety."""
+        store = IndexStore(base_path=tmp_path)
+        store.add(sample_trace)
+
+        await store.save()
+
+        # Verify file exists and is valid JSON
+        assert store.index_file.exists()
+        with open(store.index_file) as f:
+            data = json.load(f)
+
+        # atomic_write should ensure complete write
+        assert len(data) == 1
+
+
+class TestIndexStoreRoundTrip:
+    """Test save/load round-trip consistency."""
+
+    @pytest.mark.asyncio
+    async def test_round_trip_single_trace(self, tmp_path: Path, sample_trace: TraceIndex):
+        """Save then load preserves single trace."""
+        # Save
+        store1 = IndexStore(base_path=tmp_path)
+        store1.add(sample_trace)
+        await store1.save()
+
+        # Load
+        store2 = IndexStore(base_path=tmp_path)
+        await store2.load()
+
+        assert len(store2.index) == 1
+        loaded = store2.get(sample_trace.run_id)
+        assert loaded is not None
+        assert loaded.run_id == sample_trace.run_id
+        assert loaded.agent_id == sample_trace.agent_id
+        assert loaded.status == sample_trace.status
+        assert loaded.total_latency_ms == sample_trace.total_latency_ms
+        assert loaded.total_tokens == sample_trace.total_tokens
+
+    @pytest.mark.asyncio
+    async def test_round_trip_multiple_traces(
+        self, tmp_path: Path, sample_trace: TraceIndex, failed_trace: TraceIndex
+    ):
+        """Save then load preserves multiple traces."""
+        # Save
+        store1 = IndexStore(base_path=tmp_path)
+        store1.add(sample_trace)
+        store1.add(failed_trace)
+        await store1.save()
+
+        # Load
+        store2 = IndexStore(base_path=tmp_path)
+        await store2.load()
+
+        assert len(store2.index) == 2
+
+        loaded_success = store2.get(sample_trace.run_id)
+        assert loaded_success is not None
+        assert loaded_success.status == "success"
+
+        loaded_failure = store2.get(failed_trace.run_id)
+        assert loaded_failure is not None
+        assert loaded_failure.status == "failure"
+        assert loaded_failure.error_message == "Timeout in web_search"
+
+    @pytest.mark.asyncio
+    async def test_round_trip_preserves_computed_fields(
+        self, tmp_path: Path, sample_trace: TraceIndex
+    ):
+        """Save then load preserves computed field values."""
+        # Save
+        store1 = IndexStore(base_path=tmp_path)
+        store1.add(sample_trace)
+        await store1.save()
+
+        # Load
+        store2 = IndexStore(base_path=tmp_path)
+        await store2.load()
+
+        loaded = store2.get(sample_trace.run_id)
+        assert loaded.total_tokens == sample_trace.total_tokens
+        assert loaded.success_rate == sample_trace.success_rate
+
+
+class TestIndexStoreOperations:
+    """Test add/get/list operations."""
+
+    def test_add_trace(self, sample_trace: TraceIndex):
+        """Adding trace stores it in memory."""
+        store = IndexStore()
+
+        store.add(sample_trace)
+
+        assert len(store.index) == 1
+        assert sample_trace.run_id in store.index
+        assert store.index[sample_trace.run_id] is sample_trace
+
+    def test_add_multiple_traces(self, sample_trace: TraceIndex, failed_trace: TraceIndex):
+        """Adding multiple traces stores all."""
+        store = IndexStore()
+
+        store.add(sample_trace)
+        store.add(failed_trace)
+
+        assert len(store.index) == 2
+        assert sample_trace.run_id in store.index
+        assert failed_trace.run_id in store.index
+
+    def test_add_overwrites_existing(self, sample_trace: TraceIndex):
+        """Adding trace with existing run_id overwrites."""
+        store = IndexStore()
+        store.add(sample_trace)
+
+        # Create new trace with same run_id
+        updated_trace = TraceIndex(
+            run_id=sample_trace.run_id,
+            agent_id="updated_agent",
+            session_id="updated_session",
+            status="failure",
+            summary_path="/new/path/summary.json",
+            details_path="/new/path/details.jsonl",
+            tool_logs_path="/new/path/tool_logs.jsonl",
+        )
+        store.add(updated_trace)
+
+        assert len(store.index) == 1
+        assert store.index[sample_trace.run_id].agent_id == "updated_agent"
+
+    def test_get_existing_trace(self, sample_trace: TraceIndex):
+        """Getting existing trace returns it."""
+        store = IndexStore()
+        store.add(sample_trace)
+
+        result = store.get(sample_trace.run_id)
+
+        assert result is not None
+        assert result.run_id == sample_trace.run_id
+
+    def test_get_nonexistent_trace(self):
+        """Getting nonexistent trace returns None."""
+        store = IndexStore()
+
+        result = store.get("nonexistent_id")
+
+        assert result is None
+
+    def test_list_all_empty(self):
+        """Listing empty index returns empty list."""
+        store = IndexStore()
+
+        result = store.list_all()
+
+        assert result == []
+
+    def test_list_all_multiple_traces(self, sample_trace: TraceIndex, failed_trace: TraceIndex):
+        """Listing index returns all traces."""
+        store = IndexStore()
+        store.add(sample_trace)
+        store.add(failed_trace)
+
+        result = store.list_all()
+
+        assert len(result) == 2
+        assert sample_trace in result
+        assert failed_trace in result
+
+
+class TestIndexStoreConcurrency:
+    """Test concurrent operations and thread safety."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_loads(self, tmp_path: Path, sample_trace: TraceIndex):
+        """Multiple concurrent loads work correctly."""
+        # Setup initial data
+        store = IndexStore(base_path=tmp_path)
+        store.add(sample_trace)
+        await store.save()
+
+        # Create multiple stores and load concurrently
+        stores = [IndexStore(base_path=tmp_path) for _ in range(5)]
+        await asyncio.gather(*[s.load() for s in stores])
+
+        # All should have loaded the same data
+        for s in stores:
+            assert len(s.index) == 1
+            assert sample_trace.run_id in s.index
+
+    @pytest.mark.asyncio
+    async def test_concurrent_saves(self, tmp_path: Path):
+        """Multiple concurrent saves complete without errors."""
+        stores = [IndexStore(base_path=tmp_path) for _ in range(3)]
+
+        # Add different traces to each store
+        for i, store in enumerate(stores):
+            trace = TraceIndex(
+                run_id=f"run_{i}",
+                agent_id=f"agent_{i}",
+                session_id=f"session_{i}",
+                status="success",
+                summary_path="/path/summary.json",
+                details_path="/path/details.jsonl",
+                tool_logs_path="/path/tool_logs.jsonl",
+            )
+            store.add(trace)
+
+        # Save concurrently
+        await asyncio.gather(*[s.save() for s in stores])
+
+        # Last save should win (this is expected behavior)
+        assert tmp_path.joinpath(".trace_index.json").exists()

--- a/core/framework/debugging/tests/test_llm_provider.py
+++ b/core/framework/debugging/tests/test_llm_provider.py
@@ -1,0 +1,172 @@
+"""
+Tests for LLM provider factory.
+
+Tests multi-provider support for OpenAI, Anthropic, and Google.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from framework.debugging.llm_provider import (
+    _create_anthropic,
+    _detect_provider,
+    create_llm,
+)
+
+
+class TestProviderDetection:
+    """Test automatic provider detection."""
+
+    def test_detect_from_env_var(self, monkeypatch):
+        """Should use HIVE_LLM_PROVIDER if set."""
+        monkeypatch.setenv("HIVE_LLM_PROVIDER", "openai")
+        assert _detect_provider() == "openai"
+
+        monkeypatch.setenv("HIVE_LLM_PROVIDER", "anthropic")
+        assert _detect_provider() == "anthropic"
+
+        monkeypatch.setenv("HIVE_LLM_PROVIDER", "google")
+        assert _detect_provider() == "google"
+
+    def test_detect_from_openai_key(self, monkeypatch):
+        """Should detect OpenAI when OPENAI_API_KEY is set."""
+        monkeypatch.delenv("HIVE_LLM_PROVIDER", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        assert _detect_provider() == "openai"
+
+    def test_detect_from_anthropic_key(self, monkeypatch):
+        """Should detect Anthropic when ANTHROPIC_API_KEY is set."""
+        monkeypatch.delenv("HIVE_LLM_PROVIDER", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        assert _detect_provider() == "anthropic"
+
+    def test_detect_from_google_key(self, monkeypatch):
+        """Should detect Google when GOOGLE_API_KEY is set."""
+        monkeypatch.delenv("HIVE_LLM_PROVIDER", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+        assert _detect_provider() == "google"
+
+    def test_detect_no_provider(self, monkeypatch):
+        """Should raise ValueError when no provider can be detected."""
+        monkeypatch.delenv("HIVE_LLM_PROVIDER", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+        with pytest.raises(ValueError, match="No LLM provider configured"):
+            _detect_provider()
+
+
+class TestAnthropicProvider:
+    """Test Anthropic provider creation (available in environment)."""
+
+    @patch("langchain_anthropic.ChatAnthropic")
+    def test_create_with_defaults(self, mock_chat, monkeypatch):
+        """Should create Anthropic with default model and env API key."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        mock_instance = MagicMock()
+        mock_chat.return_value = mock_instance
+
+        result = _create_anthropic(None, None, 0.0)
+
+        mock_chat.assert_called_once_with(
+            model="claude-3-5-sonnet-20241022", anthropic_api_key="sk-ant-test", temperature=0.0
+        )
+        assert result == mock_instance
+
+    @patch("langchain_anthropic.ChatAnthropic")
+    def test_create_with_custom_model(self, mock_chat, monkeypatch):
+        """Should use custom model when provided."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        mock_instance = MagicMock()
+        mock_chat.return_value = mock_instance
+
+        result = _create_anthropic("claude-3-opus-20240229", None, 0.7)
+
+        mock_chat.assert_called_once_with(
+            model="claude-3-opus-20240229", anthropic_api_key="sk-ant-test", temperature=0.7
+        )
+        assert result == mock_instance
+
+    @patch("langchain_anthropic.ChatAnthropic")
+    def test_create_with_explicit_key(self, mock_chat):
+        """Should use explicit API key over env var."""
+        mock_instance = MagicMock()
+        mock_chat.return_value = mock_instance
+
+        result = _create_anthropic(None, "sk-ant-explicit", 0.0)
+
+        mock_chat.assert_called_once_with(
+            model="claude-3-5-sonnet-20241022", anthropic_api_key="sk-ant-explicit", temperature=0.0
+        )
+        assert result == mock_instance
+
+    def test_create_missing_key(self, monkeypatch):
+        """Should raise ValueError when API key is missing."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        with pytest.raises(ValueError, match="Anthropic API key required"):
+            _create_anthropic(None, None, 0.0)
+
+
+class TestCreateLLM:
+    """Test main create_llm factory function."""
+
+    @patch("framework.debugging.llm_provider._create_openai")
+    def test_create_with_explicit_provider(self, mock_create, monkeypatch):
+        """Should use explicit provider parameter."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        mock_llm = MagicMock()
+        mock_create.return_value = mock_llm
+
+        result = create_llm(provider="openai", model="gpt-4-turbo")
+
+        mock_create.assert_called_once_with("gpt-4-turbo", None, 0.0)
+        assert result == mock_llm
+
+    @patch("framework.debugging.llm_provider._create_anthropic")
+    @patch("framework.debugging.llm_provider._detect_provider")
+    def test_create_with_auto_detect(self, mock_detect, mock_create, monkeypatch):
+        """Should auto-detect provider when not specified."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        mock_detect.return_value = "anthropic"
+        mock_llm = MagicMock()
+        mock_create.return_value = mock_llm
+
+        result = create_llm()
+
+        mock_detect.assert_called_once()
+        mock_create.assert_called_once_with(None, None, 0.0)
+        assert result == mock_llm
+
+    @patch("framework.debugging.llm_provider._create_google")
+    def test_create_with_custom_temperature(self, mock_create, monkeypatch):
+        """Should pass custom temperature to provider."""
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+        mock_llm = MagicMock()
+        mock_create.return_value = mock_llm
+
+        result = create_llm(provider="google", temperature=0.8)
+
+        mock_create.assert_called_once_with(None, None, 0.8)
+        assert result == mock_llm
+
+    def test_create_invalid_provider(self):
+        """Should raise ValueError for invalid provider."""
+        with pytest.raises(ValueError, match="Invalid provider"):
+            create_llm(provider="invalid")  # type: ignore
+
+    @patch("framework.debugging.llm_provider._create_openai")
+    def test_create_with_api_key(self, mock_create):
+        """Should pass explicit API key to provider."""
+        mock_llm = MagicMock()
+        mock_create.return_value = mock_llm
+
+        result = create_llm(provider="openai", api_key="sk-explicit")
+
+        mock_create.assert_called_once_with(None, "sk-explicit", 0.0)
+        assert result == mock_llm

--- a/core/framework/debugging/tests/test_trace_embedder.py
+++ b/core/framework/debugging/tests/test_trace_embedder.py
@@ -1,0 +1,189 @@
+"""
+Tests for TraceEmbedder.
+
+Follows Hive patterns:
+- pytest with @pytest.mark.asyncio
+- Mock external dependencies
+- Test classes grouping related tests
+- Descriptive test names and docstrings
+
+Reference: core/tests/test_concurrent_storage.py
+"""
+
+import pytest
+
+from framework.debugging.trace_embedder import TraceEmbedder
+from framework.debugging.trace_index import TraceIndex
+
+
+class MockEmbeddings:
+    """Mock embeddings provider for testing."""
+
+    def __init__(self, dimension: int = 1024):
+        self.dimension = dimension
+        self.call_count = 0
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        """Mock batch embedding."""
+        self.call_count += 1
+        return [[0.1] * self.dimension for _ in texts]
+
+    def embed_query(self, text: str) -> list[float]:
+        """Mock single query embedding."""
+        self.call_count += 1
+        return [0.1] * self.dimension
+
+
+class TestTraceEmbedderInitialization:
+    """Test TraceEmbedder initialization."""
+
+    def test_initialization_with_custom_provider(self):
+        """TraceEmbedder accepts custom embeddings provider."""
+        mock_embeddings = MockEmbeddings()
+        embedder = TraceEmbedder(embeddings_provider=mock_embeddings)
+
+        assert embedder.embeddings is mock_embeddings
+
+
+class TestTraceEmbedderDocumentConversion:
+    """Test converting TraceIndex to text documents."""
+
+    def test_trace_to_document_minimal(self, sample_trace: TraceIndex):
+        """Minimal trace converts to structured document."""
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+
+        document = embedder.trace_to_document(sample_trace)
+
+        assert sample_trace.run_id in document
+        assert sample_trace.agent_id in document
+        assert sample_trace.status in document
+        assert str(sample_trace.total_latency_ms) in document
+
+    def test_trace_to_document_with_nodes(self, sample_trace: TraceIndex):
+        """Trace with nodes includes execution sequence."""
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+
+        document = embedder.trace_to_document(sample_trace)
+
+        assert "Nodes Executed:" in document
+        assert "intake" in document
+        assert "process" in document
+        assert "output" in document
+
+    def test_trace_to_document_with_error(self, failed_trace: TraceIndex):
+        """Failed trace includes error information."""
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+
+        document = embedder.trace_to_document(failed_trace)
+
+        assert "Error:" in document
+        assert failed_trace.error_message in document
+        assert "Failed at Node:" in document
+        assert failed_trace.failed_node_id in document
+
+    def test_trace_to_document_structure(self, sample_trace: TraceIndex):
+        """Document has consistent structure."""
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+
+        document = embedder.trace_to_document(sample_trace)
+
+        lines = document.split("\n")
+        assert any("Run ID:" in line for line in lines)
+        assert any("Agent:" in line for line in lines)
+        assert any("Status:" in line for line in lines)
+        assert any("Execution Quality:" in line for line in lines)
+        assert any("Total Latency:" in line for line in lines)
+
+
+class TestTraceEmbedderEmbedding:
+    """Test embedding generation."""
+
+    @pytest.mark.asyncio
+    async def test_embed_single_trace(self, sample_trace: TraceIndex):
+        """Embedding single trace returns vector."""
+        mock_embeddings = MockEmbeddings(dimension=128)
+        embedder = TraceEmbedder(embeddings_provider=mock_embeddings)
+
+        embedding = await embedder.embed_trace(sample_trace)
+
+        assert isinstance(embedding, list)
+        assert len(embedding) == 128
+        assert all(isinstance(x, float) for x in embedding)
+        assert mock_embeddings.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_embed_multiple_traces(self, sample_trace: TraceIndex, failed_trace: TraceIndex):
+        """Embedding multiple traces returns list of vectors."""
+        mock_embeddings = MockEmbeddings(dimension=128)
+        embedder = TraceEmbedder(embeddings_provider=mock_embeddings)
+
+        traces = [sample_trace, failed_trace]
+        embeddings = await embedder.embed_traces(traces)
+
+        assert isinstance(embeddings, list)
+        assert len(embeddings) == 2
+        assert all(len(emb) == 128 for emb in embeddings)
+        assert mock_embeddings.call_count == 1  # Batch call
+
+    @pytest.mark.asyncio
+    async def test_embed_query(self):
+        """Embedding query string returns vector."""
+        mock_embeddings = MockEmbeddings(dimension=128)
+        embedder = TraceEmbedder(embeddings_provider=mock_embeddings)
+
+        query = "find failed runs with timeout errors"
+        embedding = await embedder.embed_query(query)
+
+        assert isinstance(embedding, list)
+        assert len(embedding) == 128
+        assert mock_embeddings.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_batch_embedding_more_efficient(
+        self, sample_trace: TraceIndex, failed_trace: TraceIndex
+    ):
+        """Batch embedding uses fewer API calls than individual."""
+        mock_embeddings = MockEmbeddings()
+        embedder = TraceEmbedder(embeddings_provider=mock_embeddings)
+
+        traces = [sample_trace, failed_trace]
+
+        # Batch embedding
+        await embedder.embed_traces(traces)
+        batch_calls = mock_embeddings.call_count
+
+        # Reset counter
+        mock_embeddings.call_count = 0
+
+        # Individual embeddings
+        for trace in traces:
+            await embedder.embed_trace(trace)
+        individual_calls = mock_embeddings.call_count
+
+        # Batch should use fewer calls (1 vs 2)
+        assert batch_calls < individual_calls
+
+
+class TestTraceEmbedderIntegration:
+    """Integration tests for embedder."""
+
+    @pytest.mark.asyncio
+    async def test_end_to_end_workflow(self, sample_trace: TraceIndex, failed_trace: TraceIndex):
+        """End-to-end workflow: traces to embeddings."""
+        mock_embeddings = MockEmbeddings(dimension=64)
+        embedder = TraceEmbedder(embeddings_provider=mock_embeddings)
+
+        # Create traces list
+        traces = [sample_trace, failed_trace]
+
+        # Generate embeddings
+        embeddings = await embedder.embed_traces(traces)
+
+        # Verify results
+        assert len(embeddings) == len(traces)
+        assert all(len(emb) == 64 for emb in embeddings)
+
+        # Each trace should produce unique document
+        doc1 = embedder.trace_to_document(sample_trace)
+        doc2 = embedder.trace_to_document(failed_trace)
+        assert doc1 != doc2

--- a/core/framework/debugging/tests/test_trace_index.py
+++ b/core/framework/debugging/tests/test_trace_index.py
@@ -1,0 +1,312 @@
+"""
+Tests for TraceIndex schema.
+
+Follows Hive patterns:
+- pytest framework with descriptive test names
+- Test classes grouping related tests
+- Docstrings explaining test behavior
+- Pydantic model validation testing
+
+Reference: core/tests/test_llm_judge.py
+"""
+
+import json
+from datetime import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from framework.debugging.trace_index import TraceIndex
+
+
+class TestTraceIndexCreation:
+    """Test TraceIndex model creation and validation."""
+
+    def test_create_minimal_trace_index(self):
+        """Minimal required fields creates valid TraceIndex."""
+        trace = TraceIndex(
+            run_id="test_run_123",
+            agent_id="test_agent",
+            session_id="session_20260212_120000_abc",
+            status="success",
+            summary_path="/fake/path/summary.json",
+            details_path="/fake/path/details.jsonl",
+            tool_logs_path="/fake/path/tool_logs.jsonl",
+        )
+
+        assert trace.run_id == "test_run_123"
+        assert trace.agent_id == "test_agent"
+        assert trace.status == "success"
+        assert trace.total_latency_ms == 0
+        assert trace.total_input_tokens == 0
+        assert trace.node_ids == []
+
+    def test_create_full_trace_index(self):
+        """All fields can be set and are preserved."""
+        trace = TraceIndex(
+            run_id="test_run_456",
+            agent_id="sales_agent",
+            session_id="session_20260212_130000_def",
+            status="failure",
+            execution_quality="degraded",
+            total_latency_ms=5000,
+            total_input_tokens=1000,
+            total_output_tokens=2000,
+            node_count=5,
+            error_message="Timeout in web_search",
+            failed_node_id="research",
+            timestamp=datetime(2026, 2, 12, 13, 0, 0),
+            summary_path="/path/summary.json",
+            details_path="/path/details.jsonl",
+            tool_logs_path="/path/tool_logs.jsonl",
+            node_ids=["intake", "research", "analyze", "output"],
+        )
+
+        assert trace.run_id == "test_run_456"
+        assert trace.status == "failure"
+        assert trace.execution_quality == "degraded"
+        assert trace.total_latency_ms == 5000
+        assert trace.error_message == "Timeout in web_search"
+        assert trace.failed_node_id == "research"
+        assert len(trace.node_ids) == 4
+
+    def test_timestamp_defaults_to_now(self):
+        """Timestamp defaults to current time when not provided."""
+        before = datetime.now()
+        trace = TraceIndex(
+            run_id="test_run",
+            agent_id="agent",
+            session_id="session",
+            status="success",
+            summary_path="/path/summary.json",
+            details_path="/path/details.jsonl",
+            tool_logs_path="/path/tool_logs.jsonl",
+        )
+        after = datetime.now()
+
+        assert before <= trace.timestamp <= after
+
+
+class TestTraceIndexComputedFields:
+    """Test computed properties follow Pydantic patterns."""
+
+    def test_total_tokens_computed(self):
+        """total_tokens sums input and output tokens."""
+        trace = TraceIndex(
+            run_id="test_run",
+            agent_id="agent",
+            session_id="session",
+            status="success",
+            total_input_tokens=500,
+            total_output_tokens=1500,
+            summary_path="/path/summary.json",
+            details_path="/path/details.jsonl",
+            tool_logs_path="/path/tool_logs.jsonl",
+        )
+
+        assert trace.total_tokens == 2000
+
+    def test_total_tokens_with_zero_values(self):
+        """total_tokens returns 0 when no tokens used."""
+        trace = TraceIndex(
+            run_id="test_run",
+            agent_id="agent",
+            session_id="session",
+            status="success",
+            summary_path="/path/summary.json",
+            details_path="/path/details.jsonl",
+            tool_logs_path="/path/tool_logs.jsonl",
+        )
+
+        assert trace.total_tokens == 0
+
+    def test_success_rate_for_success(self):
+        """success_rate returns 1.0 for successful runs."""
+        trace = TraceIndex(
+            run_id="test_run",
+            agent_id="agent",
+            session_id="session",
+            status="success",
+            node_count=5,
+            summary_path="/path/summary.json",
+            details_path="/path/details.jsonl",
+            tool_logs_path="/path/tool_logs.jsonl",
+        )
+
+        assert trace.success_rate == 1.0
+
+    def test_success_rate_for_failure(self):
+        """success_rate returns 0.0 for failed runs."""
+        trace = TraceIndex(
+            run_id="test_run",
+            agent_id="agent",
+            session_id="session",
+            status="failure",
+            node_count=5,
+            summary_path="/path/summary.json",
+            details_path="/path/details.jsonl",
+            tool_logs_path="/path/tool_logs.jsonl",
+        )
+
+        assert trace.success_rate == 0.0
+
+    def test_success_rate_with_zero_nodes(self):
+        """success_rate returns 0.0 when node_count is 0."""
+        trace = TraceIndex(
+            run_id="test_run",
+            agent_id="agent",
+            session_id="session",
+            status="success",
+            node_count=0,
+            summary_path="/path/summary.json",
+            details_path="/path/details.jsonl",
+            tool_logs_path="/path/tool_logs.jsonl",
+        )
+
+        assert trace.success_rate == 0.0
+
+
+class TestTraceIndexSerialization:
+    """Test JSON serialization/deserialization patterns."""
+
+    def test_model_dump_json(self):
+        """model_dump_json() produces valid JSON string."""
+        trace = TraceIndex(
+            run_id="test_run",
+            agent_id="agent",
+            session_id="session",
+            status="success",
+            total_latency_ms=1000,
+            summary_path="/path/summary.json",
+            details_path="/path/details.jsonl",
+            tool_logs_path="/path/tool_logs.jsonl",
+        )
+
+        json_str = trace.model_dump_json()
+        data = json.loads(json_str)
+
+        assert data["run_id"] == "test_run"
+        assert data["agent_id"] == "agent"
+        assert data["status"] == "success"
+        assert data["total_latency_ms"] == 1000
+
+    def test_model_validate_from_dict(self):
+        """TraceIndex can be created from dict (deserialization)."""
+        data = {
+            "run_id": "test_run",
+            "agent_id": "agent",
+            "session_id": "session",
+            "status": "failure",
+            "total_latency_ms": 2000,
+            "total_input_tokens": 100,
+            "total_output_tokens": 200,
+            "summary_path": "/path/summary.json",
+            "details_path": "/path/details.jsonl",
+            "tool_logs_path": "/path/tool_logs.jsonl",
+            "timestamp": "2026-02-12T13:00:00",
+        }
+
+        trace = TraceIndex.model_validate(data)
+
+        assert trace.run_id == "test_run"
+        assert trace.status == "failure"
+        assert trace.total_latency_ms == 2000
+        assert trace.total_tokens == 300
+
+    def test_round_trip_serialization(self):
+        """Serialize then deserialize preserves all data."""
+        original = TraceIndex(
+            run_id="test_run_789",
+            agent_id="complex_agent",
+            session_id="session_xyz",
+            status="degraded",
+            execution_quality="degraded",
+            total_latency_ms=3500,
+            total_input_tokens=1500,
+            total_output_tokens=2500,
+            node_count=7,
+            error_message="Partial failure",
+            failed_node_id="node_3",
+            summary_path="/path/summary.json",
+            details_path="/path/details.jsonl",
+            tool_logs_path="/path/tool_logs.jsonl",
+            node_ids=["n1", "n2", "n3", "n4"],
+        )
+
+        json_str = original.model_dump_json()
+        restored = TraceIndex.model_validate_json(json_str)
+
+        assert restored.run_id == original.run_id
+        assert restored.agent_id == original.agent_id
+        assert restored.status == original.status
+        assert restored.total_latency_ms == original.total_latency_ms
+        assert restored.total_tokens == original.total_tokens
+        assert restored.node_ids == original.node_ids
+
+    def test_path_serialization(self):
+        """Path strings remain as strings in serialized form."""
+        trace = TraceIndex(
+            run_id="test_run",
+            agent_id="agent",
+            session_id="session",
+            status="success",
+            summary_path="/path/to/summary.json",
+            details_path="/path/to/details.jsonl",
+            tool_logs_path="/path/to/tool_logs.jsonl",
+        )
+
+        data = trace.model_dump()
+
+        assert isinstance(data["summary_path"], str)
+        assert isinstance(data["details_path"], str)
+        assert isinstance(data["tool_logs_path"], str)
+
+
+class TestTraceIndexValidation:
+    """Test Pydantic validation behavior."""
+
+    def test_missing_required_field_raises_error(self):
+        """Missing required field raises ValidationError."""
+        with pytest.raises(ValidationError) as exc_info:
+            TraceIndex(
+                # Missing run_id
+                agent_id="agent",
+                session_id="session",
+                status="success",
+                summary_path="/path/summary.json",
+                details_path="/path/details.jsonl",
+                tool_logs_path="/path/tool_logs.jsonl",
+            )
+
+        assert "run_id" in str(exc_info.value)
+
+    def test_invalid_type_raises_error(self):
+        """Invalid field type raises ValidationError."""
+        with pytest.raises(ValidationError):
+            TraceIndex(
+                run_id="test_run",
+                agent_id="agent",
+                session_id="session",
+                status="success",
+                total_latency_ms="not_an_int",  # Should be int
+                summary_path="/path/summary.json",
+                details_path="/path/details.jsonl",
+                tool_logs_path="/path/tool_logs.jsonl",
+            )
+
+    def test_none_for_optional_fields(self):
+        """None values work for optional fields."""
+        trace = TraceIndex(
+            run_id="test_run",
+            agent_id="agent",
+            session_id="session",
+            status="success",
+            error_message=None,
+            failed_node_id=None,
+            summary_path="/path/summary.json",
+            details_path="/path/details.jsonl",
+            tool_logs_path="/path/tool_logs.jsonl",
+        )
+
+        assert trace.error_message is None
+        assert trace.failed_node_id is None

--- a/core/framework/debugging/tests/test_trace_indexer.py
+++ b/core/framework/debugging/tests/test_trace_indexer.py
@@ -1,0 +1,562 @@
+"""
+Tests for TraceIndexer.
+
+Follows Hive patterns:
+- pytest with @pytest.mark.asyncio
+- tmp_path fixture for file operations
+- Test classes grouping related tests
+- Descriptive test names and docstrings
+
+Reference: core/tests/test_concurrent_storage.py
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from framework.debugging.index_store import IndexStore
+from framework.debugging.trace_indexer import TraceIndexer
+
+
+def create_session_logs(
+    session_dir: Path,
+    run_id: str,
+    agent_id: str = "test_agent",
+    status: str = "success",
+    with_error: bool = False,
+) -> None:
+    """
+    Create mock L1/L2/L3 log files for testing.
+
+    Args:
+        session_dir: Session directory path
+        run_id: Run identifier
+        agent_id: Agent identifier
+        status: Run status
+        with_error: Whether to include error information
+    """
+    logs_dir = session_dir / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    # L1: summary.json
+    summary = {
+        "run_id": run_id,
+        "agent_id": agent_id,
+        "goal_id": "test_goal",
+        "status": status,
+        "total_nodes_executed": 3,
+        "node_path": ["intake", "process", "output"],
+        "total_input_tokens": 1000,
+        "total_output_tokens": 2000,
+        "needs_attention": with_error,
+        "attention_reasons": ["high_retry_count"] if with_error else [],
+        "started_at": "2026-02-12T12:00:00",
+        "duration_ms": 5000,
+        "execution_quality": "degraded" if with_error else "clean",
+    }
+
+    with open(logs_dir / "summary.json", "w") as f:
+        json.dump(summary, f, indent=2)
+
+    # L2: details.jsonl
+    details = [
+        {
+            "node_id": "intake",
+            "node_name": "Intake Node",
+            "node_type": "event_loop",
+            "success": True,
+            "error": None,
+            "total_steps": 2,
+            "tokens_used": 500,
+            "input_tokens": 200,
+            "output_tokens": 300,
+            "latency_ms": 1500,
+            "exit_status": "success",
+            "retry_count": 0,
+            "needs_attention": False,
+        },
+        {
+            "node_id": "process",
+            "node_name": "Process Node",
+            "node_type": "event_loop",
+            "success": not with_error,
+            "error": "Timeout in web_search" if with_error else None,
+            "total_steps": 5,
+            "tokens_used": 1500,
+            "input_tokens": 600,
+            "output_tokens": 900,
+            "latency_ms": 2500,
+            "exit_status": "escalate" if with_error else "success",
+            "retry_count": 5 if with_error else 0,
+            "needs_attention": with_error,
+        },
+        {
+            "node_id": "output",
+            "node_name": "Output Node",
+            "node_type": "event_loop",
+            "success": True,
+            "error": None,
+            "total_steps": 1,
+            "tokens_used": 1000,
+            "input_tokens": 200,
+            "output_tokens": 800,
+            "latency_ms": 1000,
+            "exit_status": "success",
+            "retry_count": 0,
+            "needs_attention": False,
+        },
+    ]
+
+    with open(logs_dir / "details.jsonl", "w") as f:
+        for detail in details:
+            f.write(json.dumps(detail) + "\n")
+
+    # L3: tool_logs.jsonl (minimal for testing)
+    steps = [
+        {
+            "node_id": "intake",
+            "step_index": 0,
+            "llm_text": "Processing intake",
+            "tool_calls": [],
+            "input_tokens": 100,
+            "output_tokens": 150,
+            "latency_ms": 750,
+            "verdict": "ACCEPT",
+        },
+    ]
+
+    with open(logs_dir / "tool_logs.jsonl", "w") as f:
+        for step in steps:
+            f.write(json.dumps(step) + "\n")
+
+
+class TestTraceIndexerInitialization:
+    """Test TraceIndexer initialization."""
+
+    def test_initialization(self, tmp_path: Path):
+        """TraceIndexer initializes with agent base path."""
+        indexer = TraceIndexer(tmp_path)
+
+        assert indexer.agent_base_path == tmp_path
+        assert indexer.sessions_dir == tmp_path / "sessions"
+
+
+class TestTraceIndexerDiscovery:
+    """Test session discovery."""
+
+    @pytest.mark.asyncio
+    async def test_discover_no_sessions(self, tmp_path: Path):
+        """No sessions returns empty list."""
+        indexer = TraceIndexer(tmp_path)
+
+        sessions = await indexer._discover_sessions()
+
+        assert sessions == []
+
+    @pytest.mark.asyncio
+    async def test_discover_single_session(self, tmp_path: Path):
+        """Single session directory is discovered."""
+        sessions_dir = tmp_path / "sessions"
+        session_dir = sessions_dir / "session_20260212_120000_abc"
+        session_dir.mkdir(parents=True)
+
+        indexer = TraceIndexer(tmp_path)
+        sessions = await indexer._discover_sessions()
+
+        assert len(sessions) == 1
+        assert sessions[0].name == "session_20260212_120000_abc"
+
+    @pytest.mark.asyncio
+    async def test_discover_multiple_sessions(self, tmp_path: Path):
+        """Multiple session directories are discovered."""
+        sessions_dir = tmp_path / "sessions"
+        (sessions_dir / "session_20260212_120000_abc").mkdir(parents=True)
+        (sessions_dir / "session_20260212_130000_def").mkdir(parents=True)
+        (sessions_dir / "session_20260212_140000_ghi").mkdir(parents=True)
+
+        indexer = TraceIndexer(tmp_path)
+        sessions = await indexer._discover_sessions()
+
+        assert len(sessions) == 3
+
+    @pytest.mark.asyncio
+    async def test_discover_ignores_non_session_dirs(self, tmp_path: Path):
+        """Non-session directories are ignored."""
+        sessions_dir = tmp_path / "sessions"
+        (sessions_dir / "session_20260212_120000_abc").mkdir(parents=True)
+        (sessions_dir / "other_dir").mkdir(parents=True)
+        (sessions_dir / "not_a_session").mkdir(parents=True)
+
+        indexer = TraceIndexer(tmp_path)
+        sessions = await indexer._discover_sessions()
+
+        assert len(sessions) == 1
+        assert sessions[0].name.startswith("session_")
+
+
+class TestTraceIndexerReadLogs:
+    """Test reading L1/L2/L3 logs."""
+
+    @pytest.mark.asyncio
+    async def test_read_summary_success(self, tmp_path: Path):
+        """Reading valid summary.json returns RunSummaryLog."""
+        session_dir = tmp_path / "sessions" / "session_test"
+        create_session_logs(session_dir, run_id="run_123", agent_id="test_agent")
+
+        indexer = TraceIndexer(tmp_path)
+        summary = await indexer._read_summary(session_dir / "logs")
+
+        assert summary is not None
+        assert summary.run_id == "run_123"
+        assert summary.agent_id == "test_agent"
+        assert summary.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_read_summary_missing(self, tmp_path: Path):
+        """Reading missing summary.json returns None."""
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir(parents=True)
+
+        indexer = TraceIndexer(tmp_path)
+        summary = await indexer._read_summary(logs_dir)
+
+        assert summary is None
+
+    @pytest.mark.asyncio
+    async def test_read_summary_corrupted(self, tmp_path: Path):
+        """Reading corrupted summary.json returns None."""
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir(parents=True)
+
+        # Write invalid JSON
+        with open(logs_dir / "summary.json", "w") as f:
+            f.write("{ invalid json")
+
+        indexer = TraceIndexer(tmp_path)
+        summary = await indexer._read_summary(logs_dir)
+
+        assert summary is None
+
+    @pytest.mark.asyncio
+    async def test_read_details_success(self, tmp_path: Path):
+        """Reading valid details.jsonl returns list of NodeDetail."""
+        session_dir = tmp_path / "sessions" / "session_test"
+        create_session_logs(session_dir, run_id="run_123", agent_id="test_agent")
+
+        indexer = TraceIndexer(tmp_path)
+        details = await indexer._read_details(session_dir / "logs")
+
+        assert details is not None
+        assert len(details) == 3
+        assert details[0].node_id == "intake"
+        assert details[1].node_id == "process"
+        assert details[2].node_id == "output"
+
+    @pytest.mark.asyncio
+    async def test_read_details_missing(self, tmp_path: Path):
+        """Reading missing details.jsonl returns None."""
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir(parents=True)
+
+        indexer = TraceIndexer(tmp_path)
+        details = await indexer._read_details(logs_dir)
+
+        assert details is None
+
+    @pytest.mark.asyncio
+    async def test_read_details_skips_corrupt_lines(self, tmp_path: Path):
+        """Reading details.jsonl skips corrupt lines."""
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir(parents=True)
+
+        with open(logs_dir / "details.jsonl", "w") as f:
+            # Valid line
+            f.write(
+                json.dumps(
+                    {
+                        "node_id": "node1",
+                        "success": True,
+                        "total_steps": 1,
+                    }
+                )
+                + "\n"
+            )
+            # Corrupt line
+            f.write("{ invalid\n")
+            # Another valid line
+            f.write(
+                json.dumps(
+                    {
+                        "node_id": "node2",
+                        "success": True,
+                        "total_steps": 2,
+                    }
+                )
+                + "\n"
+            )
+
+        indexer = TraceIndexer(tmp_path)
+        details = await indexer._read_details(logs_dir)
+
+        assert details is not None
+        assert len(details) == 2
+        assert details[0].node_id == "node1"
+        assert details[1].node_id == "node2"
+
+
+class TestTraceIndexerIndexSession:
+    """Test indexing a single session."""
+
+    @pytest.mark.asyncio
+    async def test_index_successful_session(self, tmp_path: Path):
+        """Indexing successful session creates TraceIndex."""
+        session_dir = tmp_path / "sessions" / "session_20260212_120000_abc"
+        create_session_logs(
+            session_dir,
+            run_id="session_20260212_120000_abc",
+            agent_id="test_agent",
+            status="success",
+        )
+
+        indexer = TraceIndexer(tmp_path)
+        trace = await indexer.index_session(session_dir)
+
+        assert trace is not None
+        assert trace.run_id == "session_20260212_120000_abc"
+        assert trace.agent_id == "test_agent"
+        assert trace.session_id == "session_20260212_120000_abc"
+        assert trace.status == "success"
+        assert trace.execution_quality == "clean"
+        assert trace.total_latency_ms == 5000
+        assert trace.total_input_tokens == 1000
+        assert trace.total_output_tokens == 2000
+        assert trace.node_count == 3
+        assert trace.node_ids == ["intake", "process", "output"]
+        assert trace.error_message is None
+        assert trace.failed_node_id is None
+
+    @pytest.mark.asyncio
+    async def test_index_failed_session(self, tmp_path: Path):
+        """Indexing failed session captures error information."""
+        session_dir = tmp_path / "sessions" / "session_20260212_130000_def"
+        create_session_logs(
+            session_dir,
+            run_id="session_20260212_130000_def",
+            agent_id="test_agent",
+            status="failure",
+            with_error=True,
+        )
+
+        indexer = TraceIndexer(tmp_path)
+        trace = await indexer.index_session(session_dir)
+
+        assert trace is not None
+        assert trace.status == "failure"
+        assert trace.execution_quality == "degraded"
+        assert trace.error_message == "Timeout in web_search"
+        assert trace.failed_node_id == "process"
+
+    @pytest.mark.asyncio
+    async def test_index_session_no_logs(self, tmp_path: Path):
+        """Indexing session without logs returns None."""
+        session_dir = tmp_path / "sessions" / "session_empty"
+        session_dir.mkdir(parents=True)
+
+        indexer = TraceIndexer(tmp_path)
+        trace = await indexer.index_session(session_dir)
+
+        assert trace is None
+
+    @pytest.mark.asyncio
+    async def test_index_session_no_summary(self, tmp_path: Path):
+        """Indexing session without summary.json returns None."""
+        session_dir = tmp_path / "sessions" / "session_incomplete"
+        logs_dir = session_dir / "logs"
+        logs_dir.mkdir(parents=True)
+
+        # Create only details.jsonl (no summary)
+        with open(logs_dir / "details.jsonl", "w") as f:
+            f.write(json.dumps({"node_id": "test"}) + "\n")
+
+        indexer = TraceIndexer(tmp_path)
+        trace = await indexer.index_session(session_dir)
+
+        assert trace is None
+
+    @pytest.mark.asyncio
+    async def test_index_session_paths(self, tmp_path: Path):
+        """Indexed session contains correct file paths."""
+        session_dir = tmp_path / "sessions" / "session_test"
+        create_session_logs(session_dir, run_id="session_test", agent_id="test_agent")
+
+        indexer = TraceIndexer(tmp_path)
+        trace = await indexer.index_session(session_dir)
+
+        assert trace is not None
+        assert trace.summary_path.endswith("summary.json")
+        assert trace.details_path.endswith("details.jsonl")
+        assert trace.tool_logs_path.endswith("tool_logs.jsonl")
+
+
+class TestTraceIndexerIndexAll:
+    """Test indexing all sessions."""
+
+    @pytest.mark.asyncio
+    async def test_index_all_no_sessions(self, tmp_path: Path):
+        """Indexing with no sessions returns zero counts."""
+        indexer = TraceIndexer(tmp_path)
+        store = IndexStore(base_path=tmp_path / "index")
+
+        stats = await indexer.index_all_sessions(store)
+
+        assert stats["indexed"] == 0
+        assert stats["skipped"] == 0
+        assert stats["errors"] == 0
+        assert len(store.index) == 0
+
+    @pytest.mark.asyncio
+    async def test_index_all_single_session(self, tmp_path: Path):
+        """Indexing single session populates store."""
+        session_dir = tmp_path / "sessions" / "session_20260212_120000_abc"
+        create_session_logs(
+            session_dir, run_id="session_20260212_120000_abc", agent_id="test_agent"
+        )
+
+        indexer = TraceIndexer(tmp_path)
+        store = IndexStore(base_path=tmp_path / "index")
+
+        stats = await indexer.index_all_sessions(store)
+
+        assert stats["indexed"] == 1
+        assert stats["skipped"] == 0
+        assert stats["errors"] == 0
+        assert len(store.index) == 1
+        assert "session_20260212_120000_abc" in store.index
+
+    @pytest.mark.asyncio
+    async def test_index_all_multiple_sessions(self, tmp_path: Path):
+        """Indexing multiple sessions populates store with all."""
+        sessions_dir = tmp_path / "sessions"
+
+        # Create 3 sessions
+        for i, session_id in enumerate(
+            [
+                "session_20260212_120000_abc",
+                "session_20260212_130000_def",
+                "session_20260212_140000_ghi",
+            ]
+        ):
+            session_dir = sessions_dir / session_id
+            create_session_logs(session_dir, run_id=session_id, agent_id=f"agent_{i}")
+
+        indexer = TraceIndexer(tmp_path)
+        store = IndexStore(base_path=tmp_path / "index")
+
+        stats = await indexer.index_all_sessions(store)
+
+        assert stats["indexed"] == 3
+        assert stats["skipped"] == 0
+        assert stats["errors"] == 0
+        assert len(store.index) == 3
+
+    @pytest.mark.asyncio
+    async def test_index_all_mixed_sessions(self, tmp_path: Path):
+        """Indexing mix of complete and incomplete sessions."""
+        sessions_dir = tmp_path / "sessions"
+
+        # Complete session
+        create_session_logs(
+            sessions_dir / "session_complete", run_id="session_complete", agent_id="test_agent"
+        )
+
+        # Incomplete session (no logs)
+        (sessions_dir / "session_incomplete").mkdir(parents=True)
+
+        # Empty session (no logs dir)
+        (sessions_dir / "session_empty").mkdir(parents=True)
+
+        indexer = TraceIndexer(tmp_path)
+        store = IndexStore(base_path=tmp_path / "index")
+
+        stats = await indexer.index_all_sessions(store)
+
+        assert stats["indexed"] == 1
+        assert stats["skipped"] == 2
+        assert len(store.index) == 1
+
+    @pytest.mark.asyncio
+    async def test_index_all_handles_errors(self, tmp_path: Path):
+        """Indexing continues after errors in individual sessions."""
+        sessions_dir = tmp_path / "sessions"
+
+        # Good session
+        create_session_logs(
+            sessions_dir / "session_good", run_id="session_good", agent_id="test_agent"
+        )
+
+        # Corrupted session (invalid JSON)
+        corrupted_dir = sessions_dir / "session_corrupted"
+        logs_dir = corrupted_dir / "logs"
+        logs_dir.mkdir(parents=True)
+        with open(logs_dir / "summary.json", "w") as f:
+            f.write("{ invalid json")
+
+        indexer = TraceIndexer(tmp_path)
+        store = IndexStore(base_path=tmp_path / "index")
+
+        stats = await indexer.index_all_sessions(store)
+
+        # Good session indexed, corrupted skipped (no summary)
+        assert stats["indexed"] == 1
+        assert stats["skipped"] == 1
+
+
+class TestTraceIndexerIntegration:
+    """Integration tests for full indexing workflow."""
+
+    @pytest.mark.asyncio
+    async def test_full_indexing_workflow(self, tmp_path: Path):
+        """Full workflow: index sessions, save, load, query."""
+        sessions_dir = tmp_path / "agent" / "sessions"
+
+        # Create multiple sessions
+        create_session_logs(
+            sessions_dir / "session_success_1",
+            run_id="session_success_1",
+            agent_id="sales_agent",
+            status="success",
+        )
+
+        create_session_logs(
+            sessions_dir / "session_failure_1",
+            run_id="session_failure_1",
+            agent_id="sales_agent",
+            status="failure",
+            with_error=True,
+        )
+
+        # Index sessions
+        indexer = TraceIndexer(tmp_path / "agent")
+        store = IndexStore(base_path=tmp_path / "agent")
+
+        stats = await indexer.index_all_sessions(store)
+
+        assert stats["indexed"] == 2
+
+        # Save index
+        await store.save()
+
+        # Load in new store
+        store2 = IndexStore(base_path=tmp_path / "agent")
+        await store2.load()
+
+        assert len(store2.index) == 2
+
+        # Query by status
+        success_traces = [t for t in store2.list_all() if t.status == "success"]
+        assert len(success_traces) == 1
+
+        failure_traces = [t for t in store2.list_all() if t.status == "failure"]
+        assert len(failure_traces) == 1
+        assert failure_traces[0].error_message == "Timeout in web_search"

--- a/core/framework/debugging/tests/test_trace_rag.py
+++ b/core/framework/debugging/tests/test_trace_rag.py
@@ -1,0 +1,377 @@
+"""
+Tests for TraceRAG.
+
+Follows Hive patterns:
+- pytest with @pytest.mark.asyncio
+- Mock external dependencies (LLM)
+- Test classes grouping related tests
+- Descriptive test names and docstrings
+
+Reference: core/tests/test_llm_judge.py for mocking LLM
+"""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from framework.debugging.trace_embedder import TraceEmbedder
+from framework.debugging.trace_index import TraceIndex
+from framework.debugging.trace_rag import TraceRAG
+from framework.debugging.trace_vector_store import TraceVectorStore
+
+
+class MockLLMResponse:
+    """Mock LangChain LLM response."""
+
+    def __init__(self, content: str):
+        self.content = content
+
+
+class MockEmbeddings:
+    """Mock embeddings provider."""
+
+    def __init__(self, dimension: int = 128):
+        self.dimension = dimension
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [[0.1] * self.dimension for _ in texts]
+
+    def embed_query(self, text: str) -> list[float]:
+        return [0.1] * self.dimension
+
+
+def generate_mock_embedding(dimension: int = 128, seed: int = 0) -> list[float]:
+    """Generate deterministic mock embedding for testing."""
+    return [(i + seed) / dimension for i in range(dimension)]
+
+
+async def create_populated_store(tmp_path, sample_trace: TraceIndex, failed_trace: TraceIndex):
+    """Helper to create populated vector store."""
+    store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+    await store.initialize()
+
+    traces = [sample_trace, failed_trace]
+    embeddings = [generate_mock_embedding(128, seed=1), generate_mock_embedding(128, seed=2)]
+    await store.add_traces(traces, embeddings)
+
+    return store
+
+
+class TestTraceRAGInitialization:
+    """Test TraceRAG initialization."""
+
+    @pytest.mark.asyncio
+    async def test_initialization(self, tmp_path):
+        """TraceRAG initializes with embedder and vector store."""
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+
+        # Create mock LLM
+        mock_llm = Mock()
+        mock_llm.ainvoke = AsyncMock()
+
+        rag = TraceRAG(embedder, store, llm=mock_llm)
+
+        assert rag.embedder is embedder
+        assert rag.vector_store is store
+        assert rag.llm is not None
+
+
+class TestTraceRAGQuery:
+    """Test RAG query functionality."""
+
+    @pytest.mark.asyncio
+    async def test_query_empty_index(self, tmp_path):
+        """Querying empty index returns no results message."""
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store.initialize()
+
+        # Create mock LLM
+        mock_llm = Mock()
+        mock_llm.ainvoke = AsyncMock()
+
+        rag = TraceRAG(embedder, store, llm=mock_llm)
+
+        result = await rag.query("find failed runs")
+
+        assert "answer" in result
+        assert "No traces found" in result["answer"]
+        assert result.get("traces", []) == []
+
+    @pytest.mark.asyncio
+    async def test_query_returns_answer_and_traces(self, tmp_path, populated_vector_store):
+        """Query returns LLM answer and retrieved traces."""
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+        rag = TraceRAG(embedder, populated_vector_store, api_key="test-key")
+
+        # Mock LLM response
+        mock_response = MockLLMResponse("The agent had 2 runs with mixed results.")
+        with patch.object(rag.llm, "ainvoke", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = mock_response
+
+            result = await rag.query("summarize agent runs", k=2)
+
+        assert "answer" in result
+        assert result["answer"] == "The agent had 2 runs with mixed results."
+        assert "traces" in result
+        assert len(result["traces"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_query_without_context(self, tmp_path, populated_vector_store):
+        """Query with include_context=False doesn't return traces."""
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+        rag = TraceRAG(embedder, populated_vector_store, api_key="test-key")
+
+        mock_response = MockLLMResponse("Analysis complete.")
+        with patch.object(rag.llm, "ainvoke", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = mock_response
+
+            result = await rag.query("analyze runs", k=2, include_context=False)
+
+        assert "answer" in result
+        assert "traces" not in result
+
+    @pytest.mark.asyncio
+    async def test_query_respects_k_parameter(self, tmp_path, populated_vector_store):
+        """Query k parameter limits number of retrieved traces."""
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+        rag = TraceRAG(embedder, populated_vector_store, api_key="test-key")
+
+        mock_response = MockLLMResponse("Found 1 trace.")
+        with patch.object(rag.llm, "ainvoke", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = mock_response
+
+            result = await rag.query("find runs", k=1)
+
+        assert len(result["traces"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_query_handles_llm_error(self, tmp_path, populated_vector_store):
+        """Query handles LLM errors gracefully."""
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+        rag = TraceRAG(embedder, populated_vector_store, api_key="test-key")
+
+        # Mock LLM to raise exception
+        with patch.object(rag.llm, "ainvoke", new_callable=AsyncMock) as mock_llm:
+            mock_llm.side_effect = Exception("API error")
+
+            result = await rag.query("find runs")
+
+        assert "answer" in result
+        assert "Error" in result["answer"]
+
+
+class TestTraceRAGPatternAnalysis:
+    """Test pattern analysis functionality."""
+
+    @pytest.mark.asyncio
+    async def test_analyze_failures_pattern(self, tmp_path, populated_vector_store):
+        """Analyze failures pattern queries for failed runs."""
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+        rag = TraceRAG(embedder, populated_vector_store, api_key="test-key")
+
+        mock_response = MockLLMResponse("Found 1 failure with timeout error.")
+        with patch.object(rag.llm, "ainvoke", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = mock_response
+
+            analysis = await rag.analyze_pattern("failures", limit=5)
+
+        assert "timeout error" in analysis
+
+    @pytest.mark.asyncio
+    async def test_analyze_performance_pattern(self, tmp_path, populated_vector_store):
+        """Analyze performance pattern queries for high latency runs."""
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+        rag = TraceRAG(embedder, populated_vector_store, api_key="test-key")
+
+        mock_response = MockLLMResponse("High latency detected in 1 run.")
+        with patch.object(rag.llm, "ainvoke", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = mock_response
+
+            analysis = await rag.analyze_pattern("performance", limit=5)
+
+        assert "latency" in analysis.lower()
+
+    @pytest.mark.asyncio
+    async def test_analyze_empty_results(self, tmp_path):
+        """Pattern analysis with no traces returns message."""
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store.initialize()
+
+        # Create mock LLM
+        mock_llm = Mock()
+        mock_llm.ainvoke = AsyncMock()
+
+        rag = TraceRAG(embedder, store, llm=mock_llm)
+
+        analysis = await rag.analyze_pattern("failures")
+
+        assert "No traces found" in analysis
+
+
+class TestTraceRAGSimilarFailures:
+    """Test finding similar failures."""
+
+    @pytest.mark.asyncio
+    async def test_find_similar_failures(self, tmp_path, failed_trace: TraceIndex):
+        """Find similar failures returns similar failed traces."""
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store.initialize()
+
+        # Add multiple failed traces
+        failed_trace2 = TraceIndex(
+            run_id="failed_run_2",
+            agent_id="test_agent",
+            session_id="session_2",
+            status="failure",
+            error_message="Timeout in web_search",
+            failed_node_id="search",
+            summary_path="/path/summary.json",
+            details_path="/path/details.jsonl",
+            tool_logs_path="/path/tool_logs.jsonl",
+        )
+
+        traces = [failed_trace, failed_trace2]
+        embeddings = [generate_mock_embedding(128, seed=1), generate_mock_embedding(128, seed=2)]
+        await store.add_traces(traces, embeddings)
+
+        # Create mock LLM
+        mock_llm = Mock()
+        mock_llm.ainvoke = AsyncMock()
+
+        rag = TraceRAG(embedder, store, llm=mock_llm)
+
+        # Find similar failures
+        similar = await rag.find_similar_failures(failed_trace, k=1)
+
+        # Should find the other failed trace
+        assert len(similar) <= 1
+        if similar:
+            assert similar[0][0].status in ["failure", "degraded"]
+            assert similar[0][0].run_id != failed_trace.run_id
+
+    @pytest.mark.asyncio
+    async def test_find_similar_filters_self(self, tmp_path, failed_trace: TraceIndex):
+        """Find similar failures excludes the reference trace."""
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store.initialize()
+
+        # Add only one trace
+        embedding = generate_mock_embedding(128, seed=1)
+        await store.add_traces([failed_trace], [embedding])
+
+        # Create mock LLM
+        mock_llm = Mock()
+        mock_llm.ainvoke = AsyncMock()
+
+        rag = TraceRAG(embedder, store, llm=mock_llm)
+
+        # Find similar should not return itself
+        similar = await rag.find_similar_failures(failed_trace, k=5)
+
+        assert all(t.run_id != failed_trace.run_id for t, _ in similar)
+
+
+class TestTraceRAGContextFormatting:
+    """Test context formatting for LLM."""
+
+    @pytest.mark.asyncio
+    async def test_format_context_includes_metadata(self, tmp_path, sample_trace: TraceIndex):
+        """Format context includes all trace metadata."""
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+
+        # Create mock LLM
+        mock_llm = Mock()
+        mock_llm.ainvoke = AsyncMock()
+
+        rag = TraceRAG(embedder, store, llm=mock_llm)
+
+        context = rag._format_context([sample_trace])
+
+        assert sample_trace.run_id in context
+        assert sample_trace.agent_id in context
+        assert sample_trace.status in context
+        assert str(sample_trace.total_latency_ms) in context
+
+    @pytest.mark.asyncio
+    async def test_format_context_includes_errors(self, tmp_path, failed_trace: TraceIndex):
+        """Format context includes error information for failed traces."""
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+
+        # Create mock LLM
+        mock_llm = Mock()
+        mock_llm.ainvoke = AsyncMock()
+
+        rag = TraceRAG(embedder, store, llm=mock_llm)
+
+        context = rag._format_context([failed_trace])
+
+        assert "Error:" in context
+        assert failed_trace.error_message in context
+        assert failed_trace.failed_node_id in context
+
+    @pytest.mark.asyncio
+    async def test_format_context_multiple_traces(
+        self, tmp_path, sample_trace: TraceIndex, failed_trace: TraceIndex
+    ):
+        """Format context handles multiple traces."""
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings())
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+
+        # Create mock LLM
+        mock_llm = Mock()
+        mock_llm.ainvoke = AsyncMock()
+
+        rag = TraceRAG(embedder, store, llm=mock_llm)
+
+        context = rag._format_context([sample_trace, failed_trace])
+
+        assert "Trace 1" in context
+        assert "Trace 2" in context
+        assert sample_trace.run_id in context
+        assert failed_trace.run_id in context
+
+
+class TestTraceRAGIntegration:
+    """Integration tests for RAG workflow."""
+
+    @pytest.mark.asyncio
+    async def test_full_rag_workflow(
+        self, tmp_path, sample_trace: TraceIndex, failed_trace: TraceIndex
+    ):
+        """Full RAG workflow: embed → store → query → generate."""
+        # Setup components
+        embedder = TraceEmbedder(embeddings_provider=MockEmbeddings(128))
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store.initialize()
+
+        # Add traces
+        traces = [sample_trace, failed_trace]
+        embeddings = await embedder.embed_traces(traces)
+        await store.add_traces(traces, embeddings)
+
+        # Create RAG
+        # Create mock LLM
+        mock_llm = Mock()
+        mock_llm.ainvoke = AsyncMock()
+
+        rag = TraceRAG(embedder, store, llm=mock_llm)
+
+        # Query with mocked LLM
+        mock_response = MockLLMResponse("Found 2 runs: 1 successful, 1 failed with timeout.")
+        with patch.object(rag.llm, "ainvoke", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = mock_response
+
+            result = await rag.query("summarize runs", k=2)
+
+        # Verify complete workflow
+        assert result["answer"] == mock_response.content
+        assert len(result["traces"]) == 2
+        assert any(t.status == "success" for t in result["traces"])
+        assert any(t.status == "failure" for t in result["traces"])

--- a/core/framework/debugging/tests/test_trace_vector_store.py
+++ b/core/framework/debugging/tests/test_trace_vector_store.py
@@ -1,0 +1,378 @@
+"""
+Tests for TraceVectorStore.
+
+Follows Hive patterns:
+- pytest with @pytest.mark.asyncio
+- tmp_path fixture for file operations
+- Test classes grouping related tests
+- Descriptive test names and docstrings
+
+Reference: core/tests/test_concurrent_storage.py
+"""
+
+from pathlib import Path
+
+import pytest
+
+from framework.debugging.trace_index import TraceIndex
+from framework.debugging.trace_vector_store import TraceVectorStore
+
+
+def generate_mock_embedding(dimension: int = 128, seed: int = 0) -> list[float]:
+    """Generate deterministic mock embedding for testing."""
+    return [(i + seed) / dimension for i in range(dimension)]
+
+
+class TestTraceVectorStoreInitialization:
+    """Test TraceVectorStore initialization."""
+
+    def test_initialization_default_path(self):
+        """VectorStore initializes with default path."""
+        store = TraceVectorStore(dimension=128)
+
+        expected_path = Path.home() / ".hive" / "agents" / ".vector_index"
+        assert store.storage_path == expected_path
+        assert store.dimension == 128
+        assert store.index is None
+        assert store.metadata == {}
+        assert store.index_to_run_id == []
+
+    def test_initialization_custom_path(self, tmp_path: Path):
+        """VectorStore accepts custom storage path."""
+        custom_path = tmp_path / "custom" / "vector_store"
+        store = TraceVectorStore(storage_path=custom_path, dimension=64)
+
+        assert store.storage_path == custom_path
+        assert store.dimension == 64
+
+    @pytest.mark.asyncio
+    async def test_initialize_creates_new_index(self, tmp_path: Path):
+        """Initialize creates new FAISS index."""
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+
+        await store.initialize()
+
+        assert store.index is not None
+        assert store.size() == 0
+
+
+class TestTraceVectorStoreAddTraces:
+    """Test adding traces to vector store."""
+
+    @pytest.mark.asyncio
+    async def test_add_single_trace(self, tmp_path: Path, sample_trace: TraceIndex):
+        """Adding single trace stores it in index."""
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store.initialize()
+
+        embedding = generate_mock_embedding(128, seed=1)
+        await store.add_traces([sample_trace], [embedding])
+
+        assert store.size() == 1
+        assert sample_trace.run_id in store.metadata
+        assert len(store.index_to_run_id) == 1
+
+    @pytest.mark.asyncio
+    async def test_add_multiple_traces(
+        self, tmp_path: Path, sample_trace: TraceIndex, failed_trace: TraceIndex
+    ):
+        """Adding multiple traces stores all."""
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store.initialize()
+
+        traces = [sample_trace, failed_trace]
+        embeddings = [generate_mock_embedding(128, seed=1), generate_mock_embedding(128, seed=2)]
+
+        await store.add_traces(traces, embeddings)
+
+        assert store.size() == 2
+        assert sample_trace.run_id in store.metadata
+        assert failed_trace.run_id in store.metadata
+
+    @pytest.mark.asyncio
+    async def test_add_mismatched_lengths_raises_error(
+        self, tmp_path: Path, sample_trace: TraceIndex
+    ):
+        """Adding traces with mismatched embeddings raises ValueError."""
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store.initialize()
+
+        traces = [sample_trace]
+        embeddings = []  # Empty embeddings
+
+        with pytest.raises(ValueError, match="must have same length"):
+            await store.add_traces(traces, embeddings)
+
+    @pytest.mark.asyncio
+    async def test_add_without_initialize(self, tmp_path: Path, sample_trace: TraceIndex):
+        """Adding traces without initialize auto-initializes."""
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+
+        embedding = generate_mock_embedding(128)
+        await store.add_traces([sample_trace], [embedding])
+
+        assert store.index is not None
+        assert store.size() == 1
+
+
+class TestTraceVectorStoreSearch:
+    """Test semantic search."""
+
+    @pytest.mark.asyncio
+    async def test_search_empty_index(self, tmp_path: Path):
+        """Searching empty index returns empty list."""
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store.initialize()
+
+        query_embedding = generate_mock_embedding(128)
+        results = await store.search(query_embedding, k=5)
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_search_returns_similar_traces(
+        self, tmp_path: Path, sample_trace: TraceIndex, failed_trace: TraceIndex
+    ):
+        """Search returns traces sorted by similarity."""
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store.initialize()
+
+        # Add traces with different embeddings
+        traces = [sample_trace, failed_trace]
+        embeddings = [
+            generate_mock_embedding(128, seed=1),
+            generate_mock_embedding(128, seed=10),  # More different
+        ]
+        await store.add_traces(traces, embeddings)
+
+        # Search with query similar to first trace
+        query_embedding = generate_mock_embedding(128, seed=2)
+        results = await store.search(query_embedding, k=2)
+
+        assert len(results) == 2
+        # Each result is (TraceIndex, distance)
+        assert isinstance(results[0][0], TraceIndex)
+        assert isinstance(results[0][1], float)
+
+    @pytest.mark.asyncio
+    async def test_search_respects_k_limit(
+        self, tmp_path: Path, sample_trace: TraceIndex, failed_trace: TraceIndex
+    ):
+        """Search respects k parameter."""
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store.initialize()
+
+        # Add 3 traces
+        trace1 = sample_trace
+        trace2 = failed_trace
+        trace3 = TraceIndex(
+            run_id="run_3",
+            agent_id="agent_3",
+            session_id="session_3",
+            status="success",
+            summary_path="/path/summary.json",
+            details_path="/path/details.jsonl",
+            tool_logs_path="/path/tool_logs.jsonl",
+        )
+
+        traces = [trace1, trace2, trace3]
+        embeddings = [generate_mock_embedding(128, seed=i) for i in range(len(traces))]
+        await store.add_traces(traces, embeddings)
+
+        # Search with k=2
+        query_embedding = generate_mock_embedding(128, seed=0)
+        results = await store.search(query_embedding, k=2)
+
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_search_returns_sorted_by_distance(
+        self, tmp_path: Path, sample_trace: TraceIndex
+    ):
+        """Search results are sorted by distance (closest first)."""
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store.initialize()
+
+        # Add multiple traces
+        traces = [
+            TraceIndex(
+                run_id=f"run_{i}",
+                agent_id="test_agent",
+                session_id=f"session_{i}",
+                status="success",
+                summary_path="/path/summary.json",
+                details_path="/path/details.jsonl",
+                tool_logs_path="/path/tool_logs.jsonl",
+            )
+            for i in range(5)
+        ]
+
+        embeddings = [generate_mock_embedding(128, seed=i * 2) for i in range(5)]
+        await store.add_traces(traces, embeddings)
+
+        # Search
+        query_embedding = generate_mock_embedding(128, seed=1)
+        results = await store.search(query_embedding, k=5)
+
+        # Verify distances are sorted
+        distances = [dist for _, dist in results]
+        assert distances == sorted(distances)
+
+
+class TestTraceVectorStorePersistence:
+    """Test save/load persistence."""
+
+    @pytest.mark.asyncio
+    async def test_save_empty_index(self, tmp_path: Path):
+        """Saving empty index creates files."""
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store.initialize()
+
+        await store.save()
+
+        # Verify files exist but index remains empty
+        assert (tmp_path / "faiss.index").exists()
+        assert (tmp_path / "metadata.json").exists()
+        assert (tmp_path / "index_mapping.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_save_and_load(
+        self, tmp_path: Path, sample_trace: TraceIndex, failed_trace: TraceIndex
+    ):
+        """Save and load preserves index and metadata."""
+        # Create and populate store
+        store1 = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store1.initialize()
+
+        traces = [sample_trace, failed_trace]
+        embeddings = [generate_mock_embedding(128, seed=1), generate_mock_embedding(128, seed=2)]
+        await store1.add_traces(traces, embeddings)
+
+        # Save
+        await store1.save()
+
+        # Load in new store
+        store2 = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store2.initialize()
+
+        # Verify loaded state
+        assert store2.size() == 2
+        assert sample_trace.run_id in store2.metadata
+        assert failed_trace.run_id in store2.metadata
+        assert len(store2.index_to_run_id) == 2
+
+    @pytest.mark.asyncio
+    async def test_round_trip_preserves_search(
+        self, tmp_path: Path, sample_trace: TraceIndex, failed_trace: TraceIndex
+    ):
+        """Save/load round trip preserves search functionality."""
+        # Create and populate store
+        store1 = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store1.initialize()
+
+        traces = [sample_trace, failed_trace]
+        embeddings = [generate_mock_embedding(128, seed=1), generate_mock_embedding(128, seed=2)]
+        await store1.add_traces(traces, embeddings)
+
+        # Search before save
+        query_embedding = generate_mock_embedding(128, seed=1)
+        results_before = await store1.search(query_embedding, k=2)
+
+        # Save
+        await store1.save()
+
+        # Load and search
+        store2 = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store2.initialize()
+        results_after = await store2.search(query_embedding, k=2)
+
+        # Results should be similar (same traces, similar distances)
+        assert len(results_before) == len(results_after)
+        assert results_before[0][0].run_id == results_after[0][0].run_id
+
+    @pytest.mark.asyncio
+    async def test_load_nonexistent_creates_new(self, tmp_path: Path):
+        """Loading nonexistent index creates new index."""
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+
+        # Initialize will try to load (fails) then create new
+        await store.initialize()
+
+        assert store.index is not None
+        assert store.size() == 0
+
+
+class TestTraceVectorStoreOperations:
+    """Test store operations."""
+
+    def test_size_empty_index(self, tmp_path: Path):
+        """Size returns 0 for empty index."""
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+
+        assert store.size() == 0
+
+    @pytest.mark.asyncio
+    async def test_size_after_adding(self, tmp_path: Path, sample_trace: TraceIndex):
+        """Size returns correct count after adding traces."""
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store.initialize()
+
+        embedding = generate_mock_embedding(128)
+        await store.add_traces([sample_trace], [embedding])
+
+        assert store.size() == 1
+
+    @pytest.mark.asyncio
+    async def test_clear_resets_index(self, tmp_path: Path, sample_trace: TraceIndex):
+        """Clear removes all traces and creates fresh index."""
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store.initialize()
+
+        # Add trace
+        embedding = generate_mock_embedding(128)
+        await store.add_traces([sample_trace], [embedding])
+        assert store.size() == 1
+
+        # Clear
+        store.clear()
+
+        assert store.size() == 0
+        assert store.metadata == {}
+        assert store.index_to_run_id == []
+        assert store.index is not None  # New index created
+
+
+class TestTraceVectorStoreIntegration:
+    """Integration tests for vector store."""
+
+    @pytest.mark.asyncio
+    async def test_full_workflow(
+        self, tmp_path: Path, sample_trace: TraceIndex, failed_trace: TraceIndex
+    ):
+        """Full workflow: add → search → save → load → search."""
+        # Step 1: Add traces
+        store = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store.initialize()
+
+        traces = [sample_trace, failed_trace]
+        embeddings = [generate_mock_embedding(128, seed=1), generate_mock_embedding(128, seed=10)]
+        await store.add_traces(traces, embeddings)
+
+        # Step 2: Search
+        query_embedding = generate_mock_embedding(128, seed=2)
+        results1 = await store.search(query_embedding, k=2)
+        assert len(results1) == 2
+
+        # Step 3: Save
+        await store.save()
+
+        # Step 4: Load in new store
+        store2 = TraceVectorStore(storage_path=tmp_path, dimension=128)
+        await store2.initialize()
+
+        # Step 5: Search again
+        results2 = await store2.search(query_embedding, k=2)
+        assert len(results2) == 2
+
+        # Results should match
+        assert results1[0][0].run_id == results2[0][0].run_id

--- a/core/framework/debugging/trace_embedder.py
+++ b/core/framework/debugging/trace_embedder.py
@@ -1,0 +1,177 @@
+"""
+TraceEmbedder: Generates embeddings for trace documents.
+
+Follows Hive patterns:
+- Async I/O with asyncio.to_thread()
+- Type safety with Pydantic models
+- LangChain integration
+- Non-fatal error handling
+
+Reference: LangChain documentation for embeddings
+"""
+
+import asyncio
+import logging
+from typing import Protocol
+
+try:
+    from langchain_community.embeddings import HuggingFaceEmbeddings
+
+    DEFAULT_EMBEDDINGS_AVAILABLE = True
+except ImportError:
+    DEFAULT_EMBEDDINGS_AVAILABLE = False
+
+from framework.debugging.trace_index import TraceIndex
+
+logger = logging.getLogger(__name__)
+
+
+class EmbeddingsProvider(Protocol):
+    """Protocol for embeddings providers."""
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        """Embed multiple documents."""
+        ...
+
+    def embed_query(self, text: str) -> list[float]:
+        """Embed a single query."""
+        ...
+
+
+class TraceEmbedder:
+    """
+    Generates embeddings for trace documents using LangChain.
+
+    Converts TraceIndex objects into text documents and generates
+    embeddings using Claude's embeddings model via LangChain.
+
+    Follows Hive patterns:
+    - Async I/O with asyncio.to_thread()
+    - Type safety with Pydantic
+    - Non-fatal error handling
+    """
+
+    def __init__(
+        self,
+        embeddings_provider: EmbeddingsProvider | None = None,
+        model_name: str = "sentence-transformers/all-MiniLM-L6-v2",
+    ):
+        """
+        Initialize trace embedder.
+
+        Args:
+            embeddings_provider: Custom embeddings provider. If None,
+                                uses HuggingFaceEmbeddings (local, no API key needed).
+            model_name: HuggingFace model name for default embeddings.
+                       Default is a small, fast model suitable for local use.
+        """
+        if embeddings_provider is None:
+            if not DEFAULT_EMBEDDINGS_AVAILABLE:
+                raise ImportError(
+                    "langchain_community is required for default embeddings. "
+                    "Install with: pip install langchain-community"
+                )
+            # Use HuggingFace embeddings (local, no API needed)
+            self.embeddings = HuggingFaceEmbeddings(model_name=model_name)
+        else:
+            self.embeddings = embeddings_provider
+
+    def trace_to_document(self, trace: TraceIndex) -> str:
+        """
+        Convert TraceIndex to searchable text document.
+
+        Creates a structured text representation that captures:
+        - Run metadata (status, quality, timing)
+        - Error information (if any)
+        - Node execution sequence
+        - Performance metrics
+
+        Args:
+            trace: TraceIndex to convert
+
+        Returns:
+            Text document suitable for embedding
+        """
+        parts = [
+            f"Run ID: {trace.run_id}",
+            f"Agent: {trace.agent_id}",
+            f"Status: {trace.status}",
+            f"Execution Quality: {trace.execution_quality}",
+            f"Total Latency: {trace.total_latency_ms}ms",
+            f"Total Tokens: {trace.total_tokens}",
+            f"Node Count: {trace.node_count}",
+        ]
+
+        # Add node sequence
+        if trace.node_ids:
+            parts.append(f"Nodes Executed: {' -> '.join(trace.node_ids)}")
+
+        # Add error information if present
+        if trace.error_message:
+            parts.append(f"Error: {trace.error_message}")
+            if trace.failed_node_id:
+                parts.append(f"Failed at Node: {trace.failed_node_id}")
+
+        return "\n".join(parts)
+
+    async def embed_trace(self, trace: TraceIndex) -> list[float]:
+        """
+        Generate embedding for a single trace.
+
+        Follows Hive pattern: asyncio.to_thread for blocking I/O.
+
+        Args:
+            trace: TraceIndex to embed
+
+        Returns:
+            Embedding vector
+
+        Raises:
+            Exception: If embedding generation fails
+        """
+        document = self.trace_to_document(trace)
+
+        def _embed() -> list[float]:
+            """Blocking embed operation."""
+            return self.embeddings.embed_query(document)
+
+        return await asyncio.to_thread(_embed)
+
+    async def embed_traces(self, traces: list[TraceIndex]) -> list[list[float]]:
+        """
+        Generate embeddings for multiple traces (batch).
+
+        More efficient than calling embed_trace repeatedly.
+
+        Follows Hive pattern: asyncio.to_thread for blocking I/O.
+
+        Args:
+            traces: List of TraceIndex objects
+
+        Returns:
+            List of embedding vectors
+        """
+        documents = [self.trace_to_document(trace) for trace in traces]
+
+        def _embed_batch() -> list[list[float]]:
+            """Blocking batch embed operation."""
+            return self.embeddings.embed_documents(documents)
+
+        return await asyncio.to_thread(_embed_batch)
+
+    async def embed_query(self, query: str) -> list[float]:
+        """
+        Generate embedding for a search query.
+
+        Args:
+            query: Search query text
+
+        Returns:
+            Embedding vector
+        """
+
+        def _embed() -> list[float]:
+            """Blocking embed operation."""
+            return self.embeddings.embed_query(query)
+
+        return await asyncio.to_thread(_embed)

--- a/core/framework/debugging/trace_index.py
+++ b/core/framework/debugging/trace_index.py
@@ -1,0 +1,84 @@
+"""
+TraceIndex schema for debugging traces.
+
+Follows Hive patterns:
+- Pydantic BaseModel with Field descriptors
+- Computed fields with @computed_field
+- JSON serialization
+
+Reference: core/framework/schemas/decision.py
+"""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field, computed_field
+
+
+class TraceIndex(BaseModel):
+    """
+    Index entry for a single agent execution trace.
+
+    Stores metadata about a run for fast querying without loading
+    full L1/L2/L3 logs.
+
+    Follows Hive pattern: Pydantic BaseModel with Field descriptors
+    Reference: framework/schemas/decision.py
+    """
+
+    # Core identifiers
+    run_id: str = Field(description="Unique run identifier")
+    agent_id: str = Field(description="Agent that executed this run")
+    session_id: str = Field(description="Session directory name")
+
+    # Execution status
+    status: str = Field(description="Run status: 'success' | 'failure' | 'degraded'")
+    execution_quality: str = Field(
+        default="clean", description="Execution quality: 'clean' | 'degraded' | 'failed'"
+    )
+
+    # Performance metrics
+    total_latency_ms: int = Field(default=0, description="Total execution time in milliseconds")
+    total_input_tokens: int = Field(default=0, description="Total input tokens consumed")
+    total_output_tokens: int = Field(default=0, description="Total output tokens generated")
+    node_count: int = Field(default=0, description="Number of nodes executed")
+
+    # Error tracking
+    error_message: str | None = Field(default=None, description="Error message if run failed")
+    failed_node_id: str | None = Field(default=None, description="Node ID where failure occurred")
+
+    # Timestamp
+    timestamp: datetime = Field(default_factory=datetime.now, description="Run start timestamp")
+
+    # File paths (stored as strings for JSON serialization)
+    summary_path: str = Field(description="Path to L1 summary.json file")
+    details_path: str = Field(description="Path to L2 details.jsonl file")
+    tool_logs_path: str = Field(description="Path to L3 tool_logs.jsonl file")
+
+    # Node metadata
+    node_ids: list[str] = Field(
+        default_factory=list, description="List of node IDs executed in this run"
+    )
+
+    # Computed fields (following Hive pattern)
+    @computed_field
+    @property
+    def total_tokens(self) -> int:
+        """
+        Total tokens consumed (input + output).
+
+        Follows Hive pattern: @computed_field decorator
+        Reference: framework/schemas/decision.py lines 150-171
+        """
+        return self.total_input_tokens + self.total_output_tokens
+
+    @computed_field
+    @property
+    def success_rate(self) -> float:
+        """
+        Success rate based on status.
+
+        Returns 1.0 for success, 0.0 for failure, accounting for node_count.
+        """
+        if self.node_count == 0:
+            return 0.0
+        return 1.0 if self.status == "success" else 0.0

--- a/core/framework/debugging/trace_indexer.py
+++ b/core/framework/debugging/trace_indexer.py
@@ -1,0 +1,261 @@
+"""
+TraceIndexer: Builds trace index from runtime logs.
+
+Follows Hive patterns:
+- Async I/O with asyncio.to_thread()
+- Non-fatal error handling
+- Type safety with Pydantic models
+- Clean data flow
+
+Reference: core/framework/runtime/runtime_log_store.py
+"""
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+
+from framework.debugging.index_store import IndexStore
+from framework.debugging.trace_index import TraceIndex
+from framework.runtime.runtime_log_schemas import (
+    NodeDetail,
+    RunSummaryLog,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TraceIndexer:
+    """
+    Builds trace index from L1/L2/L3 runtime logs.
+
+    Scans session directories, reads runtime logs, extracts metadata,
+    and builds an indexed catalog for fast querying.
+
+    Follows Hive patterns:
+    - Async I/O with asyncio.to_thread()
+    - Non-fatal error handling (logs, doesn't crash)
+    - Type safety with Pydantic models
+
+    Reference: framework/runtime/runtime_log_store.py
+    """
+
+    def __init__(self, agent_base_path: Path):
+        """
+        Initialize trace indexer.
+
+        Args:
+            agent_base_path: Base path for agent storage
+                            (e.g., ~/.hive/agents/{agent_name})
+        """
+        self.agent_base_path = Path(agent_base_path)
+        self.sessions_dir = self.agent_base_path / "sessions"
+
+    async def index_all_sessions(self, store: IndexStore) -> dict[str, int]:
+        """
+        Index all sessions and store in IndexStore.
+
+        Scans sessions directory, reads L1/L2/L3 logs, creates TraceIndex
+        entries, and stores them.
+
+        Args:
+            store: IndexStore to populate
+
+        Returns:
+            dict with counts: {"indexed": N, "skipped": M, "errors": K}
+        """
+        stats = {"indexed": 0, "skipped": 0, "errors": 0}
+
+        if not self.sessions_dir.exists():
+            logger.info("No sessions directory found at %s", self.sessions_dir)
+            return stats
+
+        # Discover all session directories
+        session_dirs = await self._discover_sessions()
+        logger.info(f"Found {len(session_dirs)} sessions to index")
+
+        # Index each session
+        for session_dir in session_dirs:
+            try:
+                trace = await self.index_session(session_dir)
+                if trace:
+                    store.add(trace)
+                    stats["indexed"] += 1
+                else:
+                    stats["skipped"] += 1
+            except Exception:
+                logger.exception("Failed to index session %s (non-fatal)", session_dir.name)
+                stats["errors"] += 1
+
+        return stats
+
+    async def index_session(self, session_dir: Path) -> TraceIndex | None:
+        """
+        Index a single session directory.
+
+        Reads L1 summary.json and L2 details.jsonl to extract metadata.
+
+        Args:
+            session_dir: Path to session directory
+
+        Returns:
+            TraceIndex if successful, None if logs don't exist or are incomplete
+        """
+        session_id = session_dir.name
+        logs_dir = session_dir / "logs"
+
+        # Check if logs directory exists
+        if not logs_dir.exists():
+            logger.debug("No logs directory for session %s", session_id)
+            return None
+
+        # Read L1 summary
+        summary = await self._read_summary(logs_dir)
+        if summary is None:
+            # In-progress or incomplete session
+            logger.debug("No summary.json for session %s", session_id)
+            return None
+
+        # Read L2 details for additional metrics
+        details = await self._read_details(logs_dir)
+
+        # Extract agent_id from session_id or summary
+        agent_id = summary.agent_id or "unknown"
+
+        # Aggregate metrics from L2
+        total_input_tokens = summary.total_input_tokens
+        total_output_tokens = summary.total_output_tokens
+        total_latency_ms = summary.duration_ms
+        node_count = summary.total_nodes_executed
+        node_ids = summary.node_path
+
+        # Find error information
+        error_message = None
+        failed_node_id = None
+
+        if details:
+            # Find first failed node
+            for detail in details:
+                if not detail.success or detail.error:
+                    error_message = detail.error or f"Node {detail.node_id} failed"
+                    failed_node_id = detail.node_id
+                    break
+
+        # Build paths
+        summary_path = str(logs_dir / "summary.json")
+        details_path = str(logs_dir / "details.jsonl")
+        tool_logs_path = str(logs_dir / "tool_logs.jsonl")
+
+        # Create TraceIndex
+        trace = TraceIndex(
+            run_id=summary.run_id,
+            agent_id=agent_id,
+            session_id=session_id,
+            status=summary.status,
+            execution_quality=summary.execution_quality or "clean",
+            total_latency_ms=total_latency_ms,
+            total_input_tokens=total_input_tokens,
+            total_output_tokens=total_output_tokens,
+            node_count=node_count,
+            error_message=error_message,
+            failed_node_id=failed_node_id,
+            summary_path=summary_path,
+            details_path=details_path,
+            tool_logs_path=tool_logs_path,
+            node_ids=node_ids,
+        )
+
+        return trace
+
+    async def _discover_sessions(self) -> list[Path]:
+        """
+        Discover all session directories.
+
+        Follows Hive pattern: asyncio.to_thread for blocking I/O.
+
+        Returns:
+            List of session directory paths
+        """
+
+        def _scan() -> list[Path]:
+            """Blocking scan operation."""
+            if not self.sessions_dir.exists():
+                return []
+
+            sessions = []
+            for item in self.sessions_dir.iterdir():
+                if item.is_dir() and item.name.startswith("session_"):
+                    sessions.append(item)
+
+            return sessions
+
+        return await asyncio.to_thread(_scan)
+
+    async def _read_summary(self, logs_dir: Path) -> RunSummaryLog | None:
+        """
+        Read L1 summary.json.
+
+        Follows Hive pattern: asyncio.to_thread for blocking I/O.
+
+        Args:
+            logs_dir: Path to logs directory
+
+        Returns:
+            RunSummaryLog if successful, None otherwise
+        """
+
+        def _read() -> RunSummaryLog | None:
+            """Blocking read operation."""
+            summary_path = logs_dir / "summary.json"
+            if not summary_path.exists():
+                return None
+
+            try:
+                with open(summary_path) as f:
+                    data = json.load(f)
+                return RunSummaryLog(**data)
+            except Exception:
+                logger.exception("Failed to read summary from %s (non-fatal)", summary_path)
+                return None
+
+        return await asyncio.to_thread(_read)
+
+    async def _read_details(self, logs_dir: Path) -> list[NodeDetail] | None:
+        """
+        Read L2 details.jsonl.
+
+        Follows Hive pattern: asyncio.to_thread for blocking I/O.
+
+        Args:
+            logs_dir: Path to logs directory
+
+        Returns:
+            List of NodeDetail if successful, None otherwise
+        """
+
+        def _read() -> list[NodeDetail] | None:
+            """Blocking read operation."""
+            details_path = logs_dir / "details.jsonl"
+            if not details_path.exists():
+                return None
+
+            details = []
+            try:
+                with open(details_path) as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            data = json.loads(line)
+                            details.append(NodeDetail(**data))
+                        except Exception:
+                            # Skip corrupt lines (Hive pattern)
+                            logger.debug("Skipping corrupt line in %s", details_path)
+                            continue
+                return details
+            except Exception:
+                logger.exception("Failed to read details from %s (non-fatal)", details_path)
+                return None
+
+        return await asyncio.to_thread(_read)

--- a/core/framework/debugging/trace_rag.py
+++ b/core/framework/debugging/trace_rag.py
@@ -1,0 +1,268 @@
+"""
+TraceRAG: Retrieval-Augmented Generation for trace analysis.
+
+Combines semantic search with LLM to provide intelligent insights
+about agent execution traces.
+
+Follows Hive patterns:
+- Async I/O
+- Type safety with Pydantic
+- LangChain integration
+- Non-fatal error handling
+
+Reference: LangChain RAG documentation
+"""
+
+import logging
+from typing import Literal
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from framework.debugging.llm_provider import LLMProvider, create_llm
+from framework.debugging.trace_embedder import TraceEmbedder
+from framework.debugging.trace_index import TraceIndex
+from framework.debugging.trace_vector_store import TraceVectorStore
+
+logger = logging.getLogger(__name__)
+
+
+class TraceRAG:
+    """
+    Retrieval-Augmented Generation for trace analysis.
+
+    Combines semantic search with LLM to answer questions about
+    agent execution traces, identify patterns, and provide insights.
+
+    Follows Hive patterns:
+    - Async I/O
+    - Type safety
+    - Non-fatal error handling
+    """
+
+    def __init__(
+        self,
+        embedder: TraceEmbedder,
+        vector_store: TraceVectorStore,
+        llm: BaseChatModel | None = None,
+        provider: LLMProvider | None = None,
+        model: str | None = None,
+        api_key: str | None = None,
+    ):
+        """
+        Initialize RAG query engine with multi-provider LLM support.
+
+        Args:
+            embedder: TraceEmbedder for generating query embeddings
+            vector_store: TraceVectorStore for semantic search
+            llm: Pre-configured LangChain chat model. If None, creates via provider factory.
+            provider: LLM provider ("openai", "anthropic", "google"). Auto-detects if None.
+            model: Model name (uses provider default if None)
+            api_key: API key (uses environment variable if None)
+
+        Environment Variables:
+            HIVE_LLM_PROVIDER: Default provider (openai|anthropic|google)
+            OPENAI_API_KEY: OpenAI API key
+            ANTHROPIC_API_KEY: Anthropic API key
+            GOOGLE_API_KEY: Google API key
+
+        Example:
+            # Auto-detect provider
+            rag = TraceRAG(embedder, vector_store)
+
+            # Explicit provider
+            rag = TraceRAG(embedder, vector_store, provider="openai", model="gpt-4")
+            rag = TraceRAG(embedder, vector_store, provider="anthropic")
+            rag = TraceRAG(embedder, vector_store, provider="google", model="gemini-1.5-pro")
+        """
+        self.embedder = embedder
+        self.vector_store = vector_store
+
+        # Initialize LLM via provider factory
+        if llm is None:
+            self.llm = create_llm(
+                provider=provider,
+                model=model,
+                api_key=api_key,
+                temperature=0.0,  # Deterministic for analysis
+            )
+        else:
+            self.llm = llm
+
+    async def query(
+        self, question: str, k: int = 5, include_context: bool = True
+    ) -> dict[str, str | list[TraceIndex]]:
+        """
+        Answer a question about traces using RAG.
+
+        Steps:
+        1. Generate embedding for the question
+        2. Retrieve similar traces from vector store
+        3. Format context from retrieved traces
+        4. Generate answer using LLM
+
+        Args:
+            question: User question about traces
+            k: Number of traces to retrieve
+            include_context: Whether to include retrieved traces in response
+
+        Returns:
+            dict with 'answer' (str) and optionally 'traces' (list[TraceIndex])
+        """
+        # Step 1: Generate query embedding
+        logger.debug("Generating embedding for query: %s", question)
+        query_embedding = await self.embedder.embed_query(question)
+
+        # Step 2: Retrieve similar traces
+        logger.debug("Searching for %d similar traces", k)
+        results = await self.vector_store.search(query_embedding, k=k)
+
+        if not results:
+            return {"answer": "No traces found. The index may be empty.", "traces": []}
+
+        traces = [trace for trace, _ in results]
+
+        # Step 3: Format context
+        context = self._format_context(traces)
+
+        # Step 4: Generate answer
+        logger.debug("Generating answer using LLM")
+        answer = await self._generate_answer(question, context)
+
+        response = {"answer": answer}
+        if include_context:
+            response["traces"] = traces
+
+        return response
+
+    async def analyze_pattern(
+        self,
+        pattern_type: Literal["failures", "performance", "retry_patterns", "error_clusters"],
+        limit: int = 10,
+    ) -> str:
+        """
+        Analyze patterns across traces.
+
+        Args:
+            pattern_type: Type of pattern to analyze
+            limit: Maximum number of traces to analyze
+
+        Returns:
+            Analysis summary
+        """
+        # Build query based on pattern type
+        queries = {
+            "failures": "agent runs that failed with errors",
+            "performance": "agent runs with high latency or token usage",
+            "retry_patterns": "agent runs with high retry counts",
+            "error_clusters": "common error messages across runs",
+        }
+
+        query = queries.get(pattern_type, "all agent runs")
+        result = await self.query(query, k=limit, include_context=True)
+
+        # Generate pattern analysis
+        traces = result.get("traces", [])
+        if not traces:
+            return "No traces found for pattern analysis."
+
+        context = self._format_context(traces)
+        analysis_prompt = (
+            f"Analyze the following traces to identify {pattern_type}. "
+            f"Provide insights, common patterns, and recommendations.\n\n"
+            f"{context}"
+        )
+
+        return await self._generate_answer(analysis_prompt, context)
+
+    def _format_context(self, traces: list[TraceIndex]) -> str:
+        """
+        Format retrieved traces as context for LLM.
+
+        Args:
+            traces: List of retrieved traces
+
+        Returns:
+            Formatted context string
+        """
+        context_parts = ["Retrieved Traces:\n"]
+
+        for i, trace in enumerate(traces, 1):
+            context_parts.append(f"\n--- Trace {i} ---")
+            context_parts.append(f"Run ID: {trace.run_id}")
+            context_parts.append(f"Agent: {trace.agent_id}")
+            context_parts.append(f"Status: {trace.status}")
+            context_parts.append(f"Quality: {trace.execution_quality}")
+            context_parts.append(f"Latency: {trace.total_latency_ms}ms")
+            context_parts.append(f"Tokens: {trace.total_tokens}")
+            context_parts.append(f"Nodes: {trace.node_count}")
+
+            if trace.node_ids:
+                context_parts.append(f"Execution Path: {' -> '.join(trace.node_ids)}")
+
+            if trace.error_message:
+                context_parts.append(f"Error: {trace.error_message}")
+                if trace.failed_node_id:
+                    context_parts.append(f"Failed Node: {trace.failed_node_id}")
+
+        return "\n".join(context_parts)
+
+    async def _generate_answer(self, question: str, context: str) -> str:
+        """
+        Generate answer using LLM with retrieved context.
+
+        Args:
+            question: User question
+            context: Retrieved trace context
+
+        Returns:
+            LLM-generated answer
+        """
+        system_prompt = """You are a debugging assistant analyzing Hive agent execution traces.
+Your role is to:
+- Identify patterns in failures, performance issues, and retry loops
+- Provide actionable insights for debugging
+- Suggest root causes and solutions
+- Be concise and specific
+
+Use the retrieved trace data to answer questions accurately."""
+
+        messages = [
+            SystemMessage(content=system_prompt),
+            HumanMessage(content=f"Context:\n{context}\n\nQuestion: {question}"),
+        ]
+
+        try:
+            response = await self.llm.ainvoke(messages)
+            return response.content
+        except Exception:
+            logger.exception("Failed to generate answer using LLM")
+            return "Error: Failed to generate answer. Please check your API key and try again."
+
+    async def find_similar_failures(
+        self, trace: TraceIndex, k: int = 5
+    ) -> list[tuple[TraceIndex, float]]:
+        """
+        Find traces with similar failures.
+
+        Args:
+            trace: Reference trace to find similar failures for
+            k: Number of similar traces to return
+
+        Returns:
+            List of (TraceIndex, distance) tuples
+        """
+        # Generate embedding for the reference trace
+        embedding = await self.embedder.embed_trace(trace)
+
+        # Search for similar traces
+        results = await self.vector_store.search(embedding, k=k + 1)
+
+        # Filter out the reference trace itself and failed traces only
+        similar_failures = [
+            (t, dist)
+            for t, dist in results
+            if t.run_id != trace.run_id and t.status in ["failure", "degraded"]
+        ]
+
+        return similar_failures[:k]

--- a/core/framework/debugging/trace_vector_store.py
+++ b/core/framework/debugging/trace_vector_store.py
@@ -1,0 +1,277 @@
+"""
+TraceVectorStore: FAISS-based vector storage for trace embeddings.
+
+Follows Hive patterns:
+- Async I/O with asyncio.to_thread()
+- File-based storage
+- Type safety with Pydantic models
+- Non-fatal error handling
+
+Reference: LangChain FAISS documentation
+"""
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+
+import faiss
+import numpy as np
+
+from framework.debugging.trace_index import TraceIndex
+
+logger = logging.getLogger(__name__)
+
+
+class TraceVectorStore:
+    """
+    FAISS-based vector storage for trace embeddings.
+
+    Stores trace embeddings and provides efficient similarity search.
+    Persists index and metadata to disk for durability.
+
+    Follows Hive patterns:
+    - Async I/O with asyncio.to_thread()
+    - File-based storage (no external databases)
+    - Non-fatal error handling
+    """
+
+    def __init__(
+        self,
+        storage_path: Path | None = None,
+        dimension: int = 384,  # Default HuggingFace all-MiniLM-L6-v2 dimension
+    ):
+        """
+        Initialize vector store.
+
+        Args:
+            storage_path: Path to store index and metadata.
+                         Defaults to ~/.hive/agents/.vector_index/
+            dimension: Embedding vector dimension
+        """
+        if storage_path is None:
+            storage_path = Path.home() / ".hive" / "agents" / ".vector_index"
+
+        self.storage_path = Path(storage_path)
+        self.dimension = dimension
+
+        # FAISS index for similarity search
+        self.index: faiss.IndexFlatL2 | None = None
+
+        # Metadata storage (run_id -> TraceIndex)
+        self.metadata: dict[str, TraceIndex] = {}
+
+        # Mapping from FAISS index position to run_id
+        self.index_to_run_id: list[str] = []
+
+    async def initialize(self) -> None:
+        """
+        Initialize or load existing index.
+
+        Creates a new FAISS index or loads from disk if available.
+        """
+        # Try to load existing index
+        if await self._index_exists():
+            await self.load()
+        else:
+            # Create new index
+            self.index = faiss.IndexFlatL2(self.dimension)
+            logger.info("Created new FAISS index with dimension %d", self.dimension)
+
+    async def add_traces(self, traces: list[TraceIndex], embeddings: list[list[float]]) -> None:
+        """
+        Add traces and their embeddings to the index.
+
+        Args:
+            traces: List of TraceIndex objects
+            embeddings: Corresponding embedding vectors
+
+        Raises:
+            ValueError: If traces and embeddings lengths don't match
+        """
+        if len(traces) != len(embeddings):
+            raise ValueError(
+                f"Traces ({len(traces)}) and embeddings ({len(embeddings)}) must have same length"
+            )
+
+        if self.index is None:
+            await self.initialize()
+
+        def _add() -> None:
+            """Blocking add operation."""
+            # Convert embeddings to numpy array
+            vectors = np.array(embeddings, dtype=np.float32)
+
+            # Add to FAISS index
+            self.index.add(vectors)
+
+            # Store metadata
+            for trace in traces:
+                self.metadata[trace.run_id] = trace
+                self.index_to_run_id.append(trace.run_id)
+
+        await asyncio.to_thread(_add)
+        logger.info("Added %d traces to vector index", len(traces))
+
+    async def search(
+        self, query_embedding: list[float], k: int = 5
+    ) -> list[tuple[TraceIndex, float]]:
+        """
+        Search for similar traces.
+
+        Args:
+            query_embedding: Query embedding vector
+            k: Number of results to return
+
+        Returns:
+            List of (TraceIndex, distance) tuples, sorted by similarity
+        """
+        if self.index is None or self.index.ntotal == 0:
+            logger.warning("Vector index is empty")
+            return []
+
+        def _search() -> list[tuple[TraceIndex, float]]:
+            """Blocking search operation."""
+            # Convert query to numpy array
+            query_vector = np.array([query_embedding], dtype=np.float32)
+
+            # Search FAISS index
+            distances, indices = self.index.search(query_vector, k)
+
+            # Convert results to TraceIndex objects
+            results = []
+            for distance, idx in zip(distances[0], indices[0], strict=False):
+                if idx >= 0 and idx < len(self.index_to_run_id):
+                    run_id = self.index_to_run_id[idx]
+                    if run_id in self.metadata:
+                        trace = self.metadata[run_id]
+                        results.append((trace, float(distance)))
+
+            return results
+
+        return await asyncio.to_thread(_search)
+
+    async def save(self) -> None:
+        """
+        Save index and metadata to disk.
+
+        Follows Hive patterns:
+        - asyncio.to_thread for blocking I/O
+        - Non-fatal error handling
+        """
+        if self.index is None:
+            logger.debug("No index to save")
+            return
+
+        def _save() -> None:
+            """Blocking save operation."""
+            # Ensure directory exists
+            self.storage_path.mkdir(parents=True, exist_ok=True)
+
+            # Save FAISS index
+            index_path = self.storage_path / "faiss.index"
+            faiss.write_index(self.index, str(index_path))
+
+            # Save metadata
+            metadata_path = self.storage_path / "metadata.json"
+            metadata_dict = {
+                run_id: trace.model_dump(mode="json") for run_id, trace in self.metadata.items()
+            }
+
+            with open(metadata_path, "w") as f:
+                json.dump(metadata_dict, f, indent=2, default=str)
+
+            # Save index mapping
+            mapping_path = self.storage_path / "index_mapping.json"
+            with open(mapping_path, "w") as f:
+                json.dump(self.index_to_run_id, f)
+
+        try:
+            await asyncio.to_thread(_save)
+            logger.info("Saved vector index to %s", self.storage_path)
+        except Exception:
+            logger.exception("Failed to save vector index to %s (non-fatal)", self.storage_path)
+
+    async def load(self) -> None:
+        """
+        Load index and metadata from disk.
+
+        Follows Hive patterns:
+        - asyncio.to_thread for blocking I/O
+        - Non-fatal error handling
+        """
+
+        def _load() -> tuple[faiss.IndexFlatL2, dict, list]:
+            """Blocking load operation."""
+            # Load FAISS index
+            index_path = self.storage_path / "faiss.index"
+            if not index_path.exists():
+                raise FileNotFoundError(f"Index not found at {index_path}")
+
+            index = faiss.read_index(str(index_path))
+
+            # Load metadata
+            metadata_path = self.storage_path / "metadata.json"
+            with open(metadata_path) as f:
+                metadata_dict = json.load(f)
+
+            metadata = {
+                run_id: TraceIndex.model_validate(data) for run_id, data in metadata_dict.items()
+            }
+
+            # Load index mapping
+            mapping_path = self.storage_path / "index_mapping.json"
+            with open(mapping_path) as f:
+                index_to_run_id = json.load(f)
+
+            return index, metadata, index_to_run_id
+
+        try:
+            self.index, self.metadata, self.index_to_run_id = await asyncio.to_thread(_load)
+            logger.info(
+                "Loaded vector index with %d traces from %s", len(self.metadata), self.storage_path
+            )
+        except Exception:
+            logger.exception("Failed to load vector index from %s (non-fatal)", self.storage_path)
+            # Initialize new index on failure
+            self.index = faiss.IndexFlatL2(self.dimension)
+
+    async def _index_exists(self) -> bool:
+        """
+        Check if index files exist on disk.
+
+        Returns:
+            True if index exists, False otherwise
+        """
+
+        def _check() -> bool:
+            """Blocking check operation."""
+            index_path = self.storage_path / "faiss.index"
+            metadata_path = self.storage_path / "metadata.json"
+            mapping_path = self.storage_path / "index_mapping.json"
+
+            return index_path.exists() and metadata_path.exists() and mapping_path.exists()
+
+        return await asyncio.to_thread(_check)
+
+    def size(self) -> int:
+        """
+        Get number of traces in the index.
+
+        Returns:
+            Number of indexed traces
+        """
+        if self.index is None:
+            return 0
+        return self.index.ntotal
+
+    def clear(self) -> None:
+        """
+        Clear the index and metadata.
+
+        Creates a fresh index.
+        """
+        self.index = faiss.IndexFlatL2(self.dimension)
+        self.metadata = {}
+        self.index_to_run_id = []
+        logger.info("Cleared vector index")

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -16,6 +16,15 @@ dependencies = [
   "pytest-asyncio>=0.23",
   "pytest-xdist>=3.0",
   "tools",
+  # Multi-provider LLM support (for Production Agent Debugger)
+  "langchain-core>=1.2.11",
+  "langchain-community>=0.4.1",
+  "langchain-anthropic>=1.3.3",
+  "langchain-openai>=1.1.9",
+  "langchain-google-genai>=4.2.0",
+  # Embeddings and vector search (for semantic search)
+  "sentence-transformers>=5.2.2",
+  "faiss-cpu>=1.13.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes #4549

## Summary

- Adds a complete **Production Agent Debugger** system to `core/framework/debugging/`
- Introduces multi-provider LLM support (OpenAI, Anthropic, Google Gemini) via a provider factory with env-var auto-detection
- Enables semantic search and RAG-based analysis over agent execution traces (L1/L2/L3 session logs)

## Components

| Module | Description |
|--------|-------------|
| `TraceIndex` | Pydantic data model for agent execution traces |
| `TraceIndexer` | Scans `sessions/*/logs/` and builds a structured index |
| `IndexStore` | Async JSON-backed persistent store with atomic writes |
| `TraceEmbedder` | Converts traces to embeddings (HuggingFace MiniLM by default) |
| `TraceVectorStore` | FAISS-backed vector store for similarity search |
| `TraceRAG` | Retrieval-augmented generation for natural-language trace analysis |
| `LLM Provider Factory` | Auto-detects OpenAI/Anthropic/Google from env vars |
| `CLI` | `hive debug index/query/analyze` commands |

## Multi-Provider LLM Support

Provider is selected via priority: `HIVE_LLM_PROVIDER` env → `OPENAI_API_KEY` → `ANTHROPIC_API_KEY` → `GOOGLE_API_KEY`

```bash
# Auto-detected from env
hive debug query --agent-path ./agents/sales_agent "Why did runs fail?"

# Explicit provider
hive debug query --provider anthropic --model claude-3-5-sonnet-20241022 "Analyze failures"
```

## New Dependencies (`core/pyproject.toml`)

```
langchain-core, langchain-community, langchain-anthropic,
langchain-openai, langchain-google-genai,
sentence-transformers, faiss-cpu
```

## Test plan

- [x] `make check` passes (ruff lint + format, 0 errors)
- [x] `make test` passes (683 tests, 51 pre-existing skips)
- [x] 74 unit tests covering all 7 modules
- [x] E2E workflow verified manually (FAISS has known crash on Apple Silicon in test runner)
- [x] Multi-provider factory tested with mocked LangChain providers