### PR TITLE
fix: enable root-level pytest collection with importlib mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,8 @@
 [tool.uv.workspace]
 members = ["core", "tools"]
+
+[tool.pytest.ini_options]
+# Use importlib import mode to avoid namespace collisions between
+# core/tests and tools/tests (both named "tests").
+import_mode = "importlib"
+testpaths = ["core/tests", "tools/tests"]


### PR DESCRIPTION
## Problem

Running `pytest -q` from the repo root fails with `ModuleNotFoundError: No module named 'tests.conftest'` because both `core/tests` and `tools/tests` are treated as the same top-level `tests` package, causing import collisions.

Fixes #5006

## Fix

Add `[tool.pytest.ini_options]` to the root `pyproject.toml` with:
- `import_mode = 'importlib'` — PEP 451 imports give each test directory its own namespace
- `testpaths = ['core/tests', 'tools/tests']` — explicitly collect from both

## Changes

- `pyproject.toml`: Add pytest configuration