### PR TITLE
micro-fix: Improve manual agent example session storage & remove misleading warning

### DIFF
--- a/core/examples/manual_agent.py
+++ b/core/examples/manual_agent.py
@@ -103,9 +103,18 @@ async def main():
     # 6. Initialize Runtime & Executor
     # Runtime handles state/memory; Executor runs the graph
     from pathlib import Path
+    from datetime import datetime
 
-    runtime = Runtime(storage_path=Path("./agent_logs"))
-    executor = GraphExecutor(runtime=runtime)
+    # Create a unique session directory for this run
+    session_dir = (
+        Path("./agent_logs") / f"session_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    )
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    runtime = Runtime(storage_path=session_dir)
+    executor = GraphExecutor(runtime=runtime, storage_path=session_dir)
+
+    print(f"\nLogs & state will be written to: {session_dir.resolve()}")
 
     # 7. Register Node Implementations
     # Connect node IDs in the graph to actual Python implementations
@@ -115,7 +124,9 @@ async def main():
     # 8. Execute Agent
     print("Executing agent with input: name='Alice'...")
 
-    result = await executor.execute(graph=graph, goal=goal, input_data={"name": "Alice"})
+    result = await executor.execute(
+        graph=graph, goal=goal, input_data={"name": "Alice"}
+    )
 
     # 9. Verify Results
     if result.success:

--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -52,12 +52,18 @@ class ExecutionResult:
     # Execution quality metrics
     total_retries: int = 0  # Total number of retries across all nodes
     nodes_with_failures: list[str] = field(default_factory=list)  # Failed but recovered
-    retry_details: dict[str, int] = field(default_factory=dict)  # {node_id: retry_count}
-    had_partial_failures: bool = False  # True if any node failed but eventually succeeded
+    retry_details: dict[str, int] = field(
+        default_factory=dict
+    )  # {node_id: retry_count}
+    had_partial_failures: bool = (
+        False  # True if any node failed but eventually succeeded
+    )
     execution_quality: str = "clean"  # "clean", "degraded", or "failed"
 
     # Visit tracking (for feedback/callback edges)
-    node_visit_counts: dict[str, int] = field(default_factory=dict)  # {node_id: visit_count}
+    node_visit_counts: dict[str, int] = field(
+        default_factory=dict
+    )  # {node_id: visit_count}
 
     @property
     def is_clean_success(self) -> bool:
@@ -245,7 +251,9 @@ class GraphExecutor:
             if node.tools:
                 missing = set(node.tools) - available_tool_names
                 if missing:
-                    available = sorted(available_tool_names) if available_tool_names else "none"
+                    available = (
+                        sorted(available_tool_names) if available_tool_names else "none"
+                    )
                     errors.append(
                         f"Node '{node.name}' (id={node.id}) requires tools "
                         f"{sorted(missing)} but they are not registered. "
@@ -331,7 +339,9 @@ class GraphExecutor:
                 # positives on the code-indicator heuristic.
                 for key, value in memory_data.items():
                     memory.write(key, value, validate=False)
-                self.logger.info(f"📥 Restored session state with {len(memory_data)} memory keys")
+                self.logger.info(
+                    f"📥 Restored session state with {len(memory_data)} memory keys"
+                )
 
         # Write new input data to memory (each key individually).
         # Skip when resuming from a paused session — restored memory already
@@ -343,7 +353,9 @@ class GraphExecutor:
                 memory.write(key, value)
 
         # Detect event-triggered execution (timer/webhook) — no interactive user.
-        _event_triggered = bool(input_data and isinstance(input_data.get("event"), dict))
+        _event_triggered = bool(
+            input_data and isinstance(input_data.get("event"), dict)
+        )
 
         path: list[str] = []
         total_tokens = 0
@@ -375,7 +387,11 @@ class GraphExecutor:
 
         # Determine entry point (may differ if resuming)
         # Check if resuming from checkpoint
-        if session_state and session_state.get("resume_from_checkpoint") and checkpoint_store:
+        if (
+            session_state
+            and session_state.get("resume_from_checkpoint")
+            and checkpoint_store
+        ):
             checkpoint_id = session_state["resume_from_checkpoint"]
             try:
                 checkpoint = await checkpoint_store.load_checkpoint(checkpoint_id)
@@ -392,7 +408,9 @@ class GraphExecutor:
 
                     # Start from checkpoint's next node or current node
                     current_node_id = (
-                        checkpoint.next_node or checkpoint.current_node or graph.entry_node
+                        checkpoint.next_node
+                        or checkpoint.current_node
+                        or graph.entry_node
                     )
 
                     # Restore execution path
@@ -407,7 +425,9 @@ class GraphExecutor:
                         f"Checkpoint {checkpoint_id} not found, resuming from normal entry point"
                     )
                     # Check if resuming from paused_at (fallback to session state)
-                    paused_at = session_state.get("paused_at") if session_state else None
+                    paused_at = (
+                        session_state.get("paused_at") if session_state else None
+                    )
                     if paused_at and graph.get_node(paused_at) is not None:
                         current_node_id = paused_at
                         self.logger.info(f"🔄 Resuming from paused node: {paused_at}")
@@ -451,9 +471,11 @@ class GraphExecutor:
                     self.logger.info(f"🔄 Resuming from paused node: {paused_at}")
             else:
                 # Fall back to normal entry point logic
-                self.logger.warning(
-                    f"⚠ paused_at={paused_at} is not a valid node, falling back to entry point"
-                )
+                if paused_at is not None:
+                    self.logger.warning(
+                        f"⚠ paused_at={paused_at} is not a valid node, falling back to entry point"
+                    )
+
                 current_node_id = graph.get_entry_point(session_state)
 
         steps = 0
@@ -591,7 +613,9 @@ class GraphExecutor:
                             is_clean=True,
                         )
                         await checkpoint_store.save_checkpoint(pause_checkpoint)
