### PR TITLE
feat: integrate AWS CloudWatch tools for agent observability

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -84,6 +84,10 @@ python mcp_server.py
 | `calendar_delete_event`| Delete a calendar event                        |
 | `calendar_get_calendar`| Get calendar metadata                          |
 | `calendar_check_availability` | Check free/busy status for attendees    |
+| `cloudwatch_put_metric` | Publish custom metrics to AWS CloudWatch |
+| `cloudwatch_put_log_event` | Send log events to AWS CloudWatch Logs |
+| `cloudwatch_create_alarm` | Create or update CloudWatch Alarms |
+| `cloudwatch_get_metric_stats` | Retrieve metric statistics from CloudWatch |
 
 ## Project Structure
 
@@ -107,7 +111,8 @@ tools/
 │       ├── web_scrape_tool/
 │       ├── pdf_read_tool/
 │       ├── time_tool/
-│       └── calendar_tool/
+│       ├── calendar_tool/
+│       └── cloudwatch_tool/
 ├── tests/                   # Test suite
 ├── mcp_server.py            # MCP server entry point
 ├── README.md

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "litellm>=1.81.0",
     "dnspython>=2.4.0",
     "resend>=2.0.0",
+    "boto3>=1.34.0",
     "framework",
     
 ]

--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -57,6 +57,7 @@ from .base import CredentialError, CredentialSpec
 from .bigquery import BIGQUERY_CREDENTIALS
 from .browser import get_aden_auth_url, get_aden_setup_url, open_browser
 from .calcom import CALCOM_CREDENTIALS
+from .cloudwatch import CLOUDWATCH_CREDENTIALS
 from .email import EMAIL_CREDENTIALS
 from .gcp_vision import GCP_VISION_CREDENTIALS
 from .github import GITHUB_CREDENTIALS
