### PR TITLE
fix: remove duplicate CredentialStoreAdapter entry in credentials __all__

### DIFF
--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -84,8 +84,6 @@ __all__ = [
     "CredentialSpec",
     "CredentialStoreAdapter",
     "CredentialError",
-    # Credential store adapter (replaces deprecated CredentialManager)
-    "CredentialStoreAdapter",
     # Health check utilities
     "HealthCheckResult",
     "check_credential_health",


### PR DESCRIPTION
## Summary
- Remove duplicate `CredentialStoreAdapter` export from `tools/src/aden_tools/credentials/__init__.py` `__all__`
- Remove stale comment referencing deprecated `CredentialManager` class which no longer exists in the codebase

Closes #4629

## Test plan
- [x] Verify `__all__` contains exactly one `CredentialStoreAdapter` entry
- [x] Verify no other references to `CredentialManager` remain in this file
- [x] Change is a 2-line deletion — no runtime behavior affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)