### PR TITLE
micro-fix(cli): remove incorrect project directory check in wrapper script

### DIFF
--- a/hive
+++ b/hive
@@ -21,19 +21,6 @@ while [ -L "$SOURCE" ]; do
 done
 SCRIPT_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-# Verify user is running from the hive project directory
-USER_CWD="$(pwd)"
-if [ "$USER_CWD" != "$SCRIPT_DIR" ]; then
-    echo "Error: hive must be run from the project directory." >&2
-    echo "" >&2
-    echo "  Current directory: $USER_CWD" >&2
-    echo "  Expected directory: $SCRIPT_DIR" >&2
-    echo "" >&2
-    echo "Run: cd $SCRIPT_DIR" >&2
-    exit 1
-fi
-
-cd "$SCRIPT_DIR"
 
 # Verify this is a valid Hive project directory
 if [ ! -f "$SCRIPT_DIR/pyproject.toml" ] || [ ! -d "$SCRIPT_DIR/core" ]; then


### PR DESCRIPTION
## Description

Fixes an onboarding issue where the installed `hive` CLI wrapper forces users to run the command from the script directory (`~/.local/bin`) instead of the actual Hive project root.

This caused `hive --help` to fail even when executed correctly from the repo folder after running `./quickstart.sh`.

The fix removes the incorrect directory check and allows the CLI to run properly from the project root.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #4691

## Testing

Manual testing performed:

- Verified `./hive --help` works from project root
- Confirmed previous error no longer appears
- Confirmed CLI commands execute normally

## Checklist

- [x] Manual testing performed
- [x] Self-review completed
