### PR TITLE
feat: Terraform - Infrastructure as Code Automation Tool

### DIFF
--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -68,6 +68,7 @@ from .ssl_tls_scanner import register_tools as register_ssl_tls_scanner
 from .stripe_tool import register_tools as register_stripe
 from .subdomain_enumerator import register_tools as register_subdomain_enumerator
 from .tech_stack_detector import register_tools as register_tech_stack_detector
+from .terraform_tool import register_tools as register_terraform
 from .telegram_tool import register_tools as register_telegram
 from .time_tool import register_tools as register_time
 from .vision_tool import register_tools as register_vision
@@ -143,6 +144,9 @@ def register_all_tools(
     register_tech_stack_detector(mcp)
     register_subdomain_enumerator(mcp)
     register_risk_scorer(mcp)
+
+    # Infrastructure as Code tools (no credentials needed)
+    register_terraform(mcp)
     register_stripe(mcp, credentials=credentials)
 
     # Return the list of all registered tool names

--- a/tools/src/aden_tools/tools/terraform_tool/README.md
+++ b/tools/src/aden_tools/tools/terraform_tool/README.md
@@ -1,0 +1,125 @@
+# Terraform Tool
+
+Infrastructure as Code automation for Aden agents, enabling programmatic management of cloud infrastructure via the Terraform CLI.
+
+## Description
+
+This tool provides structured, agent-friendly wrappers around the [Terraform CLI](https://developer.hashicorp.com/terraform). It enables DevOps agents to initialise working directories, generate execution plans, apply or destroy infrastructure, manage workspaces, and read state — all through the MCP protocol.
+
+Terraform must be installed on the host system and available on `PATH`.
+
+## Tools
+
+### Core Lifecycle
+
+| Tool | Description |
+|------|-------------|
+| `terraform_init` | Initialise a Terraform working directory (downloads providers, configures backend) |
+| `terraform_validate` | Validate configuration files for syntax and internal consistency |
+| `terraform_plan` | Generate an execution plan showing proposed changes |
+| `terraform_apply` | Apply changes to create or update infrastructure |
+| `terraform_destroy` | Destroy Terraform-managed infrastructure |
+
+### State & Output Inspection
+
+| Tool | Description |
+|------|-------------|
+| `terraform_show` | Display current state in structured JSON |
+| `terraform_output` | Read output values from the state |
+| `terraform_read_state` | Read state and return a resource summary |
+
+### Workspace Management
+
+| Tool | Description |
+|------|-------------|
+| `terraform_workspace_list` | List available workspaces and identify the current one |
+| `terraform_workspace_select` | Switch to a different workspace |
+
+### Configuration Management
+
+| Tool | Description |
+|------|-------------|
+| `terraform_write_config` | Write `.tf` or `.tfvars` configuration files |
+| `terraform_import_resource` | Import existing infrastructure into Terraform state |
+
+## Arguments
+
+### `terraform_init`
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `working_dir` | str | Yes | — | Path to Terraform working directory |
+| `backend_config` | str | No | `""` | Comma-separated key=value backend config overrides |
+| `upgrade` | bool | No | `False` | Upgrade modules and plugins |
+| `reconfigure` | bool | No | `False` | Reconfigure backend ignoring saved config |
+
+### `terraform_plan`
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `working_dir` | str | Yes | — | Path to Terraform working directory |
+| `variables` | str | No | `""` | Comma-separated key=value variable overrides |
+| `var_file` | str | No | `""` | Path to `.tfvars` file |
+| `target` | str | No | `""` | Resource address to target |
+| `destroy` | bool | No | `False` | Plan a destroy operation |
+
+### `terraform_apply` / `terraform_destroy`
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `working_dir` | str | Yes | — | Path to Terraform working directory |
+| `variables` | str | No | `""` | Comma-separated key=value variable overrides |
+| `var_file` | str | No | `""` | Path to `.tfvars` file |
+| `target` | str | No | `""` | Resource address to target |
+| `auto_approve` | bool | No | `False` | Skip interactive approval (**use with caution**) |
+
+### `terraform_write_config`
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `working_dir` | str | Yes | — | Path to Terraform working directory |
+| `filename` | str | Yes | — | File name (must end with `.tf` or `.tfvars`) |
+| `config_content` | str | Yes | — | HCL or variable content to write |
+
+### `terraform_import_resource`
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `working_dir` | str | Yes | — | Path to Terraform working directory |
+| `address` | str | Yes | — | Terraform resource address (e.g. `aws_instance.web`) |
+| `resource_id` | str | Yes | — | Provider-specific resource ID |
+
+## Environment Variables
+
+This tool does **not** require any API keys or secrets of its own. Terraform providers use standard cloud credentials (e.g. `AWS_ACCESS_KEY_ID`, `GOOGLE_CREDENTIALS`, `ARM_CLIENT_ID`). These should be set independently in the host environment.
+
+## Prerequisites
+
+- **Terraform CLI** ≥ 1.0 on `PATH` — [Install guide](https://developer.hashicorp.com/terraform/install)
+
+## Security Considerations
+
+- **Destructive operations** (`apply`, `destroy`) default to `auto_approve=False` — an explicit opt-in is required.
+- **State files** may contain sensitive data; use remote state backends with encryption in production.
+- **`write_config`** restricts filenames to `.tf` / `.tfvars` and prevents path traversal.
+- Commands run with `TF_IN_AUTOMATION=1` and `TF_INPUT=0` to prevent interactive prompts.
+
+## Error Handling
+
+All tools return `{"error": "..."}` on failure instead of raising exceptions. Common errors:
+
+- `Working directory does not exist` — invalid `working_dir` path
+- `Terraform CLI not found on PATH` — Terraform is not installed
+- `Terraform command timed out` — operation exceeded the timeout limit
+
+## Example Workflow
+
+```
+1. Agent generates Terraform HCL → terraform_write_config(dir, "main.tf", hcl)
+2. Agent initialises → terraform_init(dir)
+3. Agent validates → terraform_validate(dir)
+4. Agent previews changes → terraform_plan(dir, variables="region=us-east-1")
+5. Agent applies → terraform_apply(dir, variables="region=us-east-1", auto_approve=True)
+6. Agent reads outputs → terraform_output(dir)
+7. When done → terraform_destroy(dir, auto_approve=True)
+```

--- a/tools/src/aden_tools/tools/terraform_tool/__init__.py
+++ b/tools/src/aden_tools/tools/terraform_tool/__init__.py
@@ -1,0 +1,5 @@
+"""Terraform Tool package - Infrastructure as Code automation."""
+
+from .terraform_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/terraform_tool/terraform_tool.py
+++ b/tools/src/aden_tools/tools/terraform_tool/terraform_tool.py
@@ -1,0 +1,583 @@
+"""Terraform Tool - Infrastructure as Code automation for FastMCP.
+
+Provides structured wrappers around the Terraform CLI, enabling agents
+to initialise working directories, plan and apply infrastructure changes,
+manage workspaces, read state and outputs, validate configurations, and
+write Terraform configuration files.
+
+Terraform must be installed and available on the system PATH.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+# Default timeout for Terraform commands (seconds).
+_DEFAULT_TIMEOUT = 300
+# Maximum allowed timeout a caller may request.
+_MAX_TIMEOUT = 600
+
+
+def _validate_working_dir(working_dir: str) -> Path | None:
+    """Validate and resolve a working directory path.
+
+    Args:
+        working_dir: The directory path to validate.
+
+    Returns:
+        A resolved ``Path`` if valid, otherwise ``None``.
+    """
+    path = Path(working_dir).resolve()
+    if not path.is_dir():
+        return None
+    return path
+
+
+def _run_terraform(
+    args: list[str],
+    working_dir: Path,
+    timeout: int = _DEFAULT_TIMEOUT,
+) -> dict:
+    """Execute a Terraform CLI command and return structured output.
+
+    Args:
+        args: Command-line arguments to pass to ``terraform``.
+        working_dir: The Terraform working directory.
+        timeout: Maximum seconds to wait for the command.
+
+    Returns:
+        A dict with ``success`` (bool), ``stdout`` (str), ``stderr`` (str),
+        and ``return_code`` (int).
+    """
+    terraform_bin = shutil.which("terraform")
+    if not terraform_bin:
+        return {
+            "success": False,
+            "error": (
+                "Terraform CLI not found on PATH. "
+                "Install from https://developer.hashicorp.com/terraform/install"
+            ),
+        }
+
+    cmd = [terraform_bin, *args]
+    env = {**os.environ, "TF_IN_AUTOMATION": "1", "TF_INPUT": "0"}
+    logger.info("Running: %s in %s", " ".join(cmd), working_dir)
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=working_dir,
+            capture_output=True,
+            text=True,
+            timeout=min(timeout, _MAX_TIMEOUT),
+            env=env,
+        )
+        return {
+            "success": result.returncode == 0,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "return_code": result.returncode,
+        }
+    except subprocess.TimeoutExpired:
+        return {
+            "success": False,
+            "error": f"Terraform command timed out after {timeout}s",
+        }
+    except Exception as exc:
+        return {"success": False, "error": f"Failed to run Terraform: {exc}"}
+
+
+def _parse_json_output(raw: str) -> list[dict] | dict | str:
+    """Attempt to parse Terraform JSON output.
+
+    Terraform ``-json`` output is newline-delimited JSON; each line is a
+    separate JSON object.
+
+    Args:
+        raw: Raw stdout from Terraform.
+
+    Returns:
+        Parsed JSON objects (single dict, list, or the raw string on failure).
+    """
+    lines = [line.strip() for line in raw.strip().splitlines() if line.strip()]
+    if not lines:
+        return raw
+
+    parsed: list[dict] = []
+    for line in lines:
+        try:
+            parsed.append(json.loads(line))
+        except json.JSONDecodeError:
+            return raw
+
+    if len(parsed) == 1:
+        return parsed[0]
+    return parsed
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register Terraform tools with the MCP server.
+
+    Args:
+        mcp: The FastMCP server instance.
+    """
+
+    # ------------------------------------------------------------------
+    # Core lifecycle commands
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    def terraform_init(
+        working_dir: str,
+        backend_config: str = "",
+        upgrade: bool = False,
+        reconfigure: bool = False,
+    ) -> dict:
+        """Initialise a Terraform working directory.
+
+        Downloads providers, initialises the backend, and prepares the
+        directory for other Terraform commands.
+
+        Args:
+            working_dir: Path to the Terraform working directory.
+            backend_config: Optional key=value backend config overrides
+                (comma-separated, e.g. "bucket=my-bucket,region=us-east-1").
+            upgrade: If True, upgrade modules and plugins to the latest
+                allowed versions.
+            reconfigure: If True, reconfigure the backend, ignoring any
+                saved configuration.
+
+        Returns:
+            Dict with command results.
+        """
+        path = _validate_working_dir(working_dir)
+        if path is None:
+            return {"error": f"Working directory does not exist: {working_dir}"}
+
+        args = ["init", "-no-color"]
+        if upgrade:
+            args.append("-upgrade")
+        if reconfigure:
+            args.append("-reconfigure")
+        if backend_config:
+            for pair in backend_config.split(","):
+                args.extend(["-backend-config", pair.strip()])
+
+        result = _run_terraform(args, path)
+        return {
+            "command": "terraform init",
+            "working_dir": str(path),
+            **result,
+        }
+
+    @mcp.tool()
+    def terraform_validate(working_dir: str) -> dict:
+        """Validate Terraform configuration files for syntax and consistency.
+
+        Args:
+            working_dir: Path to the Terraform working directory.
+
+        Returns:
+            Dict with validation results (uses ``-json`` for structured output).
+        """
+        path = _validate_working_dir(working_dir)
+        if path is None:
+            return {"error": f"Working directory does not exist: {working_dir}"}
+
+        result = _run_terraform(["validate", "-json", "-no-color"], path)
+        if result.get("stdout"):
+            result["parsed"] = _parse_json_output(result["stdout"])
+        return {"command": "terraform validate", "working_dir": str(path), **result}
+
+    @mcp.tool()
+    def terraform_plan(
+        working_dir: str,
+        variables: str = "",
+        var_file: str = "",
+        target: str = "",
+        destroy: bool = False,
+    ) -> dict:
+        """Generate a Terraform execution plan.
+
+        Shows what actions Terraform would take without actually applying
+        any changes.
+
+        Args:
+            working_dir: Path to the Terraform working directory.
+            variables: Comma-separated key=value variable overrides
+                (e.g. "region=us-east-1,instance_type=t3.micro").
+            var_file: Path to a ``.tfvars`` variable definitions file.
+            target: Resource address to target (e.g.
+                "module.vpc.aws_subnet.public").
+            destroy: If True, plan a destroy operation.
+
+        Returns:
+            Dict with plan results (uses ``-json`` for machine-readable output
+            when possible).
+        """
+        path = _validate_working_dir(working_dir)
+        if path is None:
+            return {"error": f"Working directory does not exist: {working_dir}"}
+
+        args = ["plan", "-no-color", "-input=false"]
+        if destroy:
+            args.append("-destroy")
+        if var_file:
+            args.extend(["-var-file", var_file])
+        if variables:
+            for pair in variables.split(","):
+                args.extend(["-var", pair.strip()])
+        if target:
+            args.extend(["-target", target])
+
+        result = _run_terraform(args, path)
+        return {"command": "terraform plan", "working_dir": str(path), **result}
+
+    @mcp.tool()
+    def terraform_apply(
+        working_dir: str,
+        variables: str = "",
+        var_file: str = "",
+        target: str = "",
+        auto_approve: bool = False,
+    ) -> dict:
+        """Apply Terraform changes to create or update infrastructure.
+
+        **Warning:** This modifies real infrastructure. Set ``auto_approve``
+        to ``True`` only when you are certain the plan is correct.
+
+        Args:
+            working_dir: Path to the Terraform working directory.
+            variables: Comma-separated key=value variable overrides.
+            var_file: Path to a ``.tfvars`` variable definitions file.
+            target: Resource address to target.
+            auto_approve: If True, skip interactive approval. Defaults to
+                False for safety.
+
+        Returns:
+            Dict with apply results.
+        """
+        path = _validate_working_dir(working_dir)
+        if path is None:
+            return {"error": f"Working directory does not exist: {working_dir}"}
+
+        args = ["apply", "-no-color", "-input=false"]
+        if auto_approve:
+            args.append("-auto-approve")
+        if var_file:
+            args.extend(["-var-file", var_file])
+        if variables:
+            for pair in variables.split(","):
+                args.extend(["-var", pair.strip()])
+        if target:
+            args.extend(["-target", target])
+
+        result = _run_terraform(args, path, timeout=_MAX_TIMEOUT)
+        return {"command": "terraform apply", "working_dir": str(path), **result}
+
+    @mcp.tool()
+    def terraform_destroy(
+        working_dir: str,
+        variables: str = "",
+        var_file: str = "",
+        target: str = "",
+        auto_approve: bool = False,
+    ) -> dict:
+        """Destroy Terraform-managed infrastructure.
+
+        **Warning:** This is a destructive operation. Set ``auto_approve``
+        to ``True`` only when you are certain you want to destroy resources.
+
+        Args:
+            working_dir: Path to the Terraform working directory.
+            variables: Comma-separated key=value variable overrides.
+            var_file: Path to a ``.tfvars`` variable definitions file.
+            target: Resource address to target for partial destroy.
+            auto_approve: If True, skip interactive approval. Defaults to
+                False for safety.
+
+        Returns:
+            Dict with destroy results.
+        """
+        path = _validate_working_dir(working_dir)
+        if path is None:
+            return {"error": f"Working directory does not exist: {working_dir}"}
+
+        args = ["destroy", "-no-color", "-input=false"]
+        if auto_approve:
+            args.append("-auto-approve")
+        if var_file:
+            args.extend(["-var-file", var_file])
+        if variables:
+            for pair in variables.split(","):
+                args.extend(["-var", pair.strip()])
+        if target:
+            args.extend(["-target", target])
+
+        result = _run_terraform(args, path, timeout=_MAX_TIMEOUT)
+        return {"command": "terraform destroy", "working_dir": str(path), **result}
+
+    # ------------------------------------------------------------------
+    # State / output inspection
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    def terraform_show(working_dir: str) -> dict:
+        """Display the current Terraform state in a human-readable format.
+
+        Args:
+            working_dir: Path to the Terraform working directory.
+
+        Returns:
+            Dict with current state information (uses ``-json`` for
+            structured output).
+        """
+        path = _validate_working_dir(working_dir)
+        if path is None:
+            return {"error": f"Working directory does not exist: {working_dir}"}
+
+        result = _run_terraform(["show", "-json", "-no-color"], path)
+        if result.get("stdout"):
+            result["parsed"] = _parse_json_output(result["stdout"])
+        return {"command": "terraform show", "working_dir": str(path), **result}
+
+    @mcp.tool()
+    def terraform_output(
+        working_dir: str,
+        output_name: str = "",
+    ) -> dict:
+        """Read Terraform output values.
+
+        Args:
+            working_dir: Path to the Terraform working directory.
+            output_name: Specific output name to read. If empty, returns
+                all outputs.
+
+        Returns:
+            Dict with output values (uses ``-json`` for structured output).
+        """
+        path = _validate_working_dir(working_dir)
+        if path is None:
+            return {"error": f"Working directory does not exist: {working_dir}"}
+
+        args = ["output", "-json", "-no-color"]
+        if output_name:
+            args.append(output_name)
+
+        result = _run_terraform(args, path)
+        if result.get("stdout"):
+            result["parsed"] = _parse_json_output(result["stdout"])
+        return {"command": "terraform output", "working_dir": str(path), **result}
+
+    @mcp.tool()
+    def terraform_read_state(working_dir: str) -> dict:
+        """Read the current Terraform state file and return resource details.
+
+        Uses ``terraform show -json`` to provide a full structured view of
+        the managed infrastructure without exposing raw state file contents.
+
+        Args:
+            working_dir: Path to the Terraform working directory.
+
+        Returns:
+            Dict with state information including managed resources.
+        """
+        path = _validate_working_dir(working_dir)
+        if path is None:
+            return {"error": f"Working directory does not exist: {working_dir}"}
+
+        result = _run_terraform(["show", "-json", "-no-color"], path)
+        if result.get("success") and result.get("stdout"):
+            parsed = _parse_json_output(result["stdout"])
+            # Extract resource summary if possible.
+            resources: list[dict] = []
+            if isinstance(parsed, dict):
+                values = parsed.get("values", {})
+                root_module = values.get("root_module", {})
+                for res in root_module.get("resources", []):
+                    resources.append(
+                        {
+                            "address": res.get("address"),
+                            "type": res.get("type"),
+                            "name": res.get("name"),
+                            "provider": res.get("provider_name"),
+                        }
+                    )
+            result["resources"] = resources
+            result["parsed"] = parsed
+        return {"command": "terraform state", "working_dir": str(path), **result}
+
+    # ------------------------------------------------------------------
+    # Workspace management
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    def terraform_workspace_list(working_dir: str) -> dict:
+        """List available Terraform workspaces.
+
+        Args:
+            working_dir: Path to the Terraform working directory.
+
+        Returns:
+            Dict with a list of workspace names and the currently selected
+            workspace.
+        """
+        path = _validate_working_dir(working_dir)
+        if path is None:
+            return {"error": f"Working directory does not exist: {working_dir}"}
+
+        result = _run_terraform(["workspace", "list", "-no-color"], path)
+        if result.get("success") and result.get("stdout"):
+            workspaces: list[str] = []
+            current = ""
+            for line in result["stdout"].strip().splitlines():
+                name = line.strip().lstrip("* ").strip()
+                if name:
+                    workspaces.append(name)
+                if line.strip().startswith("*"):
+                    current = name
+            result["workspaces"] = workspaces
+            result["current"] = current
+        return {
+            "command": "terraform workspace list",
+            "working_dir": str(path),
+            **result,
+        }
+
+    @mcp.tool()
+    def terraform_workspace_select(
+        working_dir: str,
+        workspace: str,
+    ) -> dict:
+        """Switch to a different Terraform workspace.
+
+        Args:
+            working_dir: Path to the Terraform working directory.
+            workspace: Name of the workspace to select.
+
+        Returns:
+            Dict with workspace switch results.
+        """
+        path = _validate_working_dir(working_dir)
+        if path is None:
+            return {"error": f"Working directory does not exist: {working_dir}"}
+
+        if not workspace or not workspace.strip():
+            return {"error": "Workspace name must not be empty"}
+
+        result = _run_terraform(
+            ["workspace", "select", "-no-color", workspace.strip()], path
+        )
+        return {
+            "command": "terraform workspace select",
+            "working_dir": str(path),
+            "workspace": workspace.strip(),
+            **result,
+        }
+
+    # ------------------------------------------------------------------
+    # Configuration management
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    def terraform_write_config(
+        working_dir: str,
+        filename: str,
+        config_content: str,
+    ) -> dict:
+        """Write a Terraform configuration file (.tf or .tfvars).
+
+        Creates or overwrites a file in the given working directory. Only
+        ``.tf`` and ``.tfvars`` extensions are permitted.
+
+        Args:
+            working_dir: Path to the Terraform working directory.
+            filename: Name of the file to write (must end with ``.tf`` or
+                ``.tfvars``).
+            config_content: The HCL or variable content to write.
+
+        Returns:
+            Dict confirming the write operation.
+        """
+        path = _validate_working_dir(working_dir)
+        if path is None:
+            return {"error": f"Working directory does not exist: {working_dir}"}
+
+        if not filename:
+            return {"error": "Filename must not be empty"}
+
+        # Security: only allow .tf and .tfvars extensions.
+        allowed_extensions = {".tf", ".tfvars"}
+        if not any(filename.endswith(ext) for ext in allowed_extensions):
+            return {
+                "error": (
+                    f"Only {', '.join(allowed_extensions)} files are allowed. "
+                    f"Got: {filename}"
+                )
+            }
+
+        # Prevent path traversal.
+        if ".." in filename or "/" in filename or "\\" in filename:
+            return {"error": "Filename must not contain path separators or '..'"}
+
+        target = path / filename
+        try:
+            target.write_text(config_content, encoding="utf-8")
+            return {
+                "success": True,
+                "file": str(target),
+                "bytes_written": len(config_content.encode("utf-8")),
+            }
+        except Exception as exc:
+            return {"error": f"Failed to write config: {exc}"}
+
+    @mcp.tool()
+    def terraform_import_resource(
+        working_dir: str,
+        address: str,
+        resource_id: str,
+    ) -> dict:
+        """Import an existing infrastructure resource into Terraform state.
+
+        Maps a real-world resource to a Terraform resource address so that
+        it can be managed by Terraform going forward.
+
+        Args:
+            working_dir: Path to the Terraform working directory.
+            address: Terraform resource address (e.g.
+                "aws_instance.my_server").
+            resource_id: Provider-specific resource ID (e.g.
+                "i-0123456789abcdef0").
+
+        Returns:
+            Dict with import results.
+        """
+        path = _validate_working_dir(working_dir)
+        if path is None:
+            return {"error": f"Working directory does not exist: {working_dir}"}
+
+        if not address or not address.strip():
+            return {"error": "Resource address must not be empty"}
+        if not resource_id or not resource_id.strip():
+            return {"error": "Resource ID must not be empty"}
+
+        result = _run_terraform(
+            ["import", "-no-color", "-input=false", address.strip(), resource_id.strip()],
+            path,
+        )
+        return {
+            "command": "terraform import",
+            "working_dir": str(path),
+            "address": address.strip(),
+            "resource_id": resource_id.strip(),
+            **result,
+        }

--- a/tools/tests/tools/test_terraform_tool.py
+++ b/tools/tests/tools/test_terraform_tool.py
@@ -1,0 +1,559 @@
+"""Tests for terraform_tool - Infrastructure as Code automation."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.terraform_tool.terraform_tool import register_tools
+
+
+@pytest.fixture
+def mcp() -> FastMCP:
+    """Create a fresh FastMCP instance for testing."""
+    return FastMCP("test-server")
+
+
+def _get_fn(mcp: FastMCP, name: str):
+    """Retrieve a registered tool function by name.
+
+    Args:
+        mcp: The FastMCP server instance.
+        name: Tool name.
+
+    Returns:
+        The underlying tool function.
+    """
+    return mcp._tool_manager._tools[name].fn
+
+
+@pytest.fixture
+def tools(mcp: FastMCP) -> dict:
+    """Register and return all terraform tool functions as a dict.
+
+    Args:
+        mcp: The FastMCP server instance.
+
+    Returns:
+        Dict mapping tool name to its function.
+    """
+    register_tools(mcp)
+    names = [
+        "terraform_init",
+        "terraform_validate",
+        "terraform_plan",
+        "terraform_apply",
+        "terraform_destroy",
+        "terraform_show",
+        "terraform_output",
+        "terraform_read_state",
+        "terraform_workspace_list",
+        "terraform_workspace_select",
+        "terraform_write_config",
+        "terraform_import_resource",
+    ]
+    return {n: _get_fn(mcp, n) for n in names}
+
+
+# ---------------------------------------------------------------------------
+# Registration tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    """Verify all expected tools are registered."""
+
+    def test_all_tools_registered(self, mcp: FastMCP):
+        """All 12 Terraform tools should be registered."""
+        register_tools(mcp)
+        expected = {
+            "terraform_init",
+            "terraform_validate",
+            "terraform_plan",
+            "terraform_apply",
+            "terraform_destroy",
+            "terraform_show",
+            "terraform_output",
+            "terraform_read_state",
+            "terraform_workspace_list",
+            "terraform_workspace_select",
+            "terraform_write_config",
+            "terraform_import_resource",
+        }
+        registered = set(mcp._tool_manager._tools.keys())
+        assert expected.issubset(registered)
+
+
+# ---------------------------------------------------------------------------
+# Input-validation tests (no subprocess calls needed)
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    """Verify every tool rejects invalid working directories."""
+
+    def test_init_invalid_dir(self, tools):
+        """terraform_init returns error for non-existent directory."""
+        result = tools["terraform_init"](working_dir="/nonexistent/path")
+        assert "error" in result
+
+    def test_validate_invalid_dir(self, tools):
+        """terraform_validate returns error for non-existent directory."""
+        result = tools["terraform_validate"](working_dir="/nonexistent/path")
+        assert "error" in result
+
+    def test_plan_invalid_dir(self, tools):
+        """terraform_plan returns error for non-existent directory."""
+        result = tools["terraform_plan"](working_dir="/nonexistent/path")
+        assert "error" in result
+
+    def test_apply_invalid_dir(self, tools):
+        """terraform_apply returns error for non-existent directory."""
+        result = tools["terraform_apply"](working_dir="/nonexistent/path")
+        assert "error" in result
+
+    def test_destroy_invalid_dir(self, tools):
+        """terraform_destroy returns error for non-existent directory."""
+        result = tools["terraform_destroy"](working_dir="/nonexistent/path")
+        assert "error" in result
+
+    def test_show_invalid_dir(self, tools):
+        """terraform_show returns error for non-existent directory."""
+        result = tools["terraform_show"](working_dir="/nonexistent/path")
+        assert "error" in result
+
+    def test_output_invalid_dir(self, tools):
+        """terraform_output returns error for non-existent directory."""
+        result = tools["terraform_output"](working_dir="/nonexistent/path")
+        assert "error" in result
+
+    def test_read_state_invalid_dir(self, tools):
+        """terraform_read_state returns error for non-existent directory."""
+        result = tools["terraform_read_state"](working_dir="/nonexistent/path")
+        assert "error" in result
+
+    def test_workspace_list_invalid_dir(self, tools):
+        """terraform_workspace_list returns error for non-existent directory."""
+        result = tools["terraform_workspace_list"](working_dir="/nonexistent/path")
+        assert "error" in result
+
+    def test_workspace_select_invalid_dir(self, tools):
+        """terraform_workspace_select returns error for non-existent directory."""
+        result = tools["terraform_workspace_select"](
+            working_dir="/nonexistent/path", workspace="dev"
+        )
+        assert "error" in result
+
+    def test_workspace_select_empty_name(self, tools, tmp_path):
+        """terraform_workspace_select rejects empty workspace name."""
+        result = tools["terraform_workspace_select"](
+            working_dir=str(tmp_path), workspace=""
+        )
+        assert "error" in result
+        assert "empty" in result["error"].lower()
+
+    def test_write_config_invalid_dir(self, tools):
+        """terraform_write_config returns error for non-existent directory."""
+        result = tools["terraform_write_config"](
+            working_dir="/nonexistent/path",
+            filename="main.tf",
+            config_content="resource {}",
+        )
+        assert "error" in result
+
+    def test_import_resource_invalid_dir(self, tools):
+        """terraform_import_resource returns error for non-existent directory."""
+        result = tools["terraform_import_resource"](
+            working_dir="/nonexistent/path",
+            address="aws_instance.web",
+            resource_id="i-123",
+        )
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# terraform_write_config security tests
+# ---------------------------------------------------------------------------
+
+
+class TestWriteConfig:
+    """Tests for terraform_write_config security and functionality."""
+
+    def test_write_tf_file(self, tools, tmp_path):
+        """Writing a .tf file succeeds."""
+        result = tools["terraform_write_config"](
+            working_dir=str(tmp_path),
+            filename="main.tf",
+            config_content='resource "null_resource" "test" {}',
+        )
+        assert result.get("success") is True
+        assert (tmp_path / "main.tf").exists()
+        assert (tmp_path / "main.tf").read_text() == 'resource "null_resource" "test" {}'
+
+    def test_write_tfvars_file(self, tools, tmp_path):
+        """Writing a .tfvars file succeeds."""
+        result = tools["terraform_write_config"](
+            working_dir=str(tmp_path),
+            filename="dev.tfvars",
+            config_content='region = "us-east-1"',
+        )
+        assert result.get("success") is True
+        assert (tmp_path / "dev.tfvars").exists()
+
+    def test_reject_invalid_extension(self, tools, tmp_path):
+        """Files without .tf or .tfvars extension are rejected."""
+        result = tools["terraform_write_config"](
+            working_dir=str(tmp_path),
+            filename="script.sh",
+            config_content="#!/bin/bash",
+        )
+        assert "error" in result
+        assert ".tf" in result["error"]
+
+    def test_reject_path_traversal(self, tools, tmp_path):
+        """Path traversal attempts are rejected."""
+        result = tools["terraform_write_config"](
+            working_dir=str(tmp_path),
+            filename="../escape.tf",
+            config_content="bad",
+        )
+        assert "error" in result
+
+    def test_reject_directory_separator(self, tools, tmp_path):
+        """Filenames with directory separators are rejected."""
+        result = tools["terraform_write_config"](
+            working_dir=str(tmp_path),
+            filename="sub/main.tf",
+            config_content="bad",
+        )
+        assert "error" in result
+
+    def test_reject_empty_filename(self, tools, tmp_path):
+        """Empty filename is rejected."""
+        result = tools["terraform_write_config"](
+            working_dir=str(tmp_path),
+            filename="",
+            config_content="content",
+        )
+        assert "error" in result
+
+    def test_bytes_written_count(self, tools, tmp_path):
+        """Bytes written should match content length."""
+        content = 'variable "name" { default = "test" }'
+        result = tools["terraform_write_config"](
+            working_dir=str(tmp_path),
+            filename="vars.tf",
+            config_content=content,
+        )
+        assert result.get("bytes_written") == len(content.encode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# terraform_import_resource validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestImportResource:
+    """Tests for terraform_import_resource input validation."""
+
+    def test_reject_empty_address(self, tools, tmp_path):
+        """Empty address is rejected."""
+        result = tools["terraform_import_resource"](
+            working_dir=str(tmp_path),
+            address="",
+            resource_id="i-123",
+        )
+        assert "error" in result
+        assert "address" in result["error"].lower()
+
+    def test_reject_empty_resource_id(self, tools, tmp_path):
+        """Empty resource_id is rejected."""
+        result = tools["terraform_import_resource"](
+            working_dir=str(tmp_path),
+            address="aws_instance.web",
+            resource_id="",
+        )
+        assert "error" in result
+        assert "resource id" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Subprocess-mocked tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubprocessExecution:
+    """Tests that verify CLI execution with mocked subprocess."""
+
+    @patch("shutil.which", return_value=None)
+    def test_terraform_not_installed(self, mock_which, tools, tmp_path):
+        """All tools return error when Terraform is not on PATH."""
+        result = tools["terraform_init"](working_dir=str(tmp_path))
+        assert result.get("success") is False
+        assert "not found" in result.get("error", "").lower()
+
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    @patch("subprocess.run")
+    def test_init_success(self, mock_run, mock_which, tools, tmp_path):
+        """terraform_init passes correct args on success."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="Terraform has been successfully initialized!\n",
+            stderr="",
+        )
+        result = tools["terraform_init"](working_dir=str(tmp_path))
+        assert result["success"] is True
+        assert result["command"] == "terraform init"
+
+        # Verify the CLI args.
+        call_args = mock_run.call_args
+        cmd = call_args[0][0]
+        assert cmd[0] == "/usr/bin/terraform"
+        assert "init" in cmd
+
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    @patch("subprocess.run")
+    def test_init_with_upgrade(self, mock_run, mock_which, tools, tmp_path):
+        """terraform_init includes -upgrade flag."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+        tools["terraform_init"](working_dir=str(tmp_path), upgrade=True)
+
+        cmd = mock_run.call_args[0][0]
+        assert "-upgrade" in cmd
+
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    @patch("subprocess.run")
+    def test_init_with_backend_config(self, mock_run, mock_which, tools, tmp_path):
+        """terraform_init passes backend-config flags."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+        tools["terraform_init"](
+            working_dir=str(tmp_path), backend_config="bucket=my-bucket,region=us-east-1"
+        )
+
+        cmd = mock_run.call_args[0][0]
+        assert "-backend-config" in cmd
+        assert "bucket=my-bucket" in cmd
+
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    @patch("subprocess.run")
+    def test_validate_json_output(self, mock_run, mock_which, tools, tmp_path):
+        """terraform_validate parses JSON output."""
+        json_out = '{"valid": true, "error_count": 0}'
+        mock_run.return_value = MagicMock(returncode=0, stdout=json_out, stderr="")
+
+        result = tools["terraform_validate"](working_dir=str(tmp_path))
+        assert result["success"] is True
+        assert result["parsed"]["valid"] is True
+
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    @patch("subprocess.run")
+    def test_plan_with_variables(self, mock_run, mock_which, tools, tmp_path):
+        """terraform_plan passes -var flags."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="Plan: 1 to add", stderr="")
+        tools["terraform_plan"](
+            working_dir=str(tmp_path), variables="region=us-east-1,instance_type=t3.micro"
+        )
+
+        cmd = mock_run.call_args[0][0]
+        assert "-var" in cmd
+        assert "region=us-east-1" in cmd
+        assert "instance_type=t3.micro" in cmd
+
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    @patch("subprocess.run")
+    def test_plan_destroy_flag(self, mock_run, mock_which, tools, tmp_path):
+        """terraform_plan includes -destroy flag."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="Destroy plan", stderr="")
+        tools["terraform_plan"](working_dir=str(tmp_path), destroy=True)
+
+        cmd = mock_run.call_args[0][0]
+        assert "-destroy" in cmd
+
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    @patch("subprocess.run")
+    def test_apply_auto_approve(self, mock_run, mock_which, tools, tmp_path):
+        """terraform_apply includes -auto-approve when requested."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="Apply complete!", stderr=""
+        )
+        result = tools["terraform_apply"](
+            working_dir=str(tmp_path), auto_approve=True
+        )
+
+        cmd = mock_run.call_args[0][0]
+        assert "-auto-approve" in cmd
+        assert result["success"] is True
+
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    @patch("subprocess.run")
+    def test_apply_no_auto_approve_default(
+        self, mock_run, mock_which, tools, tmp_path
+    ):
+        """terraform_apply does NOT include -auto-approve by default."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+        tools["terraform_apply"](working_dir=str(tmp_path))
+
+        cmd = mock_run.call_args[0][0]
+        assert "-auto-approve" not in cmd
+
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    @patch("subprocess.run")
+    def test_destroy_auto_approve(self, mock_run, mock_which, tools, tmp_path):
+        """terraform_destroy includes -auto-approve when requested."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="Destroy complete!", stderr=""
+        )
+        result = tools["terraform_destroy"](
+            working_dir=str(tmp_path), auto_approve=True
+        )
+        assert result["success"] is True
+
+        cmd = mock_run.call_args[0][0]
+        assert "-auto-approve" in cmd
+
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    @patch("subprocess.run")
+    def test_show_json_output(self, mock_run, mock_which, tools, tmp_path):
+        """terraform_show parses JSON state output."""
+        state_json = '{"values": {"root_module": {"resources": []}}}'
+        mock_run.return_value = MagicMock(returncode=0, stdout=state_json, stderr="")
+
+        result = tools["terraform_show"](working_dir=str(tmp_path))
+        assert result["success"] is True
+        assert isinstance(result["parsed"], dict)
+
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    @patch("subprocess.run")
+    def test_output_all(self, mock_run, mock_which, tools, tmp_path):
+        """terraform_output returns parsed JSON outputs."""
+        out_json = '{"vpc_id": {"value": "vpc-123", "type": "string"}}'
+        mock_run.return_value = MagicMock(returncode=0, stdout=out_json, stderr="")
+
+        result = tools["terraform_output"](working_dir=str(tmp_path))
+        assert result["success"] is True
+        assert "vpc_id" in result["parsed"]
+
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    @patch("subprocess.run")
+    def test_output_specific_name(self, mock_run, mock_which, tools, tmp_path):
+        """terraform_output appends output_name to the command."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout='"vpc-123"', stderr=""
+        )
+        tools["terraform_output"](working_dir=str(tmp_path), output_name="vpc_id")
+
+        cmd = mock_run.call_args[0][0]
+        assert "vpc_id" in cmd
+
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    @patch("subprocess.run")
+    def test_read_state_extracts_resources(
+        self, mock_run, mock_which, tools, tmp_path
+    ):
+        """terraform_read_state extracts a resource summary."""
+        state_json = (
+            '{"values": {"root_module": {"resources": ['
+            '{"address": "aws_instance.web", "type": "aws_instance", '
+            '"name": "web", "provider_name": "registry.terraform.io/hashicorp/aws"}'
+            "]}}}"
+        )
+        mock_run.return_value = MagicMock(returncode=0, stdout=state_json, stderr="")
+
+        result = tools["terraform_read_state"](working_dir=str(tmp_path))
+        assert result["success"] is True
+        assert len(result["resources"]) == 1
+        assert result["resources"][0]["address"] == "aws_instance.web"
+
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    @patch("subprocess.run")
+    def test_workspace_list_parsing(self, mock_run, mock_which, tools, tmp_path):
+        """terraform_workspace_list parses workspace list output."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="  default\n* dev\n  staging\n",
+            stderr="",
+        )
+        result = tools["terraform_workspace_list"](working_dir=str(tmp_path))
+        assert result["success"] is True
+        assert "default" in result["workspaces"]
+        assert "dev" in result["workspaces"]
+        assert "staging" in result["workspaces"]
+        assert result["current"] == "dev"
+
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    @patch("subprocess.run")
+    def test_workspace_select_success(self, mock_run, mock_which, tools, tmp_path):
+        """terraform_workspace_select passes workspace name to CLI."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout='Switched to workspace "staging".',
+            stderr="",
+        )
+        result = tools["terraform_workspace_select"](
+            working_dir=str(tmp_path), workspace="staging"
+        )
+        assert result["success"] is True
+        assert result["workspace"] == "staging"
+
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    @patch("subprocess.run")
+    def test_import_resource_success(self, mock_run, mock_which, tools, tmp_path):
+        """terraform_import_resource passes address and id to CLI."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="Import successful!",
+            stderr="",
+        )
+        result = tools["terraform_import_resource"](
+            working_dir=str(tmp_path),
+            address="aws_instance.web",
+            resource_id="i-0123456789abcdef0",
+        )
+        assert result["success"] is True
+        assert result["address"] == "aws_instance.web"
+        assert result["resource_id"] == "i-0123456789abcdef0"
+
+        cmd = mock_run.call_args[0][0]
+        assert "import" in cmd
+        assert "aws_instance.web" in cmd
+        assert "i-0123456789abcdef0" in cmd
+
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    @patch("subprocess.run")
+    def test_command_failure(self, mock_run, mock_which, tools, tmp_path):
+        """Non-zero return code is reported as failure."""
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="Error: No configuration files",
+        )
+        result = tools["terraform_validate"](working_dir=str(tmp_path))
+        assert result["success"] is False
+        assert result["return_code"] == 1
+
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    @patch(
+        "subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="terraform", timeout=300),
+    )
+    def test_timeout_handling(self, mock_run, mock_which, tools, tmp_path):
+        """Timeout is caught and reported cleanly."""
+        result = tools["terraform_apply"](
+            working_dir=str(tmp_path), auto_approve=True
+        )
+        assert result.get("success") is False
+        assert "timed out" in result.get("error", "").lower()
+
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    @patch("subprocess.run")
+    def test_tf_in_automation_env(self, mock_run, mock_which, tools, tmp_path):
+        """TF_IN_AUTOMATION and TF_INPUT env vars are always set."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+        tools["terraform_init"](working_dir=str(tmp_path))
+
+        env = mock_run.call_args[1].get("env", {})
+        assert env.get("TF_IN_AUTOMATION") == "1"
+        assert env.get("TF_INPUT") == "0"


