### PR TITLE
micro-fix: import GraphExecutor to resolve NameError in Deep Research Agent

### DIFF
--- a/examples/templates/deep_research_agent/agent.py
+++ b/examples/templates/deep_research_agent/agent.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from framework.graph import EdgeSpec, EdgeCondition, Goal, SuccessCriterion, Constraint
 from framework.graph.edge import GraphSpec
-from framework.graph.executor import ExecutionResult
+from framework.graph.executor import ExecutionResult, GraphExecutor
 from framework.graph.checkpoint_config import CheckpointConfig
 from framework.llm import LiteLLMProvider
 from framework.runner.tool_registry import ToolRegistry


### PR DESCRIPTION
## Description
The Deep Research Agent was failing to load with `NameError: 'GraphExecutor' is not defined`. This PR adds the missing import for `GraphExecutor` from `framework.graph.executor`.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
Fixes https://github.com/adenhq/hive/issues/4768

## Changes Made
- Imported `GraphExecutor` from `framework.graph.executor` in `examples/templates/deep_research_agent/agent.py`

## Testing
- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed
Verified by successfully importing `DeepResearchAgent`:
`python -c "from examples.templates.deep_research_agent.agent import DeepResearchAgent"`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
## Screenshots (if applicable)
N/A