### PR TITLE
Add dev-focused Docker Compose setup with uv-based CLI smoke support

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,30 @@
+# Dockerfile.dev
+FROM python:3.11-slim
+
+# Prevent interactive prompts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system deps required for uv + build
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv
+RUN curl -Ls https://astral.sh/uv/install.sh | sh
+
+# Add uv to PATH
+ENV PATH="/root/.local/bin:$PATH"
+ENV UV_LINK_MODE=copy
+# Set working directory
+WORKDIR /app
+
+# Copy project files
+COPY . .
+
+# Install workspace dependencies
+RUN uv sync
+
+# Default to interactive shell
+CMD ["bash"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,10 @@
+
+services:
+  hive:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    volumes:
+      - .:/app
+    working_dir: /app
+    tty: true


### PR DESCRIPTION
## Summary

This PR introduces a dev-oriented Docker setup to simplify onboarding and provide a reproducible local environment for Hive development.

## Scope

- Adds `Dockerfile.dev`
- Adds `docker-compose.dev.yml`
- Uses `uv sync` inside container
- Runs CLI via `uv run hive`
- Designed for development use only (not production optimized)

## Smoke Test

Verified locally with:

docker compose -f docker-compose.dev.yml build
docker compose -f docker-compose.dev.yml run --rm hive uv run hive list

This validates:
- Workspace integrity
- CLI wiring
- Project root detection
- Dependency installation

## Notes

This PR intentionally focuses on a minimal dev-first setup. Production optimizations (multi-stage builds, slim images, secret handling) can be explored in follow-ups.

Closes #5368