### PR DESCRIPTION
## Summary

Adds a new **Terraform tool** integration that enables Hive agents to automate Infrastructure as Code workflows through the Terraform CLI. This provides 12 FastMCP-registered tools covering the complete Terraform lifecycle — from writing configuration and initialising directories to planning, applying, and destroying infrastructure.

Resolves #4773

---

## What's Included

### New Files

| File | Description |
|------|-------------|
| `tools/src/aden_tools/tools/terraform_tool/__init__.py` | Package init exporting `register_tools` |
| `tools/src/aden_tools/tools/terraform_tool/terraform_tool.py` | Core implementation — 12 tools wrapping the Terraform CLI |
| `tools/src/aden_tools/tools/terraform_tool/README.md` | Comprehensive documentation with argument tables, security notes, and example workflows |
| `tools/tests/tools/test_terraform_tool.py` | 43 unit tests covering registration, validation, security, and CLI execution |

### Modified Files

| File | Change |
|------|--------|
| `tools/src/aden_tools/tools/__init__.py` | Import and register `terraform_tool` (no credentials needed) |

---

## Tools Provided

### Core Lifecycle
- **`terraform_init`** — Initialise working directory (providers, backend)
- **`terraform_validate`** — Validate configuration syntax and consistency (JSON output)
- **`terraform_plan`** — Generate execution plan showing proposed changes
- **`terraform_apply`** — Apply changes to create/update infrastructure
- **`terraform_destroy`** — Destroy managed infrastructure

