### PR TITLE
feat(ci): add check for optional dependency lazy imports

### DIFF
--- a/core/framework/runtime/README.md
+++ b/core/framework/runtime/README.md
@@ -162,7 +162,7 @@ In headless mode, `AgentRunner` subscribes to `CLIENT_OUTPUT_DELTA` and `CLIENT_
 ~/.hive/agents/{agent_name}/
   sessions/
     session_YYYYMMDD_HHMMSS_{uuid}/
-      state.json              # Session state (status, memory, progress)
+      state.json              # Session state (status, memory, progress, decisions, problems)
       checkpoints/            # Node-boundary snapshots
       logs/
         summary.json          # Execution summary

--- a/core/tests/test_builder_query_unified_sessions.py
+++ b/core/tests/test_builder_query_unified_sessions.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from framework.builder.query import BuilderQuery
+from framework.schemas.decision import Decision, DecisionType, Option, Outcome
+from framework.schemas.run import Problem, Run, RunMetrics, RunStatus
+from framework.schemas.session_state import (
+    SessionMetrics,
+    SessionProgress,
+    SessionResult,
+    SessionState,
+    SessionStatus,
+    SessionTimestamps,
+)
+
+
+def _write_session_state(tmp_path, state: SessionState) -> None:
+    session_dir = tmp_path / "sessions" / state.session_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+    (session_dir / "state.json").write_text(state.model_dump_json(indent=2), encoding="utf-8")
+
+
+def test_builder_query_reads_unified_session_state(tmp_path) -> None:
+    session_id = "session_20260214_120000_abc12345"
+    now = datetime.now().isoformat()
+
+    decision = Decision(
+        id="dec_0",
+        node_id="node_a",
+        intent="Try something",
+        decision_type=DecisionType.CUSTOM,
+        options=[
+            Option(id="ok", description="Succeed", action_type="execute"),
+            Option(id="bad", description="Fail", action_type="execute"),
+        ],
+        chosen_option_id="bad",
+        reasoning="Testing failure path",
+        outcome=Outcome(
+            success=False, error="boom", summary="failed", tokens_used=3, latency_ms=10
+        ),
+    )
+
+    problem = Problem(id="prob_0", severity="critical", description="boom", decision_id="dec_0")
+
+    state = SessionState(
+        session_id=session_id,
+        goal_id="goal_1",
+        status=SessionStatus.FAILED,
+        timestamps=SessionTimestamps(started_at=now, updated_at=now, completed_at=now),
+        progress=SessionProgress(paused_at=None, steps_executed=1, total_latency_ms=10),
+        result=SessionResult(success=False, error="boom", output={"ok": False}),
+        metrics=SessionMetrics(decision_count=1, problem_count=1),
+        decisions=[decision.model_dump()],
+        problems=[problem.model_dump()],
+        input_data={"x": 1},
+    )
+    _write_session_state(tmp_path, state)
+
+    q = BuilderQuery(tmp_path)
+
+    summary = q.get_run_summary(session_id)
+    assert summary is not None
+    assert summary.run_id == session_id
+    assert summary.goal_id == "goal_1"
+    assert summary.status == RunStatus.FAILED
+    assert summary.decision_count == 1
+    assert summary.problem_count == 1
+
+    trace = q.get_decision_trace(session_id)
+    assert len(trace) == 1
+
+    analysis = q.analyze_failure(session_id)
+    assert analysis is not None
+    assert analysis.run_id == session_id
+    assert "boom" in analysis.root_cause
+
+    runs = q.list_runs_for_goal("goal_1")
+    assert any(r.run_id == session_id for r in runs)
+
+    failures = q.get_recent_failures(limit=10)
+    assert any(r.run_id == session_id for r in failures)
+
+
+def test_session_state_attach_run_populates_decisions_and_problems() -> None:
+    now_dt = datetime.now()
+
+    decision = Decision(
+        id="dec_0",
+        node_id="node_a",
+        intent="Succeed",
+        options=[Option(id="ok", description="Ok", action_type="execute")],
+        chosen_option_id="ok",
+        reasoning="",
+        outcome=Outcome(success=True, summary="ok", tokens_used=2, latency_ms=5),
+    )
+    problem = Problem(id="prob_0", severity="warning", description="minor issue")
+
+    run = Run(
+        id="run_1",
+        goal_id="goal_1",
+        started_at=now_dt,
+        status=RunStatus.COMPLETED,
+        completed_at=now_dt,
+        decisions=[decision],
+        problems=[problem],
+        metrics=RunMetrics(
+            total_decisions=1,
+            successful_decisions=1,
+            failed_decisions=0,
+            total_tokens=2,
+            total_latency_ms=5,
+            nodes_executed=["node_a"],
+            edges_traversed=[],
+        ),
+        narrative="done",
+    )
+
+    state = SessionState(
+        session_id="session_20260214_120100_def67890",
+        goal_id="goal_1",
+        status=SessionStatus.COMPLETED,
+        timestamps=SessionTimestamps(
+            started_at=now_dt.isoformat(),
+            updated_at=now_dt.isoformat(),
+            completed_at=now_dt.isoformat(),
+        ),
+        progress=SessionProgress(),
+        result=SessionResult(success=True, output={}),
+        metrics=SessionMetrics(),
+    )
+
+    state.attach_run(run)
+    assert state.metrics.decision_count == 1
+    assert state.metrics.problem_count == 1
+    assert len(state.decisions) == 1
+    assert len(state.problems) == 1

--- a/scripts/check_optional_imports.py
+++ b/scripts/check_optional_imports.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+CI check: Ensure optional dependencies use lazy imports in tool files.
+
+This script scans tool files in tools/src/aden_tools/tools/ and flags any
+top-level imports of known optional packages. Optional dependencies should
+use lazy imports (inside functions) with graceful error handling to prevent
+the entire tool registration from crashing when the package isn't available.
+
+See tools/pyproject.toml for optional-dependencies:
+- openpyxl (excel)
+- duckdb (sql)
+- pytesseract (ocr)
+- pillow (ocr)
+- RestrictedPython (sandbox)
+- google-cloud-bigquery (bigquery)
+
+Pattern to follow (from excel_tool.py):
+    def read_excel(...):
+        try:
+            from openpyxl import load_workbook
+        except ImportError:
+            return {"error": "openpyxl not installed. Install with: pip install tools[excel]"}
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+# Packages that MUST use lazy imports (from pyproject.toml optional-dependencies)
+OPTIONAL_PACKAGES = {
+    "openpyxl",  # excel
+    "duckdb",  # sql
+    "pytesseract",  # ocr
+    "pillow",  # ocr (PIL)
+    "RestrictedPython",  # sandbox
+    "google.cloud.bigquery",  # bigquery (parent package)
+    "google",  # google-cloud-*
+    # Add others as needed
+}
+
+# Known patterns for google cloud packages
+GOOGLE_PACKAGE_PREFIXES = ("google.cloud", "google.api", "google.auth")
+
+
+def get_top_level_imports(filepath: Path) -> list[tuple[int, str]]:
+    """
+    Return list of (line_number, module_name) for top-level imports.
+
+    Only checks direct children of the AST tree (not imports inside
+    functions, classes, or other nested scopes).
+    """
+    with open(filepath) as f:
+        try:
+            tree = ast.parse(f.read(), filename=str(filepath))
+        except SyntaxError as e:
+            # Skip files with syntax errors - they'll be caught by other linters
+            print(f"  Warning: Skipping {filepath} due to syntax error: {e}")
+            return []
+
+    imports = []
+    for node in ast.iter_child_nodes(tree):  # Only top-level nodes
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                module_name = alias.name.split(".")[0]
+                imports.append((node.lineno, alias.name, module_name))
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                module_name = node.module.split(".")[0]
+                imports.append((node.lineno, node.module, module_name))
+    return imports
+
+
+def is_optional_package(module: str, module_root: str) -> bool:
+    """Check if a module is in the optional packages list."""
+    # Check exact matches
+    if module in OPTIONAL_PACKAGES or module_root in OPTIONAL_PACKAGES:
+        return True
+
+    # Check google cloud packages
+    if module_root == "google":
+        return module.startswith(GOOGLE_PACKAGE_PREFIXES)
+
+    return False
+
+
+def check_tool_files(tools_dir: Path) -> list[str]:
+    """Check all tool files for forbidden top-level imports."""
+    errors = []
+
+    # Find all Python files in tools directory
+    for tool_file in tools_dir.rglob("*.py"):
+        # Skip test files and __init__.py
+        if tool_file.name.startswith("test_") or tool_file.name == "__init__.py":
+            continue
+
+        for lineno, full_module, module_root in get_top_level_imports(tool_file):
+            if is_optional_package(full_module, module_root):
+                rel_path = tool_file.relative_to(Path.cwd())
+                errors.append(
+                    f"{rel_path}:{lineno}: Top-level import of optional package '{full_module}'. "
+                    f"Use lazy import inside function with try/except ImportError."
+                )
+
+    return errors
+
+
+def main() -> int:
+    """Main entry point."""
+    # Try tools/ directory first (project root), then fall back to relative path
+    tools_dir = Path("tools/src/aden_tools/tools")
+    if not tools_dir.exists():
+        tools_dir = Path("../tools/src/aden_tools/tools")
+    if not tools_dir.exists():
+        tools_dir = Path.cwd() / "tools/src/aden_tools/tools"
+
+    if not tools_dir.exists():
+        print(f"Error: Directory not found: {tools_dir}")
+        print("Run this script from the project root or tools/ directory")
+        return 1
+
+    print(f"Checking tool files in: {tools_dir}")
+    print("-" * 60)
+
+    errors = check_tool_files(tools_dir)
+
+    if errors:
+        print("❌ Optional dependency import violations found:\n")
+        for error in errors:
+            print(f"  {error}")
+        print(f"\n{'=' * 60}")
+        print("Fix: Move import inside function and wrap with try/except ImportError")
+        print("  Example pattern from tools/src/aden_tools/tools/excel_tool/excel_tool.py:")
+        print("")
+        print("    def read_excel(...):")
+        print("        try:")
+        print("            from openpyxl import load_workbook")
+        print("        except ImportError:")
+        print("            return {'error': 'openpyxl not installed...'}")
+        print("")
+        print("  This ensures the tool loads even if the optional package is missing.")
+        return 1
+    else:
+        print("✅ All tool files use lazy imports for optional dependencies")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

Adds a CI script that scans tool files and flags any top-level imports of known optional packages. This prevents the class of bugs where missing optional packages crash the entire tool registration.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Fixes #4898

## Changes Made

- Created `scripts/check_optional_imports.py` - AST-based scanner for tool files
- Added documentation in the script comments explaining the pattern

## Testing

- [x] Verified script runs successfully on current codebase
- [x] Manual testing performed (ran `python3 scripts/check_optional_imports.py`)

```
$ python3 scripts/check_optional_imports.py
Checking tool files in: tools/src/aden_tools/tools
------------------------------------------------------------
✅ All tool files use lazy imports for optional dependencies
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
