### PR TITLE
docs(micro-fix): fix typos and formatting across security, docs, and core

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,8 +39,8 @@ We consider security research conducted in accordance with this policy to be:
 ## Security Best Practices for Users
 
 1. **Keep Updated**: Always run the latest version
-2. **Secure Configuration**: Review `config.yaml` settings, especially in production
-3. **Environment Variables**: Never commit `.env` files or `config.yaml` with secrets
+2. **Secure Configuration**: Review `configuration.json` settings, especially in production
+3. **Environment Variables**: Never commit `.env` files or `configuration.json` with secrets
 4. **Network Security**: Use HTTPS in production, configure firewalls appropriately
 5. **Database Security**: Use strong passwords, limit network access
 

--- a/core/framework/graph/conversation_judge.py
+++ b/core/framework/graph/conversation_judge.py
@@ -37,7 +37,7 @@ async def evaluate_phase_completion(
     phase_description: str,
     success_criteria: str,
     accumulator_state: dict[str, Any],
-    max_history_tokens: int = 8_196,
+    max_history_tokens: int = 8_192,
 ) -> PhaseVerdict:
     """Level 2 judge: read the conversation and evaluate quality.
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -196,7 +196,7 @@ hive/                                    # Repository root
 │   │   ├── llm/                         # LLM provider integrations (Anthropic, OpenAI, etc.)
 │   │   ├── mcp/                         # MCP server integration
 │   │   ├── runner/                      # AgentRunner - loads and runs agents
-|   |   ├── observability/               # Structured logging - human-readable and machine-parseable tracing
+│   │   ├── observability/               # Structured logging - human-readable and machine-parseable tracing
 │   │   ├── runtime/                     # Runtime environment
 │   │   ├── schemas/                     # Data schemas
 │   │   ├── storage/                     # File-based persistence


### PR DESCRIPTION
Three micro-fixes (4 lines changed total, no logic/API changes):

1. **`core/framework/graph/conversation_judge.py`** — Fix `max_history_tokens` default from `8_196` to `8_192` (standard 2^13 token bucket; keyboard typo)
2. **`docs/developer-guide.md`** — Replace ASCII pipe `|` with Unicode box-drawing char on the `observability/` line for tree diagram consistency
3. **`SECURITY.md`** — Correct `config.yaml` to `configuration.json` (no `config.yaml` exists in this project; leftover from template)
