### PR TITLE
Harden safe_eval security validation to match safe_exec + add docs and test/lint verification

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -171,6 +171,17 @@ for s in suggestions:
     print(f"[{s['priority']}] {s['recommendation']}")
 ```
 
+
+## Code Sandbox Safety
+
+Framework includes a restricted code sandbox (`framework.graph.code_sandbox`) for dynamic execution used in planning flows.
+
+- `safe_exec()` validates and runs statements in an isolated namespace.
+- `safe_eval()` validates and evaluates expressions in the same threat model as `safe_exec()`.
+- Validation blocks private attribute access (for example `.__class__`) and dangerous function names (`exec`, `eval`, `compile`, `__import__`).
+
+Use these helpers instead of raw `exec`/`eval` when evaluating planner-generated code.
+
 ## Architecture
 
 ```

--- a/core/framework/graph/code_sandbox.py
+++ b/core/framework/graph/code_sandbox.py
@@ -148,18 +148,9 @@ class CodeValidator:
     def __init__(self, blocked_nodes: set[type] | None = None):
         self.blocked_nodes = blocked_nodes or BLOCKED_AST_NODES
 
-    def validate(self, code: str) -> list[str]:
-        """
-        Validate code and return list of issues.
-
-        Returns empty list if code is safe.
-        """
+    def _validate_tree(self, tree: ast.AST) -> list[str]:
+        """Validate a parsed AST and return security issues."""
         issues = []
-
-        try:
-            tree = ast.parse(code)
-        except SyntaxError as e:
-            return [f"Syntax error: {e}"]
 
         for node in ast.walk(tree):
             # Check for blocked node types
@@ -175,14 +166,35 @@ class CodeValidator:
                     )
 
             # Check for exec/eval calls
-            if isinstance(node, ast.Call):
-                if isinstance(node.func, ast.Name):
-                    if node.func.id in ("exec", "eval", "compile", "__import__"):
-                        issues.append(
-                            f"Blocked function call: {node.func.id} at line {node.lineno}"
-                        )
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                if node.func.id in ("exec", "eval", "compile", "__import__"):
+                    issues.append(
+                        f"Blocked function call: {node.func.id} at line {node.lineno}"
+                    )
 
         return issues
+
+    def validate(self, code: str) -> list[str]:
+        """
+        Validate code and return list of issues.
+
+        Returns empty list if code is safe.
+        """
+        try:
+            tree = ast.parse(code)
+        except SyntaxError as e:
+            return [f"Syntax error: {e}"]
+
+        return self._validate_tree(tree)
+
+    def validate_expression(self, expression: str) -> list[str]:
+        """Validate an expression intended for eval()."""
+        try:
+            tree = ast.parse(expression, mode="eval")
+        except SyntaxError as e:
+            return [f"Syntax error: {e}"]
+
+        return self._validate_tree(tree)
 
 
 class CodeSandbox:
@@ -348,11 +360,13 @@ class CodeSandbox:
         """
         inputs = inputs or {}
 
-        # Validate
-        try:
-            ast.parse(expression, mode="eval")
-        except SyntaxError as e:
-            return SandboxResult(success=False, error=f"Syntax error: {e}")
+        # Validate expression with the same threat model used for execute().
+        issues = self.validator.validate_expression(expression)
+        if issues:
+            return SandboxResult(
+                success=False,
+                error=f"Code validation failed: {'; '.join(issues)}",
+            )
 
         namespace = self._create_namespace(inputs)
 

--- a/core/tests/test_flexible_executor.py
+++ b/core/tests/test_flexible_executor.py
@@ -195,6 +195,22 @@ class TestCodeSandbox:
         assert result.success is True
         assert result.result == 8
 
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            "[].__class__.__mro__",
+            "eval('1 + 1')",
+            "exec('x = 1')",
+            "compile('1 + 1', '<x>', 'eval')",
+            "__import__('os')",
+        ],
+    )
+    def test_safe_eval_blocks_dangerous_expressions(self, expression):
+        """Test safe_eval blocks dangerous expression payloads."""
+        result = safe_eval(expression)
+        assert result.success is False
+        assert "validation failed" in result.error.lower()
+
     def test_allowed_modules(self):
         """Test that allowed modules work."""
         sandbox = CodeSandbox()


### PR DESCRIPTION
## Description
This PR closes a security consistency gap in the code sandbox by ensuring expression execution (`execute_expression()` / `safe_eval()`) enforces the same AST-based validation model as statement execution (`execute()` / `safe_exec()`), before calling `eval`.

It also includes follow-up quality fixes:
- resolved lint issues introduced during the validator refactor
- documented sandbox safety behavior in README

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)

## Related Issues
Fixes security-parity issue between statement mode and expression mode execution in the sandbox.

## Changes Made
- Refactored validator internals to reuse a shared AST validation path.
- Added expression-specific validation entrypoint (`validate_expression`) using `ast.parse(..., mode="eval")`.
- Updated `CodeSandbox.execute_expression()` to run validation and return a `SandboxResult` error on violations before `eval`.
- Ensured blocked expression payloads are rejected, including:
  - private attribute access chains (e.g. `.__class__`, `.__mro__`)
  - blocked function names (`exec`, `eval`, `compile`, `__import__`)
- Added/updated tests in `core/tests/test_flexible_executor.py` for blocked expression payloads.
- Fixed Ruff E501 formatting issue in validator code.
- Added `Code Sandbox Safety` documentation to `core/README.md` describing threat-model parity and blocked patterns.

## Testing
Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && uv run pytest -q tests/test_flexible_executor.py`)
- [x] Lint passes (`cd core && uv run ruff check .`)
- [x] Manual testing performed

Additional setup run:
- `cd core && uv sync --frozen`

Result:
- `27 passed` on `tests/test_flexible_executor.py`
- Ruff checks passed with no errors

## Checklist
- [x] My code follows the project’s style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
N/A — no UI changes.
