### PR TITLE
feat(tools): add Google Ads tool for campaign monitoring

### DIFF
--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "litellm>=1.81.0",
     "dnspython>=2.4.0",
     "resend>=2.0.0",
+    "google-ads>=24.0.0",
     "framework",
     
 ]

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -50,6 +50,7 @@ from .file_system_toolkits.view_file import register_tools as register_view_file
 from .file_system_toolkits.write_to_file import register_tools as register_write_to_file
 from .github_tool import register_tools as register_github
 from .gmail_tool import register_tools as register_gmail
+from .google_ads_tool import register_tools as register_google_ads
 from .google_maps_tool import register_tools as register_google_maps
 from .http_headers_scanner import register_tools as register_http_headers_scanner
 from .hubspot_tool import register_tools as register_hubspot
@@ -113,6 +114,7 @@ def register_all_tools(
     register_telegram(mcp, credentials=credentials)
     register_vision(mcp, credentials=credentials)
     register_google_maps(mcp, credentials=credentials)
+    register_google_ads(mcp, credentials=credentials)
     register_bigquery(mcp, credentials=credentials)
 
     # Register file system toolkits
@@ -309,6 +311,9 @@ def register_all_tools(
         "maps_distance_matrix",
         "maps_place_details",
         "maps_place_search",
+        "ads_get_campaign_metrics",
+        "ads_list_campaigns",
+        "ads_pause_campaign",
         "run_bigquery_query",
         "describe_dataset",
         # Security scanning tools

--- a/tools/src/aden_tools/tools/google_ads_tool/README.md
+++ b/tools/src/aden_tools/tools/google_ads_tool/README.md
@@ -1,0 +1,222 @@
+# Google Ads Tool
+
+Campaign monitoring and management for Google Ads via the Google Ads API.
+
+## Overview
+
+This tool provides three MCP tools for interacting with Google Ads:
+
+1. **ads_get_campaign_metrics** - Retrieve campaign performance metrics (impressions, clicks, cost, CTR, ROAS)
+2. **ads_list_campaigns** - List campaigns with optional status filtering
+3. **ads_pause_campaign** - Pause an active campaign
+
+## Use Cases
+
+### Growth Agent
+Monitor ad spend and performance daily:
+```python
+# Check if any campaign exceeds budget with poor performance
+metrics = ads_get_campaign_metrics(
+    customer_id="123-456-7890",
+    date_range="TODAY"
+)
+
+for campaign in metrics["campaigns"]:
+    if campaign["cost"] > 500 and campaign["ctr"] < 1.0:
+        # Pause underperforming campaign
+        ads_pause_campaign(
+            customer_id="123-456-7890",
+            campaign_id=campaign["campaign_id"]
+        )
+```
+
+### Reporting Agent
+Generate weekly performance summaries:
+```python
+# Get top performing keywords for the marketing team
+metrics = ads_get_campaign_metrics(
+    customer_id="123-456-7890",
+    date_range="LAST_7_DAYS"
+)
+
+# Sort by ROAS and generate report
+top_campaigns = sorted(
+    metrics["campaigns"],
+    key=lambda x: x["roas"],
+    reverse=True
+)[:10]
+```
+
+## Authentication
+
+This tool requires Google Ads API credentials. You need:
+
+1. **Developer Token** - Get from Google Ads API Center
+2. **OAuth2 Credentials** - Client ID, Client Secret, and Refresh Token
+
+### Setup Steps
+
+1. **Get a Developer Token**:
+   - Go to [Google Ads API Center](https://ads.google.com/aw/apicenter)
+   - Apply for API access
+   - Once approved, copy your developer token
+
+2. **Create OAuth2 Credentials**:
+   - Go to [Google Cloud Console](https://console.cloud.google.com/)
+   - Create a new project or select existing
+   - Enable Google Ads API
+   - Create OAuth 2.0 credentials (Desktop app type)
+   - Download the client ID and client secret
+
+3. **Generate Refresh Token**:
+   ```bash
+   # Install google-ads library
+   pip install google-ads
+
+   # Run OAuth flow to get refresh token
+   python -m google.ads.googleads.oauth2.get_refresh_token \
+       --client_id=YOUR_CLIENT_ID \
+       --client_secret=YOUR_CLIENT_SECRET
+   ```
+
+4. **Set Environment Variables**:
+   ```bash
+   export GOOGLE_ADS_DEVELOPER_TOKEN="your-developer-token"
+   export GOOGLE_ADS_CLIENT_ID="your-client-id.apps.googleusercontent.com"
+   export GOOGLE_ADS_CLIENT_SECRET="your-client-secret"
+   export GOOGLE_ADS_REFRESH_TOKEN="your-refresh-token"
+   ```
+
+## Tool Reference
+
+### ads_get_campaign_metrics
+
+Retrieve campaign performance metrics for analysis and monitoring.
+
+**Parameters:**
+- `customer_id` (str, required): Google Ads customer ID (e.g., "123-456-7890")
+- `date_range` (str, optional): Date range for metrics. Options:
+  - `"TODAY"` - Today's data
+  - `"YESTERDAY"` - Yesterday's data
+  - `"LAST_7_DAYS"` - Last 7 days (default)
+  - `"LAST_30_DAYS"` - Last 30 days
+  - `"THIS_MONTH"` - Current month to date
+  - `"LAST_MONTH"` - Previous month
+
+**Returns:**
+```json
+{
+  "customer_id": "123-456-7890",
+  "date_range": "LAST_7_DAYS",
+  "campaigns": [
+    {
+      "campaign_id": 12345678,
+      "campaign_name": "Summer Sale 2024",
+      "status": "ENABLED",
+      "impressions": 150000,
+      "clicks": 3500,
+      "cost": 875.50,
+      "ctr": 2.33,
+      "conversions": 125,
+      "conversions_value": 3500.00,
+      "average_cpc": 0.25,
+      "roas": 4.00
+    }
+  ],
+  "total_campaigns": 1,
+  "retrieved_at": "2024-02-16T18:30:00.000000"
+}
+```
+
+### ads_list_campaigns
+
+List all campaigns in an account with optional status filtering.
+
+**Parameters:**
+- `customer_id` (str, required): Google Ads customer ID
+- `status` (str, optional): Filter by campaign status. Options:
+  - `"ENABLED"` - Only active campaigns (default)
+  - `"PAUSED"` - Only paused campaigns
+  - `"REMOVED"` - Only removed campaigns
+  - `"ALL"` - All campaigns
+
+**Returns:**
+```json
+{
+  "customer_id": "123-456-7890",
+  "status_filter": "ENABLED",
+  "campaigns": [
+    {
+      "campaign_id": 12345678,
+      "campaign_name": "Summer Sale 2024",
+      "status": "ENABLED",
+      "channel_type": "SEARCH",
+      "start_date": "2024-06-01",
+      "end_date": "2024-08-31",
+      "budget": 100.00
+    }
+  ],
+  "total_campaigns": 1,
+  "retrieved_at": "2024-02-16T18:30:00.000000"
+}
+```
+
+### ads_pause_campaign
+
+Pause an active campaign to stop spending.
+
+**Parameters:**
+- `customer_id` (str, required): Google Ads customer ID
+- `campaign_id` (int, required): Campaign ID to pause
+
+**Returns:**
+```json
+{
+  "customer_id": "123-456-7890",
+  "campaign_id": 12345678,
+  "status": "PAUSED",
+  "resource_name": "customers/1234567890/campaigns/12345678",
+  "paused_at": "2024-02-16T18:30:00.000000"
+}
+```
+
+## Error Handling
+
+All tools return error dictionaries when operations fail:
+
+```json
+{
+  "error": "Google Ads API error: AUTHENTICATION_ERROR: Invalid developer token"
+}
+```
+
+Common errors:
+- **Missing credentials**: Set all required environment variables
+- **Invalid customer ID**: Ensure customer ID is correct (with or without hyphens)
+- **Permission denied**: Check API access and OAuth scopes
+- **Campaign not found**: Verify campaign ID exists in the account
+- **Rate limit exceeded**: Implement exponential backoff
+
+## Metrics Glossary
+
+- **Impressions**: Number of times ads were shown
+- **Clicks**: Number of times ads were clicked
+- **Cost**: Total amount spent (in account currency)
+- **CTR (Click-Through Rate)**: Percentage of impressions that resulted in clicks
+- **Conversions**: Number of conversion actions completed
+- **Conversions Value**: Total value of conversions
+- **Average CPC**: Average cost per click
+- **ROAS (Return on Ad Spend)**: Revenue generated per dollar spent
+
+## Limitations
+
+- Requires Google Ads API access (may need approval)
+- Rate limits apply (see [Google Ads API quotas](https://developers.google.com/google-ads/api/docs/best-practices/quotas))
+- Customer ID must have proper access permissions
+- Some metrics may have data delays (up to 3 hours)
+
+## References
+
+- [Google Ads API Documentation](https://developers.google.com/google-ads/api/docs/start)
+- [Google Ads API Python Client](https://github.com/googleads/google-ads-python)
+- [Query Language Guide](https://developers.google.com/google-ads/api/docs/query/overview)

--- a/tools/src/aden_tools/tools/google_ads_tool/__init__.py
+++ b/tools/src/aden_tools/tools/google_ads_tool/__init__.py
@@ -1,0 +1,5 @@
+"""Google Ads Tool - Campaign monitoring and management."""
+
+from .google_ads_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/google_ads_tool/google_ads_tool.py
+++ b/tools/src/aden_tools/tools/google_ads_tool/google_ads_tool.py
@@ -1,0 +1,476 @@
+"""
+Google Ads Tool - Campaign monitoring and management.
+
+Provides three MCP tools for interacting with Google Ads API:
+- ads_get_campaign_metrics: Retrieve campaign performance metrics
+- ads_list_campaigns: List active campaigns
+- ads_pause_campaign: Pause an active campaign
+
+All endpoints use OAuth2 authentication via Google Ads API credentials.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import TYPE_CHECKING, Literal
+
+from fastmcp import FastMCP
+from google.ads.googleads.client import GoogleAdsClient
+from google.ads.googleads.errors import GoogleAdsException
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialStoreAdapter
+
+_MISSING_CREDENTIALS_ERROR = {
+    "error": "Google Ads credentials not configured",
+    "help": (
+        "Set the following environment variables:\n"
+        "- GOOGLE_ADS_DEVELOPER_TOKEN\n"
+        "- GOOGLE_ADS_CLIENT_ID\n"
+        "- GOOGLE_ADS_CLIENT_SECRET\n"
+        "- GOOGLE_ADS_REFRESH_TOKEN\n"
+        "Get credentials at https://developers.google.com/google-ads/api/docs/get-started"
+    ),
+}
+
+
+class _GoogleAdsClientWrapper:
+    """Internal wrapper for Google Ads API client."""
+
+    def __init__(
+        self,
+        developer_token: str,
+        client_id: str,
+        client_secret: str,
+        refresh_token: str,
+    ):
+        """Initialize Google Ads client with OAuth2 credentials.
+
+        Args:
+            developer_token: Google Ads API developer token
+            client_id: OAuth2 client ID
+            client_secret: OAuth2 client secret
+            refresh_token: OAuth2 refresh token
+        """
+        self._credentials = {
+            "developer_token": developer_token,
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "refresh_token": refresh_token,
+            "use_proto_plus": True,
+        }
+        self._client = GoogleAdsClient.load_from_dict(self._credentials)
+
+    def get_service(self, service_name: str):
+        """Get a Google Ads API service.
+
+        Args:
+            service_name: Name of the service (e.g., 'GoogleAdsService')
+
+        Returns:
+            Service instance
+        """
+        return self._client.get_service(service_name)
+
+    def get_campaign_metrics(
+        self,
+        customer_id: str,
+        date_range: Literal["TODAY", "YESTERDAY", "LAST_7_DAYS", "LAST_30_DAYS", "THIS_MONTH", "LAST_MONTH"],
+    ) -> dict:
+        """Retrieve campaign performance metrics.
+
+        Args:
+            customer_id: Google Ads customer ID (without hyphens)
+            date_range: Date range for metrics
+
+        Returns:
+            Dict with campaign metrics including impressions, clicks, cost, CTR, and conversions
+        """
+        try:
+            ga_service = self.get_service("GoogleAdsService")
+
+            query = f"""
+                SELECT
+                    campaign.id,
+                    campaign.name,
+                    campaign.status,
+                    metrics.impressions,
+                    metrics.clicks,
+                    metrics.cost_micros,
+                    metrics.ctr,
+                    metrics.conversions,
+                    metrics.conversions_value,
+                    metrics.average_cpc
+                FROM campaign
+                WHERE segments.date DURING {date_range}
+                ORDER BY metrics.impressions DESC
+            """
+
+            # Remove hyphens from customer ID
+            customer_id_clean = customer_id.replace("-", "")
+
+            response = ga_service.search(customer_id=customer_id_clean, query=query)
+
+            campaigns = []
+            for row in response:
+                campaign = row.campaign
+                metrics = row.metrics
+
+                # Convert cost from micros to currency
+                cost = metrics.cost_micros / 1_000_000 if metrics.cost_micros else 0
+
+                # Calculate ROAS if conversions_value exists
+                roas = (
+                    (metrics.conversions_value / cost) if cost > 0 and metrics.conversions_value else 0
+                )
+
+                campaigns.append(
+                    {
+                        "campaign_id": campaign.id,
+                        "campaign_name": campaign.name,
+                        "status": campaign.status.name,
+                        "impressions": metrics.impressions,
+                        "clicks": metrics.clicks,
+                        "cost": round(cost, 2),
+                        "ctr": round(metrics.ctr * 100, 2) if metrics.ctr else 0,  # Convert to percentage
+                        "conversions": metrics.conversions,
+                        "conversions_value": round(metrics.conversions_value, 2) if metrics.conversions_value else 0,
+                        "average_cpc": round(metrics.average_cpc / 1_000_000, 2) if metrics.average_cpc else 0,
+                        "roas": round(roas, 2),
+                    }
+                )
+
+            return {
+                "customer_id": customer_id,
+                "date_range": date_range,
+                "campaigns": campaigns,
+                "total_campaigns": len(campaigns),
+                "retrieved_at": datetime.utcnow().isoformat(),
+            }
+
+        except GoogleAdsException as ex:
+            error_messages = []
+            for error in ex.failure.errors:
+                error_messages.append(f"{error.error_code.name}: {error.message}")
+            return {"error": f"Google Ads API error: {'; '.join(error_messages)}"}
+        except Exception as e:
+            return {"error": f"Failed to retrieve campaign metrics: {str(e)}"}
+
+    def list_campaigns(
+        self,
+        customer_id: str,
+        status: Literal["ENABLED", "PAUSED", "REMOVED", "ALL"] = "ENABLED",
+    ) -> dict:
+        """List campaigns with optional status filter.
+
+        Args:
+            customer_id: Google Ads customer ID (without hyphens)
+            status: Campaign status filter (ENABLED, PAUSED, REMOVED, or ALL)
+
+        Returns:
+            Dict with list of campaigns
+        """
+        try:
+            ga_service = self.get_service("GoogleAdsService")
+
+            # Build query with optional status filter
+            where_clause = ""
+            if status != "ALL":
+                where_clause = f"WHERE campaign.status = {status}"
+
+            query = f"""
+                SELECT
+                    campaign.id,
+                    campaign.name,
+                    campaign.status,
+                    campaign.advertising_channel_type,
+                    campaign.start_date,
+                    campaign.end_date,
+                    campaign_budget.amount_micros
+                FROM campaign
+                {where_clause}
+                ORDER BY campaign.name
+            """
+
+            # Remove hyphens from customer ID
+            customer_id_clean = customer_id.replace("-", "")
+
+            response = ga_service.search(customer_id=customer_id_clean, query=query)
+
+            campaigns = []
+            for row in response:
+                campaign = row.campaign
+                budget = row.campaign_budget if hasattr(row, "campaign_budget") else None
+
+                campaigns.append(
+                    {
+                        "campaign_id": campaign.id,
+                        "campaign_name": campaign.name,
+                        "status": campaign.status.name,
+                        "channel_type": campaign.advertising_channel_type.name,
+                        "start_date": campaign.start_date if campaign.start_date else None,
+                        "end_date": campaign.end_date if campaign.end_date else None,
+                        "budget": (
+                            round(budget.amount_micros / 1_000_000, 2)
+                            if budget and budget.amount_micros
+                            else None
+                        ),
+                    }
+                )
+
+            return {
+                "customer_id": customer_id,
+                "status_filter": status,
+                "campaigns": campaigns,
+                "total_campaigns": len(campaigns),
+                "retrieved_at": datetime.utcnow().isoformat(),
+            }
+
+        except GoogleAdsException as ex:
+            error_messages = []
+            for error in ex.failure.errors:
+                error_messages.append(f"{error.error_code.name}: {error.message}")
+            return {"error": f"Google Ads API error: {'; '.join(error_messages)}"}
+        except Exception as e:
+            return {"error": f"Failed to list campaigns: {str(e)}"}
+
+    def pause_campaign(self, customer_id: str, campaign_id: int) -> dict:
+        """Pause an active campaign.
+
+        Args:
+            customer_id: Google Ads customer ID (without hyphens)
+            campaign_id: Campaign ID to pause
+
+        Returns:
+            Dict with operation result
+        """
+        try:
+            campaign_service = self.get_service("CampaignService")
+
+            # Remove hyphens from customer ID
+            customer_id_clean = customer_id.replace("-", "")
+
+            # Create campaign operation
+            campaign_operation = self._client.get_type("CampaignOperation")
+            campaign = campaign_operation.update
+            campaign.resource_name = campaign_service.campaign_path(customer_id_clean, campaign_id)
+
+            # Set status to PAUSED
+            campaign.status = self._client.enums.CampaignStatusEnum.PAUSED
+
+            # Set update mask
+            self._client.copy_from(
+                campaign_operation.update_mask,
+                self._client.get_type("FieldMask")(paths=["status"]),
+            )
+
+            # Execute the operation
+            response = campaign_service.mutate_campaigns(
+                customer_id=customer_id_clean,
+                operations=[campaign_operation],
+            )
+
+            return {
+                "customer_id": customer_id,
+                "campaign_id": campaign_id,
+                "status": "PAUSED",
+                "resource_name": response.results[0].resource_name,
+                "paused_at": datetime.utcnow().isoformat(),
+            }
+
+        except GoogleAdsException as ex:
+            error_messages = []
+            for error in ex.failure.errors:
+                error_messages.append(f"{error.error_code.name}: {error.message}")
+            return {"error": f"Google Ads API error: {'; '.join(error_messages)}"}
+        except Exception as e:
+            return {"error": f"Failed to pause campaign: {str(e)}"}
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: CredentialStoreAdapter | None = None,
+) -> None:
+    """Register Google Ads tools with the MCP server.
+
+    Args:
+        mcp: FastMCP server instance
+        credentials: Optional credential store adapter
+    """
+
+    def _get_credentials() -> dict[str, str] | None:
+        """Get Google Ads credentials from credential store or environment.
+
+        Returns:
+            Dict with developer_token, client_id, client_secret, and refresh_token,
+            or None if credentials are not available
+        """
+        if credentials is not None:
+            creds = credentials.get("google_ads")
+            if creds:
+                # Credentials should be a dict with the required keys
+                if isinstance(creds, dict):
+                    return creds
+                # If it's a string, it might be JSON
+                import json
+
+                try:
+                    return json.loads(creds)
+                except (json.JSONDecodeError, TypeError):
+                    return None
+
+        # Fall back to environment variables
+        developer_token = os.getenv("GOOGLE_ADS_DEVELOPER_TOKEN")
+        client_id = os.getenv("GOOGLE_ADS_CLIENT_ID")
+        client_secret = os.getenv("GOOGLE_ADS_CLIENT_SECRET")
+        refresh_token = os.getenv("GOOGLE_ADS_REFRESH_TOKEN")
+
+        if all([developer_token, client_id, client_secret, refresh_token]):
+            return {
+                "developer_token": developer_token,
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "refresh_token": refresh_token,
+            }
+
+        return None
+
+    def _make_client() -> _GoogleAdsClientWrapper | None:
+        """Create a Google Ads client if credentials are available.
+
+        Returns:
+            _GoogleAdsClientWrapper instance or None if credentials are missing
+        """
+        creds = _get_credentials()
+        if not creds:
+            return None
+
+        return _GoogleAdsClientWrapper(
+            developer_token=creds["developer_token"],
+            client_id=creds["client_id"],
+            client_secret=creds["client_secret"],
+            refresh_token=creds["refresh_token"],
+        )
+
+    # ── Tool 1: Get Campaign Metrics ───────────────────────────────────
+
+    @mcp.tool()
+    def ads_get_campaign_metrics(
+        customer_id: str,
+        date_range: Literal["TODAY", "YESTERDAY", "LAST_7_DAYS", "LAST_30_DAYS", "THIS_MONTH", "LAST_MONTH"] = "LAST_7_DAYS",
+    ) -> dict:
+        """
+        Retrieve campaign performance metrics for a Google Ads account.
+
+        Use this to monitor campaign performance, track ROAS, CTR, and other key metrics.
+        Ideal for daily performance checks and identifying underperforming campaigns.
+
+        Args:
+            customer_id: Google Ads customer ID (e.g., "123-456-7890" or "1234567890")
+            date_range: Date range for metrics. Options:
+                - TODAY: Today's data
+                - YESTERDAY: Yesterday's data
+                - LAST_7_DAYS: Last 7 days (default)
+                - LAST_30_DAYS: Last 30 days
+                - THIS_MONTH: Current month to date
+                - LAST_MONTH: Previous month
+
+        Returns:
+            Dict with campaign metrics including:
+            - campaign_id: Campaign identifier
+            - campaign_name: Campaign name
+            - status: Campaign status (ENABLED, PAUSED, etc.)
+            - impressions: Number of ad impressions
+            - clicks: Number of clicks
+            - cost: Total cost in currency
+            - ctr: Click-through rate (percentage)
+            - conversions: Number of conversions
+            - conversions_value: Total conversion value
+            - average_cpc: Average cost per click
+            - roas: Return on ad spend
+        """
+        if not customer_id:
+            return {"error": "customer_id is required"}
+
+        client = _make_client()
+        if client is None:
+            return _MISSING_CREDENTIALS_ERROR
+
+        return client.get_campaign_metrics(customer_id=customer_id, date_range=date_range)
+
+    # ── Tool 2: List Campaigns ─────────────────────────────────────────
+
+    @mcp.tool()
+    def ads_list_campaigns(
+        customer_id: str,
+        status: Literal["ENABLED", "PAUSED", "REMOVED", "ALL"] = "ENABLED",
+    ) -> dict:
+        """
+        List campaigns in a Google Ads account with optional status filter.
+
+        Use this to see all active campaigns, check campaign configurations,
+        or audit campaign statuses.
+
+        Args:
+            customer_id: Google Ads customer ID (e.g., "123-456-7890" or "1234567890")
+            status: Filter campaigns by status. Options:
+                - ENABLED: Only active campaigns (default)
+                - PAUSED: Only paused campaigns
+                - REMOVED: Only removed campaigns
+                - ALL: All campaigns regardless of status
+
+        Returns:
+            Dict with list of campaigns including:
+            - campaign_id: Campaign identifier
+            - campaign_name: Campaign name
+            - status: Campaign status
+            - channel_type: Advertising channel (SEARCH, DISPLAY, etc.)
+            - start_date: Campaign start date
+            - end_date: Campaign end date (if set)
+            - budget: Daily budget amount
+        """
+        if not customer_id:
+            return {"error": "customer_id is required"}
+
+        client = _make_client()
+        if client is None:
+            return _MISSING_CREDENTIALS_ERROR
+
+        return client.list_campaigns(customer_id=customer_id, status=status)
+
+    # ── Tool 3: Pause Campaign ─────────────────────────────────────────
+
+    @mcp.tool()
+    def ads_pause_campaign(
+        customer_id: str,
+        campaign_id: int,
+    ) -> dict:
+        """
+        Pause an active Google Ads campaign.
+
+        Use this to stop an underperforming campaign or temporarily halt spending.
+        This is a safer alternative to removing a campaign, as it can be easily resumed.
+
+        Args:
+            customer_id: Google Ads customer ID (e.g., "123-456-7890" or "1234567890")
+            campaign_id: Campaign ID to pause (numeric ID from ads_list_campaigns)
+
+        Returns:
+            Dict with operation result including:
+            - customer_id: Customer ID
+            - campaign_id: Campaign ID that was paused
+            - status: New status (PAUSED)
+            - resource_name: Google Ads resource name
+            - paused_at: Timestamp when campaign was paused
+        """
+        if not customer_id:
+            return {"error": "customer_id is required"}
+        if not campaign_id:
+            return {"error": "campaign_id is required"}
+
+        client = _make_client()
+        if client is None:
+            return _MISSING_CREDENTIALS_ERROR
+
+        return client.pause_campaign(customer_id=customer_id, campaign_id=campaign_id)

--- a/tools/tests/tools/test_google_ads_tool.py
+++ b/tools/tests/tools/test_google_ads_tool.py
@@ -1,0 +1,557 @@
+"""Tests for Google Ads tool with FastMCP."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.google_ads_tool import register_tools
+
+# ── Fixtures ───────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mcp():
+    """Create a FastMCP instance for testing."""
+    return FastMCP("test-server")
+
+
+@pytest.fixture
+def ads_get_campaign_metrics_fn(mcp: FastMCP):
+    """Register and return the ads_get_campaign_metrics tool function."""
+    register_tools(mcp)
+    return mcp._tool_manager._tools["ads_get_campaign_metrics"].fn
+
+
+@pytest.fixture
+def ads_list_campaigns_fn(mcp: FastMCP):
+    """Register and return the ads_list_campaigns tool function."""
+    register_tools(mcp)
+    return mcp._tool_manager._tools["ads_list_campaigns"].fn
+
+
+@pytest.fixture
+def ads_pause_campaign_fn(mcp: FastMCP):
+    """Register and return the ads_pause_campaign tool function."""
+    register_tools(mcp)
+    return mcp._tool_manager._tools["ads_pause_campaign"].fn
+
+
+# ── Credential Tests ──────────────────────────────────────────────────
+
+
+class TestGoogleAdsCredentials:
+    """Test credential handling for all Google Ads tools."""
+
+    def test_get_campaign_metrics_no_credentials_returns_error(
+        self, ads_get_campaign_metrics_fn, monkeypatch
+    ):
+        """Get campaign metrics without credentials returns helpful error."""
+        monkeypatch.delenv("GOOGLE_ADS_DEVELOPER_TOKEN", raising=False)
+        monkeypatch.delenv("GOOGLE_ADS_CLIENT_ID", raising=False)
+        monkeypatch.delenv("GOOGLE_ADS_CLIENT_SECRET", raising=False)
+        monkeypatch.delenv("GOOGLE_ADS_REFRESH_TOKEN", raising=False)
+
+        result = ads_get_campaign_metrics_fn(customer_id="123-456-7890")
+
+        assert "error" in result
+        assert "not configured" in result["error"]
+        assert "help" in result
+
+    def test_list_campaigns_no_credentials_returns_error(
+        self, ads_list_campaigns_fn, monkeypatch
+    ):
+        """List campaigns without credentials returns helpful error."""
+        monkeypatch.delenv("GOOGLE_ADS_DEVELOPER_TOKEN", raising=False)
+        monkeypatch.delenv("GOOGLE_ADS_CLIENT_ID", raising=False)
+        monkeypatch.delenv("GOOGLE_ADS_CLIENT_SECRET", raising=False)
+        monkeypatch.delenv("GOOGLE_ADS_REFRESH_TOKEN", raising=False)
+
+        result = ads_list_campaigns_fn(customer_id="123-456-7890")
+
+        assert "error" in result
+        assert "not configured" in result["error"]
+
+    def test_pause_campaign_no_credentials_returns_error(
+        self, ads_pause_campaign_fn, monkeypatch
+    ):
+        """Pause campaign without credentials returns helpful error."""
+        monkeypatch.delenv("GOOGLE_ADS_DEVELOPER_TOKEN", raising=False)
+        monkeypatch.delenv("GOOGLE_ADS_CLIENT_ID", raising=False)
+        monkeypatch.delenv("GOOGLE_ADS_CLIENT_SECRET", raising=False)
+        monkeypatch.delenv("GOOGLE_ADS_REFRESH_TOKEN", raising=False)
+
+        result = ads_pause_campaign_fn(customer_id="123-456-7890", campaign_id=12345)
+
+        assert "error" in result
+        assert "not configured" in result["error"]
+
+
+# ── Input Validation Tests ────────────────────────────────────────────
+
+
+class TestInputValidation:
+    """Test input validation across tools."""
+
+    def test_get_campaign_metrics_no_customer_id(self, ads_get_campaign_metrics_fn):
+        """Get campaign metrics without customer_id returns error."""
+        result = ads_get_campaign_metrics_fn(customer_id="")
+
+        assert "error" in result
+        assert "required" in result["error"].lower()
+
+    def test_list_campaigns_no_customer_id(self, ads_list_campaigns_fn):
+        """List campaigns without customer_id returns error."""
+        result = ads_list_campaigns_fn(customer_id="")
+
+        assert "error" in result
+        assert "required" in result["error"].lower()
+
+    def test_pause_campaign_no_customer_id(self, ads_pause_campaign_fn):
+        """Pause campaign without customer_id returns error."""
+        result = ads_pause_campaign_fn(customer_id="", campaign_id=12345)
+
+        assert "error" in result
+        assert "required" in result["error"].lower()
+
+    def test_pause_campaign_no_campaign_id(self, ads_pause_campaign_fn):
+        """Pause campaign without campaign_id returns error."""
+        result = ads_pause_campaign_fn(customer_id="123-456-7890", campaign_id=None)
+
+        assert "error" in result
+        assert "required" in result["error"].lower()
+
+
+# ── Get Campaign Metrics Tests ────────────────────────────────────────
+
+
+class TestAdsGetCampaignMetrics:
+    """Tests for ads_get_campaign_metrics tool."""
+
+    @patch("aden_tools.tools.google_ads_tool.google_ads_tool._GoogleAdsClientWrapper")
+    def test_get_campaign_metrics_success(
+        self, mock_client_class, ads_get_campaign_metrics_fn, monkeypatch
+    ):
+        """Successful campaign metrics retrieval returns formatted results."""
+        monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "test-dev-token")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_ID", "test-client-id")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_SECRET", "test-client-secret")
+        monkeypatch.setenv("GOOGLE_ADS_REFRESH_TOKEN", "test-refresh-token")
+
+        # Mock the client instance
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        # Mock the get_campaign_metrics method
+        mock_client.get_campaign_metrics.return_value = {
+            "customer_id": "123-456-7890",
+            "date_range": "LAST_7_DAYS",
+            "campaigns": [
+                {
+                    "campaign_id": 12345678,
+                    "campaign_name": "Summer Sale 2024",
+                    "status": "ENABLED",
+                    "impressions": 150000,
+                    "clicks": 3500,
+                    "cost": 875.50,
+                    "ctr": 2.33,
+                    "conversions": 125,
+                    "conversions_value": 3500.00,
+                    "average_cpc": 0.25,
+                    "roas": 4.00,
+                }
+            ],
+            "total_campaigns": 1,
+            "retrieved_at": "2024-02-16T18:30:00.000000",
+        }
+
+        result = ads_get_campaign_metrics_fn(
+            customer_id="123-456-7890", date_range="LAST_7_DAYS"
+        )
+
+        assert result["total_campaigns"] == 1
+        assert result["campaigns"][0]["campaign_name"] == "Summer Sale 2024"
+        assert result["campaigns"][0]["impressions"] == 150000
+        assert result["campaigns"][0]["roas"] == 4.00
+
+    @patch("aden_tools.tools.google_ads_tool.google_ads_tool._GoogleAdsClientWrapper")
+    def test_get_campaign_metrics_empty_results(
+        self, mock_client_class, ads_get_campaign_metrics_fn, monkeypatch
+    ):
+        """Campaign metrics with no campaigns returns empty list."""
+        monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "test-dev-token")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_ID", "test-client-id")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_SECRET", "test-client-secret")
+        monkeypatch.setenv("GOOGLE_ADS_REFRESH_TOKEN", "test-refresh-token")
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_campaign_metrics.return_value = {
+            "customer_id": "123-456-7890",
+            "date_range": "LAST_7_DAYS",
+            "campaigns": [],
+            "total_campaigns": 0,
+            "retrieved_at": "2024-02-16T18:30:00.000000",
+        }
+
+        result = ads_get_campaign_metrics_fn(customer_id="123-456-7890")
+
+        assert result["total_campaigns"] == 0
+        assert result["campaigns"] == []
+
+    @patch("aden_tools.tools.google_ads_tool.google_ads_tool._GoogleAdsClientWrapper")
+    def test_get_campaign_metrics_api_error(
+        self, mock_client_class, ads_get_campaign_metrics_fn, monkeypatch
+    ):
+        """API error returns error message."""
+        monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "test-dev-token")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_ID", "test-client-id")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_SECRET", "test-client-secret")
+        monkeypatch.setenv("GOOGLE_ADS_REFRESH_TOKEN", "test-refresh-token")
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_campaign_metrics.return_value = {
+            "error": "Google Ads API error: AUTHENTICATION_ERROR: Invalid developer token"
+        }
+
+        result = ads_get_campaign_metrics_fn(customer_id="123-456-7890")
+
+        assert "error" in result
+        assert "AUTHENTICATION_ERROR" in result["error"]
+
+    @patch("aden_tools.tools.google_ads_tool.google_ads_tool._GoogleAdsClientWrapper")
+    def test_get_campaign_metrics_different_date_ranges(
+        self, mock_client_class, ads_get_campaign_metrics_fn, monkeypatch
+    ):
+        """Test different date range options."""
+        monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "test-dev-token")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_ID", "test-client-id")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_SECRET", "test-client-secret")
+        monkeypatch.setenv("GOOGLE_ADS_REFRESH_TOKEN", "test-refresh-token")
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        for date_range in ["TODAY", "YESTERDAY", "LAST_30_DAYS", "THIS_MONTH", "LAST_MONTH"]:
+            mock_client.get_campaign_metrics.return_value = {
+                "customer_id": "123-456-7890",
+                "date_range": date_range,
+                "campaigns": [],
+                "total_campaigns": 0,
+                "retrieved_at": "2024-02-16T18:30:00.000000",
+            }
+
+            result = ads_get_campaign_metrics_fn(
+                customer_id="123-456-7890", date_range=date_range
+            )
+
+            assert result["date_range"] == date_range
+
+
+# ── List Campaigns Tests ──────────────────────────────────────────────
+
+
+class TestAdsListCampaigns:
+    """Tests for ads_list_campaigns tool."""
+
+    @patch("aden_tools.tools.google_ads_tool.google_ads_tool._GoogleAdsClientWrapper")
+    def test_list_campaigns_success(
+        self, mock_client_class, ads_list_campaigns_fn, monkeypatch
+    ):
+        """Successful campaign listing returns formatted results."""
+        monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "test-dev-token")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_ID", "test-client-id")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_SECRET", "test-client-secret")
+        monkeypatch.setenv("GOOGLE_ADS_REFRESH_TOKEN", "test-refresh-token")
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.list_campaigns.return_value = {
+            "customer_id": "123-456-7890",
+            "status_filter": "ENABLED",
+            "campaigns": [
+                {
+                    "campaign_id": 12345678,
+                    "campaign_name": "Summer Sale 2024",
+                    "status": "ENABLED",
+                    "channel_type": "SEARCH",
+                    "start_date": "2024-06-01",
+                    "end_date": "2024-08-31",
+                    "budget": 100.00,
+                },
+                {
+                    "campaign_id": 87654321,
+                    "campaign_name": "Winter Campaign",
+                    "status": "ENABLED",
+                    "channel_type": "DISPLAY",
+                    "start_date": "2024-12-01",
+                    "end_date": None,
+                    "budget": 200.00,
+                },
+            ],
+            "total_campaigns": 2,
+            "retrieved_at": "2024-02-16T18:30:00.000000",
+        }
+
+        result = ads_list_campaigns_fn(customer_id="123-456-7890", status="ENABLED")
+
+        assert result["total_campaigns"] == 2
+        assert result["campaigns"][0]["campaign_name"] == "Summer Sale 2024"
+        assert result["campaigns"][0]["channel_type"] == "SEARCH"
+        assert result["campaigns"][1]["campaign_name"] == "Winter Campaign"
+
+    @patch("aden_tools.tools.google_ads_tool.google_ads_tool._GoogleAdsClientWrapper")
+    def test_list_campaigns_different_statuses(
+        self, mock_client_class, ads_list_campaigns_fn, monkeypatch
+    ):
+        """Test different status filters."""
+        monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "test-dev-token")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_ID", "test-client-id")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_SECRET", "test-client-secret")
+        monkeypatch.setenv("GOOGLE_ADS_REFRESH_TOKEN", "test-refresh-token")
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        for status in ["ENABLED", "PAUSED", "REMOVED", "ALL"]:
+            mock_client.list_campaigns.return_value = {
+                "customer_id": "123-456-7890",
+                "status_filter": status,
+                "campaigns": [],
+                "total_campaigns": 0,
+                "retrieved_at": "2024-02-16T18:30:00.000000",
+            }
+
+            result = ads_list_campaigns_fn(customer_id="123-456-7890", status=status)
+
+            assert result["status_filter"] == status
+
+    @patch("aden_tools.tools.google_ads_tool.google_ads_tool._GoogleAdsClientWrapper")
+    def test_list_campaigns_empty_results(
+        self, mock_client_class, ads_list_campaigns_fn, monkeypatch
+    ):
+        """List campaigns with no results returns empty list."""
+        monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "test-dev-token")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_ID", "test-client-id")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_SECRET", "test-client-secret")
+        monkeypatch.setenv("GOOGLE_ADS_REFRESH_TOKEN", "test-refresh-token")
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.list_campaigns.return_value = {
+            "customer_id": "123-456-7890",
+            "status_filter": "ENABLED",
+            "campaigns": [],
+            "total_campaigns": 0,
+            "retrieved_at": "2024-02-16T18:30:00.000000",
+        }
+
+        result = ads_list_campaigns_fn(customer_id="123-456-7890")
+
+        assert result["total_campaigns"] == 0
+        assert result["campaigns"] == []
+
+    @patch("aden_tools.tools.google_ads_tool.google_ads_tool._GoogleAdsClientWrapper")
+    def test_list_campaigns_api_error(
+        self, mock_client_class, ads_list_campaigns_fn, monkeypatch
+    ):
+        """API error returns error message."""
+        monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "test-dev-token")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_ID", "test-client-id")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_SECRET", "test-client-secret")
+        monkeypatch.setenv("GOOGLE_ADS_REFRESH_TOKEN", "test-refresh-token")
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.list_campaigns.return_value = {
+            "error": "Google Ads API error: CUSTOMER_NOT_FOUND: Customer not found"
+        }
+
+        result = ads_list_campaigns_fn(customer_id="999-999-9999")
+
+        assert "error" in result
+        assert "CUSTOMER_NOT_FOUND" in result["error"]
+
+
+# ── Pause Campaign Tests ──────────────────────────────────────────────
+
+
+class TestAdsPauseCampaign:
+    """Tests for ads_pause_campaign tool."""
+
+    @patch("aden_tools.tools.google_ads_tool.google_ads_tool._GoogleAdsClientWrapper")
+    def test_pause_campaign_success(
+        self, mock_client_class, ads_pause_campaign_fn, monkeypatch
+    ):
+        """Successful campaign pause returns confirmation."""
+        monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "test-dev-token")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_ID", "test-client-id")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_SECRET", "test-client-secret")
+        monkeypatch.setenv("GOOGLE_ADS_REFRESH_TOKEN", "test-refresh-token")
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.pause_campaign.return_value = {
+            "customer_id": "123-456-7890",
+            "campaign_id": 12345678,
+            "status": "PAUSED",
+            "resource_name": "customers/1234567890/campaigns/12345678",
+            "paused_at": "2024-02-16T18:30:00.000000",
+        }
+
+        result = ads_pause_campaign_fn(customer_id="123-456-7890", campaign_id=12345678)
+
+        assert result["status"] == "PAUSED"
+        assert result["campaign_id"] == 12345678
+        assert "paused_at" in result
+
+    @patch("aden_tools.tools.google_ads_tool.google_ads_tool._GoogleAdsClientWrapper")
+    def test_pause_campaign_not_found(
+        self, mock_client_class, ads_pause_campaign_fn, monkeypatch
+    ):
+        """Pausing non-existent campaign returns error."""
+        monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "test-dev-token")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_ID", "test-client-id")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_SECRET", "test-client-secret")
+        monkeypatch.setenv("GOOGLE_ADS_REFRESH_TOKEN", "test-refresh-token")
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.pause_campaign.return_value = {
+            "error": "Google Ads API error: CAMPAIGN_NOT_FOUND: Campaign not found"
+        }
+
+        result = ads_pause_campaign_fn(customer_id="123-456-7890", campaign_id=99999999)
+
+        assert "error" in result
+        assert "CAMPAIGN_NOT_FOUND" in result["error"]
+
+    @patch("aden_tools.tools.google_ads_tool.google_ads_tool._GoogleAdsClientWrapper")
+    def test_pause_campaign_already_paused(
+        self, mock_client_class, ads_pause_campaign_fn, monkeypatch
+    ):
+        """Pausing already paused campaign still succeeds."""
+        monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "test-dev-token")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_ID", "test-client-id")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_SECRET", "test-client-secret")
+        monkeypatch.setenv("GOOGLE_ADS_REFRESH_TOKEN", "test-refresh-token")
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.pause_campaign.return_value = {
+            "customer_id": "123-456-7890",
+            "campaign_id": 12345678,
+            "status": "PAUSED",
+            "resource_name": "customers/1234567890/campaigns/12345678",
+            "paused_at": "2024-02-16T18:30:00.000000",
+        }
+
+        result = ads_pause_campaign_fn(customer_id="123-456-7890", campaign_id=12345678)
+
+        assert result["status"] == "PAUSED"
+
+    @patch("aden_tools.tools.google_ads_tool.google_ads_tool._GoogleAdsClientWrapper")
+    def test_pause_campaign_permission_denied(
+        self, mock_client_class, ads_pause_campaign_fn, monkeypatch
+    ):
+        """Pausing campaign without permission returns error."""
+        monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "test-dev-token")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_ID", "test-client-id")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_SECRET", "test-client-secret")
+        monkeypatch.setenv("GOOGLE_ADS_REFRESH_TOKEN", "test-refresh-token")
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.pause_campaign.return_value = {
+            "error": "Google Ads API error: PERMISSION_DENIED: User does not have permission"
+        }
+
+        result = ads_pause_campaign_fn(customer_id="123-456-7890", campaign_id=12345678)
+
+        assert "error" in result
+        assert "PERMISSION_DENIED" in result["error"]
+
+
+# ── Integration Tests ─────────────────────────────────────────────────
+
+
+class TestGoogleAdsIntegration:
+    """Integration tests for Google Ads tools."""
+
+    @patch("aden_tools.tools.google_ads_tool.google_ads_tool._GoogleAdsClientWrapper")
+    def test_workflow_list_then_pause(
+        self,
+        mock_client_class,
+        ads_list_campaigns_fn,
+        ads_pause_campaign_fn,
+        monkeypatch,
+    ):
+        """Test workflow: list campaigns, then pause one."""
+        monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "test-dev-token")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_ID", "test-client-id")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_SECRET", "test-client-secret")
+        monkeypatch.setenv("GOOGLE_ADS_REFRESH_TOKEN", "test-refresh-token")
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        # Step 1: List campaigns
+        mock_client.list_campaigns.return_value = {
+            "customer_id": "123-456-7890",
+            "status_filter": "ENABLED",
+            "campaigns": [
+                {
+                    "campaign_id": 12345678,
+                    "campaign_name": "Test Campaign",
+                    "status": "ENABLED",
+                    "channel_type": "SEARCH",
+                    "start_date": "2024-01-01",
+                    "end_date": None,
+                    "budget": 100.00,
+                }
+            ],
+            "total_campaigns": 1,
+            "retrieved_at": "2024-02-16T18:30:00.000000",
+        }
+
+        list_result = ads_list_campaigns_fn(customer_id="123-456-7890")
+        assert list_result["total_campaigns"] == 1
+        campaign_id = list_result["campaigns"][0]["campaign_id"]
+
+        # Step 2: Pause the campaign
+        mock_client.pause_campaign.return_value = {
+            "customer_id": "123-456-7890",
+            "campaign_id": campaign_id,
+            "status": "PAUSED",
+            "resource_name": f"customers/1234567890/campaigns/{campaign_id}",
+            "paused_at": "2024-02-16T18:30:00.000000",
+        }
+
+        pause_result = ads_pause_campaign_fn(customer_id="123-456-7890", campaign_id=campaign_id)
+        assert pause_result["status"] == "PAUSED"
+        assert pause_result["campaign_id"] == campaign_id
+
+    @patch("aden_tools.tools.google_ads_tool.google_ads_tool._GoogleAdsClientWrapper")
+    def test_customer_id_with_hyphens_normalized(
+        self, mock_client_class, ads_list_campaigns_fn, monkeypatch
+    ):
+        """Customer ID with hyphens is accepted and normalized."""
+        monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "test-dev-token")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_ID", "test-client-id")
+        monkeypatch.setenv("GOOGLE_ADS_CLIENT_SECRET", "test-client-secret")
+        monkeypatch.setenv("GOOGLE_ADS_REFRESH_TOKEN", "test-refresh-token")
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.list_campaigns.return_value = {
+            "customer_id": "123-456-7890",
+            "status_filter": "ENABLED",
+            "campaigns": [],
+            "total_campaigns": 0,
+            "retrieved_at": "2024-02-16T18:30:00.000000",
+        }
+
+        result = ads_list_campaigns_fn(customer_id="123-456-7890")
+
+        assert result["customer_id"] == "123-456-7890"


