### PR TITLE
fix(runtime): restore Runtime->BuilderQuery persistence via unified session storage, fixes #5312

### DIFF
--- a/core/tests/test_builder_query.py
+++ b/core/tests/test_builder_query.py
@@ -1,0 +1,70 @@
+"""Tests for BuilderQuery compatibility with unified session storage."""
+
+from pathlib import Path
+
+from framework import BuilderQuery, Runtime
+
+
+def _run_once(
+    storage_path: Path,
+    *,
+    goal_id: str,
+    node_id: str,
+    success: bool,
+) -> str:
+    runtime = Runtime(storage_path)
+    run_id = runtime.start_run(goal_id=goal_id, goal_description="Test goal")
+    runtime.set_node(node_id)
+    decision_id = runtime.decide(
+        intent="Process input",
+        options=[{"id": "process", "description": "Process"}],
+        chosen="process",
+        reasoning="Test decision",
+    )
+    runtime.record_outcome(
+        decision_id=decision_id,
+        success=success,
+        result={"ok": success},
+        error=None if success else "Synthetic failure",
+        summary="Done" if success else "Failed",
+        tokens_used=10,
+        latency_ms=15,
+    )
+    runtime.end_run(success=success)
+    return run_id
+
+
+def test_builder_query_lists_goal_runs_from_unified_sessions(tmp_path: Path):
+    run_1 = _run_once(tmp_path, goal_id="goal-a", node_id="node-a", success=True)
+    run_2 = _run_once(tmp_path, goal_id="goal-a", node_id="node-a", success=False)
+    _run_once(tmp_path, goal_id="goal-b", node_id="node-b", success=True)
+
+    query = BuilderQuery(tmp_path)
+    goal_a_summaries = query.list_runs_for_goal("goal-a")
+    run_ids = {s.run_id for s in goal_a_summaries}
+
+    assert run_ids == {run_1, run_2}
+
+
+def test_builder_query_recent_failures_from_unified_sessions(tmp_path: Path):
+    _run_once(tmp_path, goal_id="goal-a", node_id="node-a", success=True)
+    failed_run = _run_once(tmp_path, goal_id="goal-a", node_id="node-a", success=False)
+
+    query = BuilderQuery(tmp_path)
+    failures = query.get_recent_failures(limit=5)
+
+    assert any(summary.run_id == failed_run for summary in failures)
+
+
+def test_builder_query_node_performance_from_unified_sessions(tmp_path: Path):
+    _run_once(tmp_path, goal_id="goal-a", node_id="intake", success=True)
+    _run_once(tmp_path, goal_id="goal-a", node_id="intake", success=False)
+    _run_once(tmp_path, goal_id="goal-a", node_id="other", success=True)
+
+    query = BuilderQuery(tmp_path)
+    perf = query.get_node_performance("intake")
+
+    assert perf["node_id"] == "intake"
+    assert perf["total_decisions"] == 2
+    assert perf["total_tokens"] == 20
+    assert 0.0 <= perf["success_rate"] <= 1.0


### PR DESCRIPTION
## Description

Fixes a regression where the documented `Runtime` + `BuilderQuery` workflow silently lost run data after `FileStorage.save_run()` became a no-op.  
`Runtime.end_run()` now persists runs to unified session storage, and `BuilderQuery` can read unified sessions (with legacy fallback), so run analysis works again.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #5312 

## Changes Made

- Persist completed runs from `Runtime` to `sessions/<run_id>/state.json` on `end_run()`.
- Add unified-session read support to `BuilderQuery` while preserving legacy `FileStorage` compatibility.
- Re-enable/update runtime persistence tests and add regression tests for BuilderQuery over unified sessions.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

Commands run:
- `make test`
- `cd core && pytest tests/test_runtime.py tests/test_builder_query.py -q`
- `cd core && pytest tests/test_execution_quality.py -q`
- `uv run --project core ruff check core/`
- `uv run --project core ruff check tools/`
- `uv run --project core ruff format --check core/`
- `uv run --project core ruff format --check tools/`

Manual check:
- Reproduced `Runtime -> end_run -> BuilderQuery` flow and confirmed:
  - `sessions/<run_id>/state.json` is created
  - `BuilderQuery.get_full_run(run_id)` returns data
  - `BuilderQuery.list_runs_for_goal(...)` includes the run

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A (no UI changes)
