### PR TITLE
docs: fix broken exports/ link in environment-setup.md

### DIFF
--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -563,7 +563,7 @@ test -d .agents/skills/hive && echo "OK: Skills" || echo "MISSING: .agents/skill
 
 - **Framework Documentation:** [core/README.md](../core/README.md)
 - **Tools Documentation:** [tools/README.md](../tools/README.md)
-- **Example Agents:** [exports/](../exports/)
+- **Example Agents:** [examples/](../examples/)
 - **Agent Building Guide:** [.claude/skills/hive-create/SKILL.md](../.claude/skills/hive-create/SKILL.md)
 - **Testing Guide:** [.claude/skills/hive-test/SKILL.md](../.claude/skills/hive-test/SKILL.md)
 


### PR DESCRIPTION
## Summary
- Fixed broken link to nonexistent `exports/` directory in environment-setup.md
- Changed to point to `examples/` which contains the actual example agents
- `exports/` is gitignored and only exists locally when users generate agents

Closes #4645

## Test plan
- [ ] Link resolves correctly on GitHub
- [ ] environment-setup.md renders correctly