### PR DESCRIPTION
## Summary

Implements `google_ads_tool` for campaign monitoring and management via the Google Ads API. This enables future Marketing Agents to read performance metrics, list campaigns, and pause underperforming ads.

Closes #2868

## Changes

### New Files
- **`tools/src/aden_tools/tools/google_ads_tool/google_ads_tool.py`** — Core implementation with:
  - `_GoogleAdsClientWrapper` — internal client handling OAuth2 auth via `google-ads` Python library
  - `ads_get_campaign_metrics` — retrieve impressions, clicks, cost, CTR, ROAS, conversions for a date range
  - `ads_list_campaigns` — list campaigns filtered by status (ENABLED/PAUSED/REMOVED/ALL)
  - `ads_pause_campaign` — pause an active campaign
  - `register_tools()` — MCP tool registration with credential support
- **`tools/src/aden_tools/tools/google_ads_tool/__init__.py`** — package init
- **`tools/src/aden_tools/tools/google_ads_tool/README.md`** — setup instructions, use cases, API reference, and metrics glossary
- **`tools/tests/tools/test_google_ads_tool.py`** — 21 unit tests covering credentials, validation, success/error paths, and integration workflows

### Modified Files
- **`tools/src/aden_tools/tools/__init__.py`** — import and register `google_ads_tool`
- **`tools/pyproject.toml`** — add `google-ads>=24.0.0` dependency

