### PR TITLE
fix(tui): add Alt+Left/Right/Backspace/Delete word-level navigation and deletion in chat input

### DIFF
--- a/core/framework/tui/widgets/chat_repl.py
+++ b/core/framework/tui/widgets/chat_repl.py
@@ -74,14 +74,6 @@ class ChatTextArea(TextArea):
             self.action_delete_word_right()
             event.stop()
             event.prevent_default()
-        elif event.key == "alt+shift+left":
-            self.action_cursor_word_left(True)
-            event.stop()
-            event.prevent_default()
-        elif event.key == "alt+shift+right":
-            self.action_cursor_word_right(True)
-            event.stop()
-            event.prevent_default()
         else:
             await super()._on_key(event)
 

--- a/core/framework/tui/widgets/chat_repl.py
+++ b/core/framework/tui/widgets/chat_repl.py
@@ -58,6 +58,30 @@ class ChatTextArea(TextArea):
         elif event.key == "shift+enter":
             event.key = "enter"
             await super()._on_key(event)
+        elif event.key == "alt+left":
+            self.action_cursor_word_left()
+            event.stop()
+            event.prevent_default()
+        elif event.key == "alt+right":
+            self.action_cursor_word_right()
+            event.stop()
+            event.prevent_default()
+        elif event.key == "alt+backspace":
+            self.action_delete_word_left()
+            event.stop()
+            event.prevent_default()
+        elif event.key == "alt+delete":
+            self.action_delete_word_right()
+            event.stop()
+            event.prevent_default()
+        elif event.key == "alt+shift+left":
+            self.action_cursor_word_left(True)
+            event.stop()
+            event.prevent_default()
+        elif event.key == "alt+shift+right":
+            self.action_cursor_word_right(True)
+            event.stop()
+            event.prevent_default()
         else:
             await super()._on_key(event)
 


### PR DESCRIPTION
## Description
The TUI chat input had no bindings for `Alt`-modified keys, leaving word-level
navigation and deletion non-functional for macOS and Linux users who rely on
these as standard OS conventions. This fix handles four key events in `ChatRepl`
and dispatches them to the existing Textual `TextArea` actions. `event.stop()`
and `event.prevent_default()` are called on each to prevent raw escape sequences
from bleeding through.

| Key | Action |
|---|---|
| `Alt+Left` | Move cursor one word left |
| `Alt+Right` | Move cursor one word right |
| `Alt+Backspace` | Delete word to the left of cursor |
| `Alt+Delete` | Delete word to the right of cursor |

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
Fixes #5220 

## Changes Made
- Added `alt+left` → `action_cursor_word_left()` key event handling in `ChatRepl`
- Added `alt+right` → `action_cursor_word_right()` key event handling in `ChatRepl`
- Added `alt+backspace` → `action_delete_word_left()` key event handling in `ChatRepl`
- Added `alt+delete` → `action_delete_word_right()` key event handling in `ChatRepl`

## Testing
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

Manually verified in `hive tui`:
- `Alt+Left` / `Alt+Right` jump between words as expected
- `Alt+Backspace` deletes word to the left of cursor
- `Alt+Delete` deletes word to the right of cursor
- Existing `Ctrl+Left` / `Ctrl+Right` still work unchanged
- No raw escape sequences bleed through on macOS Terminal and iTerm2

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
N/A — keyboard shortcut fix with no visual UI changes.