### PR TITLE
[Integration] Add Databricks integration for workspace, SQL, and job management

### DIFF
--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -58,6 +58,7 @@ from .base import CredentialError, CredentialSpec
 from .bigquery import BIGQUERY_CREDENTIALS
 from .browser import get_aden_auth_url, get_aden_setup_url, open_browser
 from .calcom import CALCOM_CREDENTIALS
+from .databricks import DATABRICKS_CREDENTIALS
 from .discord import DISCORD_CREDENTIALS
 from .email import EMAIL_CREDENTIALS
 from .gcp_vision import GCP_VISION_CREDENTIALS
@@ -104,6 +105,7 @@ CREDENTIAL_SPECS = {
     **BIGQUERY_CREDENTIALS,
     **CALCOM_CREDENTIALS,
     **STRIPE_CREDENTIALS,
+    **DATABRICKS_CREDENTIALS,
 }
 
 __all__ = [
@@ -147,4 +149,5 @@ __all__ = [
     "CALCOM_CREDENTIALS",
     "DISCORD_CREDENTIALS",
     "STRIPE_CREDENTIALS",
+    "DATABRICKS_CREDENTIALS",
 ]

--- a/tools/src/aden_tools/credentials/databricks.py
+++ b/tools/src/aden_tools/credentials/databricks.py
@@ -1,0 +1,76 @@
+"""
+Databricks tool credentials.
+
+Contains credentials for Databricks workspace integration.
+Supports Databricks on AWS and Azure.
+"""
+
+from .base import CredentialSpec
+
+DATABRICKS_CREDENTIALS = {
+    "databricks": CredentialSpec(
+        env_var="DATABRICKS_TOKEN",
+        tools=[
+            "run_databricks_sql",
+            "trigger_databricks_job",
+            "describe_table",
+            "list_workspace",
+            "databricks_list_jobs",
+            "databricks_get_job_status",
+            "databricks_list_warehouses",
+            "databricks_list_catalogs",
+            "databricks_list_schemas",
+            "databricks_list_tables",
+        ],
+        required=True,
+        startup_required=False,
+        help_url="https://docs.databricks.com/en/dev-tools/auth.html",
+        description="Databricks Personal Access Token or Service Principal token",
+        aden_supported=False,
+        aden_provider_name="databricks",
+        direct_api_key_supported=True,
+        api_key_instructions="""To get a Databricks Personal Access Token:
+1. Log in to your Databricks workspace
+2. Click on your username in the top right corner
+3. Select "Settings" from the dropdown
+4. Go to "Developer" tab (or "User Settings" > "Access Tokens")
+5. Click "Generate new token"
+6. Give your token a comment and lifetime (or leave blank for indefinite)
+7. Click "Generate" and copy the token immediately
+8. Also set DATABRICKS_HOST to your workspace URL (e.g., https://your-workspace.cloud.databricks.com)
+
+For Service Principal authentication:
+1. Create a Service Principal in Azure AD or Databricks
+2. Generate a secret for the Service Principal
+3. Use the Application ID and Secret as the token""",
+        health_check_endpoint="",
+        health_check_method="GET",
+        credential_id="databricks",
+        credential_key="access_token",
+        credential_group="databricks",
+    ),
+    "databricks_host": CredentialSpec(
+        env_var="DATABRICKS_HOST",
+        tools=[
+            "run_databricks_sql",
+            "trigger_databricks_job",
+            "describe_table",
+            "list_workspace",
+            "databricks_list_jobs",
+            "databricks_get_job_status",
+            "databricks_list_warehouses",
+            "databricks_list_catalogs",
+            "databricks_list_schemas",
+            "databricks_list_tables",
+        ],
+        required=True,
+        startup_required=False,
+        help_url="https://docs.databricks.com/en/workspace/workspace-url.html",
+        description="Databricks workspace URL (e.g., https://your-workspace.cloud.databricks.com)",
+        aden_supported=False,
+        direct_api_key_supported=True,
+        credential_id="databricks_host",
+        credential_key="host",
+        credential_group="databricks",
+    ),
+}

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -27,6 +27,7 @@ from .bigquery_tool import register_tools as register_bigquery
 from .calcom_tool import register_tools as register_calcom
 from .calendar_tool import register_tools as register_calendar
 from .csv_tool import register_tools as register_csv
+from .databricks_tool import register_tools as register_databricks
 from .discord_tool import register_tools as register_discord
 
 # Security scanning tools
@@ -110,6 +111,7 @@ def register_all_tools(
     register_bigquery(mcp, credentials=credentials)
     register_calcom(mcp, credentials=credentials)
     register_calendar(mcp, credentials=credentials)
+    register_databricks(mcp, credentials=credentials)
     register_discord(mcp, credentials=credentials)
     register_exa_search(mcp, credentials=credentials)
     register_news(mcp, credentials=credentials)

--- a/tools/src/aden_tools/tools/databricks_tool/__init__.py
+++ b/tools/src/aden_tools/tools/databricks_tool/__init__.py
@@ -1,0 +1,3 @@
+from .databricks_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/databricks_tool/databricks_tool.py
+++ b/tools/src/aden_tools/tools/databricks_tool/databricks_tool.py
@@ -1,0 +1,638 @@
+"""
+Databricks Tool - Interact with Databricks workspace, SQL warehouses, and jobs.
+
+Supports:
+- Execute SQL queries on SQL Warehouses
+- Trigger and monitor Databricks jobs
+- Explore Unity Catalog (tables, schemas, catalogs)
+- Browse workspace notebooks and folders
+
+API Reference: https://docs.databricks.com/api/
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialStoreAdapter
+
+
+class _DatabricksClient:
+    """Internal client wrapping Databricks REST API calls."""
+
+    def __init__(self, host: str, token: str):
+        self._host = host.rstrip("/")
+        self._token = token
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._token}",
+            "Content-Type": "application/json",
+        }
+
+    def _handle_response(self, response: httpx.Response) -> dict[str, Any]:
+        """Handle Databricks API response."""
+        if response.status_code >= 400:
+            try:
+                error_data = response.json()
+                error_msg = error_data.get("message", response.text)
+            except Exception:
+                error_msg = response.text
+            return {"error": f"HTTP {response.status_code}: {error_msg}"}
+        try:
+            return response.json()
+        except Exception:
+            return {"success": True, "raw_response": response.text}
+
+    def _get(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Make a GET request to the Databricks API."""
+        response = httpx.get(
+            f"{self._host}{path}",
+            headers=self._headers,
+            params=params,
+            timeout=60.0,
+        )
+        return self._handle_response(response)
+
+    def _post(self, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Make a POST request to the Databricks API."""
+        response = httpx.post(
+            f"{self._host}{path}",
+            headers=self._headers,
+            json=body or {},
+            timeout=60.0,
+        )
+        return self._handle_response(response)
+
+    def execute_sql(
+        self,
+        warehouse_id: str,
+        query: str,
+        catalog: str | None = None,
+        schema: str | None = None,
+    ) -> dict[str, Any]:
+        """Execute a SQL statement on a SQL Warehouse."""
+        body: dict[str, Any] = {
+            "warehouse_id": warehouse_id,
+            "statement": query,
+        }
+        if catalog:
+            body["catalog"] = catalog
+        if schema:
+            body["schema"] = schema
+        return self._post("/api/2.0/sql/statements", body)
+
+    def get_statement_status(self, statement_id: str) -> dict[str, Any]:
+        """Get the status of a SQL statement execution."""
+        return self._get(f"/api/2.0/sql/statements/{statement_id}")
+
+    def cancel_statement(self, statement_id: str) -> dict[str, Any]:
+        """Cancel a running SQL statement."""
+        return self._post(f"/api/2.0/sql/statements/{statement_id}/cancel")
+
+    def list_warehouses(self) -> dict[str, Any]:
+        """List all SQL warehouses."""
+        return self._get("/api/2.0/sql/warehouses")
+
+    def list_jobs(self, limit: int = 20, name: str | None = None) -> dict[str, Any]:
+        """List Databricks jobs."""
+        params: dict[str, Any] = {"limit": min(limit, 100)}
+        if name:
+            params["name"] = name
+        return self._get("/api/2.1/jobs/list", params)
+
+    def get_job(self, job_id: int) -> dict[str, Any]:
+        """Get details of a specific job."""
+        return self._get("/api/2.1/jobs/get", {"job_id": job_id})
+
+    def run_job(
+        self,
+        job_id: int,
+        parameters: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Trigger a Databricks job run."""
+        body: dict[str, Any] = {"job_id": job_id}
+        if parameters:
+            body["notebook_params"] = parameters
+        return self._post("/api/2.1/jobs/run-now", body)
+
+    def get_run_status(self, run_id: int) -> dict[str, Any]:
+        """Get the status of a job run."""
+        return self._get("/api/2.1/jobs/runs/get", {"run_id": run_id})
+
+    def cancel_run(self, run_id: int) -> dict[str, Any]:
+        """Cancel a job run."""
+        return self._post("/api/2.1/jobs/runs/cancel", {"run_id": run_id})
+
+    def list_workspace(self, path: str = "/") -> dict[str, Any]:
+        """List contents of a workspace path (notebooks, directories)."""
+        return self._get("/api/2.0/workspace/list", {"path": path})
+
+    def get_status(self, path: str) -> dict[str, Any]:
+        """Get the status of a workspace object."""
+        return self._get("/api/2.0/workspace/get-status", {"path": path})
+
+    def export_notebook(self, path: str, format: str = "SOURCE") -> dict[str, Any]:
+        """Export a notebook's content."""
+        return self._get("/api/2.0/workspace/export", {"path": path, "format": format})
+
+    def list_catalogs(self) -> dict[str, Any]:
+        """List all catalogs in Unity Catalog."""
+        return self._get("/api/2.1/unity-catalog/catalogs")
+
+    def get_catalog(self, name: str) -> dict[str, Any]:
+        """Get details of a specific catalog."""
+        return self._get(f"/api/2.1/unity-catalog/catalogs/{name}")
+
+    def list_schemas(self, catalog_name: str) -> dict[str, Any]:
+        """List schemas in a catalog."""
+        return self._get("/api/2.1/unity-catalog/schemas", {"catalog_name": catalog_name})
+
+    def get_schema(self, full_name: str) -> dict[str, Any]:
+        """Get details of a specific schema."""
+        return self._get(f"/api/2.1/unity-catalog/schemas/{full_name}")
+
+    def list_tables(self, catalog_name: str, schema_name: str) -> dict[str, Any]:
+        """List tables in a schema."""
+        return self._get(
+            "/api/2.1/unity-catalog/tables",
+            {"catalog_name": catalog_name, "schema_name": schema_name},
+        )
+
+    def get_table(self, full_name: str) -> dict[str, Any]:
+        """Get details of a specific table (including schema/columns)."""
+        return self._get(f"/api/2.1/unity-catalog/tables/{full_name}")
+
+    def list_functions(self, catalog_name: str, schema_name: str) -> dict[str, Any]:
+        """List functions in a schema."""
+        return self._get(
+            "/api/2.1/unity-catalog/functions",
+            {"catalog_name": catalog_name, "schema_name": schema_name},
+        )
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: CredentialStoreAdapter | None = None,
+) -> None:
+    """Register Databricks tools with the MCP server."""
+
+    def _get_token() -> str | None:
+        """Get Databricks token from credential manager or environment."""
+        if credentials is not None:
+            token = credentials.get("databricks")
+            if token is not None and not isinstance(token, str):
+                raise TypeError(
+                    f"Expected string from credentials.get('databricks'), got {type(token).__name__}"
+                )
+            return token
+        return os.getenv("DATABRICKS_TOKEN")
+
+    def _get_host() -> str | None:
+        """Get Databricks host from credential manager or environment."""
+        if credentials is not None:
+            host = credentials.get("databricks_host")
+            if host is not None and not isinstance(host, str):
+                raise TypeError(
+                    f"Expected string from credentials.get('databricks_host'), got {type(host).__name__}"
+                )
+            return host
+        return os.getenv("DATABRICKS_HOST")
+
+    def _get_client() -> _DatabricksClient | dict[str, str]:
+        """Get a Databricks client, or return an error dict if no credentials."""
+        token = _get_token()
+        host = _get_host()
+        if not token or not host:
+            return {
+                "error": "Databricks credentials not configured",
+                "help": "Set DATABRICKS_TOKEN and DATABRICKS_HOST environment variables",
+            }
+        return _DatabricksClient(host, token)
+
+    @mcp.tool()
+    def run_databricks_sql(
+        query: str,
+        warehouse_id: str,
+        catalog: str | None = None,
+        schema: str | None = None,
+    ) -> dict:
+        """
+        Execute a SQL query on a Databricks SQL Warehouse.
+        The query is executed asynchronously. Use the returned statement_id to check status.
+
+        Args:
+            query: SQL query to execute (SELECT statements recommended for read-only)
+            warehouse_id: ID of the SQL Warehouse to use
+            catalog: Optional catalog name to use
+            schema: Optional schema name to use
+
+        Returns:
+            Dict with statement_id and status, or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.execute_sql(warehouse_id, query, catalog, schema)
+            if "error" in result:
+                return result
+            return {
+                "success": True,
+                "statement_id": result.get("statement_id"),
+                "status": result.get("status", {}).get("state"),
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def databricks_get_statement_status(statement_id: str) -> dict:
+        """
+        Get the status and results of a SQL statement execution.
+
+        Args:
+            statement_id: ID of the SQL statement from run_databricks_sql
+
+        Returns:
+            Dict with statement status and results (if complete)
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.get_statement_status(statement_id)
+            if "error" in result:
+                return result
+            status = result.get("status", {})
+            response: dict[str, Any] = {
+                "success": True,
+                "statement_id": statement_id,
+                "state": status.get("state"),
+            }
+            if result.get("result"):
+                response["result"] = result.get("result")
+            if status.get("error"):
+                response["error"] = status.get("error")
+            return response
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def trigger_databricks_job(
+        job_id: int,
+        parameters: dict[str, Any] | None = None,
+    ) -> dict:
+        """
+        Trigger a Databricks job to run.
+
+        Args:
+            job_id: ID of the job to trigger
+            parameters: Optional dictionary of parameters to pass to the job
+
+        Returns:
+            Dict with run_id and initial status, or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.run_job(job_id, parameters)
+            if "error" in result:
+                return result
+            return {
+                "success": True,
+                "run_id": result.get("run_id"),
+                "number_in_job": result.get("number_in_job"),
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def databricks_get_job_status(run_id: int) -> dict:
+        """
+        Get the status of a Databricks job run.
+
+        Args:
+            run_id: ID of the job run (from trigger_databricks_job)
+
+        Returns:
+            Dict with job run status and details
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.get_run_status(run_id)
+            if "error" in result:
+                return result
+            return {
+                "success": True,
+                "run_id": run_id,
+                "state": result.get("state", {}).get("life_cycle_state"),
+                "result_state": result.get("state", {}).get("result_state"),
+                "state_message": result.get("state", {}).get("state_message"),
+                "start_time": result.get("start_time"),
+                "end_time": result.get("end_time"),
+                "run_duration": result.get("run_duration"),
+                "run_page_url": result.get("run_page_url"),
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def describe_table(full_name: str) -> dict:
+        """
+        Get schema and metadata for a table in Unity Catalog.
+
+        Args:
+            full_name: Full table name (catalog.schema.table)
+
+        Returns:
+            Dict with table schema including column names, types, and comments
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.get_table(full_name)
+            if "error" in result:
+                return result
+            table_info = result
+            columns = [
+                {
+                    "name": col.get("name"),
+                    "type_text": col.get("type_text"),
+                    "type_name": col.get("type_name"),
+                    "comment": col.get("comment"),
+                    "nullable": col.get("nullable", True),
+                }
+                for col in table_info.get("columns", [])
+            ]
+            return {
+                "success": True,
+                "name": table_info.get("name"),
+                "full_name": table_info.get("full_name"),
+                "catalog_name": table_info.get("catalog_name"),
+                "schema_name": table_info.get("schema_name"),
+                "table_type": table_info.get("table_type"),
+                "data_source_format": table_info.get("data_source_format"),
+                "comment": table_info.get("comment"),
+                "columns": columns,
+                "owner": table_info.get("owner"),
+                "created_at": table_info.get("created_at"),
+                "updated_at": table_info.get("updated_at"),
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def list_workspace(path: str = "/") -> dict:
+        """
+        List notebooks and folders in a Databricks workspace path.
+
+        Args:
+            path: Workspace path to list (default: root "/")
+
+        Returns:
+            Dict with list of objects (notebooks, directories, files)
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.list_workspace(path)
+            if "error" in result:
+                return result
+            objects = result.get("objects", [])
+            items = [
+                {
+                    "path": obj.get("path"),
+                    "object_type": obj.get("object_type"),
+                    "object_id": obj.get("object_id"),
+                }
+                for obj in objects
+            ]
+            return {
+                "success": True,
+                "path": path,
+                "objects": items,
+                "count": len(items),
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def databricks_list_warehouses() -> dict:
+        """
+        List all SQL Warehouses in the Databricks workspace.
+
+        Returns:
+            Dict with list of SQL warehouses
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.list_warehouses()
+            if "error" in result:
+                return result
+            warehouses = result.get("warehouses", [])
+            items = [
+                {
+                    "id": wh.get("id"),
+                    "name": wh.get("name"),
+                    "size": wh.get("size"),
+                    "state": wh.get("state"),
+                    "auto_stop_min": wh.get("auto_stop_mins"),
+                    "spot_instance_policy": wh.get("spot_instance_policy"),
+                    "enable_serverless_compute": wh.get("enable_serverless_compute"),
+                }
+                for wh in warehouses
+            ]
+            return {
+                "success": True,
+                "warehouses": items,
+                "count": len(items),
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def databricks_list_jobs(limit: int = 20, name: str | None = None) -> dict:
+        """
+        List Databricks jobs in the workspace.
+
+        Args:
+            limit: Maximum number of jobs to return (1-100)
+            name: Optional filter by job name
+
+        Returns:
+            Dict with list of jobs
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.list_jobs(limit, name)
+            if "error" in result:
+                return result
+            jobs = result.get("jobs", [])
+            items = [
+                {
+                    "job_id": job.get("job_id"),
+                    "settings": job.get("settings", {}),
+                    "created_time": job.get("created_time"),
+                    "creator_user_name": job.get("creator_user_name"),
+                }
+                for job in jobs
+            ]
+            return {
+                "success": True,
+                "jobs": items,
+                "count": len(items),
+                "has_more": result.get("has_more", False),
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def databricks_list_catalogs() -> dict:
+        """
+        List all catalogs in Unity Catalog.
+
+        Returns:
+            Dict with list of catalogs
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.list_catalogs()
+            if "error" in result:
+                return result
+            catalogs = result.get("catalogs", [])
+            items = [
+                {
+                    "name": cat.get("name"),
+                    "comment": cat.get("comment"),
+                    "owner": cat.get("owner"),
+                    "metastore_id": cat.get("metastore_id"),
+                    "created_at": cat.get("created_at"),
+                }
+                for cat in catalogs
+            ]
+            return {
+                "success": True,
+                "catalogs": items,
+                "count": len(items),
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def databricks_list_schemas(catalog_name: str) -> dict:
+        """
+        List schemas in a Unity Catalog catalog.
+
+        Args:
+            catalog_name: Name of the catalog
+
+        Returns:
+            Dict with list of schemas
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.list_schemas(catalog_name)
+            if "error" in result:
+                return result
+            schemas = result.get("schemas", [])
+            items = [
+                {
+                    "name": schema.get("name"),
+                    "full_name": schema.get("full_name"),
+                    "comment": schema.get("comment"),
+                    "owner": schema.get("owner"),
+                    "created_at": schema.get("created_at"),
+                }
+                for schema in schemas
+            ]
+            return {
+                "success": True,
+                "catalog_name": catalog_name,
+                "schemas": items,
+                "count": len(items),
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def databricks_list_tables(catalog_name: str, schema_name: str) -> dict:
+        """
+        List tables in a Unity Catalog schema.
+
+        Args:
+            catalog_name: Name of the catalog
+            schema_name: Name of the schema
+
+        Returns:
+            Dict with list of tables
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.list_tables(catalog_name, schema_name)
+            if "error" in result:
+                return result
+            tables = result.get("tables", [])
+            items = [
+                {
+                    "name": tbl.get("name"),
+                    "full_name": tbl.get("full_name"),
+                    "table_type": tbl.get("table_type"),
+                    "data_source_format": tbl.get("data_source_format"),
+                    "comment": tbl.get("comment"),
+                    "owner": tbl.get("owner"),
+                    "created_at": tbl.get("created_at"),
+                }
+                for tbl in tables
+            ]
+            return {
+                "success": True,
+                "catalog_name": catalog_name,
+                "schema_name": schema_name,
+                "tables": items,
+                "count": len(items),
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}

--- a/tools/tests/tools/test_databricks_tool.py
+++ b/tools/tests/tools/test_databricks_tool.py
@@ -1,0 +1,577 @@
+"""Tests for Databricks tool with FastMCP."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.databricks_tool import register_tools
+
+
+@pytest.fixture
+def mcp():
+    """Create a FastMCP instance for testing."""
+    return FastMCP("test-server")
+
+
+@pytest.fixture
+def get_tool_fn(mcp: FastMCP):
+    """Factory fixture to get any tool function by name."""
+    register_tools(mcp)
+
+    def _get(name: str):
+        return mcp._tool_manager._tools[name].fn
+
+    return _get
+
+
+class TestDatabricksCredentials:
+    """Tests for Databricks credential handling."""
+
+    def test_no_credentials_returns_error(self, get_tool_fn, monkeypatch):
+        """Tool without credentials returns helpful error."""
+        monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
+        monkeypatch.delenv("DATABRICKS_HOST", raising=False)
+        fn = get_tool_fn("run_databricks_sql")
+
+        result = fn(query="SELECT 1", warehouse_id="abc123")
+
+        assert "error" in result
+        assert "Databricks credentials not configured" in result["error"]
+        assert "help" in result
+
+    def test_no_token_returns_error(self, get_tool_fn, monkeypatch):
+        """Missing token returns helpful error."""
+        monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
+        monkeypatch.setenv("DATABRICKS_HOST", "https://test.cloud.databricks.com")
+        fn = get_tool_fn("run_databricks_sql")
+
+        result = fn(query="SELECT 1", warehouse_id="abc123")
+
+        assert "error" in result
+        assert "Databricks credentials not configured" in result["error"]
+
+    def test_no_host_returns_error(self, get_tool_fn, monkeypatch):
+        """Missing host returns helpful error."""
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi123")
+        monkeypatch.delenv("DATABRICKS_HOST", raising=False)
+        fn = get_tool_fn("run_databricks_sql")
+
+        result = fn(query="SELECT 1", warehouse_id="abc123")
+
+        assert "error" in result
+        assert "Databricks credentials not configured" in result["error"]
+
+
+class TestRunDatabricksSQL:
+    """Tests for run_databricks_sql tool."""
+
+    def test_execute_sql_success(self, get_tool_fn, monkeypatch):
+        """Execute SQL returns statement_id."""
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi123")
+        monkeypatch.setenv("DATABRICKS_HOST", "https://test.cloud.databricks.com")
+        fn = get_tool_fn("run_databricks_sql")
+
+        with patch("httpx.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "statement_id": "stmt-123",
+                "status": {"state": "PENDING"},
+            }
+            mock_post.return_value = mock_response
+
+            result = fn(
+                query="SELECT * FROM sales",
+                warehouse_id="wh-123",
+                catalog="main",
+                schema="default",
+            )
+
+        assert result["success"] is True
+        assert result["statement_id"] == "stmt-123"
+        assert result["status"] == "PENDING"
+
+    def test_execute_sql_error(self, get_tool_fn, monkeypatch):
+        """Execute SQL error returns helpful message."""
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi123")
+        monkeypatch.setenv("DATABRICKS_HOST", "https://test.cloud.databricks.com")
+        fn = get_tool_fn("run_databricks_sql")
+
+        with patch("httpx.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.status_code = 400
+            mock_response.json.return_value = {
+                "message": "Warehouse not found",
+            }
+            mock_post.return_value = mock_response
+
+            result = fn(query="SELECT 1", warehouse_id="invalid-wh")
+
+        assert "error" in result
+        assert "400" in result["error"]
+
+
+class TestDatabricksGetStatementStatus:
+    """Tests for databricks_get_statement_status tool."""
+
+    def test_get_statement_status_success(self, get_tool_fn, monkeypatch):
+        """Get statement status returns status."""
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi123")
+        monkeypatch.setenv("DATABRICKS_HOST", "https://test.cloud.databricks.com")
+        fn = get_tool_fn("databricks_get_statement_status")
+
+        with patch("httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "statement_id": "stmt-123",
+                "status": {"state": "SUCCEEDED"},
+                "result": {
+                    "data": [[1, "Alice"], [2, "Bob"]],
+                    "schema": {"columns": [{"name": "id"}, {"name": "name"}]},
+                },
+            }
+            mock_get.return_value = mock_response
+
+            result = fn(statement_id="stmt-123")
+
+        assert result["success"] is True
+        assert result["state"] == "SUCCEEDED"
+        assert "result" in result
+
+    def test_get_statement_status_failed(self, get_tool_fn, monkeypatch):
+        """Get statement status for failed statement."""
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi123")
+        monkeypatch.setenv("DATABRICKS_HOST", "https://test.cloud.databricks.com")
+        fn = get_tool_fn("databricks_get_statement_status")
+
+        with patch("httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "statement_id": "stmt-123",
+                "status": {
+                    "state": "FAILED",
+                    "error": {"message": "Table not found"},
+                },
+            }
+            mock_get.return_value = mock_response
+
+            result = fn(statement_id="stmt-123")
+
+        assert result["success"] is True
+        assert result["state"] == "FAILED"
+        assert result["error"]["message"] == "Table not found"
+
+
+class TestTriggerDatabricksJob:
+    """Tests for trigger_databricks_job tool."""
+
+    def test_trigger_job_success(self, get_tool_fn, monkeypatch):
+        """Trigger job returns run_id."""
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi123")
+        monkeypatch.setenv("DATABRICKS_HOST", "https://test.cloud.databricks.com")
+        fn = get_tool_fn("trigger_databricks_job")
+
+        with patch("httpx.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "run_id": 12345,
+                "number_in_job": 1,
+            }
+            mock_post.return_value = mock_response
+
+            result = fn(job_id=100, parameters={"param1": "value1"})
+
+        assert result["success"] is True
+        assert result["run_id"] == 12345
+        assert result["number_in_job"] == 1
+
+    def test_trigger_job_error(self, get_tool_fn, monkeypatch):
+        """Trigger job error returns helpful message."""
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi123")
+        monkeypatch.setenv("DATABRICKS_HOST", "https://test.cloud.databricks.com")
+        fn = get_tool_fn("trigger_databricks_job")
+
+        with patch("httpx.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.status_code = 400
+            mock_response.json.return_value = {
+                "message": "Job not found",
+            }
+            mock_post.return_value = mock_response
+
+            result = fn(job_id=999)
+
+        assert "error" in result
+        assert "400" in result["error"]
+
+
+class TestDatabricksGetJobStatus:
+    """Tests for databricks_get_job_status tool."""
+
+    def test_get_job_status_success(self, get_tool_fn, monkeypatch):
+        """Get job status returns status."""
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi123")
+        monkeypatch.setenv("DATABRICKS_HOST", "https://test.cloud.databricks.com")
+        fn = get_tool_fn("databricks_get_job_status")
+
+        with patch("httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "run_id": 12345,
+                "state": {
+                    "life_cycle_state": "RUNNING",
+                    "result_state": None,
+                    "state_message": "Job is running",
+                },
+                "start_time": 1234567890,
+                "run_page_url": "https://test.cloud.databricks.com/jobs/12345",
+            }
+            mock_get.return_value = mock_response
+
+            result = fn(run_id=12345)
+
+        assert result["success"] is True
+        assert result["state"] == "RUNNING"
+        assert result["run_page_url"] == "https://test.cloud.databricks.com/jobs/12345"
+
+    def test_get_job_status_completed(self, get_tool_fn, monkeypatch):
+        """Get job status for completed job."""
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi123")
+        monkeypatch.setenv("DATABRICKS_HOST", "https://test.cloud.databricks.com")
+        fn = get_tool_fn("databricks_get_job_status")
+
+        with patch("httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "run_id": 12345,
+                "state": {
+                    "life_cycle_state": "TERMINATED",
+                    "result_state": "SUCCESS",
+                    "state_message": "Job completed successfully",
+                },
+                "start_time": 1234567890,
+                "end_time": 1234567999,
+                "run_duration": 109000,
+            }
+            mock_get.return_value = mock_response
+
+            result = fn(run_id=12345)
+
+        assert result["success"] is True
+        assert result["state"] == "TERMINATED"
+        assert result["result_state"] == "SUCCESS"
+
+
+class TestDescribeTable:
+    """Tests for describe_table tool."""
+
+    def test_describe_table_success(self, get_tool_fn, monkeypatch):
+        """Describe table returns table schema."""
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi123")
+        monkeypatch.setenv("DATABRICKS_HOST", "https://test.cloud.databricks.com")
+        fn = get_tool_fn("describe_table")
+
+        with patch("httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "name": "sales",
+                "full_name": "main.default.sales",
+                "catalog_name": "main",
+                "schema_name": "default",
+                "table_type": "MANAGED",
+                "data_source_format": "DELTA",
+                "comment": "Sales transactions table",
+                "owner": "admin",
+                "columns": [
+                    {
+                        "name": "id",
+                        "type_text": "BIGINT",
+                        "nullable": False,
+                        "comment": "Primary key",
+                    },
+                    {
+                        "name": "amount",
+                        "type_text": "DOUBLE",
+                        "nullable": True,
+                        "comment": "Sale amount",
+                    },
+                    {
+                        "name": "date",
+                        "type_text": "DATE",
+                        "nullable": True,
+                        "comment": "Transaction date",
+                    },
+                ],
+            }
+            mock_get.return_value = mock_response
+
+            result = fn(full_name="main.default.sales")
+
+        assert result["success"] is True
+        assert result["full_name"] == "main.default.sales"
+        assert result["table_type"] == "MANAGED"
+        assert len(result["columns"]) == 3
+        assert result["columns"][0]["name"] == "id"
+        assert result["columns"][0]["type_text"] == "BIGINT"
+
+    def test_describe_table_not_found(self, get_tool_fn, monkeypatch):
+        """Describe table error for non-existent table."""
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi123")
+        monkeypatch.setenv("DATABRICKS_HOST", "https://test.cloud.databricks.com")
+        fn = get_tool_fn("describe_table")
+
+        with patch("httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 404
+            mock_response.json.return_value = {
+                "message": "Table not found",
+            }
+            mock_get.return_value = mock_response
+
+            result = fn(full_name="main.nonexistent.table")
+
+        assert "error" in result
+
+
+class TestListWorkspace:
+    """Tests for list_workspace tool."""
+
+    def test_list_workspace_success(self, get_tool_fn, monkeypatch):
+        """List workspace returns objects."""
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi123")
+        monkeypatch.setenv("DATABRICKS_HOST", "https://test.cloud.databricks.com")
+        fn = get_tool_fn("list_workspace")
+
+        with patch("httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "objects": [
+                    {
+                        "path": "/Users/user@company.com/notebook1",
+                        "object_type": "NOTEBOOK",
+                        "object_id": 123,
+                    },
+                    {
+                        "path": "/Users/user@company.com/folder1",
+                        "object_type": "DIRECTORY",
+                        "object_id": 456,
+                    },
+                    {
+                        "path": "/Users/user@company.com/file1.py",
+                        "object_type": "FILE",
+                        "object_id": 789,
+                    },
+                ],
+            }
+            mock_get.return_value = mock_response
+
+            result = fn(path="/Users/user@company.com")
+
+        assert result["success"] is True
+        assert result["count"] == 3
+        assert result["objects"][0]["object_type"] == "NOTEBOOK"
+
+    def test_list_workspace_root(self, get_tool_fn, monkeypatch):
+        """List workspace root returns objects."""
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi123")
+        monkeypatch.setenv("DATABRICKS_HOST", "https://test.cloud.databricks.com")
+        fn = get_tool_fn("list_workspace")
+
+        with patch("httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "objects": [
+                    {"path": "/Shared", "object_type": "DIRECTORY", "object_id": 1},
+                    {"path": "/Users", "object_type": "DIRECTORY", "object_id": 2},
+                ],
+            }
+            mock_get.return_value = mock_response
+
+            result = fn()
+
+        assert result["success"] is True
+        assert result["path"] == "/"
+
+
+class TestDatabricksListWarehouses:
+    """Tests for databricks_list_warehouses tool."""
+
+    def test_list_warehouses_success(self, get_tool_fn, monkeypatch):
+        """List warehouses returns warehouses."""
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi123")
+        monkeypatch.setenv("DATABRICKS_HOST", "https://test.cloud.databricks.com")
+        fn = get_tool_fn("databricks_list_warehouses")
+
+        with patch("httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "warehouses": [
+                    {
+                        "id": "wh-123",
+                        "name": "Starter Warehouse",
+                        "size": "2X-Small",
+                        "state": "RUNNING",
+                        "auto_stop_mins": 10,
+                    },
+                    {
+                        "id": "wh-456",
+                        "name": "Production Warehouse",
+                        "size": "Small",
+                        "state": "STOPPED",
+                        "auto_stop_mins": 5,
+                    },
+                ],
+            }
+            mock_get.return_value = mock_response
+
+            result = fn()
+
+        assert result["success"] is True
+        assert result["count"] == 2
+        assert result["warehouses"][0]["name"] == "Starter Warehouse"
+        assert result["warehouses"][0]["state"] == "RUNNING"
+
+
+class TestDatabricksListCatalogs:
+    """Tests for databricks_list_catalogs tool."""
+
+    def test_list_catalogs_success(self, get_tool_fn, monkeypatch):
+        """List catalogs returns catalogs."""
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi123")
+        monkeypatch.setenv("DATABRICKS_HOST", "https://test.cloud.databricks.com")
+        fn = get_tool_fn("databricks_list_catalogs")
+
+        with patch("httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "catalogs": [
+                    {"name": "main", "comment": "Main catalog", "owner": "admin"},
+                    {"name": "dev", "comment": "Development catalog", "owner": "dev_team"},
+                ],
+            }
+            mock_get.return_value = mock_response
+
+            result = fn()
+
+        assert result["success"] is True
+        assert result["count"] == 2
+        assert result["catalogs"][0]["name"] == "main"
+
+
+class TestDatabricksListSchemas:
+    """Tests for databricks_list_schemas tool."""
+
+    def test_list_schemas_success(self, get_tool_fn, monkeypatch):
+        """List schemas returns schemas."""
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi123")
+        monkeypatch.setenv("DATABRICKS_HOST", "https://test.cloud.databricks.com")
+        fn = get_tool_fn("databricks_list_schemas")
+
+        with patch("httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "schemas": [
+                    {"name": "default", "full_name": "main.default", "comment": "Default schema"},
+                    {
+                        "name": "analytics",
+                        "full_name": "main.analytics",
+                        "comment": "Analytics data",
+                    },
+                ],
+            }
+            mock_get.return_value = mock_response
+
+            result = fn(catalog_name="main")
+
+        assert result["success"] is True
+        assert result["catalog_name"] == "main"
+        assert result["count"] == 2
+        assert result["schemas"][0]["name"] == "default"
+
+
+class TestDatabricksListTables:
+    """Tests for databricks_list_tables tool."""
+
+    def test_list_tables_success(self, get_tool_fn, monkeypatch):
+        """List tables returns tables."""
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi123")
+        monkeypatch.setenv("DATABRICKS_HOST", "https://test.cloud.databricks.com")
+        fn = get_tool_fn("databricks_list_tables")
+
+        with patch("httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "tables": [
+                    {
+                        "name": "sales",
+                        "full_name": "main.default.sales",
+                        "table_type": "MANAGED",
+                        "data_source_format": "DELTA",
+                    },
+                    {
+                        "name": "customers",
+                        "full_name": "main.default.customers",
+                        "table_type": "EXTERNAL",
+                        "data_source_format": "DELTA",
+                    },
+                ],
+            }
+            mock_get.return_value = mock_response
+
+            result = fn(catalog_name="main", schema_name="default")
+
+        assert result["success"] is True
+        assert result["catalog_name"] == "main"
+        assert result["schema_name"] == "default"
+        assert result["count"] == 2
+        assert result["tables"][0]["name"] == "sales"
+
+
+class TestDatabricksListJobs:
+    """Tests for databricks_list_jobs tool."""
+
+    def test_list_jobs_success(self, get_tool_fn, monkeypatch):
+        """List jobs returns jobs."""
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi123")
+        monkeypatch.setenv("DATABRICKS_HOST", "https://test.cloud.databricks.com")
+        fn = get_tool_fn("databricks_list_jobs")
+
+        with patch("httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "jobs": [
+                    {
+                        "job_id": 100,
+                        "settings": {"name": "Daily ETL"},
+                        "created_time": 1234567890,
+                    },
+                    {
+                        "job_id": 200,
+                        "settings": {"name": "Weekly Report"},
+                        "created_time": 1234567900,
+                    },
+                ],
+                "has_more": False,
+            }
+            mock_get.return_value = mock_response
+
+            result = fn(limit=20)
+
+        assert result["success"] is True
+        assert result["count"] == 2
+        assert result["has_more"] is False
+        assert result["jobs"][0]["job_id"] == 100


### PR DESCRIPTION
Resolves #5167

## Summary

This PR implements the Databricks integration for Hive agents, enabling interaction with Databricks workspaces, SQL warehouses, and jobs. This allows teams using Azure or AWS to leverage Databricks Delta Lakes and Unity Catalog in their data-driven autonomous workflows.

## Use Cases Enabled

1. **Automated BI Reporting:** An agent can query a Databricks SQL Warehouse to generate weekly revenue summaries and post them to Slack.
2. **Data-Triggered Actions:** An agent can monitor specific tables for anomalies and trigger a "root cause analysis" workflow if data quality drops.
3. **Job Orchestration:** Agents can trigger Databricks Jobs (e.g., refreshing a model) as part of a larger business process.

## Tools Implemented

### Core Tools (as specified in issue)
| Tool | Description |
|------|-------------|
| `run_databricks_sql` | Execute read-only queries on a SQL Warehouse |
| `trigger_databricks_job` | Trigger specific job IDs |
| `describe_table` | Fetch schema/metadata from Unity Catalog |
| `list_workspace` | Explore notebooks and folders |

### Additional Helper Tools
| Tool | Description |
|------|-------------|
| `databricks_get_statement_status` | Check SQL statement execution status |
| `databricks_get_job_status` | Monitor job run status |
| `databricks_list_warehouses` | List available SQL warehouses |
| `databricks_list_jobs` | List workspace jobs |
| `databricks_list_catalogs` | List Unity Catalog catalogs |
| `databricks_list_schemas` | List schemas in a catalog |
| `databricks_list_tables` | List tables in a schema |

## Files Changed

### New Files
- `tools/src/aden_tools/credentials/databricks.py` - Credential specification for Databricks authentication
- `tools/src/aden_tools/tools/databricks_tool/__init__.py` - Package init
- `tools/src/aden_tools/tools/databricks_tool/databricks_tool.py` - Tool implementation with all 11 tools
- `tools/tests/tools/test_databricks_tool.py` - Unit tests covering all tools

### Modified Files
- `tools/src/aden_tools/credentials/__init__.py` - Registered Databricks credentials
- `tools/src/aden_tools/tools/__init__.py` - Registered Databricks tools

## Configuration

Set the following environment variables:

```bash
DATABRICKS_HOST=https://your-workspace.cloud.databricks.com
DATABRICKS_TOKEN=dapi1234567890abcdef...
```

## Testing

Unit tests cover:
- Credential handling (missing credentials, partial credentials)
- All 11 tools with mocked HTTP responses
- Error handling scenarios

Run tests with:
```bash
cd tools && python -m pytest tests/tools/test_databricks_tool.py -v
```

## API Reference

The integration uses the following Databricks REST APIs:
- [SQL Statement Execution API](https://docs.databricks.com/api/workspace/statementexecution)
- [Jobs API](https://docs.databricks.com/api/workspace/jobs)
- [Workspace API](https://docs.databricks.com/api/workspace/workspace)
- [Unity Catalog API](https://docs.databricks.com/api/workspace/unitycatalog)
