### PR TITLE
fix: replace silent exception suppression with proper error logging `micro-fix`

### DIFF
--- a/core/framework/tui/screens/credential_setup.py
+++ b/core/framework/tui/screens/credential_setup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 
 from textual.app import ComposeResult
@@ -11,6 +12,8 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Label
 
 from framework.credentials.setup import CredentialSetupSession, MissingCredential
+
+logger = logging.getLogger(__name__)
 
 
 class CredentialSetupScreen(ModalScreen[bool | None]):
@@ -308,8 +311,8 @@ class CredentialSetupScreen(ModalScreen[bool | None]):
                 auto_refresh=True,
             )
             EncryptedFileStorage().save(cred_obj)
-        except Exception:
-            pass  # Best-effort; env var is the primary delivery mechanism
+        except Exception as e:
+            logger.warning("Failed to persist credential '%s' to local store: %s", cred_id, e)
 
     def action_dismiss_setup(self) -> None:
         self.dismiss(None)


### PR DESCRIPTION
## Summary
- Replaced silent `except Exception: pass` with proper warning logging in `_persist_to_local_store()` method
- Added `logging` import and module-level logger following the project's standard pattern
- Warning log now captures the credential ID and error message for debugging

## Changes
- **File**: `core/framework/tui/screens/credential_setup.py`
  - Added `import logging` and `logger = logging.getLogger(__name__)`
  - Changed exception handler from silent `pass` to `logger.warning()` call

## Why This Matters
The previous implementation silently suppressed errors when persisting credentials to the local encrypted store. This made it difficult to diagnose issues where credentials were lost on restart. The new implementation logs the failure with context, making debugging significantly easier while maintaining the best-effort persistence behavior.

## Testing
- No new tests required; this is a logging change that follows the existing pattern used throughout the credentials module
- The change maintains the same control flow (exception is caught and logged, not re-raised)

Resolves #751
