### PR TITLE
feat(tools): add Brevo transactional email and SMS integration

### DIFF
--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -67,6 +67,7 @@ from .google_docs import GOOGLE_DOCS_CREDENTIALS
 from .google_maps import GOOGLE_MAPS_CREDENTIALS
 from .health_check import HealthCheckResult, check_credential_health
 from .hubspot import HUBSPOT_CREDENTIALS
+from .brevo import BREVO_CREDENTIALS
 from .llm import LLM_CREDENTIALS
 from .news import NEWS_CREDENTIALS
 from .razorpay import RAZORPAY_CREDENTIALS
@@ -95,6 +96,7 @@ CREDENTIAL_SPECS = {
     **GOOGLE_DOCS_CREDENTIALS,
     **GOOGLE_MAPS_CREDENTIALS,
     **HUBSPOT_CREDENTIALS,
+    **BREVO_CREDENTIALS,
     **GOOGLE_CALENDAR_CREDENTIALS,
     **SLACK_CREDENTIALS,
     **SERPAPI_CREDENTIALS,
@@ -135,6 +137,7 @@ __all__ = [
     "GOOGLE_DOCS_CREDENTIALS",
     "GOOGLE_MAPS_CREDENTIALS",
     "HUBSPOT_CREDENTIALS",
+    "BREVO_CREDENTIALS",
     "GOOGLE_CALENDAR_CREDENTIALS",
     "SLACK_CREDENTIALS",
     "APOLLO_CREDENTIALS",

--- a/tools/src/aden_tools/credentials/brevo.py
+++ b/tools/src/aden_tools/credentials/brevo.py
@@ -1,0 +1,35 @@
+"""
+Brevo tool credentials.
+Contains credentials for Brevo email and SMS integration.
+"""
+from .base import CredentialSpec
+
+BREVO_CREDENTIALS = {
+    "brevo": CredentialSpec(
+        env_var="BREVO_API_KEY",
+        tools=[
+            "brevo_send_email",
+            "brevo_send_sms",
+            "brevo_create_contact",
+            "brevo_get_contact",
+            "brevo_update_contact",
+            "brevo_get_email_stats",
+        ],
+        required=True,
+        startup_required=False,
+        help_url="https://app.brevo.com/settings/keys/api",
+        description="Brevo API key for transactional email, SMS, and contact management",
+        aden_supported=False,
+        direct_api_key_supported=True,
+        api_key_instructions="""To get a Brevo API key:
+1. Sign up or log in at https://www.brevo.com
+2. Go to Settings → API Keys
+3. Click 'Generate a new API key'
+4. Give it a name (e.g., 'Hive Agent')
+5. Copy the API key and set it as BREVO_API_KEY""",
+        health_check_endpoint="https://api.brevo.com/v3/account",
+        health_check_method="GET",
+        credential_id="brevo",
+        credential_key="api_key",
+    ),
+}

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 # Import register_tools from each tool module
 from .apollo_tool import register_tools as register_apollo
 from .bigquery_tool import register_tools as register_bigquery
+from .brevo_tool import register_tools as register_brevo
 from .calcom_tool import register_tools as register_calcom
 from .calendar_tool import register_tools as register_calendar
 from .csv_tool import register_tools as register_csv
@@ -105,6 +106,7 @@ def register_all_tools(
     register_gmail(mcp, credentials=credentials)
     register_hubspot(mcp, credentials=credentials)
     register_apollo(mcp, credentials=credentials)
+    register_brevo(mcp, credentials=credentials)
     register_bigquery(mcp, credentials=credentials)
     register_calcom(mcp, credentials=credentials)
     register_calendar(mcp, credentials=credentials)

--- a/tools/src/aden_tools/tools/brevo_tool/README.md
+++ b/tools/src/aden_tools/tools/brevo_tool/README.md
@@ -1,0 +1,172 @@
+# Brevo Tool
+
+Interact with [Brevo](https://www.brevo.com) (formerly Sendinblue) to send 
+transactional emails, SMS messages, and manage contacts via the 
+[Brevo API](https://developers.brevo.com/reference).
+
+## Setup
+
+### 1. Create a Brevo Account
+Sign up for free at [brevo.com](https://www.brevo.com). The free tier includes
+300 emails/day and basic contact management.
+
+### 2. Get Your API Key
+1. Log in to your Brevo account
+2. Go to **Settings → API Keys**
+3. Click **Generate a new API key**
+4. Copy the key
+
+### 3. Set Environment Variable
+```bash
+export BREVO_API_KEY=your_api_key_here
+```
+
+### 4. Verify Your Sender Email
+Before sending emails, verify your sender address in Brevo under
+**Senders & IP → Senders**.
+
+---
+
+## Tools (6 Total)
+
+### Email (2)
+| Tool | Purpose |
+|---|---|
+| `brevo_send_email` | Send a transactional email with HTML content |
+| `brevo_get_email_stats` | Get delivery status and events for a sent email |
+
+### SMS (1)
+| Tool | Purpose |
+|---|---|
+| `brevo_send_sms` | Send a transactional SMS to a phone number |
+
+### Contacts (3)
+| Tool | Purpose |
+|---|---|
+| `brevo_create_contact` | Create a new contact in your Brevo account |
+| `brevo_get_contact` | Retrieve contact details by email address |
+| `brevo_update_contact` | Update an existing contact's attributes |
+
+---
+
+## Usage Examples
+
+### Send a Transactional Email
+```python
+brevo_send_email(
+    to_email="user@example.com",
+    to_name="John Doe",
+    subject="Your report is ready",
+    html_content="<h1>Hello John!</h1><p>Your report has been generated.</p>",
+    from_email="agent@yourcompany.com",
+    from_name="Hive Agent",
+    text_content="Hello John! Your report has been generated."  # optional
+)
+# Returns: {"success": True, "message_id": "<abc123@smtp-relay.brevo.com>"}
+```
+
+### Send an SMS
+```python
+brevo_send_sms(
+    to="+919876543210",       # international format required
+    content="Your OTP is 4821. Valid for 10 minutes.",
+    sender="HiveAgent"        # max 11 alphanumeric characters
+)
+# Returns: {"success": True, "reference": "...", "remaining_credits": 95.0}
+```
+
+### Create a Contact
+```python
+brevo_create_contact(
+    email="lead@example.com",
+    first_name="Jane",
+    last_name="Smith",
+    phone="+14155552671",
+    list_ids="2,5"            # comma-separated list IDs
+)
+# Returns: {"success": True, "id": 42, "email": "lead@example.com"}
+```
+
+### Get a Contact
+```python
+brevo_get_contact(email="lead@example.com")
+# Returns:
+# {
+#   "success": True,
+#   "id": 42,
+#   "email": "lead@example.com",
+#   "first_name": "Jane",
+#   "last_name": "Smith",
+#   "list_ids": [2, 5],
+#   "email_blacklisted": False,
+#   "created_at": "2024-01-15T10:30:00Z"
+# }
+```
+
+### Update a Contact
+```python
+brevo_update_contact(
+    email="lead@example.com",
+    first_name="Jane",
+    last_name="Johnson",      # updated last name
+    list_ids="2,5,8"          # added to list 8
+)
+# Returns: {"success": True, "email": "lead@example.com"}
+```
+
+### Check Email Delivery Status
+```python
+brevo_get_email_stats(message_id="<abc123@smtp-relay.brevo.com>")
+# Returns:
+# {
+#   "success": True,
+#   "message_id": "<abc123@smtp-relay.brevo.com>",
+#   "email": "user@example.com",
+#   "subject": "Your report is ready",
+#   "events": [{"name": "delivered", "time": "..."}]
+# }
+```
+
+---
+
+## Use Cases for AI Agents
+
+- **Task Completion Alerts:** Agent sends email when a long-running job finishes
+- **Human-in-the-Loop:** Agent sends SMS requesting approval before a sensitive action
+- **Lead Management:** Agent creates/updates contacts after qualifying leads from Slack or HubSpot
+- **Error Notifications:** Agent sends SMS alert when a critical workflow fails
+- **Verification:** Agent sends OTP via SMS for user identity verification
+
+---
+
+## Error Handling
+
+All tools return `{"error": "message"}` on failure. Always check for the 
+`error` key before using results.
+
+Common errors:
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Invalid Brevo API key` | Wrong or expired key | Regenerate key in Brevo settings |
+| `Access forbidden` | Insufficient permissions | Check API key permissions |
+| `Resource not found` | Contact/email doesn't exist | Verify the email or message ID |
+| `Rate limit exceeded` | Too many requests | Wait and retry |
+| `Phone number must start with '+'` | Wrong phone format | Use international format e.g. `+14155552671` |
+
+---
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `BREVO_API_KEY` | Yes | API key from Brevo Settings → API Keys |
+
+---
+
+## API Reference
+
+- [Brevo API Docs](https://developers.brevo.com/reference)
+- [Transactional Email](https://developers.brevo.com/reference/sendtransacemail)
+- [Transactional SMS](https://developers.brevo.com/reference/sendtransacsms)
+- [Contacts API](https://developers.brevo.com/reference/createcontact)

--- a/tools/src/aden_tools/tools/brevo_tool/__init__.py
+++ b/tools/src/aden_tools/tools/brevo_tool/__init__.py
@@ -1,0 +1,3 @@
+from .brevo_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/brevo_tool/brevo_tool.py
+++ b/tools/src/aden_tools/tools/brevo_tool/brevo_tool.py
@@ -1,0 +1,457 @@
+"""
+Brevo Tool - Send transactional emails, SMS, and manage contacts via Brevo API.
+
+Supports:
+- API Key authentication (BREVO_API_KEY)
+
+API Reference: https://developers.brevo.com/reference
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialStoreAdapter
+
+BREVO_API_BASE = "https://api.brevo.com/v3"
+
+
+class _BrevoClient:
+    """Internal client wrapping Brevo API calls."""
+
+    def __init__(self, api_key: str):
+        self._api_key = api_key
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {
+            "api-key": self._api_key,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def _handle_response(self, response: httpx.Response) -> dict[str, Any]:
+        """Handle Brevo API response."""
+        if response.status_code == 401:
+            return {"error": "Invalid Brevo API key"}
+        if response.status_code == 403:
+            return {"error": "Access forbidden - check API key permissions"}
+        if response.status_code == 404:
+            return {"error": "Resource not found"}
+        if response.status_code == 429:
+            return {"error": "Rate limit exceeded. Try again later."}
+        if response.status_code not in (200, 201, 204):
+            return {"error": f"HTTP error {response.status_code}: {response.text}"}
+        if response.status_code == 204 or not response.content:
+            return {"success": True}
+        return response.json()
+
+    def send_email(
+        self,
+        to_email: str,
+        to_name: str,
+        subject: str,
+        html_content: str,
+        from_email: str,
+        from_name: str,
+        text_content: str | None = None,
+    ) -> dict[str, Any]:
+        """Send a transactional email."""
+        body: dict[str, Any] = {
+            "sender": {"email": from_email, "name": from_name},
+            "to": [{"email": to_email, "name": to_name}],
+            "subject": subject,
+            "htmlContent": html_content,
+        }
+        if text_content:
+            body["textContent"] = text_content
+
+        response = httpx.post(
+            f"{BREVO_API_BASE}/smtp/email",
+            headers=self._headers,
+            json=body,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def send_sms(
+        self,
+        to: str,
+        content: str,
+        sender: str,
+    ) -> dict[str, Any]:
+        """Send a transactional SMS."""
+        body = {
+            "sender": sender,
+            "recipient": to,
+            "content": content,
+        }
+        response = httpx.post(
+            f"{BREVO_API_BASE}/transactionalSMS/sms",
+            headers=self._headers,
+            json=body,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def create_contact(
+        self,
+        email: str,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        phone: str | None = None,
+        list_ids: list[int] | None = None,
+    ) -> dict[str, Any]:
+        """Create a new contact."""
+        attributes: dict[str, Any] = {}
+        if first_name:
+            attributes["FIRSTNAME"] = first_name
+        if last_name:
+            attributes["LASTNAME"] = last_name
+        if phone:
+            attributes["SMS"] = phone
+
+        body: dict[str, Any] = {
+            "email": email,
+            "attributes": attributes,
+        }
+        if list_ids:
+            body["listIds"] = list_ids
+
+        response = httpx.post(
+            f"{BREVO_API_BASE}/contacts",
+            headers=self._headers,
+            json=body,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def get_contact(self, email: str) -> dict[str, Any]:
+        """Get a contact by email."""
+        response = httpx.get(
+            f"{BREVO_API_BASE}/contacts/{email}",
+            headers=self._headers,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def update_contact(
+        self,
+        email: str,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        phone: str | None = None,
+        list_ids: list[int] | None = None,
+    ) -> dict[str, Any]:
+        """Update an existing contact."""
+        attributes: dict[str, Any] = {}
+        if first_name:
+            attributes["FIRSTNAME"] = first_name
+        if last_name:
+            attributes["LASTNAME"] = last_name
+        if phone:
+            attributes["SMS"] = phone
+
+        body: dict[str, Any] = {"attributes": attributes}
+        if list_ids:
+            body["listIds"] = list_ids
+
+        response = httpx.put(
+            f"{BREVO_API_BASE}/contacts/{email}",
+            headers=self._headers,
+            json=body,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def get_email_stats(self, message_id: str) -> dict[str, Any]:
+        """Get delivery stats for a sent email."""
+        response = httpx.get(
+            f"{BREVO_API_BASE}/smtp/emails/{message_id}",
+            headers=self._headers,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: "CredentialStoreAdapter | None" = None,
+) -> None:
+    """Register Brevo tools with the MCP server."""
+
+    def _get_api_key() -> str | None:
+        if credentials is not None:
+            key = credentials.get("brevo")
+            if key is not None and not isinstance(key, str):
+                raise TypeError(
+                    f"Expected string from credentials, got {type(key).__name__}"
+                )
+            return key
+        return os.getenv("BREVO_API_KEY")
+
+    def _get_client() -> _BrevoClient | dict[str, str]:
+        api_key = _get_api_key()
+        if not api_key:
+            return {
+                "error": "Brevo credentials not configured",
+                "help": (
+                    "Set BREVO_API_KEY environment variable or configure via credential store. "
+                    "Get your API key at https://app.brevo.com/settings/keys/api"
+                ),
+            }
+        return _BrevoClient(api_key)
+
+    @mcp.tool()
+    def brevo_send_email(
+        to_email: str,
+        to_name: str,
+        subject: str,
+        html_content: str,
+        from_email: str,
+        from_name: str,
+        text_content: str | None = None,
+    ) -> dict:
+        """
+        Send a transactional email via Brevo.
+
+        Args:
+            to_email: Recipient email address
+            to_name: Recipient display name
+            subject: Email subject line
+            html_content: HTML body of the email
+            from_email: Sender email address (must be verified in Brevo)
+            from_name: Sender display name
+            text_content: Optional plain text version of the email
+
+        Returns:
+            Dict with message ID or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not to_email or "@" not in to_email:
+            return {"error": "Invalid recipient email address"}
+        if not subject:
+            return {"error": "Email subject cannot be empty"}
+        if not html_content:
+            return {"error": "Email content cannot be empty"}
+        try:
+            result = client.send_email(
+                to_email, to_name, subject, html_content, from_email, from_name, text_content
+            )
+            if "error" in result:
+                return result
+            return {
+                "success": True,
+                "message_id": result.get("messageId"),
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def brevo_send_sms(
+        to: str,
+        content: str,
+        sender: str,
+    ) -> dict:
+        """
+        Send a transactional SMS via Brevo.
+
+        Args:
+            to: Recipient phone number in international format (e.g. '+919876543210')
+            content: SMS message content (max 160 characters for single SMS)
+            sender: Sender name or number (max 11 alphanumeric characters)
+
+        Returns:
+            Dict with success status and reference or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not to.startswith("+"):
+            return {"error": "Phone number must be in international format starting with '+'"}
+        if not content:
+            return {"error": "SMS content cannot be empty"}
+        if len(content) > 640:
+            return {"error": "SMS content too long (max 640 characters)"}
+        try:
+            result = client.send_sms(to, content, sender)
+            if "error" in result:
+                return result
+            return {
+                "success": True,
+                "reference": result.get("reference"),
+                "remaining_credits": result.get("remainingCredits"),
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def brevo_create_contact(
+        email: str,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        phone: str | None = None,
+        list_ids: str | None = None,
+    ) -> dict:
+        """
+        Create a new contact in Brevo.
+
+        Args:
+            email: Contact email address
+            first_name: Optional first name
+            last_name: Optional last name
+            phone: Optional phone number in international format
+            list_ids: Optional comma-separated list IDs to add contact to (e.g. '2,5,8')
+
+        Returns:
+            Dict with new contact ID or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not email or "@" not in email:
+            return {"error": "Invalid email address"}
+        parsed_list_ids = None
+        if list_ids:
+            try:
+                parsed_list_ids = [int(x.strip()) for x in list_ids.split(",")]
+            except ValueError:
+                return {"error": "list_ids must be comma-separated integers (e.g. '2,5,8')"}
+        try:
+            result = client.create_contact(email, first_name, last_name, phone, parsed_list_ids)
+            if "error" in result:
+                return result
+            return {
+                "success": True,
+                "id": result.get("id"),
+                "email": email,
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def brevo_get_contact(email: str) -> dict:
+        """
+        Retrieve a contact from Brevo by email address.
+
+        Args:
+            email: Contact email address to look up
+
+        Returns:
+            Dict with contact details or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not email or "@" not in email:
+            return {"error": "Invalid email address"}
+        try:
+            result = client.get_contact(email)
+            if "error" in result:
+                return result
+            attributes = result.get("attributes", {})
+            return {
+                "success": True,
+                "id": result.get("id"),
+                "email": result.get("email"),
+                "first_name": attributes.get("FIRSTNAME"),
+                "last_name": attributes.get("LASTNAME"),
+                "phone": attributes.get("SMS"),
+                "list_ids": result.get("listIds", []),
+                "email_blacklisted": result.get("emailBlacklisted", False),
+                "sms_blacklisted": result.get("smsBlacklisted", False),
+                "created_at": result.get("createdAt"),
+                "modified_at": result.get("modifiedAt"),
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def brevo_update_contact(
+        email: str,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        phone: str | None = None,
+        list_ids: str | None = None,
+    ) -> dict:
+        """
+        Update an existing contact in Brevo.
+
+        Args:
+            email: Email address of the contact to update
+            first_name: Updated first name
+            last_name: Updated last name
+            phone: Updated phone number in international format
+            list_ids: Comma-separated list IDs to add contact to (e.g. '2,5,8')
+
+        Returns:
+            Dict with success status or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not email or "@" not in email:
+            return {"error": "Invalid email address"}
+        parsed_list_ids = None
+        if list_ids:
+            try:
+                parsed_list_ids = [int(x.strip()) for x in list_ids.split(",")]
+            except ValueError:
+                return {"error": "list_ids must be comma-separated integers (e.g. '2,5,8')"}
+        try:
+            result = client.update_contact(email, first_name, last_name, phone, parsed_list_ids)
+            if "error" in result:
+                return result
+            return {"success": True, "email": email}
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def brevo_get_email_stats(message_id: str) -> dict:
+        """
+        Get delivery statistics for a sent transactional email.
+
+        Args:
+            message_id: The message ID returned when the email was sent
+
+        Returns:
+            Dict with delivery status and events or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not message_id:
+            return {"error": "message_id cannot be empty"}
+        try:
+            result = client.get_email_stats(message_id)
+            if "error" in result:
+                return result
+            return {
+                "success": True,
+                "message_id": result.get("messageId"),
+                "email": result.get("email"),
+                "subject": result.get("subject"),
+                "date": result.get("date"),
+                "events": result.get("events", []),
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}

--- a/tools/tests/tools/test_brevo_tool.py
+++ b/tools/tests/tools/test_brevo_tool.py
@@ -1,0 +1,645 @@
+"""Tests for Brevo tool with FastMCP."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.brevo_tool import register_tools
+
+
+@pytest.fixture
+def mcp():
+    """Create a FastMCP instance for testing."""
+    return FastMCP("test-server")
+
+
+@pytest.fixture
+def get_tool_fn(mcp: FastMCP):
+    """Factory fixture to get any tool function by name."""
+    register_tools(mcp)
+
+    def _get(name: str):
+        return mcp._tool_manager._tools[name].fn
+
+    return _get
+
+
+# ============================================================================
+# Credential Tests
+# ============================================================================
+
+
+class TestBrevoCredentials:
+    """Tests for Brevo credential handling."""
+
+    def test_no_credentials_returns_error(self, get_tool_fn, monkeypatch):
+        """Send email without credentials returns helpful error."""
+        monkeypatch.delenv("BREVO_API_KEY", raising=False)
+        fn = get_tool_fn("brevo_send_email")
+
+        result = fn(
+            to_email="user@example.com",
+            to_name="Test User",
+            subject="Test",
+            html_content="<p>Test</p>",
+            from_email="sender@example.com",
+            from_name="Sender",
+        )
+
+        assert "error" in result
+        assert "Brevo credentials not configured" in result["error"]
+        assert "help" in result
+
+    def test_no_credentials_sms_returns_error(self, get_tool_fn, monkeypatch):
+        """Send SMS without credentials returns helpful error."""
+        monkeypatch.delenv("BREVO_API_KEY", raising=False)
+        fn = get_tool_fn("brevo_send_sms")
+
+        result = fn(to="+919876543210", content="Test SMS", sender="TestSender")
+
+        assert "error" in result
+        assert "Brevo credentials not configured" in result["error"]
+
+
+# ============================================================================
+# Send Email Tests
+# ============================================================================
+
+
+class TestBrevoSendEmail:
+    """Tests for brevo_send_email tool."""
+
+    def test_send_email_success(self, get_tool_fn, monkeypatch):
+        """Successful email send returns message ID."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_send_email")
+
+        with patch("httpx.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.status_code = 201
+            mock_response.content = b'{"messageId": "<abc123@smtp-relay.brevo.com>"}'
+            mock_response.json.return_value = {
+                "messageId": "<abc123@smtp-relay.brevo.com>"
+            }
+            mock_post.return_value = mock_response
+
+            result = fn(
+                to_email="user@example.com",
+                to_name="John Doe",
+                subject="Hello",
+                html_content="<p>Hello!</p>",
+                from_email="sender@example.com",
+                from_name="Sender",
+            )
+
+        assert result["success"] is True
+        assert result["message_id"] == "<abc123@smtp-relay.brevo.com>"
+
+    def test_send_email_with_text_content(self, get_tool_fn, monkeypatch):
+        """Email with text content includes it in request."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_send_email")
+
+        with patch("httpx.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.status_code = 201
+            mock_response.content = b'{"messageId": "<abc123@smtp-relay.brevo.com>"}'
+            mock_response.json.return_value = {
+                "messageId": "<abc123@smtp-relay.brevo.com>"
+            }
+            mock_post.return_value = mock_response
+
+            fn(
+                to_email="user@example.com",
+                to_name="John",
+                subject="Hello",
+                html_content="<p>Hello!</p>",
+                from_email="sender@example.com",
+                from_name="Sender",
+                text_content="Hello!",
+            )
+
+        call_kwargs = mock_post.call_args[1]
+        assert call_kwargs["json"]["textContent"] == "Hello!"
+
+    def test_send_email_invalid_email(self, get_tool_fn, monkeypatch):
+        """Invalid recipient email returns error."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_send_email")
+
+        result = fn(
+            to_email="not-an-email",
+            to_name="John",
+            subject="Hello",
+            html_content="<p>Hello!</p>",
+            from_email="sender@example.com",
+            from_name="Sender",
+        )
+
+        assert "error" in result
+        assert "Invalid recipient email" in result["error"]
+
+    def test_send_email_empty_subject(self, get_tool_fn, monkeypatch):
+        """Empty subject returns error."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_send_email")
+
+        result = fn(
+            to_email="user@example.com",
+            to_name="John",
+            subject="",
+            html_content="<p>Hello!</p>",
+            from_email="sender@example.com",
+            from_name="Sender",
+        )
+
+        assert "error" in result
+        assert "subject" in result["error"].lower()
+
+    def test_send_email_empty_content(self, get_tool_fn, monkeypatch):
+        """Empty HTML content returns error."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_send_email")
+
+        result = fn(
+            to_email="user@example.com",
+            to_name="John",
+            subject="Hello",
+            html_content="",
+            from_email="sender@example.com",
+            from_name="Sender",
+        )
+
+        assert "error" in result
+        assert "content" in result["error"].lower()
+
+    def test_send_email_invalid_auth(self, get_tool_fn, monkeypatch):
+        """Invalid API key returns error."""
+        monkeypatch.setenv("BREVO_API_KEY", "invalid-key")
+        fn = get_tool_fn("brevo_send_email")
+
+        with patch("httpx.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.status_code = 401
+            mock_response.content = b'{"message": "Key not found"}'
+            mock_response.json.return_value = {"message": "Key not found"}
+            mock_post.return_value = mock_response
+
+            result = fn(
+                to_email="user@example.com",
+                to_name="John",
+                subject="Hello",
+                html_content="<p>Hello!</p>",
+                from_email="sender@example.com",
+                from_name="Sender",
+            )
+
+        assert "error" in result
+        assert "Invalid Brevo API key" in result["error"]
+
+    def test_send_email_timeout(self, get_tool_fn, monkeypatch):
+        """Timeout returns error."""
+        import httpx
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_send_email")
+
+        with patch("httpx.post", side_effect=httpx.TimeoutException("timeout")):
+            result = fn(
+                to_email="user@example.com",
+                to_name="John",
+                subject="Hello",
+                html_content="<p>Hello!</p>",
+                from_email="sender@example.com",
+                from_name="Sender",
+            )
+
+        assert "error" in result
+        assert "timed out" in result["error"]
+
+
+# ============================================================================
+# Send SMS Tests
+# ============================================================================
+
+
+class TestBrevoSendSMS:
+    """Tests for brevo_send_sms tool."""
+
+    def test_send_sms_success(self, get_tool_fn, monkeypatch):
+        """Successful SMS send returns reference."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_send_sms")
+
+        with patch("httpx.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.status_code = 201
+            mock_response.content = b'{"reference": "ref123", "remainingCredits": 95.0}'
+            mock_response.json.return_value = {
+                "reference": "ref123",
+                "remainingCredits": 95.0,
+            }
+            mock_post.return_value = mock_response
+
+            result = fn(
+                to="+919876543210",
+                content="Your OTP is 1234",
+                sender="HiveAgent",
+            )
+
+        assert result["success"] is True
+        assert result["reference"] == "ref123"
+        assert result["remaining_credits"] == 95.0
+
+    def test_send_sms_invalid_phone_format(self, get_tool_fn, monkeypatch):
+        """Phone number without + prefix returns error."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_send_sms")
+
+        result = fn(to="919876543210", content="Hello", sender="HiveAgent")
+
+        assert "error" in result
+        assert "international format" in result["error"]
+
+    def test_send_sms_empty_content(self, get_tool_fn, monkeypatch):
+        """Empty SMS content returns error."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_send_sms")
+
+        result = fn(to="+919876543210", content="", sender="HiveAgent")
+
+        assert "error" in result
+        assert "empty" in result["error"].lower()
+
+    def test_send_sms_content_too_long(self, get_tool_fn, monkeypatch):
+        """SMS content over 640 chars returns error."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_send_sms")
+
+        result = fn(to="+919876543210", content="x" * 641, sender="HiveAgent")
+
+        assert "error" in result
+        assert "too long" in result["error"].lower()
+
+    def test_send_sms_timeout(self, get_tool_fn, monkeypatch):
+        """Timeout returns error."""
+        import httpx
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_send_sms")
+
+        with patch("httpx.post", side_effect=httpx.TimeoutException("timeout")):
+            result = fn(to="+919876543210", content="Hello", sender="HiveAgent")
+
+        assert "error" in result
+        assert "timed out" in result["error"]
+
+
+# ============================================================================
+# Create Contact Tests
+# ============================================================================
+
+
+class TestBrevoCreateContact:
+    """Tests for brevo_create_contact tool."""
+
+    def test_create_contact_success(self, get_tool_fn, monkeypatch):
+        """Successful contact creation returns ID."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_create_contact")
+
+        with patch("httpx.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.status_code = 201
+            mock_response.content = b'{"id": 42}'
+            mock_response.json.return_value = {"id": 42}
+            mock_post.return_value = mock_response
+
+            result = fn(
+                email="user@example.com",
+                first_name="John",
+                last_name="Doe",
+            )
+
+        assert result["success"] is True
+        assert result["id"] == 42
+        assert result["email"] == "user@example.com"
+
+    def test_create_contact_with_list_ids(self, get_tool_fn, monkeypatch):
+        """Contact creation with list IDs parses correctly."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_create_contact")
+
+        with patch("httpx.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.status_code = 201
+            mock_response.content = b'{"id": 43}'
+            mock_response.json.return_value = {"id": 43}
+            mock_post.return_value = mock_response
+
+            fn(email="user@example.com", list_ids="2,5,8")
+
+        call_kwargs = mock_post.call_args[1]
+        assert call_kwargs["json"]["listIds"] == [2, 5, 8]
+
+    def test_create_contact_invalid_email(self, get_tool_fn, monkeypatch):
+        """Invalid email returns error."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_create_contact")
+
+        result = fn(email="not-an-email")
+
+        assert "error" in result
+        assert "Invalid email" in result["error"]
+
+    def test_create_contact_invalid_list_ids(self, get_tool_fn, monkeypatch):
+        """Non-integer list IDs return error."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_create_contact")
+
+        result = fn(email="user@example.com", list_ids="abc,def")
+
+        assert "error" in result
+        assert "list_ids" in result["error"].lower()
+
+    def test_create_contact_timeout(self, get_tool_fn, monkeypatch):
+        """Timeout returns error."""
+        import httpx
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_create_contact")
+
+        with patch("httpx.post", side_effect=httpx.TimeoutException("timeout")):
+            result = fn(email="user@example.com")
+
+        assert "error" in result
+        assert "timed out" in result["error"]
+
+
+# ============================================================================
+# Get Contact Tests
+# ============================================================================
+
+
+class TestBrevoGetContact:
+    """Tests for brevo_get_contact tool."""
+
+    def test_get_contact_success(self, get_tool_fn, monkeypatch):
+        """Get contact returns full contact details."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_get_contact")
+
+        with patch("httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.content = b'{}'
+            mock_response.json.return_value = {
+                "id": 42,
+                "email": "user@example.com",
+                "attributes": {
+                    "FIRSTNAME": "John",
+                    "LASTNAME": "Doe",
+                    "SMS": "+919876543210",
+                },
+                "listIds": [2, 5],
+                "emailBlacklisted": False,
+                "smsBlacklisted": False,
+                "createdAt": "2024-01-15T10:30:00Z",
+                "modifiedAt": "2024-01-20T12:00:00Z",
+            }
+            mock_get.return_value = mock_response
+
+            result = fn(email="user@example.com")
+
+        assert result["success"] is True
+        assert result["id"] == 42
+        assert result["email"] == "user@example.com"
+        assert result["first_name"] == "John"
+        assert result["last_name"] == "Doe"
+        assert result["list_ids"] == [2, 5]
+        assert result["email_blacklisted"] is False
+
+    def test_get_contact_not_found(self, get_tool_fn, monkeypatch):
+        """Contact not found returns error."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_get_contact")
+
+        with patch("httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 404
+            mock_response.content = b'{"message": "Contact not found"}'
+            mock_response.text = '{"message": "Contact not found"}'
+            mock_get.return_value = mock_response
+
+            result = fn(email="notfound@example.com")
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_get_contact_invalid_email(self, get_tool_fn, monkeypatch):
+        """Invalid email returns error."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_get_contact")
+
+        result = fn(email="not-valid")
+
+        assert "error" in result
+        assert "Invalid email" in result["error"]
+
+    def test_get_contact_timeout(self, get_tool_fn, monkeypatch):
+        """Timeout returns error."""
+        import httpx
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_get_contact")
+
+        with patch("httpx.get", side_effect=httpx.TimeoutException("timeout")):
+            result = fn(email="user@example.com")
+
+        assert "error" in result
+        assert "timed out" in result["error"]
+
+
+# ============================================================================
+# Update Contact Tests
+# ============================================================================
+
+
+class TestBrevoUpdateContact:
+    """Tests for brevo_update_contact tool."""
+
+    def test_update_contact_success(self, get_tool_fn, monkeypatch):
+        """Successful update returns success."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_update_contact")
+
+        with patch("httpx.put") as mock_put:
+            mock_response = MagicMock()
+            mock_response.status_code = 204
+            mock_response.content = b""
+            mock_put.return_value = mock_response
+
+            result = fn(
+                email="user@example.com",
+                first_name="Jane",
+                last_name="Smith",
+            )
+
+        assert result["success"] is True
+        assert result["email"] == "user@example.com"
+
+    def test_update_contact_with_list_ids(self, get_tool_fn, monkeypatch):
+        """Update with list IDs parses correctly."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_update_contact")
+
+        with patch("httpx.put") as mock_put:
+            mock_response = MagicMock()
+            mock_response.status_code = 204
+            mock_response.content = b""
+            mock_put.return_value = mock_response
+
+            fn(email="user@example.com", list_ids="2,5,8")
+
+        call_kwargs = mock_put.call_args[1]
+        assert call_kwargs["json"]["listIds"] == [2, 5, 8]
+
+    def test_update_contact_invalid_email(self, get_tool_fn, monkeypatch):
+        """Invalid email returns error."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_update_contact")
+
+        result = fn(email="not-valid")
+
+        assert "error" in result
+        assert "Invalid email" in result["error"]
+
+    def test_update_contact_invalid_list_ids(self, get_tool_fn, monkeypatch):
+        """Non-integer list IDs return error."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_update_contact")
+
+        result = fn(email="user@example.com", list_ids="abc,def")
+
+        assert "error" in result
+        assert "list_ids" in result["error"].lower()
+
+    def test_update_contact_timeout(self, get_tool_fn, monkeypatch):
+        """Timeout returns error."""
+        import httpx
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_update_contact")
+
+        with patch("httpx.put", side_effect=httpx.TimeoutException("timeout")):
+            result = fn(email="user@example.com", first_name="Jane")
+
+        assert "error" in result
+        assert "timed out" in result["error"]
+
+
+# ============================================================================
+# Get Email Stats Tests
+# ============================================================================
+
+
+class TestBrevoGetEmailStats:
+    """Tests for brevo_get_email_stats tool."""
+
+    def test_get_email_stats_success(self, get_tool_fn, monkeypatch):
+        """Get email stats returns delivery details."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_get_email_stats")
+
+        with patch("httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.content = b'{}'
+            mock_response.json.return_value = {
+                "messageId": "<abc123@smtp-relay.brevo.com>",
+                "email": "user@example.com",
+                "subject": "Hello",
+                "date": "2024-01-15T10:30:00Z",
+                "events": [
+                    {"name": "delivered", "time": "2024-01-15T10:30:05Z"}
+                ],
+            }
+            mock_get.return_value = mock_response
+
+            result = fn(message_id="<abc123@smtp-relay.brevo.com>")
+
+        assert result["success"] is True
+        assert result["email"] == "user@example.com"
+        assert result["subject"] == "Hello"
+        assert len(result["events"]) == 1
+        assert result["events"][0]["name"] == "delivered"
+
+    def test_get_email_stats_empty_message_id(self, get_tool_fn, monkeypatch):
+        """Empty message ID returns error."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_get_email_stats")
+
+        result = fn(message_id="")
+
+        assert "error" in result
+        assert "message_id" in result["error"].lower()
+
+    def test_get_email_stats_not_found(self, get_tool_fn, monkeypatch):
+        """Message ID not found returns error."""
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_get_email_stats")
+
+        with patch("httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 404
+            mock_response.content = b'{"message": "Not found"}'
+            mock_response.text = '{"message": "Not found"}'
+            mock_get.return_value = mock_response
+
+            result = fn(message_id="nonexistent")
+
+        assert "error" in result
+
+    def test_get_email_stats_timeout(self, get_tool_fn, monkeypatch):
+        """Timeout returns error."""
+        import httpx
+        monkeypatch.setenv("BREVO_API_KEY", "test-api-key")
+        fn = get_tool_fn("brevo_get_email_stats")
+
+        with patch("httpx.get", side_effect=httpx.TimeoutException("timeout")):
+            result = fn(message_id="<abc123@smtp-relay.brevo.com>")
+
+        assert "error" in result
+        assert "timed out" in result["error"]
+
+
+# ============================================================================
+# Tool Registration Tests
+# ============================================================================
+
+
+class TestBrevoToolRegistration:
+    """Tests for tool registration."""
+
+    def test_all_tools_registered(self, mcp: FastMCP):
+        """All 6 Brevo tools are registered."""
+        register_tools(mcp)
+        tools = list(mcp._tool_manager._tools.keys())
+
+        expected_tools = [
+            "brevo_send_email",
+            "brevo_send_sms",
+            "brevo_create_contact",
+            "brevo_get_contact",
+            "brevo_update_contact",
+            "brevo_get_email_stats",
+        ]
+        for tool in expected_tools:
+            assert tool in tools
+
+    def test_tools_registered_with_credentials(self, mcp: FastMCP):
+        """Tools register correctly when credentials adapter is provided."""
+        from aden_tools.credentials import CredentialStoreAdapter
+
+        creds = CredentialStoreAdapter.for_testing({"brevo": "test-key"})
+        register_tools(mcp, credentials=creds)
+        tools = list(mcp._tool_manager._tools.keys())
+
+        assert "brevo_send_email" in tools
+        assert "brevo_send_sms" in tools


### PR DESCRIPTION
<h2>Description</h2>
<p>Adds a Brevo integration that enables Hive agents to send transactional
emails, SMS messages, and manage contacts via the Brevo API.</p>
<h2>Type of Change</h2>
<ul>
<li>[ ] Bug fix (non-breaking change that fixes an issue)</li>
<li>[x] New feature (non-breaking change that adds functionality)</li>
<li>[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)</li>
<li>[ ] Documentation update</li>
<li>[ ] Refactoring (no functional changes)</li>
</ul>
<h2>Related Issues</h2>
<p>Fixes #5127</p>
<h2>Changes Made</h2>
<ul>
<li>Add <code>tools/src/aden_tools/tools/brevo_tool/brevo_tool.py</code> with 6 MCP tools:
<code>brevo_send_email</code>, <code>brevo_send_sms</code>, <code>brevo_create_contact</code>, <code>brevo_get_contact</code>,
<code>brevo_update_contact</code>, <code>brevo_get_email_stats</code></li>
<li>Add <code>tools/src/aden_tools/tools/brevo_tool/__init__.py</code> with <code>register_tools</code> export</li>
<li>Add <code>tools/src/aden_tools/tools/brevo_tool/README.md</code> with setup instructions and usage examples</li>
<li>Add <code>tools/src/aden_tools/credentials/brevo.py</code> with <code>CredentialSpec</code> for <code>BREVO_API_KEY</code></li>
<li>Add <code>tools/tests/tools/test_brevo_tool.py</code> with 34 unit tests</li>
<li>Register <code>brevo_tool</code> in <code>tools/src/aden_tools/tools/__init__.py</code></li>
<li>Register <code>BREVO_CREDENTIALS</code> in <code>tools/src/aden_tools/credentials/__init__.py</code></li>
</ul>
<h2>Tool Summary</h2>

Tool | Purpose
-- | --
brevo_send_email | Send a transactional email with HTML content
brevo_send_sms | Send a transactional SMS to a phone number
brevo_create_contact | Create a new contact in Brevo
brevo_get_contact | Retrieve contact details by email
brevo_update_contact | Update an existing contact's attributes
brevo_get_email_stats | Get delivery status for a sent email


<h2>Setup Instructions</h2>
<ol>
<li>Sign up at https://www.brevo.com (free tier available - 300 emails/day)</li>
<li>Go to <strong>Settings → API Keys → Generate a new API key</strong></li>
<li>Set <code>BREVO_API_KEY</code> environment variable or configure via credential store</li>
<li>Verify your sender email address in Brevo before sending emails</li>
</ol>
<h2>Testing</h2>
<p>Verified import success:</p>
<pre><code class="language-bash">uv run python3 -c "from src.aden_tools.tools.brevo_tool.brevo_tool import register_tools; print('Import OK!')"
# Output: Import OK!
</code></pre>
<p>Verified all 6 tools register correctly:</p>
<pre><code class="language-bash">uv run python3 -c "
from fastmcp import FastMCP
from src.aden_tools.tools import register_all_tools
mcp = FastMCP('test')
tools = register_all_tools(mcp)
brevo_tools = [t for t in tools if t.startswith('brevo')]
print(brevo_tools)
"
# Output: ['brevo_send_email', 'brevo_send_sms', 'brevo_create_contact',
#          'brevo_get_contact', 'brevo_update_contact', 'brevo_get_email_stats']
</code></pre>
<p>34 unit tests pass:</p>
<pre><code class="language-bash">uv run pytest tests/tools/test_brevo_tool.py -v
# Output: 34 passed in 2.45s
</code></pre>
<p>Tests cover:</p>
<ul>
<li>Credential handling (missing credentials error)</li>
<li><code>brevo_send_email</code> — success, input validation, auth error, timeout</li>
<li><code>brevo_send_sms</code> — success, phone format validation, content length, timeout</li>
<li><code>brevo_create_contact</code> — success, list_ids parsing, validation, timeout</li>
<li><code>brevo_get_contact</code> — success, not found, validation, timeout</li>
<li><code>brevo_update_contact</code> — success, list_ids parsing, validation, timeout</li>
<li><code>brevo_get_email_stats</code> — success, empty message_id, not found, timeout</li>
<li>Tool registration — all 6 tools, with and without credentials</li>
</ul>
<h2>Checklist</h2>
<ul>
<li>[x] My code follows the project's style guidelines</li>
<li>[x] I have performed a self-review of my code</li>
<li>[x] I have commented my code, particularly in hard-to-understand areas</li>
<li>[x] I have made corresponding changes to the documentation</li>
<li>[x] My changes generate no new warnings</li>
<li>[x] I have added tests that prove my fix is effective or that my feature works</li>
<li>[x] New and existing unit tests pass locally with my changes</li>
</ul></body></html>