### PR TITLE
feat(credentials): Pre-flight credential validation with actionable error messages

### DIFF
--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -89,10 +89,37 @@ def main():
 
     register_testing_commands(subparsers)
 
+    # Register doctor command (diagnostic checks)
+    doctor_parser = subparsers.add_parser(
+        "doctor",
+        help="Run diagnostic checks on Hive setup",
+        description="Check credentials, Python version, and dependencies.",
+    )
+    doctor_parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Show suggested fixes for each issue",
+    )
+    doctor_parser.set_defaults(func=_cmd_doctor)
+
     args = parser.parse_args()
 
     if hasattr(args, "func"):
         sys.exit(args.func(args))
+
+
+def _cmd_doctor(args) -> int:
+    """Run diagnostic checks on Hive setup.
+
+    Args:
+        args: Parsed CLI arguments with an optional ``fix`` flag.
+
+    Returns:
+        Exit code: 0 if all checks pass, 1 otherwise.
+    """
+    from framework.cli.doctor import run_doctor
+
+    return run_doctor(fix=getattr(args, "fix", False))
 
 
 if __name__ == "__main__":

--- a/core/framework/cli/__init__.py
+++ b/core/framework/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI sub-package for Hive command implementations."""

--- a/core/framework/cli/doctor.py
+++ b/core/framework/cli/doctor.py
@@ -1,0 +1,144 @@
+"""Diagnostic tool for checking Hive setup.
+
+Provides the ``hive doctor`` command that verifies:
+
+- LLM provider credentials are present and properly formatted.
+- Python version meets the minimum requirement (3.11+).
+- Core dependencies are importable.
+
+This helps new users quickly diagnose configuration issues instead of
+encountering cryptic runtime errors.
+
+Resolves: https://github.com/aden-hive/hive/issues/4391
+
+Usage::
+
+    hive doctor           # Check all providers and dependencies
+    hive doctor --fix     # Attempt automatic fixes (e.g., suggest exports)
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def run_doctor(fix: bool = False) -> int:
+    """Check Hive installation and configuration.
+
+    Runs a series of diagnostic checks and prints a summary indicating
+    which items pass and which require attention.
+
+    Args:
+        fix: If True, print suggested fix commands for each issue.
+
+    Returns:
+        Exit code: 0 if all checks pass, 1 if any issue was found.
+    """
+    print("🏥 Running Hive Doctor...\n")
+
+    issues_found: list[str] = []
+
+    # ── 1. Check credentials ──────────────────────────────────────────
+    _check_credentials(issues_found)
+
+    # ── 2. Check Python version ───────────────────────────────────────
+    _check_python_version(issues_found)
+
+    # ── 3. Check core dependencies ────────────────────────────────────
+    _check_dependencies(issues_found)
+
+    # ── Summary ───────────────────────────────────────────────────────
+    print("\n" + "=" * 60)
+    if not issues_found:
+        print("✅ All checks passed! Hive is ready to use.")
+        return 0
+    else:
+        print(f"❌ Found {len(issues_found)} issue(s). See details above.")
+        if fix:
+            print("\n🔧 Suggested fixes:")
+            for suggestion in issues_found:
+                print(f"  • {suggestion}")
+        else:
+            print("\nRun with --fix to see suggested fixes.")
+        return 1
+
+
+def _check_credentials(issues: list[str]) -> None:
+    """Check LLM provider credentials for presence and basic validity.
+
+    Args:
+        issues: Mutable list to append fix suggestions to.
+    """
+    from framework.credentials.validator import CredentialValidator
+
+    print("📋 Checking credentials...")
+    for provider, config in CredentialValidator.PROVIDERS.items():
+        error = CredentialValidator.validate(provider)
+        if error is None:
+            print(f"  ✅ {config['display_name']}: OK")
+        elif error.error_type == "missing":
+            print(f"  ⚠️  {config['display_name']}: NOT SET")
+            issues.append(
+                f"Set {config['env_var']} — "
+                f"get a key at {config['console_url']}"
+            )
+        else:
+            print(f"  ❌ {config['display_name']}: {error.error_type.upper()}")
+            issues.append(
+                f"Fix {config['env_var']} — "
+                f"{error.error_type} (see {config['console_url']})"
+            )
+
+
+def _check_python_version(issues: list[str]) -> None:
+    """Verify the Python version meets the minimum requirement.
+
+    Args:
+        issues: Mutable list to append fix suggestions to.
+    """
+    print("\n🐍 Checking Python version...")
+    major, minor = sys.version_info.major, sys.version_info.minor
+    if (major, minor) >= (3, 11):
+        print(f"  ✅ Python {major}.{minor}")
+    else:
+        print(f"  ❌ Python {major}.{minor} (need 3.11+)")
+        issues.append(
+            "Upgrade to Python 3.11+: "
+            "https://www.python.org/downloads/"
+        )
+
+
+def _check_dependencies(issues: list[str]) -> None:
+    """Verify that core Hive dependencies are importable.
+
+    Args:
+        issues: Mutable list to append fix suggestions to.
+    """
+    print("\n📦 Checking dependencies...")
+
+    deps = [
+        ("litellm", "LiteLLM (LLM provider)"),
+        ("pydantic", "Pydantic (data models)"),
+    ]
+
+    for module_name, label in deps:
+        try:
+            __import__(module_name)
+            print(f"  ✅ {label}")
+        except ImportError:
+            print(f"  ❌ {label}: NOT INSTALLED")
+            issues.append(f"Install {module_name}: pip install {module_name}")
+
+    # Optional dependencies — warn but don't count as issues
+    optional_deps = [
+        ("textual", "Textual (TUI dashboard)"),
+        ("httpx", "httpx (Aden sync)"),
+    ]
+
+    print("\n📦 Checking optional dependencies...")
+    for module_name, label in optional_deps:
+        try:
+            __import__(module_name)
+            print(f"  ✅ {label}")
+        except ImportError:
+            print(f"  ⚠️  {label}: not installed (optional)")

