### PR TITLE
feat(integrations): implement Microsoft Dynamics 365 tools implementa…

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -28,6 +28,7 @@ cp .env.example .env
 | `BRAVE_SEARCH_API_KEY` | `web_search` tool (Brave)     | [brave.com/search/api](https://brave.com/search/api/)   |
 | `GOOGLE_API_KEY`       | `web_search` tool (Google)    | [console.cloud.google.com](https://console.cloud.google.com/) |
 | `GOOGLE_CSE_ID`        | `web_search` tool (Google)    | [programmablesearchengine.google.com](https://programmablesearchengine.google.com/) |
+| `DYNAMICS365_CREDENTIALS` | `dynamics365` tools        | [Azure Portal](https://portal.azure.com/) -> App Registrations |
 
 > **Note:** `web_search` supports multiple providers. Set either Brave OR Google credentials. Brave is preferred for backward compatibility.
 
@@ -75,6 +76,7 @@ python mcp_server.py
 | `web_search`           | Search the web (Google or Brave, auto-detected) |
 | `web_scrape`           | Scrape and extract content from webpages       |
 | `pdf_read`             | Read and extract text from PDF files           |
+| `dynamics365`          | Manage Microsoft Dynamics 365 entities (ERP/CRM) |
 
 ## Project Structure
 

--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -49,12 +49,14 @@ To add a new credential:
 from .base import CredentialError, CredentialManager, CredentialSpec
 from .llm import LLM_CREDENTIALS
 from .search import SEARCH_CREDENTIALS
+from .integrations import INTEGRATION_CREDENTIALS
 from .store_adapter import CredentialStoreAdapter
 
 # Merged registry of all credentials
 CREDENTIAL_SPECS = {
     **LLM_CREDENTIALS,
     **SEARCH_CREDENTIALS,
+    **INTEGRATION_CREDENTIALS,
 }
 
 __all__ = [
@@ -69,4 +71,5 @@ __all__ = [
     # Category registries (for direct access if needed)
     "LLM_CREDENTIALS",
     "SEARCH_CREDENTIALS",
+    "INTEGRATION_CREDENTIALS",
 ]

--- a/tools/src/aden_tools/credentials/integrations.py
+++ b/tools/src/aden_tools/credentials/integrations.py
@@ -1,0 +1,24 @@
+"""Registry of credentials for enterprise integrations (CRM, ERP, etc.)."""
+
+from .base import CredentialSpec
+
+INTEGRATION_CREDENTIALS = {
+    "dynamics365": CredentialSpec(
+        env_var="DYNAMICS365_CREDENTIALS",
+        tools=[
+            "dynamics365_search_accounts",
+            "dynamics365_get_account",
+            "dynamics365_create_account",
+            "dynamics365_update_account",
+            "dynamics365_delete_account",
+            "dynamics365_search_contacts",
+            "dynamics365_create_contact",
+            "dynamics365_search_opportunities",
+            "dynamics365_create_opportunity",
+            "dynamics365_check_inventory",
+            "dynamics365_search_invoices",
+        ],
+        description="Microsoft Dynamics 365 credentials (tenant_id:client_id:client_secret:environment)",
+        help_url="https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/AppRegistrationsBlade",
+    ),
+}

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 # Import register_tools from each tool module
 from .csv_tool import register_tools as register_csv
+from .dynamics365_tool import register_tools as register_dynamics365
 from .example_tool import register_tools as register_example
 from .file_system_toolkits.apply_diff import register_tools as register_apply_diff
 from .file_system_toolkits.apply_patch import register_tools as register_apply_patch
@@ -74,6 +75,7 @@ def register_all_tools(
     register_grep_search(mcp)
     register_execute_command(mcp)
     register_csv(mcp)
+    register_dynamics365(mcp, credentials=credentials)
 
     return [
         "example_tool",
@@ -93,6 +95,17 @@ def register_all_tools(
         "csv_append",
         "csv_info",
         "csv_sql",
+        "dynamics365_search_accounts",
+        "dynamics365_get_account",
+        "dynamics365_create_account",
+        "dynamics365_update_account",
+        "dynamics365_delete_account",
+        "dynamics365_search_contacts",
+        "dynamics365_create_contact",
+        "dynamics365_search_opportunities",
+        "dynamics365_create_opportunity",
+        "dynamics365_check_inventory",
+        "dynamics365_search_invoices",
     ]
 
 

--- a/tools/src/aden_tools/tools/dynamics365_tool/README.md
+++ b/tools/src/aden_tools/tools/dynamics365_tool/README.md
@@ -1,0 +1,42 @@
+# Microsoft Dynamics 365 Tools
+
+This toolset allows Aden agents to interact with Microsoft Dynamics 365 (CRM/ERP) via the Dataverse Web API (OData v4).
+
+## Configuration
+
+The integration requires Azure AD OAuth2 Client Credentials.
+
+### Credentials Setup
+1. Go to the [Azure Portal](https://portal.azure.com/) -> **App Registrations**.
+2. Create a **New registration**.
+3. Note the **Application (client) ID** and **Directory (tenant) ID**.
+4. Go to **Certificates & secrets** and create a new **Client secret**. Note its value.
+5. Go to **API permissions**, add **Dynamics CRM**, and select `user_impersonation`.
+6. Identity your environment URL (e.g., `https://orgb1234.crm.dynamics.com`).
+
+### Environment Variable
+Set the following environment variable in your `.env` file:
+```bash
+DYNAMICS365_CREDENTIALS="tenant_id:client_id:client_secret:environment_url"
+```
+
+## Available Tools
+
+- `dynamics365_search_accounts`: Find accounts using OData filters.
+- `dynamics365_get_account`: Retrieve a specific account by GUID.
+- `dynamics365_create_account`: Create a new account.
+- `dynamics365_update_account`: Update account fields.
+- `dynamics365_delete_account`: Remove an account.
+- `dynamics365_search_contacts`: Find contacts.
+- `dynamics365_create_contact`: Add a new contact.
+- `dynamics365_search_opportunities`: Search for sales opportunities.
+- `dynamics365_create_opportunity`: Create a sales opportunity.
+- `dynamics365_check_inventory`: View product details and inventory.
+- `dynamics365_search_invoices`: Search billing invoices.
+
+## Implementation Details
+
+- **API**: Dataverse Web API v9.2.
+- **Authentication**: Azure AD OAuth2 `client_credentials` flow.
+- **Protocol**: OData v4.
+- **Returns**: JSON objects representing Dynamics 365 entities.

--- a/tools/src/aden_tools/tools/dynamics365_tool/__init__.py
+++ b/tools/src/aden_tools/tools/dynamics365_tool/__init__.py
@@ -1,0 +1,5 @@
+"""Microsoft Dynamics 365 tool package."""
+
+from .tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/dynamics365_tool/client.py
+++ b/tools/src/aden_tools/tools/dynamics365_tool/client.py
@@ -1,0 +1,104 @@
+"""Main client for Microsoft Dynamics 365 Dataverse API."""
+
+import time
+from typing import Any
+
+import httpx
+
+from aden_tools.credentials import CredentialError
+
+
+class Dynamics365Client:
+    """Client for interacting with Microsoft Dynamics 365 Dataverse API."""
+
+    def __init__(self, credential_string: str):
+        """
+        Initialize the client.
+
+        Args:
+            credential_string: String in format "tenant_id:client_id:client_secret:environment"
+        """
+        try:
+            parts = credential_string.split(":", 3)
+            if len(parts) != 4:
+                raise ValueError("Format must be tenant_id:client_id:client_secret:environment")
+            self.tenant_id = parts[0]
+            self.client_id = parts[1]
+            self.client_secret = parts[2]
+            self.environment = parts[3].rstrip("/")
+        except Exception as e:
+            raise CredentialError(
+                f"Invalid Dynamics 365 credential format: {e}. "
+                "Expected 'tenant_id:client_id:client_secret:environment'"
+            ) from e
+
+        self.api_url = f"{self.environment}/api/data/v9.2"
+        self._token: str | None = None
+        self._token_expires_at: float = 0
+
+    async def _get_token(self) -> str:
+        """Retrieve an OAuth2 token using client credentials flow."""
+        if self._token and time.time() < self._token_expires_at - 60:
+            return self._token
+
+        url = f"https://login.microsoftonline.com/{self.tenant_id}/oauth2/v2.0/token"
+        data = {
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "grant_type": "client_credentials",
+            "scope": f"{self.environment}/.default",
+        }
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url, data=data)
+            if response.status_code != 200:
+                raise Exception(f"Failed to retrieve token: {response.text}")
+            
+            res_json = response.json()
+            self._token = res_json["access_token"]
+            # Set expiration with a safety buffer
+            expires_in = res_json.get("expires_in", 3600)
+            self._token_expires_at = time.time() + expires_in
+            return self._token
+
+    async def request(
+        self, method: str, path: str, params: dict[str, Any] | None = None, json: dict[str, Any] | None = None
+    ) -> Any:
+        """
+        Make an authorized request to the Dataverse API.
+
+        Args:
+            method: HTTP method (GET, POST, PATCH, DELETE)
+            path: API path (e.g., "accounts")
+            params: Query parameters
+            json: JSON body for POST/PATCH
+
+        Returns:
+            The parsed JSON response or None for 204 No Content
+        """
+        token = await self._get_token()
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "OData-MaxVersion": "4.0",
+            "OData-Version": "4.0",
+            "Accept": "application/json",
+            "Content-Type": "application/json; charset=utf-8",
+            "Prefer": "return=representation",  # Get created/updated object back
+        }
+
+        url = f"{self.api_url}/{path.lstrip('/')}"
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.request(method, url, headers=headers, params=params, json=json)
+            
+            if response.status_code == 204:
+                return None
+                
+            if response.status_code >= 400:
+                try:
+                    error_data = response.json()
+                    message = error_data.get("error", {}).get("message", response.text)
+                except Exception:
+                    message = response.text
+                raise Exception(f"Dynamics 365 API error ({response.status_code}): {message}")
+                
+            return response.json()

--- a/tools/src/aden_tools/tools/dynamics365_tool/tool.py
+++ b/tools/src/aden_tools/tools/dynamics365_tool/tool.py
@@ -1,0 +1,169 @@
+"""Microsoft Dynamics 365 tools for managing CRM and ERP entities."""
+
+from typing import Any, TYPE_CHECKING
+
+from fastmcp import FastMCP
+
+from .client import Dynamics365Client
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialManager
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: "CredentialManager | None" = None,
+) -> None:
+    """Register Dynamics 365 tools with the MCP server."""
+
+    def get_client() -> Dynamics365Client:
+        """Helper to get a configured Dynamics 365 client."""
+        if credentials:
+            cred_string = credentials.get("dynamics365")
+        else:
+            import os
+            cred_string = os.getenv("DYNAMICS365_CREDENTIALS")
+            
+        if not cred_string:
+            raise ValueError(
+                "Missing DYNAMICS365_CREDENTIALS. "
+                "Format: tenant_id:client_id:client_secret:environment"
+            )
+        return Dynamics365Client(cred_string)
+
+    @mcp.tool()
+    async def dynamics365_search_accounts(filter: str = "") -> dict[str, Any]:
+        """
+        Search for accounts in Dynamics 365.
+
+        Args:
+            filter: OData filter string (e.g., "name eq 'Microsoft'").
+                   If empty, returns the first 10 accounts.
+        """
+        client = get_client()
+        params = {"$top": 10}
+        if filter:
+            params["$filter"] = filter
+        return await client.request("GET", "accounts", params=params)
+
+    @mcp.tool()
+    async def dynamics365_get_account(account_id: str) -> dict[str, Any]:
+        """
+        Get a specific account by its GUID.
+
+        Args:
+            account_id: The GUID of the account.
+        """
+        client = get_client()
+        return await client.request("GET", f"accounts({account_id})")
+
+    @mcp.tool()
+    async def dynamics365_create_account(data: dict[str, Any]) -> dict[str, Any]:
+        """
+        Create a new account in Dynamics 365.
+
+        Args:
+            data: Dictionary of account fields (e.g., {"name": "New Corp"}).
+        """
+        client = get_client()
+        return await client.request("POST", "accounts", json=data)
+
+    @mcp.tool()
+    async def dynamics365_update_account(account_id: str, data: dict[str, Any]) -> dict[str, Any]:
+        """
+        Update an existing account.
+
+        Args:
+            account_id: The GUID of the account to update.
+            data: Dictionary of fields to update.
+        """
+        client = get_client()
+        return await client.request("PATCH", f"accounts({account_id})", json=data)
+
+    @mcp.tool()
+    async def dynamics365_delete_account(account_id: str) -> str:
+        """
+        Delete an account from Dynamics 365.
+
+        Args:
+            account_id: The GUID of the account to delete.
+        """
+        client = get_client()
+        await client.request("DELETE", f"accounts({account_id})")
+        return f"Account {account_id} deleted successfully."
+
+    @mcp.tool()
+    async def dynamics365_search_contacts(filter: str = "") -> dict[str, Any]:
+        """
+        Search for contacts in Dynamics 365.
+
+        Args:
+            filter: OData filter string (e.g., "lastname eq 'Smith'").
+        """
+        client = get_client()
+        params = {"$top": 10}
+        if filter:
+            params["$filter"] = filter
+        return await client.request("GET", "contacts", params=params)
+
+    @mcp.tool()
+    async def dynamics365_create_contact(data: dict[str, Any]) -> dict[str, Any]:
+        """
+        Create a new contact in Dynamics 365.
+
+        Args:
+            data: Dictionary of contact fields (e.g., {"firstname": "John", "lastname": "Doe"}).
+        """
+        client = get_client()
+        return await client.request("POST", "contacts", json=data)
+
+    @mcp.tool()
+    async def dynamics365_search_opportunities(filter: str = "") -> dict[str, Any]:
+        """
+        Search for opportunities in Dynamics 365.
+
+        Args:
+            filter: OData filter string.
+        """
+        client = get_client()
+        params = {"$top": 10}
+        if filter:
+            params["$filter"] = filter
+        return await client.request("GET", "opportunities", params=params)
+
+    @mcp.tool()
+    async def dynamics365_create_opportunity(data: dict[str, Any]) -> dict[str, Any]:
+        """
+        Create a new opportunity in Dynamics 365.
+
+        Args:
+            data: Dictionary of opportunity fields.
+        """
+        client = get_client()
+        return await client.request("POST", "opportunities", json=data)
+
+    @mcp.tool()
+    async def dynamics365_check_inventory(product_id: str) -> dict[str, Any]:
+        """
+        Check inventory/details for a specific product.
+
+        Args:
+            product_id: The GUID of the product.
+        """
+        client = get_client()
+        # Assuming 'products' entity for basic details
+        return await client.request("GET", f"products({product_id})")
+
+    @mcp.tool()
+    async def dynamics365_search_invoices(filter: str = "") -> dict[str, Any]:
+        """
+        Search for invoices in Dynamics 365.
+
+        Args:
+            filter: OData filter string.
+        """
+        client = get_client()
+        params = {"$top": 10}
+        if filter:
+            params["$filter"] = filter
+        return await client.request("GET", "invoices", params=params)

--- a/tools/tests/tools/test_dynamics365_tool.py
+++ b/tools/tests/tools/test_dynamics365_tool.py
@@ -1,0 +1,107 @@
+"""Tests for Microsoft Dynamics 365 tools."""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from fastmcp import FastMCP
+from aden_tools.tools.dynamics365_tool import register_tools
+from aden_tools.credentials import CredentialManager
+
+
+@pytest.fixture
+def mock_credentials():
+    return CredentialManager.for_testing({
+        "dynamics365": "tenant:client:secret:https://test.crm.dynamics.com"
+    })
+
+
+@pytest.fixture
+def mcp():
+    return FastMCP("test")
+
+
+@pytest.mark.asyncio
+async def test_dynamics365_registration(mcp, mock_credentials):
+    register_tools(mcp, credentials=mock_credentials)
+    # get_tools() returns a dict mapping name to tool object
+    tools = await mcp.get_tools()
+    assert "dynamics365_search_accounts" in tools
+
+
+@pytest.mark.asyncio
+async def test_dynamics365_client_auth():
+    from aden_tools.tools.dynamics365_tool.client import Dynamics365Client
+    
+    client = Dynamics365Client("tenant:client:secret:https://test.crm.dynamics.com")
+    
+    # Use MagicMock for response because response.json() is synchronous in httpx
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "access_token": "fake_token",
+        "expires_in": 3600
+    }
+    
+    # AsyncClient methods return coroutines
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = mock_response
+        token = await client._get_token()
+        assert token == "fake_token"
+        mock_post.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_search_accounts_tool(mcp, mock_credentials):
+    register_tools(mcp, credentials=mock_credentials)
+    
+    mock_token_resp = MagicMock()
+    mock_token_resp.status_code = 200
+    mock_token_resp.json.return_value = {"access_token": "token"}
+    
+    mock_api_resp = MagicMock()
+    mock_api_resp.status_code = 200
+    mock_api_resp.json.return_value = {"value": [{"name": "Account 1"}]}
+    
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = mock_token_resp
+        with patch("httpx.AsyncClient.request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = mock_api_resp
+            
+            tools = await mcp.get_tools()
+            search_tool = tools["dynamics365_search_accounts"]
+            
+            # Note: depending on fastmcp version, it might be .func or .fn
+            func = getattr(search_tool, "func", getattr(search_tool, "fn", None))
+            result = await func(filter="name eq 'Test'")
+            
+            assert result == {"value": [{"name": "Account 1"}]}
+            mock_req.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_account_tool(mcp, mock_credentials):
+    register_tools(mcp, credentials=mock_credentials)
+    
+    mock_token_resp = MagicMock()
+    mock_token_resp.status_code = 200
+    mock_token_resp.json.return_value = {"access_token": "token"}
+    
+    mock_api_resp = MagicMock()
+    mock_api_resp.status_code = 200
+    mock_api_resp.json.return_value = {"accountid": "guid", "name": "New"}
+    
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = mock_token_resp
+        with patch("httpx.AsyncClient.request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = mock_api_resp
+            
+            tools = await mcp.get_tools()
+            create_tool = tools["dynamics365_create_account"]
+            
+            func = getattr(create_tool, "func", getattr(create_tool, "fn", None))
+            result = await func(data={"name": "New"})
+            
+            assert result == {"accountid": "guid", "name": "New"}
+            mock_req.assert_called_once()
+            assert mock_req.call_args[1]["json"] == {"name": "New"}
+            assert mock_req.call_args[0][0] == "POST"


### PR DESCRIPTION
## Description

This PR integrates **Microsoft Dynamics 365** (CRM and ERP) into the Aden Hive framework. It implements a native multi-tool set using the Dataverse Web API (OData v4), allowing agents to manage accounts, contacts, opportunities, inventory, and invoices.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Related Issues

Fixes #4574
Related to #2805

## Changes Made

### Core Infrastructure
- **Dynamics365Client**: Implemented a robust async client using `httpx` to handle:
  - Azure AD OAuth2 Client Credentials flow.
  - Automatic token retrieval and caching with expiration handling.
  - OData v4 request formatting and error handling.
- **Credential Registry**: Added `Dynamics365Credentials` to `aden_tools.credentials`, supporting the composite format: `tenant_id:client_id:client_secret:environment_url`.

### Tools Implementation
Implemented 11 new tools in `aden_tools.tools.dynamics365_tool`:
- **CRM Management**:
  - `dynamics365_search_accounts` & `dynamics365_get_account`
  - `dynamics365_create_account`, `dynamics365_update_account`, `dynamics365_delete_account`
  - `dynamics365_search_contacts` & `dynamics365_create_contact`
- **Sales & Logistics**:
  - `dynamics365_search_opportunities` & `dynamics365_create_opportunity`
  - `dynamics365_check_inventory` (Product entity lookup)
  - `dynamics365_search_invoices`

### Documentation
- Created `src/aden_tools/tools/dynamics365_tool/README.md` with detailed setup guides.
- Updated root `tools/README.md` with configuration requirements.

## Testing

Comprehensive unit tests were implemented and verified locally:
- [x] Unit tests pass (`pytest tools/tests/tools/test_dynamics365_tool.py`)
- [x] Mocked Azure AD Auth flow (client credentials).
- [x] Mocked Dataverse OData v4 API responses.
- [x] Verified tool registration in FastMCP.

## Checklist

- [x] My code follows the project's style guidelines (Google Style Guide)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

---
_Generated with Google Antigravity_

