### PR TITLE
feat(tools): add Exa Search API integration with 4 MCP tools

### DIFF
--- a/tools/src/aden_tools/credentials/search.py
+++ b/tools/src/aden_tools/credentials/search.py
@@ -79,4 +79,29 @@ SEARCH_CREDENTIALS = {
         credential_key="api_key",
         credential_group="google_custom_search",
     ),
+    "exa_search": CredentialSpec(
+        env_var="EXA_API_KEY",
+        tools=["exa_search", "exa_find_similar", "exa_get_contents", "exa_answer"],
+        node_types=[],
+        required=True,
+        startup_required=False,
+        help_url="https://dashboard.exa.ai/api-keys",
+        description="API key for Exa Search",
+        # Auth method support
+        direct_api_key_supported=True,
+        api_key_instructions="""To get an Exa Search API key:
+1. Go to https://dashboard.exa.ai/
+2. Sign up for an Exa account (or sign in)
+3. Navigate to "API Keys" in the dashboard
+4. Click "Create new API key"
+5. Give your API key a name (e.g., "Hive Agent")
+6. Copy the API key and store it securely
+Note: Free tier includes 1,000 searches/month.""",
+        # Health check configuration
+        health_check_endpoint="https://api.exa.ai/search",
+        health_check_method="POST",
+        # Credential store mapping
+        credential_id="exa_search",
+        credential_key="api_key",
+    ),
 }

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -30,6 +30,7 @@ from .csv_tool import register_tools as register_csv
 # Security scanning tools
 from .dns_security_scanner import register_tools as register_dns_security_scanner
 from .email_tool import register_tools as register_email
+from .exa_search_tool import register_tools as register_exa_search
 from .example_tool import register_tools as register_example
 from .excel_tool import register_tools as register_excel
 from .file_system_toolkits.apply_diff import register_tools as register_apply_diff
