### PR TITLE
micro-fix: replace retired claude-3-5-haiku-20241022 with claude-haiku-4-5

### DIFF
--- a/core/framework/graph/edge.py
+++ b/core/framework/graph/edge.py
@@ -422,7 +422,7 @@ class GraphSpec(BaseModel):
 
     # Cleanup LLM for JSON extraction fallback (fast/cheap model preferred)
     # If not set, uses CEREBRAS_API_KEY -> cerebras/llama-3.3-70b or
-    # ANTHROPIC_API_KEY -> claude-3-5-haiku as fallback
+    # ANTHROPIC_API_KEY -> claude-haiku-4-5 as fallback
     cleanup_llm_model: str | None = None
 
     # Execution limits

--- a/core/framework/graph/hitl.py
+++ b/core/framework/graph/hitl.py
@@ -197,7 +197,7 @@ Example format:
 
             client = anthropic.Anthropic(api_key=api_key)
             message = client.messages.create(
-                model="claude-3-5-haiku-20241022",
+                model="claude-haiku-4-5-20251001",
                 max_tokens=500,
                 messages=[{"role": "user", "content": prompt}],
             )

--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -591,7 +591,7 @@ class NodeResult:
 
             client = anthropic.Anthropic(api_key=api_key)
             message = client.messages.create(
-                model="claude-3-5-haiku-20241022",
+                model="claude-haiku-4-5-20251001",
                 max_tokens=200,
                 messages=[{"role": "user", "content": prompt}],
             )

--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -1063,7 +1063,7 @@ Output ONLY valid JSON, no explanation:"""
 
     try:
         message = client.messages.create(
-            model="claude-3-5-haiku-20241022",  # Fast and cheap
+            model="claude-haiku-4-5-20251001",  # Fast and cheap
             max_tokens=500,
             messages=[{"role": "user", "content": prompt}],
         )


### PR DESCRIPTION
## Description

Replace all occurrences of the retired claude-3-5-haiku-20241022 model with its recommended replacement claude-haiku-4-5-20251001. The old model was retired by Anthropic on February 19, 2026, and now returns 404 errors on every API request, breaking the interactive shell's natural language formatter, node output summarization, and human-in-the-loop question parsing.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #5316

## Changes Made

- Replace claude-3-5-haiku-20241022 with claude-haiku-4-5-20251001 in core/framework/runner/cli.py (shell natural language → JSON formatter)
- Replace claude-3-5-haiku-20241022 with claude-haiku-4-5-20251001 in core/framework/graph/node.py (node output summarization for client-facing messages)
- Replace claude-3-5-haiku-20241022 with claude-haiku-4-5-20251001 in core/framework/graph/hitl.py (human-in-the-loop multi-question parser)
- Update comment in core/framework/graph/edge.py to reference the new model name

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

Manual Testing:
- Verified the old model returns 404 Not Found from the Anthropic API
- Verified the replacement model claude-haiku-4-5-20251001 is active per [Anthropic's model deprecations page](https://platform.claude.com/docs/en/about-claude/model-deprecations)
- Confirmed zero remaining occurrences of claude-3-5-haiku in the codebase after the fix

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
