### PR TITLE
feat: expand error categories, improve hive validate UX, and fix MCP configs

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -5,3 +5,8 @@
 command = "uv"
 args = ["run", "--directory", "core", "-m", "framework.mcp.agent_builder_server"]
 cwd = "."
+
+[mcp_servers.tools]
+command = "uv"
+args = ["run", "--directory", "core", "-m", "framework.tools.mcp_server"]
+cwd = "."

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,20 @@
   "mcpServers": {
     "agent-builder": {
       "command": "uv",
-      "args": ["run", "-m", "framework.mcp.agent_builder_server"],
+      "args": [
+        "run",
+        "-m",
+        "framework.mcp.agent_builder_server"
+      ],
+      "cwd": "core"
+    },
+    "tools": {
+      "command": "uv",
+      "args": [
+        "run",
+        "-m",
+        "framework.tools.mcp_server"
+      ],
       "cwd": "core"
     }
   }

--- a/core/framework/testing/test_result.py
+++ b/core/framework/testing/test_result.py
@@ -20,11 +20,21 @@ class ErrorCategory(StrEnum):
     - LOGIC_ERROR: Goal definition is wrong → update success_criteria/constraints
     - IMPLEMENTATION_ERROR: Code bug → fix nodes/edges in Agent stage
     - EDGE_CASE: New scenario discovered → add new test only
