### PR TITLE
 fix[bug](graph): add execution_id to base Runtime and restore ctx.execution_id in escalation handler

### DIFF
--- a/core/framework/graph/event_loop_node.py
+++ b/core/framework/graph/event_loop_node.py
@@ -1319,7 +1319,7 @@ class EventLoopNode(NodeProtocol):
                             node_id=node_id,
                             reason=tc.tool_input.get("reason", ""),
                             context=tc.tool_input.get("context", ""),
-                            execution_id=stream_id,
+                            execution_id=ctx.execution_id,
                         )
                     # Block like ask_user — the TUI loads the coder,
                     # and /back injects a message to unblock us.

--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -1541,6 +1541,7 @@ class GraphExecutor:
             cumulative_output_keys=cumulative_output_keys or [],
             event_triggered=event_triggered,
             accounts_prompt=self.accounts_prompt,
+            execution_id=self.runtime.execution_id,
         )
 
     VALID_NODE_TYPES = {

--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -508,6 +508,9 @@ class NodeContext:
     # Event-triggered execution (no interactive user attached)
     event_triggered: bool = False
 
+    # Execution ID (from StreamRuntimeAdapter)
+    execution_id: str = ""
+
 
 @dataclass
 class NodeResult:

--- a/core/framework/runtime/core.py
+++ b/core/framework/runtime/core.py
@@ -66,6 +66,10 @@ class Runtime:
         self._current_run: Run | None = None
         self._current_node: str = "unknown"
 
+    @property
+    def execution_id(self) -> str:
+        return ""
+
     # === RUN LIFECYCLE ===
 
     def start_run(

--- a/core/framework/runtime/stream_runtime.py
+++ b/core/framework/runtime/stream_runtime.py
@@ -449,6 +449,10 @@ class StreamRuntimeAdapter:
         return self._runtime._storage
 
     @property
+    def execution_id(self) -> str:
+        return self._execution_id
+
+    @property
     def current_run(self) -> Run | None:
         return self._runtime.get_run(self._execution_id)
 

--- a/core/tests/test_graph_executor.py
+++ b/core/tests/test_graph_executor.py
@@ -13,6 +13,8 @@ from framework.graph.node import NodeResult, NodeSpec
 
 # ---- Dummy runtime (no real logging) ----
 class DummyRuntime:
+    execution_id = ""
+
     def start_run(self, **kwargs):
         return "run-1"
 


### PR DESCRIPTION
 ## Description                                                                                                                                                                                                                                                                                       
   
  Fixes two problems with `escalate_to_coder`:                                                                                                                                                                                                                                                         
                                                                                          
  1. `NodeContext` had no `execution_id` field, so `ctx.execution_id` raised `AttributeError` and crashed the agent
  2. Commit `76d4d0d` worked around the crash by swapping `ctx.execution_id` to `stream_id`, but `stream_id` is actually `ctx.node_id` (line 232 of event_loop_node.py), so the escalation event was carrying a node name like `"intake"` instead of the real execution ID like `"exec_abc123"`.
  No downstream code reads this value today so it wasn't visibly broken, but it's incorrect data sitting in the AgentEvent.

  This PR adds `execution_id` as a proper field on `NodeContext`, wires it through from the runtime, and restores the original `ctx.execution_id` in the escalation handler.

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)

  ## Related Issues

  Fixes #5180

  ## Changes Made

  - Added `execution_id: str = ""` field to `NodeContext` dataclass (`node.py`)
  - Added `execution_id` property to `StreamRuntimeAdapter` to expose the private `_execution_id` (`stream_runtime.py`)
  - Added `execution_id` property to base `Runtime` returning `""` so both runtime types share the same interface (`core.py`)
  - Wired `self.runtime.execution_id` through `GraphExecutor._build_context` into `NodeContext` (`executor.py`)
  - Restored `execution_id=ctx.execution_id` in the `escalate_to_coder` handler, replacing the `stream_id` workaround (`event_loop_node.py`)
  - Added `execution_id` to `DummyRuntime` in `test_graph_executor.py` to match the contract
  - Added 5 tests covering the execution_id plumbing

  ## Testing

  - [x] Unit tests pass (708 passed, 0 failed)
  - [x] Lint passes (`cd core && ruff check .`)

  ## Checklist

  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes