### PR TITLE
fix: replace deprecated asyncio.get_event_loop() with get_running_loop()

### DIFF
--- a/examples/templates/deep_research_agent/__main__.py
+++ b/examples/templates/deep_research_agent/__main__.py
@@ -187,7 +187,7 @@ async def _interactive_shell(verbose=False):
     try:
         while True:
             try:
-                topic = await asyncio.get_event_loop().run_in_executor(
+                topic = await asyncio.get_running_loop().run_in_executor(
                     None, input, "Topic> "
                 )
                 if topic.lower() in ["quit", "exit", "q"]:

--- a/examples/templates/tech_news_reporter/__main__.py
+++ b/examples/templates/tech_news_reporter/__main__.py
@@ -185,7 +185,7 @@ async def _interactive_shell(verbose=False):
     try:
         while True:
             try:
-                user_input = await asyncio.get_event_loop().run_in_executor(
+                user_input = await asyncio.get_running_loop().run_in_executor(
                     None, input, "News> "
                 )
                 if user_input.lower() in ["quit", "exit", "q"]:


### PR DESCRIPTION
## Fixes #4625

Both `examples/templates/deep_research_agent/__main__.py` (line 190) and `examples/templates/tech_news_reporter/__main__.py` (line 188) call `asyncio.get_event_loop()` inside a running `async def` coroutine.

`get_event_loop()` is deprecated since Python 3.10 and emits `DeprecationWarning` on Python 3.12+. Since these are already inside a running async context, `get_running_loop()` is the correct call.

### Changes
- `deep_research_agent/__main__.py:190` — `get_event_loop()` → `get_running_loop()`
- `tech_news_reporter/__main__.py:188` — `get_event_loop()` → `get_running_loop()`

This bug was found and fixed by **Qwen3-14B** (4-bit quantized) running locally on an RTX 3090. ��