### PR TITLE
docs(security): add CodeQL scanning, quality gates, org templates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: codeql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * 1' # Weekly Monday 03:00 UTC
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript-typescript', 'python']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - uses: github/codeql-action/autobuild@v3
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/README.md
+++ b/README.md
@@ -435,6 +435,114 @@ Hive focuses on generating agents that run real business processes, rather than 
 
 ---
 
+## Quality Gates & Autofix
+
+### TL;DR
+
+Every PR to `main` runs:
+1. **CodeQL Code Scanning** — static analysis for security vulnerabilities (Python + JS/TS)
+2. **Copilot Autofix** — AI-suggested patches for CodeQL alerts (always review before accepting)
+3. **CI checks** — lint, unit tests, and agent export validation must pass
+
+Weekly scheduled scans catch issues in code that bypassed PR checks.
+
+### How Copilot Autofix Works
+
+When CodeQL finds a vulnerability in your PR:
+1. An alert annotation appears on the affected line
+2. Copilot Autofix may propose a fix directly in the alert
+3. You review the suggestion, test locally, and accept or modify
+4. Alerts are also visible under **Security → Code scanning alerts**
+
+### Branch Protection (Required Checks)
+
+Before merging any PR to `main`, the following checks must pass:
+- `Analyze (python)` / `Analyze (javascript-typescript)` — CodeQL
+- `Lint Python` — Ruff linting and formatting
+- `Test Python Framework` — pytest on core/
+- `Test Tools` — pytest on tools/
+
+#### Enable via UI
+1. Go to **Settings → Branches → Add branch protection rule**
+2. Branch name pattern: `main`
+3. Check **Require status checks to pass before merging**
+4. Search and add: `Analyze (python)`, `Lint Python`, `Test Python Framework`
+5. Check **Require branches to be up to date before merging**
+6. Check **Include administrators**
+7. Save
+
+#### Enable via GH CLI
+
+```bash
+gh api \
+  -X PUT \
+  -H "Accept: application/vnd.github+json" \
+  /repos/kostasuser01gr/hive/branches/main/protection \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["Analyze (python)", "Lint Python", "Test Python Framework"]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+EOF
+```
+
+---
+
+## Sentry Copilot Extension
+
+### Installation
+1. Open **VS Code / Codespaces** → Extensions → search **"Sentry"** → Install
+2. Connect to your Sentry project: run `Sentry: Connect` from the Command Palette and authenticate with your Sentry org
+3. Ensure your project DSN is set in `.env` (see `.env.example` if available)
+
+### Usage in PR Flow
+- Open Copilot Chat and mention `@sentry` to pull in error context from your Sentry project
+- Ask for fix suggestions: _"@sentry suggest a fix for the latest unhandled exception in the agent runner"_
+- Generate tests: _"@sentry generate unit tests covering the error path in commit \<SHA\>"_
+- Sentry surfaces production errors relevant to your PR diff — review them before merging
+
+### Prompt Examples
+```
+@sentry What are the top unresolved issues affecting the agent TUI?
+@sentry Suggest a minimal fix and generate tests for the IndexError in core/framework/runner.py
+@sentry Show me recent errors related to the files changed in this PR
+```
+
+---
+
+## Docker Copilot
+
+> Hive includes a Dockerfile at `tools/Dockerfile`. Use Docker Copilot to optimize and secure it.
+
+### Installation
+1. Install the **Docker** extension in VS Code / Codespaces
+2. Ensure Docker Desktop (or Docker Engine) is running locally or in your Codespace
+
+### Optimization Prompts
+Use these in Copilot Chat to improve your Docker setup:
+
+```
+@docker Optimize tools/Dockerfile for smaller image size using multi-stage builds
+@docker Add a HEALTHCHECK instruction to tools/Dockerfile
+@docker Review tools/Dockerfile for security best practices
+@docker What base image should I use for a Python 3.11 CLI application?
+@docker Scan this Dockerfile for common vulnerabilities and misconfigurations
+```
+
+### Best Practices
+- Use multi-stage builds to separate build dependencies from runtime
+- Pin base image versions (e.g., `python:3.11-slim` not `python:latest`)
+- Add `.dockerignore` to exclude unnecessary files
+- Use non-root users in production images
+- Add `HEALTHCHECK` for orchestrated deployments
+
+---
+
 <p align="center">
   Made with 🔥 Passion in San Francisco
 </p>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,22 @@ We consider security research conducted in accordance with this policy to be:
 - Authorized concerning any relevant anti-circumvention laws
 - Exempt from restrictions in our Terms of Service that would interfere with conducting security research
 
