### PR TITLE
feat(tools): add Pinecone vector database integration for RAG workflows

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -28,6 +28,7 @@ Some tools require API keys to function. Credentials are managed through the enc
 | `BRAVE_SEARCH_API_KEY` | `web_search` tool (Brave)     | [brave.com/search/api](https://brave.com/search/api/)   |
 | `GOOGLE_API_KEY`       | `web_search` tool (Google)    | [console.cloud.google.com](https://console.cloud.google.com/) |
 | `GOOGLE_CSE_ID`        | `web_search` tool (Google)    | [programmablesearchengine.google.com](https://programmablesearchengine.google.com/) |
+| `PINECONE_API_KEY`     | `pinecone_*` tools            | [app.pinecone.io](https://app.pinecone.io/)             |
 
 > **Note:** `web_search` supports multiple providers. Set either Brave OR Google credentials. Brave is preferred for backward compatibility.
 
@@ -141,9 +142,16 @@ python mcp_server.py
 | `vision_*` | Analyze images with Google Cloud Vision (labels, OCR, faces, objects, etc.) |
 | `google_docs_*` | Read and write Google Docs |
 | `maps_*` | Places search, geocoding, directions (Google Maps) |
-| `run_bigquery_query`, `describe_dataset` | Run queries against Google BigQuery |
 | `razorpay_*` | Razorpay payments and orders |
 | `github_*` | GitHub repos, issues, and pull requests |
+
+### Databases
+
+| Tool | Description |
+| ---- | ----------- |
+| `pinecone_*` | Pinecone vector database for RAG workflows |
+| `run_bigquery_query`, `describe_dataset` | Run queries against Google BigQuery |
+| `postgres_*` | PostgreSQL database operations |
 
 ### Security
 

--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -69,6 +69,7 @@ from .health_check import HealthCheckResult, check_credential_health
 from .hubspot import HUBSPOT_CREDENTIALS
 from .llm import LLM_CREDENTIALS
 from .news import NEWS_CREDENTIALS
+from .pinecone import PINECONE_CREDENTIALS
 from .postgres import POSTGRES_CREDENTIALS
 from .razorpay import RAZORPAY_CREDENTIALS
 from .search import SEARCH_CREDENTIALS
@@ -106,6 +107,7 @@ CREDENTIAL_SPECS = {
     **CALCOM_CREDENTIALS,
     **STRIPE_CREDENTIALS,
     **POSTGRES_CREDENTIALS,
+    **PINECONE_CREDENTIALS,
 }
 
 __all__ = [
@@ -150,4 +152,5 @@ __all__ = [
     "DISCORD_CREDENTIALS",
     "STRIPE_CREDENTIALS",
     "POSTGRES_CREDENTIALS",
+    "PINECONE_CREDENTIALS",
 ]

--- a/tools/src/aden_tools/credentials/pinecone.py
+++ b/tools/src/aden_tools/credentials/pinecone.py
@@ -1,0 +1,42 @@
+"""
+Pinecone vector database credentials.
+
+Contains credentials for Pinecone integration enabling RAG agent workflows.
+"""
+
+from .base import CredentialSpec
+
+PINECONE_CREDENTIALS = {
+    "pinecone": CredentialSpec(
+        env_var="PINECONE_API_KEY",
+        tools=[
+            "pinecone_list_indexes",
+            "pinecone_create_index",
+            "pinecone_describe_index",
+            "pinecone_delete_index",
+            "pinecone_upsert_vectors",
+            "pinecone_query_vectors",
+            "pinecone_fetch_vectors",
+            "pinecone_delete_vectors",
+            "pinecone_upsert_records",
+            "pinecone_search_records",
+            "pinecone_list_namespaces",
+            "pinecone_delete_namespace",
+        ],
+        required=True,
+        startup_required=False,
+        help_url="https://app.pinecone.io/",
+        description="Pinecone API key for vector database operations",
+        aden_supported=False,
+        direct_api_key_supported=True,
+        api_key_instructions="""To get a Pinecone API Key:
+1. Go to https://app.pinecone.io/ and sign up or log in
+2. Navigate to API Keys in the left sidebar
+3. Click Create API Key or copy the default key
+4. Copy the API key value""",
+        health_check_endpoint="https://api.pinecone.io/indexes",
+        health_check_method="GET",
+        credential_id="pinecone",
+        credential_key="api_key",
+    ),
+}

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -59,6 +59,7 @@ from .http_headers_scanner import register_tools as register_http_headers_scanne
 from .hubspot_tool import register_tools as register_hubspot
 from .news_tool import register_tools as register_news
 from .pdf_read_tool import register_tools as register_pdf_read
+from .pinecone_tool import register_tools as register_pinecone
 from .port_scanner import register_tools as register_port_scanner
 from .postgres_tool import register_tools as register_postgres
 from .razorpay_tool import register_tools as register_razorpay
@@ -150,6 +151,9 @@ def register_all_tools(
 
     # Postgres tool
     register_postgres(mcp, credentials=credentials)
+
+    # Pinecone vector database tool
+    register_pinecone(mcp, credentials=credentials)
 
     # Return the list of all registered tool names
     return list(mcp._tool_manager._tools.keys())

--- a/tools/src/aden_tools/tools/pinecone_tool/README.md
+++ b/tools/src/aden_tools/tools/pinecone_tool/README.md
@@ -1,0 +1,153 @@
+# Pinecone Vector Database Tool
+
+Vector database operations for RAG agent workflows.
+
+## Overview
+
+Pinecone is a managed vector database purpose-built for semantic search and retrieval-augmented generation (RAG). This integration enables Hive agents to store, query, and manage vector embeddings — unlocking workflows like knowledge base search, document retrieval, semantic deduplication, and multi-index cascading search.
+
+## Tools Provided
+
+| Tool | Description |
+|------|-------------|
+| `pinecone_list_indexes` | List all indexes in your Pinecone project |
+| `pinecone_create_index` | Create a new serverless index |
+| `pinecone_describe_index` | Get details about a specific index |
+| `pinecone_delete_index` | Delete an index (permanent) |
+| `pinecone_upsert_vectors` | Upsert vectors into an index |
+| `pinecone_query_vectors` | Query for similar vectors |
+| `pinecone_fetch_vectors` | Fetch vectors by ID |
+| `pinecone_delete_vectors` | Delete vectors from an index |
+| `pinecone_upsert_records` | Upsert records using integrated inference |
+| `pinecone_search_records` | Search records using integrated inference |
+| `pinecone_list_namespaces` | List all namespaces in an index |
+| `pinecone_delete_namespace` | Delete a namespace (permanent) |
+
+## Setup
+
+### 1. Get API Key
+
+1. Go to [https://app.pinecone.io/](https://app.pinecone.io/) and sign up or log in
+2. Navigate to **API Keys** in the left sidebar
+3. Click **Create API Key** or copy the default key
+4. Copy the API key value
+
+### 2. Configure Credentials
+
+Set the environment variable:
+
+```bash
+export PINECONE_API_KEY=your_api_key_here
+```
+
+Or add to your `.env` file:
+
+```
+PINECONE_API_KEY=your_api_key_here
+```
+
+## Usage Examples
+
+### Create an Index
+
+```python
+# Create a serverless index for OpenAI embeddings
+pinecone_create_index(
+    name="documents",
+    dimension=1536,  # OpenAI ada-002 dimension
+    metric="cosine",
+    cloud="aws",
+    region="us-east-1"
+)
+```
+
+### Upsert Vectors
+
+```python
+# First get the index host from describe_index
+index = pinecone_describe_index(name="documents")
+host = index["index"]["host"]
+
+# Upsert vectors
+pinecone_upsert_vectors(
+    index_host=host,
+    vectors=[
+        {
+            "id": "doc1",
+            "values": [0.1, 0.2, 0.3, ...],  # 1536 floats
+            "metadata": {"title": "Document 1", "category": "tech"}
+        },
+        {
+            "id": "doc2",
+            "values": [0.4, 0.5, 0.6, ...],
+            "metadata": {"title": "Document 2", "category": "news"}
+        }
+    ],
+    namespace="production"
+)
+```
+
+### Query Vectors
+
+```python
+# Query for similar vectors
+results = pinecone_query_vectors(
+    index_host=host,
+    vector=query_embedding,  # Your query vector
+    top_k=10,
+    filter={"category": "tech"},  # Optional metadata filter
+    include_metadata=True
+)
+
+# Access matches
+for match in results["matches"]:
+    print(f"ID: {match['id']}, Score: {match['score']}")
+```
+
+### Namespaces
+
+```python
+# List namespaces
+namespaces = pinecone_list_namespaces(index_host=host)
+
+# Delete a namespace (removes all vectors in it)
+pinecone_delete_namespace(
+    index_host=host,
+    namespace="old-data"
+)
+```
+
+## Integrated Inference
+
+For indexes created with an embedding model, use record-based operations:
+
+```python
+# Upsert records (auto-embeds text)
+pinecone_upsert_records(
+    index_host=host,
+    records=[
+        {"_id": "doc1", "title": "AI News", "content": "Full text..."}
+    ]
+)
+
+# Search records (auto-embeds query)
+results = pinecone_search_records(
+    index_host=host,
+    query={"text": "artificial intelligence"},
+    top_k=5
+)
+```
+
+## API Reference
+
+- [Pinecone API Docs](https://docs.pinecone.io/reference/api/introduction)
+- [Python SDK](https://github.com/pinecone-io/pinecone-python-client)
+
+## Free Tier
+
+Starter plan includes:
+- 2GB storage
+- 1 index
+- Unlimited reads
+
+Sufficient for development and testing.

--- a/tools/src/aden_tools/tools/pinecone_tool/__init__.py
+++ b/tools/src/aden_tools/tools/pinecone_tool/__init__.py
@@ -1,0 +1,7 @@
+"""
+Pinecone Tool - Vector database operations for RAG agent workflows.
+"""
+
+from .pinecone_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/pinecone_tool/pinecone_tool.py
+++ b/tools/src/aden_tools/tools/pinecone_tool/pinecone_tool.py
@@ -1,0 +1,867 @@
+"""
+Pinecone Tool - Vector database operations for RAG agent workflows.
+
+Supports:
+- Index management (list, create, describe, delete)
+- Vector operations (upsert, query, fetch, delete)
+- Record operations with integrated inference (upsert, search)
+- Namespace management (list, delete)
+
+API Reference: https://docs.pinecone.io/reference/api/introduction
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialStoreAdapter
+
+PINECONE_API_BASE = "https://api.pinecone.io"
+
+
+class _PineconeClient:
+    """Internal client wrapping Pinecone REST API calls."""
+
+    def __init__(self, api_key: str):
+        self._api_key = api_key
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Api-Key": self._api_key,
+            "Content-Type": "application/json",
+        }
+
+    def _handle_response(self, response: httpx.Response) -> dict[str, Any]:
+        """Handle Pinecone API response."""
+        if response.status_code == 401:
+            return {"error": "Invalid or expired Pinecone API key"}
+        if response.status_code == 403:
+            return {"error": "Insufficient permissions for this operation"}
+        if response.status_code == 404:
+            return {"error": "Resource not found"}
+        if response.status_code == 429:
+            return {"error": "Rate limit exceeded. Please try again later."}
+        if response.status_code >= 500:
+            return {"error": f"Pinecone server error: {response.status_code}"}
+
+        if response.status_code not in (200, 201, 202):
+            return {"error": f"HTTP error {response.status_code}: {response.text}"}
+
+        try:
+            return response.json()
+        except Exception:
+            return {"success": True, "status_code": response.status_code}
+
+    def list_indexes(self) -> dict[str, Any]:
+        """List all indexes in the project."""
+        response = httpx.get(
+            f"{PINECONE_API_BASE}/indexes",
+            headers=self._headers,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def create_index(
+        self,
+        name: str,
+        dimension: int,
+        metric: str = "cosine",
+        cloud: str = "aws",
+        region: str = "us-east-1",
+        spec: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Create a new index."""
+        if spec:
+            body = {"name": name, "dimension": dimension, "metric": metric, "spec": spec}
+        else:
+            body = {
+                "name": name,
+                "dimension": dimension,
+                "metric": metric,
+                "spec": {"serverless": {"cloud": cloud, "region": region}},
+            }
+        response = httpx.post(
+            f"{PINECONE_API_BASE}/indexes",
+            headers=self._headers,
+            json=body,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def describe_index(self, name: str) -> dict[str, Any]:
+        """Get details about an index."""
+        response = httpx.get(
+            f"{PINECONE_API_BASE}/indexes/{name}",
+            headers=self._headers,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def delete_index(self, name: str) -> dict[str, Any]:
+        """Delete an index."""
+        response = httpx.delete(
+            f"{PINECONE_API_BASE}/indexes/{name}",
+            headers=self._headers,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def upsert_vectors(
+        self,
+        index_host: str,
+        vectors: list[dict[str, Any]],
+        namespace: str = "",
+    ) -> dict[str, Any]:
+        """Upsert vectors into an index.
+
+        Args:
+            index_host: Index host URL (from describe_index)
+            vectors: List of vectors, each with 'id', 'values', and optional 'metadata'
+            namespace: Optional namespace within the index
+        """
+        body: dict[str, Any] = {"vectors": vectors}
+        if namespace:
+            body["namespace"] = namespace
+
+        response = httpx.post(
+            f"https://{index_host}/vectors/upsert",
+            headers=self._headers,
+            json=body,
+            timeout=60.0,
+        )
+        return self._handle_response(response)
+
+    def query_vectors(
+        self,
+        index_host: str,
+        vector: list[float] | None = None,
+        id: str | None = None,
+        top_k: int = 10,
+        namespace: str = "",
+        filter: dict[str, Any] | None = None,
+        include_values: bool = False,
+        include_metadata: bool = True,
+    ) -> dict[str, Any]:
+        """Query an index for similar vectors.
+
+        Args:
+            index_host: The host URL of the index
+            vector: Query vector (required if id not provided)
+            id: ID of existing vector to use as query (required if vector not provided)
+            top_k: Number of results to return
+            namespace: Optional namespace within the index
+            filter: Optional metadata filter
+            include_values: Whether to include vector values in results
+            include_metadata: Whether to include metadata in results
+        """
+        body: dict[str, Any] = {
+            "top_k": top_k,
+            "include_values": include_values,
+            "include_metadata": include_metadata,
+        }
+        if vector is not None:
+            body["vector"] = vector
+        elif id is not None:
+            body["id"] = id
+        else:
+            return {"error": "Either 'vector' or 'id' must be provided"}
+
+        if namespace:
+            body["namespace"] = namespace
+        if filter:
+            body["filter"] = filter
+
+        response = httpx.post(
+            f"https://{index_host}/query",
+            headers=self._headers,
+            json=body,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def fetch_vectors(
+        self,
+        index_host: str,
+        ids: list[str],
+        namespace: str = "",
+    ) -> dict[str, Any]:
+        """Fetch vectors by ID.
+
+        Args:
+            index_host: The host URL of the index
+            ids: List of vector IDs to fetch
+            namespace: Optional namespace within the index
+        """
+        params: dict[str, Any] = {"ids": ids}
+        if namespace:
+            params["namespace"] = namespace
+
+        response = httpx.get(
+            f"https://{index_host}/vectors/fetch",
+            headers=self._headers,
+            params=params,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def delete_vectors(
+        self,
+        index_host: str,
+        ids: list[str] | None = None,
+        delete_all: bool = False,
+        namespace: str = "",
+        filter: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Delete vectors from an index.
+
+        Args:
+            index_host: The host URL of the index
+            ids: List of vector IDs to delete
+            delete_all: If True, delete all vectors in namespace
+            namespace: Namespace within the index
+            filter: Optional metadata filter for deletion
+        """
+        body: dict[str, Any] = {}
+        if delete_all:
+            body["deleteAll"] = True
+        elif ids:
+            body["ids"] = ids
+        elif filter:
+            body["filter"] = filter
+        else:
+            return {"error": "Must provide 'ids', 'delete_all', or 'filter'"}
+
+        if namespace:
+            body["namespace"] = namespace
+
+        response = httpx.post(
+            f"https://{index_host}/vectors/delete",
+            headers=self._headers,
+            json=body,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def upsert_records(
+        self,
+        index_host: str,
+        records: list[dict[str, Any]],
+        namespace: str = "",
+    ) -> dict[str, Any]:
+        """Upsert records using integrated inference.
+
+        This endpoint uses Pinecone's integrated inference to automatically
+        generate embeddings from text data.
+
+        Args:
+            index_host: The host URL of the index (must be an integrated inference index)
+            records: List of records with '_id' and data fields matching the index model
+            namespace: Optional namespace within the index
+        """
+        body: dict[str, Any] = {"records": records}
+        if namespace:
+            body["namespace"] = namespace
+
+        response = httpx.post(
+            f"https://{index_host}/records/upsert",
+            headers=self._headers,
+            json=body,
+            timeout=60.0,
+        )
+        return self._handle_response(response)
+
+    def search_records(
+        self,
+        index_host: str,
+        query: dict[str, Any],
+        namespace: str = "",
+        top_k: int = 10,
+        filter: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Search records using integrated inference.
+
+        This endpoint uses Pinecone's integrated inference to automatically
+        generate query embeddings from text.
+
+        Args:
+            index_host: The host URL of the index (must be an integrated inference index)
+            query: Query dict with fields matching the index model's text field
+            namespace: Optional namespace within the index
+            top_k: Number of results to return
+            filter: Optional metadata filter
+        """
+        body: dict[str, Any] = {
+            "query": query,
+            "top_k": top_k,
+        }
+        if namespace:
+            body["namespace"] = namespace
+        if filter:
+            body["filter"] = filter
+
+        response = httpx.post(
+            f"https://{index_host}/records/search",
+            headers=self._headers,
+            json=body,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def list_namespaces(
+        self,
+        index_host: str,
+    ) -> dict[str, Any]:
+        """List all namespaces in an index."""
+        response = httpx.get(
+            f"https://{index_host}/namespaces",
+            headers=self._headers,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def delete_namespace(
+        self,
+        index_host: str,
+        namespace: str,
+    ) -> dict[str, Any]:
+        """Delete a namespace and all vectors within it."""
+        response = httpx.delete(
+            f"https://{index_host}/namespaces/{namespace}",
+            headers=self._headers,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def describe_index_stats(
+        self,
+        index_host: str,
+        filter: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Get statistics about an index."""
+        body: dict[str, Any] = {}
+        if filter:
+            body["filter"] = filter
+
+        response = httpx.post(
+            f"https://{index_host}/describe_index_stats",
+            headers=self._headers,
+            json=body,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: CredentialStoreAdapter | None = None,
+) -> None:
+    """Register Pinecone tools with the MCP server."""
+
+    def _get_api_key() -> str | None:
+        """Get Pinecone API key from credential manager or environment."""
+        if credentials is not None:
+            return credentials.get("pinecone")
+        return os.getenv("PINECONE_API_KEY")
+
+    def _get_client() -> _PineconeClient | dict[str, str]:
+        """Get a Pinecone client, or return an error dict if no credentials."""
+        api_key = _get_api_key()
+        if not api_key:
+            return {
+                "error": "Pinecone credentials not configured",
+                "help": (
+                    "Set PINECONE_API_KEY environment variable or configure via credential store"
+                ),
+            }
+        return _PineconeClient(api_key)
+
+    @mcp.tool()
+    def pinecone_list_indexes() -> dict:
+        """
+        List all indexes in your Pinecone project.
+
+        Returns:
+            Dict with list of indexes or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.list_indexes()
+            if "error" in result:
+                return result
+            indexes = result.get("indexes", [])
+            return {
+                "success": True,
+                "indexes": [
+                    {
+                        "name": idx.get("name"),
+                        "dimension": idx.get("dimension"),
+                        "metric": idx.get("metric"),
+                        "host": idx.get("host"),
+                        "spec": idx.get("spec"),
+                        "status": idx.get("status", {}).get("ready", False),
+                    }
+                    for idx in indexes
+                ],
+                "count": len(indexes),
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def pinecone_create_index(
+        name: str,
+        dimension: int,
+        metric: str = "cosine",
+        cloud: str = "aws",
+        region: str = "us-east-1",
+    ) -> dict:
+        """
+        Create a new Pinecone serverless index.
+
+        Args:
+            name: Index name (must be unique within project)
+            dimension: Vector dimension (e.g., 1536 for OpenAI embeddings)
+            metric: Distance metric - 'cosine', 'dotproduct', or 'euclidean'
+            cloud: Cloud provider - 'aws', 'gcp', or 'azure'
+            region: Region for the index (e.g., 'us-east-1', 'us-west-4')
+
+        Returns:
+            Dict with created index details or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.create_index(name, dimension, metric, cloud, region)
+            if "error" in result:
+                return result
+            return {
+                "success": True,
+                "index": {
+                    "name": result.get("name"),
+                    "dimension": result.get("dimension"),
+                    "metric": result.get("metric"),
+                    "host": result.get("host"),
+                    "status": result.get("status"),
+                },
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def pinecone_describe_index(name: str) -> dict:
+        """
+        Get details about a specific Pinecone index.
+
+        Args:
+            name: Index name
+
+        Returns:
+            Dict with index details including host URL needed for vector operations
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.describe_index(name)
+            if "error" in result:
+                return result
+            return {
+                "success": True,
+                "index": {
+                    "name": result.get("name"),
+                    "dimension": result.get("dimension"),
+                    "metric": result.get("metric"),
+                    "host": result.get("host"),
+                    "spec": result.get("spec"),
+                    "status": result.get("status"),
+                },
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def pinecone_delete_index(name: str) -> dict:
+        """
+        Delete a Pinecone index.
+
+        WARNING: This permanently deletes the index and all its data.
+
+        Args:
+            name: Index name to delete
+
+        Returns:
+            Dict with success status or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.delete_index(name)
+            if "error" in result:
+                return result
+            return {"success": True, "message": f"Index '{name}' deleted"}
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def pinecone_upsert_vectors(
+        index_host: str,
+        vectors: list[dict],
+        namespace: str = "",
+    ) -> dict:
+        """
+        Upsert vectors into a Pinecone index.
+
+        Args:
+            index_host: Index host URL (from describe_index, e.g., 'my-index.svc.apw5.pinecone.io')
+            vectors: List of vectors, each with:
+                     - id: Unique identifier (string)
+                     - values: Vector values (list of floats)
+                     - metadata: Optional dict of key-value pairs
+            namespace: Optional namespace within the index
+
+        Returns:
+            Dict with upsert count or error
+
+        Example:
+            vectors = [
+                {"id": "doc1", "values": [0.1, 0.2, ...], "metadata": {"title": "Doc 1"}},
+                {"id": "doc2", "values": [0.3, 0.4, ...], "metadata": {"title": "Doc 2"}}
+            ]
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.upsert_vectors(index_host, vectors, namespace)
+            if "error" in result:
+                return result
+            return {
+                "success": True,
+                "upserted_count": result.get("upsertedCount", len(vectors)),
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def pinecone_query_vectors(
+        index_host: str,
+        vector: list[float] | None = None,
+        id: str | None = None,
+        top_k: int = 10,
+        namespace: str = "",
+        filter: dict | None = None,
+        include_values: bool = False,
+        include_metadata: bool = True,
+    ) -> dict:
+        """
+        Query a Pinecone index for similar vectors.
+
+        Provide either 'vector' (query embedding) or 'id' (existing vector ID).
+
+        Args:
+            index_host: Index host URL
+            vector: Query vector values (list of floats)
+            id: ID of existing vector to use as query
+            top_k: Number of results to return (default 10)
+            namespace: Optional namespace to search within
+            filter: Optional metadata filter (e.g., {"category": "tech"})
+            include_values: Whether to include vector values in results
+            include_metadata: Whether to include metadata in results
+
+        Returns:
+            Dict with matching vectors or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.query_vectors(
+                index_host,
+                vector=vector,
+                id=id,
+                top_k=top_k,
+                namespace=namespace,
+                filter=filter,
+                include_values=include_values,
+                include_metadata=include_metadata,
+            )
+            if "error" in result:
+                return result
+            matches = result.get("matches", [])
+            return {
+                "success": True,
+                "matches": [
+                    {
+                        "id": m.get("id"),
+                        "score": m.get("score"),
+                        "values": m.get("values") if include_values else None,
+                        "metadata": m.get("metadata") if include_metadata else None,
+                    }
+                    for m in matches
+                ],
+                "namespace": result.get("namespace", ""),
+                "count": len(matches),
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def pinecone_fetch_vectors(
+        index_host: str,
+        ids: list[str],
+        namespace: str = "",
+    ) -> dict:
+        """
+        Fetch vectors by their IDs.
+
+        Args:
+            index_host: Index host URL
+            ids: List of vector IDs to fetch
+            namespace: Optional namespace within the index
+
+        Returns:
+            Dict with fetched vectors or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.fetch_vectors(index_host, ids, namespace)
+            if "error" in result:
+                return result
+            vectors = result.get("vectors", {})
+            return {
+                "success": True,
+                "vectors": {
+                    vid: {
+                        "id": v.get("id"),
+                        "values": v.get("values"),
+                        "metadata": v.get("metadata"),
+                    }
+                    for vid, v in vectors.items()
+                },
+                "namespace": result.get("namespace", ""),
+                "count": len(vectors),
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def pinecone_delete_vectors(
+        index_host: str,
+        ids: list[str] | None = None,
+        delete_all: bool = False,
+        namespace: str = "",
+        filter: dict | None = None,
+    ) -> dict:
+        """
+        Delete vectors from a Pinecone index.
+
+        Must provide exactly one of: ids, delete_all, or filter.
+
+        Args:
+            index_host: Index host URL
+            ids: List of vector IDs to delete
+            delete_all: If True, delete all vectors in the namespace
+            namespace: Namespace within the index
+            filter: Metadata filter for selective deletion
+
+        Returns:
+            Dict with success status or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.delete_vectors(
+                index_host,
+                ids=ids,
+                delete_all=delete_all,
+                namespace=namespace,
+                filter=filter,
+            )
+            if "error" in result:
+                return result
+            return {"success": True, "message": "Vectors deleted"}
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def pinecone_upsert_records(
+        index_host: str,
+        records: list[dict],
+        namespace: str = "",
+    ) -> dict:
+        """
+        Upsert records using Pinecone's integrated inference.
+
+        This endpoint automatically generates embeddings from text data.
+        Requires an index created with an embedding model.
+
+        Args:
+            index_host: Index host URL (must be integrated inference index)
+            records: List of records with '_id' and text fields matching index model
+            namespace: Optional namespace within the index
+
+        Returns:
+            Dict with success status or error
+
+        Example:
+            records = [
+                {"_id": "doc1", "title": "Document Title", "content": "Full text..."}
+            ]
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.upsert_records(index_host, records, namespace)
+            if "error" in result:
+                return result
+            return {"success": True, "message": f"Upserted {len(records)} records"}
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def pinecone_search_records(
+        index_host: str,
+        query: dict,
+        namespace: str = "",
+        top_k: int = 10,
+        filter: dict | None = None,
+    ) -> dict:
+        """
+        Search records using Pinecone's integrated inference.
+
+        This endpoint automatically generates query embeddings from text.
+        Requires an index created with an embedding model.
+
+        Args:
+            index_host: Index host URL (must be integrated inference index)
+            query: Query dict with text field matching index model (e.g., {"text": "search query"})
+            namespace: Optional namespace to search within
+            top_k: Number of results to return
+            filter: Optional metadata filter
+
+        Returns:
+            Dict with matching records or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.search_records(
+                index_host,
+                query,
+                namespace=namespace,
+                top_k=top_k,
+                filter=filter,
+            )
+            if "error" in result:
+                return result
+            hits = result.get("result", {}).get("hits", [])
+            return {
+                "success": True,
+                "hits": [
+                    {
+                        "_id": h.get("_id"),
+                        "_score": h.get("_score"),
+                        "fields": h.get("fields"),
+                    }
+                    for h in hits
+                ],
+                "count": len(hits),
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def pinecone_list_namespaces(index_host: str) -> dict:
+        """
+        List all namespaces in a Pinecone index.
+
+        Args:
+            index_host: Index host URL
+
+        Returns:
+            Dict with list of namespaces or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.list_namespaces(index_host)
+            if "error" in result:
+                return result
+            namespaces = result.get("namespaces", {})
+            return {
+                "success": True,
+                "namespaces": [
+                    {"name": name, "vector_count": ns.get("vectorCount", 0)}
+                    for name, ns in namespaces.items()
+                ],
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def pinecone_delete_namespace(
+        index_host: str,
+        namespace: str,
+    ) -> dict:
+        """
+        Delete a namespace and all vectors within it.
+
+        WARNING: This permanently deletes all data in the namespace.
+
+        Args:
+            index_host: Index host URL
+            namespace: Namespace name to delete
+
+        Returns:
+            Dict with success status or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.delete_namespace(index_host, namespace)
+            if "error" in result:
+                return result
+            return {"success": True, "message": f"Namespace '{namespace}' deleted"}
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}

--- a/tools/src/aden_tools/tools/pinecone_tool/tests/__init__.py
+++ b/tools/src/aden_tools/tools/pinecone_tool/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Pinecone tool."""

--- a/tools/src/aden_tools/tools/pinecone_tool/tests/test_pinecone_tool.py
+++ b/tools/src/aden_tools/tools/pinecone_tool/tests/test_pinecone_tool.py
@@ -1,0 +1,709 @@
+"""
+Tests for Pinecone vector database tool.
+
+Covers:
+- _PineconeClient methods (list_indexes, create_index, query_vectors, etc.)
+- Error handling (401, 403, 404, 429, 500, timeout)
+- Credential retrieval (CredentialStoreAdapter vs env var)
+- All 12 MCP tool functions
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from aden_tools.tools.pinecone_tool.pinecone_tool import (
+    PINECONE_API_BASE,
+    _PineconeClient,
+    register_tools,
+)
+
+
+class TestPineconeClient:
+    def setup_method(self):
+        self.client = _PineconeClient("test-api-key")
+
+    def test_headers(self):
+        headers = self.client._headers
+        assert headers["Api-Key"] == "test-api-key"
+        assert headers["Content-Type"] == "application/json"
+
+    def test_handle_response_success(self):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"indexes": []}
+        assert self.client._handle_response(response) == {"indexes": []}
+
+    def test_handle_response_201(self):
+        response = MagicMock()
+        response.status_code = 201
+        response.json.return_value = {"name": "test-index"}
+        assert self.client._handle_response(response) == {"name": "test-index"}
+
+    @pytest.mark.parametrize(
+        "status_code,expected_substring",
+        [
+            (401, "Invalid or expired"),
+            (403, "Insufficient permissions"),
+            (404, "not found"),
+            (429, "Rate limit"),
+            (500, "server error"),
+        ],
+    )
+    def test_handle_response_errors(self, status_code, expected_substring):
+        response = MagicMock()
+        response.status_code = status_code
+        result = self.client._handle_response(response)
+        assert "error" in result
+        assert expected_substring in result["error"]
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.get")
+    def test_list_indexes(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "indexes": [
+                {
+                    "name": "test-index",
+                    "dimension": 1536,
+                    "metric": "cosine",
+                    "host": "test-index.svc.pinecone.io",
+                    "status": {"ready": True},
+                }
+            ]
+        }
+        mock_get.return_value = mock_response
+
+        result = self.client.list_indexes()
+
+        mock_get.assert_called_once_with(
+            f"{PINECONE_API_BASE}/indexes",
+            headers=self.client._headers,
+            timeout=30.0,
+        )
+        assert "indexes" in result
+        assert len(result["indexes"]) == 1
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.post")
+    def test_create_index(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {
+            "name": "new-index",
+            "dimension": 1536,
+            "metric": "cosine",
+            "host": "new-index.svc.pinecone.io",
+        }
+        mock_post.return_value = mock_response
+
+        self.client.create_index("new-index", 1536)
+
+        mock_post.assert_called_once()
+        call_json = mock_post.call_args.kwargs["json"]
+        assert call_json["name"] == "new-index"
+        assert call_json["dimension"] == 1536
+        assert call_json["metric"] == "cosine"
+        assert "serverless" in call_json["spec"]
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.post")
+    def test_create_index_with_custom_spec(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {"name": "custom-index"}
+        mock_post.return_value = mock_response
+
+        custom_spec = {"pod": {"environment": "us-west1-gcp", "replicas": 2}}
+        self.client.create_index("custom-index", 768, spec=custom_spec)
+
+        call_json = mock_post.call_args.kwargs["json"]
+        assert call_json["spec"] == custom_spec
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.get")
+    def test_describe_index(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "name": "test-index",
+            "dimension": 1536,
+            "metric": "cosine",
+            "host": "test-index.svc.pinecone.io",
+            "status": {"ready": True},
+        }
+        mock_get.return_value = mock_response
+
+        result = self.client.describe_index("test-index")
+
+        mock_get.assert_called_once_with(
+            f"{PINECONE_API_BASE}/indexes/test-index",
+            headers=self.client._headers,
+            timeout=30.0,
+        )
+        assert result["name"] == "test-index"
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.delete")
+    def test_delete_index(self, mock_delete):
+        mock_response = MagicMock()
+        mock_response.status_code = 202
+        mock_delete.return_value = mock_response
+
+        self.client.delete_index("test-index")
+
+        mock_delete.assert_called_once_with(
+            f"{PINECONE_API_BASE}/indexes/test-index",
+            headers=self.client._headers,
+            timeout=30.0,
+        )
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.post")
+    def test_upsert_vectors(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"upsertedCount": 2}
+        mock_post.return_value = mock_response
+
+        vectors = [
+            {"id": "doc1", "values": [0.1, 0.2, 0.3]},
+            {"id": "doc2", "values": [0.4, 0.5, 0.6]},
+        ]
+        result = self.client.upsert_vectors("test-index.svc.pinecone.io", vectors)
+
+        mock_post.assert_called_once_with(
+            "https://test-index.svc.pinecone.io/vectors/upsert",
+            headers=self.client._headers,
+            json={"vectors": vectors},
+            timeout=60.0,
+        )
+        assert result["upsertedCount"] == 2
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.post")
+    def test_upsert_vectors_with_namespace(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"upsertedCount": 1}
+        mock_post.return_value = mock_response
+
+        vectors = [{"id": "doc1", "values": [0.1, 0.2]}]
+        self.client.upsert_vectors("test-index.svc.pinecone.io", vectors, namespace="production")
+
+        call_json = mock_post.call_args.kwargs["json"]
+        assert call_json["namespace"] == "production"
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.post")
+    def test_query_vectors(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "matches": [
+                {"id": "doc1", "score": 0.95, "metadata": {"title": "Doc 1"}},
+                {"id": "doc2", "score": 0.85, "metadata": {"title": "Doc 2"}},
+            ],
+            "namespace": "",
+        }
+        mock_post.return_value = mock_response
+
+        result = self.client.query_vectors(
+            "test-index.svc.pinecone.io",
+            vector=[0.1, 0.2, 0.3],
+            top_k=5,
+        )
+
+        mock_post.assert_called_once()
+        call_json = mock_post.call_args.kwargs["json"]
+        assert call_json["vector"] == [0.1, 0.2, 0.3]
+        assert call_json["top_k"] == 5
+        assert "matches" in result
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.post")
+    def test_query_vectors_by_id(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"matches": []}
+        mock_post.return_value = mock_response
+
+        self.client.query_vectors(
+            "test-index.svc.pinecone.io",
+            id="doc1",
+            top_k=10,
+        )
+
+        call_json = mock_post.call_args.kwargs["json"]
+        assert call_json["id"] == "doc1"
+        assert "vector" not in call_json
+
+    def test_query_vectors_no_vector_or_id(self):
+        result = self.client.query_vectors("test-index.svc.pinecone.io")
+        assert "error" in result
+        assert "Either 'vector' or 'id'" in result["error"]
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.get")
+    def test_fetch_vectors(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "vectors": {
+                "doc1": {"id": "doc1", "values": [0.1, 0.2], "metadata": {}},
+            },
+            "namespace": "",
+        }
+        mock_get.return_value = mock_response
+
+        self.client.fetch_vectors("test-index.svc.pinecone.io", ["doc1"])
+
+        mock_get.assert_called_once()
+        call_params = mock_get.call_args.kwargs["params"]
+        assert call_params["ids"] == ["doc1"]
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.post")
+    def test_delete_vectors_by_ids(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        self.client.delete_vectors("test-index.svc.pinecone.io", ids=["doc1", "doc2"])
+
+        call_json = mock_post.call_args.kwargs["json"]
+        assert call_json["ids"] == ["doc1", "doc2"]
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.post")
+    def test_delete_vectors_delete_all(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        self.client.delete_vectors("test-index.svc.pinecone.io", delete_all=True, namespace="test")
+
+        call_json = mock_post.call_args.kwargs["json"]
+        assert call_json["deleteAll"] is True
+        assert call_json["namespace"] == "test"
+
+    def test_delete_vectors_no_params(self):
+        result = self.client.delete_vectors("test-index.svc.pinecone.io")
+        assert "error" in result
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.post")
+    def test_upsert_records(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        records = [{"_id": "doc1", "title": "Test Document"}]
+        self.client.upsert_records("test-index.svc.pinecone.io", records, namespace="docs")
+
+        mock_post.assert_called_once_with(
+            "https://test-index.svc.pinecone.io/records/upsert",
+            headers=self.client._headers,
+            json={"records": records, "namespace": "docs"},
+            timeout=60.0,
+        )
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.post")
+    def test_search_records(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "result": {"hits": [{"_id": "doc1", "_score": 0.95, "fields": {"title": "Test"}}]}
+        }
+        mock_post.return_value = mock_response
+
+        self.client.search_records(
+            "test-index.svc.pinecone.io",
+            query={"text": "search query"},
+            top_k=5,
+        )
+
+        mock_post.assert_called_once()
+        call_json = mock_post.call_args.kwargs["json"]
+        assert call_json["query"] == {"text": "search query"}
+        assert call_json["top_k"] == 5
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.get")
+    def test_list_namespaces(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "namespaces": {
+                "": {"vectorCount": 100},
+                "production": {"vectorCount": 500},
+            }
+        }
+        mock_get.return_value = mock_response
+
+        result = self.client.list_namespaces("test-index.svc.pinecone.io")
+
+        mock_get.assert_called_once_with(
+            "https://test-index.svc.pinecone.io/namespaces",
+            headers=self.client._headers,
+            timeout=30.0,
+        )
+        assert "namespaces" in result
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.delete")
+    def test_delete_namespace(self, mock_delete):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_delete.return_value = mock_response
+
+        self.client.delete_namespace("test-index.svc.pinecone.io", "old-namespace")
+
+        mock_delete.assert_called_once_with(
+            "https://test-index.svc.pinecone.io/namespaces/old-namespace",
+            headers=self.client._headers,
+            timeout=30.0,
+        )
+
+
+class TestToolRegistration:
+    def _get_tool_fn(self, mcp_mock, tool_name):
+        """Extract a registered tool function by name from mcp.tool() calls."""
+        for call in mcp_mock.tool.return_value.call_args_list:
+            fn = call[0][0]
+            if fn.__name__ == tool_name:
+                return fn
+        raise ValueError(f"Tool '{tool_name}' not found in registered tools")
+
+    def test_register_tools_registers_all_tools(self):
+        mcp = MagicMock()
+        mcp.tool.return_value = lambda fn: fn
+        register_tools(mcp)
+        assert mcp.tool.call_count == 12
+
+    def test_no_credentials_returns_error(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        with patch.dict("os.environ", {}, clear=True):
+            register_tools(mcp, credentials=None)
+
+        list_fn = next(fn for fn in registered_fns if fn.__name__ == "pinecone_list_indexes")
+        result = list_fn()
+        assert "error" in result
+        assert "not configured" in result["error"]
+
+    def test_credentials_from_credential_manager(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        cred_manager = MagicMock()
+        cred_manager.get.return_value = "test-api-key"
+
+        register_tools(mcp, credentials=cred_manager)
+
+        list_fn = next(fn for fn in registered_fns if fn.__name__ == "pinecone_list_indexes")
+
+        with patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"indexes": []}
+            mock_get.return_value = mock_response
+
+            result = list_fn()
+
+        cred_manager.get.assert_called_with("pinecone")
+        assert result["success"] is True
+
+    def test_credentials_from_env_var(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        register_tools(mcp, credentials=None)
+
+        list_fn = next(fn for fn in registered_fns if fn.__name__ == "pinecone_list_indexes")
+
+        with (
+            patch.dict("os.environ", {"PINECONE_API_KEY": "env-api-key"}),
+            patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.get") as mock_get,
+        ):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"indexes": []}
+            mock_get.return_value = mock_response
+
+            result = list_fn()
+
+        assert result["success"] is True
+        call_headers = mock_get.call_args.kwargs["headers"]
+        assert call_headers["Api-Key"] == "env-api-key"
+
+
+class TestIndexTools:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.fns = []
+        self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
+        cred = MagicMock()
+        cred.get.return_value = "test-key"
+        register_tools(self.mcp, credentials=cred)
+
+    def _fn(self, name):
+        return next(f for f in self.fns if f.__name__ == name)
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.get")
+    def test_list_indexes(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value={
+                    "indexes": [
+                        {
+                            "name": "test-index",
+                            "dimension": 1536,
+                            "metric": "cosine",
+                            "host": "test.svc.pinecone.io",
+                            "status": {"ready": True},
+                        }
+                    ]
+                }
+            ),
+        )
+        result = self._fn("pinecone_list_indexes")()
+        assert result["success"] is True
+        assert result["count"] == 1
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.post")
+    def test_create_index(self, mock_post):
+        mock_post.return_value = MagicMock(
+            status_code=201,
+            json=MagicMock(
+                return_value={
+                    "name": "new-index",
+                    "dimension": 1536,
+                    "metric": "cosine",
+                    "host": "new.svc.pinecone.io",
+                }
+            ),
+        )
+        result = self._fn("pinecone_create_index")(
+            name="new-index", dimension=1536, metric="cosine"
+        )
+        assert result["success"] is True
+        assert result["index"]["name"] == "new-index"
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.get")
+    def test_describe_index(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value={
+                    "name": "test-index",
+                    "dimension": 1536,
+                    "metric": "cosine",
+                    "host": "test.svc.pinecone.io",
+                    "status": {"ready": True},
+                }
+            ),
+        )
+        result = self._fn("pinecone_describe_index")(name="test-index")
+        assert result["success"] is True
+        assert result["index"]["name"] == "test-index"
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.delete")
+    def test_delete_index(self, mock_delete):
+        mock_delete.return_value = MagicMock(status_code=202)
+        result = self._fn("pinecone_delete_index")(name="test-index")
+        assert result["success"] is True
+
+
+class TestVectorTools:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.fns = []
+        self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
+        cred = MagicMock()
+        cred.get.return_value = "test-key"
+        register_tools(self.mcp, credentials=cred)
+
+    def _fn(self, name):
+        return next(f for f in self.fns if f.__name__ == name)
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.post")
+    def test_upsert_vectors(self, mock_post):
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(return_value={"upsertedCount": 2}),
+        )
+        vectors = [
+            {"id": "doc1", "values": [0.1, 0.2]},
+            {"id": "doc2", "values": [0.3, 0.4]},
+        ]
+        result = self._fn("pinecone_upsert_vectors")(
+            index_host="test.svc.pinecone.io", vectors=vectors
+        )
+        assert result["success"] is True
+        assert result["upserted_count"] == 2
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.post")
+    def test_query_vectors(self, mock_post):
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value={
+                    "matches": [{"id": "doc1", "score": 0.95, "metadata": {"title": "Test"}}],
+                    "namespace": "",
+                }
+            ),
+        )
+        result = self._fn("pinecone_query_vectors")(
+            index_host="test.svc.pinecone.io",
+            vector=[0.1, 0.2, 0.3],
+            top_k=5,
+        )
+        assert result["success"] is True
+        assert result["count"] == 1
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.get")
+    def test_fetch_vectors(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value={
+                    "vectors": {"doc1": {"id": "doc1", "values": [0.1, 0.2], "metadata": {}}},
+                    "namespace": "",
+                }
+            ),
+        )
+        result = self._fn("pinecone_fetch_vectors")(index_host="test.svc.pinecone.io", ids=["doc1"])
+        assert result["success"] is True
+        assert result["count"] == 1
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.post")
+    def test_delete_vectors(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        result = self._fn("pinecone_delete_vectors")(
+            index_host="test.svc.pinecone.io", ids=["doc1"]
+        )
+        assert result["success"] is True
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.post")
+    def test_upsert_vectors_timeout(self, mock_post):
+        mock_post.side_effect = httpx.TimeoutException("timed out")
+        result = self._fn("pinecone_upsert_vectors")(
+            index_host="test.svc.pinecone.io", vectors=[{"id": "1", "values": [0.1]}]
+        )
+        assert "error" in result
+        assert "timed out" in result["error"]
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.post")
+    def test_query_vectors_network_error(self, mock_post):
+        mock_post.side_effect = httpx.RequestError("connection failed")
+        result = self._fn("pinecone_query_vectors")(
+            index_host="test.svc.pinecone.io", vector=[0.1, 0.2]
+        )
+        assert "error" in result
+        assert "Network error" in result["error"]
+
+
+class TestRecordTools:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.fns = []
+        self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
+        cred = MagicMock()
+        cred.get.return_value = "test-key"
+        register_tools(self.mcp, credentials=cred)
+
+    def _fn(self, name):
+        return next(f for f in self.fns if f.__name__ == name)
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.post")
+    def test_upsert_records(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        records = [{"_id": "doc1", "title": "Test Document"}]
+        result = self._fn("pinecone_upsert_records")(
+            index_host="test.svc.pinecone.io", records=records
+        )
+        assert result["success"] is True
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.post")
+    def test_search_records(self, mock_post):
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value={
+                    "result": {
+                        "hits": [{"_id": "doc1", "_score": 0.95, "fields": {"title": "Test"}}]
+                    }
+                }
+            ),
+        )
+        result = self._fn("pinecone_search_records")(
+            index_host="test.svc.pinecone.io",
+            query={"text": "search query"},
+            top_k=5,
+        )
+        assert result["success"] is True
+        assert result["count"] == 1
+
+
+class TestNamespaceTools:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.fns = []
+        self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
+        cred = MagicMock()
+        cred.get.return_value = "test-key"
+        register_tools(self.mcp, credentials=cred)
+
+    def _fn(self, name):
+        return next(f for f in self.fns if f.__name__ == name)
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.get")
+    def test_list_namespaces(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value={
+                    "namespaces": {
+                        "": {"vectorCount": 100},
+                        "production": {"vectorCount": 500},
+                    }
+                }
+            ),
+        )
+        result = self._fn("pinecone_list_namespaces")(index_host="test.svc.pinecone.io")
+        assert result["success"] is True
+        assert len(result["namespaces"]) == 2
+
+    @patch("aden_tools.tools.pinecone_tool.pinecone_tool.httpx.delete")
+    def test_delete_namespace(self, mock_delete):
+        mock_delete.return_value = MagicMock(status_code=200)
+        result = self._fn("pinecone_delete_namespace")(
+            index_host="test.svc.pinecone.io", namespace="old-namespace"
+        )
+        assert result["success"] is True
+
+
+class TestCredentialSpec:
+    def test_pinecone_credential_spec_exists(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        assert "pinecone" in CREDENTIAL_SPECS
+
+    def test_pinecone_spec_env_var(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["pinecone"]
+        assert spec.env_var == "PINECONE_API_KEY"
+
+    def test_pinecone_spec_tools(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["pinecone"]
+        assert "pinecone_list_indexes" in spec.tools
+        assert "pinecone_query_vectors" in spec.tools
+        assert "pinecone_upsert_vectors" in spec.tools
+        assert len(spec.tools) == 12
+
+    def test_pinecone_spec_health_check(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["pinecone"]
+        assert spec.health_check_endpoint == "https://api.pinecone.io/indexes"
+        assert spec.health_check_method == "GET"
+        assert spec.credential_id == "pinecone"
+        assert spec.credential_key == "api_key"


### PR DESCRIPTION
## Summary

This PR adds a native Pinecone vector database integration for RAG agent workflows, implementing the recommended Approach B from issue #4080.

### Tools Added (12 total)

**Index Management:**
- `pinecone_list_indexes` - List all indexes in the project
- `pinecone_create_index` - Create a new serverless index
- `pinecone_describe_index` - Get details about an index
- `pinecone_delete_index` - Delete an index

**Vector Operations:**
- `pinecone_upsert_vectors` - Upsert vectors into an index
- `pinecone_query_vectors` - Query for similar vectors
- `pinecone_fetch_vectors` - Fetch vectors by ID
- `pinecone_delete_vectors` - Delete vectors from an index

**Integrated Inference (for indexes with embedding models):**
- `pinecone_upsert_records` - Upsert records with auto-embedding
- `pinecone_search_records` - Search records with auto-embedding

**Namespace Management:**
- `pinecone_list_namespaces` - List all namespaces in an index
- `pinecone_delete_namespace` - Delete a namespace

### Key Features

- **Native Python implementation** using httpx for HTTP requests
- **Credential management** via `CredentialSpec` with health check endpoint
- **Consistent snake_case naming** following Hive conventions
- **Comprehensive error handling** with user-friendly error messages
- **48 unit tests** covering all tools and edge cases

### Files Changed

- `tools/src/aden_tools/credentials/pinecone.py` - Credential spec
- `tools/src/aden_tools/credentials/__init__.py` - Register credential
- `tools/src/aden_tools/tools/pinecone_tool/` - Tool implementation and tests
- `tools/src/aden_tools/tools/__init__.py` - Register tool
- `tools/README.md` - Documentation update

### Setup

Users can configure Pinecone by setting:
```bash
export PINECONE_API_KEY=your_api_key
```

Or via the credential store at `~/.hive/credentials`.

Resolves #4080
