### PR TITLE
fix: guard resend import to prevent tool registration crash

### DIFF
--- a/tools/src/aden_tools/tools/email_tool/email_tool.py
+++ b/tools/src/aden_tools/tools/email_tool/email_tool.py
@@ -12,7 +12,6 @@ import os
 from typing import TYPE_CHECKING, Literal
 
 import httpx
-import resend
 from fastmcp import FastMCP
 
 if TYPE_CHECKING:
@@ -35,6 +34,15 @@ def register_tools(
         bcc: list[str] | None = None,
     ) -> dict:
         """Send email using Resend API."""
+        try:
+            import resend
+        except ImportError:
+            return {
+                "error": (
+                    "resend not installed. Install with: "
+                    "pip install resend  or  pip install tools[email]"
+                )
+            }
         resend.api_key = api_key
         try:
             payload: dict = {


### PR DESCRIPTION
## Summary
- Moves `import resend` from module-level to inside `_send_via_resend()` with a `try/except ImportError` guard
- Prevents `ModuleNotFoundError` from crashing all MCP tool registration when `resend` is not installed
- Follows the existing lazy-import pattern used by `excel_tool.py`, `csv_tool.py`, and `bigquery_tool.py`

Fixes #4816

## Test plan
- Start agent without `resend` installed → all other tools should register successfully
- Start agent with `resend` installed → email tool should work as before
- Call email tool without `resend` → should return helpful error dict instead of crash