### PR TITLE
feat: [Integration] Pipedrive CRM Integration

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -84,6 +84,9 @@ python mcp_server.py
 | `calendar_delete_event`| Delete a calendar event                        |
 | `calendar_get_calendar`| Get calendar metadata                          |
 | `calendar_check_availability` | Check free/busy status for attendees    |
+| `pipedrive_create_person` | Create a new person in Pipedrive CRM    |
+| `pipedrive_search_person` | Search for a person in Pipedrive CRM    |
+| `pipedrive_create_deal` | Create a new deal in Pipedrive CRM      |
 
 ## Project Structure
 

--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -77,6 +77,7 @@ from .shell_config import (
 from .slack import SLACK_CREDENTIALS
 from .store_adapter import CredentialStoreAdapter
 from .telegram import TELEGRAM_CREDENTIALS
+from .pipedrive import PIPEDRIVE_CREDENTIALS
 
 # Merged registry of all credentials
 CREDENTIAL_SPECS = {
@@ -95,6 +96,7 @@ CREDENTIAL_SPECS = {
     **TELEGRAM_CREDENTIALS,
     **BIGQUERY_CREDENTIALS,
     **CALCOM_CREDENTIALS,
+    **PIPEDRIVE_CREDENTIALS,
 }
 
 __all__ = [
@@ -134,4 +136,5 @@ __all__ = [
     "TELEGRAM_CREDENTIALS",
     "BIGQUERY_CREDENTIALS",
     "CALCOM_CREDENTIALS",
+    "PIPEDRIVE_CREDENTIALS",
 ]

--- a/tools/src/aden_tools/credentials/pipedrive.py
+++ b/tools/src/aden_tools/credentials/pipedrive.py
@@ -1,0 +1,40 @@
+"""
+Pipedrive CRM tool credentials.
+
+Contains credentials for Pipedrive CRM integration.
+"""
+
+from .base import CredentialSpec
+
+PIPEDRIVE_CREDENTIALS = {
+    "pipedrive": CredentialSpec(
+        env_var="PIPEDRIVE_API_TOKEN",
+        tools=[
+            "pipedrive_create_person",
+            "pipedrive_search_person",
+            "pipedrive_get_person_details",
+            "pipedrive_create_deal",
+            "pipedrive_update_deal_stage",
+            "pipedrive_list_deals",
+            "pipedrive_add_note_to_deal",
+        ],
+        required=True,
+        startup_required=False,
+        help_url="https://pipedrive.readme.io/docs/how-to-find-the-api-token",
+        description="Pipedrive Personal API Token",
+        # Auth method support
+        aden_supported=True,
+        aden_provider_name="pipedrive",
+        direct_api_key_supported=True,
+        api_key_instructions="""To get a Pipedrive API token:
+1. Log in to your Pipedrive account.
+2. Go to Settings > Personal preferences > API.
+3. Find your personal API token and copy it.""",
+        # Health check configuration
+        health_check_endpoint="https://api.pipedrive.com/v1/users/me",
+        health_check_method="GET",
+        # Credential store mapping
+        credential_id="pipedrive",
+        credential_key="api_token",
+    ),
+}

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -49,6 +49,7 @@ from .gmail_tool import register_tools as register_gmail
 from .google_maps_tool import register_tools as register_google_maps
 from .hubspot_tool import register_tools as register_hubspot
 from .news_tool import register_tools as register_news
+from .pipedrive_tool import register_tools as register_pipedrive
 from .pdf_read_tool import register_tools as register_pdf_read
 from .runtime_logs_tool import register_tools as register_runtime_logs
 from .serpapi_tool import register_tools as register_serpapi
@@ -91,6 +92,7 @@ def register_all_tools(
     # Gmail inbox management (read, trash, modify labels)
     register_gmail(mcp, credentials=credentials)
     register_hubspot(mcp, credentials=credentials)
+    register_pipedrive(mcp, credentials=credentials)
     register_news(mcp, credentials=credentials)
     register_apollo(mcp, credentials=credentials)
     register_serpapi(mcp, credentials=credentials)
@@ -196,6 +198,13 @@ def register_all_tools(
         "hubspot_get_deal",
         "hubspot_create_deal",
         "hubspot_update_deal",
+        "pipedrive_create_person",
+        "pipedrive_search_person",
+        "pipedrive_get_person_details",
+        "pipedrive_create_deal",
+        "pipedrive_update_deal_stage",
+        "pipedrive_list_deals",
+        "pipedrive_add_note_to_deal",
         "news_search",
         "news_headlines",
         "news_by_company",

--- a/tools/src/aden_tools/tools/pipedrive_tool/README.md
+++ b/tools/src/aden_tools/tools/pipedrive_tool/README.md
@@ -1,0 +1,33 @@
+# Pipedrive CRM Tool
+
+Manage persons, deals, and notes in Pipedrive.
+
+## Credentials
+
+The tool requires a Pipedrive Personal API Token.
+
+- **Environment Variable**: `PIPEDRIVE_API_TOKEN`
+- **Credential Name**: `pipedrive` (key: `api_token`)
+
+To get a Pipedrive API token:
+1. Log in to your Pipedrive account.
+2. Go to Settings > Personal preferences > API.
+3. Find your personal API token and copy it.
+
+## Tools
+
+### Persons
+- `pipedrive_create_person`: Create a new person with name, email, and phone.
+- `pipedrive_search_person`: Search for a person by email (exact match).
+- `pipedrive_get_person_details`: Get full details of a person by ID.
+
+### Deals
+- `pipedrive_create_deal`: Create a new deal with title, person ID, value, and currency.
+- `pipedrive_update_deal_stage`: Update the stage of an existing deal.
+- `pipedrive_list_deals`: List deals with status filtering (default: 'open').
+
+### Notes
+- `pipedrive_add_note_to_deal`: Add a note (interaction summary, research) to a deal.
+
+## API Reference
+https://developers.pipedrive.com/docs/api/v1

--- a/tools/src/aden_tools/tools/pipedrive_tool/__init__.py
+++ b/tools/src/aden_tools/tools/pipedrive_tool/__init__.py
@@ -1,0 +1,5 @@
+"""Pipedrive CRM tool package."""
+
+from .pipedrive_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/pipedrive_tool/pipedrive_tool.py
+++ b/tools/src/aden_tools/tools/pipedrive_tool/pipedrive_tool.py
@@ -1,0 +1,391 @@
+"""
+Pipedrive CRM Tool - Manage persons, deals, and notes via Pipedrive API v1.
+
+Supports:
+- Personal API tokens (PIPEDRIVE_API_TOKEN)
+- API tokens via the credential store
+
+API Reference: https://developers.pipedrive.com/docs/api/v1
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialStoreAdapter
+
+PIPEDRIVE_API_BASE = "https://api.pipedrive.com/v1"
+
+
+class _PipedriveClient:
+    """Internal client wrapping Pipedrive CRM API v1 calls."""
+
+    def __init__(self, api_token: str):
+        self._token = api_token
+
+    @property
+    def _params(self) -> dict[str, str]:
+        return {"api_token": self._token}
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def _handle_response(self, response: httpx.Response) -> dict[str, Any]:
+        """Handle common HTTP error codes."""
+        if response.status_code == 401:
+            return {"error": "Invalid or expired Pipedrive API token"}
+        if response.status_code == 403:
+            return {"error": "Insufficient permissions. Check your Pipedrive token scopes."}
+        if response.status_code == 404:
+            return {"error": "Resource not found"}
+        if response.status_code == 410:
+            return {"error": "Resource gone (deleted)"}
+        if response.status_code == 429:
+            return {"error": "Pipedrive rate limit exceeded. Try again later."}
+        if response.status_code >= 400:
+            try:
+                detail = response.json().get("error", response.text)
+            except Exception:
+                detail = response.text
+            return {"error": f"Pipedrive API error (HTTP {response.status_code}): {detail}"}
+        
+        try:
+            return response.json()
+        except Exception as e:
+            return {"error": f"Failed to parse JSON response: {e}"}
+
+    def create_person(self, name: str, email: str | list[str] | None = None, phone: str | list[str] | None = None, **kwargs) -> dict[str, Any]:
+        """Create a new person."""
+        body = {"name": name, **kwargs}
+        if email:
+            body["email"] = email
+        if phone:
+            body["phone"] = phone
+        
+        response = httpx.post(
+            f"{PIPEDRIVE_API_BASE}/persons",
+            headers=self._headers,
+            params=self._params,
+            json=body,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def search_persons(self, term: str, fields: str = "email", exact_match: bool = False) -> dict[str, Any]:
+        """Search for persons by email or other terms."""
+        params = self._params.copy()
+        params["term"] = term
+        params["fields"] = fields
+        if exact_match:
+            params["exact_match"] = "true"
+        
+        response = httpx.get(
+            f"{PIPEDRIVE_API_BASE}/persons/search",
+            headers=self._headers,
+            params=params,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def get_person(self, person_id: int) -> dict[str, Any]:
+        """Get details of a person by ID."""
+        response = httpx.get(
+            f"{PIPEDRIVE_API_BASE}/persons/{person_id}",
+            headers=self._headers,
+            params=self._params,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def create_deal(self, title: str, person_id: int | None = None, org_id: int | None = None, value: float | None = None, currency: str | None = None, **kwargs) -> dict[str, Any]:
+        """Create a new deal."""
+        body = {"title": title, **kwargs}
+        if person_id:
+            body["person_id"] = person_id
+        if org_id:
+            body["org_id"] = org_id
+        if value is not None:
+            body["value"] = value
+        if currency:
+            body["currency"] = currency
+        
+        response = httpx.post(
+            f"{PIPEDRIVE_API_BASE}/deals",
+            headers=self._headers,
+            params=self._params,
+            json=body,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def update_deal(self, deal_id: int, **kwargs) -> dict[str, Any]:
+        """Update an existing deal (e.g., stage_id, status, value)."""
+        response = httpx.put(
+            f"{PIPEDRIVE_API_BASE}/deals/{deal_id}",
+            headers=self._headers,
+            params=self._params,
+            json=kwargs,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def list_deals(self, user_id: int | None = None, filter_id: int | None = None, status: str | None = None, limit: int = 10) -> dict[str, Any]:
+        """List deals with optional filtering."""
+        params = self._params.copy()
+        if user_id:
+            params["user_id"] = str(user_id)
+        if filter_id:
+            params["filter_id"] = str(filter_id)
+        if status:
+            params["status"] = status
+        params["limit"] = str(min(limit, 100))
+        
+        response = httpx.get(
+            f"{PIPEDRIVE_API_BASE}/deals",
+            headers=self._headers,
+            params=params,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def add_note(self, content: str, deal_id: int | None = None, person_id: int | None = None, org_id: int | None = None) -> dict[str, Any]:
+        """Add a note to a deal, person, or organization."""
+        body = {"content": content}
+        if deal_id:
+            body["deal_id"] = deal_id
+        if person_id:
+            body["person_id"] = person_id
+        if org_id:
+            body["org_id"] = org_id
+        
+        response = httpx.post(
+            f"{PIPEDRIVE_API_BASE}/notes",
+            headers=self._headers,
+            params=self._params,
+            json=body,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: CredentialStoreAdapter | None = None,
+) -> None:
+    """Register Pipedrive CRM tools with the MCP server."""
+
+    def _get_token() -> str | None:
+        """Get Pipedrive API token from credential manager or environment."""
+        if credentials is not None:
+            token = credentials.get("pipedrive")
+            if token is not None and not isinstance(token, str):
+                raise TypeError(
+                    f"Expected string from credentials.get('pipedrive'), got {type(token).__name__}"
+                )
+            return token
+        return os.getenv("PIPEDRIVE_API_TOKEN")
+
+    def _get_client() -> _PipedriveClient | dict[str, str]:
+        """Get a Pipedrive client, or return an error dict if no credentials."""
+        token = _get_token()
+        if not token:
+            return {
+                "error": "Pipedrive credentials not configured",
+                "help": (
+                    "Set PIPEDRIVE_API_TOKEN environment variable "
+                    "or configure via credential store"
+                ),
+            }
+        return _PipedriveClient(token)
+
+    # --- Persons ---
+
+    @mcp.tool()
+    def pipedrive_create_person(
+        name: str,
+        email: str | None = None,
+        phone: str | None = None,
+    ) -> dict:
+        """
+        Create a new person in Pipedrive.
+
+        Args:
+            name: Name of the person
+            email: Email address of the person
+            phone: Phone number of the person
+
+        Returns:
+            Dict with created person data or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.create_person(name=name, email=email, phone=phone)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def pipedrive_search_person(
+        email: str,
+    ) -> dict:
+        """
+        Search for a person in Pipedrive by email.
+
+        Args:
+            email: Email address to search for
+
+        Returns:
+            Dict with search results or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.search_persons(term=email, fields="email", exact_match=True)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def pipedrive_get_person_details(
+        person_id: int,
+    ) -> dict:
+        """
+        Get full details of a Pipedrive person by ID.
+
+        Args:
+            person_id: The Pipedrive person ID
+
+        Returns:
+            Dict with person data or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.get_person(person_id)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    # --- Deals ---
+
+    @mcp.tool()
+    def pipedrive_create_deal(
+        title: str,
+        person_id: int | None = None,
+        value: float | None = None,
+        currency: str | None = None,
+    ) -> dict:
+        """
+        Create a new deal in Pipedrive.
+
+        Args:
+            title: Title of the deal
+            person_id: Optional ID of the person this deal is associated with
+            value: Optional monetary value of the deal
+            currency: Optional currency code (e.g., 'USD', 'EUR')
+
+        Returns:
+            Dict with created deal data or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.create_deal(title=title, person_id=person_id, value=value, currency=currency)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def pipedrive_update_deal_stage(
+        deal_id: int,
+        stage_id: int,
+    ) -> dict:
+        """
+        Update the stage of an existing Pipedrive deal.
+
+        Args:
+            deal_id: The Pipedrive deal ID
+            stage_id: The ID of the new stage
+
+        Returns:
+            Dict with updated deal data or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.update_deal(deal_id, stage_id=stage_id)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def pipedrive_list_deals(
+        status: str | None = "open",
+        limit: int = 10,
+    ) -> dict:
+        """
+        List deals from Pipedrive.
+
+        Args:
+            status: Optional filter by status ('open', 'won', 'lost', 'deleted', 'all_not_deleted')
+            limit: Maximum number of deals to return (default 10)
+
+        Returns:
+            Dict with deals list or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_deals(status=status, limit=limit)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    # --- Notes ---
+
+    @mcp.tool()
+    def pipedrive_add_note_to_deal(
+        deal_id: int,
+        content: str,
+    ) -> dict:
+        """
+        Add a note to a Pipedrive deal.
+
+        Args:
+            deal_id: The Pipedrive deal ID
+            content: The text content of the note (can be HTML)
+
+        Returns:
+            Dict with created note data or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.add_note(content=content, deal_id=deal_id)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}

--- a/tools/src/aden_tools/tools/pipedrive_tool/tests/test_pipedrive_tool.py
+++ b/tools/src/aden_tools/tools/pipedrive_tool/tests/test_pipedrive_tool.py
@@ -1,0 +1,266 @@
+"""
+Tests for Pipedrive CRM tool.
+
+Covers:
+- _PipedriveClient methods
+- Error handling
+- All 7 MCP tool functions
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from aden_tools.tools.pipedrive_tool.pipedrive_tool import (
+    PIPEDRIVE_API_BASE,
+    _PipedriveClient,
+    register_tools,
+)
+
+
+class TestPipedriveClient:
+    def setup_method(self):
+        self.client = _PipedriveClient("test-token")
+
+    def test_params(self):
+        params = self.client._params
+        assert params["api_token"] == "test-token"
+
+    def test_headers(self):
+        headers = self.client._headers
+        assert headers["Content-Type"] == "application/json"
+
+    def test_handle_response_success(self):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"success": True, "data": []}
+        assert self.client._handle_response(response) == {"success": True, "data": []}
+
+    @pytest.mark.parametrize(
+        "status_code,expected_substring",
+        [
+            (401, "Invalid or expired"),
+            (403, "Insufficient permissions"),
+            (404, "not found"),
+            (429, "rate limit"),
+        ],
+    )
+    def test_handle_response_errors(self, status_code, expected_substring):
+        response = MagicMock()
+        response.status_code = status_code
+        result = self.client._handle_response(response)
+        assert "error" in result
+        assert expected_substring in result["error"]
+
+    @patch("aden_tools.tools.pipedrive_tool.pipedrive_tool.httpx.post")
+    def test_create_person(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {"success": True, "data": {"id": 1, "name": "John Doe"}}
+        mock_post.return_value = mock_response
+
+        result = self.client.create_person(name="John Doe", email="john@example.com")
+
+        mock_post.assert_called_once_with(
+            f"{PIPEDRIVE_API_BASE}/persons",
+            headers=self.client._headers,
+            params=self.client._params,
+            json={"name": "John Doe", "email": "john@example.com"},
+            timeout=30.0,
+        )
+        assert result["success"] is True
+
+    @patch("aden_tools.tools.pipedrive_tool.pipedrive_tool.httpx.get")
+    def test_search_persons(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"success": True, "data": {"items": []}}
+        mock_get.return_value = mock_response
+
+        result = self.client.search_persons(term="test@example.com", exact_match=True)
+
+        mock_get.assert_called_once_with(
+            f"{PIPEDRIVE_API_BASE}/persons/search",
+            headers=self.client._headers,
+            params={**self.client._params, "term": "test@example.com", "fields": "email", "exact_match": "true"},
+            timeout=30.0,
+        )
+        assert result["success"] is True
+
+    @patch("aden_tools.tools.pipedrive_tool.pipedrive_tool.httpx.get")
+    def test_get_person(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"success": True, "data": {"id": 1}}
+        mock_get.return_value = mock_response
+
+        result = self.client.get_person(1)
+
+        mock_get.assert_called_once_with(
+            f"{PIPEDRIVE_API_BASE}/persons/1",
+            headers=self.client._headers,
+            params=self.client._params,
+            timeout=30.0,
+        )
+        assert result["data"]["id"] == 1
+
+    @patch("aden_tools.tools.pipedrive_tool.pipedrive_tool.httpx.post")
+    def test_create_deal(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {"success": True, "data": {"id": 123}}
+        mock_post.return_value = mock_response
+
+        result = self.client.create_deal(title="Big Deal", person_id=1, value=1000.0, currency="USD")
+
+        mock_post.assert_called_once_with(
+            f"{PIPEDRIVE_API_BASE}/deals",
+            headers=self.client._headers,
+            params=self.client._params,
+            json={"title": "Big Deal", "person_id": 1, "value": 1000.0, "currency": "USD"},
+            timeout=30.0,
+        )
+        assert result["data"]["id"] == 123
+
+    @patch("aden_tools.tools.pipedrive_tool.pipedrive_tool.httpx.put")
+    def test_update_deal(self, mock_put):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"success": True}
+        mock_put.return_value = mock_response
+
+        result = self.client.update_deal(123, stage_id=2)
+
+        mock_put.assert_called_once_with(
+            f"{PIPEDRIVE_API_BASE}/deals/123",
+            headers=self.client._headers,
+            params=self.client._params,
+            json={"stage_id": 2},
+            timeout=30.0,
+        )
+        assert result["success"] is True
+
+    @patch("aden_tools.tools.pipedrive_tool.pipedrive_tool.httpx.get")
+    def test_list_deals(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"success": True, "data": []}
+        mock_get.return_value = mock_response
+
+        result = self.client.list_deals(status="open", limit=5)
+
+        mock_get.assert_called_once_with(
+            f"{PIPEDRIVE_API_BASE}/deals",
+            headers=self.client._headers,
+            params={**self.client._params, "status": "open", "limit": "5"},
+            timeout=30.0,
+        )
+        assert result["success"] is True
+
+    @patch("aden_tools.tools.pipedrive_tool.pipedrive_tool.httpx.post")
+    def test_add_note(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {"success": True}
+        mock_post.return_value = mock_response
+
+        result = self.client.add_note(content="Test note", deal_id=123)
+
+        mock_post.assert_called_once_with(
+            f"{PIPEDRIVE_API_BASE}/notes",
+            headers=self.client._headers,
+            params=self.client._params,
+            json={"content": "Test note", "deal_id": 123},
+            timeout=30.0,
+        )
+        assert result["success"] is True
+
+
+class TestPipedriveMCPTools:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.registered_tools = {}
+
+        def tool_decorator(name=None, **kwargs):
+            def decorator(f):
+                tool_name = name or f.__name__
+                self.registered_tools[tool_name] = f
+                return f
+
+            return decorator
+
+        self.mcp.tool.side_effect = tool_decorator
+
+        self.mock_creds = MagicMock()
+        self.mock_creds.get.return_value = "test-token"
+        register_tools(self.mcp, credentials=self.mock_creds)
+
+    @patch("aden_tools.tools.pipedrive_tool.pipedrive_tool._PipedriveClient.create_person")
+    def test_create_person_tool(self, mock_create):
+        mock_create.return_value = {"success": True}
+        tool = self.registered_tools["pipedrive_create_person"]
+        result = tool(name="John Doe", email="john@example.com")
+        assert result == {"success": True}
+        mock_create.assert_called_once_with(name="John Doe", email="john@example.com", phone=None)
+
+    @patch("aden_tools.tools.pipedrive_tool.pipedrive_tool._PipedriveClient.search_persons")
+    def test_search_person_tool(self, mock_search):
+        mock_search.return_value = {"success": True}
+        tool = self.registered_tools["pipedrive_search_person"]
+        result = tool(email="john@example.com")
+        assert result == {"success": True}
+        mock_search.assert_called_once_with(term="john@example.com", fields="email", exact_match=True)
+
+    @patch("aden_tools.tools.pipedrive_tool.pipedrive_tool._PipedriveClient.get_person")
+    def test_get_person_details_tool(self, mock_get):
+        mock_get.return_value = {"success": True}
+        tool = self.registered_tools["pipedrive_get_person_details"]
+        result = tool(person_id=1)
+        assert result == {"success": True}
+        mock_get.assert_called_once_with(1)
+
+    @patch("aden_tools.tools.pipedrive_tool.pipedrive_tool._PipedriveClient.create_deal")
+    def test_create_deal_tool(self, mock_create):
+        mock_create.return_value = {"success": True}
+        tool = self.registered_tools["pipedrive_create_deal"]
+        result = tool(title="Big Deal", person_id=1, value=100.0, currency="USD")
+        assert result == {"success": True}
+        mock_create.assert_called_once_with(title="Big Deal", person_id=1, value=100.0, currency="USD")
+
+    @patch("aden_tools.tools.pipedrive_tool.pipedrive_tool._PipedriveClient.update_deal")
+    def test_update_deal_stage_tool(self, mock_update):
+        mock_update.return_value = {"success": True}
+        tool = self.registered_tools["pipedrive_update_deal_stage"]
+        result = tool(deal_id=123, stage_id=2)
+        assert result == {"success": True}
+        mock_update.assert_called_once_with(123, stage_id=2)
+
+    @patch("aden_tools.tools.pipedrive_tool.pipedrive_tool._PipedriveClient.list_deals")
+    def test_list_deals_tool(self, mock_list):
+        mock_list.return_value = {"success": True}
+        tool = self.registered_tools["pipedrive_list_deals"]
+        result = tool(status="open", limit=5)
+        assert result == {"success": True}
+        mock_list.assert_called_once_with(status="open", limit=5)
+
+    @patch("aden_tools.tools.pipedrive_tool.pipedrive_tool._PipedriveClient.add_note")
+    def test_add_note_to_deal_tool(self, mock_add):
+        mock_add.return_value = {"success": True}
+        tool = self.registered_tools["pipedrive_add_note_to_deal"]
+        result = tool(deal_id=123, content="Note")
+        assert result == {"success": True}
+        mock_add.assert_called_once_with(content="Note", deal_id=123)
+
+    def test_no_creds_error(self):
+        # Reset registered_tools
+        self.registered_tools = {}
+        register_tools(self.mcp, credentials=None)
+        # Clear env just in case
+        with patch.dict("os.environ", {}, clear=True):
+            create_person_tool = self.registered_tools["pipedrive_create_person"]
+            result = create_person_tool(name="Test")
+            assert "error" in result
+            assert "not configured" in result["error"]


### PR DESCRIPTION
## Summary
This PR implements a native Pipedrive CRM integration for the Hive framework. It allows agents to autonomously manage Persons, Deals, and Notes in Pipedrive, expanding Hive's CRM capabilities beyond HubSpot.

## Changes
- **Credentials**: Added `PIPEDRIVE_CREDENTIALS` support for Personal API Tokens.
- **Client**: Implemented `_PipedriveClient` to handle Pipedrive API v1 requests with standard error handling and rate limit awareness.
- **MCP Tools**: Added 7 new tools:
    - `pipedrive_create_person`: Create Persons.
    - `pipedrive_search_person`: Search Persons by email (exact match).
    - `pipedrive_get_person_details`: Get full Person metadata.
    - `pipedrive_create_deal`: Create Deals.
    - `pipedrive_update_deal_stage`: Update Deal stages.
    - `pipedrive_list_deals`: List Deals with status filtering.
    - `pipedrive_add_note_to_deal`: Log agent research or interaction summaries.
- **Registry**: Registered Pipedrive tools in the central `aden_tools` registry.
- **Tests**: Added comprehensive unit tests (22 test cases) with 100% pass rate.
- **Documentation**: Created tool-specific README and updated central tools list.

## Verification
Executed `pytest tools/src/aden_tools/tools/pipedrive_tool/tests/test_pipedrive_tool.py` in the `agents` conda environment.
- All 22 tests passed.
- Verified correct credential retrieval and error handling.
- Verified tool registration and argument passing.

## Related Issue
Closes #4611
Parent Issue: #2805
---
_Pull request was created with Google Antigravity_