### PR TITLE
micro-fix: remove duplicate CredentialStoreAdapter in credentials __all__

### DIFF
--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -92,8 +92,6 @@ __all__ = [
     "CredentialSpec",
     "CredentialStoreAdapter",
     "CredentialError",
-    # Credential store adapter (replaces deprecated CredentialManager)
-    "CredentialStoreAdapter",
     # Health check utilities
     "HealthCheckResult",
     "check_credential_health",


### PR DESCRIPTION
Fixes #4629. Removes the duplicate CredentialStoreAdapter entry and its stale comment in __init__.py. No logic change.

Identified by Qwen3-14B.