### PR TITLE
docs(readme): clarify prerequisites for Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ Hive is designed to be used with an AI coding assistant.
 
 ### Prerequisites
 
-1.  **[Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview)** OR **[Cursor](https://www.cursor.com/)** (Install one)
+1.  **[Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview)**, **[Cursor](https://www.cursor.com/)**, or **[Codex CLI](https://github.com/openai/codex)** (Install one)
 2.  Python 3.11+
-3.  Anthropic API Key
+3.  LLM API Key (e.g., Anthropic, OpenAI, Gemini)
 
 ### Start Guide
 
@@ -97,17 +97,25 @@ Hive is designed to be used with an AI coding assistant.
     cd hive
     ./quickstart.sh
     ```
+    *(Sets up the python environment and installs dependencies)*
     > **Windows Users:** Use WSL (Windows Subsystem for Linux) or Git Bash.
-3.  **Run**:
+3.  **Build the Agent**:
     ```bash
-    # If using Claude Code:
+    # If using Claude Code / Codex CLI:
     claude> /hive
 
     # If using Cursor (Agent Mode):
     cursor> /hive
     ```
+    This starts the **build workflow**, where the coding agent generates your agent graph based on your goals.
 
-    That's it! You are now running a Hive agent.
+4.  **Run the Agent**:
+    Once the agent is built, run it using the TUI or CLI:
+    ```bash
+    hive tui                       # Interactive dashboard
+    hive run exports/my_agent      # Run specific agent
+    ```
+
 ##  Coding Agent Support
 ### Codex CLI
 Hive includes native support for [OpenAI Codex CLI](https://github.com/openai/codex) (v0.101.0+).

--- a/README.md
+++ b/README.md
@@ -78,47 +78,36 @@ Use Hive when you need:
 
 ## Quick Start
 
+Hive is designed to be used with an AI coding assistant.
+
 ### Prerequisites
 
-- Python 3.11+ for agent development
-- Claude Code, Codex CLI, or Cursor for utilizing agent skills
+1.  **[Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview)** OR **[Cursor](https://www.cursor.com/)** (Install one)
+2.  Python 3.11+
+3.  Anthropic API Key
 
-> **Note for Windows Users:** It is strongly recommended to use **WSL (Windows Subsystem for Linux)** or **Git Bash** to run this framework. Some core automation scripts may not execute correctly in standard Command Prompt or PowerShell.
+### Start Guide
 
-### Installation
+**Do everything inside Claude Code or Cursor.**
 
-```bash
-# Clone the repository
-git clone https://github.com/adenhq/hive.git
-cd hive
+1.  **Open Terminal** within your tool (View → Terminal or `Ctrl+``).
+2.  **Clone & Setup**:
+    ```bash
+    git clone https://github.com/adenhq/hive.git
+    cd hive
+    ./quickstart.sh
+    ```
+    > **Windows Users:** Use WSL (Windows Subsystem for Linux) or Git Bash.
+3.  **Run**:
+    ```bash
+    # If using Claude Code:
+    claude> /hive
 
-# Run quickstart setup
-./quickstart.sh
-```
+    # If using Cursor (Agent Mode):
+    cursor> /hive
+    ```
 
-This sets up:
-
-- **framework** - Core agent runtime and graph executor (in `core/.venv`)
-- **aden_tools** - MCP tools for agent capabilities (in `tools/.venv`)
-- **credential store** - Encrypted API key storage (`~/.hive/credentials`)
-- **LLM provider** - Interactive default model configuration
-- All required Python dependencies with `uv`
-
-### Build Your First Agent
-
-```bash
-# Build an agent using Claude Code
-claude> /hive
-
-# Test your agent
-claude> /hive-debugger
-
-# (at separate terminal) Launch the interactive dashboard
-hive tui
-
-# Or run directly
-hive run exports/your_agent_name --input '{"key": "value"}'
-```
+    That's it! You are now running a Hive agent.
 ##  Coding Agent Support
 ### Codex CLI
 Hive includes native support for [OpenAI Codex CLI](https://github.com/openai/codex) (v0.101.0+).
@@ -129,6 +118,7 @@ Hive includes native support for [OpenAI Codex CLI](https://github.com/openai/co
 
 Example:
 ```
+# Using Codex CLI
 codex> use hive
 ```
 


### PR DESCRIPTION
## Description
This PR simplifies the `README.md` "Quick Start" section to focus exclusively on the **Claude Code** and **Cursor** workflows, as requested in #4396. It removes the CLI-based installation steps from the immediate quick start to reduce cognitive load and confusion for new users.

It also explicitly links the `claude>` and `cursor>` prompts to their respective tools to address #4723.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #4723
Fixes #4396

## Changes Made

- Rewrote "Quick Start" to be tool-centric (Claude Code / Cursor).
- Consolidated prerequisites list.
- Removed CLI installation steps from the primary Quick Start flow.
- Added "Windows Users" note to the new flow.

## Testing

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

Manual review of `README.md` to ensure clarity and correctness of the new flow.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A