### PR TITLE
micro-fix : resolve ruff E501 line length violation in runner.py

### DIFF
--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -686,7 +686,9 @@ class AgentRunner:
             else:
                 # Fall back to environment variable
                 # First check api_key_env_var from config (set by quickstart)
-                api_key_env = llm_config.get("api_key_env_var") or self._get_api_key_env_var(self.model)
+                api_key_env = llm_config.get("api_key_env_var") or self._get_api_key_env_var(
+                    self.model
+                )
                 if api_key_env and os.environ.get(api_key_env):
                     self._llm = LiteLLMProvider(model=self.model)
                 else:


### PR DESCRIPTION
Closes #4687 

## Summary

This PR resolves a `ruff` E501 (line too long) violation in
`core/framework/runner/runner.py`.

## Changes

- Reformatted the long assignment statement
- No functional changes introduced

## Validation

- `make check` passes successfully
