### PR TITLE
cli: validate agent before starting shell; abort on validation errors

### DIFF
--- a/core/tests/test_cli_shell_validation.py
+++ b/core/tests/test_cli_shell_validation.py
@@ -1,0 +1,34 @@
+import sys
+from argparse import Namespace
+
+import framework.runner as runner_pkg
+import framework.runner.cli as cli
+
+
+class FakeRunner:
+    def validate(self):
+        from framework.runner import ValidationResult
+
+        return ValidationResult(valid=False, errors=["Entry node '' not found"])
+
+    def cleanup(self):
+        pass
+
+
+def test_shell_aborts_on_invalid_agent(monkeypatch, capsys, tmp_path):
+    # Patch AgentRunner.load to return a fake invalid runner
+    monkeypatch.setattr(
+        "framework.runner.AgentRunner.load", lambda *a, **k: FakeRunner()
+    )
+
+    # Ensure no interactive prompts (stdin is not a TTY)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+
+    args = Namespace(agent_path=str(tmp_path), agents_dir="exports", multi=False, no_approve=True)
+
+    ret = cli.cmd_shell(args)
+
+    captured = capsys.readouterr()
+    assert ret == 1
+    assert "Agent has validation errors" in captured.err
+    assert "Entry node" in captured.err


### PR DESCRIPTION
Title
cli: validate agent before starting shell; abort on validation errors

Description

Call runner.validate() in cmd_shell and abort the interactive session with exit code 1 when validation fails. Print a concise stderr banner and a short summary (up to 5) of validation errors/warnings to give immediate context. Add a unit test asserting the shell aborts on invalid agents.

Type of Change

 Bug fix (non-breaking change that fixes an issue)

 New feature (non-breaking change that adds functionality)

 Breaking change (fix or feature that would cause existing functionality to not work as expected)

 Documentation update

 Refactoring (no functional changes)

Related Issues

Fixes #5124 

Changes Made

Added pre-start validation in cmd_shell: call runner.validate() and abort if invalid.

Print a clear stderr message and a short errors/warnings summary when validation fails.

Ensure runner.cleanup() is called on validation failure to avoid resource leaks.

Added unit test test_cli_shell_validation.py asserting shell abort behavior.

Files changed:

File: cli.py

File: test_cli_shell_validation.py

Testing

Describe the tests you ran to verify your changes:

 Unit tests pass
(ran: pytest -q core/tests/test_cli_shell_validation.py::test_shell_aborts_on_invalid_agent)

 Full test suite pass (pytest)

 Lint passes (cd core && ruff check .)

Manual testing performed:

python -m framework shell exports/test_broken now prints an error and exits with code 1 (does not start broken REPL).

Commands to reproduce:

# run unit test
pytest -q core/tests/test_cli_shell_validation.py::test_shell_aborts_on_invalid_agent

# manual CLI check
python -m framework shell exports\test_broken
echo $LASTEXITCODE  # should be 1
Checklist

 My code follows the project's style guidelines (kept minimal, consistent formatting)

 I have performed a self-review of my code

 I have commented my code, particularly in hard-to-understand areas

 I have made corresponding changes to the documentation (not required for this small CLI change)

 My changes generate no new warnings

 I have added tests that prove my fix is effective

 New and existing unit tests pass locally with my changes (please run full test suite in CI)

Notes / Follow-ups

Consider applying the same pre-start validation to cmd_run and the TUI entry points for consistent behavior.

Optionally provide a --no-validate flag if maintainers prefer to allow forcing shell launch for advanced users.