### PR TITLE
Improve Windows setup reliability with troubleshooting docs and Git Bash pre‑flight check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,7 @@ You may submit PRs without prior assignment for:
 > **Windows Users:**  
 > If you are on native Windows, it is recommended to use **WSL (Windows Subsystem for Linux)**.  
 > Alternatively, make sure to run PowerShell or Git Bash with Python 3.11+ installed, and disable "App Execution Aliases" in Windows settings.
+> If you see cygpath or WSL errors, see the [Windows troubleshooting](docs/environment-setup.md#windows-troubleshooting) section in docs/environment-setup.md.
 
 > **Tip:** Installing Claude Code skills is optional for running existing agents, but required if you plan to **build new agents**.
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Use Hive when you need:
 - Claude Code, Codex CLI, or Cursor for utilizing agent skills
 
 > **Note for Windows Users:** It is strongly recommended to use **WSL (Windows Subsystem for Linux)** or **Git Bash** to run this framework. Some core automation scripts may not execute correctly in standard Command Prompt or PowerShell.
+> If you see cygpath or WSL errors on Windows, see the [Windows troubleshooting](docs/environment-setup.md#windows-troubleshooting) section in docs/environment-setup.md.
 
 ### Installation
 

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -36,6 +36,24 @@ Windows users should use **WSL (Windows Subsystem for Linux)** to set up and run
    ./quickstart.sh
    ```
 
+### Windows Troubleshooting
+
+If setup fails on Windows when using Git Bash with errors involving `cygpath` or `execvpe(/bin/bash) failed: No such file or directory`, the cause is usually that Git Bash is delegating path conversion to WSL, and WSL has a broken or non-functional distribution (e.g. a leftover `docker-desktop` or `Ubuntu` entry from Docker Desktop).
+
+**Diagnose:**
+
+- Run `wsl --list` to see registered distributions.
+- Unregister non-functional ones: `wsl --unregister docker-desktop`, `wsl --unregister Ubuntu` (use the exact names from the list).
+
+**Fix path resolution:**
+
+- Ensure Git's own tools are used for path conversion by putting Git's `usr\bin` (and optionally `bin`) **earlier** in your PATH than any WSL-related entries. For example, add to your user PATH:
+  - `C:\Users\<your-username>\Git\usr\bin`
+  - `C:\Users\<your-username>\Git\bin`
+  (Adjust if Git is installed elsewhere.)
+
+After unregistering broken WSL distros and fixing PATH, run `./quickstart.sh` again.
+
 ## Alpine Linux Setup
 
 If you are using Alpine Linux (e.g., inside a Docker container), you must install system dependencies and use a virtual environment before running the setup script:

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -97,6 +97,20 @@ fi
 
 echo ""
 
+# Pre-flight: on Windows Git Bash, cygpath must work (WSL must not be broken)
+if [ -n "${MSYSTEM:-}" ]; then
+    if ! cygpath -u "${TEMP:-$TMP:-.}" >/dev/null 2>&1; then
+        echo -e "${RED}Path conversion (cygpath) failed.${NC}"
+        echo ""
+        echo "On Windows, this usually means WSL is registered but has no working distribution,"
+        echo "so Git Bash is delegating to WSL instead of using its own cygpath."
+        echo ""
+        echo "See the Windows troubleshooting section in docs/environment-setup.md for how to"
+        echo "unregister broken WSL distros and ensure Git's usr/bin is in your PATH."
+        exit 1
+    fi
+fi
+
 # ============================================================
 # Step 1: Check Python
 # ============================================================


### PR DESCRIPTION
## Description

This PR improves the Windows developer setup experience by adding clear troubleshooting guidance for cygpath/WSL failures and introducing a lightweight pre‑flight check in quickstart.sh to detect broken WSL configurations when using Git Bash. It also adds small pointers in the README and CONTRIBUTING docs to make the troubleshooting section easier to discover.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #4312 

## Changes Made

- Added a new Windows Troubleshooting section to docs/environment-setup.md explaining symptoms, causes, diagnosis, and fixes for cygpath/WSL failures on Windows.
- Added a pre‑flight check in quickstart.sh to detect broken WSL path conversion when running under Git Bash and provide a clear error message with a link to the docs.
- Added a pointer in README.md directing Windows users to the troubleshooting section.
- Added a pointer in CONTRIBUTING.md for contributors encountering cygpath or WSL errors.

## Testing

Describe the tests you ran to verify your changes:

- [x] Manual testing performed (verified quickstart.sh pre‑flight behavior under Git Bash)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
