### PR TITLE
micro-fix: add duplicate label via POST instead of replacing all labels

### DIFF
--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -146,6 +146,14 @@ async function closeIssueAsDuplicate(
     {
       state: "closed",
       state_reason: "duplicate",
+    }
+  );
+
+  await githubRequest(
+    `/repos/${owner}/${repo}/issues/${issueNumber}/labels`,
+    token,
+    "POST",
+    {
       labels: ["duplicate"],
     }
   );


### PR DESCRIPTION
## Summary

Fixes #4633 — `closeIssueAsDuplicate` in `scripts/auto-close-duplicates.ts` sends `labels: ["duplicate"]` inside a PATCH to the Issues API, which **replaces** all existing labels (e.g., `bug`, `enhancement`, `good first issue`) with just `["duplicate"]`.

## Problem

The [GitHub Issues PATCH endpoint](https://docs.github.com/en/rest/issues/issues#update-an-issue) treats the `labels` field as a **full replacement**, not an additive merge. Every auto-closed duplicate silently loses its original labels.

## Fix

1. Removed `labels` from the PATCH body (only `state` + `state_reason` remain).
2. Added a separate POST to [`/repos/{owner}/{repo}/issues/{n}/labels`](https://docs.github.com/en/rest/issues/labels#add-labels-to-an-issue), which **adds** the `"duplicate"` label without touching existing labels.

## Scope

| File | Change |
|------|--------|
| `scripts/auto-close-duplicates.ts` | +8 lines (split PATCH + add POST) |

## Validation

- [x] `pytest tests/ -x -q` — 683 passed, 51 skipped, 0 failed (Python suite unaffected)
- [x] `ruff check` + `ruff format --check` — clean
- [x] Existing TS unit tests (`auto-close-duplicates.test.ts`) do not cover `closeIssueAsDuplicate` (internal function, not exported) — no test breakage
- [x] API behavior verified against GitHub REST API docs