-                        pause_session_state["latest_checkpoint_id"] = pause_checkpoint.checkpoint_id
+                        pause_session_state["latest_checkpoint_id"] = (
+                            pause_checkpoint.checkpoint_id
+                        )
                         pause_session_state["resume_from_checkpoint"] = (
                             pause_checkpoint.checkpoint_id
                         )
@@ -649,7 +673,9 @@ class GraphExecutor:
                 # from visit 1 triggers even when visit 2 sets "final_summary" instead).
                 # Clearing them ensures only the CURRENT visit's outputs affect routing.
                 if node_visit_counts.get(current_node_id, 0) > 1:
-                    nullable_keys = getattr(node_spec, "nullable_output_keys", None) or []
+                    nullable_keys = (
+                        getattr(node_spec, "nullable_output_keys", None) or []
+                    )
                     for key in nullable_keys:
                         if memory.read(key) is not None:
                             memory.write(key, None, validate=False)
@@ -663,14 +689,19 @@ class GraphExecutor:
                     # Execute this node, then pause
                     # (We'll check again after execution and save state)
 
-                self.logger.info(f"\n▶ Step {steps}: {node_spec.name} ({node_spec.node_type})")
+                self.logger.info(
+                    f"\n▶ Step {steps}: {node_spec.name} ({node_spec.node_type})"
+                )
                 self.logger.info(f"   Inputs: {node_spec.input_keys}")
                 self.logger.info(f"   Outputs: {node_spec.output_keys}")
 
                 # Continuous mode: accumulate tools and output keys from this node
                 if is_continuous and node_spec.tools:
                     for t in self.tools:
-                        if t.name in node_spec.tools and t.name not in cumulative_tool_names:
+                        if (
+                            t.name in node_spec.tools
+                            and t.name not in cumulative_tool_names
+                        ):
                             cumulative_tools.append(t)
                             cumulative_tool_names.add(t.name)
                 if is_continuous and node_spec.output_keys:
@@ -686,9 +717,13 @@ class GraphExecutor:
                     input_data=input_data or {},
                     max_tokens=graph.max_tokens,
                     continuous_mode=is_continuous,
-                    inherited_conversation=continuous_conversation if is_continuous else None,
+                    inherited_conversation=(
+                        continuous_conversation if is_continuous else None
+                    ),
                     override_tools=cumulative_tools if is_continuous else None,
