### PR TITLE
feat(tools): add clickup MCP integration for workspaces and tasks

### DIFF
--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -42,6 +42,7 @@ Credential categories:
 - slack.py: Slack workspace credentials
 - google_maps.py: Google Maps Platform credentials
 - calcom.py: Cal.com scheduling API credentials
+- clickup.py: ClickUp workspace and task credentials
 
 Note: Tools that don't need credentials simply omit the 'credentials' parameter
 from their register_tools() function. This convention is enforced by CI tests.
@@ -57,6 +58,7 @@ from .base import CredentialError, CredentialSpec
 from .bigquery import BIGQUERY_CREDENTIALS
 from .browser import get_aden_auth_url, get_aden_setup_url, open_browser
 from .calcom import CALCOM_CREDENTIALS
+from .clickup import CLICKUP_CREDENTIALS
 from .email import EMAIL_CREDENTIALS
 from .gcp_vision import GCP_VISION_CREDENTIALS
 from .github import GITHUB_CREDENTIALS
@@ -95,6 +97,7 @@ CREDENTIAL_SPECS = {
     **TELEGRAM_CREDENTIALS,
     **BIGQUERY_CREDENTIALS,
     **CALCOM_CREDENTIALS,
+    **CLICKUP_CREDENTIALS,
 }
 
 __all__ = [
@@ -134,4 +137,5 @@ __all__ = [
     "TELEGRAM_CREDENTIALS",
     "BIGQUERY_CREDENTIALS",
     "CALCOM_CREDENTIALS",
+    "CLICKUP_CREDENTIALS",
 ]

--- a/tools/src/aden_tools/credentials/clickup.py
+++ b/tools/src/aden_tools/credentials/clickup.py
@@ -1,0 +1,38 @@
+"""
+ClickUp tool credentials.
+
+Contains credentials for ClickUp workspace and task API integration.
+"""
+
+from .base import CredentialSpec
+
+CLICKUP_CREDENTIALS = {
+    "clickup": CredentialSpec(
+        env_var="CLICKUP_API_TOKEN",
+        tools=[
+            "clickup_list_workspaces",
+            "clickup_list_spaces",
+            "clickup_list_lists",
+            "clickup_list_tasks",
+            "clickup_get_task",
+            "clickup_create_task",
+            "clickup_update_task",
+            "clickup_add_task_comment",
+        ],
+        required=True,
+        startup_required=False,
+        help_url="https://developer.clickup.com/docs/authentication",
+        description="ClickUp personal API token for workspace and task operations",
+        aden_supported=False,
+        direct_api_key_supported=True,
+        api_key_instructions="""To get a ClickUp API token:
+1. Sign in to ClickUp
+2. Open your profile and go to Settings > Apps
+3. Generate a personal API token
+4. Copy the token and store it securely""",
+        health_check_endpoint="https://api.clickup.com/api/v2/team",
+        health_check_method="GET",
+        credential_id="clickup",
+        credential_key="api_token",
+    ),
+}

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -25,6 +25,7 @@ from .apollo_tool import register_tools as register_apollo
 from .bigquery_tool import register_tools as register_bigquery
 from .calcom_tool import register_tools as register_calcom
 from .calendar_tool import register_tools as register_calendar
+from .clickup_tool import register_tools as register_clickup
 from .csv_tool import register_tools as register_csv
 from .email_tool import register_tools as register_email
 from .example_tool import register_tools as register_example
@@ -96,6 +97,7 @@ def register_all_tools(
     register_serpapi(mcp, credentials=credentials)
     register_calendar(mcp, credentials=credentials)
     register_calcom(mcp, credentials=credentials)
+    register_clickup(mcp, credentials=credentials)
     register_slack(mcp, credentials=credentials)
     register_telegram(mcp, credentials=credentials)
     register_vision(mcp, credentials=credentials)
@@ -160,6 +162,14 @@ def register_all_tools(
         "calcom_list_schedules",
         "calcom_list_event_types",
         "calcom_get_event_type",
+        "clickup_list_workspaces",
+        "clickup_list_spaces",
+        "clickup_list_lists",
+        "clickup_list_tasks",
+        "clickup_get_task",
+        "clickup_create_task",
+        "clickup_update_task",
+        "clickup_add_task_comment",
         "github_list_repos",
         "github_get_repo",
         "github_search_repos",

--- a/tools/src/aden_tools/tools/clickup_tool/README.md
+++ b/tools/src/aden_tools/tools/clickup_tool/README.md
@@ -1,0 +1,22 @@
+# ClickUp Tool
+
+ClickUp integration for Hive MCP tools.
+
+## Included tools
+
+- `clickup_list_workspaces`
+- `clickup_list_spaces`
+- `clickup_list_lists`
+- `clickup_list_tasks`
+- `clickup_get_task`
+- `clickup_create_task`
+- `clickup_update_task`
+- `clickup_add_task_comment`
+
+## Credential
+
+Set `CLICKUP_API_TOKEN` or configure `clickup` in the credential store.
+
+## API docs
+
+- [ClickUp API v2](https://developer.clickup.com/reference/getauthorizedteams)

--- a/tools/src/aden_tools/tools/clickup_tool/__init__.py
+++ b/tools/src/aden_tools/tools/clickup_tool/__init__.py
@@ -1,0 +1,9 @@
+"""
+ClickUp Tool - Workspace and task operations.
+
+Provides ClickUp MCP tools for listing and updating project work items.
+"""
+
+from .clickup_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/clickup_tool/clickup_tool.py
+++ b/tools/src/aden_tools/tools/clickup_tool/clickup_tool.py
@@ -1,0 +1,376 @@
+"""
+ClickUp Tool - Task and workspace operations via ClickUp API v2.
+
+Supports:
+- Workspace, space, and list discovery
+- Task listing and retrieval
+- Task creation, update, and comments
+
+API Reference: https://developer.clickup.com/reference/getauthorizedteams
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any, Callable
+
+import httpx
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialStoreAdapter
+
+CLICKUP_API_BASE = "https://api.clickup.com/api/v2"
+DEFAULT_TIMEOUT = 30.0
+
+
+class _ClickUpClient:
+    """Internal client wrapping ClickUp API calls."""
+
+    def __init__(self, api_token: str):
+        self._api_token = api_token
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": self._api_token,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def _extract_error_message(self, response: httpx.Response) -> str:
+        """Extract a readable API error message."""
+        try:
+            payload = response.json()
+            if isinstance(payload, dict):
+                return str(
+                    payload.get("err")
+                    or payload.get("error")
+                    or payload.get("error_description")
+                    or payload.get("message")
+                    or response.text
+                )
+        except Exception:
+            pass
+        return response.text
+
+    def _handle_response(self, response: httpx.Response) -> dict[str, Any]:
+        """Map common HTTP failures to stable error messages."""
+        if response.status_code in (200, 201):
+            return response.json()
+        if response.status_code == 400:
+            return {
+                "error": "Invalid request to ClickUp API",
+                "details": self._extract_error_message(response),
+            }
+        if response.status_code == 401:
+            return {"error": "Invalid or expired ClickUp API token"}
+        if response.status_code == 403:
+            return {
+                "error": "Insufficient permissions. Check your ClickUp workspace access and token."
+            }
+        if response.status_code == 404:
+            return {"error": "Resource not found"}
+        if response.status_code == 429:
+            return {"error": "ClickUp rate limit exceeded. Try again later."}
+
+        detail = self._extract_error_message(response)
+        return {"error": f"ClickUp API error (HTTP {response.status_code}): {detail}"}
+
+    def list_workspaces(self) -> dict[str, Any]:
+        response = httpx.get(
+            f"{CLICKUP_API_BASE}/team",
+            headers=self._headers,
+            timeout=DEFAULT_TIMEOUT,
+        )
+        return self._handle_response(response)
+
+    def list_spaces(self, workspace_id: str, archived: bool = False) -> dict[str, Any]:
+        response = httpx.get(
+            f"{CLICKUP_API_BASE}/team/{workspace_id}/space",
+            headers=self._headers,
+            params={"archived": str(archived).lower()},
+            timeout=DEFAULT_TIMEOUT,
+        )
+        return self._handle_response(response)
+
+    def list_lists(self, space_id: str, archived: bool = False) -> dict[str, Any]:
+        response = httpx.get(
+            f"{CLICKUP_API_BASE}/space/{space_id}/list",
+            headers=self._headers,
+            params={"archived": str(archived).lower()},
+            timeout=DEFAULT_TIMEOUT,
+        )
+        return self._handle_response(response)
+
+    def list_tasks(
+        self,
+        list_id: str,
+        *,
+        include_closed: bool = False,
+        archived: bool = False,
+        page: int = 0,
+        statuses: list[str] | None = None,
+        assignees: list[str] | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {
+            "include_closed": str(include_closed).lower(),
+            "archived": str(archived).lower(),
+            "page": max(page, 0),
+        }
+        if statuses:
+            params["statuses[]"] = statuses
+        if assignees:
+            params["assignees[]"] = assignees
+
+        response = httpx.get(
+            f"{CLICKUP_API_BASE}/list/{list_id}/task",
+            headers=self._headers,
+            params=params,
+            timeout=DEFAULT_TIMEOUT,
+        )
+        return self._handle_response(response)
+
+    def get_task(self, task_id: str) -> dict[str, Any]:
+        response = httpx.get(
+            f"{CLICKUP_API_BASE}/task/{task_id}",
+            headers=self._headers,
+            timeout=DEFAULT_TIMEOUT,
+        )
+        return self._handle_response(response)
+
+    def create_task(
+        self,
+        *,
+        list_id: str,
+        name: str,
+        description: str | None = None,
+        status: str | None = None,
+        assignees: list[str] | None = None,
+        due_date: int | None = None,
+        priority: int | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {"name": name}
+        if description is not None:
+            body["description"] = description
+        if status is not None:
+            body["status"] = status
+        if assignees is not None:
+            body["assignees"] = assignees
+        if due_date is not None:
+            body["due_date"] = due_date
+        if priority is not None:
+            body["priority"] = priority
+
+        response = httpx.post(
+            f"{CLICKUP_API_BASE}/list/{list_id}/task",
+            headers=self._headers,
+            json=body,
+            timeout=DEFAULT_TIMEOUT,
+        )
+        return self._handle_response(response)
+
+    def update_task(
+        self,
+        *,
+        task_id: str,
+        name: str | None = None,
+        description: str | None = None,
+        status: str | None = None,
+        assignees: list[str] | None = None,
+        due_date: int | None = None,
+        priority: int | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if name is not None:
+            body["name"] = name
+        if description is not None:
+            body["description"] = description
+        if status is not None:
+            body["status"] = status
+        if assignees is not None:
+            body["assignees"] = assignees
+        if due_date is not None:
+            body["due_date"] = due_date
+        if priority is not None:
+            body["priority"] = priority
+
+        response = httpx.put(
+            f"{CLICKUP_API_BASE}/task/{task_id}",
+            headers=self._headers,
+            json=body,
+            timeout=DEFAULT_TIMEOUT,
+        )
+        return self._handle_response(response)
+
+    def add_task_comment(
+        self,
+        *,
+        task_id: str,
+        comment_text: str,
+        notify_all: bool = False,
+    ) -> dict[str, Any]:
+        response = httpx.post(
+            f"{CLICKUP_API_BASE}/task/{task_id}/comment",
+            headers=self._headers,
+            json={
+                "comment_text": comment_text,
+                "notify_all": notify_all,
+            },
+            timeout=DEFAULT_TIMEOUT,
+        )
+        return self._handle_response(response)
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: CredentialStoreAdapter | None = None,
+) -> None:
+    """Register ClickUp tools with the MCP server."""
+
+    def _get_api_token() -> str | None:
+        """Get ClickUp token from credential manager or environment."""
+        if credentials is not None:
+            token = credentials.get("clickup")
+            if token is not None and not isinstance(token, str):
+                return None
+            return token
+        return os.getenv("CLICKUP_API_TOKEN")
+
+    def _get_client() -> _ClickUpClient | dict[str, str]:
+        """Create ClickUp client or return credential error."""
+        token = _get_api_token()
+        if not token:
+            return {
+                "error": "ClickUp API token not configured",
+                "help": (
+                    "Set CLICKUP_API_TOKEN environment variable "
+                    "or configure via credential store"
+                ),
+            }
+        return _ClickUpClient(token)
+
+    def _execute(callable_fn: Callable[[_ClickUpClient], dict[str, Any]]) -> dict[str, Any]:
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return callable_fn(client)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def clickup_list_workspaces() -> dict:
+        """List ClickUp workspaces accessible with the current token."""
+        return _execute(lambda client: client.list_workspaces())
+
+    @mcp.tool()
+    def clickup_list_spaces(workspace_id: str, archived: bool = False) -> dict:
+        """List spaces for a ClickUp workspace."""
+        return _execute(lambda client: client.list_spaces(workspace_id, archived=archived))
+
+    @mcp.tool()
+    def clickup_list_lists(space_id: str, archived: bool = False) -> dict:
+        """List lists for a ClickUp space."""
+        return _execute(lambda client: client.list_lists(space_id, archived=archived))
+
+    @mcp.tool()
+    def clickup_list_tasks(
+        list_id: str,
+        include_closed: bool = False,
+        archived: bool = False,
+        page: int = 0,
+        statuses: list[str] | None = None,
+        assignees: list[str] | None = None,
+    ) -> dict:
+        """List tasks in a ClickUp list with optional filters."""
+        return _execute(
+            lambda client: client.list_tasks(
+                list_id,
+                include_closed=include_closed,
+                archived=archived,
+                page=page,
+                statuses=statuses,
+                assignees=assignees,
+            )
+        )
+
+    @mcp.tool()
+    def clickup_get_task(task_id: str) -> dict:
+        """Get a single ClickUp task by ID."""
+        return _execute(lambda client: client.get_task(task_id))
+
+    @mcp.tool()
+    def clickup_create_task(
+        list_id: str,
+        name: str,
+        description: str | None = None,
+        status: str | None = None,
+        assignees: list[str] | None = None,
+        due_date: int | None = None,
+        priority: int | None = None,
+    ) -> dict:
+        """Create a task in a ClickUp list."""
+        if not name.strip():
+            return {"error": "Task name is required"}
+
+        return _execute(
+            lambda client: client.create_task(
+                list_id=list_id,
+                name=name,
+                description=description,
+                status=status,
+                assignees=assignees,
+                due_date=due_date,
+                priority=priority,
+            )
+        )
+
+    @mcp.tool()
+    def clickup_update_task(
+        task_id: str,
+        name: str | None = None,
+        description: str | None = None,
+        status: str | None = None,
+        assignees: list[str] | None = None,
+        due_date: int | None = None,
+        priority: int | None = None,
+    ) -> dict:
+        """Update one or more fields on a ClickUp task."""
+        if all(
+            field is None
+            for field in (name, description, status, assignees, due_date, priority)
+        ):
+            return {"error": "At least one field must be provided for update"}
+
+        return _execute(
+            lambda client: client.update_task(
+                task_id=task_id,
+                name=name,
+                description=description,
+                status=status,
+                assignees=assignees,
+                due_date=due_date,
+                priority=priority,
+            )
+        )
+
+    @mcp.tool()
+    def clickup_add_task_comment(
+        task_id: str,
+        comment_text: str,
+        notify_all: bool = False,
+    ) -> dict:
+        """Add a comment to a ClickUp task."""
+        if not comment_text.strip():
+            return {"error": "Comment text is required"}
+
+        return _execute(
+            lambda client: client.add_task_comment(
+                task_id=task_id,
+                comment_text=comment_text,
+                notify_all=notify_all,
+            )
+        )

--- a/tools/tests/tools/test_clickup_tool.py
+++ b/tools/tests/tools/test_clickup_tool.py
@@ -1,0 +1,279 @@
+"""Tests for ClickUp tool with FastMCP."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from fastmcp import FastMCP
+
+from aden_tools.tools.clickup_tool import register_tools
+
+
+class TestToolRegistration:
+    """Tests for ClickUp tool registration."""
+
+    def test_all_tools_registered(self, monkeypatch):
+        monkeypatch.setenv("CLICKUP_API_TOKEN", "test-token")
+        mcp = FastMCP("test-clickup-registration")
+
+        register_tools(mcp)
+
+        expected_tools = [
+            "clickup_list_workspaces",
+            "clickup_list_spaces",
+            "clickup_list_lists",
+            "clickup_list_tasks",
+            "clickup_get_task",
+            "clickup_create_task",
+            "clickup_update_task",
+            "clickup_add_task_comment",
+        ]
+
+        for tool_name in expected_tools:
+            assert tool_name in mcp._tool_manager._tools
+
+
+class TestCredentialHandling:
+    """Tests for ClickUp credential handling."""
+
+    def test_missing_credentials_returns_error_and_help(self, monkeypatch):
+        monkeypatch.delenv("CLICKUP_API_TOKEN", raising=False)
+        mcp = FastMCP("test-clickup-no-creds")
+        register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["clickup_list_workspaces"].fn
+        result = fn()
+
+        assert "error" in result
+        assert "not configured" in result["error"]
+        assert "help" in result
+
+    def test_non_string_credential_returns_error(self, monkeypatch):
+        monkeypatch.delenv("CLICKUP_API_TOKEN", raising=False)
+        mcp = FastMCP("test-clickup-bad-creds")
+
+        creds = MagicMock()
+        creds.get.return_value = {"token": "bad-type"}
+        register_tools(mcp, credentials=creds)
+
+        fn = mcp._tool_manager._tools["clickup_list_workspaces"].fn
+        result = fn()
+
+        assert "error" in result
+        assert "not configured" in result["error"]
+
+
+class TestWorkspaceAndStructureReads:
+    """Tests for workspace, space, and list reads."""
+
+    def test_list_workspaces_success(self, monkeypatch):
+        monkeypatch.setenv("CLICKUP_API_TOKEN", "test-token")
+        mcp = FastMCP("test-clickup-list-workspaces")
+        register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["clickup_list_workspaces"].fn
+
+        with patch("aden_tools.tools.clickup_tool.clickup_tool.httpx.get") as mock_get:
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {
+                "teams": [{"id": "team_1", "name": "Engineering"}],
+            }
+            mock_get.return_value = response
+
+            result = fn()
+
+            assert "teams" in result
+            assert result["teams"][0]["id"] == "team_1"
+            assert mock_get.call_args.kwargs["headers"]["Authorization"] == "test-token"
+
+    def test_list_spaces_with_archived_filter(self, monkeypatch):
+        monkeypatch.setenv("CLICKUP_API_TOKEN", "test-token")
+        mcp = FastMCP("test-clickup-list-spaces")
+        register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["clickup_list_spaces"].fn
+
+        with patch("aden_tools.tools.clickup_tool.clickup_tool.httpx.get") as mock_get:
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {"spaces": []}
+            mock_get.return_value = response
+
+            fn(workspace_id="team_1", archived=True)
+
+            params = mock_get.call_args.kwargs["params"]
+            assert params["archived"] == "true"
+
+    def test_list_tasks_with_filters(self, monkeypatch):
+        monkeypatch.setenv("CLICKUP_API_TOKEN", "test-token")
+        mcp = FastMCP("test-clickup-list-tasks")
+        register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["clickup_list_tasks"].fn
+
+        with patch("aden_tools.tools.clickup_tool.clickup_tool.httpx.get") as mock_get:
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {"tasks": []}
+            mock_get.return_value = response
+
+            fn(
+                list_id="list_1",
+                include_closed=True,
+                archived=True,
+                page=2,
+                statuses=["in progress", "review"],
+                assignees=["u1", "u2"],
+            )
+
+            params = mock_get.call_args.kwargs["params"]
+            assert params["include_closed"] == "true"
+            assert params["archived"] == "true"
+            assert params["page"] == 2
+            assert params["statuses[]"] == ["in progress", "review"]
+            assert params["assignees[]"] == ["u1", "u2"]
+
+
+class TestTaskOperations:
+    """Tests for task create/read/update/comment operations."""
+
+    def test_get_task_not_found(self, monkeypatch):
+        monkeypatch.setenv("CLICKUP_API_TOKEN", "test-token")
+        mcp = FastMCP("test-clickup-get-task-404")
+        register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["clickup_get_task"].fn
+
+        with patch("aden_tools.tools.clickup_tool.clickup_tool.httpx.get") as mock_get:
+            response = MagicMock()
+            response.status_code = 404
+            response.text = "Task not found"
+            mock_get.return_value = response
+
+            result = fn(task_id="missing")
+
+            assert "error" in result
+            assert "not found" in result["error"].lower()
+
+    def test_create_task_validates_name(self, monkeypatch):
+        monkeypatch.setenv("CLICKUP_API_TOKEN", "test-token")
+        mcp = FastMCP("test-clickup-create-task-validation")
+        register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["clickup_create_task"].fn
+
+        result = fn(list_id="list_1", name="   ")
+
+        assert result == {"error": "Task name is required"}
+
+    def test_create_task_success_payload(self, monkeypatch):
+        monkeypatch.setenv("CLICKUP_API_TOKEN", "test-token")
+        mcp = FastMCP("test-clickup-create-task")
+        register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["clickup_create_task"].fn
+
+        with patch("aden_tools.tools.clickup_tool.clickup_tool.httpx.post") as mock_post:
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {"id": "task_1", "name": "Ship integration"}
+            mock_post.return_value = response
+
+            result = fn(
+                list_id="list_1",
+                name="Ship integration",
+                description="Build ClickUp MCP integration",
+                status="in progress",
+                assignees=["u1"],
+                due_date=1735689600000,
+                priority=2,
+            )
+
+            assert result["id"] == "task_1"
+            call = mock_post.call_args
+            assert call.kwargs["json"]["name"] == "Ship integration"
+            assert call.kwargs["json"]["status"] == "in progress"
+            assert call.kwargs["json"]["assignees"] == ["u1"]
+
+    def test_update_task_requires_at_least_one_field(self, monkeypatch):
+        monkeypatch.setenv("CLICKUP_API_TOKEN", "test-token")
+        mcp = FastMCP("test-clickup-update-task-validation")
+        register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["clickup_update_task"].fn
+
+        result = fn(task_id="task_1")
+
+        assert result == {"error": "At least one field must be provided for update"}
+
+    def test_update_task_success(self, monkeypatch):
+        monkeypatch.setenv("CLICKUP_API_TOKEN", "test-token")
+        mcp = FastMCP("test-clickup-update-task")
+        register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["clickup_update_task"].fn
+
+        with patch("aden_tools.tools.clickup_tool.clickup_tool.httpx.put") as mock_put:
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {"id": "task_1", "status": "done"}
+            mock_put.return_value = response
+
+            result = fn(task_id="task_1", status="done")
+
+            assert result["status"] == "done"
+            assert mock_put.call_args.kwargs["json"] == {"status": "done"}
+
+    def test_add_comment_validates_text(self, monkeypatch):
+        monkeypatch.setenv("CLICKUP_API_TOKEN", "test-token")
+        mcp = FastMCP("test-clickup-comment-validation")
+        register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["clickup_add_task_comment"].fn
+
+        result = fn(task_id="task_1", comment_text="  ")
+
+        assert result == {"error": "Comment text is required"}
+
+    def test_add_comment_success(self, monkeypatch):
+        monkeypatch.setenv("CLICKUP_API_TOKEN", "test-token")
+        mcp = FastMCP("test-clickup-comment")
+        register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["clickup_add_task_comment"].fn
+
+        with patch("aden_tools.tools.clickup_tool.clickup_tool.httpx.post") as mock_post:
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {"id": "comment_1"}
+            mock_post.return_value = response
+
+            result = fn(task_id="task_1", comment_text="Looks good", notify_all=True)
+
+            assert result["id"] == "comment_1"
+            payload = mock_post.call_args.kwargs["json"]
+            assert payload["comment_text"] == "Looks good"
+            assert payload["notify_all"] is True
+
+
+class TestErrorHandling:
+    """Tests for network and API error handling."""
+
+    def test_rate_limit_error(self, monkeypatch):
+        monkeypatch.setenv("CLICKUP_API_TOKEN", "test-token")
+        mcp = FastMCP("test-clickup-rate-limit")
+        register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["clickup_list_workspaces"].fn
+
+        with patch("aden_tools.tools.clickup_tool.clickup_tool.httpx.get") as mock_get:
+            response = MagicMock()
+            response.status_code = 429
+            response.text = "Too Many Requests"
+            mock_get.return_value = response
+
+            result = fn()
+
+            assert "error" in result
+            assert "rate limit" in result["error"].lower()


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
Closes #4928
Related: #4150

## Changes Made
- Added new ClickUp tool module with 8 MCP tools:
  - `clickup_list_workspaces`
  - `clickup_list_spaces`
  - `clickup_list_lists`
  - `clickup_list_tasks`
  - `clickup_get_task`
  - `clickup_create_task`
  - `clickup_update_task`
  - `clickup_add_task_comment`
- Added ClickUp credential spec (`CLICKUP_API_TOKEN`) and wired it into credential registry.
- Wired ClickUp tool registration into global tools registry.
- Added unit tests for registration, credential handling, payload validation, and error cases.

## Testing
Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual/smoke validation performed

Notes:
- `python3 -m py_compile` passed on all changed files.
- Full `pytest`/`ruff` could not be run locally in this environment because required tooling (`fastmcp`, `uv`, `ruff`) was not installed.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [ ] New and existing unit tests pass locally with my changes
