### PR TITLE
micro-fix: replace deprecated asyncio.get_event_loop() with get_running_loop() across 3 modules

### DIFF
--- a/core/framework/credentials/oauth2/lifecycle.py
+++ b/core/framework/credentials/oauth2/lifecycle.py
@@ -157,7 +157,7 @@ class TokenLifecycleManager:
             New OAuth2Token
         """
         # Run in executor to avoid blocking
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         token = await loop.run_in_executor(
             None, lambda: self.provider.client_credentials_grant(scopes=scopes)
         )
@@ -287,7 +287,7 @@ class TokenLifecycleManager:
 
     async def _async_refresh_token(self, credential: CredentialObject) -> TokenRefreshResult:
         """Async wrapper for token refresh."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, lambda: self._sync_refresh_token(credential))
 
     def _sync_refresh_token(self, credential: CredentialObject) -> TokenRefreshResult:

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -914,7 +914,7 @@ class AgentRunner:
 
                 node_id = event.node_id
                 try:
-                    loop = asyncio.get_event_loop()
+                    loop = asyncio.get_running_loop()
                     user_input = await loop.run_in_executor(None, input, "\n>>> ")
                 except EOFError:
                     user_input = ""

--- a/core/framework/storage/concurrent.py
+++ b/core/framework/storage/concurrent.py
@@ -210,7 +210,7 @@ class ConcurrentStorage:
                     return await with_locks(locks[1:], callback)
 
             async def perform_save():
-                loop = asyncio.get_event_loop()
+                loop = asyncio.get_running_loop()
                 await loop.run_in_executor(None, self._base_storage.save_run, run)
 
             await with_locks(index_locks, perform_save)
@@ -239,7 +239,7 @@ class ConcurrentStorage:
         # CRITICAL: Acquire lock to trigger LRU update
         lock_key = f"run:{run_id}"
         async with await self._get_lock(lock_key):
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             run = await loop.run_in_executor(None, self._base_storage.load_run, run_id)
 
         # Update cache
@@ -261,7 +261,7 @@ class ConcurrentStorage:
         # Load from storage
         lock_key = f"summary:{run_id}"
         async with await self._get_lock(lock_key):
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             summary = await loop.run_in_executor(None, self._base_storage.load_summary, run_id)
 
         # Update cache
@@ -274,7 +274,7 @@ class ConcurrentStorage:
         """Delete a run from storage."""
         lock_key = f"run:{run_id}"
         async with await self._get_lock(lock_key):
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             result = await loop.run_in_executor(None, self._base_storage.delete_run, run_id)
 
         # Clear cache
@@ -288,7 +288,7 @@ class ConcurrentStorage:
     async def get_runs_by_goal(self, goal_id: str) -> list[str]:
         """Get all run IDs for a goal."""
         async with await self._get_lock(f"index:by_goal:{goal_id}"):
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             return await loop.run_in_executor(None, self._base_storage.get_runs_by_goal, goal_id)
 
     async def get_runs_by_status(self, status: str | RunStatus) -> list[str]:
@@ -296,23 +296,23 @@ class ConcurrentStorage:
         if isinstance(status, RunStatus):
             status = status.value
         async with await self._get_lock(f"index:by_status:{status}"):
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             return await loop.run_in_executor(None, self._base_storage.get_runs_by_status, status)
 
     async def get_runs_by_node(self, node_id: str) -> list[str]:
         """Get all run IDs that executed a node."""
         async with await self._get_lock(f"index:by_node:{node_id}"):
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             return await loop.run_in_executor(None, self._base_storage.get_runs_by_node, node_id)
 
     async def list_all_runs(self) -> list[str]:
         """List all run IDs."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self._base_storage.list_all_runs)
 
     async def list_all_goals(self) -> list[str]:
         """List all goal IDs that have runs."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self._base_storage.list_all_goals)
 
     # === BATCH OPERATIONS ===
@@ -410,7 +410,7 @@ class ConcurrentStorage:
 
     async def get_stats(self) -> dict:
         """Get storage statistics."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         base_stats = await loop.run_in_executor(None, self._base_storage.get_stats)
 
         return {


### PR DESCRIPTION
## Summary

- Replace all 13 occurrences of the deprecated `asyncio.get_event_loop()` with `asyncio.get_running_loop()` across 3 core modules
- Eliminates `DeprecationWarning` on Python 3.10+ and prevents `RuntimeError` on Python 3.12+
- Pure mechanical substitution — no logic changes, no new dependencies

## Root Cause

`asyncio.get_event_loop()` was deprecated in Python 3.10 and will raise `RuntimeError` on Python 3.12+ when no event loop is running in the current thread. All 13 call sites are inside `async def` functions where a running loop is guaranteed, making `asyncio.get_running_loop()` the correct and future-proof API.

## Affected Files

| File | Occurrences | Methods |
|------|-------------|---------|
| `core/framework/storage/concurrent.py` | 10 | `_save_run_locked`, `load_run`, `load_summary`, `delete_run`, `get_runs_by_goal`, `get_runs_by_status`, `get_runs_by_node`, `list_all_runs`, `list_all_goals`, `get_stats` |
| `core/framework/credentials/oauth2/lifecycle.py` | 2 | `acquire_token_client_credentials`, `_async_refresh_token` |
| `core/framework/runner/runner.py` | 1 | `_handle_input_requested` |

## Validation

```
$ uv run ruff check framework/ tests/
All checks passed!

$ uv run ruff format --check framework/ tests/
145 files already formatted

$ uv run pytest tests/ -q --tb=short
683 passed, 51 skipped, 228 warnings in 16.27s
```

## Checklist

- [x] Linked to issue
- [x] Local lint/format/test passing
- [x] Minimal diff, no unrelated changes
- [x] Commit messages follow convention

Fixes #4599
