### PR TITLE
micro-fix: remove deprecated ast.Index visitor (dead code on Python >=3.11)

### DIFF
--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -216,10 +216,6 @@ class SafeEvalVisitor(ast.NodeVisitor):
 
         return func(*args, **keywords)
 
-    def visit_Index(self, node: ast.Index) -> Any:
-        # Python < 3.9
-        return self.visit(node.value)
-
 
 def safe_eval(expr: str, context: dict[str, Any] | None = None) -> Any:
     """


### PR DESCRIPTION
## Summary

Remove the `visit_Index()` stub in `SafeEvalVisitor` (core/framework/graph/safe_eval.py).

`ast.Index` was deprecated in Python 3.9 and removed in 3.12. Hive requires Python ≥ 3.11. The visitor was already dead code — `visit_Subscript()` reads `node.slice` directly and never produces an `ast.Index` node.

## Changes
- Delete `visit_Index()` (3 lines, lines 219-221).
- No behaviour change; all existing tests pass.

## Testing
```
uv run pytest tests/test_safe_eval.py tests/test_sandbox.py tests/test_conditional_edge.py -v   # 19 passed
```

Fixes #4563