### PR TITLE
docs(readme): clarify uv workspace setup and prevent root pip install misuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ Use Hive when you need:
 
 ### Installation
 
+>**Note**
+> Hive uses a `uv` workspace layout and is not installed with `pip install`.
+> Running `pip install -e .` from the repository root will create a placeholder package and Hive will not function correctly.
+> Please use the quickstart script below to set up the environment.
+
 ```bash
 # Clone the repository
 git clone https://github.com/adenhq/hive.git


### PR DESCRIPTION
## Description
Adds a clarification in the Installation section explaining that Hive uses a `uv` workspace layout and should not be installed with `pip install -e .`.

Without this note, running pip from the repository root installs a placeholder package (`UNKNOWN 0.0.0`) which appears successful but results in a non-functional setup.
This improves onboarding and prevents incorrect environment setup.

## Type of Change
- [x] Documentation update

## Related Issues
N/A

## Changes Made
- Added installation note warning against using `pip install -e .`
- Clarified correct setup method using `./quickstart.sh`

## Testing
- [x] Manual review performed (documentation only change)

## Checklist
- [x] I have performed a self-review of my changes
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
