### PR TITLE
fix: prevent UnboundLocalError and None pointer in GraphExecutor

### DIFF
--- a/docs/antigravity-setup.md
+++ b/docs/antigravity-setup.md
@@ -34,7 +34,7 @@ Done. For details, prerequisites, and troubleshooting, read on.
 - [Antigravity IDE](https://antigravity.google/) installed.
 - **Python 3.11+** and project dependencies. If you haven’t set up the repo yet, from repo root run:
   ```bash
-  ./scripts/setup-python.sh
+  ./quickstart.sh
   ```
 - **MCP server dependencies** (one-time). From repo root:
   ```bash
@@ -112,7 +112,7 @@ The **setup script** writes your **user** config (`~/.gemini/antigravity/mcp_con
 **MCP servers don’t connect**
 
 - Run the setup script again from the hive repo root: `./scripts/setup-antigravity-mcp.sh`, then restart Antigravity.
-- Make sure Python and deps are installed: from repo root run `./scripts/setup-python.sh`.
+- Make sure Python and deps are installed: from repo root run `./quickstart.sh`.
 - Check that the servers can start: from repo root run
   `cd core && uv run -m framework.mcp.agent_builder_server` (Ctrl+C to stop), and in another terminal
   `cd tools && uv run mcp_server.py --stdio` (Ctrl+C to stop).


### PR DESCRIPTION
## Summary

This PR fixes two bugs in `core/framework/graph/executor.py`:

### Bug 1: UnboundLocalError masks real exceptions
- **Issue**: The exception handler at line ~1176 references `node_spec`, but `node_spec` is first assigned inside the `while` loop (line ~533). If an exception occurs before the first loop iteration completes, `node_spec` is unbound.
- **Fix**: Initialize `node_spec = None` before the try block (line ~491)

### Bug 2: AttributeError in parallel branch failure
- **Issue**: Line ~1803 calls `.name` on the result of `graph.get_node(b.node_id)` which may return `None` for invalid branch node IDs, causing `AttributeError`.
- **Fix**: Safely get node names with a guard against `None`

## Changes
- Added `node_spec = None` initialization before try block
- Changed parallel branch failure handling to check for `None` from `graph.get_node()`

## Testing
- All 721 tests pass (`make test`)
- Lint checks pass (`make check`)

Fixes #4514