### PR TITLE
feat(apollo): replace hardcoded error checks with centralized handler

### DIFF
--- a/tools/src/aden_tools/utils/__init__.py
+++ b/tools/src/aden_tools/utils/__init__.py
@@ -2,6 +2,7 @@
 Utility functions for Aden Tools.
 """
 
+from .api_handler import handle_api_response
 from .env_helpers import get_env_var
 
-__all__ = ["get_env_var"]
+__all__ = ["get_env_var", "handle_api_response"]

--- a/tools/src/aden_tools/utils/api_handler.py
+++ b/tools/src/aden_tools/utils/api_handler.py
@@ -1,0 +1,56 @@
+from typing import Any
+import httpx
+
+
+def handle_api_response(
+    response: httpx.Response,
+    service_name: str = "API",
+    error_map: dict[int, str | dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """
+    Handle API response and map HTTP errors to human-readable messages.
+
+    Args:
+        response: The HTTP response object.
+        service_name: Name of the service (e.g., "Apollo").
+        error_map: Optional dictionary mapping status codes to error messages or dicts.
+            - If value is str: returns {"error": value}
+            - If value is dict: returns the dict as-is (useful for keys like "help")
+
+    Returns:
+        Dict returning either the JSON response (success) or an error dict.
+    """
+    if response.is_success:
+        return response.json()
+
+    status_code = response.status_code
+
+    # 1. Check custom error map specifically passed for this tool
+    if error_map and status_code in error_map:
+        mapping = error_map[status_code]
+        if isinstance(mapping, str):
+            return {"error": mapping}
+        return mapping
+
+    # 2. Extract error details from response body if possible
+    try:
+        data = response.json()
+        # Apollo specifically uses "error" key often, but sometimes just text
+        detail = data.get("error", data.get("message", response.text))
+    except Exception:
+        detail = response.text
+
+    # 3. Handle common status codes with generic messages if not overridden
+    if status_code == 401:
+        return {"error": f"Invalid {service_name} API key or unauthorized access."}
+    if status_code == 403:
+        return {"error": f"Access denied by {service_name} (Forbidden)."}
+    if status_code == 404:
+        return {"error": f"Resource not found in {service_name}."}
+    if status_code == 422:
+        return {"error": f"Invalid parameters sent to {service_name}: {detail}"}
+    if status_code == 429:
+        return {"error": f"{service_name} rate limit exceeded. Please retry later."}
+
+    # 4. Generic catch-all
+    return {"error": f"{service_name} error (HTTP {status_code}): {detail}"}

--- a/tools/tests/tools/test_apollo_tool.py
+++ b/tools/tests/tools/test_apollo_tool.py
@@ -47,13 +47,14 @@ class TestApolloClient:
         [
             (401, "Invalid Apollo API key"),
             (403, "Insufficient credits"),
-            (404, "not found"),
+            (404, "Resource not found in Apollo"),
             (422, "Invalid parameters"),
-            (429, "rate limit"),
+            (429, "Apollo rate limit exceeded"),
         ],
     )
     def test_handle_response_errors(self, status_code, expected_substring):
         response = MagicMock()
+        response.is_success = False
         response.status_code = status_code
         response.json.return_value = {"error": "Test error"}
         response.text = "Test error"
@@ -63,11 +64,13 @@ class TestApolloClient:
 
     def test_handle_response_generic_error(self):
         response = MagicMock()
+        response.is_success = False
         response.status_code = 500
         response.json.return_value = {"error": "Internal Server Error"}
         result = self.client._handle_response(response)
         assert "error" in result
         assert "500" in result["error"]
+        assert "Internal Server Error" in result["error"]
 
     @patch("aden_tools.tools.apollo_tool.apollo_tool.httpx.post")
     def test_enrich_person_by_email(self, mock_post):


### PR DESCRIPTION
## Description

This PR introduces a centralized error handling mechanism for external API tools to improve consistency and user experience.

1.  **Centralized Handler**: Created [aden_tools/utils/api_handler.py](cci:7://file:///Users/nd/Developer/hive/tools/src/aden_tools/utils/api_handler.py:0:0-0:0) to handle common HTTP errors (401, 403, 404, 429, 500) with clear, human-readable messages.
2.  **Apollo Tool Refactor**: Refactored [apollo_tool.py](cci:7://file:///Users/nd/Developer/hive/tools/tests/tools/test_apollo_tool.py:0:0-0:0) to use this new handler as a Proof of Concept (PoC).
3.  **Custom Logic Preservation**: Demonstrated how to keep service-specific error logic (e.g., Apollo's 403 "Insufficient credits") while delegating standard errors to the handler.
This implementation serves as a pattern that can be applied to other tools in future PRs.
## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [x] Refactoring (no functional changes - logic remains same but cleaner)
## Related Issues

This PR addresses the lack of detailed error context in external tool integrations.
**Fixes #4735**

## Changes Made
- Created [tools/src/aden_tools/utils/api_handler.py](cci:7://file:///Users/nd/Developer/hive/tools/src/aden_tools/utils/api_handler.py:0:0-0:0) with [handle_api_response](cci:1://file:///Users/nd/Developer/hive/tools/src/aden_tools/utils/api_handler.py:4:0-55:76) function.
- Exported [handle_api_response](cci:1://file:///Users/nd/Developer/hive/tools/src/aden_tools/utils/api_handler.py:4:0-55:76) in [tools/src/aden_tools/utils/__init__.py](cci:7://file:///Users/nd/Developer/hive/tools/src/aden_tools/utils/__init__.py:0:0-0:0).
- Refactored [_handle_response](cci:1://file:///Users/nd/Developer/hive/tools/src/aden_tools/tools/apollo_tool/apollo_tool.py:46:4-55:95) in [tools/src/aden_tools/tools/apollo_tool/apollo_tool.py](cci:7://file:///Users/nd/Developer/hive/tools/src/aden_tools/tools/apollo_tool/apollo_tool.py:0:0-0:0) to remove duplicate code.
- Updated unit tests in [tools/tests/tools/test_apollo_tool.py](cci:7://file:///Users/nd/Developer/hive/tools/tests/tools/test_apollo_tool.py:0:0-0:0) to verify both generic and specific error messages.
## Testing
Describe the tests you ran to verify your changes:
- [x] Unit tests pass (`uv run pytest tools/tests/tools/test_apollo_tool.py`)
- [x] Manual verification of error mappings.
## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A for now)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