+    - TIMEOUT_ERROR: Agent exceeded time budget → optimize node logic or increase timeout
+    - AUTH_ERROR: Missing or invalid API credentials → run `hive credentials set`
+    - RATE_LIMIT_ERROR: LLM/tool API quota hit → add retry logic or reduce test parallelism
+    - TOOL_ERROR: External tool call failed → check tool config, network, or API key
+    - IMPORT_ERROR: Missing Python package → add to pyproject.toml / run `uv add <pkg>`
     """
 
     LOGIC_ERROR = "logic_error"
     IMPLEMENTATION_ERROR = "implementation_error"
     EDGE_CASE = "edge_case"
+    TIMEOUT_ERROR = "timeout_error"
+    AUTH_ERROR = "auth_error"
+    RATE_LIMIT_ERROR = "rate_limit_error"
+    TOOL_ERROR = "tool_error"
+    IMPORT_ERROR = "import_error"
 
 
 class TestResult(BaseModel):

--- a/core/tests/test_testing_framework.py
+++ b/core/tests/test_testing_framework.py
@@ -445,9 +445,59 @@ class TestErrorCategorizer:
             test_id="t1",
             passed=False,
             duration_ms=100,
-            error_message="timeout: request took longer than expected",
+            error_message="unexpected format: received xml instead of json",
         )
         assert categorizer.categorize(result) == ErrorCategory.EDGE_CASE
+
+    def test_categorize_timeout_error(self, categorizer):
+        """Test categorization of timeout errors."""
+        result = TestResult(
+            test_id="t1",
+            passed=False,
+            duration_ms=100,
+            error_message="timeout: request took longer than expected",
+        )
+        assert categorizer.categorize(result) == ErrorCategory.TIMEOUT_ERROR
+
+    def test_categorize_auth_error(self, categorizer):
+        """Test categorization of auth errors."""
+        result = TestResult(
+            test_id="t1",
+            passed=False,
+            duration_ms=100,
+            error_message="401 Unauthorized: Invalid API key",
+        )
+        assert categorizer.categorize(result) == ErrorCategory.AUTH_ERROR
+
+    def test_categorize_rate_limit_error(self, categorizer):
+        """Test categorization of rate limit errors."""
+        result = TestResult(
+            test_id="t1",
+            passed=False,
+            duration_ms=100,
+            error_message="429 Too Many Requests: quota exceeded",
+        )
+        assert categorizer.categorize(result) == ErrorCategory.RATE_LIMIT_ERROR
+
+    def test_categorize_tool_error(self, categorizer):
+        """Test categorization of tool errors."""
+        result = TestResult(
+            test_id="t1",
+            passed=False,
+            duration_ms=100,
+            error_message="tool execution failed: ConnectionError",
+        )
+        assert categorizer.categorize(result) == ErrorCategory.TOOL_ERROR
+
+    def test_categorize_import_error(self, categorizer):
+        """Test categorization of import errors."""
+        result = TestResult(
+            test_id="t1",
+            passed=False,
+            duration_ms=100,
+            error_message="ModuleNotFoundError: No module named 'numpy'",
+        )
+        assert categorizer.categorize(result) == ErrorCategory.IMPORT_ERROR
 
     def test_categorize_from_stack_trace(self, categorizer):
         """Test categorization from stack trace."""


### PR DESCRIPTION
## Description

This PR significantly enhances the debugging experience by introducing 5 new error categories (`TIMEOUT_ERROR`, `AUTH_ERROR`, `RATE_LIMIT_ERROR`, `TOOL_ERROR`, `IMPORT_ERROR`) to the testing framework. This allows the system to prioritize actionable infrastructure fixes (like missing keys or packages) over generic "implementation error" messages.

Additionally, the `hive validate` command has been completely rewritten to provide a structured, human-readable report with distinct sections for Graph, Goal, Tools, and Credentials, making it much easier to verify agent validity at a glance. It now also supports a `--json` flag for CI pipelines.

Finally, inconsistencies in MCP server configurations were resolved to ensure reliable tool discovery across VS Code and Cursor.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #4336

## Changes Made

- **Core Framework**:
  - [core/framework/testing/test_result.py](cci:7://file:///c:/Users/ansha/Downloads/hive-main/core/framework/testing/test_result.py:0:0-0:0): Added 5 new [ErrorCategory](cci:2://file:///c:/Users/ansha/Downloads/hive-main/core/framework/testing/test_result.py:14:0-36:33) enum members.
  - [core/framework/testing/categorizer.py](cci:7://file:///c:/Users/ansha/Downloads/hive-main/core/framework/testing/categorizer.py:0:0-0:0): Updated [ErrorCategorizer](cci:2://file:///c:/Users/ansha/Downloads/hive-main/core/framework/testing/categorizer.py:20:0-423:9) to check infrastructure errors first (using new regex patterns) and provided detailed remediation steps for all 8 categories.
  - [core/framework/testing/debug_tool.py](cci:7://file:///c:/Users/ansha/Downloads/hive-main/core/framework/testing/debug_tool.py:0:0-0:0): Updated failure summary logic to bucket and report on the new categories.
- **CLI**:
  - [core/framework/runner/cli.py](cci:7://file:///c:/Users/ansha/Downloads/hive-main/core/framework/runner/cli.py:0:0-0:0): Refactored [cmd_validate](cci:1://file:///c:/Users/ansha/Downloads/hive-main/core/framework/runner/cli.py:827:0-933:39) to verify graph structure, goals, tools, and credentials explicitly with visual indicators (✓/✗/⚠) and fix suggestions. Added `--json` output support.
- **Config**:
  - [.mcp.json](cci:7://file:///c:/Users/ansha/Downloads/hive-main/.mcp.json:0:0-0:0) & [.codex/config.toml](cci:7://file:///c:/Users/ansha/Downloads/hive-main/.codex/config.toml:0:0-0:0): Added missing [tools](cci:1://file:///c:/Users/ansha/Downloads/hive-main/core/framework/runner/runner.py:593:4-603:68) MCP server configuration.
- **Tests**:
  - [core/tests/test_testing_framework.py](cci:7://file:///c:/Users/ansha/Downloads/hive-main/core/tests/test_testing_framework.py:0:0-0:0): Added unit tests for the new error categories and updated existing tests to match the new strict categorization logic.

## Testing

- [x] Unit tests pass (`cd core && pytest tests/`): Verified [tests/test_testing_framework.py](cci:7://file:///c:/Users/ansha/Downloads/hive-main/core/tests/test_testing_framework.py:0:0-0:0) passes (31 tests) with the new logic.
- [x] Lint passes (`cd core && ruff check .`): Verified mostly clean output.
- [x] Manual testing performed: Created a dummy agent to verify `hive validate` correctly identifies and reports on missing tools and credentials.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (docstrings)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

**New `hive validate` output:**
```text
Validating agent: manual-test-agent
==================================================

Graph Structure
  ✓ Nodes: 1
  ✓ Edges: 0
  ✓ Entry points: node1

Goal
  ✓ Goal: Validate this agent....
  ✓ Success criteria: 1

Tools
  ✓ All required tools are registered

Credentials
  ✓ All required credentials are set

✓ Agent is valid and ready to run


Fixes #4336

Fixes #5116