### PR TITLE
docs(examples): fix tech_news_reporter README usage section

### DIFF
--- a/examples/templates/tech_news_reporter/README.md
+++ b/examples/templates/tech_news_reporter/README.md
@@ -86,23 +86,31 @@ intake → research → compile-report
 
 ### Basic Usage
 
+Run the agent through the interactive TUI dashboard:
+```bash
+# Launch the dashboard and select "Tech & AI News Reporter"
+hive tui
+
+# Or run directly from the command line
+hive run examples/templates/tech_news_reporter
+```
+
+To run programmatically:
 ```python
 from framework.runner import AgentRunner
 
 # Load the agent
 runner = AgentRunner.load("examples/templates/tech_news_reporter")
 
-# Run with input
-result = await runner.run({"input_key": "value"})
+# The intake node will interactively ask the user for topic preferences
+result = await runner.run({})
 
-# Access results
-print(result.output)
 print(result.status)
 ```
 
 ### Input Schema
 
-The agent's entry node `intake` requires:
+No input keys are required at launch. The `intake` node is client-facing and will interactively prompt the user to choose their preferred tech/AI news topics before the research begins.
 
 
 ### Output Schema


### PR DESCRIPTION
## Description

Updates the `tech_news_reporter` example agent's README to provide accurate usage instructions instead of generic placeholders.

**Before:** The code example used `{"input_key": "value"}` which is a generic placeholder. The `intake` node actually accepts no input keys — it interactively prompts the user for topic preferences. The "Input Schema" section was also blank.

**After:** Replaced with both CLI usage (the primary method) and a corrected programmatic example. Added a note clarifying that no input is required at launch.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

N/A (documentation fix — no assignment needed per CONTRIBUTING.md)

## Testing

- Verified `agent.json` confirms `intake` node has `"input_keys": []`
- Verified the agent runs correctly via `hive tui` without any input arguments
- Changes are documentation-only — no logic affected