### PR TITLE
Feat/tui visual diff 4352

### DIFF
--- a/core/examples/README.md
+++ b/core/examples/README.md
@@ -1,0 +1,31 @@
+Evolution demo
+----------------
+
+This folder contains a small demo script that listens for `GRAPH_EVOLUTION_REQUEST` and proposes
+a candidate graph to `AgentRuntime.update_graph(...)`.
+
+How to run
+
+1. Activate the project's virtualenv (created with proto as described in repo docs):
+
+```bash
+source .venv/bin/activate
+```
+
+2. Run the demo script:
+
+```bash
+python core/examples/evolution_demo.py
+```
+
+3. Optionally start the TUI in another terminal to see the visual diff when the candidate is applied:
+
+```bash
+# In separate terminal
+source .venv/bin/activate
+python -m framework.tui.app
+```
+
+Notes
+- The demo uses simple stub guards to demonstrate both approve and reject flows.
+- Audit entries are persisted to `storage_path/evolution_audit/` or written to the runtime log store if provided.

--- a/core/examples/evolution_demo.py
+++ b/core/examples/evolution_demo.py
@@ -1,0 +1,108 @@
+"""Simple evolution demo script.
+
+Demonstrates listening for GRAPH_EVOLUTION_REQUEST and proposing a candidate
+graph to runtime.update_graph(...). The demo runs two scenarios: one using
+an approving stub guard and one using a rejecting stub guard.
+
+Run with:
+
+    source .venv/bin/activate
+    python core/examples/evolution_demo.py
+
+"""
+import argparse
+import asyncio
+import json
+import tempfile
+from pathlib import Path
+
+from framework.graph.edge import GraphSpec
+from framework.graph.goal import Goal
+from framework.runtime.agent_runtime import AgentRuntime
+from framework.runtime.event_bus import EventType
+
+# Simple stub guards
+class StubGuardApprove:
+    def snapshot(self, graph):
+        return "snap-approve"
+
+    async def probation_run(self, snapshot_id, candidate_graph, steps=10):
+        return type("VR", (), {"passed": True, "violations": [], "metrics": {}})()
+
+    def approve(self, result):
+        return bool(result.passed)
+
+    def rollback(self, snapshot_id):
+        return None
+
+    def audit_log(self, entry):
+        print("[audit]", json.dumps(entry, indent=2))
+
+
+class StubGuardReject(StubGuardApprove):
+    async def probation_run(self, snapshot_id, candidate_graph, steps=10):
+        return type("VR", (), {"passed": False, "violations": ["infinite_loop"], "metrics": {}})()
+
+    def approve(self, result):
+        return False
+
+
+async def run_scenario(guard, scenario_name: str, storage_path: str | None = None):
+    print(f"=== Running scenario: {scenario_name} ===")
+
+    old = GraphSpec(id="g1", goal_id="goal1", entry_node="start", nodes=[], edges=[])
+    goal = Goal(id="goal1", name="G", description="demo")
+
+    runtime = AgentRuntime(graph=old, goal=goal, storage_path=storage_path, evolution_guard=guard)
+
+    # Subscribe to GRAPH_EVOLUTION_REQUEST to demonstrate a builder that proposes a change
+    async def on_request(event):
+        print("Received GRAPH_EVOLUTION_REQUEST, proposing candidate graph...")
+        # Create a tiny candidate graph that changes the id and adds a node
+        candidate = GraphSpec(
+            id="g1-evolved",
+            goal_id=old.goal_id,
+            entry_node="start",
+            nodes=[{"id": "start", "type": "start"}, {"id": "new_node", "type": "task"}],
+            edges=[{"source": "start", "target": "new_node", "condition": "always"}],
+        )
+        await runtime.update_graph(new_graph=candidate, correlation_id="demo-1")
+
+    sub_id = runtime.event_bus.subscribe(
+        event_types=[EventType.GRAPH_EVOLUTION_REQUEST], handler=on_request
+    )
+
+    # Fire a request to simulate aggregator recommending an adjustment
+    await runtime.event_bus.emit_graph_evolution_request(
+        stream_id="demo", context={"why": "demo"}, correlation_id="demo-ctx"
+    )
+
+    # Small sleep to allow async handler to run
+    await asyncio.sleep(0.2)
+
+    # Clean up subscription if possible
+    try:
+        runtime.event_bus.unsubscribe(sub_id)
+    except Exception:
+        pass
+
+
+async def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--storage-path",
+        type=str,
+        default=None,
+        help="Storage path for runtime data",
+    )
+    args = parser.parse_args()
+
+    storage_path = args.storage_path or tempfile.gettempdir()
+
+    await run_scenario(StubGuardApprove(), "approve-path", storage_path=storage_path)
+    await asyncio.sleep(0.2)
+    await run_scenario(StubGuardReject(), "reject-path", storage_path=storage_path)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/core/framework/runtime/evolution_guard.py
+++ b/core/framework/runtime/evolution_guard.py
@@ -1,0 +1,79 @@
+"""EvolutionGuard skeleton for safe graph mutations.
+
+This module provides a minimal, placeholder EvolutionGuard and
+ValidationResult class. The real implementation (probation, snapshot,
+rollback) will be provided in a follow-up PR (per the agreed split).
+
+The guard API is intentionally small and synchronous/async where needed:
+  - snapshot(graph) -> snapshot_id
+  - probation_run(snapshot_id, candidate_graph, steps) -> ValidationResult (async)
+  - approve(result) -> bool
+  - rollback(snapshot_id) -> None
+  - audit_log(entry) -> None
+
+Clients (AgentRuntime) should treat the guard as optional.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+@dataclass
+class ValidationResult:
+    """Result of probation/validation for a candidate graph.
+
+    Attributes:
+        passed: True if candidate passed probation checks
+        violations: List of human-readable violation messages
+        metrics: Arbitrary metrics (e.g., loop-detection score, tool-call rates)
+    """
+
+    passed: bool = True
+    violations: list[str] = field(default_factory=list)
+    metrics: dict[str, Any] = field(default_factory=dict)
+
+
+class EvolutionGuard:
+    """Minimal placeholder EvolutionGuard.
+
+    Replace with a fuller implementation that snapshots runtime state,
+    runs probation executions, validates, and can rollback.
+    """
+
+    def snapshot(self, graph: Any) -> str:
+        """Create a lightweight snapshot of `graph` and return an id.
+
+        Placeholder returns a simple textual id. Real impl should store
+        snapshot content in durable storage (or memory with eviction).
+        """
+        return "snapshot:1"
+
+    async def probation_run(
+        self,
+        snapshot_id: str,
+        candidate_graph: Any,
+        steps: int = 10,
+    ) -> ValidationResult:
+        """Run candidate graph in probation mode for `steps` iterations.
+
+        Placeholder implementation always returns passed=True. Real
+        implementation should run smoke tests and collect violations.
+        """
+        return ValidationResult(passed=True, violations=[], metrics={})
+
+    def approve(self, result: ValidationResult) -> bool:
+        """Decide whether the candidate passes based on ValidationResult."""
+        return bool(result.passed)
+
+    def rollback(self, snapshot_id: str) -> None:
+        """Rollback to a previously taken snapshot.
+
+        Placeholder is a no-op. Real impl should restore the runtime state.
+        """
+        return None
+
+    def audit_log(self, entry: dict[str, Any]) -> None:
+        """Record audit information about the evolution attempt."""
+        # Placeholder: no-op
+        return None

--- a/core/safety/evolution_guard.py
+++ b/core/safety/evolution_guard.py
@@ -1,0 +1,119 @@
+import uuid
+import copy
+import asyncio
+import logging
+from typing import Dict, Any, Optional, Callable, Awaitable
+from pydantic import BaseModel, Field
+from datetime import datetime
+
+logger = logging.getLogger("hive.safety")
+
+#------------------------------------------------------------
+# Data Models
+#------------------------------------------------------------------
+
+class Snapshot(BaseModel):
+    """
+    Immutable backup of an agent's brain (graph state).
+    """
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    timestamp: datetime = Field(default_factory=datetime.now)
+    graph_state: Dict[str, Any] 
+    reason_for_snapshot: str = "Pre-Evolution Backup"
+
+class ValidationResult(BaseModel):
+    """
+    Report card after testing a new brain.
+    """
+    success: bool
+    snapshot_id: str
+    error_message: Optional[str] = None
+    steps_survived: int = 0
+    execution_time_ms: float = 0.0
+#------------------------------------------------
+# The Evolution Guard 
+#------------------------------------------------
+
+class EvolutionGuard:
+    """
+    Transaction Manager for Agent Evolution.
+    1. SNAPSHOT: Backup the old brain.
+    2. PROBATION: Run the new brain in a sandbox.
+    3. ROLLBACK: Revert if the new brain is defective.
+    """
+    
+    def __init__(self):
+        self._snapshots: Dict[str, Snapshot] = {}
+        self._active_probation_id: Optional[str] = None
+
+    def snapshot(self, current_graph: Dict[str, Any], reason: str = "Manual Snapshot") -> str:
+        """
+        Creates a deep copy of the agent's graph and saves it.
+        """
+        safe_copy = copy.deepcopy(current_graph)
+        
+        snapshot = Snapshot(graph_state=safe_copy, reason_for_snapshot=reason)
+        self._snapshots[snapshot.id] = snapshot
+        
+        logger.info(f"🛡️ [EvolutionGuard] Snapshot created: {snapshot.id} ({reason})")
+        return snapshot.id
+
+    def rollback(self, snapshot_id: str) -> Dict[str, Any]:
+        """
+        Retrieves a saved graph state. Used when evolution fails.
+        """
+        if snapshot_id not in self._snapshots:
+            raise ValueError(f"Snapshot {snapshot_id} not found! Cannot rollback.")
+            
+        print(f"🔄 [EvolutionGuard] Rolling back to Snapshot {snapshot_id}")
+        return copy.deepcopy(self._snapshots[snapshot_id].graph_state)
+
+    async def probation_run(
+        self, 
+        snapshot_id: str, 
+        candidate_graph: Dict[str, Any], 
+        test_function: Callable[[Dict[str, Any]], Awaitable[bool]],
+        max_steps: int = 5
+    ) -> ValidationResult:
+        """
+        Runs the new 'candidate_graph' through a sandbox test.
+        
+        Args:
+            snapshot_id: The ID of the safe backup.
+            candidate_graph: The new brain to test.
+            test_function: An async function that actually runs the agent (injected dependency).
+            max_steps: How many steps to allow before declaring an "Infinite Loop".
+        """
+        start_time = datetime.now()
+        print(f"🧪 [EvolutionGuard] Starting Probation Mode for Snapshot {snapshot_id}...")
+
+        try:
+            if "nodes" not in candidate_graph or "edges" not in candidate_graph:
+                raise ValueError("Invalid Graph: Missing 'nodes' or 'edges'")
+
+            try:
+                result = await asyncio.wait_for(test_function(candidate_graph), timeout=5.0)
+                
+                if not result:
+                    raise RuntimeError("Agent failed to complete the test task.")
+
+            except asyncio.TimeoutError:
+                raise RuntimeError(f"Infinite Loop Detected: Agent exceeded {max_steps} steps or 5s timeout.")
+
+            execution_time = (datetime.now() - start_time).total_seconds() * 1000
+            print(f"✅ [EvolutionGuard] Probation Passed! ({execution_time:.2f}ms)")
+            
+            return ValidationResult(
+                success=True,
+                snapshot_id=snapshot_id,
+                steps_survived=max_steps,
+                execution_time_ms=execution_time
+            )
+
+        except Exception as e:
+            print(f"❌ [EvolutionGuard] Probation FAILED: {str(e)}")
+            return ValidationResult(
+                success=False,
+                snapshot_id=snapshot_id,
+                error_message=str(e)
+            )

--- a/core/tests/test_evolution_audit_and_rollback.py
+++ b/core/tests/test_evolution_audit_and_rollback.py
@@ -1,0 +1,72 @@
+import asyncio
+import json
+import os
+import pytest
+
+from framework.graph.edge import GraphSpec
+from framework.graph.goal import Goal
+from framework.runtime.agent_runtime import AgentRuntime
+from framework.runtime.event_bus import EventType
+
+
+class StubGuardAuditAndReject:
+    def __init__(self):
+        self.audit_entries = []
+        self.rolled_back = False
+
+    def snapshot(self, graph):
+        return "s-audit-1"
+
+    async def probation_run(self, snapshot_id, candidate_graph, steps=10):
+        # Fail probation to trigger rejection
+        return type("VR", (), {"passed": False, "violations": ["bad"], "metrics": {}})()
+
+    def approve(self, result):
+        return False
+
+    def rollback(self, snapshot_id):
+        self.rolled_back = True
+
+    def audit_log(self, entry):
+        # record in-memory
+        self.audit_entries.append(entry)
+
+
+@pytest.mark.asyncio
+async def test_audit_and_rollback_persisted_to_disk(tmp_path):
+    old = GraphSpec(id="g1", goal_id="goal1", entry_node="start", nodes=[], edges=[])
+    new = GraphSpec(id="g2", goal_id="goal1", entry_node="start", nodes=[], edges=[])
+
+    goal = Goal(id="goal1", name="G", description="d")
+
+    guard = StubGuardAuditAndReject()
+    runtime = AgentRuntime(graph=old, goal=goal, storage_path=tmp_path, evolution_guard=guard)
+
+    # Subscribe to rejection event
+    received = []
+
+    async def on_rejected(event):
+        received.append(event)
+
+    runtime.event_bus.subscribe(event_types=[EventType.GRAPH_EVOLUTION_REJECTED], handler=on_rejected)
+
+    await runtime.update_graph(new_graph=new, correlation_id="cid-123")
+
+    # allow async event dispatch
+    await asyncio.sleep(0.01)
+
+    # guard should have recorded audit entry
+    assert len(guard.audit_entries) == 1
+    entry = guard.audit_entries[0]
+    assert entry.get("correlation_id") == "cid-123"
+
+    # audit file should exist on disk under storage_path/evolution_audit
+    audit_dir = tmp_path / "evolution_audit"
+    files = list(audit_dir.glob("*.json"))
+    assert len(files) >= 1
+
+    # rollback should have been invoked
+    assert guard.rolled_back is True
+
+    # event should have been emitted
+    assert len(received) == 1

--- a/core/tests/test_evolution_audit_approve_runtime_log_store.py
+++ b/core/tests/test_evolution_audit_approve_runtime_log_store.py
@@ -1,0 +1,67 @@
+import asyncio
+import pytest
+
+from framework.graph.edge import GraphSpec
+from framework.graph.goal import Goal
+from framework.runtime.agent_runtime import AgentRuntime
+
+
+class FakeStore:
+    def __init__(self):
+        self.writes = []
+
+    def write(self, entry):
+        self.writes.append(entry)
+
+
+class StubGuardApproveAndAudit:
+    def __init__(self):
+        self.audit_entries = []
+
+    def snapshot(self, graph):
+        return "snap-approve-2"
+
+    async def probation_run(self, snapshot_id, candidate_graph, steps=10):
+        return type("VR", (), {"passed": True, "violations": [], "metrics": {}})()
+
+    def approve(self, result):
+        return True
+
+    def rollback(self, snapshot_id):
+        # should not be called in approve path
+        raise RuntimeError("rollback called unexpectedly")
+
+    def audit_log(self, entry):
+        self.audit_entries.append(entry)
+
+
+@pytest.mark.asyncio
+async def test_approve_path_persists_audit_and_applies_graph(tmp_path):
+    old = GraphSpec(id="g1", goal_id="goal1", entry_node="start", nodes=[], edges=[])
+    new = GraphSpec(id="g2", goal_id="goal1", entry_node="start", nodes=[], edges=[])
+
+    goal = Goal(id="goal1", name="G", description="d")
+
+    fake = FakeStore()
+    guard = StubGuardApproveAndAudit()
+
+    runtime = AgentRuntime(graph=old, goal=goal, storage_path=tmp_path, evolution_guard=guard, runtime_log_store=fake)
+
+    received = []
+
+    async def on_evolved(event):
+        received.append(event)
+
+    runtime.event_bus.subscribe(event_types=["graph_evolved"], handler=on_evolved)
+
+    await runtime.update_graph(new_graph=new, correlation_id="cid-approve-2")
+    await asyncio.sleep(0.01)
+
+    assert runtime.graph is new
+    # runtime_log_store.write should have been called
+    assert len(fake.writes) >= 1
+    assert any(w.get("correlation_id") == "cid-approve-2" for w in fake.writes)
+    # guard audit should have been called
+    assert len(guard.audit_entries) == 1
+    # event emitted
+    assert len(received) == 1

--- a/core/tests/test_evolution_audit_runtime_log_store.py
+++ b/core/tests/test_evolution_audit_runtime_log_store.py
@@ -1,0 +1,62 @@
+import asyncio
+import pytest
+
+from framework.graph.edge import GraphSpec
+from framework.graph.goal import Goal
+from framework.runtime.agent_runtime import AgentRuntime
+# EventType not required in this test
+
+
+class FakeRuntimeLogStore:
+    def __init__(self):
+        self.writes = []
+
+    def write(self, entry):
+        # simple capture
+        self.writes.append(entry)
+
+
+class StubGuardRejectAndAudit:
+    def __init__(self):
+        self.rolled_back = False
+
+    def snapshot(self, graph):
+        return "snap-rls"
+
+    async def probation_run(self, snapshot_id, candidate_graph, steps=10):
+        return type("VR", (), {"passed": False, "violations": ["bad"], "metrics": {}})()
+
+    def approve(self, result):
+        return False
+
+    def rollback(self, snapshot_id):
+        self.rolled_back = True
+
+    def audit_log(self, entry):
+        # no-op: runtime should also persist via runtime_log_store
+        return None
+
+
+@pytest.mark.asyncio
+async def test_runtime_log_store_used_for_audit(tmp_path):
+    old = GraphSpec(id="g1", goal_id="goal1", entry_node="start", nodes=[], edges=[])
+    new = GraphSpec(id="g2", goal_id="goal1", entry_node="start", nodes=[], edges=[])
+
+    goal = Goal(id="goal1", name="G", description="d")
+
+    fake_store = FakeRuntimeLogStore()
+    guard = StubGuardRejectAndAudit()
+
+    runtime = AgentRuntime(
+        graph=old, goal=goal, storage_path=tmp_path, evolution_guard=guard, runtime_log_store=fake_store
+    )
+
+    # trigger update
+    await runtime.update_graph(new_graph=new, correlation_id="cid-rls")
+
+    # allow async dispatch
+    await asyncio.sleep(0.01)
+
+    # runtime_log_store.write should have been called with an audit entry
+    assert len(fake_store.writes) >= 1
+    assert any(w.get("correlation_id") == "cid-rls" for w in fake_store.writes)

--- a/core/tests/test_evolution_guard.py
+++ b/core/tests/test_evolution_guard.py
@@ -1,0 +1,68 @@
+import pytest
+import asyncio
+from core.safety.evolution_guard import EvolutionGuard
+
+#--------------------------------------------------------------
+# Mock Data 
+#---------------------------------------------------------------
+HEALTHY_GRAPH = {
+    "nodes": ["Start", "Think", "Act"],
+    "edges": [("Start", "Think"), ("Think", "Act")],
+    "version": 1.0
+}
+
+BROKEN_GRAPH = {
+    "nodes": ["Start", "Loop_A", "Loop_B"],
+    "edges": [("Start", "Loop_A"), ("Loop_A", "Loop_B"), ("Loop_B", "Loop_A")], 
+    "version": 2.0
+}
+
+# Fixture
+@pytest.fixture
+def guard():
+    return EvolutionGuard()
+
+async def mock_execution_engine(graph):
+    """Simulates running the agent."""
+    await asyncio.sleep(0.01)
+    if "Loop_A" in graph["nodes"]:
+        await asyncio.sleep(10) 
+        return False
+    return True
+
+#------------------------------------------------------------------------
+# Actual Tests
+#------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_snapshot_creation(guard):
+    """Test 1: Does snapshotting work?"""
+    snapshot_id = guard.snapshot(HEALTHY_GRAPH, reason="Unit Test")
+    assert snapshot_id is not None
+    assert guard._snapshots[snapshot_id].graph_state["version"] == 1.0
+
+@pytest.mark.asyncio
+async def test_probation_catch_failure(guard):
+    """Test 2: Does it catch the infinite loop?"""
+    snapshot_id = guard.snapshot(HEALTHY_GRAPH)
+    
+    result = await guard.probation_run(
+        snapshot_id=snapshot_id,
+        candidate_graph=BROKEN_GRAPH,
+        test_function=mock_execution_engine,
+        max_steps=5
+    )
+
+    assert result.success is False
+    assert "Infinite Loop" in result.error_message
+
+@pytest.mark.asyncio
+async def test_rollback_integrity(guard):
+    """Test 3: Does rollback give back the exact original?"""
+    snapshot_id = guard.snapshot(HEALTHY_GRAPH)
+    
+    HEALTHY_GRAPH["version"] = 999.0 
+    
+    restored = guard.rollback(snapshot_id)
+    
+    assert restored["version"] == 1.0

--- a/core/tests/test_runtime_update_graph_guard.py
+++ b/core/tests/test_runtime_update_graph_guard.py
@@ -1,0 +1,141 @@
+import asyncio
+import asyncio
+import pytest
+
+from framework.graph.edge import GraphSpec
+from framework.graph.goal import Goal
+from framework.runtime.agent_runtime import AgentRuntime
+from framework.runtime.event_bus import EventType
+
+# Use the ValidationResult from the runtime skeleton for typing
+from framework.runtime.evolution_guard import ValidationResult
+
+
+class StubGuardApprove:
+    def snapshot(self, graph):
+        return "s1"
+
+    async def probation_run(self, snapshot_id, candidate_graph, steps=10):
+        return ValidationResult(passed=True, violations=[], metrics={})
+
+    def approve(self, result):
+        return bool(result.passed)
+
+    def rollback(self, snapshot_id):
+        # No-op for approved
+        return None
+
+    def audit_log(self, entry):
+        return None
+
+
+class StubGuardReject:
+    def snapshot(self, graph):
+        return "s2"
+
+    async def probation_run(self, snapshot_id, candidate_graph, steps=10):
+        return ValidationResult(passed=False, violations=["infinite_loop"], metrics={})
+
+    def approve(self, result):
+        return False
+
+    def rollback(self, snapshot_id):
+        # No-op for test
+        return None
+
+    def audit_log(self, entry):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_update_graph_with_guard_approved(tmp_path):
+    """When guard approves, graph should be replaced and GRAPH_EVOLVED should be emitted."""
+    old = GraphSpec(
+        id="g1",
+        goal_id="goal1",
+        entry_node="start",
+        nodes=[],
+        edges=[],
+    )
+    new = GraphSpec(
+        id="g2",
+        goal_id="goal1",
+        entry_node="start",
+        nodes=[],
+        edges=[],
+    )
+
+    goal = Goal(id="goal1", name="G", description="d")
+
+    runtime = AgentRuntime(
+        graph=old,
+        goal=goal,
+        storage_path=tmp_path,
+        evolution_guard=StubGuardApprove(),
+    )
+
+    # Subscribe to event
+    received = []
+    evt = asyncio.Event()
+
+    async def on_evolved(event):
+        received.append(event)
+        evt.set()
+
+    runtime.event_bus.subscribe(event_types=[EventType.GRAPH_EVOLVED], handler=on_evolved)
+
+    await runtime.update_graph(new_graph=new)
+
+    # Wait briefly if needed (handler should be awaited by publish)
+    await asyncio.sleep(0.01)
+
+    assert runtime.graph is new
+    assert len(received) == 1
+
+
+@pytest.mark.asyncio
+async def test_update_graph_with_guard_rejected(tmp_path):
+    """When guard rejects, graph should remain and GRAPH_EVOLUTION_REJECTED emitted."""
+    old = GraphSpec(
+        id="g1",
+        goal_id="goal1",
+        entry_node="start",
+        nodes=[],
+        edges=[],
+    )
+    new = GraphSpec(
+        id="g2",
+        goal_id="goal1",
+        entry_node="start",
+        nodes=[],
+        edges=[],
+    )
+
+    goal = Goal(id="goal1", name="G", description="d")
+
+    runtime = AgentRuntime(
+        graph=old,
+        goal=goal,
+        storage_path=tmp_path,
+        evolution_guard=StubGuardReject(),
+    )
+
+    # Subscribe to rejection event
+    received = []
+    evt = asyncio.Event()
+
+    async def on_rejected(event):
+        received.append(event)
+        evt.set()
+
+    runtime.event_bus.subscribe(
+        event_types=[EventType.GRAPH_EVOLUTION_REJECTED], handler=on_rejected
+    )
+
+    await runtime.update_graph(new_graph=new)
+
+    # Wait briefly to allow event dispatch
+    await asyncio.sleep(0.01)
+
+    assert runtime.graph is old
+    assert len(received) == 1

--- a/docs/visual-diff.md
+++ b/docs/visual-diff.md
@@ -1,0 +1,36 @@
+Visual Diff (TUI)
+===================
+
+Overview
+--------
+
+The Visual Diff feature displays topology and property-level differences when the
+agent's graph is evolved. The TUI's `GraphOverview` widget enters diff mode on
+`GRAPH_EVOLVED` events and can be toggled with `d`.
+
+Keybindings
+-----------
+- `d` — toggle graph diff view
+- `Up/Down` — navigate between modified nodes
+- `Enter` — show a focused per-field diff for the selected node (old vs. new)
+
+How it works
+------------
+- `OutcomeAggregator` may emit `GRAPH_EVOLUTION_REQUEST` when it recommends an
+  adjustment.
+- A Builder / CodingAgent may propose a candidate graph and call
+  `AgentRuntime.update_graph(new_graph, correlation_id=...)`.
+- `AgentRuntime` optionally runs an `EvolutionGuard` probation flow which
+  snapshots, runs smoke/probation tests, and may approve or reject the candidate.
+- If approved, `GRAPH_EVOLVED` is emitted containing `old_graph` and `new_graph`.
+  The TUI renders a color-coded diff:
+  - green `+` added nodes/edges
+  - red `-` removed nodes/edges
+  - yellow `~` modified nodes
+
+Audit & Safety
+--------------
+- The runtime calls `evolution_guard.audit_log(...)` with a structured payload
+  containing `snapshot_id`, `candidate_graph_id`, `result` and `correlation_id`.
+- Audit entries are persisted to the runtime log store when available, otherwise
+  they are written to `<storage_path>/evolution_audit/<id>.json` as a fallback.


### PR DESCRIPTION
## Description

Adds a Visual Diff mode to the TUI to inspect self-evolving graph topology and property changes, and wires a safe apply path for proposed graph evolutions. This includes runtime events for evolution requests/notifications, an evolution guard integration for snapshot/probation/approve/rollback/audit, a headless demo, and tests for the safety/audit behavior.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #4352

## Changes Made

**TUI**
- **graph_view.py**: Implemented `diff_mode` rendering showing topology diffs and property-level diffs. Added keyboard navigation of diffs (Up/Down) and Enter → focused full diff view.
- **app.py**: Bound `d` to toggle diff mode and `Enter` to show full node diff. Subscribed to `GRAPH_EVOLVED` and `GRAPH_EVOLUTION_REJECTED` events to surface notifications/logging.

**Runtime / Events / Safety**
- **event_bus.py**: Added new EventType values (`GRAPH_EVOLVED`, `GRAPH_EVOLUTION_REQUEST`, `GRAPH_EVOLUTION_REJECTED`) and convenience emitters.
- **agent_runtime.py**:
    - Added `AgentRuntime.update_graph(new_graph, *, correlation_id=None, probation_steps=10)` convenience method.
    - Integrated optional `EvolutionGuard` flow: `snapshot` → `probation_run` → `approve` → `audit_log` → `rollback`.
    - Persist audit entries: try `runtime_log_store.write(...)` when available, otherwise write JSON to `<storage_path>/evolution_audit/`.
    - Exposed `probation_steps` parameter to callers.
- **outcome_aggregator.py**: Emit `GRAPH_EVOLUTION_REQUEST` when aggregator recommends an adjustment; attach a generated `correlation_id` and a recent decisions summary.
- **evolution_guard.py**: Added `ValidationResult` and `EvolutionGuard` contract (skeleton). Merged concrete implementation for snapshot/probation/rollback flows.

**Demo & Docs**
- **evolution_demo.py**: Headless demo that listens for `GRAPH_EVOLUTION_REQUEST` and proposes candidate graphs (approve and reject scenarios). Accepts `--storage-path`.
- **README.md** and **visual-diff.md**: Short usage & run instructions, feature summary.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

**Specific Test Coverage:**
- `test_runtime_update_graph_guard.py`: Approve/reject guard/integration tests.
- `test_evolution_audit_and_rollback.py`: Audit + rollback disk persistence test.
- `test_evolution_audit_runtime_log_store.py`: Runtime_log_store persistence test.
- `test_evolution_audit_approve_runtime_log_store.py`: Approve path + runtime_log_store persistence test.
- `test_evolution_guard.py`: EvolutionGuard unit tests.
- Test harness updates and small test fixes to run cleanly under core.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)