+## Code Scanning & Copilot Autofix
+
+This repository uses **GitHub Code Scanning (CodeQL)** on every pull request targeting `main` and on a weekly schedule (Monday 03:00 UTC).
+
+### How It Works
+
+- **PR Annotations**: CodeQL alerts appear as inline annotations on pull requests. Review them before merging.
+- **Security Tab**: All alerts are also visible under the repo's **Security → Code scanning alerts** tab.
+- **Copilot Autofix**: GitHub Copilot may suggest patches for certain CodeQL alerts directly in the PR. **Always review and test these suggestions locally and in CI before merging.** Do not rely solely on automated fixes for high-risk changes.
+
+### Scope
+
+- **Languages**: Python, JavaScript/TypeScript
+- **Schedule**: On every PR to `main` + weekly scan
+- **Workflow**: `.github/workflows/codeql.yml`
+
 ## Security Best Practices for Users
 
 1. **Keep Updated**: Always run the latest version

--- a/org/_org_checklist.md
+++ b/org/_org_checklist.md
@@ -1,0 +1,83 @@
+# Org-Wide Security & Quality Checklist
+
+Use this checklist when onboarding a new repository to the org's security and quality standards.
+
+## Per-Repository Setup
+
+- [ ] **Enable GitHub Advanced Security** (if on GHEC/GHES with license)
+  - Settings → Code security and analysis → GitHub Advanced Security → Enable
+- [ ] **Enable CodeQL Code Scanning**
+  - Option A (Default Setup): Settings → Code security → Code scanning → CodeQL analysis → Default setup → Enable
+  - Option B (Advanced): Copy `.github/workflows/codeql.yml` from the org template repo or use the reusable workflow (see below)
+- [ ] **Verify Copilot Autofix is active**
+  - Settings → Code security → Code scanning → Copilot Autofix → Enable (enabled by default with GHAS)
+- [ ] **Add `SECURITY.md`** — copy from this repo's template
+- [ ] **Branch Protection Rules**
+  - Settings → Branches → Add rule for `main`
+  - ✅ Require status checks to pass: `code-scanning`, `lint`, `test`
+  - ✅ Require branches to be up to date
+  - ✅ Enforce for administrators
+  - Or use the GH CLI snippet below
+
+## Org-Level Extensions (Install Once per Developer)
+
+- [ ] **Sentry for GitHub Copilot**
+  - Install from VS Code / Codespaces Marketplace
+  - Connect to org's Sentry project (DSN in `.env.example`)
+  - In PRs: use `@sentry` in Copilot Chat for error context, fix suggestions, and test generation
+- [ ] **Docker for GitHub Copilot**
+  - Install Docker extension in VS Code / Codespaces
+  - Use Copilot Chat prompts to optimize Dockerfiles (see README)
+
+## Reusable Workflow
+
+Place the reusable workflow in the org's `.github` repo:
+
+```
+kostasuser01gr/.github/
+  .github/
+    workflows/
+      reusable-codeql.yml   ← copy from org/reusable-codeql.yml
+```
+
+Then, in each repo's CI:
+
+```yaml
+# .github/workflows/ci.yml (caller example)
+name: org-ci
+on: [pull_request]
+jobs:
+  security:
+    uses: kostasuser01gr/.github/.github/workflows/reusable-codeql.yml@main
+    secrets: inherit
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.11' }
+      - run: pip install uv && cd core && uv sync && uv run pytest tests/ -v
+```
+
+> The reusable workflow is maintained centrally in `kostasuser01gr/.github` so updates automatically propagate to all repos that call it.
+
+## GH CLI — Branch Protection (Quick Apply)
+
+```bash
+# Replace <REPO> with the target repo name
+gh api \
+  -X PUT \
+  -H "Accept: application/vnd.github+json" \
+  /repos/kostasuser01gr/<REPO>/branches/main/protection \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["code-scanning", "lint", "test"]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+EOF
+```

