### PR TITLE
 micro-fix : resolve ruff E501 line length violation in runner.py

### DIFF
--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -686,7 +686,9 @@ class AgentRunner:
             else:
                 # Fall back to environment variable
                 # First check api_key_env_var from config (set by quickstart)
-                api_key_env = llm_config.get("api_key_env_var") or self._get_api_key_env_var(self.model)
+                api_key_env = llm_config.get("api_key_env_var") or self._get_api_key_env_var(
+                    self.model
+                )
                 if api_key_env and os.environ.get(api_key_env):
                     self._llm = LiteLLMProvider(model=self.model)
                 else:


### PR DESCRIPTION
Closes #4687 

## Summary

This PR resolves a `ruff` E501 (line too long) violation in
`core/framework/runner/runner.py`.

## Changes

- Reformatted a long assignment statement to comply with
  the repository’s configured line length limits.
- No functional or behavioral changes introduced.

## Validation

- `ruff check` passes
- `ruff format --check` passes
- `make check` completes successfully

This change strictly improves code style consistency and
adheres to the project's linting standards.

## verification
<img width="594" height="240" alt="Screenshot 2026-02-13 145711" src="https://github.com/user-attachments/assets/e270b5f7-2881-40d8-ae21-a80030ea12e9" />