### State & Output
- **`terraform_show`** — Display current state (structured JSON)
- **`terraform_output`** — Read output values
- **`terraform_read_state`** — Read state with resource summary extraction

### Workspace Management
- **`terraform_workspace_list`** — List workspaces, identify current
- **`terraform_workspace_select`** — Switch workspace

### Configuration Management
- **`terraform_write_config`** — Write `.tf` / `.tfvars` files (with extension and path traversal safety)
- **`terraform_import_resource`** — Import existing infrastructure into state

---

## Security Considerations

- **Destructive operations** (`apply`, `destroy`) default to `auto_approve=False` — explicit opt-in required
- **`write_config`** restricts filenames to `.tf` / `.tfvars` and blocks path traversal (`..`, `/`, `\`)
- All commands run with `TF_IN_AUTOMATION=1` and `TF_INPUT=0` to prevent interactive prompts
- State files are never exposed as raw files — accessed only through `terraform show -json`

## Technical Approach

- Executes Terraform CLI via `subprocess.run` with configurable timeout (max 600s)
- Parses JSON output (`-json` flag) for structured, agent-friendly results
- Uses `shutil.which` to verify Terraform is installed before execution
- No external Python dependencies — only stdlib (`subprocess`, `json`, `shutil`, `pathlib`)
- No API credentials required (cloud provider credentials are handled by Terraform itself)

## Test Results

```
43 passed in 0.53s
```

Tests cover:
- ✅ All 12 tools registered correctly
- ✅ Input validation for every tool (invalid directories, empty names)
- ✅ Write config security (path traversal, extension restrictions, empty filenames)
- ✅ Import resource validation (empty address/ID)
- ✅ Subprocess execution with mocked CLI (init, validate, plan, apply, destroy, show, output, workspaces, import)
- ✅ JSON output parsing
- ✅ Timeout handling
- ✅ Terraform-not-installed detection
- ✅ TF_IN_AUTOMATION env var enforcement

## Example Agent Workflow

```
1. Agent generates HCL → terraform_write_config(dir, "main.tf", hcl)
2. Agent initialises → terraform_init(dir)
3. Agent validates → terraform_validate(dir)
4. Agent previews → terraform_plan(dir, variables="region=us-east-1")
5. Agent applies → terraform_apply(dir, auto_approve=True)
6. Agent reads outputs → terraform_output(dir)
7. When done → terraform_destroy(dir, auto_approve=True)
```
