### PR TITLE
fix(verify_mcp): remove unused return value from check() helper `micro-fix`

### DIFF
--- a/core/verify_mcp.py
+++ b/core/verify_mcp.py
@@ -32,11 +32,10 @@ class Colors:
     NC = "\033[0m"
 
 
-def check(description: str) -> bool:
-    """Print check description and return a context manager for result."""
+def check(description: str) -> None:
+    """Print check description to stdout."""
     logger.info(f"Checking {description}... ", extra={"end": ""})
     sys.stdout.flush()
-    return True
 
 
 def success(msg: str = "OK"):


### PR DESCRIPTION
## Summary

- Fix the `check()` helper function in `core/verify_mcp.py` to return `None` instead of an unused `bool` value
- Update the docstring to accurately describe the function's purpose (it prints a check description, not a context manager)

## Changes

The `check()` function previously:
- Returned `True` but the return value was never used by any caller
- Had a misleading docstring claiming it returned "a context manager for result"

Now it:
- Explicitly returns `None` (implicitly)
- Has an accurate docstring: "Print check description to stdout."

## Testing

- Verified Python syntax compiles correctly
- Ran ruff linter: all checks passed

Resolves #2133
