### PR TITLE
fix(executor): BFS-based convergence detection for multi-hop graphs

### DIFF
--- a/core/tests/test_convergence_bfs.py
+++ b/core/tests/test_convergence_bfs.py
@@ -1,0 +1,124 @@
+"""the old convergence finder only looked at immediate successors
+which broke on any non-trivial parallel fork.  now it does BFS.
+"""
+
+from types import SimpleNamespace
+
+from framework.graph.edge import EdgeCondition, EdgeSpec, GraphSpec
+from framework.graph.executor import GraphExecutor
+
+
+def _node(nid: str) -> SimpleNamespace:
+    return SimpleNamespace(id=nid)
+
+
+def _edge(src: str, tgt: str) -> EdgeSpec:
+    return EdgeSpec(
+        id=f"{src}->{tgt}",
+        source=src,
+        target=tgt,
+        condition=EdgeCondition.ALWAYS,
+    )
+
+
+def _ex() -> GraphExecutor:
+    return object.__new__(GraphExecutor)
+
+
+class TestFindConvergenceNodeBFS:
+    def test_immediate_convergence(self):
+        # A->C, B->C => C
+        g = GraphSpec(
+            id="g",
+            goal_id="g",
+            entry_node="start",
+            nodes=[_node("A"), _node("B"), _node("C")],
+            edges=[_edge("A", "C"), _edge("B", "C")],
+        )
+        assert _ex()._find_convergence_node(g, ["A", "B"]) == "C"
+
+    def test_multi_hop_convergence(self):
+        # A->X->C, B->C   should still find C
+        g = GraphSpec(
+            id="g",
+            goal_id="g",
+            entry_node="start",
+            nodes=[_node(n) for n in ["A", "B", "X", "C"]],
+            edges=[_edge("A", "X"), _edge("X", "C"), _edge("B", "C")],
+        )
+        assert _ex()._find_convergence_node(g, ["A", "B"]) == "C"
+
+    def test_deep_convergence(self):
+        g = GraphSpec(
+            id="g",
+            goal_id="g",
+            entry_node="start",
+            nodes=[_node(n) for n in ["A", "B", "X", "Y", "Z", "P"]],
+            edges=[
+                _edge("A", "X"),
+                _edge("X", "Y"),
+                _edge("Y", "Z"),
+                _edge("B", "P"),
+                _edge("P", "Z"),
+            ],
+        )
+        assert _ex()._find_convergence_node(g, ["A", "B"]) == "Z"
+
+    def test_no_convergence(self):
+        g = GraphSpec(
+            id="g",
+            goal_id="g",
+            entry_node="start",
+            nodes=[_node("A"), _node("B"), _node("X"), _node("Y")],
+            edges=[_edge("A", "X"), _edge("B", "Y")],
+        )
+        result = _ex()._find_convergence_node(g, ["A", "B"])
+        assert result in ("X", "Y") or result is None
+
+    def test_empty_targets(self):
+        g = GraphSpec(
+            id="g",
+            goal_id="g",
+            entry_node="start",
+            nodes=[],
+            edges=[],
+        )
+        assert _ex()._find_convergence_node(g, []) is None
+
+    def test_single_branch(self):
+        g = GraphSpec(
+            id="g",
+            goal_id="g",
+            entry_node="start",
+            nodes=[_node("A"), _node("B")],
+            edges=[_edge("A", "B")],
+        )
+        result = _ex()._find_convergence_node(g, ["A"])
+        assert result in ("B", None)
+
+    def test_diamond(self):
+        # classic diamond pattern
+        g = GraphSpec(
+            id="g",
+            goal_id="g",
+            entry_node="S",
+            nodes=[_node(n) for n in ["S", "A", "B", "C"]],
+            edges=[_edge("S", "A"), _edge("S", "B"), _edge("A", "C"), _edge("B", "C")],
+        )
+        assert _ex()._find_convergence_node(g, ["A", "B"]) == "C"
+
+    def test_nearest_convergence_preferred(self):
+        # A->X->M->Z, B->M->Z  -- M is closer so pick that
+        g = GraphSpec(
+            id="g",
+            goal_id="g",
+            entry_node="start",
+            nodes=[_node(n) for n in ["A", "B", "X", "M", "Z"]],
+            edges=[
+                _edge("A", "X"),
+                _edge("X", "M"),
+                _edge("M", "Z"),
+                _edge("B", "M"),
+            ],
+        )
+        assert _ex()._find_convergence_node(g, ["A", "B"]) == "M"


### PR DESCRIPTION
## Description

`_find_convergence_node` only looked at immediate successors of each parallel branch, so it couldn't find convergence points that were multiple hops away (e.g., A->X->C and B->C â€” it wouldn't realize C is reachable from A). Rewrote it to do a proper BFS from each branch start, collect the full reachable set, intersect them, and return the nearest common node by BFS order. Falls back to the most commonly reachable node via Counter if there's no full intersection.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #4847

## Changes Made

- Added inner `_reachable_bfs(start)` helper for BFS traversal
- Rewrote `_find_convergence_node` to intersect reachable sets from all branches
- Picks nearest convergence point by BFS discovery order for determinism
- Falls back to `Counter` most-common when no full intersection exists

## Testing

8 tests covering immediate convergence, multi-hop, deep chains, no convergence, empty targets, single branch, diamond patterns, and nearest-first ordering.

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
