### PR TITLE
feat(runtime): add LifecycleServer REST API for agent lifecycle control

### DIFF
--- a/core/framework/runtime/lifecycle_server.py
+++ b/core/framework/runtime/lifecycle_server.py
@@ -1,0 +1,315 @@
+"""
+Lifecycle HTTP Server - REST API for external agent lifecycle control.
+
+Exposes AgentRuntime lifecycle operations over HTTP so agents can be
+managed programmatically from external systems, CI pipelines, or
+orchestration tools without requiring direct Python access.
+
+Endpoints
+---------
+GET  /health                                 Liveness check
+GET  /status                                 Full runtime status and stats
+POST /trigger/{entry_point_id}               Trigger execution (non-blocking)
+POST /trigger/{entry_point_id}/wait          Trigger and wait for result
+GET  /executions/{entry_point_id}/{exec_id}  Fetch a completed execution result
+POST /stop                                   Stop the runtime gracefully
+
+Usage::
+
+    from framework.runtime.lifecycle_server import LifecycleServer, LifecycleServerConfig
+
+    server = LifecycleServer(runtime, LifecycleServerConfig(host="0.0.0.0", port=8090))
+    await server.start()
+    # ... runtime running ...
+    await server.stop()
+
+Or via AgentRuntimeConfig::
+
+    config = AgentRuntimeConfig(
+        lifecycle_host="0.0.0.0",
+        lifecycle_port=8090,
+        lifecycle_enabled=True,
+    )
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from aiohttp import web
+
+if TYPE_CHECKING:
+    from framework.runtime.agent_runtime import AgentRuntime
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LifecycleServerConfig:
+    """Configuration for the lifecycle HTTP server."""
+
+    host: str = "127.0.0.1"
+    port: int = 8090
+
+
+class LifecycleServer:
+    """
+    Embedded HTTP server exposing AgentRuntime lifecycle operations as REST endpoints.
+
+    The server wraps ``AgentRuntime`` methods without duplicating lifecycle logic.
+    All heavy lifting (state tracking, streams, storage) stays inside the runtime.
+
+    Lifecycle::
+
+        server = LifecycleServer(runtime, config)
+        await server.start()
+        # server is now accepting requests
+        await server.stop()
+    """
+
+    def __init__(
+        self,
+        runtime: AgentRuntime,
+        config: LifecycleServerConfig | None = None,
+    ) -> None:
+        self._runtime = runtime
+        self._config = config or LifecycleServerConfig()
+        self._app: web.Application | None = None
+        self._runner: web.AppRunner | None = None
+        self._site: web.TCPSite | None = None
+
+    # ------------------------------------------------------------------
+    # Server lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Start the HTTP server."""
+        self._app = web.Application()
+        self._register_routes(self._app)
+
+        self._runner = web.AppRunner(self._app)
+        await self._runner.setup()
+        self._site = web.TCPSite(self._runner, self._config.host, self._config.port)
+        await self._site.start()
+
+        logger.info(
+            "LifecycleServer started on %s:%d",
+            self._config.host,
+            self._config.port,
+        )
+
+    async def stop(self) -> None:
+        """Stop the HTTP server gracefully."""
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+            self._app = None
+            self._site = None
+            logger.info("LifecycleServer stopped")
+
+    def _register_routes(self, app: web.Application) -> None:
+        app.router.add_get("/health", self._handle_health)
+        app.router.add_get("/status", self._handle_status)
+        app.router.add_post("/trigger/{entry_point_id}", self._handle_trigger)
+        app.router.add_post("/trigger/{entry_point_id}/wait", self._handle_trigger_wait)
+        app.router.add_get(
+            "/executions/{entry_point_id}/{execution_id}",
+            self._handle_get_execution,
+        )
+        app.router.add_post("/stop", self._handle_stop)
+
+    # ------------------------------------------------------------------
+    # Request helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _json_ok(data: dict[str, Any], status: int = 200) -> web.Response:
+        return web.Response(
+            status=status,
+            content_type="application/json",
+            text=json.dumps(data),
+        )
+
+    @staticmethod
+    def _json_error(message: str, status: int) -> web.Response:
+        return web.Response(
+            status=status,
+            content_type="application/json",
+            text=json.dumps({"error": message}),
+        )
+
+    async def _parse_body(self, request: web.Request) -> dict[str, Any]:
+        """Read and parse JSON body; return empty dict on empty / non-JSON body."""
+        try:
+            body = await request.read()
+            if body:
+                return json.loads(body)
+        except (json.JSONDecodeError, ValueError):
+            pass
+        return {}
+
+    # ------------------------------------------------------------------
+    # Handlers
+    # ------------------------------------------------------------------
+
+    async def _handle_health(self, request: web.Request) -> web.Response:  # noqa: ARG002
+        """GET /health — liveness check."""
+        return self._json_ok(
+            {
+                "ok": True,
+                "running": self._runtime.is_running,
+            }
+        )
+
+    async def _handle_status(self, request: web.Request) -> web.Response:  # noqa: ARG002
+        """GET /status — full runtime statistics."""
+        try:
+            stats = self._runtime.get_stats()
+        except Exception as exc:
+            logger.exception("Error fetching runtime stats")
+            return self._json_error(str(exc), 500)
+
+        return self._json_ok(
+            {
+                "running": self._runtime.is_running,
+                "graph_id": self._runtime.graph_id,
+                "graphs": self._runtime.list_graphs(),
+                "stats": stats,
+            }
+        )
+
+    async def _handle_trigger(self, request: web.Request) -> web.Response:
+        """POST /trigger/{entry_point_id} — trigger execution, return exec_id immediately."""
+        entry_point_id = request.match_info["entry_point_id"]
+
+        if not self._runtime.is_running:
+            return self._json_error("Runtime is not running", 503)
+
+        body = await self._parse_body(request)
+        input_data: dict[str, Any] = body.get("input", body)
+        correlation_id: str | None = body.get("correlation_id")
+
+        try:
+            exec_id = await self._runtime.trigger(
+                entry_point_id,
+                input_data,
+                correlation_id=correlation_id,
+            )
+        except ValueError as exc:
+            return self._json_error(str(exc), 404)
+        except RuntimeError as exc:
+            return self._json_error(str(exc), 503)
+        except Exception as exc:
+            logger.exception("Trigger failed for entry point '%s'", entry_point_id)
+            return self._json_error(str(exc), 500)
+
+        return self._json_ok(
+            {
+                "execution_id": exec_id,
+                "entry_point_id": entry_point_id,
+                "status": "accepted",
+            },
+            status=202,
+        )
+
+    async def _handle_trigger_wait(self, request: web.Request) -> web.Response:
+        """POST /trigger/{entry_point_id}/wait — trigger and wait for result.
+
+        Optional body fields:
+        - ``input``   (dict)  Input data forwarded to the entry point
+        - ``timeout`` (float) Max seconds to wait (default: no timeout)
+        """
+        entry_point_id = request.match_info["entry_point_id"]
+
+        if not self._runtime.is_running:
+            return self._json_error("Runtime is not running", 503)
+
+        body = await self._parse_body(request)
+        input_data: dict[str, Any] = body.get("input", {})
+        timeout: float | None = body.get("timeout")
+        if timeout is not None:
+            timeout = float(timeout)
+
+        try:
+            result = await self._runtime.trigger_and_wait(
+                entry_point_id,
+                input_data,
+                timeout=timeout,
+            )
+        except ValueError as exc:
+            return self._json_error(str(exc), 404)
+        except RuntimeError as exc:
+            return self._json_error(str(exc), 503)
+        except Exception as exc:
+            logger.exception("Trigger-and-wait failed for entry point '%s'", entry_point_id)
+            return self._json_error(str(exc), 500)
+
+        if result is None:
+            return self._json_ok({"status": "timeout"}, status=408)
+
+        return self._json_ok(
+            {
+                "status": "completed",
+                "success": result.success,
+                "output": result.output,
+                "error": result.error,
+                "node_path": result.node_path,
+            }
+        )
+
+    async def _handle_get_execution(self, request: web.Request) -> web.Response:
+        """GET /executions/{entry_point_id}/{execution_id} — fetch a completed result."""
+        entry_point_id = request.match_info["entry_point_id"]
+        execution_id = request.match_info["execution_id"]
+
+        result = self._runtime.get_execution_result(entry_point_id, execution_id)
+        if result is None:
+            return self._json_error(
+                f"Execution '{execution_id}' not found for entry point '{entry_point_id}'",
+                404,
+            )
+
+        return self._json_ok(
+            {
+                "execution_id": execution_id,
+                "entry_point_id": entry_point_id,
+                "success": result.success,
+                "output": result.output,
+                "error": result.error,
+                "node_path": result.node_path,
+            }
+        )
+
+    async def _handle_stop(self, request: web.Request) -> web.Response:  # noqa: ARG002
+        """POST /stop — gracefully stop the AgentRuntime.
+
+        The runtime shutdown is scheduled as a background task so this
+        handler can return a 202 before the shutdown completes (avoiding
+        a deadlock where the server waits for itself to stop).
+        """
+        if not self._runtime.is_running:
+            return self._json_ok({"status": "already_stopped"})
+
+        import asyncio
+
+        asyncio.get_event_loop().create_task(self._runtime.stop())
+        return self._json_ok({"status": "stopping"}, status=202)
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def is_running(self) -> bool:
+        """True when the HTTP server is accepting requests."""
+        return self._site is not None
+
+    @property
+    def port(self) -> int | None:
+        """Actual listening port (useful when configured with port=0)."""
+        if self._site and self._site._server and self._site._server.sockets:
+            return self._site._server.sockets[0].getsockname()[1]
+        return None

