### PR TITLE
 feat(executor): add credential-aware tool resolution to prevent hallucination on auth failures 

### DIFF
--- a/core/framework/credentials/validation.py
+++ b/core/framework/credentials/validation.py
@@ -104,9 +104,11 @@ def validate_agent_credentials(nodes: list, quiet: bool = False, verify: bool = 
         quiet: If True, suppress the credential summary output.
         verify: If True (default), run health checks on present credentials.
     """
-    # Collect required tools and node types
-    required_tools = {tool for node in nodes if node.tools for tool in node.tools}
-    node_types = {node.node_type for node in nodes}
+    required_tools: set[str] = set()
+    for node in nodes:
+        if node.tools:
+            required_tools.update(node.all_tool_names)
+    node_types: set[str] = {node.node_type for node in nodes}
 
     try:
         from aden_tools.credentials import CREDENTIAL_SPECS

--- a/core/framework/graph/event_loop_node.py
+++ b/core/framework/graph/event_loop_node.py
@@ -1369,6 +1369,22 @@ class EventLoopNode(NodeProtocol):
                         result = raw
                     results_by_id[tc.tool_use_id] = self._truncate_tool_result(result, tc.tool_name)
 
+            # Credential error check: if any tool signalled credential_error,
+            # stop immediately — do not let the LLM continue with training data.
+            for tc in pending_real:
+                r = results_by_id.get(tc.tool_use_id)
+                if r and r.is_error:
+                    try:
+                        parsed = json.loads(r.content)
+                        if parsed.get("credential_error"):
+                            raise RuntimeError(
+                                f"Tool '{tc.tool_name}' failed: credential is invalid or "
+                                f"unauthorized. Check your API key and re-run the agent.\n"
+                                f"Details: {parsed.get('error', r.content)}"
+                            )
+                    except (json.JSONDecodeError, AttributeError):
+                        pass
+
             # Phase 3: record results into conversation in original order,
             # build logged/real lists, and publish completed events.
             for tc in tool_calls[:executed_in_batch]:
@@ -2283,7 +2299,7 @@ class EventLoopNode(NodeProtocol):
 
         # 4. Available tools reminder
         if spec.tools:
-            parts.append(f"AVAILABLE TOOLS: {', '.join(spec.tools)}")
+            parts.append(f"AVAILABLE TOOLS: {', '.join(spec.all_tool_names)}")
 
         # 5. Spillover files — list actual files so the LLM can load
         # them immediately instead of having to call list_data_files first.

--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -199,7 +199,27 @@ class NodeSpec(BaseModel):
 
     # For LLM nodes
     system_prompt: str | None = Field(default=None, description="System prompt for LLM nodes")
-    tools: list[str] = Field(default_factory=list, description="Tool names this node can use")
+    tools: list[str | list[str]] = Field(
+        default_factory=list,
+        description=(
+            "Tool names this node can use. "
+            "Tier 1: exact name — tools=['web_search']. "
+            "Tier 2: fallback group — tools=[['web_search', 'exa_search']], "
+            "framework picks first tool whose credential is set."
+        ),
+    )
+
+    @property
+    def all_tool_names(self) -> list[str]:
+        """Flat list of all candidate tool names (flattens Tier 2 groups)."""
+        result = []
+        for entry in self.tools:
+            if isinstance(entry, list):
+                result.extend(entry)
+            else:
+                result.append(entry)
+        return result
+
     model: str | None = Field(
         default=None, description="Specific model to use (defaults to graph default)"
     )

--- a/core/framework/mcp/agent_builder_server.py
+++ b/core/framework/mcp/agent_builder_server.py
@@ -1457,7 +1457,7 @@ def _generate_readme(session: BuildSession, export_data: dict, all_tools: set) -
         if node.output_keys:
             node_info.append(f"   - Writes: `{', '.join(node.output_keys)}`")
         if node.tools:
-            node_info.append(f"   - Tools: `{', '.join(node.tools)}`")
+            node_info.append(f"   - Tools: `{', '.join(node.all_tool_names)}`")
         if node.routes:
             routes_str = ", ".join([f"{k}→{v}" for k, v in node.routes.items()])
             node_info.append(f"   - Routes: {routes_str}")
@@ -1746,7 +1746,7 @@ def export_graph() -> str:
     # Collect all tools referenced by nodes
     all_tools = set()
     for node in session.nodes:
-        all_tools.update(node.tools)
+        all_tools.update(node.all_tool_names)
 
     # Build export data
     export_data = {

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -1216,8 +1216,8 @@ class AgentRunner:
             }
 
             if node.tools:
-                required_tools.update(node.tools)
-                node_info["tools"] = node.tools
+                required_tools.update(node.all_tool_names)
+                node_info["tools"] = node.all_tool_names
 
             nodes_info.append(node_info)
 

--- a/core/tests/test_continuous_conversation.py
+++ b/core/tests/test_continuous_conversation.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -385,6 +385,7 @@ class TestCumulativeTools:
     """Test that tools accumulate in continuous mode."""
 
     @pytest.mark.asyncio
+    @patch("aden_tools.credentials.CREDENTIAL_SPECS", {}, create=True)
     async def test_isolated_mode_tools_scoped(self):
         """In isolated mode, each node only gets its own declared tools."""
         runtime = _make_runtime()
@@ -446,6 +447,7 @@ class TestCumulativeTools:
             assert "web_search" not in real_tools
 
     @pytest.mark.asyncio
+    @patch("aden_tools.credentials.CREDENTIAL_SPECS", {}, create=True)
     async def test_continuous_mode_tools_accumulate(self):
         """In continuous mode, node B should have both web_search and save_data."""
         runtime = _make_runtime()

--- a/core/tests/test_tool_resolution.py
+++ b/core/tests/test_tool_resolution.py
@@ -1,0 +1,234 @@
+"""Tests for Tier 1 and Tier 2 tool resolution.
+
+Tier 1: tools=["web_search"]          — exact, credential must be set
+Tier 2: tools=[["web_search", "exa"]] — fallback group, first with credential wins
+"""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from framework.graph.node import NodeSpec
+from framework.llm.provider import Tool, ToolUse
+from framework.runner.tool_registry import ToolRegistry, _is_auth_error
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+CRED_SPECS_PATCH = {
+    "brave_search": MagicMock(env_var="BRAVE_SEARCH_API_KEY", tools=["web_search"]),
+    "exa_search": MagicMock(env_var="EXA_API_KEY", tools=["exa_search"]),
+}
+
+
+def _make_tool(name: str) -> Tool:
+    return Tool(name=name, description="", parameters={"type": "object", "properties": {}})
+
+
+def _make_executor(tools: list[Tool]):
+    from framework.graph.executor import GraphExecutor
+
+    return GraphExecutor(runtime=MagicMock(), llm=MagicMock(), tools=tools)
+
+
+def _make_graph(node_tools: list):
+    node = NodeSpec(
+        id="node1",
+        name="research",
+        description="",
+        node_type="event_loop",
+        tools=node_tools,
+    )
+    graph = MagicMock()
+    graph.nodes = [node]
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# _is_auth_error helper
+# ---------------------------------------------------------------------------
+
+
+def test_is_auth_error_detects_401():
+    assert _is_auth_error("HTTP 401 Unauthorized") is True
+
+
+def test_is_auth_error_detects_403():
+    assert _is_auth_error("403 Forbidden") is True
+
+
+def test_is_auth_error_detects_invalid_api_key():
+    assert _is_auth_error("Invalid API key provided") is True
+
+
+def test_is_auth_error_ignores_generic_error():
+    assert _is_auth_error("No results found") is False
+
+
+def test_is_auth_error_ignores_timeout():
+    assert _is_auth_error("Connection timeout") is False
+
+
+# ---------------------------------------------------------------------------
+# NodeSpec.all_tool_names
+# ---------------------------------------------------------------------------
+
+
+def test_all_tool_names_tier1():
+    spec = NodeSpec(
+        id="n1",
+        name="N1",
+        description="",
+        tools=["web_search", "github_search"],
+    )
+    assert spec.all_tool_names == ["web_search", "github_search"]
+
+
+def test_all_tool_names_tier2():
+    spec = NodeSpec(
+        id="n1",
+        name="N1",
+        description="",
+        tools=[["web_search", "exa_search"], "github_search"],
+    )
+    assert spec.all_tool_names == ["web_search", "exa_search", "github_search"]
+
+
+def test_all_tool_names_empty():
+    spec = NodeSpec(id="n1", name="N1", description="", tools=[])
+    assert spec.all_tool_names == []
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — key missing → error before agent starts
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_tier1_key_missing_returns_error_message():
+    """_validate_tools returns an error when Tier 1 tool credential is missing."""
+    executor = _make_executor([_make_tool("web_search")])
+    graph = _make_graph(["web_search"])
+
+    with patch("aden_tools.credentials.CREDENTIAL_SPECS", CRED_SPECS_PATCH, create=True):
+        errors = executor._validate_tools(graph)
+
+    assert any("BRAVE_SEARCH_API_KEY" in e for e in errors), errors
+
+
+@patch.dict(os.environ, {"BRAVE_SEARCH_API_KEY": "valid-key"})
+def test_tier1_key_present_no_error():
+    """_validate_tools passes when Tier 1 tool credential is set."""
+    executor = _make_executor([_make_tool("web_search")])
+    graph = _make_graph(["web_search"])
+
+    with patch("aden_tools.credentials.CREDENTIAL_SPECS", CRED_SPECS_PATCH, create=True):
+        errors = executor._validate_tools(graph)
+
+    assert errors == []
+    assert executor._resolved_node_tools["node1"] == ["web_search"]
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — fallback resolution
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, {"EXA_API_KEY": "exa-key"})
+def test_tier2_first_missing_resolves_to_second():
+    """Tier 2: web_search skipped (key missing), exa_search used."""
+    executor = _make_executor([_make_tool("web_search"), _make_tool("exa_search")])
+    graph = _make_graph([["web_search", "exa_search"]])
+
+    with patch("aden_tools.credentials.CREDENTIAL_SPECS", CRED_SPECS_PATCH, create=True):
+        errors = executor._validate_tools(graph)
+
+    assert errors == []
+    assert executor._resolved_node_tools["node1"] == ["exa_search"]
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_tier2_all_keys_missing_errors():
+    """Tier 2: no tool in group has credentials → error before agent starts."""
+    executor = _make_executor([_make_tool("web_search"), _make_tool("exa_search")])
+    graph = _make_graph([["web_search", "exa_search"]])
+
+    with patch("aden_tools.credentials.CREDENTIAL_SPECS", CRED_SPECS_PATCH, create=True):
+        errors = executor._validate_tools(graph)
+
+    assert len(errors) == 1
+    assert "no tool in" in errors[0]
+
+
+@patch.dict(os.environ, {"BRAVE_SEARCH_API_KEY": "brave-key"})
+def test_tier2_first_present_uses_first():
+    """Tier 2: web_search has credential → uses web_search, no fallback needed."""
+    executor = _make_executor([_make_tool("web_search"), _make_tool("exa_search")])
+    graph = _make_graph([["web_search", "exa_search"]])
+
+    with patch("aden_tools.credentials.CREDENTIAL_SPECS", CRED_SPECS_PATCH, create=True):
+        errors = executor._validate_tools(graph)
+
+    assert errors == []
+    assert executor._resolved_node_tools["node1"] == ["web_search"]
+
+
+# ---------------------------------------------------------------------------
+# Runtime: credential_error flag stops the agent
+# ---------------------------------------------------------------------------
+
+
+def test_credential_error_flag_in_tool_result():
+    """get_executor tags auth errors with credential_error: True."""
+    registry = ToolRegistry()
+
+    def bad_executor(_inputs):
+        raise RuntimeError("401 Unauthorized: invalid API key")
+
+    registry.register("web_search", _make_tool("web_search"), bad_executor)
+    executor_fn = registry.get_executor()
+
+    result = executor_fn(ToolUse(id="t1", name="web_search", input={}))
+
+    assert result.is_error is True
+    parsed = json.loads(result.content)
+    assert parsed.get("credential_error") is True
+
+
+def test_non_auth_error_no_credential_flag():
+    """get_executor does NOT tag non-auth errors with credential_error."""
+    registry = ToolRegistry()
+
+    def bad_executor(_inputs):
+        raise RuntimeError("No results found for query")
+
+    registry.register("web_search", _make_tool("web_search"), bad_executor)
+    executor_fn = registry.get_executor()
+
+    result = executor_fn(ToolUse(id="t1", name="web_search", input={}))
+
+    assert result.is_error is True
+    parsed = json.loads(result.content)
+    assert "credential_error" not in parsed
+
+
+# ---------------------------------------------------------------------------
+# Backward compat: Tier 1 plain string still works
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tool_decl",
+    [
+        ["web_search"],
+        [["web_search", "exa_search"]],
+    ],
+)
+def test_all_tool_names_is_always_flat(tool_decl):
+    """all_tool_names always returns a flat list regardless of tier."""
+    spec = NodeSpec(id="n1", name="N1", description="", tools=tool_decl)
+    for name in spec.all_tool_names:
+        assert isinstance(name, str)


### PR DESCRIPTION
## Description
 When a tool's API key is missing or invalid, the LLM was silently falling back to training data instead of stopping. This PR adds Tier 1 and Tier 2 tool resolution to catch credential issues early and halt the agent immediately.

**Tier 1** (`tools=["web_search"]`) — validates both tool registration and credential env var at startup. Stops the agent before it runs if credentials are missing.

**Tier 2** (`tools=[["web_search", "exa_search"]]`) — fallback group. Framework picks the first tool whose credential is set, logs skipped tools, and errors if none are available.

At runtime, any tool returning a 401/403/auth error is tagged with `credential_error: true` and the agent halts immediately instead of continuing with training data.


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #5053 

## Changes Made

 When a tool's API key is missing or invalid, the LLM was silently falling back to training data instead of stopping. This PR adds Tier 1 and Tier 2 tool resolution to catch credential issues early and halt the agent immediately.

**Tier 1** (`tools=["web_search"]`) — validates both tool registration and credential env var at startup. Stops the agent before it runs if credentials are missing.

**Tier 2** (`tools=[["web_search", "exa_search"]]`) — fallback group. Framework picks the first tool whose credential is set, logs skipped tools, and errors if none are available.

At runtime, any tool returning a 401/403/auth error is tagged with `credential_error: true` and the agent halts immediately instead of continuing with training data.

## Testing:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed (scene_scout agent with TUI — credential errors surface correctly)

 New test file: `core/tests/test_tool_resolution.py` — 13 tests covering Tier 1 registration, Tier 2 fallback, `_is_auth_error`, `credential_error` flag, and  `all_tool_names`.


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots:
#Before:
<img width="1856" height="1032" alt="Screenshot 2026-02-18 024942" src="https://github.com/user-attachments/assets/3e8c7faa-b0b0-4101-8cc5-3444e960531f" />


#After:
<img width="1848" height="788" alt="Screenshot 2026-02-23 030735" src="https://github.com/user-attachments/assets/3da456d0-30d5-450c-843a-fc0c7b55cc84" />

@Hundao ,Thanks for the Trust, looking forward to  make further changes if required:)