### PR TITLE
feat(tools): add Notion integration tool

### DIFF
--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -56,6 +56,7 @@ from .google_maps_tool import register_tools as register_google_maps
 from .http_headers_scanner import register_tools as register_http_headers_scanner
 from .hubspot_tool import register_tools as register_hubspot
 from .news_tool import register_tools as register_news
+from .notion_tool import register_tools as register_notion
 from .pdf_read_tool import register_tools as register_pdf_read
 from .port_scanner import register_tools as register_port_scanner
 from .razorpay_tool import register_tools as register_razorpay
@@ -99,6 +100,7 @@ def register_all_tools(
     # web_search supports multiple providers (Google, Brave) with auto-detection
     register_web_search(mcp, credentials=credentials)
     register_github(mcp, credentials=credentials)
+    register_notion(mcp, credentials=credentials)
     # email supports multiple providers (Gmail, Resend)
     register_email(mcp, credentials=credentials)
     # Gmail inbox management (read, trash, modify labels)

--- a/tools/src/aden_tools/tools/notion_tool/README.md
+++ b/tools/src/aden_tools/tools/notion_tool/README.md
@@ -1,0 +1,84 @@
+# Notion Tool
+
+Interact with Notion databases and pages within the Aden agent framework.
+
+## Installation
+
+The Notion tool uses `httpx` which is already included in the base dependencies. No additional installation required.
+
+## Setup
+
+You need a Notion Integration Token to use this tool.
+
+### Getting a Notion Token
+
+1. Go to [https://www.notion.so/my-integrations](https://www.notion.so/my-integrations)
+2. Click "+ New integration"
+3. Give your integration a name (e.g., "Aden Agent")
+4. Select the workspace you want to use it in
+5. Click "Submit" to create the integration
+6. Copy the "Internal Integration Token" (starts with `secret_`)
+
+**Important:** You must share specific databases or pages with your integration for it to access them. In Notion, go to the database/page, click "...", and select "Add connections".
+
+### Configuration
+
+Set the token as an environment variable:
+
+```bash
+export NOTION_TOKEN=secret_your_token_here
+```
+
+Or configure via the credential store.
+
+## Available Functions
+
+### `notion_search`
+
+Search for pages, databases, or blocks.
+
+**Parameters:**
+- `query` (str, optional): The search text
+- `filter_type` (str, optional): Filter by object type ("page" or "database")
+- `limit` (int, optional): Maximum number of results (1-100, default 30)
+
+### `notion_get_database`
+
+Retrieve a database's schema and information.
+
+**Parameters:**
+- `database_id` (str): The ID of the database to retrieve
+
+### `notion_query_database`
+
+Query a database for specific pages based on filters.
+
+**Parameters:**
+- `database_id` (str): The ID of the database to query
+- `filter_params` (dict, optional): Notion filter object
+- `limit` (int, optional): Maximum number of results
+
+### `notion_create_database_page`
+
+Create a new page in a Notion database.
+
+**Parameters:**
+- `database_id` (str): The ID of the parent database
+- `properties` (dict): Properties for the new page (must match database schema)
+- `content` (list[dict], optional): Optional blocks representing the page content
+
+### `notion_get_page_content`
+
+Retrieve the content (blocks) of a Notion page.
+
+**Parameters:**
+- `page_id` (str): The ID of the page to retrieve content from
+- `limit` (int, optional): Maximum number of blocks to return
+
+### `notion_update_page`
+
+Update the properties of an existing Notion page.
+
+**Parameters:**
+- `page_id` (str): The ID of the page to update
+- `properties` (dict): The new properties for the page

--- a/tools/src/aden_tools/tools/notion_tool/__init__.py
+++ b/tools/src/aden_tools/tools/notion_tool/__init__.py
@@ -1,0 +1,3 @@
+from .notion_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/notion_tool/notion_tool.py
+++ b/tools/src/aden_tools/tools/notion_tool/notion_tool.py
@@ -1,0 +1,350 @@
+"""
+Notion Tool - Interact with Notion databases and pages.
+
+API Reference: https://developers.notion.com/reference
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialStoreAdapter
+
+NOTION_API_BASE = "https://api.notion.com/v1"
+NOTION_VERSION = "2022-06-28"
+
+
+def _sanitize_error_message(error: Exception) -> str:
+    """Sanitize error messages to prevent token leaks."""
+    error_str = str(error)
+    if "Authorization" in error_str or "Bearer" in error_str:
+        return "Network error occurred"
+    return f"Network error: {error_str}"
+
+
+class _NotionClient:
+    """Internal client wrapping Notion API v1 calls."""
+
+    def __init__(self, token: str):
+        self._token = token
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._token}",
+            "Notion-Version": NOTION_VERSION,
+            "Content-Type": "application/json",
+        }
+
+    def _handle_response(self, response: httpx.Response) -> dict[str, Any]:
+        """Handle Notion API response format."""
+        if response.status_code == 401:
+            return {"error": "Invalid or expired Notion token"}
+        if response.status_code == 403:
+            return {"error": "Forbidden - check integration permissions"}
+        if response.status_code == 404:
+            return {"error": "Resource not found"}
+        if response.status_code == 429:
+            return {"error": "Rate limit exceeded"}
+        if response.status_code >= 400:
+            try:
+                detail = response.json().get("message", response.text)
+            except Exception:
+                detail = response.text
+            return {"error": f"Notion API error (HTTP {response.status_code}): {detail}"}
+
+        try:
+            return {"success": True, "data": response.json()}
+        except Exception:
+            return {"success": True, "data": {}}
+
+    def search(
+        self,
+        query: str | None = None,
+        filter_type: str | None = None,
+        sort_direction: str = "descending",
+        limit: int = 30,
+    ) -> dict[str, Any]:
+        """Search for pages, databases, or blocks."""
+        payload: dict[str, Any] = {
+            "page_size": min(limit, 100),
+        }
+        if query:
+            payload["query"] = query
+        if filter_type:
+            payload["filter"] = {"value": filter_type, "property": "object"}
+        if sort_direction:
+            payload["sort"] = {"direction": sort_direction, "timestamp": "last_edited_time"}
+
+        response = httpx.post(
+            f"{NOTION_API_BASE}/search",
+            headers=self._headers,
+            json=payload,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def get_database(self, database_id: str) -> dict[str, Any]:
+        """Retrieve a database schema."""
+        response = httpx.get(
+            f"{NOTION_API_BASE}/databases/{database_id}",
+            headers=self._headers,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def query_database(
+        self,
+        database_id: str,
+        filter_params: dict[str, Any] | None = None,
+        sort_params: list[dict[str, Any]] | None = None,
+        limit: int = 30,
+    ) -> dict[str, Any]:
+        """Filter and search pages within a database."""
+        payload: dict[str, Any] = {
+            "page_size": min(limit, 100),
+        }
+        if filter_params:
+            payload["filter"] = filter_params
+        if sort_params:
+            payload["sorts"] = sort_params
+
+        response = httpx.post(
+            f"{NOTION_API_BASE}/databases/{database_id}/query",
+            headers=self._headers,
+            json=payload,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def create_page(
+        self,
+        parent_id: str,
+        parent_type: str = "database_id",
+        properties: dict[str, Any] | None = None,
+        children: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Create a new page."""
+        payload: dict[str, Any] = {
+            "parent": {parent_type: parent_id},
+            "properties": properties or {},
+        }
+        if children:
+            payload["children"] = children
+
+        response = httpx.post(
+            f"{NOTION_API_BASE}/pages",
+            headers=self._headers,
+            json=payload,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def update_page_properties(
+        self,
+        page_id: str,
+        properties: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Update properties of an existing page."""
+        payload = {"properties": properties}
+        response = httpx.patch(
+            f"{NOTION_API_BASE}/pages/{page_id}",
+            headers=self._headers,
+            json=payload,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def get_page(self, page_id: str) -> dict[str, Any]:
+        """Retrieve a page's properties."""
+        response = httpx.get(
+            f"{NOTION_API_BASE}/pages/{page_id}",
+            headers=self._headers,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def get_block_children(
+        self,
+        block_id: str,
+        limit: int = 50,
+    ) -> dict[str, Any]:
+        """Retrieve content of a page or block (children blocks)."""
+        params = {"page_size": min(limit, 100)}
+        response = httpx.get(
+            f"{NOTION_API_BASE}/blocks/{block_id}/children",
+            headers=self._headers,
+            params=params,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: CredentialStoreAdapter | None = None,
+) -> None:
+    """Register Notion tools with the MCP server."""
+
+    def _get_token() -> str | None:
+        """Get Notion token from credential manager or environment."""
+        if credentials is not None:
+            token = credentials.get("notion")
+            if token is not None and not isinstance(token, str):
+                raise TypeError(
+                    f"Expected string from credentials.get('notion'), got {type(token).__name__}"
+                )
+            return token
+        return os.getenv("NOTION_TOKEN")
+
+    def _get_client() -> _NotionClient | dict[str, str]:
+        """Get a Notion client, or return an error dict if no credentials."""
+        token = _get_token()
+        if not token:
+            return {
+                "error": "Notion credentials not configured",
+                "help": (
+                    "Set NOTION_TOKEN environment variable "
+                    "or configure via credential store. "
+                    "Get a token at https://www.notion.so/my-integrations"
+                ),
+            }
+        return _NotionClient(token)
+
+    @mcp.tool()
+    def notion_search(
+        query: str | None = None,
+        filter_type: str | None = None,
+        limit: int = 30,
+    ) -> dict:
+        """
+        Search for pages, databases, or blocks in Notion.
+
+        Args:
+            query: The search text
+            filter_type: Optional filter by object type ("page" or "database")
+            limit: Maximum number of results to return (1-100, default 30)
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.search(query=query, filter_type=filter_type, limit=limit)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": _sanitize_error_message(e)}
+
+    @mcp.tool()
+    def notion_get_database(database_id: str) -> dict:
+        """
+        Retrieve a database's schema and information.
+
+        Args:
+            database_id: The ID of the database to retrieve
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.get_database(database_id)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": _sanitize_error_message(e)}
+
+    @mcp.tool()
+    def notion_query_database(
+        database_id: str,
+        filter_params: dict | None = None,
+        limit: int = 30,
+    ) -> dict:
+        """
+        Query a database for specific pages based on filters.
+
+        Args:
+            database_id: The ID of the database to query
+            filter_params: Notion filter object (optional)
+            limit: Maximum number of results (1-100, default 30)
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.query_database(database_id, filter_params=filter_params, limit=limit)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": _sanitize_error_message(e)}
+
+    @mcp.tool()
+    def notion_create_database_page(
+        database_id: str,
+        properties: dict,
+        content: list[dict] | None = None,
+    ) -> dict:
+        """
+        Create a new page in a Notion database.
+
+        Args:
+            database_id: The ID of the parent database
+            properties: Properties for the new page (must match database schema)
+            content: Optional blocks representing the page content
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.create_page(
+                parent_id=database_id,
+                parent_type="database_id",
+                properties=properties,
+                children=content,
+            )
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": _sanitize_error_message(e)}
+
+    @mcp.tool()
+    def notion_get_page_content(page_id: str, limit: int = 50) -> dict:
+        """
+        Retrieve the content (blocks) of a Notion page.
+
+        Args:
+            page_id: The ID of the page to retrieve content from
+            limit: Maximum number of blocks to return
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.get_block_children(page_id, limit=limit)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": _sanitize_error_message(e)}
+
+    @mcp.tool()
+    def notion_update_page(page_id: str, properties: dict) -> dict:
+        """
+        Update the properties of an existing Notion page.
+
+        Args:
+            page_id: The ID of the page to update
+            properties: The new properties for the page
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.update_page_properties(page_id, properties)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": _sanitize_error_message(e)}


### PR DESCRIPTION
Fixes #5144

### Summary
This PR adds a native Notion integration tool to the Hive framework. 

### Features
- [notion_search](cci:1://file:///c:/Users/divyanshu/OneDrive/Desktop/Personal/Aden/hive/tools/src/aden_tools/tools/notion_tool/notion_tool.py:218:4-240:56): Search across pages and databases.
- [notion_query_database](cci:1://file:///c:/Users/divyanshu/OneDrive/Desktop/Personal/Aden/hive/tools/src/aden_tools/tools/notion_tool/notion_tool.py:260:4-282:56): Advanced filtering/querying of databases.
- [notion_create_database_page](cci:1://file:///c:/Users/divyanshu/OneDrive/Desktop/Personal/Aden/hive/tools/src/aden_tools/tools/notion_tool/notion_tool.py:284:4-311:56): Add records to databases.
- [notion_get_page_content](cci:1://file:///c:/Users/divyanshu/OneDrive/Desktop/Personal/Aden/hive/tools/src/aden_tools/tools/notion_tool/notion_tool.py:313:4-330:56): Retrieve block data from pages.

### Testing
- Added `tools/tests/tools/test_notion_tool.py` with mocked API responses.