-                    cumulative_output_keys=cumulative_output_keys if is_continuous else None,
+                    cumulative_output_keys=(
+                        cumulative_output_keys if is_continuous else None
+                    ),
                     event_triggered=_event_triggered,
                 )
 
@@ -705,7 +740,9 @@ class GraphExecutor:
                             self.logger.info(f"      {key}: {value_str}")
 
                 # Get or create node implementation
-                node_impl = self._get_node_implementation(node_spec, graph.cleanup_llm_model)
+                node_impl = self._get_node_implementation(
+                    node_spec, graph.cleanup_llm_model
+                )
 
                 # Validate inputs
                 validation_errors = node_impl.validate_input(ctx)
@@ -732,7 +769,9 @@ class GraphExecutor:
 
                     if checkpoint_config.async_checkpoint:
                         # Non-blocking checkpoint save
-                        asyncio.create_task(checkpoint_store.save_checkpoint(checkpoint))
+                        asyncio.create_task(
+                            checkpoint_store.save_checkpoint(checkpoint)
+                        )
                     else:
                         # Blocking checkpoint save
                         await checkpoint_store.save_checkpoint(checkpoint)
@@ -783,7 +822,9 @@ class GraphExecutor:
                             nullable_keys=node_spec.nullable_output_keys,
                         )
                         if not validation.success:
-                            self.logger.error(f"   ✗ Output validation failed: {validation.error}")
+                            self.logger.error(
+                                f"   ✗ Output validation failed: {validation.error}"
+                            )
                             result = NodeResult(
                                 success=False,
                                 error=f"Output validation failed: {validation.error}",
@@ -854,7 +895,9 @@ class GraphExecutor:
                         retry_count = node_retry_counts[current_node_id]
                         # Backoff formula: 1.0 * (2^(retry - 1)) -> 1s, 2s, 4s...
                         delay = 1.0 * (2 ** (retry_count - 1))
-                        self.logger.info(f"   Using backoff: Sleeping {delay}s before retry...")
+                        self.logger.info(
+                            f"   Using backoff: Sleeping {delay}s before retry..."
+                        )
                         await asyncio.sleep(delay)
                         # --------------------------------------
 
@@ -892,7 +935,9 @@ class GraphExecutor:
 
                         if next_node:
                             # Found a failure handler - route to it
-                            self.logger.info(f"   → Routing to failure handler: {next_node}")
+                            self.logger.info(
+                                f"   → Routing to failure handler: {next_node}"
+                            )
                             current_node_id = next_node
                             continue  # Continue execution with handler
                         else:
@@ -985,7 +1030,9 @@ class GraphExecutor:
 
                     # Calculate quality metrics
                     total_retries_count = sum(node_retry_counts.values())
-                    nodes_failed = [nid for nid, count in node_retry_counts.items() if count > 0]
+                    nodes_failed = [
+                        nid for nid, count in node_retry_counts.items() if count > 0
+                    ]
                     exec_quality = "degraded" if total_retries_count > 0 else "clean"
 
                     if self.runtime_logger:
@@ -1033,7 +1080,9 @@ class GraphExecutor:
                         )
 
                     current_node_id = result.next_node
-                    self._write_progress(current_node_id, path, memory, node_visit_counts)
+                    self._write_progress(
+                        current_node_id, path, memory, node_visit_counts
+                    )
                 else:
                     # Get all traversable edges for fan-out detection
                     traversable_edges = await self._get_all_traversable_edges(
@@ -1062,9 +1111,11 @@ class GraphExecutor:
                                     stream_id=self._stream_id,
                                     source_node=current_node_id,
                                     target_node=edge.target,
-                                    edge_condition=edge.condition.value
-                                    if hasattr(edge.condition, "value")
-                                    else str(edge.condition),
+                                    edge_condition=(
+                                        edge.condition.value
+                                        if hasattr(edge.condition, "value")
+                                        else str(edge.condition)
+                                    ),
                                 )
 
                         # Execute branches in parallel
@@ -1087,12 +1138,18 @@ class GraphExecutor:
 
                         # Continue from fan-in node
                         if fan_in_node:
