### PR TITLE
[Integration]: PostHog — Analytics-Driven Agent Automation

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -28,6 +28,8 @@ Some tools require API keys to function. Credentials are managed through the enc
 | `BRAVE_SEARCH_API_KEY` | `web_search` tool (Brave)     | [brave.com/search/api](https://brave.com/search/api/)   |
 | `GOOGLE_API_KEY`       | `web_search` tool (Google)    | [console.cloud.google.com](https://console.cloud.google.com/) |
 | `GOOGLE_CSE_ID`        | `web_search` tool (Google)    | [programmablesearchengine.google.com](https://programmablesearchengine.google.com/) |
+| `POSTHOG_API_KEY`     | `posthog` tools               | [posthog.com](https://posthog.com/) |
+| `POSTHOG_PROJECT_ID`  | `posthog` tools               | PostHog Project Settings |
 
 > **Note:** `web_search` supports multiple providers. Set either Brave OR Google credentials. Brave is preferred for backward compatibility.
 
@@ -76,6 +78,9 @@ python mcp_server.py
 | `web_scrape`           | Scrape and extract content from webpages       |
 | `pdf_read`             | Read and extract text from PDF files           |
 | `get_current_time`     | Get current date/time with timezone support    |
+| `posthog_query`        | Execute HogQL queries for analytics            |
+| `posthog_list_events`  | List recent raw events from PostHog            |
+| `posthog_list_cohorts` | List user cohorts from PostHog                |
 
 ## Project Structure
 

--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -74,6 +74,7 @@ from .shell_config import (
 from .slack import SLACK_CREDENTIALS
 from .store_adapter import CredentialStoreAdapter
 from .telegram import TELEGRAM_CREDENTIALS
+from .posthog import POSTHOG_CREDENTIALS
 
 # Merged registry of all credentials
 CREDENTIAL_SPECS = {
@@ -90,6 +91,7 @@ CREDENTIAL_SPECS = {
     **SERPAPI_CREDENTIALS,
     **TELEGRAM_CREDENTIALS,
     **BIGQUERY_CREDENTIALS,
+    **POSTHOG_CREDENTIALS,
 }
 
 __all__ = [
@@ -127,4 +129,5 @@ __all__ = [
     "SERPAPI_CREDENTIALS",
     "TELEGRAM_CREDENTIALS",
     "BIGQUERY_CREDENTIALS",
+    "POSTHOG_CREDENTIALS",
 ]

--- a/tools/src/aden_tools/credentials/posthog.py
+++ b/tools/src/aden_tools/credentials/posthog.py
@@ -1,0 +1,32 @@
+"""PostHog credential specification."""
+
+from __future__ import annotations
+
+from .base import CredentialSpec
+
+POSTHOG_CREDENTIALS = {
+    "posthog": CredentialSpec(
+        env_var="POSTHOG_API_KEY",
+        tools=[
+            "posthog_query",
+            "posthog_list_events",
+            "posthog_get_funnel_metrics",
+            "posthog_list_cohorts",
+        ],
+        required=True,
+        direct_api_key_supported=True,
+        api_key_instructions="Create a Personal API Key in your PostHog User Settings.",
+    ),
+    "posthog_project_id": CredentialSpec(
+        env_var="POSTHOG_PROJECT_ID",
+        required=True,
+        direct_api_key_supported=True,
+        api_key_instructions="The ID of your PostHog project (found in Project Settings).",
+    ),
+    "posthog_url": CredentialSpec(
+        env_var="POSTHOG_URL",
+        required=False,
+        direct_api_key_supported=True,
+        api_key_instructions="Optional: Custom PostHog API URL (defaults to https://app.posthog.com).",
+    ),
+}

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -50,6 +50,7 @@ from .news_tool import register_tools as register_news
 from .pdf_read_tool import register_tools as register_pdf_read
 from .runtime_logs_tool import register_tools as register_runtime_logs
 from .serpapi_tool import register_tools as register_serpapi
+from .posthog_tool import register_tools as register_posthog
 from .slack_tool import register_tools as register_slack
 from .telegram_tool import register_tools as register_telegram
 from .time_tool import register_tools as register_time
@@ -97,6 +98,7 @@ def register_all_tools(
     register_vision(mcp, credentials=credentials)
     register_google_maps(mcp, credentials=credentials)
     register_bigquery(mcp, credentials=credentials)
+    register_posthog(mcp, credentials=credentials)
 
     # Register file system toolkits
     register_view_file(mcp)
@@ -262,6 +264,10 @@ def register_all_tools(
         "maps_place_search",
         "run_bigquery_query",
         "describe_dataset",
+        "posthog_query",
+        "posthog_list_events",
+        "posthog_get_funnel_metrics",
+        "posthog_list_cohorts",
     ]
 
 

--- a/tools/src/aden_tools/tools/posthog_tool/README.md
+++ b/tools/src/aden_tools/tools/posthog_tool/README.md
@@ -1,0 +1,61 @@
+# PostHog Tool
+
+Analytics-driven agent automation. Allows agents to query product data, analyze funnels, and react to user behavior patterns.
+
+## Features
+- **HogQL Queries**: Execute powerful SQL-like queries directly against your PostHog data.
+- **Event Retrieval**: List recent events to monitor specific user actions.
+- **Funnel Analysis**: Retrieve metrics for existing funnel insights.
+- **Cohort Management**: Access user cohorts for targeted automation.
+- **Self-Hostable**: Supports both app.posthog.com and self-hosted instances.
+
+## Configuration
+
+Set the following environment variables or configure via the Hive Credential Store:
+
+- `POSTHOG_API_KEY`: Your Personal API Key (requires `query:read` and `project:read` scopes).
+- `POSTHOG_PROJECT_ID`: The ID of your PostHog project.
+- `POSTHOG_URL` (Optional): Custom base URL (e.g., `https://posthog.example.com`). Defaults to `https://app.posthog.com`.
+
+### Getting a Personal API Key
+1. Log in to PostHog.
+2. Go to **Settings** > **Personal API Keys**.
+3. Create a new key with appropriate permissions.
+
+## Available Tools
+
+### `posthog_query`
+Execute a HogQL query for advanced analytics.
+- `hogql` (str): The HogQL query string.
+- **Example**: `SELECT event, count() FROM events GROUP BY event`
+
+### `posthog_list_events`
+List recent raw events.
+- `limit` (int, default=100): Max events to return.
+- `event_name` (str, optional): Filter by event type (e.g., `$pageview`).
+
+### `posthog_get_funnel_metrics`
+Retrieve conversion metrics for a saved funnel insight.
+- `insight_id` (str): The ID of the saved insight.
+
+### `posthog_list_cohorts`
+List all user cohorts defined in the project.
+
+## Example Workflow
+
+### Funnel Drop-off Alert
+An agent monitors a conversion funnel and alerts Slack if the drop-off exceeds a threshold.
+```python
+funnel = posthog_get_funnel_metrics(insight_id="12345")
+conversion_rate = funnel['results'][0]['count'] / funnel['results'][1]['count']
+if conversion_rate < 0.2:
+    slack_send_message(channel="#growth", message="Conversion drop-off detected!")
+```
+
+### Behavioral Trigger
+Trigger a follow-up for users who signed up but didn't complete onboarding.
+```python
+query = "SELECT distinct_id FROM events WHERE event = 'signup' AND distinct_id NOT IN (SELECT distinct_id FROM events WHERE event = 'onboarding_complete')"
+users = posthog_query(hogql=query)
+# ... trigger outreach for users
+```

--- a/tools/src/aden_tools/tools/posthog_tool/__init__.py
+++ b/tools/src/aden_tools/tools/posthog_tool/__init__.py
@@ -1,0 +1,5 @@
+"""PostHog tool registration."""
+
+from .posthog_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/posthog_tool/posthog_tool.py
+++ b/tools/src/aden_tools/tools/posthog_tool/posthog_tool.py
@@ -1,0 +1,217 @@
+"""
+PostHog Tool - Analytics-driven agent automation.
+
+Supports:
+- HogQL queries (SQL for analytics)
+- Event retrieval
+- Funnel metrics
+- Cohort data
+- Targeted triggers based on user behavior
+
+API Reference: https://posthog.com/docs/api
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialStoreAdapter
+
+DEFAULT_POSTHOG_URL = "https://app.posthog.com"
+
+
+class _PostHogClient:
+    """Internal client wrapping PostHog API calls."""
+
+    def __init__(self, api_key: str, project_id: str, base_url: str | None = None):
+        self._api_key = api_key
+        self._project_id = project_id
+        self._base_url = (base_url or DEFAULT_POSTHOG_URL).rstrip("/")
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _handle_response(self, response: httpx.Response) -> dict[str, Any]:
+        """Handle common HTTP error codes."""
+        if response.status_code == 401:
+            return {"error": "Invalid or expired PostHog API key"}
+        if response.status_code == 403:
+            return {"error": "Insufficient permissions for this PostHog project"}
+        if response.status_code == 404:
+            return {"error": "PostHog resource not found"}
+        if response.status_code == 429:
+            return {"error": "PostHog rate limit exceeded"}
+        if response.status_code >= 400:
+            try:
+                detail = response.json()
+            except Exception:
+                detail = response.text
+            return {"error": f"PostHog API error (HTTP {response.status_code}): {detail}"}
+        
+        return response.json()
+
+    def query(self, hogql: str) -> dict[str, Any]:
+        """Execute a HogQL query."""
+        payload = {
+            "query": {
+                "kind": "HogQLQuery",
+                "query": hogql
+            }
+        }
+        response = httpx.post(
+            f"{self._base_url}/api/projects/{self._project_id}/query/",
+            headers=self._headers,
+            json=payload,
+            timeout=60.0,
+        )
+        return self._handle_response(response)
+
+    def list_events(self, limit: int = 100, event_name: str | None = None) -> dict[str, Any]:
+        """List raw events."""
+        params: dict[str, Any] = {"limit": min(limit, 1000)}
+        if event_name:
+            params["event"] = event_name
+
+        response = httpx.get(
+            f"{self._base_url}/api/projects/{self._project_id}/events/",
+            headers=self._headers,
+            params=params,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def list_cohorts(self) -> dict[str, Any]:
+        """List user cohorts."""
+        response = httpx.get(
+            f"{self._base_url}/api/projects/{self._project_id}/cohorts/",
+            headers=self._headers,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def get_insight(self, insight_id: int | str) -> dict[str, Any]:
+        """Retrieve insight metadata and data (useful for funnels)."""
+        response = httpx.get(
+            f"{self._base_url}/api/projects/{self._project_id}/insights/{insight_id}/",
+            headers=self._headers,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: CredentialStoreAdapter | None = None,
+) -> None:
+    """Register PostHog tools with the MCP server."""
+
+    def _get_credentials() -> tuple[str | None, str | None, str | None]:
+        """Get PostHog credentials from store or environment."""
+        if credentials is not None:
+            api_key = credentials.get("posthog")
+            project_id = credentials.get("posthog_project_id")
+            url = credentials.get("posthog_url")
+            return api_key, project_id, url
+        return os.getenv("POSTHOG_API_KEY"), os.getenv("POSTHOG_PROJECT_ID"), os.getenv("POSTHOG_URL")
+
+    def _get_client() -> _PostHogClient | dict[str, str]:
+        """Get initialized PostHog client or error."""
+        api_key, project_id, url = _get_credentials()
+        if not api_key:
+            return {
+                "error": "PostHog API key not configured",
+                "help": "Set POSTHOG_API_KEY environment variable.",
+            }
+        if not project_id:
+            return {
+                "error": "PostHog Project ID not configured",
+                "help": "Set POSTHOG_PROJECT_ID environment variable.",
+            }
+        return _PostHogClient(api_key, project_id, url)
+
+    @mcp.tool()
+    def posthog_query(hogql: str) -> dict[str, Any]:
+        """
+        Execute a HogQL (PostHog SQL) query for advanced analytics.
+        
+        Example: "SELECT event, count() FROM events WHERE timestamp > minus(now(), toIntervalDays(7)) GROUP BY event"
+
+        Args:
+            hogql: The HogQL query string.
+
+        Returns:
+            Dictionary containing columns and results.
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.query(hogql)
+        except httpx.TimeoutException:
+            return {"error": "PostHog query timed out"}
+        except Exception as e:
+            return {"error": f"PostHog API error: {str(e)}"}
+
+    @mcp.tool()
+    def posthog_list_events(limit: int = 100, event_name: str | None = None) -> dict[str, Any]:
+        """
+        List recent raw events from PostHog.
+
+        Args:
+            limit: Maximum number of events to return (default 100, max 1000).
+            event_name: Optional filter for a specific event type.
+
+        Returns:
+            List of events with their properties.
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_events(limit=limit, event_name=event_name)
+        except Exception as e:
+            return {"error": f"PostHog API error: {str(e)}"}
+
+    @mcp.tool()
+    def posthog_get_funnel_metrics(insight_id: str) -> dict[str, Any]:
+        """
+        Retrieve conversion metrics for a saved funnel insight.
+
+        Args:
+            insight_id: The ID or short ID of the saved funnel insight.
+
+        Returns:
+            Funnel steps, completion rates, and drop-off data.
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.get_insight(insight_id)
+        except Exception as e:
+            return {"error": f"PostHog API error: {str(e)}"}
+
+    @mcp.tool()
+    def posthog_list_cohorts() -> dict[str, Any]:
+        """
+        List all user cohorts defined in the project.
+
+        Returns:
+            List of cohorts with their definitions and sizes.
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_cohorts()
+        except Exception as e:
+            return {"error": f"PostHog API error: {str(e)}"}

--- a/tools/src/aden_tools/tools/posthog_tool/tests/test_posthog_tool.py
+++ b/tools/src/aden_tools/tools/posthog_tool/tests/test_posthog_tool.py
@@ -1,0 +1,125 @@
+"""Tests for PostHog tool."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from aden_tools.tools.posthog_tool.posthog_tool import (
+    DEFAULT_POSTHOG_URL,
+    _PostHogClient,
+    register_tools,
+)
+
+
+class TestPostHogClient:
+    def setup_method(self):
+        self.client = _PostHogClient("test-key", "test-project")
+
+    def test_headers(self):
+        headers = self.client._headers
+        assert headers["Authorization"] == "Bearer test-key"
+        assert headers["Content-Type"] == "application/json"
+
+    def test_handle_response_success(self):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"results": []}
+        assert self.client._handle_response(response) == {"results": []}
+
+    @pytest.mark.parametrize(
+        "status_code,expected_substring",
+        [
+            (401, "Invalid or expired"),
+            (403, "Insufficient permissions"),
+            (404, "not found"),
+            (429, "rate limit"),
+        ],
+    )
+    def test_handle_response_errors(self, status_code, expected_substring):
+        response = MagicMock()
+        response.status_code = status_code
+        result = self.client._handle_response(response)
+        assert "error" in result
+        assert expected_substring in result["error"]
+
+    @patch("aden_tools.tools.posthog_tool.posthog_tool.httpx.post")
+    def test_query(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"results": [["event1", 10]]}
+        mock_post.return_value = mock_response
+
+        hogql = "SELECT event, count() FROM events GROUP BY event"
+        result = self.client.query(hogql)
+
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        assert args[0] == f"{DEFAULT_POSTHOG_URL}/api/projects/test-project/query/"
+        assert kwargs["json"]["query"]["query"] == hogql
+        assert result["results"] == [["event1", 10]]
+
+    @patch("aden_tools.tools.posthog_tool.posthog_tool.httpx.get")
+    def test_list_events(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"results": []}
+        mock_get.return_value = mock_response
+
+        self.client.list_events(limit=50, event_name="pageview")
+
+        mock_get.assert_called_once_with(
+            f"{DEFAULT_POSTHOG_URL}/api/projects/test-project/events/",
+            headers=self.client._headers,
+            params={"limit": 50, "event": "pageview"},
+            timeout=30.0,
+        )
+
+
+class TestToolRegistration:
+    def test_register_tools_registers_all(self):
+        mcp = MagicMock()
+        mcp.tool.return_value = lambda fn: fn
+        register_tools(mcp)
+        assert mcp.tool.call_count == 4
+
+    def test_no_credentials_returns_error(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        with patch.dict("os.environ", {}, clear=True):
+            register_tools(mcp, credentials=None)
+
+        query_fn = next(fn for fn in registered_fns if fn.__name__ == "posthog_query")
+        result = query_fn(hogql="SELECT 1")
+        assert "error" in result
+        assert "not configured" in result["error"]
+
+    @patch("aden_tools.tools.posthog_tool.posthog_tool.httpx.post")
+    def test_credentials_from_store(self, mock_post):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        cred_store = MagicMock()
+        cred_store.get.side_effect = lambda key: {
+            "posthog": "store-key",
+            "posthog_project_id": "store-project"
+        }.get(key)
+        
+        register_tools(mcp, credentials=cred_store)
+        query_fn = next(fn for fn in registered_fns if fn.__name__ == "posthog_query")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"results": []}
+        mock_post.return_value = mock_response
+
+        query_fn(hogql="SELECT 1")
+
+        call_headers = mock_post.call_args.kwargs["headers"]
+        assert call_headers["Authorization"] == "Bearer store-key"
+        assert "/api/projects/store-project/" in mock_post.call_args.args[0]


### PR DESCRIPTION
## Summary
This PR implements native support for PostHog as an analytics-driven automation layer for Hive agents. It allows agents to perform advanced data analysis using HogQL, track events, monitor funnels, and access cohorts, resolving Issue #4833.

## Changes
- **PostHog Analytics Tool**: Implemented `posthog_tool` in `tools/src/aden_tools/tools/posthog_tool/`.
  - `posthog_query`: Runs custom HogQL queries for direct data access.
  - `posthog_list_events`: Retrieves recent raw events with project filtering.
  - `posthog_get_funnel_metrics`: Fetches conversion and drop-off data from saved funnel insights.
  - `posthog_list_cohorts`: Lists user cohorts for behavioral targeting.
- **Credential Support**: Added `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID`, and `POSTHOG_URL` for full flexibility, including self-hosted instances.
- **Standardized Client**: Implemented `_PostHogClient` using `httpx` with built-in error mapping and project context handling.
- **Unit Testing**: Added 11 unit tests covering query execution, event listing, credential store integration, and API error handling.
- **Documentation**: 
  - Created a detailed tool `README.md` with usage examples for funnel monitoring and behavioral triggers.
  - Updated the main tools `README.md` with PostHog's configuration details.

## Verification
- Ran unit tests: `pytest tools/src/aden_tools/tools/posthog_tool/tests/test_posthog_tool.py`
- **Result**: 11 passed in 1.39s.
- Verified tool registration and schema validation in the MCP server.

## Related Issues
Resolves #4833

---

_Pull request created with Google Antigravity_