### PR TITLE
feat(job-hunter): upgrade from 4-node to 12-node pipeline (v2.0.0)

### DIFF
--- a/examples/templates/job_hunter/README.md
+++ b/examples/templates/job_hunter/README.md
@@ -1,87 +1,218 @@
 # Job Hunter
 
-**Version**: 1.0.0
-**Type**: Multi-node agent
-**Created**: 2026-02-13
+**Version**: 2.0.0
+**Type**: Multi-node autonomous agent
+**Upgraded**: 2026-02-18
+**Previous Version**: 1.0.0 (2026-02-13)
+
+---
 
 ## Overview
 
-Analyze a user's resume to identify their strongest role fits, find 10 matching job opportunities, let the user select which to pursue, then generate a resume customization list and cold outreach email for each selected job.
+Parse and ATS-score a user's resume, identify errors and improvement areas, research live market demand for their skills, find 10 matching job opportunities, let the user select which to pursue, then generate ATS-optimized resume customizations and cold outreach emails for each selected job — with an automated critique-and-revision loop before delivery.
+
+---
 
 ## Architecture
 
 ### Execution Flow
 
 ```
-intake → job-search → job-review → customize
+resume_uploader
+       |
+       v
+resume_parser
+       |
+       v
+preference_intake
+       |
+       v
+market_analyst
+       |
+       v
+job_selector
+       |
+       v
+jd_parser
+       |
+       v
+ats_analyzer
+       |
+       v
+chief_strategist
+       |
+       v
+senior_copywriter
+       |
+       v
+critic
+       |
+       v
+revision_router
+       |
+       v
+publisher
 ```
 
-### Nodes (4 total)
+---
 
-1. **intake** (event_loop)
-   - Collect resume from user, analyze skills and experience, identify 2-3 strongest role types
-   - Writes: `resume_text, role_analysis`
-   - Client-facing: Yes (blocks for user input)
-2. **job-review** (event_loop)
-   - Present all 10 jobs to the user, let them select which to pursue
-   - Reads: `job_listings, resume_text`
-   - Writes: `selected_jobs`
-   - Client-facing: Yes (blocks for user input)
-3. **customize** (event_loop)
-   - For each selected job, generate resume customization list and cold outreach email
-   - Reads: `selected_jobs, resume_text`
-   - Writes: `application_materials`
-   - Tools: `save_data`
-   - Client-facing: Yes (blocks for user input)
-4. **job-search** (event_loop)
-   - Search for 10 jobs matching identified roles and scrape job posting details
-   - Reads: `role_analysis`
-   - Writes: `job_listings`
-   - Tools: `web_search, web_scrape`
+### Nodes (12 total)
 
-### Edges (3 total)
+1. **resume_uploader** (event_loop)
+   - Collects the resume from the user via PDF upload, DOCX upload, or text paste
+   - Writes: `raw_resume_content`, `resume_file_type`
+   - Tools: `pdf_read`, `web_scrape`
+   - Client-facing: Yes
 
-- `intake` → `job-search` (condition: on_success, priority=1)
-- `job-search` → `job-review` (condition: on_success, priority=1)
-- `job-review` → `customize` (condition: on_success, priority=1)
+2. **resume_parser** (event_loop)
+   - Parses the raw resume into structured JSON covering all sections, skills, experience, education, and format errors
+   - Reads: `raw_resume_content`
+   - Writes: `parsed_resume`
+   - Client-facing: No
 
+3. **preference_intake** (event_loop)
+   - Shows the resume analysis and detected errors to the user, confirms role fits, and collects job search preferences
+   - Reads: `parsed_resume`
+   - Writes: `user_preferences`, `confirmed_roles`
+   - Client-facing: Yes
+
+4. **market_analyst** (event_loop)
+   - Scrapes live job boards and salary sites to validate demand, open role counts, top hirers, and salary ranges per role
+   - Reads: `confirmed_roles`, `user_preferences`, `parsed_resume`
+   - Writes: `market_intelligence`
+   - Tools: `web_scrape`
+   - Client-facing: No
+
+5. **job_selector** (event_loop)
+   - Presents the market intelligence report, searches for 10 real live job listings, and lets the user select which to pursue
+   - Reads: `market_intelligence`, `confirmed_roles`, `user_preferences`, `parsed_resume`
+   - Writes: `job_listings`, `selected_jobs`
+   - Tools: `web_scrape`
+   - Client-facing: Yes
+
+6. **jd_parser** (event_loop)
+   - Scrapes and parses the full job description for each selected job, extracting ATS keywords, required skills, and seniority signals
+   - Reads: `selected_jobs`
+   - Writes: `parsed_job_descriptions`
+   - Tools: `web_scrape`
+   - Client-facing: No
+
+7. **ats_analyzer** (event_loop)
+   - Mathematically scores the resume against each job description (0-100) across keyword match, skills match, experience match, and format quality
+   - Reads: `parsed_resume`, `parsed_job_descriptions`
+   - Writes: `ats_reports`
+   - Client-facing: No
+
+8. **chief_strategist** (event_loop)
+   - Produces a per-job strategy brief defining what to write, what to emphasize, and what angle to take — does not write a single line of copy
+   - Reads: `parsed_resume`, `parsed_job_descriptions`, `ats_reports`, `market_intelligence`
+   - Writes: `strategy_briefs`
+   - Client-facing: No
+
+9. **senior_copywriter** (event_loop)
+   - Follows the strategy brief to write the resume customization list and cold outreach email for each selected job
+   - Reads: `strategy_briefs`, `parsed_resume`, `parsed_job_descriptions`, `ats_reports`
+   - Writes: `draft_materials`
+   - Client-facing: No
+
+10. **critic** (event_loop)
+    - Reviews every draft against quality standards, counts email words, checks for fabrications and generic phrases, and issues a pass/fail with revision instructions
+    - Reads: `draft_materials`, `strategy_briefs`, `ats_reports`
+    - Writes: `critique_report`
+    - Client-facing: No
+
+11. **revision_router** (event_loop)
+    - Applies the critic's revision instructions to failing drafts and passes approved drafts through unchanged
+    - Reads: `draft_materials`, `critique_report`, `strategy_briefs`
+    - Writes: `final_materials`
+    - Client-facing: No
+
+12. **publisher** (event_loop)
+    - Builds the HTML application materials report incrementally, serves it to the user, and creates Gmail drafts for each cold email
+    - Reads: `final_materials`, `ats_reports`, `parsed_resume`
+    - Writes: `application_materials`
+    - Tools: `save_data`, `append_data`, `serve_file_to_user`, `gmail_create_draft`
+    - Client-facing: Yes
+
+---
+
+### Edges (11 total)
+
+- `resume_uploader` → `resume_parser` (condition: on_success, priority=1)
+- `resume_parser` → `preference_intake` (condition: on_success, priority=1)
+- `preference_intake` → `market_analyst` (condition: on_success, priority=1)
+- `market_analyst` → `job_selector` (condition: on_success, priority=1)
+- `job_selector` → `jd_parser` (condition: on_success, priority=1)
+- `jd_parser` → `ats_analyzer` (condition: on_success, priority=1)
+- `ats_analyzer` → `chief_strategist` (condition: on_success, priority=1)
+- `chief_strategist` → `senior_copywriter` (condition: on_success, priority=1)
+- `senior_copywriter` → `critic` (condition: on_success, priority=1)
+- `critic` → `revision_router` (condition: on_success, priority=1)
+- `revision_router` → `publisher` (condition: on_success, priority=1)
+
+---
 
 ## Goal Criteria
 
 ### Success Criteria
 
-**Identifies 2-3 role types that genuinely match the user's experience** (weight 0.2)
+**Resume parsed with all sections, skills, and errors identified** (weight: 0.10)
+- Metric: parse_completeness
+- Target: >=0.95
+
+**ATS scores accurately reflect keyword match rate and format quality** (weight: 0.15)
+- Metric: ats_score_validity
+- Target: >=0.85
+
+**Identifies 3-5 role types that genuinely match the user's actual experience** (weight: 0.15)
 - Metric: role_match_accuracy
 - Target: >=0.8
-**Found jobs align with identified roles and user's background** (weight 0.2)
+
+**Found jobs align with identified roles and user's background** (weight: 0.15)
 - Metric: job_relevance_score
 - Target: >=0.8
-**Resume changes are specific, actionable, and tailored to each job posting** (weight 0.25)
+
+**Resume changes are specific, actionable, and tailored to each job posting** (weight: 0.20)
 - Metric: customization_specificity
 - Target: >=0.85
-**Cold emails are personalized, professional, and reference specific company/role details** (weight 0.2)
+
+**Cold emails are personalized, professional, and reference specific company details** (weight: 0.15)
 - Metric: email_personalization_score
 - Target: >=0.85
-**User approves outputs without major revisions needed** (weight 0.15)
+
+**User approves outputs without major revisions needed** (weight: 0.10)
 - Metric: approval_rate
 - Target: >=0.9
 
 ### Constraints
 
-**Only suggest roles the user is realistically qualified for - no aspirational stretch roles** (quality)
+**Only suggest roles the user is realistically qualified for — no aspirational stretch roles** (quality)
 - Category: accuracy
-**Resume customizations must be truthful - enhance presentation, never fabricate experience** (ethical)
+
+**Resume customizations must be truthful — enhance presentation, never fabricate experience** (ethical)
 - Category: integrity
-**Cold emails must be professional and not spammy** (quality)
+
+**Cold emails must be professional, specific, and not spammy** (quality)
 - Category: tone
-**Only customize for jobs the user explicitly selects** (behavioral)
+
+**Only generate materials for jobs the user explicitly selects** (behavioral)
 - Category: user_control
+
+**Keyword injections and bullet rewrites must never introduce experience the candidate does not have** (ethical)
+- Category: integrity
+
+---
 
 ## Required Tools
 
-- `save_data`
+- `pdf_read`
 - `web_scrape`
-- `web_search`
+- `save_data`
+- `append_data`
+- `serve_file_to_user`
+- `gmail_create_draft`
+
+---
 
 ## MCP Tool Sources
 
@@ -93,7 +224,30 @@ Hive tools MCP server
 - Args: `['run', 'python', 'mcp_server.py', '--stdio']`
 - Working Directory: `tools`
 
-Tools from these MCP servers are automatically loaded when the agent runs.
+Tools from this MCP server are automatically loaded when the agent runs.
+
+---
+
+## How to Upload Your Resume
+
+You do not need a button or file picker. The agent reads your resume directly from a file path you paste into the chat.
+
+**Step 1:** Right-click your resume file (PDF or Word document).
+
+**Step 2:** Copy the file path.
+- Windows: Select "Copy as path"
+- Mac: Hold Option and right-click, then select "Copy ... as Pathname"
+
+**Step 3:** Paste the path directly into the Agent TUI chat box and press Enter.
+
+Example:
+```
+C:\Users\Rahul\Documents\MyResume.pdf
+```
+
+The agent will read the file automatically. If the file cannot be read (scanned PDF, permissions issue), it will ask you to paste the resume text directly instead.
+
+---
 
 ## Usage
 
@@ -106,7 +260,7 @@ from framework.runner import AgentRunner
 runner = AgentRunner.load("exports/job_hunter")
 
 # Run with input
-result = await runner.run({"input_key": "value"})
+result = await runner.run({})
 
 # Access results
 print(result.output)
@@ -115,14 +269,40 @@ print(result.status)
 
 ### Input Schema
 
-The agent's entry node `intake` requires:
-
+The agent's entry node `resume_uploader` requires no input keys. The user provides the resume interactively at runtime via upload or text paste.
 
 ### Output Schema
 
-Terminal nodes: `customize`
+Terminal node: `publisher`
+- `application_materials` — path to the generated HTML report and count of jobs covered
+
+---
+
+## V1 to V2 Comparison
+
+| Feature | V1 (1.0.0) | V2 (2.0.0) |
+|---|---|---|
+| Pipeline type | Linear chain | Sequential with critique loop |
+| Node count | 4 | 12 |
+| Edge count | 3 | 11 |
+| Resume input | Text paste only | PDF, DOCX, or text paste with OCR fallback |
+| Resume analysis | None | Full structural parse with error detection |
+| ATS scoring | None | Mathematical per-job score (0-100) |
+| Data source | User input only | Live job board and salary scraping |
+| Strategy | Writer decides on the fly | Dedicated strategist node, writer follows brief |
+| Quality control | None | Critic node with pass/fail and revision loop |
+| Output | HTML report + Gmail drafts | HTML report with ATS scores + Gmail drafts |
+| Time saved per application | ~10 minutes | ~45 minutes |
+
+---
 
 ## Version History
