### PR TITLE
docs: add inline comments explaining manual_agent.py demo

### DIFF
--- a/core/examples/manual_agent.py
+++ b/core/examples/manual_agent.py
@@ -8,6 +8,11 @@ It uses 'function' nodes to define logic in pure Python, making it perfect
 for understanding the core runtime loop:
 Setup -> Graph definition -> Execution -> Result
 
+What this demo does:
+    Constructs a two-node graph (greeter -> uppercaser), feeds in a hard-coded
+    name, and prints the uppercased greeting.  No LLM calls are involved;
+    every node is a plain Python function.
+
 Run with:
     uv run python core/examples/manual_agent.py
 """
@@ -20,6 +25,9 @@ from framework.runtime.core import Runtime
 
 
 # 1. Define Node Logic (Pure Python Functions)
+# "greeter" node — takes a name string and returns a greeting.
+# "uppercaser" node — takes that greeting and returns it in uppercase.
+# Together they form a simple pipeline: name -> greeting -> GREETING.
 def greet(name: str) -> str:
     """Generate a simple greeting."""
     return f"Hello, {name}!"
@@ -104,6 +112,11 @@ async def main():
     executor.register_function("uppercaser", uppercase)
 
     # 8. Execute Agent
+    # Input is hard-coded here because this is a self-contained demo whose
+    # purpose is to illustrate the runtime flow, not to be a production tool.
+    # For dynamic input, replace the dict below with e.g.:
+    #     import sys
+    #     input_data = {"name": sys.argv[1] if len(sys.argv) > 1 else "Alice"}
     print("▶ Executing agent with input: name='Alice'...")
 
     result = await executor.execute(graph=graph, goal=goal, input_data={"name": "Alice"})


### PR DESCRIPTION
## Summary
- Adds concise inline comments to `core/examples/manual_agent.py` explaining the demo's purpose, how the greeter/uppercaser nodes work, why input is hard-coded, and how to switch to dynamic input (e.g. `sys.argv`).
- No functional code was changed — comments only.

Closes #3931

🤖 Generated with [Claude Code](https://claude.com/claude-code)