### PR TITLE
fix(vault): improve error handling in soft_delete and get_secret_metadata

### DIFF
--- a/core/framework/credentials/vault/hashicorp.py
+++ b/core/framework/credentials/vault/hashicorp.py
@@ -20,10 +20,14 @@ from ..storage import CredentialStorage
 try:
     from hvac.exceptions import InvalidPath, Forbidden, Unauthorized, VaultError
 except ImportError:
-    class VaultError(Exception): pass
-    class InvalidPath(VaultError): pass
-    class Forbidden(VaultError): pass
-    class Unauthorized(VaultError): pass
+    class VaultError(Exception):
+        pass
+    class InvalidPath(VaultError):
+        pass
+    class Forbidden(VaultError):
+        pass
+    class Unauthorized(VaultError):
+        pass
 
 logger = logging.getLogger(__name__)
 

--- a/core/framework/credentials/vault/hashicorp.py
+++ b/core/framework/credentials/vault/hashicorp.py
@@ -17,6 +17,14 @@ from pydantic import SecretStr
 from ..models import CredentialKey, CredentialObject, CredentialType
 from ..storage import CredentialStorage
 
+try:
+    from hvac.exceptions import InvalidPath, Forbidden, Unauthorized, VaultError
+except ImportError:
+    class VaultError(Exception): pass
+    class InvalidPath(VaultError): pass
+    class Forbidden(VaultError): pass
+    class Unauthorized(VaultError): pass
+
 logger = logging.getLogger(__name__)
 
 
@@ -303,6 +311,11 @@ class HashiCorpVaultStorage(CredentialStorage):
 
         Returns:
             Metadata dict or None if not found
+
+        Raises:
+            Forbidden: If token lacks read permissions
+            Unauthorized: If token is invalid/expired
+            VaultError: For other Vault errors
         """
         path = self._path(credential_id)
 
@@ -312,8 +325,17 @@ class HashiCorpVaultStorage(CredentialStorage):
                 mount_point=self._mount,
             )
             return response.get("data", {})
-        except Exception:
+        except InvalidPath:
+            # Secret doesn't exist - this is expected
             return None
+        except (Forbidden, Unauthorized) as e:
+            # Permission/auth errors should be raised
+            logger.error(f"Permission denied reading metadata for '{credential_id}': {e}")
+            raise
+        except VaultError as e:
+            # Other Vault errors (network, server issues)
+            logger.error(f"Failed to read metadata for '{credential_id}': {e}")
+            raise
 
     def soft_delete(self, credential_id: str, versions: list[int] | None = None) -> bool:
         """
@@ -324,26 +346,74 @@ class HashiCorpVaultStorage(CredentialStorage):
             versions: Version numbers to delete. If None, deletes latest.
 
         Returns:
-            True if successful
+            True if successful, False if credential/versions not found
+
+        Raises:
+            Forbidden: If token lacks delete permissions
+            VaultError: For infrastructure/server errors
         """
         path = self._path(credential_id)
 
-        try:
-            if versions:
-                self._client.secrets.kv.v2.delete_secret_versions(
-                    path=path,
-                    versions=versions,
-                    mount_point=self._mount,
-                )
-            else:
+        # Case 1: Delete latest version
+        if versions is None:
+            try:
                 self._client.secrets.kv.v2.delete_latest_version_of_secret(
                     path=path,
                     mount_point=self._mount,
                 )
-            return True
-        except Exception as e:
-            logger.error(f"Soft delete failed for '{credential_id}': {e}")
+                logger.debug(f"Soft deleted latest version of '{credential_id}'")
+                return True
+            except InvalidPath:
+                # Secret doesn't exist - nothing to delete
+                logger.debug(f"Soft delete (latest): credential '{credential_id}' not found")
+                return False
+            except (Forbidden, Unauthorized) as e:
+                logger.error(f"Permission denied deleting '{credential_id}': {e}")
+                raise
+            except VaultError as e:
+                logger.error(f"Soft delete (latest) failed for '{credential_id}': {e}")
+                raise
+
+        # Case 2: Delete specific versions - validate via metadata first
+        metadata = self.get_secret_metadata(credential_id)
+        if metadata is None:
+            logger.debug(f"Soft delete: credential '{credential_id}' not found when reading metadata")
             return False
+
+        # Build set of existing version numbers from metadata
+        versions_dict = metadata.get("versions", {}) or {}
+        existing_versions = {int(k) for k in versions_dict.keys() if k.isdigit()}
+
+        to_delete = [v for v in versions if v in existing_versions]
+        skipped = [v for v in versions if v not in existing_versions]
+
+        if skipped:
+            logger.debug(
+                f"Soft delete skipped non-existent versions for '{credential_id}': {skipped}"
+            )
+
+        if not to_delete:
+            # All requested versions don't exist
+            return False
+
+        try:
+            self._client.secrets.kv.v2.delete_secret_versions(
+                path=path,
+                versions=to_delete,
+                mount_point=self._mount,
+            )
+            logger.debug(f"Soft deleted versions {to_delete} of '{credential_id}'")
+            return True
+        except InvalidPath:
+            # Race condition - deleted between metadata check and delete
+            logger.debug(f"Soft delete: versions not found for '{credential_id}': {to_delete}")
+            return False
+        except (Forbidden, Unauthorized) as e:
+            logger.error(f"Permission denied deleting '{credential_id}' versions {to_delete}: {e}")
+            raise
+        except VaultError as e:
+            logger.error(f"Soft delete failed for '{credential_id}' versions={to_delete}: {e}")
+            raise
 
     def undelete(self, credential_id: str, versions: list[int]) -> bool:
         """

