### PR TITLE
fix: use DEFAULT_MAX_TOKENS (8192) instead of hardcoded 40000 in hive_coder

### DIFF
--- a/core/framework/agents/hive_coder/config.py
+++ b/core/framework/agents/hive_coder/config.py
@@ -1,32 +1,17 @@
 """Runtime configuration for Hive Coder agent."""
 
-import json
 from dataclasses import dataclass, field
-from pathlib import Path
 
-
-def _load_preferred_model() -> str:
-    """Load preferred model from ~/.hive/configuration.json."""
-    config_path = Path.home() / ".hive" / "configuration.json"
-    if config_path.exists():
-        try:
-            with open(config_path) as f:
-                config = json.load(f)
-            llm = config.get("llm", {})
-            if llm.get("provider") and llm.get("model"):
-                return f"{llm['provider']}/{llm['model']}"
-        except Exception:
-            pass
-    return "anthropic/claude-sonnet-4-20250514"
+from framework.config import get_preferred_model, get_max_tokens, get_api_key, get_api_base
 
 
 @dataclass
 class RuntimeConfig:
-    model: str = field(default_factory=_load_preferred_model)
+    model: str = field(default_factory=get_preferred_model)
     temperature: float = 0.7
-    max_tokens: int = 40000
-    api_key: str | None = None
-    api_base: str | None = None
+    max_tokens: int = field(default_factory=get_max_tokens)
+    api_key: str | None = field(default_factory=get_api_key)
+    api_base: str | None = field(default_factory=get_api_base)
 
 
 default_config = RuntimeConfig()

--- a/core/framework/agents/hive_coder/reference/file_templates.md
+++ b/core/framework/agents/hive_coder/reference/file_templates.md
@@ -7,34 +7,9 @@ Complete code templates for each file in a Hive agent package.
 ```python
 """Runtime configuration."""
 
-import json
 from dataclasses import dataclass, field
-from pathlib import Path
 
-
-def _load_preferred_model() -> str:
-    """Load preferred model from ~/.hive/configuration.json."""
-    config_path = Path.home() / ".hive" / "configuration.json"
-    if config_path.exists():
-        try:
-            with open(config_path) as f:
-                config = json.load(f)
-            llm = config.get("llm", {})
-            if llm.get("provider") and llm.get("model"):
-                return f"{llm['provider']}/{llm['model']}"
-        except Exception:
-            pass
-    return "anthropic/claude-sonnet-4-20250514"
-
-
-@dataclass
-class RuntimeConfig:
-    model: str = field(default_factory=_load_preferred_model)
-    temperature: float = 0.7
-    max_tokens: int = 40000
-    api_key: str | None = None
-    api_base: str | None = None
-
+from framework.config import RuntimeConfig
 
 default_config = RuntimeConfig()
 


### PR DESCRIPTION
## Summary

- Fixed `hive_coder/config.py` to use `get_max_tokens()` instead of hardcoded `40000`
- Updated `file_templates.md` to use `framework.config.RuntimeConfig` pattern

## Problem

The `hive_coder` agent had `max_tokens=40000` hardcoded, which exceeds OpenAI model limits:
- OpenAI GPT-4o: 16384 max completion tokens
- This caused `OpenAIException: max_tokens is too large: 40000` runtime failures

## Solution

Changed `hive_coder/config.py` to use the centralized configuration functions:
- `get_max_tokens()` → returns `DEFAULT_MAX_TOKENS` (8192)
- `get_preferred_model()` → loads model from `~/.hive/configuration.json`
- `get_api_key()` → handles API key resolution
- `get_api_base()` → handles custom API base URLs

This aligns `hive_coder` with all other agent templates (deep_research_agent, tech_news_reporter, etc.) which already use `framework.config.RuntimeConfig`.

## Files Changed

- `core/framework/agents/hive_coder/config.py` - Use centralized config functions
- `core/framework/agents/hive_coder/reference/file_templates.md` - Update template to use RuntimeConfig

## Testing

The change was verified by:
1. Confirming `DEFAULT_MAX_TOKENS = 8192` in `framework/graph/edge.py`
2. Ensuring the new config follows the same pattern as other agent templates

Resolves #3988
