### PR TITLE
fix: remove duplicate CredentialStoreAdapter in credentials __all__

### DIFF
--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -92,8 +92,6 @@ __all__ = [
     "CredentialSpec",
     "CredentialStoreAdapter",
     "CredentialError",
-    # Credential store adapter (replaces deprecated CredentialManager)
-    "CredentialStoreAdapter",
     # Health check utilities
     "HealthCheckResult",
     "check_credential_health",


### PR DESCRIPTION
Fixes #4629. Removed duplicate CredentialStoreAdapter entry and stale CredentialManager comment from __all__ in tools/src/aden_tools/credentials/__init__.py. Found and fixed by Qwen3-14B running locally on an RTX 3090.