### PR TITLE
fix: add max_file_size limit to replace_file_content to prevent OOM

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/replace_file_content/replace_file_content.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/replace_file_content/replace_file_content.py
@@ -10,7 +10,13 @@ def register_tools(mcp: FastMCP) -> None:
 
     @mcp.tool()
     def replace_file_content(
-        path: str, target: str, replacement: str, workspace_id: str, agent_id: str, session_id: str
+        path: str,
+        target: str,
+        replacement: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
+        max_file_size: int = 10 * 1024 * 1024,
     ) -> dict:
         """
         Purpose
@@ -33,6 +39,7 @@ def register_tools(mcp: FastMCP) -> None:
             workspace_id: The ID of the workspace
             agent_id: The ID of the agent
             session_id: The ID of the current session
+            max_file_size: Maximum file size in bytes (default: 10 MB)
 
         Returns:
             Dict with replacement count and status, or error dict
@@ -41,6 +48,10 @@ def register_tools(mcp: FastMCP) -> None:
             secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
             if not os.path.exists(secure_path):
                 return {"error": f"File not found at {path}"}
+
+            file_size = os.path.getsize(secure_path)
+            if file_size > max_file_size:
+                return {"error": f"File too large: {file_size} bytes (max: {max_file_size})"}
 
             with open(secure_path, encoding="utf-8") as f:
                 content = f.read()


### PR DESCRIPTION

## Summary
- Adds a `max_file_size` parameter (default: 10 MB) to the `replace_file_content` tool to prevent loading large files into memory
- Checks file size before reading content to protect against OOM (Out Of Memory) errors in containerized environments
- Includes comprehensive unit tests for the new file size limit behavior

## Changes
- **File**: `tools/src/aden_tools/tools/file_system_toolkits/replace_file_content/replace_file_content.py`
  - Added `max_file_size` parameter with default value of 10 MB (10 * 1024 * 1024 bytes)
  - Added file size check using `os.path.getsize()` before reading file content
  - Returns clear error message when file exceeds the limit

- **File**: `tools/tests/tools/test_file_system_toolkits.py`
  - Added `test_replace_file_too_large`: Tests that files exceeding max_file_size return appropriate error
  - Added `test_replace_file_exactly_at_size_limit`: Tests that files exactly at the limit succeed
  - Added `test_replace_file_with_custom_max_size`: Tests custom max_file_size parameter
  - Added `test_replace_file_default_max_size`: Tests default 10 MB limit behavior

## Test Results
All 9 tests in `TestReplaceFileContentTool` pass:
```
tests/tools/test_file_system_toolkits.py::TestReplaceFileContentTool::test_replace_content PASSED
tests/tools/test_file_system_toolkits.py::TestReplaceFileContentTool::test_replace_target_not_found PASSED
tests/tools/test_file_system_toolkits.py::TestReplaceFileContentTool::test_replace_file_not_found PASSED
tests/tools/test_file_system_toolkits.py::TestReplaceFileContentTool::test_replace_single_occurrence PASSED
tests/tools/test_file_system_toolkits.py::TestReplaceFileContentTool::test_replace_multiline_content PASSED
tests/tools/test_file_system_toolkits.py::TestReplaceFileContentTool::test_replace_file_too_large PASSED
tests/tools/test_file_system_toolkits.py::TestReplaceFileContentTool::test_replace_file_exactly_at_size_limit PASSED
tests/tools/test_file_system_toolkits.py::TestReplaceFileContentTool::test_replace_file_with_custom_max_size PASSED
tests/tools/test_file_system_toolkits.py::TestReplaceFileContentTool::test_replace_file_default_max_size PASSED
```

## Impact
- Protects against memory exhaustion when processing large files (e.g., 10 GB log files)
- Prevents OOM kills in containerized environments
- Provides protection against memory exhaustion attacks
- Backward compatible - existing callers will use the default 10 MB limit

Resolves #2106