### PR TITLE
Added Discord link to Quick Links for better community visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Use Hive when you need:
 - **[Documentation](https://docs.adenhq.com/)** - Complete guides and API reference
 - **[Self-Hosting Guide](https://docs.adenhq.com/getting-started/quickstart)** - Deploy Hive on your infrastructure
 - **[Changelog](https://github.com/adenhq/hive/releases)** - Latest updates and releases
+- **[Community Discord](https://discord.gg/MXE49hrKDk)** - Join the discussion and get support
 - **[Roadmap](docs/roadmap.md)** - Upcoming features and plans
 - **[Report Issues](https://github.com/adenhq/hive/issues)** - Bug reports and feature requests
 - **[Contributing](CONTRIBUTING.md)** - How to contribute and submit PRs


### PR DESCRIPTION

Hi team,
I noticed the Discord link was missing from the 'Quick Links' section. Since community growth is a priority, I added it there to reduce friction for new developers looking for support or discussion.
Best,
Immanuel

