### PR TITLE
test(core): add test coverage for session_store.py and conversation_store.py

### DIFF
--- a/core/tests/test_conversation_store.py
+++ b/core/tests/test_conversation_store.py
@@ -1,0 +1,307 @@
+"""Tests for framework.storage.conversation_store.FileConversationStore.
+
+Covers part write/read, metadata persistence, cursor persistence,
+partial deletion, full destruction, and edge cases (empty store,
+corrupted JSON, missing directories).  All I/O is isolated via the
+``tmp_path`` fixture.
+
+Resolves: https://github.com/adenhq/hive/issues/4100
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from framework.storage.conversation_store import FileConversationStore
+
+
+# ---------------------------------------------------------------------------
+# write_part / read_parts
+# ---------------------------------------------------------------------------
+
+
+class TestWriteReadParts:
+    """Tests for writing and reading conversation parts."""
+
+    @pytest.mark.asyncio
+    async def test_single_part_round_trip(self, tmp_path: Path) -> None:
+        """A single part should round-trip correctly."""
+        store = FileConversationStore(tmp_path / "conv")
+        data = {"role": "user", "content": "hello"}
+        await store.write_part(0, data)
+
+        parts = await store.read_parts()
+        assert len(parts) == 1
+        assert parts[0] == data
+
+    @pytest.mark.asyncio
+    async def test_multiple_parts_ordered(self, tmp_path: Path) -> None:
+        """Parts should be returned in sequence-number order."""
+        store = FileConversationStore(tmp_path / "conv")
+        for i in range(5):
+            await store.write_part(i, {"seq": i, "content": f"msg-{i}"})
+
+        parts = await store.read_parts()
+        assert len(parts) == 5
+        for i, part in enumerate(parts):
+            assert part["seq"] == i
+
+    @pytest.mark.asyncio
+    async def test_read_empty_store(self, tmp_path: Path) -> None:
+        """Reading from a store with no parts should return an empty list."""
+        store = FileConversationStore(tmp_path / "empty")
+        assert await store.read_parts() == []
+
+    @pytest.mark.asyncio
+    async def test_part_file_naming(self, tmp_path: Path) -> None:
+        """Part files should be zero-padded 10-digit names."""
+        store = FileConversationStore(tmp_path / "conv")
+        await store.write_part(42, {"data": "x"})
+
+        expected = tmp_path / "conv" / "parts" / "0000000042.json"
+        assert expected.exists()
+
+    @pytest.mark.asyncio
+    async def test_overwrite_existing_part(self, tmp_path: Path) -> None:
+        """Writing to the same sequence number should overwrite."""
+        store = FileConversationStore(tmp_path / "conv")
+        await store.write_part(0, {"version": 1})
+        await store.write_part(0, {"version": 2})
+
+        parts = await store.read_parts()
+        assert len(parts) == 1
+        assert parts[0]["version"] == 2
+
+    @pytest.mark.asyncio
+    async def test_skips_corrupted_part(self, tmp_path: Path) -> None:
+        """Corrupted part files should be silently skipped."""
+        store = FileConversationStore(tmp_path / "conv")
+        await store.write_part(0, {"good": True})
+
+        # Manually corrupt a part file
+        bad_file = tmp_path / "conv" / "parts" / "0000000001.json"
+        bad_file.parent.mkdir(parents=True, exist_ok=True)
+        bad_file.write_text("{broken json!!")
+
+        parts = await store.read_parts()
+        assert len(parts) == 1
+        assert parts[0]["good"] is True
+
+
+# ---------------------------------------------------------------------------
+# write_meta / read_meta
+# ---------------------------------------------------------------------------
+
+
+class TestMetaPersistence:
+    """Tests for conversation metadata."""
+
+    @pytest.mark.asyncio
+    async def test_meta_round_trip(self, tmp_path: Path) -> None:
+        """Metadata should round-trip correctly."""
+        store = FileConversationStore(tmp_path / "conv")
+        meta = {"node_id": "search", "model": "gpt-4o", "tokens": 150}
+        await store.write_meta(meta)
+
+        loaded = await store.read_meta()
+        assert loaded == meta
+
+    @pytest.mark.asyncio
+    async def test_read_meta_missing(self, tmp_path: Path) -> None:
+        """Reading metadata from a fresh store should return None."""
+        store = FileConversationStore(tmp_path / "conv")
+        assert await store.read_meta() is None
+
+    @pytest.mark.asyncio
+    async def test_meta_overwrite(self, tmp_path: Path) -> None:
+        """Writing metadata twice should overwrite."""
+        store = FileConversationStore(tmp_path / "conv")
+        await store.write_meta({"version": 1})
+        await store.write_meta({"version": 2})
+
+        loaded = await store.read_meta()
+        assert loaded["version"] == 2
+
+    @pytest.mark.asyncio
+    async def test_meta_file_location(self, tmp_path: Path) -> None:
+        """Meta should be stored as meta.json in the base directory."""
+        store = FileConversationStore(tmp_path / "conv")
+        await store.write_meta({"k": "v"})
+
+        meta_file = tmp_path / "conv" / "meta.json"
+        assert meta_file.exists()
+        data = json.loads(meta_file.read_text())
+        assert data["k"] == "v"
+
+    @pytest.mark.asyncio
+    async def test_read_corrupted_meta(self, tmp_path: Path) -> None:
+        """Corrupted meta.json should return None."""
+        base = tmp_path / "conv"
+        base.mkdir(parents=True)
+        (base / "meta.json").write_text("not-json{{")
+
+        store = FileConversationStore(base)
+        assert await store.read_meta() is None
+
+
+# ---------------------------------------------------------------------------
+# write_cursor / read_cursor
+# ---------------------------------------------------------------------------
+
+
+class TestCursorPersistence:
+    """Tests for cursor state."""
+
+    @pytest.mark.asyncio
+    async def test_cursor_round_trip(self, tmp_path: Path) -> None:
+        """Cursor data should round-trip correctly."""
+        store = FileConversationStore(tmp_path / "conv")
+        cursor = {"position": 42, "node": "output"}
+        await store.write_cursor(cursor)
+
+        loaded = await store.read_cursor()
+        assert loaded == cursor
+
+    @pytest.mark.asyncio
+    async def test_read_cursor_missing(self, tmp_path: Path) -> None:
+        """Reading cursor from a fresh store should return None."""
+        store = FileConversationStore(tmp_path / "conv")
+        assert await store.read_cursor() is None
+
+    @pytest.mark.asyncio
+    async def test_cursor_file_location(self, tmp_path: Path) -> None:
+        """Cursor should be stored as cursor.json in the base directory."""
+        store = FileConversationStore(tmp_path / "conv")
+        await store.write_cursor({"pos": 0})
+
+        cursor_file = tmp_path / "conv" / "cursor.json"
+        assert cursor_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_read_corrupted_cursor(self, tmp_path: Path) -> None:
+        """Corrupted cursor.json should return None."""
+        base = tmp_path / "conv"
+        base.mkdir(parents=True)
+        (base / "cursor.json").write_text("}}bad")
+
+        store = FileConversationStore(base)
+        assert await store.read_cursor() is None
+
+
+# ---------------------------------------------------------------------------
+# delete_parts_before
+# ---------------------------------------------------------------------------
+
+
+class TestDeletePartsBefore:
+    """Tests for partial cleanup of old parts."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_earlier_parts(self, tmp_path: Path) -> None:
+        """Parts with seq < threshold should be removed."""
+        store = FileConversationStore(tmp_path / "conv")
+        for i in range(5):
+            await store.write_part(i, {"seq": i})
+
+        await store.delete_parts_before(3)
+
+        parts = await store.read_parts()
+        assert len(parts) == 2
+        seqs = [p["seq"] for p in parts]
+        assert seqs == [3, 4]
+
+    @pytest.mark.asyncio
+    async def test_delete_all_before_first(self, tmp_path: Path) -> None:
+        """Deleting before seq 0 should be a no-op."""
+        store = FileConversationStore(tmp_path / "conv")
+        await store.write_part(0, {"seq": 0})
+        await store.write_part(1, {"seq": 1})
+
+        await store.delete_parts_before(0)
+
+        parts = await store.read_parts()
+        assert len(parts) == 2
+
+    @pytest.mark.asyncio
+    async def test_delete_on_empty_store(self, tmp_path: Path) -> None:
+        """Deleting from an empty store should not raise."""
+        store = FileConversationStore(tmp_path / "conv")
+        await store.delete_parts_before(10)  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_delete_preserves_meta_and_cursor(
+        self, tmp_path: Path
+    ) -> None:
+        """delete_parts_before should not affect meta or cursor files."""
+        store = FileConversationStore(tmp_path / "conv")
+        await store.write_part(0, {"seq": 0})
+        await store.write_meta({"node": "x"})
+        await store.write_cursor({"pos": 5})
+
+        await store.delete_parts_before(1)
+
+        assert await store.read_meta() == {"node": "x"}
+        assert await store.read_cursor() == {"pos": 5}
+
+
+# ---------------------------------------------------------------------------
+# destroy
+# ---------------------------------------------------------------------------
+
+
+class TestDestroy:
+    """Tests for full cleanup (destroy)."""
+
+    @pytest.mark.asyncio
+    async def test_destroy_removes_everything(self, tmp_path: Path) -> None:
+        """destroy() should remove the entire base directory."""
+        base = tmp_path / "conv"
+        store = FileConversationStore(base)
+        await store.write_part(0, {"data": "x"})
+        await store.write_meta({"m": 1})
+        await store.write_cursor({"c": 2})
+
+        await store.destroy()
+
+        assert not base.exists()
+
+    @pytest.mark.asyncio
+    async def test_destroy_nonexistent_dir(self, tmp_path: Path) -> None:
+        """destroy() on a non-existent directory should not raise."""
+        store = FileConversationStore(tmp_path / "ghost")
+        await store.destroy()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_read_after_destroy(self, tmp_path: Path) -> None:
+        """Reads after destroy should return empty/None values."""
+        base = tmp_path / "conv"
+        store = FileConversationStore(base)
+        await store.write_part(0, {"data": "x"})
+        await store.destroy()
+
+        assert await store.read_parts() == []
+        assert await store.read_meta() is None
+        assert await store.read_cursor() is None
+
+
+# ---------------------------------------------------------------------------
+# close (no-op)
+# ---------------------------------------------------------------------------
+
+
+class TestClose:
+    """Tests for the close() method."""
+
+    @pytest.mark.asyncio
+    async def test_close_is_noop(self, tmp_path: Path) -> None:
+        """close() should complete without error and not affect data."""
+        store = FileConversationStore(tmp_path / "conv")
+        await store.write_part(0, {"data": "x"})
+        await store.close()
+
+        # Data should still be readable
+        parts = await store.read_parts()
+        assert len(parts) == 1

