### PR TITLE
feat(tools): add Stripe payment processing integration

### DIFF
--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "dnspython>=2.4.0",
     "resend>=2.0.0",
     "framework",
-    
+    "stripe>=14.3.0",
 ]
 
 [project.optional-dependencies]

--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -80,6 +80,7 @@ from .shell_config import (
 )
 from .slack import SLACK_CREDENTIALS
 from .store_adapter import CredentialStoreAdapter
+from .stripe import STRIPE_CREDENTIALS
 from .telegram import TELEGRAM_CREDENTIALS
 
 # Merged registry of all credentials
@@ -102,6 +103,7 @@ CREDENTIAL_SPECS = {
     **TELEGRAM_CREDENTIALS,
     **BIGQUERY_CREDENTIALS,
     **CALCOM_CREDENTIALS,
+    **STRIPE_CREDENTIALS,
 }
 
 __all__ = [
@@ -144,4 +146,5 @@ __all__ = [
     "BIGQUERY_CREDENTIALS",
     "CALCOM_CREDENTIALS",
     "DISCORD_CREDENTIALS",
+    "STRIPE_CREDENTIALS",
 ]

--- a/tools/src/aden_tools/credentials/stripe.py
+++ b/tools/src/aden_tools/credentials/stripe.py
@@ -1,0 +1,85 @@
+"""
+Stripe tool credentials.
+Contains credentials for Stripe payments integration.
+"""
+
+from .base import CredentialSpec
+
+STRIPE_CREDENTIALS = {
+    "stripe": CredentialSpec(
+        env_var="STRIPE_API_KEY",
+        tools=[
+            "stripe_create_customer",
+            "stripe_get_customer",
+            "stripe_get_customer_by_email",
+            "stripe_update_customer",
+            "stripe_list_customers",
+            "stripe_get_subscription",
+            "stripe_get_subscription_status",
+            "stripe_list_subscriptions",
+            "stripe_create_subscription",
+            "stripe_update_subscription",
+            "stripe_cancel_subscription",
+            "stripe_create_payment_intent",
+            "stripe_get_payment_intent",
+            "stripe_confirm_payment_intent",
+            "stripe_cancel_payment_intent",
+            "stripe_list_payment_intents",
+            "stripe_list_charges",
+            "stripe_get_charge",
+            "stripe_capture_charge",
+            "stripe_create_charge",
+            "stripe_create_refund",
+            "stripe_get_refund",
+            "stripe_list_refunds",
+            "stripe_list_invoices",
+            "stripe_get_invoice",
+            "stripe_create_invoice",
+            "stripe_finalize_invoice",
+            "stripe_pay_invoice",
+            "stripe_void_invoice",
+            "stripe_create_invoice_item",
+            "stripe_list_invoice_items",
+            "stripe_delete_invoice_item",
+            "stripe_create_product",
+            "stripe_get_product",
+            "stripe_list_products",
+            "stripe_update_product",
+            "stripe_create_price",
+            "stripe_get_price",
+            "stripe_list_prices",
+            "stripe_update_price",
+            "stripe_create_payment_link",
+            "stripe_get_payment_link",
+            "stripe_list_payment_links",
+            "stripe_create_coupon",
+            "stripe_list_coupons",
+            "stripe_delete_coupon",
+            "stripe_get_balance",
+            "stripe_list_balance_transactions",
+            "stripe_list_webhook_endpoints",
+            "stripe_list_payment_methods",
+            "stripe_get_payment_method",
+            "stripe_detach_payment_method",
+        ],
+        required=True,
+        startup_required=False,
+        help_url="https://stripe.com/docs/keys",
+        description="Stripe Secret API Key for authenticating all API requests",
+        # Auth method support
+        aden_supported=False,
+        direct_api_key_supported=True,
+        api_key_instructions="""To get your Stripe API key:
+1. Log in to the Stripe Dashboard at https://dashboard.stripe.com
+2. Navigate to Developers -> API keys
+3. Copy the Secret key (starts with sk_test_ for test mode or sk_live_ for live mode)
+Note: Use test keys (sk_test_*) for development to avoid real charges""",
+        # Health check configuration
+        health_check_endpoint="https://api.stripe.com/v1/balance",
+        health_check_method="GET",
+        # Credential store mapping
+        credential_id="stripe",
+        credential_key="api_key",
+        credential_group="stripe",
+    ),
+}

--- a/tools/src/aden_tools/credentials/stripe.py
+++ b/tools/src/aden_tools/credentials/stripe.py
@@ -28,7 +28,6 @@ STRIPE_CREDENTIALS = {
             "stripe_list_charges",
             "stripe_get_charge",
             "stripe_capture_charge",
-            "stripe_create_charge",
             "stripe_create_refund",
             "stripe_get_refund",
             "stripe_list_refunds",
@@ -80,6 +79,6 @@ Note: Use test keys (sk_test_*) for development to avoid real charges""",
         # Credential store mapping
         credential_id="stripe",
         credential_key="api_key",
-        credential_group="stripe",
+        credential_group="",
     ),
 }

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -64,6 +64,7 @@ from .runtime_logs_tool import register_tools as register_runtime_logs
 from .serpapi_tool import register_tools as register_serpapi
 from .slack_tool import register_tools as register_slack
 from .ssl_tls_scanner import register_tools as register_ssl_tls_scanner
+from .stripe_tool import register_tools as register_stripe
 from .subdomain_enumerator import register_tools as register_subdomain_enumerator
 from .tech_stack_detector import register_tools as register_tech_stack_detector
 from .telegram_tool import register_tools as register_telegram
@@ -140,6 +141,7 @@ def register_all_tools(
     register_tech_stack_detector(mcp)
     register_subdomain_enumerator(mcp)
     register_risk_scorer(mcp)
+    register_stripe(mcp, credentials=credentials)
 
     # Return the list of all registered tool names
     return list(mcp._tool_manager._tools.keys())

--- a/tools/src/aden_tools/tools/stripe_tool/README.md
+++ b/tools/src/aden_tools/tools/stripe_tool/README.md
@@ -1,0 +1,195 @@
+# Stripe Tool
+
+Integration with Stripe for payment processing, subscription management, invoicing, and refund handling.
+
+## Overview
+
+This tool enables Hive agents to interact with Stripe's payment infrastructure for:
+- Managing customers and subscriptions
+- Creating and confirming payment intents
+- Listing and capturing charges
+- Creating and managing invoices and invoice items
+- Managing products and prices
+- Creating payment links
+- Processing refunds
+- Managing coupons
+- Inspecting account balance and transactions
+- Listing webhook endpoints
+- Managing payment methods
+
+## Available Tools
+
+This integration provides 52 MCP tools for comprehensive payment operations:
+
+**Customers**
+- `stripe_create_customer` - Create a new customer
+- `stripe_get_customer` - Retrieve a customer by ID
+- `stripe_get_customer_by_email` - Look up a customer by email address
+- `stripe_update_customer` - Update an existing customer
+- `stripe_list_customers` - List customers with optional filters
+
+**Subscriptions**
+- `stripe_get_subscription` - Retrieve a subscription by ID
+- `stripe_get_subscription_status` - Check active/past_due status for a customer
+- `stripe_list_subscriptions` - List subscriptions with optional filters
+- `stripe_create_subscription` - Create a new subscription
+- `stripe_update_subscription` - Update price, quantity, or schedule cancellation
+- `stripe_cancel_subscription` - Cancel immediately or at period end
+
+**Payment Intents**
+- `stripe_create_payment_intent` - Create a PaymentIntent to collect payment
+- `stripe_get_payment_intent` - Retrieve a PaymentIntent by ID
+- `stripe_confirm_payment_intent` - Confirm a PaymentIntent to attempt collection
+- `stripe_cancel_payment_intent` - Cancel a PaymentIntent
+- `stripe_list_payment_intents` - List PaymentIntents with optional filters
+
+**Charges**
+- `stripe_list_charges` - List charges with optional filters
+- `stripe_get_charge` - Retrieve a charge by ID
+- `stripe_capture_charge` - Capture an uncaptured charge
+- `stripe_create_charge` - Create a charge directly (legacy)
+
+**Refunds**
+- `stripe_create_refund` - Create a full or partial refund
+- `stripe_get_refund` - Retrieve a refund by ID
+- `stripe_list_refunds` - List refunds with optional filters
+
+**Invoices**
+- `stripe_list_invoices` - List invoices with optional filters
+- `stripe_get_invoice` - Retrieve an invoice by ID
+- `stripe_create_invoice` - Create a new invoice for a customer
+- `stripe_finalize_invoice` - Finalize a draft invoice
+- `stripe_pay_invoice` - Attempt to pay an open invoice immediately
+- `stripe_void_invoice` - Void an open invoice
+
+**Invoice Items**
+- `stripe_create_invoice_item` - Add a line item to an invoice
+- `stripe_list_invoice_items` - List invoice items with optional filters
+- `stripe_delete_invoice_item` - Delete a pending invoice item
+
+**Products**
+- `stripe_create_product` - Create a new product
+- `stripe_get_product` - Retrieve a product by ID
+- `stripe_list_products` - List products with optional filters
+- `stripe_update_product` - Update an existing product
+
+**Prices**
+- `stripe_create_price` - Create a price for a product
+- `stripe_get_price` - Retrieve a price by ID
+- `stripe_list_prices` - List prices with optional filters
+- `stripe_update_price` - Update active status, nickname, or metadata
+
+**Payment Links**
+- `stripe_create_payment_link` - Create a shareable payment link
+- `stripe_get_payment_link` - Retrieve a payment link by ID
+- `stripe_list_payment_links` - List payment links with optional filters
+
+**Coupons**
+- `stripe_create_coupon` - Create a discount coupon (percent or fixed amount off)
+- `stripe_list_coupons` - List all coupons
+- `stripe_delete_coupon` - Delete a coupon
+
+**Balance**
+- `stripe_get_balance` - Retrieve the current account balance
+- `stripe_list_balance_transactions` - List balance transactions
+
+**Webhook Endpoints**
+- `stripe_list_webhook_endpoints` - List all configured webhook endpoints
+
+**Payment Methods**
+- `stripe_list_payment_methods` - List payment methods attached to a customer
+- `stripe_get_payment_method` - Retrieve a payment method by ID
+- `stripe_detach_payment_method` - Detach a payment method from its customer
+
+## Setup
+
+### 1. Get Stripe API Credentials
+
+1. Log in to the [Stripe Dashboard](https://dashboard.stripe.com)
+2. Navigate to **Developers -> API keys**
+3. Copy the **Secret key** (starts with `sk_test_` for test mode or `sk_live_` for live mode)
+
+### 2. Configure Environment Variables
+
+```bash
+export STRIPE_API_KEY="sk_test_your_secret_key"
+```
+
+**Important:** Use test keys (`sk_test_*`) for development. Never commit live keys to version control.
+
+## Usage
+
+### stripe_get_customer_by_email
+
+```python
+stripe_get_customer_by_email(email="alice@example.com")
+```
+
+### stripe_get_subscription_status
+
+```python
+stripe_get_subscription_status(customer_id="cus_AbcDefGhijkLmn")
+```
+
+### stripe_create_payment_link
+
+```python
+# First create a product and price, then create the link
+stripe_create_payment_link(price_id="price_AbcDefGhijkLmn", quantity=1)
+```
+
+### stripe_list_invoices
+
+```python
+stripe_list_invoices(status="open", limit=20)
+```
+
+### stripe_create_refund
+
+```python
+# Full refund
+stripe_create_refund(payment_intent_id="pi_AbcDefGhijkLmn")
+
+# Partial refund with reason
+stripe_create_refund(
+    charge_id="ch_AbcDefGhijkLmn",
+    amount=1000,
+    reason="customer_request"
+)
+```
+
+## Authentication
+
+Stripe uses Bearer token authentication. The tool passes your `STRIPE_API_KEY` to the official `stripe` Python library, which handles all request signing automatically.
+
+## Error Handling
+
+All tools return error dicts for failures:
+
+```json
+{
+  "error": "No such customer: cus_AbcDefGhijkLmn"
+}
+```
+
+Common errors:
+- Invalid API key - check `STRIPE_API_KEY` is set correctly
+- Resource not found - verify the ID exists in your Stripe account
+- Invalid request - check parameter values and types
+- Rate limit exceeded - reduce request frequency
+
+## Testing
+
+Use Stripe test mode to avoid real charges:
+1. Generate test API keys (they start with `sk_test_`)
+2. Use test payment methods from [Stripe Testing Docs](https://stripe.com/docs/testing)
+
+## API Reference
+
+- [Stripe API Docs](https://stripe.com/docs/api)
+- [Authentication](https://stripe.com/docs/keys)
+- [Customers API](https://stripe.com/docs/api/customers)
+- [Subscriptions API](https://stripe.com/docs/api/subscriptions)
+- [Payment Intents API](https://stripe.com/docs/api/payment_intents)
+- [Invoices API](https://stripe.com/docs/api/invoices)
+- [Refunds API](https://stripe.com/docs/api/refunds)

--- a/tools/src/aden_tools/tools/stripe_tool/__init__.py
+++ b/tools/src/aden_tools/tools/stripe_tool/__init__.py
@@ -1,0 +1,3 @@
+from .stripe_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/stripe_tool/stripe_tool.py
+++ b/tools/src/aden_tools/tools/stripe_tool/stripe_tool.py
@@ -1,0 +1,2628 @@
+"""
+Stripe Tool - Online payments, subscriptions, and billing management via Stripe API.
+
+Supports:
+- API key authentication (STRIPE_API_KEY)
+
+Use Cases:
+- Manage customers and subscriptions
+- Create and confirm payment intents
+- List and capture charges
+- Create and manage invoices and invoice items
+- Manage products and prices
+- Create payment links
+- Process refunds
+- Manage coupons
+- Inspect account balance and transactions
+- List webhook endpoints
+- Manage payment methods
+
+API Reference: https://stripe.com/docs/api
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+import stripe
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialStoreAdapter
+
+
+class _StripeClient:
+    """Internal client wrapping Stripe API calls via the official stripe library."""
+
+    def __init__(self, api_key: str):
+        self._api_key = api_key
+
+    def _stripe(self) -> stripe.StripeClient:
+        return stripe.StripeClient(self._api_key)
+
+    # --- Customers ---
+
+    def create_customer(
+        self,
+        email: str | None = None,
+        name: str | None = None,
+        phone: str | None = None,
+        description: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if email:
+            params["email"] = email
+        if name:
+            params["name"] = name
+        if phone:
+            params["phone"] = phone
+        if description:
+            params["description"] = description
+        if metadata:
+            params["metadata"] = metadata
+        customer = self._stripe().customers.create(params)
+        return self._format_customer(customer)
+
+    def get_customer(self, customer_id: str) -> dict[str, Any]:
+        customer = self._stripe().customers.retrieve(customer_id)
+        return self._format_customer(customer)
+
+    def get_customer_by_email(self, email: str) -> dict[str, Any]:
+        result = self._stripe().customers.list({"email": email, "limit": 1})
+        items = result.data
+        if not items:
+            return {"error": f"No customer found with email: {email}"}
+        return self._format_customer(items[0])
+
+    def update_customer(
+        self,
+        customer_id: str,
+        email: str | None = None,
+        name: str | None = None,
+        phone: str | None = None,
+        description: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if email:
+            params["email"] = email
+        if name:
+            params["name"] = name
+        if phone:
+            params["phone"] = phone
+        if description:
+            params["description"] = description
+        if metadata:
+            params["metadata"] = metadata
+        customer = self._stripe().customers.update(customer_id, params)
+        return self._format_customer(customer)
+
+    def list_customers(
+        self,
+        limit: int = 10,
+        starting_after: str | None = None,
+        email: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"limit": min(limit, 100)}
+        if starting_after:
+            params["starting_after"] = starting_after
+        if email:
+            params["email"] = email
+        result = self._stripe().customers.list(params)
+        return {
+            "has_more": result.has_more,
+            "customers": [self._format_customer(c) for c in result.data],
+        }
+
+    def _format_customer(self, c: Any) -> dict[str, Any]:
+        return {
+            "id": c.id,
+            "email": c.email,
+            "name": c.name,
+            "phone": c.phone,
+            "description": c.description,
+            "created": c.created,
+            "currency": c.currency,
+            "delinquent": c.delinquent,
+            "metadata": c.metadata,
+        }
+
+    # --- Subscriptions ---
+
+    def get_subscription(self, subscription_id: str) -> dict[str, Any]:
+        sub = self._stripe().subscriptions.retrieve(subscription_id)
+        return self._format_subscription(sub)
+
+    def get_subscription_status(self, customer_id: str) -> dict[str, Any]:
+        result = self._stripe().subscriptions.list({"customer": customer_id, "limit": 10})
+        subs = result.data
+        if not subs:
+            return {"customer_id": customer_id, "status": "no_subscription", "subscriptions": []}
+        return {
+            "customer_id": customer_id,
+            "status": subs[0].status,
+            "subscriptions": [self._format_subscription(s) for s in subs],
+        }
+
+    def list_subscriptions(
+        self,
+        customer_id: str | None = None,
+        status: str | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"limit": min(limit, 100)}
+        if customer_id:
+            params["customer"] = customer_id
+        if status:
+            params["status"] = status
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = self._stripe().subscriptions.list(params)
+        return {
+            "has_more": result.has_more,
+            "subscriptions": [self._format_subscription(s) for s in result.data],
+        }
+
+    def create_subscription(
+        self,
+        customer_id: str,
+        price_id: str,
+        quantity: int = 1,
+        trial_period_days: int | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {
+            "customer": customer_id,
+            "items": [{"price": price_id, "quantity": quantity}],
+        }
+        if trial_period_days is not None:
+            params["trial_period_days"] = trial_period_days
+        if metadata:
+            params["metadata"] = metadata
+        sub = self._stripe().subscriptions.create(params)
+        return self._format_subscription(sub)
+
+    def update_subscription(
+        self,
+        subscription_id: str,
+        price_id: str | None = None,
+        quantity: int | None = None,
+        metadata: dict[str, str] | None = None,
+        cancel_at_period_end: bool | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if metadata:
+            params["metadata"] = metadata
+        if cancel_at_period_end is not None:
+            params["cancel_at_period_end"] = cancel_at_period_end
+        if price_id:
+            sub = self._stripe().subscriptions.retrieve(subscription_id)
+            item_id = sub.items.data[0].id if sub.items.data else None
+            if item_id:
+                item_params: dict[str, Any] = {"price": price_id}
+                if quantity is not None:
+                    item_params["quantity"] = quantity
+                params["items"] = [{"id": item_id, **item_params}]
+        sub = self._stripe().subscriptions.update(subscription_id, params)
+        return self._format_subscription(sub)
+
+    def cancel_subscription(
+        self,
+        subscription_id: str,
+        at_period_end: bool = False,
+    ) -> dict[str, Any]:
+        if at_period_end:
+            sub = self._stripe().subscriptions.update(
+                subscription_id, {"cancel_at_period_end": True}
+            )
+        else:
+            sub = self._stripe().subscriptions.cancel(subscription_id)
+        return self._format_subscription(sub)
+
+    def _format_subscription(self, s: Any) -> dict[str, Any]:
+        return {
+            "id": s.id,
+            "customer": s.customer,
+            "status": s.status,
+            "current_period_start": s.current_period_start,
+            "current_period_end": s.current_period_end,
+            "cancel_at_period_end": s.cancel_at_period_end,
+            "canceled_at": s.canceled_at,
+            "trial_end": s.trial_end,
+            "created": s.created,
+            "items": [
+                {
+                    "id": item.id,
+                    "price_id": item.price.id,
+                    "quantity": item.quantity,
+                }
+                for item in s.items.data
+            ],
+            "metadata": s.metadata,
+        }
+
+    # --- Payment Intents ---
+
+    def create_payment_intent(
+        self,
+        amount: int,
+        currency: str,
+        customer_id: str | None = None,
+        description: str | None = None,
+        payment_method_types: list[str] | None = None,
+        metadata: dict[str, str] | None = None,
+        receipt_email: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {
+            "amount": amount,
+            "currency": currency,
+            "payment_method_types": payment_method_types or ["card"],
+        }
+        if customer_id:
+            params["customer"] = customer_id
+        if description:
+            params["description"] = description
+        if metadata:
+            params["metadata"] = metadata
+        if receipt_email:
+            params["receipt_email"] = receipt_email
+        pi = self._stripe().payment_intents.create(params)
+        return self._format_payment_intent(pi)
+
+    def get_payment_intent(self, payment_intent_id: str) -> dict[str, Any]:
+        pi = self._stripe().payment_intents.retrieve(payment_intent_id)
+        return self._format_payment_intent(pi)
+
+    def confirm_payment_intent(
+        self,
+        payment_intent_id: str,
+        payment_method: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if payment_method:
+            params["payment_method"] = payment_method
+        pi = self._stripe().payment_intents.confirm(payment_intent_id, params)
+        return self._format_payment_intent(pi)
+
+    def cancel_payment_intent(self, payment_intent_id: str) -> dict[str, Any]:
+        pi = self._stripe().payment_intents.cancel(payment_intent_id)
+        return self._format_payment_intent(pi)
+
+    def list_payment_intents(
+        self,
+        customer_id: str | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"limit": min(limit, 100)}
+        if customer_id:
+            params["customer"] = customer_id
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = self._stripe().payment_intents.list(params)
+        return {
+            "has_more": result.has_more,
+            "payment_intents": [self._format_payment_intent(pi) for pi in result.data],
+        }
+
+    def _format_payment_intent(self, pi: Any) -> dict[str, Any]:
+        return {
+            "id": pi.id,
+            "amount": pi.amount,
+            "amount_received": pi.amount_received,
+            "currency": pi.currency,
+            "status": pi.status,
+            "customer": pi.customer,
+            "description": pi.description,
+            "receipt_email": pi.receipt_email,
+            "payment_method": pi.payment_method,
+            "created": pi.created,
+            "metadata": pi.metadata,
+            "client_secret": pi.client_secret,
+        }
+
+    # --- Charges ---
+
+    def list_charges(
+        self,
+        customer_id: str | None = None,
+        payment_intent_id: str | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"limit": min(limit, 100)}
+        if customer_id:
+            params["customer"] = customer_id
+        if payment_intent_id:
+            params["payment_intent"] = payment_intent_id
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = self._stripe().charges.list(params)
+        return {
+            "has_more": result.has_more,
+            "charges": [self._format_charge(c) for c in result.data],
+        }
+
+    def get_charge(self, charge_id: str) -> dict[str, Any]:
+        charge = self._stripe().charges.retrieve(charge_id)
+        return self._format_charge(charge)
+
+    def capture_charge(self, charge_id: str, amount: int | None = None) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if amount is not None:
+            params["amount"] = amount
+        charge = self._stripe().charges.capture(charge_id, params)
+        return self._format_charge(charge)
+
+    def create_charge(
+        self,
+        amount: int,
+        currency: str,
+        source: str | None = None,
+        customer_id: str | None = None,
+        description: str | None = None,
+        receipt_email: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"amount": amount, "currency": currency}
+        if source:
+            params["source"] = source
+        if customer_id:
+            params["customer"] = customer_id
+        if description:
+            params["description"] = description
+        if receipt_email:
+            params["receipt_email"] = receipt_email
+        if metadata:
+            params["metadata"] = metadata
+        charge = self._stripe().charges.create(params)
+        return self._format_charge(charge)
+
+    def _format_charge(self, c: Any) -> dict[str, Any]:
+        return {
+            "id": c.id,
+            "amount": c.amount,
+            "amount_captured": c.amount_captured,
+            "amount_refunded": c.amount_refunded,
+            "currency": c.currency,
+            "status": c.status,
+            "paid": c.paid,
+            "refunded": c.refunded,
+            "customer": c.customer,
+            "description": c.description,
+            "receipt_email": c.receipt_email,
+            "receipt_url": c.receipt_url,
+            "payment_intent": c.payment_intent,
+            "created": c.created,
+            "metadata": c.metadata,
+        }
+
+    # --- Refunds ---
+
+    def create_refund(
+        self,
+        charge_id: str | None = None,
+        payment_intent_id: str | None = None,
+        amount: int | None = None,
+        reason: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if charge_id:
+            params["charge"] = charge_id
+        if payment_intent_id:
+            params["payment_intent"] = payment_intent_id
+        if amount is not None:
+            params["amount"] = amount
+        if reason:
+            params["reason"] = reason
+        if metadata:
+            params["metadata"] = metadata
+        refund = self._stripe().refunds.create(params)
+        return self._format_refund(refund)
+
+    def get_refund(self, refund_id: str) -> dict[str, Any]:
+        refund = self._stripe().refunds.retrieve(refund_id)
+        return self._format_refund(refund)
+
+    def list_refunds(
+        self,
+        charge_id: str | None = None,
+        payment_intent_id: str | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"limit": min(limit, 100)}
+        if charge_id:
+            params["charge"] = charge_id
+        if payment_intent_id:
+            params["payment_intent"] = payment_intent_id
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = self._stripe().refunds.list(params)
+        return {
+            "has_more": result.has_more,
+            "refunds": [self._format_refund(r) for r in result.data],
+        }
+
+    def _format_refund(self, r: Any) -> dict[str, Any]:
+        return {
+            "id": r.id,
+            "amount": r.amount,
+            "currency": r.currency,
+            "status": r.status,
+            "charge": r.charge,
+            "payment_intent": r.payment_intent,
+            "reason": r.reason,
+            "created": r.created,
+            "metadata": r.metadata,
+        }
+
+    # --- Invoices ---
+
+    def list_invoices(
+        self,
+        customer_id: str | None = None,
+        status: str | None = None,
+        subscription_id: str | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"limit": min(limit, 100)}
+        if customer_id:
+            params["customer"] = customer_id
+        if status:
+            params["status"] = status
+        if subscription_id:
+            params["subscription"] = subscription_id
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = self._stripe().invoices.list(params)
+        return {
+            "has_more": result.has_more,
+            "invoices": [self._format_invoice(inv) for inv in result.data],
+        }
+
+    def get_invoice(self, invoice_id: str) -> dict[str, Any]:
+        inv = self._stripe().invoices.retrieve(invoice_id)
+        return self._format_invoice(inv)
+
+    def create_invoice(
+        self,
+        customer_id: str,
+        description: str | None = None,
+        auto_advance: bool = True,
+        collection_method: str = "charge_automatically",
+        days_until_due: int | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {
+            "customer": customer_id,
+            "auto_advance": auto_advance,
+            "collection_method": collection_method,
+        }
+        if description:
+            params["description"] = description
+        if days_until_due is not None:
+            params["days_until_due"] = days_until_due
+        if metadata:
+            params["metadata"] = metadata
+        inv = self._stripe().invoices.create(params)
+        return self._format_invoice(inv)
+
+    def finalize_invoice(self, invoice_id: str) -> dict[str, Any]:
+        inv = self._stripe().invoices.finalize_invoice(invoice_id)
+        return self._format_invoice(inv)
+
+    def pay_invoice(self, invoice_id: str) -> dict[str, Any]:
+        inv = self._stripe().invoices.pay(invoice_id)
+        return self._format_invoice(inv)
+
+    def void_invoice(self, invoice_id: str) -> dict[str, Any]:
+        inv = self._stripe().invoices.void_invoice(invoice_id)
+        return self._format_invoice(inv)
+
+    def _format_invoice(self, inv: Any) -> dict[str, Any]:
+        return {
+            "id": inv.id,
+            "customer": inv.customer,
+            "subscription": inv.subscription,
+            "status": inv.status,
+            "amount_due": inv.amount_due,
+            "amount_paid": inv.amount_paid,
+            "amount_remaining": inv.amount_remaining,
+            "currency": inv.currency,
+            "description": inv.description,
+            "hosted_invoice_url": inv.hosted_invoice_url,
+            "invoice_pdf": inv.invoice_pdf,
+            "due_date": inv.due_date,
+            "created": inv.created,
+            "period_start": inv.period_start,
+            "period_end": inv.period_end,
+            "metadata": inv.metadata,
+        }
+
+    # --- Invoice Items ---
+
+    def create_invoice_item(
+        self,
+        customer_id: str,
+        amount: int,
+        currency: str,
+        description: str | None = None,
+        invoice_id: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {
+            "customer": customer_id,
+            "amount": amount,
+            "currency": currency,
+        }
+        if description:
+            params["description"] = description
+        if invoice_id:
+            params["invoice"] = invoice_id
+        if metadata:
+            params["metadata"] = metadata
+        item = self._stripe().invoice_items.create(params)
+        return self._format_invoice_item(item)
+
+    def list_invoice_items(
+        self,
+        customer_id: str | None = None,
+        invoice_id: str | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"limit": min(limit, 100)}
+        if customer_id:
+            params["customer"] = customer_id
+        if invoice_id:
+            params["invoice"] = invoice_id
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = self._stripe().invoice_items.list(params)
+        return {
+            "has_more": result.has_more,
+            "invoice_items": [self._format_invoice_item(i) for i in result.data],
+        }
+
+    def delete_invoice_item(self, invoice_item_id: str) -> dict[str, Any]:
+        deleted = self._stripe().invoice_items.delete(invoice_item_id)
+        return {"id": deleted.id, "deleted": deleted.deleted}
+
+    def _format_invoice_item(self, item: Any) -> dict[str, Any]:
+        return {
+            "id": item.id,
+            "customer": item.customer,
+            "invoice": item.invoice,
+            "amount": item.amount,
+            "currency": item.currency,
+            "description": item.description,
+            "quantity": item.quantity,
+            "created": item.created,
+            "metadata": item.metadata,
+        }
+
+    # --- Products ---
+
+    def create_product(
+        self,
+        name: str,
+        description: str | None = None,
+        active: bool = True,
+        metadata: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"name": name, "active": active}
+        if description:
+            params["description"] = description
+        if metadata:
+            params["metadata"] = metadata
+        product = self._stripe().products.create(params)
+        return self._format_product(product)
+
+    def get_product(self, product_id: str) -> dict[str, Any]:
+        product = self._stripe().products.retrieve(product_id)
+        return self._format_product(product)
+
+    def list_products(
+        self,
+        active: bool | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"limit": min(limit, 100)}
+        if active is not None:
+            params["active"] = active
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = self._stripe().products.list(params)
+        return {
+            "has_more": result.has_more,
+            "products": [self._format_product(p) for p in result.data],
+        }
+
+    def update_product(
+        self,
+        product_id: str,
+        name: str | None = None,
+        description: str | None = None,
+        active: bool | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if name:
+            params["name"] = name
+        if description:
+            params["description"] = description
+        if active is not None:
+            params["active"] = active
+        if metadata:
+            params["metadata"] = metadata
+        product = self._stripe().products.update(product_id, params)
+        return self._format_product(product)
+
+    def _format_product(self, p: Any) -> dict[str, Any]:
+        return {
+            "id": p.id,
+            "name": p.name,
+            "description": p.description,
+            "active": p.active,
+            "created": p.created,
+            "updated": p.updated,
+            "metadata": p.metadata,
+        }
+
+    # --- Prices ---
+
+    def create_price(
+        self,
+        unit_amount: int,
+        currency: str,
+        product_id: str,
+        recurring_interval: str | None = None,
+        recurring_interval_count: int | None = None,
+        nickname: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {
+            "unit_amount": unit_amount,
+            "currency": currency,
+            "product": product_id,
+        }
+        if recurring_interval:
+            params["recurring"] = {"interval": recurring_interval}
+            if recurring_interval_count is not None:
+                params["recurring"]["interval_count"] = recurring_interval_count
+        if nickname:
+            params["nickname"] = nickname
+        if metadata:
+            params["metadata"] = metadata
+        price = self._stripe().prices.create(params)
+        return self._format_price(price)
+
+    def get_price(self, price_id: str) -> dict[str, Any]:
+        price = self._stripe().prices.retrieve(price_id)
+        return self._format_price(price)
+
+    def list_prices(
+        self,
+        product_id: str | None = None,
+        active: bool | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"limit": min(limit, 100)}
+        if product_id:
+            params["product"] = product_id
+        if active is not None:
+            params["active"] = active
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = self._stripe().prices.list(params)
+        return {
+            "has_more": result.has_more,
+            "prices": [self._format_price(p) for p in result.data],
+        }
+
+    def update_price(
+        self,
+        price_id: str,
+        active: bool | None = None,
+        nickname: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if active is not None:
+            params["active"] = active
+        if nickname:
+            params["nickname"] = nickname
+        if metadata:
+            params["metadata"] = metadata
+        price = self._stripe().prices.update(price_id, params)
+        return self._format_price(price)
+
+    def _format_price(self, p: Any) -> dict[str, Any]:
+        recurring = None
+        if p.recurring:
+            recurring = {
+                "interval": p.recurring.interval,
+                "interval_count": p.recurring.interval_count,
+            }
+        return {
+            "id": p.id,
+            "product": p.product,
+            "currency": p.currency,
+            "unit_amount": p.unit_amount,
+            "nickname": p.nickname,
+            "active": p.active,
+            "type": p.type,
+            "recurring": recurring,
+            "created": p.created,
+            "metadata": p.metadata,
+        }
+
+    # --- Payment Links ---
+
+    def create_payment_link(
+        self,
+        price_id: str,
+        quantity: int = 1,
+        metadata: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {
+            "line_items": [{"price": price_id, "quantity": quantity}],
+        }
+        if metadata:
+            params["metadata"] = metadata
+        link = self._stripe().payment_links.create(params)
+        return self._format_payment_link(link)
+
+    def get_payment_link(self, payment_link_id: str) -> dict[str, Any]:
+        link = self._stripe().payment_links.retrieve(payment_link_id)
+        return self._format_payment_link(link)
+
+    def list_payment_links(
+        self,
+        active: bool | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"limit": min(limit, 100)}
+        if active is not None:
+            params["active"] = active
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = self._stripe().payment_links.list(params)
+        return {
+            "has_more": result.has_more,
+            "payment_links": [self._format_payment_link(link) for link in result.data],
+        }
+
+    def _format_payment_link(self, link: Any) -> dict[str, Any]:
+        return {
+            "id": link.id,
+            "url": link.url,
+            "active": link.active,
+            "currency": link.currency,
+            "line_items": [
+                {
+                    "price": item.price.id if item.price else None,
+                    "quantity": item.quantity,
+                }
+                for item in (link.line_items.data if link.line_items else [])
+            ],
+            "created": link.created,
+            "metadata": link.metadata,
+        }
+
+    # --- Coupons ---
+
+    def create_coupon(
+        self,
+        percent_off: float | None = None,
+        amount_off: int | None = None,
+        currency: str | None = None,
+        duration: str = "once",
+        duration_in_months: int | None = None,
+        name: str | None = None,
+        max_redemptions: int | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"duration": duration}
+        if percent_off is not None:
+            params["percent_off"] = percent_off
+        if amount_off is not None:
+            params["amount_off"] = amount_off
+        if currency:
+            params["currency"] = currency
+        if duration_in_months is not None:
+            params["duration_in_months"] = duration_in_months
+        if name:
+            params["name"] = name
+        if max_redemptions is not None:
+            params["max_redemptions"] = max_redemptions
+        if metadata:
+            params["metadata"] = metadata
+        coupon = self._stripe().coupons.create(params)
+        return self._format_coupon(coupon)
+
+    def list_coupons(
+        self,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"limit": min(limit, 100)}
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = self._stripe().coupons.list(params)
+        return {
+            "has_more": result.has_more,
+            "coupons": [self._format_coupon(c) for c in result.data],
+        }
+
+    def delete_coupon(self, coupon_id: str) -> dict[str, Any]:
+        deleted = self._stripe().coupons.delete(coupon_id)
+        return {"id": deleted.id, "deleted": deleted.deleted}
+
+    def _format_coupon(self, c: Any) -> dict[str, Any]:
+        return {
+            "id": c.id,
+            "name": c.name,
+            "percent_off": c.percent_off,
+            "amount_off": c.amount_off,
+            "currency": c.currency,
+            "duration": c.duration,
+            "duration_in_months": c.duration_in_months,
+            "max_redemptions": c.max_redemptions,
+            "times_redeemed": c.times_redeemed,
+            "valid": c.valid,
+            "created": c.created,
+            "metadata": c.metadata,
+        }
+
+    # --- Balance ---
+
+    def get_balance(self) -> dict[str, Any]:
+        bal = self._stripe().balance.retrieve()
+        return {
+            "available": [{"amount": b.amount, "currency": b.currency} for b in bal.available],
+            "pending": [{"amount": b.amount, "currency": b.currency} for b in bal.pending],
+        }
+
+    def list_balance_transactions(
+        self,
+        type_filter: str | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"limit": min(limit, 100)}
+        if type_filter:
+            params["type"] = type_filter
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = self._stripe().balance_transactions.list(params)
+        return {
+            "has_more": result.has_more,
+            "transactions": [
+                {
+                    "id": t.id,
+                    "amount": t.amount,
+                    "currency": t.currency,
+                    "net": t.net,
+                    "fee": t.fee,
+                    "type": t.type,
+                    "status": t.status,
+                    "description": t.description,
+                    "created": t.created,
+                }
+                for t in result.data
+            ],
+        }
+
+    # --- Webhook Endpoints ---
+
+    def list_webhook_endpoints(
+        self,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"limit": min(limit, 100)}
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = self._stripe().webhook_endpoints.list(params)
+        return {
+            "has_more": result.has_more,
+            "webhook_endpoints": [
+                {
+                    "id": we.id,
+                    "url": we.url,
+                    "status": we.status,
+                    "enabled_events": we.enabled_events,
+                    "created": we.created,
+                }
+                for we in result.data
+            ],
+        }
+
+    # --- Payment Methods ---
+
+    def list_payment_methods(
+        self,
+        customer_id: str,
+        type_filter: str = "card",
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {
+            "customer": customer_id,
+            "type": type_filter,
+            "limit": min(limit, 100),
+        }
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = self._stripe().payment_methods.list(params)
+        return {
+            "has_more": result.has_more,
+            "payment_methods": [self._format_payment_method(pm) for pm in result.data],
+        }
+
+    def get_payment_method(self, payment_method_id: str) -> dict[str, Any]:
+        pm = self._stripe().payment_methods.retrieve(payment_method_id)
+        return self._format_payment_method(pm)
+
+    def detach_payment_method(self, payment_method_id: str) -> dict[str, Any]:
+        pm = self._stripe().payment_methods.detach(payment_method_id)
+        return self._format_payment_method(pm)
+
+    def _format_payment_method(self, pm: Any) -> dict[str, Any]:
+        card = None
+        if pm.card:
+            card = {
+                "brand": pm.card.brand,
+                "last4": pm.card.last4,
+                "exp_month": pm.card.exp_month,
+                "exp_year": pm.card.exp_year,
+                "country": pm.card.country,
+            }
+        return {
+            "id": pm.id,
+            "type": pm.type,
+            "customer": pm.customer,
+            "card": card,
+            "created": pm.created,
+            "metadata": pm.metadata,
+        }
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: CredentialStoreAdapter | None = None,
+) -> None:
+    """Register Stripe payment tools with the MCP server."""
+
+    def _get_api_key() -> str | dict[str, str]:
+        """Get Stripe API key from credential manager or environment."""
+        if credentials is not None:
+            api_key = credentials.get("stripe")
+            if api_key and isinstance(api_key, str):
+                return api_key
+        else:
+            api_key = os.getenv("STRIPE_API_KEY")
+            if api_key:
+                return api_key
+
+        return {
+            "error": "Stripe credentials not configured",
+            "help": (
+                "Set STRIPE_API_KEY environment variable. "
+                "Get your credentials at https://dashboard.stripe.com/apikeys"
+            ),
+        }
+
+    def _get_client() -> _StripeClient | dict[str, str]:
+        """Get a Stripe client, or return an error dict if no credentials."""
+        key = _get_api_key()
+        if isinstance(key, dict):
+            return key
+        return _StripeClient(key)
+
+    def _stripe_error(e: stripe.StripeError) -> dict[str, Any]:
+        return {"error": str(e)}
+
+    # --- Customer Tools ---
+
+    @mcp.tool()
+    def stripe_create_customer(
+        email: str | None = None,
+        name: str | None = None,
+        phone: str | None = None,
+        description: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict:
+        """
+        Create a new Stripe customer.
+
+        Args:
+            email: Customer email address
+            name: Customer full name
+            phone: Customer phone number
+            description: Arbitrary description for the customer
+            metadata: Key-value metadata to attach
+
+        Returns:
+            Dict with customer details or error
+
+        Example:
+            stripe_create_customer(email="alice@example.com", name="Alice Smith")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.create_customer(email, name, phone, description, metadata)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_get_customer(customer_id: str) -> dict:
+        """
+        Retrieve a Stripe customer by ID.
+
+        Args:
+            customer_id: Stripe customer ID (e.g., "cus_AbcDefGhijkLmn")
+
+        Returns:
+            Dict with customer details or error
+
+        Example:
+            stripe_get_customer("cus_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not customer_id or not customer_id.startswith("cus_"):
+            return {"error": "Invalid customer_id. Must start with: cus_"}
+        try:
+            return client.get_customer(customer_id)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_get_customer_by_email(email: str) -> dict:
+        """
+        Look up a Stripe customer by email address.
+
+        Args:
+            email: Customer email address to search for
+
+        Returns:
+            Dict with customer details or error
+
+        Example:
+            stripe_get_customer_by_email("alice@example.com")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not email or "@" not in email:
+            return {"error": "Invalid email address"}
+        try:
+            return client.get_customer_by_email(email)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_update_customer(
+        customer_id: str,
+        email: str | None = None,
+        name: str | None = None,
+        phone: str | None = None,
+        description: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict:
+        """
+        Update an existing Stripe customer.
+
+        Args:
+            customer_id: Stripe customer ID (e.g., "cus_AbcDefGhijkLmn")
+            email: Updated email address
+            name: Updated full name
+            phone: Updated phone number
+            description: Updated description
+            metadata: Updated key-value metadata
+
+        Returns:
+            Dict with updated customer details or error
+
+        Example:
+            stripe_update_customer("cus_AbcDefGhijkLmn", email="new@example.com")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not customer_id or not customer_id.startswith("cus_"):
+            return {"error": "Invalid customer_id. Must start with: cus_"}
+        try:
+            return client.update_customer(customer_id, email, name, phone, description, metadata)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_list_customers(
+        limit: int = 10,
+        starting_after: str | None = None,
+        email: str | None = None,
+    ) -> dict:
+        """
+        List Stripe customers with optional filters.
+
+        Args:
+            limit: Number of customers to fetch (1-100, default 10)
+            starting_after: Cursor for pagination (last customer ID from previous page)
+            email: Filter by email address
+
+        Returns:
+            Dict with customer list or error
+
+        Example:
+            stripe_list_customers(limit=20)
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_customers(limit, starting_after, email)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    # --- Subscription Tools ---
+
+    @mcp.tool()
+    def stripe_get_subscription(subscription_id: str) -> dict:
+        """
+        Retrieve a Stripe subscription by ID.
+
+        Args:
+            subscription_id: Stripe subscription ID (e.g., "sub_AbcDefGhijkLmn")
+
+        Returns:
+            Dict with subscription details or error
+
+        Example:
+            stripe_get_subscription("sub_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not subscription_id or not subscription_id.startswith("sub_"):
+            return {"error": "Invalid subscription_id. Must start with: sub_"}
+        try:
+            return client.get_subscription(subscription_id)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_get_subscription_status(customer_id: str) -> dict:
+        """
+        Check the subscription status for a customer.
+
+        Args:
+            customer_id: Stripe customer ID (e.g., "cus_AbcDefGhijkLmn")
+
+        Returns:
+            Dict with status and subscription list or error
+
+        Example:
+            stripe_get_subscription_status("cus_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not customer_id or not customer_id.startswith("cus_"):
+            return {"error": "Invalid customer_id. Must start with: cus_"}
+        try:
+            return client.get_subscription_status(customer_id)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_list_subscriptions(
+        customer_id: str | None = None,
+        status: str | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict:
+        """
+        List Stripe subscriptions with optional filters.
+
+        Args:
+            customer_id: Filter by customer ID
+            status: Filter by status (active, past_due, canceled, etc.)
+            limit: Number of subscriptions to fetch (1-100, default 10)
+            starting_after: Cursor for pagination
+
+        Returns:
+            Dict with subscription list or error
+
+        Example:
+            stripe_list_subscriptions(status="active", limit=20)
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_subscriptions(customer_id, status, limit, starting_after)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_create_subscription(
+        customer_id: str,
+        price_id: str,
+        quantity: int = 1,
+        trial_period_days: int | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict:
+        """
+        Create a new subscription for a customer.
+
+        Args:
+            customer_id: Stripe customer ID (e.g., "cus_AbcDefGhijkLmn")
+            price_id: Stripe price ID (e.g., "price_AbcDefGhijkLmn")
+            quantity: Quantity of the price to subscribe to (default 1)
+            trial_period_days: Number of trial days before billing begins
+            metadata: Key-value metadata to attach
+
+        Returns:
+            Dict with subscription details or error
+
+        Example:
+            stripe_create_subscription("cus_AbcDefGhijkLmn", "price_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not customer_id or not customer_id.startswith("cus_"):
+            return {"error": "Invalid customer_id. Must start with: cus_"}
+        if not price_id or not price_id.startswith("price_"):
+            return {"error": "Invalid price_id. Must start with: price_"}
+        if quantity < 1:
+            return {"error": "Quantity must be at least 1"}
+        try:
+            return client.create_subscription(
+                customer_id, price_id, quantity, trial_period_days, metadata
+            )
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_update_subscription(
+        subscription_id: str,
+        price_id: str | None = None,
+        quantity: int | None = None,
+        metadata: dict[str, str] | None = None,
+        cancel_at_period_end: bool | None = None,
+    ) -> dict:
+        """
+        Update an existing subscription.
+
+        Args:
+            subscription_id: Stripe subscription ID (e.g., "sub_AbcDefGhijkLmn")
+            price_id: New price ID to switch to
+            quantity: Updated quantity
+            metadata: Updated key-value metadata
+            cancel_at_period_end: If True, cancel at end of current billing period
+
+        Returns:
+            Dict with updated subscription details or error
+
+        Example:
+            stripe_update_subscription("sub_AbcDefGhijkLmn", cancel_at_period_end=True)
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not subscription_id or not subscription_id.startswith("sub_"):
+            return {"error": "Invalid subscription_id. Must start with: sub_"}
+        try:
+            return client.update_subscription(
+                subscription_id, price_id, quantity, metadata, cancel_at_period_end
+            )
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_cancel_subscription(
+        subscription_id: str,
+        at_period_end: bool = False,
+    ) -> dict:
+        """
+        Cancel a Stripe subscription.
+
+        Args:
+            subscription_id: Stripe subscription ID (e.g., "sub_AbcDefGhijkLmn")
+            at_period_end: If True, cancel at end of current billing period instead of immediately
+
+        Returns:
+            Dict with updated subscription details or error
+
+        Example:
+            stripe_cancel_subscription("sub_AbcDefGhijkLmn", at_period_end=True)
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not subscription_id or not subscription_id.startswith("sub_"):
+            return {"error": "Invalid subscription_id. Must start with: sub_"}
+        try:
+            return client.cancel_subscription(subscription_id, at_period_end)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    # --- Payment Intent Tools ---
+
+    @mcp.tool()
+    def stripe_create_payment_intent(
+        amount: int,
+        currency: str,
+        customer_id: str | None = None,
+        description: str | None = None,
+        payment_method_types: list[str] | None = None,
+        metadata: dict[str, str] | None = None,
+        receipt_email: str | None = None,
+    ) -> dict:
+        """
+        Create a PaymentIntent to collect a payment.
+
+        Args:
+            amount: Amount in smallest currency unit (e.g., cents for USD)
+            currency: ISO 4217 currency code (e.g., "usd", "inr")
+            customer_id: Stripe customer ID to attach to the intent
+            description: Description of the payment
+            payment_method_types: List of payment method types (default ["card"])
+            metadata: Key-value metadata to attach
+            receipt_email: Email to send receipt to
+
+        Returns:
+            Dict with payment intent details including client_secret or error
+
+        Example:
+            stripe_create_payment_intent(amount=2000, currency="usd", description="Order #123")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if amount <= 0:
+            return {"error": "Amount must be positive"}
+        if not currency or len(currency) != 3:
+            return {"error": "Currency must be a 3-letter ISO code (e.g., usd, inr)"}
+        try:
+            return client.create_payment_intent(
+                amount,
+                currency,
+                customer_id,
+                description,
+                payment_method_types,
+                metadata,
+                receipt_email,
+            )
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_get_payment_intent(payment_intent_id: str) -> dict:
+        """
+        Retrieve a PaymentIntent by ID.
+
+        Args:
+            payment_intent_id: Stripe PaymentIntent ID (e.g., "pi_AbcDefGhijkLmn")
+
+        Returns:
+            Dict with payment intent details or error
+
+        Example:
+            stripe_get_payment_intent("pi_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not payment_intent_id or not payment_intent_id.startswith("pi_"):
+            return {"error": "Invalid payment_intent_id. Must start with: pi_"}
+        try:
+            return client.get_payment_intent(payment_intent_id)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_confirm_payment_intent(
+        payment_intent_id: str,
+        payment_method: str | None = None,
+    ) -> dict:
+        """
+        Confirm a PaymentIntent to attempt payment collection.
+
+        Args:
+            payment_intent_id: Stripe PaymentIntent ID (e.g., "pi_AbcDefGhijkLmn")
+            payment_method: Payment method ID to use for this payment
+
+        Returns:
+            Dict with confirmed payment intent details or error
+
+        Example:
+            stripe_confirm_payment_intent("pi_AbcDefGhijkLmn", payment_method="pm_card_visa")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not payment_intent_id or not payment_intent_id.startswith("pi_"):
+            return {"error": "Invalid payment_intent_id. Must start with: pi_"}
+        try:
+            return client.confirm_payment_intent(payment_intent_id, payment_method)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_cancel_payment_intent(payment_intent_id: str) -> dict:
+        """
+        Cancel a PaymentIntent.
+
+        Args:
+            payment_intent_id: Stripe PaymentIntent ID (e.g., "pi_AbcDefGhijkLmn")
+
+        Returns:
+            Dict with canceled payment intent details or error
+
+        Example:
+            stripe_cancel_payment_intent("pi_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not payment_intent_id or not payment_intent_id.startswith("pi_"):
+            return {"error": "Invalid payment_intent_id. Must start with: pi_"}
+        try:
+            return client.cancel_payment_intent(payment_intent_id)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_list_payment_intents(
+        customer_id: str | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict:
+        """
+        List PaymentIntents with optional filters.
+
+        Args:
+            customer_id: Filter by customer ID
+            limit: Number of payment intents to fetch (1-100, default 10)
+            starting_after: Cursor for pagination
+
+        Returns:
+            Dict with payment intent list or error
+
+        Example:
+            stripe_list_payment_intents(limit=20)
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_payment_intents(customer_id, limit, starting_after)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    # --- Charge Tools ---
+
+    @mcp.tool()
+    def stripe_list_charges(
+        customer_id: str | None = None,
+        payment_intent_id: str | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict:
+        """
+        List Stripe charges with optional filters.
+
+        Args:
+            customer_id: Filter by customer ID
+            payment_intent_id: Filter by payment intent ID
+            limit: Number of charges to fetch (1-100, default 10)
+            starting_after: Cursor for pagination
+
+        Returns:
+            Dict with charge list or error
+
+        Example:
+            stripe_list_charges(limit=20)
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_charges(customer_id, payment_intent_id, limit, starting_after)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_get_charge(charge_id: str) -> dict:
+        """
+        Retrieve a charge by ID.
+
+        Args:
+            charge_id: Stripe charge ID (e.g., "ch_AbcDefGhijkLmn")
+
+        Returns:
+            Dict with charge details or error
+
+        Example:
+            stripe_get_charge("ch_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not charge_id or not charge_id.startswith("ch_"):
+            return {"error": "Invalid charge_id. Must start with: ch_"}
+        try:
+            return client.get_charge(charge_id)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_capture_charge(
+        charge_id: str,
+        amount: int | None = None,
+    ) -> dict:
+        """
+        Capture an uncaptured charge.
+
+        Args:
+            charge_id: Stripe charge ID (e.g., "ch_AbcDefGhijkLmn")
+            amount: Amount to capture in smallest currency unit (omit to capture full amount)
+
+        Returns:
+            Dict with captured charge details or error
+
+        Example:
+            stripe_capture_charge("ch_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not charge_id or not charge_id.startswith("ch_"):
+            return {"error": "Invalid charge_id. Must start with: ch_"}
+        if amount is not None and amount <= 0:
+            return {"error": "Amount must be positive"}
+        try:
+            return client.capture_charge(charge_id, amount)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_create_charge(
+        amount: int,
+        currency: str,
+        source: str | None = None,
+        customer_id: str | None = None,
+        description: str | None = None,
+        receipt_email: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict:
+        """
+        Create a charge directly (legacy). Prefer PaymentIntents for new integrations.
+
+        Args:
+            amount: Amount in smallest currency unit (e.g., cents for USD)
+            currency: ISO 4217 currency code (e.g., "usd")
+            source: Token or source ID (e.g., "tok_visa")
+            customer_id: Stripe customer ID to charge
+            description: Description of the charge
+            receipt_email: Email to send receipt to
+            metadata: Key-value metadata to attach
+
+        Returns:
+            Dict with charge details or error
+
+        Example:
+            stripe_create_charge(amount=2000, currency="usd", source="tok_visa")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if amount <= 0:
+            return {"error": "Amount must be positive"}
+        if not currency or len(currency) != 3:
+            return {"error": "Currency must be a 3-letter ISO code (e.g., usd)"}
+        if not source and not customer_id:
+            return {"error": "Either source or customer_id is required"}
+        try:
+            return client.create_charge(
+                amount, currency, source, customer_id, description, receipt_email, metadata
+            )
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    # --- Refund Tools ---
+
+    @mcp.tool()
+    def stripe_create_refund(
+        charge_id: str | None = None,
+        payment_intent_id: str | None = None,
+        amount: int | None = None,
+        reason: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict:
+        """
+        Create a full or partial refund.
+
+        Args:
+            charge_id: Stripe charge ID to refund (e.g., "ch_AbcDefGhijkLmn")
+            payment_intent_id: Stripe PaymentIntent ID to refund (e.g., "pi_AbcDefGhijkLmn")
+            amount: Amount to refund in smallest currency unit (omit for full refund)
+            reason: Reason for refund (duplicate, fraudulent, customer_request)
+            metadata: Key-value metadata to attach
+
+        Returns:
+            Dict with refund details or error
+
+        Example:
+            stripe_create_refund(charge_id="ch_AbcDefGhijkLmn", amount=1000)
+            stripe_create_refund(payment_intent_id="pi_AbcDefGhijkLmn", reason="customer_request")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not charge_id and not payment_intent_id:
+            return {"error": "Either charge_id or payment_intent_id is required"}
+        if amount is not None and amount <= 0:
+            return {"error": "Refund amount must be positive"}
+        try:
+            return client.create_refund(charge_id, payment_intent_id, amount, reason, metadata)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_get_refund(refund_id: str) -> dict:
+        """
+        Retrieve a refund by ID.
+
+        Args:
+            refund_id: Stripe refund ID (e.g., "re_AbcDefGhijkLmn")
+
+        Returns:
+            Dict with refund details or error
+
+        Example:
+            stripe_get_refund("re_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not refund_id or not refund_id.startswith("re_"):
+            return {"error": "Invalid refund_id. Must start with: re_"}
+        try:
+            return client.get_refund(refund_id)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_list_refunds(
+        charge_id: str | None = None,
+        payment_intent_id: str | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict:
+        """
+        List refunds with optional filters.
+
+        Args:
+            charge_id: Filter by charge ID
+            payment_intent_id: Filter by payment intent ID
+            limit: Number of refunds to fetch (1-100, default 10)
+            starting_after: Cursor for pagination
+
+        Returns:
+            Dict with refund list or error
+
+        Example:
+            stripe_list_refunds(charge_id="ch_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_refunds(charge_id, payment_intent_id, limit, starting_after)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    # --- Invoice Tools ---
+
+    @mcp.tool()
+    def stripe_list_invoices(
+        customer_id: str | None = None,
+        status: str | None = None,
+        subscription_id: str | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict:
+        """
+        List Stripe invoices with optional filters.
+
+        Args:
+            customer_id: Filter by customer ID
+            status: Filter by status (draft, open, paid, uncollectible, void)
+            subscription_id: Filter by subscription ID
+            limit: Number of invoices to fetch (1-100, default 10)
+            starting_after: Cursor for pagination
+
+        Returns:
+            Dict with invoice list or error
+
+        Example:
+            stripe_list_invoices(status="open", limit=20)
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_invoices(customer_id, status, subscription_id, limit, starting_after)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_get_invoice(invoice_id: str) -> dict:
+        """
+        Retrieve an invoice by ID.
+
+        Args:
+            invoice_id: Stripe invoice ID (e.g., "in_AbcDefGhijkLmn")
+
+        Returns:
+            Dict with invoice details or error
+
+        Example:
+            stripe_get_invoice("in_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not invoice_id or not invoice_id.startswith("in_"):
+            return {"error": "Invalid invoice_id. Must start with: in_"}
+        try:
+            return client.get_invoice(invoice_id)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_create_invoice(
+        customer_id: str,
+        description: str | None = None,
+        auto_advance: bool = True,
+        collection_method: str = "charge_automatically",
+        days_until_due: int | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict:
+        """
+        Create a new invoice for a customer.
+
+        Args:
+            customer_id: Stripe customer ID (e.g., "cus_AbcDefGhijkLmn")
+            description: Description shown on the invoice
+            auto_advance: If True, invoice will auto-finalize (default True)
+            collection_method: "charge_automatically" or "send_invoice"
+              (default "charge_automatically")
+            days_until_due: Days until invoice is due (required for send_invoice)
+            metadata: Key-value metadata to attach
+
+        Returns:
+            Dict with invoice details or error
+
+        Example:
+            stripe_create_invoice("cus_AbcDefGhijkLmn", collection_method="send_invoice",
+              days_until_due=30)
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not customer_id or not customer_id.startswith("cus_"):
+            return {"error": "Invalid customer_id. Must start with: cus_"}
+        try:
+            return client.create_invoice(
+                customer_id,
+                description,
+                auto_advance,
+                collection_method,
+                days_until_due,
+                metadata,
+            )
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_finalize_invoice(invoice_id: str) -> dict:
+        """
+        Finalize a draft invoice, moving it to open status.
+
+        Args:
+            invoice_id: Stripe invoice ID (e.g., "in_AbcDefGhijkLmn")
+
+        Returns:
+            Dict with finalized invoice details or error
+
+        Example:
+            stripe_finalize_invoice("in_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not invoice_id or not invoice_id.startswith("in_"):
+            return {"error": "Invalid invoice_id. Must start with: in_"}
+        try:
+            return client.finalize_invoice(invoice_id)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_pay_invoice(invoice_id: str) -> dict:
+        """
+        Attempt to pay an open invoice immediately.
+
+        Args:
+            invoice_id: Stripe invoice ID (e.g., "in_AbcDefGhijkLmn")
+
+        Returns:
+            Dict with paid invoice details or error
+
+        Example:
+            stripe_pay_invoice("in_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not invoice_id or not invoice_id.startswith("in_"):
+            return {"error": "Invalid invoice_id. Must start with: in_"}
+        try:
+            return client.pay_invoice(invoice_id)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_void_invoice(invoice_id: str) -> dict:
+        """
+        Void an open invoice, marking it uncollectible.
+
+        Args:
+            invoice_id: Stripe invoice ID (e.g., "in_AbcDefGhijkLmn")
+
+        Returns:
+            Dict with voided invoice details or error
+
+        Example:
+            stripe_void_invoice("in_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not invoice_id or not invoice_id.startswith("in_"):
+            return {"error": "Invalid invoice_id. Must start with: in_"}
+        try:
+            return client.void_invoice(invoice_id)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    # --- Invoice Item Tools ---
+
+    @mcp.tool()
+    def stripe_create_invoice_item(
+        customer_id: str,
+        amount: int,
+        currency: str,
+        description: str | None = None,
+        invoice_id: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict:
+        """
+        Add a line item to an existing or upcoming invoice.
+
+        Args:
+            customer_id: Stripe customer ID (e.g., "cus_AbcDefGhijkLmn")
+            amount: Amount in smallest currency unit (e.g., cents for USD)
+            currency: ISO 4217 currency code (e.g., "usd")
+            description: Description of the line item
+            invoice_id: Specific invoice to add item to (omit for upcoming invoice)
+            metadata: Key-value metadata to attach
+
+        Returns:
+            Dict with invoice item details or error
+
+        Example:
+            stripe_create_invoice_item("cus_AbcDefGhijkLmn", amount=1500, currency="usd",
+            description="Setup fee")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not customer_id or not customer_id.startswith("cus_"):
+            return {"error": "Invalid customer_id. Must start with: cus_"}
+        if amount <= 0:
+            return {"error": "Amount must be positive"}
+        if not currency or len(currency) != 3:
+            return {"error": "Currency must be a 3-letter ISO code (e.g., usd)"}
+        try:
+            return client.create_invoice_item(
+                customer_id, amount, currency, description, invoice_id, metadata
+            )
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_list_invoice_items(
+        customer_id: str | None = None,
+        invoice_id: str | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict:
+        """
+        List invoice items with optional filters.
+
+        Args:
+            customer_id: Filter by customer ID
+            invoice_id: Filter by invoice ID
+            limit: Number of items to fetch (1-100, default 10)
+            starting_after: Cursor for pagination
+
+        Returns:
+            Dict with invoice item list or error
+
+        Example:
+            stripe_list_invoice_items(customer_id="cus_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_invoice_items(customer_id, invoice_id, limit, starting_after)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_delete_invoice_item(invoice_item_id: str) -> dict:
+        """
+        Delete a pending invoice item.
+
+        Args:
+            invoice_item_id: Stripe invoice item ID (e.g., "ii_AbcDefGhijkLmn")
+
+        Returns:
+            Dict with deletion confirmation or error
+
+        Example:
+            stripe_delete_invoice_item("ii_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not invoice_item_id or not invoice_item_id.startswith("ii_"):
+            return {"error": "Invalid invoice_item_id. Must start with: ii_"}
+        try:
+            return client.delete_invoice_item(invoice_item_id)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    # --- Product Tools ---
+
+    @mcp.tool()
+    def stripe_create_product(
+        name: str,
+        description: str | None = None,
+        active: bool = True,
+        metadata: dict[str, str] | None = None,
+    ) -> dict:
+        """
+        Create a new Stripe product.
+
+        Args:
+            name: Product name
+            description: Product description
+            active: Whether the product is available (default True)
+            metadata: Key-value metadata to attach
+
+        Returns:
+            Dict with product details or error
+
+        Example:
+            stripe_create_product(name="Premium Plan", description="Full access subscription")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not name:
+            return {"error": "Product name is required"}
+        try:
+            return client.create_product(name, description, active, metadata)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_get_product(product_id: str) -> dict:
+        """
+        Retrieve a product by ID.
+
+        Args:
+            product_id: Stripe product ID (e.g., "prod_AbcDefGhijkLmn")
+
+        Returns:
+            Dict with product details or error
+
+        Example:
+            stripe_get_product("prod_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not product_id or not product_id.startswith("prod_"):
+            return {"error": "Invalid product_id. Must start with: prod_"}
+        try:
+            return client.get_product(product_id)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_list_products(
+        active: bool | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict:
+        """
+        List Stripe products with optional filters.
+
+        Args:
+            active: Filter by active status
+            limit: Number of products to fetch (1-100, default 10)
+            starting_after: Cursor for pagination
+
+        Returns:
+            Dict with product list or error
+
+        Example:
+            stripe_list_products(active=True, limit=20)
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_products(active, limit, starting_after)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_update_product(
+        product_id: str,
+        name: str | None = None,
+        description: str | None = None,
+        active: bool | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict:
+        """
+        Update an existing product.
+
+        Args:
+            product_id: Stripe product ID (e.g., "prod_AbcDefGhijkLmn")
+            name: Updated product name
+            description: Updated description
+            active: Updated active status
+            metadata: Updated key-value metadata
+
+        Returns:
+            Dict with updated product details or error
+
+        Example:
+            stripe_update_product("prod_AbcDefGhijkLmn", name="Premium Plan v2")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not product_id or not product_id.startswith("prod_"):
+            return {"error": "Invalid product_id. Must start with: prod_"}
+        try:
+            return client.update_product(product_id, name, description, active, metadata)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    # --- Price Tools ---
+
+    @mcp.tool()
+    def stripe_create_price(
+        unit_amount: int,
+        currency: str,
+        product_id: str,
+        recurring_interval: str | None = None,
+        recurring_interval_count: int | None = None,
+        nickname: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict:
+        """
+        Create a price for a product.
+
+        Args:
+            unit_amount: Amount in smallest currency unit (e.g., cents for USD)
+            currency: ISO 4217 currency code (e.g., "usd")
+            product_id: Stripe product ID (e.g., "prod_AbcDefGhijkLmn")
+            recurring_interval: Billing interval for subscriptions (day, week, month, year)
+            recurring_interval_count: Number of intervals between billing cycles
+            nickname: Friendly label for the price
+            metadata: Key-value metadata to attach
+
+        Returns:
+            Dict with price details or error
+
+        Example:
+            stripe_create_price(unit_amount=999, currency="usd", product_id="prod_AbcDefGhijkLmn",
+              recurring_interval="month")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if unit_amount <= 0:
+            return {"error": "unit_amount must be positive"}
+        if not currency or len(currency) != 3:
+            return {"error": "Currency must be a 3-letter ISO code (e.g., usd)"}
+        if not product_id or not product_id.startswith("prod_"):
+            return {"error": "Invalid product_id. Must start with: prod_"}
+        try:
+            return client.create_price(
+                unit_amount,
+                currency,
+                product_id,
+                recurring_interval,
+                recurring_interval_count,
+                nickname,
+                metadata,
+            )
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_get_price(price_id: str) -> dict:
+        """
+        Retrieve a price by ID.
+
+        Args:
+            price_id: Stripe price ID (e.g., "price_AbcDefGhijkLmn")
+
+        Returns:
+            Dict with price details or error
+
+        Example:
+            stripe_get_price("price_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not price_id or not price_id.startswith("price_"):
+            return {"error": "Invalid price_id. Must start with: price_"}
+        try:
+            return client.get_price(price_id)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_list_prices(
+        product_id: str | None = None,
+        active: bool | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict:
+        """
+        List Stripe prices with optional filters.
+
+        Args:
+            product_id: Filter by product ID
+            active: Filter by active status
+            limit: Number of prices to fetch (1-100, default 10)
+            starting_after: Cursor for pagination
+
+        Returns:
+            Dict with price list or error
+
+        Example:
+            stripe_list_prices(product_id="prod_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_prices(product_id, active, limit, starting_after)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_update_price(
+        price_id: str,
+        active: bool | None = None,
+        nickname: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict:
+        """
+        Update an existing price (only active, nickname, and metadata can be updated).
+
+        Args:
+            price_id: Stripe price ID (e.g., "price_AbcDefGhijkLmn")
+            active: Updated active status
+            nickname: Updated friendly label
+            metadata: Updated key-value metadata
+
+        Returns:
+            Dict with updated price details or error
+
+        Example:
+            stripe_update_price("price_AbcDefGhijkLmn", active=False)
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not price_id or not price_id.startswith("price_"):
+            return {"error": "Invalid price_id. Must start with: price_"}
+        try:
+            return client.update_price(price_id, active, nickname, metadata)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    # --- Payment Link Tools ---
+
+    @mcp.tool()
+    def stripe_create_payment_link(
+        price_id: str,
+        quantity: int = 1,
+        metadata: dict[str, str] | None = None,
+    ) -> dict:
+        """
+        Create a shareable payment link for a price.
+
+        Args:
+            price_id: Stripe price ID (e.g., "price_AbcDefGhijkLmn")
+            quantity: Quantity of the price to include (default 1)
+            metadata: Key-value metadata to attach
+
+        Returns:
+            Dict with payment link details including URL or error
+
+        Example:
+            stripe_create_payment_link("price_AbcDefGhijkLmn", quantity=1)
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not price_id or not price_id.startswith("price_"):
+            return {"error": "Invalid price_id. Must start with: price_"}
+        if quantity < 1:
+            return {"error": "Quantity must be at least 1"}
+        try:
+            return client.create_payment_link(price_id, quantity, metadata)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_get_payment_link(payment_link_id: str) -> dict:
+        """
+        Retrieve a payment link by ID.
+
+        Args:
+            payment_link_id: Stripe payment link ID (e.g., "plink_AbcDefGhijkLmn")
+
+        Returns:
+            Dict with payment link details or error
+
+        Example:
+            stripe_get_payment_link("plink_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not payment_link_id or not payment_link_id.startswith("plink_"):
+            return {"error": "Invalid payment_link_id. Must start with: plink_"}
+        try:
+            return client.get_payment_link(payment_link_id)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_list_payment_links(
+        active: bool | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict:
+        """
+        List payment links with optional filters.
+
+        Args:
+            active: Filter by active status
+            limit: Number of payment links to fetch (1-100, default 10)
+            starting_after: Cursor for pagination
+
+        Returns:
+            Dict with payment link list or error
+
+        Example:
+            stripe_list_payment_links(active=True)
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_payment_links(active, limit, starting_after)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    # --- Coupon Tools ---
+
+    @mcp.tool()
+    def stripe_create_coupon(
+        percent_off: float | None = None,
+        amount_off: int | None = None,
+        currency: str | None = None,
+        duration: str = "once",
+        duration_in_months: int | None = None,
+        name: str | None = None,
+        max_redemptions: int | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> dict:
+        """
+        Create a discount coupon.
+
+        Args:
+            percent_off: Percentage discount (e.g., 25.0 for 25% off)
+            amount_off: Fixed discount in smallest currency unit
+            currency: Currency for amount_off (required when using amount_off)
+            duration: How long the coupon applies: "once", "repeating", or "forever"
+            duration_in_months: Months the coupon applies (required for "repeating")
+            name: Friendly name for the coupon
+            max_redemptions: Maximum number of times the coupon can be redeemed
+            metadata: Key-value metadata to attach
+
+        Returns:
+            Dict with coupon details or error
+
+        Example:
+            stripe_create_coupon(percent_off=20.0, duration="once", name="WELCOME20")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if percent_off is None and amount_off is None:
+            return {"error": "Either percent_off or amount_off is required"}
+        if percent_off is not None and amount_off is not None:
+            return {"error": "Only one of percent_off or amount_off can be specified"}
+        if amount_off is not None and not currency:
+            return {"error": "currency is required when using amount_off"}
+        if duration not in ("once", "repeating", "forever"):
+            return {"error": "duration must be one of: once, repeating, forever"}
+        if duration == "repeating" and duration_in_months is None:
+            return {"error": "duration_in_months is required when duration is repeating"}
+        try:
+            return client.create_coupon(
+                percent_off,
+                amount_off,
+                currency,
+                duration,
+                duration_in_months,
+                name,
+                max_redemptions,
+                metadata,
+            )
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_list_coupons(
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict:
+        """
+        List all coupons.
+
+        Args:
+            limit: Number of coupons to fetch (1-100, default 10)
+            starting_after: Cursor for pagination
+
+        Returns:
+            Dict with coupon list or error
+
+        Example:
+            stripe_list_coupons(limit=20)
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_coupons(limit, starting_after)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_delete_coupon(coupon_id: str) -> dict:
+        """
+        Delete a coupon.
+
+        Args:
+            coupon_id: Stripe coupon ID
+
+        Returns:
+            Dict with deletion confirmation or error
+
+        Example:
+            stripe_delete_coupon("WELCOME20")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not coupon_id:
+            return {"error": "coupon_id is required"}
+        try:
+            return client.delete_coupon(coupon_id)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    # --- Balance Tools ---
+
+    @mcp.tool()
+    def stripe_get_balance() -> dict:
+        """
+        Retrieve the current account balance.
+
+        Returns:
+            Dict with available and pending balance amounts or error
+
+        Example:
+            stripe_get_balance()
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.get_balance()
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_list_balance_transactions(
+        type_filter: str | None = None,
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict:
+        """
+        List balance transactions (payouts, charges, refunds, etc.).
+
+        Args:
+            type_filter: Filter by type (charge, refund, payout, payment, etc.)
+            limit: Number of transactions to fetch (1-100, default 10)
+            starting_after: Cursor for pagination
+
+        Returns:
+            Dict with transaction list or error
+
+        Example:
+            stripe_list_balance_transactions(type_filter="charge", limit=20)
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_balance_transactions(type_filter, limit, starting_after)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    # --- Webhook Endpoint Tools ---
+
+    @mcp.tool()
+    def stripe_list_webhook_endpoints(
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict:
+        """
+        List all configured webhook endpoints.
+
+        Args:
+            limit: Number of endpoints to fetch (1-100, default 10)
+            starting_after: Cursor for pagination
+
+        Returns:
+            Dict with webhook endpoint list or error
+
+        Example:
+            stripe_list_webhook_endpoints()
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_webhook_endpoints(limit, starting_after)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    # --- Payment Method Tools ---
+
+    @mcp.tool()
+    def stripe_list_payment_methods(
+        customer_id: str,
+        type_filter: str = "card",
+        limit: int = 10,
+        starting_after: str | None = None,
+    ) -> dict:
+        """
+        List payment methods attached to a customer.
+
+        Args:
+            customer_id: Stripe customer ID (e.g., "cus_AbcDefGhijkLmn")
+            type_filter: Payment method type to list (default "card")
+            limit: Number of payment methods to fetch (1-100, default 10)
+            starting_after: Cursor for pagination
+
+        Returns:
+            Dict with payment method list or error
+
+        Example:
+            stripe_list_payment_methods("cus_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not customer_id or not customer_id.startswith("cus_"):
+            return {"error": "Invalid customer_id. Must start with: cus_"}
+        try:
+            return client.list_payment_methods(customer_id, type_filter, limit, starting_after)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_get_payment_method(payment_method_id: str) -> dict:
+        """
+        Retrieve a payment method by ID.
+
+        Args:
+            payment_method_id: Stripe payment method ID (e.g., "pm_AbcDefGhijkLmn")
+
+        Returns:
+            Dict with payment method details or error
+
+        Example:
+            stripe_get_payment_method("pm_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not payment_method_id or not payment_method_id.startswith("pm_"):
+            return {"error": "Invalid payment_method_id. Must start with: pm_"}
+        try:
+            return client.get_payment_method(payment_method_id)
+        except stripe.StripeError as e:
+            return _stripe_error(e)
+
+    @mcp.tool()
+    def stripe_detach_payment_method(payment_method_id: str) -> dict:
+        """
+        Detach a payment method from its customer.
+
+        Args:
+            payment_method_id: Stripe payment method ID (e.g., "pm_AbcDefGhijkLmn")
+
+        Returns:
+            Dict with detached payment method details or error
+
+        Example:
+            stripe_detach_payment_method("pm_AbcDefGhijkLmn")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not payment_method_id or not payment_method_id.startswith("pm_"):
+            return {"error": "Invalid payment_method_id. Must start with: pm_"}
+        try:
+            return client.detach_payment_method(payment_method_id)
+        except stripe.StripeError as e:
+            return _stripe_error(e)

--- a/tools/tests/test_credentials.py
+++ b/tools/tests/test_credentials.py
@@ -481,7 +481,7 @@ class TestSpecCompleteness:
     def test_credential_group_default_empty(self):
         """Specs without a group have empty credential_group."""
         for name, spec in CREDENTIAL_SPECS.items():
-            if name not in ("google_search", "google_cse", "razorpay", "razorpay_secret"):
+            if name not in ("google_search", "google_cse", "razorpay", "razorpay_secret","stripe"):
                 assert spec.credential_group == "", (
                     f"Credential '{name}' has unexpected credential_group='{spec.credential_group}'"
                 )

--- a/tools/tests/test_credentials.py
+++ b/tools/tests/test_credentials.py
@@ -481,7 +481,7 @@ class TestSpecCompleteness:
     def test_credential_group_default_empty(self):
         """Specs without a group have empty credential_group."""
         for name, spec in CREDENTIAL_SPECS.items():
-            if name not in ("google_search", "google_cse", "razorpay", "razorpay_secret","stripe"):
+            if name not in ("google_search", "google_cse", "razorpay", "razorpay_secret", "stripe"):
                 assert spec.credential_group == "", (
                     f"Credential '{name}' has unexpected credential_group='{spec.credential_group}'"
                 )

--- a/tools/tests/test_credentials.py
+++ b/tools/tests/test_credentials.py
@@ -481,7 +481,7 @@ class TestSpecCompleteness:
     def test_credential_group_default_empty(self):
         """Specs without a group have empty credential_group."""
         for name, spec in CREDENTIAL_SPECS.items():
-            if name not in ("google_search", "google_cse", "razorpay", "razorpay_secret", "stripe"):
+            if name not in ("google_search", "google_cse", "razorpay", "razorpay_secret"):
                 assert spec.credential_group == "", (
                     f"Credential '{name}' has unexpected credential_group='{spec.credential_group}'"
                 )

--- a/tools/tests/tools/test_stripe_tool.py
+++ b/tools/tests/tools/test_stripe_tool.py
@@ -1,0 +1,1687 @@
+"""
+Tests for Stripe payment tool.
+
+Covers:
+- _StripeClient methods (all customer, subscription, payment intent, charge,
+  refund, invoice, invoice item, product, price, payment link, coupon,
+  balance, webhook endpoint, and payment method operations)
+- Error handling (StripeError, invalid credentials, missing credentials)
+- Credential retrieval (CredentialStoreAdapter vs env var)
+- All 52 MCP tool functions
+- Input validation
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import stripe
+
+from aden_tools.tools.stripe_tool.stripe_tool import (
+    _StripeClient,
+    register_tools,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_stripe_list(items: list, has_more: bool = False):
+    """Return a mock object that looks like a stripe ListObject."""
+    obj = MagicMock()
+    obj.data = items
+    obj.has_more = has_more
+    return obj
+
+
+def _customer(**kwargs):
+    defaults = {
+        "id": "cus_test123",
+        "email": "test@example.com",
+        "name": "Test User",
+        "phone": "+10000000000",
+        "description": "A test customer",
+        "created": 1700000000,
+        "currency": "usd",
+        "delinquent": False,
+        "metadata": {},
+    }
+    defaults.update(kwargs)
+    obj = MagicMock()
+    for k, v in defaults.items():
+        setattr(obj, k, v)
+    return obj
+
+
+def _subscription(**kwargs):
+    defaults = {
+        "id": "sub_test123",
+        "customer": "cus_test123",
+        "status": "active",
+        "current_period_start": 1700000000,
+        "current_period_end": 1702592000,
+        "cancel_at_period_end": False,
+        "canceled_at": None,
+        "trial_end": None,
+        "created": 1700000000,
+        "metadata": {},
+    }
+    defaults.update(kwargs)
+    obj = MagicMock()
+    for k, v in defaults.items():
+        setattr(obj, k, v)
+    item = MagicMock()
+    item.id = "si_test123"
+    item.price.id = "price_test123"
+    item.quantity = 1
+    obj.items = MagicMock()
+    obj.items.data = [item]
+    return obj
+
+
+def _payment_intent(**kwargs):
+    defaults = {
+        "id": "pi_test123",
+        "amount": 2000,
+        "amount_received": 0,
+        "currency": "usd",
+        "status": "requires_payment_method",
+        "customer": "cus_test123",
+        "description": "Test payment",
+        "receipt_email": None,
+        "payment_method": None,
+        "created": 1700000000,
+        "metadata": {},
+        "client_secret": "pi_test123_secret_abc",
+    }
+    defaults.update(kwargs)
+    obj = MagicMock()
+    for k, v in defaults.items():
+        setattr(obj, k, v)
+    return obj
+
+
+def _charge(**kwargs):
+    defaults = {
+        "id": "ch_test123",
+        "amount": 2000,
+        "amount_captured": 2000,
+        "amount_refunded": 0,
+        "currency": "usd",
+        "status": "succeeded",
+        "paid": True,
+        "refunded": False,
+        "customer": "cus_test123",
+        "description": "Test charge",
+        "receipt_email": None,
+        "receipt_url": "https://pay.stripe.com/receipts/test",
+        "payment_intent": "pi_test123",
+        "created": 1700000000,
+        "metadata": {},
+    }
+    defaults.update(kwargs)
+    obj = MagicMock()
+    for k, v in defaults.items():
+        setattr(obj, k, v)
+    return obj
+
+
+def _refund(**kwargs):
+    defaults = {
+        "id": "re_test123",
+        "amount": 1000,
+        "currency": "usd",
+        "status": "succeeded",
+        "charge": "ch_test123",
+        "payment_intent": "pi_test123",
+        "reason": "customer_request",
+        "created": 1700000000,
+        "metadata": {},
+    }
+    defaults.update(kwargs)
+    obj = MagicMock()
+    for k, v in defaults.items():
+        setattr(obj, k, v)
+    return obj
+
+
+def _invoice(**kwargs):
+    defaults = {
+        "id": "in_test123",
+        "customer": "cus_test123",
+        "subscription": "sub_test123",
+        "status": "open",
+        "amount_due": 2000,
+        "amount_paid": 0,
+        "amount_remaining": 2000,
+        "currency": "usd",
+        "description": "Test invoice",
+        "hosted_invoice_url": "https://invoice.stripe.com/test",
+        "invoice_pdf": "https://invoice.stripe.com/test/pdf",
+        "due_date": None,
+        "created": 1700000000,
+        "period_start": 1700000000,
+        "period_end": 1702592000,
+        "metadata": {},
+    }
+    defaults.update(kwargs)
+    obj = MagicMock()
+    for k, v in defaults.items():
+        setattr(obj, k, v)
+    return obj
+
+
+def _invoice_item(**kwargs):
+    defaults = {
+        "id": "ii_test123",
+        "customer": "cus_test123",
+        "invoice": "in_test123",
+        "amount": 1500,
+        "currency": "usd",
+        "description": "Setup fee",
+        "quantity": 1,
+        "created": 1700000000,
+        "metadata": {},
+    }
+    defaults.update(kwargs)
+    obj = MagicMock()
+    for k, v in defaults.items():
+        setattr(obj, k, v)
+    return obj
+
+
+def _product(**kwargs):
+    defaults = {
+        "id": "prod_test123",
+        "name": "Premium Plan",
+        "description": "Full access",
+        "active": True,
+        "created": 1700000000,
+        "updated": 1700000000,
+        "metadata": {},
+    }
+    defaults.update(kwargs)
+    obj = MagicMock()
+    for k, v in defaults.items():
+        setattr(obj, k, v)
+    return obj
+
+
+def _price(**kwargs):
+    rec = MagicMock()
+    rec.interval = "month"
+    rec.interval_count = 1
+    defaults = {
+        "id": "price_test123",
+        "product": "prod_test123",
+        "currency": "usd",
+        "unit_amount": 999,
+        "nickname": "Monthly",
+        "active": True,
+        "type": "recurring",
+        "recurring": rec,
+        "created": 1700000000,
+        "metadata": {},
+    }
+    defaults.update(kwargs)
+    obj = MagicMock()
+    for k, v in defaults.items():
+        setattr(obj, k, v)
+    return obj
+
+
+def _payment_link(**kwargs):
+    line_item = MagicMock()
+    line_item.price.id = "price_test123"
+    line_item.quantity = 1
+    line_items_obj = MagicMock()
+    line_items_obj.data = [line_item]
+    defaults = {
+        "id": "plink_test123",
+        "url": "https://buy.stripe.com/test",
+        "active": True,
+        "currency": "usd",
+        "line_items": line_items_obj,
+        "created": 1700000000,
+        "metadata": {},
+    }
+    defaults.update(kwargs)
+    obj = MagicMock()
+    for k, v in defaults.items():
+        setattr(obj, k, v)
+    return obj
+
+
+def _coupon(**kwargs):
+    defaults = {
+        "id": "WELCOME20",
+        "name": "Welcome 20% off",
+        "percent_off": 20.0,
+        "amount_off": None,
+        "currency": None,
+        "duration": "once",
+        "duration_in_months": None,
+        "max_redemptions": None,
+        "times_redeemed": 0,
+        "valid": True,
+        "created": 1700000000,
+        "metadata": {},
+    }
+    defaults.update(kwargs)
+    obj = MagicMock()
+    for k, v in defaults.items():
+        setattr(obj, k, v)
+    return obj
+
+
+def _payment_method(**kwargs):
+    card = MagicMock()
+    card.brand = "visa"
+    card.last4 = "4242"
+    card.exp_month = 12
+    card.exp_year = 2025
+    card.country = "US"
+    defaults = {
+        "id": "pm_test123",
+        "type": "card",
+        "customer": "cus_test123",
+        "card": card,
+        "created": 1700000000,
+        "metadata": {},
+    }
+    defaults.update(kwargs)
+    obj = MagicMock()
+    for k, v in defaults.items():
+        setattr(obj, k, v)
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# _StripeClient unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestStripeClientCustomers:
+    def setup_method(self):
+        self.client = _StripeClient("sk_test_key123")
+
+    def _mock_stripe(self):
+        return MagicMock()
+
+    def test_create_customer(self):
+        sc = self._mock_stripe()
+        sc.customers.create.return_value = _customer()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.create_customer(
+                email="test@example.com",
+                name="Test User",
+                phone="+10000000000",
+                description="desc",
+                metadata={"key": "val"},
+            )
+        sc.customers.create.assert_called_once_with(
+            {
+                "email": "test@example.com",
+                "name": "Test User",
+                "phone": "+10000000000",
+                "description": "desc",
+                "metadata": {"key": "val"},
+            }
+        )
+        assert result["id"] == "cus_test123"
+        assert result["email"] == "test@example.com"
+
+    def test_create_customer_minimal(self):
+        sc = self._mock_stripe()
+        sc.customers.create.return_value = _customer(email=None, name=None)
+        with patch.object(self.client, "_stripe", return_value=sc):
+            self.client.create_customer()
+        call_args = sc.customers.create.call_args[0][0]
+        assert "email" not in call_args
+        assert "name" not in call_args
+
+    def test_get_customer(self):
+        sc = self._mock_stripe()
+        sc.customers.retrieve.return_value = _customer()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.get_customer("cus_test123")
+        sc.customers.retrieve.assert_called_once_with("cus_test123")
+        assert result["id"] == "cus_test123"
+
+    def test_get_customer_by_email_found(self):
+        sc = self._mock_stripe()
+        sc.customers.list.return_value = _make_stripe_list([_customer()])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.get_customer_by_email("test@example.com")
+        sc.customers.list.assert_called_once_with({"email": "test@example.com", "limit": 1})
+        assert result["id"] == "cus_test123"
+
+    def test_get_customer_by_email_not_found(self):
+        sc = self._mock_stripe()
+        sc.customers.list.return_value = _make_stripe_list([])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.get_customer_by_email("nobody@example.com")
+        assert "error" in result
+        assert "nobody@example.com" in result["error"]
+
+    def test_update_customer(self):
+        sc = self._mock_stripe()
+        sc.customers.update.return_value = _customer(name="Updated Name")
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.update_customer("cus_test123", name="Updated Name")
+        sc.customers.update.assert_called_once_with("cus_test123", {"name": "Updated Name"})
+        assert result["name"] == "Updated Name"
+
+    def test_list_customers(self):
+        sc = self._mock_stripe()
+        sc.customers.list.return_value = _make_stripe_list([_customer(), _customer(id="cus_456")])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.list_customers(limit=10)
+        assert len(result["customers"]) == 2
+        assert result["has_more"] is False
+
+    def test_list_customers_limit_capped(self):
+        sc = self._mock_stripe()
+        sc.customers.list.return_value = _make_stripe_list([])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            self.client.list_customers(limit=500)
+        call_params = sc.customers.list.call_args[0][0]
+        assert call_params["limit"] == 100
+
+
+class TestStripeClientSubscriptions:
+    def setup_method(self):
+        self.client = _StripeClient("sk_test_key123")
+
+    def _mock_stripe(self):
+        return MagicMock()
+
+    def test_get_subscription(self):
+        sc = self._mock_stripe()
+        sc.subscriptions.retrieve.return_value = _subscription()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.get_subscription("sub_test123")
+        sc.subscriptions.retrieve.assert_called_once_with("sub_test123")
+        assert result["id"] == "sub_test123"
+        assert result["status"] == "active"
+
+    def test_get_subscription_status_active(self):
+        sc = self._mock_stripe()
+        sc.subscriptions.list.return_value = _make_stripe_list([_subscription()])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.get_subscription_status("cus_test123")
+        assert result["status"] == "active"
+        assert result["customer_id"] == "cus_test123"
+        assert len(result["subscriptions"]) == 1
+
+    def test_get_subscription_status_no_subscription(self):
+        sc = self._mock_stripe()
+        sc.subscriptions.list.return_value = _make_stripe_list([])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.get_subscription_status("cus_test123")
+        assert result["status"] == "no_subscription"
+        assert result["subscriptions"] == []
+
+    def test_list_subscriptions(self):
+        sc = self._mock_stripe()
+        sc.subscriptions.list.return_value = _make_stripe_list([_subscription()])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.list_subscriptions(customer_id="cus_test123", status="active")
+        call_params = sc.subscriptions.list.call_args[0][0]
+        assert call_params["customer"] == "cus_test123"
+        assert call_params["status"] == "active"
+        assert len(result["subscriptions"]) == 1
+
+    def test_create_subscription(self):
+        sc = self._mock_stripe()
+        sc.subscriptions.create.return_value = _subscription()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.create_subscription(
+                "cus_test123",
+                "price_test123",
+                quantity=1,
+                trial_period_days=14,
+            )
+        call_params = sc.subscriptions.create.call_args[0][0]
+        assert call_params["customer"] == "cus_test123"
+        assert call_params["items"][0]["price"] == "price_test123"
+        assert call_params["trial_period_days"] == 14
+        assert result["id"] == "sub_test123"
+
+    def test_update_subscription_metadata(self):
+        sc = self._mock_stripe()
+        sc.subscriptions.update.return_value = _subscription()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            self.client.update_subscription(
+                "sub_test123", metadata={"note": "updated"}, cancel_at_period_end=True
+            )
+        call_params = sc.subscriptions.update.call_args[0][1]
+        assert call_params["cancel_at_period_end"] is True
+        assert call_params["metadata"] == {"note": "updated"}
+
+    def test_cancel_subscription_immediately(self):
+        sc = self._mock_stripe()
+        sc.subscriptions.cancel.return_value = _subscription(status="canceled")
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.cancel_subscription("sub_test123", at_period_end=False)
+        sc.subscriptions.cancel.assert_called_once_with("sub_test123")
+        assert result["status"] == "canceled"
+
+    def test_cancel_subscription_at_period_end(self):
+        sc = self._mock_stripe()
+        sc.subscriptions.update.return_value = _subscription(cancel_at_period_end=True)
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.cancel_subscription("sub_test123", at_period_end=True)
+        sc.subscriptions.update.assert_called_once_with(
+            "sub_test123", {"cancel_at_period_end": True}
+        )
+        assert result["cancel_at_period_end"] is True
+
+
+class TestStripeClientPaymentIntents:
+    def setup_method(self):
+        self.client = _StripeClient("sk_test_key123")
+
+    def _mock_stripe(self):
+        return MagicMock()
+
+    def test_create_payment_intent(self):
+        sc = self._mock_stripe()
+        sc.payment_intents.create.return_value = _payment_intent()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.create_payment_intent(
+                amount=2000,
+                currency="usd",
+                customer_id="cus_test123",
+                description="Test",
+                receipt_email="test@example.com",
+            )
+        call_params = sc.payment_intents.create.call_args[0][0]
+        assert call_params["amount"] == 2000
+        assert call_params["currency"] == "usd"
+        assert call_params["customer"] == "cus_test123"
+        assert result["id"] == "pi_test123"
+        assert result["client_secret"] == "pi_test123_secret_abc"
+
+    def test_get_payment_intent(self):
+        sc = self._mock_stripe()
+        sc.payment_intents.retrieve.return_value = _payment_intent()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.get_payment_intent("pi_test123")
+        sc.payment_intents.retrieve.assert_called_once_with("pi_test123")
+        assert result["id"] == "pi_test123"
+
+    def test_confirm_payment_intent(self):
+        sc = self._mock_stripe()
+        sc.payment_intents.confirm.return_value = _payment_intent(status="succeeded")
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.confirm_payment_intent("pi_test123", payment_method="pm_card_visa")
+        sc.payment_intents.confirm.assert_called_once_with(
+            "pi_test123", {"payment_method": "pm_card_visa"}
+        )
+        assert result["status"] == "succeeded"
+
+    def test_cancel_payment_intent(self):
+        sc = self._mock_stripe()
+        sc.payment_intents.cancel.return_value = _payment_intent(status="canceled")
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.cancel_payment_intent("pi_test123")
+        sc.payment_intents.cancel.assert_called_once_with("pi_test123")
+        assert result["status"] == "canceled"
+
+    def test_list_payment_intents(self):
+        sc = self._mock_stripe()
+        sc.payment_intents.list.return_value = _make_stripe_list([_payment_intent()])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.list_payment_intents(customer_id="cus_test123", limit=5)
+        call_params = sc.payment_intents.list.call_args[0][0]
+        assert call_params["customer"] == "cus_test123"
+        assert call_params["limit"] == 5
+        assert len(result["payment_intents"]) == 1
+
+
+class TestStripeClientCharges:
+    def setup_method(self):
+        self.client = _StripeClient("sk_test_key123")
+
+    def _mock_stripe(self):
+        return MagicMock()
+
+    def test_list_charges(self):
+        sc = self._mock_stripe()
+        sc.charges.list.return_value = _make_stripe_list([_charge(), _charge(id="ch_456")])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.list_charges(customer_id="cus_test123")
+        call_params = sc.charges.list.call_args[0][0]
+        assert call_params["customer"] == "cus_test123"
+        assert len(result["charges"]) == 2
+
+    def test_get_charge(self):
+        sc = self._mock_stripe()
+        sc.charges.retrieve.return_value = _charge()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.get_charge("ch_test123")
+        sc.charges.retrieve.assert_called_once_with("ch_test123")
+        assert result["id"] == "ch_test123"
+        assert result["paid"] is True
+
+    def test_capture_charge(self):
+        sc = self._mock_stripe()
+        sc.charges.capture.return_value = _charge(amount_captured=2000)
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.capture_charge("ch_test123", amount=2000)
+        sc.charges.capture.assert_called_once_with("ch_test123", {"amount": 2000})
+        assert result["amount_captured"] == 2000
+
+    def test_capture_charge_full(self):
+        sc = self._mock_stripe()
+        sc.charges.capture.return_value = _charge()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            self.client.capture_charge("ch_test123")
+        call_params = sc.charges.capture.call_args[0][1]
+        assert call_params == {}  # No amount means full capture
+
+    def test_create_charge(self):
+        sc = self._mock_stripe()
+        sc.charges.create.return_value = _charge()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.create_charge(
+                amount=2000,
+                currency="usd",
+                source="tok_visa",
+                description="Test",
+            )
+        call_params = sc.charges.create.call_args[0][0]
+        assert call_params["amount"] == 2000
+        assert call_params["source"] == "tok_visa"
+        assert result["id"] == "ch_test123"
+
+
+class TestStripeClientRefunds:
+    def setup_method(self):
+        self.client = _StripeClient("sk_test_key123")
+
+    def _mock_stripe(self):
+        return MagicMock()
+
+    def test_create_refund_by_charge(self):
+        sc = self._mock_stripe()
+        sc.refunds.create.return_value = _refund()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.create_refund(charge_id="ch_test123", amount=1000)
+        call_params = sc.refunds.create.call_args[0][0]
+        assert call_params["charge"] == "ch_test123"
+        assert call_params["amount"] == 1000
+        assert result["id"] == "re_test123"
+
+    def test_create_refund_by_payment_intent(self):
+        sc = self._mock_stripe()
+        sc.refunds.create.return_value = _refund()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            self.client.create_refund(
+                payment_intent_id="pi_test123",
+                reason="customer_request",
+            )
+        call_params = sc.refunds.create.call_args[0][0]
+        assert call_params["payment_intent"] == "pi_test123"
+        assert call_params["reason"] == "customer_request"
+
+    def test_get_refund(self):
+        sc = self._mock_stripe()
+        sc.refunds.retrieve.return_value = _refund()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.get_refund("re_test123")
+        sc.refunds.retrieve.assert_called_once_with("re_test123")
+        assert result["id"] == "re_test123"
+
+    def test_list_refunds(self):
+        sc = self._mock_stripe()
+        sc.refunds.list.return_value = _make_stripe_list([_refund()])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.list_refunds(charge_id="ch_test123", limit=10)
+        call_params = sc.refunds.list.call_args[0][0]
+        assert call_params["charge"] == "ch_test123"
+        assert len(result["refunds"]) == 1
+
+
+class TestStripeClientInvoices:
+    def setup_method(self):
+        self.client = _StripeClient("sk_test_key123")
+
+    def _mock_stripe(self):
+        return MagicMock()
+
+    def test_list_invoices(self):
+        sc = self._mock_stripe()
+        sc.invoices.list.return_value = _make_stripe_list([_invoice(), _invoice(id="in_456")])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.list_invoices(customer_id="cus_test123", status="open")
+        call_params = sc.invoices.list.call_args[0][0]
+        assert call_params["customer"] == "cus_test123"
+        assert call_params["status"] == "open"
+        assert len(result["invoices"]) == 2
+
+    def test_get_invoice(self):
+        sc = self._mock_stripe()
+        sc.invoices.retrieve.return_value = _invoice()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.get_invoice("in_test123")
+        sc.invoices.retrieve.assert_called_once_with("in_test123")
+        assert result["id"] == "in_test123"
+        assert result["hosted_invoice_url"] == "https://invoice.stripe.com/test"
+
+    def test_create_invoice(self):
+        sc = self._mock_stripe()
+        sc.invoices.create.return_value = _invoice(status="draft")
+        with patch.object(self.client, "_stripe", return_value=sc):
+            self.client.create_invoice(
+                "cus_test123",
+                description="Test invoice",
+                collection_method="send_invoice",
+                days_until_due=30,
+            )
+        call_params = sc.invoices.create.call_args[0][0]
+        assert call_params["customer"] == "cus_test123"
+        assert call_params["collection_method"] == "send_invoice"
+        assert call_params["days_until_due"] == 30
+
+    def test_finalize_invoice(self):
+        sc = self._mock_stripe()
+        sc.invoices.finalize_invoice.return_value = _invoice(status="open")
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.finalize_invoice("in_test123")
+        sc.invoices.finalize_invoice.assert_called_once_with("in_test123")
+        assert result["status"] == "open"
+
+    def test_pay_invoice(self):
+        sc = self._mock_stripe()
+        sc.invoices.pay.return_value = _invoice(status="paid", amount_paid=2000)
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.pay_invoice("in_test123")
+        sc.invoices.pay.assert_called_once_with("in_test123")
+        assert result["status"] == "paid"
+
+    def test_void_invoice(self):
+        sc = self._mock_stripe()
+        sc.invoices.void_invoice.return_value = _invoice(status="void")
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.void_invoice("in_test123")
+        sc.invoices.void_invoice.assert_called_once_with("in_test123")
+        assert result["status"] == "void"
+
+
+class TestStripeClientInvoiceItems:
+    def setup_method(self):
+        self.client = _StripeClient("sk_test_key123")
+
+    def _mock_stripe(self):
+        return MagicMock()
+
+    def test_create_invoice_item(self):
+        sc = self._mock_stripe()
+        sc.invoice_items.create.return_value = _invoice_item()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.create_invoice_item(
+                customer_id="cus_test123",
+                amount=1500,
+                currency="usd",
+                description="Setup fee",
+                invoice_id="in_test123",
+            )
+        call_params = sc.invoice_items.create.call_args[0][0]
+        assert call_params["customer"] == "cus_test123"
+        assert call_params["amount"] == 1500
+        assert call_params["invoice"] == "in_test123"
+        assert result["id"] == "ii_test123"
+
+    def test_list_invoice_items(self):
+        sc = self._mock_stripe()
+        sc.invoice_items.list.return_value = _make_stripe_list([_invoice_item()])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.list_invoice_items(
+                customer_id="cus_test123", invoice_id="in_test123"
+            )
+        call_params = sc.invoice_items.list.call_args[0][0]
+        assert call_params["customer"] == "cus_test123"
+        assert call_params["invoice"] == "in_test123"
+        assert len(result["invoice_items"]) == 1
+
+    def test_delete_invoice_item(self):
+        sc = self._mock_stripe()
+        deleted = MagicMock()
+        deleted.id = "ii_test123"
+        deleted.deleted = True
+        sc.invoice_items.delete.return_value = deleted
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.delete_invoice_item("ii_test123")
+        sc.invoice_items.delete.assert_called_once_with("ii_test123")
+        assert result["deleted"] is True
+        assert result["id"] == "ii_test123"
+
+
+class TestStripeClientProducts:
+    def setup_method(self):
+        self.client = _StripeClient("sk_test_key123")
+
+    def _mock_stripe(self):
+        return MagicMock()
+
+    def test_create_product(self):
+        sc = self._mock_stripe()
+        sc.products.create.return_value = _product()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.create_product(
+                name="Premium Plan",
+                description="Full access",
+                active=True,
+                metadata={"tier": "premium"},
+            )
+        call_params = sc.products.create.call_args[0][0]
+        assert call_params["name"] == "Premium Plan"
+        assert call_params["active"] is True
+        assert result["id"] == "prod_test123"
+
+    def test_get_product(self):
+        sc = self._mock_stripe()
+        sc.products.retrieve.return_value = _product()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.get_product("prod_test123")
+        sc.products.retrieve.assert_called_once_with("prod_test123")
+        assert result["name"] == "Premium Plan"
+
+    def test_list_products(self):
+        sc = self._mock_stripe()
+        sc.products.list.return_value = _make_stripe_list([_product(), _product(id="prod_456")])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.list_products(active=True)
+        call_params = sc.products.list.call_args[0][0]
+        assert call_params["active"] is True
+        assert len(result["products"]) == 2
+
+    def test_update_product(self):
+        sc = self._mock_stripe()
+        sc.products.update.return_value = _product(name="Updated Plan", active=False)
+        with patch.object(self.client, "_stripe", return_value=sc):
+            self.client.update_product("prod_test123", name="Updated Plan", active=False)
+        call_params = sc.products.update.call_args[0][1]
+        assert call_params["name"] == "Updated Plan"
+        assert call_params["active"] is False
+
+
+class TestStripeClientPrices:
+    def setup_method(self):
+        self.client = _StripeClient("sk_test_key123")
+
+    def _mock_stripe(self):
+        return MagicMock()
+
+    def test_create_price_recurring(self):
+        sc = self._mock_stripe()
+        sc.prices.create.return_value = _price()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.create_price(
+                unit_amount=999,
+                currency="usd",
+                product_id="prod_test123",
+                recurring_interval="month",
+            )
+        call_params = sc.prices.create.call_args[0][0]
+        assert call_params["recurring"]["interval"] == "month"
+        assert result["id"] == "price_test123"
+
+    def test_create_price_one_time(self):
+        sc = self._mock_stripe()
+        sc.prices.create.return_value = _price(recurring=None, type="one_time")
+        with patch.object(self.client, "_stripe", return_value=sc):
+            self.client.create_price(
+                unit_amount=4999,
+                currency="usd",
+                product_id="prod_test123",
+            )
+        call_params = sc.prices.create.call_args[0][0]
+        assert "recurring" not in call_params
+
+    def test_get_price(self):
+        sc = self._mock_stripe()
+        sc.prices.retrieve.return_value = _price()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.get_price("price_test123")
+        sc.prices.retrieve.assert_called_once_with("price_test123")
+        assert result["unit_amount"] == 999
+        assert result["recurring"]["interval"] == "month"
+
+    def test_list_prices(self):
+        sc = self._mock_stripe()
+        sc.prices.list.return_value = _make_stripe_list([_price()])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.list_prices(product_id="prod_test123", active=True)
+        call_params = sc.prices.list.call_args[0][0]
+        assert call_params["product"] == "prod_test123"
+        assert call_params["active"] is True
+        assert len(result["prices"]) == 1
+
+    def test_update_price(self):
+        sc = self._mock_stripe()
+        sc.prices.update.return_value = _price(active=False, nickname="Legacy")
+        with patch.object(self.client, "_stripe", return_value=sc):
+            self.client.update_price("price_test123", active=False, nickname="Legacy")
+        call_params = sc.prices.update.call_args[0][1]
+        assert call_params["active"] is False
+        assert call_params["nickname"] == "Legacy"
+
+
+class TestStripeClientPaymentLinks:
+    def setup_method(self):
+        self.client = _StripeClient("sk_test_key123")
+
+    def _mock_stripe(self):
+        return MagicMock()
+
+    def test_create_payment_link(self):
+        sc = self._mock_stripe()
+        sc.payment_links.create.return_value = _payment_link()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.create_payment_link("price_test123", quantity=2)
+        call_params = sc.payment_links.create.call_args[0][0]
+        assert call_params["line_items"][0]["price"] == "price_test123"
+        assert call_params["line_items"][0]["quantity"] == 2
+        assert result["id"] == "plink_test123"
+        assert result["url"] == "https://buy.stripe.com/test"
+
+    def test_get_payment_link(self):
+        sc = self._mock_stripe()
+        sc.payment_links.retrieve.return_value = _payment_link()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.get_payment_link("plink_test123")
+        sc.payment_links.retrieve.assert_called_once_with("plink_test123")
+        assert result["active"] is True
+
+    def test_list_payment_links(self):
+        sc = self._mock_stripe()
+        sc.payment_links.list.return_value = _make_stripe_list([_payment_link()])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.list_payment_links(active=True)
+        call_params = sc.payment_links.list.call_args[0][0]
+        assert call_params["active"] is True
+        assert len(result["payment_links"]) == 1
+
+
+class TestStripeClientCoupons:
+    def setup_method(self):
+        self.client = _StripeClient("sk_test_key123")
+
+    def _mock_stripe(self):
+        return MagicMock()
+
+    def test_create_coupon_percent_off(self):
+        sc = self._mock_stripe()
+        sc.coupons.create.return_value = _coupon()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.create_coupon(
+                percent_off=20.0,
+                duration="once",
+                name="WELCOME20",
+            )
+        call_params = sc.coupons.create.call_args[0][0]
+        assert call_params["percent_off"] == 20.0
+        assert call_params["duration"] == "once"
+        assert result["id"] == "WELCOME20"
+
+    def test_create_coupon_amount_off(self):
+        sc = self._mock_stripe()
+        sc.coupons.create.return_value = _coupon(percent_off=None, amount_off=500, currency="usd")
+        with patch.object(self.client, "_stripe", return_value=sc):
+            self.client.create_coupon(
+                amount_off=500,
+                currency="usd",
+                duration="forever",
+            )
+        call_params = sc.coupons.create.call_args[0][0]
+        assert call_params["amount_off"] == 500
+        assert call_params["currency"] == "usd"
+
+    def test_create_coupon_repeating(self):
+        sc = self._mock_stripe()
+        sc.coupons.create.return_value = _coupon(duration="repeating", duration_in_months=3)
+        with patch.object(self.client, "_stripe", return_value=sc):
+            self.client.create_coupon(
+                percent_off=10.0,
+                duration="repeating",
+                duration_in_months=3,
+            )
+        call_params = sc.coupons.create.call_args[0][0]
+        assert call_params["duration_in_months"] == 3
+
+    def test_list_coupons(self):
+        sc = self._mock_stripe()
+        sc.coupons.list.return_value = _make_stripe_list([_coupon()])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.list_coupons(limit=5)
+        assert len(result["coupons"]) == 1
+
+    def test_delete_coupon(self):
+        sc = self._mock_stripe()
+        deleted = MagicMock()
+        deleted.id = "WELCOME20"
+        deleted.deleted = True
+        sc.coupons.delete.return_value = deleted
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.delete_coupon("WELCOME20")
+        sc.coupons.delete.assert_called_once_with("WELCOME20")
+        assert result["deleted"] is True
+
+
+class TestStripeClientBalance:
+    def setup_method(self):
+        self.client = _StripeClient("sk_test_key123")
+
+    def _mock_stripe(self):
+        return MagicMock()
+
+    def test_get_balance(self):
+        sc = self._mock_stripe()
+        avail = MagicMock()
+        avail.amount = 10000
+        avail.currency = "usd"
+        pend = MagicMock()
+        pend.amount = 5000
+        pend.currency = "usd"
+        sc.balance.retrieve.return_value = MagicMock(available=[avail], pending=[pend])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.get_balance()
+        assert result["available"][0]["amount"] == 10000
+        assert result["pending"][0]["currency"] == "usd"
+
+    def test_list_balance_transactions(self):
+        txn = MagicMock()
+        txn.id = "txn_test123"
+        txn.amount = 2000
+        txn.currency = "usd"
+        txn.net = 1942
+        txn.fee = 58
+        txn.type = "charge"
+        txn.status = "available"
+        txn.description = "Test"
+        txn.created = 1700000000
+        sc = self._mock_stripe()
+        sc.balance_transactions.list.return_value = _make_stripe_list([txn])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.list_balance_transactions(type_filter="charge")
+        call_params = sc.balance_transactions.list.call_args[0][0]
+        assert call_params["type"] == "charge"
+        assert len(result["transactions"]) == 1
+        assert result["transactions"][0]["net"] == 1942
+
+
+class TestStripeClientWebhookEndpoints:
+    def setup_method(self):
+        self.client = _StripeClient("sk_test_key123")
+
+    def _mock_stripe(self):
+        return MagicMock()
+
+    def test_list_webhook_endpoints(self):
+        we = MagicMock()
+        we.id = "we_test123"
+        we.url = "https://example.com/webhook"
+        we.status = "enabled"
+        we.enabled_events = ["payment_intent.succeeded"]
+        we.created = 1700000000
+        sc = self._mock_stripe()
+        sc.webhook_endpoints.list.return_value = _make_stripe_list([we])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.list_webhook_endpoints(limit=10)
+        assert len(result["webhook_endpoints"]) == 1
+        assert result["webhook_endpoints"][0]["url"] == "https://example.com/webhook"
+        assert result["webhook_endpoints"][0]["status"] == "enabled"
+
+
+class TestStripeClientPaymentMethods:
+    def setup_method(self):
+        self.client = _StripeClient("sk_test_key123")
+
+    def _mock_stripe(self):
+        return MagicMock()
+
+    def test_list_payment_methods(self):
+        sc = self._mock_stripe()
+        sc.payment_methods.list.return_value = _make_stripe_list([_payment_method()])
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.list_payment_methods("cus_test123", type_filter="card")
+        call_params = sc.payment_methods.list.call_args[0][0]
+        assert call_params["customer"] == "cus_test123"
+        assert call_params["type"] == "card"
+        assert len(result["payment_methods"]) == 1
+        assert result["payment_methods"][0]["card"]["last4"] == "4242"
+
+    def test_get_payment_method(self):
+        sc = self._mock_stripe()
+        sc.payment_methods.retrieve.return_value = _payment_method()
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.get_payment_method("pm_test123")
+        sc.payment_methods.retrieve.assert_called_once_with("pm_test123")
+        assert result["type"] == "card"
+
+    def test_detach_payment_method(self):
+        sc = self._mock_stripe()
+        detached = _payment_method(customer=None)
+        sc.payment_methods.detach.return_value = detached
+        with patch.object(self.client, "_stripe", return_value=sc):
+            result = self.client.detach_payment_method("pm_test123")
+        sc.payment_methods.detach.assert_called_once_with("pm_test123")
+        assert result["customer"] is None
+
+
+# ---------------------------------------------------------------------------
+# MCP tool registration and credential tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolRegistration:
+    def test_register_tools_registers_all_tools(self):
+        mcp = MagicMock()
+        mcp.tool.return_value = lambda fn: fn
+        register_tools(mcp)
+        assert mcp.tool.call_count == 52
+
+    def test_no_credentials_returns_error(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        with patch.dict("os.environ", {}, clear=True):
+            register_tools(mcp, credentials=None)
+            list_fn = next(f for f in registered_fns if f.__name__ == "stripe_list_customers")
+            result = list_fn()
+
+        assert "error" in result
+        assert "not configured" in result["error"]
+
+    def test_credentials_from_credential_manager(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        cred_manager = MagicMock()
+        cred_manager.get.return_value = "sk_test_fromcredstore"
+
+        register_tools(mcp, credentials=cred_manager)
+
+        fn = next(f for f in registered_fns if f.__name__ == "stripe_get_balance")
+
+        with patch("aden_tools.tools.stripe_tool.stripe_tool._StripeClient") as MockClient:
+            instance = MockClient.return_value
+            instance.get_balance.return_value = {"available": [], "pending": []}
+            fn()
+
+        MockClient.assert_called_once_with("sk_test_fromcredstore")
+        cred_manager.get.assert_called_with("stripe")
+
+    def test_credentials_from_env_vars(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        register_tools(mcp, credentials=None)
+
+        fn = next(f for f in registered_fns if f.__name__ == "stripe_get_balance")
+
+        with (
+            patch.dict("os.environ", {"STRIPE_API_KEY": "sk_test_fromenv"}),
+            patch("aden_tools.tools.stripe_tool.stripe_tool._StripeClient") as MockClient,
+        ):
+            instance = MockClient.return_value
+            instance.get_balance.return_value = {"available": [], "pending": []}
+            fn()
+
+        MockClient.assert_called_once_with("sk_test_fromenv")
+
+    def test_stripe_error_is_caught(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        cred_manager = MagicMock()
+        cred_manager.get.return_value = "sk_test_key"
+
+        register_tools(mcp, credentials=cred_manager)
+
+        fn = next(f for f in registered_fns if f.__name__ == "stripe_get_balance")
+
+        with patch("aden_tools.tools.stripe_tool.stripe_tool._StripeClient") as MockClient:
+            instance = MockClient.return_value
+            instance.get_balance.side_effect = stripe.AuthenticationError("Invalid API key")
+            result = fn()
+
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Individual MCP tool validation tests
+# ---------------------------------------------------------------------------
+
+
+def _setup_tools():
+    """Helper to register tools with a mock credential manager."""
+    mcp = MagicMock()
+    fns = []
+    mcp.tool.return_value = lambda fn: fns.append(fn) or fn
+    cred = MagicMock()
+    cred.get.return_value = "sk_test_key"
+    register_tools(mcp, credentials=cred)
+    fn_map = {f.__name__: f for f in fns}
+    return fn_map
+
+
+class TestCustomerToolValidation:
+    def setup_method(self):
+        self.fns = _setup_tools()
+
+    def test_get_customer_invalid_id(self):
+        result = self.fns["stripe_get_customer"](customer_id="not_a_customer")
+        assert "error" in result
+        assert "cus_" in result["error"]
+
+    def test_update_customer_invalid_id(self):
+        result = self.fns["stripe_update_customer"](customer_id="bad_id")
+        assert "error" in result
+        assert "cus_" in result["error"]
+
+    def test_get_customer_by_email_invalid(self):
+        result = self.fns["stripe_get_customer_by_email"](email="notanemail")
+        assert "error" in result
+
+    def test_list_customers_success(self):
+        with patch("aden_tools.tools.stripe_tool.stripe_tool._StripeClient") as MockClient:
+            MockClient.return_value.list_customers.return_value = {
+                "has_more": False,
+                "customers": [],
+            }
+            result = self.fns["stripe_list_customers"](limit=5)
+        assert "customers" in result
+
+    def test_create_customer_success(self):
+        with patch("aden_tools.tools.stripe_tool.stripe_tool._StripeClient") as MockClient:
+            MockClient.return_value.create_customer.return_value = {
+                "id": "cus_new",
+                "email": "new@example.com",
+            }
+            result = self.fns["stripe_create_customer"](email="new@example.com")
+        assert result["id"] == "cus_new"
+
+
+class TestSubscriptionToolValidation:
+    def setup_method(self):
+        self.fns = _setup_tools()
+
+    def test_get_subscription_invalid_id(self):
+        result = self.fns["stripe_get_subscription"](subscription_id="not_a_sub")
+        assert "error" in result
+        assert "sub_" in result["error"]
+
+    def test_get_subscription_status_invalid_customer(self):
+        result = self.fns["stripe_get_subscription_status"](customer_id="bad_id")
+        assert "error" in result
+        assert "cus_" in result["error"]
+
+    def test_create_subscription_invalid_customer(self):
+        result = self.fns["stripe_create_subscription"](customer_id="bad", price_id="price_test123")
+        assert "error" in result
+        assert "cus_" in result["error"]
+
+    def test_create_subscription_invalid_price(self):
+        result = self.fns["stripe_create_subscription"](
+            customer_id="cus_test123", price_id="bad_price"
+        )
+        assert "error" in result
+        assert "price_" in result["error"]
+
+    def test_create_subscription_invalid_quantity(self):
+        result = self.fns["stripe_create_subscription"](
+            customer_id="cus_test123", price_id="price_test123", quantity=0
+        )
+        assert "error" in result
+        assert "Quantity" in result["error"]
+
+    def test_update_subscription_invalid_id(self):
+        result = self.fns["stripe_update_subscription"](subscription_id="bad_id")
+        assert "error" in result
+        assert "sub_" in result["error"]
+
+    def test_cancel_subscription_invalid_id(self):
+        result = self.fns["stripe_cancel_subscription"](subscription_id="bad_id")
+        assert "error" in result
+        assert "sub_" in result["error"]
+
+
+class TestPaymentIntentToolValidation:
+    def setup_method(self):
+        self.fns = _setup_tools()
+
+    def test_create_payment_intent_zero_amount(self):
+        result = self.fns["stripe_create_payment_intent"](amount=0, currency="usd")
+        assert "error" in result
+        assert "positive" in result["error"]
+
+    def test_create_payment_intent_negative_amount(self):
+        result = self.fns["stripe_create_payment_intent"](amount=-100, currency="usd")
+        assert "error" in result
+        assert "positive" in result["error"]
+
+    def test_create_payment_intent_invalid_currency(self):
+        result = self.fns["stripe_create_payment_intent"](amount=2000, currency="INVALID")
+        assert "error" in result
+        assert "3-letter" in result["error"]
+
+    def test_get_payment_intent_invalid_id(self):
+        result = self.fns["stripe_get_payment_intent"](payment_intent_id="bad_id")
+        assert "error" in result
+        assert "pi_" in result["error"]
+
+    def test_confirm_payment_intent_invalid_id(self):
+        result = self.fns["stripe_confirm_payment_intent"](payment_intent_id="bad_id")
+        assert "error" in result
+        assert "pi_" in result["error"]
+
+    def test_cancel_payment_intent_invalid_id(self):
+        result = self.fns["stripe_cancel_payment_intent"](payment_intent_id="bad_id")
+        assert "error" in result
+        assert "pi_" in result["error"]
+
+
+class TestChargeToolValidation:
+    def setup_method(self):
+        self.fns = _setup_tools()
+
+    def test_get_charge_invalid_id(self):
+        result = self.fns["stripe_get_charge"](charge_id="bad_id")
+        assert "error" in result
+        assert "ch_" in result["error"]
+
+    def test_capture_charge_invalid_id(self):
+        result = self.fns["stripe_capture_charge"](charge_id="bad_id")
+        assert "error" in result
+        assert "ch_" in result["error"]
+
+    def test_capture_charge_negative_amount(self):
+        result = self.fns["stripe_capture_charge"](charge_id="ch_test123", amount=-100)
+        assert "error" in result
+        assert "positive" in result["error"]
+
+    def test_create_charge_zero_amount(self):
+        result = self.fns["stripe_create_charge"](amount=0, currency="usd", source="tok_visa")
+        assert "error" in result
+        assert "positive" in result["error"]
+
+    def test_create_charge_invalid_currency(self):
+        result = self.fns["stripe_create_charge"](
+            amount=2000, currency="INVALID", source="tok_visa"
+        )
+        assert "error" in result
+        assert "3-letter" in result["error"]
+
+    def test_create_charge_no_source_or_customer(self):
+        result = self.fns["stripe_create_charge"](amount=2000, currency="usd")
+        assert "error" in result
+        assert "source" in result["error"]
+
+
+class TestRefundToolValidation:
+    def setup_method(self):
+        self.fns = _setup_tools()
+
+    def test_create_refund_no_identifiers(self):
+        result = self.fns["stripe_create_refund"]()
+        assert "error" in result
+        assert "charge_id" in result["error"]
+
+    def test_create_refund_negative_amount(self):
+        result = self.fns["stripe_create_refund"](charge_id="ch_test123", amount=-100)
+        assert "error" in result
+        assert "positive" in result["error"]
+
+    def test_get_refund_invalid_id(self):
+        result = self.fns["stripe_get_refund"](refund_id="bad_id")
+        assert "error" in result
+        assert "re_" in result["error"]
+
+
+class TestInvoiceToolValidation:
+    def setup_method(self):
+        self.fns = _setup_tools()
+
+    def test_get_invoice_invalid_id(self):
+        result = self.fns["stripe_get_invoice"](invoice_id="bad_id")
+        assert "error" in result
+        assert "in_" in result["error"]
+
+    def test_create_invoice_invalid_customer(self):
+        result = self.fns["stripe_create_invoice"](customer_id="bad_id")
+        assert "error" in result
+        assert "cus_" in result["error"]
+
+    def test_finalize_invoice_invalid_id(self):
+        result = self.fns["stripe_finalize_invoice"](invoice_id="bad_id")
+        assert "error" in result
+        assert "in_" in result["error"]
+
+    def test_pay_invoice_invalid_id(self):
+        result = self.fns["stripe_pay_invoice"](invoice_id="bad_id")
+        assert "error" in result
+        assert "in_" in result["error"]
+
+    def test_void_invoice_invalid_id(self):
+        result = self.fns["stripe_void_invoice"](invoice_id="bad_id")
+        assert "error" in result
+        assert "in_" in result["error"]
+
+
+class TestInvoiceItemToolValidation:
+    def setup_method(self):
+        self.fns = _setup_tools()
+
+    def test_create_invoice_item_invalid_customer(self):
+        result = self.fns["stripe_create_invoice_item"](
+            customer_id="bad", amount=1000, currency="usd"
+        )
+        assert "error" in result
+        assert "cus_" in result["error"]
+
+    def test_create_invoice_item_zero_amount(self):
+        result = self.fns["stripe_create_invoice_item"](
+            customer_id="cus_test123", amount=0, currency="usd"
+        )
+        assert "error" in result
+        assert "positive" in result["error"]
+
+    def test_create_invoice_item_invalid_currency(self):
+        result = self.fns["stripe_create_invoice_item"](
+            customer_id="cus_test123", amount=1000, currency="INVALID"
+        )
+        assert "error" in result
+        assert "3-letter" in result["error"]
+
+    def test_delete_invoice_item_invalid_id(self):
+        result = self.fns["stripe_delete_invoice_item"](invoice_item_id="bad_id")
+        assert "error" in result
+        assert "ii_" in result["error"]
+
+
+class TestProductToolValidation:
+    def setup_method(self):
+        self.fns = _setup_tools()
+
+    def test_get_product_invalid_id(self):
+        result = self.fns["stripe_get_product"](product_id="bad_id")
+        assert "error" in result
+        assert "prod_" in result["error"]
+
+    def test_update_product_invalid_id(self):
+        result = self.fns["stripe_update_product"](product_id="bad_id")
+        assert "error" in result
+        assert "prod_" in result["error"]
+
+    def test_create_product_missing_name(self):
+        result = self.fns["stripe_create_product"](name="")
+        assert "error" in result
+        assert "name" in result["error"]
+
+
+class TestPriceToolValidation:
+    def setup_method(self):
+        self.fns = _setup_tools()
+
+    def test_get_price_invalid_id(self):
+        result = self.fns["stripe_get_price"](price_id="bad_id")
+        assert "error" in result
+        assert "price_" in result["error"]
+
+    def test_update_price_invalid_id(self):
+        result = self.fns["stripe_update_price"](price_id="bad_id")
+        assert "error" in result
+        assert "price_" in result["error"]
+
+    def test_create_price_zero_amount(self):
+        result = self.fns["stripe_create_price"](
+            unit_amount=0, currency="usd", product_id="prod_test123"
+        )
+        assert "error" in result
+        assert "positive" in result["error"]
+
+    def test_create_price_invalid_currency(self):
+        result = self.fns["stripe_create_price"](
+            unit_amount=999, currency="INVALID", product_id="prod_test123"
+        )
+        assert "error" in result
+        assert "3-letter" in result["error"]
+
+    def test_create_price_invalid_product(self):
+        result = self.fns["stripe_create_price"](
+            unit_amount=999, currency="usd", product_id="bad_id"
+        )
+        assert "error" in result
+        assert "prod_" in result["error"]
+
+
+class TestPaymentLinkToolValidation:
+    def setup_method(self):
+        self.fns = _setup_tools()
+
+    def test_create_payment_link_invalid_price(self):
+        result = self.fns["stripe_create_payment_link"](price_id="bad_id")
+        assert "error" in result
+        assert "price_" in result["error"]
+
+    def test_create_payment_link_zero_quantity(self):
+        result = self.fns["stripe_create_payment_link"](price_id="price_test123", quantity=0)
+        assert "error" in result
+        assert "Quantity" in result["error"]
+
+    def test_get_payment_link_invalid_id(self):
+        result = self.fns["stripe_get_payment_link"](payment_link_id="bad_id")
+        assert "error" in result
+        assert "plink_" in result["error"]
+
+
+class TestCouponToolValidation:
+    def setup_method(self):
+        self.fns = _setup_tools()
+
+    def test_create_coupon_no_discount(self):
+        result = self.fns["stripe_create_coupon"](duration="once")
+        assert "error" in result
+        assert "percent_off" in result["error"]
+
+    def test_create_coupon_both_discount_types(self):
+        result = self.fns["stripe_create_coupon"](percent_off=20.0, amount_off=500, duration="once")
+        assert "error" in result
+        assert "one of" in result["error"]
+
+    def test_create_coupon_amount_off_missing_currency(self):
+        result = self.fns["stripe_create_coupon"](amount_off=500, duration="once")
+        assert "error" in result
+        assert "currency" in result["error"]
+
+    def test_create_coupon_invalid_duration(self):
+        result = self.fns["stripe_create_coupon"](percent_off=20.0, duration="invalid")
+        assert "error" in result
+        assert "duration" in result["error"]
+
+    def test_create_coupon_repeating_missing_months(self):
+        result = self.fns["stripe_create_coupon"](percent_off=20.0, duration="repeating")
+        assert "error" in result
+        assert "duration_in_months" in result["error"]
+
+    def test_delete_coupon_missing_id(self):
+        result = self.fns["stripe_delete_coupon"](coupon_id="")
+        assert "error" in result
+        assert "coupon_id" in result["error"]
+
+
+class TestPaymentMethodToolValidation:
+    def setup_method(self):
+        self.fns = _setup_tools()
+
+    def test_list_payment_methods_invalid_customer(self):
+        result = self.fns["stripe_list_payment_methods"](customer_id="bad_id")
+        assert "error" in result
+        assert "cus_" in result["error"]
+
+    def test_get_payment_method_invalid_id(self):
+        result = self.fns["stripe_get_payment_method"](payment_method_id="bad_id")
+        assert "error" in result
+        assert "pm_" in result["error"]
+
+    def test_detach_payment_method_invalid_id(self):
+        result = self.fns["stripe_detach_payment_method"](payment_method_id="bad_id")
+        assert "error" in result
+        assert "pm_" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Stripe error propagation across tool categories
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tool_name,kwargs",
+    [
+        ("stripe_get_customer", {"customer_id": "cus_test123"}),
+        ("stripe_get_subscription", {"subscription_id": "sub_test123"}),
+        ("stripe_get_payment_intent", {"payment_intent_id": "pi_test123"}),
+        ("stripe_get_charge", {"charge_id": "ch_test123"}),
+        ("stripe_get_refund", {"refund_id": "re_test123"}),
+        ("stripe_get_invoice", {"invoice_id": "in_test123"}),
+        ("stripe_get_product", {"product_id": "prod_test123"}),
+        ("stripe_get_price", {"price_id": "price_test123"}),
+        ("stripe_get_payment_link", {"payment_link_id": "plink_test123"}),
+        ("stripe_get_payment_method", {"payment_method_id": "pm_test123"}),
+        ("stripe_get_balance", {}),
+    ],
+)
+def test_stripe_error_propagation(tool_name, kwargs):
+    fns = _setup_tools()
+    with patch("aden_tools.tools.stripe_tool.stripe_tool._StripeClient") as MockClient:
+        method_name = tool_name.replace("stripe_", "")
+        getattr(MockClient.return_value, method_name).side_effect = stripe.APIConnectionError(
+            "Network error"
+        )
+        result = fns[tool_name](**kwargs)
+    assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Credential spec tests
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialSpec:
+    def test_stripe_credential_spec_exists(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        assert "stripe" in CREDENTIAL_SPECS
+
+    def test_stripe_spec_env_var(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["stripe"]
+        assert spec.env_var == "STRIPE_API_KEY"
+
+    def test_stripe_spec_tool_count(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["stripe"]
+        assert len(spec.tools) == 52
+
+    def test_stripe_spec_tools_include_core_methods(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["stripe"]
+        expected = [
+            "stripe_create_customer",
+            "stripe_get_customer",
+            "stripe_get_customer_by_email",
+            "stripe_update_customer",
+            "stripe_list_customers",
+            "stripe_get_subscription",
+            "stripe_get_subscription_status",
+            "stripe_list_subscriptions",
+            "stripe_create_subscription",
+            "stripe_update_subscription",
+            "stripe_cancel_subscription",
+            "stripe_create_payment_intent",
+            "stripe_get_payment_intent",
+            "stripe_confirm_payment_intent",
+            "stripe_cancel_payment_intent",
+            "stripe_list_payment_intents",
+            "stripe_list_charges",
+            "stripe_get_charge",
+            "stripe_capture_charge",
+            "stripe_create_charge",
+            "stripe_create_refund",
+            "stripe_get_refund",
+            "stripe_list_refunds",
+            "stripe_list_invoices",
+            "stripe_get_invoice",
+            "stripe_create_invoice",
+            "stripe_finalize_invoice",
+            "stripe_pay_invoice",
+            "stripe_void_invoice",
+            "stripe_create_invoice_item",
+            "stripe_list_invoice_items",
+            "stripe_delete_invoice_item",
+            "stripe_create_product",
+            "stripe_get_product",
+            "stripe_list_products",
+            "stripe_update_product",
+            "stripe_create_price",
+            "stripe_get_price",
+            "stripe_list_prices",
+            "stripe_update_price",
+            "stripe_create_payment_link",
+            "stripe_get_payment_link",
+            "stripe_list_payment_links",
+            "stripe_create_coupon",
+            "stripe_list_coupons",
+            "stripe_delete_coupon",
+            "stripe_get_balance",
+            "stripe_list_balance_transactions",
+            "stripe_list_webhook_endpoints",
+            "stripe_list_payment_methods",
+            "stripe_get_payment_method",
+            "stripe_detach_payment_method",
+        ]
+        for tool in expected:
+            assert tool in spec.tools, f"Missing tool in credential spec: {tool}"
+
+    def test_stripe_spec_health_check(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["stripe"]
+        assert spec.health_check_endpoint == "https://api.stripe.com/v1/balance"
+        assert spec.health_check_method == "GET"
+
+    def test_stripe_spec_auth_support(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["stripe"]
+        assert spec.aden_supported is False
+        assert spec.direct_api_key_supported is True
+        assert "dashboard.stripe.com" in spec.api_key_instructions
+
+    def test_stripe_spec_credential_store_fields(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["stripe"]
+        assert spec.credential_id == "stripe"
+        assert spec.credential_key == "api_key"
+        assert spec.credential_group == "stripe"
+
+    def test_stripe_spec_required_not_startup(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["stripe"]
+        assert spec.required is True
+        assert spec.startup_required is False

--- a/tools/tests/tools/test_stripe_tool.py
+++ b/tools/tests/tools/test_stripe_tool.py
@@ -313,7 +313,7 @@ class TestStripeClientCustomers:
     def test_create_customer(self):
         sc = self._mock_stripe()
         sc.customers.create.return_value = _customer()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.create_customer(
                 email="test@example.com",
                 name="Test User",
@@ -336,7 +336,7 @@ class TestStripeClientCustomers:
     def test_create_customer_minimal(self):
         sc = self._mock_stripe()
         sc.customers.create.return_value = _customer(email=None, name=None)
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             self.client.create_customer()
         call_args = sc.customers.create.call_args[0][0]
         assert "email" not in call_args
@@ -345,7 +345,7 @@ class TestStripeClientCustomers:
     def test_get_customer(self):
         sc = self._mock_stripe()
         sc.customers.retrieve.return_value = _customer()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.get_customer("cus_test123")
         sc.customers.retrieve.assert_called_once_with("cus_test123")
         assert result["id"] == "cus_test123"
@@ -353,7 +353,7 @@ class TestStripeClientCustomers:
     def test_get_customer_by_email_found(self):
         sc = self._mock_stripe()
         sc.customers.list.return_value = _make_stripe_list([_customer()])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.get_customer_by_email("test@example.com")
         sc.customers.list.assert_called_once_with({"email": "test@example.com", "limit": 1})
         assert result["id"] == "cus_test123"
@@ -361,7 +361,7 @@ class TestStripeClientCustomers:
     def test_get_customer_by_email_not_found(self):
         sc = self._mock_stripe()
         sc.customers.list.return_value = _make_stripe_list([])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.get_customer_by_email("nobody@example.com")
         assert "error" in result
         assert "nobody@example.com" in result["error"]
@@ -369,7 +369,7 @@ class TestStripeClientCustomers:
     def test_update_customer(self):
         sc = self._mock_stripe()
         sc.customers.update.return_value = _customer(name="Updated Name")
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.update_customer("cus_test123", name="Updated Name")
         sc.customers.update.assert_called_once_with("cus_test123", {"name": "Updated Name"})
         assert result["name"] == "Updated Name"
@@ -377,7 +377,7 @@ class TestStripeClientCustomers:
     def test_list_customers(self):
         sc = self._mock_stripe()
         sc.customers.list.return_value = _make_stripe_list([_customer(), _customer(id="cus_456")])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.list_customers(limit=10)
         assert len(result["customers"]) == 2
         assert result["has_more"] is False
@@ -385,7 +385,7 @@ class TestStripeClientCustomers:
     def test_list_customers_limit_capped(self):
         sc = self._mock_stripe()
         sc.customers.list.return_value = _make_stripe_list([])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             self.client.list_customers(limit=500)
         call_params = sc.customers.list.call_args[0][0]
         assert call_params["limit"] == 100
@@ -401,7 +401,7 @@ class TestStripeClientSubscriptions:
     def test_get_subscription(self):
         sc = self._mock_stripe()
         sc.subscriptions.retrieve.return_value = _subscription()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.get_subscription("sub_test123")
         sc.subscriptions.retrieve.assert_called_once_with("sub_test123")
         assert result["id"] == "sub_test123"
@@ -410,7 +410,7 @@ class TestStripeClientSubscriptions:
     def test_get_subscription_status_active(self):
         sc = self._mock_stripe()
         sc.subscriptions.list.return_value = _make_stripe_list([_subscription()])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.get_subscription_status("cus_test123")
         assert result["status"] == "active"
         assert result["customer_id"] == "cus_test123"
@@ -419,7 +419,7 @@ class TestStripeClientSubscriptions:
     def test_get_subscription_status_no_subscription(self):
         sc = self._mock_stripe()
         sc.subscriptions.list.return_value = _make_stripe_list([])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.get_subscription_status("cus_test123")
         assert result["status"] == "no_subscription"
         assert result["subscriptions"] == []
@@ -427,7 +427,7 @@ class TestStripeClientSubscriptions:
     def test_list_subscriptions(self):
         sc = self._mock_stripe()
         sc.subscriptions.list.return_value = _make_stripe_list([_subscription()])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.list_subscriptions(customer_id="cus_test123", status="active")
         call_params = sc.subscriptions.list.call_args[0][0]
         assert call_params["customer"] == "cus_test123"
@@ -437,7 +437,7 @@ class TestStripeClientSubscriptions:
     def test_create_subscription(self):
         sc = self._mock_stripe()
         sc.subscriptions.create.return_value = _subscription()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.create_subscription(
                 "cus_test123",
                 "price_test123",
@@ -453,7 +453,7 @@ class TestStripeClientSubscriptions:
     def test_update_subscription_metadata(self):
         sc = self._mock_stripe()
         sc.subscriptions.update.return_value = _subscription()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             self.client.update_subscription(
                 "sub_test123", metadata={"note": "updated"}, cancel_at_period_end=True
             )
@@ -461,10 +461,30 @@ class TestStripeClientSubscriptions:
         assert call_params["cancel_at_period_end"] is True
         assert call_params["metadata"] == {"note": "updated"}
 
+    def test_update_subscription_quantity_only(self):
+        sc = self._mock_stripe()
+        sc.subscriptions.retrieve.return_value = _subscription()
+        sc.subscriptions.update.return_value = _subscription()
+        with patch.object(self.client, "_client", sc):
+            self.client.update_subscription("sub_test123", quantity=3)
+        call_params = sc.subscriptions.update.call_args[0][1]
+        assert call_params["items"][0]["quantity"] == 3
+        assert "price" not in call_params["items"][0]
+
+    def test_update_subscription_no_items_returns_error(self):
+        sc = self._mock_stripe()
+        empty_sub = _subscription()
+        empty_sub.items.data = []
+        sc.subscriptions.retrieve.return_value = empty_sub
+        with patch.object(self.client, "_client", sc):
+            result = self.client.update_subscription("sub_test123", price_id="price_new")
+        assert "error" in result
+        assert "no items" in result["error"]
+
     def test_cancel_subscription_immediately(self):
         sc = self._mock_stripe()
         sc.subscriptions.cancel.return_value = _subscription(status="canceled")
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.cancel_subscription("sub_test123", at_period_end=False)
         sc.subscriptions.cancel.assert_called_once_with("sub_test123")
         assert result["status"] == "canceled"
@@ -472,7 +492,7 @@ class TestStripeClientSubscriptions:
     def test_cancel_subscription_at_period_end(self):
         sc = self._mock_stripe()
         sc.subscriptions.update.return_value = _subscription(cancel_at_period_end=True)
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.cancel_subscription("sub_test123", at_period_end=True)
         sc.subscriptions.update.assert_called_once_with(
             "sub_test123", {"cancel_at_period_end": True}
@@ -490,7 +510,7 @@ class TestStripeClientPaymentIntents:
     def test_create_payment_intent(self):
         sc = self._mock_stripe()
         sc.payment_intents.create.return_value = _payment_intent()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.create_payment_intent(
                 amount=2000,
                 currency="usd",
@@ -503,12 +523,12 @@ class TestStripeClientPaymentIntents:
         assert call_params["currency"] == "usd"
         assert call_params["customer"] == "cus_test123"
         assert result["id"] == "pi_test123"
-        assert result["client_secret"] == "pi_test123_secret_abc"
+        assert result["status"] == "requires_payment_method"
 
     def test_get_payment_intent(self):
         sc = self._mock_stripe()
         sc.payment_intents.retrieve.return_value = _payment_intent()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.get_payment_intent("pi_test123")
         sc.payment_intents.retrieve.assert_called_once_with("pi_test123")
         assert result["id"] == "pi_test123"
@@ -516,7 +536,7 @@ class TestStripeClientPaymentIntents:
     def test_confirm_payment_intent(self):
         sc = self._mock_stripe()
         sc.payment_intents.confirm.return_value = _payment_intent(status="succeeded")
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.confirm_payment_intent("pi_test123", payment_method="pm_card_visa")
         sc.payment_intents.confirm.assert_called_once_with(
             "pi_test123", {"payment_method": "pm_card_visa"}
@@ -526,7 +546,7 @@ class TestStripeClientPaymentIntents:
     def test_cancel_payment_intent(self):
         sc = self._mock_stripe()
         sc.payment_intents.cancel.return_value = _payment_intent(status="canceled")
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.cancel_payment_intent("pi_test123")
         sc.payment_intents.cancel.assert_called_once_with("pi_test123")
         assert result["status"] == "canceled"
@@ -534,7 +554,7 @@ class TestStripeClientPaymentIntents:
     def test_list_payment_intents(self):
         sc = self._mock_stripe()
         sc.payment_intents.list.return_value = _make_stripe_list([_payment_intent()])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.list_payment_intents(customer_id="cus_test123", limit=5)
         call_params = sc.payment_intents.list.call_args[0][0]
         assert call_params["customer"] == "cus_test123"
@@ -552,7 +572,7 @@ class TestStripeClientCharges:
     def test_list_charges(self):
         sc = self._mock_stripe()
         sc.charges.list.return_value = _make_stripe_list([_charge(), _charge(id="ch_456")])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.list_charges(customer_id="cus_test123")
         call_params = sc.charges.list.call_args[0][0]
         assert call_params["customer"] == "cus_test123"
@@ -561,7 +581,7 @@ class TestStripeClientCharges:
     def test_get_charge(self):
         sc = self._mock_stripe()
         sc.charges.retrieve.return_value = _charge()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.get_charge("ch_test123")
         sc.charges.retrieve.assert_called_once_with("ch_test123")
         assert result["id"] == "ch_test123"
@@ -570,7 +590,7 @@ class TestStripeClientCharges:
     def test_capture_charge(self):
         sc = self._mock_stripe()
         sc.charges.capture.return_value = _charge(amount_captured=2000)
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.capture_charge("ch_test123", amount=2000)
         sc.charges.capture.assert_called_once_with("ch_test123", {"amount": 2000})
         assert result["amount_captured"] == 2000
@@ -578,25 +598,10 @@ class TestStripeClientCharges:
     def test_capture_charge_full(self):
         sc = self._mock_stripe()
         sc.charges.capture.return_value = _charge()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             self.client.capture_charge("ch_test123")
         call_params = sc.charges.capture.call_args[0][1]
         assert call_params == {}  # No amount means full capture
-
-    def test_create_charge(self):
-        sc = self._mock_stripe()
-        sc.charges.create.return_value = _charge()
-        with patch.object(self.client, "_stripe", return_value=sc):
-            result = self.client.create_charge(
-                amount=2000,
-                currency="usd",
-                source="tok_visa",
-                description="Test",
-            )
-        call_params = sc.charges.create.call_args[0][0]
-        assert call_params["amount"] == 2000
-        assert call_params["source"] == "tok_visa"
-        assert result["id"] == "ch_test123"
 
 
 class TestStripeClientRefunds:
@@ -609,7 +614,7 @@ class TestStripeClientRefunds:
     def test_create_refund_by_charge(self):
         sc = self._mock_stripe()
         sc.refunds.create.return_value = _refund()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.create_refund(charge_id="ch_test123", amount=1000)
         call_params = sc.refunds.create.call_args[0][0]
         assert call_params["charge"] == "ch_test123"
@@ -619,7 +624,7 @@ class TestStripeClientRefunds:
     def test_create_refund_by_payment_intent(self):
         sc = self._mock_stripe()
         sc.refunds.create.return_value = _refund()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             self.client.create_refund(
                 payment_intent_id="pi_test123",
                 reason="customer_request",
@@ -631,7 +636,7 @@ class TestStripeClientRefunds:
     def test_get_refund(self):
         sc = self._mock_stripe()
         sc.refunds.retrieve.return_value = _refund()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.get_refund("re_test123")
         sc.refunds.retrieve.assert_called_once_with("re_test123")
         assert result["id"] == "re_test123"
@@ -639,7 +644,7 @@ class TestStripeClientRefunds:
     def test_list_refunds(self):
         sc = self._mock_stripe()
         sc.refunds.list.return_value = _make_stripe_list([_refund()])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.list_refunds(charge_id="ch_test123", limit=10)
         call_params = sc.refunds.list.call_args[0][0]
         assert call_params["charge"] == "ch_test123"
@@ -656,7 +661,7 @@ class TestStripeClientInvoices:
     def test_list_invoices(self):
         sc = self._mock_stripe()
         sc.invoices.list.return_value = _make_stripe_list([_invoice(), _invoice(id="in_456")])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.list_invoices(customer_id="cus_test123", status="open")
         call_params = sc.invoices.list.call_args[0][0]
         assert call_params["customer"] == "cus_test123"
@@ -666,7 +671,7 @@ class TestStripeClientInvoices:
     def test_get_invoice(self):
         sc = self._mock_stripe()
         sc.invoices.retrieve.return_value = _invoice()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.get_invoice("in_test123")
         sc.invoices.retrieve.assert_called_once_with("in_test123")
         assert result["id"] == "in_test123"
@@ -675,7 +680,7 @@ class TestStripeClientInvoices:
     def test_create_invoice(self):
         sc = self._mock_stripe()
         sc.invoices.create.return_value = _invoice(status="draft")
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             self.client.create_invoice(
                 "cus_test123",
                 description="Test invoice",
@@ -690,7 +695,7 @@ class TestStripeClientInvoices:
     def test_finalize_invoice(self):
         sc = self._mock_stripe()
         sc.invoices.finalize_invoice.return_value = _invoice(status="open")
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.finalize_invoice("in_test123")
         sc.invoices.finalize_invoice.assert_called_once_with("in_test123")
         assert result["status"] == "open"
@@ -698,7 +703,7 @@ class TestStripeClientInvoices:
     def test_pay_invoice(self):
         sc = self._mock_stripe()
         sc.invoices.pay.return_value = _invoice(status="paid", amount_paid=2000)
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.pay_invoice("in_test123")
         sc.invoices.pay.assert_called_once_with("in_test123")
         assert result["status"] == "paid"
@@ -706,7 +711,7 @@ class TestStripeClientInvoices:
     def test_void_invoice(self):
         sc = self._mock_stripe()
         sc.invoices.void_invoice.return_value = _invoice(status="void")
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.void_invoice("in_test123")
         sc.invoices.void_invoice.assert_called_once_with("in_test123")
         assert result["status"] == "void"
@@ -722,7 +727,7 @@ class TestStripeClientInvoiceItems:
     def test_create_invoice_item(self):
         sc = self._mock_stripe()
         sc.invoice_items.create.return_value = _invoice_item()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.create_invoice_item(
                 customer_id="cus_test123",
                 amount=1500,
@@ -739,7 +744,7 @@ class TestStripeClientInvoiceItems:
     def test_list_invoice_items(self):
         sc = self._mock_stripe()
         sc.invoice_items.list.return_value = _make_stripe_list([_invoice_item()])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.list_invoice_items(
                 customer_id="cus_test123", invoice_id="in_test123"
             )
@@ -754,7 +759,7 @@ class TestStripeClientInvoiceItems:
         deleted.id = "ii_test123"
         deleted.deleted = True
         sc.invoice_items.delete.return_value = deleted
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.delete_invoice_item("ii_test123")
         sc.invoice_items.delete.assert_called_once_with("ii_test123")
         assert result["deleted"] is True
@@ -771,7 +776,7 @@ class TestStripeClientProducts:
     def test_create_product(self):
         sc = self._mock_stripe()
         sc.products.create.return_value = _product()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.create_product(
                 name="Premium Plan",
                 description="Full access",
@@ -786,7 +791,7 @@ class TestStripeClientProducts:
     def test_get_product(self):
         sc = self._mock_stripe()
         sc.products.retrieve.return_value = _product()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.get_product("prod_test123")
         sc.products.retrieve.assert_called_once_with("prod_test123")
         assert result["name"] == "Premium Plan"
@@ -794,7 +799,7 @@ class TestStripeClientProducts:
     def test_list_products(self):
         sc = self._mock_stripe()
         sc.products.list.return_value = _make_stripe_list([_product(), _product(id="prod_456")])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.list_products(active=True)
         call_params = sc.products.list.call_args[0][0]
         assert call_params["active"] is True
@@ -803,7 +808,7 @@ class TestStripeClientProducts:
     def test_update_product(self):
         sc = self._mock_stripe()
         sc.products.update.return_value = _product(name="Updated Plan", active=False)
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             self.client.update_product("prod_test123", name="Updated Plan", active=False)
         call_params = sc.products.update.call_args[0][1]
         assert call_params["name"] == "Updated Plan"
@@ -820,7 +825,7 @@ class TestStripeClientPrices:
     def test_create_price_recurring(self):
         sc = self._mock_stripe()
         sc.prices.create.return_value = _price()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.create_price(
                 unit_amount=999,
                 currency="usd",
@@ -834,7 +839,7 @@ class TestStripeClientPrices:
     def test_create_price_one_time(self):
         sc = self._mock_stripe()
         sc.prices.create.return_value = _price(recurring=None, type="one_time")
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             self.client.create_price(
                 unit_amount=4999,
                 currency="usd",
@@ -846,7 +851,7 @@ class TestStripeClientPrices:
     def test_get_price(self):
         sc = self._mock_stripe()
         sc.prices.retrieve.return_value = _price()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.get_price("price_test123")
         sc.prices.retrieve.assert_called_once_with("price_test123")
         assert result["unit_amount"] == 999
@@ -855,7 +860,7 @@ class TestStripeClientPrices:
     def test_list_prices(self):
         sc = self._mock_stripe()
         sc.prices.list.return_value = _make_stripe_list([_price()])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.list_prices(product_id="prod_test123", active=True)
         call_params = sc.prices.list.call_args[0][0]
         assert call_params["product"] == "prod_test123"
@@ -865,7 +870,7 @@ class TestStripeClientPrices:
     def test_update_price(self):
         sc = self._mock_stripe()
         sc.prices.update.return_value = _price(active=False, nickname="Legacy")
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             self.client.update_price("price_test123", active=False, nickname="Legacy")
         call_params = sc.prices.update.call_args[0][1]
         assert call_params["active"] is False
@@ -882,7 +887,7 @@ class TestStripeClientPaymentLinks:
     def test_create_payment_link(self):
         sc = self._mock_stripe()
         sc.payment_links.create.return_value = _payment_link()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.create_payment_link("price_test123", quantity=2)
         call_params = sc.payment_links.create.call_args[0][0]
         assert call_params["line_items"][0]["price"] == "price_test123"
@@ -893,7 +898,7 @@ class TestStripeClientPaymentLinks:
     def test_get_payment_link(self):
         sc = self._mock_stripe()
         sc.payment_links.retrieve.return_value = _payment_link()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.get_payment_link("plink_test123")
         sc.payment_links.retrieve.assert_called_once_with("plink_test123")
         assert result["active"] is True
@@ -901,7 +906,7 @@ class TestStripeClientPaymentLinks:
     def test_list_payment_links(self):
         sc = self._mock_stripe()
         sc.payment_links.list.return_value = _make_stripe_list([_payment_link()])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.list_payment_links(active=True)
         call_params = sc.payment_links.list.call_args[0][0]
         assert call_params["active"] is True
@@ -918,7 +923,7 @@ class TestStripeClientCoupons:
     def test_create_coupon_percent_off(self):
         sc = self._mock_stripe()
         sc.coupons.create.return_value = _coupon()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.create_coupon(
                 percent_off=20.0,
                 duration="once",
@@ -932,7 +937,7 @@ class TestStripeClientCoupons:
     def test_create_coupon_amount_off(self):
         sc = self._mock_stripe()
         sc.coupons.create.return_value = _coupon(percent_off=None, amount_off=500, currency="usd")
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             self.client.create_coupon(
                 amount_off=500,
                 currency="usd",
@@ -945,7 +950,7 @@ class TestStripeClientCoupons:
     def test_create_coupon_repeating(self):
         sc = self._mock_stripe()
         sc.coupons.create.return_value = _coupon(duration="repeating", duration_in_months=3)
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             self.client.create_coupon(
                 percent_off=10.0,
                 duration="repeating",
@@ -957,7 +962,7 @@ class TestStripeClientCoupons:
     def test_list_coupons(self):
         sc = self._mock_stripe()
         sc.coupons.list.return_value = _make_stripe_list([_coupon()])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.list_coupons(limit=5)
         assert len(result["coupons"]) == 1
 
@@ -967,7 +972,7 @@ class TestStripeClientCoupons:
         deleted.id = "WELCOME20"
         deleted.deleted = True
         sc.coupons.delete.return_value = deleted
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.delete_coupon("WELCOME20")
         sc.coupons.delete.assert_called_once_with("WELCOME20")
         assert result["deleted"] is True
@@ -989,7 +994,7 @@ class TestStripeClientBalance:
         pend.amount = 5000
         pend.currency = "usd"
         sc.balance.retrieve.return_value = MagicMock(available=[avail], pending=[pend])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.get_balance()
         assert result["available"][0]["amount"] == 10000
         assert result["pending"][0]["currency"] == "usd"
@@ -1007,7 +1012,7 @@ class TestStripeClientBalance:
         txn.created = 1700000000
         sc = self._mock_stripe()
         sc.balance_transactions.list.return_value = _make_stripe_list([txn])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.list_balance_transactions(type_filter="charge")
         call_params = sc.balance_transactions.list.call_args[0][0]
         assert call_params["type"] == "charge"
@@ -1031,7 +1036,7 @@ class TestStripeClientWebhookEndpoints:
         we.created = 1700000000
         sc = self._mock_stripe()
         sc.webhook_endpoints.list.return_value = _make_stripe_list([we])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.list_webhook_endpoints(limit=10)
         assert len(result["webhook_endpoints"]) == 1
         assert result["webhook_endpoints"][0]["url"] == "https://example.com/webhook"
@@ -1048,7 +1053,7 @@ class TestStripeClientPaymentMethods:
     def test_list_payment_methods(self):
         sc = self._mock_stripe()
         sc.payment_methods.list.return_value = _make_stripe_list([_payment_method()])
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.list_payment_methods("cus_test123", type_filter="card")
         call_params = sc.payment_methods.list.call_args[0][0]
         assert call_params["customer"] == "cus_test123"
@@ -1059,7 +1064,7 @@ class TestStripeClientPaymentMethods:
     def test_get_payment_method(self):
         sc = self._mock_stripe()
         sc.payment_methods.retrieve.return_value = _payment_method()
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.get_payment_method("pm_test123")
         sc.payment_methods.retrieve.assert_called_once_with("pm_test123")
         assert result["type"] == "card"
@@ -1068,7 +1073,7 @@ class TestStripeClientPaymentMethods:
         sc = self._mock_stripe()
         detached = _payment_method(customer=None)
         sc.payment_methods.detach.return_value = detached
-        with patch.object(self.client, "_stripe", return_value=sc):
+        with patch.object(self.client, "_client", sc):
             result = self.client.detach_payment_method("pm_test123")
         sc.payment_methods.detach.assert_called_once_with("pm_test123")
         assert result["customer"] is None
@@ -1084,7 +1089,7 @@ class TestToolRegistration:
         mcp = MagicMock()
         mcp.tool.return_value = lambda fn: fn
         register_tools(mcp)
-        assert mcp.tool.call_count == 52
+        assert mcp.tool.call_count == 51
 
     def test_no_credentials_returns_error(self):
         mcp = MagicMock()
@@ -1310,23 +1315,6 @@ class TestChargeToolValidation:
         assert "error" in result
         assert "positive" in result["error"]
 
-    def test_create_charge_zero_amount(self):
-        result = self.fns["stripe_create_charge"](amount=0, currency="usd", source="tok_visa")
-        assert "error" in result
-        assert "positive" in result["error"]
-
-    def test_create_charge_invalid_currency(self):
-        result = self.fns["stripe_create_charge"](
-            amount=2000, currency="INVALID", source="tok_visa"
-        )
-        assert "error" in result
-        assert "3-letter" in result["error"]
-
-    def test_create_charge_no_source_or_customer(self):
-        result = self.fns["stripe_create_charge"](amount=2000, currency="usd")
-        assert "error" in result
-        assert "source" in result["error"]
-
 
 class TestRefundToolValidation:
     def setup_method(self):
@@ -1394,7 +1382,22 @@ class TestInvoiceItemToolValidation:
             customer_id="cus_test123", amount=0, currency="usd"
         )
         assert "error" in result
-        assert "positive" in result["error"]
+        assert "non-zero" in result["error"]
+
+    def test_create_invoice_item_negative_amount_allowed(self):
+        with patch("aden_tools.tools.stripe_tool.stripe_tool._StripeClient") as MockClient:
+            MockClient.return_value.create_invoice_item.return_value = {
+                "id": "ii_credit",
+                "amount": -500,
+                "currency": "usd",
+            }
+            result = self.fns["stripe_create_invoice_item"](
+                customer_id="cus_test123",
+                amount=-500,
+                currency="usd",
+                description="Discount credit",
+            )
+        assert result["id"] == "ii_credit"
 
     def test_create_invoice_item_invalid_currency(self):
         result = self.fns["stripe_create_invoice_item"](
@@ -1593,7 +1596,7 @@ class TestCredentialSpec:
         from aden_tools.credentials import CREDENTIAL_SPECS
 
         spec = CREDENTIAL_SPECS["stripe"]
-        assert len(spec.tools) == 52
+        assert len(spec.tools) == 51
 
     def test_stripe_spec_tools_include_core_methods(self):
         from aden_tools.credentials import CREDENTIAL_SPECS
@@ -1619,7 +1622,6 @@ class TestCredentialSpec:
             "stripe_list_charges",
             "stripe_get_charge",
             "stripe_capture_charge",
-            "stripe_create_charge",
             "stripe_create_refund",
             "stripe_get_refund",
             "stripe_list_refunds",
@@ -1677,7 +1679,7 @@ class TestCredentialSpec:
         spec = CREDENTIAL_SPECS["stripe"]
         assert spec.credential_id == "stripe"
         assert spec.credential_key == "api_key"
-        assert spec.credential_group == "stripe"
+        assert spec.credential_group == ""
 
     def test_stripe_spec_required_not_startup(self):
         from aden_tools.credentials import CREDENTIAL_SPECS


### PR DESCRIPTION
feat(tools): add Stripe payment processing integration

Closes #2860 

Motivation

Hive agents currently have no way to interact with billing or subscription
data. This was raised as a gap for three key agent workflows: support agents
checking subscription status before escalating tickets, sales agents
generating checkout links during conversations, and ops agents listing unpaid
invoices to draft reminder emails. 


- get_customer_by_email(email) — retrieve customer ID and status
- get_subscription_status(customer_id) — check active or past_due
- create_payment_link(amount, currency, name) — generate a checkout URL

What was implemented

The MVP methods are included. The scope was expanded to 52 tools so agents
have full coverage of the Stripe API without needing repeated incremental
additions.

Customers (5 tools)
- stripe_create_customer
- stripe_get_customer
- stripe_get_customer_by_email
- stripe_update_customer
- stripe_list_customers

Subscriptions (6 tools)
- stripe_create_subscription
- stripe_get_subscription
- stripe_get_subscription_status
- stripe_list_subscriptions
- stripe_update_subscription
- stripe_cancel_subscription

Payment Intents (5 tools)
- stripe_create_payment_intent
- stripe_get_payment_intent
- stripe_confirm_payment_intent
- stripe_cancel_payment_intent
- stripe_list_payment_intents

Charges (4 tools)
- stripe_create_charge
- stripe_get_charge
- stripe_capture_charge
- stripe_list_charges

Refunds (3 tools)
- stripe_create_refund
- stripe_get_refund
- stripe_list_refunds

Invoices (5 tools)
- stripe_create_invoice
- stripe_get_invoice
- stripe_finalize_invoice
- stripe_pay_invoice
- stripe_void_invoice
- stripe_list_invoices

Invoice Items (3 tools)
- stripe_create_invoice_item
- stripe_list_invoice_items
- stripe_delete_invoice_item

Products (4 tools)
- stripe_create_product
- stripe_get_product
- stripe_update_product
- stripe_list_products

Prices (4 tools)
- stripe_create_price
- stripe_get_price
- stripe_update_price
- stripe_list_prices

Payment Links (3 tools)
- stripe_create_payment_link
- stripe_get_payment_link
- stripe_list_payment_links

Coupons (3 tools)
- stripe_create_coupon
- stripe_list_coupons
- stripe_delete_coupon

Balance (2 tools)
- stripe_get_balance
- stripe_list_balance_transactions

Webhook Endpoints (1 tool)
- stripe_list_webhook_endpoints

Payment Methods (3 tools)
- stripe_list_payment_methods
- stripe_get_payment_method
- stripe_detach_payment_method

Files added
- src/aden_tools/tools/stripe_tool/__init__.py
- src/aden_tools/tools/stripe_tool/stripe_tool.py
- src/aden_tools/tools/stripe_tool/README.md
- src/aden_tools/credentials/stripe.py
- tests/tools/test_stripe_tool.py

Files modified
- src/aden_tools/tools/__init__.py — imported register_stripe and called it
  inside register_all_tools with credentials passthrough
- src/aden_tools/credentials/__init__.py — imported STRIPE_CREDENTIALS,
  merged into CREDENTIAL_SPECS, added to __all__


Tests
- 142 test cases across _StripeClient unit tests, MCP tool validation,
  StripeError propagation, credential fallback behaviour, and credential
  spec assertions.
- One fix applied during review: test_no_credentials_returns_error had the
  tool call outside the patch.dict context block, causing the real
  STRIPE_API_KEY to be picked up from the environment. Moved inside the
  block to correctly test the no-credentials path.

Dependency added
- stripe (official Stripe Python SDK)
<img width="800" height="667" alt="image" src="https://github.com/user-attachments/assets/9d08723c-ab60-47fc-939b-b424e2cf6e37" />
<img width="1000" height="889" alt="image" src="https://github.com/user-attachments/assets/3797dbf9-5f44-42bf-853a-ab21095240b9" />

