### PR TITLE
fix(core): move pytest dependencies to optional extras

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -12,13 +12,15 @@ dependencies = [
   "mcp>=1.0.0",
   "fastmcp>=2.0.0",
   "textual>=1.0.0",
-  "pytest>=8.0",
-  "pytest-asyncio>=0.23",
-  "pytest-xdist>=3.0",
   "tools",
 ]
 
 [project.optional-dependencies]
+testing = [
+  "pytest>=8.0",
+  "pytest-asyncio>=0.23",
+  "pytest-xdist>=3.0",
+]
 tui = ["textual>=0.75.0"]
 webhook = ["aiohttp>=3.9.0"]
 


### PR DESCRIPTION
## Problem

The `framework` package (in `core/`) lists `pytest`, `pytest-asyncio`, and `pytest-xdist` as core runtime dependencies. This pulls in the entire pytest stack for every consumer of the framework, even if they never run tests.

The `tools` package already correctly handles this by placing pytest under `[project.optional-dependencies].dev`.

Fixes #5048

## Fix

Move the three pytest packages from `[project].dependencies` to a new `[project.optional-dependencies].testing` extra:

```bash
# Runtime only
pip install framework

# With test tooling
pip install framework[testing]
```

## Changes

- `core/pyproject.toml`: Move pytest deps to `[project.optional-dependencies].testing`