-                            self.logger.info(f"   ⑃ Fan-in: converging at {fan_in_node}")
+                            self.logger.info(
+                                f"   ⑃ Fan-in: converging at {fan_in_node}"
+                            )
                             current_node_id = fan_in_node
-                            self._write_progress(current_node_id, path, memory, node_visit_counts)
+                            self._write_progress(
+                                current_node_id, path, memory, node_visit_counts
+                            )
                         else:
                             # No convergence point - branches are terminal
-                            self.logger.info("   → Parallel branches completed (no convergence)")
+                            self.logger.info(
+                                "   → Parallel branches completed (no convergence)"
+                            )
                             break
                     else:
                         # Sequential: follow single edge (existing logic via _follow_edges)
@@ -1108,7 +1165,9 @@ class GraphExecutor:
                             self.logger.info("   → No more edges, ending execution")
                             break
                         next_spec = graph.get_node(next_node)
-                        self.logger.info(f"   → Next: {next_spec.name if next_spec else next_node}")
+                        self.logger.info(
+                            f"   → Next: {next_spec.name if next_spec else next_node}"
+                        )
 
                         # Emit edge traversed event for sequential edge
                         if self._event_bus:
@@ -1134,7 +1193,9 @@ class GraphExecutor:
                             )
 
                             if checkpoint_config.async_checkpoint:
-                                asyncio.create_task(checkpoint_store.save_checkpoint(checkpoint))
+                                asyncio.create_task(
+                                    checkpoint_store.save_checkpoint(checkpoint)
+                                )
                             else:
                                 await checkpoint_store.save_checkpoint(checkpoint)
 
@@ -1187,12 +1248,20 @@ class GraphExecutor:
                                 FileConversationStore,
                             )
 
-                            next_store_path = self._storage_path / "conversations" / next_spec.id
-                            next_store = FileConversationStore(base_path=next_store_path)
+                            next_store_path = (
+                                self._storage_path / "conversations" / next_spec.id
+                            )
+                            next_store = FileConversationStore(
+                                base_path=next_store_path
+                            )
                             await continuous_conversation.switch_store(next_store)
 
                         # Insert transition marker into conversation
-                        data_dir = str(self._storage_path / "data") if self._storage_path else None
+                        data_dir = (
+                            str(self._storage_path / "data")
+                            if self._storage_path
+                            else None
+                        )
                         marker = build_transition_marker(
                             previous_node=node_spec,
                             next_node=next_spec,
@@ -1244,7 +1313,9 @@ class GraphExecutor:
 
             # Calculate execution quality metrics
             total_retries_count = sum(node_retry_counts.values())
-            nodes_failed = [nid for nid, count in node_retry_counts.items() if count > 0]
+            nodes_failed = [
+                nid for nid, count in node_retry_counts.items() if count > 0
+            ]
             exec_quality = "degraded" if total_retries_count > 0 else "clean"
 
             # Update narrative to reflect execution quality
@@ -1304,10 +1375,15 @@ class GraphExecutor:
                     import json as _json
 
                     cursor_path = (
-                        self._storage_path / "conversations" / current_node_id / "cursor.json"
+                        self._storage_path
+                        / "conversations"
+                        / current_node_id
+                        / "cursor.json"
                     )
                     if cursor_path.exists():
-                        cursor_data = _json.loads(cursor_path.read_text(encoding="utf-8"))
+                        cursor_data = _json.loads(
+                            cursor_path.read_text(encoding="utf-8")
+                        )
                         wip_outputs = cursor_data.get("outputs", {})
                         for key, value in wip_outputs.items():
                             if value is not None:
@@ -1334,7 +1410,9 @@ class GraphExecutor:
 
             # Calculate quality metrics
             total_retries_count = sum(node_retry_counts.values())
-            nodes_failed = [nid for nid, count in node_retry_counts.items() if count > 0]
+            nodes_failed = [
+                nid for nid, count in node_retry_counts.items() if count > 0
+            ]
             exec_quality = "degraded" if total_retries_count > 0 else "clean"
 
             if self.runtime_logger:
@@ -1407,10 +1485,15 @@ class GraphExecutor:
                     import json as _json
 
                     cursor_path = (
-                        self._storage_path / "conversations" / current_node_id / "cursor.json"
+                        self._storage_path
+                        / "conversations"
+                        / current_node_id
+                        / "cursor.json"
                     )
                     if cursor_path.exists():
-                        cursor_data = _json.loads(cursor_path.read_text(encoding="utf-8"))
+                        cursor_data = _json.loads(
+                            cursor_path.read_text(encoding="utf-8")
+                        )
                         for key, value in cursor_data.get("outputs", {}).items():
                             if value is not None:
                                 memory.write(key, value, validate=False)
@@ -1449,7 +1532,9 @@ class GraphExecutor:
                                     f"💾 Marked checkpoint for resume: {latest_clean.checkpoint_id}"
                                 )
                 except Exception as checkpoint_err:
