### PR TITLE
Handle missing paths in grep_search

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/grep_search/grep_search.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/grep_search/grep_search.py
@@ -49,6 +49,9 @@ def register_tools(mcp: FastMCP) -> None:
 
             matches = []
 
+            if not os.path.exists(secure_path):
+                raise FileNotFoundError
+
             if os.path.isfile(secure_path):
                 files = [secure_path]
             elif recursive:

--- a/tools/tests/tools/test_file_system_toolkits.py
+++ b/tools/tests/tools/test_file_system_toolkits.py
@@ -470,6 +470,17 @@ class TestGrepSearchTool:
         assert result["total_matches"] == 0
         assert result["matches"] == []
 
+    def test_grep_search_nonexistent_path(
+        self, grep_search_fn, mock_workspace, mock_secure_path
+    ):
+        """Searching a nonexistent path returns error."""
+        result = grep_search_fn(
+            path="missing_dir", pattern="pattern", recursive=True, **mock_workspace
+        )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
     def test_grep_search_directory_non_recursive(
         self, grep_search_fn, mock_workspace, mock_secure_path, tmp_path
     ):


### PR DESCRIPTION
## Summary
- Return a clear not-found error when grep_search is given a missing path
- Add coverage for missing-path searches

## Testing
- make check (fails: ruff not installed)
- make test (fails: uv not installed)