### PR TITLE
micro-fix: replace dead openai import with LiteLLMProvider in llm_judge

### DIFF
--- a/core/framework/testing/llm_judge.py
+++ b/core/framework/testing/llm_judge.py
@@ -44,9 +44,9 @@ class LLMJudge:
         Priority: OpenAI -> Anthropic.
         """
         if os.environ.get("OPENAI_API_KEY"):
-            from framework.llm.openai import OpenAIProvider
+            from framework.llm.litellm import LiteLLMProvider
 
-            return OpenAIProvider(model="gpt-4o-mini")
+            return LiteLLMProvider(model="gpt-4o-mini")
 
         if os.environ.get("ANTHROPIC_API_KEY"):
             from framework.llm.anthropic import AnthropicProvider


### PR DESCRIPTION
## Summary

`_get_fallback_provider()` in `core/framework/testing/llm_judge.py` imports `OpenAIProvider` from `framework.llm.openai`, but that module does not exist. When `OPENAI_API_KEY` is set, this raises `ModuleNotFoundError`.

## What changed

- Replaced `from framework.llm.openai import OpenAIProvider` with `from framework.llm.litellm import LiteLLMProvider`
- `LiteLLMProvider(model="gpt-4o-mini")` auto-detects the OpenAI provider from the model name and reads `OPENAI_API_KEY` from the environment — same behavior, working import path

## Why

The `framework/llm/` package contains: `anthropic.py`, `litellm.py`, `mock.py`, `provider.py`, `stream_events.py`. There is no `openai.py`. The `LiteLLMProvider` is the framework's universal provider that supports OpenAI models natively.

## Validation

```
$ uv run ruff check framework/testing/llm_judge.py   # All checks passed!
$ uv run ruff format --check framework/testing/llm_judge.py  # already formatted
$ uv run pytest tests/ -v  # 683 passed, 51 skipped, 0 failed (16.16s)
$ python -c "import os; os.environ['OPENAI_API_KEY']='test'; from framework.testing.llm_judge import LLMJudge; j=LLMJudge(); p=j._get_fallback_provider(); print(type(p).__name__)"  # LiteLLMProvider
```

Fixes #4492
