### PR TITLE
micro-fix: replace silent error swallowing with warning logs in executor

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -232,7 +232,7 @@ class GraphExecutor:
 
             state_path.write_text(_json.dumps(state_data, indent=2), encoding="utf-8")
         except Exception:
-            pass  # Best-effort — never block execution
+            self.logger.warning("Failed to persist state.json progress", exc_info=True)
 
     def _validate_tools(self, graph: GraphSpec) -> list[str]:
         """
@@ -1341,7 +1341,7 @@ class GraphExecutor:
                                 list(wip_outputs.keys()),
                             )
                 except Exception:
-                    self.logger.debug(
+                    self.logger.warning(
                         "Could not flush accumulator outputs from cursor",
                         exc_info=True,
                     )
@@ -1437,7 +1437,7 @@ class GraphExecutor:
                             if value is not None:
                                 memory.write(key, value, validate=False)
                 except Exception:
-                    self.logger.debug(
+                    self.logger.warning(
                         "Could not flush accumulator outputs from cursor",
                         exc_info=True,
                     )


### PR DESCRIPTION
 ## Description

  Log state.json write failures and accumulator flush errors at WARNING
  level for audit and tracing, instead of silently swallowing them.

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)

  ## Changes Made

  - `_write_progress()`: `except Exception: pass` → `logger.warning()` with `exc_info=True`
  - Accumulator flush (normal exit path): `logger.debug()` → `logger.warning()`
  - Accumulator flush (error path): `logger.debug()` → `logger.warning()`

  ## Testing

  - [x] Unit tests pass (`cd core && pytest tests/`) — 721 passed, 0 failed