### PR TITLE
refactor: replace print statements with logger in client.py docstrings

### DIFF
--- a/core/framework/credentials/aden/client.py
+++ b/core/framework/credentials/aden/client.py
@@ -20,7 +20,7 @@ Usage:
     # Fetch a credential
     response = client.get_credential("hubspot")
     if response:
-        print(f"Token expires at: {response.expires_at}")
+        logger.debug(f"Token expires at: {response.expires_at}")
 
     # Request a refresh
     refreshed = client.request_refresh("hubspot")
@@ -227,7 +227,7 @@ class AdenCredentialClient:
         # List all integrations
         integrations = client.list_integrations()
         for info in integrations:
-            print(f"{info.integration_id}: {info.status}")
+            logger.debug(f"{info.integration_id}: {info.status}")
 
         # Clean up
         client.close()


### PR DESCRIPTION
This PR addresses issue #4783 by replacing `print()` statements with `logger.debug()` calls for consistency with the rest of the codebase.

**Changes:**
- Line 23: Replaced `print(f"Token expires at: {response.expires_at}")` with `logger.debug(f"Token expires at: {response.expires_at}")`
- Line 230: Replaced `print(f"{info.integration_id}: {info.status}")` with `logger.debug(f"{info.integration_id}: {info.status}")`

**Why This Matters:**
- Print statements don't respect log levels
- Can't be filtered/configured like proper logging
- Inconsistent with project conventions

Fixes #4783