### PR TITLE
fix: SharedMemory.read_all() now returns deep copy

### DIFF
--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -16,6 +16,7 @@ Protocol:
 """
 
 import asyncio
+import copy
 import json
 import logging
 from abc import ABC, abstractmethod
@@ -428,10 +429,15 @@ class SharedMemory:
         return False
 
     def read_all(self) -> dict[str, Any]:
-        """Read all accessible data."""
+        """Read all accessible data.
+
+        Returns a deep copy to prevent unintended mutation of shared state.
+        Modifications to the returned dictionary or its values will not
+        affect the internal state.
+        """
         if self._allowed_read:
-            return {k: v for k, v in self._data.items() if k in self._allowed_read}
-        return dict(self._data)
+            return copy.deepcopy({k: v for k, v in self._data.items() if k in self._allowed_read})
+        return copy.deepcopy(self._data)
 
     def with_permissions(
         self,


### PR DESCRIPTION
## Summary
- Fixed `SharedMemory.read_all()` to return a deep copy instead of a shallow copy
- Prevents unintended mutation of shared memory state when callers modify returned data

## Problem
The `read_all()` method returned a shallow copy of the internal dictionary using `dict(self._data)`. This allowed callers to inadvertently modify nested mutable objects (lists, dicts, sets) and corrupt the shared memory state:

```python
memory = SharedMemory()
memory.write("config", {"nested": {"value": 42}})

data = memory.read_all()
data["config"]["nested"]["value"] = 999  # Bug: This modified shared memory!

# memory.read("config") now returned {"nested": {"value": 999}}
```

## Solution
Changed `read_all()` to use `copy.deepcopy()` which creates a fully independent copy:

```python
def read_all(self) -> dict[str, Any]:
    if self._allowed_read:
        return copy.deepcopy(
            {k: v for k, v in self._data.items() if k in self._allowed_read}
        )
    return copy.deepcopy(self._data)
```

## Changes
- **core/framework/graph/node.py**: Added `import copy` and updated `read_all()` to use `copy.deepcopy()`
- **core/tests/test_hallucination_detection.py**: Added `TestSharedMemoryReadAllDeepCopy` test class with 6 tests covering:
  - Deep copy of lists
  - Deep copy of nested dicts
  - Deep copy of deeply nested structures
  - Independence of dictionary keys
  - Deep copy with permission scoping
  - Deep copy of sets

## Testing
All 25 tests in `test_hallucination_detection.py` pass, including the 6 new deep copy tests.

Resolves #804
