### PR TITLE
docs(mcp): replace stale 'goal-agent' path with 'hive' in MCP config examples

### DIFF
--- a/core/MCP_SERVER_GUIDE.md
+++ b/core/MCP_SERVER_GUIDE.md
@@ -24,7 +24,7 @@ Add to your MCP client configuration (e.g., Claude Desktop):
     "agent-builder": {
       "command": "python",
       "args": ["-m", "framework.mcp.agent_builder_server"],
-      "cwd": "/path/to/goal-agent"
+      "cwd": "/path/to/hive"
     }
   }
 }

--- a/core/README.md
+++ b/core/README.md
@@ -64,7 +64,7 @@ To use the agent builder with Claude Desktop or other MCP clients, add this to y
     "agent-builder": {
       "command": "python",
       "args": ["-m", "framework.mcp.agent_builder_server"],
-      "cwd": "/path/to/goal-agent"
+      "cwd": "/path/to/hive"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Replace stale project name `goal-agent` with `hive` in MCP client configuration examples

## Root Cause
The project was renamed from `goal-agent` to `hive`, but the `cwd` path placeholder in two MCP setup guides was never updated.

## Changes
- **core/README.md** — update `"cwd": "/path/to/goal-agent"` → `"/path/to/hive"` in MCP client config example
- **core/MCP_SERVER_GUIDE.md** — same `cwd` path fix in the manual configuration section

## Validation
```bash
$ cd core && uv run ruff check framework/ tests/ && uv run ruff format --check framework/ tests/
All checks passed!

$ uv run pytest tests/ -x -q
683 passed, 51 skipped
```

## Risk Assessment
- Regression risk: **none** — documentation-only change
- Affected consumers: 0 (no code change)
- Test coverage: N/A

## Checklist
- [x] Linked to issue
- [x] All CI-equivalent checks passing locally
- [x] Minimal diff — no unrelated changes
- [x] Commit messages follow convention
- [x] Self-reviewed

Fixes #4621
