### PR TITLE
Import GraphExecutor in agent.py

### DIFF
--- a/examples/templates/deep_research_agent/agent.py
+++ b/examples/templates/deep_research_agent/agent.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from framework.graph import EdgeSpec, EdgeCondition, Goal, SuccessCriterion, Constraint
 from framework.graph.edge import GraphSpec
 from framework.graph.executor import ExecutionResult
+from framework.graph.executor import GraphExecutor
 from framework.graph.checkpoint_config import CheckpointConfig
 from framework.llm import LiteLLMProvider
 from framework.runner.tool_registry import ToolRegistry


### PR DESCRIPTION
## Description

This error happens because the file uses the execution system that depends on GraphExecutor, but it was not imported. When the TUI loads the Deep Research Agent, Python cannot find GraphExecutor, so it throws a NameError and crashes. To fix this, we add the missing import for GraphExecutor from framework.graph.executor at the top of the file. After this change, the agent loads correctly without crashing. #4936 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #4936 

## Changes Made

	•	TUI loads the agent
	•	Agent setup calls runtime
	•	Runtime internally uses GraphExecutor
	•	Python looks for GraphExecutor
	•	Before: ❌ Not found → crash
	•	After: ✅ Found → works

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes