### PR TITLE
fix: replace print statements with logger in credentials/aden/client.py

### DIFF
--- a/core/framework/credentials/aden/client.py
+++ b/core/framework/credentials/aden/client.py
@@ -20,7 +20,7 @@ Usage:
     # Fetch a credential
     response = client.get_credential("hubspot")
     if response:
-        print(f"Token expires at: {response.expires_at}")
+        logger.info(f"Token expires at: {response.expires_at}")
 
     # Request a refresh
     refreshed = client.request_refresh("hubspot")
@@ -227,7 +227,7 @@ class AdenCredentialClient:
         # List all integrations
         integrations = client.list_integrations()
         for info in integrations:
-            print(f"{info.integration_id}: {info.status}")
+            logger.info(f"{info.integration_id}: {info.status}")
 
         # Clean up
         client.close()


### PR DESCRIPTION
Fixes #4783

## Summary
Replaced `print()` statements with `logger.info()` in docstring examples for consistency with project logging conventions.

## Changes
- Line 23: Changed `print(f"Token expires at: {response.expires_at}")` to `logger.info(...)`
- Line 230: Changed `print(f"{info.integration_id}: {info.status}")` to `logger.info(...)`

## Why This Matters
- Print statements don't respect log levels
- Can't be filtered/configured like proper logging
- Inconsistent with project conventions
- These are in docstring examples that users may copy

## Testing
- Verified changes are in docstring examples only
- No functional code changes
- Maintains same information output with proper logging