### PR TITLE
micro-fix: convert web_search to async to prevent blocking event loop (refs #5332)

### DIFF
--- a/tools/tests/tools/test_web_search_tool.py
+++ b/tools/tests/tools/test_web_search_tool.py
@@ -16,32 +16,37 @@ def web_search_fn(mcp: FastMCP):
 class TestWebSearchTool:
     """Tests for web_search tool."""
 
-    def test_no_credentials_returns_error(self, web_search_fn, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_no_credentials_returns_error(self, web_search_fn, monkeypatch):
         """Search without any credentials returns helpful error."""
         monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
         monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
         monkeypatch.delenv("GOOGLE_CSE_ID", raising=False)
 
-        result = web_search_fn(query="test query")
+        result = await web_search_fn(query="test query")
 
         assert "error" in result
         assert "No search credentials configured" in result["error"]
         assert "help" in result
 
-    def test_empty_query_returns_error(self, web_search_fn, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_empty_query_returns_error(self, web_search_fn, monkeypatch):
         """Empty query returns error."""
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "test-key")
 
-        result = web_search_fn(query="")
+        result = await web_search_fn(query="")
 
         assert "error" in result
-        assert "1-500" in result["error"].lower() or "character" in result["error"].lower()
+        assert (
+            "1-500" in result["error"].lower() or "character" in result["error"].lower()
+        )
 
-    def test_long_query_returns_error(self, web_search_fn, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_long_query_returns_error(self, web_search_fn, monkeypatch):
         """Query exceeding 500 chars returns error."""
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "test-key")
 
-        result = web_search_fn(query="x" * 501)
+        result = await web_search_fn(query="x" * 501)
 
         assert "error" in result
 
@@ -49,99 +54,111 @@ class TestWebSearchTool:
 class TestBraveProvider:
     """Tests for Brave Search provider."""
 
-    def test_brave_missing_api_key(self, web_search_fn, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_brave_missing_api_key(self, web_search_fn, monkeypatch):
         """Brave provider without API key returns error."""
         monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
         monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
 
-        result = web_search_fn(query="test", provider="brave")
+        result = await web_search_fn(query="test", provider="brave")
 
         assert "error" in result
         assert "Brave credentials not configured" in result["error"]
 
-    def test_brave_explicit_provider(self, web_search_fn, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_brave_explicit_provider(self, web_search_fn, monkeypatch):
         """Brave provider can be explicitly selected."""
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "test-key")
         monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
 
-        result = web_search_fn(query="test", provider="brave")
+        result = await web_search_fn(query="test", provider="brave")
         assert isinstance(result, dict)
 
 
 class TestGoogleProvider:
     """Tests for Google Custom Search provider."""
 
-    def test_google_missing_api_key(self, web_search_fn, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_google_missing_api_key(self, web_search_fn, monkeypatch):
         """Google provider without API key returns error."""
         monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
         monkeypatch.delenv("GOOGLE_CSE_ID", raising=False)
 
-        result = web_search_fn(query="test", provider="google")
+        result = await web_search_fn(query="test", provider="google")
 
         assert "error" in result
         assert "Google credentials not configured" in result["error"]
 
-    def test_google_missing_cse_id(self, web_search_fn, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_google_missing_cse_id(self, web_search_fn, monkeypatch):
         """Google provider with API key but missing CSE ID returns error."""
         monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
         monkeypatch.delenv("GOOGLE_CSE_ID", raising=False)
 
-        result = web_search_fn(query="test", provider="google")
+        result = await web_search_fn(query="test", provider="google")
 
         assert "error" in result
         assert "Google credentials not configured" in result["error"]
 
-    def test_google_explicit_provider(self, web_search_fn, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_google_explicit_provider(self, web_search_fn, monkeypatch):
         """Google provider can be explicitly selected."""
         monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
         monkeypatch.setenv("GOOGLE_CSE_ID", "test-cse-id")
 
-        result = web_search_fn(query="test", provider="google")
+        result = await web_search_fn(query="test", provider="google")
         assert isinstance(result, dict)
 
 
 class TestAutoProvider:
     """Tests for auto provider selection."""
 
-    def test_auto_prefers_brave_for_backward_compatibility(self, web_search_fn, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_auto_prefers_brave_for_backward_compatibility(
+        self, web_search_fn, monkeypatch
+    ):
         """Auto mode uses Brave first for backward compatibility."""
         monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
         monkeypatch.setenv("GOOGLE_CSE_ID", "test-cse-id")
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "test-brave-key")
 
-        result = web_search_fn(query="test", provider="auto")
+        result = await web_search_fn(query="test", provider="auto")
         assert isinstance(result, dict)
 
-    def test_auto_falls_back_to_google(self, web_search_fn, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_auto_falls_back_to_google(self, web_search_fn, monkeypatch):
         """Auto mode falls back to Google when Brave not available."""
         monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
         monkeypatch.setenv("GOOGLE_CSE_ID", "test-cse-id")
         monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
 
-        result = web_search_fn(query="test", provider="auto")
+        result = await web_search_fn(query="test", provider="auto")
         assert isinstance(result, dict)
 
-    def test_default_provider_is_auto(self, web_search_fn, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_default_provider_is_auto(self, web_search_fn, monkeypatch):
         """Default provider is auto."""
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "test-key")
 
-        result = web_search_fn(query="test")
+        result = await web_search_fn(query="test")
         assert isinstance(result, dict)
 
 
 class TestParameters:
     """Tests for tool parameters."""
 
-    def test_custom_language_and_country(self, web_search_fn, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_custom_language_and_country(self, web_search_fn, monkeypatch):
         """Custom language and country parameters are accepted."""
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "test-key")
 
-        result = web_search_fn(query="test", language="id", country="id")
+        result = await web_search_fn(query="test", language="id", country="id")
         assert isinstance(result, dict)
 
-    def test_num_results_parameter(self, web_search_fn, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_num_results_parameter(self, web_search_fn, monkeypatch):
         """num_results parameter is accepted."""
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "test-key")
 
-        result = web_search_fn(query="test", num_results=5)
+        result = await web_search_fn(query="test", num_results=5)
         assert isinstance(result, dict)


### PR DESCRIPTION
Summary:
- Converted `web_search` tool and its internal provider functions (`_search_google`, `_search_brave`) to `async def`.
- Replaced synchronous `httpx.get` with `httpx.AsyncClient`.
- Replaced `time.sleep` with `await asyncio.sleep` for rate-limit backoff.
- Updated unit tests to support async execution.

Root cause:
- The previous implementation used synchronous I/O and `time.sleep`, which blocks the `asyncio` event loop. In high-concurrency environments like Hive, this creates significant performance bottlenecks and exhausts the thread pool.

Solution:
- Migrated to a fully asynchronous implementation matching the pattern used in `web_scrape_tool.py`.

Validation:
- Ran `uv run pytest tests/tools/test_web_search_tool.py -v` in the `tools` directory.
- Result: 13 passed.

Fixes #5332