### PR TITLE
docs: Add CLI usage examples to README and update guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,27 +231,38 @@ flowchart LR
 4. **Control Plane Monitors** → Real-time metrics, budget enforcement, policy management
 5. **[Adaptiveness](docs/key_concepts/evolution.md)** → On failure, the system evolves the graph and redeploys automatically
 
-## Run Agents
+## ⌨️ CLI Usage
 
-The `hive` CLI is the primary interface for running agents.
+The `hive` CLI is the primary interface for creating, running, and managing agents.
 
-```bash
-# Browse and run agents interactively (Recommended)
-hive tui
+### Core Commands
 
-# Run a specific agent directly
-hive run exports/my_agent --input '{"task": "Your input here"}'
+| Command | Description | Example |
+| :--- | :--- | :--- |
+| `hive tui` | **(Recommended)** Launch the interactive terminal dashboard | `hive tui` |
+| `hive run` | Run an agent with specific input | `hive run exports/my-agent --input '{"task": "research"}'` |
+| `hive shell` | Start an interactive REPL session | `hive shell exports/my-agent` |
+| `hive list` | List all available agents in `exports/` | `hive list` |
+| `hive info` | Display agent metadata, goals, and nodes | `hive info exports/my-agent` |
+| `hive validate` | Check agent validity and missing tools | `hive validate exports/my-agent` |
 
-# Run a specific agent with the TUI dashboard
-hive run exports/my_agent --tui
+### Session Management
 
-# Interactive REPL
-hive shell
-```
+| Command | Description | Example |
+| :--- | :--- | :--- |
+| `hive sessions list` | List active/past sessions for an agent | `hive sessions list exports/my-agent` |
+| `hive pause` | Pause a running agent session | `hive pause exports/my-agent <session_id>` |
+| `hive resume` | Resume a paused or failed session | `hive resume exports/my-agent <session_id>` |
 
-The TUI scans both `exports/` and `examples/templates/` for available agents.
+### Testing & Quality Assurance
 
-> **Using Python directly (alternative):** You can also run agents with `PYTHONPATH=exports uv run python -m agent_name run --input '{...}'`
+| Command | Description | Example |
+| :--- | :--- | :--- |
+| `hive test-run` | Run generated tests for an agent | `hive test-run exports/my-agent --goal goal-1` |
+| `hive test-list` | List available test cases | `hive test-list exports/my-agent` |
+| `hive test-debug` | Debug a specific failed test case | `hive test-debug exports/my-agent test_function_name` |
+
+> **Pro Tip:** Add `--verbose` to `hive run` for detailed execution logs, or `--quiet` for JSON-only output.
 
 See [environment-setup.md](docs/environment-setup.md) for complete setup instructions.
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -154,7 +154,7 @@ uv run python -c "import aden_tools; print('✓ aden_tools OK')"
 uv run python -c "import litellm; print('✓ litellm OK')"
 
 # Run an agent (after building one via /hive-create)
-PYTHONPATH=exports uv run python -m your_agent_name validate
+hive validate exports/your_agent_name
 ```
 
 ---
@@ -289,7 +289,7 @@ claude> /hive-test
 4. **Validate the Agent**
 
    ```bash
-   PYTHONPATH=exports uv run python -m your_agent_name validate
+   hive validate exports/your_agent_name
    ```
 
 5. **Test the Agent**
@@ -368,17 +368,18 @@ This generates and runs:
 
 ```bash
 # Run all tests for an agent
-PYTHONPATH=exports uv run python -m agent_name test
+# Run all tests for an agent
+hive test-run exports/agent_name
 
 # Run specific test type
-PYTHONPATH=exports uv run python -m agent_name test --type constraint
-PYTHONPATH=exports uv run python -m agent_name test --type success
+hive test-run exports/agent_name --type constraint
+hive test-run exports/agent_name --type success
 
 # Run with parallel execution
-PYTHONPATH=exports uv run python -m agent_name test --parallel 4
+hive test-run exports/agent_name --parallel 4
 
 # Fail fast (stop on first failure)
-PYTHONPATH=exports uv run python -m agent_name test --fail-fast
+hive test-run exports/agent_name --fail-fast
 ```
 
 ### Writing Custom Tests

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,7 +56,7 @@ cd exports/my_agent
 # Create agent.json, tools.py, README.md (see developer-guide.md for structure)
 
 # Validate the agent
-PYTHONPATH=exports uv run python -m my_agent validate
+hive validate exports/my_agent
 ```
 
 ### Option 3: Manual Code-First (Minimal Example)
@@ -154,12 +154,12 @@ Get your API keys:
 # Using Claude Code
 claude> /hive-test
 
-# Or manually
-PYTHONPATH=exports uv run python -m my_agent test
+# Run all tests for a specific goal
+hive test-run exports/my_agent --goal <goal_id>
 
-# Run with specific test type
-PYTHONPATH=exports uv run python -m my_agent test --type constraint
-PYTHONPATH=exports uv run python -m my_agent test --type success
+# Run specific test type
+hive test-run exports/my_agent --goal <goal_id> --type constraint
+hive test-run exports/my_agent --goal <goal_id> --type success
 ```
 
 ## Next Steps


### PR DESCRIPTION
This PR adds comprehensive CLI usage examples to the `README.md` and updates the documentation to use the cleaner `hive` CLI commands instead of verbose Python commands. This directly addresses issue #2357 and significantly improves the onboarding experience by making command usage clearer and more consistent across guides.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #2357

## Changes Made

- **`README.md`**: Replaced the basic "Run Agents" section with a structured **"CLI Usage"** section. This new section includes organized tables for:
    - **Core Commands** (e.g., `hive run`, `hive tui`, `hive shell`)
    - **Session Management** (e.g., `hive sessions list`, `pause`, `resume`)
    - **Testing & QA** (e.g., `hive test-run`)
- **`docs/getting-started.md`**: Updated examples to use `hive` CLI commands (e.g., `hive validate`, `hive test-run`) instead of the verbose `PYTHONPATH=exports uv run python -m ...` syntax.
- **`docs/developer-guide.md`**: similarly updated command examples in the "Validate the Agent", "Agent Development Workflow", "Testing Agents", and "Common Tasks" sections to reflect the preferred CLI usage.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (N/A for docs)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
---
_Pull request created with Google Antigravity_