### PR TITLE
Centralize default LLM model configuration with env override

### DIFF
--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -19,6 +19,7 @@ Testing commands:
 import argparse
 import sys
 from pathlib import Path
+from framework.config import DEFAULT_LLM_MODEL
 
 
 def _configure_paths():
@@ -66,7 +67,7 @@ def main():
     )
     parser.add_argument(
         "--model",
-        default="claude-haiku-4-5-20251001",
+        default=DEFAULT_LLM_MODEL,
         help="Anthropic model to use",
     )
 

--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -14,6 +14,19 @@ from typing import Any
 from framework.graph.edge import DEFAULT_MAX_TOKENS
 
 # ---------------------------------------------------------------------------
+# Default LLM configuration
+# ---------------------------------------------------------------------------
+
+# Default LLM model used when no explicit model is provided.
+# Can be overridden via the HIVE_DEFAULT_MODEL environment variable to allow
+# environment-specific configuration without modifying source code.
+DEFAULT_LLM_MODEL = os.getenv(
+    "HIVE_DEFAULT_MODEL",
+    "claude-haiku-4-5-20251001",
+)
+
+
+# ---------------------------------------------------------------------------
 # Low-level config file access
 # ---------------------------------------------------------------------------
 

--- a/core/framework/llm/anthropic.py
+++ b/core/framework/llm/anthropic.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from framework.llm.litellm import LiteLLMProvider
 from framework.llm.provider import LLMProvider, LLMResponse, Tool, ToolResult, ToolUse
+from framework.config import DEFAULT_LLM_MODEL
 
 
 def _get_api_key_from_credential_store() -> str | None:
@@ -38,7 +39,7 @@ class AnthropicProvider(LLMProvider):
     def __init__(
         self,
         api_key: str | None = None,
-        model: str = "claude-haiku-4-5-20251001",
+        model: str = DEFAULT_LLM_MODEL,
     ):
         """
         Initialize the Anthropic provider.
@@ -46,7 +47,7 @@ class AnthropicProvider(LLMProvider):
         Args:
             api_key: Anthropic API key. If not provided, uses CredentialStoreAdapter
                      or ANTHROPIC_API_KEY env var.
-            model: Model to use (default: claude-haiku-4-5-20251001)
+            model: Model to use (defaults to the configured Hive default model)
         """
         # Delegate to LiteLLMProvider internally.
         self.api_key = api_key or _get_api_key_from_credential_store()


### PR DESCRIPTION
##  Description

Centralizes the default LLM model configuration to remove hardcoded values and allow environment-level overrides without changing source code.

---

## Type of Change

* [ ] Bug fix (non-breaking change that fixes an issue)
* [x] **New feature (non-breaking change that adds functionality)**
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Refactoring (no functional changes)

---

## Related Issues

Fixes #4888

---

## Changes Made

* Introduced a single default LLM model constant configurable via the `HIVE_DEFAULT_MODEL` environment variable.
* Updated the CLI to reference the centralized default model configuration.
* Updated the Anthropic provider to use the centralized default model instead of a hardcoded value.

---

## Testing

Describe the tests you ran to verify your changes:

* [ ] Unit tests pass (`cd core && pytest tests/`)
* [ ] Lint passes (`cd core && ruff check .`)
* [x] **Manual testing performed**

**Notes:**
This change is configuration-only and backward compatible. Manual verification was performed to ensure defaults remain unchanged when the environment variable is unset.

---

## Checklist

* [x] **My code follows the project's style guidelines**
* [x] **I have performed a self-review of my code**
* [x] **I have commented my code, particularly in hard-to-understand areas**
* [ ] I have made corresponding changes to the documentation
* [x] **My changes generate no new warnings**
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes

---

## Screenshots (if applicable)

N/A