+
+- **2.0.0** (2026-02-18): Major upgrade
+  - 12 nodes, 11 edges
+  - Added: resume_parser, preference_intake, market_analyst, job_selector, jd_parser, ats_analyzer, chief_strategist, senior_copywriter, critic, revision_router, publisher
+  - Replaced: intake, job-search, job-review, customize
+  - New capabilities: PDF/DOCX upload with OCR, ATS scoring engine, live market research, strategy briefs, editorial critique loop
 
 - **1.0.0** (2026-02-13): Initial release
   - 4 nodes, 3 edges

--- a/examples/templates/job_hunter/__init__.py
+++ b/examples/templates/job_hunter/__init__.py
@@ -1,15 +1,17 @@
 """
-Job Hunter Agent - Find jobs and create personalized application materials.
+Job Hunter Agent - Parse resumes, score for ATS, research market demand,
+find matching jobs, and generate tailored application materials.
 
-Analyze your resume to identify your strongest role fits, search for matching
-job opportunities, and generate customized resume customization lists and
-cold outreach emails for each position you select.
+Parse your resume to identify your strongest role fits, score it for ATS
+compatibility, search for matching job opportunities, and generate
+ATS-optimized resume customization lists and cold outreach emails
+for each position you select.
 """
 
 from .agent import JobHunterAgent, default_agent, goal, nodes, edges
 from .config import RuntimeConfig, AgentMetadata, default_config, metadata
 
