### PR TITLE
docs: fix Roadmap Mermaid diagram not rendering on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,16 +378,16 @@ flowchart TB
     SA -->|"Inform"| ELN_EL
     SA -->|"Starts"| B
     B -->|"Report"| ELN_EL
-    TR -->|"Assigned"| EventLoopNode
-    CB -->|"Modify Worker Bee"| WorkerBees
+    TR -->|"Assigned"| ELN_EL
+    CB -->|"Modify Worker Bee"| WB_C
 
     %% =========================================
     %% SHARED MEMORY & LOGS ACCESS
     %% =========================================
 
-    %% Worker Bees Access
-    Graph <-->|"Read/Write"| WTM
-    Graph <-->|"Read/Write"| SM
+    %% Worker Bees Access (link to node inside Graph subgraph)
+    AN <-->|"Read/Write"| WTM
+    AN <-->|"Read/Write"| SM
 
     %% Queen Bee Access
     QB_C <-->|"Read/Write"| WTM


### PR DESCRIPTION
## Description

Fix the Roadmap Mermaid diagram that failed to render on GitHub with "Unable to render rich display" / "Could not find a suitable point for the given distance" by replacing subgraph-to-subgraph/subgraph-as-target links with links to concrete node IDs inside those subgraphs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #5314

## Changes Made

- **README.md** – In the Roadmap Mermaid block: `TR --> EventLoopNode` → `TR --> ELN_EL`; `CB --> WorkerBees` → `CB --> WB_C`; `Graph <--> WTM` / `Graph <--> SM` → `AN <--> WTM` / `AN <--> SM`.
- **docs/roadmap.md** – Same diagram: same link fixes so the flowchart renders on GitHub.

## Testing

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed — verified Mermaid syntax; diagram should render on GitHub after merge.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
<img width="1379" height="813" alt="Screenshot 2026-02-24 at 10 38 13 AM" src="https://github.com/user-attachments/assets/b49708bd-b75b-4933-9436-0a191615038f" />
<img width="844" height="433" alt="Screenshot 2026-02-24 at 10 38 00 AM" src="https://github.com/user-attachments/assets/a175294b-dab5-4db7-a146-9f0bb179c836" />
