### PR TITLE
Fixed grep_search to return error for missing paths

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/grep_search/grep_search.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/grep_search/grep_search.py
@@ -44,6 +44,8 @@ def register_tools(mcp: FastMCP) -> None:
 
         try:
             secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+            if not os.path.exists(secure_path):
+                return {"error": f"Directory or file not found: {path}"}
             # Use session dir root for relative path calculations
             session_root = os.path.join(WORKSPACES_DIR, workspace_id, agent_id, session_id)
 

--- a/tools/tests/tools/test_file_system_toolkits.py
+++ b/tools/tests/tools/test_file_system_toolkits.py
@@ -533,6 +533,17 @@ class TestGrepSearchTool:
         assert result["success"] is True
         assert result["total_matches"] == 2  # Line 1 and Line 3
 
+    def test_grep_search_nonexistent_path(
+        self, grep_search_fn, mock_workspace, mock_secure_path
+    ):
+        """Searching a non-existent path returns an error."""
+        result = grep_search_fn(
+            path="nonexistent_path", pattern="anything", **mock_workspace
+        )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
 
 class TestExecuteCommandTool:
     """Tests for execute_command_tool."""


### PR DESCRIPTION
## Description
- The issue is that when the grep_search tool is given a directory or file path that does not exist, it fails silently.
Current Behavior: If you search for a string in a non-existent folder, the tool returns "Success" but shows 0 matches.
- Expected Behavior: The tool should recognize that the path is invalid and return an explicit error message (e.g., "Path not found") so the agent using the tool knows it made a mistake.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related Issues

Fixes #4807

## Changes Made

- Change 1: Added 
test_grep_search_nonexistent_path to  test_file_system_toolkit.py  --  verifies that a missing path returns {"error": "...not found..."}.
- Change 2 : Added an explicit os.path.exists() check after get_secure_path() resolves the sandbox path. This ensures a missing path always returns an error, regardless of the  recursive flag.

## Testing

All 7 grep_search tests passed on Python 3.11.14, including the new test_grep_search_nonexistent_path:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

<img width="725" height="389" alt="image" src="https://github.com/user-attachments/assets/729bb9c6-1e64-4082-984c-5afd25841012" />

