### PR TITLE
feat: local credential testing

### DIFF
--- a/core/framework/agents/credential_tester/__init__.py
+++ b/core/framework/agents/credential_tester/__init__.py
@@ -1,17 +1,21 @@
 """
-Credential Tester — verify synced credentials via live API calls.
+Credential Tester — verify credentials (Aden OAuth + local API keys) via live API calls.
 
-Interactive agent that lists connected accounts, lets the user pick one,
+Interactive agent that lists all testable accounts, lets the user pick one,
 loads the provider's tools, and runs a chat session to test the credential.
 """
 
 from .agent import (
     CredentialTesterAgent,
+    _list_aden_accounts,
+    _list_env_fallback_accounts,
+    _list_local_accounts,
     configure_for_account,
     conversation_mode,
     edges,
     entry_node,
     entry_points,
+    get_tools_for_provider,
     goal,
     identity_prompt,
     list_connected_accounts,
@@ -35,6 +39,7 @@ __all__ = [
     "edges",
     "entry_node",
     "entry_points",
+    "get_tools_for_provider",
     "goal",
     "identity_prompt",
     "list_connected_accounts",
@@ -45,4 +50,8 @@ __all__ = [
     "skip_credential_validation",
     "skip_guardian",
     "terminal_nodes",
+    # Internal list helpers (exposed for testing)
+    "_list_aden_accounts",
+    "_list_local_accounts",
+    "_list_env_fallback_accounts",
 ]

--- a/core/framework/agents/credential_tester/agent.py
+++ b/core/framework/agents/credential_tester/agent.py
@@ -116,8 +116,7 @@ def _list_local_accounts() -> list[dict]:
         from framework.credentials.local.registry import LocalCredentialRegistry
 
         return [
-            info.to_account_dict()
-            for info in LocalCredentialRegistry.default().list_accounts()
+            info.to_account_dict() for info in LocalCredentialRegistry.default().list_accounts()
         ]
     except Exception:
         return []
@@ -257,7 +256,8 @@ def _activate_local_account(credential_id: str, alias: str) -> None:
     group_specs = [
         (cred_name, spec)
         for cred_name, spec in CREDENTIAL_SPECS.items()
-        if spec.credential_group == credential_id or spec.credential_id == credential_id
+        if spec.credential_group == credential_id
+        or spec.credential_id == credential_id
         or cred_name == credential_id
     ]
     # Deduplicate — credential_id and credential_group may both match the same spec
@@ -270,7 +270,7 @@ def _activate_local_account(credential_id: str, alias: str) -> None:
         registry = LocalCredentialRegistry.default()
         flat_storage = EncryptedFileStorage()
 
-        for cred_name, spec in group_specs:
+        for _cred_name, spec in group_specs:
             if spec.env_var in seen_env_vars:
                 continue
             # If env var is already set, nothing to do for this one

--- a/core/framework/agents/credential_tester/agent.py
+++ b/core/framework/agents/credential_tester/agent.py
@@ -1,7 +1,8 @@
-"""Credential Tester agent — verify synced credentials via live API calls.
+"""Credential Tester agent — verify credentials via live API calls.
 
-A framework agent that lets the user pick a connected account and test it
-by making real API calls via the provider's tools.
+Supports both Aden OAuth2-synced accounts AND locally-stored API key accounts.
+Aden accounts use account="alias" routing; local accounts inject the key into
+the session environment so tools read it without an account= parameter.
 
 When loaded via AgentRunner.load() (TUI picker, ``hive run``), the module-level
 ``nodes`` / ``edges`` variables provide a static graph.  The TUI detects
@@ -40,7 +41,7 @@ if TYPE_CHECKING:
 goal = Goal(
     id="credential-tester",
     name="Credential Tester",
-    description="Verify that a synced credential can make real API calls.",
+    description="Verify that a credential can make real API calls.",
     success_criteria=[
         SuccessCriterion(
             id="api-call-success",
@@ -59,51 +60,148 @@ goal = Goal(
 
 
 def get_tools_for_provider(provider_name: str) -> list[str]:
-    """Collect tool names for a specific Aden credential by credential_id.
+    """Collect tool names for a credential by credential_id OR credential_group.
 
-    Matches on ``credential_id`` (e.g. "google" → Gmail tools only),
-    NOT ``aden_provider_name`` which can be shared across products
-    (e.g. both google and google_docs have aden_provider_name="google").
+    Matches on both ``credential_id`` (e.g. "google" → Gmail tools) and
+    ``credential_group`` (e.g. "google_custom_search" → all google search tools).
     """
     from aden_tools.credentials import CREDENTIAL_SPECS
 
     tools: list[str] = []
     for spec in CREDENTIAL_SPECS.values():
-        if spec.credential_id == provider_name:
+        if spec.credential_id == provider_name or spec.credential_group == provider_name:
             tools.extend(spec.tools)
     return sorted(set(tools))
 
 
-def list_connected_accounts() -> list[dict]:
-    """List connected accounts from GET /v1/credentials."""
+def _list_aden_accounts() -> list[dict]:
+    """List active accounts from the Aden platform (requires ADEN_API_KEY)."""
     import os
-
-    from framework.credentials.aden.client import AdenClientConfig, AdenCredentialClient
 
     api_key = os.environ.get("ADEN_API_KEY")
     if not api_key:
         return []
 
-    client = AdenCredentialClient(
-        AdenClientConfig(
-            base_url=os.environ.get("ADEN_API_URL", "https://api.adenhq.com"),
-        )
-    )
     try:
-        integrations = client.list_integrations()
-    finally:
-        client.close()
+        from framework.credentials.aden.client import AdenClientConfig, AdenCredentialClient
 
-    return [
-        {
-            "provider": c.provider,
-            "alias": c.alias,
-            "identity": {"email": c.email} if c.email else {},
-            "integration_id": c.integration_id,
-        }
-        for c in integrations
-        if c.status == "active"
+        client = AdenCredentialClient(
+            AdenClientConfig(
+                base_url=os.environ.get("ADEN_API_URL", "https://api.adenhq.com"),
+            )
+        )
+        try:
+            integrations = client.list_integrations()
+        finally:
+            client.close()
+
+        return [
+            {
+                "provider": c.provider,
+                "alias": c.alias,
+                "identity": {"email": c.email} if c.email else {},
+                "integration_id": c.integration_id,
+                "source": "aden",
+            }
+            for c in integrations
+            if c.status == "active"
+        ]
+    except Exception:
+        return []
+
+
+def _list_local_accounts() -> list[dict]:
+    """List named local API key accounts from LocalCredentialRegistry."""
+    try:
+        from framework.credentials.local.registry import LocalCredentialRegistry
+
+        return [
+            info.to_account_dict()
+            for info in LocalCredentialRegistry.default().list_accounts()
+        ]
+    except Exception:
+        return []
+
+
+def _list_env_fallback_accounts() -> list[dict]:
+    """Surface configured-but-unregistered credentials as testable entries.
+
+    Detects credentials available via env vars OR stored in the encrypted
+    store in the old flat format (e.g. ``brave_search`` with no alias).
+    These are users who haven't yet run ``save_account()`` but have a working key.
+    Shows with alias="default" and status="unknown".
+    """
+    import os
+
+    from aden_tools.credentials import CREDENTIAL_SPECS
+
+    # Collect IDs in encrypted store (includes old flat entries like "brave_search")
+    try:
+        from framework.credentials.storage import EncryptedFileStorage
+
+        encrypted_ids: set[str] = set(EncryptedFileStorage().list_all())
+    except Exception:
+        encrypted_ids = set()
+
+    def _is_configured(cred_name: str, spec) -> bool:
+        # 1. Env var present
+        if os.environ.get(spec.env_var):
+            return True
+        # 2. Old flat encrypted entry (no slash — new entries have {x}/{y})
+        if cred_name in encrypted_ids:
+            return True
+        return False
+
+    seen_groups: set[str] = set()
+    accounts: list[dict] = []
+
+    for cred_name, spec in CREDENTIAL_SPECS.items():
+        if not spec.direct_api_key_supported or not spec.tools:
+            continue
+
+        if spec.credential_group:
+            if spec.credential_group in seen_groups:
+                continue
+            group_available = all(
+                _is_configured(n, s)
+                for n, s in CREDENTIAL_SPECS.items()
+                if s.credential_group == spec.credential_group
+            )
+            if not group_available:
+                continue
+            seen_groups.add(spec.credential_group)
+            provider = spec.credential_group
+        else:
+            if not _is_configured(cred_name, spec):
+                continue
+            provider = cred_name
+
+        accounts.append(
+            {
+                "provider": provider,
+                "alias": "default",
+                "identity": {},
+                "integration_id": None,
+                "source": "local",
+                "status": "unknown",
+            }
+        )
+
+    return accounts
+
+
+def list_connected_accounts() -> list[dict]:
+    """List all testable accounts: Aden-synced + named local + env-var fallbacks."""
+    aden = _list_aden_accounts()
+    local = _list_local_accounts()
+
+    # Show env-var fallbacks only for credentials not already in the named registry
+    local_providers = {a["provider"] for a in local}
+    env_fallbacks = [
+        a for a in _list_env_fallback_accounts() if a["provider"] not in local_providers
     ]
+
+    return aden + local + env_fallbacks
 
 
 # ---------------------------------------------------------------------------
@@ -123,22 +221,101 @@ requires_account_selection = True
 def configure_for_account(runner: AgentRunner, account: dict) -> None:
     """Scope the tester node's tools to the selected provider.
 
-    Called by the TUI after the user picks an account from the picker.
-    After scoping, re-enables credential validation so the selected
-    provider's credentials are checked before the agent starts.
+    Handles both Aden accounts (account= routing) and local accounts
+    (session-level env var injection, no account= parameter in prompt).
     """
     provider = account["provider"]
-    tools = get_tools_for_provider(provider)
-    tools.append("get_account_info")
-
+    source = account.get("source", "aden")
     alias = account.get("alias", "unknown")
-    email = account.get("identity", {}).get("email", "")
-    detail = f" (email: {email})" if email else ""
+    identity = account.get("identity", {})
+    tools = get_tools_for_provider(provider)
 
+    if source == "aden":
+        tools.append("get_account_info")
+        email = identity.get("email", "")
+        detail = f" (email: {email})" if email else ""
+        _configure_aden_node(runner, provider, alias, detail, tools)
+    else:
+        status = account.get("status", "unknown")
+        _activate_local_account(provider, alias)
+        _configure_local_node(runner, provider, alias, identity, tools, status)
+
+
+def _activate_local_account(credential_id: str, alias: str) -> None:
+    """Inject a named local account's key into the session environment.
+
+    Handles three cases:
+    1. Named account in LocalCredentialRegistry (new format: {credential_id}/{alias})
+    2. Old flat credential in EncryptedFileStorage (id == credential_id, no alias)
+    3. Env var already set — skip injection (nothing to do)
+    """
+    import os
+
+    from aden_tools.credentials import CREDENTIAL_SPECS
+
+    # Collect specs for this credential (handles grouped credentials too)
+    group_specs = [
+        (cred_name, spec)
+        for cred_name, spec in CREDENTIAL_SPECS.items()
+        if spec.credential_group == credential_id or spec.credential_id == credential_id
+        or cred_name == credential_id
+    ]
+    # Deduplicate — credential_id and credential_group may both match the same spec
+    seen_env_vars: set[str] = set()
+
+    try:
+        from framework.credentials.local.registry import LocalCredentialRegistry
+        from framework.credentials.storage import EncryptedFileStorage
+
+        registry = LocalCredentialRegistry.default()
+        flat_storage = EncryptedFileStorage()
+
+        for cred_name, spec in group_specs:
+            if spec.env_var in seen_env_vars:
+                continue
+            # If env var is already set, nothing to do for this one
+            if os.environ.get(spec.env_var):
+                seen_env_vars.add(spec.env_var)
+                continue
+
+            seen_env_vars.add(spec.env_var)
+
+            # Determine key name based on spec
+            key_name = "api_key"
+            if spec.credential_group and "cse" in spec.env_var.lower():
+                key_name = "cse_id"
+
+            key: str | None = None
+
+            # 1. Try named account in registry (new format)
+            if alias != "default":
+                key = registry.get_key(credential_id, alias, key_name)
+            else:
+                # For "default" alias, check registry first, then fall back to flat store
+                key = registry.get_key(credential_id, "default", key_name)
+
+            # 2. Fall back to old flat encrypted entry (id == credential_id, no alias)
+            if key is None:
+                flat_cred = flat_storage.load(credential_id)
+                if flat_cred is not None:
+                    key = flat_cred.get_key(key_name) or flat_cred.get_default_key()
+
+            if key:
+                os.environ[spec.env_var] = key
+    except Exception:
+        pass
+
+
+def _configure_aden_node(
+    runner: AgentRunner,
+    provider: str,
+    alias: str,
+    detail: str,
+    tools: list[str],
+) -> None:
     for node in runner.graph.nodes:
         if node.id == "tester":
             node.tools = sorted(set(tools))
-            # Update system prompt to be provider-specific
             node.system_prompt = f"""\
 You are a credential tester for the account: {provider}/{alias}{detail}
 
@@ -165,19 +342,60 @@ or any other identifier — always use the alias exactly as shown.
 """
             break
 
-    # Set intro message for TUI display
     runner.intro_message = (
         f"Testing {provider}/{alias}{detail} — "
         f"{len(tools)} tools loaded. "
-        f"I'll suggest a read-only API call to verify the credential works."
+        "I'll suggest a read-only API call to verify the credential works."
+    )
+
+
+def _configure_local_node(
+    runner: AgentRunner,
+    provider: str,
+    alias: str,
+    identity: dict,
+    tools: list[str],
+    status: str,
+) -> None:
+    identity_parts = [f"{k}: {v}" for k, v in identity.items() if v]
+    detail = f" ({', '.join(identity_parts)})" if identity_parts else ""
+    status_note = " [key not yet validated]" if status == "unknown" else ""
+
+    for node in runner.graph.nodes:
+        if node.id == "tester":
+            node.tools = sorted(set(tools))
+            node.system_prompt = f"""\
+You are a credential tester for the local API key: {provider}/{alias}{detail}{status_note}
+
+# Instructions
+
+1. Suggest a simple test call to verify the credential works \
+(e.g. search for "test", list items, get profile info).
+2. Execute the call when the user agrees.
+3. Report the result: success (with sample data) or failure (with error).
+4. Let the user request additional API calls to further test the credential.
+
+# Rules
+
+- Do NOT pass an `account` parameter — this credential is injected \
+directly into the session environment and tools read it automatically.
+- Start with read-only operations before write operations.
+- Always confirm with the user before performing write operations.
+- If a call fails, report the exact error — this helps diagnose credential issues.
+- Be concise. No emojis.
+"""
+            break
+
+    runner.intro_message = (
+        f"Testing {provider}/{alias}{detail} — "
+        f"{len(tools)} tools loaded. "
+        "I'll suggest a test API call to verify the credential works."
     )
 
 
 # ---------------------------------------------------------------------------
 # Module-level graph variables (read by AgentRunner.load)
 # ---------------------------------------------------------------------------
-# The static node starts with minimal tools. configure_for_account() scopes
-# it to the selected provider's tools before execution.
 
 nodes = [
     NodeSpec(
@@ -195,7 +413,7 @@ nodes = [
         tools=["get_account_info"],
         system_prompt="""\
 You are a credential tester. Your job is to help the user verify that their \
-connected accounts can make real API calls.
+connected accounts and API keys can make real API calls.
 
 # Startup
 
@@ -208,12 +426,11 @@ connected accounts can make real API calls.
 6. Report the result: success (with sample data) or failure (with error).
 7. Let the user request additional API calls to further test the credential.
 
-# Account routing
+# Account routing (Aden accounts only)
 
-IMPORTANT: Always pass the account's **alias** as the ``account`` parameter \
-when calling any tool. The alias is the routing key — never use the email or \
-any other identifier. For example, if the alias is "Timothy", call \
-``gmail_list_messages(account="Timothy", ...)``.
+IMPORTANT: For Aden-synced accounts, always pass the account's **alias** as the \
+``account`` parameter when calling any tool. For local API key accounts, do NOT \
+pass an account parameter — they are pre-injected into the session.
 
 # Rules
 
@@ -234,7 +451,8 @@ terminal_nodes = []  # Forever-alive: loops until user exits
 
 conversation_mode = "continuous"
 identity_prompt = (
-    "You are a credential tester that verifies connected accounts can make real API calls."
+    "You are a credential tester that verifies connected accounts and API keys "
+    "can make real API calls."
 )
 loop_config = {
     "max_iterations": 50,
@@ -255,7 +473,6 @@ class CredentialTesterAgent:
         accounts = agent.list_accounts()
         agent.select_account(accounts[0])
         await agent.start()
-        # ... user chats via TUI or CLI ...
         await agent.stop()
     """
 
@@ -267,7 +484,7 @@ class CredentialTesterAgent:
         self._storage_path: Path | None = None
 
     def list_accounts(self) -> list[dict]:
-        """List connected accounts from the Aden credential store."""
+        """List all testable accounts (Aden + local named + env-var fallbacks)."""
         return list_connected_accounts()
 
     def select_account(self, account: dict) -> None:
@@ -275,7 +492,7 @@ class CredentialTesterAgent:
 
         Args:
             account: Account dict from list_accounts() with
-                     provider, alias, identity keys.
+                     provider, alias, identity, source keys.
         """
         self._selected_account = account
 
@@ -294,14 +511,21 @@ class CredentialTesterAgent:
     def _build_graph(self) -> GraphSpec:
         provider = self.selected_provider
         alias = self.selected_alias
+        source = self._selected_account.get("source", "aden")
         identity = self._selected_account.get("identity", {})
         tools = get_tools_for_provider(provider)
+
+        if source == "local":
+            _activate_local_account(provider, alias)
+        elif source == "aden":
+            tools.append("get_account_info")
 
         tester_node = build_tester_node(
             provider=provider,
             alias=alias,
             tools=tools,
             identity=identity,
+            source=source,
         )
 
         return GraphSpec(

--- a/core/framework/agents/credential_tester/nodes/__init__.py
+++ b/core/framework/agents/credential_tester/nodes/__init__.py
@@ -8,17 +8,37 @@ def build_tester_node(
     alias: str,
     tools: list[str],
     identity: dict[str, str],
+    source: str = "aden",
 ) -> NodeSpec:
     """Build the tester node dynamically for the selected account.
 
     Args:
-        provider: Aden provider name (e.g. "google", "slack").
-        alias: User-set alias (e.g. "Timothy").
+        provider: Provider / credential name (e.g. "google", "brave_search").
+        alias: User-set alias (e.g. "Timothy", "work").
         tools: Tool names available for this provider.
         identity: Identity dict (email, workspace, etc.) for context.
+        source: "aden" or "local" — controls routing instructions in the prompt.
     """
     detail_parts = [f"{k}: {v}" for k, v in identity.items() if v]
     detail = f" ({', '.join(detail_parts)})" if detail_parts else ""
+
+    if source == "aden":
+        routing_section = f"""\
+# Account routing
+
+IMPORTANT: Always pass `account="{alias}"` when calling any tool. \
+This routes the API call to the correct credential. Never use the email \
+or any other identifier — always use the alias exactly as shown.
+"""
+    else:
+        routing_section = """\
+# Credential routing
+
+This is a local API key credential — do NOT pass an `account` parameter. \
+The key is pre-injected into the session environment and tools read it automatically.
+"""
+
+    account_label = "account" if source == "aden" else "local API key"
 
     return NodeSpec(
         id="tester",
@@ -34,22 +54,17 @@ def build_tester_node(
         output_keys=[],
         tools=tools,
         system_prompt=f"""\
-You are a credential tester for the account: {provider}/{alias}{detail}
+You are a credential tester for the {account_label}: {provider}/{alias}{detail}
 
 Your job is to help the user verify that this credential works by making \
 real API calls using the available tools.
 
-# Account routing
-
-IMPORTANT: Always pass `account="{alias}"` when calling any tool. \
-This routes the API call to the correct credential. Never use the email \
-or any other identifier — always use the alias exactly as shown.
-
+{routing_section}
 # Instructions
 
 1. Start by greeting the user and confirming which account you're testing.
 2. Suggest a simple, safe, read-only API call to verify the credential works \
-(e.g. list messages, list channels, list contacts).
+(e.g. list messages, list channels, list contacts, search for "test").
 3. Execute the call when the user agrees.
 4. Report the result clearly: success (with sample data) or failure (with error).
 5. Let the user request additional API calls to further test the credential.

--- a/core/framework/credentials/__init__.py
+++ b/core/framework/credentials/__init__.py
@@ -92,6 +92,14 @@ try:
 except ImportError:
     _ADEN_AVAILABLE = False
 
+# Local credential registry (named API key accounts with identity metadata)
+try:
+    from .local import LocalAccountInfo, LocalCredentialRegistry
+
+    _LOCAL_AVAILABLE = True
+except ImportError:
+    _LOCAL_AVAILABLE = False
+
 __all__ = [
     # Main store
     "CredentialStore",
@@ -133,7 +141,11 @@ __all__ = [
     "AdenCredentialClient",
     "AdenClientConfig",
     "AdenCachedStorage",
+    # Local credential registry (optional - requires cryptography)
+    "LocalCredentialRegistry",
+    "LocalAccountInfo",
 ]
 
 # Track Aden availability for runtime checks
 ADEN_AVAILABLE = _ADEN_AVAILABLE
+LOCAL_AVAILABLE = _LOCAL_AVAILABLE

--- a/core/framework/credentials/local/__init__.py
+++ b/core/framework/credentials/local/__init__.py
@@ -1,0 +1,31 @@
+"""
+Local credential registry — named API key accounts with identity metadata.
+
+Provides feature parity with Aden OAuth credentials for locally-stored API keys:
+aliases, identity metadata, status tracking, CRUD, and health validation.
+
+Usage:
+    from framework.credentials.local import LocalCredentialRegistry, LocalAccountInfo
+
+    registry = LocalCredentialRegistry.default()
+
+    # Add a named account
+    info, health = registry.save_account("brave_search", "work", "BSA-xxx")
+
+    # List all stored local accounts
+    for account in registry.list_accounts():
+        print(f"{account.credential_id}/{account.alias}: {account.status}")
+        if account.identity.is_known:
+            print(f"  Identity: {account.identity.label}")
+
+    # Re-validate a stored account
+    result = registry.validate_account("github", "personal")
+"""
+
+from .models import LocalAccountInfo
+from .registry import LocalCredentialRegistry
+
+__all__ = [
+    "LocalAccountInfo",
+    "LocalCredentialRegistry",
+]

--- a/core/framework/credentials/local/models.py
+++ b/core/framework/credentials/local/models.py
@@ -1,0 +1,58 @@
+"""
+Data models for the local credential registry.
+
+LocalAccountInfo mirrors AdenIntegrationInfo, giving local API key credentials
+the same identity/status metadata as Aden OAuth credentials.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from framework.credentials.models import CredentialIdentity
+
+
+@dataclass
+class LocalAccountInfo:
+    """
+    A locally-stored named credential account.
+
+    Mirrors AdenIntegrationInfo so local and Aden accounts can be treated
+    uniformly in the credential tester and account selection UI.
+
+    Attributes:
+        credential_id: The logical credential name (e.g. "brave_search", "github")
+        alias: User-provided name for this account (e.g. "work", "personal")
+        status: "active" | "failed" | "unknown"
+        identity: Email, username, workspace, or account_id extracted from health check
+        last_validated: When the key was last verified against the live API
+        created_at: When this account was first stored
+    """
+
+    credential_id: str
+    alias: str
+    status: str = "unknown"
+    identity: CredentialIdentity = field(default_factory=CredentialIdentity)
+    last_validated: datetime | None = None
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+    @property
+    def storage_id(self) -> str:
+        """The key used in EncryptedFileStorage: '{credential_id}/{alias}'."""
+        return f"{self.credential_id}/{self.alias}"
+
+    def to_account_dict(self) -> dict:
+        """
+        Format compatible with AccountSelectionScreen and configure_for_account().
+
+        Same shape as Aden account dicts, with source='local' added.
+        """
+        return {
+            "provider": self.credential_id,
+            "alias": self.alias,
+            "identity": self.identity.to_dict(),
+            "integration_id": None,
+            "source": "local",
+            "status": self.status,
+        }

--- a/core/framework/credentials/local/registry.py
+++ b/core/framework/credentials/local/registry.py
@@ -1,0 +1,328 @@
+"""
+Local Credential Registry.
+
+Manages named local API key accounts stored in EncryptedFileStorage.
+Mirrors the Aden integration model so local credentials have feature parity:
+aliases, identity metadata, status tracking, CRUD, and health validation.
+
+Storage convention:
+    {credential_id}/{alias}  →  CredentialObject
+    e.g. "brave_search/work" →  { api_key: "BSA-xxx", _alias: "work",
+                                   _integration_type: "brave_search",
+                                   _status: "active",
+                                   _identity_username: "acme", ... }
+
+Usage:
+    registry = LocalCredentialRegistry.default()
+
+    # Add a new account
+    info, health = registry.save_account("brave_search", "work", "BSA-xxx")
+    print(info.status, info.identity.label)
+
+    # List all accounts
+    for account in registry.list_accounts():
+        print(f"{account.credential_id}/{account.alias}: {account.status}")
+
+    # Get the raw API key for a specific account
+    key = registry.get_key("github", "personal")
+
+    # Re-validate a stored account
+    result = registry.validate_account("github", "personal")
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from pydantic import SecretStr
+
+from framework.credentials.models import CredentialIdentity, CredentialKey, CredentialObject
+from framework.credentials.storage import EncryptedFileStorage
+
+from .models import LocalAccountInfo
+
+if TYPE_CHECKING:
+    from aden_tools.credentials.health_check import HealthCheckResult
+
+logger = logging.getLogger(__name__)
+
+_SEPARATOR = "/"
+
+
+class LocalCredentialRegistry:
+    """
+    Named local API key account store backed by EncryptedFileStorage.
+
+    Provides the same list/save/get/delete/validate surface as the Aden
+    client, but for locally-stored API keys.
+    """
+
+    def __init__(self, storage: EncryptedFileStorage) -> None:
+        self._storage = storage
+
+    # ------------------------------------------------------------------
+    # Listing
+    # ------------------------------------------------------------------
+
+    def list_accounts(self, credential_id: str | None = None) -> list[LocalAccountInfo]:
+        """
+        List all stored local accounts.
+
+        Args:
+            credential_id: If given, filter to this credential type only.
+
+        Returns:
+            List of LocalAccountInfo sorted by credential_id then alias.
+        """
+        all_ids = self._storage.list_all()
+        accounts: list[LocalAccountInfo] = []
+
+        for storage_id in all_ids:
+            if _SEPARATOR not in storage_id:
+                continue  # Skip legacy un-aliased entries
+
+            try:
+                cred_obj = self._storage.load(storage_id)
+            except Exception as exc:
+                logger.debug("Skipping unreadable credential %s: %s", storage_id, exc)
+                continue
+
+            if cred_obj is None:
+                continue
+
+            info = self._to_account_info(cred_obj)
+            if info is None:
+                continue
+
+            if credential_id and info.credential_id != credential_id:
+                continue
+
+            accounts.append(info)
+
+        return sorted(accounts, key=lambda a: (a.credential_id, a.alias))
+
+    # ------------------------------------------------------------------
+    # Save / add
+    # ------------------------------------------------------------------
+
+    def save_account(
+        self,
+        credential_id: str,
+        alias: str,
+        api_key: str,
+        run_health_check: bool = True,
+        extra_keys: dict[str, str] | None = None,
+    ) -> tuple[LocalAccountInfo, HealthCheckResult | None]:
+        """
+        Store a named account, optionally validating it first.
+
+        Args:
+            credential_id: Logical credential name (e.g. "brave_search").
+            alias: User-chosen name (e.g. "work"). Defaults to "default".
+            api_key: The raw API key / token value.
+            run_health_check: If True, verify the key against the live API
+                and extract identity metadata. Failure still saves with
+                status="failed" so the user can re-validate later.
+            extra_keys: Additional key/value pairs to store (e.g.
+                cse_id for google_custom_search).
+
+        Returns:
+            (LocalAccountInfo, HealthCheckResult | None)
+        """
+        alias = alias or "default"
+        health_result: HealthCheckResult | None = None
+        identity: dict[str, str] = {}
+        status = "active"
+
+        if run_health_check:
+            try:
+                from aden_tools.credentials.health_check import check_credential_health
+
+                kwargs: dict[str, Any] = {}
+                if extra_keys and "cse_id" in extra_keys:
+                    kwargs["cse_id"] = extra_keys["cse_id"]
+
+                health_result = check_credential_health(credential_id, api_key, **kwargs)
+                status = "active" if health_result.valid else "failed"
+                identity = health_result.details.get("identity", {})
+            except Exception as exc:
+                logger.warning("Health check failed for %s/%s: %s", credential_id, alias, exc)
+                status = "unknown"
+
+        storage_id = f"{credential_id}{_SEPARATOR}{alias}"
+        now = datetime.now(UTC)
+
+        cred_obj = CredentialObject(id=storage_id)
+        cred_obj.set_key("api_key", api_key)
+        cred_obj.set_key("_alias", alias)
+        cred_obj.set_key("_integration_type", credential_id)
+        cred_obj.set_key("_status", status)
+
+        if extra_keys:
+            for k, v in extra_keys.items():
+                cred_obj.set_key(k, v)
+
+        if identity:
+            valid_fields = set(CredentialIdentity.model_fields)
+            filtered = {k: v for k, v in identity.items() if k in valid_fields}
+            if filtered:
+                cred_obj.set_identity(**filtered)
+
+        cred_obj.last_refreshed = now if run_health_check else None
+        self._storage.save(cred_obj)
+
+        account_info = LocalAccountInfo(
+            credential_id=credential_id,
+            alias=alias,
+            status=status,
+            identity=cred_obj.identity,
+            last_validated=cred_obj.last_refreshed,
+            created_at=cred_obj.created_at,
+        )
+        return account_info, health_result
+
+    # ------------------------------------------------------------------
+    # Get
+    # ------------------------------------------------------------------
+
+    def get_account(self, credential_id: str, alias: str) -> CredentialObject | None:
+        """Load the raw CredentialObject for a specific account."""
+        return self._storage.load(f"{credential_id}{_SEPARATOR}{alias}")
+
+    def get_key(self, credential_id: str, alias: str, key_name: str = "api_key") -> str | None:
+        """
+        Return the stored secret value for a specific account.
+
+        Args:
+            credential_id: Logical credential name (e.g. "brave_search").
+            alias: Account alias (e.g. "work").
+            key_name: Key within the credential (default "api_key").
+
+        Returns:
+            The secret value, or None if not found.
+        """
+        cred = self.get_account(credential_id, alias)
+        if cred is None:
+            return None
+        return cred.get_key(key_name)
+
+    def get_account_info(self, credential_id: str, alias: str) -> LocalAccountInfo | None:
+        """Load a LocalAccountInfo for a specific account."""
+        cred = self.get_account(credential_id, alias)
+        if cred is None:
+            return None
+        return self._to_account_info(cred)
+
+    # ------------------------------------------------------------------
+    # Delete
+    # ------------------------------------------------------------------
+
+    def delete_account(self, credential_id: str, alias: str) -> bool:
+        """
+        Remove a stored account.
+
+        Returns:
+            True if the account existed and was deleted, False otherwise.
+        """
+        return self._storage.delete(f"{credential_id}{_SEPARATOR}{alias}")
+
+    # ------------------------------------------------------------------
+    # Validate
+    # ------------------------------------------------------------------
+
+    def validate_account(self, credential_id: str, alias: str) -> HealthCheckResult:
+        """
+        Re-run health check for a stored account and update its status.
+
+        Args:
+            credential_id: Logical credential name.
+            alias: Account alias.
+
+        Returns:
+            HealthCheckResult from the live API check.
+
+        Raises:
+            KeyError: If the account doesn't exist.
+        """
+        from aden_tools.credentials.health_check import HealthCheckResult, check_credential_health
+
+        cred = self.get_account(credential_id, alias)
+        if cred is None:
+            raise KeyError(f"No local account found: {credential_id}/{alias}")
+
+        api_key = cred.get_key("api_key")
+        if not api_key:
+            return HealthCheckResult(valid=False, message="No api_key stored for this account")
+
+        try:
+            kwargs: dict[str, Any] = {}
+            cse_id = cred.get_key("cse_id")
+            if cse_id:
+                kwargs["cse_id"] = cse_id
+
+            result = check_credential_health(credential_id, api_key, **kwargs)
+        except Exception as exc:
+            result = HealthCheckResult(
+                valid=False,
+                message=f"Health check error: {exc}",
+                details={"error": str(exc)},
+            )
+
+        # Update status and timestamp in-place
+        new_status = "active" if result.valid else "failed"
+        cred.set_key("_status", new_status)
+        cred.last_refreshed = datetime.now(UTC)
+
+        # Re-extract identity if available
+        identity = result.details.get("identity", {})
+        if identity:
+            valid_fields = set(CredentialIdentity.model_fields)
+            filtered = {k: v for k, v in identity.items() if k in valid_fields}
+            if filtered:
+                cred.set_identity(**filtered)
+
+        self._storage.save(cred)
+        return result
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def default(cls) -> LocalCredentialRegistry:
+        """Create a registry using the default encrypted storage at ~/.hive/credentials."""
+        return cls(EncryptedFileStorage())
+
+    @classmethod
+    def at_path(cls, path: str | Path) -> LocalCredentialRegistry:
+        """Create a registry using a custom storage path."""
+        return cls(EncryptedFileStorage(base_path=path))
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _to_account_info(self, cred_obj: CredentialObject) -> LocalAccountInfo | None:
+        """Build LocalAccountInfo from a CredentialObject."""
+        cred_type_key = cred_obj.keys.get("_integration_type")
+        if cred_type_key is None:
+            return None
+        cred_id = cred_type_key.get_secret_value()
+
+        alias_key = cred_obj.keys.get("_alias")
+        alias = alias_key.get_secret_value() if alias_key else cred_obj.id.split(_SEPARATOR, 1)[-1]
+
+        status_key = cred_obj.keys.get("_status")
+        status = status_key.get_secret_value() if status_key else "unknown"
+
+        return LocalAccountInfo(
+            credential_id=cred_id,
+            alias=alias,
+            status=status,
+            identity=cred_obj.identity,
+            last_validated=cred_obj.last_refreshed,
+            created_at=cred_obj.created_at,
+        )

--- a/core/framework/credentials/local/registry.py
+++ b/core/framework/credentials/local/registry.py
@@ -37,9 +37,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from pydantic import SecretStr
-
-from framework.credentials.models import CredentialIdentity, CredentialKey, CredentialObject
+from framework.credentials.models import CredentialIdentity, CredentialObject
 from framework.credentials.storage import EncryptedFileStorage
 
 from .models import LocalAccountInfo

--- a/core/framework/mcp/agent_builder_server.py
+++ b/core/framework/mcp/agent_builder_server.py
@@ -3413,9 +3413,7 @@ def list_stored_credentials() -> str:
                 "storage_id": info.storage_id,
                 "status": info.status,
                 "created_at": info.created_at.isoformat() if info.created_at else None,
-                "last_validated": info.last_validated.isoformat()
-                if info.last_validated
-                else None,
+                "last_validated": info.last_validated.isoformat() if info.last_validated else None,
             }
             identity = info.identity.to_dict()
             if identity:

--- a/core/framework/mcp/agent_builder_server.py
+++ b/core/framework/mcp/agent_builder_server.py
@@ -3338,6 +3338,11 @@ def store_credential(
         str, "Logical credential name (e.g., 'hubspot', 'brave_search', 'anthropic')"
     ],
     credential_value: Annotated[str, "The secret value to store (API key, token, etc.)"],
+    alias: Annotated[
+        str,
+        "Named alias for this account (e.g., 'work', 'personal'). Defaults to 'default'. "
+        "Use aliases to store multiple accounts for the same service.",
+    ] = "default",
     key_name: Annotated[
         str, "Key name within the credential (e.g., 'api_key', 'access_token')"
     ] = "api_key",
@@ -3347,38 +3352,42 @@ def store_credential(
     Store a credential securely in the local encrypted store at ~/.hive/credentials.
 
     Uses Fernet encryption (AES-128-CBC + HMAC). Requires HIVE_CREDENTIAL_KEY env var.
+
+    Credentials are stored as {credential_name}/{alias}, allowing multiple named accounts
+    per service (e.g., 'brave_search/work', 'brave_search/personal').
+    A health check is run automatically to validate the key and extract identity metadata.
     """
     try:
-        from pydantic import SecretStr
+        from framework.credentials.local.registry import LocalCredentialRegistry
 
-        from framework.credentials import CredentialKey, CredentialObject
-
-        store = _get_credential_store()
-
-        if not display_name:
-            display_name = credential_name.replace("_", " ").title()
-
-        cred = CredentialObject(
-            id=credential_name,
-            name=display_name,
-            keys={
-                key_name: CredentialKey(
-                    name=key_name,
-                    value=SecretStr(credential_value),
-                )
-            },
+        registry = LocalCredentialRegistry.default()
+        info, health_result = registry.save_account(
+            credential_id=credential_name,
+            alias=alias,
+            api_key=credential_value,
+            run_health_check=True,
         )
-        store.save_credential(cred)
 
-        return json.dumps(
-            {
-                "success": True,
-                "credential": credential_name,
-                "key": key_name,
-                "location": "~/.hive/credentials",
-                "encrypted": True,
+        result: dict = {
+            "success": True,
+            "credential": credential_name,
+            "alias": alias,
+            "storage_id": info.storage_id,
+            "status": info.status,
+            "location": "~/.hive/credentials",
+            "encrypted": True,
+        }
+
+        if health_result is not None:
+            result["health_check"] = {
+                "valid": health_result.valid,
+                "message": health_result.message,
             }
-        )
+            identity = info.identity.to_dict()
+            if identity:
+                result["identity"] = identity
+
+        return json.dumps(result)
     except Exception as e:
         return json.dumps({"success": False, "error": str(e)})
 
@@ -3388,26 +3397,30 @@ def list_stored_credentials() -> str:
     """
     List all credentials currently stored in the local encrypted store.
 
-    Returns credential IDs and metadata (never returns secret values).
+    Returns credential IDs, aliases, status, and identity metadata (never returns secret values).
     """
     try:
-        store = _get_credential_store()
-        credential_ids = store.list_credentials()
+        from framework.credentials.local.registry import LocalCredentialRegistry
+
+        registry = LocalCredentialRegistry.default()
+        accounts = registry.list_accounts()
 
         credentials = []
-        for cred_id in credential_ids:
-            try:
-                cred = store.get_credential(cred_id)
-                credentials.append(
-                    {
-                        "id": cred.id,
-                        "name": cred.name,
-                        "keys": list(cred.keys.keys()),
-                        "created_at": cred.created_at.isoformat() if cred.created_at else None,
-                    }
-                )
-            except Exception:
-                credentials.append({"id": cred_id, "error": "Could not load"})
+        for info in accounts:
+            entry: dict = {
+                "credential_id": info.credential_id,
+                "alias": info.alias,
+                "storage_id": info.storage_id,
+                "status": info.status,
+                "created_at": info.created_at.isoformat() if info.created_at else None,
+                "last_validated": info.last_validated.isoformat()
+                if info.last_validated
+                else None,
+            }
+            identity = info.identity.to_dict()
+            if identity:
+                entry["identity"] = identity
+            credentials.append(entry)
 
         return json.dumps(
             {
@@ -3424,22 +3437,71 @@ def list_stored_credentials() -> str:
 @mcp.tool()
 def delete_stored_credential(
     credential_name: Annotated[str, "Logical credential name to delete (e.g., 'hubspot')"],
+    alias: Annotated[
+        str,
+        "Alias of the account to delete (e.g., 'work', 'personal'). Defaults to 'default'.",
+    ] = "default",
 ) -> str:
     """
     Delete a credential from the local encrypted store.
     """
     try:
-        store = _get_credential_store()
-        deleted = store.delete_credential(credential_name)
+        from framework.credentials.local.registry import LocalCredentialRegistry
+
+        registry = LocalCredentialRegistry.default()
+        storage_id = f"{credential_name}/{alias}"
+        deleted = registry.delete_account(credential_name, alias)
         return json.dumps(
             {
                 "success": deleted,
                 "credential": credential_name,
-                "message": f"Credential '{credential_name}' deleted"
+                "alias": alias,
+                "storage_id": storage_id,
+                "message": f"Credential '{storage_id}' deleted"
                 if deleted
-                else f"Credential '{credential_name}' not found",
+                else f"Credential '{storage_id}' not found",
             }
         )
+    except Exception as e:
+        return json.dumps({"success": False, "error": str(e)})
+
+
+@mcp.tool()
+def validate_credential(
+    credential_name: Annotated[
+        str, "Logical credential name to validate (e.g., 'brave_search', 'github')"
+    ],
+    alias: Annotated[
+        str,
+        "Alias of the account to validate (e.g., 'work', 'personal'). Defaults to 'default'.",
+    ] = "default",
+) -> str:
+    """
+    Re-run health check for a stored credential and update its status.
+
+    Makes a live API call to verify the credential is still valid and updates
+    the stored status and last_validated timestamp.
+    """
+    try:
+        from framework.credentials.local.registry import LocalCredentialRegistry
+
+        registry = LocalCredentialRegistry.default()
+        result = registry.validate_account(credential_name, alias)
+
+        response: dict = {
+            "credential": credential_name,
+            "alias": alias,
+            "storage_id": f"{credential_name}/{alias}",
+            "valid": result.valid,
+            "status": "active" if result.valid else "failed",
+            "message": result.message,
+        }
+
+        identity = result.details.get("identity") if result.details else None
+        if identity:
+            response["identity"] = identity
+
+        return json.dumps(response)
     except Exception as e:
         return json.dumps({"success": False, "error": str(e)})
 

--- a/core/framework/tui/screens/__init__.py
+++ b/core/framework/tui/screens/__init__.py
@@ -1,0 +1,13 @@
+"""TUI screens package."""
+
+from .account_selection import AccountSelectionScreen
+from .add_local_credential import AddLocalCredentialScreen
+from .agent_picker import AgentPickerScreen
+from .credential_setup import CredentialSetupScreen
+
+__all__ = [
+    "AccountSelectionScreen",
+    "AddLocalCredentialScreen",
+    "AgentPickerScreen",
+    "CredentialSetupScreen",
+]

--- a/core/framework/tui/screens/add_local_credential.py
+++ b/core/framework/tui/screens/add_local_credential.py
@@ -155,7 +155,9 @@ class AddLocalCredentialScreen(ModalScreen[dict | None]):
             type_list.display = False
             form.display = True
             spec = self._selected_spec
-            description = getattr(spec, "description", self._selected_id) if spec else self._selected_id
+            description = (
+                getattr(spec, "description", self._selected_id) if spec else self._selected_id
+            )
             subtitle = self.query_one("#alc-subtitle", Label)
             subtitle.update(f"[dim]{self._selected_id}[/dim]  {description}")
             self._clear_status()
@@ -223,9 +225,7 @@ class AddLocalCredentialScreen(ModalScreen[dict | None]):
                 if identity:
                     parts = [f"{k}: {v}" for k, v in identity.items() if v]
                     identity_str = "  " + ", ".join(parts) if parts else ""
-                self._set_status(
-                    f"[green]Saved:[/green] {info.storage_id}{identity_str}"
-                )
+                self._set_status(f"[green]Saved:[/green] {info.storage_id}{identity_str}")
                 # Dismiss with result so callers can react
                 self.set_timer(1.0, lambda: self.dismiss(info.to_account_dict()))
                 return

--- a/core/framework/tui/screens/add_local_credential.py
+++ b/core/framework/tui/screens/add_local_credential.py
@@ -1,0 +1,244 @@
+"""Add Local Credential ModalScreen for storing named local API key accounts."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Label, OptionList
+from textual.widgets._option_list import Option
+
+
+class AddLocalCredentialScreen(ModalScreen[dict | None]):
+    """Modal screen for adding a named local API key credential.
+
+    Phase 1: Pick credential type from list.
+    Phase 2: Enter alias + API key, run health check, save.
+
+    Returns a dict with credential_id, alias, and identity on success, or None on cancel.
+    """
+
+    BINDINGS = [
+        Binding("escape", "dismiss_screen", "Cancel"),
+    ]
+
+    DEFAULT_CSS = """
+    AddLocalCredentialScreen {
+        align: center middle;
+    }
+    #alc-container {
+        width: 80%;
+        max-width: 90;
+        height: 80%;
+        background: $surface;
+        border: heavy $primary;
+        padding: 1 2;
+    }
+    #alc-title {
+        text-align: center;
+        text-style: bold;
+        width: 100%;
+        color: $text;
+    }
+    #alc-subtitle {
+        text-align: center;
+        width: 100%;
+        margin-bottom: 1;
+    }
+    #alc-type-list {
+        height: 1fr;
+    }
+    #alc-form {
+        height: 1fr;
+    }
+    .alc-field {
+        margin-bottom: 1;
+        height: auto;
+    }
+    .alc-field Label {
+        margin-bottom: 0;
+    }
+    #alc-status {
+        width: 100%;
+        height: auto;
+        margin-top: 1;
+        padding: 1;
+        background: $panel;
+    }
+    .alc-buttons {
+        height: auto;
+        margin-top: 1;
+        align: center middle;
+    }
+    .alc-buttons Button {
+        margin: 0 1;
+    }
+    #alc-footer {
+        text-align: center;
+        width: 100%;
+        margin-top: 1;
+    }
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Load credential specs that support direct API keys
+        self._specs: list[tuple[str, object]] = self._load_specs()
+        # Selected credential spec (set in phase 2)
+        self._selected_id: str = ""
+        self._selected_spec: object = None
+        self._phase: int = 1  # 1 = type selection, 2 = form
+
+    @staticmethod
+    def _load_specs() -> list[tuple[str, object]]:
+        """Return (credential_id, spec) pairs for direct-API-key credentials."""
+        try:
+            from aden_tools.credentials import CREDENTIAL_SPECS
+
+            return [
+                (cid, spec)
+                for cid, spec in CREDENTIAL_SPECS.items()
+                if getattr(spec, "direct_api_key_supported", False)
+            ]
+        except Exception:
+            return []
+
+    # ------------------------------------------------------------------
+    # Compose
+    # ------------------------------------------------------------------
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="alc-container"):
+            yield Label("Add Local Credential", id="alc-title")
+            yield Label("[dim]Store a named API key account[/dim]", id="alc-subtitle")
+            # Phase 1: type selection
+            option_list = OptionList(id="alc-type-list")
+            for cid, spec in self._specs:
+                description = getattr(spec, "description", cid)
+                option_list.add_option(Option(f"{cid}  [dim]{description}[/dim]", id=f"type-{cid}"))
+            yield option_list
+            # Phase 2: form (hidden initially)
+            with VerticalScroll(id="alc-form"):
+                with Vertical(classes="alc-field"):
+                    yield Label("[bold]Alias[/bold]  [dim](e.g. work, personal)[/dim]")
+                    yield Input(value="default", id="alc-alias")
+                with Vertical(classes="alc-field"):
+                    yield Label("[bold]API Key[/bold]")
+                    yield Input(placeholder="Paste API key...", password=True, id="alc-key")
+                yield Label("", id="alc-status")
+                with Vertical(classes="alc-buttons"):
+                    yield Button("Test & Save", variant="primary", id="btn-save")
+                    yield Button("Back", variant="default", id="btn-back")
+            yield Label(
+                "[dim]Enter[/dim] Select  [dim]Esc[/dim] Cancel",
+                id="alc-footer",
+            )
+
+    def on_mount(self) -> None:
+        self._show_phase(1)
+
+    # ------------------------------------------------------------------
+    # Phase switching
+    # ------------------------------------------------------------------
+
+    def _show_phase(self, phase: int) -> None:
+        self._phase = phase
+        type_list = self.query_one("#alc-type-list", OptionList)
+        form = self.query_one("#alc-form", VerticalScroll)
+        if phase == 1:
+            type_list.display = True
+            form.display = False
+            subtitle = self.query_one("#alc-subtitle", Label)
+            subtitle.update("[dim]Select the credential type to add[/dim]")
+        else:
+            type_list.display = False
+            form.display = True
+            spec = self._selected_spec
+            description = getattr(spec, "description", self._selected_id) if spec else self._selected_id
+            subtitle = self.query_one("#alc-subtitle", Label)
+            subtitle.update(f"[dim]{self._selected_id}[/dim]  {description}")
+            self._clear_status()
+            # Focus the alias input
+            self.query_one("#alc-alias", Input).focus()
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        if self._phase != 1:
+            return
+        option_id = event.option.id or ""
+        if option_id.startswith("type-"):
+            cid = option_id[5:]  # strip "type-" prefix
+            self._selected_id = cid
+            self._selected_spec = next(
+                (spec for spec_id, spec in self._specs if spec_id == cid), None
+            )
+            self._show_phase(2)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-save":
+            self._do_save()
+        elif event.button.id == "btn-back":
+            self._show_phase(1)
+
+    # ------------------------------------------------------------------
+    # Save logic
+    # ------------------------------------------------------------------
+
+    def _do_save(self) -> None:
+        alias = self.query_one("#alc-alias", Input).value.strip() or "default"
+        api_key = self.query_one("#alc-key", Input).value.strip()
+
+        if not api_key:
+            self._set_status("[red]API key cannot be empty.[/red]")
+            return
+
+        self._set_status("[dim]Running health check...[/dim]")
+        # Disable save button while running
+        btn = self.query_one("#btn-save", Button)
+        btn.disabled = True
+
+        try:
+            from framework.credentials.local.registry import LocalCredentialRegistry
+
+            registry = LocalCredentialRegistry.default()
+            info, health_result = registry.save_account(
+                credential_id=self._selected_id,
+                alias=alias,
+                api_key=api_key,
+                run_health_check=True,
+            )
+
+            if health_result is not None and not health_result.valid:
+                self._set_status(
+                    f"[yellow]Saved with failed health check:[/yellow] {health_result.message}\n"
+                    "[dim]You can re-validate later via validate_credential().[/dim]"
+                )
+            else:
+                identity = info.identity.to_dict()
+                identity_str = ""
+                if identity:
+                    parts = [f"{k}: {v}" for k, v in identity.items() if v]
+                    identity_str = "  " + ", ".join(parts) if parts else ""
+                self._set_status(
+                    f"[green]Saved:[/green] {info.storage_id}{identity_str}"
+                )
+                # Dismiss with result so callers can react
+                self.set_timer(1.0, lambda: self.dismiss(info.to_account_dict()))
+                return
+        except Exception as e:
+            self._set_status(f"[red]Error:[/red] {e}")
+        finally:
+            btn.disabled = False
+
+    def _set_status(self, markup: str) -> None:
+        self.query_one("#alc-status", Label).update(markup)
+
+    def _clear_status(self) -> None:
+        self.query_one("#alc-status", Label).update("")
+
+    def action_dismiss_screen(self) -> None:
+        self.dismiss(None)

--- a/tools/src/aden_tools/credentials/store_adapter.py
+++ b/tools/src/aden_tools/credentials/store_adapter.py
@@ -317,9 +317,7 @@ class CredentialStoreAdapter:
 
     # --- Local credential registry ---
 
-    def list_local_accounts(
-        self, credential_id: str | None = None
-    ) -> list[dict]:
+    def list_local_accounts(self, credential_id: str | None = None) -> list[dict]:
         """
         List named local API key accounts from LocalCredentialRegistry.
 

--- a/tools/src/aden_tools/credentials/store_adapter.py
+++ b/tools/src/aden_tools/credentials/store_adapter.py
@@ -85,7 +85,7 @@ class CredentialStoreAdapter:
 
     # --- Existing CredentialManager API ---
 
-    def get(self, name: str) -> str | None:
+    def get(self, name: str, account: str | None = None) -> str | None:
         """
         Get a credential value by logical name.
 
@@ -94,6 +94,10 @@ class CredentialStoreAdapter:
 
         Args:
             name: Logical credential name (e.g., "brave_search")
+            account: Optional alias for per-call routing to a specific named local
+                account (e.g. "work"). When provided, looks up the named account
+                from LocalCredentialRegistry before falling through to the store.
+                This mirrors the ``account=`` routing available for Aden credentials.
 
         Returns:
             The credential value, or None if not set
@@ -103,6 +107,16 @@ class CredentialStoreAdapter:
         """
         if name not in self._specs:
             raise KeyError(f"Unknown credential '{name}'. Available: {list(self._specs.keys())}")
+
+        if account is not None:
+            try:
+                from framework.credentials.local.registry import LocalCredentialRegistry
+
+                key = LocalCredentialRegistry.default().get_key(name, account)
+                if key is not None:
+                    return key
+            except Exception:
+                pass  # Fall through to standard store lookup
 
         return self._store.get(name)
 
@@ -300,6 +314,60 @@ class CredentialStoreAdapter:
     def get_by_identity(self, provider_name: str, label: str) -> str | None:
         """Alias for get_by_alias (backward compat)."""
         return self.get_by_alias(provider_name, label)
+
+    # --- Local credential registry ---
+
+    def list_local_accounts(
+        self, credential_id: str | None = None
+    ) -> list[dict]:
+        """
+        List named local API key accounts from LocalCredentialRegistry.
+
+        Args:
+            credential_id: If given, filter to this credential type only.
+
+        Returns:
+            List of account dicts (same shape as Aden account dicts, source='local').
+        """
+        try:
+            from framework.credentials.local.registry import LocalCredentialRegistry
+
+            registry = LocalCredentialRegistry.default()
+            return [info.to_account_dict() for info in registry.list_accounts(credential_id)]
+        except Exception:
+            return []
+
+    def activate_local_account(self, credential_id: str, alias: str) -> bool:
+        """
+        Inject a named local account's API key into the environment for this session.
+
+        This enables session-level routing: select an account → inject its key as
+        the env var that tools already read. No tool signature changes required.
+
+        Args:
+            credential_id: Logical credential name (e.g. "brave_search").
+            alias: Account alias (e.g. "work").
+
+        Returns:
+            True if the key was found and injected, False otherwise.
+        """
+        import os
+
+        try:
+            from framework.credentials.local.registry import LocalCredentialRegistry
+
+            key = LocalCredentialRegistry.default().get_key(credential_id, alias)
+            if key is None:
+                return False
+
+            spec = self._specs.get(credential_id)
+            if spec is None:
+                return False
+
+            os.environ[spec.env_var] = key
+            return True
+        except Exception:
+            return False
 
     @property
     def store(self) -> CredentialStore:


### PR DESCRIPTION
closes #5271

# Local credential parity: aliases, identity, status, and credential tester integration

## Summary

Gives local API key credentials (Brave Search, GitHub, Exa, Stripe, etc.) the same feature set as Aden OAuth credentials: named aliases, identity metadata, status tracking, CRUD management, and full visibility in the credential tester.

Fixes a bug where credentials configured with the existing `store_credential` MCP tool were invisible in the credential tester account picker.

---

## Changes

### New: `core/framework/credentials/local/`

**`models.py`** — `LocalAccountInfo` dataclass mirroring `AdenIntegrationInfo`:
- Fields: `credential_id`, `alias`, `status` (`active` / `failed` / `unknown`), `identity`, `last_validated`, `created_at`
- `storage_id` property returns `"{credential_id}/{alias}"` (e.g. `brave_search/work`)
- `to_account_dict()` returns same shape as Aden account dicts — feeds account picker without changes

**`registry.py`** — `LocalCredentialRegistry`, the core engine:
- `save_account(credential_id, alias, api_key)` — runs health check, extracts identity, stores at `{credential_id}/{alias}` in `EncryptedFileStorage`
- `list_accounts(credential_id=None)` — reads all `{x}/{y}` entries from storage
- `get_key(credential_id, alias)` — returns raw secret
- `delete_account(credential_id, alias)` — removes entry
- `validate_account(credential_id, alias)` — re-runs health check, updates `_status` and `last_refreshed` in-place
- `default()` classmethod — uses `~/.hive/credentials`

Storage convention: `{credential_id}/{alias}` as `CredentialObject.id`. Legacy flat entries (`brave_search`, no slash) continue to work — env var fallback is unchanged.

---

### Modified: `tools/src/aden_tools/credentials/store_adapter.py`

- `get(name, account=None)` — added `account=` param for per-call routing to a named local account; mirrors Aden `account=` routing
- `activate_local_account(credential_id, alias)` — injects a named account's key into `os.environ[spec.env_var]` for session-level activation
- `list_local_accounts(credential_id=None)` — delegates to `LocalCredentialRegistry`

---

### Modified: `core/framework/credentials/__init__.py`

Exports `LocalAccountInfo` and `LocalCredentialRegistry`.

---

### Modified: `core/framework/agents/credential_tester/agent.py`

Full rewrite of account listing and configuration:

- `_list_aden_accounts()` — extracted from old `list_connected_accounts()`
- `_list_local_accounts()` — uses `LocalCredentialRegistry`
- `_list_env_fallback_accounts()` — detects credentials configured via env var **or** in old flat encrypted format; fixes the invisible-credential bug
- `list_connected_accounts()` — combines all three, deduplicates
- `configure_for_account()` — branches on `source` field:
  - `"aden"` → adds `get_account_info` tool, prompts with `account="alias"`
  - `"local"` → calls `_activate_local_account()`, prompt has no `account=` param
- `_activate_local_account()` — handles three cases: named registry entry, old flat encrypted entry, env var already set; also handles grouped credentials (e.g. `google_custom_search` sets both `GOOGLE_API_KEY` and `GOOGLE_CSE_ID`)
- `get_tools_for_provider()` — fixed to match both `credential_id` AND `credential_group`

---

### Modified: `core/framework/mcp/agent_builder_server.py`

- `store_credential(name, value, alias="default", ...)` — added `alias` param; now delegates to `LocalCredentialRegistry.save_account()` with auto health check; returns `status` and `identity`
- `list_stored_credentials()` — delegates to `LocalCredentialRegistry.list_accounts()`; returns `credential_id`, `alias`, `status`, `identity`, `last_validated`
- `delete_stored_credential(name, alias="default")` — added `alias` param
- `validate_credential(name, alias="default")` — **new tool** — re-runs health check via `LocalCredentialRegistry.validate_account()`, returns updated status and identity

---

### Modified: `core/framework/tui/screens/account_selection.py`

- Aden accounts rendered first, local accounts second
- Local accounts display a `[local]` badge
- Identity label shows email, username, or workspace when available

---

### New: `core/framework/tui/screens/add_local_credential.py`

Two-phase modal for adding a named local API key:

1. **Type selection** — filtered list of all `direct_api_key_supported=True` credentials
2. **Form** — alias input + password input → "Test & Save" runs health check inline, shows identity result, auto-dismisses on success

Exported from `core/framework/tui/screens/__init__.py`.

---

## Bug fix

**Credential tester not showing configured credentials** (e.g. Brave Search stored via `store_credential`):

- `_list_env_fallback_accounts()` previously used `CredentialStoreAdapter.with_env_storage()`, which only checked `os.environ`. Credentials stored in `EncryptedFileStorage` with the old flat format (`brave_search`, no slash) were invisible.
- `_activate_local_account()` early-returned when `alias == "default"`, assuming the env var was already set. Old flat encrypted credentials are not in `os.environ`.

**Fix**: `_list_env_fallback_accounts()` now also reads `EncryptedFileStorage.list_all()` and treats any flat entry (no `/`) as configured. `_activate_local_account()` now falls through to load from the flat encrypted entry when the env var is not set and the registry has no named entry.

---

## Test plan

- [ ] `store_credential("brave_search", "BSA-xxx", alias="work")` → health check runs, identity shown, stored as `brave_search/work`
- [ ] `list_stored_credentials()` → shows `credential_id`, `alias`, `status`, `identity`, `last_validated`
- [ ] `validate_credential("brave_search", "work")` → re-runs health check, updates status
- [ ] `delete_stored_credential("brave_search", alias="work")` → removes entry
- [ ] Credential tester account picker shows local accounts with `[local]` badge alongside Aden accounts
- [ ] Selecting a local account activates the key and tools work without `account=` param
- [ ] Selecting a legacy flat credential (stored before this PR) activates it correctly
- [ ] `AddLocalCredentialScreen` — select type, enter alias + key, health check runs inline, screen closes on success
- [ ] `CredentialStoreAdapter.get("brave_search", account="work")` returns key from registry
