### PR TITLE
micro-fix(tools): add future annotations for Python 3.9 compatibility

### DIFF
--- a/tools/src/aden_tools/tools/csv_tool/csv_tool.py
+++ b/tools/src/aden_tools/tools/csv_tool/csv_tool.py
@@ -1,5 +1,7 @@
 """CSV Tool - Read and manipulate CSV files."""
 
+from __future__ import annotations
+
 import csv
 import os
 

--- a/tools/src/aden_tools/tools/excel_tool/excel_tool.py
+++ b/tools/src/aden_tools/tools/excel_tool/excel_tool.py
@@ -1,5 +1,7 @@
 """Excel Tool - Read and manipulate Excel files (.xlsx, .xlsm)."""
 
+from __future__ import annotations
+
 import os
 from datetime import datetime
 from typing import Any


### PR DESCRIPTION
## Summary

Adds missing `from __future__ import annotations` import to files using modern type hints.

## Changes
- Added import to `csv_tool.py` (line 3)
- Added import to `excel_tool.py` (line 3)

## Why
These files use Python 3.9+ type hint syntax (`list[str]`, `dict[str, ...]`) which requires this import for compatibility with Python 3.9-3.10.

## Type
Micro-fix (2 lines changed, no logic changes) - qualifies for submission without prior issue assignment per CONTRIBUTING.md