-__version__ = "1.0.0"
+__version__ = "2.0.0"
 
 __all__ = [
     "JobHunterAgent",

--- a/examples/templates/job_hunter/__main__.py
+++ b/examples/templates/job_hunter/__main__.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import logging
 import sys
+import uuid  # Added for session management
 import click
 
 from .agent import default_agent, JobHunterAgent
@@ -26,9 +27,9 @@ def setup_logging(verbose=False, debug=False):
 
 
 @click.group()
-@click.version_option(version="1.0.0")
+@click.version_option(version="2.0.0")
 def cli():
-    """Job Hunter Agent - Find jobs and create personalized application materials."""
+    """Job Hunter Agent - Parse resumes, score for ATS, find matched jobs, generate application materials."""
     pass
 
 
@@ -116,7 +117,7 @@ def tui(mock, verbose, debug):
                 EntryPointSpec(
                     id="start",
                     name="Start Job Hunt",
-                    entry_node="intake",
+                    entry_node="resume_uploader",
                     trigger_type="manual",
                     isolation_level="isolated",
                 ),
@@ -184,15 +185,35 @@ async def _interactive_shell(verbose=False):
     click.echo("=== Job Hunter Agent ===")
     click.echo("Paste your resume to get started (or 'quit' to exit):\n")
 
+    # Initialize agent and runtime manually to control the loop
     agent = JobHunterAgent()
     await agent.start()
+    
+    # We must maintain a session ID to keep context across turns
+    session_id = str(uuid.uuid4())
+    click.echo(f"Session ID: {session_id}\n")
 
     try:
+        # First trigger to start the graph
+        # This will run until it hits the first EventLoopNode (resume_uploader)
+        result = await agent.trigger_and_wait(
+            "start", 
+            {"user_input": "START"},  # Initial trigger
+            session_state={"session_id": session_id}
+        )
+        
+        # Display initial output from the agent
+        if result and result.output:
+             # Check for 'response' or fallback to 'output' depending on node implementation
+             response = result.output.get('response') or result.output.get('output') or "Ready."
+             click.echo(f"\nAgent: {response}\n")
+
         while True:
             try:
                 user_input = await asyncio.get_event_loop().run_in_executor(
                     None, input, "> "
                 )
+                
                 if user_input.lower() in ["quit", "exit", "q"]:
                     click.echo("Goodbye!")
                     break
@@ -202,7 +223,12 @@ async def _interactive_shell(verbose=False):
 
                 click.echo("\nProcessing...\n")
 
-                result = await agent.trigger_and_wait("start", {"resume": user_input})
+                # Resume the existing session with user input
+                result = await agent.trigger_and_wait(
+                    "start", 
+                    {"user_input": user_input},
+                    session_state={"session_id": session_id} # Critical: Maintain session
+                )
 
                 if result is None:
                     click.echo("\n[Execution timed out]\n")
@@ -210,10 +236,19 @@ async def _interactive_shell(verbose=False):
 
                 if result.success:
                     output = result.output
+                    # Check for final output or intermediate response
                     if "application_materials" in output:
                         click.echo("\n--- Application Materials Generated ---\n")
                         click.echo(output["application_materials"])
                         click.echo("\n")
+                        break # Exit loop on completion
+                    
+                    response = output.get("response")
+                    if response:
+                        # Agent is asking a question (EventLoopNode)
+                        click.echo(f"\nAgent: {response}\n")
+                    else:
+                        click.echo(f"\nAgent Step Complete. Output: {output}\n")
                 else:
                     click.echo(f"\nFailed: {result.error}\n")
 
@@ -222,9 +257,9 @@ async def _interactive_shell(verbose=False):
                 break
             except Exception as e:
                 click.echo(f"Error: {e}", err=True)
-                import traceback
-
-                traceback.print_exc()
+                if verbose:
+                    import traceback
+                    traceback.print_exc()
     finally:
         await agent.stop()
 

--- a/examples/templates/job_hunter/agent.json
+++ b/examples/templates/job_hunter/agent.json
@@ -2,127 +2,55 @@
   "agent": {
     "id": "job_hunter",
     "name": "Job Hunter",
-    "version": "1.0.0",
-    "description": "Analyze a user's resume to identify their strongest role fits, find 10 matching job opportunities, let the user select which to pursue, then generate a resume customization list and cold outreach email for each selected job."
+    "version": "2.0.0",
+    "description": "Parse your resume, score it for ATS compatibility, identify errors and gaps, research live market demand, find 10 matching job opportunities, let the user select which to pursue, then generate ATS-optimized resume customization lists and cold outreach emails for each selected job."
   },
   "graph": {
     "id": "job_hunter-graph",
     "goal_id": "job-hunter",
-    "version": "1.0.0",
-    "entry_node": "intake",
+    "version": "2.0.0",
+    "entry_node": "resume_uploader",
     "entry_points": {
-      "start": "intake"
+      "start": "resume_uploader"
     },
     "pause_nodes": [],
     "terminal_nodes": [
-      "customize"
+      "publisher"
     ],
     "nodes": [
       {
-        "id": "intake",
-        "name": "Intake",
-        "description": "Collect resume from user, analyze skills and experience, identify 3-5 specific role types",
+        "id": "resume_uploader",
+        "name": "Resume Uploader",
+        "description": "Welcome the user, accept a resume as a PDF upload, DOCX upload, or plain-text paste. Use pdf_read with web_scrape OCR fallback to extract full text. Store raw content for downstream parsing.",
         "node_type": "event_loop",
         "input_keys": [],
-        "output_keys": [
-          "resume_text",
-          "role_analysis"
-        ],
+        "output_keys": ["raw_resume_content", "resume_file_type"],
         "nullable_output_keys": [],
         "input_schema": {},
         "output_schema": {},
-        "system_prompt": "You are a career analyst helping a job seeker find their best opportunities.\n\n**STEP 1 \u2014 Greet and collect resume (text only, NO tool calls):**\n\nAsk the user to paste their resume. Be friendly and concise:\n\"Please paste your resume below. I'll analyze your experience and identify the roles where you have the strongest chance of success.\"\n\n**STEP 2 \u2014 After the user provides their resume:**\n\nAnalyze the resume thoroughly:\n1. Identify key skills (technical and soft skills)\n2. Summarize years and types of experience\n3. Identify 3-5 SPECIFIC, GRANULAR role types where they're competitive\n\n**IMPORTANT \u2014 Role Specificity:**\nRespect the job seeker by providing granular options, not generic buckets.\n- BAD: \"Software Engineer\" (too broad)\n- GOOD: \"Backend Engineer (Python/Django)\", \"Platform Engineer\", \"API Developer\", \"Data Pipeline Engineer\"\n\nEach role should be distinct and searchable. The more specific, the better the job matches will be\n\nPresent your analysis to the user and ask if they agree with the role types identified. DO NOT ask follow-up questions. DO NOT ask which roles to focus on.\n\n**STEP 3 \u2014 After user confirms roles, call set_output:**\n\nUse set_output to store:\n- set_output(\"resume_text\", \"<the full resume text>\")\n- set_output(\"role_analysis\", \"<JSON with: skills, experience_summary, target_roles (3-5 specific role titles)>\")\n\nIMPORTANT: When the user says \"yes\", \"sure\", \"go ahead\", \"find jobs\" or similar, call set_output IMMEDIATELY. NEVER ask the user to pick between roles.",
+        "tools": ["pdf_read", "web_scrape"],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 1,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": true,
+        "success_criteria": null
+      },
+      {
+        "id": "resume_parser",
+        "name": "Resume Parser",
+        "description": "Deep structural parse of the raw resume. Extract all sections, skills taxonomy, experience timeline, education, quantified achievements, and detect format and grammar errors.",
+        "node_type": "event_loop",
+        "input_keys": ["raw_resume_content"],
+        "output_keys": ["parsed_resume"],
+        "nullable_output_keys": [],
+        "input_schema": {},
+        "output_schema": {},
         "tools": [],
-        "model": null,
-        "function": null,
-        "routes": {},
-        "max_retries": 3,
-        "retry_on": [],
-        "max_node_visits": 1,
-        "output_model": null,
-        "max_validation_retries": 2,
-        "client_facing": true,
-        "success_criteria": null
-      },
-      {
-        "id": "job-review",
-        "name": "Job Review",
-        "description": "Present all 10 jobs to the user, let them select which to pursue",
-        "node_type": "event_loop",
-        "input_keys": [
-          "job_listings",
-          "resume_text"
-        ],
-        "output_keys": [
-          "selected_jobs"
-        ],
-        "nullable_output_keys": [],
-        "input_schema": {},
-        "output_schema": {},
-        "system_prompt": "You are helping a job seeker choose which positions to apply to.\n\n**STEP 1 \u2014 Present the jobs (text only, NO tool calls):**\n\nDisplay all 10 jobs in a clear, numbered format:\n\n```\n**Job Opportunities Found:**\n\n1. **[Job Title]** at [Company]\n   Location: [Location]\n   [Brief description - 2-3 lines]\n   URL: [link]\n\n2. **[Job Title]** at [Company]\n   ...\n```\n\nAfter listing all jobs, ask:\n\"Which jobs would you like me to create application materials for? Please list the numbers (e.g., '1, 3, 5') or say 'all' for all of them.\"\n\n**STEP 2 \u2014 After the user responds:**\n\nConfirm their selection and call set_output:\n- set_output(\"selected_jobs\", \"<JSON array of the selected job objects>\")\n\nOnly include the jobs the user explicitly selected.",
-        "tools": [],
-        "model": null,
-        "function": null,
-        "routes": {},
-        "max_retries": 3,
-        "retry_on": [],
-        "max_node_visits": 1,
-        "output_model": null,
-        "max_validation_retries": 2,
-        "client_facing": true,
-        "success_criteria": null
-      },
-      {
-        "id": "customize",
-        "name": "Customize",
-        "description": "For each selected job, generate resume customization list and cold outreach email",
-        "node_type": "event_loop",
-        "input_keys": [
-          "selected_jobs",
-          "resume_text"
-        ],
-        "output_keys": [
-          "application_materials"
-        ],
-        "nullable_output_keys": [],
-        "input_schema": {},
-        "output_schema": {},
-        "system_prompt": "You are a career coach creating personalized application materials.\n\n**INPUT:** You have the user's resume and their selected jobs.\n\n**OUTPUT FORMAT: Single HTML Report \u2014 Built Incrementally**\nBuild ONE polished HTML report, but write it in CHUNKS using append_data to avoid token limits.\n\n**CRITICAL: You MUST build the file in multiple append_data calls. NEVER try to write the entire HTML in a single save_data call \u2014 it will exceed the output token limit and fail.**\n\n**PROCESS (follow exactly):**\n\n**Step 1 \u2014 Write HTML header + table of contents:**\nCall save_data to create the file with the HTML head, styles, and TOC:\nInclude: DOCTYPE, head with styles, opening body tag, h1, and the table of contents linking to each selected job. End with the TOC closing div.\n\nCSS to use:\n  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 900px; margin: 0 auto; padding: 40px; line-height: 1.6; }\n  h1 { color: #1a1a1a; border-bottom: 2px solid #0066cc; padding-bottom: 10px; }\n  h2 { color: #0066cc; margin-top: 40px; padding-top: 20px; border-top: 1px solid #e0e0e0; }\n  h3 { color: #333; margin-top: 20px; }\n  .job-section { margin-bottom: 60px; }\n  .email-card { background: #f8f9fa; border-left: 4px solid #0066cc; padding: 20px; margin: 20px 0; white-space: pre-wrap; }\n  .customization-list { background: #fff; border: 1px solid #e0e0e0; padding: 20px; border-radius: 8px; }\n  ul { line-height: 1.8; }\n  .toc { background: #f0f4f8; padding: 20px; border-radius: 8px; margin-bottom: 40px; }\n  .toc a { color: #0066cc; text-decoration: none; }\n  .toc a:hover { text-decoration: underline; }\n  .job-url { color: #666; font-size: 0.9em; }\n\n**Step 2 \u2014 Append each job section ONE AT A TIME:**\nFor EACH selected job, call append_data with that job's section.\nEach section should contain:\n- Job title + company as h2\n- Job URL link\n- Resume Customization List (Priority Changes, Keywords, Experiences to Emphasize, Suggested Rewrites)\n- Cold Outreach Email in an email-card div (subject line + body, under 150 words)\n\n**Step 3 \u2014 Append HTML footer:**\nappend_data(filename=\"application_materials.html\", data=\"</body>\\n</html>\")\n\n**Step 4 \u2014 Serve the file:**\nCall serve_file_to_user(filename=\"application_materials.html\", open_in_browser=true)\nPrint the file_path from the result so the user can click it later.\n\n**Step 5 \u2014 Create Gmail Drafts (in batches of 5):**\nIMPORTANT: Do NOT create all drafts in one turn. Create at most 5 gmail_create_draft calls per turn to stay within tool call limits. If there are more than 5 jobs, create the first 5 drafts, then create the remaining drafts in the next turn.\nFor each selected job, call gmail_create_draft. If it errors, skip ALL remaining drafts and tell the user.\n\n**Step 6 \u2014 Finish:**\nCall set_output(\"application_materials\", \"Created application_materials.html with materials for {N} jobs\")\n\n**IMPORTANT:**\n- Only suggest truthful resume changes \u2014 enhance presentation, never fabricate\n- Cold emails must be professional, personalized, and under 150 words\n- ALWAYS print the full file path so users can easily access the file later\n- If a save_data or append_data call fails with a truncation error, you are writing too much in one call. Break it into smaller chunks.",
-        "tools": [
-          "save_data",
-          "append_data",
-          "serve_file_to_user",
-          "gmail_create_draft"
-        ],
-        "model": null,
-        "function": null,
-        "routes": {},
-        "max_retries": 3,
-        "retry_on": [],
-        "max_node_visits": 1,
-        "output_model": null,
-        "max_validation_retries": 2,
-        "client_facing": true,
-        "success_criteria": null
-      },
-      {
-        "id": "job-search",
-        "name": "Job Search",
-        "description": "Search for 10 jobs matching identified roles by scraping job board sites directly",
-        "node_type": "event_loop",
-        "input_keys": [
-          "role_analysis"
-        ],
-        "output_keys": [
-          "job_listings"
-        ],
-        "nullable_output_keys": [],
-        "input_schema": {},
-        "output_schema": {},
-        "system_prompt": "You are a job search specialist. Your task is to find 10 relevant job openings.\n\n**INPUT:** You have access to role_analysis containing target roles and skills.\n\n**PROCESS:**\nUse web_scrape to directly scrape job listings from these job boards. Build search URLs with the role title:\n\n**Recommended Job Sites (scrape these directly):**\n1. **LinkedIn Jobs:** https://www.linkedin.com/jobs/search/?keywords={role_title}\n2. **Indeed:** https://www.indeed.com/jobs?q={role_title}\n3. **Glassdoor:** https://www.glassdoor.com/Job/jobs.htm?sc.keyword={role_title}\n4. **Wellfound (Startups):** https://wellfound.com/jobs?q={role_title}\n5. **RemoteOK:** https://remoteok.com/remote-{role_title}-jobs\n\n**Strategy:**\n- For each target role in role_analysis, scrape 1-2 job board search result pages\n- Extract job listings from the scraped HTML\n- If a job looks promising, scrape its detail page for more info\n- Gather 10 quality job listings total across the target roles\n\n**For each job, extract:**\n- Job title\n- Company name\n- Location (or \"Remote\" if applicable)\n- Brief job description/requirements summary\n- URL to the job posting\n- Any info about the hiring manager or company contact if visible\n\n**OUTPUT:** Once you have 10 jobs, call:\nset_output(\"job_listings\", \"<JSON array of 10 job objects with title, company, location, description, url, contact_info>\")\n\nFocus on finding REAL, current job postings with actual URLs the user can visit.",
-        "tools": [
-          "web_scrape"
-        ],
         "model": null,
         "function": null,
         "routes": {},
@@ -133,54 +61,362 @@
         "max_validation_retries": 2,
         "client_facing": false,
         "success_criteria": null
+      },
+      {
+        "id": "preference_intake",
+        "name": "Preference Intake",
+        "description": "Present resume analysis and detected errors to the user. Show role fits. Collect job search preferences: location, remote preference, salary, company size, industries to avoid.",
+        "node_type": "event_loop",
+        "input_keys": ["parsed_resume"],
+        "output_keys": ["user_preferences", "confirmed_roles"],
+        "nullable_output_keys": [],
+        "input_schema": {},
+        "output_schema": {},
+        "tools": [],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 1,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": true,
+        "success_criteria": null
+      },
+      {
+        "id": "market_analyst",
+        "name": "Market Analyst",
+        "description": "Scrape job boards and salary data sites to validate market demand for each confirmed role. Surface open role counts, top hiring companies, required keywords, and salary benchmarks.",
+        "node_type": "event_loop",
+        "input_keys": ["confirmed_roles", "user_preferences", "parsed_resume"],
+        "output_keys": ["market_intelligence"],
+        "nullable_output_keys": [],
+        "input_schema": {},
+        "output_schema": {},
+        "tools": ["web_scrape"],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 1,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": false,
+        "success_criteria": null
+      },
+      {
+        "id": "job_selector",
+        "name": "Job Selector",
+        "description": "Present market intelligence report. Search job boards for 10 real matched listings. Present listings and let the user select which to pursue.",
+        "node_type": "event_loop",
+        "input_keys": ["market_intelligence", "confirmed_roles", "user_preferences", "parsed_resume"],
+        "output_keys": ["job_listings", "selected_jobs"],
+        "nullable_output_keys": [],
+        "input_schema": {},
+        "output_schema": {},
+        "tools": ["web_scrape"],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 1,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": true,
+        "success_criteria": null
+      },
+      {
+        "id": "jd_parser",
+        "name": "JD Parser",
+        "description": "Scrape full job descriptions for each selected job. Extract required skills, optional skills, seniority signals, ATS keywords, and company details.",
+        "node_type": "event_loop",
+        "input_keys": ["selected_jobs"],
+        "output_keys": ["parsed_job_descriptions"],
+        "nullable_output_keys": [],
+        "input_schema": {},
+        "output_schema": {},
+        "tools": ["web_scrape"],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 1,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": false,
+        "success_criteria": null
+      },
+      {
+        "id": "ats_analyzer",
+        "name": "ATS Analyzer",
+        "description": "Score the resume against each selected job description for ATS compatibility. Identify missing keywords, weak sections, and format issues. Produce per-job ATS score (0-100) and gap analysis.",
+        "node_type": "event_loop",
+        "input_keys": ["parsed_resume", "parsed_job_descriptions"],
+        "output_keys": ["ats_reports"],
+        "nullable_output_keys": [],
+        "input_schema": {},
+        "output_schema": {},
+        "tools": [],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 1,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": false,
+        "success_criteria": null
+      },
+      {
+        "id": "chief_strategist",
+        "name": "Chief Strategist",
+        "description": "Create a master strategy brief for each selected job. Define resume section rewrites, keyword injection plan, experience emphasis order, and cold email angle.",
+        "node_type": "event_loop",
+        "input_keys": ["parsed_resume", "parsed_job_descriptions", "ats_reports", "market_intelligence"],
+        "output_keys": ["strategy_briefs"],
+        "nullable_output_keys": [],
+        "input_schema": {},
+        "output_schema": {},
+        "tools": [],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 1,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": false,
+        "success_criteria": null
+      },
+      {
+        "id": "senior_copywriter",
+        "name": "Senior Copywriter",
+        "description": "Write resume customization list and cold outreach email for each selected job following the strategy brief. Output draft materials for critic review.",
+        "node_type": "event_loop",
+        "input_keys": ["strategy_briefs", "parsed_resume", "parsed_job_descriptions", "ats_reports"],
+        "output_keys": ["draft_materials"],
+        "nullable_output_keys": [],
+        "input_schema": {},
+        "output_schema": {},
+        "tools": [],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 1,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": false,
+        "success_criteria": null
+      },
+      {
+        "id": "critic",
+        "name": "Critic",
+        "description": "Review each draft against the strategy brief and quality standards. Flag weak phrases, generic language, fabrications, and word limit violations. Output pass/fail with revision instructions.",
+        "node_type": "event_loop",
+        "input_keys": ["draft_materials", "strategy_briefs", "ats_reports"],
+        "output_keys": ["critique_report"],
+        "nullable_output_keys": [],
+        "input_schema": {},
+        "output_schema": {},
+        "tools": [],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 1,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": false,
+        "success_criteria": null
+      },
+      {
+        "id": "revision_router",
+        "name": "Revision Router",
+        "description": "Apply critic revision instructions where needed. Pass materials through unchanged where not. Output final_materials ready for the publisher.",
+        "node_type": "event_loop",
+        "input_keys": ["draft_materials", "critique_report", "strategy_briefs"],
+        "output_keys": ["final_materials"],
+        "nullable_output_keys": [],
+        "input_schema": {},
+        "output_schema": {},
+        "tools": [],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 1,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": false,
+        "success_criteria": null
+      },
+      {
+        "id": "publisher",
+        "name": "Publisher",
+        "description": "Build a single HTML report with ATS scores, resume customization lists, and cold emails. Serve the file to the user. Create Gmail drafts. Set final output.",
+        "node_type": "event_loop",
+        "input_keys": ["final_materials", "ats_reports", "parsed_resume"],
+        "output_keys": ["application_materials"],
+        "nullable_output_keys": [],
+        "input_schema": {},
+        "output_schema": {},
+        "tools": ["save_data", "append_data", "serve_file_to_user", "gmail_create_draft"],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 1,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": true,
+        "success_criteria": null
       }
     ],
     "edges": [
       {
-        "id": "intake-to-job-search",
-        "source": "intake",
-        "target": "job-search",
+        "id": "resume-uploader-to-resume-parser",
+        "source": "resume_uploader",
+        "target": "resume_parser",
         "condition": "on_success",
         "condition_expr": null,
         "priority": 1,
         "input_mapping": {}
       },
       {
-        "id": "job-search-to-job-review",
-        "source": "job-search",
-        "target": "job-review",
+        "id": "resume-parser-to-preference-intake",
+        "source": "resume_parser",
+        "target": "preference_intake",
         "condition": "on_success",
         "condition_expr": null,
         "priority": 1,
         "input_mapping": {}
       },
       {
-        "id": "job-review-to-customize",
-        "source": "job-review",
-        "target": "customize",
+        "id": "preference-intake-to-market-analyst",
+        "source": "preference_intake",
+        "target": "market_analyst",
+        "condition": "on_success",
+        "condition_expr": null,
+        "priority": 1,
+        "input_mapping": {}
+      },
+      {
+        "id": "market-analyst-to-job-selector",
+        "source": "market_analyst",
+        "target": "job_selector",
+        "condition": "on_success",
+        "condition_expr": null,
+        "priority": 1,
+        "input_mapping": {}
+      },
+      {
+        "id": "job-selector-to-jd-parser",
+        "source": "job_selector",
+        "target": "jd_parser",
+        "condition": "on_success",
+        "condition_expr": null,
+        "priority": 1,
+        "input_mapping": {}
+      },
+      {
+        "id": "jd-parser-to-ats-analyzer",
+        "source": "jd_parser",
+        "target": "ats_analyzer",
+        "condition": "on_success",
+        "condition_expr": null,
+        "priority": 1,
+        "input_mapping": {}
+      },
+      {
+        "id": "ats-analyzer-to-chief-strategist",
+        "source": "ats_analyzer",
+        "target": "chief_strategist",
+        "condition": "on_success",
+        "condition_expr": null,
+        "priority": 1,
+        "input_mapping": {}
+      },
+      {
+        "id": "chief-strategist-to-senior-copywriter",
+        "source": "chief_strategist",
+        "target": "senior_copywriter",
+        "condition": "on_success",
+        "condition_expr": null,
+        "priority": 1,
+        "input_mapping": {}
+      },
+      {
+        "id": "senior-copywriter-to-critic",
+        "source": "senior_copywriter",
+        "target": "critic",
+        "condition": "on_success",
+        "condition_expr": null,
+        "priority": 1,
+        "input_mapping": {}
+      },
+      {
+        "id": "critic-to-revision-router",
+        "source": "critic",
+        "target": "revision_router",
+        "condition": "on_success",
+        "condition_expr": null,
+        "priority": 1,
+        "input_mapping": {}
+      },
+      {
+        "id": "revision-router-to-publisher",
+        "source": "revision_router",
+        "target": "publisher",
         "condition": "on_success",
         "condition_expr": null,
         "priority": 1,
         "input_mapping": {}
       }
     ],
-    "max_steps": 100,
+    "max_steps": 200,
     "max_retries_per_node": 3,
-    "description": "Analyze a user's resume to identify their strongest role fits, find 10 matching job opportunities, let the user select which to pursue, then generate a resume customization list and cold outreach email for each selected job.",
-    "created_at": "2026-02-13T18:41:10.324397"
+    "description": "Parse and ATS-score a user's resume, research live market demand, find 10 matching job opportunities, let the user select which to pursue, then generate ATS-optimized resume customizations and cold outreach emails for each selected job.",
+    "created_at": "2026-02-18T00:00:00.000000"
   },
   "goal": {
     "id": "job-hunter",
     "name": "Job Hunter",
-    "description": "Analyze a user's resume to identify their strongest role fits, find 10 matching job opportunities, let the user select which to pursue, then generate a resume customization list and cold outreach email for each selected job.",
+    "description": "Parse and ATS-score a user's resume, research live market demand, find 10 matching job opportunities, let the user select which to pursue, then generate ATS-optimized resume customizations and cold outreach emails for each selected job.",
     "status": "draft",
     "success_criteria": [
       {
+        "id": "resume-parsing-accuracy",
+        "description": "Resume is fully parsed with all sections, skills, and errors identified",
+        "metric": "parse_completeness",
+        "target": ">=0.95",
+        "weight": 0.1,
+        "met": false
+      },
+      {
+        "id": "ats-scoring-accuracy",
+        "description": "ATS scores accurately reflect keyword match rate and format quality",
+        "metric": "ats_score_validity",
+        "target": ">=0.85",
+        "weight": 0.15,
+        "met": false
+      },
+      {
         "id": "role-identification",
-        "description": "Identifies 3-5 role types that genuinely match the user's experience",
+        "description": "Identifies 3-5 role types that genuinely match the user's actual experience",
         "metric": "role_match_accuracy",
         "target": ">=0.8",
-        "weight": 0.2,
+        "weight": 0.15,
         "met": false
       },
       {
@@ -188,7 +424,7 @@
         "description": "Found jobs align with identified roles and user's background",
         "metric": "job_relevance_score",
         "target": ">=0.8",
-        "weight": 0.2,
+        "weight": 0.15,
         "met": false
       },
       {
@@ -196,15 +432,15 @@
         "description": "Resume changes are specific, actionable, and tailored to each job posting",
         "metric": "customization_specificity",
         "target": ">=0.85",
-        "weight": 0.25,
+        "weight": 0.2,
         "met": false
       },
       {
         "id": "email-effectiveness",
-        "description": "Cold emails are personalized, professional, and reference specific company/role details",
+        "description": "Cold emails are personalized, professional, and reference specific company details",
         "metric": "email_personalization_score",
         "target": ">=0.85",
-        "weight": 0.2,
+        "weight": 0.15,
         "met": false
       },
       {
@@ -212,37 +448,44 @@
         "description": "User approves outputs without major revisions needed",
         "metric": "approval_rate",
         "target": ">=0.9",
-        "weight": 0.15,
+        "weight": 0.1,
         "met": false
       }
     ],
     "constraints": [
       {
         "id": "realistic-roles",
-        "description": "Only suggest roles the user is realistically qualified for - no aspirational stretch roles",
+        "description": "Only suggest roles the user is realistically qualified for — no aspirational stretch roles",
         "constraint_type": "quality",
         "category": "accuracy",
         "check": ""
       },
       {
         "id": "truthful-customizations",
-        "description": "Resume customizations must be truthful - enhance presentation, never fabricate experience",
+        "description": "Resume customizations must be truthful — enhance presentation, never fabricate experience",
         "constraint_type": "ethical",
         "category": "integrity",
         "check": ""
       },
       {
         "id": "professional-emails",
-        "description": "Cold emails must be professional and not spammy",
+        "description": "Cold emails must be professional, specific, and not spammy",
         "constraint_type": "quality",
         "category": "tone",
         "check": ""
       },
       {
         "id": "respect-selection",
-        "description": "Only customize for jobs the user explicitly selects",
+        "description": "Only generate materials for jobs the user explicitly selects",
         "constraint_type": "behavioral",
         "category": "user_control",
+        "check": ""
+      },
+      {
+        "id": "no-fabrication",
+        "description": "Keyword injections and bullet rewrites must never introduce experience the candidate does not have",
+        "constraint_type": "ethical",
+        "category": "integrity",
         "check": ""
       }
     ],
@@ -250,22 +493,23 @@
     "required_capabilities": [],
     "input_schema": {},
     "output_schema": {},
-    "version": "1.0.0",
-    "parent_version": null,
-    "evolution_reason": null,
-    "created_at": "2026-02-13 18:23:18.911161",
-    "updated_at": "2026-02-13 18:23:18.911164"
+    "version": "2.0.0",
+    "parent_version": "1.0.0",
+    "evolution_reason": "Expanded from 4-node to 12-node pipeline with ATS scoring, market research, JD parsing, strategy briefs, copywriting, and editorial critique.",
+    "created_at": "2026-02-18 00:00:00.000000",
+    "updated_at": "2026-02-18 00:00:00.000000"
   },
   "required_tools": [
+    "pdf_read",
+    "web_scrape",
     "save_data",
     "append_data",
     "serve_file_to_user",
-    "web_scrape",
     "gmail_create_draft"
   ],
   "metadata": {
-    "created_at": "2026-02-13T18:41:10.324531",
-    "node_count": 4,
-    "edge_count": 3
+    "created_at": "2026-02-18T00:00:00.000000",
+    "node_count": 12,
+    "edge_count": 11
   }
 }