@@ -97,6 +98,7 @@ CREDENTIAL_SPECS = {
     **TELEGRAM_CREDENTIALS,
     **BIGQUERY_CREDENTIALS,
     **CALCOM_CREDENTIALS,
+    **CLOUDWATCH_CREDENTIALS,
 }
 
 __all__ = [
@@ -137,4 +139,5 @@ __all__ = [
     "TELEGRAM_CREDENTIALS",
     "BIGQUERY_CREDENTIALS",
     "CALCOM_CREDENTIALS",
+    "CLOUDWATCH_CREDENTIALS",
 ]

--- a/tools/src/aden_tools/credentials/cloudwatch.py
+++ b/tools/src/aden_tools/credentials/cloudwatch.py
@@ -1,0 +1,14 @@
+"""AWS CloudWatch credential specification."""
+
+from .base import CredentialSpec
+
+CLOUDWATCH_CREDENTIALS = {
+    "aws_cloudwatch": CredentialSpec(
+        env_var="AWS_ACCESS_KEY_ID",
+        tools=["cloudwatch_put_metric", "cloudwatch_put_log_event", "cloudwatch_create_alarm", "cloudwatch_get_metric_stats"],
+        required=True,
+        startup_required=False,
+        help_url="https://console.aws.amazon.com/iam/",
+        description="AWS access key ID for CloudWatch access. Also requires AWS_SECRET_ACCESS_KEY and optionally AWS_REGION.",
+    )
+}

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -26,6 +26,7 @@ from .bigquery_tool import register_tools as register_bigquery
 from .calcom_tool import register_tools as register_calcom
 from .calendar_tool import register_tools as register_calendar
 from .csv_tool import register_tools as register_csv
+from .cloudwatch_tool import register_tools as register_cloudwatch
 
 # Security scanning tools
 from .dns_security_scanner import register_tools as register_dns_security_scanner
@@ -114,6 +115,7 @@ def register_all_tools(
     register_vision(mcp, credentials=credentials)
     register_google_maps(mcp, credentials=credentials)
     register_bigquery(mcp, credentials=credentials)
+    register_cloudwatch(mcp, credentials=credentials)
 
     # Register file system toolkits
     register_view_file(mcp)
@@ -311,6 +313,10 @@ def register_all_tools(
         "maps_place_search",
         "run_bigquery_query",
         "describe_dataset",
+        "cloudwatch_put_metric",
+        "cloudwatch_put_log_event",
+        "cloudwatch_create_alarm",
+        "cloudwatch_get_metric_stats",
         # Security scanning tools
         "ssl_tls_scan",
         "http_headers_scan",

--- a/tools/src/aden_tools/tools/cloudwatch_tool/README.md
+++ b/tools/src/aden_tools/tools/cloudwatch_tool/README.md
@@ -1,0 +1,66 @@
+# AWS CloudWatch Toolkit
+
+Native integration with AWS CloudWatch for Hive agent observability and monitoring.
+
+## Overview
+The CloudWatch toolkit enables agents to publish custom metrics, stream execution logs, and manage alarms directly within the AWS ecosystem. This is essential for production deployments where teams need centralized monitoring and alerting.
+
+## Requirements
+- `boto3` Python library
+- AWS Credentials with CloudWatch permissions (`CloudWatchFullAccess` or scoped permissions)
+
+## Configuration
+Requires the following environment variables or credentials in the store:
+- `AWS_ACCESS_KEY_ID`: AWS access key
+- `AWS_SECRET_ACCESS_KEY`: AWS secret key
+- `AWS_REGION`: AWS region (defaults to `us-east-1`)
+
+## Available Tools
+
+### Metrics
+- `cloudwatch_put_metric`: Publish custom metrics (e.g., execution time, token usage, cost).
+- `cloudwatch_get_metric_stats`: Retrieve metric statistics for self-monitoring and adaptive behavior.
+
+### Logs
+- `cloudwatch_put_log_event`: Stream log events to CloudWatch Logs (auto-creates log groups/streams).
+
+### Alarms
+- `cloudwatch_create_alarm`: Create or update CloudWatch Alarms with configurable thresholds and actions.
+
+## Usage Examples
+
+### Publishing a Metric
+```python
+cloudwatch_put_metric(
+    namespace="HiveAgents",
+    metric_name="ExecutionDuration",
+    value=45.2,
+    unit="Seconds",
+    dimensions={"AgentID": "invoice-processor-01"}
+)
+```
+
+### Sending a Log Event
+```python
+cloudwatch_put_log_event(
+    log_group="/hive/agents/production",
+    log_stream="invoice-processor-01",
+    message="Agent started node: validate_schema"
+)
+```
+
+### Creating an Alarm
+```python
+cloudwatch_create_alarm(
+    alarm_name="HighTokenUsageAlarm",
+    namespace="HiveAgents",
+    metric_name="TokensUsed",
+    threshold=50000.0,
+    comparison_operator="GreaterThanThreshold",
+    alarm_actions=["arn:aws:sns:us-east-1:123456789012:MyAlertTopic"]
+)
+```
+
+## Setup Instructions
+1. Ensure your AWS user/role has `cloudwatch:PutMetricData`, `cloudwatch:PutMetricAlarm`, `logs:CreateLogGroup`, `logs:CreateLogStream`, and `logs:PutLogEvents` permissions.
+2. Set your AWS credentials in the environment or use the Hive credential manager.

--- a/tools/src/aden_tools/tools/cloudwatch_tool/__init__.py
+++ b/tools/src/aden_tools/tools/cloudwatch_tool/__init__.py
@@ -1,0 +1,5 @@
+"""AWS CloudWatch tool package."""
+
+from .cloudwatch_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/cloudwatch_tool/cloudwatch_tool.py
+++ b/tools/src/aden_tools/tools/cloudwatch_tool/cloudwatch_tool.py
@@ -1,0 +1,312 @@
+"""AWS CloudWatch tool implementation."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+    from aden_tools.credentials import CredentialStoreAdapter
+
+logger = logging.getLogger(__name__)
+
+
+def get_cloudwatch_client(credentials: CredentialStoreAdapter | None = None):
+    """
+    Initialize a CloudWatch client using available credentials.
+    """
+    import os
+    aws_access_key = os.environ.get("AWS_ACCESS_KEY_ID")
+    aws_secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+    aws_region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
+
+    if credentials:
+        # Try to get from adapter if available
+        key = credentials.get("aws_cloudwatch")
+        if key:
+            aws_access_key = key
+            # If the adapter is a store adapter, we can try to get the secret too
+            # but for now we assume it's in env if possible or just use what we have
+            try:
+                secret = credentials.get_key("aws_cloudwatch", "aws_secret_access_key")
+                if secret:
+                    aws_secret_key = secret
+                region = credentials.get_key("aws_cloudwatch", "aws_region")
+                if region:
+                    aws_region = region
+            except (AttributeError, KeyError):
+                pass
+
+    return boto3.client(
+        "cloudwatch",
+        aws_access_key_id=aws_access_key,
+        aws_secret_access_key=aws_secret_key,
+        region_name=aws_region,
+    )
+
+
+def get_logs_client(credentials: CredentialStoreAdapter | None = None):
+    """
+    Initialize a CloudWatch Logs client using available credentials.
+    """
+    import os
+    aws_access_key = os.environ.get("AWS_ACCESS_KEY_ID")
+    aws_secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+    aws_region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
+
+    if credentials:
+        key = credentials.get("aws_cloudwatch")
+        if key:
+            aws_access_key = key
+            try:
+                secret = credentials.get_key("aws_cloudwatch", "aws_secret_access_key")
+                if secret:
+                    aws_secret_key = secret
+                region = credentials.get_key("aws_cloudwatch", "aws_region")
+                if region:
+                    aws_region = region
+            except (AttributeError, KeyError):
+                pass
+
+    return boto3.client(
+        "logs",
+        aws_access_key_id=aws_access_key,
+        aws_secret_access_key=aws_secret_key,
+        region_name=aws_region,
+    )
+
+
+def register_tools(mcp: FastMCP, credentials: CredentialStoreAdapter | None = None) -> None:
+    """
+    Register CloudWatch tools with the FastMCP server.
+    
+    Args:
+        mcp: FastMCP server instance
+        credentials: Optional CredentialStoreAdapter instance
+    """
+
+    @mcp.tool()
+    async def cloudwatch_put_metric(
+        namespace: str,
+        metric_name: str,
+        value: float,
+        unit: str = "None",
+        dimensions: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Publish a custom metric data point to CloudWatch.
+        
+        Args:
+            namespace: The namespace for the metric data.
+            metric_name: The name of the metric.
+            value: The value for the metric.
+            unit: The unit of the metric (e.g., Seconds, Bytes, Count, Percent).
+            dimensions: Optional dictionary of dimensions (key-value pairs) for the metric.
+        """
+        try:
+            client = get_cloudwatch_client(credentials)
+            
+            metric_data = {
+                "MetricName": metric_name,
+                "Value": value,
+                "Unit": unit,
+            }
+            
+            if dimensions:
+                metric_data["Dimensions"] = [
+                    {"Name": k, "Value": v} for k, v in dimensions.items()
+                ]
+                
+            client.put_metric_data(
+                Namespace=namespace,
+                MetricData=[metric_data]
+            )
+            
+            return {
+                "status": "success",
+                "message": f"Successfully published metric {metric_name} to namespace {namespace}",
+            }
+        except ClientError as e:
+            return {"status": "error", "message": str(e)}
+        except Exception as e:
+            return {"status": "error", "message": f"An unexpected error occurred: {e!s}"}
+
+    @mcp.tool()
+    async def cloudwatch_put_log_event(
+        log_group: str,
+        log_stream: str,
+        message: str,
+    ) -> Dict[str, Any]:
+        """
+        Send a log event to a CloudWatch Log Group/Stream.
+        Auto-creates the log group and stream if they don't exist.
+        
+        Args:
+            log_group: The name of the log group.
+            log_stream: The name of the log stream.
+            message: The log message to send.
+        """
+        try:
+            client = get_logs_client(credentials)
+            
+            # Ensure log group exists
+            try:
+                client.create_log_group(logGroupName=log_group)
+            except client.exceptions.ResourceAlreadyExistsException:
+                pass
+                
+            # Ensure log stream exists
+            try:
+                client.create_log_stream(logGroupName=log_group, logStreamName=log_stream)
+            except client.exceptions.ResourceAlreadyExistsException:
+                pass
+                
+            # Put log event
+            # Note: For V1 we're not handling sequence tokens for simplicity as Boto3 handles it
+            # or it might not be required for newer log streams. 
+            import time
+            client.put_log_events(
+                logGroupName=log_group,
+                logStreamName=log_stream,
+                logEvents=[
+                    {
+                        "timestamp": int(time.time() * 1000),
+                        "message": message
+                    }
+                ]
+            )
+            
+            return {
+                "status": "success",
+                "message": f"Successfully sent log event to {log_group}/{log_stream}",
+            }
+        except ClientError as e:
+            return {"status": "error", "message": str(e)}
+        except Exception as e:
+            return {"status": "error", "message": f"An unexpected error occurred: {e!s}"}
+
+    @mcp.tool()
+    async def cloudwatch_create_alarm(
+        alarm_name: str,
+        namespace: str,
+        metric_name: str,
+        threshold: float,
+        comparison_operator: str = "GreaterThanThreshold",
+        evaluation_periods: int = 1,
+        period: int = 300,
+        statistic: str = "Average",
+        alarm_actions: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Create or update a CloudWatch Alarm.
+        
+        Args:
+            alarm_name: The name for the alarm.
+            namespace: The namespace for the metric associated with the alarm.
+            metric_name: The name for the metric associated with the alarm.
+            threshold: The value against which the specified statistic is compared.
+            comparison_operator: The arithmetic operation to use when comparing the specified statistic and threshold.
+            evaluation_periods: The number of periods over which data is compared to the specified threshold.
+            period: The length, in seconds, used each time the metric specified in metric_name is evaluated.
+            statistic: The statistic for the metric specified in metric_name, other than percentile.
+            alarm_actions: The actions to execute when this alarm transitions to an ALARM state from any other state.
+        """
+        try:
+            client = get_cloudwatch_client(credentials)
+            
+            params = {
+                "AlarmName": alarm_name,
+                "ComparisonOperator": comparison_operator,
+                "EvaluationPeriods": evaluation_periods,
+                "MetricName": metric_name,
+                "Namespace": namespace,
+                "Period": period,
+                "Statistic": statistic,
+                "Threshold": threshold,
+            }
+            
+            if alarm_actions:
+                params["AlarmActions"] = alarm_actions
+                
+            client.put_metric_alarm(**params)
+            
+            return {
+                "status": "success",
+                "message": f"Successfully created/updated alarm {alarm_name}",
+            }
+        except ClientError as e:
+            return {"status": "error", "message": str(e)}
+        except Exception as e:
+            return {"status": "error", "message": f"An unexpected error occurred: {e!s}"}
+
+    @mcp.tool()
+    async def cloudwatch_get_metric_stats(
+        namespace: str,
+        metric_name: str,
+        start_time: str,
+        end_time: str,
+        period: int = 300,
+        statistics: List[str] = None,
+        dimensions: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Retrieve metric statistics from CloudWatch.
+        
+        Args:
+            namespace: The namespace of the metric.
+            metric_name: The name of the metric.
+            start_time: The time stamp that determines the first data point to return (ISO 8601).
+            end_time: The time stamp that determines the last data point to return (ISO 8601).
+            period: The granularity, in seconds, of the returned data points.
+            statistics: The metric statistics to return. Defaults to ["Average"].
+            dimensions: Optional dictionary of dimensions.
+        """
+        if statistics is None:
+            statistics = ["Average"]
+            
+        try:
+            client = get_cloudwatch_client(credentials)
+            from datetime import datetime
+            
+            # Helper to parse ISO format
+            def parse_time(t_str):
+                try:
+                    return datetime.fromisoformat(t_str.replace("Z", "+00:00"))
+                except ValueError:
+                    return datetime.strptime(t_str, "%Y-%m-%dT%H:%M:%S")
+
+            params = {
+                "Namespace": namespace,
+                "MetricName": metric_name,
+                "StartTime": parse_time(start_time),
+                "EndTime": parse_time(end_time),
+                "Period": period,
+                "Statistics": statistics,
+            }
+            
+            if dimensions:
+                params["Dimensions"] = [
+                    {"Name": k, "Value": v} for k, v in dimensions.items()
+                ]
+                
+            response = client.get_metric_statistics(**params)
+            
+            # Convert datetimes to strings for JSON serialization
+            datapoints = response.get("Datapoints", [])
+            for dp in datapoints:
+                if "Timestamp" in dp:
+                    dp["Timestamp"] = dp["Timestamp"].isoformat()
+                    
+            return {
+                "status": "success",
+                "datapoints": datapoints,
+                "label": response.get("Label"),
+            }
+        except ClientError as e:
+            return {"status": "error", "message": str(e)}
+        except Exception as e:
+            return {"status": "error", "message": f"An unexpected error occurred: {e!s}"}

--- a/tools/src/aden_tools/tools/cloudwatch_tool/tests/test_cloudwatch_tool.py
+++ b/tools/src/aden_tools/tools/cloudwatch_tool/tests/test_cloudwatch_tool.py
@@ -1,0 +1,182 @@
+"""Unit tests for AWS CloudWatch tools."""
+
+import unittest
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import boto3
+from botocore.exceptions import ClientError
+from botocore.stub import Stubber
+
+from aden_tools.tools.cloudwatch_tool.cloudwatch_tool import (
+    register_tools,
+)
+
+
+class TestCloudWatchTool(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.mcp = MagicMock()
+        self.credentials = MagicMock()
+        self.credentials.get.side_effect = lambda name: {
+            "aws_cloudwatch": "test-key",
+        }.get(name)
+        self.credentials.get_key.side_effect = lambda name, key: {
+            ("aws_cloudwatch", "aws_secret_access_key"): "test-secret",
+            ("aws_cloudwatch", "aws_region"): "us-east-1",
+        }.get((name, key))
+
+        # Register tools to capture the decorated functions
+        register_tools(self.mcp, self.credentials)
+        
+        # The decorator mock is self.mcp.tool.return_value
+        # It was called for each function
+        decorator = self.mcp.tool.return_value
+        self.put_metric = decorator.call_args_list[0][0][0]
+        self.put_log = decorator.call_args_list[1][0][0]
+        self.create_alarm = decorator.call_args_list[2][0][0]
+        self.get_stats = decorator.call_args_list[3][0][0]
+
+        # Real clients for stubbing
+        self.cw_client = boto3.client("cloudwatch", region_name="us-east-1")
+        self.logs_client = boto3.client("logs", region_name="us-east-1")
+
+    @patch("aden_tools.tools.cloudwatch_tool.cloudwatch_tool.get_cloudwatch_client")
+    async def test_cloudwatch_put_metric_success(self, mock_get_client):
+        mock_get_client.return_value = self.cw_client
+        with Stubber(self.cw_client) as stubber:
+            expected_params = {
+                "Namespace": "TestNS",
+                "MetricData": [
+                    {
+                        "MetricName": "TestMetric",
+                        "Value": 1.0,
+                        "Unit": "Count",
+                        "Dimensions": [{"Name": "Agent", "Value": "TestAgent"}]
+                    }
+                ]
+            }
+            stubber.add_response("put_metric_data", {}, expected_params)
+            
+            result = await self.put_metric(
+                namespace="TestNS",
+                metric_name="TestMetric",
+                value=1.0,
+                unit="Count",
+                dimensions={"Agent": "TestAgent"}
+            )
+
+            self.assertEqual(result["status"], "success")
+            stubber.assert_no_pending_responses()
+
+    @patch("aden_tools.tools.cloudwatch_tool.cloudwatch_tool.get_logs_client")
+    async def test_cloudwatch_put_log_event_success(self, mock_get_client):
+        mock_get_client.return_value = self.logs_client
+        with Stubber(self.logs_client) as stubber:
+            # Responses for create_log_group and create_log_stream
+            stubber.add_response("create_log_group", {}, {"logGroupName": "TestGroup"})
+            stubber.add_response("create_log_stream", {}, {"logGroupName": "TestGroup", "logStreamName": "TestStream"})
+            
+            # Response for put_log_events
+            stubber.add_response("put_log_events", {"nextSequenceToken": "token"}, {
+                "logGroupName": "TestGroup",
+                "logStreamName": "TestStream",
+                "logEvents": [{"timestamp": unittest.mock.ANY, "message": "Test Message"}]
+            })
+            
+            result = await self.put_log(
+                log_group="TestGroup",
+                log_stream="TestStream",
+                message="Test Message"
+            )
+
+            self.assertEqual(result["status"], "success")
+            stubber.assert_no_pending_responses()
+
+    @patch("aden_tools.tools.cloudwatch_tool.cloudwatch_tool.get_cloudwatch_client")
+    async def test_cloudwatch_create_alarm_success(self, mock_get_client):
+        mock_get_client.return_value = self.cw_client
+        with Stubber(self.cw_client) as stubber:
+            expected_params = {
+                "AlarmName": "TestAlarm",
+                "ComparisonOperator": "GreaterThanThreshold",
+                "EvaluationPeriods": 1,
+                "MetricName": "TestMetric",
+                "Namespace": "TestNS",
+                "Period": 300,
+                "Statistic": "Average",
+                "Threshold": 10.0,
+                "AlarmActions": ["arn:aws:sns:test"]
+            }
+            stubber.add_response("put_metric_alarm", {}, expected_params)
+
+            result = await self.create_alarm(
+                alarm_name="TestAlarm",
+                namespace="TestNS",
+                metric_name="TestMetric",
+                threshold=10.0,
+                alarm_actions=["arn:aws:sns:test"]
+            )
+
+            self.assertEqual(result["status"], "success")
+            stubber.assert_no_pending_responses()
+
+    @patch("aden_tools.tools.cloudwatch_tool.cloudwatch_tool.get_cloudwatch_client")
+    async def test_cloudwatch_get_metric_stats_success(self, mock_get_client):
+        mock_get_client.return_value = self.cw_client
+        with Stubber(self.cw_client) as stubber:
+            start_time = "2024-01-01T00:00:00Z"
+            end_time = "2024-01-01T01:00:00Z"
+            
+            # Use UTC timezone for comparison
+            dt = datetime.fromisoformat("2024-01-01T00:05:00+00:00")
+            
+            response = {
+                "Label": "TestLabel",
+                "Datapoints": [
+                    {
+                        "Timestamp": dt,
+                        "Average": 5.0,
+                        "Unit": "Count"
+                    }
+                ]
+            }
+            
+            stubber.add_response("get_metric_statistics", response, {
+                "Namespace": "TestNS",
+                "MetricName": "TestMetric",
+                "StartTime": datetime.fromisoformat("2024-01-01T00:00:00+00:00"),
+                "EndTime": datetime.fromisoformat("2024-01-01T01:00:00+00:00"),
+                "Period": 300,
+                "Statistics": ["Average"]
+            })
+
+            result = await self.get_stats(
+                namespace="TestNS",
+                metric_name="TestMetric",
+                start_time=start_time,
+                end_time=end_time
+            )
+
+            self.assertEqual(result["status"], "success")
+            self.assertEqual(len(result["datapoints"]), 1)
+            self.assertEqual(result["datapoints"][0]["Average"], 5.0)
+            stubber.assert_no_pending_responses()
+
+    @patch("aden_tools.tools.cloudwatch_tool.cloudwatch_tool.get_cloudwatch_client")
+    async def test_client_error_handling(self, mock_get_client):
+        mock_get_client.return_value = self.cw_client
+        with Stubber(self.cw_client) as stubber:
+            stubber.add_client_error("put_metric_data", "AccessDenied", "User is not authorized")
+
+            result = await self.put_metric(
+                namespace="Test",
+                metric_name="Test",
+                value=1.0
+            )
+
+            self.assertEqual(result["status"], "error")
+            self.assertIn("AccessDenied", result["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This Pull Request integrates **AWS CloudWatch** capabilities into the `aden_tools` framework. This integration provides agents with native tools for observability, monitoring, and alerting, enabling them to publish custom metrics, send log events, and manage CloudWatch Alarms.

## Related Issue
Closes #4530

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Unit tests addition

## Implementation Details

### Core Features
- **Metric Publishing**: Added `cloudwatch_put_metric` to allow agents to track custom performance indicators.
- **Log Management**: Added `cloudwatch_put_log_event` with built-in auto-creation of Log Groups and Log Streams to reduce friction.
- **Alerting**: Added `cloudwatch_create_alarm` for setting up automated responses to metric thresholds.
- **Data Retrieval**: Added `cloudwatch_get_metric_stats` for historical analysis of system performance.

### Configuration & Security
- Implemented `CLOUDWATCH_CREDENTIALS` spec supporting `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION`.
- Integrated with `CredentialStoreAdapter` for unified credential handling.
- Added client initialization logic that gracefully handles both environment variables and framework-provided credentials.

### File Changes
- **Tools**:
    - `tools/src/aden_tools/tools/cloudwatch_tool/cloudwatch_tool.py`: Core logic for AWS interactions using `boto3`.
    - `tools/src/aden_tools/tools/cloudwatch_tool/README.md`: Usage documentation and examples.
    - `tools/src/aden_tools/tools/__init__.py`: Registered new tools in the central registry.
- **Credentials**:
    - `tools/src/aden_tools/credentials/cloudwatch.py`: Credential specification for AWS authentication.
    - `tools/src/aden_tools/credentials/__init__.py`: Registered CloudWatch credentials.
- **Project Configuration**:
    - `tools/pyproject.toml`: Added `boto3` as a dependency.
    - `tools/README.md`: Updated available tools list and project structure.
- **Tests**:
    - `tools/src/aden_tools/tools/cloudwatch_tool/tests/test_cloudwatch_tool.py`: Comprehensive unit tests using `botocore.stub`.

## How to Test
1. **Environment Setup**: Ensure `boto3` is installed (`pip install boto3`).
2. **Run Unit Tests**:
   ```bash
   conda activate agents
   pytest tools/src/aden_tools/tools/cloudwatch_tool/tests/test_cloudwatch_tool.py
   ```
   *Expected: All 5 tests pass (successful operations and error handling).*

3. **Credential Validation**:
   - Verify that the tool registers correctly in the MCP server.
   - Ensure it requests `AWS_ACCESS_KEY_ID` when called if not provided in the environment.

## Checklist
- [x] Code follows the [Google Style Guide](https://google.github.io/styleguide/).
- [x] All functions/classes have Google-style docstrings.
- [x] Unit tests cover primary use cases and error paths.
- [x] Documentation updated in `README.md` and tool-specific README.
- [x] No sensitive information (API keys, etc.) committed.
- [x] Changes pushed to `feat/aws-cloudwatch-integration-4530`.
