### PR TITLE
Fix pytest collection: avoid tests package import collisions

### DIFF
--- a/core/tests/__init__.py
+++ b/core/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Tests for framework runtime."""

--- a/tools/tests/__init__.py
+++ b/tools/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Aden Tools test suite."""


### PR DESCRIPTION
### Problem
`uv run pytest -q` fails during test collection with:
ModuleNotFoundError: No module named 'tests.conftest'

This appears to be caused by test directories being treated as importable packages.

### Fix
Removed `__init__.py` from:
- core/tests
- tools/tests

so pytest does not treat these as top-level packages.

### Testing
- Before: pytest collection fails
- After: `uv run pytest -q` runs and executes the suite (Windows). Remaining failures are unrelated and due to Unix shell commands (`ls`, `tr`) on Windows.
