### PR TITLE
fix: isolate SharedMemory per parallel branch to prevent fan-out race…

### DIFF
--- a/core/framework/graph/__init__.py
+++ b/core/framework/graph/__init__.py
@@ -21,7 +21,15 @@ from framework.graph.executor import GraphExecutor
 from framework.graph.flexible_executor import ExecutorConfig, FlexibleGraphExecutor
 from framework.graph.goal import Constraint, Goal, GoalStatus, SuccessCriterion
 from framework.graph.judge import HybridJudge, create_default_judge
-from framework.graph.node import NodeContext, NodeProtocol, NodeResult, NodeSpec
+from framework.graph.node import (
+    MemoryMergeConflictError,
+    MemoryMergeStrategy,
+    NodeContext,
+    NodeProtocol,
+    NodeResult,
+    NodeSpec,
+    SharedMemory,
+)
 
 # Flexible execution (Worker-Judge pattern)
 from framework.graph.plan import (
@@ -54,6 +62,9 @@ __all__ = [
     "NodeContext",
     "NodeResult",
     "NodeProtocol",
+    "SharedMemory",
+    "MemoryMergeStrategy",
+    "MemoryMergeConflictError",
     # Edge
     "EdgeSpec",
     "EdgeCondition",


### PR DESCRIPTION


- Add MemoryMergeStrategy enum (LAST_WINS, FIRST_WINS, ERROR)
- Add MemoryMergeConflictError for conflict detection
- Add SharedMemory.deep_copy() for branch isolation with independent locks
- Add SharedMemory.merge_from() with change-detection against baseline
- Rewrite _execute_parallel_branches() to give each branch its own memory copy
- Merge branch memories back after completion using configured strategy
- ERROR strategy permits identical values written by multiple branches
- Add unit tests for deep_copy and merge, plus integration tests for executor

## Description

Brief description of the changes in this PR.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #3692 


## Changes Made

- [node.py](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Added [MemoryMergeStrategy](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html) enum ([LAST_WINS](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [FIRST_WINS](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [ERROR](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html)), [MemoryMergeConflictError](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html) exception, [SharedMemory.deep_copy()](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for creating independent copies with fresh locks, and [SharedMemory.merge_from()](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with change-detection against a baseline snapshot
- [executor.py](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Rewrote _execute_parallel_branches() so each branch receives its own [memory.deep_copy()](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html); after [asyncio.gather()](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html), successful branch memories are merged back into the original memory using the configured [MemoryMergeStrategy](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html); also changed [ParallelExecutionConfig.memory_conflict_strategy](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html) from [str](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to [MemoryMergeStrategy](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html) enum
- [__init__.py](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Exported [SharedMemory](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [MemoryMergeStrategy](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and [MemoryMergeConflictError](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [test_fanout.py](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Added [OverlappingWriteNode](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html) test helper, 3 unit tests for [deep_copy()](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html) isolation, 7 unit tests for all [merge_from()](vscode-file://vscode-app/c:/Users/Devarshi/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html) strategies (including same-value-no-conflict edge case), and 3 executor-level integration tests for branch isolation and conflict handling

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x]  Format passes (cd core && ruff format --check . all files formatted)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A  backend-only change, no UI impact.
