### PR TITLE
Feat/Resolve MyPy Type Errors in Agent Builder and Tools

### DIFF
--- a/tools/mcp_server.py
+++ b/tools/mcp_server.py
@@ -59,7 +59,7 @@ if "--stdio" in sys.argv:
         kwargs["file"] = sys.stderr  # Force all rich output to stderr
         _original_console_init(self, *args, **kwargs)
 
-    rich.console.Console.__init__ = _patched_console_init
+    rich.console.Console.__init__ = _patched_console_init  # type: ignore[method-assign]
 
 from fastmcp import FastMCP  # noqa: E402
 from starlette.requests import Request  # noqa: E402

--- a/tools/src/aden_tools/credentials/store_adapter.py
+++ b/tools/src/aden_tools/credentials/store_adapter.py
@@ -26,7 +26,7 @@ Usage:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from .base import CredentialError, CredentialSpec
 
@@ -104,7 +104,7 @@ class CredentialStoreAdapter:
         if name not in self._specs:
             raise KeyError(f"Unknown credential '{name}'. Available: {list(self._specs.keys())}")
 
-        return self._store.get(name)
+        return cast(str | None, self._store.get(name))
 
     def get_spec(self, name: str) -> CredentialSpec:
         """Get the spec for a credential."""
@@ -232,7 +232,7 @@ class CredentialStoreAdapter:
         Returns:
             The key value or None
         """
-        return self._store.get_key(credential_id, key_name)
+        return cast(str | None, self._store.get_key(credential_id, key_name))
 
     def resolve(self, template: str) -> str:
         """
@@ -248,7 +248,7 @@ class CredentialStoreAdapter:
             >>> credentials.resolve("Bearer {{github.access_token}}")
             "Bearer ghp_xxxxxxxxxxxx"
         """
-        return self._store.resolve(template)
+        return cast(str, self._store.resolve(template))
 
     def resolve_headers(self, headers: dict[str, str]) -> dict[str, str]:
         """
@@ -266,11 +266,11 @@ class CredentialStoreAdapter:
             ... })
             {"Authorization": "Bearer ghp_xxx"}
         """
-        return self._store.resolve_headers(headers)
+        return cast(dict[str, str], self._store.resolve_headers(headers))
 
     def resolve_params(self, params: dict[str, str]) -> dict[str, str]:
         """Resolve credential templates in query parameters."""
-        return self._store.resolve_params(params)
+        return cast(dict[str, str], self._store.resolve_params(params))
 
     @property
     def store(self) -> CredentialStore:

--- a/tools/src/aden_tools/credentials/telegram.py
+++ b/tools/src/aden_tools/credentials/telegram.py
@@ -19,7 +19,7 @@ TELEGRAM_CREDENTIALS = {
         description="Telegram Bot Token from @BotFather",
         # Auth method support
         aden_supported=False,
-        aden_provider_name=None,
+        aden_provider_name="",
         direct_api_key_supported=True,
         api_key_instructions="""To get a Telegram Bot Token:
 1. Open Telegram and search for @BotFather

--- a/tools/src/aden_tools/tools/csv_tool/csv_tool.py
+++ b/tools/src/aden_tools/tools/csv_tool/csv_tool.py
@@ -55,7 +55,7 @@ def register_tools(mcp: FastMCP) -> None:
                 columns = list(reader.fieldnames)
 
                 # Apply offset and limit
-                rows = []
+                rows: list[dict] = []
                 for i, row in enumerate(reader):
                     if i < offset:
                         continue
@@ -65,8 +65,8 @@ def register_tools(mcp: FastMCP) -> None:
 
             # Get total row count (re-read for accurate count)
             with open(secure_path, encoding="utf-8", newline="") as f:
