### PR TITLE
fix(credentials): handle empty and whitespace env vars in EnvVarStorage

### DIFF
--- a/core/framework/credentials/storage.py
+++ b/core/framework/credentials/storage.py
@@ -331,9 +331,8 @@ class EnvVarStorage(CredentialStorage):
     def _read_env_value(self, env_var: str) -> str | None:
         """Read value from env var or .env file."""
         # Check os.environ first (takes precedence)
-        value = os.environ.get(env_var)
-        if value:
-            return value
+        if env_var in os.environ:
+            return os.environ[env_var]
 
         # Fallback: read from .env file (hot-reload)
         if self._dotenv_path.exists():
@@ -360,7 +359,7 @@ class EnvVarStorage(CredentialStorage):
         env_var = self._get_env_var_name(credential_id)
         value = self._read_env_value(env_var)
 
-        if not value:
+        if not value or not value.strip():
             return None
 
         return CredentialObject(
@@ -390,7 +389,8 @@ class EnvVarStorage(CredentialStorage):
     def exists(self, credential_id: str) -> bool:
         """Check if credential is available in environment."""
         env_var = self._get_env_var_name(credential_id)
-        return self._read_env_value(env_var) is not None
+        value = self._read_env_value(env_var)
+        return bool(value and value.strip())
 
     def add_mapping(self, credential_id: str, env_var: str) -> None:
         """

--- a/core/framework/credentials/tests/test_credential_store.py
+++ b/core/framework/credentials/tests/test_credential_store.py
@@ -260,6 +260,20 @@ class TestEnvVarStorage:
         with pytest.raises(NotImplementedError):
             storage.delete("test")
 
+    def test_empty_env_var(self):
+        """Test that empty environment variables are ignored."""
+        with patch.dict(os.environ, {"TEST_API_KEY": ""}):
+            storage = EnvVarStorage(env_mapping={"test": "TEST_API_KEY"})
+            assert not storage.exists("test")
+            assert storage.load("test") is None
+
+    def test_whitespace_env_var(self):
+        """Test that whitespace environment variables are ignored."""
+        with patch.dict(os.environ, {"TEST_API_KEY": "   "}):
+            storage = EnvVarStorage(env_mapping={"test": "TEST_API_KEY"})
+            assert not storage.exists("test")
+            assert storage.load("test") is None
+
 
 class TestEncryptedFileStorage:
     """Tests for EncryptedFileStorage."""


### PR DESCRIPTION
Resolves #5388

### **Problem**
The current implementation of `EnvVarStorage` fails to correctly process environment variables that are declared but left empty (e.g., `export API_KEY=`) or contain only whitespace. 
* In `_read_env_value`, the logic `if value:` evaluates to `False` for empty strings, causing the system to ignore the environment override and incorrectly fall back to the `.env` file.
* There is a state mismatch between `exists()` and `load()`. A key might technically "exist" in `os.environ`, but fail to load a valid credential if it's just an empty string or whitespace.

### **Solution**
Refactored the `EnvVarStorage` class to correctly recognize empty environment variables and strictly validate their contents before loading. 

* **Fixed Environment Override (`_read_env_value`):** Changed the check to `if env_var in os.environ:` to ensure explicitly declared variables (even if empty) are correctly read rather than bypassed.
* **Synchronized Validation:** * Updated `exists()` to verify that the environment variable contains non-whitespace characters: `return bool(value and value.strip())`.
  * Updated `load()` to mirror this validation, safely returning `None` if the string is empty or whitespace-only.
* **Added Test Coverage:** Added `test_empty_env_var` and `test_whitespace_env_var` in `test_credential_store.py` to prevent future regressions.

### **Testing**
- [x] Added unit tests for empty string variables (`""`).
- [x] Added unit tests for whitespace variables (`"   "`).
- [x] All existing tests pass successfully.