### PR TITLE
Docs/fix readme formatting and links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,8 @@ feat(component): add new feature description
 - Use meaningful variable and function names
 - Keep functions focused and small
 
+For linting and formatting (Ruff, pre-commit hooks), see [Linting & Formatting Setup](docs/contributing-lint-setup.md).
+
 ## Testing
 
 > **Note:** When testing agents in `exports/`, always set PYTHONPATH:

--- a/examples/templates/deep_research_agent/README.md
+++ b/examples/templates/deep_research_agent/README.md
@@ -9,11 +9,13 @@ Run the agent using the following command:
 ### Linux / Mac
 ```bash
 PYTHONPATH=core:examples/templates python -m deep_research_agent run --mock --topic "Artificial Intelligence"
+```
 
 ### Windows
 ```powershell
 $env:PYTHONPATH="core;examples\templates"
 python -m deep_research_agent run --mock --topic "Artificial Intelligence"
+```
 
 ## Options
 


### PR DESCRIPTION
## Description

This PR includes two small documentation improvements to enhance readability and contributor onboarding.
It fixes a formatting issue in the deep research agent template and adds a missing link to the linting setup guide in CONTRIBUTING.md.

## Type of Change

- [x] Documentation update

## Related Issues

None

## Changes Made

- Added a missing closing code block in examples/templates/deep_research_agent/README.md so the Linux, Windows, and Options sections render correctly
- Added a link in CONTRIBUTING.md to docs/contributing-lint-setup.md to make the linting and formatting workflow easier to discover

## Testing

Describe the tests you ran to verify your changes:

- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if applicable)

Not applicable