### PR TITLE
fix(storage): add retry with dead-letter logging to _flush_batch

### DIFF
--- a/core/tests/test_flush_batch_retry.py
+++ b/core/tests/test_flush_batch_retry.py
@@ -1,0 +1,98 @@
+"""flush_batch used to silently drop writes on failure which was
+fun to debug.  these tests make sure it retries and logs.
+"""
+
+import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from framework.storage.concurrent import ConcurrentStorage
+
+
+def _storage(tmp_path: Path) -> ConcurrentStorage:
+    return ConcurrentStorage(tmp_path, cache_ttl=60.0, batch_interval=0.1)
+
+
+class _FakeRun:
+    """just needs an .id"""
+
+    def __init__(self, rid: str):
+        self.id = rid
+
+
+class TestFlushBatchRetry:
+    @pytest.mark.asyncio
+    async def test_successful_flush_no_retry(self, tmp_path: Path):
+        storage = _storage(tmp_path)
+        run = _FakeRun("run_1")
+
+        with patch.object(storage, "_save_run_locked", new_callable=AsyncMock) as mock_save:
+            await storage._flush_batch([("run", run)])
+            mock_save.assert_awaited_once_with(run)
+            assert f"run:{run.id}" in storage._cache
+
+    @pytest.mark.asyncio
+    async def test_transient_failure_retried(self, tmp_path: Path):
+        storage = _storage(tmp_path)
+        run = _FakeRun("run_2")
+
+        calls = 0
+
+        async def flaky_save(item):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise OSError("disk full (transient)")
+
+        with patch.object(storage, "_save_run_locked", side_effect=flaky_save):
+            await storage._flush_batch([("run", run)], _max_retries=2)
+
+        assert calls == 2
+        assert f"run:{run.id}" in storage._cache
+
+    @pytest.mark.asyncio
+    async def test_permanent_failure_logged(self, tmp_path: Path, caplog):
+        """if it fails all retries we should at least log the data"""
+        storage = _storage(tmp_path)
+        run = _FakeRun("run_3")
+
+        async def always_fail(item):
+            raise OSError("permanent disk failure")
+
+        with (
+            patch.object(storage, "_save_run_locked", side_effect=always_fail),
+            caplog.at_level(logging.ERROR),
+        ):
+            await storage._flush_batch([("run", run)], _max_retries=2)
+
+        assert f"run:{run.id}" not in storage._cache
+        assert any("DATA DROPPED" in r.message for r in caplog.records)
+        assert any("run_3" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_mixed_batch_only_failed_retried(self, tmp_path: Path):
+        storage = _storage(tmp_path)
+        good = _FakeRun("good")
+        bad = _FakeRun("bad")
+
+        save_count: dict[str, int] = {"good": 0, "bad": 0}
+
+        async def selective_save(item):
+            save_count[item.id] += 1
+            if item.id == "bad" and save_count["bad"] < 2:
+                raise OSError("transient")
+
+        with patch.object(storage, "_save_run_locked", side_effect=selective_save):
+            await storage._flush_batch([("run", good), ("run", bad)], _max_retries=2)
+
+        assert save_count["good"] == 1  # no unnecessary retry
+        assert save_count["bad"] == 2
+        assert "run:good" in storage._cache
+        assert "run:bad" in storage._cache
+
+    @pytest.mark.asyncio
+    async def test_empty_batch_is_noop(self, tmp_path: Path):
+        storage = _storage(tmp_path)
+        await storage._flush_batch([])  # should just return


### PR DESCRIPTION
## Description

`_flush_batch` was doing a bare try/except and just moving on when a write failed â€” transient storage hiccups silently dropped data with no trace. Now it retries up to 2 times with a short backoff. If it still fails after that, the item gets logged at ERROR with the full payload and a `DATA DROPPED` marker so you can at least grep for it and recover manually.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #4842

## Changes Made

- Added retry loop (up to 2 retries) with `asyncio.sleep(0.1 * attempt)` backoff
- Failed items collected and retried; only permanently failed items are logged
- Permanent failures logged at ERROR with `DATA DROPPED` marker and `%r` payload
- Cache only updated on successful writes

## Testing

5 tests covering transient failures that succeed on retry, permanent failures that log correctly, mixed batches where only failed items retry, empty batches.

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
