### PR TITLE
feat: Add output-first response style for faster time-to-value

### DIFF
--- a/core/framework/graph/edge.py
+++ b/core/framework/graph/edge.py
@@ -454,6 +454,16 @@ class GraphSpec(BaseModel):
         ),
     )
 
+    response_style: str = Field(
+        default="output_first",
+        description=(
+            "Controls how the agent structures responses. "
+            "'output_first' (default): Lead with the answer/output, then add context. "
+            "Ask clarifying questions only when genuinely ambiguous. "
+            "'conversational': Traditional conversational style with introductions and clarifications."
+        ),
+    )
+
     # Metadata
     description: str = ""
     created_by: str = ""  # "human" or "builder_agent"

--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -1197,6 +1197,7 @@ class GraphExecutor:
                             focus_prompt=next_spec.system_prompt,
                             narrative=narrative,
                             accounts_prompt=self.accounts_prompt or None,
+                            response_style=getattr(graph, "response_style", "output_first"),
                         )
                         continuous_conversation.update_system_prompt(new_system)
 

--- a/core/framework/runtime/execution_stream.py
+++ b/core/framework/runtime/execution_stream.py
@@ -752,6 +752,7 @@ class ExecutionStream:
             loop_config=self.graph.loop_config,
             conversation_mode=self.graph.conversation_mode,
             identity_prompt=self.graph.identity_prompt,
+            response_style=self.graph.response_style,
         )
 
     async def wait_for_completion(

--- a/core/tests/test_continuous_conversation.py
+++ b/core/tests/test_continuous_conversation.py
@@ -23,7 +23,9 @@ from framework.graph.executor import GraphExecutor
 from framework.graph.goal import Goal
 from framework.graph.node import NodeResult, NodeSpec, SharedMemory
 from framework.graph.prompt_composer import (
+    RESPONSE_STYLES,
     build_narrative,
+    build_response_style_prompt,
     build_transition_marker,
     compose_system_prompt,
 )
@@ -159,6 +161,43 @@ class TestComposeSystemPrompt:
     def test_empty(self):
         result = compose_system_prompt(identity_prompt=None, focus_prompt=None)
         assert "Current date and time:" in result
+
+
+class TestResponseStyle:
+    def test_build_response_style_output_first(self):
+        result = build_response_style_prompt("output_first")
+        assert "LEAD WITH THE ANSWER" in result
+        assert "BE CONCISE" in result
+        assert "FAST TIME-TO-VALUE" in result
+
+    def test_build_response_style_conversational(self):
+        result = build_response_style_prompt("conversational")
+        assert "conversational assistant" in result
+        assert "Greet users" in result
+
+    def test_build_response_style_unknown_defaults_to_output_first(self):
+        result = build_response_style_prompt("unknown_style")
+        assert "LEAD WITH THE ANSWER" in result
+
+    def test_compose_includes_output_first_style_by_default(self):
+        result = compose_system_prompt(
+            identity_prompt="I am a research agent.",
+            focus_prompt="Focus on writing the report.",
+        )
+        assert "LEAD WITH THE ANSWER" in result
+
+    def test_compose_includes_conversational_style_when_specified(self):
+        result = compose_system_prompt(
+            identity_prompt="I am a research agent.",
+            focus_prompt="Focus on writing the report.",
+            response_style="conversational",
+        )
+        assert "conversational assistant" in result
+        assert "LEAD WITH THE ANSWER" not in result
+
+    def test_response_style_styles_dict_has_required_keys(self):
+        assert "output_first" in RESPONSE_STYLES
+        assert "conversational" in RESPONSE_STYLES
 
 
 class TestBuildNarrative:

--- a/examples/templates/deep_research_agent/agent.py
+++ b/examples/templates/deep_research_agent/agent.py
@@ -198,6 +198,7 @@ class DeepResearchAgent:
                 "max_tool_calls_per_turn": 20,
                 "max_history_tokens": 32000,
             },
+            response_style="output_first",
         )
 
     def _setup(self, mock_mode: bool = False) -> None:


### PR DESCRIPTION

## Summary

This PR addresses issue #4030 by implementing an `output_first` response style that instructs agents to prioritize delivering answers over conversational filler.

**Key Changes:**
- Added `response_style` field to `GraphSpec` with two options: `output_first` (default) and `conversational`
- The `output_first` style is now the default, promoting faster time-to-value for users
- Updated prompt composition to include response style guidance in the system prompt
- Simplified node prompts in the `deep_research_agent` template to leverage the output-first style

## Problem

Users reported that agents often respond with multi-line conversational framing and clarification questions before delivering the actual answer. This delays value for users who already have clear intent.

Examples:
- "I'd be happy to help with that!"
- "Good question! Let me think..."
- Asking clarifying questions when the prompt is not actually ambiguous

## Solution

Added a `response_style` configuration option that controls how agents structure their responses:

### `output_first` (default)
```
1. LEAD WITH THE ANSWER. When the user's request is clear, provide the output/result first.
2. BE CONCISE. No introductions, no "good question" filler, no restating the obvious.
3. CLARIFY ONLY WHEN AMBIGUOUS. If the request is genuinely unclear, ask 1-2 focused questions.
   Do not ask clarifying questions when a reasonable interpretation exists.
4. CONTEXT AFTER OUTPUT. Add explanation, alternatives, or follow-up suggestions after the main answer.
5. NO CONVERSATIONAL FILLER. Skip "I'd be happy to help" or "Let me think about that."
```

### `conversational`
Traditional style for use cases that benefit from a warmer tone.

## Files Changed

- `core/framework/graph/edge.py` - Add `response_style` field to `GraphSpec`
- `core/framework/graph/prompt_composer.py` - Add `RESPONSE_STYLES` dict and `build_response_style_prompt()` function
- `core/framework/graph/executor.py` - Pass `response_style` to `compose_system_prompt()`
- `core/framework/runtime/execution_stream.py` - Include `response_style` in graph cloning
- `core/tests/test_continuous_conversation.py` - Add tests for response style functionality
- `examples/templates/deep_research_agent/agent.py` - Use `output_first` style
- `examples/templates/deep_research_agent/nodes/__init__.py` - Simplify prompts for output-first style
- `.claude/skills/hive-create/examples/deep_research_agent/nodes/__init__.py` - Updated template

## Testing

Added comprehensive tests for the response style feature:
- Test that `output_first` style contains expected guidance
- Test that `conversational` style contains expected guidance
- Test that unknown styles default to `output_first`
- Test that `compose_system_prompt()` includes response style by default
- Test that `RESPONSE_STYLES` dict has required keys

## Backwards Compatibility

- Default behavior is now `output_first` (more direct responses)
- To restore previous conversational behavior, set `response_style="conversational"` in GraphSpec
- Existing agents continue to work, but will now use the output-first style by default

Resolves #4030
