### PR TITLE
Fix root pytest collection failure caused by core/tests vs tools/tests package collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,17 @@ We welcome contributions from the community! We’re especially looking for help
 
 **Important:** Please get assigned to an issue before submitting a PR. Comment on an issue to claim it, and a maintainer will assign you. Issues with reproducible steps and proposals are prioritized. This helps prevent duplicate work.
 
+### Running Tests Locally
+
+From the repository root, run:
+
+```bash
+source .venv/bin/activate
+pytest -q
+```
+
+The test layout is set up so root-level `pytest` collection works cleanly across both `core/` and `tools/`.
+
 1. Find or create an issue and get assigned
 2. Fork the repository
 3. Create your feature branch (`git checkout -b feature/amazing-feature`)

--- a/core/tests/__init__.py
+++ b/core/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Tests for framework runtime."""


### PR DESCRIPTION
## Description

Fixes a root-level test collection bug where running `pytest -q` from the repository root could fail with `ModuleNotFoundError: No module named 'tests.conftest'` due to a package-name collision between `core/tests` and `tools/tests`. Also adds a README note for running tests locally from repo root.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #<issue number>

## Changes Made

- Removed `core/tests/__init__.py` so `core/tests` is no longer treated as a top-level `tests` package.
- Resolved root pytest import collision between `core/tests` and `tools/tests`.
- Updated `README.md` with a **Running Tests Locally** section under Contributing.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A (no UI changes).
