### PR TITLE
feat(tools): add arxiv search and download tools

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -84,6 +84,7 @@ python mcp_server.py
 | `calendar_delete_event`| Delete a calendar event                        |
 | `calendar_get_calendar`| Get calendar metadata                          |
 | `calendar_check_availability` | Check free/busy status for attendees    |
+| `arxiv_search_papers`     | Search for scholarly papers on ArXiv       |
 
 ## Project Structure
 

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "litellm>=1.81.0",
     "dnspython>=2.4.0",
     "resend>=2.0.0",
+    "arxiv>=2.1.0",
     "framework",
     
 ]

--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -53,6 +53,7 @@ To add a new credential:
 """
 
 from .apollo import APOLLO_CREDENTIALS
+from .arxiv import ARXIV_CREDENTIALS
 from .base import CredentialError, CredentialSpec
 from .bigquery import BIGQUERY_CREDENTIALS
 from .browser import get_aden_auth_url, get_aden_setup_url, open_browser
@@ -87,6 +88,7 @@ CREDENTIAL_SPECS = {
     **EMAIL_CREDENTIALS,
     **GCP_VISION_CREDENTIALS,
     **APOLLO_CREDENTIALS,
+    **ARXIV_CREDENTIALS,
     **GITHUB_CREDENTIALS,
     **GOOGLE_MAPS_CREDENTIALS,
     **HUBSPOT_CREDENTIALS,
@@ -126,6 +128,7 @@ __all__ = [
     "SEARCH_CREDENTIALS",
     "EMAIL_CREDENTIALS",
     "GCP_VISION_CREDENTIALS",
+    "ARXIV_CREDENTIALS",
     "GITHUB_CREDENTIALS",
     "GOOGLE_MAPS_CREDENTIALS",
     "HUBSPOT_CREDENTIALS",

--- a/tools/src/aden_tools/credentials/arxiv.py
+++ b/tools/src/aden_tools/credentials/arxiv.py
@@ -1,0 +1,24 @@
+"""ArXiv tool credentials.
+
+Contains metadata for the public ArXiv API integration.
+"""
+
+from .base import CredentialSpec
+
+ARXIV_CREDENTIALS = {
+    "arxiv_public": CredentialSpec(
+        env_var="N/A",  # Public API
+        tools=[
+            "arxiv_search_papers",
+            "arxiv_download_paper",
+        ],
+        required=False,
+        startup_required=False,
+        help_url="https://arxiv.org/help/api/user-manual",
+        description="Public Access (No Token Required)",
+        direct_api_key_supported=False,
+        health_check_endpoint="https://export.arxiv.org/api/query?search_query=all:test&start=0&max_results=1",
+        health_check_method="GET",
+        credential_id="arxiv_public",
+    ),
+}

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 # Import register_tools from each tool module
 from .apollo_tool import register_tools as register_apollo
+from .arxiv_tool import register_tools as register_arxiv
 from .bigquery_tool import register_tools as register_bigquery
 from .calcom_tool import register_tools as register_calcom
 from .calendar_tool import register_tools as register_calendar
@@ -91,6 +92,7 @@ def register_all_tools(
     register_pdf_read(mcp)
     register_time(mcp)
     register_runtime_logs(mcp)
+    register_arxiv(mcp, credentials=credentials)
 
     # Tools that need credentials (pass credentials if provided)
     # web_search supports multiple providers (Google, Brave) with auto-detection
@@ -289,6 +291,8 @@ def register_all_tools(
         "slack_find_user_by_email",
         "slack_kick_user_from_channel",
         "slack_delete_file",
+        "arxiv_search_papers",
+        "arxiv_download_paper",
         "slack_get_team_stats",
         "vision_detect_labels",
         "vision_detect_text",

--- a/tools/src/aden_tools/tools/arxiv_tool/README.md
+++ b/tools/src/aden_tools/tools/arxiv_tool/README.md
@@ -1,0 +1,36 @@
+# ArXiv Toolkit
+
+Native integration with ArXiv Public API for Hive agents.
+
+## Overview
+The ArXiv toolkit enables agents to perform rigorous scientific research and literature reviews by searching for scholarly papers and downloading their PDFs for analysis.
+
+## Requirements
+- `arxiv` Python library
+- No authentication required (Public API)
+
+## Configuration
+This tool utilizes public endpoints and does not require an API key or token. However, it respects the official rate limit of a 3-second delay between requests.
+
+## Available Tools
+
+### Search & Discovery
+- `arxiv_search_papers`: Search for papers by keywords, authors, or specific IDs. Supports filtering by relevance.
+
+### Document Retrieval
+- `arxiv_download_paper`: Downloads the full PDF of a paper to a local directory (defaults to temp). Returns the file path for ingestion by other tools like `pdf_read_tool`.
+
+## Usage Examples
+
+### Searching for AI Agent Research
+```python
+arxiv_search_papers(query='AI Agents', max_results=3)
+```
+
+### Downloading a specific paper
+```python
+arxiv_download_paper(paper_id='1706.03762')
+```
+
+## Setup Instructions
+No setup required. ArXiv is an open-access repository.

--- a/tools/src/aden_tools/tools/arxiv_tool/__init__.py
+++ b/tools/src/aden_tools/tools/arxiv_tool/__init__.py
@@ -1,0 +1,4 @@
+"""ArXiv tool package."""
+from .arxiv_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/arxiv_tool/arxiv_tool.py
+++ b/tools/src/aden_tools/tools/arxiv_tool/arxiv_tool.py
@@ -1,0 +1,103 @@
+"""ArXiv toolkit for Hive agents.
+
+Enables searching for papers and downloading PDFs for research.
+"""
+
+import os
+import tempfile
+import time
+from typing import Any, Optional
+
+import arxiv
+from fastmcp import FastMCP
+
+from aden_tools.credentials import CredentialStoreAdapter
+
+# ArXiv API suggests a 3-second delay between requests.
+# The library might handle some of this, but we'll add a minimal safety delay.
+LAST_REQUEST_TIME = 0.0
+RATE_LIMIT_DELAY = 3.0
+
+
+def _rate_limit():
+    """Ensure we respect ArXiv rate limits."""
+    global LAST_REQUEST_TIME
+    elapsed = time.time() - LAST_REQUEST_TIME
+    if elapsed < RATE_LIMIT_DELAY:
+        time.sleep(RATE_LIMIT_DELAY - elapsed)
+    LAST_REQUEST_TIME = time.time()
+
+
+def register_tools(mcp: FastMCP, credentials: Optional[CredentialStoreAdapter] = None):
+    """Register ArXiv tools with the provided MCP instance."""
+
+    @mcp.tool()
+    def arxiv_search_papers(query: str, max_results: int = 5) -> dict[str, Any]:
+        """
+        Search for scholarly papers on ArXiv.
+
+        Args:
+            query: Search query (e.g., 'AI Agents', 'id:1706.03762', 'au:Hinton').
+            max_results: Maximum number of papers to return (default: 5).
+
+        Returns:
+            List of papers with metadata (title, summary, authors, paper_id).
+        """
+        _rate_limit()
+        try:
+            client = arxiv.Client()
+            search = arxiv.Search(
+                query=query,
+                max_results=max_results,
+                sort_by=arxiv.SortCriterion.Relevance
+            )
+
+            results = []
+            for paper in client.results(search):
+                results.append({
+                    "title": paper.title,
+                    "summary": paper.summary,
+                    "authors": [author.name for author in paper.authors],
+                    "published": paper.published.isoformat(),
+                    "paper_id": paper.get_short_id(),
+                    "pdf_url": paper.pdf_url,
+                    "entry_id": paper.entry_id,
+                })
+            
+            return {"papers": results, "count": len(results)}
+        except Exception as e:
+            return {"error": str(e)}
+
+    @mcp.tool()
+    def arxiv_download_paper(paper_id: str, download_dir: Optional[str] = None) -> dict[str, Any]:
+        """
+        Download a paper as a PDF file from ArXiv.
+
+        Args:
+            paper_id: The ID of the paper (e.g., '1706.03762').
+            download_dir: Optional directory to save the PDF. Defaults to a temporary directory.
+
+        Returns:
+            Local file path to the downloaded PDF.
+        """
+        _rate_limit()
+        try:
+            client = arxiv.Client()
+            search = arxiv.Search(id_list=[paper_id])
+            paper = next(client.results(search))
+
+            if not download_dir:
+                download_dir = tempfile.gettempdir()
+            
+            # download_pdf returns the filename
+            file_path = paper.download_pdf(dirpath=download_dir)
+            
+            return {
+                "file_path": file_path,
+                "title": paper.title,
+                "paper_id": paper_id
+            }
+        except StopIteration:
+            return {"error": f"Paper with ID {paper_id} not found."}
+        except Exception as e:
+            return {"error": str(e)}

--- a/tools/src/aden_tools/tools/arxiv_tool/tests/test_arxiv_tool.py
+++ b/tools/src/aden_tools/tools/arxiv_tool/tests/test_arxiv_tool.py
@@ -1,0 +1,77 @@
+"""Tests for the ArXiv tool."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aden_tools.tools.arxiv_tool.arxiv_tool import register_tools
+
+
+class TestArXivTools:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.fns = []
+        # Mocking the decorator behavior
+        self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
+        self.cred = MagicMock()
+        register_tools(self.mcp, credentials=self.cred)
+
+    def _fn(self, name):
+        """Retrieve a registered function by its name."""
+        return next(f for f in self.fns if f.__name__ == name)
+
+    @patch("arxiv.Client")
+    @patch("arxiv.Search")
+    def test_arxiv_search_papers(self, mock_search, mock_client):
+        # Mock paper objects
+        mock_paper = MagicMock()
+        mock_paper.title = "Attention is All You Need"
+        mock_paper.summary = "Deep learning paper"
+        mock_author = MagicMock()
+        mock_author.name = "Ashish Vaswani"
+        mock_paper.authors = [mock_author]
+        mock_paper.published.isoformat.return_value = "2017-06-12T00:00:00Z"
+        mock_paper.get_short_id.return_value = "1706.03762v1"
+        mock_paper.pdf_url = "http://arxiv.org/pdf/1706.03762v1"
+        mock_paper.entry_id = "http://arxiv.org/abs/1706.03762v1"
+
+        # Mock client.results
+        mock_client_instance = mock_client.return_value
+        mock_client_instance.results.return_value = [mock_paper]
+
+        tool = self._fn("arxiv_search_papers")
+        result = tool(query="Attention")
+
+        assert "papers" in result
+        assert result["count"] == 1
+        assert result["papers"][0]["title"] == "Attention is All You Need"
+        assert result["papers"][0]["paper_id"] == "1706.03762v1"
+
+    @patch("arxiv.Client")
+    @patch("arxiv.Search")
+    def test_arxiv_download_paper(self, mock_search, mock_client):
+        mock_paper = MagicMock()
+        mock_paper.title = "Attention"
+        mock_paper.download_pdf.return_value = "/tmp/attention.pdf"
+
+        mock_client_instance = mock_client.return_value
+        mock_client_instance.results.return_value = iter([mock_paper])
+
+        tool = self._fn("arxiv_download_paper")
+        result = tool(paper_id="1706.03762")
+
+        assert result["file_path"] == "/tmp/attention.pdf"
+        assert result["paper_id"] == "1706.03762"
+        mock_paper.download_pdf.assert_called_once()
+
+    @patch("arxiv.Client")
+    @patch("arxiv.Search")
+    def test_arxiv_download_paper_not_found(self, mock_search, mock_client):
+        mock_client_instance = mock_client.return_value
+        mock_client_instance.results.return_value = iter([])
+
+        tool = self._fn("arxiv_download_paper")
+        result = tool(paper_id="nonexistent")
+
+        assert "error" in result
+        assert "not found" in result["error"]


### PR DESCRIPTION
This PR implements native integration with the ArXiv Public API, allowing Hive agents to:
1. **Search** for scholarly papers using keywords, authors, or IDs with relevance sorting.
2. **Download** full-text PDFs to local storage for ingestion and analysis (e.g., via `pdf_read_tool`).

## Changes
- **New Credentials**: Added `ARXIV_CREDENTIALS` for public API discovery and health checks.
- **New Tool**: `arxiv_tool.py` providing `arxiv_search_papers` and `arxiv_download_paper`.
- **Logic**: Implemented built-in rate limiting (3s delay) as required by ArXiv terms of service.
- **Documentation**: New `README.md` in the arxiv toolkit and entries in the main tools registry.
- **Tests**: Comprehensive unit tests covering search, download, and error scenarios.

## Verification
- Ran `pytest tools/src/aden_tools/tools/arxiv_tool/tests/test_arxiv_tool.py`:
  - `arxiv_search_papers` - PASS
  - `arxiv_download_paper` - PASS
  - `arxiv_download_paper_not_found` - PASS

Resolves #4331

---
_Pull request created with Google Antigravity_