### PR TITLE
Move test_output_cleaner_live.py to core/tests

### DIFF
--- a/core/tests/test_output_cleaner_live.py
+++ b/core/tests/test_output_cleaner_live.py
@@ -7,9 +7,9 @@ Demonstrates how OutputCleaner fixes the JSON parsing trap using llama-3.3-70b.
 import json
 import os
 
-from framework.graph.node import NodeSpec
-from framework.graph.output_cleaner import CleansingConfig, OutputCleaner
-from framework.llm.litellm import LiteLLMProvider
+from core.framework.graph.node import NodeSpec
+from core.framework.graph.output_cleaner import CleansingConfig, OutputCleaner
+from core.framework.llm.litellm import LiteLLMProvider
 
 
 def test_cleaning_with_cerebras():


### PR DESCRIPTION
## Description

This PR moves a test file from the production code directory into the
appropriate core/tests directory to align with standard Python project structure.

No functional code changes are introduced.

Fixes #4786