-                reader = csv.reader(f)
-                total_rows = sum(1 for row in reader if any(row)) - 1
+                count_reader = csv.reader(f)
+                total_rows = sum(1 for row in count_reader if any(row)) - 1
 
             return {
                 "success": True,
@@ -194,8 +194,8 @@ def register_tools(mcp: FastMCP) -> None:
 
             # Get new total row count
             with open(secure_path, encoding="utf-8", newline="") as f:
-                reader = csv.reader(f)
-                total_rows = sum(1 for row in reader if any(row)) - 1  # Subtract header
+                count_reader = csv.reader(f)
+                total_rows = sum(1 for row in count_reader if any(row)) - 1  # Subtract header
 
             return {
                 "success": True,
@@ -309,7 +309,7 @@ def register_tools(mcp: FastMCP) -> None:
             query="SELECT * FROM data WHERE LOWER(name) LIKE '%phone%'"
         """
         try:
-            import duckdb
+            import duckdb  # type: ignore[import-untyped]
         except ImportError:
             return {
                 "error": (

--- a/tools/src/aden_tools/tools/excel_tool/excel_tool.py
+++ b/tools/src/aden_tools/tools/excel_tool/excel_tool.py
@@ -41,7 +41,7 @@ def register_tools(mcp: FastMCP) -> None:
             return {"error": "offset and limit must be non-negative"}
 
         try:
-            from openpyxl import load_workbook
+            from openpyxl import load_workbook  # type: ignore[import-untyped]  # type: ignore[import-untyped]
         except ImportError:
             return {
                 "error": (
@@ -170,7 +170,7 @@ def register_tools(mcp: FastMCP) -> None:
             dict with success status and metadata
         """
         try:
-            from openpyxl import Workbook
+            from openpyxl import Workbook  # type: ignore[import-untyped]
         except ImportError:
             return {
                 "error": (
@@ -251,7 +251,7 @@ def register_tools(mcp: FastMCP) -> None:
             dict with success status and metadata
         """
         try:
-            from openpyxl import load_workbook
+            from openpyxl import load_workbook  # type: ignore[import-untyped]
         except ImportError:
             return {
                 "error": (
@@ -349,7 +349,7 @@ def register_tools(mcp: FastMCP) -> None:
             dict with file metadata (sheets, columns per sheet, row counts, file size)
         """
         try:
-            from openpyxl import load_workbook
+            from openpyxl import load_workbook  # type: ignore[import-untyped]
         except ImportError:
             return {
                 "error": (
@@ -436,7 +436,7 @@ def register_tools(mcp: FastMCP) -> None:
             dict with list of sheet names
         """
         try:
-            from openpyxl import load_workbook
+            from openpyxl import load_workbook  # type: ignore[import-untyped]
         except ImportError:
             return {
                 "error": (
@@ -508,7 +508,7 @@ def register_tools(mcp: FastMCP) -> None:
             query="SELECT s.*, p.name FROM Sales s JOIN Products p ON s.product_id = p.id"
         """
         try:
-            import duckdb
+            import duckdb  # type: ignore[import-untyped]
         except ImportError:
             return {
                 "error": (
@@ -518,7 +518,7 @@ def register_tools(mcp: FastMCP) -> None:
             }
 
         try:
-            from openpyxl import load_workbook
+            from openpyxl import load_workbook  # type: ignore[import-untyped]
         except ImportError:
             return {
                 "error": (
@@ -573,7 +573,7 @@ def register_tools(mcp: FastMCP) -> None:
                     target_sheet = wb.sheetnames[0]
 
                 # Load all sheets into DuckDB
-                import pandas as pd
+                import pandas as pd  # type: ignore[import-untyped]
 
                 con = duckdb.connect(":memory:")
 
@@ -681,7 +681,7 @@ def register_tools(mcp: FastMCP) -> None:
             dict with list of matches containing sheet, row, column, and value
         """
         try:
-            from openpyxl import load_workbook
+            from openpyxl import load_workbook  # type: ignore[import-untyped]
         except ImportError:
             return {
                 "error": (

--- a/tools/src/aden_tools/tools/file_system_toolkits/security.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/security.py
@@ -4,7 +4,12 @@ import os
 WORKSPACES_DIR = os.path.expanduser("~/.hive/workdir/workspaces")
 
 
-def get_secure_path(path: str, workspace_id: str, agent_id: str, session_id: str) -> str:
+def get_secure_path(
+    path: str,
+    workspace_id: str | None,
+    agent_id: str | None,
+    session_id: str | None,
+) -> str:
     """Resolve and verify a path within a 3-layer sandbox (workspace/agent/session)."""
     if not workspace_id or not agent_id or not session_id:
         raise ValueError("workspace_id, agent_id, and session_id are all required")

--- a/tools/src/aden_tools/tools/file_system_toolkits/view_file/view_file.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/view_file/view_file.py
@@ -1,6 +1,6 @@
 import os
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from ..security import get_secure_path
 
@@ -9,7 +9,7 @@ def register_tools(mcp: FastMCP) -> None:
     """Register file view tools with the MCP server."""
     if getattr(mcp, "_file_tools_registered", False):
         return
-    mcp._file_tools_registered = True
+    mcp._file_tools_registered = True  # type: ignore[attr-defined]
 
     @mcp.tool()
     def view_file(

--- a/tools/src/aden_tools/tools/runtime_logs_tool/runtime_logs_tool.py
+++ b/tools/src/aden_tools/tools/runtime_logs_tool/runtime_logs_tool.py
@@ -27,7 +27,7 @@ def _read_jsonl(path: Path) -> list[dict]:
 
     Skips blank lines and corrupt JSON lines (partial writes from crashes).
     """
-    results = []
+    results: list[dict] = []
     if not path.exists():
         return results
     try:

--- a/tools/src/aden_tools/tools/tech_stack_detector/tech_stack_detector.py
+++ b/tools/src/aden_tools/tools/tech_stack_detector/tech_stack_detector.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import re
 
 import httpx
+from typing import cast
 from fastmcp import FastMCP
 
 # Patterns to detect JS frameworks/libraries in HTML source
@@ -282,7 +283,7 @@ def _detect_framework_from_headers(headers: httpx.Headers) -> str | None:
     """Detect framework from HTTP headers."""
     powered_by = headers.get("x-powered-by")
     if powered_by:
-        return powered_by
+        return cast("str | None", powered_by)
     return None
 
 

--- a/tools/src/aden_tools/tools/web_scrape_tool/web_scrape_tool.py
+++ b/tools/src/aden_tools/tools/web_scrape_tool/web_scrape_tool.py
@@ -126,7 +126,7 @@ def register_tools(mcp: FastMCP) -> None:
             description = ""
             meta_desc = soup.find("meta", attrs={"name": "description"})
             if meta_desc:
-                description = meta_desc.get("content", "")
+                description = str(meta_desc.get("content", ""))
 
             # Target content
             if selector:
@@ -165,7 +165,7 @@ def register_tools(mcp: FastMCP) -> None:
                 links: list[dict[str, str]] = []
                 base_url = str(response.url)  # Use final URL after redirects
                 for a in soup.find_all("a", href=True)[:50]:
-                    href = a["href"]
+                    href = str(a["href"])
                     # Convert relative URLs to absolute URLs
                     absolute_href = urljoin(base_url, href)
                     link_text = a.get_text(strip=True)


### PR DESCRIPTION
## Description

This PR addresses and resolves a significant number of Type Errors reported by MyPy in the Agent Builder server codebase and various Aden Tools. The main goal is to enforce stricter type safety, eliminate potential runtime bugs related to `None` values, and improve code reliability.

Resolves #4890

## Key Changes

### 1. Agent Builder Server (`agent_builder_server.py`)
- **None Safety:** Added explicit checks for `session.goal` and `node_obj` to handle cases where these objects might be `None` (e.g., during initialization or specific edge cases). This prevents `AttributeError` at runtime.
- **Import Handling:** Added `# type: ignore[import-untyped]` for `aden_tools.credentials` imports where stubs are missing, silencing false positive errors.
- **Variable Scoping:** Renamed reused loop variables (e.g., `e` -> `exc`, `node` -> `node_obj`) to prevent type inference conflicts and clearer code.
- **Logic Refactoring:** Streamlined validation logic by using internal helper functions like `_validate_graph_internal` directly, avoiding unnecessary JSON serialization/deserialization cycles.
- **Return Types:** Updated function return types to be more precise (e.g., `dict[str, Any]` instead of `Any` or `str`).

### 2. Aden Tools Improvements
- **SSL/TLS Scanner (`ssl_tls_scanner.py`):**
    - Handled cases where `getpeercert()` returns `None`.
    - Added `Any` and `cast` imports to properly type hint certificate parsing logic.
- **Tech Stack Detector (`tech_stack_detector.py`):**
    - Corrected return type for `_detect_framework_from_headers` to match its signature (`str | None`).
    - Added `cast` to explicitly handle potential `None` returns.
- **CSV Tool (`csv_tool.py`):**
    - Fixed variable reuse issues where `reader` was being redefined with different types.
    - Added explicit type hints for list variables (`rows: list[dict] = []`).
    - Ignored `duckdb` import errors for missing stubs.
- **Excel Tool (`excel_tool.py`):**
    - Added `# type: ignore[import-untyped]` for `openpyxl` and `duckdb` imports.
    - Added type ignore for `pandas` import.
- **Runtime Logs Tool (`runtime_logs_tool.py`):**
    - Added explicit type annotation for the `results` list.
- **Security Utility (`security.py`):**
    - Updated `get_secure_path` signature to explicitly allow `None` for `workspace_id`, `agent_id`, and `session_id`, improving compatibility with test cases and caller logic.

## Motivation and Context

These changes are necessary to:
- Enforce static type checking standards across the project.
- Reduce the risk of `AttributeError: NoneType object has no attribute ...` in production.
- Clean up the codebase by removing ambiguous types.
- Ensure tools function correctly even with incomplete type stubs from dependencies.

## Testing

- Ran `uv run mypy core/framework/mcp/agent_builder_server.py` -> **0 errors**.
- Ran `uv run mypy tools/` -> Addressed major errors in key files.
- Manual verification of tool functionality (CSV read/write, Excel read/write, SSL scan).

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings (related to the fixed files).

---

_Pull request created with Google Antigravity_