@@ -103,6 +104,7 @@ def register_all_tools(
     register_hubspot(mcp, credentials=credentials)
     register_news(mcp, credentials=credentials)
     register_apollo(mcp, credentials=credentials)
+    register_exa_search(mcp, credentials=credentials)
     register_serpapi(mcp, credentials=credentials)
     register_calendar(mcp, credentials=credentials)
     register_calcom(mcp, credentials=credentials)
@@ -317,6 +319,11 @@ def register_all_tools(
         "tech_stack_detect",
         "subdomain_enumerate",
         "risk_score",
+        # Exa Search tools
+        "exa_search",
+        "exa_find_similar",
+        "exa_get_contents",
+        "exa_answer",
     ]
 
 

--- a/tools/src/aden_tools/tools/exa_search_tool/README.md
+++ b/tools/src/aden_tools/tools/exa_search_tool/README.md
@@ -1,0 +1,98 @@
+# Exa Search Tool
+
+AI-powered web search, content extraction, and research using the Exa API.
+
+## Description
+
+Provides four tools for interacting with web content:
+
+- **`exa_search`** — Neural/keyword web search with domain and date filters
+- **`exa_find_similar`** — Find pages similar to a given URL
+- **`exa_get_contents`** — Extract full text from URLs
+- **`exa_answer`** — Get citation-backed answers to questions
+
+## Arguments
+
+### `exa_search`
+
+| Argument               | Type      | Required | Default | Description                                     |
+| ---------------------- | --------- | -------- | ------- | ----------------------------------------------- |
+| `query`                | str       | Yes      | -       | The search query (1-500 chars)                  |
+| `num_results`          | int       | No       | `10`    | Number of results (1-20)                        |
+| `search_type`          | str       | No       | `auto`  | Search mode: "auto", "neural", or "keyword"     |
+| `include_domains`      | list[str] | No       | `None`  | Only include results from these domains         |
+| `exclude_domains`      | list[str] | No       | `None`  | Exclude results from these domains              |
+| `start_published_date` | str       | No       | `None`  | Filter by publish date (ISO 8601)               |
+| `end_published_date`   | str       | No       | `None`  | Filter by publish date (ISO 8601)               |
+| `include_text`         | bool      | No       | `True`  | Include full page text                          |
+| `include_highlights`   | bool      | No       | `False` | Include relevant text highlights                |
+| `category`             | str       | No       | `None`  | Category filter (e.g. "research paper", "news") |
+
+### `exa_find_similar`
+
+| Argument          | Type      | Required | Default | Description                             |
+| ----------------- | --------- | -------- | ------- | --------------------------------------- |
+| `url`             | str       | Yes      | -       | Source URL to find similar pages for    |
+| `num_results`     | int       | No       | `10`    | Number of results (1-20)                |
+| `include_domains` | list[str] | No       | `None`  | Only include results from these domains |
+| `exclude_domains` | list[str] | No       | `None`  | Exclude results from these domains      |
+| `include_text`    | bool      | No       | `True`  | Include full page text                  |
+
+### `exa_get_contents`
+
+| Argument             | Type      | Required | Default | Description                         |
+| -------------------- | --------- | -------- | ------- | ----------------------------------- |
+| `urls`               | list[str] | Yes      | -       | URLs to extract content from (1-10) |
+| `include_text`       | bool      | No       | `True`  | Include full page text              |
+| `include_highlights` | bool      | No       | `False` | Include relevant highlights         |
+
+### `exa_answer`
+
+| Argument            | Type | Required | Default | Description                          |
+| ------------------- | ---- | -------- | ------- | ------------------------------------ |
+| `query`             | str  | Yes      | -       | The question to answer (1-500 chars) |
+| `include_citations` | bool | No       | `True`  | Include source citations             |
+
+## Environment Variables
+
+| Variable      | Required | Description                                                     |
+| ------------- | -------- | --------------------------------------------------------------- |
+| `EXA_API_KEY` | Yes      | API key from [Exa Dashboard](https://dashboard.exa.ai/api-keys) |
+
+## Example Usage
+
+```python
+# Neural web search
+result = exa_search(query="latest advances in quantum computing")
+
+# Search with filters
+result = exa_search(
+    query="AI safety research",
+    search_type="neural",
+    include_domains=["arxiv.org", "openai.com"],
+    start_published_date="2024-01-01",
+    num_results=5,
+)
+
+# Find pages similar to a URL
+result = exa_find_similar(url="https://example.com/article")
+
+# Extract content from URLs
+result = exa_get_contents(urls=["https://example.com/page1", "https://example.com/page2"])
+
+# Get a citation-backed answer
+result = exa_answer(query="What are the main causes of climate change?")
+```
+
+## Error Handling
+
+Returns error dicts for common issues:
+
+- `Exa credentials not configured` - EXA_API_KEY not set
+- `Query must be 1-500 characters` - Empty or too long query
+- `URL is required` - Missing URL for find_similar
+- `At least one URL is required` - Empty URL list for get_contents
+- `Maximum 10 URLs per request` - Too many URLs for get_contents
+- `Invalid Exa API key` - API key rejected (401)
+- `Exa rate limit exceeded` - Too many requests (429)
+- `Exa search request timed out` - Request exceeded 30s timeout

--- a/tools/src/aden_tools/tools/exa_search_tool/__init__.py
+++ b/tools/src/aden_tools/tools/exa_search_tool/__init__.py
@@ -1,0 +1,5 @@
+"""Exa Search Tool - AI-powered web search, content extraction, and research."""
+
+from .exa_search_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/exa_search_tool/exa_search_tool.py
+++ b/tools/src/aden_tools/tools/exa_search_tool/exa_search_tool.py
@@ -1,0 +1,401 @@
+"""
+Exa Search Tool - AI-powered web search using the Exa API.
+
+Supports:
+- Neural/keyword web search with filters (exa_search)
+- Similar page discovery (exa_find_similar)
+- Content extraction from URLs (exa_get_contents)
+- Citation-backed answers (exa_answer)
+
+All tools use the EXA_API_KEY credential for authentication.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import TYPE_CHECKING, Literal
+
+import httpx
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialStoreAdapter
+
+# Exa API base URL
+EXA_API_BASE = "https://api.exa.ai"
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: CredentialStoreAdapter | None = None,
+) -> None:
+    """Register Exa search tools with the MCP server."""
+
+    def _get_api_key() -> str | None:
+        """Get the Exa API key from credentials or environment."""
+        if credentials is not None:
+            return credentials.get("exa_search")
+        return os.getenv("EXA_API_KEY")
+
+    def _make_request(
+        endpoint: str,
+        payload: dict,
+        api_key: str,
+    ) -> dict:
+        """Make a POST request to the Exa API with retry on rate limit.
+
+        Args:
+            endpoint: API endpoint path (e.g., "/search")
+            payload: JSON request body
+            api_key: Exa API key
+
+        Returns:
+            Parsed JSON response dict, or error dict on failure
+        """
+        max_retries = 3
+        for attempt in range(max_retries + 1):
+            response = httpx.post(
+                f"{EXA_API_BASE}{endpoint}",
+                json=payload,
+                headers={
+                    "x-api-key": api_key,
+                    "Content-Type": "application/json",
+                },
+                timeout=30.0,
+            )
+
+            if response.status_code == 429 and attempt < max_retries:
+                time.sleep(2**attempt)
+                continue
+
+            if response.status_code == 401:
+                return {"error": "Invalid Exa API key"}
+            elif response.status_code == 429:
+                return {"error": "Exa rate limit exceeded. Try again later."}
+            elif response.status_code != 200:
+                return {"error": f"Exa API request failed: HTTP {response.status_code}"}
+
+            break
+
+        return response.json()
+
+    @mcp.tool()
+    def exa_search(
+        query: str,
+        num_results: int = 10,
+        search_type: Literal["auto", "neural", "keyword"] = "auto",
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
+        start_published_date: str | None = None,
+        end_published_date: str | None = None,
+        include_text: bool = True,
+        include_highlights: bool = False,
+        category: str | None = None,
+    ) -> dict:
+        """
+        Search the web using Exa's AI-powered search engine.
+
+        Supports neural (semantic) and keyword search with domain and date filters.
+
+        Args:
+            query: The search query (1-500 chars)
+            num_results: Number of results to return (1-20)
+            search_type: Search mode - "auto", "neural" (semantic), or "keyword"
+            include_domains: Only include results from these domains
+            exclude_domains: Exclude results from these domains
+            start_published_date: Filter by publish date start (ISO 8601, e.g. "2024-01-01")
+            end_published_date: Filter results published before this date (ISO 8601)
+            include_text: Include full page text in results
+            include_highlights: Include relevant text highlights
+            category: Content category filter (e.g. "research paper", "news", "company")
+
+        Returns:
+            Dict with search results including titles, URLs, and optionally text/highlights
+        """
+        if not query or len(query) > 500:
+            return {"error": "Query must be 1-500 characters"}
+
+        num_results = max(1, min(num_results, 20))
+
+        api_key = _get_api_key()
+        if not api_key:
+            return {
+                "error": "Exa credentials not configured",
+                "help": "Set EXA_API_KEY environment variable",
+            }
+
+        payload: dict = {
+            "query": query,
+            "numResults": num_results,
+            "contents": {},
+        }
+
+        if search_type != "auto":
+            payload["type"] = search_type
+
+        if include_domains:
+            payload["includeDomains"] = include_domains
+        if exclude_domains:
+            payload["excludeDomains"] = exclude_domains
+        if start_published_date:
+            payload["startPublishedDate"] = start_published_date
+        if end_published_date:
+            payload["endPublishedDate"] = end_published_date
+        if category:
+            payload["category"] = category
+
+        if include_text:
+            payload["contents"]["text"] = True
+        if include_highlights:
+            payload["contents"]["highlights"] = True
+
+        try:
+            data = _make_request("/search", payload, api_key)
+
+            if "error" in data:
+                return data
+
+            results = []
+            for item in data.get("results", []):
+                result = {
+                    "title": item.get("title", ""),
+                    "url": item.get("url", ""),
+                    "published_date": item.get("publishedDate", ""),
+                    "author": item.get("author", ""),
+                }
+                if include_text and "text" in item:
+                    result["text"] = item["text"]
+                if include_highlights and "highlights" in item:
+                    result["highlights"] = item["highlights"]
+                results.append(result)
+
+            return {
+                "query": query,
+                "results": results,
+                "total": len(results),
+                "provider": "exa",
+            }
+
+        except httpx.TimeoutException:
+            return {"error": "Exa search request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {str(e)}"}
+        except Exception as e:
+            return {"error": f"Exa search failed: {str(e)}"}
+
+    @mcp.tool()
+    def exa_find_similar(
+        url: str,
+        num_results: int = 10,
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
+        include_text: bool = True,
+    ) -> dict:
+        """
+        Find web pages similar to a given URL.
+
+        Uses Exa's neural understanding to find semantically similar content.
+
+        Args:
+            url: The source URL to find similar pages for
+            num_results: Number of similar results to return (1-20)
+            include_domains: Only include results from these domains
+            exclude_domains: Exclude results from these domains
+            include_text: Include full page text in results
+
+        Returns:
+            Dict with similar pages including titles, URLs, and optionally text
+        """
+        if not url:
+            return {"error": "URL is required"}
+
+        num_results = max(1, min(num_results, 20))
+
+        api_key = _get_api_key()
+        if not api_key:
+            return {
+                "error": "Exa credentials not configured",
+                "help": "Set EXA_API_KEY environment variable",
+            }
+
+        payload: dict = {
+            "url": url,
+            "numResults": num_results,
+            "contents": {},
+        }
+
+        if include_domains:
+            payload["includeDomains"] = include_domains
+        if exclude_domains:
+            payload["excludeDomains"] = exclude_domains
+
+        if include_text:
+            payload["contents"]["text"] = True
+
+        try:
+            data = _make_request("/findSimilar", payload, api_key)
+
+            if "error" in data:
+                return data
+
+            results = []
+            for item in data.get("results", []):
+                result = {
+                    "title": item.get("title", ""),
+                    "url": item.get("url", ""),
+                    "published_date": item.get("publishedDate", ""),
+                }
+                if include_text and "text" in item:
+                    result["text"] = item["text"]
+                results.append(result)
+
+            return {
+                "source_url": url,
+                "results": results,
+                "total": len(results),
+                "provider": "exa",
+            }
+
+        except httpx.TimeoutException:
+            return {"error": "Exa find similar request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {str(e)}"}
+        except Exception as e:
+            return {"error": f"Exa find similar failed: {str(e)}"}
+
+    @mcp.tool()
+    def exa_get_contents(
+        urls: list[str],
+        include_text: bool = True,
+        include_highlights: bool = False,
+    ) -> dict:
+        """
+        Extract content from one or more URLs using Exa's content extraction.
+
+        Args:
+            urls: List of URLs to extract content from (1-10 URLs)
+            include_text: Include full page text
+            include_highlights: Include relevant text highlights
+
+        Returns:
+            Dict with extracted content for each URL
+        """
+        if not urls:
+            return {"error": "At least one URL is required"}
+        if len(urls) > 10:
+            return {"error": "Maximum 10 URLs per request"}
+
+        api_key = _get_api_key()
+        if not api_key:
+            return {
+                "error": "Exa credentials not configured",
+                "help": "Set EXA_API_KEY environment variable",
+            }
+
+        payload: dict = {
+            "ids": urls,
+        }
+
+        contents: dict = {}
+        if include_text:
+            contents["text"] = True
+        if include_highlights:
+            contents["highlights"] = True
+        if contents:
+            payload["contents"] = contents
+
+        try:
+            data = _make_request("/contents", payload, api_key)
+
+            if "error" in data:
+                return data
+
+            results = []
+            for item in data.get("results", []):
+                result = {
+                    "url": item.get("url", ""),
+                    "title": item.get("title", ""),
+                }
+                if include_text and "text" in item:
+                    result["text"] = item["text"]
+                if include_highlights and "highlights" in item:
+                    result["highlights"] = item["highlights"]
+                results.append(result)
+
+            return {
+                "results": results,
+                "total": len(results),
+                "provider": "exa",
+            }
+
+        except httpx.TimeoutException:
+            return {"error": "Exa content extraction request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {str(e)}"}
+        except Exception as e:
+            return {"error": f"Exa content extraction failed: {str(e)}"}
+
+    @mcp.tool()
+    def exa_answer(
+        query: str,
+        include_citations: bool = True,
+    ) -> dict:
+        """
+        Get an answer to a question with citations from web sources.
+
+        Uses Exa to search the web and generate a citation-backed answer.
+
+        Args:
+            query: The question to answer (1-500 chars)
+            include_citations: Include source citations in the response
+
+        Returns:
+            Dict with the answer text and optionally source citations
+        """
+        if not query or len(query) > 500:
+            return {"error": "Query must be 1-500 characters"}
+
+        api_key = _get_api_key()
+        if not api_key:
+            return {
+                "error": "Exa credentials not configured",
+                "help": "Set EXA_API_KEY environment variable",
+            }
+
+        payload: dict = {
+            "query": query,
+        }
+
+        try:
+            data = _make_request("/answer", payload, api_key)
+
+            if "error" in data:
+                return data
+
+            result: dict = {
+                "query": query,
+                "answer": data.get("answer", ""),
+                "provider": "exa",
+            }
+
+            if include_citations:
+                citations = []
+                for source in data.get("citations", []):
+                    citations.append(
+                        {
+                            "title": source.get("title", ""),
+                            "url": source.get("url", ""),
+                            "published_date": source.get("publishedDate", ""),
+                        }
+                    )
+                result["citations"] = citations
+
+            return result
+
+        except httpx.TimeoutException:
+            return {"error": "Exa answer request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {str(e)}"}
+        except Exception as e:
+            return {"error": f"Exa answer failed: {str(e)}"}

--- a/tools/tests/tools/test_exa_search_tool.py
+++ b/tools/tests/tools/test_exa_search_tool.py
@@ -1,0 +1,241 @@
+"""Tests for exa_search tools (FastMCP)."""
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.exa_search_tool import register_tools
+
+
+@pytest.fixture
+def mcp():
+    """Create a fresh FastMCP instance for testing."""
+    return FastMCP("test-server")
+
+
+@pytest.fixture
+def exa_search_fn(mcp: FastMCP):
+    """Register and return the exa_search tool function."""
+    register_tools(mcp)
+    return mcp._tool_manager._tools["exa_search"].fn
+
+
+@pytest.fixture
+def exa_find_similar_fn(mcp: FastMCP):
+    """Register and return the exa_find_similar tool function."""
+    register_tools(mcp)
+    return mcp._tool_manager._tools["exa_find_similar"].fn
+
+
+@pytest.fixture
+def exa_get_contents_fn(mcp: FastMCP):
+    """Register and return the exa_get_contents tool function."""
+    register_tools(mcp)
+    return mcp._tool_manager._tools["exa_get_contents"].fn
+
+
+@pytest.fixture
+def exa_answer_fn(mcp: FastMCP):
+    """Register and return the exa_answer tool function."""
+    register_tools(mcp)
+    return mcp._tool_manager._tools["exa_answer"].fn
+
+
+class TestExaSearchCredentials:
+    """Tests for Exa credential handling."""
+
+    def test_no_credentials_returns_error(self, exa_search_fn, monkeypatch):
+        """Search without API key returns helpful error."""
+        monkeypatch.delenv("EXA_API_KEY", raising=False)
+
+        result = exa_search_fn(query="test query")
+
+        assert "error" in result
+        assert "Exa credentials not configured" in result["error"]
+        assert "help" in result
+
+    def test_find_similar_no_credentials(self, exa_find_similar_fn, monkeypatch):
+        """Find similar without API key returns error."""
+        monkeypatch.delenv("EXA_API_KEY", raising=False)
+
+        result = exa_find_similar_fn(url="https://example.com")
+
+        assert "error" in result
+        assert "Exa credentials not configured" in result["error"]
+
+    def test_get_contents_no_credentials(self, exa_get_contents_fn, monkeypatch):
+        """Get contents without API key returns error."""
+        monkeypatch.delenv("EXA_API_KEY", raising=False)
+
+        result = exa_get_contents_fn(urls=["https://example.com"])
+
+        assert "error" in result
+        assert "Exa credentials not configured" in result["error"]
+
+    def test_answer_no_credentials(self, exa_answer_fn, monkeypatch):
+        """Answer without API key returns error."""
+        monkeypatch.delenv("EXA_API_KEY", raising=False)
+
+        result = exa_answer_fn(query="test question")
+
+        assert "error" in result
+        assert "Exa credentials not configured" in result["error"]
+
+
+class TestExaSearchValidation:
+    """Tests for input validation."""
+
+    def test_empty_query_returns_error(self, exa_search_fn, monkeypatch):
+        """Empty query returns error."""
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+
+        result = exa_search_fn(query="")
+
+        assert "error" in result
+        assert "1-500" in result["error"]
+
+    def test_long_query_returns_error(self, exa_search_fn, monkeypatch):
+        """Query exceeding 500 chars returns error."""
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+
+        result = exa_search_fn(query="x" * 501)
+
+        assert "error" in result
+
+    def test_find_similar_empty_url(self, exa_find_similar_fn, monkeypatch):
+        """Find similar with empty URL returns error."""
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+
+        result = exa_find_similar_fn(url="")
+
+        assert "error" in result
+        assert "URL is required" in result["error"]
+
+    def test_get_contents_empty_urls(self, exa_get_contents_fn, monkeypatch):
+        """Get contents with empty URL list returns error."""
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+
+        result = exa_get_contents_fn(urls=[])
+
+        assert "error" in result
+        assert "At least one URL is required" in result["error"]
+
+    def test_get_contents_too_many_urls(self, exa_get_contents_fn, monkeypatch):
+        """Get contents with more than 10 URLs returns error."""
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+
+        urls = [f"https://example.com/{i}" for i in range(11)]
+        result = exa_get_contents_fn(urls=urls)
+
+        assert "error" in result
+        assert "Maximum 10 URLs" in result["error"]
+
+    def test_answer_empty_query(self, exa_answer_fn, monkeypatch):
+        """Answer with empty query returns error."""
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+
+        result = exa_answer_fn(query="")
+
+        assert "error" in result
+        assert "1-500" in result["error"]
+
+    def test_answer_long_query(self, exa_answer_fn, monkeypatch):
+        """Answer with query exceeding 500 chars returns error."""
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+
+        result = exa_answer_fn(query="x" * 501)
+
+        assert "error" in result
+
+
+class TestExaSearchWithKey:
+    """Tests that verify tools accept valid credentials."""
+
+    def test_search_with_key_makes_request(self, exa_search_fn, monkeypatch):
+        """Search with valid API key attempts API call."""
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+
+        # Will fail (test key is invalid) but should not be a credential error
+        result = exa_search_fn(query="test query")
+        assert isinstance(result, dict)
+
+    def test_find_similar_with_key(self, exa_find_similar_fn, monkeypatch):
+        """Find similar with valid API key attempts API call."""
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+
+        result = exa_find_similar_fn(url="https://example.com")
+        assert isinstance(result, dict)
+
+    def test_get_contents_with_key(self, exa_get_contents_fn, monkeypatch):
+        """Get contents with valid API key attempts API call."""
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+
+        result = exa_get_contents_fn(urls=["https://example.com"])
+        assert isinstance(result, dict)
+
+    def test_answer_with_key(self, exa_answer_fn, monkeypatch):
+        """Answer with valid API key attempts API call."""
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+
+        result = exa_answer_fn(query="What is AI?")
+        assert isinstance(result, dict)
+
+
+class TestExaSearchParameters:
+    """Tests for tool parameters."""
+
+    def test_search_type_parameter(self, exa_search_fn, monkeypatch):
+        """search_type parameter is accepted."""
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+
+        result = exa_search_fn(query="test", search_type="neural")
+        assert isinstance(result, dict)
+
+    def test_num_results_clamped(self, exa_search_fn, monkeypatch):
+        """num_results is clamped to valid range."""
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+
+        result = exa_search_fn(query="test", num_results=50)
+        assert isinstance(result, dict)
+
+    def test_domain_filters(self, exa_search_fn, monkeypatch):
+        """Domain filter parameters are accepted."""
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+
+        result = exa_search_fn(
+            query="test",
+            include_domains=["example.com"],
+            exclude_domains=["spam.com"],
+        )
+        assert isinstance(result, dict)
+
+    def test_date_filters(self, exa_search_fn, monkeypatch):
+        """Date filter parameters are accepted."""
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+
+        result = exa_search_fn(
+            query="test",
+            start_published_date="2024-01-01",
+            end_published_date="2024-12-31",
+        )
+        assert isinstance(result, dict)
+
+    def test_category_parameter(self, exa_search_fn, monkeypatch):
+        """Category parameter is accepted."""
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+
+        result = exa_search_fn(query="test", category="news")
+        assert isinstance(result, dict)
+
+
+class TestExaToolRegistration:
+    """Tests for tool registration."""
+
+    def test_all_tools_registered(self, mcp: FastMCP):
+        """All four Exa tools are registered."""
+        register_tools(mcp)
+
+        tools = mcp._tool_manager._tools
+        assert "exa_search" in tools
+        assert "exa_find_similar" in tools
+        assert "exa_get_contents" in tools
+        assert "exa_answer" in tools


### PR DESCRIPTION
## Summary

Implements AI-powered web search, content extraction, and research tools via the [Exa API](https://docs.exa.ai/) for agent workflows.

**Tools:** `exa_search`, `exa_find_similar`, `exa_get_contents`, `exa_answer`

## Changes

### Tool Implementation

- **`exa_search`** — Neural/keyword web search with domain, date, and category filters
- **`exa_find_similar`** — Find pages similar to a given URL via neural embeddings
- **`exa_get_contents`** — Extract full text from up to 10 URLs per request
- **`exa_answer`** — Get citation-backed answers to questions from web sources

### Architecture

Follows existing tool pattern (`web_search_tool`, `hubspot_tool`, `slack_tool`):

- `register_tools(mcp, credentials)` with `@mcp.tool()` decorators
- Credential fallback: `CredentialStoreAdapter` → `EXA_API_KEY` env var
- Error handling: always returns dicts, never raises
- Retry with exponential backoff on HTTP 429 (3 retries)

### Files Changed

| File                                                            | Change                                        |
| --------------------------------------------------------------- | --------------------------------------------- |
| `tools/src/aden_tools/tools/exa_search_tool/exa_search_tool.py` | Tool implementation (4 tools)                 |
| `tools/src/aden_tools/tools/exa_search_tool/__init__.py`        | Package re-export                             |
| `tools/src/aden_tools/tools/exa_search_tool/README.md`          | Tool documentation                            |
| `tools/src/aden_tools/tools/__init__.py`                        | Register exa_search in `register_all_tools()` |
| `tools/src/aden_tools/credentials/search.py`                    | `CredentialSpec` for `exa_search`             |
| `tools/tests/tools/test_exa_search_tool.py`                     | 21 unit tests                                 |

## Testing

- **21 unit tests** covering credentials, input validation, API key handling, parameters, and registration
- **500/500 integration CI tests** passing (spec conformance, registration, credential coverage)
- **Live integration tests** verified against the real Exa API — all 4 tools return correct results

## Credential Configuration

| Field            | Value                               |
| ---------------- | ----------------------------------- |
| `credential_id`  | `exa_search`                        |
| `env_var`        | `EXA_API_KEY`                       |
| `credential_key` | `api_key`                           |
| Auth method      | Direct API key (`x-api-key` header) |
| Health check     | `POST https://api.exa.ai/search`    |
| Free tier        | 1,000 searches/month                |

Fixes #4177