-                    self.logger.warning(f"Failed to mark checkpoint for resume: {checkpoint_err}")
+                    self.logger.warning(
+                        f"Failed to mark checkpoint for resume: {checkpoint_err}"
+                    )
 
             return ExecutionResult(
                 success=False,
@@ -1625,8 +1710,12 @@ class GraphExecutor:
                 memory=memory.read_all(),
                 llm=self.llm,
                 goal=goal,
-                source_node_name=current_node_spec.name if current_node_spec else current_node_id,
-                target_node_name=target_node_spec.name if target_node_spec else edge.target,
+                source_node_name=(
+                    current_node_spec.name if current_node_spec else current_node_id
+                ),
+                target_node_name=(
+                    target_node_spec.name if target_node_spec else edge.target
+                ),
             ):
                 # Validate and clean output before mapping inputs.
                 # Use full memory state (not just result.output) because
@@ -1642,7 +1731,9 @@ class GraphExecutor:
                     )
 
                     if not validation.valid:
-                        self.logger.warning(f"⚠ Output validation failed: {validation.errors}")
+                        self.logger.warning(
+                            f"⚠ Output validation failed: {validation.errors}"
+                        )
 
                         # Clean the output
                         cleaned_output = await self.output_cleaner.clean_output(
@@ -1667,7 +1758,9 @@ class GraphExecutor:
                         )
 
                         if revalidation.valid:
-                            self.logger.info("✓ Output cleaned and validated successfully")
+                            self.logger.info(
+                                "✓ Output cleaned and validated successfully"
+                            )
                         else:
                             self.logger.error(
                                 f"✗ Cleaning failed, errors remain: {revalidation.errors}"
@@ -1709,8 +1802,12 @@ class GraphExecutor:
                 memory=memory.read_all(),
                 llm=self.llm,
                 goal=goal,
-                source_node_name=current_node_spec.name if current_node_spec else current_node_id,
-                target_node_name=target_node_spec.name if target_node_spec else edge.target,
+                source_node_name=(
+                    current_node_spec.name if current_node_spec else current_node_id
+                ),
+                target_node_name=(
+                    target_node_spec.name if target_node_spec else edge.target
+                ),
             ):
                 traversable.append(edge)
 
@@ -1720,13 +1817,16 @@ class GraphExecutor:
         # forward vs. feedback) from incorrectly triggering fan-out.
         # ON_SUCCESS / other edge types are unaffected.
         if len(traversable) > 1:
-            conditionals = [e for e in traversable if e.condition == EdgeCondition.CONDITIONAL]
+            conditionals = [
+                e for e in traversable if e.condition == EdgeCondition.CONDITIONAL
+            ]
             if len(conditionals) > 1:
                 max_prio = max(e.priority for e in conditionals)
                 traversable = [
                     e
                     for e in traversable
-                    if e.condition != EdgeCondition.CONDITIONAL or e.priority == max_prio
+                    if e.condition != EdgeCondition.CONDITIONAL
+                    or e.priority == max_prio
                 ]
 
         return traversable
@@ -1801,10 +1901,14 @@ class GraphExecutor:
                 edge=edge,
             )
 