--- a/core/tests/test_session_store.py
+++ b/core/tests/test_session_store.py
@@ -1,0 +1,305 @@
+"""Tests for framework.storage.session_store.SessionStore.
+
+Covers session ID generation, path construction, state write/read
+round-trips, session listing with filters, deletion, and existence
+checks.  All I/O is isolated via the ``tmp_path`` fixture.
+
+Resolves: https://github.com/adenhq/hive/issues/4100
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from framework.schemas.session_state import (
+    SessionState,
+    SessionStatus,
+    SessionTimestamps,
+)
+from framework.storage.session_store import SessionStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_state(
+    session_id: str = "session_test",
+    goal_id: str = "goal-1",
+    status: SessionStatus = SessionStatus.ACTIVE,
+) -> SessionState:
+    """Create a minimal ``SessionState`` for testing."""
+    now = datetime.now().isoformat()
+    return SessionState(
+        session_id=session_id,
+        goal_id=goal_id,
+        status=status,
+        timestamps=SessionTimestamps(started_at=now, updated_at=now),
+    )
+
+
+# ---------------------------------------------------------------------------
+# generate_session_id
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSessionId:
+    """Tests for SessionStore.generate_session_id()."""
+
+    def test_format(self, tmp_path: Path) -> None:
+        """ID should match session_YYYYMMDD_HHMMSS_{8-char-hex}."""
+        store = SessionStore(tmp_path)
+        sid = store.generate_session_id()
+        pattern = r"^session_\d{8}_\d{6}_[0-9a-f]{8}$"
+        assert re.match(pattern, sid), f"{sid!r} doesn't match expected format"
+
+    def test_uniqueness(self, tmp_path: Path) -> None:
+        """Two calls should produce different IDs."""
+        store = SessionStore(tmp_path)
+        ids = {store.generate_session_id() for _ in range(20)}
+        assert len(ids) == 20
+
+
+# ---------------------------------------------------------------------------
+# get_session_path / get_state_path
+# ---------------------------------------------------------------------------
+
+
+class TestPathConstruction:
+    """Tests for get_session_path() and get_state_path()."""
+
+    def test_session_path(self, tmp_path: Path) -> None:
+        """Session dir should be under <base>/sessions/<id>."""
+        store = SessionStore(tmp_path)
+        path = store.get_session_path("s1")
+        assert path == tmp_path / "sessions" / "s1"
+
+    def test_state_path(self, tmp_path: Path) -> None:
+        """State file should be <session_dir>/state.json."""
+        store = SessionStore(tmp_path)
+        path = store.get_state_path("s1")
+        assert path == tmp_path / "sessions" / "s1" / "state.json"
+
+
+# ---------------------------------------------------------------------------
+# write_state / read_state
+# ---------------------------------------------------------------------------
+
+
+class TestWriteReadState:
+    """Tests for async write and read of session state."""
+
+    @pytest.mark.asyncio
+    async def test_round_trip(self, tmp_path: Path) -> None:
+        """Written state should be readable and equal."""
+        store = SessionStore(tmp_path)
+        state = _make_state(session_id="rt-1", goal_id="g-1")
+        await store.write_state("rt-1", state)
+
+        loaded = await store.read_state("rt-1")
+        assert loaded is not None
+        assert loaded.session_id == "rt-1"
+        assert loaded.goal_id == "g-1"
+        assert loaded.status == SessionStatus.ACTIVE
+
+    @pytest.mark.asyncio
+    async def test_read_nonexistent_returns_none(
+        self, tmp_path: Path
+    ) -> None:
+        """Reading a missing session should return None."""
+        store = SessionStore(tmp_path)
+        assert await store.read_state("nope") is None
+
+    @pytest.mark.asyncio
+    async def test_overwrite(self, tmp_path: Path) -> None:
+        """Writing twice should overwrite the previous state."""
+        store = SessionStore(tmp_path)
+        state_v1 = _make_state(session_id="ow-1", goal_id="old")
+        await store.write_state("ow-1", state_v1)
+
+        state_v2 = _make_state(
+            session_id="ow-1",
+            goal_id="new",
+            status=SessionStatus.COMPLETED,
+        )
+        await store.write_state("ow-1", state_v2)
+
+        loaded = await store.read_state("ow-1")
+        assert loaded is not None
+        assert loaded.goal_id == "new"
+        assert loaded.status == SessionStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_state_file_is_valid_json(self, tmp_path: Path) -> None:
+        """The persisted file should be valid JSON parseable as SessionState."""
+        store = SessionStore(tmp_path)
+        state = _make_state(session_id="json-1")
+        await store.write_state("json-1", state)
+
+        state_path = store.get_state_path("json-1")
+        assert state_path.exists()
+        # Should parse via Pydantic without error
+        loaded = SessionState.model_validate_json(state_path.read_text())
+        assert loaded.session_id == "json-1"
+
+
+# ---------------------------------------------------------------------------
+# list_sessions
+# ---------------------------------------------------------------------------
+
+
+class TestListSessions:
+    """Tests for listing sessions with optional filters."""
+
+    @pytest.mark.asyncio
+    async def test_empty_base(self, tmp_path: Path) -> None:
+        """Listing without any sessions should return an empty list."""
+        store = SessionStore(tmp_path)
+        assert await store.list_sessions() == []
+
+    @pytest.mark.asyncio
+    async def test_lists_all(self, tmp_path: Path) -> None:
+        """All written sessions should appear in the listing."""
+        store = SessionStore(tmp_path)
+        for i in range(3):
+            s = _make_state(session_id=f"ls-{i}", goal_id="g")
+            await store.write_state(f"ls-{i}", s)
+
+        results = await store.list_sessions()
+        assert len(results) == 3
+
+    @pytest.mark.asyncio
+    async def test_filter_by_status(self, tmp_path: Path) -> None:
+        """Only sessions matching the status filter should be returned."""
+        store = SessionStore(tmp_path)
+        await store.write_state(
+            "active-1",
+            _make_state("active-1", status=SessionStatus.ACTIVE),
+        )
+        await store.write_state(
+            "paused-1",
+            _make_state("paused-1", status=SessionStatus.PAUSED),
+        )
+        await store.write_state(
+            "active-2",
+            _make_state("active-2", status=SessionStatus.ACTIVE),
+        )
+
+        active = await store.list_sessions(status="active")
+        assert len(active) == 2
+        assert all(s.status == SessionStatus.ACTIVE for s in active)
+
+    @pytest.mark.asyncio
+    async def test_filter_by_goal_id(self, tmp_path: Path) -> None:
+        """Only sessions matching the goal_id filter should be returned."""
+        store = SessionStore(tmp_path)
+        await store.write_state(
+            "g1-1", _make_state("g1-1", goal_id="goal-a")
+        )
+        await store.write_state(
+            "g2-1", _make_state("g2-1", goal_id="goal-b")
+        )
+
+        filtered = await store.list_sessions(goal_id="goal-a")
+        assert len(filtered) == 1
+        assert filtered[0].goal_id == "goal-a"
+
+    @pytest.mark.asyncio
+    async def test_limit(self, tmp_path: Path) -> None:
+        """The limit parameter should cap the number of returned sessions."""
+        store = SessionStore(tmp_path)
+        for i in range(5):
+            await store.write_state(
+                f"lim-{i}", _make_state(f"lim-{i}")
+            )
+
+        results = await store.list_sessions(limit=2)
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_skips_malformed_state(self, tmp_path: Path) -> None:
+        """Directories with invalid state.json should be silently skipped."""
+        store = SessionStore(tmp_path)
+        # Write a valid session
+        await store.write_state("good", _make_state("good"))
+
+        # Create a malformed session manually
+        bad_dir = store.sessions_dir / "bad_session"
+        bad_dir.mkdir(parents=True)
+        (bad_dir / "state.json").write_text("{invalid json!!")
+
+        results = await store.list_sessions()
+        assert len(results) == 1
+        assert results[0].session_id == "good"
+
+    @pytest.mark.asyncio
+    async def test_skips_non_directory_entries(self, tmp_path: Path) -> None:
+        """Non-directory entries in sessions/ should be skipped."""
+        store = SessionStore(tmp_path)
+        await store.write_state("real", _make_state("real"))
+
+        # Create a stray file in sessions/
+        (store.sessions_dir / "stray.txt").write_text("oops")
+
+        results = await store.list_sessions()
+        assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# delete_session
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteSession:
+    """Tests for session deletion."""
+
+    @pytest.mark.asyncio
+    async def test_delete_existing(self, tmp_path: Path) -> None:
+        """Deleting an existing session should remove it and return True."""
+        store = SessionStore(tmp_path)
+        await store.write_state("del-1", _make_state("del-1"))
+
+        assert await store.delete_session("del-1") is True
+        assert await store.read_state("del-1") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent(self, tmp_path: Path) -> None:
+        """Deleting a missing session should return False."""
+        store = SessionStore(tmp_path)
+        assert await store.delete_session("ghost") is False
+
+
+# ---------------------------------------------------------------------------
+# session_exists
+# ---------------------------------------------------------------------------
+
+
+class TestSessionExists:
+    """Tests for session existence checks."""
+
+    @pytest.mark.asyncio
+    async def test_exists_after_write(self, tmp_path: Path) -> None:
+        """A written session should be reported as existing."""
+        store = SessionStore(tmp_path)
+        await store.write_state("ex-1", _make_state("ex-1"))
+        assert await store.session_exists("ex-1") is True
+
+    @pytest.mark.asyncio
+    async def test_not_exists(self, tmp_path: Path) -> None:
+        """A non-existent session should return False."""
+        store = SessionStore(tmp_path)
+        assert await store.session_exists("nope") is False
+
+    @pytest.mark.asyncio
+    async def test_not_exists_after_delete(self, tmp_path: Path) -> None:
+        """A deleted session should no longer be reported as existing."""
+        store = SessionStore(tmp_path)
+        await store.write_state("gone", _make_state("gone"))
+        await store.delete_session("gone")
+        assert await store.session_exists("gone") is False


### PR DESCRIPTION
## Summary

Adds comprehensive async test coverage for the two untested storage modules: `framework/storage/session_store.py` and `framework/storage/conversation_store.py`.

Resolves #4100

## Problem

`session_store.py` (213 lines) and `conversation_store.py` (114 lines) handle critical session state persistence and conversation storage using async file I/O, but had **zero dedicated test coverage**.

## Solution

### `core/tests/test_session_store.py` — 20 tests

| Test Class | Methods Covered | Tests |
|---|---|---|
| `TestGenerateSessionId` | `generate_session_id()` | Format validation, uniqueness |
| `TestPathConstruction` | `get_session_path()`, `get_state_path()` | Path correctness |
| `TestWriteReadState` | `write_state()`, `read_state()` | Round-trip, missing session, overwrite, valid JSON |
| `TestListSessions` | `list_sessions()` | Empty base, list all, filter by status, filter by goal_id, limit, malformed state.json resilience, non-directory entries |
| `TestDeleteSession` | `delete_session()` | Existing and non-existent sessions |
| `TestSessionExists` | `session_exists()` | After write, missing, after delete |

### `core/tests/test_conversation_store.py` — 23 tests

| Test Class | Methods Covered | Tests |
|---|---|---|
| `TestWriteReadParts` | `write_part()`, `read_parts()` | Single part, ordering, empty store, file naming, overwrite, corrupted part resilience |
| `TestMetaPersistence` | `write_meta()`, `read_meta()` | Round-trip, missing, overwrite, file location, corrupted JSON |
| `TestCursorPersistence` | `write_cursor()`, `read_cursor()` | Round-trip, missing, file location, corrupted JSON |
| `TestDeletePartsBefore` | `delete_parts_before()` | Partial cleanup, boundary (seq 0), empty store, preserves meta/cursor |
| `TestDestroy` | `destroy()` | Full cleanup, non-existent dir, reads after destroy |
| `TestClose` | `close()` | No-op verification |

## Testing

```bash
cd core && python -m pytest tests/test_session_store.py tests/test_conversation_store.py -v
# 43 passed
```

## Acceptance Criteria Checklist

- [x] Tests in `core/tests/test_session_store.py` and `core/tests/test_conversation_store.py`
- [x] All tests pass with `pytest tests/test_session_store.py tests/test_conversation_store.py -v`
- [x] Uses `pytest-asyncio` for async tests
- [x] Uses `tmp_path` fixture for isolated file I/O
- [x] Covers all public methods of both modules
- [x] Edge cases: empty store, corrupted JSON, missing directories