--- a/core/framework/credentials/vault/hashicorp.py
+++ b/core/framework/credentials/vault/hashicorp.py
@@ -17,7 +17,6 @@ from pydantic import SecretStr
 from ..models import CredentialKey, CredentialObject, CredentialType
 from ..storage import CredentialStorage
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -96,7 +95,7 @@ class HashiCorpVaultStorage(CredentialStorage):
         """
         try:
             import hvac
-            from hvac.exceptions import InvalidPath, Forbidden, Unauthorized, VaultError
+            from hvac.exceptions import Forbidden, InvalidPath, Unauthorized, VaultError
 
             # Store exception classes on the instance for access in other methods
             self._InvalidPath = InvalidPath

--- a/core/framework/credentials/vault/hashicorp.py
+++ b/core/framework/credentials/vault/hashicorp.py
@@ -22,12 +22,8 @@ try:
 except Exception:
     class VaultError(Exception):
         pass
-    class InvalidPath(VaultError):
-        pass
-    class Forbidden(VaultError):
-        pass
-    class Unauthorized(VaultError):
-        pass
+    InvalidPath = Forbidden = Unauthorized = VaultError
+
 
 logger = logging.getLogger(__name__)
 

--- a/core/framework/credentials/vault/hashicorp.py
+++ b/core/framework/credentials/vault/hashicorp.py
@@ -377,7 +377,9 @@ class HashiCorpVaultStorage(CredentialStorage):
         # Case 2: Delete specific versions - validate via metadata first
         metadata = self.get_secret_metadata(credential_id)
         if metadata is None:
-            logger.debug(f"Soft delete: credential '{credential_id}' not found when reading metadata")
+            logger.debug(
+                f"Soft delete: credential '{credential_id}' not found when reading metadata"
+            )
             return False
 
         # Build set of existing version numbers from metadata

--- a/core/framework/credentials/vault/hashicorp.py
+++ b/core/framework/credentials/vault/hashicorp.py
@@ -19,7 +19,7 @@ from ..storage import CredentialStorage
 
 try:
     from hvac.exceptions import InvalidPath, Forbidden, Unauthorized, VaultError
-except ImportError:
+except Exception:
     class VaultError(Exception):
         pass
     class InvalidPath(VaultError):


### PR DESCRIPTION
## Description

Improves error handling in the HashiCorp Vault storage adapter to prevent silent failures and enable proper error propagation. The current implementation uses broad except Exception blocks that catch and suppress critical errors like permission denials (403) and authentication failures (401), making them indistinguishable from simple "not found" (404) responses. This PR refactors soft_delete and get_secret_metadata to use specific hvac exception types, allowing applications to respond appropriately to infrastructure and security issues.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #3084 

## Changes Made

- Replaced catch-all exception handling with specific hvac exception types (InvalidPath, Forbidden, Unauthorized, VaultError)
- Fixed soft_delete logic to distinguish between versions=None (delete latest) and versions=[] (do nothing), preventing accidental deletion.
- Updated get_secret_metadata to raise permission/auth errors instead of returning None, preventing silent failures
- Added fallback exception classes at module level to support imports when hvac is not installed.

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A