--- a/core/tests/test_lifecycle_server.py
+++ b/core/tests/test_lifecycle_server.py
@@ -1,0 +1,582 @@
+"""
+Tests for LifecycleServer REST API.
+
+Tests the HTTP lifecycle control surface that wraps AgentRuntime.
+All tests use port=0 so the OS picks a free port, preventing conflicts.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
+import pytest
+
+from framework.graph.edge import GraphSpec
+from framework.graph.goal import Goal, SuccessCriterion
+from framework.graph.node import NodeSpec
+from framework.runtime.agent_runtime import AgentRuntime, AgentRuntimeConfig
+from framework.runtime.execution_stream import EntryPointSpec
+from framework.runtime.lifecycle_server import LifecycleServer, LifecycleServerConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_graph_and_goal() -> tuple[GraphSpec, Goal]:
+    """Minimal graph + goal for testing."""
+    nodes = [
+        NodeSpec(
+            id="start-node",
+            name="Start",
+            description="Entry node",
+            node_type="event_loop",
+            input_keys=["task"],
+            output_keys=["result"],
+        ),
+    ]
+    graph = GraphSpec(
+        id="test-graph",
+        goal_id="test-goal",
+        version="1.0.0",
+        entry_node="start-node",
+        entry_points={"main": "start-node"},
+        async_entry_points=[],
+        terminal_nodes=[],
+        pause_nodes=[],
+        nodes=nodes,
+        edges=[],
+    )
+    goal = Goal(
+        id="test-goal",
+        name="Test",
+        description="Test goal",
+        success_criteria=[
+            SuccessCriterion(
+                id="sc-1",
+                description="Done",
+                metric="done",
+                target="yes",
+                weight=1.0,
+            )
+        ],
+    )
+    return graph, goal
+
+
+def _make_runtime(tmpdir: str) -> AgentRuntime:
+    graph, goal = _make_graph_and_goal()
+    runtime = AgentRuntime(
+        graph=graph,
+        goal=goal,
+        storage_path=Path(tmpdir),
+    )
+    runtime.register_entry_point(
+        EntryPointSpec(
+            id="main",
+            name="Main",
+            entry_node="start-node",
+            trigger_type="manual",
+        )
+    )
+    return runtime
+
+
+def _make_server(runtime: AgentRuntime) -> LifecycleServer:
+    """Create a LifecycleServer on port=0 (OS-assigned)."""
+    return LifecycleServer(runtime, LifecycleServerConfig(host="127.0.0.1", port=0))
+
+
+def _base_url(server: LifecycleServer) -> str:
+    return f"http://127.0.0.1:{server.port}"
+
+
+# ---------------------------------------------------------------------------
+# Server lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycleServerLifecycle:
+    @pytest.mark.asyncio
+    async def test_start_stop(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime = _make_runtime(tmpdir)
+            server = _make_server(runtime)
+
+            await server.start()
+            assert server.is_running
+            assert server.port is not None
+
+            await server.stop()
+            assert not server.is_running
+            assert server.port is None
+
+    @pytest.mark.asyncio
+    async def test_stop_when_not_started_is_noop(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime = _make_runtime(tmpdir)
+            server = _make_server(runtime)
+
+            # Should not raise
+            await server.stop()
+            assert not server.is_running
+
+
+# ---------------------------------------------------------------------------
+# GET /health
+# ---------------------------------------------------------------------------
+
+
+class TestHealthEndpoint:
+    @pytest.mark.asyncio
+    async def test_health_when_not_running(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime = _make_runtime(tmpdir)
+            server = _make_server(runtime)
+
+            await server.start()
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(f"{_base_url(server)}/health") as resp:
+                        assert resp.status == 200
+                        body = await resp.json()
+                        assert body["ok"] is True
+                        assert body["running"] is False  # runtime not started
+            finally:
+                await server.stop()
+
+    @pytest.mark.asyncio
+    async def test_health_when_running(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime = _make_runtime(tmpdir)
+            server = _make_server(runtime)
+
+            await server.start()
+            await runtime.start()
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(f"{_base_url(server)}/health") as resp:
+                        assert resp.status == 200
+                        body = await resp.json()
+                        assert body["ok"] is True
+                        assert body["running"] is True
+            finally:
+                await runtime.stop()
+                await server.stop()
+
+
+# ---------------------------------------------------------------------------
+# GET /status
+# ---------------------------------------------------------------------------
+
+
+class TestStatusEndpoint:
+    @pytest.mark.asyncio
+    async def test_status_shape(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime = _make_runtime(tmpdir)
+            server = _make_server(runtime)
+
+            await server.start()
+            await runtime.start()
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(f"{_base_url(server)}/status") as resp:
+                        assert resp.status == 200
+                        body = await resp.json()
+                        assert "running" in body
+                        assert "graph_id" in body
+                        assert "graphs" in body
+                        assert "stats" in body
+                        assert body["running"] is True
+                        assert isinstance(body["graphs"], list)
+            finally:
+                await runtime.stop()
+                await server.stop()
+
+
+# ---------------------------------------------------------------------------
+# POST /trigger/{entry_point_id}
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerEndpoint:
+    @pytest.mark.asyncio
+    async def test_trigger_returns_202_and_exec_id(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime = _make_runtime(tmpdir)
+            server = _make_server(runtime)
+
+            await server.start()
+            await runtime.start()
+            try:
+                with patch.object(runtime, "trigger", new=AsyncMock(return_value="exec-abc123")):
+                    async with aiohttp.ClientSession() as session:
+                        async with session.post(
+                            f"{_base_url(server)}/trigger/main",
+                            json={"input": {"task": "do something"}},
+                        ) as resp:
+                            assert resp.status == 202
+                            body = await resp.json()
+                            assert body["execution_id"] == "exec-abc123"
+                            assert body["entry_point_id"] == "main"
+                            assert body["status"] == "accepted"
+            finally:
+                await runtime.stop()
+                await server.stop()
+
+    @pytest.mark.asyncio
+    async def test_trigger_unknown_entry_point_returns_404(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime = _make_runtime(tmpdir)
+            server = _make_server(runtime)
+
+            await server.start()
+            await runtime.start()
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(
+                        f"{_base_url(server)}/trigger/nonexistent",
+                        json={"input": {}},
+                    ) as resp:
+                        assert resp.status == 404
+                        body = await resp.json()
+                        assert "error" in body
+            finally:
+                await runtime.stop()
+                await server.stop()
+
+    @pytest.mark.asyncio
+    async def test_trigger_when_runtime_not_running_returns_503(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime = _make_runtime(tmpdir)
+            server = _make_server(runtime)
+
+            await server.start()
+            # runtime is NOT started
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(
+                        f"{_base_url(server)}/trigger/main",
+                        json={"input": {}},
+                    ) as resp:
+                        assert resp.status == 503
+                        body = await resp.json()
+                        assert "error" in body
+            finally:
+                await server.stop()
+
+    @pytest.mark.asyncio
+    async def test_trigger_passes_input_and_correlation_id(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime = _make_runtime(tmpdir)
+            server = _make_server(runtime)
+
+            await server.start()
+            await runtime.start()
+
+            captured_calls: list[tuple] = []
+
+            async def _mock_trigger(ep_id, input_data, correlation_id=None, **kwargs):
+                captured_calls.append((ep_id, input_data, correlation_id))
+                return "exec-xyz"
+
+            try:
+                with patch.object(runtime, "trigger", side_effect=_mock_trigger):
+                    async with aiohttp.ClientSession() as session:
+                        async with session.post(
+                            f"{_base_url(server)}/trigger/main",
+                            json={
+                                "input": {"task": "hello"},
+                                "correlation_id": "corr-1",
+                            },
+                        ) as resp:
+                            assert resp.status == 202
+
+                assert len(captured_calls) == 1
+                ep_id, input_data, corr_id = captured_calls[0]
+                assert ep_id == "main"
+                assert input_data == {"task": "hello"}
+                assert corr_id == "corr-1"
+            finally:
+                await runtime.stop()
+                await server.stop()
+
+    @pytest.mark.asyncio
+    async def test_trigger_empty_body_uses_empty_input(self):
+        """Empty POST body should not raise; input defaults to empty dict."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime = _make_runtime(tmpdir)
+            server = _make_server(runtime)
+
+            await server.start()
+            await runtime.start()
+
+            captured: list[dict] = []
+
+            async def _mock_trigger(ep_id, input_data, **kwargs):
+                captured.append(input_data)
+                return "exec-empty"
+
+            try:
+                with patch.object(runtime, "trigger", side_effect=_mock_trigger):
+                    async with aiohttp.ClientSession() as session:
+                        async with session.post(
+                            f"{_base_url(server)}/trigger/main",
+                        ) as resp:
+                            assert resp.status == 202
+
+                assert captured == [{}]
+            finally:
+                await runtime.stop()
+                await server.stop()
+
+
+# ---------------------------------------------------------------------------
+# POST /trigger/{entry_point_id}/wait
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerWaitEndpoint:
+    @pytest.mark.asyncio
+    async def test_trigger_wait_success(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime = _make_runtime(tmpdir)
+            server = _make_server(runtime)
+
+            from framework.graph.executor import ExecutionResult
+
+            mock_result = ExecutionResult(
+                success=True,
+                output={"result": "done"},
+                error=None,
+                node_path=["start-node"],
+            )
+
+            await server.start()
+            await runtime.start()
+            try:
+                with patch.object(
+                    runtime,
+                    "trigger_and_wait",
+                    new=AsyncMock(return_value=mock_result),
+                ):
+                    async with aiohttp.ClientSession() as session:
+                        async with session.post(
+                            f"{_base_url(server)}/trigger/main/wait",
+                            json={"input": {"task": "run"}},
+                        ) as resp:
+                            assert resp.status == 200
+                            body = await resp.json()
+                            assert body["status"] == "completed"
+                            assert body["success"] is True
+                            assert body["output"] == {"result": "done"}
+                            assert body["node_path"] == ["start-node"]
+            finally:
+                await runtime.stop()
+                await server.stop()
+
+    @pytest.mark.asyncio
+    async def test_trigger_wait_timeout_returns_408(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime = _make_runtime(tmpdir)
+            server = _make_server(runtime)
+
+            await server.start()
+            await runtime.start()
+            try:
+                with patch.object(
+                    runtime,
+                    "trigger_and_wait",
+                    new=AsyncMock(return_value=None),
+                ):
+                    async with aiohttp.ClientSession() as session:
+                        async with session.post(
+                            f"{_base_url(server)}/trigger/main/wait",
+                            json={"input": {}, "timeout": 1.0},
+                        ) as resp:
+                            assert resp.status == 408
+                            body = await resp.json()
+                            assert body["status"] == "timeout"
+            finally:
+                await runtime.stop()
+                await server.stop()
+
+
+# ---------------------------------------------------------------------------
+# GET /executions/{entry_point_id}/{execution_id}
+# ---------------------------------------------------------------------------
+
+
+class TestGetExecutionEndpoint:
+    @pytest.mark.asyncio
+    async def test_get_existing_result(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime = _make_runtime(tmpdir)
+            server = _make_server(runtime)
+
+            from framework.graph.executor import ExecutionResult
+
+            mock_result = ExecutionResult(
+                success=True,
+                output={"result": "42"},
+                error=None,
+                node_path=["start-node"],
+            )
+
+            await server.start()
+            try:
+                with patch.object(
+                    runtime,
+                    "get_execution_result",
+                    return_value=mock_result,
+                ):
+                    async with aiohttp.ClientSession() as session:
+                        async with session.get(
+                            f"{_base_url(server)}/executions/main/exec-abc"
+                        ) as resp:
+                            assert resp.status == 200
+                            body = await resp.json()
+                            assert body["execution_id"] == "exec-abc"
+                            assert body["entry_point_id"] == "main"
+                            assert body["success"] is True
+                            assert body["output"] == {"result": "42"}
+            finally:
+                await server.stop()
+
+    @pytest.mark.asyncio
+    async def test_get_missing_execution_returns_404(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime = _make_runtime(tmpdir)
+            server = _make_server(runtime)
+
+            await server.start()
+            try:
+                with patch.object(runtime, "get_execution_result", return_value=None):
+                    async with aiohttp.ClientSession() as session:
+                        async with session.get(
+                            f"{_base_url(server)}/executions/main/no-such-exec"
+                        ) as resp:
+                            assert resp.status == 404
+                            body = await resp.json()
+                            assert "error" in body
+            finally:
+                await server.stop()
+
+
+# ---------------------------------------------------------------------------
+# POST /stop
+# ---------------------------------------------------------------------------
+
+
+class TestStopEndpoint:
+    @pytest.mark.asyncio
+    async def test_stop_schedules_shutdown(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime = _make_runtime(tmpdir)
+            server = _make_server(runtime)
+
+            await server.start()
+            await runtime.start()
+
+            stop_called = []
+
+            async def _mock_stop():
+                stop_called.append(True)
+
+            try:
+                with patch.object(runtime, "stop", side_effect=_mock_stop):
+                    async with aiohttp.ClientSession() as session:
+                        async with session.post(f"{_base_url(server)}/stop") as resp:
+                            assert resp.status == 202
+                            body = await resp.json()
+                            assert body["status"] == "stopping"
+
+                import asyncio
+
+                await asyncio.sleep(0.05)
+                assert len(stop_called) == 1
+            finally:
+                await server.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_when_already_stopped(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime = _make_runtime(tmpdir)
+            server = _make_server(runtime)
+
+            await server.start()
+            # runtime is NOT started
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(f"{_base_url(server)}/stop") as resp:
+                        assert resp.status == 200
+                        body = await resp.json()
+                        assert body["status"] == "already_stopped"
+            finally:
+                await server.stop()
+
+
+# ---------------------------------------------------------------------------
+# AgentRuntimeConfig integration
+# ---------------------------------------------------------------------------
+
+
+class TestAgentRuntimeLifecycleConfig:
+    @pytest.mark.asyncio
+    async def test_lifecycle_disabled_by_default(self):
+        graph, goal = _make_graph_and_goal()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime = AgentRuntime(
+                graph=graph,
+                goal=goal,
+                storage_path=Path(tmpdir),
+            )
+            runtime.register_entry_point(
+                EntryPointSpec(
+                    id="main",
+                    name="Main",
+                    entry_node="start-node",
+                    trigger_type="manual",
+                )
+            )
+            await runtime.start()
+            try:
+                assert runtime.lifecycle_server is None
+            finally:
+                await runtime.stop()
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_enabled_via_config(self):
+        graph, goal = _make_graph_and_goal()
+        config = AgentRuntimeConfig(
+            lifecycle_enabled=True,
+            lifecycle_host="127.0.0.1",
+            lifecycle_port=0,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime = AgentRuntime(
+                graph=graph,
+                goal=goal,
+                storage_path=Path(tmpdir),
+                config=config,
+            )
+            runtime.register_entry_point(
+                EntryPointSpec(
+                    id="main",
+                    name="Main",
+                    entry_node="start-node",
+                    trigger_type="manual",
+                )
+            )
+            await runtime.start()
+            try:
+                assert runtime.lifecycle_server is not None
+                assert runtime.lifecycle_server.is_running
+                assert runtime.lifecycle_server.port is not None
+            finally:
+                await runtime.stop()
+                assert runtime.lifecycle_server is None


### PR DESCRIPTION
Closes #5330

## Summary

Adds `LifecycleServer` — a thin aiohttp HTTP server that wraps `AgentRuntime` and exposes lifecycle operations as REST endpoints. This is the bridge between "framework that runs locally" and "framework you can deploy".

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/health` | Liveness probe |
| `GET` | `/status` | Runtime stats, graph list, entry points |
| `POST` | `/trigger/{entry_point_id}` | Non-blocking trigger → returns `execution_id` (202) |
| `POST` | `/trigger/{entry_point_id}/wait` | Blocking trigger with optional `timeout` |
| `GET` | `/executions/{ep_id}/{exec_id}` | Fetch completed execution result |
| `POST` | `/stop` | Schedule graceful runtime shutdown (202) |

## Usage

```python
from framework.runtime.agent_runtime import AgentRuntimeConfig

config = AgentRuntimeConfig(
    lifecycle_enabled=True,
    lifecycle_host="0.0.0.0",
    lifecycle_port=8090,
)

runtime = AgentRuntime(graph=..., goal=..., storage_path=..., config=config)
await runtime.start()
# LifecycleServer now running on :8090
```

Or directly:

```python
from framework.runtime.lifecycle_server import LifecycleServer, LifecycleServerConfig

server = LifecycleServer(runtime, LifecycleServerConfig(host="0.0.0.0", port=8090))
await server.start()
```

## Files changed

| File | Change |
|------|--------|
| `core/framework/runtime/lifecycle_server.py` | New — `LifecycleServer` + `LifecycleServerConfig` |
| `core/framework/runtime/agent_runtime.py` | Add `lifecycle_enabled/host/port` to `AgentRuntimeConfig`; wire start/stop; expose `.lifecycle_server` property |
| `core/tests/test_lifecycle_server.py` | 14 async tests covering all endpoints, config integration, error cases |

## Design decisions

- **Opt-in, disabled by default** — zero impact on existing agents
- **No new dependencies** — aiohttp is already used by `WebhookServer` (the `webhook` optional extra)
- **Stop is async-safe** — `POST /stop` schedules `runtime.stop()` as a background task so the handler returns before the server shuts down
- **Port 0 support** — tests use `port=0` (OS-assigned) so no hardcoded ports in the test suite
- **Pause/resume not included** — the runtime has no native pause at the stream level; that belongs in a follow-up that adds proper execution suspension

## Testing

```bash
cd core && pytest tests/test_lifecycle_server.py -v
```