### PR TITLE
fix(safe-eval): cap exponentiation to prevent DoS via unbounded pow

### DIFF
--- a/core/tests/test_safe_eval_pow_limit.py
+++ b/core/tests/test_safe_eval_pow_limit.py
@@ -1,0 +1,60 @@
+"""make sure safe_eval caps exponentiation so nobody can DoS us
+with something like 2**2**2**2**2**2
+"""
+
+import pytest
+
+from framework.graph.safe_eval import _MAX_EXPONENT, _MAX_POW_BASE, safe_eval
+
+
+class TestSafePowLimits:
+    """check that pow is bounded in the expression sandbox"""
+
+    def test_small_exponent_allowed(self):
+        assert safe_eval("2 ** 10") == 1024
+
+    def test_negative_base_allowed(self):
+        assert safe_eval("(-2) ** 3") == -8
+
+    def test_float_exponent_allowed(self):
+        result = safe_eval("4.0 ** 0.5")
+        assert result == pytest.approx(2.0)
+
+    def test_zero_exponent(self):
+        assert safe_eval("999 ** 0") == 1
+
+    def test_exponent_at_limit(self):
+        # 1 ** anything is just 1 so this is fine perf-wise
+        assert safe_eval(f"1 ** {_MAX_EXPONENT}") == 1
+
+    def test_exponent_exceeds_limit_raises(self):
+        with pytest.raises(ValueError, match="exceeds maximum allowed value"):
+            safe_eval(f"2 ** {_MAX_EXPONENT + 1}")
+
+    def test_large_negative_exponent_rejected(self):
+        with pytest.raises(ValueError, match="exceeds maximum allowed value"):
+            safe_eval(f"2 ** (-{_MAX_EXPONENT + 1})")
+
+    def test_large_base_with_large_exponent_rejected(self):
+        with pytest.raises(ValueError, match="unreasonably large result"):
+            safe_eval(f"{_MAX_POW_BASE + 1} ** 3")
+
+    def test_large_base_with_small_exponent_allowed(self):
+        # base > limit but exp <= 2 is still fine
+        result = safe_eval(f"{_MAX_POW_BASE + 1} ** 2")
+        assert result == (_MAX_POW_BASE + 1) ** 2
+
+    def test_nested_pow_tower_rejected(self):
+        # 2**2**2**2**2**2 right-associates into something ridiculous
+        with pytest.raises(ValueError):
+            safe_eval("2 ** 2 ** 2 ** 2 ** 2 ** 2")
+
+    def test_pow_in_expression_context(self):
+        assert safe_eval("1 + 2 ** 3") == 9
+
+    def test_variable_exponent_within_bounds(self):
+        assert safe_eval("base ** exp", {"base": 2, "exp": 8}) == 256
+
+    def test_variable_exponent_exceeding_bounds(self):
+        with pytest.raises(ValueError, match="exceeds maximum allowed value"):
+            safe_eval("base ** exp", {"base": 2, "exp": _MAX_EXPONENT + 1})


### PR DESCRIPTION
## Description

`safe_eval` passes `operator.pow` straight through which means someone can put `10**10**10` in a condition expression and the worker will sit there until it OOMs. Swapped `operator.pow` for a wrapper (`_safe_pow`) that caps the exponent at 1000 and the base at 10k. Anything over that raises `ValueError`. The limits are module-level constants so they're easy to change if someone has a legit reason to raise them.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #4840

## Changes Made

- Added `_MAX_EXPONENT = 1000` and `_MAX_POW_BASE = 10_000` constants
- Added `_safe_pow(base, exp)` wrapper that enforces limits before delegating to `operator.pow`
- Wired `_safe_pow` into the `SAFE_OPERATORS` dict at `ast.Pow`

## Testing

13 tests covering boundary values, nested pow towers, negative exponents, variable-based exponents, and expressions using pow in context.

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
