### PR TITLE
Fix deprecated asyncio.get_event_loop usage in example templates

### DIFF
--- a/examples/templates/deep_research_agent/__main__.py
+++ b/examples/templates/deep_research_agent/__main__.py
@@ -184,10 +184,12 @@ async def _interactive_shell(verbose=False):
     agent = DeepResearchAgent()
     await agent.start()
 
+    loop = asyncio.get_running_loop()
+
     try:
         while True:
             try:
-                topic = await asyncio.get_event_loop().run_in_executor(
+                topic = await loop.run_in_executor(
                     None, input, "Topic> "
                 )
                 if topic.lower() in ["quit", "exit", "q"]:

--- a/examples/templates/tech_news_reporter/__main__.py
+++ b/examples/templates/tech_news_reporter/__main__.py
@@ -182,10 +182,12 @@ async def _interactive_shell(verbose=False):
     agent = TechNewsReporterAgent()
     await agent.start()
 
+    loop = asyncio.get_running_loop()
+
     try:
         while True:
             try:
-                user_input = await asyncio.get_event_loop().run_in_executor(
+                user_input = await loop.run_in_executor(
                     None, input, "News> "
                 )
                 if user_input.lower() in ["quit", "exit", "q"]:


### PR DESCRIPTION
### Summary
This PR replaces deprecated `asyncio.get_event_loop()` usage inside running coroutines in example templates with the recommended asyncio APIs for Python 3.12+.

### Changes
- Updated `deep_research_agent` example to use `asyncio.get_running_loop()`
- Updated `tech_news_reporter` example to use `asyncio.get_running_loop()`

### Motivation
`asyncio.get_event_loop()` is deprecated inside running coroutines and may break on Python 3.12+. These changes align the examples with modern asyncio best practices.

