### PR TITLE
fix: import GraphExecutor in deep_research_agent

### DIFF
--- a/examples/templates/deep_research_agent/agent.py
+++ b/examples/templates/deep_research_agent/agent.py
@@ -2,6 +2,11 @@
 
 from pathlib import Path
 
+from framework.graph.executor import GraphExecutor
+
+from framework.graph.executor import ExecutionResult
+
+
 from framework.graph import EdgeSpec, EdgeCondition, Goal, SuccessCriterion, Constraint
 from framework.graph.edge import GraphSpec
 from framework.graph.executor import ExecutionResult


### PR DESCRIPTION
 Fixes #4936

## Description

Fixes a runtime error in the Deep Research Agent template.

Selecting the agent in TUI caused:

NameError: name 'GraphExecutor' is not defined

The issue was due to a missing import in:
examples/templates/deep_research_agent/agent.py

This PR adds the required `GraphExecutor` import to resolve the error.


## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)


## Related Issues

Fixes #4936


## Changes Made

- Added missing `GraphExecutor` import in `deep_research_agent/agent.py`
- Verified that the Deep Research Agent loads without crashing


## Testing

- [ ] Unit tests pass (`cd core && pytest tests/`) — not fully executed
- [ ] Lint passes (`cd core && ruff check .`) — not fully executed
- [x] Manual testing performed

Manual Testing:
- Ran `.\hive.ps1 tui`
- Selected "Deep Research Agent"
- Confirmed the NameError no longer occurs


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (not required)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective (not added for this minor import fix)
- [ ] New and existing unit tests pass locally with my changes (not fully verified)
