### PR TITLE
feat(cli): Fix arrow key navigation in CLI agent selection menu micro-fix

### DIFF
--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -1431,6 +1431,10 @@ def _read_key() -> str:
                 return "RIGHT"
             elif ch3 == "D":  # Left arrow
                 return "LEFT"
+            elif ch3 == "A":  # Up arrow
+                return "UP"
+            elif ch3 == "B":  # Down arrow
+                return "DOWN"
     return ch
 
 
@@ -1510,6 +1514,10 @@ def _select_agent(agents_dir: Path) -> str | None:
                 print()  # Newline before redrawing
             elif key == "LEFT" and page > 0:
                 page -= 1
+                print()
+            elif key in ("UP", "DOWN"):
+                # UP/DOWN arrows are not used for navigation in this menu
+                # Just redraw without showing "Invalid input"
                 print()
             elif key == "q":
                 print()


### PR DESCRIPTION
## Description
Fixes #4877

The CLI agent selection menu suggested arrow key navigation but only LEFT/RIGHT arrows worked. UP/DOWN arrows were triggering "Invalid input" errors.

## Changes
- Updated `_read_key()` function to detect UP (`\x1b[A`) and DOWN (`\x1b[B`) arrow key escape sequences
- Added graceful handling in `_select_agent()` for UP/DOWN arrows (they now redraw the menu without error)
- LEFT/RIGHT arrow navigation for pages continues to work as intended

## Root Cause
The `_read_key()` function only handled LEFT and RIGHT arrow escape sequences. When users pressed UP or DOWN, the escape sequences were partially consumed but not recognized, falling through to the "Invalid input" message.

## Testing
- ✅ UP/DOWN arrows no longer show "Invalid input"
- ✅ LEFT/RIGHT arrows continue to work for page navigation
- ✅ Number input and other commands work as expected
- ✅ No errors in file

## Checklist
- [x] Code follows the project's style guidelines
- [x] Changes are backwards compatible
- [x] No breaking changes introduced

### Test Result

https://github.com/user-attachments/assets/8541b864-a726-4449-8157-0f9156b9d214