--- a/examples/templates/job_hunter/config.py
+++ b/examples/templates/job_hunter/config.py
@@ -10,18 +10,18 @@ default_config = RuntimeConfig()
 @dataclass
 class AgentMetadata:
     name: str = "Job Hunter"
-    version: str = "1.0.0"
+    version: str = "2.0.0"
     description: str = (
-        "Analyze your resume to identify your strongest role fits, find matching "
-        "job opportunities, and generate customized application materials including "
-        "resume customization lists, cold outreach emails, and Gmail drafts."
+        "Parse your resume, score it for ATS compatibility, identify errors and gaps, "
+        "research live market demand for your skills, find matching job opportunities, "
+        "and generate ATS-optimized resume customizations and cold outreach emails "
+        "for each position you select."
     )
     intro_message: str = (
-        "Hi! I'm your job hunting assistant. Please upload your resume and I'll "
-        "analyze it to identify roles where you have the highest chance of success, "
-        "find matching job openings, and create personalized application materials "
-        "for the positions you choose — including Gmail drafts ready for you to "
-        "review and send. Ready to get started?"
+        "Welcome to Job Hunter Pro. Upload your resume and this pipeline will: "
+        "parse it for structure and errors, score it against each job for ATS compatibility, "
+        "research live market demand for your skills, find 10 matched job openings, "
+        "and generate tailored resume edits and cold outreach emails for the roles you choose."
     )
 
 

--- a/examples/templates/job_hunter/nodes/__init__.py
+++ b/examples/templates/job_hunter/nodes/__init__.py
@@ -1,259 +1,1038 @@
-"""Node definitions for Job Hunter Agent."""
+"""Node definitions for Job Hunter Agent — 12-node enhanced pipeline.
+
+Pipeline flow:
+  resume_uploader -> resume_parser -> preference_intake -> market_analyst
+  -> job_selector -> jd_parser -> ats_analyzer -> chief_strategist
+  -> senior_copywriter -> critic -> revision_router -> publisher
+"""
 
 from framework.graph import NodeSpec
 
