### PR TITLE
[Safety] Add force_overwrite protection to write_to_file tool

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/write_to_file/write_to_file.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/write_to_file/write_to_file.py
@@ -16,6 +16,7 @@ def register_tools(mcp: FastMCP) -> None:
         agent_id: str,
         session_id: str,
         append: bool = False,
+        force_overwrite: bool = False,
     ) -> dict:
         """
         Purpose
@@ -41,12 +42,21 @@ def register_tools(mcp: FastMCP) -> None:
             agent_id: The ID of the agent
             session_id: The ID of the current session
             append: Whether to append to the file instead of overwriting (default: False)
+            force_overwrite: Whether to allow overwriting an existing file (default: False)
 
         Returns:
             Dict with success status and path, or error dict
         """
         try:
             secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+
+            if not append and not force_overwrite and os.path.exists(secure_path):
+                return {
+                    "error": (
+                        f"File '{path}' already exists. Set force_overwrite=True to replace it."
+                    )
+                }
+
             os.makedirs(os.path.dirname(secure_path), exist_ok=True)
             mode = "a" if append else "w"
             with open(secure_path, mode, encoding="utf-8") as f:


### PR DESCRIPTION
## Summary

This PR adds a safety mechanism to the `write_to_file` tool to prevent accidental file overwrites, addressing the security concern raised in the issue.

## Problem

The `write_to_file` tool documentation states it "Must not overwrite canonical memory unless explicitly allowed", but the implementation used standard write mode ("w") which immediately truncates and overwrites any existing file without confirmation.

This meant an agent could accidentally wipe out critical "canonical memory" files or configuration logs by making an unintended `write_to_file` call instead of using append mode.

## Solution

- Added a new `force_overwrite: bool = False` parameter to `write_to_file`
- When `append=False` and `force_overwrite=False`, the tool now checks if the file exists
- If the file exists, it returns an error: `"File '{path}' already exists. Set force_overwrite=True to replace it."`
- Append mode (`append=True`) continues to work without restriction

## Changes

### Core Logic
- `tools/src/aden_tools/tools/file_system_toolkits/write_to_file/write_to_file.py`: Added `force_overwrite` parameter with safety check

### Tests
- `tools/tests/tools/test_file_system_toolkits.py`: 
  - Updated existing overwrite test to use `force_overwrite=True`
  - Added test for error when overwriting without `force_overwrite=True`
  - Added test confirming append mode works regardless of `force_overwrite`

## Testing

All 46 file system toolkit tests pass, including 7 write_to_file specific tests:
- `test_write_new_file` - New files are created successfully
- `test_write_append_mode` - Append mode works
- `test_write_overwrite_existing_with_force` - Overwrite works with `force_overwrite=True`
- `test_write_existing_file_without_force_returns_error` - Error returned when attempting overwrite
- `test_write_existing_file_append_mode_succeeds` - Append always works
- `test_write_creates_parent_directories` - Parent directories created
- `test_write_empty_content` - Empty content handling

Resolves #4059
