### PR TITLE
feat: add Notion workspace integration tool

### DIFF
--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -75,6 +75,7 @@ from .health_check import (
 from .hubspot import HUBSPOT_CREDENTIALS
 from .llm import LLM_CREDENTIALS
 from .news import NEWS_CREDENTIALS
+from .notion import NOTION_CREDENTIALS
 from .postgres import POSTGRES_CREDENTIALS
 from .razorpay import RAZORPAY_CREDENTIALS
 from .search import SEARCH_CREDENTIALS
@@ -94,6 +95,7 @@ from .telegram import TELEGRAM_CREDENTIALS
 CREDENTIAL_SPECS = {
     **LLM_CREDENTIALS,
     **NEWS_CREDENTIALS,
+    **NOTION_CREDENTIALS,
     **SEARCH_CREDENTIALS,
     **EMAIL_CREDENTIALS,
     **GCP_VISION_CREDENTIALS,
@@ -141,6 +143,7 @@ __all__ = [
     # Category registries (for direct access if needed)
     "LLM_CREDENTIALS",
     "NEWS_CREDENTIALS",
+    "NOTION_CREDENTIALS",
     "SEARCH_CREDENTIALS",
     "EMAIL_CREDENTIALS",
     "GCP_VISION_CREDENTIALS",

--- a/tools/src/aden_tools/credentials/notion.py
+++ b/tools/src/aden_tools/credentials/notion.py
@@ -1,0 +1,52 @@
+"""
+Notion tool credentials.
+Contains credentials for Notion workspace integration.
+"""
+
+from .base import CredentialSpec
+
+NOTION_CREDENTIALS = {
+    "notion": CredentialSpec(
+        env_var="NOTION_API_KEY",
+        tools=[
+            "notion_create_page",
+            "notion_get_page",
+            "notion_update_page",
+            "notion_archive_page",
+            "notion_query_database",
+            "notion_get_database",
+            "notion_create_database",
+            "notion_update_database",
+            "notion_get_block",
+            "notion_get_block_children",
+            "notion_append_block_children",
+            "notion_delete_block",
+            "notion_search",
+            "notion_list_users",
+            "notion_get_user",
+            "notion_create_comment",
+            "notion_list_comments",
+        ],
+        required=True,
+        startup_required=False,
+        help_url="https://www.notion.so/my-integrations",
+        description="Notion Internal Integration Secret for authenticating all API requests",
+        # Auth method support
+        aden_supported=False,
+        direct_api_key_supported=True,
+        api_key_instructions="""To get your Notion API key:
+1. Go to https://www.notion.so/my-integrations
+2. Click "New integration"
+3. Name it and select a workspace
+4. Copy the Internal Integration Secret (starts with ntn_ or secret_)
+5. Share target pages/databases with the integration via the "..." menu -> "Add connections"
+Note: The integration can only access pages explicitly shared with it""",
+        # Health check configuration
+        health_check_endpoint="https://api.notion.com/v1/users/me",
+        health_check_method="GET",
+        # Credential store mapping
+        credential_id="notion",
+        credential_key="api_key",
+        credential_group="",
+    ),
+}

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -59,6 +59,7 @@ from .google_maps_tool import register_tools as register_google_maps
 from .http_headers_scanner import register_tools as register_http_headers_scanner
 from .hubspot_tool import register_tools as register_hubspot
 from .news_tool import register_tools as register_news
+from .notion_tool import register_tools as register_notion
 from .pdf_read_tool import register_tools as register_pdf_read
 from .port_scanner import register_tools as register_port_scanner
 from .postgres_tool import register_tools as register_postgres
@@ -121,6 +122,7 @@ def register_all_tools(
     register_discord(mcp, credentials=credentials)
     register_exa_search(mcp, credentials=credentials)
     register_news(mcp, credentials=credentials)
+    register_notion(mcp, credentials=credentials)
     register_razorpay(mcp, credentials=credentials)
     register_serpapi(mcp, credentials=credentials)
     register_slack(mcp, credentials=credentials)

--- a/tools/src/aden_tools/tools/notion_tool/README.md
+++ b/tools/src/aden_tools/tools/notion_tool/README.md
@@ -1,0 +1,177 @@
+# Notion Tool
+
+Integration with Notion for workspace management, page creation, database queries, and content automation.
+
+## Overview
+
+This tool enables Hive agents to interact with Notion's workspace API for:
+- Creating, reading, updating, and archiving pages
+- Querying and managing databases
+- Reading and appending block content
+- Searching across the workspace
+- Listing workspace users
+- Creating and listing comments
+
+## Available Tools
+
+This integration provides 17 MCP tools for comprehensive workspace operations:
+
+**Pages**
+- `notion_create_page` - Create a new page in a database or as a child of another page
+- `notion_get_page` - Retrieve a page by ID
+- `notion_update_page` - Update page properties, icon, cover, or archive status
+- `notion_archive_page` - Archive (soft-delete) a page
+
+**Databases**
+- `notion_query_database` - Query a database with filters and sorting
+- `notion_get_database` - Retrieve a database schema and metadata
+- `notion_create_database` - Create a new database as a child of a page
+- `notion_update_database` - Update a database title or property schema
+
+**Blocks**
+- `notion_get_block` - Retrieve a single block by ID
+- `notion_get_block_children` - Retrieve content blocks (children) of a page or block
+- `notion_append_block_children` - Append content blocks to a page or block
+- `notion_delete_block` - Delete (archive) a block
+
+**Search**
+- `notion_search` - Search across all pages and databases in the workspace
+
+**Users**
+- `notion_list_users` - List all users in the workspace
+- `notion_get_user` - Retrieve a user by ID
+
+**Comments**
+- `notion_create_comment` - Add a comment to a page or reply to a discussion
+- `notion_list_comments` - List comments on a page or block
+
+## Setup
+
+### 1. Create a Notion Integration
+
+1. Go to [My Integrations](https://www.notion.so/my-integrations)
+2. Click **"New integration"**
+3. Give it a name (e.g., "Hive Agent")
+4. Select the workspace to connect
+5. Copy the **Internal Integration Secret** (starts with `ntn_` or `secret_`)
+
+### 2. Share Pages with the Integration
+
+Notion integrations can only access pages they've been explicitly shared with:
+
+1. Open a Notion page or database
+2. Click **"..."** in the top-right corner
+3. Select **"Add connections"**
+4. Find and select your integration
+
+### 3. Configure Environment Variables
+```bash
+export NOTION_API_KEY="ntn_your_integration_secret"
+```
+
+## Usage
+
+### notion_search
+```python
+notion_search(query="Meeting Notes", filter_object="page")
+```
+
+### notion_query_database
+```python
+notion_query_database(
+    database_id="abc123def456...",
+    filter={"property": "Status", "select": {"equals": "In Progress"}},
+    sorts=[{"property": "Due Date", "direction": "ascending"}]
+)
+```
+
+### notion_create_page
+```python
+# Create a page in a database
+notion_create_page(
+    parent_type="database_id",
+    parent_id="abc123def456...",
+    properties={"Name": {"title": [{"text": {"content": "New Task"}}]}}
+)
+
+# Create a sub-page under an existing page
+notion_create_page(
+    parent_type="page_id",
+    parent_id="abc123def456...",
+    properties={"title": {"title": [{"text": {"content": "Sub Page"}}]}}
+)
+```
+
+### notion_update_page
+```python
+notion_update_page(
+    "abc123def456...",
+    properties={"Status": {"select": {"name": "Done"}}}
+)
+```
+
+### notion_append_block_children
+```python
+notion_append_block_children(
+    "abc123def456...",
+    children=[
+        {
+            "object": "block",
+            "type": "heading_2",
+            "heading_2": {
+                "rich_text": [{"type": "text", "text": {"content": "Section Title"}}]
+            }
+        },
+        {
+            "object": "block",
+            "type": "paragraph",
+            "paragraph": {
+                "rich_text": [{"type": "text", "text": {"content": "Paragraph content here."}}]
+            }
+        }
+    ]
+)
+```
+
+### notion_create_comment
+```python
+notion_create_comment("abc123def456...", text="Looks good, approved!")
+```
+
+## Authentication
+
+Notion uses Bearer token authentication. The tool passes your `NOTION_API_KEY` to all API requests via the `Authorization` header, along with the required `Notion-Version` header. A single `httpx.Client` instance is created per `_NotionClient` and reused across all calls.
+
+## Error Handling
+
+All tools return error dicts on failure so agents can handle errors without raising exceptions:
+```json
+{
+  "error": "Notion API error (object_not_found): Could not find page with ID: abc123..."
+}
+```
+
+Common errors:
+- Invalid API key - check `NOTION_API_KEY` is set correctly
+- Object not found - verify the ID exists and the integration has access
+- Validation error - check property names and value formats match the schema
+- Rate limit exceeded - reduce request frequency (Notion allows ~3 requests/second)
+
+All IDs are validated as UUIDs before making API calls.
+
+## Testing
+
+Use a dedicated test workspace or test pages:
+1. Create a Notion integration for testing
+2. Share test pages/databases with the integration
+3. Use the integration secret as `NOTION_API_KEY`
+
+## API Reference
+
+- [Notion API Docs](https://developers.notion.com/reference)
+- [Authentication](https://developers.notion.com/docs/authorization)
+- [Pages API](https://developers.notion.com/reference/page)
+- [Databases API](https://developers.notion.com/reference/database)
+- [Blocks API](https://developers.notion.com/reference/block)
+- [Search API](https://developers.notion.com/reference/post-search)
+- [Comments API](https://developers.notion.com/reference/create-a-comment)

--- a/tools/src/aden_tools/tools/notion_tool/__init__.py
+++ b/tools/src/aden_tools/tools/notion_tool/__init__.py
@@ -1,0 +1,5 @@
+"""Notion Tool package."""
+
+from .notion_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/notion_tool/notion_tool.py
+++ b/tools/src/aden_tools/tools/notion_tool/notion_tool.py
@@ -1,0 +1,1015 @@
+"""
+Notion Tool - Workspace management via the Notion API.
+
+Supports:
+- API key authentication (NOTION_API_KEY)
+
+Use Cases:
+- Create, read, update, and archive pages
+- Query and manage databases
+- Append and manage block content
+- Search across the workspace
+- List users and manage comments
+
+API Reference: https://developers.notion.com/reference
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialStoreAdapter
+
+_BASE_URL = "https://api.notion.com/v1"
+_NOTION_VERSION = "2022-06-28"
+
+
+class _NotionClient:
+    """Internal client wrapping Notion API calls via httpx."""
+
+    def __init__(self, api_key: str):
+        self._api_key = api_key
+        self._client = httpx.Client(
+            base_url=_BASE_URL,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Notion-Version": _NOTION_VERSION,
+                "Content-Type": "application/json",
+            },
+            timeout=30.0,
+        )
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        json: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Make an API request and return the JSON response or error dict."""
+        response = self._client.request(method, path, json=json, params=params)
+        data = response.json()
+        if response.status_code >= 400:
+            msg = data.get("message", response.text)
+            code = data.get("code", "unknown")
+            return {"error": f"Notion API error ({code}): {msg}"}
+        return data
+
+    # --- Pages ---
+
+    def create_page(
+        self,
+        parent: dict[str, Any],
+        properties: dict[str, Any],
+        children: list[dict[str, Any]] | None = None,
+        icon: dict[str, Any] | None = None,
+        cover: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {"parent": parent, "properties": properties}
+        if children:
+            body["children"] = children
+        if icon:
+            body["icon"] = icon
+        if cover:
+            body["cover"] = cover
+        result = self._request("POST", "/pages", json=body)
+        if "error" in result:
+            return result
+        return self._format_page(result)
+
+    def get_page(self, page_id: str) -> dict[str, Any]:
+        result = self._request("GET", f"/pages/{page_id}")
+        if "error" in result:
+            return result
+        return self._format_page(result)
+
+    def update_page(
+        self,
+        page_id: str,
+        properties: dict[str, Any] | None = None,
+        archived: bool | None = None,
+        icon: dict[str, Any] | None = None,
+        cover: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if properties is not None:
+            body["properties"] = properties
+        if archived is not None:
+            body["archived"] = archived
+        if icon is not None:
+            body["icon"] = icon
+        if cover is not None:
+            body["cover"] = cover
+        result = self._request("PATCH", f"/pages/{page_id}", json=body)
+        if "error" in result:
+            return result
+        return self._format_page(result)
+
+    def archive_page(self, page_id: str) -> dict[str, Any]:
+        return self.update_page(page_id, archived=True)
+
+    @staticmethod
+    def _format_page(page: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "id": page.get("id"),
+            "object": page.get("object"),
+            "created_time": page.get("created_time"),
+            "last_edited_time": page.get("last_edited_time"),
+            "archived": page.get("archived"),
+            "url": page.get("url"),
+            "properties": page.get("properties", {}),
+            "parent": page.get("parent"),
+            "icon": page.get("icon"),
+            "cover": page.get("cover"),
+        }
+
+    # --- Databases ---
+
+    def query_database(
+        self,
+        database_id: str,
+        filter: dict[str, Any] | None = None,
+        sorts: list[dict[str, Any]] | None = None,
+        start_cursor: str | None = None,
+        page_size: int = 100,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if filter:
+            body["filter"] = filter
+        if sorts:
+            body["sorts"] = sorts
+        if start_cursor:
+            body["start_cursor"] = start_cursor
+        body["page_size"] = min(page_size, 100)
+        result = self._request("POST", f"/databases/{database_id}/query", json=body)
+        if "error" in result:
+            return result
+        return {
+            "results": [self._format_page(p) for p in result.get("results", [])],
+            "has_more": result.get("has_more", False),
+            "next_cursor": result.get("next_cursor"),
+        }
+
+    def get_database(self, database_id: str) -> dict[str, Any]:
+        result = self._request("GET", f"/databases/{database_id}")
+        if "error" in result:
+            return result
+        return self._format_database(result)
+
+    def create_database(
+        self,
+        parent: dict[str, Any],
+        title: list[dict[str, Any]],
+        properties: dict[str, Any],
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "parent": parent,
+            "title": title,
+            "properties": properties,
+        }
+        result = self._request("POST", "/databases", json=body)
+        if "error" in result:
+            return result
+        return self._format_database(result)
+
+    def update_database(
+        self,
+        database_id: str,
+        title: list[dict[str, Any]] | None = None,
+        properties: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if title is not None:
+            body["title"] = title
+        if properties is not None:
+            body["properties"] = properties
+        result = self._request("PATCH", f"/databases/{database_id}", json=body)
+        if "error" in result:
+            return result
+        return self._format_database(result)
+
+    @staticmethod
+    def _format_database(db: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "id": db.get("id"),
+            "object": db.get("object"),
+            "created_time": db.get("created_time"),
+            "last_edited_time": db.get("last_edited_time"),
+            "title": db.get("title"),
+            "url": db.get("url"),
+            "properties": db.get("properties", {}),
+            "parent": db.get("parent"),
+            "archived": db.get("archived"),
+        }
+
+    # --- Blocks ---
+
+    def get_block(self, block_id: str) -> dict[str, Any]:
+        result = self._request("GET", f"/blocks/{block_id}")
+        if "error" in result:
+            return result
+        return self._format_block(result)
+
+    def get_block_children(
+        self,
+        block_id: str,
+        start_cursor: str | None = None,
+        page_size: int = 100,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"page_size": min(page_size, 100)}
+        if start_cursor:
+            params["start_cursor"] = start_cursor
+        result = self._request("GET", f"/blocks/{block_id}/children", params=params)
+        if "error" in result:
+            return result
+        return {
+            "results": [self._format_block(b) for b in result.get("results", [])],
+            "has_more": result.get("has_more", False),
+            "next_cursor": result.get("next_cursor"),
+        }
+
+    def append_block_children(
+        self,
+        block_id: str,
+        children: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        result = self._request(
+            "PATCH",
+            f"/blocks/{block_id}/children",
+            json={"children": children},
+        )
+        if "error" in result:
+            return result
+        return {
+            "results": [self._format_block(b) for b in result.get("results", [])],
+        }
+
+    def delete_block(self, block_id: str) -> dict[str, Any]:
+        result = self._request("DELETE", f"/blocks/{block_id}")
+        if "error" in result:
+            return result
+        return self._format_block(result)
+
+    @staticmethod
+    def _format_block(block: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "id": block.get("id"),
+            "object": block.get("object"),
+            "type": block.get("type"),
+            "created_time": block.get("created_time"),
+            "last_edited_time": block.get("last_edited_time"),
+            "has_children": block.get("has_children"),
+            "archived": block.get("archived"),
+            block.get("type", "_"): block.get(block.get("type", "_")),
+        }
+
+    # --- Search ---
+
+    def search(
+        self,
+        query: str = "",
+        filter_object: str | None = None,
+        sort_direction: str = "descending",
+        sort_timestamp: str = "last_edited_time",
+        start_cursor: str | None = None,
+        page_size: int = 100,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {"page_size": min(page_size, 100)}
+        if query:
+            body["query"] = query
+        if filter_object:
+            body["filter"] = {"value": filter_object, "property": "object"}
+        body["sort"] = {"direction": sort_direction, "timestamp": sort_timestamp}
+        if start_cursor:
+            body["start_cursor"] = start_cursor
+        result = self._request("POST", "/search", json=body)
+        if "error" in result:
+            return result
+        formatted = []
+        for item in result.get("results", []):
+            if item.get("object") == "page":
+                formatted.append(self._format_page(item))
+            elif item.get("object") == "database":
+                formatted.append(self._format_database(item))
+            else:
+                formatted.append(item)
+        return {
+            "results": formatted,
+            "has_more": result.get("has_more", False),
+            "next_cursor": result.get("next_cursor"),
+        }
+
+    # --- Users ---
+
+    def list_users(
+        self,
+        start_cursor: str | None = None,
+        page_size: int = 100,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"page_size": min(page_size, 100)}
+        if start_cursor:
+            params["start_cursor"] = start_cursor
+        result = self._request("GET", "/users", params=params)
+        if "error" in result:
+            return result
+        return {
+            "users": [self._format_user(u) for u in result.get("results", [])],
+            "has_more": result.get("has_more", False),
+            "next_cursor": result.get("next_cursor"),
+        }
+
+    def get_user(self, user_id: str) -> dict[str, Any]:
+        result = self._request("GET", f"/users/{user_id}")
+        if "error" in result:
+            return result
+        return self._format_user(result)
+
+    @staticmethod
+    def _format_user(user: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "id": user.get("id"),
+            "object": user.get("object"),
+            "type": user.get("type"),
+            "name": user.get("name"),
+            "avatar_url": user.get("avatar_url"),
+            "person": user.get("person"),
+            "bot": user.get("bot"),
+        }
+
+    # --- Comments ---
+
+    def create_comment(
+        self,
+        parent: dict[str, Any],
+        rich_text: list[dict[str, Any]],
+        discussion_id: str | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {"rich_text": rich_text}
+        if discussion_id:
+            body["discussion_id"] = discussion_id
+        else:
+            body["parent"] = parent
+        result = self._request("POST", "/comments", json=body)
+        if "error" in result:
+            return result
+        return self._format_comment(result)
+
+    def list_comments(
+        self,
+        block_id: str,
+        start_cursor: str | None = None,
+        page_size: int = 100,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {
+            "block_id": block_id,
+            "page_size": min(page_size, 100),
+        }
+        if start_cursor:
+            params["start_cursor"] = start_cursor
+        result = self._request("GET", "/comments", params=params)
+        if "error" in result:
+            return result
+        return {
+            "comments": [self._format_comment(c) for c in result.get("results", [])],
+            "has_more": result.get("has_more", False),
+            "next_cursor": result.get("next_cursor"),
+        }
+
+    @staticmethod
+    def _format_comment(comment: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "id": comment.get("id"),
+            "object": comment.get("object"),
+            "parent": comment.get("parent"),
+            "discussion_id": comment.get("discussion_id"),
+            "rich_text": comment.get("rich_text"),
+            "created_time": comment.get("created_time"),
+            "created_by": comment.get("created_by"),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+_UUID_MIN_LEN = 32  # UUIDs without dashes
+
+
+def _is_valid_id(value: str) -> bool:
+    """Check if a value looks like a valid Notion UUID (with or without dashes)."""
+    if not value:
+        return False
+    stripped = value.replace("-", "")
+    return len(stripped) >= _UUID_MIN_LEN and all(c in "0123456789abcdef" for c in stripped)
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: CredentialStoreAdapter | None = None,
+) -> None:
+    """Register Notion workspace tools with the MCP server."""
+
+    def _get_api_key() -> str | dict[str, str]:
+        """Get Notion API key from credential manager or environment."""
+        if credentials is not None:
+            api_key = credentials.get("notion")
+            if api_key and isinstance(api_key, str):
+                return api_key
+        else:
+            api_key = os.getenv("NOTION_API_KEY")
+            if api_key:
+                return api_key
+
+        return {
+            "error": "Notion credentials not configured",
+            "help": (
+                "Set NOTION_API_KEY environment variable. "
+                "Create an integration at https://www.notion.so/my-integrations"
+            ),
+        }
+
+    def _get_client() -> _NotionClient | dict[str, str]:
+        """Get a Notion client, or return an error dict if no credentials."""
+        key = _get_api_key()
+        if isinstance(key, dict):
+            return key
+        return _NotionClient(key)
+
+    def _api_error(e: httpx.HTTPError) -> dict[str, Any]:
+        return {"error": str(e)}
+
+    # --- Page Tools ---
+
+    @mcp.tool()
+    def notion_create_page(
+        parent_type: str,
+        parent_id: str,
+        properties: dict,
+        children: list[dict] | None = None,
+        icon: dict | None = None,
+        cover: dict | None = None,
+    ) -> dict:
+        """
+        Create a new Notion page.
+
+        Args:
+            parent_type: Parent type - "database_id" or "page_id"
+            parent_id: ID of the parent database or page
+            properties: Page properties (title, etc.) as Notion property objects
+            children: Optional list of block objects for page content
+            icon: Optional icon object (emoji or external URL)
+            cover: Optional cover image object (external URL)
+
+        Returns:
+            Dict with page details or error
+
+        Example:
+            notion_create_page(
+                parent_type="database_id",
+                parent_id="abc123...",
+                properties={"Name": {"title": [{"text": {"content": "My Page"}}]}}
+            )
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if parent_type not in ("database_id", "page_id"):
+            return {"error": "parent_type must be 'database_id' or 'page_id'"}
+        if not _is_valid_id(parent_id):
+            return {"error": f"Invalid {parent_type}. Must be a valid Notion UUID."}
+        try:
+            return client.create_page(
+                parent={parent_type: parent_id},
+                properties=properties,
+                children=children,
+                icon=icon,
+                cover=cover,
+            )
+        except httpx.HTTPError as e:
+            return _api_error(e)
+
+    @mcp.tool()
+    def notion_get_page(page_id: str) -> dict:
+        """
+        Retrieve a Notion page by ID.
+
+        Args:
+            page_id: Notion page ID (UUID format)
+
+        Returns:
+            Dict with page details or error
+
+        Example:
+            notion_get_page("abc123def456...")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not _is_valid_id(page_id):
+            return {"error": "Invalid page_id. Must be a valid Notion UUID."}
+        try:
+            return client.get_page(page_id)
+        except httpx.HTTPError as e:
+            return _api_error(e)
+
+    @mcp.tool()
+    def notion_update_page(
+        page_id: str,
+        properties: dict | None = None,
+        archived: bool | None = None,
+        icon: dict | None = None,
+        cover: dict | None = None,
+    ) -> dict:
+        """
+        Update a Notion page's properties, icon, cover, or archive status.
+
+        Args:
+            page_id: Notion page ID (UUID format)
+            properties: Properties to update as Notion property objects
+            archived: Set to True to archive, False to un-archive
+            icon: Icon object (emoji or external URL), or None to skip
+            cover: Cover image object (external URL), or None to skip
+
+        Returns:
+            Dict with updated page details or error
+
+        Example:
+            notion_update_page(
+                "abc123...",
+                properties={"Status": {"select": {"name": "Done"}}}
+            )
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not _is_valid_id(page_id):
+            return {"error": "Invalid page_id. Must be a valid Notion UUID."}
+        try:
+            return client.update_page(page_id, properties, archived, icon, cover)
+        except httpx.HTTPError as e:
+            return _api_error(e)
+
+    @mcp.tool()
+    def notion_archive_page(page_id: str) -> dict:
+        """
+        Archive (soft-delete) a Notion page.
+
+        Args:
+            page_id: Notion page ID (UUID format)
+
+        Returns:
+            Dict with archived page details or error
+
+        Example:
+            notion_archive_page("abc123def456...")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not _is_valid_id(page_id):
+            return {"error": "Invalid page_id. Must be a valid Notion UUID."}
+        try:
+            return client.archive_page(page_id)
+        except httpx.HTTPError as e:
+            return _api_error(e)
+
+    # --- Database Tools ---
+
+    @mcp.tool()
+    def notion_query_database(
+        database_id: str,
+        filter: dict | None = None,
+        sorts: list[dict] | None = None,
+        start_cursor: str | None = None,
+        page_size: int = 100,
+    ) -> dict:
+        """
+        Query a Notion database with optional filters and sorting.
+
+        Args:
+            database_id: Notion database ID (UUID format)
+            filter: Notion filter object for narrowing results
+            sorts: List of sort objects (property name + direction)
+            start_cursor: Cursor for pagination from a previous response
+            page_size: Number of results per page (max 100)
+
+        Returns:
+            Dict with results list, has_more flag, and next_cursor
+
+        Example:
+            notion_query_database(
+                "abc123...",
+                filter={"property": "Status", "select": {"equals": "Active"}}
+            )
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not _is_valid_id(database_id):
+            return {"error": "Invalid database_id. Must be a valid Notion UUID."}
+        if page_size < 1:
+            return {"error": "page_size must be at least 1"}
+        try:
+            return client.query_database(database_id, filter, sorts, start_cursor, page_size)
+        except httpx.HTTPError as e:
+            return _api_error(e)
+
+    @mcp.tool()
+    def notion_get_database(database_id: str) -> dict:
+        """
+        Retrieve a Notion database schema and metadata.
+
+        Args:
+            database_id: Notion database ID (UUID format)
+
+        Returns:
+            Dict with database details including properties schema
+
+        Example:
+            notion_get_database("abc123def456...")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not _is_valid_id(database_id):
+            return {"error": "Invalid database_id. Must be a valid Notion UUID."}
+        try:
+            return client.get_database(database_id)
+        except httpx.HTTPError as e:
+            return _api_error(e)
+
+    @mcp.tool()
+    def notion_create_database(
+        parent_id: str,
+        title: str,
+        properties: dict,
+    ) -> dict:
+        """
+        Create a new Notion database as a child of an existing page.
+
+        Args:
+            parent_id: Parent page ID (UUID format)
+            title: Database title text
+            properties: Database property schema as Notion property config objects
+
+        Returns:
+            Dict with new database details or error
+
+        Example:
+            notion_create_database(
+                parent_id="abc123...",
+                title="Project Tracker",
+                properties={
+                    "Name": {"title": {}},
+                    "Status": {"select": {"options": [
+                        {"name": "To Do", "color": "red"},
+                        {"name": "Done", "color": "green"}
+                    ]}}
+                }
+            )
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not _is_valid_id(parent_id):
+            return {"error": "Invalid parent_id. Must be a valid Notion UUID."}
+        if not title:
+            return {"error": "title is required and cannot be empty"}
+        try:
+            return client.create_database(
+                parent={"type": "page_id", "page_id": parent_id},
+                title=[{"type": "text", "text": {"content": title}}],
+                properties=properties,
+            )
+        except httpx.HTTPError as e:
+            return _api_error(e)
+
+    @mcp.tool()
+    def notion_update_database(
+        database_id: str,
+        title: str | None = None,
+        properties: dict | None = None,
+    ) -> dict:
+        """
+        Update a Notion database's title or property schema.
+
+        Args:
+            database_id: Notion database ID (UUID format)
+            title: New title text, or None to skip
+            properties: Updated property schema config, or None to skip
+
+        Returns:
+            Dict with updated database details or error
+
+        Example:
+            notion_update_database("abc123...", title="Updated Tracker")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not _is_valid_id(database_id):
+            return {"error": "Invalid database_id. Must be a valid Notion UUID."}
+        title_obj = None
+        if title is not None:
+            title_obj = [{"type": "text", "text": {"content": title}}]
+        try:
+            return client.update_database(database_id, title_obj, properties)
+        except httpx.HTTPError as e:
+            return _api_error(e)
+
+    # --- Block Tools ---
+
+    @mcp.tool()
+    def notion_get_block(block_id: str) -> dict:
+        """
+        Retrieve a single Notion block by ID.
+
+        Args:
+            block_id: Notion block ID (UUID format)
+
+        Returns:
+            Dict with block details or error
+
+        Example:
+            notion_get_block("abc123def456...")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not _is_valid_id(block_id):
+            return {"error": "Invalid block_id. Must be a valid Notion UUID."}
+        try:
+            return client.get_block(block_id)
+        except httpx.HTTPError as e:
+            return _api_error(e)
+
+    @mcp.tool()
+    def notion_get_block_children(
+        block_id: str,
+        start_cursor: str | None = None,
+        page_size: int = 100,
+    ) -> dict:
+        """
+        Retrieve the content blocks (children) of a page or block.
+
+        Args:
+            block_id: Parent block or page ID (UUID format)
+            start_cursor: Cursor for pagination
+            page_size: Number of blocks per page (max 100)
+
+        Returns:
+            Dict with results list, has_more flag, and next_cursor
+
+        Example:
+            notion_get_block_children("abc123def456...")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not _is_valid_id(block_id):
+            return {"error": "Invalid block_id. Must be a valid Notion UUID."}
+        if page_size < 1:
+            return {"error": "page_size must be at least 1"}
+        try:
+            return client.get_block_children(block_id, start_cursor, page_size)
+        except httpx.HTTPError as e:
+            return _api_error(e)
+
+    @mcp.tool()
+    def notion_append_block_children(
+        block_id: str,
+        children: list[dict],
+    ) -> dict:
+        """
+        Append content blocks to a page or existing block.
+
+        Args:
+            block_id: Parent block or page ID (UUID format)
+            children: List of Notion block objects to append
+
+        Returns:
+            Dict with the appended block results or error
+
+        Example:
+            notion_append_block_children(
+                "abc123...",
+                children=[{
+                    "object": "block",
+                    "type": "paragraph",
+                    "paragraph": {
+                        "rich_text": [{"type": "text", "text": {"content": "Hello!"}}]
+                    }
+                }]
+            )
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not _is_valid_id(block_id):
+            return {"error": "Invalid block_id. Must be a valid Notion UUID."}
+        if not children:
+            return {"error": "children list cannot be empty"}
+        try:
+            return client.append_block_children(block_id, children)
+        except httpx.HTTPError as e:
+            return _api_error(e)
+
+    @mcp.tool()
+    def notion_delete_block(block_id: str) -> dict:
+        """
+        Delete (archive) a Notion block.
+
+        Args:
+            block_id: Notion block ID (UUID format)
+
+        Returns:
+            Dict with the deleted block details or error
+
+        Example:
+            notion_delete_block("abc123def456...")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not _is_valid_id(block_id):
+            return {"error": "Invalid block_id. Must be a valid Notion UUID."}
+        try:
+            return client.delete_block(block_id)
+        except httpx.HTTPError as e:
+            return _api_error(e)
+
+    # --- Search ---
+
+    @mcp.tool()
+    def notion_search(
+        query: str = "",
+        filter_object: str | None = None,
+        sort_direction: str = "descending",
+        start_cursor: str | None = None,
+        page_size: int = 100,
+    ) -> dict:
+        """
+        Search across all pages and databases in the workspace.
+
+        Args:
+            query: Text to search for (empty string returns all)
+            filter_object: Filter by object type - "page" or "database"
+            sort_direction: Sort order - "ascending" or "descending"
+            start_cursor: Cursor for pagination
+            page_size: Number of results per page (max 100)
+
+        Returns:
+            Dict with results list, has_more flag, and next_cursor
+
+        Example:
+            notion_search(query="Meeting Notes", filter_object="page")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if filter_object and filter_object not in ("page", "database"):
+            return {"error": "filter_object must be 'page' or 'database'"}
+        if sort_direction not in ("ascending", "descending"):
+            return {"error": "sort_direction must be 'ascending' or 'descending'"}
+        if page_size < 1:
+            return {"error": "page_size must be at least 1"}
+        try:
+            return client.search(query, filter_object, sort_direction, "last_edited_time",
+                                 start_cursor, page_size)
+        except httpx.HTTPError as e:
+            return _api_error(e)
+
+    # --- User Tools ---
+
+    @mcp.tool()
+    def notion_list_users(
+        start_cursor: str | None = None,
+        page_size: int = 100,
+    ) -> dict:
+        """
+        List all users in the Notion workspace.
+
+        Args:
+            start_cursor: Cursor for pagination
+            page_size: Number of users per page (max 100)
+
+        Returns:
+            Dict with users list, has_more flag, and next_cursor
+
+        Example:
+            notion_list_users()
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if page_size < 1:
+            return {"error": "page_size must be at least 1"}
+        try:
+            return client.list_users(start_cursor, page_size)
+        except httpx.HTTPError as e:
+            return _api_error(e)
+
+    @mcp.tool()
+    def notion_get_user(user_id: str) -> dict:
+        """
+        Retrieve a Notion user by ID.
+
+        Args:
+            user_id: Notion user ID (UUID format)
+
+        Returns:
+            Dict with user details or error
+
+        Example:
+            notion_get_user("abc123def456...")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not _is_valid_id(user_id):
+            return {"error": "Invalid user_id. Must be a valid Notion UUID."}
+        try:
+            return client.get_user(user_id)
+        except httpx.HTTPError as e:
+            return _api_error(e)
+
+    # --- Comment Tools ---
+
+    @mcp.tool()
+    def notion_create_comment(
+        page_id: str,
+        text: str,
+        discussion_id: str | None = None,
+    ) -> dict:
+        """
+        Add a comment to a Notion page or reply to a discussion thread.
+
+        Args:
+            page_id: Page ID to comment on (UUID format)
+            text: Comment text content
+            discussion_id: Optional discussion thread ID to reply to
+
+        Returns:
+            Dict with comment details or error
+
+        Example:
+            notion_create_comment("abc123...", text="Looks good!")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not _is_valid_id(page_id):
+            return {"error": "Invalid page_id. Must be a valid Notion UUID."}
+        if not text:
+            return {"error": "text cannot be empty"}
+        rich_text = [{"type": "text", "text": {"content": text}}]
+        try:
+            return client.create_comment(
+                parent={"page_id": page_id},
+                rich_text=rich_text,
+                discussion_id=discussion_id,
+            )
+        except httpx.HTTPError as e:
+            return _api_error(e)
+
+    @mcp.tool()
+    def notion_list_comments(
+        block_id: str,
+        start_cursor: str | None = None,
+        page_size: int = 100,
+    ) -> dict:
+        """
+        List comments on a Notion page or block.
+
+        Args:
+            block_id: Page or block ID to list comments for (UUID format)
+            start_cursor: Cursor for pagination
+            page_size: Number of comments per page (max 100)
+
+        Returns:
+            Dict with comments list, has_more flag, and next_cursor
+
+        Example:
+            notion_list_comments("abc123def456...")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        if not _is_valid_id(block_id):
+            return {"error": "Invalid block_id. Must be a valid Notion UUID."}
+        if page_size < 1:
+            return {"error": "page_size must be at least 1"}
+        try:
+            return client.list_comments(block_id, start_cursor, page_size)
+        except httpx.HTTPError as e:
+            return _api_error(e)

--- a/tools/tests/tools/test_notion_tool.py
+++ b/tools/tests/tools/test_notion_tool.py
@@ -1,0 +1,781 @@
+"""
+Tests for Notion workspace tool.
+
+Covers:
+- _NotionClient methods (all page, database, block, search, user,
+  and comment operations)
+- Error handling (API errors, invalid credentials, missing credentials)
+- Credential retrieval (CredentialStoreAdapter vs env var)
+- All 17 MCP tool functions
+- Input validation (UUID format checks, required fields)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from aden_tools.tools.notion_tool.notion_tool import (
+    _NotionClient,
+    _is_valid_id,
+    register_tools,
+)
+
+# ---------------------------------------------------------------------------
+# Test data constants
+# ---------------------------------------------------------------------------
+
+_VALID_UUID = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"
+_VALID_UUID_DASHES = "a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4"
+_INVALID_ID = "not-a-valid-id"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _page(**kwargs):
+    defaults = {
+        "id": _VALID_UUID,
+        "object": "page",
+        "created_time": "2024-01-01T00:00:00.000Z",
+        "last_edited_time": "2024-01-02T00:00:00.000Z",
+        "archived": False,
+        "url": "https://www.notion.so/Test-Page-abc123",
+        "properties": {"Name": {"title": [{"text": {"content": "Test Page"}}]}},
+        "parent": {"type": "database_id", "database_id": _VALID_UUID},
+        "icon": None,
+        "cover": None,
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+def _database(**kwargs):
+    defaults = {
+        "id": _VALID_UUID,
+        "object": "database",
+        "created_time": "2024-01-01T00:00:00.000Z",
+        "last_edited_time": "2024-01-02T00:00:00.000Z",
+        "title": [{"type": "text", "text": {"content": "Test DB"}}],
+        "url": "https://www.notion.so/Test-DB-abc123",
+        "properties": {"Name": {"id": "title", "type": "title", "title": {}}},
+        "parent": {"type": "page_id", "page_id": _VALID_UUID},
+        "archived": False,
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+def _block(**kwargs):
+    defaults = {
+        "id": _VALID_UUID,
+        "object": "block",
+        "type": "paragraph",
+        "created_time": "2024-01-01T00:00:00.000Z",
+        "last_edited_time": "2024-01-02T00:00:00.000Z",
+        "has_children": False,
+        "archived": False,
+        "paragraph": {
+            "rich_text": [{"type": "text", "text": {"content": "Hello"}}]
+        },
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+def _user(**kwargs):
+    defaults = {
+        "id": _VALID_UUID,
+        "object": "user",
+        "type": "person",
+        "name": "Test User",
+        "avatar_url": "https://example.com/avatar.png",
+        "person": {"email": "test@example.com"},
+        "bot": None,
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+def _comment(**kwargs):
+    defaults = {
+        "id": _VALID_UUID,
+        "object": "comment",
+        "parent": {"type": "page_id", "page_id": _VALID_UUID},
+        "discussion_id": _VALID_UUID,
+        "rich_text": [{"type": "text", "text": {"content": "Nice!"}}],
+        "created_time": "2024-01-01T00:00:00.000Z",
+        "created_by": {"id": _VALID_UUID, "object": "user"},
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+def _list_response(results, has_more=False, next_cursor=None):
+    return {
+        "object": "list",
+        "results": results,
+        "has_more": has_more,
+        "next_cursor": next_cursor,
+    }
+
+
+def _error_response(code="object_not_found", message="Not found", status=404):
+    return {"object": "error", "code": code, "message": message, "status": status}
+
+
+def _mock_response(json_data, status_code=200):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.text = str(json_data)
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# UUID validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestUUIDValidation:
+    def test_valid_uuid_no_dashes(self):
+        assert _is_valid_id(_VALID_UUID) is True
+
+    def test_valid_uuid_with_dashes(self):
+        assert _is_valid_id(_VALID_UUID_DASHES) is True
+
+    def test_invalid_short_string(self):
+        assert _is_valid_id("abc123") is False
+
+    def test_invalid_empty(self):
+        assert _is_valid_id("") is False
+
+    def test_invalid_non_hex(self):
+        assert _is_valid_id("z" * 32) is False
+
+
+# ---------------------------------------------------------------------------
+# _NotionClient unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestNotionClientPages:
+    def setup_method(self):
+        self.client = _NotionClient("ntn_test_key123")
+
+    def test_create_page(self):
+        with patch.object(self.client._client, "request", return_value=_mock_response(_page())):
+            result = self.client.create_page(
+                parent={"database_id": _VALID_UUID},
+                properties={"Name": {"title": [{"text": {"content": "New"}}]}},
+            )
+        assert result["id"] == _VALID_UUID
+        assert result["object"] == "page"
+
+    def test_get_page(self):
+        with patch.object(self.client._client, "request", return_value=_mock_response(_page())):
+            result = self.client.get_page(_VALID_UUID)
+        assert result["id"] == _VALID_UUID
+        assert result["url"] == "https://www.notion.so/Test-Page-abc123"
+
+    def test_update_page(self):
+        updated = _page(archived=True)
+        with patch.object(self.client._client, "request", return_value=_mock_response(updated)):
+            result = self.client.update_page(_VALID_UUID, archived=True)
+        assert result["archived"] is True
+
+    def test_archive_page(self):
+        archived = _page(archived=True)
+        with patch.object(self.client._client, "request", return_value=_mock_response(archived)):
+            result = self.client.archive_page(_VALID_UUID)
+        assert result["archived"] is True
+
+    def test_get_page_api_error(self):
+        err = _error_response()
+        with patch.object(self.client._client, "request", return_value=_mock_response(err, 404)):
+            result = self.client.get_page(_VALID_UUID)
+        assert "error" in result
+        assert "object_not_found" in result["error"]
+
+
+class TestNotionClientDatabases:
+    def setup_method(self):
+        self.client = _NotionClient("ntn_test_key123")
+
+    def test_query_database(self):
+        resp = _list_response([_page(), _page(id="b" * 32)])
+        with patch.object(self.client._client, "request", return_value=_mock_response(resp)):
+            result = self.client.query_database(_VALID_UUID)
+        assert len(result["results"]) == 2
+        assert result["has_more"] is False
+
+    def test_query_database_with_filter(self):
+        resp = _list_response([_page()])
+        with patch.object(self.client._client, "request", return_value=_mock_response(resp)) as m:
+            self.client.query_database(
+                _VALID_UUID,
+                filter={"property": "Status", "select": {"equals": "Done"}},
+                sorts=[{"property": "Name", "direction": "ascending"}],
+            )
+        # Verify the request was made (filter passed through to API)
+        m.assert_called_once()
+
+    def test_query_database_page_size_capped(self):
+        resp = _list_response([])
+        with patch.object(self.client._client, "request", return_value=_mock_response(resp)):
+            result = self.client.query_database(_VALID_UUID, page_size=500)
+        assert result["results"] == []
+
+    def test_get_database(self):
+        with patch.object(self.client._client, "request", return_value=_mock_response(_database())):
+            result = self.client.get_database(_VALID_UUID)
+        assert result["id"] == _VALID_UUID
+        assert result["object"] == "database"
+
+    def test_create_database(self):
+        with patch.object(self.client._client, "request", return_value=_mock_response(_database())):
+            result = self.client.create_database(
+                parent={"type": "page_id", "page_id": _VALID_UUID},
+                title=[{"type": "text", "text": {"content": "New DB"}}],
+                properties={"Name": {"title": {}}},
+            )
+        assert result["id"] == _VALID_UUID
+
+    def test_update_database(self):
+        updated = _database(title=[{"type": "text", "text": {"content": "Updated"}}])
+        with patch.object(self.client._client, "request", return_value=_mock_response(updated)):
+            result = self.client.update_database(
+                _VALID_UUID,
+                title=[{"type": "text", "text": {"content": "Updated"}}],
+            )
+        assert result["id"] == _VALID_UUID
+
+
+class TestNotionClientBlocks:
+    def setup_method(self):
+        self.client = _NotionClient("ntn_test_key123")
+
+    def test_get_block(self):
+        with patch.object(self.client._client, "request", return_value=_mock_response(_block())):
+            result = self.client.get_block(_VALID_UUID)
+        assert result["id"] == _VALID_UUID
+        assert result["type"] == "paragraph"
+
+    def test_get_block_children(self):
+        resp = _list_response([_block(), _block(id="b" * 32)])
+        with patch.object(self.client._client, "request", return_value=_mock_response(resp)):
+            result = self.client.get_block_children(_VALID_UUID)
+        assert len(result["results"]) == 2
+
+    def test_append_block_children(self):
+        resp = _list_response([_block()])
+        with patch.object(self.client._client, "request", return_value=_mock_response(resp)):
+            result = self.client.append_block_children(
+                _VALID_UUID,
+                children=[{"object": "block", "type": "paragraph", "paragraph": {
+                    "rich_text": [{"type": "text", "text": {"content": "New"}}]
+                }}],
+            )
+        assert len(result["results"]) == 1
+
+    def test_delete_block(self):
+        deleted = _block(archived=True)
+        with patch.object(self.client._client, "request", return_value=_mock_response(deleted)):
+            result = self.client.delete_block(_VALID_UUID)
+        assert result["archived"] is True
+
+
+class TestNotionClientSearch:
+    def setup_method(self):
+        self.client = _NotionClient("ntn_test_key123")
+
+    def test_search_pages(self):
+        resp = _list_response([_page()])
+        with patch.object(self.client._client, "request", return_value=_mock_response(resp)):
+            result = self.client.search(query="Meeting", filter_object="page")
+        assert len(result["results"]) == 1
+        assert result["results"][0]["object"] == "page"
+
+    def test_search_databases(self):
+        resp = _list_response([_database()])
+        with patch.object(self.client._client, "request", return_value=_mock_response(resp)):
+            result = self.client.search(query="Tracker", filter_object="database")
+        assert len(result["results"]) == 1
+        assert result["results"][0]["object"] == "database"
+
+    def test_search_empty_query(self):
+        resp = _list_response([_page(), _database()])
+        with patch.object(self.client._client, "request", return_value=_mock_response(resp)):
+            result = self.client.search()
+        assert len(result["results"]) == 2
+
+    def test_search_with_pagination(self):
+        resp = _list_response([_page()], has_more=True, next_cursor="cursor_abc")
+        with patch.object(self.client._client, "request", return_value=_mock_response(resp)):
+            result = self.client.search(query="test")
+        assert result["has_more"] is True
+        assert result["next_cursor"] == "cursor_abc"
+
+
+class TestNotionClientUsers:
+    def setup_method(self):
+        self.client = _NotionClient("ntn_test_key123")
+
+    def test_list_users(self):
+        resp = _list_response([_user(), _user(id="b" * 32, name="User 2")])
+        with patch.object(self.client._client, "request", return_value=_mock_response(resp)):
+            result = self.client.list_users()
+        assert len(result["users"]) == 2
+        assert result["users"][0]["name"] == "Test User"
+
+    def test_get_user(self):
+        with patch.object(self.client._client, "request", return_value=_mock_response(_user())):
+            result = self.client.get_user(_VALID_UUID)
+        assert result["name"] == "Test User"
+        assert result["type"] == "person"
+
+
+class TestNotionClientComments:
+    def setup_method(self):
+        self.client = _NotionClient("ntn_test_key123")
+
+    def test_create_comment(self):
+        with patch.object(self.client._client, "request", return_value=_mock_response(_comment())):
+            result = self.client.create_comment(
+                parent={"page_id": _VALID_UUID},
+                rich_text=[{"type": "text", "text": {"content": "Nice!"}}],
+            )
+        assert result["id"] == _VALID_UUID
+        assert result["discussion_id"] == _VALID_UUID
+
+    def test_list_comments(self):
+        resp = _list_response([_comment(), _comment(id="b" * 32)])
+        with patch.object(self.client._client, "request", return_value=_mock_response(resp)):
+            result = self.client.list_comments(_VALID_UUID)
+        assert len(result["comments"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# MCP tool registration and credential tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolRegistration:
+    def test_register_tools_registers_all_tools(self):
+        mcp = MagicMock()
+        mcp.tool.return_value = lambda fn: fn
+        register_tools(mcp)
+        assert mcp.tool.call_count == 17
+
+    def test_no_credentials_returns_error(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        with patch.dict("os.environ", {}, clear=True):
+            register_tools(mcp, credentials=None)
+            search_fn = next(f for f in registered_fns if f.__name__ == "notion_search")
+            result = search_fn()
+
+        assert "error" in result
+        assert "not configured" in result["error"]
+
+    def test_credentials_from_credential_manager(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        cred_manager = MagicMock()
+        cred_manager.get.return_value = "ntn_test_fromcredstore"
+
+        register_tools(mcp, credentials=cred_manager)
+
+        fn = next(f for f in registered_fns if f.__name__ == "notion_list_users")
+
+        with patch("aden_tools.tools.notion_tool.notion_tool._NotionClient") as MockClient:
+            instance = MockClient.return_value
+            instance.list_users.return_value = {"users": [], "has_more": False, "next_cursor": None}
+            fn()
+
+        MockClient.assert_called_once_with("ntn_test_fromcredstore")
+        cred_manager.get.assert_called_with("notion")
+
+    def test_credentials_from_env_vars(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        register_tools(mcp, credentials=None)
+
+        fn = next(f for f in registered_fns if f.__name__ == "notion_list_users")
+
+        with (
+            patch.dict("os.environ", {"NOTION_API_KEY": "ntn_test_fromenv"}),
+            patch("aden_tools.tools.notion_tool.notion_tool._NotionClient") as MockClient,
+        ):
+            instance = MockClient.return_value
+            instance.list_users.return_value = {"users": [], "has_more": False, "next_cursor": None}
+            fn()
+
+        MockClient.assert_called_once_with("ntn_test_fromenv")
+
+    def test_http_error_is_caught(self):
+        mcp = MagicMock()
+        registered_fns = []
+        mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
+
+        cred_manager = MagicMock()
+        cred_manager.get.return_value = "ntn_test_key"
+
+        register_tools(mcp, credentials=cred_manager)
+
+        fn = next(f for f in registered_fns if f.__name__ == "notion_list_users")
+
+        with patch("aden_tools.tools.notion_tool.notion_tool._NotionClient") as MockClient:
+            instance = MockClient.return_value
+            instance.list_users.side_effect = httpx.ConnectError("Network error")
+            result = fn()
+
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Individual MCP tool validation tests
+# ---------------------------------------------------------------------------
+
+
+def _setup_tools():
+    """Helper to register tools with a mock credential manager."""
+    mcp = MagicMock()
+    fns = []
+    mcp.tool.return_value = lambda fn: fns.append(fn) or fn
+    cred = MagicMock()
+    cred.get.return_value = "ntn_test_key"
+    register_tools(mcp, credentials=cred)
+    fn_map = {f.__name__: f for f in fns}
+    return fn_map
+
+
+class TestPageToolValidation:
+    def setup_method(self):
+        self.fns = _setup_tools()
+
+    def test_create_page_invalid_parent_type(self):
+        result = self.fns["notion_create_page"](
+            parent_type="invalid", parent_id=_VALID_UUID, properties={}
+        )
+        assert "error" in result
+        assert "parent_type" in result["error"]
+
+    def test_create_page_invalid_parent_id(self):
+        result = self.fns["notion_create_page"](
+            parent_type="database_id", parent_id=_INVALID_ID, properties={}
+        )
+        assert "error" in result
+        assert "UUID" in result["error"]
+
+    def test_get_page_invalid_id(self):
+        result = self.fns["notion_get_page"](page_id=_INVALID_ID)
+        assert "error" in result
+        assert "UUID" in result["error"]
+
+    def test_update_page_invalid_id(self):
+        result = self.fns["notion_update_page"](page_id=_INVALID_ID)
+        assert "error" in result
+        assert "UUID" in result["error"]
+
+    def test_archive_page_invalid_id(self):
+        result = self.fns["notion_archive_page"](page_id=_INVALID_ID)
+        assert "error" in result
+        assert "UUID" in result["error"]
+
+    def test_get_page_success(self):
+        with patch("aden_tools.tools.notion_tool.notion_tool._NotionClient") as MockClient:
+            MockClient.return_value.get_page.return_value = _page()
+            result = self.fns["notion_get_page"](page_id=_VALID_UUID)
+        assert result["id"] == _VALID_UUID
+
+    def test_create_page_success(self):
+        with patch("aden_tools.tools.notion_tool.notion_tool._NotionClient") as MockClient:
+            MockClient.return_value.create_page.return_value = _page()
+            result = self.fns["notion_create_page"](
+                parent_type="database_id",
+                parent_id=_VALID_UUID,
+                properties={"Name": {"title": [{"text": {"content": "Test"}}]}},
+            )
+        assert result["id"] == _VALID_UUID
+
+
+class TestDatabaseToolValidation:
+    def setup_method(self):
+        self.fns = _setup_tools()
+
+    def test_query_database_invalid_id(self):
+        result = self.fns["notion_query_database"](database_id=_INVALID_ID)
+        assert "error" in result
+        assert "UUID" in result["error"]
+
+    def test_query_database_invalid_page_size(self):
+        result = self.fns["notion_query_database"](database_id=_VALID_UUID, page_size=0)
+        assert "error" in result
+        assert "page_size" in result["error"]
+
+    def test_get_database_invalid_id(self):
+        result = self.fns["notion_get_database"](database_id=_INVALID_ID)
+        assert "error" in result
+        assert "UUID" in result["error"]
+
+    def test_create_database_invalid_parent(self):
+        result = self.fns["notion_create_database"](
+            parent_id=_INVALID_ID, title="Test", properties={}
+        )
+        assert "error" in result
+        assert "UUID" in result["error"]
+
+    def test_create_database_empty_title(self):
+        result = self.fns["notion_create_database"](
+            parent_id=_VALID_UUID, title="", properties={}
+        )
+        assert "error" in result
+        assert "title" in result["error"]
+
+    def test_update_database_invalid_id(self):
+        result = self.fns["notion_update_database"](database_id=_INVALID_ID)
+        assert "error" in result
+        assert "UUID" in result["error"]
+
+    def test_query_database_success(self):
+        with patch("aden_tools.tools.notion_tool.notion_tool._NotionClient") as MockClient:
+            MockClient.return_value.query_database.return_value = {
+                "results": [], "has_more": False, "next_cursor": None
+            }
+            result = self.fns["notion_query_database"](database_id=_VALID_UUID)
+        assert "results" in result
+
+
+class TestBlockToolValidation:
+    def setup_method(self):
+        self.fns = _setup_tools()
+
+    def test_get_block_invalid_id(self):
+        result = self.fns["notion_get_block"](block_id=_INVALID_ID)
+        assert "error" in result
+        assert "UUID" in result["error"]
+
+    def test_get_block_children_invalid_id(self):
+        result = self.fns["notion_get_block_children"](block_id=_INVALID_ID)
+        assert "error" in result
+        assert "UUID" in result["error"]
+
+    def test_get_block_children_invalid_page_size(self):
+        result = self.fns["notion_get_block_children"](block_id=_VALID_UUID, page_size=0)
+        assert "error" in result
+        assert "page_size" in result["error"]
+
+    def test_append_block_children_invalid_id(self):
+        result = self.fns["notion_append_block_children"](block_id=_INVALID_ID, children=[{}])
+        assert "error" in result
+        assert "UUID" in result["error"]
+
+    def test_append_block_children_empty(self):
+        result = self.fns["notion_append_block_children"](block_id=_VALID_UUID, children=[])
+        assert "error" in result
+        assert "empty" in result["error"]
+
+    def test_delete_block_invalid_id(self):
+        result = self.fns["notion_delete_block"](block_id=_INVALID_ID)
+        assert "error" in result
+        assert "UUID" in result["error"]
+
+
+class TestSearchToolValidation:
+    def setup_method(self):
+        self.fns = _setup_tools()
+
+    def test_search_invalid_filter_object(self):
+        result = self.fns["notion_search"](filter_object="invalid")
+        assert "error" in result
+        assert "filter_object" in result["error"]
+
+    def test_search_invalid_sort_direction(self):
+        result = self.fns["notion_search"](sort_direction="invalid")
+        assert "error" in result
+        assert "sort_direction" in result["error"]
+
+    def test_search_invalid_page_size(self):
+        result = self.fns["notion_search"](page_size=0)
+        assert "error" in result
+        assert "page_size" in result["error"]
+
+    def test_search_success(self):
+        with patch("aden_tools.tools.notion_tool.notion_tool._NotionClient") as MockClient:
+            MockClient.return_value.search.return_value = {
+                "results": [], "has_more": False, "next_cursor": None
+            }
+            result = self.fns["notion_search"](query="test")
+        assert "results" in result
+
+
+class TestUserToolValidation:
+    def setup_method(self):
+        self.fns = _setup_tools()
+
+    def test_list_users_invalid_page_size(self):
+        result = self.fns["notion_list_users"](page_size=0)
+        assert "error" in result
+        assert "page_size" in result["error"]
+
+    def test_get_user_invalid_id(self):
+        result = self.fns["notion_get_user"](user_id=_INVALID_ID)
+        assert "error" in result
+        assert "UUID" in result["error"]
+
+    def test_list_users_success(self):
+        with patch("aden_tools.tools.notion_tool.notion_tool._NotionClient") as MockClient:
+            MockClient.return_value.list_users.return_value = {
+                "users": [], "has_more": False, "next_cursor": None
+            }
+            result = self.fns["notion_list_users"]()
+        assert "users" in result
+
+
+class TestCommentToolValidation:
+    def setup_method(self):
+        self.fns = _setup_tools()
+
+    def test_create_comment_invalid_page_id(self):
+        result = self.fns["notion_create_comment"](page_id=_INVALID_ID, text="Hello")
+        assert "error" in result
+        assert "UUID" in result["error"]
+
+    def test_create_comment_empty_text(self):
+        result = self.fns["notion_create_comment"](page_id=_VALID_UUID, text="")
+        assert "error" in result
+        assert "empty" in result["error"]
+
+    def test_list_comments_invalid_id(self):
+        result = self.fns["notion_list_comments"](block_id=_INVALID_ID)
+        assert "error" in result
+        assert "UUID" in result["error"]
+
+    def test_list_comments_invalid_page_size(self):
+        result = self.fns["notion_list_comments"](block_id=_VALID_UUID, page_size=0)
+        assert "error" in result
+        assert "page_size" in result["error"]
+
+    def test_create_comment_success(self):
+        with patch("aden_tools.tools.notion_tool.notion_tool._NotionClient") as MockClient:
+            MockClient.return_value.create_comment.return_value = _comment()
+            result = self.fns["notion_create_comment"](page_id=_VALID_UUID, text="Looks good")
+        assert result["id"] == _VALID_UUID
+
+
+# ---------------------------------------------------------------------------
+# HTTP error propagation across tool categories
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tool_name,kwargs",
+    [
+        ("notion_get_page", {"page_id": _VALID_UUID}),
+        ("notion_get_database", {"database_id": _VALID_UUID}),
+        ("notion_get_block", {"block_id": _VALID_UUID}),
+        ("notion_search", {}),
+        ("notion_get_user", {"user_id": _VALID_UUID}),
+        ("notion_list_users", {}),
+        ("notion_list_comments", {"block_id": _VALID_UUID}),
+    ],
+)
+def test_http_error_propagation(tool_name, kwargs):
+    fns = _setup_tools()
+    with patch("aden_tools.tools.notion_tool.notion_tool._NotionClient") as MockClient:
+        method_name = tool_name.replace("notion_", "")
+        getattr(MockClient.return_value, method_name).side_effect = httpx.ConnectError(
+            "Network error"
+        )
+        result = fns[tool_name](**kwargs)
+    assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Credential spec tests
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialSpec:
+    def test_notion_credential_spec_exists(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        assert "notion" in CREDENTIAL_SPECS
+
+    def test_notion_spec_env_var(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["notion"]
+        assert spec.env_var == "NOTION_API_KEY"
+
+    def test_notion_spec_tool_count(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["notion"]
+        assert len(spec.tools) == 17
+
+    def test_notion_spec_tools_include_core_methods(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["notion"]
+        expected = [
+            "notion_create_page",
+            "notion_get_page",
+            "notion_update_page",
+            "notion_archive_page",
+            "notion_query_database",
+            "notion_get_database",
+            "notion_create_database",
+            "notion_update_database",
+            "notion_get_block",
+            "notion_get_block_children",
+            "notion_append_block_children",
+            "notion_delete_block",
+            "notion_search",
+            "notion_list_users",
+            "notion_get_user",
+            "notion_create_comment",
+            "notion_list_comments",
+        ]
+        for tool in expected:
+            assert tool in spec.tools, f"Missing tool in credential spec: {tool}"
+
+    def test_notion_spec_health_check(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["notion"]
+        assert spec.health_check_endpoint == "https://api.notion.com/v1/users/me"
+        assert spec.health_check_method == "GET"
+
+    def test_notion_spec_auth_support(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["notion"]
+        assert spec.aden_supported is False
+        assert spec.direct_api_key_supported is True
+        assert "notion.so/my-integrations" in spec.api_key_instructions
+
+    def test_notion_spec_credential_store_fields(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["notion"]
+        assert spec.credential_id == "notion"
+        assert spec.credential_key == "api_key"
+        assert spec.credential_group == ""
+
+    def test_notion_spec_required_not_startup(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["notion"]
+        assert spec.required is True
+        assert spec.startup_required is False


### PR DESCRIPTION
## Summary

Adds a Notion workspace integration (`notion_tool`) with 17 MCP tools, following the existing Stripe integration pattern.

## Tools Added

| Category | Tools | Count |
|----------|-------|-------|
| Pages | `create_page`, `get_page`, `update_page`, `archive_page` | 4 |
| Databases | `query_database`, `get_database`, `create_database`, `update_database` | 4 |
| Blocks | `get_block`, `get_block_children`, `append_block_children`, `delete_block` | 4 |
| Search | `search` | 1 |
| Users | `list_users`, `get_user` | 2 |
| Comments | `create_comment`, `list_comments` | 2 |

## Implementation

- `_NotionClient` wrapper class using `httpx` with Bearer token auth and `Notion-Version` header
- UUID validation on all ID inputs before API calls
- All tools return error dicts (no raised exceptions) for agent-friendly error handling
- Credential spec with `NOTION_API_KEY` env var and health check endpoint (`/v1/users/me`)
- Wired into `register_all_tools()` and `CREDENTIAL_SPECS`

## Tests

80 unit tests covering:
- Client methods for all 6 resource categories
- Input validation (invalid UUIDs, empty fields, bad enum values)
- Credential retrieval (CredentialStoreAdapter vs env var fallback)
- HTTP error propagation across all tool categories
- Credential spec field validation

## Files Changed

- **New:** `tools/src/aden_tools/tools/notion_tool/` (tool, init, README)
- **New:** `tools/src/aden_tools/credentials/notion.py`
- **New:** `tools/tests/tools/test_notion_tool.py`
- **Modified:** `tools/src/aden_tools/tools/__init__.py` (register)
- **Modified:** `tools/src/aden_tools/credentials/__init__.py` (wire spec)

Relates to #2805