### PR TITLE
fix(csv_read): detect duplicate column names to prevent data loss

### DIFF
--- a/tools/src/aden_tools/tools/csv_tool/csv_tool.py
+++ b/tools/src/aden_tools/tools/csv_tool/csv_tool.py
@@ -54,6 +54,23 @@ def register_tools(mcp: FastMCP) -> None:
 
                 columns = list(reader.fieldnames)
 
+                seen = set()
+                duplicates = set()
+                for col in columns:
+                    if col in seen:
+                        duplicates.add(col)
+                    seen.add(col)
+
+                if duplicates:
+                    sorted_duplicates = sorted(duplicates)
+                    return {
+                        "error": (
+                            f"Duplicate column names detected: {', '.join(sorted_duplicates)}. "
+                            "CSV file has duplicate column names which would result in data loss. "
+                            "Please ensure all column names are unique."
+                        )
+                    }
+
                 # Apply offset and limit
                 rows = []
                 for i, row in enumerate(reader):
@@ -182,6 +199,7 @@ def register_tools(mcp: FastMCP) -> None:
                 reader = csv.DictReader(f)
                 if reader.fieldnames is None:
                     return {"error": "CSV file is empty or has no headers"}
+
                 columns = list(reader.fieldnames)
 
             # Append rows

--- a/tools/tests/tools/test_csv_tool.py
+++ b/tools/tests/tools/test_csv_tool.py
@@ -360,6 +360,41 @@ class TestCsvRead:
         assert result["rows"] == []
         assert result["total_rows"] == 3
 
+    def test_duplicate_column_names_error(self, csv_tool_fn, session_dir, tmp_path):
+        """Return error for CSV with duplicate column names."""
+        csv_file = session_dir / "duplicate.csv"
+        csv_file.write_text("name,name,age\nAlice,Smith,30\nBob,Jones,25\n")
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = csv_tool_fn(
+                path="duplicate.csv",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert "duplicate column" in result["error"].lower()
+        assert "name" in result["error"]
+
+    def test_multiple_duplicate_column_names_error(self, csv_tool_fn, session_dir, tmp_path):
+        """Return error for CSV with multiple duplicate column names."""
+        csv_file = session_dir / "multi_duplicate.csv"
+        csv_file.write_text("a,a,b,b,c\n1,2,3,4,5\n")
+
+        with patch("aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR", str(tmp_path)):
+            result = csv_tool_fn(
+                path="multi_duplicate.csv",
+                workspace_id=TEST_WORKSPACE_ID,
+                agent_id=TEST_AGENT_ID,
+                session_id=TEST_SESSION_ID,
+            )
+
+        assert "error" in result
+        assert "duplicate column" in result["error"].lower()
+        assert "a" in result["error"]
+        assert "b" in result["error"]
+
 
 class TestCsvWrite:
     """Tests for csv_write function."""


### PR DESCRIPTION
## Summary
- Fixed `csv_read` silently losing data when CSV files contain duplicate column names
- Added duplicate column detection that returns an error with the list of duplicate columns
- Added unit tests for single and multiple duplicate column scenarios

## Problem
Python's `csv.DictReader` overwrites values for duplicate keys in dictionaries. When a CSV file has duplicate column names (e.g., `name,name,age`), the `csv_read` function would silently lose data from the earlier columns without any warning to the user.

## Solution
Added duplicate column detection before reading CSV data. If duplicate column names are found:
- The function immediately returns an error response
- The error message lists all duplicate column names
- The user is informed that column names must be unique

## Example
Before fix:
```python
# CSV file: name,name,age
# Alice,Smith,30
# Bob,Jones,25
# Result: silently loses first "name" column data
```

After fix:
```python
# Returns error:
# "Duplicate column names detected: name. CSV file has duplicate column names 
#  which would result in data loss. Please ensure all column names are unique."
```

## Files Changed
- `tools/src/aden_tools/tools/csv_tool/csv_tool.py` - Added duplicate column detection
- `tools/tests/tools/test_csv_tool.py` - Added tests for duplicate column handling

## Testing
- All 51 existing tests continue to pass
- Added 2 new tests for duplicate column scenarios

Resolves #2153
