### PR TITLE
feat: Add AWS S3 Object Storage MCP Tool 

### DIFF
--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "resend>=2.0.0",
     "framework",
     "stripe>=14.3.0",
+    "boto3>=1.34.0",
 ]
 
 [project.optional-dependencies]

--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -54,6 +54,7 @@ To add a new credential:
 """
 
 from .apollo import APOLLO_CREDENTIALS
+from .aws_s3 import AWS_S3_CREDENTIALS
 from .base import CredentialError, CredentialSpec
 from .bigquery import BIGQUERY_CREDENTIALS
 from .browser import get_aden_auth_url, get_aden_setup_url, open_browser
@@ -104,6 +105,7 @@ CREDENTIAL_SPECS = {
     **BIGQUERY_CREDENTIALS,
     **CALCOM_CREDENTIALS,
     **STRIPE_CREDENTIALS,
+    **AWS_S3_CREDENTIALS,
 }
 
 __all__ = [
@@ -147,4 +149,5 @@ __all__ = [
     "CALCOM_CREDENTIALS",
     "DISCORD_CREDENTIALS",
     "STRIPE_CREDENTIALS",
+    "AWS_S3_CREDENTIALS",
 ]

--- a/tools/src/aden_tools/credentials/aws_s3.py
+++ b/tools/src/aden_tools/credentials/aws_s3.py
@@ -1,0 +1,74 @@
+"""
+AWS S3 tool credentials.
+
+Contains credentials for AWS S3 Object Storage access.
+"""
+
+from .base import CredentialSpec
+
+AWS_S3_CREDENTIALS = {
+    "aws_s3": CredentialSpec(
+        env_var="AWS_ACCESS_KEY_ID",
+        tools=[
+            "list_s3_buckets",
+            "list_s3_objects",
+            "get_s3_object_content",
+        ],
+        required=True,
+        startup_required=False,
+        help_url="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html",
+        description="AWS Access Key ID for S3 object storage access",
+        aden_supported=False,
+        direct_api_key_supported=True,
+        api_key_instructions="""To set up AWS S3 authentication:
+
+1. Log in to AWS Console at https://console.aws.amazon.com
+2. Navigate to IAM > Users > Create user (or select existing)
+3. Add permissions: "AmazonS3ReadOnlyAccess" (for read-only) or "AmazonS3FullAccess"
+4. Create access keys: Security credentials > Create access key
+5. Copy the Access Key ID and Secret Access Key
+
+Set environment variables:
+  export AWS_ACCESS_KEY_ID=your_access_key_id
+  export AWS_SECRET_ACCESS_KEY=your_secret_access_key
+  export AWS_DEFAULT_REGION=us-east-1 (or your preferred region)""",
+        health_check_endpoint="https://s3.amazonaws.com",
+        health_check_method="GET",
+        credential_id="aws_s3",
+        credential_key="access_key_id",
+    ),
+    "aws_s3_secret": CredentialSpec(
+        env_var="AWS_SECRET_ACCESS_KEY",
+        tools=[
+            "list_s3_buckets",
+            "list_s3_objects",
+            "get_s3_object_content",
+        ],
+        required=True,
+        startup_required=False,
+        help_url="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html",
+        description="AWS Secret Access Key for S3 object storage access",
+        aden_supported=False,
+        direct_api_key_supported=True,
+        api_key_instructions="Set AWS_SECRET_ACCESS_KEY environment variable to your AWS secret key",
+        credential_id="aws_s3",
+        credential_key="secret_access_key",
+    ),
+    "aws_s3_region": CredentialSpec(
+        env_var="AWS_DEFAULT_REGION",
+        tools=[
+            "list_s3_buckets",
+            "list_s3_objects",
+            "get_s3_object_content",
+        ],
+        required=False,
+        startup_required=False,
+        help_url="https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints",
+        description="AWS Region for S3 operations (defaults to us-east-1)",
+        aden_supported=False,
+        direct_api_key_supported=True,
+        api_key_instructions="Set AWS_DEFAULT_REGION environment variable (e.g., us-east-1, eu-west-1)",
+        credential_id="aws_s3",
+        credential_key="region",
+    ),
+}

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 # Import register_tools from each tool module
 from .account_info_tool import register_tools as register_account_info
 from .apollo_tool import register_tools as register_apollo
+from .aws_s3_tool import register_tools as register_aws_s3
 from .bigquery_tool import register_tools as register_bigquery
 from .calcom_tool import register_tools as register_calcom
 from .calendar_tool import register_tools as register_calendar
@@ -121,6 +122,7 @@ def register_all_tools(
     register_google_docs(mcp, credentials=credentials)
     register_google_maps(mcp, credentials=credentials)
     register_account_info(mcp, credentials=credentials)
+    register_aws_s3(mcp, credentials=credentials)
 
     # Register file system toolkits
     register_view_file(mcp)

--- a/tools/src/aden_tools/tools/aws_s3_tool/__init__.py
+++ b/tools/src/aden_tools/tools/aws_s3_tool/__init__.py
@@ -1,0 +1,3 @@
+from .aws_s3_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/aws_s3_tool/aws_s3_tool.py
+++ b/tools/src/aden_tools/tools/aws_s3_tool/aws_s3_tool.py
@@ -1,0 +1,298 @@
+"""
+AWS S3 Tool - Object storage operations via AWS S3.
+
+Supports:
+- AWS access key authentication (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION)
+
+Use Cases:
+- List available S3 buckets in an AWS account
+- List objects (files) within a specific bucket path
+- Read text-based S3 objects (JSON, CSV, logs) into agent context
+
+API Reference: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialStoreAdapter
+
+MAX_OBJECT_SIZE_BYTES = 2 * 1024 * 1024
+
+
+class _S3Client:
+    """Internal client wrapping AWS S3 API calls via boto3."""
+
+    def __init__(self, access_key_id: str, secret_access_key: str, region: str = "us-east-1"):
+        self._client = boto3.client(
+            "s3",
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+            region_name=region,
+        )
+
+    def _s3(self):
+        return self._client
+
+    def list_buckets(self) -> dict[str, Any]:
+        """List all S3 buckets in the AWS account."""
+        response = self._s3().list_buckets()
+        buckets = []
+        for bucket in response.get("Buckets", []):
+            buckets.append(
+                {
+                    "name": bucket["Name"],
+                    "creation_date": bucket["CreationDate"].isoformat()
+                    if bucket.get("CreationDate")
+                    else None,
+                }
+            )
+        return {"buckets": buckets, "count": len(buckets)}
+
+    def list_objects(
+        self,
+        bucket_name: str,
+        prefix: str = "",
+        max_keys: int = 1000,
+    ) -> dict[str, Any]:
+        """List objects in an S3 bucket with optional prefix filter."""
+        params: dict[str, Any] = {"Bucket": bucket_name, "MaxKeys": min(max_keys, 1000)}
+        if prefix:
+            params["Prefix"] = prefix
+
+        response = self._s3().list_objects_v2(**params)
+
+        objects = []
+        for obj in response.get("Contents", []):
+            objects.append(
+                {
+                    "key": obj["Key"],
+                    "size": obj["Size"],
+                    "last_modified": obj["LastModified"].isoformat()
+                    if obj.get("LastModified")
+                    else None,
+                    "etag": obj.get("ETag", "").strip('"'),
+                    "storage_class": obj.get("StorageClass", "STANDARD"),
+                }
+            )
+
+        return {
+            "bucket": bucket_name,
+            "prefix": prefix,
+            "objects": objects,
+            "count": len(objects),
+            "is_truncated": response.get("IsTruncated", False),
+            "next_continuation_token": response.get("NextContinuationToken"),
+        }
+
+    def get_object_content(
+        self,
+        bucket_name: str,
+        object_key: str,
+        max_size_bytes: int = MAX_OBJECT_SIZE_BYTES,
+    ) -> dict[str, Any]:
+        """Get the content of an S3 object with size limit protection."""
+        s3_client = self._s3()
+
+        head_response = s3_client.head_object(Bucket=bucket_name, Key=object_key)
+        object_size = head_response.get("ContentLength", 0)
+
+        if object_size > max_size_bytes:
+            return {
+                "error": f"Object too large ({object_size} bytes). Maximum allowed: {max_size_bytes} bytes.",
+                "object_key": object_key,
+                "bucket": bucket_name,
+                "size_bytes": object_size,
+                "max_allowed_bytes": max_size_bytes,
+            }
+
+        response = s3_client.get_object(Bucket=bucket_name, Key=object_key)
+        content_bytes = response["Body"].read()
+
+        try:
+            content = content_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            try:
+                content = content_bytes.decode("latin-1")
+            except Exception:
+                return {
+                    "error": "Unable to decode object content. File may be binary.",
+                    "object_key": object_key,
+                    "bucket": bucket_name,
+                    "size_bytes": object_size,
+                    "content_type": response.get("ContentType", "unknown"),
+                }
+
+        return {
+            "bucket": bucket_name,
+            "object_key": object_key,
+            "content": content,
+            "size_bytes": object_size,
+            "content_type": response.get("ContentType", "application/octet-stream"),
+            "last_modified": response.get("LastModified").isoformat()
+            if response.get("LastModified")
+            else None,
+            "etag": response.get("ETag", "").strip('"'),
+        }
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: CredentialStoreAdapter | None = None,
+) -> None:
+    """Register AWS S3 tools with the MCP server."""
+
+    def _get_aws_credentials() -> dict[str, str] | dict[str, Any]:
+        """Get AWS credentials from credential manager or environment."""
+        access_key_id = None
+        secret_access_key = None
+        region = None
+
+        if credentials is not None:
+            access_key_id = credentials.get("aws_s3")
+            secret_access_key = credentials.get("aws_s3_secret")
+            region = credentials.get("aws_s3_region")
+        else:
+            access_key_id = os.getenv("AWS_ACCESS_KEY_ID")
+            secret_access_key = os.getenv("AWS_SECRET_ACCESS_KEY")
+            region = os.getenv("AWS_DEFAULT_REGION")
+
+        if not access_key_id or not secret_access_key:
+            return {
+                "error": "AWS S3 credentials not configured",
+                "help": (
+                    "Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables. "
+                    "Optionally set AWS_DEFAULT_REGION (defaults to us-east-1). "
+                    "Get your credentials at https://console.aws.amazon.com/iam"
+                ),
+            }
+
+        return {
+            "access_key_id": access_key_id,
+            "secret_access_key": secret_access_key,
+            "region": region or "us-east-1",
+        }
+
+    def _get_client() -> _S3Client | dict[str, Any]:
+        """Get an S3 client, or return an error dict if no credentials."""
+        creds = _get_aws_credentials()
+        if isinstance(creds, dict) and "error" in creds:
+            return creds
+        return _S3Client(
+            access_key_id=creds["access_key_id"],
+            secret_access_key=creds["secret_access_key"],
+            region=creds["region"],
+        )
+
+    def _s3_error(e: Exception) -> dict[str, Any]:
+        """Format AWS/Boto3 errors into consistent dict format."""
+        if isinstance(e, ClientError):
+            error_code = e.response.get("Error", {}).get("Code", "Unknown")
+            error_msg = e.response.get("Error", {}).get("Message", str(e))
+            return {"error": f"AWS Error [{error_code}]: {error_msg}"}
+        elif isinstance(e, NoCredentialsError):
+            return {
+                "error": "AWS credentials not found. Please configure AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"
+            }
+        elif isinstance(e, BotoCoreError):
+            return {"error": f"AWS SDK Error: {str(e)}"}
+        return {"error": str(e)}
+
+    @mcp.tool()
+    def list_s3_buckets() -> dict:
+        """
+        List all S3 buckets available in the current AWS account.
+
+        Returns:
+            Dict with list of buckets (name, creation_date) and count.
+
+        Example:
+            list_s3_buckets()
+            # Returns: {"buckets": [{"name": "my-bucket", "creation_date": "2024-01-15T10:30:00"}], "count": 1}
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_buckets()
+        except (ClientError, BotoCoreError, NoCredentialsError) as e:
+            return _s3_error(e)
+
+    @mcp.tool()
+    def list_s3_objects(
+        bucket_name: str,
+        prefix: str = "",
+        max_keys: int = 1000,
+    ) -> dict:
+        """
+        List objects (files) within an S3 bucket.
+
+        Args:
+            bucket_name: Name of the S3 bucket to list objects from
+            prefix: Optional prefix to filter objects (e.g., "logs/2024/")
+            max_keys: Maximum number of objects to return (1-1000, default 1000)
+
+        Returns:
+            Dict with list of objects (key, size, last_modified, etag, storage_class)
+            and pagination info.
+
+        Example:
+            list_s3_objects(bucket_name="my-bucket", prefix="data/", max_keys=100)
+            # Returns: {"bucket": "my-bucket", "objects": [...], "count": 50}
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+
+        if not bucket_name:
+            return {"error": "bucket_name is required"}
+
+        if max_keys < 1:
+            return {"error": "max_keys must be at least 1"}
+
+        try:
+            return client.list_objects(bucket_name, prefix, max_keys)
+        except (ClientError, BotoCoreError, NoCredentialsError) as e:
+            return _s3_error(e)
+
+    @mcp.tool()
+    def get_s3_object_content(
+        bucket_name: str,
+        object_key: str,
+    ) -> dict:
+        """
+        Read the content of a text-based S3 object (JSON, CSV, logs, etc.).
+
+        Args:
+            bucket_name: Name of the S3 bucket containing the object
+            object_key: Key (path) of the object to read (e.g., "data/sales.csv")
+
+        Returns:
+            Dict with object content, metadata (size, content_type, last_modified).
+            Returns error if object exceeds 2MB size limit.
+
+        Example:
+            get_s3_object_content(bucket_name="my-bucket", object_key="config.json")
+            # Returns: {"content": '{"setting": true}', "size_bytes": 18, "content_type": "application/json"}
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+
+        if not bucket_name:
+            return {"error": "bucket_name is required"}
+
+        if not object_key:
+            return {"error": "object_key is required"}
+
+        try:
+            return client.get_object_content(bucket_name, object_key)
+        except (ClientError, BotoCoreError, NoCredentialsError) as e:
+            return _s3_error(e)

--- a/tools/tests/tools/test_aws_s3_tool.py
+++ b/tools/tests/tools/test_aws_s3_tool.py
@@ -1,0 +1,495 @@
+"""
+Tests for AWS S3 Object Storage tool.
+
+Covers:
+- _S3Client methods (list_buckets, list_objects, get_object_content)
+- Error handling (ClientError, NoCredentialsError, BotoCoreError)
+- Credential retrieval (CredentialStoreAdapter vs env var)
+- All 3 MCP tool functions
+- Input validation
+- Size limit protection for get_object_content
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError
+
+from aden_tools.tools.aws_s3_tool.aws_s3_tool import (
+    MAX_OBJECT_SIZE_BYTES,
+    _S3Client,
+    register_tools,
+)
+
+
+def _make_datetime(iso_str: str = "2024-01-15T10:30:00+00:00") -> datetime:
+    """Parse ISO format string to datetime."""
+    return datetime.fromisoformat(iso_str)
+
+
+class TestS3ClientListBuckets:
+    def setup_method(self):
+        self.client = _S3Client(
+            access_key_id="test_access_key",
+            secret_access_key="test_secret_key",
+            region="us-east-1",
+        )
+
+    def test_list_buckets_success(self):
+        mock_s3 = MagicMock()
+        mock_s3.list_buckets.return_value = {
+            "Buckets": [
+                {"Name": "bucket-one", "CreationDate": _make_datetime()},
+                {"Name": "bucket-two", "CreationDate": _make_datetime("2024-02-20T14:00:00+00:00")},
+            ]
+        }
+
+        with patch.object(self.client, "_client", mock_s3):
+            result = self.client.list_buckets()
+
+        assert result["count"] == 2
+        assert len(result["buckets"]) == 2
+        assert result["buckets"][0]["name"] == "bucket-one"
+        assert result["buckets"][1]["name"] == "bucket-two"
+
+    def test_list_buckets_empty(self):
+        mock_s3 = MagicMock()
+        mock_s3.list_buckets.return_value = {"Buckets": []}
+
+        with patch.object(self.client, "_client", mock_s3):
+            result = self.client.list_buckets()
+
+        assert result["count"] == 0
+        assert result["buckets"] == []
+
+
+class TestS3ClientListObjects:
+    def setup_method(self):
+        self.client = _S3Client(
+            access_key_id="test_access_key",
+            secret_access_key="test_secret_key",
+            region="us-east-1",
+        )
+
+    def test_list_objects_success(self):
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {
+            "Contents": [
+                {
+                    "Key": "file1.csv",
+                    "Size": 1024,
+                    "LastModified": _make_datetime(),
+                    "ETag": '"abc123"',
+                    "StorageClass": "STANDARD",
+                },
+                {
+                    "Key": "folder/file2.json",
+                    "Size": 2048,
+                    "LastModified": _make_datetime(),
+                    "ETag": '"def456"',
+                    "StorageClass": "STANDARD",
+                },
+            ],
+            "IsTruncated": False,
+        }
+
+        with patch.object(self.client, "_client", mock_s3):
+            result = self.client.list_objects("my-bucket", prefix="data/")
+
+        assert result["bucket"] == "my-bucket"
+        assert result["prefix"] == "data/"
+        assert result["count"] == 2
+        assert len(result["objects"]) == 2
+        assert result["objects"][0]["key"] == "file1.csv"
+        assert result["objects"][0]["size"] == 1024
+        assert result["objects"][1]["key"] == "folder/file2.json"
+
+    def test_list_objects_with_prefix(self):
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {
+            "Contents": [
+                {
+                    "Key": "logs/2024/app.log",
+                    "Size": 500,
+                    "LastModified": _make_datetime(),
+                    "ETag": '"xyz"',
+                    "StorageClass": "STANDARD",
+                },
+            ],
+            "IsTruncated": False,
+        }
+
+        with patch.object(self.client, "_client", mock_s3):
+            result = self.client.list_objects("logs-bucket", prefix="logs/2024/")
+
+        mock_s3.list_objects_v2.assert_called_once()
+        call_args = mock_s3.list_objects_v2.call_args[1]
+        assert call_args["Bucket"] == "logs-bucket"
+        assert call_args["Prefix"] == "logs/2024/"
+        assert result["prefix"] == "logs/2024/"
+
+    def test_list_objects_empty_bucket(self):
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
+
+        with patch.object(self.client, "_client", mock_s3):
+            result = self.client.list_objects("empty-bucket")
+
+        assert result["count"] == 0
+        assert result["objects"] == []
+
+    def test_list_objects_truncated(self):
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {
+            "Contents": [
+                {
+                    "Key": "file1.txt",
+                    "Size": 100,
+                    "LastModified": _make_datetime(),
+                    "ETag": '"a"',
+                    "StorageClass": "STANDARD",
+                },
+            ],
+            "IsTruncated": True,
+            "NextContinuationToken": "token123",
+        }
+
+        with patch.object(self.client, "_client", mock_s3):
+            result = self.client.list_objects("my-bucket", max_keys=1)
+
+        assert result["is_truncated"] is True
+        assert result["next_continuation_token"] == "token123"
+
+    def test_list_objects_max_keys_capped(self):
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
+
+        with patch.object(self.client, "_client", mock_s3):
+            self.client.list_objects("my-bucket", max_keys=5000)
+
+        call_args = mock_s3.list_objects_v2.call_args[1]
+        assert call_args["MaxKeys"] == 1000
+
+
+class TestS3ClientGetObjectContent:
+    def setup_method(self):
+        self.client = _S3Client(
+            access_key_id="test_access_key",
+            secret_access_key="test_secret_key",
+            region="us-east-1",
+        )
+
+    def test_get_object_content_success(self):
+        content = b'{"name": "test", "value": 42}'
+        mock_body = MagicMock()
+        mock_body.read.return_value = content
+
+        mock_s3 = MagicMock()
+        mock_s3.head_object.return_value = {
+            "ContentLength": len(content),
+            "ContentType": "application/json",
+            "LastModified": _make_datetime(),
+            "ETag": '"json123"',
+        }
+        mock_s3.get_object.return_value = {
+            "Body": mock_body,
+            "ContentType": "application/json",
+            "LastModified": _make_datetime(),
+            "ETag": '"json123"',
+        }
+
+        with patch.object(self.client, "_client", mock_s3):
+            result = self.client.get_object_content("my-bucket", "data/config.json")
+
+        assert result["bucket"] == "my-bucket"
+        assert result["object_key"] == "data/config.json"
+        assert result["content"] == '{"name": "test", "value": 42}'
+        assert result["size_bytes"] == len(content)
+        assert result["content_type"] == "application/json"
+
+    def test_get_object_content_csv(self):
+        content = b"id,name,value\n1,Alice,100\n2,Bob,200"
+        mock_body = MagicMock()
+        mock_body.read.return_value = content
+
+        mock_s3 = MagicMock()
+        mock_s3.head_object.return_value = {
+            "ContentLength": len(content),
+            "ContentType": "text/csv",
+            "LastModified": _make_datetime(),
+            "ETag": '"csv123"',
+        }
+        mock_s3.get_object.return_value = {
+            "Body": mock_body,
+            "ContentType": "text/csv",
+            "LastModified": _make_datetime(),
+            "ETag": '"csv123"',
+        }
+
+        with patch.object(self.client, "_client", mock_s3):
+            result = self.client.get_object_content("data-bucket", "exports/sales.csv")
+
+        assert "id,name,value" in result["content"]
+        assert result["content_type"] == "text/csv"
+
+    def test_get_object_content_too_large(self):
+        large_size = MAX_OBJECT_SIZE_BYTES + 1000
+
+        mock_s3 = MagicMock()
+        mock_s3.head_object.return_value = {"ContentLength": large_size}
+
+        with patch.object(self.client, "_client", mock_s3):
+            result = self.client.get_object_content("my-bucket", "large-file.bin")
+
+        assert "error" in result
+        assert "too large" in result["error"].lower()
+        assert result["size_bytes"] == large_size
+        assert result["max_allowed_bytes"] == MAX_OBJECT_SIZE_BYTES
+
+    def test_get_object_content_binary_fallback_to_latin1(self):
+        content = b"Some text with \xe9 accent"
+        mock_body = MagicMock()
+        mock_body.read.return_value = content
+
+        mock_s3 = MagicMock()
+        mock_s3.head_object.return_value = {
+            "ContentLength": len(content),
+            "ContentType": "text/plain",
+        }
+        mock_s3.get_object.return_value = {
+            "Body": mock_body,
+            "ContentType": "text/plain",
+            "LastModified": _make_datetime(),
+            "ETag": '"txt123"',
+        }
+
+        with patch.object(self.client, "_client", mock_s3):
+            result = self.client.get_object_content("my-bucket", "notes.txt")
+
+        assert result["content"] == "Some text with é accent"
+
+    def test_get_object_content_truly_binary(self):
+        content = bytes(range(256))
+        mock_body = MagicMock()
+        mock_body.read.return_value = content
+
+        mock_s3 = MagicMock()
+        mock_s3.head_object.return_value = {
+            "ContentLength": len(content),
+            "ContentType": "application/octet-stream",
+        }
+        mock_s3.get_object.return_value = {
+            "Body": mock_body,
+            "ContentType": "application/octet-stream",
+            "LastModified": _make_datetime(),
+            "ETag": '"bin123"',
+        }
+
+        with patch.object(self.client, "_client", mock_s3):
+            result = self.client.get_object_content("my-bucket", "binary-file.exe")
+
+        assert "error" in result
+        assert "binary" in result["error"].lower()
+
+
+class TestToolRegistration:
+    def test_register_tools_registers_all_tools(self):
+        mcp = MagicMock()
+        mcp.tool.return_value = lambda fn: fn
+        register_tools(mcp)
+        assert mcp.tool.call_count == 3
+
+    def test_no_credentials_returns_error(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        with patch.dict("os.environ", {}, clear=True):
+            register_tools(mcp, credentials=None)
+            list_fn = next(f for f in registered_fns if f.__name__ == "list_s3_buckets")
+            result = list_fn()
+
+        assert "error" in result
+        assert "not configured" in result["error"]
+
+    def test_credentials_from_credential_manager(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        cred_manager = MagicMock()
+        cred_manager.get.side_effect = lambda name: {
+            "aws_s3": "test_access_key",
+            "aws_s3_secret": "test_secret_key",
+            "aws_s3_region": "us-west-2",
+        }.get(name)
+
+        register_tools(mcp, credentials=cred_manager)
+
+        fn = next(f for f in registered_fns if f.__name__ == "list_s3_buckets")
+
+        with patch("aden_tools.tools.aws_s3_tool.aws_s3_tool._S3Client") as MockClient:
+            instance = MockClient.return_value
+            instance.list_buckets.return_value = {"buckets": [], "count": 0}
+            fn()
+
+        MockClient.assert_called_once_with(
+            access_key_id="test_access_key",
+            secret_access_key="test_secret_key",
+            region="us-west-2",
+        )
+
+    def test_credentials_from_env_vars(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        register_tools(mcp, credentials=None)
+
+        fn = next(f for f in registered_fns if f.__name__ == "list_s3_buckets")
+
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "AWS_ACCESS_KEY_ID": "env_access_key",
+                    "AWS_SECRET_ACCESS_KEY": "env_secret_key",
+                    "AWS_DEFAULT_REGION": "eu-west-1",
+                },
+            ),
+            patch("aden_tools.tools.aws_s3_tool.aws_s3_tool._S3Client") as MockClient,
+        ):
+            instance = MockClient.return_value
+            instance.list_buckets.return_value = {"buckets": [], "count": 0}
+            fn()
+
+        MockClient.assert_called_once_with(
+            access_key_id="env_access_key",
+            secret_access_key="env_secret_key",
+            region="eu-west-1",
+        )
+
+
+class TestErrorHandling:
+    def setup_method(self):
+        self.client = _S3Client(
+            access_key_id="test_access_key",
+            secret_access_key="test_secret_key",
+            region="us-east-1",
+        )
+
+    def test_client_error_handling(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        cred_manager = MagicMock()
+        cred_manager.get.side_effect = lambda name: {
+            "aws_s3": "test_key",
+            "aws_s3_secret": "test_secret",
+            "aws_s3_region": None,
+        }.get(name)
+
+        register_tools(mcp, credentials=cred_manager)
+
+        fn = next(f for f in registered_fns if f.__name__ == "list_s3_buckets")
+
+        error_response = {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}}
+        with patch("aden_tools.tools.aws_s3_tool.aws_s3_tool._S3Client") as MockClient:
+            instance = MockClient.return_value
+            instance.list_buckets.side_effect = ClientError(error_response, "ListBuckets")
+            result = fn()
+
+        assert "error" in result
+        assert "AccessDenied" in result["error"]
+
+    def test_no_credentials_error(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        cred_manager = MagicMock()
+        cred_manager.get.side_effect = lambda name: {
+            "aws_s3": "test_key",
+            "aws_s3_secret": "test_secret",
+            "aws_s3_region": None,
+        }.get(name)
+
+        register_tools(mcp, credentials=cred_manager)
+
+        fn = next(f for f in registered_fns if f.__name__ == "list_s3_objects")
+
+        with patch("aden_tools.tools.aws_s3_tool.aws_s3_tool._S3Client") as MockClient:
+            instance = MockClient.return_value
+            instance.list_objects.side_effect = NoCredentialsError()
+            result = fn(bucket_name="my-bucket")
+
+        assert "error" in result
+        assert "credentials" in result["error"].lower()
+
+
+class TestInputValidation:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.registered_fns = []
+        self.mcp.tool.return_value = lambda fn: self.registered_fns.append(fn) or fn
+
+        cred_manager = MagicMock()
+        cred_manager.get.side_effect = lambda name: {
+            "aws_s3": "test_key",
+            "aws_s3_secret": "test_secret",
+            "aws_s3_region": "us-east-1",
+        }.get(name)
+
+        register_tools(self.mcp, credentials=cred_manager)
+        self.fn_map = {f.__name__: f for f in self.registered_fns}
+
+    def test_list_s3_objects_missing_bucket(self):
+        result = self.fn_map["list_s3_objects"](bucket_name="")
+        assert "error" in result
+        assert "bucket_name" in result["error"]
+
+    def test_list_s3_objects_invalid_max_keys(self):
+        result = self.fn_map["list_s3_objects"](bucket_name="my-bucket", max_keys=0)
+        assert "error" in result
+        assert "max_keys" in result["error"]
+
+    def test_get_s3_object_content_missing_bucket(self):
+        result = self.fn_map["get_s3_object_content"](bucket_name="", object_key="file.txt")
+        assert "error" in result
+        assert "bucket_name" in result["error"]
+
+    def test_get_s3_object_content_missing_key(self):
+        result = self.fn_map["get_s3_object_content"](bucket_name="my-bucket", object_key="")
+        assert "error" in result
+        assert "object_key" in result["error"]
+
+
+class TestDefaultRegion:
+    def test_default_region_us_east_1(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        cred_manager = MagicMock()
+        cred_manager.get.side_effect = lambda name: {
+            "aws_s3": "test_key",
+            "aws_s3_secret": "test_secret",
+            "aws_s3_region": None,
+        }.get(name)
+
+        register_tools(mcp, credentials=cred_manager)
+
+        fn = next(f for f in registered_fns if f.__name__ == "list_s3_buckets")
+
+        with patch("aden_tools.tools.aws_s3_tool.aws_s3_tool._S3Client") as MockClient:
+            instance = MockClient.return_value
+            instance.list_buckets.return_value = {"buckets": [], "count": 0}
+            fn()
+
+        call_kwargs = MockClient.call_args[1]
+        assert call_kwargs["region"] == "us-east-1"


### PR DESCRIPTION
## Summary
This PR adds native AWS S3 Object Storage integration to the Aden Tools package using `boto3`. The tool provides three FastMCP capabilities that enable agents to securely access and read data from S3 buckets without falling back to shell commands.

## Related Issue
Resolves #5214

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Unit tests addition
- [x] Dependency update

## Implementation Details

### Core Features
- **`list_s3_buckets()`**: Discover all S3 buckets available in the current AWS account
- **`list_s3_objects(bucket_name, prefix, max_keys)`**: List files inside a specific bucket path with optional prefix filtering
- **`get_s3_object_content(bucket_name, object_key)`**: Read the contents of text-based S3 objects (JSON, CSV, logs) directly into agent context

### Security & Guardrails
- Integrates with Hive's `CredentialStoreAdapter` to securely fetch `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_DEFAULT_REGION`
- File size limit of 2MB in `get_s3_object_content` prevents agents from accidentally downloading massive files and overwhelming the LLM context
- Graceful error handling for AWS API errors (AccessDenied, NoSuchBucket, etc.)

### File Changes
- **Credentials**:
  - `tools/src/aden_tools/credentials/aws_s3.py`: Credential specifications for AWS S3
  - `tools/src/aden_tools/credentials/__init__.py`: Registered AWS S3 credentials
- **Tools**:
  - `tools/src/aden_tools/tools/aws_s3_tool/aws_s3_tool.py`: Core S3 client and tool implementations
  - `tools/src/aden_tools/tools/aws_s3_tool/__init__.py`: Tool module exports
  - `tools/src/aden_tools/tools/__init__.py`: Registered AWS S3 tools
- **Tests**:
  - `tools/tests/tools/test_aws_s3_tool.py`: Comprehensive pytest coverage using mocks
- **Configuration**:
  - `tools/pyproject.toml`: Added `boto3>=1.34.0` dependency

## How to Test
1. **Environment Setup**: Set AWS credentials:
   ```bash
   export AWS_ACCESS_KEY_ID=your_access_key
   export AWS_SECRET_ACCESS_KEY=your_secret_key
   export AWS_DEFAULT_REGION=us-east-1
   ```

2. **Run Unit Tests**:
   ```bash
   pytest tools/tests/tools/test_aws_s3_tool.py -v
   ```
   *Expected: All tests pass (covers success cases, error handling, input validation, size limits)*

3. **Tool Registration Verification**:
   - Verify that the tool registers correctly in the MCP server
   - Ensure tools request AWS credentials when called if not provided

## Use Cases
This tool is particularly valuable for:
- **Data Analytics Agents**: Reading CSV/JSON datasets stored in S3
- **Log Analysis Agents**: Accessing application logs in S3 for debugging
- **Report Generation Agents**: Fetching source data from cloud storage

## Checklist
- [x] Code follows the [Google Style Guide](https://google.github.io/styleguide/)
- [x] All functions/classes have Google-style docstrings
- [x] Unit tests cover primary use cases and error paths
- [x] No sensitive information (API keys, etc.) committed
- [x] Branch contains only commits relevant to this issue
