### PR TITLE
feat(cli): add hive doctor diagnostic command

### DIFF
--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -89,6 +89,11 @@ def main():
 
     register_testing_commands(subparsers)
 
+    # Register doctor command (diagnostic checks)
+    from framework.doctor import register_doctor_command
+
+    register_doctor_command(subparsers)
+
     args = parser.parse_args()
 
     if hasattr(args, "func"):

--- a/core/framework/doctor.py
+++ b/core/framework/doctor.py
@@ -1,0 +1,172 @@
+"""Diagnostic tool for checking Hive setup.
+
+Usage:
+    hive doctor          - Run all diagnostic checks
+    hive doctor --verify - Also health-check credentials via API calls
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+
+def register_doctor_command(subparsers: argparse._SubParsersAction) -> None:
+    """Register the doctor command with the main CLI."""
+    doctor_parser = subparsers.add_parser(
+        "doctor",
+        help="Run diagnostic checks on Hive setup",
+        description="Check Python version, credentials, and dependencies.",
+    )
+    doctor_parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Health-check credentials via live API calls (slower)",
+    )
+    doctor_parser.set_defaults(func=cmd_doctor)
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    """Run diagnostic checks on Hive installation and configuration."""
+    # Ensure stdout can handle emoji/Unicode on Windows subprocesses
+    if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+        import io
+
+        sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+
+    verify = getattr(args, "verify", False)
+    issues: list[str] = []
+
+    print()
+    print("🏥 Hive Doctor")
+    print("=" * 60)
+
+    # ── 1. Python version ────────────────────────────────────────
+    print("\n🐍 Python version")
+    v = sys.version_info
+    if v >= (3, 11):
+        print(f"   ✅ Python {v.major}.{v.minor}.{v.micro}")
+    else:
+        msg = f"Python {v.major}.{v.minor}.{v.micro} (need ≥ 3.11)"
+        print(f"   ❌ {msg}")
+        issues.append(msg)
+
+    # ── 2. Credential key environment ────────────────────────────
+    print("\n🔑 Credential environment")
+    try:
+        from framework.credentials.validation import ensure_credential_key_env
+
+        ensure_credential_key_env()
+    except Exception as exc:
+        print(f"   ⚠️  Could not load credential env: {exc}")
+
+    hive_key = bool(os.environ.get("HIVE_CREDENTIAL_KEY"))
+    aden_key = bool(os.environ.get("ADEN_API_KEY"))
+    print(f"   {'✅' if hive_key else '❌'} HIVE_CREDENTIAL_KEY {'set' if hive_key else 'not set'}")
+    aden_status = "set" if aden_key else "not set (optional)"
+    aden_icon = "✅" if aden_key else "⚠️ "
+    print(f"   {aden_icon} ADEN_API_KEY {aden_status}")
+    if not hive_key:
+        issues.append("HIVE_CREDENTIAL_KEY not set")
+
+    # ── 3. Credential checks ────────────────────────────────────
+    print("\n📋 Credentials")
+    try:
+        from aden_tools.credentials import CREDENTIAL_SPECS, check_credential_health
+
+        from framework.credentials.storage import (
+            CompositeStorage,
+            EncryptedFileStorage,
+            EnvVarStorage,
+        )
+        from framework.credentials.store import CredentialStore
+
+        # Build credential store (same logic as validate_agent_credentials)
+        env_mapping = {
+            (spec.credential_id or name): spec.env_var for name, spec in CREDENTIAL_SPECS.items()
+        }
+        env_storage = EnvVarStorage(env_mapping=env_mapping)
+        if hive_key:
+            storage = CompositeStorage(primary=env_storage, fallbacks=[EncryptedFileStorage()])
+        else:
+            storage = env_storage
+        store = CredentialStore(storage=storage)
+
+        ok_count = 0
+        missing_count = 0
+        invalid_count = 0
+
+        for name, spec in sorted(CREDENTIAL_SPECS.items()):
+            cred_id = spec.credential_id or name
+            available = store.is_available(cred_id)
+
+            if not available:
+                missing_count += 1
+                print(f"   ➖ {name:<28} not configured")
+                continue
+
+            # Credential is present — optionally health-check it
+            if verify and spec.health_check_endpoint:
+                value = store.get(cred_id)
+                if value:
+                    try:
+                        result = check_credential_health(
+                            name,
+                            value,
+                            health_check_endpoint=spec.health_check_endpoint,
+                            health_check_method=spec.health_check_method,
+                        )
+                        if result.valid:
+                            ok_count += 1
+                            print(f"   ✅ {name:<28} valid — {result.message}")
+                        else:
+                            invalid_count += 1
+                            print(f"   ❌ {name:<28} INVALID — {result.message}")
+                            issues.append(f"{name}: {result.message}")
+                    except Exception as exc:
+                        ok_count += 1  # present, check failed — don't penalize
+                        print(f"   ⚠️  {name:<28} present (check failed: {exc})")
+                else:
+                    ok_count += 1
+                    print(f"   ✅ {name:<28} present")
+            else:
+                ok_count += 1
+                print(f"   ✅ {name:<28} present")
+
+        print(
+            f"\n   Summary: {ok_count} present, {missing_count} not configured, "
+            f"{invalid_count} invalid"
+        )
+        if invalid_count:
+            issues.append(f"{invalid_count} credential(s) invalid")
+
+    except ImportError:
+        print("   ⚠️  aden_tools not installed — skipping credential checks")
+
+    # ── 4. Core dependencies ─────────────────────────────────────
+    print("\n📦 Core dependencies")
+    deps = ["anthropic", "httpx", "litellm", "pydantic", "textual", "mcp"]
+    for dep in deps:
+        try:
+            mod = __import__(dep)
+            version = getattr(mod, "__version__", "?")
+            print(f"   ✅ {dep:<20} {version}")
+        except ImportError:
+            print(f"   ❌ {dep:<20} not installed")
+            issues.append(f"Missing dependency: {dep}")
+
+    # ── Summary ──────────────────────────────────────────────────
+    print()
+    print("=" * 60)
+    if not issues:
+        print("✅ All checks passed! Hive is ready to use.")
+    else:
+        print(f"❌ Found {len(issues)} issue(s):")
+        for issue in issues:
+            print(f"   • {issue}")
+        print("\nTo fix credentials: run 'hive setup-credentials <agent_path>'")
+        print("                    or set env vars in your shell config.")
+    print()
+
+    return 1 if issues else 0

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -1,0 +1,90 @@
+"""Tests for the hive doctor CLI command."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Subprocess env that forces UTF-8 so emoji output doesn't crash on Windows.
+_UTF8_ENV = {**os.environ, "PYTHONIOENCODING": "utf-8"}
+
+
+@pytest.fixture
+def project_root():
+    """Return the project root directory."""
+    return Path(__file__).resolve().parent.parent.parent
+
+
+class TestDoctorSubcommand:
+    """Test `hive doctor` CLI subcommand registration and execution."""
+
+    def test_doctor_help(self, project_root):
+        """Verify ``python -m framework doctor --help`` prints usage and exits 0."""
+        result = subprocess.run(
+            [sys.executable, "-m", "framework", "doctor", "--help"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=str(project_root / "core"),
+            env=_UTF8_ENV,
+        )
+        assert result.returncode == 0
+        assert "diagnostic" in result.stdout.lower() or "doctor" in result.stdout.lower()
+
+    def test_doctor_runs(self, project_root):
+        """Verify ``python -m framework doctor`` runs without crashing.
+
+        The command may report missing credentials (exit code 1) or all-clear
+        (exit code 0) depending on the environment — either is acceptable.
+        The key assertion is that it does NOT crash with an unhandled exception.
+        """
+        result = subprocess.run(
+            [sys.executable, "-m", "framework", "doctor"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=str(project_root / "core"),
+            env=_UTF8_ENV,
+            timeout=60,
+        )
+        # Should exit cleanly (0 = all ok, 1 = issues found)
+        assert result.returncode in (0, 1), (
+            f"doctor crashed with exit code {result.returncode}.\n"
+            f"stdout: {result.stdout[-500:]}\n"
+            f"stderr: {result.stderr[-500:]}"
+        )
+        # Should produce the doctor header
+        assert "Hive Doctor" in result.stdout
+
+    def test_doctor_verify_flag(self, project_root):
+        """Verify ``python -m framework doctor --verify`` is accepted."""
+        result = subprocess.run(
+            [sys.executable, "-m", "framework", "doctor", "--verify"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=str(project_root / "core"),
+            env=_UTF8_ENV,
+            timeout=120,
+        )
+        assert result.returncode in (0, 1)
+        assert "Hive Doctor" in result.stdout
+
+    def test_existing_commands_still_work(self, project_root):
+        """Ensure adding doctor didn't break existing subcommands."""
+        result = subprocess.run(
+            [sys.executable, "-m", "framework", "--help"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=str(project_root / "core"),
+            env=_UTF8_ENV,
+        )
+        assert result.returncode == 0
+        # Existing commands should still appear
+        assert "run" in result.stdout.lower()
+        assert "validate" in result.stdout.lower()
+        # Doctor should also appear
+        assert "doctor" in result.stdout.lower()


### PR DESCRIPTION
## Summary

Add `hive doctor` CLI subcommand that runs diagnostic checks on the Hive installation and configuration.

Resolves #4391

## What it does

- **Python version check** — verifies >= 3.11
- **Credential environment** — checks `HIVE_CREDENTIAL_KEY` and `ADEN_API_KEY`
- **Credential presence & health** — iterates all `CREDENTIAL_SPECS`, reports status
- **Core dependencies** — verifies anthropic, httpx, litellm, pydantic, textual, mcp

## Usage

```bash
hive doctor          # run all checks
hive doctor --verify # also health-check credentials via live API calls
```

## Design

- Reuses **100% existing infrastructure** — zero new validation logic
  - `ensure_credential_key_env()` from `credentials/validation.py`
  - `CREDENTIAL_SPECS` + `check_credential_health()` from `aden_tools`
  - `CredentialStore` composite storage (env + encrypted)
- Follows existing CLI patterns (`register_commands` + argparse subparsers)
- Clean exit codes: `0` = all ok, `1` = issues found

## Files changed

| File | Change |
|------|--------|
| `core/framework/doctor.py` | **NEW** — diagnostic command (~150 lines) |
| `core/framework/cli.py` | +5 lines — register subcommand |
| `core/tests/test_doctor.py` | **NEW** — 4 tests (~90 lines) |

## Test results

- ✅ 4/4 new doctor tests pass
- ✅ 8/8 existing CLI tests pass (1 skipped)
