### PR TITLE
`feat(core): Add DeepSeek support and Execution Summary report`

### DIFF
--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -551,7 +551,17 @@ def cmd_run(args: argparse.Namespace) -> int:
             print(f"Status: {status_str}")
             print(f"Steps executed: {result.steps_executed}")
             print(f"Path: {' → '.join(result.path)}")
+            
+            # --- SUMMARY REPORT ---
+            print("\n--- Summary Report ---")
+            print(f"  Duration: {result.duration_seconds:.2f}s")
+            if result.cost_usd > 0:
+                print(f"  Cost: ${result.cost_usd:.4f}")
+            else:
+                 print("  Cost: $0.00 (or untracked)")
+            print(f"  Tokens: {result.total_tokens} tokens")
             print("=" * 60)
+
 
             if result.success:
                 print("\n--- Results ---")

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -646,6 +646,8 @@ class AgentRunner:
             return "GROQ_API_KEY"
         elif model_lower.startswith("ollama/"):
             return None  # Ollama doesn't need an API key (local)
+        elif model_lower.startswith("deepseek/"):
+            return "DEEPSEEK_API_KEY"
         elif model_lower.startswith("azure/"):
             return "AZURE_API_KEY"
         elif model_lower.startswith("cohere/"):


### PR DESCRIPTION
**Description:**
### Summary
Enhancements to the core runner to support the DeepSeek model family and provide better post-run visibility.
Fixes the issue #4995 

### Rationale
- **DeepSeek Support:** DeepSeek-R1 is a leading open-reasoning model. Native support allows users to easily swap models via `DEEPSEEK_API_KEY` without custom configuration hacks.
- **Execution Summary:** Users need immediate feedback on the "cost" of a run. The new summary report provides instant visibility into Duration, Token Usage, and Estimated Cost at the end of every execution.

### Implementation Details
- **Runner (`runner.py`):** Added mapping for `deepseek/` model prefixes to correct environment variables.
- **CLI (`runner/cli.py`):** Added a "Summary Report" block to the `cmd_run` output, displaying:
    - Duration (seconds)
    - Total Tokens
    - Cost (USD)

### Verification
- Run any agent with `hive run ...`.
- Verify the "--- Summary Report ---" section appears at the end of the log.

---
**Contributor:** Muhammed Roshan M <muhammedroshanmangat@gmail.com>