-        self.logger.info(f"   ⑂ Fan-out: executing {len(branches)} branches in parallel")
+        self.logger.info(
+            f"   ⑂ Fan-out: executing {len(branches)} branches in parallel"
+        )
         for branch in branches.values():
             target_spec = graph.get_node(branch.node_id)
-            self.logger.info(f"      • {target_spec.name if target_spec else branch.node_id}")
+            self.logger.info(
+                f"      • {target_spec.name if target_spec else branch.node_id}"
+            )
 
         async def execute_single_branch(
             branch: ParallelBranch,
@@ -1817,7 +1921,9 @@ class GraphExecutor:
                 return branch, RuntimeError(branch.error)
 
             # Get node implementation to check its type
-            branch_impl = self._get_node_implementation(node_spec, graph.cleanup_llm_model)
+            branch_impl = self._get_node_implementation(
+                node_spec, graph.cleanup_llm_model
+            )
 
             effective_max_retries = node_spec.max_retries
             # Only override for actual EventLoopNode instances, not custom NodeProtocol impls
@@ -1841,7 +1947,9 @@ class GraphExecutor:
                     mem_snapshot = memory.read_all()
                     validation = self.output_cleaner.validate_output(
                         output=mem_snapshot,
-                        source_node_id=source_node_spec.id if source_node_spec else "unknown",
+                        source_node_id=(
+                            source_node_spec.id if source_node_spec else "unknown"
+                        ),
                         target_node_spec=node_spec,
                     )
 
@@ -1852,7 +1960,9 @@ class GraphExecutor:
                         )
                         cleaned_output = await self.output_cleaner.clean_output(
                             output=mem_snapshot,
-                            source_node_id=source_node_spec.id if source_node_spec else "unknown",
+                            source_node_id=(
+                                source_node_spec.id if source_node_spec else "unknown"
+                            ),
                             target_node_spec=node_spec,
                             validation_errors=validation.errors,
                         )
@@ -1871,8 +1981,12 @@ class GraphExecutor:
                     branch.retry_count = attempt
 
                     # Build context for this branch
-                    ctx = self._build_context(node_spec, memory, goal, mapped, graph.max_tokens)
-                    node_impl = self._get_node_implementation(node_spec, graph.cleanup_llm_model)
+                    ctx = self._build_context(
+                        node_spec, memory, goal, mapped, graph.max_tokens
+                    )
+                    node_impl = self._get_node_implementation(
+                        node_spec, graph.cleanup_llm_model
+                    )
 
                     # Emit node-started event (skip event_loop nodes)
                     if self._event_bus and node_spec.node_type != "event_loop":
@@ -1901,7 +2015,9 @@ class GraphExecutor:
                     # Emit node-completed event (skip event_loop nodes)
                     if self._event_bus and node_spec.node_type != "event_loop":
                         await self._event_bus.emit_node_loop_completed(
-                            stream_id=self._stream_id, node_id=branch.node_id, iterations=1
+                            stream_id=self._stream_id,
+                            node_id=branch.node_id,
+                            iterations=1,
                         )
 
                     if result.success:
@@ -1979,7 +2095,9 @@ class GraphExecutor:
         if failed_branches:
             failed_names = [graph.get_node(b.node_id).name for b in failed_branches]
             if self._parallel_config.on_branch_failure == "fail_all":
-                raise RuntimeError(f"Parallel execution failed: branches {failed_names} failed")
+                raise RuntimeError(
+                    f"Parallel execution failed: branches {failed_names} failed"
+                )
             elif self._parallel_config.on_branch_failure == "continue_others":
                 self.logger.warning(
                     f"⚠ Some branches failed ({failed_names}), continuing with successful ones"


### PR DESCRIPTION
## Summary
Improves developer experience and execution clarity for the manual agent example.

## Changes
- Removed misleading warning when `paused_at` is `None`
- Manual agent example now writes session artifacts and prints the output path

## Why
- Prevents confusing warning during normal execution
- Makes execution state discoverable for debugging and HITL workflows
- Improves onboarding experience

## Testing
Ran:

uv run python core/examples/manual_agent.py

Verified session state is written to:
agent_logs/session_*/state.json