### PR TITLE
micro-fix: Remove test __init__.py to prevent pytest collection collision

### DIFF
--- a/core/tests/__init__.py
+++ b/core/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Tests for framework runtime."""

--- a/tools/tests/__init__.py
+++ b/tools/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Aden Tools test suite."""


### PR DESCRIPTION
Fixes #5006

Pytest collection fails when running from the repository root because both core/tests and tools/tests can be treated as a top-level `tests` package, causing:
ModuleNotFoundError: No module named 'tests.conftest'

This removes __init__.py from:
- core/tests/
- tools/tests/

so pytest discovery does not treat these directories as importable packages.