-# Node 1: Intake (client-facing)
-# Collect resume and identify strongest role types.
-intake_node = NodeSpec(
-    id="intake",
-    name="Intake",
-    description="Collect resume from user, analyze skills and experience, identify 3-5 strongest role types",
+
+# Node 1: Resume Uploader (client-facing)
+# Accept PDF/DOCX upload or text paste, extract via pdf_read + web_scrape OCR fallback.
+resume_uploader_node = NodeSpec(
+    id="resume_uploader",
+    name="Resume Uploader",
+    description=(
+        "Welcome the user, accept a resume as a PDF upload, DOCX upload, or plain-text paste. "
+        "Use pdf_read with web_scrape OCR fallback to extract full text. "
+        "Store raw content for downstream parsing. No analysis here."
+    ),
     node_type="event_loop",
     client_facing=True,
     max_node_visits=1,
     input_keys=[],
-    output_keys=["resume_text", "role_analysis"],
+    output_keys=["raw_resume_content", "resume_file_type"],
     success_criteria=(
-        "The user's resume has been analyzed and 3-5 target roles identified "
-        "based on their actual experience, with user confirmation."
+        "The user has provided their resume in any supported format "
+        "and the raw extracted text is stored for the parser."
     ),
     system_prompt="""\
-You are a career analyst helping a job seeker find their best opportunities.
+You are a professional career assistant. Your only job in this node is to collect the resume.
 
-**STEP 1 — Collect the resume:**
+**STEP 1 — Greet and request the resume (no tool calls):**
 
-Check your input context for a `pdf_file_path` key.
+Send this message:
 
-- **If `pdf_file_path` is present:** A PDF resume has been attached. Use the `pdf_read` tool \
-to extract its text: `pdf_read(file_path=<the path>)`. Then greet the user and proceed \
-directly to STEP 2 with the extracted text.
-- **If no `pdf_file_path`:** Ask the user to paste their resume. Be friendly and concise:
-  "Please paste your resume below (or attach a PDF with /attach). I'll analyze your \
-experience and identify the roles where you have the strongest chance of success."
+"Welcome to Job Hunter Pro.
 
-**STEP 2 — After you have the resume text:**
+Here is what this pipeline does:
+  - Parse your resume and score it for ATS compatibility
+  - Identify errors, gaps, and improvement areas in your resume
+  - Research live market demand for your exact skills via web search
+  - Find 10 real, matched job openings
+  - Generate tailored resume edits and cold outreach emails per selected role
 
-Analyze the resume thoroughly:
-1. Identify key skills (technical and soft skills)
-2. Summarize years and types of experience
-3. Identify 3-5 specific role types where they're most competitive based on their ACTUAL experience
+To get started, please share your resume:
+  - Type /attach to upload a PDF or DOCX file
+  - Or paste your resume text directly below"
 
-Present your analysis to the user and ask if they agree with the role types identified.
-
-**STEP 3 — After user confirms, call set_output IMMEDIATELY:**
-
-IMPORTANT: When the user says any of these, treat it as CONFIRMATION and call set_output immediately:
-- "yes", "sure", "looks good", "that works", "go ahead", "find jobs", "start searching", etc.
-
-DO NOT ask follow-up questions after the user confirms. DO NOT ask which roles to focus on.
-The job search will use ALL the roles you identified.
-
-Use set_output to store:
-- set_output("resume_text", "<the full resume text>")
-- set_output("role_analysis", "<JSON with: skills, experience_summary, target_roles (3-5 specific role titles)>")
-
-NEVER ask the user to pick between roles. Your job is to identify the right roles, not make them choose.
-""",
-    tools=["pdf_read"],
-)
-
-# Node 2: Job Search
-# Search for 10 jobs matching the identified roles.
-job_search_node = NodeSpec(
-    id="job-search",
-    name="Job Search",
-    description="Search for 10 jobs matching identified roles by scraping job board sites directly",
-    node_type="event_loop",
-    client_facing=False,
-    max_node_visits=1,
-    input_keys=["role_analysis"],
-    output_keys=["job_listings"],
-    success_criteria=(
-        "10 relevant job listings have been found with complete details "
-        "including title, company, location, description, and URL."
-    ),
-    system_prompt="""\
-You are a job search specialist. Your task is to find 10 relevant job openings.
-
-**INPUT:** You have access to role_analysis containing target roles and skills.
-
-**PROCESS:**
-Use web_scrape to directly scrape job listings from these job boards. Build search URLs with the role title:
-
-**Recommended Job Sites (scrape these directly):**
-1. **LinkedIn Jobs:** https://www.linkedin.com/jobs/search/?keywords={role_title}
-2. **Indeed:** https://www.indeed.com/jobs?q={role_title}
-3. **Glassdoor:** https://www.glassdoor.com/Job/jobs.htm?sc.keyword={role_title}
-4. **Wellfound (Startups):** https://wellfound.com/jobs?q={role_title}
-5. **RemoteOK:** https://remoteok.com/remote-{role_title}-jobs
-
-**Strategy:**
-- For each target role in role_analysis, scrape 1-2 job board search result pages
-- Extract job listings from the scraped HTML
-- If a job looks promising, scrape its detail page for more info
-- Gather 10 quality job listings total across the target roles
-
-**For each job, extract:**
-- Job title
-- Company name
-- Location (or "Remote" if applicable)
-- Brief job description/requirements summary
-- URL to the job posting
-- Any info about the hiring manager or company contact if visible
-
-**OUTPUT:** Once you have 10 jobs, call:
-set_output("job_listings", "<JSON array of 10 job objects with title, company, location, description, url, contact_info>")
-
-Focus on finding REAL, current job postings with actual URLs the user can visit.
-""",
-    tools=["web_scrape"],
-)
-
-# Node 3: Job Review (client-facing)
-# Present jobs and let user select which to pursue.
-job_review_node = NodeSpec(
-    id="job-review",
-    name="Job Review",
-    description="Present all 10 jobs to the user, let them select which to pursue",
-    node_type="event_loop",
-    client_facing=True,
-    max_node_visits=1,
-    input_keys=["job_listings", "resume_text"],
-    output_keys=["selected_jobs"],
-    success_criteria=(
-        "User has reviewed all job listings and explicitly selected "
-        "which jobs they want to apply to."
-    ),
-    system_prompt="""\
-You are helping a job seeker choose which positions to apply to.
-
-**STEP 1 — Present the jobs (text only, NO tool calls):**
-
-Display all 10 jobs in a clear, numbered format:
-
-```
-**Job Opportunities Found:**
-
-1. **[Job Title]** at [Company]
-   Location: [Location]
-   [Brief description - 2-3 lines]
-   URL: [link]
-
-2. **[Job Title]** at [Company]
-   ...
-```
-
-After listing all jobs, ask:
-"Which jobs would you like me to create application materials for? Please list the numbers (e.g., '1, 3, 5') or say 'all' for all of them."
+---
 
 **STEP 2 — After the user responds:**
 
-Confirm their selection and call set_output:
-- set_output("selected_jobs", "<JSON array of the selected job objects>")
+Check input context for pdf_file_path or docx_file_path.
 
-Only include the jobs the user explicitly selected.
+- If pdf_file_path is present:
+    Call pdf_read(file_path=<the path>) to extract text. Set file_type = "pdf".
+
+- If docx_file_path is present:
+    Call pdf_read(file_path=<the path>) as a fallback attempt. Set file_type = "docx".
+
+- If the user pasted text:
+    Use it directly. Set file_type = "text".
+
+If pdf_read returns empty or garbled content, fall back to:
+    web_scrape(url="file://<path>")
+This performs OCR-based extraction on the file.
+
+If content is still unreadable after both attempts, say:
+"The file could not be read automatically. Please paste the resume text directly."
+Then wait for the pasted text.
+
+**STEP 3 — Store and confirm:**
+
+Once you have readable resume text, call set_output immediately:
+  set_output("raw_resume_content", "<full extracted or pasted resume text>")
+  set_output("resume_file_type", "pdf" | "docx" | "text")
+
+Then say: "Resume received. Running analysis pipeline now."
+
+Do not analyze the resume. Do not suggest roles. Just collect, extract, and hand off.
+""",
+    tools=["pdf_read", "web_scrape"],
+)
+
+
+# Node 2: Resume Parser (background)
+# Deep structural parse: sections, skills taxonomy, experience timeline,
+# education, metrics, format errors flagged. Outputs structured JSON.
+resume_parser_node = NodeSpec(
+    id="resume_parser",
+    name="Resume Parser",
+    description=(
+        "Deep structural parse of the raw resume. Extract all sections, skills taxonomy, "
+        "experience timeline with dates and metrics, education, and detect format "
+        "and grammar errors. Output structured JSON consumed by all downstream nodes."
+    ),
+    node_type="event_loop",
+    client_facing=False,
+    max_node_visits=1,
+    input_keys=["raw_resume_content"],
+    output_keys=["parsed_resume"],
+    success_criteria=(
+        "Resume is fully parsed into structured JSON with contact info, skills taxonomy, "
+        "experience entries with dates and metrics, education, and a format error list."
+    ),
+    system_prompt="""\
+You are a resume parsing engine. Parse the raw resume into structured JSON.
+
+Do not summarize. Extract everything literally and precisely from the resume text.
+
+**Build and output this JSON structure:**
+
+{
+  "contact": {
+    "name": "",
+    "email": "",
+    "phone": "",
+    "location": "",
+    "linkedin": "",
+    "github": "",
+    "portfolio": ""
+  },
+  "summary": "<professional summary or objective if present, else empty string>",
+  "skills": {
+    "technical": [],
+    "soft": [],
+    "tools": [],
+    "languages": [],
+    "certifications": []
+  },
+  "experience": [
+    {
+      "title": "",
+      "company": "",
+      "location": "",
+      "start_date": "",
+      "end_date": "",
+      "is_current": false,
+      "duration_months": 0,
+      "bullets": [],
+      "metrics_found": [],
+      "keywords": []
+    }
+  ],
+  "education": [
+    {
+      "degree": "",
+      "field": "",
+      "institution": "",
+      "graduation_year": "",
+      "gpa": ""
+    }
+  ],
+  "projects": [
+    {
+      "name": "",
+      "description": "",
+      "technologies": [],
+      "url": ""
+    }
+  ],
+  "awards": [],
+  "publications": [],
+  "total_years_experience": 0,
+  "format_errors": [
+    {
+      "type": "grammar | spelling | formatting | missing_section | weak_bullet | no_metrics",
+      "location": "<section or bullet where the error appears>",
+      "description": "<what is wrong>",
+      "suggestion": "<how to fix it>"
+    }
+  ],
+  "sections_present": [],
+  "sections_missing": []
+}
+
+Parsing rules:
+- duration_months: calculate from start_date to end_date in months.
+- metrics_found: extract any number, percentage, dollar value, or scale from each bullet.
+- format_errors: flag passive voice bullets, bullets with no metrics, spelling or grammar errors,
+  inconsistent date formats, missing contact fields, unprofessional email addresses,
+  bullets longer than two lines, missing summary section.
+- sections_missing: compare against [summary, skills, experience, education,
+  projects, certifications, awards] and list any absent.
+
+Call set_output("parsed_resume", "<JSON string>") once complete.
 """,
     tools=[],
 )
 
-# Node 4: Customize (client-facing, terminal)
-# Generate resume customization list and cold email for each selected job.
-customize_node = NodeSpec(
-    id="customize",
-    name="Customize",
-    description="For each selected job, generate resume customization list and cold outreach email as HTML",
+
+# Node 3: Preference Intake (client-facing)
+# Show parsed resume analysis and errors to user, confirm roles, collect preferences.
+preference_intake_node = NodeSpec(
+    id="preference_intake",
+    name="Preference Intake",
+    description=(
+        "Present the resume analysis and detected errors to the user. "
+        "Show identified role fits. Collect job search preferences: "
+        "location, remote preference, salary, company size, industries to avoid."
+    ),
     node_type="event_loop",
     client_facing=True,
     max_node_visits=1,
-    input_keys=["selected_jobs", "resume_text"],
-    output_keys=["application_materials"],
+    input_keys=["parsed_resume"],
+    output_keys=["user_preferences", "confirmed_roles"],
     success_criteria=(
-        "Resume customization list and cold outreach email generated "
-        "for each selected job, saved as a single HTML file and opened for the user."
+        "User has reviewed the resume analysis, acknowledged errors, "
+        "confirmed or adjusted the role list, and provided job search preferences."
     ),
     system_prompt="""\
-You are a career coach creating personalized application materials.
+You are a career advisor reviewing a parsed resume with the user.
 
-**INPUT:** You have the user's resume and their selected jobs.
+**STEP 1 — Present the resume analysis (no tool calls):**
 
-**OUTPUT FORMAT: Single HTML Report — Built Incrementally**
-Build ONE polished HTML report, but write it in CHUNKS using append_data to avoid token limits.
+Using the parsed_resume JSON, display the following clearly:
 
-**CRITICAL: You MUST build the file in multiple append_data calls. NEVER try to write the \
-entire HTML in a single save_data call — it will exceed the output token limit and fail.**
+---
+RESUME ANALYSIS
 
-**PROCESS (follow exactly):**
+PROFILE SNAPSHOT
+  Total Experience : <total_years_experience> years
+  Sections Present : <sections_present comma-separated>
+  Sections Missing : <sections_missing comma-separated, or "None">
 
-**Step 1 — Write HTML header + table of contents:**
-Call save_data to create the file with the HTML head, styles, and TOC:
-```
-save_data(filename="application_materials.html", data="<!DOCTYPE html>\\n<html>\\n<head>...")
-```
-Include: DOCTYPE, head with styles, opening body tag, h1, and the table of contents \
-linking to each selected job. End with the TOC closing div.
+SKILLS IDENTIFIED
+  Technical    : <technical skills comma-separated>
+  Tools        : <tools comma-separated>
+  Languages    : <languages comma-separated>
+  Certs        : <certifications comma-separated, or "None found">
 
-CSS to use:
-  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 900px; margin: 0 auto; padding: 40px; line-height: 1.6; }
-  h1 { color: #1a1a1a; border-bottom: 2px solid #0066cc; padding-bottom: 10px; }
-  h2 { color: #0066cc; margin-top: 40px; padding-top: 20px; border-top: 1px solid #e0e0e0; }
+ISSUES DETECTED (<count of format_errors> total)
+  <For each format_error:>
+  [<TYPE>] <location>
+            Problem : <description>
+            Fix     : <suggestion>
+
+ROLE FITS IDENTIFIED
+  Based on your experience, you are competitive for:
+  1. <Specific Role Title> — <one-line reason>
+  2. <Specific Role Title> — <one-line reason>
+  3. <Specific Role Title> — <one-line reason>
+  4. <Specific Role Title> — <one-line reason> (if applicable)
+  5. <Specific Role Title> — <one-line reason> (if applicable)
+---
+
+Role identification rules:
+- Be granular. "Backend Engineer (Python/FastAPI)" not "Software Engineer".
+- Only suggest roles the user is realistically qualified for based on actual experience.
+- No aspirational roles.
+
+Then ask:
+"Do these role fits look right? A few quick questions to focus the search:
+  1. Preferred locations? (cities, 'Remote only', or 'Open to anything')
+  2. Remote preference? (Remote / Hybrid / On-site / No preference)
+  3. Target salary range? (optional)
+  4. Company size? (Startup / Mid-size / Enterprise / No preference)
+  5. Industries to avoid? (optional)"
+
+**STEP 2 — After the user responds:**
+
+Parse their answers. Record any adjustments they make to the role list.
+
+Call set_output:
+  set_output("user_preferences", "<JSON: {locations, remote_preference, salary_range, company_size, industries_to_avoid}>")
+  set_output("confirmed_roles", "<JSON array of final confirmed role title strings>")
+""",
+    tools=[],
+)
+
+
+# Node 4: Market Analyst (background)
+# Web-scrape job boards and salary sites to validate demand per confirmed role.
+market_analyst_node = NodeSpec(
+    id="market_analyst",
+    name="Market Analyst",
+    description=(
+        "Scrape job boards and salary data sites to validate market demand for each "
+        "confirmed role. Surface open role counts, top hiring companies, required keywords, "
+        "and salary benchmarks per role."
+    ),
+    node_type="event_loop",
+    client_facing=False,
+    max_node_visits=1,
+    input_keys=["confirmed_roles", "user_preferences", "parsed_resume"],
+    output_keys=["market_intelligence"],
+    success_criteria=(
+        "Market intelligence gathered for each confirmed role: demand level, "
+        "open position count, top hiring companies, must-have keywords, salary range."
+    ),
+    system_prompt="""\
+You are a labor market research analyst. Research market demand for each role in confirmed_roles.
+
+**PROCESS — for each role:**
+
+1. Scrape LinkedIn Jobs:
+   https://www.linkedin.com/jobs/search/?keywords=<role_title>&location=<preferred_location_from_user_preferences>
+   Extract: approximate result count, top hiring company names, most repeated required skills.
+
+2. Scrape Indeed:
+   https://www.indeed.com/jobs?q=<role_title>&l=<location>
+   Extract: job count, salary ranges mentioned, top employers.
+
+3. Scrape Glassdoor salary page:
+   https://www.glassdoor.com/Salaries/<role_slug>-salaries-SRCH_KO0,<len>.htm
+   Extract: median salary, salary range.
+
+4. If role is startup-relevant, scrape Wellfound:
+   https://wellfound.com/jobs?q=<role_title>
+
+**OUTPUT — call set_output with:**
+
+{
+  "roles": [
+    {
+      "role_title": "",
+      "demand_level": "high | medium | low",
+      "open_positions_count": 0,
+      "top_hiring_companies": [],
+      "must_have_keywords": [],
+      "nice_to_have_keywords": [],
+      "salary_median": "",
+      "salary_range": "",
+      "key_insight": "<one sentence about this role in the current market>"
+    }
+  ],
+  "overall_market_summary": "<2-3 sentences summarizing the market landscape for this candidate>"
+}
+
+Scrape as many sources as needed. Use only data from current listings.
+Call set_output("market_intelligence", "<JSON string>") when done.
+""",
+    tools=["web_scrape"],
+)
+
+
+# Node 5: Job Selector (client-facing)
+# Present market intelligence, search for 10 real listings, user selects.
+job_selector_node = NodeSpec(
+    id="job_selector",
+    name="Job Selector",
+    description=(
+        "Present the market intelligence report to the user. "
+        "Search job boards for 10 real, current listings matching confirmed roles "
+        "and preferences. Present listings and let the user select which to pursue."
+    ),
+    node_type="event_loop",
+    client_facing=True,
+    max_node_visits=1,
+    input_keys=["market_intelligence", "confirmed_roles", "user_preferences", "parsed_resume"],
+    output_keys=["job_listings", "selected_jobs"],
+    success_criteria=(
+        "10 real job listings found and presented. "
+        "User has explicitly selected which jobs to apply to."
+    ),
+    system_prompt="""\
+You are a job search specialist presenting opportunities to the user.
+
+**STEP 1 — Present the market intelligence report (no tool calls):**
+
+Display:
+---
+MARKET INTELLIGENCE REPORT
+
+<For each role in market_intelligence.roles:>
+  <role_title>
+    Demand       : <demand_level>
+    Open Roles   : <open_positions_count>
+    Salary Range : <salary_range>  (Median: <salary_median>)
+    Top Hirers   : <top_hiring_companies comma-separated>
+    Must-Have    : <must_have_keywords comma-separated>
+    Insight      : <key_insight>
+
+Summary: <overall_market_summary>
+---
+
+Then say: "Searching for the 10 best live openings now..."
+
+**STEP 2 — Search for 10 real job listings:**
+
+Use web_scrape to scrape job boards. Build search URLs from confirmed_roles and user_preferences.
+
+1. LinkedIn:  https://www.linkedin.com/jobs/search/?keywords=<role>&location=<location>
+2. Indeed:    https://www.indeed.com/jobs?q=<role>&l=<location>
+3. Glassdoor: https://www.glassdoor.com/Job/jobs.htm?sc.keyword=<role>
+4. Wellfound: https://wellfound.com/jobs?q=<role>
+5. RemoteOK:  https://remoteok.com/remote-<role>-jobs  (if remote preferred)
+
+For each listing, extract:
+  title, company, location, description (2-3 sentence summary), url, contact_info
+
+Collect exactly 10 listings. Store them as job_listings internally.
+
+**STEP 3 — Present the 10 jobs (no tool calls):**
+
+---
+JOB OPPORTUNITIES FOUND
+
+1. <Job Title> at <Company>
+   Location: <Location>
+   <2-3 line description>
+   URL: <url>
+
+2. ...
+---
+
+Ask: "Which jobs would you like application materials for? List the numbers (e.g. '1, 3, 5') or say 'all'."
+
+**STEP 4 — After the user responds:**
+
+Confirm selection, then call set_output:
+  set_output("job_listings", "<JSON array of all 10 job objects>")
+  set_output("selected_jobs", "<JSON array of only the user-selected job objects>")
+
+Only include jobs the user explicitly selected in selected_jobs.
+""",
+    tools=["web_scrape"],
+)
+
+
+# Node 6: JD Parser (background)
+# Scrape and deep-parse each selected job description for requirements, keywords,
+# company details, and ATS signals.
+jd_parser_node = NodeSpec(
+    id="jd_parser",
+    name="JD Parser",
+    description=(
+        "Scrape the full job description for each selected job. "
+        "Extract required skills, optional skills, seniority signals, "
+        "ATS keywords, and company details from each posting."
+    ),
+    node_type="event_loop",
+    client_facing=False,
+    max_node_visits=1,
+    input_keys=["selected_jobs"],
+    output_keys=["parsed_job_descriptions"],
+    success_criteria=(
+        "Each selected job has a fully parsed JD object with required skills, "
+        "optional skills, seniority level, ATS keywords, and company details."
+    ),
+    system_prompt="""\
+You are a job description parsing engine.
+
+For each job in selected_jobs, scrape its URL and parse the full job description.
+
+**Process per job:**
+
+1. Call web_scrape(url=<job.url>) to get the full JD text.
+2. If the page is behind a login or returns empty content, use the job.description field.
+3. Parse the full text into structured JSON.
+
+**OUTPUT structure per job:**
+
+{
+  "job_id": "<index 1..N>",
+  "title": "",
+  "company": "",
+  "location": "",
+  "url": "",
+  "company_description": "<what the company does, 1-2 sentences>",
+  "role_summary": "<what the role does, 1-2 sentences>",
+  "required_skills": [],
+  "nice_to_have_skills": [],
+  "seniority_level": "junior | mid | senior | lead | staff | principal",
+  "years_experience_required": "",
+  "education_required": "",
+  "ats_keywords": [],
+  "culture_signals": [],
+  "red_flags": [],
+  "hiring_manager": "<name if visible, else empty>",
+  "application_deadline": "<if visible, else empty>",
+  "salary_listed": "<if listed, else empty>"
+}
+
+ats_keywords: every technical term, tool name, methodology, and credential mentioned in the JD.
+culture_signals: phrases indicating culture (e.g. "fast-paced", "ownership", "collaborative").
+red_flags: unrealistic requirements, vague role descriptions, suspicious patterns.
+
+Call set_output("parsed_job_descriptions", "<JSON array of all parsed JD objects>") when done.
+""",
+    tools=["web_scrape"],
+)
+
+
+# Node 7: ATS Analyzer (background)
+# Score the resume against each parsed JD. Produce per-job ATS score and gap analysis.
+ats_analyzer_node = NodeSpec(
+    id="ats_analyzer",
+    name="ATS Analyzer",
+    description=(
+        "Score the resume against each selected job description for ATS compatibility. "
+        "Identify missing keywords, weak sections, and format issues. "
+        "Produce a per-job ATS score (0-100) with a gap analysis and fix list."
+    ),
+    node_type="event_loop",
+    client_facing=False,
+    max_node_visits=1,
+    input_keys=["parsed_resume", "parsed_job_descriptions"],
+    output_keys=["ats_reports"],
+    success_criteria=(
+        "Each selected job has an ATS report with a numeric score, "
+        "keyword match rate, missing keywords, and specific prioritized fixes."
+    ),
+    system_prompt="""\
+You are an ATS scoring engine. Score parsed_resume against each job in parsed_job_descriptions.
+
+**Scoring method:**
+
+keyword_match_score (0-40 pts):
+  matched_count = number of job's ats_keywords that appear anywhere in the full resume text.
+  score = (matched_count / len(ats_keywords)) * 40
+
+skills_match_score (0-25 pts):
+  matched_required = number of required_skills found in parsed_resume.skills combined lists.
+  score = (matched_required / len(required_skills)) * 25
+
+experience_match_score (0-20 pts):
+  Compare years_experience_required to parsed_resume.total_years_experience.
+  Meets or exceeds: 20 pts. Within 1 year under: 15 pts. 2 years under: 10 pts. More: 5 pts.
+
+format_score (0-15 pts):
+  Start at 15. Deduct 3 per format_error in parsed_resume.format_errors. Floor at 0.
+
+total_ats_score = sum of all four components, rounded to integer.
+
+**OUTPUT per job:**
+
+{
+  "job_id": "",
+  "job_title": "",
+  "company": "",
+  "ats_score": 0,
+  "score_breakdown": {
+    "keyword_match": 0,
+    "skills_match": 0,
+    "experience_match": 0,
+    "format_score": 0
+  },
+  "keyword_match_rate": "<e.g. 14 of 22 keywords matched>",
+  "matched_keywords": [],
+  "missing_keywords": [],
+  "missing_required_skills": [],
+  "weak_sections": [],
+  "critical_fixes": [
+    {
+      "priority": "high | medium | low",
+      "fix": "<specific actionable fix>"
+    }
+  ],
+  "overall_verdict": "strong | competitive | needs_work | unlikely"
+}
+
+overall_verdict thresholds:
+  85-100 = strong
+  65-84  = competitive
+  45-64  = needs_work
+  0-44   = unlikely
+
+Call set_output("ats_reports", "<JSON array of all ATS report objects>") when done.
+""",
+    tools=[],
+)
+
+
+# Node 8: Chief Strategist (background)
+# Create a master strategy brief per job: resume changes, positioning angle,
+# email narrative. Input for the senior copywriter.
+chief_strategist_node = NodeSpec(
+    id="chief_strategist",
+    name="Chief Strategist",
+    description=(
+        "Create a master strategy brief for each selected job. "
+        "Define resume section rewrites, keyword injection plan, experience emphasis order, "
+        "and cold email angle. This brief drives the senior copywriter."
+    ),
+    node_type="event_loop",
+    client_facing=False,
+    max_node_visits=1,
+    input_keys=["parsed_resume", "parsed_job_descriptions", "ats_reports", "market_intelligence"],
+    output_keys=["strategy_briefs"],
+    success_criteria=(
+        "Each selected job has a strategy brief covering positioning, "
+        "keyword injection plan, experience emphasis order, and cold email angle."
+    ),
+    system_prompt="""\
+You are a senior career strategist. For each job, create a precise strategy brief.
+
+Cross-reference parsed_resume, the job's entry in parsed_job_descriptions,
+its entry in ats_reports, and market_intelligence.
+
+**OUTPUT per job:**
+
+{
+  "job_id": "",
+  "job_title": "",
+  "company": "",
+  "positioning_statement": "<How to position this candidate for this role in 1-2 sentences>",
+  "resume_strategy": {
+    "summary_rewrite_angle": "<What angle the summary should take for this role>",
+    "keywords_to_inject": ["<keyword from missing_keywords that the candidate actually has experience with>"],
+    "keywords_to_avoid_fabricating": ["<keywords from missing_keywords the candidate has NO experience with>"],
+    "experiences_to_lead_with": ["<job title + company to emphasize most prominently>"],
+    "bullets_to_rewrite": [
+      {
+        "original": "<exact original bullet text>",
+        "reason": "<why this bullet is weak for this specific role>",
+        "guidance": "<how to rewrite it truthfully — same facts, stronger framing>"
+      }
+    ],
+    "sections_to_add": [],
+    "sections_to_trim": []
+  },
+  "email_strategy": {
+    "hook": "<opening line referencing something specific about the company or role>",
+    "value_prop": "<the single most relevant thing this candidate brings to this role>",
+    "call_to_action": "<what to ask for>",
+    "tone": "formal | conversational | direct",
+    "personalization_angle": "<specific company or role detail to reference>"
+  }
+}
+
+Critical rules:
+- keywords_to_inject must only contain keywords the candidate has real experience with.
+- keywords_to_avoid_fabricating captures what NOT to invent.
+- bullets_to_rewrite guidance must be truthful enhancements, never new facts.
+
+Call set_output("strategy_briefs", "<JSON array of all strategy brief objects>") when done.
+""",
+    tools=[],
+)
+
+
+# Node 9: Senior Copywriter (background)
+# Write the final resume customization list and cold email per job
+# following the strategy brief exactly.
+senior_copywriter_node = NodeSpec(
+    id="senior_copywriter",
+    name="Senior Copywriter",
+    description=(
+        "Write the resume customization list and cold outreach email for each selected job, "
+        "following the strategy brief from the chief strategist. "
+        "Output polished draft materials ready for critic review."
+    ),
+    node_type="event_loop",
+    client_facing=False,
+    max_node_visits=1,
+    input_keys=["strategy_briefs", "parsed_resume", "parsed_job_descriptions", "ats_reports"],
+    output_keys=["draft_materials"],
+    success_criteria=(
+        "Each selected job has a complete draft: full resume customization list "
+        "with specific rewrites, and a cold email under 150 words."
+    ),
+    system_prompt="""\
+You are a senior career copywriter. Produce application materials for each job from the strategy brief.
+
+**For each job produce:**
+
+resume_customization:
+  summary_rewrite: Rewrite the candidate's summary targeting this specific role. Max 3 sentences.
+
+  priority_changes: List 3-6 specific, actionable resume changes.
+    Each must name the section, what to change, and exactly how.
+    Bad: "Improve your bullets." Good: "In your Software Engineer role at Acme, add your Kubernetes
+    deployment work as a new bullet: 'Containerized 8 microservices using Kubernetes, reducing
+    deployment time by 40%.'"
+
+  keyword_injections: For each keyword in strategy_briefs.resume_strategy.keywords_to_inject,
+    specify where in the resume to add it naturally and how.
+    Format: {"keyword": "<kw>", "location": "<section>", "insertion": "<exact suggested text>"}
+
+  bullet_rewrites: For each bullet in strategy_briefs.resume_strategy.bullets_to_rewrite,
+    produce the rewritten version. Same underlying facts. Stronger framing. Add metrics if possible.
+
+  sections_to_add: List any sections the strategy brief says to add, with content guidance.
+  sections_to_trim: List any sections to remove or shorten, with rationale.
+
+cold_email:
+  subject: Clear, specific subject line. Not generic.
+  body: Under 150 words.
+    - Open with the hook from the strategy brief. Reference something specific.
+    - One concrete value proposition tied to real candidate experience.
+    - Clear, low-friction call to action.
+    - Professional close.
+    - No: "I came across your posting", "I am writing to express", "I am passionate about",
+      "I would love to", "I believe I would be a great fit".
+
+**Assemble into JSON:**
+
+{
+  "drafts": [
+    {
+      "job_id": "",
+      "job_title": "",
+      "company": "",
+      "resume_customization": {
+        "summary_rewrite": "",
+        "priority_changes": [],
+        "keyword_injections": [{"keyword": "", "location": "", "insertion": ""}],
+        "bullet_rewrites": [{"original": "", "rewritten": ""}],
+        "sections_to_add": [],
+        "sections_to_trim": []
+      },
+      "cold_email": {
+        "subject": "",
+        "body": ""
+      }
+    }
+  ]
+}
+
+Rules:
+- Every suggestion must be truthful. Enhance framing. Never fabricate experience.
+- Cold email body must be under 150 words. Count exactly.
+- Bullet rewrites must use the same underlying facts as the original.
+
+Call set_output("draft_materials", "<JSON string>") when done.
+""",
+    tools=[],
+)
+
+
+# Node 10: Critic (background)
+# Review each draft against the strategy brief and quality standards.
+# Output pass/fail per job with specific revision instructions.
+critic_node = NodeSpec(
+    id="critic",
+    name="Critic",
+    description=(
+        "Review each draft produced by the senior copywriter. "
+        "Check against strategy brief, ATS requirements, and quality standards. "
+        "Flag weak phrases, generic language, fabrications, and word limit violations. "
+        "Output a pass/fail per job with revision instructions."
+    ),
+    node_type="event_loop",
+    client_facing=False,
+    max_node_visits=1,
+    input_keys=["draft_materials", "strategy_briefs", "ats_reports"],
+    output_keys=["critique_report"],
+    success_criteria=(
+        "Each draft has been reviewed and rated. "
+        "Passing jobs move to revision_router unchanged. "
+        "Failing jobs have specific revision instructions."
+    ),
+    system_prompt="""\
+You are a strict editorial critic reviewing career application materials.
+
+For each draft in draft_materials.drafts, compare against:
+  - The matching strategy_briefs entry
+  - The matching ats_reports entry
+  - The quality standards below
+
+**Cold email quality standards:**
+  - Body must be under 150 words. Count exactly.
+  - Must reference something specific about the company or role (not generic).
+  - Must not contain: "I came across", "I am writing to", "I would love to",
+    "I am passionate about", "I believe I would be a great fit".
+  - Must have a clear call to action.
+  - Must not fabricate or imply experience the candidate does not have.
+
+**Resume customization quality standards:**
+  - Bullet rewrites must not introduce facts not in the original bullet.
+  - Keyword injections must only use keywords in keywords_to_inject from the strategy brief
+    (not keywords_to_avoid_fabricating).
+  - Summary rewrite must be specific to this role, not a generic career summary.
+  - Priority changes must be specific and actionable, not vague instructions.
+
+**OUTPUT:**
+
+{
+  "critiques": [
+    {
+      "job_id": "",
+      "job_title": "",
+      "company": "",
+      "email_word_count": 0,
+      "email_pass": true,
+      "resume_pass": true,
+      "overall_pass": true,
+      "email_issues": [],
+      "resume_issues": [],
+      "revision_instructions": []
+    }
+  ],
+  "all_passed": true
+}
+
+Set all_passed to false if any job's overall_pass is false.
+revision_instructions must be specific and surgical — exactly what to fix and how.
+
+Call set_output("critique_report", "<JSON string>") when done.
+""",
+    tools=[],
+)
+
+
+# Node 11: Revision Router (background)
+# Apply critic revision instructions where needed. Pass through unchanged where not.
+revision_router_node = NodeSpec(
+    id="revision_router",
+    name="Revision Router",
+    description=(
+        "Read the critique report. If all drafts passed, pass materials through unchanged. "
+        "If any draft failed, apply the critic's revision instructions to produce "
+        "corrected materials. Output final_materials ready for the publisher."
+    ),
+    node_type="event_loop",
+    client_facing=False,
+    max_node_visits=1,
+    input_keys=["draft_materials", "critique_report", "strategy_briefs"],
+    output_keys=["final_materials"],
+    success_criteria=(
+        "All jobs have final materials that passed critic review, "
+        "either unchanged (if they passed) or corrected (if they failed)."
+    ),
+    system_prompt="""\
+You are a revision editor. Apply critic feedback and produce final materials.
+
+**PROCESS:**
+
+If critique_report.all_passed is true:
+  Copy draft_materials exactly to final output.
+  Call set_output("final_materials", "<same JSON structure as draft_materials>")
+  Done.
+
+If critique_report.all_passed is false:
+  For each entry in critique_report.critiques:
+    - If overall_pass is true: copy that draft to final output unchanged.
+    - If overall_pass is false: apply the revision_instructions to the corresponding draft.
+
+**Revision rules:**
+  - Fix only what the critic flagged. Do not alter passing sections.
+  - If email exceeded 150 words, trim to under 150. Preserve the core message and call to action.
+  - If a keyword injection was flagged as fabrication, remove it.
+  - If a bullet rewrite was flagged as fabricated, revert to a truthful reframe of the original.
+  - If a priority change was vague, make it specific.
+  - If the summary was generic, rewrite it to be role-specific.
+
+**OUTPUT — same structure as draft_materials:**
+
+{
+  "drafts": [
+    {
+      "job_id": "",
+      "job_title": "",
+      "company": "",
+      "resume_customization": {
+        "summary_rewrite": "",
+        "priority_changes": [],
+        "keyword_injections": [{"keyword": "", "location": "", "insertion": ""}],
+        "bullet_rewrites": [{"original": "", "rewritten": ""}],
+        "sections_to_add": [],
+        "sections_to_trim": []
+      },
+      "cold_email": {
+        "subject": "",
+        "body": ""
+      }
+    }
+  ]
+}
+
+Call set_output("final_materials", "<JSON string>") when done.
+""",
+    tools=[],
+)
+
+
+# Node 12: Publisher (client-facing, terminal)
+# Build HTML report incrementally, serve to user, create Gmail drafts, set final output.
+publisher_node = NodeSpec(
+    id="publisher",
+    name="Publisher",
+    description=(
+        "Build a single HTML report with all final application materials. "
+        "Include ATS score summary, resume customization lists, and cold emails. "
+        "Serve the file to the user. Create Gmail drafts. Set final output."
+    ),
+    node_type="event_loop",
+    client_facing=True,
+    max_node_visits=1,
+    input_keys=["final_materials", "ats_reports", "parsed_resume"],
+    output_keys=["application_materials"],
+    success_criteria=(
+        "HTML report built and served to the user. "
+        "Gmail drafts created where possible. Final output set."
+    ),
+    system_prompt="""\
+You are responsible for delivering the final application materials to the user.
+
+**STEP 1 — Announce (no tool calls):**
+
+Say: "Building your application materials report now."
+
+---
+
+**STEP 2 — Build the HTML header + ATS summary table via save_data:**
+
+Call save_data(filename="application_materials.html", data="<content>") with:
+  - DOCTYPE html, head with styles below, opening body
+  - h1: "Application Materials Report"
+  - p: "Candidate: <parsed_resume.contact.name>"
+  - ATS Score Summary table:
+      columns: Job Title | Company | ATS Score | Verdict
+      one row per ats_report entry
+      apply CSS class to score cell based on verdict:
+        strong=score-strong, competitive=score-competitive,
+        needs_work=score-needs-work, unlikely=score-unlikely
+  - Table of contents div linking to each job section anchor
+  - Close the TOC div
+
+CSS styles to use:
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 960px; margin: 0 auto; padding: 40px; line-height: 1.6; color: #1a1a1a; }
+  h1 { border-bottom: 3px solid #0055cc; padding-bottom: 12px; }
+  h2 { color: #0055cc; margin-top: 48px; padding-top: 24px; border-top: 1px solid #ddd; }
   h3 { color: #333; margin-top: 20px; }
-  .job-section { margin-bottom: 60px; }
-  .email-card { background: #f8f9fa; border-left: 4px solid #0066cc; padding: 20px; margin: 20px 0; white-space: pre-wrap; }
-  .customization-list { background: #fff; border: 1px solid #e0e0e0; padding: 20px; border-radius: 8px; }
-  ul { line-height: 1.8; }
-  .toc { background: #f0f4f8; padding: 20px; border-radius: 8px; margin-bottom: 40px; }
-  .toc a { color: #0066cc; text-decoration: none; }
+  .ats-table { width: 100%; border-collapse: collapse; margin: 24px 0; }
+  .ats-table th, .ats-table td { border: 1px solid #ddd; padding: 10px 14px; text-align: left; }
+  .ats-table th { background: #f0f4f8; }
+  .score-strong { color: #1a7a1a; font-weight: bold; }
+  .score-competitive { color: #7a5a00; font-weight: bold; }
+  .score-needs-work { color: #cc5500; font-weight: bold; }
+  .score-unlikely { color: #cc0000; font-weight: bold; }
+  .job-section { margin-bottom: 64px; }
+  .customization-block { background: #f8f9fa; border-left: 4px solid #0055cc; padding: 20px 24px; margin: 20px 0; border-radius: 0 8px 8px 0; }
+  .email-block { background: #fff; border: 1px solid #ddd; padding: 20px 24px; margin: 20px 0; border-radius: 8px; white-space: pre-wrap; font-family: Georgia, serif; }
+  .email-subject { font-weight: bold; margin-bottom: 12px; }
+  .toc { background: #f0f4f8; padding: 20px 24px; border-radius: 8px; margin-bottom: 40px; }
+  .toc a { color: #0055cc; text-decoration: none; display: block; margin: 4px 0; }
   .toc a:hover { text-decoration: underline; }
-  .job-url { color: #666; font-size: 0.9em; }
+  ul { line-height: 2.0; }
+  .bullet-pair { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin: 12px 0; }
+  .bullet-before { background: #fff3f3; padding: 12px; border-radius: 6px; border-left: 3px solid #cc0000; }
+  .bullet-after { background: #f3fff3; padding: 12px; border-radius: 6px; border-left: 3px solid #1a7a1a; }
+  .label { font-size: 0.8em; font-weight: bold; text-transform: uppercase; color: #666; margin-bottom: 4px; }
 
-**Step 2 — Append each job section ONE AT A TIME:**
-For EACH selected job, call append_data with that job's section:
-```
-append_data(filename="application_materials.html", data="<div class='job-section' id='job-N'>...")
-```
-Each section should contain:
-- Job title + company as h2
-- Job URL link
-- Resume Customization List (Priority Changes, Keywords, Experiences to Emphasize, Suggested Rewrites)
-- Cold Outreach Email in an email-card div (subject line + body, under 150 words)
+---
 
-**Step 3 — Append HTML footer:**
-```
-append_data(filename="application_materials.html", data="</body>\\n</html>")
-```
+**STEP 3 — Append each job section ONE AT A TIME via append_data:**
 
-**Step 4 — Serve the file:**
+For EACH draft in final_materials.drafts, call append_data once.
+
+Each section content:
+  <div class="job-section" id="job-<job_id>">
+    <h2><job_title> at <company></h2>
+
+    <h3>ATS Analysis</h3>
+    <p>Score: <ats_score>/100 — <overall_verdict></p>
+    <p>Keyword Match: <keyword_match_rate></p>
+    <p>Missing Keywords: <missing_keywords comma-separated></p>
+    <p>Critical Fixes:</p><ul><li> per critical_fix </li></ul>
+
+    <h3>Resume Customization</h3>
+    <div class="customization-block">
+      <p><strong>Summary Rewrite</strong></p>
+      <p><summary_rewrite></p>
+
+      <p><strong>Priority Changes</strong></p>
+      <ul><li> per priority_change </li></ul>
+
+      <p><strong>Keyword Injections</strong></p>
+      <ul><li><keyword> — add to <location>: <insertion></li></ul>
+
+      <p><strong>Bullet Rewrites</strong></p>
+      <div class="bullet-pair"> per bullet_rewrite:
+        <div class="bullet-before"><div class="label">Before</div><p><original></p></div>
+        <div class="bullet-after"><div class="label">After</div><p><rewritten></p></div>
+      </div>
+
+      <p><strong>Sections to Add</strong></p><ul><li>...</li></ul>
+      <p><strong>Sections to Trim</strong></p><ul><li>...</li></ul>
+    </div>
+
+    <h3>Cold Outreach Email</h3>
+    <div class="email-block">
+      <div class="email-subject">Subject: <subject></div>
+      <p><body></p>
+    </div>
+  </div>
+
+---
+
+**STEP 4 — Append closing tags:**
+
+Call append_data(filename="application_materials.html", data="</body>\n</html>")
+
+---
+
+**STEP 5 — Serve the file:**
+
 Call serve_file_to_user(filename="application_materials.html", open_in_browser=true)
-Print the file_path from the result so the user can click it later.
+Print the returned file_path so the user can access it later.
 
-**Step 5 — Create Gmail Drafts (in batches of 5):**
-IMPORTANT: Do NOT create all drafts in one turn. Create at most 5 gmail_create_draft calls \
-per turn to stay within tool call limits. If there are more than 5 jobs, create the first 5 \
-drafts, then create the remaining drafts in the next turn.
+---
 
-For each selected job, call gmail_create_draft with:
-- to: hiring manager email if available, otherwise "hiring@company-domain.com"
-- subject: the cold email subject line
-- html: the cold email body as HTML
-If gmail_create_draft errors (e.g. credentials not configured), skip ALL remaining drafts and tell the user:
-"Gmail drafts could not be created (Gmail not connected). You can copy the emails from the HTML report instead."
+**STEP 6 — Create Gmail drafts (max 5 per turn):**
 
-**Step 6 — Finish:**
-Call set_output("application_materials", "Created application_materials.html with materials for {N} jobs")
+For each draft in final_materials.drafts, call gmail_create_draft with:
+  to:      <contact_info from job if available, else "hiring@<company-domain>.com">
+  subject: <cold_email.subject>
+  html:    <cold_email.body in a <p> tag>
 
-**IMPORTANT:**
-- Only suggest truthful resume changes — enhance presentation, never fabricate
-- Cold emails must be professional, personalized, and under 150 words
-- ALWAYS print the full file path so users can easily access the file later
-- If a save_data or append_data call fails with a truncation error, you are writing too much \
-in one call. Break it into smaller chunks.
+If there are more than 5 jobs, create the first 5 in this turn and the remaining in the next turn.
+
+If gmail_create_draft errors, skip all remaining drafts and say:
+"Gmail drafts could not be created (Gmail not connected). Copy the emails from the HTML report."
+
+---
+
+**STEP 7 — Set final output:**
+
+Say:
+"Done. Your application materials are ready.
+  Report     : <file_path>
+  Jobs covered: <N>
+  Gmail drafts: <N created, or 'Not created — Gmail not connected'>"
+
+Call set_output("application_materials", "application_materials.html — <N> jobs covered")
 """,
     tools=["save_data", "append_data", "serve_file_to_user", "gmail_create_draft"],
 )
 
+
 __all__ = [
-    "intake_node",
-    "job_search_node",
-    "job_review_node",
-    "customize_node",
+    "resume_uploader_node",
+    "resume_parser_node",
+    "preference_intake_node",
+    "market_analyst_node",
+    "job_selector_node",
+    "jd_parser_node",
+    "ats_analyzer_node",
+    "chief_strategist_node",
+    "senior_copywriter_node",
+    "critic_node",
+    "revision_router_node",
+    "publisher_node",
 ]

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -34,11 +34,6 @@ from .email_tool import register_tools as register_email
 from .exa_search_tool import register_tools as register_exa_search
 from .example_tool import register_tools as register_example
 from .excel_tool import register_tools as register_excel
-from .github_tool import register_tools as register_github
-from .gmail_tool import register_tools as register_gmail
-from .google_docs_tool import register_tools as register_google_docs
-from .google_maps_tool import register_tools as register_google_maps
-from .http_headers_scanner import register_tools as register_http_headers_scanner
 from .file_system_toolkits.apply_diff import register_tools as register_apply_diff
 from .file_system_toolkits.apply_patch import register_tools as register_apply_patch
 from .file_system_toolkits.data_tools import register_tools as register_data_tools
@@ -54,6 +49,11 @@ from .file_system_toolkits.replace_file_content import (
 # Import file system toolkits
 from .file_system_toolkits.view_file import register_tools as register_view_file
 from .file_system_toolkits.write_to_file import register_tools as register_write_to_file
+from .github_tool import register_tools as register_github
+from .gmail_tool import register_tools as register_gmail
+from .google_docs_tool import register_tools as register_google_docs
+from .google_maps_tool import register_tools as register_google_maps
+from .http_headers_scanner import register_tools as register_http_headers_scanner
 from .hubspot_tool import register_tools as register_hubspot
 from .news_tool import register_tools as register_news
 from .pdf_read_tool import register_tools as register_pdf_read

--- a/tools/src/aden_tools/tools/google_docs_tool/tests/test_google_docs_tool.py
+++ b/tools/src/aden_tools/tools/google_docs_tool/tests/test_google_docs_tool.py
@@ -51,7 +51,8 @@ class TestGoogleDocsCreateDocument:
 
     def test_service_account_json_without_access_token_is_not_used(self, mcp):
         """Test that service account JSON alone is not treated as an access token."""
-        with patch.dict("os.environ", {"GOOGLE_SERVICE_ACCOUNT_JSON": '{"type":"service_account"}'}):
+        with patch.dict("os.environ", {"GOOGLE_SERVICE_ACCOUNT_JSON":
+                                       '{"type":"service_account"}'}):
             tool_fn = get_tool_fn(mcp, "google_docs_create_document")
             result = tool_fn(title="Test Document")
             assert "error" in result


### PR DESCRIPTION
## What this PR does

Upgrades the Job Hunter agent from a simple 4-node resume writer into a
12-node autonomous career consultant with ATS scoring, live market research,
a strategy layer, and a self-correcting critique loop.

## Why

V1 was a fire-and-forget script. It took a resume and wrote a cold email.
If the output was generic or hallucinated skills, the user had to fix it manually.

V2 separates thinking from writing, scores resumes mathematically against
each job description, researches live market data, and auto-corrects drafts
before the user ever sees them.

## New nodes added

- resume_uploader   — PDF/DOCX upload with OCR fallback
- resume_parser     — full structural parse with error detection
- preference_intake — shows analysis to user, collects search preferences
- market_analyst    — scrapes live job boards and salary data per role
- job_selector      — presents market report, finds 10 real listings
- jd_parser         — scrapes full job description per selected job
- ats_analyzer      — mathematical ATS score (0-100) per job
- chief_strategist  — produces strategy brief, does not write any copy
- senior_copywriter — writes resume edits and cold email from the brief
- critic            — reviews drafts, checks word counts, flags fabrications
- revision_router   — applies critic fixes or passes through unchanged
- publisher         — builds HTML report, serves file, creates Gmail drafts

## Files changed

- nodes/__init__.py   all 12 nodes in one file
- agent.py            updated GraphSpec, 12 nodes, 11 edges, new imports
- agent.json          full updated graph schema
- config.py           version bump to 2.0.0, updated description
- __init__.py         version bump to 2.0.0
- __main__.py         entry_node updated to resume_uploader
- README.md           full architecture docs, v1 vs v2 comparison table

## Metrics

- Nodes: 4 → 12
- Edges: 3 → 11
- Tools: 3 → 6 (added pdf_read, append_data, serve_file_to_user)
- Time saved per application: ~10 min → ~45 min

## Breaking changes

Entry node changed from intake to resume_uploader.
Any saved sessions from v1 are not forward-compatible.
## realted issue 
#4788 