### PR TITLE
micro-fix: execute Makefile commands via uv run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,20 +5,20 @@ help: ## Show this help
 		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
 lint: ## Run ruff linter and formatter (with auto-fix)
-	cd core && ruff check --fix .
-	cd tools && ruff check --fix .
-	cd core && ruff format .
-	cd tools && ruff format .
+	cd core && uv run ruff check --fix .
+	cd tools && uv run ruff check --fix .
+	cd core && uv run ruff format .
+	cd tools && uv run ruff format .
 
 format: ## Run ruff formatter
-	cd core && ruff format .
-	cd tools && ruff format .
+	cd core && uv run ruff format .
+	cd tools && uv run ruff format .
 
 check: ## Run all checks without modifying files (CI-safe)
-	cd core && ruff check .
-	cd tools && ruff check .
-	cd core && ruff format --check .
-	cd tools && ruff format --check .
+	cd core && uv run ruff check .
+	cd tools && uv run ruff check .
+	cd core && uv run ruff format --check .
+	cd tools && uv run ruff format --check .
 
 test: ## Run all tests
 	cd core && uv run python -m pytest tests/ -v


### PR DESCRIPTION
Summary:
- Updated `Makefile` targets (`lint`, `format`, `check`) to use `uv run`.
- This ensures tools like `ruff` are executed within the project's virtual environment.

Root cause:
- Some `Makefile` targets invoked tools directly, which could fail if they weren't installed globally or on the system PATH, even if they existed in the `uv` managed environment.

Solution:
- Prefixed `ruff` commands with `uv run` across all relevant targets.

Validation:
- Ran `make check` successfully.
- Ran `make test` successfully (739 passed).

Fixes #4889