### PR TITLE
fix(runtime): fail fast on cron timer misconfig, add croniter dependency, and remove schedule drift

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "pytest>=8.0",
   "pytest-asyncio>=0.23",
   "pytest-xdist>=3.0",
+  "croniter>=1.4.0",
   "tools",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -795,6 +795,7 @@ version = "0.5.1"
 source = { editable = "core" }
 dependencies = [
     { name = "anthropic" },
+    { name = "croniter" },
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "litellm" },
@@ -825,6 +826,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", marker = "extra == 'webhook'", specifier = ">=3.9.0" },
     { name = "anthropic", specifier = ">=0.40.0" },
+    { name = "croniter", specifier = ">=1.4.0" },
     { name = "fastmcp", specifier = ">=2.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "litellm", specifier = ">=1.81.0" },


### PR DESCRIPTION
Closes #5353

  ## Problem
  Cron timer entry points could fail silently at runtime:
  - `croniter` was used in `AgentRuntime` but not declared in `core/pyproject.toml`
  - missing `croniter` was caught as `ImportError` and only logged, then timer was skipped
  - cron sleep calculation used two separate `datetime.now()` calls, introducing timing drift

  ## Root Cause
  In `core/framework/runtime/agent_runtime.py`, cron setup handled:
  - `ImportError` and `ValueError` with warning + `continue`, causing silent drop of cron timers
  - non-atomic next-fire computation (`datetime.now()` twice), which can bias sleep time earlier

  ## Fix
  ### 1) Declare dependency
  - Added `croniter>=1.4.0` to:
    - `core/pyproject.toml`
    - `uv.lock`

  ### 2) Fail fast for cron timer misconfiguration
  - Added helper methods in `AgentRuntime`:
    - `_import_croniter(...)`
    - `_validate_cron_expression(...)`
    - `_validate_timer_entry_points(...)`
  - `start()` now validates timer cron configs before starting runtime resources
  - `add_graph()` also validates timer cron configs before stream setup
  - Missing `croniter` now raises actionable `RuntimeError`
  - Invalid cron expression now raises `ValueError`

  ### 3) Remove cron drift
  - Added `_compute_next_cron_sleep_seconds(...)`
  - Replaced dual `datetime.now()` usage with a single captured timestamp per cycle
  - Applied in both:
    - primary runtime cron loops
    - secondary graph cron loops

  ## Tests
  Updated `core/framework/runtime/tests/test_agent_runtime.py`:
  - Added deterministic `fake_croniter` fixture for cron tests
  - Changed invalid cron test to assert fail-fast exception
  - Added missing-`croniter` regression test
  - Kept existing timer behavior coverage

  ## Validation
  Executed:
  - `uv run --package framework pytest core/framework/runtime/tests/test_agent_runtime.py -k timer -q`
  - `uv run --package framework pytest core/framework/runtime/tests/test_agent_runtime.py -q`

  Result:
  - timer subset: `7 passed`
  - full file: `27 passed`

  ## Files Changed
  - `core/framework/runtime/agent_runtime.py`
  - `core/framework/runtime/tests/test_agent_runtime.py`
  - `core/pyproject.toml`
  - `uv.lock