## Authentication

Requires four environment variables (or credential store entries):
- `GOOGLE_ADS_DEVELOPER_TOKEN`
- `GOOGLE_ADS_CLIENT_ID`
- `GOOGLE_ADS_CLIENT_SECRET`
- `GOOGLE_ADS_REFRESH_TOKEN`

Falls back gracefully with a helpful error message when credentials are missing.

## Testing

All 21 tests pass:
```
tests/tools/test_google_ads_tool.py::TestGoogleAdsCredentials           3 passed
tests/tools/test_google_ads_tool.py::TestInputValidation                4 passed
tests/tools/test_google_ads_tool.py::TestAdsGetCampaignMetrics          4 passed
tests/tools/test_google_ads_tool.py::TestAdsListCampaigns               4 passed
tests/tools/test_google_ads_tool.py::TestAdsPauseCampaign               4 passed
tests/tools/test_google_ads_tool.py::TestGoogleAdsIntegration           2 passed
```

## Design Decisions

- Follows the same pattern as `google_maps_tool` for consistency: client wrapper class, `register_tools()` function, credential fallback chain
- Uses `google-ads` official Python client library (not raw HTTP) for type safety and GAQL query support
- Customer IDs accept hyphens (e.g., `123-456-7890`) — normalized internally
- Cost values converted from micros to currency units for readability
- ROAS calculated automatically when conversion value and cost data are available