### PR TITLE
docs: clarify Python prerequisite in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 - [Docker](https://docs.docker.com/get-docker/) (v20.10+) - Optional, for containerized tools
 
 ### Installation
+The following steps will help you set up Hive locally for the first time.
 
 ```bash
 # Clone the repository

--- a/README.md
+++ b/README.md
@@ -395,3 +395,4 @@ For enterprise inquiries, contact the Aden team through [adenhq.com](https://ade
 <p align="center">
   Made with 🔥 Passion in San Francisco
 </p>
+Minor documentation improvement

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Aden is a platform for building, deploying, operating, and adapting AI agents:
 ## Quick Start
 
 ### Prerequisites
+> 💡 For beginners: Make sure you have Python 3.11 or higher installed and added to your PATH before running the setup script.
 
 - [Python 3.11+](https://www.python.org/downloads/) for agent development
 - [Docker](https://docs.docker.com/get-docker/) (v20.10+) - Optional, for containerized tools


### PR DESCRIPTION
Added a brief note in the Prerequisites section of README.md to clarify that Python 3.11+ must be installed and added to PATH before running setup. This should help beginners avoid common setup errors and improve onboarding.
