### PR TITLE
micro-fix: remove vestigial duplicate Step 3 header in quickstart.sh

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -217,17 +217,10 @@ echo -e "${GREEN}⬢${NC} All packages installed"
 echo ""
 
 # ============================================================
-# Step 3: Configure LLM API Key
-# ============================================================
-
-echo -e "${YELLOW}⬢${NC} ${BLUE}${BOLD}Step 3: Configuring LLM provider...${NC}"
-echo ""
-
-# ============================================================
 # Step 3: Verify Python Imports
 # ============================================================
 
-echo -e "${BLUE}Step 3: Verifying Python imports...${NC}"
+echo -e "${YELLOW}⬢${NC} ${BLUE}${BOLD}Step 3: Verifying Python imports...${NC}"
 echo ""
 
 IMPORT_ERRORS=0


### PR DESCRIPTION
## Summary

Remove the vestigial "Step 3: Configure LLM API Key" section in `quickstart.sh` that prints a header but contains **zero** LLM configuration logic. This dead section causes two consecutive "Step 3" messages during onboarding, confusing first-time users.

## What changed

- **Removed** the dead comment block + echo at lines 219-225 (the "Configure LLM API Key" header with no corresponding logic)
- **Upgraded** the import verification step echo to use the same formatting style as other steps (`${YELLOW}⬢${NC}` prefix + `${BOLD}`) for consistency

## Before

```
Step 3: Configuring LLM provider...    ← does nothing, immediately followed by:
Step 3: Verifying Python imports...    ← the real Step 3
```

## After

```
Step 3: Verifying Python imports...    ← sole Step 3, consistent formatting
```

Steps 1-7 are now sequential with no duplicates.

## Validation

- `bash -n quickstart.sh` — syntax OK
- `ruff check` — all checks passed
- `ruff format --check` — 145 files already formatted
- `pytest tests/` — 683 passed, 51 skipped, 0 failed

Fixes #4603
