### PR TITLE
feat(tools): add Intercom tool integration (#4256)

### DIFF
--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -40,6 +40,7 @@ Credential categories:
 - discord.py: Discord bot credentials
 - github.py: GitHub API credentials
 - hubspot.py: HubSpot CRM credentials
+- intercom.py: Intercom customer messaging credentials
 - slack.py: Slack workspace credentials
 - google_maps.py: Google Maps Platform credentials
 - calcom.py: Cal.com scheduling API credentials
@@ -67,6 +68,7 @@ from .google_docs import GOOGLE_DOCS_CREDENTIALS
 from .google_maps import GOOGLE_MAPS_CREDENTIALS
 from .health_check import HealthCheckResult, check_credential_health
 from .hubspot import HUBSPOT_CREDENTIALS
+from .intercom import INTERCOM_CREDENTIALS
 from .llm import LLM_CREDENTIALS
 from .news import NEWS_CREDENTIALS
 from .razorpay import RAZORPAY_CREDENTIALS
@@ -95,6 +97,7 @@ CREDENTIAL_SPECS = {
     **GOOGLE_DOCS_CREDENTIALS,
     **GOOGLE_MAPS_CREDENTIALS,
     **HUBSPOT_CREDENTIALS,
+    **INTERCOM_CREDENTIALS,
     **GOOGLE_CALENDAR_CREDENTIALS,
     **SLACK_CREDENTIALS,
     **SERPAPI_CREDENTIALS,
@@ -135,6 +138,7 @@ __all__ = [
     "GOOGLE_DOCS_CREDENTIALS",
     "GOOGLE_MAPS_CREDENTIALS",
     "HUBSPOT_CREDENTIALS",
+    "INTERCOM_CREDENTIALS",
     "GOOGLE_CALENDAR_CREDENTIALS",
     "SLACK_CREDENTIALS",
     "APOLLO_CREDENTIALS",

--- a/tools/src/aden_tools/credentials/health_check.py
+++ b/tools/src/aden_tools/credentials/health_check.py
@@ -702,6 +702,16 @@ class GoogleGmailHealthChecker(OAuthBearerHealthChecker):
         )
 
 
+class IntercomHealthChecker(OAuthBearerHealthChecker):
+    """Health checker for Intercom access tokens."""
+
+    def __init__(self):
+        super().__init__(
+            endpoint="https://api.intercom.io/me",
+            service_name="Intercom",
+        )
+
+
 # Registry of health checkers
 HEALTH_CHECKERS: dict[str, CredentialHealthChecker] = {
     "discord": DiscordHealthChecker(),
@@ -714,6 +724,7 @@ HEALTH_CHECKERS: dict[str, CredentialHealthChecker] = {
     "google_maps": GoogleMapsHealthChecker(),
     "anthropic": AnthropicHealthChecker(),
     "github": GitHubHealthChecker(),
+    "intercom": IntercomHealthChecker(),
     "resend": ResendHealthChecker(),
 }
 

--- a/tools/src/aden_tools/credentials/intercom.py
+++ b/tools/src/aden_tools/credentials/intercom.py
@@ -1,0 +1,49 @@
+"""
+Intercom tool credentials.
+
+Contains credentials for Intercom customer messaging integration.
+"""
+
+from .base import CredentialSpec
+
+INTERCOM_CREDENTIALS = {
+    "intercom": CredentialSpec(
+        env_var="INTERCOM_ACCESS_TOKEN",
+        tools=[
+            "intercom_search_conversations",
+            "intercom_get_conversation",
+            "intercom_get_contact",
+            "intercom_search_contacts",
+            "intercom_add_note",
+            "intercom_add_tag",
+            "intercom_assign_conversation",
+            "intercom_list_teams",
+        ],
+        required=True,
+        startup_required=False,
+        help_url=(
+            "https://developers.intercom.com/docs/build-an-integration/learn-more/authentication"
+        ),
+        description=(
+            "Intercom access token (Settings > Integrations"
+            " > Developer Hub > Your App > Authentication)"
+        ),
+        # Auth method support
+        aden_supported=False,
+        direct_api_key_supported=True,
+        api_key_instructions="""To get an Intercom access token:
+1. Go to https://app.intercom.com
+2. Navigate to Settings > Integrations > Developer Hub
+3. Click "New app" (or select an existing app)
+4. Go to the "Authentication" tab
+5. Copy the access token
+6. Required scopes: Read and write conversations, \
+Read contacts, Read and write tags, Read admins""",
+        # Health check configuration
+        health_check_endpoint="https://api.intercom.io/me",
+        health_check_method="GET",
+        # Credential store mapping
+        credential_id="intercom",
+        credential_key="access_token",
+    ),
+}

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -55,6 +55,7 @@ from .google_docs_tool import register_tools as register_google_docs
 from .google_maps_tool import register_tools as register_google_maps
 from .http_headers_scanner import register_tools as register_http_headers_scanner
 from .hubspot_tool import register_tools as register_hubspot
+from .intercom_tool import register_tools as register_intercom
 from .news_tool import register_tools as register_news
 from .pdf_read_tool import register_tools as register_pdf_read
 from .port_scanner import register_tools as register_port_scanner
@@ -104,6 +105,7 @@ def register_all_tools(
     # Gmail inbox management (read, trash, modify labels)
     register_gmail(mcp, credentials=credentials)
     register_hubspot(mcp, credentials=credentials)
+    register_intercom(mcp, credentials=credentials)
     register_apollo(mcp, credentials=credentials)
     register_bigquery(mcp, credentials=credentials)
     register_calcom(mcp, credentials=credentials)

--- a/tools/src/aden_tools/tools/intercom_tool/README.md
+++ b/tools/src/aden_tools/tools/intercom_tool/README.md
@@ -1,0 +1,99 @@
+# Intercom Tool
+
+Customer messaging, conversations, and support automation via the Intercom API (v2.11).
+
+## Setup
+
+### 1. Get an Access Token
+
+1. Log in to your [Intercom Developer Hub](https://app.intercom.com/a/apps/_/developer-hub)
+2. Create or select an app
+3. Go to **Authentication** and copy the access token
+4. Ensure the app has the required scopes for the tools you need (e.g., `Read and List conversations`, `Manage conversations`, `Read and Write contacts`)
+
+### 2. Configure the Token
+
+Set the environment variable:
+
+```bash
+export INTERCOM_ACCESS_TOKEN="your-access-token-here"
+```
+
+Or configure via the Hive credential store.
+
+## Tools (8 Total)
+
+### Conversations (2)
+
+| Tool | Description |
+|------|-------------|
+| `intercom_search_conversations` | Search conversations with filters (status, assignee, tag, date) |
+| `intercom_get_conversation` | Get full conversation details including message history |
+
+### Contacts (2)
+
+| Tool | Description |
+|------|-------------|
+| `intercom_get_contact` | Get a contact by ID or email |
+| `intercom_search_contacts` | Search contacts by email, name, or custom attributes |
+
+### Notes, Tags & Assignment (3)
+
+| Tool | Description |
+|------|-------------|
+| `intercom_add_note` | Add an internal note to a conversation |
+| `intercom_add_tag` | Add a tag to a conversation or contact |
+| `intercom_assign_conversation` | Assign a conversation to an admin or team |
+
+### Teams (1)
+
+| Tool | Description |
+|------|-------------|
+| `intercom_list_teams` | List available teams for conversation routing |
+
+## Usage Examples
+
+```python
+# Search open conversations
+intercom_search_conversations(status="open", limit=10)
+
+# Get full conversation details
+intercom_get_conversation(conversation_id="12345")
+
+# Find a contact by email
+intercom_get_contact(email="jane@example.com")
+
+# Add an internal note
+intercom_add_note(conversation_id="12345", body="Escalating to engineering")
+
+# Tag a conversation
+intercom_add_tag(name="VIP", conversation_id="12345")
+
+# Assign to a team
+intercom_assign_conversation(
+    conversation_id="12345",
+    assignee_id="67890",
+    assignee_type="team",
+    body="Routing to billing team"
+)
+
+# List available teams
+intercom_list_teams()
+```
+
+## Error Handling
+
+All tools return error dictionaries on failure:
+
+```python
+{"error": "Intercom credentials not configured", "help": "Set INTERCOM_ACCESS_TOKEN..."}
+{"error": "Invalid or expired Intercom access token"}
+{"error": "Insufficient permissions. Check your Intercom app scopes."}
+{"error": "Resource not found"}
+{"error": "Intercom rate limit exceeded. Try again later."}
+{"error": "Request timed out"}
+```
+
+## References
+
+- [Intercom API Documentation](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/)

--- a/tools/src/aden_tools/tools/intercom_tool/__init__.py
+++ b/tools/src/aden_tools/tools/intercom_tool/__init__.py
@@ -1,0 +1,9 @@
+"""
+Intercom Tool - Manage conversations, contacts, and tags via Intercom API v2.11.
+
+Supports access token authentication.
+"""
+
+from .intercom_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/intercom_tool/intercom_tool.py
+++ b/tools/src/aden_tools/tools/intercom_tool/intercom_tool.py
@@ -1,0 +1,556 @@
+"""
+Intercom Tool - Customer messaging, conversations, and support automation.
+
+Supports:
+- Access token authentication (INTERCOM_ACCESS_TOKEN)
+
+API Reference: https://developers.intercom.com/docs/references/rest-api/api.intercom.io/
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialStoreAdapter
+
+INTERCOM_API_BASE = "https://api.intercom.io"
+
+
+class _IntercomClient:
+    """Internal client wrapping Intercom API v2.11 calls."""
+
+    def __init__(self, access_token: str):
+        self._token = access_token
+        self._admin_id: str | None = None  # lazy-fetched via /me
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Intercom-Version": "2.11",
+        }
+
+    def _handle_response(self, response: httpx.Response) -> dict[str, Any]:
+        """Handle common HTTP error codes."""
+        if response.status_code == 401:
+            return {"error": "Invalid or expired Intercom access token"}
+        if response.status_code == 403:
+            return {"error": "Insufficient permissions. Check your Intercom app scopes."}
+        if response.status_code == 404:
+            return {"error": "Resource not found"}
+        if response.status_code == 429:
+            return {"error": "Intercom rate limit exceeded. Try again later."}
+        if response.status_code >= 400:
+            # Intercom errors: {"type": "error.list", "errors": [...]}
+            try:
+                errors = response.json().get("errors", [])
+                detail = errors[0].get("message", response.text) if errors else response.text
+            except Exception:
+                detail = response.text
+            return {"error": f"Intercom API error (HTTP {response.status_code}): {detail}"}
+        return response.json()
+
+    def _get_admin_id(self) -> str | dict[str, Any]:
+        """Get the current admin ID, fetching from /me on first call."""
+        if self._admin_id is not None:
+            return self._admin_id
+        response = httpx.get(
+            f"{INTERCOM_API_BASE}/me",
+            headers=self._headers,
+            timeout=30.0,
+        )
+        if response.status_code != 200:
+            return self._handle_response(response)
+        self._admin_id = str(response.json()["id"])
+        return self._admin_id
+
+    # --- Read operations ---
+
+    def search_conversations(self, query: dict[str, Any], limit: int = 20) -> dict[str, Any]:
+        """Search conversations using Intercom query syntax."""
+        body: dict[str, Any] = {
+            "query": query,
+            "pagination": {"per_page": min(limit, 150)},
+        }
+        response = httpx.post(
+            f"{INTERCOM_API_BASE}/conversations/search",
+            headers=self._headers,
+            json=body,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def get_conversation(self, conversation_id: str) -> dict[str, Any]:
+        """Get a single conversation by ID with plaintext message bodies."""
+        response = httpx.get(
+            f"{INTERCOM_API_BASE}/conversations/{conversation_id}",
+            headers=self._headers,
+            params={"display_as": "plaintext"},
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def get_contact(self, contact_id: str) -> dict[str, Any]:
+        """Get a single contact by ID."""
+        response = httpx.get(
+            f"{INTERCOM_API_BASE}/contacts/{contact_id}",
+            headers=self._headers,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def search_contacts(self, query: dict[str, Any], limit: int = 50) -> dict[str, Any]:
+        """Search contacts using Intercom query syntax."""
+        body: dict[str, Any] = {
+            "query": query,
+            "pagination": {"per_page": min(limit, 150)},
+        }
+        response = httpx.post(
+            f"{INTERCOM_API_BASE}/contacts/search",
+            headers=self._headers,
+            json=body,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def list_teams(self) -> dict[str, Any]:
+        """List all teams in the workspace."""
+        response = httpx.get(
+            f"{INTERCOM_API_BASE}/teams",
+            headers=self._headers,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def list_tags(self) -> dict[str, Any]:
+        """List all tags in the workspace."""
+        response = httpx.get(
+            f"{INTERCOM_API_BASE}/tags",
+            headers=self._headers,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    # --- Write operations ---
+
+    def reply_to_conversation(
+        self,
+        conversation_id: str,
+        body: str,
+        message_type: str = "comment",
+    ) -> dict[str, Any]:
+        """Reply to or add a note on a conversation."""
+        admin_id = self._get_admin_id()
+        if isinstance(admin_id, dict):
+            return admin_id
+        payload: dict[str, Any] = {
+            "type": "admin",
+            "admin_id": admin_id,
+            "message_type": message_type,
+            "body": body,
+        }
+        response = httpx.post(
+            f"{INTERCOM_API_BASE}/conversations/{conversation_id}/reply",
+            headers=self._headers,
+            json=payload,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def assign_conversation(
+        self,
+        conversation_id: str,
+        assignee_id: str,
+        body: str = "",
+    ) -> dict[str, Any]:
+        """Assign a conversation to an admin or team."""
+        admin_id = self._get_admin_id()
+        if isinstance(admin_id, dict):
+            return admin_id
+        payload: dict[str, Any] = {
+            "type": "admin",
+            "admin_id": admin_id,
+            "assignee_id": assignee_id,
+            "message_type": "assignment",
+            "body": body,
+        }
+        response = httpx.post(
+            f"{INTERCOM_API_BASE}/conversations/{conversation_id}/parts",
+            headers=self._headers,
+            json=payload,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def create_or_get_tag(self, name: str) -> dict[str, Any]:
+        """Create a tag or return existing tag with the same name."""
+        response = httpx.post(
+            f"{INTERCOM_API_BASE}/tags",
+            headers=self._headers,
+            json={"name": name},
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def tag_conversation(
+        self,
+        conversation_id: str,
+        tag_id: str,
+    ) -> dict[str, Any]:
+        """Attach a tag to a conversation."""
+        admin_id = self._get_admin_id()
+        if isinstance(admin_id, dict):
+            return admin_id
+        response = httpx.post(
+            f"{INTERCOM_API_BASE}/conversations/{conversation_id}/tags",
+            headers=self._headers,
+            json={"id": tag_id, "admin_id": admin_id},
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def tag_contact(
+        self,
+        contact_id: str,
+        tag_id: str,
+    ) -> dict[str, Any]:
+        """Attach a tag to a contact."""
+        response = httpx.post(
+            f"{INTERCOM_API_BASE}/contacts/{contact_id}/tags",
+            headers=self._headers,
+            json={"id": tag_id},
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: CredentialStoreAdapter | None = None,
+) -> None:
+    """Register Intercom tools with the MCP server."""
+
+    def _get_token() -> str | None:
+        """Get Intercom access token from credential store or environment."""
+        if credentials is not None:
+            token = credentials.get("intercom")
+            # Defensive check: ensure we get a string, not a complex object
+            if token is not None and not isinstance(token, str):
+                raise TypeError(
+                    f"Expected string from credentials.get('intercom'), got {type(token).__name__}"
+                )
+            return token
+        return os.getenv("INTERCOM_ACCESS_TOKEN")
+
+    def _get_client() -> _IntercomClient | dict[str, str]:
+        """Get an Intercom client, or return an error dict if no credentials."""
+        token = _get_token()
+        if not token:
+            return {
+                "error": "Intercom credentials not configured",
+                "help": (
+                    "Set INTERCOM_ACCESS_TOKEN environment variable "
+                    "or configure via credential store"
+                ),
+            }
+        return _IntercomClient(token)
+
+    # --- Conversations ---
+
+    @mcp.tool()
+    def intercom_search_conversations(
+        status: str | None = None,
+        assignee_id: str | None = None,
+        tag: str | None = None,
+        created_after: str | None = None,
+        limit: int = 20,
+    ) -> dict:
+        """
+        Search Intercom conversations with optional filters.
+
+        Args:
+            status: Filter by status ("open", "closed", "snoozed")
+            assignee_id: Filter by assigned admin/team ID
+            tag: Filter by tag name
+            created_after: ISO date string — only return conversations
+                created after this date (e.g., "2026-01-15")
+            limit: Max conversations to return (1-150, default 20)
+
+        Returns:
+            Dict with conversation summaries or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if limit < 1 or limit > 150:
+            return {"error": "limit must be between 1 and 150"}
+        if status and status not in ("open", "closed", "snoozed"):
+            return {"error": "status must be 'open', 'closed', or 'snoozed'"}
+        try:
+            filters: list[dict[str, Any]] = []
+            if status:
+                filters.append({"field": "state", "operator": "=", "value": status})
+            if assignee_id:
+                filters.append(
+                    {
+                        "field": "admin_assignee_id",
+                        "operator": "=",
+                        "value": assignee_id,
+                    }
+                )
+            if tag:
+                # Resolve tag name to ID
+                tags_result = client.list_tags()
+                if "error" in tags_result:
+                    return tags_result
+                tag_list = tags_result.get("data", [])
+                tag_obj = next((t for t in tag_list if t.get("name") == tag), None)
+                if not tag_obj:
+                    return {"error": f"Tag not found: {tag}"}
+                filters.append(
+                    {
+                        "field": "tag_ids",
+                        "operator": "IN",
+                        "value": [tag_obj["id"]],
+                    }
+                )
+            if created_after:
+                try:
+                    dt = datetime.fromisoformat(created_after)
+                    if dt.tzinfo is None:
+                        dt = dt.replace(tzinfo=UTC)
+                    ts = int(dt.timestamp())
+                except ValueError:
+                    return {
+                        "error": (
+                            "created_after must be a valid ISO date string (e.g., '2026-01-15')"
+                        )
+                    }
+                filters.append({"field": "created_at", "operator": ">", "value": ts})
+
+            # Build query from filters
+            if not filters:
+                # No filters: return recent conversations
+                query: dict[str, Any] = {
+                    "field": "created_at",
+                    "operator": ">",
+                    "value": 0,
+                }
+            elif len(filters) == 1:
+                query = filters[0]
+            else:
+                query = {"operator": "AND", "value": filters}
+
+            return client.search_conversations(query, limit=limit)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def intercom_get_conversation(conversation_id: str) -> dict:
+        """
+        Get full conversation details including message history.
+
+        Args:
+            conversation_id: Intercom conversation ID
+
+        Returns:
+            Dict with conversation details, messages, and parts
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.get_conversation(conversation_id)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    # --- Contacts ---
+
+    @mcp.tool()
+    def intercom_get_contact(
+        contact_id: str | None = None,
+        email: str | None = None,
+    ) -> dict:
+        """
+        Get an Intercom contact by ID or email.
+
+        Args:
+            contact_id: Intercom contact ID (preferred)
+            email: Email address (falls back to search if no ID)
+
+        Returns:
+            Dict with contact details, tags, and recent conversation count
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not contact_id and not email:
+            return {"error": "Either contact_id or email must be provided"}
+        try:
+            if contact_id:
+                return client.get_contact(contact_id)
+            # Fallback: search by email (no direct get-by-email endpoint)
+            query = {"field": "email", "operator": "=", "value": email}
+            result = client.search_contacts(query, limit=1)
+            if "error" in result:
+                return result
+            contacts = result.get("data", [])
+            if not contacts:
+                return {"error": f"No contact found with email: {email}"}
+            return contacts[0]
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def intercom_search_contacts(query: str, limit: int = 20) -> dict:
+        """
+        Search contacts by email, name, or custom attributes.
+
+        Args:
+            query: Search query string
+            limit: Max contacts to return (1-150, default 20)
+
+        Returns:
+            Dict with matching contacts or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if limit < 1 or limit > 150:
+            return {"error": "limit must be between 1 and 150"}
+        try:
+            search_query = {
+                "operator": "OR",
+                "value": [
+                    {"field": "email", "operator": "=", "value": query},
+                    {"field": "name", "operator": "~", "value": query},
+                ],
+            }
+            return client.search_contacts(search_query, limit=limit)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    # --- Notes, Tags & Assignment ---
+
+    @mcp.tool()
+    def intercom_add_note(conversation_id: str, body: str) -> dict:
+        """
+        Add an internal note to a conversation.
+
+        Args:
+            conversation_id: Intercom conversation ID
+            body: Note content (supports HTML)
+
+        Returns:
+            Dict with note details or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.reply_to_conversation(conversation_id, body=body, message_type="note")
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def intercom_add_tag(
+        name: str,
+        conversation_id: str | None = None,
+        contact_id: str | None = None,
+    ) -> dict:
+        """
+        Add a tag to a conversation or contact.
+
+        Args:
+            name: Tag name (created if it doesn't exist)
+            conversation_id: Tag a conversation
+                (mutually exclusive with contact_id)
+            contact_id: Tag a contact
+                (mutually exclusive with conversation_id)
+
+        Returns:
+            Dict with tag details or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not conversation_id and not contact_id:
+            return {"error": "Either conversation_id or contact_id must be provided"}
+        if conversation_id and contact_id:
+            return {"error": "Provide conversation_id or contact_id, not both"}
+        try:
+            # Step 1: create or get tag by name (idempotent)
+            tag_result = client.create_or_get_tag(name)
+            if "error" in tag_result:
+                return tag_result
+            tag_id = str(tag_result["id"])
+            # Step 2: attach to target
+            if conversation_id:
+                return client.tag_conversation(conversation_id, tag_id)
+            return client.tag_contact(contact_id, tag_id)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def intercom_assign_conversation(
+        conversation_id: str,
+        assignee_id: str,
+        assignee_type: str = "admin",
+        body: str = "",
+    ) -> dict:
+        """
+        Assign a conversation to an admin or team.
+
+        Args:
+            conversation_id: Intercom conversation ID
+            assignee_id: Admin or team ID to assign to
+            assignee_type: "admin" or "team"
+            body: Optional note about the assignment
+
+        Returns:
+            Dict with updated conversation or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if assignee_type not in ("admin", "team"):
+            return {"error": "assignee_type must be 'admin' or 'team'"}
+        try:
+            return client.assign_conversation(conversation_id, assignee_id, body=body)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def intercom_list_teams() -> dict:
+        """List available Intercom teams for conversation routing."""
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_teams()
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}

--- a/tools/src/aden_tools/tools/intercom_tool/intercom_tool.py
+++ b/tools/src/aden_tools/tools/intercom_tool/intercom_tool.py
@@ -169,6 +169,7 @@ class _IntercomClient:
         self,
         conversation_id: str,
         assignee_id: str,
+        assignee_type: str = "admin",
         body: str = "",
     ) -> dict[str, Any]:
         """Assign a conversation to an admin or team."""
@@ -179,6 +180,7 @@ class _IntercomClient:
             "type": "admin",
             "admin_id": admin_id,
             "assignee_id": assignee_id,
+            "assignee_type": assignee_type,
             "message_type": "assignment",
             "body": body,
         }
@@ -536,7 +538,9 @@ def register_tools(
         if assignee_type not in ("admin", "team"):
             return {"error": "assignee_type must be 'admin' or 'team'"}
         try:
-            return client.assign_conversation(conversation_id, assignee_id, body=body)
+            return client.assign_conversation(
+                conversation_id, assignee_id, assignee_type=assignee_type, body=body
+            )
         except httpx.TimeoutException:
             return {"error": "Request timed out"}
         except httpx.RequestError as e:

--- a/tools/src/aden_tools/tools/intercom_tool/tests/test_intercom_tool.py
+++ b/tools/src/aden_tools/tools/intercom_tool/tests/test_intercom_tool.py
@@ -1,0 +1,718 @@
+"""
+Tests for Intercom tool and credential spec.
+
+Covers:
+- _IntercomClient methods (search, get, reply, assign, tag)
+- Error handling (401, 403, 404, 429, 500, timeout)
+- Credential retrieval (CredentialStoreAdapter vs env var)
+- All 8 MCP tool functions
+- Input validation (missing params, invalid values)
+- Credential spec registration
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from aden_tools.tools.intercom_tool.intercom_tool import (
+    INTERCOM_API_BASE,
+    _IntercomClient,
+    register_tools,
+)
+
+# --- _IntercomClient tests ---
+
+
+class TestIntercomClientHeaders:
+    def setup_method(self):
+        self.client = _IntercomClient("test-token")
+
+    def test_authorization_header(self):
+        assert self.client._headers["Authorization"] == "Bearer test-token"
+
+    def test_intercom_version_header(self):
+        assert self.client._headers["Intercom-Version"] == "2.11"
+
+    def test_content_type_header(self):
+        assert self.client._headers["Content-Type"] == "application/json"
+
+
+class TestHandleResponse:
+    def setup_method(self):
+        self.client = _IntercomClient("test-token")
+
+    def test_success(self):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"type": "team.list", "teams": []}
+        assert self.client._handle_response(response) == {"type": "team.list", "teams": []}
+
+    @pytest.mark.parametrize(
+        "status_code,expected_substring",
+        [
+            (401, "Invalid or expired"),
+            (403, "Insufficient permissions"),
+            (404, "not found"),
+            (429, "rate limit"),
+        ],
+    )
+    def test_error_codes(self, status_code, expected_substring):
+        response = MagicMock()
+        response.status_code = status_code
+        result = self.client._handle_response(response)
+        assert "error" in result
+        assert expected_substring in result["error"]
+
+    def test_generic_error_with_intercom_error_format(self):
+        response = MagicMock()
+        response.status_code = 500
+        response.json.return_value = {
+            "type": "error.list",
+            "errors": [{"code": "server_error", "message": "Something went wrong"}],
+        }
+        result = self.client._handle_response(response)
+        assert "error" in result
+        assert "500" in result["error"]
+        assert "Something went wrong" in result["error"]
+
+    def test_generic_error_fallback_to_text(self):
+        response = MagicMock()
+        response.status_code = 500
+        response.json.side_effect = Exception("not json")
+        response.text = "Internal Server Error"
+        result = self.client._handle_response(response)
+        assert "error" in result
+        assert "Internal Server Error" in result["error"]
+
+
+class TestGetAdminId:
+    def setup_method(self):
+        self.client = _IntercomClient("test-token")
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.get")
+    def test_fetches_admin_id(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"type": "admin", "id": "12345"}
+        mock_get.return_value = mock_response
+
+        result = self.client._get_admin_id()
+
+        assert result == "12345"
+        mock_get.assert_called_once_with(
+            f"{INTERCOM_API_BASE}/me",
+            headers=self.client._headers,
+            timeout=30.0,
+        )
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.get")
+    def test_caches_admin_id(self, mock_get):
+        """Second call should use cached value, not hit API again."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"type": "admin", "id": "12345"}
+        mock_get.return_value = mock_response
+
+        self.client._get_admin_id()
+        self.client._get_admin_id()
+
+        # Should only call the API once
+        mock_get.assert_called_once()
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.get")
+    def test_returns_error_on_failure(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_get.return_value = mock_response
+
+        result = self.client._get_admin_id()
+
+        assert isinstance(result, dict)
+        assert "error" in result
+
+
+class TestListTeams:
+    def setup_method(self):
+        self.client = _IntercomClient("test-token")
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.get")
+    def test_list_teams_success(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "type": "team.list",
+            "teams": [{"type": "team", "id": "1", "name": "Support"}],
+        }
+        mock_get.return_value = mock_response
+
+        result = self.client.list_teams()
+
+        mock_get.assert_called_once_with(
+            f"{INTERCOM_API_BASE}/teams",
+            headers=self.client._headers,
+            timeout=30.0,
+        )
+        assert result["type"] == "team.list"
+        assert len(result["teams"]) == 1
+
+
+class TestListTags:
+    def setup_method(self):
+        self.client = _IntercomClient("test-token")
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.get")
+    def test_list_tags_success(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "type": "list",
+            "data": [{"type": "tag", "id": "1", "name": "VIP"}],
+        }
+        mock_get.return_value = mock_response
+
+        result = self.client.list_tags()
+
+        mock_get.assert_called_once_with(
+            f"{INTERCOM_API_BASE}/tags",
+            headers=self.client._headers,
+            timeout=30.0,
+        )
+        assert result["type"] == "list"
+        assert len(result["data"]) == 1
+
+
+class TestSearchContacts:
+    def setup_method(self):
+        self.client = _IntercomClient("test-token")
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.post")
+    def test_search_contacts(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "type": "list",
+            "data": [{"type": "contact", "id": "123", "email": "test@example.com"}],
+        }
+        mock_post.return_value = mock_response
+
+        query = {"field": "email", "operator": "=", "value": "test@example.com"}
+        result = self.client.search_contacts(query, limit=5)
+
+        mock_post.assert_called_once_with(
+            f"{INTERCOM_API_BASE}/contacts/search",
+            headers=self.client._headers,
+            json={"query": query, "pagination": {"per_page": 5}},
+            timeout=30.0,
+        )
+        assert result["type"] == "list"
+        assert len(result["data"]) == 1
+
+
+class TestGetContact:
+    def setup_method(self):
+        self.client = _IntercomClient("test-token")
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.get")
+    def test_get_contact_success(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "type": "contact",
+            "id": "123",
+            "email": "test@example.com",
+        }
+        mock_get.return_value = mock_response
+
+        result = self.client.get_contact("123")
+
+        mock_get.assert_called_once_with(
+            f"{INTERCOM_API_BASE}/contacts/123",
+            headers=self.client._headers,
+            timeout=30.0,
+        )
+        assert result["type"] == "contact"
+        assert result["id"] == "123"
+
+
+class TestGetConversation:
+    def setup_method(self):
+        self.client = _IntercomClient("test-token")
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.get")
+    def test_get_conversation_success(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "type": "conversation",
+            "id": "456",
+            "title": "Help needed",
+        }
+        mock_get.return_value = mock_response
+
+        result = self.client.get_conversation("456")
+
+        mock_get.assert_called_once_with(
+            f"{INTERCOM_API_BASE}/conversations/456",
+            headers=self.client._headers,
+            params={"display_as": "plaintext"},
+            timeout=30.0,
+        )
+        assert result["type"] == "conversation"
+        assert result["id"] == "456"
+
+
+class TestSearchConversations:
+    def setup_method(self):
+        self.client = _IntercomClient("test-token")
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.post")
+    def test_search_conversations_success(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "type": "conversation.list",
+            "conversations": [{"type": "conversation", "id": "456"}],
+        }
+        mock_post.return_value = mock_response
+
+        query = {"field": "updated_at", "operator": ">", "value": "1609459200"}
+        result = self.client.search_conversations(query, limit=10)
+
+        mock_post.assert_called_once_with(
+            f"{INTERCOM_API_BASE}/conversations/search",
+            headers=self.client._headers,
+            json={"query": query, "pagination": {"per_page": 10}},
+            timeout=30.0,
+        )
+        assert result["type"] == "conversation.list"
+        assert len(result["conversations"]) == 1
+
+
+class TestReplyToConversation:
+    def setup_method(self):
+        self.client = _IntercomClient("test-token")
+        self.client._admin_id = "admin-1"  # pre-cache to avoid mocking /me
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.post")
+    def test_reply_success(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"type": "conversation", "id": "456"}
+        mock_post.return_value = mock_response
+
+        result = self.client.reply_to_conversation(
+            "456",
+            body="Hello!",
+            message_type="comment",
+        )
+
+        mock_post.assert_called_once_with(
+            f"{INTERCOM_API_BASE}/conversations/456/reply",
+            headers=self.client._headers,
+            json={
+                "type": "admin",
+                "admin_id": "admin-1",
+                "message_type": "comment",
+                "body": "Hello!",
+            },
+            timeout=30.0,
+        )
+        assert result["type"] == "conversation"
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.get")
+    def test_reply_returns_error_when_admin_id_fails(self, mock_get):
+        client = _IntercomClient("bad-token")
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_get.return_value = mock_response
+
+        result = client.reply_to_conversation("456", body="Hello!")
+
+        assert "error" in result
+
+
+class TestAssignConversation:
+    def setup_method(self):
+        self.client = _IntercomClient("test-token")
+        self.client._admin_id = "admin-1"
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.post")
+    def test_assign_success(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"type": "conversation", "id": "456"}
+        mock_post.return_value = mock_response
+
+        result = self.client.assign_conversation("456", assignee_id="admin-2", body="Reassigning")
+
+        mock_post.assert_called_once_with(
+            f"{INTERCOM_API_BASE}/conversations/456/parts",
+            headers=self.client._headers,
+            json={
+                "type": "admin",
+                "admin_id": "admin-1",
+                "assignee_id": "admin-2",
+                "message_type": "assignment",
+                "body": "Reassigning",
+            },
+            timeout=30.0,
+        )
+        assert result["type"] == "conversation"
+
+
+class TestCreateOrGetTag:
+    def setup_method(self):
+        self.client = _IntercomClient("test-token")
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.post")
+    def test_create_tag_success(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"type": "tag", "id": "99", "name": "VIP"}
+        mock_post.return_value = mock_response
+
+        result = self.client.create_or_get_tag("VIP")
+
+        mock_post.assert_called_once_with(
+            f"{INTERCOM_API_BASE}/tags",
+            headers=self.client._headers,
+            json={"name": "VIP"},
+            timeout=30.0,
+        )
+        assert result["type"] == "tag"
+        assert result["name"] == "VIP"
+
+
+class TestTagConversation:
+    def setup_method(self):
+        self.client = _IntercomClient("test-token")
+        self.client._admin_id = "admin-1"
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.post")
+    def test_tag_conversation_success(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"type": "tag", "id": "99"}
+        mock_post.return_value = mock_response
+
+        result = self.client.tag_conversation("456", "99")
+
+        mock_post.assert_called_once_with(
+            f"{INTERCOM_API_BASE}/conversations/456/tags",
+            headers=self.client._headers,
+            json={"id": "99", "admin_id": "admin-1"},
+            timeout=30.0,
+        )
+        assert result["type"] == "tag"
+
+
+class TestTagContact:
+    def setup_method(self):
+        self.client = _IntercomClient("test-token")
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.post")
+    def test_tag_contact_success(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"type": "tag", "id": "99"}
+        mock_post.return_value = mock_response
+
+        result = self.client.tag_contact("123", "99")
+
+        mock_post.assert_called_once_with(
+            f"{INTERCOM_API_BASE}/contacts/123/tags",
+            headers=self.client._headers,
+            json={"id": "99"},
+            timeout=30.0,
+        )
+        assert result["type"] == "tag"
+
+
+# --- MCP tool registration and credential tests ---
+
+
+class TestToolRegistration:
+    def test_register_tools_registers_all_tools(self):
+        mcp = MagicMock()
+        mcp.tool.return_value = lambda fn: fn
+        register_tools(mcp)
+        assert mcp.tool.call_count == 8
+
+    def test_no_credentials_returns_error(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        with patch.dict("os.environ", {}, clear=True):
+            register_tools(mcp, credentials=None)
+
+        search_fn = next(fn for fn in registered_fns if fn.__name__ == "intercom_list_teams")
+        result = search_fn()
+        assert "error" in result
+        assert "not configured" in result["error"]
+        assert "help" in result
+
+    def test_credentials_from_credential_manager(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        cred_manager = MagicMock()
+        cred_manager.get.return_value = "test-token"
+
+        register_tools(mcp, credentials=cred_manager)
+
+        list_fn = next(fn for fn in registered_fns if fn.__name__ == "intercom_list_teams")
+
+        with patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"type": "team.list", "teams": []}
+            mock_get.return_value = mock_response
+
+            result = list_fn()
+
+        cred_manager.get.assert_called_with("intercom")
+        assert result["type"] == "team.list"
+
+    def test_credentials_from_env_var(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        register_tools(mcp, credentials=None)
+
+        list_fn = next(fn for fn in registered_fns if fn.__name__ == "intercom_list_teams")
+
+        with (
+            patch.dict("os.environ", {"INTERCOM_ACCESS_TOKEN": "env-token"}),
+            patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.get") as mock_get,
+        ):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"type": "team.list", "teams": []}
+            mock_get.return_value = mock_response
+
+            result = list_fn()
+
+        assert result["type"] == "team.list"
+        call_headers = mock_get.call_args.kwargs["headers"]
+        assert call_headers["Authorization"] == "Bearer env-token"
+
+
+# --- Individual tool function tests ---
+
+
+class TestConversationTools:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.fns = []
+        self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
+        cred = MagicMock()
+        cred.get.return_value = "tok"
+        register_tools(self.mcp, credentials=cred)
+
+    def _fn(self, name):
+        return next(f for f in self.fns if f.__name__ == name)
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.post")
+    def test_search_conversations(self, mock_post):
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value={"type": "conversation.list", "conversations": [{"id": "1"}]}
+            ),
+        )
+        result = self._fn("intercom_search_conversations")(status="open")
+        assert result["type"] == "conversation.list"
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.get")
+    def test_get_conversation(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=200, json=MagicMock(return_value={"type": "conversation", "id": "1"})
+        )
+        result = self._fn("intercom_get_conversation")(conversation_id="1")
+        assert result["id"] == "1"
+
+    def test_search_conversations_invalid_status(self):
+        result = self._fn("intercom_search_conversations")(status="invalid")
+        assert "error" in result
+
+    def test_search_conversations_invalid_limit(self):
+        result = self._fn("intercom_search_conversations")(limit=0)
+        assert "error" in result
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.post")
+    def test_search_conversations_timeout(self, mock_post):
+        mock_post.side_effect = httpx.TimeoutException("timed out")
+        result = self._fn("intercom_search_conversations")()
+        assert "error" in result
+        assert "timed out" in result["error"]
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.get")
+    def test_get_conversation_network_error(self, mock_get):
+        mock_get.side_effect = httpx.RequestError("connection failed")
+        result = self._fn("intercom_get_conversation")(conversation_id="1")
+        assert "error" in result
+        assert "Network error" in result["error"]
+
+
+class TestContactTools:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.fns = []
+        self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
+        cred = MagicMock()
+        cred.get.return_value = "tok"
+        register_tools(self.mcp, credentials=cred)
+
+    def _fn(self, name):
+        return next(f for f in self.fns if f.__name__ == name)
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.get")
+    def test_get_contact_by_id(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=200, json=MagicMock(return_value={"type": "contact", "id": "1"})
+        )
+        result = self._fn("intercom_get_contact")(contact_id="1")
+        assert result["id"] == "1"
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.post")
+    def test_get_contact_by_email(self, mock_post):
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value={
+                    "type": "list",
+                    "data": [{"type": "contact", "id": "2", "email": "a@b.com"}],
+                }
+            ),
+        )
+        result = self._fn("intercom_get_contact")(email="a@b.com")
+        assert result["id"] == "2"
+
+    def test_get_contact_missing_params(self):
+        result = self._fn("intercom_get_contact")()
+        assert "error" in result
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.post")
+    def test_search_contacts(self, mock_post):
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(return_value={"type": "list", "data": [{"id": "1"}]}),
+        )
+        result = self._fn("intercom_search_contacts")(query="john")
+        assert result["type"] == "list"
+
+    def test_search_contacts_invalid_limit(self):
+        result = self._fn("intercom_search_contacts")(query="john", limit=200)
+        assert "error" in result
+
+
+class TestNoteTagAssignTools:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.fns = []
+        self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
+        cred = MagicMock()
+        cred.get.return_value = "tok"
+        register_tools(self.mcp, credentials=cred)
+
+    def _fn(self, name):
+        return next(f for f in self.fns if f.__name__ == name)
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.get")
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.post")
+    def test_add_note(self, mock_post, mock_get):
+        # Mock /me for admin_id
+        mock_get.return_value = MagicMock(
+            status_code=200, json=MagicMock(return_value={"id": "admin-1"})
+        )
+        mock_post.return_value = MagicMock(
+            status_code=200, json=MagicMock(return_value={"type": "conversation", "id": "1"})
+        )
+        result = self._fn("intercom_add_note")(conversation_id="1", body="Triage note")
+        assert result["type"] == "conversation"
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.get")
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.post")
+    def test_add_tag_to_conversation(self, mock_post, mock_get):
+        # Mock /me for admin_id
+        mock_get.return_value = MagicMock(
+            status_code=200, json=MagicMock(return_value={"id": "admin-1"})
+        )
+        # First post: create_or_get_tag, second: tag_conversation
+        mock_post.side_effect = [
+            MagicMock(
+                status_code=200,
+                json=MagicMock(return_value={"type": "tag", "id": "99", "name": "VIP"}),
+            ),
+            MagicMock(status_code=200, json=MagicMock(return_value={"type": "tag", "id": "99"})),
+        ]
+        result = self._fn("intercom_add_tag")(name="VIP", conversation_id="1")
+        assert result["type"] == "tag"
+
+    def test_add_tag_missing_target(self):
+        result = self._fn("intercom_add_tag")(name="VIP")
+        assert "error" in result
+
+    def test_add_tag_both_targets(self):
+        result = self._fn("intercom_add_tag")(name="VIP", conversation_id="1", contact_id="2")
+        assert "error" in result
+        assert "not both" in result["error"]
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.get")
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.post")
+    def test_assign_conversation(self, mock_post, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=200, json=MagicMock(return_value={"id": "admin-1"})
+        )
+        mock_post.return_value = MagicMock(
+            status_code=200, json=MagicMock(return_value={"type": "conversation", "id": "1"})
+        )
+        result = self._fn("intercom_assign_conversation")(
+            conversation_id="1", assignee_id="admin-2"
+        )
+        assert result["type"] == "conversation"
+
+    def test_assign_conversation_invalid_type(self):
+        result = self._fn("intercom_assign_conversation")(
+            conversation_id="1", assignee_id="2", assignee_type="invalid"
+        )
+        assert "error" in result
+
+    @patch("aden_tools.tools.intercom_tool.intercom_tool.httpx.get")
+    def test_list_teams(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(return_value={"type": "team.list", "teams": []}),
+        )
+        result = self._fn("intercom_list_teams")()
+        assert result["type"] == "team.list"
+
+
+# --- Credential spec tests ---
+
+
+class TestCredentialSpec:
+    def test_intercom_credential_spec_exists(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        assert "intercom" in CREDENTIAL_SPECS
+
+    def test_intercom_spec_env_var(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["intercom"]
+        assert spec.env_var == "INTERCOM_ACCESS_TOKEN"
+
+    def test_intercom_spec_tools(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["intercom"]
+        assert "intercom_search_conversations" in spec.tools
+        assert "intercom_list_teams" in spec.tools
+        assert len(spec.tools) == 8

--- a/tools/tests/test_health_checks.py
+++ b/tools/tests/test_health_checks.py
@@ -64,6 +64,7 @@ class TestHealthCheckerRegistry:
             "google_maps",
             "anthropic",
             "github",
+            "intercom",
             "resend",
             "google_calendar_oauth",
             "google",


### PR DESCRIPTION
## Description

Add Intercom tool integration with 8 MCP tools for managing conversations,
contacts, tags, and team assignment via Intercom API v2.11.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Fixes #4256

## Changes Made

- Add `intercom_tool` package with `_IntercomClient` wrapping Intercom REST API v2.11
- 8 tools: `intercom_search_conversations`, `intercom_get_conversation`,
  `intercom_get_contact`, `intercom_search_contacts`, `intercom_add_note`,
  `intercom_add_tag`, `intercom_assign_conversation`, `intercom_list_teams`
- Tag name-to-ID resolution, ISO date-to-timestamp conversion, query builder
- Register tools in `tools/__init__.py`
- 50 unit tests covering client methods, tool functions, input validation,
  credential handling, and credential spec

## Testing

- [x] Unit tests pass (`uv run pytest tools/tests/ -v`)
- [x] Lint passes (`uv run ruff check && uv run ruff format --check`)
- [x] 362 tests pass (271 existing + 41 HubSpot + 50 Intercom), 0 failures

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes