### PR TITLE
fix(cli): validate agent before execution in `hive run`

### DIFF
--- a/core/tests/test_cli_entry_point.py
+++ b/core/tests/test_cli_entry_point.py
@@ -126,3 +126,20 @@ class TestHiveEntryPoint:
             text=True,
         )
         assert result.returncode != 0
+
+    def test_hive_run_invalid_agent_fails_fast(self, tmp_path):
+        """Verify ``hive run`` validates before execution and exits on errors (#5122)."""
+        # Create a minimal invalid agent (empty nodes → entry node not found)
+        agent_dir = tmp_path / "bad_agent"
+        agent_dir.mkdir()
+        (agent_dir / "agent.json").write_text(
+            '{"name": "bad", "goal": {"name": "test", "prompt": "x"}, "nodes": [], "edges": []}'
+        )
+
+        result = subprocess.run(
+            ["hive", "run", str(agent_dir), "--quiet"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "validation failed" in result.stderr.lower()


### PR DESCRIPTION
## Summary

Fixes #5122

`hive run` now calls `runner.validate()` before attempting execution. If validation fails (e.g. missing entry node, broken graph), the command prints the errors and exits with code 1 immediately — matching the behavior of `hive validate`.

## Problem

Previously, `hive run` would:
1. Print the full execution header
2. Attempt to run the agent
3. Fail at runtime with the same validation error

This caused unnecessary overhead and a confusing developer experience, since `hive validate` already detected the issue.

## Changes

- `core/framework/runner/cli.py`: Added `runner.validate()` call in both the standard execution path and the TUI path, after loading the runner but before execution begins
- `core/tests/test_cli_entry_point.py`: Added test verifying that `hive run` with an invalid agent exits with code 1 and reports validation failure

## Before / After

```bash
# Before: prints execution header, runs, then fails with same error
$ hive run exports/broken_agent
Agent: broken
Goal: test
Steps: 0
Input: {}
============================================================
Executing agent...
============================================================
✗ Agent has errors: Entry node '' not found

# After: fails fast with clear message
$ hive run exports/broken_agent
✗ Agent validation failed:
  ERROR: Entry node '' not found

Run 'hive validate' for full details. Aborting.
```