### PR TITLE
fix: set max_tokens=4000 in all example agents to prevent OpenAI context window exceeded errors

### DIFF
--- a/examples/templates/competitive_intel_agent/config.py
+++ b/examples/templates/competitive_intel_agent/config.py
@@ -3,11 +3,13 @@
 from dataclasses import dataclass
 from framework.config import RuntimeConfig
 
-default_config: RuntimeConfig = RuntimeConfig()
+default_config: RuntimeConfig = RuntimeConfig(max_tokens=4000)
+
 
 @dataclass
 class AgentMetadata:
     """Metadata for the Competitive Intelligence Agent."""
+
     name: str = "Competitive Intelligence Agent"
     version: str = "1.0.0"
     description: str = (
@@ -20,5 +22,6 @@ class AgentMetadata:
         "to monitor and what areas to focus on (pricing, features, hiring, partnerships, etc.) "
         "and I'll research them across websites, news, and GitHub to produce a detailed digest."
     )
+
 
 metadata: AgentMetadata = AgentMetadata()

--- a/examples/templates/deep_research_agent/config.py
+++ b/examples/templates/deep_research_agent/config.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 from framework.config import RuntimeConfig
 
-default_config = RuntimeConfig()
+default_config = RuntimeConfig(max_tokens=4000)
 
 
 @dataclass

--- a/examples/templates/email_inbox_management/config.py
+++ b/examples/templates/email_inbox_management/config.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 from framework.config import RuntimeConfig
 
-default_config = RuntimeConfig()
+default_config = RuntimeConfig(max_tokens=4000)
 
 
 @dataclass

--- a/examples/templates/job_hunter/config.py
+++ b/examples/templates/job_hunter/config.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 from framework.config import RuntimeConfig
 
-default_config = RuntimeConfig()
+default_config = RuntimeConfig(max_tokens=4000)
 
 
 @dataclass

--- a/examples/templates/tech_news_reporter/config.py
+++ b/examples/templates/tech_news_reporter/config.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 from framework.config import RuntimeConfig
 
-default_config = RuntimeConfig()
+default_config = RuntimeConfig(max_tokens=4000)
 
 
 @dataclass

--- a/examples/templates/vulnerability_assessment/config.py
+++ b/examples/templates/vulnerability_assessment/config.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 from framework.config import RuntimeConfig
 
-default_config = RuntimeConfig()
+default_config = RuntimeConfig(max_tokens=4000)
 
 
 @dataclass


### PR DESCRIPTION

## Summary
- All example agents in `examples/templates/` now explicitly set `max_tokens=4000` instead of using the default from `RuntimeConfig`
- This ensures compatibility with OpenAI models (gpt-4, gpt-4-turbo) which have smaller context windows
- The previous default could result in `ContextWindowExceededError` when using OpenAI models

## Problem
When using OpenAI models (e.g., gpt-4 with 8K context window), the combination of:
- Verbose system prompts
- High `max_tokens` settings (defaulting to 8192 or user-configured higher values)
- Function definitions
- Conversation messages

...would exceed the model's context window limit, causing `litellm.ContextWindowExceededError`.

## Solution
Explicitly set `max_tokens=4000` in each agent's `config.py` when creating the `RuntimeConfig`. This value is:
- Safe for all OpenAI models (gpt-4 has 8K context, gpt-4-turbo has 128K)
- Provides sufficient tokens for agent responses
- Leaves adequate room for system prompts and conversation context

## Files Modified
- `examples/templates/deep_research_agent/config.py`
- `examples/templates/tech_news_reporter/config.py`
- `examples/templates/job_hunter/config.py`
- `examples/templates/vulnerability_assessment/config.py`
- `examples/templates/email_inbox_management/config.py`
- `examples/templates/competitive_intel_agent/config.py`

## Testing
- Verified that all config.py files now set `max_tokens=4000`
- The change is minimal and non-breaking for existing users

Resolves #4137