### PR TITLE
fix: prevent delete_parts_before from crashing on non-numeric files

### DIFF
--- a/core/framework/storage/conversation_store.py
+++ b/core/framework/storage/conversation_store.py
@@ -19,9 +19,12 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import shutil
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 class FileConversationStore:
@@ -94,9 +97,13 @@ class FileConversationStore:
             if not self._parts_dir.exists():
                 return
             for f in self._parts_dir.glob("*.json"):
-                file_seq = int(f.stem)
-                if file_seq < seq:
-                    f.unlink()
+                try:
+                    file_seq = int(f.stem)
+                    if file_seq < seq:
+                        f.unlink()
+                except ValueError:
+                    logger.warning(f"FileConversationStore found non-numeric file: {f}")
+                    continue
 
         await self._run(_delete)
 

--- a/core/tests/test_conversation_store_delete_bug.py
+++ b/core/tests/test_conversation_store_delete_bug.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+import pytest
+
+from framework.storage.conversation_store import FileConversationStore
+
+
+@pytest.mark.asyncio
+async def test_delete_parts_before_skips_non_numeric(tmp_path: Path) -> None:
+    """Test that delete_parts_before doesn't crash on non-numeric filenames."""
+    store = FileConversationStore(tmp_path / "conv")
+    await store.write_part(0, {"seq": 0})
+    await store.write_part(1, {"seq": 1})
+    
+    # Manually create a non-numeric json file in the parts dir
+    parts_dir = tmp_path / "conv" / "parts"
+    parts_dir.mkdir(parents=True, exist_ok=True)
+    bad_file = parts_dir / "bad_file.json"
+    bad_file.write_text("{}")
+    
+    # Should not crash
+    await store.delete_parts_before(2)
+    
+    # Verify the remaining files
+    parts = await store.read_parts()
+    assert len(parts) == 1  # 0 and 1 are deleted, but bad_file is read as {}
+    assert parts[0] == {}
+    
+    assert bad_file.exists()


### PR DESCRIPTION
## Bug Fix Description

Resolves #4111

### Problem

`FileConversationStore.delete_parts_before()` would crash with a `ValueError` if a non-numeric `.json` file existed in the `parts/` directory. This would cause failures during cleanup and silent memory leaks of conversation data.

### Solution

Wrapped `int(f.stem)` in a `try/except` block and added a warning log for any skipped files. Added `core/tests/test_conversation_store_delete_bug.py` to cover the fix, ensuring that the process skips non-numeric filenames gracefully without crashing, verifying the test results successfully.
