### PR TITLE
docs: add minimal run example and execution clarity to tech_news_reporter template

### DIFF
--- a/examples/templates/tech_news_reporter/README.md
+++ b/examples/templates/tech_news_reporter/README.md
@@ -5,6 +5,61 @@
 **Created**: 2026-02-06
 
 ## Overview
+## Who is this template for?
+## Example Usage
+## Expected Output
+## Who is this template for?
+
+This template is intended for developers who want to:
+- Learn how to build a multi-node Hive agent
+- See how web tools (search + scrape) are integrated into an agent workflow
+- Generate structured reports from real-time data
+
+It is especially useful for:
+- Backend engineers exploring AI agent architectures
+- Developers building automated research workflows
+- Product engineers experimenting with goal-driven AI systems
+
+
+## Example Usage
+
+From the Hive root directory:
+
+```bash
+hive run examples/templates/tech_news_reporter --input '{"topic": "AI startups"}'
+
+The agent will:
+
+1. Ask for topic clarification (optional)
+2. Research recent news articles
+3. Generate a structured HTML report
+4. Provide a downloadable link
+
+## Expected Output
+
+A structured HTML report including:
+
+- Article titles
+- Summaries
+- Sources
+- Organized sections by topic
+
+Save and exit.
+
+---
+
+# 🚀 Now Commit This Properly
+
+From the Hive root:
+
+```bash
+git checkout -b improve-template-readme
+git add examples/templates/tech_news_reporter/README.md
+git commit -m "docs: improve tech_news_reporter README with usage and audience clarification"
+git push origin improve-template-readme
+
+
+
 
 Research the latest technology and AI news from the web, summarize key stories, and produce a well-organized report for the user to read.
 

--- a/examples/templates/tech_news_reporter/README.md
+++ b/examples/templates/tech_news_reporter/README.md
@@ -164,6 +164,25 @@ The agent's entry node `intake` requires:
 
 Terminal nodes: `compile-report`
 
+## Minimal Run Example
+
+You can execute this template directly using the module entry point:
+
+```bash
+uv run python -m examples.templates.tech_news_reporter \
+  --topics "AI, Python" \
+  --output-format html
+
+What Happens
+
+The agent initializes using agent.json and config.py
+
+News sources are fetched and filtered by topic
+
+A structured report is generated
+
+Output is returned in the specified format (e.g., HTML)
+
 ## Version History
 
 - **1.0.0** (2026-02-06): Initial release


### PR DESCRIPTION
This PR improves the developer onboarding experience for the tech_news_reporter template by adding a minimal working run example.

Why

While the template structure is clear from the source files, new contributors may not immediately know:

How to execute the template via its module entry point

How configuration files (agent.json, config.py) are utilized during runtime

What output behavior to expect

What’s Added

A minimal execution command using the module entry pattern

A short explanation of runtime flow (agent initialization, topic filtering, report generation)

Clarification of expected output format

The goal is to reduce friction for contributors exploring Hive templates and make the execution path more discoverable without modifying any core logic.

No functional changes were introduced.