### PR TITLE
feat: Office Skills Pack (xlsx/pptx/docx + charts) MVP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,30 @@ jobs:
           uv sync --extra dev
           uv run pytest tests/ -v
 
+  test-tools-office:
+    name: Test Tools (Office Pack Extras)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install office extras and run office tests
+        run: |
+          cd tools
+          uv sync --extra dev --extra excel --extra word --extra powerpoint --extra charts
+          uv run pytest tests/tools/test_chart_tool.py tests/tools/test_excel_write_tool.py tests/tools/test_powerpoint_tool.py tests/tools/test_word_tool.py -v
+
   validate:
     name: Validate Agent Exports
     runs-on: ubuntu-latest
-    needs: [lint, test, test-tools]
+    needs: [lint, test, test-tools, test-tools-office]
     steps:
       - uses: actions/checkout@v4
 

--- a/tools/examples/office_skills_finance_example.py
+++ b/tools/examples/office_skills_finance_example.py
@@ -1,7 +1,7 @@
 from fastmcp import FastMCP
 
 from aden_tools.tools.mcp_helpers import get_tool_fn
-from aden_tools.tools.office_skills_pack.register import register_office_skills_pack
+from aden_tools.tools.office_skills_pack import register_office_skills_pack
 
 WORKSPACE_ID = "demo-ws"
 AGENT_ID = "demo-agent"

--- a/tools/examples/office_skills_finance_example.py
+++ b/tools/examples/office_skills_finance_example.py
@@ -1,0 +1,135 @@
+from fastmcp import FastMCP
+
+from aden_tools.tools.mcp_helpers import get_tool_fn
+from aden_tools.tools.office_skills_pack.register import register_office_skills_pack
+
+WORKSPACE_ID = "demo-ws"
+AGENT_ID = "demo-agent"
+SESSION_ID = "demo-session"
+
+
+def drawdown(prices):
+    peak = prices[0]
+    dd = 0.0
+    for p in prices:
+        peak = max(peak, p)
+        dd = min(dd, (p - peak) / peak)
+    return dd
+
+
+def main():
+    mcp = FastMCP("finance-example")
+    register_office_skills_pack(mcp)
+
+    chart_png = get_tool_fn(mcp, "chart_render_png")
+    xlsx = get_tool_fn(mcp, "excel_write")
+    pptx = get_tool_fn(mcp, "powerpoint_generate")
+    docx = get_tool_fn(mcp, "word_generate")
+
+    days = [1, 2, 3, 4, 5]
+    aapl = [190, 191, 192, 191, 193]
+    msft = [410, 412, 411, 413, 414]
+
+    metrics = [
+        {"Ticker": "AAPL", "Return": (aapl[-1] / aapl[0] - 1), "Drawdown": drawdown(aapl)},
+        {"Ticker": "MSFT", "Return": (msft[-1] / msft[0] - 1), "Drawdown": drawdown(msft)},
+    ]
+
+    chart_png(
+        path="out/aapl_msft.png",
+        chart={
+            "title": "AAPL vs MSFT",
+            "x_label": "Day",
+            "y_label": "Price",
+            "series": [
+                {"name": "AAPL", "x": days, "y": aapl},
+                {"name": "MSFT", "x": days, "y": msft},
+            ],
+        },
+        workspace_id=WORKSPACE_ID,
+        agent_id=AGENT_ID,
+        session_id=SESSION_ID,
+    )
+
+    xlsx(
+        path="out/finance_report.xlsx",
+        workbook={
+            "sheets": [
+                {
+                    "name": "Summary",
+                    "columns": ["Ticker", "Return", "Drawdown"],
+                    "rows": [[m["Ticker"], m["Return"], m["Drawdown"]] for m in metrics],
+                    "number_formats": {"Return": "0.00%", "Drawdown": "0.00%"},
+                    "freeze_panes": "A2",
+                },
+                {
+                    "name": "Charts",
+                    "columns": ["Chart"],
+                    "rows": [["AAPL vs MSFT"]],
+                    "images": [{"path": "out/aapl_msft.png", "cell": "A3", "width": 600}],
+                },
+            ]
+        },
+        workspace_id=WORKSPACE_ID,
+        agent_id=AGENT_ID,
+        session_id=SESSION_ID,
+    )
+
+    pptx(
+        path="out/finance_report.pptx",
+        deck={
+            "title": "Finance Brief",
+            "slides": [
+                {
+                    "title": "Summary",
+                    "bullets": [
+                        f"{m['Ticker']}: Return {m['Return']:.2%}, DD {m['Drawdown']:.2%}"
+                        for m in metrics
+                    ],
+                    "image_paths": [],
+                    "charts": [],
+                },
+                {
+                    "title": "Chart",
+                    "bullets": ["Price series"],
+                    "image_paths": ["out/aapl_msft.png"],
+                    "charts": [],
+                },
+            ],
+        },
+        workspace_id=WORKSPACE_ID,
+        agent_id=AGENT_ID,
+        session_id=SESSION_ID,
+    )
+
+    docx(
+        path="out/finance_report.docx",
+        doc={
+            "title": "Finance Report",
+            "sections": [
+                {
+                    "heading": "Executive Summary",
+                    "paragraphs": ["Auto-generated finance artifacts (local-only MVP)."],
+                    "bullets": [],
+                },
+                {
+                    "heading": "Metrics",
+                    "paragraphs": [],
+                    "bullets": [],
+                    "table": {
+                        "columns": ["Ticker", "Return", "Drawdown"],
+                        "rows": [[m["Ticker"], m["Return"], m["Drawdown"]] for m in metrics],
+                    },
+                },
+            ],
+        },
+        workspace_id=WORKSPACE_ID,
+        agent_id=AGENT_ID,
+        session_id=SESSION_ID,
+    )
+
+    print("Generated finance_report.xlsx/.pptx/.docx (in sandbox)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/examples/office_skills_pack_demo.py
+++ b/tools/examples/office_skills_pack_demo.py
@@ -123,7 +123,7 @@ def main():
         session_id=SESSION_ID,
     )
 
-    print("✅ Generated: out/weekly_report.xlsx, out/weekly_report.pptx, out/weekly_report.docx (in sandbox)")
+    print("Generated: out/weekly_report.xlsx, out/weekly_report.pptx, out/weekly_report.docx (in sandbox)")
 
 
 if __name__ == "__main__":

--- a/tools/examples/office_skills_pack_demo.py
+++ b/tools/examples/office_skills_pack_demo.py
@@ -6,11 +6,8 @@ Run:
   - from repo root:  python tools/examples/office_skills_pack_demo.py
   - from tools/:     python examples/office_skills_pack_demo.py
 """
-from aden_tools.tools.chart_tool.chart_tool import register_tools as register_chart
-from aden_tools.tools.excel_write_tool.excel_write_tool import register_tools as register_xlsx
-from aden_tools.tools.powerpoint_tool.powerpoint_tool import register_tools as register_ppt
-from aden_tools.tools.word_tool.word_tool import register_tools as register_word
 from aden_tools.tools.mcp_helpers import get_tool_fn
+from aden_tools.tools.office_skills_pack import register_office_skills_pack
 from fastmcp import FastMCP
 
 WORKSPACE_ID = "demo-ws"
@@ -20,10 +17,7 @@ SESSION_ID = "demo-session"
 
 def main():
     mcp = FastMCP("office-skills-demo")
-    register_xlsx(mcp)
-    register_ppt(mcp)
-    register_word(mcp)
-    register_chart(mcp)
+    register_office_skills_pack(mcp)
 
     # NOTE: This still accesses the registered function, but not via private _tool_manager internals if MCP exposes a public method.
     # If FastMCP does NOT expose a public getter, keep this for now but we can swap to public API later.

--- a/tools/examples/office_skills_pack_demo.py
+++ b/tools/examples/office_skills_pack_demo.py
@@ -6,11 +6,11 @@ Run:
   - from repo root:  python tools/examples/office_skills_pack_demo.py
   - from tools/:     python examples/office_skills_pack_demo.py
 """
-
+from aden_tools.tools.chart_tool.chart_tool import register_tools as register_chart
 from aden_tools.tools.excel_write_tool.excel_write_tool import register_tools as register_xlsx
 from aden_tools.tools.powerpoint_tool.powerpoint_tool import register_tools as register_ppt
 from aden_tools.tools.word_tool.word_tool import register_tools as register_word
-from aden_tools.tools.testing_utils import get_tool_fn
+from aden_tools.tools.mcp_helpers import get_tool_fn
 from fastmcp import FastMCP
 
 WORKSPACE_ID = "demo-ws"
@@ -23,33 +23,63 @@ def main():
     register_xlsx(mcp)
     register_ppt(mcp)
     register_word(mcp)
+    register_chart(mcp)
 
     # NOTE: This still accesses the registered function, but not via private _tool_manager internals if MCP exposes a public method.
     # If FastMCP does NOT expose a public getter, keep this for now but we can swap to public API later.
-    xlsx = mcp._tool_manager._tools["excel_write"].fn
-    pptx = mcp._tool_manager._tools["powerpoint_generate"].fn
-    docx = mcp._tool_manager._tools["word_generate"].fn
 
+    xlsx = get_tool_fn(mcp, "excel_write")
+    pptx = get_tool_fn(mcp, "powerpoint_generate")
+    docx = get_tool_fn(mcp, "word_generate")
+    chart_png = get_tool_fn(mcp, "chart_render_png")
+    
     metrics = [
         {"Ticker": "AAPL", "Return": 0.0123, "Drawdown": -0.034},
         {"Ticker": "MSFT", "Return": 0.0040, "Drawdown": -0.021},
     ]
 
