### PR TITLE
Add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   <a href="https://discord.com/invite/MXE49hrKDk"><img src="https://img.shields.io/discord/1172610340073242735?logo=discord&labelColor=%235462eb&logoColor=%23f5f5f5&color=%235462eb" alt="Discord" /></a>
   <a href="https://x.com/aden_hq"><img src="https://img.shields.io/twitter/follow/teamaden?logo=X&color=%23f5f5f5" alt="Twitter Follow" /></a>
   <a href="https://www.linkedin.com/company/teamaden/"><img src="https://custom-icon-badges.demolab.com/badge/LinkedIn-0A66C2?logo=linkedin-white&logoColor=fff" alt="LinkedIn" /></a>
+  <a href="https://deepwiki.com/aden-hive/hive"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
   <img src="https://img.shields.io/badge/MCP-102_Tools-00ADD8?style=flat-square" alt="MCP" />
 </p>
 


### PR DESCRIPTION

## Summary
Add DeepWiki badge to README to surface project documentation and knowledge graph entry point directly from the repository homepage.


## What it does

**DeepWiki badge** — Adds a clickable badge that links to the project’s DeepWiki page for structured documentation, architecture insights, and indexed knowledge

**Improved discoverability** — Makes long-form docs, design rationale, and technical references accessible without searching

**Standard badge format** — Uses official DeepWiki badge styling consistent with other ecosystem projects

**Non-intrusive placement** — Positioned alongside existing badges (build, license, version, etc.)


## Usage

No runtime usage changes.

Users can click the badge in the README to open the DeepWiki page:

```

README → DeepWiki badge → DeepWiki project page

```

---

## Design

**Zero logic changes** — Documentation-only update

**No build impact** — Does not affect packaging, dependencies, or CI

**Follows README conventions** — Badge added in header section with other project status indicators

**Future-proof** — Link points to canonical DeepWiki URL



## Files changed

| File | Change |
|------|--------|
| README.md | +1 line — add DeepWiki badge |


## Test results

✅ No code changes — tests not required  
✅ CI unaffected  
✅ Documentation renders correctly on GitHub preview  


## Additional Notes

This change improves onboarding and technical transparency by exposing structured project knowledge without altering functionality.