--- a/core/framework/credentials/__init__.py
+++ b/core/framework/credentials/__init__.py
@@ -76,6 +76,7 @@ from .storage import (
 from .store import CredentialStore
 from .template import TemplateResolver
 from .validation import ensure_credential_key_env, validate_agent_credentials
+from .validator import CredentialIssue, CredentialValidator
 
 # Aden sync components (lazy import to avoid httpx dependency when not needed)
 # Usage: from core.framework.credentials.aden import AdenSyncProvider
@@ -122,6 +123,9 @@ __all__ = [
     # Validation
     "ensure_credential_key_env",
     "validate_agent_credentials",
+    # Pre-flight credential validator (DX-friendly error messages)
+    "CredentialValidator",
+    "CredentialIssue",
     # Interactive setup
     "CredentialSetupSession",
     "MissingCredential",

--- a/core/framework/credentials/validator.py
+++ b/core/framework/credentials/validator.py
@@ -1,0 +1,387 @@
+"""Pre-flight credential validation with actionable error messages.
+
+This module provides user-friendly error messages when LLM provider
+credentials are missing, invalid, or expired. Instead of cryptic errors
+like ``completion() got unexpected keyword argument 'model'``, users see
+clear instructions on what to fix and how.
+
+Resolves: https://github.com/aden-hive/hive/issues/4391
+
+Example::
+
+    from framework.credentials.validator import CredentialValidator
+
+    # Validate before making LLM calls
+    error = CredentialValidator.validate("anthropic")
+    if error:
+        print(error.format_message())
+        raise error.to_exception()
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+from framework.credentials.models import CredentialError
+
+
+# ---------------------------------------------------------------------------
+# Provider registry — maps provider names to their credential metadata.
+# ---------------------------------------------------------------------------
+
+_PROVIDER_REGISTRY: dict[str, dict] = {
+    "anthropic": {
+        "display_name": "Anthropic",
+        "env_var": "ANTHROPIC_API_KEY",
+        "console_url": "https://console.anthropic.com/settings/keys",
+        "config_example": '{\n  "anthropic_api_key": "sk-ant-your-key"\n}',
+        "key_pattern": r"^sk-ant-",
+        "key_hint": "starts with 'sk-ant-'",
+    },
+    "openai": {
+        "display_name": "OpenAI",
+        "env_var": "OPENAI_API_KEY",
+        "console_url": "https://platform.openai.com/api-keys",
+        "config_example": '{\n  "openai_api_key": "sk-your-key"\n}',
+        "key_pattern": r"^sk-",
+        "key_hint": "starts with 'sk-'",
+    },
+    "gemini": {
+        "display_name": "Google Gemini",
+        "env_var": "GEMINI_API_KEY",
+        "console_url": "https://aistudio.google.com/apikey",
+        "config_example": '{\n  "gemini_api_key": "your-key"\n}',
+        "key_pattern": r"^AI",
+        "key_hint": "starts with 'AI'",
+    },
+    "mistral": {
+        "display_name": "Mistral AI",
+        "env_var": "MISTRAL_API_KEY",
+        "console_url": "https://console.mistral.ai/api-keys/",
+        "config_example": '{\n  "mistral_api_key": "your-key"\n}',
+        "key_pattern": r".",
+        "key_hint": "",
+    },
+    "groq": {
+        "display_name": "Groq",
+        "env_var": "GROQ_API_KEY",
+        "console_url": "https://console.groq.com/keys",
+        "config_example": '{\n  "groq_api_key": "gsk_your-key"\n}',
+        "key_pattern": r"^gsk_",
+        "key_hint": "starts with 'gsk_'",
+    },
+    "deepseek": {
+        "display_name": "DeepSeek",
+        "env_var": "DEEPSEEK_API_KEY",
+        "console_url": "https://platform.deepseek.com/api_keys",
+        "config_example": '{\n  "deepseek_api_key": "your-key"\n}',
+        "key_pattern": r".",
+        "key_hint": "",
+    },
+}
+
+# Model prefix → provider mapping for auto-detection.
+_MODEL_PROVIDER_MAP: list[tuple[str, str]] = [
+    ("claude", "anthropic"),
+    ("anthropic/", "anthropic"),
+    ("gpt-", "openai"),
+    ("o1", "openai"),
+    ("o3", "openai"),
+    ("chatgpt", "openai"),
+    ("openai/", "openai"),
+    ("gemini", "gemini"),
+    ("gemini/", "gemini"),
+    ("mistral", "mistral"),
+    ("groq/", "groq"),
+    ("llama", "groq"),
+    ("mixtral", "groq"),
+    ("deepseek", "deepseek"),
+]
+
+
+@dataclass
+class CredentialIssue:
+    """User-friendly credential error with fix instructions.
+
+    Attributes:
+        provider: Human-readable provider name (e.g., "Anthropic").
+        env_var: Environment variable name (e.g., "ANTHROPIC_API_KEY").
+        error_type: One of "missing", "invalid", or "expired".
+        console_url: URL where the user can obtain/regenerate keys.
+        config_example: Example JSON for ``~/.hive/config.json``.
+        key_hint: Hint about expected key format.
+    """
+
+    provider: str
+    env_var: str
+    error_type: str  # "missing", "invalid", "expired"
+    console_url: str
+    config_example: str
+    key_hint: str = ""
+    extra_details: list[str] = field(default_factory=list)
+
+    def format_message(self) -> str:
+        """Generate actionable error message with step-by-step fix instructions.
+
+        Returns:
+            A multi-line string with a nicely formatted error box.
+        """
+        if self.error_type == "missing":
+            return self._format_missing()
+        elif self.error_type == "invalid":
+            return self._format_invalid()
+        elif self.error_type == "expired":
+            return self._format_expired()
+        return self._format_missing()  # Fallback
+
+    def _format_missing(self) -> str:
+        """Format message for a missing credential."""
+        lines = [
+            "",
+            "╔══════════════════════════════════════════════════════════════╗",
+            f"║  ❌ {self.provider} API Key Not Found",
+            "╚══════════════════════════════════════════════════════════════╝",
+            "",
+            f"The {self.provider} API requires an API key, but none was found.",
+            "",
+            f"📍 Missing: {self.env_var} environment variable",
+            "",
+            "🔧 How to Fix:",
+            "",
+            "  1. Get your API key:",
+            f"     👉 {self.console_url}",
+            "",
+            "  2. Set the environment variable:",
+            "",
+            "     # Linux/Mac:",
+            f'     export {self.env_var}="your-api-key-here"',
+            "",
+            "     # Windows:",
+            f"     set {self.env_var}=your-api-key-here",
+            "",
+            "  3. Or add to config file:",
+            "",
+            "     # ~/.hive/config.json",
+            f"     {self.config_example}",
+            "",
+            "  4. Verify setup:",
+            "     hive doctor  # Run diagnostic check",
+            "",
+            "📚 Full guide: https://docs.hive.aden.ai/credentials",
+            "",
+        ]
+        return "\n".join(lines)
+
+    def _format_invalid(self) -> str:
+        """Format message for an invalid credential."""
+        # Safely show last 4 chars of the key for identification
+        current_key = os.getenv(self.env_var, "")
+        masked = f"...{current_key[-4:]}" if len(current_key) > 4 else "(set but short)"
+
+        lines = [
+            "",
+            "╔══════════════════════════════════════════════════════════════╗",
+            f"║  ❌ {self.provider} API Key Invalid",
+            "╚══════════════════════════════════════════════════════════════╝",
+            "",
+            f"The {self.provider} API key doesn't match the expected format.",
+            "",
+            f"🔧 How to Fix:",
+            "",
+            f"  1. Check if your key is correct:",
+            f"     Current: {self.env_var}={masked}",
+        ]
+
+        if self.key_hint:
+            lines.append(f"     Expected: key {self.key_hint}")
+
+        lines.extend([
+            "",
+            "  2. Generate a new key:",
+            f"     👉 {self.console_url}",
+            "",
+            "  3. Update your environment variable:",
+            f'     export {self.env_var}="new-key-here"',
+            "",
+            "  4. Common issues:",
+            "     • Extra spaces or newlines in the key value",
+            "     • Using a revoked or deleted key",
+            "     • Copying only part of the key",
+            "",
+            "📚 More help: https://docs.hive.aden.ai/troubleshooting",
+            "",
+        ])
+        return "\n".join(lines)
+
+    def _format_expired(self) -> str:
+        """Format message for an expired credential."""
+        lines = [
+            "",
+            "╔══════════════════════════════════════════════════════════════╗",
+            f"║  ❌ {self.provider} Credentials Expired",
+            "╚══════════════════════════════════════════════════════════════╝",
+            "",
+            f"Your {self.provider} credentials have expired or been revoked.",
+            "",
+            "🔧 How to Fix:",
+            "",
+            "  1. Generate new credentials:",
+            f"     👉 {self.console_url}",
+            "",
+            "  2. Update configuration:",
+            f'     export {self.env_var}="new-key-here"',
+            "",
+            "📚 Credential rotation guide: https://docs.hive.aden.ai/rotation",
+            "",
+        ]
+        return "\n".join(lines)
+
+    def to_exception(self) -> CredentialError:
+        """Convert this issue into a ``CredentialError`` with the formatted message.
+
+        Returns:
+            A CredentialError whose string representation is the human-readable
+            actionable error message.
+        """
+        return CredentialError(self.format_message())
+
+
+class CredentialValidator:
+    """Validates LLM credentials before use and provides helpful errors.
+
+    Uses a registry of known providers to check environment variables for
+    presence and basic format validity.
+
+    Example::
+
+        error = CredentialValidator.validate("anthropic")
+        if error:
+            print(error.format_message())
+
+        # Or validate by model name
+        error = CredentialValidator.validate_for_model("claude-3-haiku-20240307")
+        if error:
+            raise error.to_exception()
+    """
+
+    PROVIDERS = _PROVIDER_REGISTRY
+
+    @classmethod
+    def get_provider_for_model(cls, model: str) -> Optional[str]:
+        """Determine the provider name from a model identifier.
+
+        Args:
+            model: Model string (e.g., "claude-3-haiku-20240307",
+                   "gpt-4o-mini", "gemini/gemini-1.5-flash").
+
+        Returns:
+            Provider key (e.g., "anthropic") or None if unrecognised.
+        """
+        model_lower = model.lower()
+        for prefix, provider in _MODEL_PROVIDER_MAP:
+            if model_lower.startswith(prefix):
+                return provider
+        return None
+
+    @classmethod
+    def validate(cls, provider: str) -> Optional[CredentialIssue]:
+        """Validate credentials for a provider.
+
+        Args:
+            provider: Provider key (e.g., "anthropic", "openai").
+
+        Returns:
+            A ``CredentialIssue`` if validation fails, ``None`` if valid.
+        """
+        if provider not in cls.PROVIDERS:
+            return None  # Unknown provider — skip validation
+
+        config = cls.PROVIDERS[provider]
+        api_key = os.getenv(config["env_var"])
+
+        # Phase 1: Check presence
+        if not api_key or not api_key.strip():
+            return CredentialIssue(
+                provider=config["display_name"],
+                env_var=config["env_var"],
+                error_type="missing",
+                console_url=config["console_url"],
+                config_example=config["config_example"],
+                key_hint=config.get("key_hint", ""),
+            )
+
+        # Phase 2: Basic format check (only if pattern is meaningful)
+        pattern = config.get("key_pattern", ".")
+        if pattern != "." and not re.match(pattern, api_key.strip()):
+            return CredentialIssue(
+                provider=config["display_name"],
+                env_var=config["env_var"],
+                error_type="invalid",
+                console_url=config["console_url"],
+                config_example=config["config_example"],
+                key_hint=config.get("key_hint", ""),
+            )
+
+        return None  # Valid!
+
+    @classmethod
+    def validate_for_model(cls, model: str) -> Optional[CredentialIssue]:
+        """Validate credentials based on a model name.
+
+        Convenience method that auto-detects the provider from the model
+        string and validates accordingly.
+
+        Args:
+            model: Model identifier (e.g., "claude-3-haiku-20240307").
+
+        Returns:
+            A ``CredentialIssue`` if validation fails, ``None`` if valid.
+        """
+        provider = cls.get_provider_for_model(model)
+        if provider is None:
+            return None  # Can't determine provider — skip
+        return cls.validate(provider)
+
+    @classmethod
+    def validate_multiple(cls, providers: list[str]) -> list[CredentialIssue]:
+        """Validate credentials for multiple providers.
+
+        Args:
+            providers: List of provider keys to validate.
+
+        Returns:
+            List of ``CredentialIssue`` objects for all failures.
+        """
+        issues = []
+        for provider in providers:
+            issue = cls.validate(provider)
+            if issue is not None:
+                issues.append(issue)
+        return issues
+
+    @classmethod
+    def format_multiple_issues(cls, issues: list[CredentialIssue]) -> str:
+        """Format multiple credential issues into a single summary.
+
+        Args:
+            issues: List of credential issues to format.
+
+        Returns:
+            Combined human-readable error string.
+        """
+        if not issues:
+            return ""
+
+        parts = []
+        for issue in issues:
+            parts.append(issue.format_message())
+
+        header = (
+            "\n╔══════════════════════════════════════════════════════════════╗\n"
+            f"║  ❌ {len(issues)} Credential Issue(s) Found\n"
+            "╚══════════════════════════════════════════════════════════════╝\n"
+        )
+        return header + "\n".join(parts)

--- a/core/tests/test_credential_validator.py
+++ b/core/tests/test_credential_validator.py
@@ -1,0 +1,353 @@
+"""Unit tests for the pre-flight credential validator.
+
+Tests cover:
+- Missing credential detection
+- Invalid key format detection
+- Valid credential pass-through
+- Model-to-provider mapping
+- Multi-provider validation
+- Error message formatting
+- CredentialIssue.to_exception()
+
+Resolves: https://github.com/aden-hive/hive/issues/4391
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Ensure framework is importable
+_core_dir = Path(__file__).resolve().parent.parent
+if str(_core_dir) not in sys.path:
+    sys.path.insert(0, str(_core_dir))
+
+from framework.credentials.validator import (
+    CredentialIssue,
+    CredentialValidator,
+)
+
+
+# ── Missing credential detection ─────────────────────────────────────────
+
+
+class TestMissingCredential:
+    """Tests that missing credentials are properly detected."""
+
+    def test_missing_anthropic_key(self, monkeypatch):
+        """Verify missing ANTHROPIC_API_KEY is detected."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        error = CredentialValidator.validate("anthropic")
+
+        assert error is not None
+        assert error.error_type == "missing"
+        assert error.env_var == "ANTHROPIC_API_KEY"
+        assert error.provider == "Anthropic"
+
+    def test_missing_openai_key(self, monkeypatch):
+        """Verify missing OPENAI_API_KEY is detected."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        error = CredentialValidator.validate("openai")
+
+        assert error is not None
+        assert error.error_type == "missing"
+        assert error.env_var == "OPENAI_API_KEY"
+
+    def test_empty_string_key_is_missing(self, monkeypatch):
+        """Verify that an empty string API key is treated as missing."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+
+        error = CredentialValidator.validate("anthropic")
+
+        assert error is not None
+        assert error.error_type == "missing"
+
+    def test_whitespace_only_key_is_missing(self, monkeypatch):
+        """Verify that a whitespace-only API key is treated as missing."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "   ")
+
+        error = CredentialValidator.validate("anthropic")
+
+        assert error is not None
+        assert error.error_type == "missing"
+
+
+# ── Invalid key format detection ──────────────────────────────────────────
+
+
+class TestInvalidCredential:
+    """Tests that incorrectly formatted credentials are flagged."""
+
+    def test_invalid_anthropic_key_format(self, monkeypatch):
+        """Verify invalid Anthropic key format is detected."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "invalid-key-123")
+
+        error = CredentialValidator.validate("anthropic")
+
+        assert error is not None
+        assert error.error_type == "invalid"
+
+    def test_invalid_openai_key_format(self, monkeypatch):
+        """Verify invalid OpenAI key format is detected."""
+        monkeypatch.setenv("OPENAI_API_KEY", "not-a-real-key")
+
+        error = CredentialValidator.validate("openai")
+
+        assert error is not None
+        assert error.error_type == "invalid"
+
+    def test_invalid_groq_key_format(self, monkeypatch):
+        """Verify invalid Groq key format is detected."""
+        monkeypatch.setenv("GROQ_API_KEY", "not-gsk-key")
+
+        error = CredentialValidator.validate("groq")
+
+        assert error is not None
+        assert error.error_type == "invalid"
+
+
+# ── Valid credential pass-through ─────────────────────────────────────────
+
+
+class TestValidCredential:
+    """Tests that properly formatted credentials pass validation."""
+
+    def test_valid_anthropic_key(self, monkeypatch):
+        """Verify valid Anthropic key passes validation."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-" + "a" * 95)
+
+        error = CredentialValidator.validate("anthropic")
+
+        assert error is None
+
+    def test_valid_openai_key(self, monkeypatch):
+        """Verify valid OpenAI key passes validation."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-" + "a" * 48)
+
+        error = CredentialValidator.validate("openai")
+
+        assert error is None
+
+    def test_valid_groq_key(self, monkeypatch):
+        """Verify valid Groq key passes validation."""
+        monkeypatch.setenv("GROQ_API_KEY", "gsk_" + "a" * 40)
+
+        error = CredentialValidator.validate("groq")
+
+        assert error is None
+
+    def test_unknown_provider_returns_none(self):
+        """Verify unknown providers return None (skip validation)."""
+        error = CredentialValidator.validate("totally_unknown_provider")
+
+        assert error is None
+
+
+# ── Model-to-provider mapping ────────────────────────────────────────────
+
+
+class TestModelProviderMapping:
+    """Tests that model names are correctly mapped to providers."""
+
+    @pytest.mark.parametrize(
+        "model,expected_provider",
+        [
+            ("claude-3-haiku-20240307", "anthropic"),
+            ("claude-3-opus", "anthropic"),
+            ("claude-haiku-4-5-20251001", "anthropic"),
+            ("gpt-4o-mini", "openai"),
+            ("gpt-4-turbo", "openai"),
+            ("o1-mini", "openai"),
+            ("gemini/gemini-1.5-flash", "gemini"),
+            ("gemini-pro", "gemini"),
+            ("groq/llama3-70b", "groq"),
+            ("deepseek/deepseek-chat", "deepseek"),
+            ("mistral-large", "mistral"),
+        ],
+    )
+    def test_model_to_provider(self, model, expected_provider):
+        """Verify model name maps to the correct provider."""
+        provider = CredentialValidator.get_provider_for_model(model)
+        assert provider == expected_provider
+
+    def test_unknown_model_returns_none(self):
+        """Verify unknown model returns None."""
+        provider = CredentialValidator.get_provider_for_model("some-random-model")
+        assert provider is None
+
+    def test_validate_for_model_missing_key(self, monkeypatch):
+        """Verify validate_for_model catches missing keys."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        error = CredentialValidator.validate_for_model("claude-3-haiku-20240307")
+
+        assert error is not None
+        assert error.error_type == "missing"
+        assert "ANTHROPIC_API_KEY" in error.format_message()
+
+    def test_validate_for_model_unknown_model(self):
+        """Verify validate_for_model returns None for unknown models."""
+        error = CredentialValidator.validate_for_model("some-random-model")
+        assert error is None
+
+
+# ── Multi-provider validation ─────────────────────────────────────────────
+
+
+class TestMultiProviderValidation:
+    """Tests for validating multiple providers at once."""
+
+    def test_validate_multiple_all_missing(self, monkeypatch):
+        """Verify all missing credentials are detected."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        issues = CredentialValidator.validate_multiple(["anthropic", "openai"])
+
+        assert len(issues) == 2
+        providers = {i.provider for i in issues}
+        assert "Anthropic" in providers
+        assert "OpenAI" in providers
+
+    def test_validate_multiple_partial(self, monkeypatch):
+        """Verify only missing credentials are flagged when some are set."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-" + "a" * 95)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        issues = CredentialValidator.validate_multiple(["anthropic", "openai"])
+
+        assert len(issues) == 1
+        assert issues[0].provider == "OpenAI"
+
+    def test_validate_multiple_all_valid(self, monkeypatch):
+        """Verify no issues when all credentials are valid."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-" + "a" * 95)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-" + "a" * 48)
+
+        issues = CredentialValidator.validate_multiple(["anthropic", "openai"])
+
+        assert len(issues) == 0
+
+
+# ── Error message formatting ─────────────────────────────────────────────
+
+
+class TestErrorMessageFormatting:
+    """Tests for human-readable error message content."""
+
+    def test_missing_message_contains_env_var(self, monkeypatch):
+        """Verify the missing error message contains the env var name."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        error = CredentialValidator.validate("anthropic")
+        message = error.format_message()
+
+        assert "ANTHROPIC_API_KEY" in message
+
+    def test_missing_message_contains_console_url(self, monkeypatch):
+        """Verify the missing error message contains the provider URL."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        error = CredentialValidator.validate("anthropic")
+        message = error.format_message()
+
+        assert "console.anthropic.com" in message
+
+    def test_missing_message_contains_export_command(self, monkeypatch):
+        """Verify the missing error message contains the export command."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        error = CredentialValidator.validate("anthropic")
+        message = error.format_message()
+
+        assert "export ANTHROPIC_API_KEY" in message
+
+    def test_missing_message_contains_doctor_hint(self, monkeypatch):
+        """Verify the missing error message mentions hive doctor."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        error = CredentialValidator.validate("anthropic")
+        message = error.format_message()
+
+        assert "hive doctor" in message
+
+    def test_invalid_message_contains_format_hint(self, monkeypatch):
+        """Verify the invalid error message mentions expected format."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "bad-key")
+
+        error = CredentialValidator.validate("anthropic")
+        message = error.format_message()
+
+        assert "Invalid" in message or "invalid" in message
+        assert "ANTHROPIC_API_KEY" in message
+
+    def test_expired_message_formatting(self):
+        """Verify the expired error message formatting."""
+        issue = CredentialIssue(
+            provider="TestProvider",
+            env_var="TEST_API_KEY",
+            error_type="expired",
+            console_url="https://example.com/keys",
+            config_example='{"key": "value"}',
+        )
+        message = issue.format_message()
+
+        assert "Expired" in message or "expired" in message
+        assert "TEST_API_KEY" in message
+        assert "example.com" in message
+
+
+# ── CredentialIssue.to_exception ──────────────────────────────────────────
+
+
+class TestCredentialIssueToException:
+    """Tests for converting CredentialIssue to CredentialError."""
+
+    def test_to_exception_returns_credential_error(self, monkeypatch):
+        """Verify to_exception returns a CredentialError."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        from framework.credentials.models import CredentialError
+
+        error = CredentialValidator.validate("anthropic")
+        exc = error.to_exception()
+
+        assert isinstance(exc, CredentialError)
+        assert "ANTHROPIC_API_KEY" in str(exc)
+
+    def test_to_exception_is_raisable(self, monkeypatch):
+        """Verify the exception can be raised and caught."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        from framework.credentials.models import CredentialError
+
+        error = CredentialValidator.validate("openai")
+
+        with pytest.raises(CredentialError, match="OPENAI_API_KEY"):
+            raise error.to_exception()
+
+
+# ── Format multiple issues ────────────────────────────────────────────────
+
+
+class TestFormatMultipleIssues:
+    """Tests for formatting multiple credential issues together."""
+
+    def test_format_empty_list(self):
+        """Verify empty issues list returns empty string."""
+        result = CredentialValidator.format_multiple_issues([])
+        assert result == ""
+
+    def test_format_multiple_includes_count(self, monkeypatch):
+        """Verify multiple issues are formatted with a count header."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        issues = CredentialValidator.validate_multiple(["anthropic", "openai"])
+        result = CredentialValidator.format_multiple_issues(issues)
+
+        assert "2 Credential Issue(s) Found" in result


### PR DESCRIPTION
Resolves #4391

## Summary

When LLM provider credentials are missing or invalid, users previously saw cryptic, unhelpful errors like `completion() got unexpected keyword argument 'model'` that gave no indication of the root cause. This PR adds **pre-flight credential validation** with clear, actionable error messages and a new `hive doctor` diagnostic command.

## What Changed

### New Files

| File | Purpose |
|------|---------|
| `core/framework/credentials/validator.py` | Pre-flight credential validation with provider registry and rich error messages |
| `core/framework/cli/__init__.py` | CLI sub-package init |
| `core/framework/cli/doctor.py` | `hive doctor` diagnostic command |
| `core/tests/test_credential_validator.py` | 38 comprehensive unit tests |

### Modified Files

| File | Change |
|------|--------|
| `core/framework/llm/litellm.py` | Added pre-flight credential check in `__init__` (+15 lines) |
| `core/framework/llm/anthropic.py` | Replaced cryptic `ValueError` with actionable `CredentialError` (+19 lines) |
| `core/framework/cli.py` | Registered `hive doctor` command (+27 lines) |
| `core/framework/credentials/__init__.py` | Exported `CredentialValidator` and `CredentialIssue` (+4 lines) |

## Before vs After

### Before (cryptic):
```
$ hive run my_agent.py
Error: completion() got unexpected keyword argument 'model'
```

### After (actionable):
```
╔══════════════════════════════════════════════════════════════╗
║  ❌ Anthropic API Key Not Found
╚══════════════════════════════════════════════════════════════╝

The Anthropic API requires an API key, but none was found.

📍 Missing: ANTHROPIC_API_KEY environment variable

🔧 How to Fix:

  1. Get your API key:
     👉 https://console.anthropic.com/settings/keys

  2. Set the environment variable:
     export ANTHROPIC_API_KEY="your-api-key-here"

  3. Or add to config file:
     # ~/.hive/config.json

  4. Verify setup:
     hive doctor  # Run diagnostic check
```

## Key Design Decisions

1. **Warning-level in LiteLLMProvider**: The pre-flight check in `LiteLLMProvider.__init__` logs a warning instead of raising — this is because LiteLLM supports many providers and the key might be passed via other mechanisms. The explicit check in `AnthropicProvider` raises an error since there's no ambiguity.

2. **Provider registry**: Uses a data-driven approach (`_PROVIDER_REGISTRY`) mapping providers to their env vars, console URLs, key patterns, and config examples. Easy to extend for new providers.

3. **Model auto-detection**: `_MODEL_PROVIDER_MAP` maps model name prefixes to providers, enabling `validate_for_model("claude-3-haiku")` to automatically check `ANTHROPIC_API_KEY`.

4. **Graceful degradation**: All validator imports are wrapped in `try/except ImportError` so the system works even if the validator module isn't available.

5. **No breaking changes**: Only adds better error messages. All existing behavior is preserved.

## Supported Providers

| Provider | Env Var | Key Validation |
|----------|---------|----------------|
| Anthropic | `ANTHROPIC_API_KEY` | Prefix `sk-ant-` |
| OpenAI | `OPENAI_API_KEY` | Prefix `sk-` |
| Google Gemini | `GEMINI_API_KEY` | Prefix `AI` |
| Groq | `GROQ_API_KEY` | Prefix `gsk_` |
| Mistral | `MISTRAL_API_KEY` | Presence only |
| DeepSeek | `DEEPSEEK_API_KEY` | Presence only |

## Testing

38 unit tests covering:
- Missing credential detection (4 tests)
- Invalid key format detection (3 tests)
- Valid credential pass-through (4 tests)
- Model-to-provider mapping (14 tests)
- Multi-provider validation (3 tests)
- Error message formatting (6 tests)
- Exception conversion (2 tests)
- Multi-issue formatting (2 tests)

All tests pass: `38 passed in 2.80s`