-    xlsx(
-        path="out/weekly_report.xlsx",
-        workbook={
-            "sheets": [{
-                "name": "Summary",
-                "columns": ["Ticker", "Return", "Drawdown"],
-                "rows": [[m["Ticker"], m["Return"], m["Drawdown"]] for m in metrics],
-                "freeze_panes": "A2",
-                "number_formats": {"Return": "0.00%", "Drawdown": "0.00%"},
-            }]
+    chart_png(
+        path="out/aapl_msft.png",
+        chart={
+            "title": "AAPL vs MSFT (synthetic)",
+            "x_label": "Day",
+            "y_label": "Price",
+            "series": [
+                {"name": "AAPL", "x": [1, 2, 3, 4, 5], "y": [190, 191, 192, 191, 193]},
+                {"name": "MSFT", "x": [1, 2, 3, 4, 5], "y": [410, 412, 411, 413, 414]},
+            ],
         },
         workspace_id=WORKSPACE_ID,
         agent_id=AGENT_ID,
         session_id=SESSION_ID,
     )
+
+    xlsx(
+        path="out/weekly_report.xlsx",
+        workbook={
+            "sheets": [
+                {
+                    "name": "Summary",
+                    "columns": ["Ticker", "Return", "Drawdown"],
+                    "rows": [[m["Ticker"], m["Return"], m["Drawdown"]] for m in metrics],
+                    "freeze_panes": "A2",
+                    "number_formats": {"Return": "0.00%", "Drawdown": "0.00%"},
+                },
+                {
+                    "name": "Charts",
+                    "columns": ["Chart"],
+                    "rows": [["AAPL vs MSFT"]],
+                    "freeze_panes": "A2",
+                    "images": [{"path": "out/aapl_msft.png", "cell": "A3", "width": 600}],
+                },
+            ]
+        },
+        workspace_id=WORKSPACE_ID,
+        agent_id=AGENT_ID,
+        session_id=SESSION_ID,
+    )
+
+
 
     pptx(
         path="out/weekly_report.pptx",
@@ -58,6 +88,8 @@ def main():
             "slides": [
                 {"title": "Summary", "bullets": ["AAPL outperformed", "MSFT stable"], "image_paths": []},
                 {"title": "Key Metrics", "bullets": [f"{m['Ticker']}: Return {m['Return']:.2%}, DD {m['Drawdown']:.2%}" for m in metrics], "image_paths": []},
+                {"title": "Chart", "bullets": ["Synthetic price chart"], "image_paths": ["out/aapl_msft.png"], "charts": []},
+                
             ],
         },
         workspace_id=WORKSPACE_ID,

--- a/tools/examples/office_skills_pack_demo.py
+++ b/tools/examples/office_skills_pack_demo.py
@@ -1,0 +1,98 @@
+"""
+Office Skills Pack demo:
+Generates XLSX + PPTX + DOCX into the session sandbox.
+
+Run:
+  - from repo root:  python tools/examples/office_skills_pack_demo.py
+  - from tools/:     python examples/office_skills_pack_demo.py
+"""
+
+from aden_tools.tools.excel_write_tool.excel_write_tool import register_tools as register_xlsx
+from aden_tools.tools.powerpoint_tool.powerpoint_tool import register_tools as register_ppt
+from aden_tools.tools.word_tool.word_tool import register_tools as register_word
+from aden_tools.tools.testing_utils import get_tool_fn
+from fastmcp import FastMCP
+
+WORKSPACE_ID = "demo-ws"
+AGENT_ID = "demo-agent"
+SESSION_ID = "demo-session"
+
+
+def main():
+    mcp = FastMCP("office-skills-demo")
+    register_xlsx(mcp)
+    register_ppt(mcp)
+    register_word(mcp)
+
+    # NOTE: This still accesses the registered function, but not via private _tool_manager internals if MCP exposes a public method.
+    # If FastMCP does NOT expose a public getter, keep this for now but we can swap to public API later.
+    xlsx = mcp._tool_manager._tools["excel_write"].fn
+    pptx = mcp._tool_manager._tools["powerpoint_generate"].fn
+    docx = mcp._tool_manager._tools["word_generate"].fn
+
+    metrics = [
+        {"Ticker": "AAPL", "Return": 0.0123, "Drawdown": -0.034},
+        {"Ticker": "MSFT", "Return": 0.0040, "Drawdown": -0.021},
+    ]
+
+    xlsx(
+        path="out/weekly_report.xlsx",
+        workbook={
+            "sheets": [{
+                "name": "Summary",
+                "columns": ["Ticker", "Return", "Drawdown"],
+                "rows": [[m["Ticker"], m["Return"], m["Drawdown"]] for m in metrics],
+                "freeze_panes": "A2",
+                "number_formats": {"Return": "0.00%", "Drawdown": "0.00%"},
+            }]
+        },
+        workspace_id=WORKSPACE_ID,
+        agent_id=AGENT_ID,
+        session_id=SESSION_ID,
+    )
+
+    pptx(
+        path="out/weekly_report.pptx",
+        deck={
+            "title": "Weekly Market Brief",
+            "slides": [
+                {"title": "Summary", "bullets": ["AAPL outperformed", "MSFT stable"], "image_paths": []},
+                {"title": "Key Metrics", "bullets": [f"{m['Ticker']}: Return {m['Return']:.2%}, DD {m['Drawdown']:.2%}" for m in metrics], "image_paths": []},
+            ],
+        },
+        workspace_id=WORKSPACE_ID,
+        agent_id=AGENT_ID,
+        session_id=SESSION_ID,
+    )
+
+    docx(
+        path="out/weekly_report.docx",
+        doc={
+            "title": "Weekly Market Report",
+            "sections": [
+                {
+                    "heading": "Executive Summary",
+                    "paragraphs": ["Auto-generated report (schema-first, local-only MVP)."],
+                    "bullets": ["XLSX + PPTX + DOCX generated locally", "Saved into session sandbox"],
+                },
+                {
+                    "heading": "Metrics",
+                    "paragraphs": [],
+                    "bullets": [],
+                    "table": {
+                        "columns": ["Ticker", "Return", "Drawdown"],
+                        "rows": [[m["Ticker"], m["Return"], m["Drawdown"]] for m in metrics],
+                    },
+                },
+            ],
+        },
+        workspace_id=WORKSPACE_ID,
+        agent_id=AGENT_ID,
+        session_id=SESSION_ID,
+    )
+
+    print("✅ Generated: out/weekly_report.xlsx, out/weekly_report.pptx, out/weekly_report.docx (in sandbox)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -63,6 +63,10 @@ all = [
     "duckdb>=1.0.0",
     "openpyxl>=3.1.0",
     "google-cloud-bigquery>=3.0.0",
+    "python-pptx>=1.0.0",
+    "matplotlib>=3.8.0",
+
+
 ]
 
 [tool.uv.sources]
@@ -110,3 +114,13 @@ dev = [
     "ruff>=0.14.14",
     "duckdb>=1.4.4",
 ]
+powerpoint = [
+    "python-pptx>=1.0.0",
+]
+word = [
+    "python-docx>=1.1.0",
+]
+charts = [
+    "matplotlib>=3.8.0",
+]
+

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -58,6 +58,7 @@ from .file_system_toolkits.view_file import register_tools as register_view_file
 from .file_system_toolkits.write_to_file import register_tools as register_write_to_file
 from .hubspot_tool import register_tools as register_hubspot
 from .news_tool import register_tools as register_news
+from .office_skills_pack.schema_tool import register_tools as register_office_schema
 from .pdf_read_tool import register_tools as register_pdf_read
 from .powerpoint_tool import register_tools as register_powerpoint
 from .port_scanner import register_tools as register_port_scanner
@@ -139,6 +140,7 @@ def register_all_tools(
     register_powerpoint(mcp)
     register_word(mcp)
     register_chart(mcp)
+    register_office_schema(mcp)
 
     # Security scanning tools (no credentials needed)
     register_ssl_tls_scanner(mcp)

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -27,6 +27,7 @@ from .calcom_tool import register_tools as register_calcom
 from .calendar_tool import register_tools as register_calendar
 from .csv_tool import register_tools as register_csv
 from .discord_tool import register_tools as register_discord
+from .chart_tool import register_tools as register_chart
 
 # Security scanning tools
 from .dns_security_scanner import register_tools as register_dns_security_scanner
@@ -34,6 +35,7 @@ from .email_tool import register_tools as register_email
 from .exa_search_tool import register_tools as register_exa_search
 from .example_tool import register_tools as register_example
 from .excel_tool import register_tools as register_excel
+from .excel_write_tool import register_tools as register_excel_write
 from .github_tool import register_tools as register_github
 from .gmail_tool import register_tools as register_gmail
 from .google_docs_tool import register_tools as register_google_docs
@@ -57,6 +59,7 @@ from .file_system_toolkits.write_to_file import register_tools as register_write
 from .hubspot_tool import register_tools as register_hubspot
 from .news_tool import register_tools as register_news
 from .pdf_read_tool import register_tools as register_pdf_read
+from .powerpoint_tool import register_tools as register_powerpoint
 from .port_scanner import register_tools as register_port_scanner
 from .razorpay_tool import register_tools as register_razorpay
 from .risk_scorer import register_tools as register_risk_scorer
@@ -71,6 +74,7 @@ from .time_tool import register_tools as register_time
 from .vision_tool import register_tools as register_vision
 from .web_scrape_tool import register_tools as register_web_scrape
 from .web_search_tool import register_tools as register_web_search
+from .word_tool import register_tools as register_word
 
 
 def register_all_tools(
@@ -131,6 +135,10 @@ def register_all_tools(
     register_data_tools(mcp)
     register_csv(mcp)
     register_excel(mcp)
+    register_excel_write(mcp)
+    register_powerpoint(mcp)
+    register_word(mcp)
+    register_chart(mcp)
 
     # Security scanning tools (no credentials needed)
     register_ssl_tls_scanner(mcp)

--- a/tools/src/aden_tools/tools/chart_tool/README.md
+++ b/tools/src/aden_tools/tools/chart_tool/README.md
@@ -1,0 +1,6 @@
+# Chart Tool (MVP)
+
+Renders simple charts to PNG in the session sandbox (local-only).
+
+Tool:
+- chart_render_png(path, chart, workspace_id, agent_id, session_id)

--- a/tools/src/aden_tools/tools/chart_tool/__init__.py
+++ b/tools/src/aden_tools/tools/chart_tool/__init__.py
@@ -1,0 +1,3 @@
+from .chart_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/chart_tool/chart_tool.py
+++ b/tools/src/aden_tools/tools/chart_tool/chart_tool.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import os
+from typing import Any, List, Optional
+
+from fastmcp import FastMCP
+from pydantic import BaseModel, Field
+
+from aden_tools.tools.office_skills_pack.contracts import ArtifactError, ArtifactResult
+from ..file_system_toolkits.security import get_secure_path
+
+
+class SeriesSpec(BaseModel):
+    name: str = Field(..., min_length=1)
+    x: List[float] = Field(..., min_length=1)
+    y: List[float] = Field(..., min_length=1)
+
+
+class ChartSpec(BaseModel):
+    title: str = Field(..., min_length=1)
+    x_label: str = Field(default="")
+    y_label: str = Field(default="")
+    series: List[SeriesSpec] = Field(..., min_length=1)
+
+
+def register_tools(mcp: FastMCP) -> None:
+    @mcp.tool()
+    def chart_render_png(
+        path: str,
+        chart: dict[str, Any],
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> dict:
+        """
+        Render a simple multi-series line chart into a PNG (schema-first) saved into the session sandbox.
+        """
+        if not path.lower().endswith(".png"):
+            return ArtifactResult(
+                success=False,
+                error=ArtifactError(code="INVALID_PATH", message="path must end with .png"),
+            ).model_dump()
+
+        try:
+            spec = ChartSpec.model_validate(chart)
+        except Exception as e:
+            return ArtifactResult(
+                success=False,
+                error=ArtifactError(code="INVALID_SCHEMA", message="Invalid chart schema", details=str(e)),
+            ).model_dump()
+
+        try:
+            import matplotlib.pyplot as plt
+        except ImportError:
+            return ArtifactResult(
+                success=False,
+                error=ArtifactError(
+                    code="DEP_MISSING",
+                    message="matplotlib not installed",
+                    details="Install with: pip install -e '.[charts]' (from tools/)",
+                ),
+            ).model_dump()
+
+        try:
+            out_path = get_secure_path(path, workspace_id, agent_id, session_id)
+            os.makedirs(os.path.dirname(out_path), exist_ok=True)
+
+            plt.figure()
+            for s in spec.series:
+                # handle mismatched lengths safely
+                n = min(len(s.x), len(s.y))
+                plt.plot(s.x[:n], s.y[:n], label=s.name)
+
+            plt.title(spec.title)
+            if spec.x_label:
+                plt.xlabel(spec.x_label)
+            if spec.y_label:
+                plt.ylabel(spec.y_label)
+
+            if len(spec.series) > 1:
+                plt.legend()
+
+            plt.tight_layout()
+            plt.savefig(out_path, dpi=150)
+            plt.close()
+
+            return ArtifactResult(
+                success=True,
+                output_path=path,
+                metadata={"series": len(spec.series)},
+            ).model_dump()
+
+        except Exception as e:
+            return ArtifactResult(
+                success=False,
+                error=ArtifactError(code="IO_ERROR", message="Failed to write png", details=str(e)),
+            ).model_dump()

--- a/tools/src/aden_tools/tools/excel_write_tool/README.md
+++ b/tools/src/aden_tools/tools/excel_write_tool/README.md
@@ -1,0 +1,18 @@
+# Excel Write Tool (Schema-First)
+
+Writes `.xlsx` workbooks with multi-sheet support and basic formatting.
+
+## Tool
+- `excel_write(path, workbook, workspace_id, agent_id, session_id)`
+
+## Features (MVP)
+- Multi-sheet
+- Header styling (bold)
+- Freeze panes
+- Per-column number formats
+- Best-effort column autosize
+
+## Schema
+- WorkbookSpec: { sheets: [SheetSpec] }
+- SheetSpec: { name, columns, rows, freeze_panes?, number_formats?, column_widths? }
+

--- a/tools/src/aden_tools/tools/excel_write_tool/__init__.py
+++ b/tools/src/aden_tools/tools/excel_write_tool/__init__.py
@@ -1,0 +1,4 @@
+from .excel_write_tool import register_tools as register_excel_write
+from .excel_write_tool import register_tools
+
+__all__ = ["register_excel_write", "register_tools"]

--- a/tools/src/aden_tools/tools/excel_write_tool/excel_write_tool.py
+++ b/tools/src/aden_tools/tools/excel_write_tool/excel_write_tool.py
@@ -175,6 +175,15 @@ def register_tools(mcp: FastMCP) -> None:
                     from openpyxl.drawing.image import Image as XLImage
 
                     for img in sheet.images:
+                        ext = os.path.splitext(img.path.lower())[1]
+                        if ext not in [".png", ".jpg", ".jpeg"]:
+                            return ArtifactResult(
+                                success=False,
+                                error=ArtifactError(
+                                    code="INVALID_PATH",
+                                    message=f"unsupported image extension: {ext}",
+                                ),
+                            ).model_dump()
                         img_abs = get_secure_path(img.path, workspace_id, agent_id, session_id)
                         if os.path.exists(img_abs):
                             xl_img = XLImage(img_abs)

--- a/tools/src/aden_tools/tools/excel_write_tool/excel_write_tool.py
+++ b/tools/src/aden_tools/tools/excel_write_tool/excel_write_tool.py
@@ -1,0 +1,204 @@
+"""Excel Write Tool - Generate .xlsx workbooks (schema-first)."""
+from __future__ import annotations
+from aden_tools.tools.office_skills_pack.contracts import ArtifactError, ArtifactResult
+
+
+import os
+from typing import Any, Dict, List, Optional
+
+from fastmcp import FastMCP
+from pydantic import BaseModel, Field
+
+from ..file_system_toolkits.security import get_secure_path
+
+
+class SheetImageSpec(BaseModel):
+    path: str = Field(..., min_length=1, description="Image path relative to session sandbox")
+    cell: str = Field(default="A1", description="Top-left anchor cell, e.g. C3")
+    width: Optional[int] = Field(default=None, ge=1)
+    height: Optional[int] = Field(default=None, ge=1)
+
+
+class SheetSpec(BaseModel):
+    name: str = Field(..., min_length=1)
+    columns: List[str] = Field(..., min_length=1)
+    rows: List[List[Any]] = Field(default_factory=list)
+
+    # "B2" style or "A2" style. Common: "A2" = freeze header row.
+    freeze_panes: Optional[str] = Field(default="A2")
+
+    # Map column name -> excel number format string, e.g. {"Return": "0.00%", "Price": "$#,##0.00"}
+    number_formats: Dict[str, str] = Field(default_factory=dict)
+
+    # Optional fixed widths: {"Ticker": 12, "Return": 10}
+    column_widths: Dict[str, float] = Field(default_factory=dict)
+    images: List[SheetImageSpec] = Field(
+        default_factory=list,
+        description="Images to place in worksheet",
+    )
+
+
+class WorkbookSpec(BaseModel):
+    sheets: List[SheetSpec] = Field(..., min_length=1)
+
+
+def _best_effort_autosize(ws) -> None:
+    # Best-effort autosize based on cell string length (cheap + good enough for MVP)
+    try:
+        from openpyxl.utils import get_column_letter
+    except Exception:
+        return
+
+    for col_idx in range(1, ws.max_column + 1):
+        letter = get_column_letter(col_idx)
+        max_len = 0
+        for row in range(1, ws.max_row + 1):
+            v = ws.cell(row=row, column=col_idx).value
+            if v is None:
+                continue
+            max_len = max(max_len, len(str(v)))
+        if max_len > 0:
+            ws.column_dimensions[letter].width = min(max(10, max_len + 2), 60)
+
+
+def register_tools(mcp: FastMCP) -> None:
+    @mcp.tool()
+    def excel_write(
+        path: str,
+        workbook: dict[str, Any],
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> dict:
+        """
+        Write an Excel (.xlsx) file from a strict schema into the session sandbox.
+        """
+
+        if not path.lower().endswith(".xlsx"):
+            return ArtifactResult(
+                success=False,
+                error=ArtifactError(
+                    code="INVALID_SCHEMA",
+                    message="path must end with .xlsx",
+                ),
+            ).model_dump()
+
+
+
+
+        try:
+            spec = WorkbookSpec.model_validate(workbook)
+        except Exception as e:
+            return ArtifactResult(
+                success=False,
+                error=ArtifactError(
+                    code="INVALID_SCHEMA",
+                    message="Invalid workbook schema",
+                    details=str(e),
+                ),
+            ).model_dump()
+
+
+        try:
+            from openpyxl import Workbook
+            from openpyxl.styles import Font
+        except ImportError:
+
+            return ArtifactResult(
+                success=False,
+                error=ArtifactError(code="DEP_MISSING", message="openpyxl not installed. Install with: pip install -e '.[excel]'"),
+            ).model_dump()
+
+
+        try:
+            out_path = get_secure_path(path, workspace_id, agent_id, session_id)
+            os.makedirs(os.path.dirname(out_path), exist_ok=True)
+
+            wb = Workbook()
+            # remove default sheet
+            if wb.sheetnames:
+                wb.remove(wb[wb.sheetnames[0]])
+
+            header_font = Font(bold=True)
+
+
+            if "sheets" not in workbook:
+                return ArtifactResult(
+                    success=False,
+                    error=ArtifactError(
+                        code="INVALID_SCHEMA",
+                        message="Invalid workbook structure: 'sheets' key not found",
+                    ),
+                ).model_dump()
+
+
+            for sheet in spec.sheets:
+                ws = wb.create_sheet(title=sheet.name[:31])  # Excel sheet name limit
+
+                # header
+                for j, col in enumerate(sheet.columns, start=1):
+                    c = ws.cell(row=1, column=j, value=col)
+                    c.font = header_font
+
+                # rows
+                for i, row in enumerate(sheet.rows, start=2):
+                    for j in range(1, len(sheet.columns) + 1):
+                        v = row[j - 1] if j - 1 < len(row) else None
+                        ws.cell(row=i, column=j, value=v)
+
+                # freeze panes
+                if sheet.freeze_panes:
+                    ws.freeze_panes = sheet.freeze_panes
+
+                # apply number formats by column name
+                col_to_idx = {name: idx + 1 for idx, name in enumerate(sheet.columns)}
+                for col_name, fmt in sheet.number_formats.items():
+                    idx = col_to_idx.get(col_name)
+                    if not idx:
+                        continue
+                    for r in range(2, ws.max_row + 1):
+                        ws.cell(row=r, column=idx).number_format = fmt
+
+                # explicit column widths
+                for col_name, width in sheet.column_widths.items():
+                    idx = col_to_idx.get(col_name)
+                    if not idx:
+                        continue
+                    from openpyxl.utils import get_column_letter
+                    ws.column_dimensions[get_column_letter(idx)].width = float(width)
+
+                # autosize as fallback
+                _best_effort_autosize(ws)
+
+                # images
+                if sheet.images:
+                    from openpyxl.drawing.image import Image as XLImage
+
+                    for img in sheet.images:
+                        img_abs = get_secure_path(img.path, workspace_id, agent_id, session_id)
+                        if os.path.exists(img_abs):
+                            xl_img = XLImage(img_abs)
+                            if img.width:
+                                xl_img.width = int(img.width)
+                            ws.add_image(xl_img, img.cell)
+
+            wb.save(out_path)
+
+            
+        
+            return ArtifactResult(
+                success=True,
+                output_path=str(out_path),
+                metadata={"sheets": len(spec.sheets)},
+            ).model_dump()
+
+
+        except Exception as e:
+            return ArtifactResult(
+                success=False,
+                error=ArtifactError(
+                    code="INTERNAL_ERROR",
+                    message="Failed to generate Excel workbook",
+                    details=str(e),
+                ),
+            ).model_dump()

--- a/tools/src/aden_tools/tools/mcp_helpers.py
+++ b/tools/src/aden_tools/tools/mcp_helpers.py
@@ -7,6 +7,6 @@ from fastmcp import FastMCP
 def get_tool_fn(mcp: FastMCP, name: str) -> Callable:
     """
     Centralized helper for tests/examples.
-    If FastMCP exposes a public getter in future, update only here.
+    If FastMCP exposes a public getter later, update only here.
     """
     return mcp._tool_manager._tools[name].fn

--- a/tools/src/aden_tools/tools/office_skills_pack/PR_BODY.md
+++ b/tools/src/aden_tools/tools/office_skills_pack/PR_BODY.md
@@ -1,0 +1,21 @@
+## What
+Adds a schema-first Office Skills Pack (local-only MVP):
+- XLSX: multi-sheet writer + formatting + image embed (charts)
+- PPTX: slide deck generator (title/bullets/images) + chart PNG embedding
+- DOCX: report generator (sections/bullets/tables)
+- PNG charts: render via matplotlib for artifact embedding
+
+## Why
+Fixes the "last-mile disconnect" where agents compute results but users manually copy into Excel/PowerPoint.
+
+## How to run demo
+From repo root:
+python tools/examples/office_skills_pack_demo.py
+
+## How to run tests
+cd tools
+python -m pytest -q -k "not symlink"
+
+## Security
+All inputs/outputs resolved using session sandbox via get_secure_path (no arbitrary FS writes).
+No cloud APIs/OAuth in MVP.

--- a/tools/src/aden_tools/tools/office_skills_pack/README.md
+++ b/tools/src/aden_tools/tools/office_skills_pack/README.md
@@ -1,59 +1,61 @@
 # Office Skills Pack (MVP)
 
-Adds local, schema-first generation of business artifacts:
-- Excel: `.xlsx` (multi-sheet + basic formatting)
-- PowerPoint: `.pptx` (title + bullets + optional images)
-- Word: `.docx` (report sections + bullets + optional tables)
-
-## Why this exists
-Eliminates the last-mile disconnect: agents can compute insights and ship editable office artifacts locally.
-
-## Design
-- Schema-first: strict Pydantic models per tool
-- Local-only MVP (no cloud OAuth)
-- Secure output paths via session sandbox (`get_secure_path`)
-
-## Demo
-Run:
-- `python tools/examples/office_skills_pack_demo.py`
-
-Outputs:
-- `out/weekly_report.xlsx`
-- `out/weekly_report.pptx`
-- `out/weekly_report.docx`
-# Office Skills Pack (MVP)
-
 Schema-first, local generation of business artifacts:
 
 - Excel: `.xlsx` (multi-sheet + formatting via openpyxl)
 - PowerPoint: `.pptx` (title + bullets + optional images via python-pptx)
 - Word: `.docx` (sections + bullets + tables via python-docx)
+- Charts: `.png` (matplotlib)
 
 ## Install
 From `tools/`:
+
 ```bash
-python -m pip install -e ".[excel,powerpoint,word]"
+python -m pip install -e ".[excel,word,powerpoint,charts]"
+```
 
 ## Contract
-All tools return a standardized response:
+All tools return:
+
 - `success: bool`
-- `output_path: str`
+- `output_path: str | null`
 - `contract_version: "0.1.0"`
-- `error: { code, message, details }`
+- `error: { code, message, details } | null`
 - `metadata: {...}`
 
-This makes it safe for agents/workflows to branch on stable error codes.
-## Chart workflow (MVP)
-Agents can generate charts as PNG and embed them:
+## Error codes
+- `INVALID_PATH`
+- `INVALID_SCHEMA`
+- `DEP_MISSING`
+- `IO_ERROR`
+- `UNKNOWN`
 
-1) `chart_render_png("out/chart.png", ...)`
-2) `powerpoint_generate(... image_paths=["out/chart.png"])`
-3) `excel_write(...)` (v2: embed PNG directly into workbook)
+Example error payload:
 
-Reason: PNG is the simplest portable intermediate for local-only MVP.
+```json
+{
+  "success": false,
+  "output_path": null,
+  "contract_version": "0.1.0",
+  "error": {
+    "code": "INVALID_SCHEMA",
+    "message": "Invalid workbook schema",
+    "details": "..."
+  },
+  "metadata": {}
+}
+```
 
 ## Charts
 Generate PNG using `chart_render_png`, then embed into:
+
 - PPTX via `powerpoint_generate` (`image_paths` / `charts`)
 - XLSX via `excel_write` (`sheets[].images`)
 - DOCX via `word_generate` (`sections[].image_paths` / `sections[].charts`)
+
+## Demo
+From repo root:
+
+```bash
+python tools/examples/office_skills_pack_demo.py
+```

--- a/tools/src/aden_tools/tools/office_skills_pack/README.md
+++ b/tools/src/aden_tools/tools/office_skills_pack/README.md
@@ -1,0 +1,45 @@
+# Office Skills Pack (MVP)
+
+Adds local, schema-first generation of business artifacts:
+- Excel: `.xlsx` (multi-sheet + basic formatting)
+- PowerPoint: `.pptx` (title + bullets + optional images)
+- Word: `.docx` (report sections + bullets + optional tables)
+
+## Why this exists
+Eliminates the last-mile disconnect: agents can compute insights and ship editable office artifacts locally.
+
+## Design
+- Schema-first: strict Pydantic models per tool
+- Local-only MVP (no cloud OAuth)
+- Secure output paths via session sandbox (`get_secure_path`)
+
+## Demo
+Run:
+- `python tools/examples/office_skills_pack_demo.py`
+
+Outputs:
+- `out/weekly_report.xlsx`
+- `out/weekly_report.pptx`
+- `out/weekly_report.docx`
+# Office Skills Pack (MVP)
+
+Schema-first, local generation of business artifacts:
+
+- Excel: `.xlsx` (multi-sheet + formatting via openpyxl)
+- PowerPoint: `.pptx` (title + bullets + optional images via python-pptx)
+- Word: `.docx` (sections + bullets + tables via python-docx)
+
+## Install
+From `tools/`:
+```bash
+python -m pip install -e ".[excel,powerpoint,word]"
+
+## Contract
+All tools return a standardized response:
+- `success: bool`
+- `output_path: str`
+- `contract_version: "0.1.0"`
+- `error: { code, message, details }`
+- `metadata: {...}`
+
+This makes it safe for agents/workflows to branch on stable error codes.

--- a/tools/src/aden_tools/tools/office_skills_pack/README.md
+++ b/tools/src/aden_tools/tools/office_skills_pack/README.md
@@ -43,3 +43,17 @@ All tools return a standardized response:
 - `metadata: {...}`
 
 This makes it safe for agents/workflows to branch on stable error codes.
+## Chart workflow (MVP)
+Agents can generate charts as PNG and embed them:
+
+1) `chart_render_png("out/chart.png", ...)`
+2) `powerpoint_generate(... image_paths=["out/chart.png"])`
+3) `excel_write(...)` (v2: embed PNG directly into workbook)
+
+Reason: PNG is the simplest portable intermediate for local-only MVP.
+
+## Charts
+Generate PNG using `chart_render_png`, then embed into:
+- PPTX via `powerpoint_generate` (`image_paths` / `charts`)
+- XLSX via `excel_write` (`sheets[].images`)
+- DOCX via `word_generate` (`sections[].image_paths` / `sections[].charts`)

--- a/tools/src/aden_tools/tools/office_skills_pack/__init__.py
+++ b/tools/src/aden_tools/tools/office_skills_pack/__init__.py
@@ -1,4 +1,14 @@
-from aden_tools.tools.office_skills_pack.contracts import ArtifactError, ArtifactResult
 from .contracts import ArtifactError, ArtifactResult, CONTRACT_VERSION
 
-__all__ = ["ArtifactError", "ArtifactResult", "CONTRACT_VERSION"]
+
+def register_office_skills_pack(mcp) -> None:
+    from .register import register_office_skills_pack as _register_office_skills_pack
+
+    _register_office_skills_pack(mcp)
+
+__all__ = [
+    "ArtifactError",
+    "ArtifactResult",
+    "CONTRACT_VERSION",
+    "register_office_skills_pack",
+]

--- a/tools/src/aden_tools/tools/office_skills_pack/__init__.py
+++ b/tools/src/aden_tools/tools/office_skills_pack/__init__.py
@@ -1,0 +1,4 @@
+from aden_tools.tools.office_skills_pack.contracts import ArtifactError, ArtifactResult
+from .contracts import ArtifactError, ArtifactResult, CONTRACT_VERSION
+
+__all__ = ["ArtifactError", "ArtifactResult", "CONTRACT_VERSION"]

--- a/tools/src/aden_tools/tools/office_skills_pack/contracts.py
+++ b/tools/src/aden_tools/tools/office_skills_pack/contracts.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+from pydantic import BaseModel, Field
+
+CONTRACT_VERSION = "0.1.0"
+
+
+class ArtifactError(BaseModel):
+    code: str = Field(..., description="Stable error code, e.g. INVALID_SCHEMA, IO_ERROR, DEP_MISSING")
+    message: str
+    details: Optional[Any] = None
+
+
+class ArtifactResult(BaseModel):
+    success: bool
+    output_path: Optional[str] = None
+    contract_version: str = CONTRACT_VERSION
+    error: Optional[ArtifactError] = None
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/tools/src/aden_tools/tools/office_skills_pack/register.py
+++ b/tools/src/aden_tools/tools/office_skills_pack/register.py
@@ -1,0 +1,17 @@
+from fastmcp import FastMCP
+
+from aden_tools.tools.chart_tool.chart_tool import register_tools as register_charts
+from aden_tools.tools.excel_write_tool.excel_write_tool import (
+    register_tools as register_excel_write,
+)
+from aden_tools.tools.powerpoint_tool.powerpoint_tool import (
+    register_tools as register_powerpoint,
+)
+from aden_tools.tools.word_tool.word_tool import register_tools as register_word
+
+
+def register_office_skills_pack(mcp: FastMCP) -> None:
+    register_charts(mcp)
+    register_excel_write(mcp)
+    register_powerpoint(mcp)
+    register_word(mcp)

--- a/tools/src/aden_tools/tools/office_skills_pack/schema_tool.py
+++ b/tools/src/aden_tools/tools/office_skills_pack/schema_tool.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+from aden_tools.tools.chart_tool.chart_tool import ChartSpec
+from aden_tools.tools.excel_write_tool.excel_write_tool import WorkbookSpec
+from aden_tools.tools.powerpoint_tool.powerpoint_tool import DeckSpec
+from aden_tools.tools.word_tool.word_tool import DocSpec
+
+
+def register_tools(mcp: FastMCP) -> None:
+    @mcp.tool()
+    def office_skills_schema(tool_name: str) -> dict:
+        """
+        Return JSON schema for Office Skills Pack input specs.
+        tool_name: one of ['chart', 'excel', 'powerpoint', 'word']
+        """
+        name = tool_name.strip().lower()
+        if name == "chart":
+            return ChartSpec.model_json_schema()
+        if name == "excel":
+            return WorkbookSpec.model_json_schema()
+        if name == "powerpoint":
+            return DeckSpec.model_json_schema()
+        if name == "word":
+            return DocSpec.model_json_schema()
+        return {"error": "unknown tool_name"}

--- a/tools/src/aden_tools/tools/office_skills_pack/schema_tool.py
+++ b/tools/src/aden_tools/tools/office_skills_pack/schema_tool.py
@@ -4,8 +4,11 @@ from fastmcp import FastMCP
 
 from aden_tools.tools.chart_tool.chart_tool import ChartSpec
 from aden_tools.tools.excel_write_tool.excel_write_tool import WorkbookSpec
+from aden_tools.tools.office_skills_pack.contracts import CONTRACT_VERSION
 from aden_tools.tools.powerpoint_tool.powerpoint_tool import DeckSpec
 from aden_tools.tools.word_tool.word_tool import DocSpec
+
+SUPPORTED_TOOL_NAMES = ["chart", "excel", "powerpoint", "word"]
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -17,11 +20,31 @@ def register_tools(mcp: FastMCP) -> None:
         """
         name = tool_name.strip().lower()
         if name == "chart":
-            return ChartSpec.model_json_schema()
+            return {
+                "contract_version": CONTRACT_VERSION,
+                "tool": "chart",
+                "schema": ChartSpec.model_json_schema(),
+            }
         if name == "excel":
-            return WorkbookSpec.model_json_schema()
+            return {
+                "contract_version": CONTRACT_VERSION,
+                "tool": "excel",
+                "schema": WorkbookSpec.model_json_schema(),
+            }
         if name == "powerpoint":
-            return DeckSpec.model_json_schema()
+            return {
+                "contract_version": CONTRACT_VERSION,
+                "tool": "powerpoint",
+                "schema": DeckSpec.model_json_schema(),
+            }
         if name == "word":
-            return DocSpec.model_json_schema()
-        return {"error": "unknown tool_name"}
+            return {
+                "contract_version": CONTRACT_VERSION,
+                "tool": "word",
+                "schema": DocSpec.model_json_schema(),
+            }
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "error": "unknown tool_name",
+            "supported": SUPPORTED_TOOL_NAMES,
+        }

--- a/tools/src/aden_tools/tools/powerpoint_tool/README.md
+++ b/tools/src/aden_tools/tools/powerpoint_tool/README.md
@@ -1,0 +1,14 @@
+# PowerPoint Tool (Schema-First)
+
+Generates local `.pptx` slide decks from a strict Pydantic schema.
+
+## Tool
+- `powerpoint_generate(path, deck, workspace_id, agent_id, session_id)`
+
+## Schema
+- DeckSpec: { title: str, slides: [SlideSpec] }
+- SlideSpec: { title: str, bullets: [str], image_paths: [str] }
+
+## Notes
+- `path` and `image_paths` are relative to the session sandbox.
+- Uses `python-pptx` (optional dependency group: `powerpoint`).

--- a/tools/src/aden_tools/tools/powerpoint_tool/__init__.py
+++ b/tools/src/aden_tools/tools/powerpoint_tool/__init__.py
@@ -1,0 +1,5 @@
+from aden_tools.tools.excel_tool import register_tools as register_excel
+from .powerpoint_tool import register_tools as register_powerpoint
+from .powerpoint_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/powerpoint_tool/powerpoint_tool.py
+++ b/tools/src/aden_tools/tools/powerpoint_tool/powerpoint_tool.py
@@ -1,0 +1,145 @@
+"""PowerPoint Tool - Generate .pptx slide decks (schema-first)."""
+from __future__ import annotations
+
+import os
+from typing import Any, List
+
+from fastmcp import FastMCP
+from pydantic import BaseModel, Field
+
+from aden_tools.tools.office_skills_pack.contracts import ArtifactError, ArtifactResult
+from ..file_system_toolkits.security import get_secure_path
+
+
+class SlideSpec(BaseModel):
+    title: str = Field(..., min_length=1)
+    bullets: List[str] = Field(default_factory=list)
+    image_paths: List[str] = Field(default_factory=list, description="Paths relative to session sandbox")
+
+    charts: List[str] = Field(
+        default_factory=list,
+        description="Chart PNG paths relative to session sandbox"
+    )
+
+
+class DeckSpec(BaseModel):
+    title: str = Field(..., min_length=1)
+    slides: List[SlideSpec] = Field(..., min_length=1)
+
+
+def register_tools(mcp: FastMCP) -> None:
+    @mcp.tool()
+    def powerpoint_generate(
+        path: str,
+        deck: dict[str, Any],
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> dict:
+        """
+        Generate a PowerPoint (.pptx) from a strict schema and save it to the session sandbox.
+
+        Args:
+            path: Output path (relative to session sandbox), must end with .pptx
+            deck: Dict matching DeckSpec schema
+            workspace_id/agent_id/session_id: sandbox identifiers
+
+        Returns:
+            ArtifactResult dict with success, output_path, and metadata
+        """
+        if not path.lower().endswith(".pptx"):
+            return ArtifactResult(
+                success=False,
+                error=ArtifactError(
+                    code="INVALID_SCHEMA",
+                    message="path must end with .pptx",
+                ),
+            ).model_dump()
+
+        try:
+            spec = DeckSpec.model_validate(deck)
+        except Exception as e:
+            return ArtifactResult(
+                success=False,
+                error=ArtifactError(
+                    code="INVALID_SCHEMA",
+                    message="Invalid deck schema",
+                    details=str(e),
+                ),
+            ).model_dump()
+
+        try:
+            from pptx import Presentation
+            from pptx.util import Inches
+        except ImportError:
+            return ArtifactResult(
+                success=False,
+                error=ArtifactError(
+                    code="DEP_MISSING",
+                    message="python-pptx not installed. Install with: pip install -e '.[powerpoint]' (from tools/)",
+                ),
+            ).model_dump()
+
+        try:
+            out_path = get_secure_path(path, workspace_id, agent_id, session_id)
+            os.makedirs(os.path.dirname(out_path), exist_ok=True)
+
+            prs = Presentation()
+
+            # Title slide
+            title_layout = prs.slide_layouts[0] if len(prs.slide_layouts) > 0 else prs.slide_layouts[5]
+            slide0 = prs.slides.add_slide(title_layout)
+            if slide0.shapes.title:
+                slide0.shapes.title.text = spec.title
+
+            # Content slides
+            content_layout = prs.slide_layouts[1] if len(prs.slide_layouts) > 1 else prs.slide_layouts[5]
+
+            for s in spec.slides:
+                sl = prs.slides.add_slide(content_layout)
+                if sl.shapes.title:
+                    sl.shapes.title.text = s.title
+
+                # Find a body text frame (best-effort)
+                body = None
+                for shape in sl.shapes:
+                    if shape.has_text_frame and shape != sl.shapes.title:
+                        body = shape.text_frame
+                        break
+
+                if body and s.bullets:
+                    body.clear()
+                    p0 = body.paragraphs[0]
+                    p0.text = s.bullets[0]
+                    p0.level = 0
+                    for b in s.bullets[1:]:
+                        p = body.add_paragraph()
+                        p.text = b
+                        p.level = 0
+
+                all_imgs = list(s.image_paths) + list(s.charts)
+                positions = [(1.0, 4.5), (3.7, 4.5), (6.4, 4.5)]  # left-to-right row
+
+                for idx, img_rel in enumerate(all_imgs[:3]):
+                    img_abs = get_secure_path(img_rel, workspace_id, agent_id, session_id)
+                    if os.path.exists(img_abs):
+                        x, y = positions[idx]
+                        sl.shapes.add_picture(img_abs, Inches(x), Inches(y), width=Inches(2.5))
+
+            prs.save(out_path)
+
+            return ArtifactResult(
+                success=True,
+                output_path=str(out_path),
+                metadata={"slides": len(prs.slides)},
+            ).model_dump()
+
+        except Exception as e:
+            return ArtifactResult(
+                success=False,
+                error=ArtifactError(
+                    code="INTERNAL_ERROR",
+                    message="Failed to generate PowerPoint",
+                    details=str(e),
+                ),
+            ).model_dump()

--- a/tools/src/aden_tools/tools/testing_utils.py
+++ b/tools/src/aden_tools/tools/testing_utils.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Callable
+from fastmcp import FastMCP
+
+
+def get_tool_fn(mcp: FastMCP, name: str) -> Callable:
+    """
+    Centralized helper for tests/examples.
+    If FastMCP exposes a public getter in future, update only here.
+    """
+    return mcp._tool_manager._tools[name].fn

--- a/tools/src/aden_tools/tools/word_tool/README.md
+++ b/tools/src/aden_tools/tools/word_tool/README.md
@@ -1,0 +1,15 @@
+# Word Tool (Schema-First)
+
+Generates local `.docx` reports from a strict schema.
+
+## Tool
+- `word_generate(path, doc, workspace_id, agent_id, session_id)`
+
+## Schema (MVP)
+- DocSpec: { title: str, sections: [SectionSpec] }
+- SectionSpec: { heading: str, paragraphs: [str], bullets: [str], table: Optional[TableSpec] }
+- TableSpec: { columns: [str], rows: [[Any]] }
+
+## Notes
+- Paths are relative to the session sandbox.
+- Uses `python-docx` optional dependency group: `word`.

--- a/tools/src/aden_tools/tools/word_tool/__init__.py
+++ b/tools/src/aden_tools/tools/word_tool/__init__.py
@@ -1,0 +1,4 @@
+from .word_tool import register_tools as register_word
+from .word_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/word_tool/word_tool.py
+++ b/tools/src/aden_tools/tools/word_tool/word_tool.py
@@ -7,7 +7,6 @@ import os
 from typing import Any, List, Optional
 
 from fastmcp import FastMCP
-from pptx import Presentation
 from pydantic import BaseModel, Field
 
 from ..file_system_toolkits.security import get_secure_path

--- a/tools/src/aden_tools/tools/word_tool/word_tool.py
+++ b/tools/src/aden_tools/tools/word_tool/word_tool.py
@@ -1,0 +1,153 @@
+"""Word Tool - Generate .docx reports (schema-first)."""
+from __future__ import annotations
+from aden_tools.tools.office_skills_pack.contracts import ArtifactError, ArtifactResult
+
+
+import os
+from typing import Any, List, Optional
+
+from fastmcp import FastMCP
+from pptx import Presentation
+from pydantic import BaseModel, Field
+
+from ..file_system_toolkits.security import get_secure_path
+
+
+class TableSpec(BaseModel):
+    columns: List[str] = Field(..., min_length=1)
+    rows: List[List[Any]] = Field(default_factory=list)
+
+
+class SectionSpec(BaseModel):
+    heading: str = Field(..., min_length=1)
+    paragraphs: List[str] = Field(default_factory=list)
+    bullets: List[str] = Field(default_factory=list)
+    table: Optional[TableSpec] = None
+    image_paths: List[str] = Field(
+        default_factory=list,
+        description="Image paths relative to session sandbox",
+    )
+    charts: List[str] = Field(
+        default_factory=list,
+        description="Chart PNG paths relative to session sandbox",
+    )
+
+
+class DocSpec(BaseModel):
+    title: str = Field(..., min_length=1)
+    sections: List[SectionSpec] = Field(..., min_length=1)
+
+
+def register_tools(mcp: FastMCP) -> None:
+    @mcp.tool()
+    def word_generate(
+        path: str,
+        doc: dict[str, Any],
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+    ) -> dict:
+        """
+        Generate a Word (.docx) report from a strict schema and save it to the session sandbox.
+        """
+
+        if not path.lower().endswith(".docx"):
+            return ArtifactResult(
+                success=False,
+                error=ArtifactError(
+                    code="INVALID_EXTENSION",
+                    message="path must end with .docx",
+                ),
+            ).model_dump()
+
+
+
+        try:
+            spec = DocSpec.model_validate(doc)
+        except Exception as e:
+            return ArtifactResult(
+                success=False,
+                error=ArtifactError(
+                    code="INVALID_SCHEMA",
+                    message="Invalid doc schema",
+                    details=str(e),
+                ),
+            ).model_dump()
+
+
+        try:
+            from docx import Document
+            from docx.shared import Inches
+        except ImportError:
+            return ArtifactResult(
+                success=False,
+                error=ArtifactError(
+                    code="DEP_MISSING",
+                    message="python-docx not installed. Install with: pip install -e '.[word]' (from tools/)",
+                ),
+            ).model_dump()
+           
+            
+
+        try:
+            out_path = get_secure_path(path, workspace_id, agent_id, session_id)
+            os.makedirs(os.path.dirname(out_path), exist_ok=True)
+
+            d = Document()
+
+            # Title
+            d.add_heading(spec.title, level=0)
+            
+            for sec in spec.sections:
+                d.add_heading(sec.heading, level=1)
+
+                for p in sec.paragraphs:
+                    d.add_paragraph(p)
+
+                for b in sec.bullets:
+                    d.add_paragraph(b, style="List Bullet")
+
+                if sec.table is not None:
+                    t = d.add_table(rows=1, cols=len(sec.table.columns))
+                    hdr = t.rows[0].cells
+                    for i, c in enumerate(sec.table.columns):
+                        hdr[i].text = str(c)
+
+                    for row in sec.table.rows:
+                        r = t.add_row().cells
+                        for i in range(min(len(r), len(row))):
+                            r[i].text = "" if row[i] is None else str(row[i])
+
+                for rel_path in [*sec.image_paths, *sec.charts]:
+                    img_path = get_secure_path(rel_path, workspace_id, agent_id, session_id)
+                    if not os.path.exists(img_path):
+                        return ArtifactResult(
+                            success=False,
+                            error=ArtifactError(
+                                code="ASSET_NOT_FOUND",
+                                message=f"Image not found: {rel_path}",
+                            ),
+                        ).model_dump()
+                    d.add_picture(str(img_path), width=Inches(5.8))
+
+                
+            d.save(out_path)
+
+
+            return ArtifactResult(
+                success=True,
+                output_path=str(out_path),
+                metadata={"sections": len(spec.sections)}
+
+            ).model_dump()
+                        
+
+        except Exception as e:
+            return ArtifactResult(
+                success=False,
+                error=ArtifactError(
+                    code="INTERNAL_ERROR",
+                    message="Failed to generate Word document",
+                    details=str(e),
+                ),
+            ).model_dump()

--- a/tools/tests/examples/test_office_skills_pack_demo.py
+++ b/tools/tests/examples/test_office_skills_pack_demo.py
@@ -8,7 +8,8 @@ from aden_tools.tools.powerpoint_tool.powerpoint_tool import register_tools as r
 from aden_tools.tools.word_tool.word_tool import register_tools as register_word
 
 from aden_tools.tools.file_system_toolkits.security import get_secure_path
-from aden_tools.tools.testing_utils import get_tool_fn
+from aden_tools.tools.mcp_helpers import get_tool_fn
+
 
 
 def test_office_skills_pack_demo_smoke(tmp_path: Path):

--- a/tools/tests/examples/test_office_skills_pack_demo.py
+++ b/tools/tests/examples/test_office_skills_pack_demo.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from fastmcp import FastMCP
+
+from aden_tools.tools.excel_write_tool.excel_write_tool import register_tools as register_xlsx
+from aden_tools.tools.powerpoint_tool.powerpoint_tool import register_tools as register_ppt
+from aden_tools.tools.word_tool.word_tool import register_tools as register_word
+
+from aden_tools.tools.file_system_toolkits.security import get_secure_path
+from aden_tools.tools.testing_utils import get_tool_fn
+
+
+def test_office_skills_pack_demo_smoke(tmp_path: Path):
+    # Redirect sandbox to tmp (Windows-safe)
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        mcp = FastMCP("office-skills-demo-test")
+        register_xlsx(mcp)
+        register_ppt(mcp)
+        register_word(mcp)
+
+        xlsx = get_tool_fn(mcp, "excel_write")
+        pptx = get_tool_fn(mcp, "powerpoint_generate")
+        docx = get_tool_fn(mcp, "word_generate")
+
+        metrics = [
+            {"Ticker": "AAPL", "Return": 0.0123, "Drawdown": -0.034},
+            {"Ticker": "MSFT", "Return": 0.0040, "Drawdown": -0.021},
+        ]
+
+        res_x = xlsx(
+            path="out/weekly_report.xlsx",
+            workbook={
+                "sheets": [{
+                    "name": "Summary",
+                    "columns": ["Ticker", "Return", "Drawdown"],
+                    "rows": [[m["Ticker"], m["Return"], m["Drawdown"]] for m in metrics],
+                    "freeze_panes": "A2",
+                    "number_formats": {"Return": "0.00%", "Drawdown": "0.00%"},
+                }]
+            },
+            workspace_id="demo-ws",
+            agent_id="demo-agent",
+            session_id="demo-session",
+        )
+        assert res_x.get("success") is True, res_x
+
+        res_p = pptx(
+            path="out/weekly_report.pptx",
+            deck={
+                "title": "Weekly Market Brief",
+                "slides": [
+                    {"title": "Summary", "bullets": ["AAPL outperformed", "MSFT stable"], "image_paths": []},
+                ],
+            },
+            workspace_id="demo-ws",
+            agent_id="demo-agent",
+            session_id="demo-session",
+        )
+        assert res_p.get("success") is True, res_p  # <- this will show the real error if any
+
+        res_d = docx(
+            path="out/weekly_report.docx",
+            doc={
+                "title": "Weekly Market Report",
+                "sections": [
+                    {"heading": "Executive Summary", "paragraphs": ["Auto-generated report."], "bullets": []},
+                ],
+            },
+            workspace_id="demo-ws",
+            agent_id="demo-agent",
+            session_id="demo-session",
+        )
+        assert res_d.get("success") is True, res_d
+
+        # Resolve expected outputs via the same sandbox function (most correct)
+        x_abs = get_secure_path("out/weekly_report.xlsx", "demo-ws", "demo-agent", "demo-session")
+        p_abs = get_secure_path("out/weekly_report.pptx", "demo-ws", "demo-agent", "demo-session")
+        d_abs = get_secure_path("out/weekly_report.docx", "demo-ws", "demo-agent", "demo-session")
+
+        assert Path(x_abs).exists()
+        assert Path(p_abs).exists()
+        assert Path(d_abs).exists()
+
+        assert Path(x_abs).stat().st_size > 0
+        assert Path(p_abs).stat().st_size > 0
+        assert Path(d_abs).stat().st_size > 0

--- a/tools/tests/tools/test_chart_tool.py
+++ b/tools/tests/tools/test_chart_tool.py
@@ -1,0 +1,69 @@
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.chart_tool.chart_tool import register_tools as register_chart
+from aden_tools.tools.powerpoint_tool.powerpoint_tool import register_tools as register_ppt
+from aden_tools.tools.file_system_toolkits.security import get_secure_path
+
+mpl_available = importlib.util.find_spec("matplotlib") is not None
+pytestmark = pytest.mark.skipif(not mpl_available, reason="matplotlib not installed")
+
+
+def test_chart_render_png_and_embed_in_pptx(tmp_path: Path):
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        mcp = FastMCP("chart-test")
+        register_chart(mcp)
+        register_ppt(mcp)
+
+        chart_png = mcp._tool_manager._tools["chart_render_png"].fn
+        pptx = mcp._tool_manager._tools["powerpoint_generate"].fn
+
+        r = chart_png(
+            path="out/chart.png",
+            chart={
+                "title": "Test Chart",
+                "x_label": "x",
+                "y_label": "y",
+                "series": [{"name": "s1", "x": [1, 2, 3], "y": [1, 4, 9]}],
+            },
+            workspace_id="w",
+            agent_id="a",
+            session_id="s",
+        )
+        assert r["success"] is True, r
+
+        chart_abs = get_secure_path("out/chart.png", "w", "a", "s")
+        assert Path(chart_abs).exists()
+        assert Path(chart_abs).stat().st_size > 0
+
+        r2 = pptx(
+            path="out/deck.pptx",
+            deck={
+                "title": "Deck",
+                "slides": [
+                    {"title": "Chart", "bullets": ["see chart"], "image_paths": ["out/chart.png"], "charts": []},
+                ],
+            },
+            workspace_id="w",
+            agent_id="a",
+            session_id="s",
+        )
+        assert r2["success"] is True, r2
+
+        ppt_abs = get_secure_path("out/deck.pptx", "w", "a", "s")
+        assert Path(ppt_abs).exists()
+
+        from pptx import Presentation
+        prs = Presentation(str(ppt_abs))
+
+        # Check: at least one picture shape exists somewhere
+        has_picture = False
+        for slide in prs.slides:
+            for shape in slide.shapes:
+                if shape.shape_type == 13:  # MSO_SHAPE_TYPE.PICTURE == 13
+                    has_picture = True
+        assert has_picture is True

--- a/tools/tests/tools/test_excel_write_tool.py
+++ b/tools/tests/tools/test_excel_write_tool.py
@@ -1,0 +1,127 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.excel_write_tool.excel_write_tool import register_tools
+
+TEST_WORKSPACE_ID = "test-workspace"
+TEST_AGENT_ID = "test-agent"
+TEST_SESSION_ID = "test-session"
+
+
+@pytest.fixture
+def excel_tools(mcp: FastMCP, tmp_path: Path):
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        register_tools(mcp)
+        yield {
+            "excel_write": mcp._tool_manager._tools["excel_write"].fn,
+            "tmp_path": tmp_path,
+        }
+
+
+def test_excel_write_multisheet_and_format(excel_tools):
+    fn = excel_tools["excel_write"]
+
+    wb = {
+        "sheets": [
+            {
+                "name": "Summary",
+                "columns": ["Ticker", "Return", "Drawdown"],
+                "rows": [["AAPL", 0.0123, -0.034], ["MSFT", 0.004, -0.021]],
+                "freeze_panes": "A2",
+                "number_formats": {"Return": "0.00%", "Drawdown": "0.00%"},
+            },
+            {
+                "name": "Raw",
+                "columns": ["Day", "AAPL", "MSFT"],
+                "rows": [["2026-02-01", 192.1, 411.2]],
+                "freeze_panes": "A2",
+            },
+        ]
+    }
+
+    res = fn(
+        path="out/weekly_report.xlsx",
+        workbook=wb,
+        workspace_id=TEST_WORKSPACE_ID,
+        agent_id=TEST_AGENT_ID,
+        session_id=TEST_SESSION_ID,
+    )
+    assert res.get("success") is True
+    assert res.get("metadata", {}).get("sheets") == 2
+
+
+    out_abs = (
+        Path(excel_tools["tmp_path"])
+        / TEST_WORKSPACE_ID
+        / TEST_AGENT_ID
+        / TEST_SESSION_ID
+        / "out"
+        / "weekly_report.xlsx"
+    )
+    assert out_abs.exists()
+    assert out_abs.stat().st_size > 0
+
+    # Light read-back checks
+    import openpyxl
+    wb2 = openpyxl.load_workbook(out_abs)
+    assert "Summary" in wb2.sheetnames
+    ws = wb2["Summary"]
+    assert ws["A1"].value == "Ticker"
+    assert ws.freeze_panes == "A2"
+    # number format applied
+    assert ws["B2"].number_format == "0.00%"
+
+
+def test_excel_write_embeds_image(tmp_path: Path):
+    import openpyxl
+    from fastmcp import FastMCP
+
+    from aden_tools.tools.chart_tool.chart_tool import register_tools as register_chart
+    from aden_tools.tools.excel_write_tool.excel_write_tool import register_tools as register_xlsx
+    from aden_tools.tools.file_system_toolkits.security import get_secure_path
+
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        mcp = FastMCP("img-xlsx-test")
+        register_chart(mcp)
+        register_xlsx(mcp)
+
+        chart_png = mcp._tool_manager._tools["chart_render_png"].fn
+        xlsx = mcp._tool_manager._tools["excel_write"].fn
+
+        r = chart_png(
+            path="out/chart.png",
+            chart={
+                "title": "T",
+                "x_label": "x",
+                "y_label": "y",
+                "series": [{"name": "s", "x": [1, 2], "y": [1, 2]}],
+            },
+            workspace_id="w",
+            agent_id="a",
+            session_id="s",
+        )
+        assert r["success"] is True, r
+
+        r2 = xlsx(
+            path="out/book.xlsx",
+            workbook={
+                "sheets": [{
+                    "name": "Charts",
+                    "columns": ["Chart"],
+                    "rows": [["demo"]],
+                    "images": [{"path": "out/chart.png", "cell": "A3", "width": 400}],
+                }]
+            },
+            workspace_id="w",
+            agent_id="a",
+            session_id="s",
+        )
+        assert r2["success"] is True, r2
+
+        x_abs = get_secure_path("out/book.xlsx", "w", "a", "s")
+        wb = openpyxl.load_workbook(x_abs)
+        ws = wb["Charts"]
+        assert len(getattr(ws, "_images", [])) >= 1

--- a/tools/tests/tools/test_office_contracts.py
+++ b/tools/tests/tools/test_office_contracts.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from fastmcp import FastMCP
+
+from aden_tools.tools.powerpoint_tool.powerpoint_tool import register_tools as register_ppt
+
+
+def test_contract_error_codes(tmp_path: Path):
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        mcp = FastMCP("contract-test")
+        register_ppt(mcp)
+        pptx = mcp._tool_manager._tools["powerpoint_generate"].fn
+
+        # invalid schema: slides missing
+        res = pptx(
+            path="out/x.pptx",
+            deck={"title": "Bad"},  # missing slides
+            workspace_id="w",
+            agent_id="a",
+            session_id="s",
+        )
+
+        assert res["success"] is False
+        assert res["error"]["code"] == "INVALID_SCHEMA"
+        assert "contract_version" in res

--- a/tools/tests/tools/test_powerpoint_tool.py
+++ b/tools/tests/tools/test_powerpoint_tool.py
@@ -1,0 +1,92 @@
+"""Tests for powerpoint_tool - Generate PowerPoint files (.pptx) schema-first."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastmcp import FastMCP
+from pptx import Presentation
+
+pptx_available = importlib.util.find_spec("pptx") is not None
+
+pytestmark = pytest.mark.skipif(not pptx_available, reason="python-pptx not installed")
+
+if pptx_available:
+    from aden_tools.tools.powerpoint_tool.powerpoint_tool import register_tools
+
+TEST_WORKSPACE_ID = "test-workspace"
+TEST_AGENT_ID = "test-agent"
+TEST_SESSION_ID = "test-session"
+
+
+@pytest.fixture
+def powerpoint_tools(mcp: FastMCP, tmp_path: Path):
+    """Register PowerPoint tools and return callable tool handles."""
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        register_tools(mcp)
+        yield {
+            "powerpoint_generate": mcp._tool_manager._tools["powerpoint_generate"].fn,
+            "tmp_path": tmp_path,
+        }
+
+
+def test_powerpoint_generate_creates_pptx(powerpoint_tools):
+    gen = powerpoint_tools["powerpoint_generate"]
+
+    deck = {
+        "title": "Weekly Report",
+        "slides": [
+            {"title": "Summary", "bullets": ["AAPL up", "MSFT stable"], "image_paths": []},
+            {"title": "Risks", "bullets": ["Volatility", "Macro"], "image_paths": []},
+        ],
+    }
+
+    res = gen(
+        path="out/weekly_report.pptx",
+        deck=deck,
+        workspace_id=TEST_WORKSPACE_ID,
+        agent_id=TEST_AGENT_ID,
+        session_id=TEST_SESSION_ID,
+    )
+
+    assert res.get("success") is True, res
+    out_abs = res.get("output_path")
+    assert out_abs, res
+    prs = Presentation(str(out_abs))
+    assert res.get("metadata", {}).get("slides") == 1 + len(deck["slides"])
+
+    texts = []
+    for s in prs.slides:
+        for shape in s.shapes:
+            if hasattr(shape, "text"):
+                texts.append(shape.text)
+    joined ="\n".join(texts)
+    assert "Weekly Report" in joined
+    assert "Summary" in joined
+    assert "Risks" in joined
+    # ensure file exists in sandbox
+    out_abs = (
+        Path(powerpoint_tools["tmp_path"])
+        / TEST_WORKSPACE_ID
+        / TEST_AGENT_ID
+        / TEST_SESSION_ID
+        / "out"
+        / "weekly_report.pptx"
+    )
+    assert out_abs.exists()
+    assert out_abs.stat().st_size > 0
+
+
+def test_powerpoint_generate_rejects_bad_extension(powerpoint_tools):
+    gen = powerpoint_tools["powerpoint_generate"]
+    res = gen(
+        path="out/not_a_ppt.txt",
+        deck={"title": "X", "slides": [{"title": "A", "bullets": []}]},
+        workspace_id=TEST_WORKSPACE_ID,
+        agent_id=TEST_AGENT_ID,
+        session_id=TEST_SESSION_ID,
+    )
+    assert res.get("success") is False
+    assert res.get("error") is not None
+

--- a/tools/tests/tools/test_word_tool.py
+++ b/tools/tests/tools/test_word_tool.py
@@ -1,0 +1,103 @@
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastmcp import FastMCP
+from docx import Document
+
+docx_available = importlib.util.find_spec("docx") is not None
+pytestmark = pytest.mark.skipif(not docx_available, reason="python-docx not installed")
+
+if docx_available:
+    from aden_tools.tools.word_tool.word_tool import register_tools
+
+TEST_WORKSPACE_ID = "test-workspace"
+TEST_AGENT_ID = "test-agent"
+TEST_SESSION_ID = "test-session"
+
+
+@pytest.fixture
+def word_tools(mcp: FastMCP, tmp_path: Path):
+    with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+        register_tools(mcp)
+        yield {
+            "word_generate": mcp._tool_manager._tools["word_generate"].fn,
+            "tmp_path": tmp_path,
+        }
+
+
+def test_word_generate_creates_docx(word_tools):
+    gen = word_tools["word_generate"]
+
+    doc = {
+        "title": "Monthly Analysis",
+        "sections": [
+            {
+                "heading": "Executive Summary",
+                "paragraphs": ["Markets were volatile.", "Risk was elevated."],
+                "bullets": ["AAPL outperformed", "MSFT stable"],
+            },
+            {
+                "heading": "Key Metrics",
+                "paragraphs": [],
+                "bullets": [],
+                "table": {
+                    "columns": ["Metric", "Value"],
+                    "rows": [["Drawdown", "-3.2%"], ["Volatility", "18%"]],
+                },
+            },
+        ],
+    }
+
+    res = gen(
+        path="out/report.docx",
+        doc=doc,
+        workspace_id=TEST_WORKSPACE_ID,
+        agent_id=TEST_AGENT_ID,
+        session_id=TEST_SESSION_ID,
+    )
+
+
+
+
+
+    # d = Document(str(out_abs))
+    assert res.get("success") is True, res
+    out_abs = res.get("output_path")
+    assert out_abs, res
+    d = Document(str(out_abs))
+    full = "\n".join(p.text for p in d.paragraphs)
+
+    assert "Monthly Analysis" in full
+    assert "Executive Summary" in full
+    assert "Auto-generated report." in full or "Markets were volatile." in full
+
+
+    assert res.get("metadata", {}).get("sections") == len(doc["sections"])
+
+
+    out_abs = (
+        Path(word_tools["tmp_path"])
+        / TEST_WORKSPACE_ID
+        / TEST_AGENT_ID
+        / TEST_SESSION_ID
+        / "out"
+        / "report.docx"
+    )
+    assert out_abs.exists()
+    assert out_abs.stat().st_size > 0
+
+
+def test_word_generate_rejects_bad_extension(word_tools):
+    gen = word_tools["word_generate"]
+    res = gen(
+        path="out/nope.txt",
+        doc={"title": "X", "sections": [{"heading": "A"}]},
+        workspace_id=TEST_WORKSPACE_ID,
+        agent_id=TEST_AGENT_ID,
+        session_id=TEST_SESSION_ID,
+    )
+    assert res.get("success") is False
+    assert res.get("error", {}).get("code") == "INVALID_EXTENSION"
+


### PR DESCRIPTION
## Description
Adds a schema-first Office Skills Pack (local-only MVP):
- XLSX: multi-sheet writer + formatting + image embed (charts)
- PPTX: slide deck generator (title/bullets/images) + chart PNG embedding
- DOCX: report generator (sections/bullets/tables)
- PNG charts: render via matplotlib for artifact embedding
- Office pack registry + schema discovery tool
- Windows-stable execute-command tests

## Type of Change
- [x] New feature
- [x] Bug fix (Windows CI stability in execute command tests)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issues
Fixes #5062

## Changes Made
- Added `chart_render_png`, `excel_write`, `powerpoint_generate`, `word_generate`
- Added office pack contracts and `register_office_skills_pack`
- Added `office_skills_schema` tool with contract-versioned schema responses
- Added demo + finance example scripts
- Added tests for chart/excel/ppt/word + office demo
- Added CI job for office extras
- Hardened excel image extension validation (`.png/.jpg/.jpeg`)
- Made execute-command tests platform-aware for Windows

## Testing
- [x] `cd tools && python -m pytest -q -k "not symlink"`
- [x] `python tools/examples/office_skills_pack_demo.py`
- [x] `python tools/examples/office_skills_finance_example.py`

## Checklist
- [x] Self-reviewed code
- [x] Tests added/updated
- [x] No unrelated changes included
- [x] Security considered (`get_secure_path`, local-only MVP)

## Screenshots (if applicable)
N/A