--- a/org/reusable-codeql.yml
+++ b/org/reusable-codeql.yml
@@ -1,0 +1,31 @@
+name: reusable-codeql
+
+on:
+  workflow_call: {}
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript-typescript', 'python']
+        # Add 'java', 'go', 'ruby' as needed per repo
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - uses: github/codeql-action/autobuild@v3
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
* docs:fix typo in docs

* docs: remove reference to nonexistent config.yaml (#4495)

* feat: Antigravity IDE support for MCP servers and skills (#2571)

- Add .antigravity/mcp_config.json with agent-builder and tools MCP servers
- Add .antigravity/skills/ with symlinks to .claude/skills/ (5 skills)
- Add docs/antigravity-setup.md with setup and troubleshooting
- Update README.md with Antigravity IDE support section
- Update DEVELOPER.md and docs/contributing-lint-setup.md with Antigravity refs

Mirrors Cursor integration for consistent multi-IDE support.

* docs: add how-to-verify section for Antigravity setup

* docs(antigravity): global config, absolute cwd, cwd warning note

- Add step to run core/setup_mcp.sh first
- Document that IDE often loads ~/.claude/mcp.json, not project config
- Add Option A: copy to ~/.claude/mcp.json with absolute cwd paths
- Note that cwd schema warning in IDE is a false positive
- Renumber setup steps (1–5)

* Antigravity: one-command setup script and clearer docs

- Add scripts/setup-antigravity-mcp.sh to auto-detect repo root and write ~/.gemini/mcp.json with absolute paths (no manual path editing)
- Lead docs with Quick start (3 steps) and note ./ vs / for the script
- README: point to one-command setup; clarify script runs from repo folder

* docs: clarify Antigravity setup for everyone

- Define repo root at top; lead with quick start (3 steps)
- Add 'What you get' and prerequisites in one place
- Full setup step-by-step; troubleshooting: problem → fix
- Manual MCP config as single section; verification optional
- Plain language, scannable structure, no duplicate sections

* fix: change the wrong antigravity mcp path

* fix: correct .antigravity/skills symlinks to point to hive-* directories

* docs: emphasize restarting Antigravity after MCP setup, fix config path and skill names

* fix: use uv run for MCP servers, script reads from template

* fix: use --directory instead of cwd for Antigravity MCP compatibility

* fix: update the antigravity config

* fix: fix the antigravity config folder

* docs: rename .antigravity to .agent for Antigravity IDE compatibility

* feat: add Antigravity workflows for all hive skills

* fix: remove incorrect rules folder

* docs: add the automonous agent guide

* docs: remove references to nonexistent CHANGELOG.md (#4493)

* feat(security): add CodeQL scanning, quality gates, org templates, and extension docs

- Add .github/workflows/codeql.yml (CodeQL + Copilot Autofix on PRs + weekly)
- Update SECURITY.md with code scanning policy and Copilot Autofix guidance
- Add org/_org_checklist.md for org-wide security rollout
- Add org/reusable-codeql.yml for centralized reusable workflow
- Update README.md: Quality Gates, Sentry Copilot, Docker Copilot, Branch Protection

---------

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
