### PR TITLE
fix(micro-fix): replace deprecated asyncio.get_event_loop with get_running_loop

### DIFF
--- a/examples/templates/deep_research_agent/__main__.py
+++ b/examples/templates/deep_research_agent/__main__.py
@@ -187,7 +187,7 @@ async def _interactive_shell(verbose=False):
     try:
         while True:
             try:
-                topic = await asyncio.get_event_loop().run_in_executor(
+                topic = await asyncio.get_running_loop().run_in_executor(
                     None, input, "Topic> "
                 )
                 if topic.lower() in ["quit", "exit", "q"]:

--- a/examples/templates/tech_news_reporter/__main__.py
+++ b/examples/templates/tech_news_reporter/__main__.py
@@ -185,7 +185,7 @@ async def _interactive_shell(verbose=False):
     try:
         while True:
             try:
-                user_input = await asyncio.get_event_loop().run_in_executor(
+                user_input = await asyncio.get_running_loop().run_in_executor(
                     None, input, "News> "
                 )
                 if user_input.lower() in ["quit", "exit", "q"]:


### PR DESCRIPTION
This PR addresses issue #4625. It is a micro-fix (< 20 lines, no logic changes) replacing deprecated asyncio calls. Linked issue: #4625