### PR TITLE
feat(tools): add Cloudflare DNS and cache management tool

### DIFF
--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -59,6 +59,7 @@ from .bigquery import BIGQUERY_CREDENTIALS
 from .brevo import BREVO_CREDENTIALS
 from .browser import get_aden_auth_url, get_aden_setup_url, open_browser
 from .calcom import CALCOM_CREDENTIALS
+from .cloudflare import CLOUDFLARE_CREDENTIALS
 from .discord import DISCORD_CREDENTIALS
 from .email import EMAIL_CREDENTIALS
 from .gcp_vision import GCP_VISION_CREDENTIALS
@@ -112,6 +113,7 @@ CREDENTIAL_SPECS = {
     **CALCOM_CREDENTIALS,
     **STRIPE_CREDENTIALS,
     **BREVO_CREDENTIALS,
+    **CLOUDFLARE_CREDENTIALS,
     **POSTGRES_CREDENTIALS,
 }
 
@@ -159,5 +161,6 @@ __all__ = [
     "DISCORD_CREDENTIALS",
     "STRIPE_CREDENTIALS",
     "BREVO_CREDENTIALS",
+    "CLOUDFLARE_CREDENTIALS",
     "POSTGRES_CREDENTIALS",
 ]

--- a/tools/src/aden_tools/credentials/cloudflare.py
+++ b/tools/src/aden_tools/credentials/cloudflare.py
@@ -1,0 +1,41 @@
+"""
+Cloudflare tool credentials.
+
+Contains credentials for Cloudflare API integration.
+"""
+
+from .base import CredentialSpec
+
+CLOUDFLARE_CREDENTIALS = {
+    "cloudflare": CredentialSpec(
+        env_var="CLOUDFLARE_API_TOKEN",
+        tools=[
+            "cloudflare_list_zones",
+            "cloudflare_get_zone",
+            "cloudflare_list_dns_records",
+            "cloudflare_create_dns_record",
+            "cloudflare_update_dns_record",
+            "cloudflare_delete_dns_record",
+            "cloudflare_purge_cache",
+        ],
+        required=True,
+        startup_required=False,
+        help_url="https://dash.cloudflare.com/profile/api-tokens",
+        description="Cloudflare API Token",
+        aden_supported=False,
+        aden_provider_name=None,
+        direct_api_key_supported=True,
+        api_key_instructions="""To get a Cloudflare API Token:
+1. Go to https://dash.cloudflare.com/profile/api-tokens
+2. Click "Create Token"
+3. Use the "Edit zone DNS" template or create a custom token
+4. Select permissions: Zone:Read, DNS:Edit, Cache Purge:Purge
+5. Choose zone resources (all zones or specific ones)
+6. Click "Continue to summary" then "Create Token"
+7. Copy the token and set as CLOUDFLARE_API_TOKEN""",
+        health_check_endpoint="https://api.cloudflare.com/client/v4/user/tokens/verify",
+        health_check_method="GET",
+        credential_id="cloudflare",
+        credential_key="api_token",
+    ),
+}

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -28,6 +28,7 @@ from .bigquery_tool import register_tools as register_bigquery
 from .brevo_tool import register_tools as register_brevo
 from .calcom_tool import register_tools as register_calcom
 from .calendar_tool import register_tools as register_calendar
+from .cloudflare_tool import register_tools as register_cloudflare
 from .csv_tool import register_tools as register_csv
 from .discord_tool import register_tools as register_discord
 
@@ -153,6 +154,9 @@ def register_all_tools(
     register_risk_scorer(mcp)
     register_stripe(mcp, credentials=credentials)
     register_brevo(mcp, credentials=credentials)
+
+    # Cloudflare tool
+    register_cloudflare(mcp, credentials=credentials)
 
     # Postgres tool
     register_postgres(mcp, credentials=credentials)

--- a/tools/src/aden_tools/tools/cloudflare_tool/README.md
+++ b/tools/src/aden_tools/tools/cloudflare_tool/README.md
@@ -1,0 +1,75 @@
+# Cloudflare Tool
+
+Manage DNS records, zones, and cache via the Cloudflare API v4.
+
+## Setup
+
+You need a Cloudflare API Token with the appropriate permissions.
+
+### Getting a Cloudflare API Token
+
+1. Go to https://dash.cloudflare.com/profile/api-tokens
+2. Click "Create Token"
+3. Use the "Edit zone DNS" template (or create a custom token)
+4. Select permissions:
+   - **Zone → Zone → Read** (for listing and viewing zones)
+   - **Zone → DNS → Edit** (for managing DNS records)
+   - **Zone → Cache Purge → Purge** (for cache management)
+5. Select zone resources (all zones or specific ones)
+6. Click "Continue to summary" → "Create Token"
+7. Copy the token
+
+**Note:** Use scoped API Tokens (not the legacy Global API Key) for security.
+
+### Configuration
+
+```bash
+export CLOUDFLARE_API_TOKEN=your_api_token_here
+```
+
+Or configure via the credential store (recommended for production).
+
+## All Tools (7 Total)
+
+### Zones (2)
+
+| Tool | Description |
+|------|-------------|
+| `cloudflare_list_zones` | List domains on the account with optional filtering |
+| `cloudflare_get_zone` | Get zone details (status, nameservers, plan) |
+
+### DNS Records (4)
+
+| Tool | Description |
+|------|-------------|
+| `cloudflare_list_dns_records` | List DNS records for a zone with type/name filtering |
+| `cloudflare_create_dns_record` | Create A, AAAA, CNAME, MX, TXT, and other records |
+| `cloudflare_update_dns_record` | Update an existing DNS record |
+| `cloudflare_delete_dns_record` | Delete a DNS record |
+
+### Cache (1)
+
+| Tool | Description |
+|------|-------------|
+| `cloudflare_purge_cache` | Purge all cached content or specific URLs/tags |
+
+## Supported Record Types
+
+| Type | Example Content | Proxied | Priority |
+|------|----------------|---------|----------|
+| A | `192.0.2.1` | Yes | No |
+| AAAA | `2001:db8::1` | Yes | No |
+| CNAME | `example.netlify.app` | Yes | No |
+| MX | `mail.example.com` | No | Required |
+| TXT | `v=spf1 include:_spf.google.com ~all` | No | No |
+| NS | `ns1.example.com` | No | No |
+| SRV | `0 5 5060 sip.example.com` | No | No |
+| CAA | `0 issue "letsencrypt.org"` | No | No |
+
+## Use Cases
+
+- *"List all DNS records for my domain and check the MX records"*
+- *"Add a CNAME record pointing blog.example.com to my hosting provider"*
+- *"After deployment, purge the Cloudflare cache for my site"*
+- *"Check if my domain is active on Cloudflare and show the nameservers"*
+- *"Create a TXT record for domain verification"*

--- a/tools/src/aden_tools/tools/cloudflare_tool/__init__.py
+++ b/tools/src/aden_tools/tools/cloudflare_tool/__init__.py
@@ -1,0 +1,5 @@
+"""Cloudflare tool package for Aden Tools."""
+
+from .cloudflare_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/cloudflare_tool/cloudflare_tool.py
+++ b/tools/src/aden_tools/tools/cloudflare_tool/cloudflare_tool.py
@@ -1,0 +1,538 @@
+"""
+Cloudflare Tool - Manage DNS records, zones, and cache via Cloudflare API v4.
+
+Supports:
+- API Token authentication (CLOUDFLARE_API_TOKEN)
+
+API Reference: https://developers.cloudflare.com/api
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialStoreAdapter
+
+CF_API_BASE = "https://api.cloudflare.com/client/v4"
+
+
+class _CloudflareClient:
+    """Internal client wrapping Cloudflare API v4 calls."""
+
+    def __init__(self, token: str):
+        self._token = token
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._token}",
+            "Content-Type": "application/json",
+        }
+
+    def _handle_response(self, response: httpx.Response) -> dict[str, Any]:
+        """Handle Cloudflare API response format."""
+        if response.status_code == 401:
+            return {"error": "Invalid or expired Cloudflare API token"}
+        if response.status_code == 403:
+            return {"error": "Forbidden - token lacks required permissions"}
+        if response.status_code == 404:
+            return {"error": "Resource not found"}
+        if response.status_code == 429:
+            return {"error": "Rate limit exceeded. Try again later."}
+        if response.status_code >= 400:
+            try:
+                data = response.json()
+                errors = data.get("errors", [])
+                if errors:
+                    msg = errors[0].get("message", response.text)
+                else:
+                    msg = response.text
+            except Exception:
+                msg = response.text
+            return {"error": f"Cloudflare API error (HTTP {response.status_code}): {msg}"}
+
+        try:
+            data = response.json()
+        except Exception:
+            return {"error": "Failed to parse Cloudflare response"}
+
+        if not data.get("success", False):
+            errors = data.get("errors", [])
+            if errors:
+                msg = errors[0].get("message", "Unknown error")
+                return {"error": f"Cloudflare API error: {msg}"}
+            return {"error": "Cloudflare API returned an unsuccessful response"}
+
+        return {"success": True, "data": data.get("result")}
+
+    # --- Zones ---
+
+    def list_zones(
+        self,
+        name: str | None = None,
+        status: str | None = None,
+        page: int = 1,
+        per_page: int = 20,
+    ) -> dict[str, Any]:
+        """List zones (domains) on the account."""
+        params: dict[str, Any] = {
+            "page": max(1, page),
+            "per_page": min(per_page, 50),
+        }
+        if name:
+            params["name"] = name
+        if status:
+            params["status"] = status
+
+        response = httpx.get(
+            f"{CF_API_BASE}/zones",
+            headers=self._headers,
+            params=params,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def get_zone(self, zone_id: str) -> dict[str, Any]:
+        """Get details about a specific zone."""
+        response = httpx.get(
+            f"{CF_API_BASE}/zones/{zone_id}",
+            headers=self._headers,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    # --- DNS Records ---
+
+    def list_dns_records(
+        self,
+        zone_id: str,
+        record_type: str | None = None,
+        name: str | None = None,
+        page: int = 1,
+        per_page: int = 20,
+    ) -> dict[str, Any]:
+        """List DNS records for a zone."""
+        params: dict[str, Any] = {
+            "page": max(1, page),
+            "per_page": min(per_page, 100),
+        }
+        if record_type:
+            params["type"] = record_type
+        if name:
+            params["name"] = name
+
+        response = httpx.get(
+            f"{CF_API_BASE}/zones/{zone_id}/dns_records",
+            headers=self._headers,
+            params=params,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def create_dns_record(
+        self,
+        zone_id: str,
+        record_type: str,
+        name: str,
+        content: str,
+        ttl: int = 1,
+        proxied: bool = False,
+        priority: int | None = None,
+    ) -> dict[str, Any]:
+        """Create a new DNS record."""
+        payload: dict[str, Any] = {
+            "type": record_type,
+            "name": name,
+            "content": content,
+            "ttl": ttl,
+            "proxied": proxied,
+        }
+        if priority is not None:
+            payload["priority"] = priority
+
+        response = httpx.post(
+            f"{CF_API_BASE}/zones/{zone_id}/dns_records",
+            headers=self._headers,
+            json=payload,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def update_dns_record(
+        self,
+        zone_id: str,
+        record_id: str,
+        record_type: str,
+        name: str,
+        content: str,
+        ttl: int = 1,
+        proxied: bool = False,
+        priority: int | None = None,
+    ) -> dict[str, Any]:
+        """Update an existing DNS record."""
+        payload: dict[str, Any] = {
+            "type": record_type,
+            "name": name,
+            "content": content,
+            "ttl": ttl,
+            "proxied": proxied,
+        }
+        if priority is not None:
+            payload["priority"] = priority
+
+        response = httpx.patch(
+            f"{CF_API_BASE}/zones/{zone_id}/dns_records/{record_id}",
+            headers=self._headers,
+            json=payload,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+    def delete_dns_record(
+        self,
+        zone_id: str,
+        record_id: str,
+    ) -> dict[str, Any]:
+        """Delete a DNS record."""
+        response = httpx.delete(
+            f"{CF_API_BASE}/zones/{zone_id}/dns_records/{record_id}",
+            headers=self._headers,
+            timeout=30.0,
+        )
+        # Cloudflare returns {"result": {"id": "..."}} on delete
+        if response.status_code == 200:
+            return {"success": True}
+        return self._handle_response(response)
+
+    # --- Cache ---
+
+    def purge_cache(
+        self,
+        zone_id: str,
+        purge_everything: bool = False,
+        files: list[str] | None = None,
+        tags: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Purge cached content for a zone."""
+        payload: dict[str, Any] = {}
+        if purge_everything:
+            payload["purge_everything"] = True
+        elif files:
+            payload["files"] = files
+        elif tags:
+            payload["tags"] = tags
+        else:
+            return {"error": "Specify purge_everything=True, files, or tags"}
+
+        response = httpx.post(
+            f"{CF_API_BASE}/zones/{zone_id}/purge_cache",
+            headers=self._headers,
+            json=payload,
+            timeout=30.0,
+        )
+        return self._handle_response(response)
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: CredentialStoreAdapter | None = None,
+) -> None:
+    """Register Cloudflare tools with the MCP server."""
+
+    def _get_token() -> str | None:
+        """Get Cloudflare API token from credentials or environment."""
+        if credentials is not None:
+            token = credentials.get("cloudflare")
+            if token is not None and not isinstance(token, str):
+                raise TypeError(
+                    f"Expected string from credentials.get('cloudflare'), got {type(token).__name__}"
+                )
+            return token
+        return os.getenv("CLOUDFLARE_API_TOKEN")
+
+    def _get_client() -> _CloudflareClient | dict[str, str]:
+        """Get a Cloudflare client, or return an error dict if no credentials."""
+        token = _get_token()
+        if not token:
+            return {
+                "error": "Cloudflare credentials not configured",
+                "help": (
+                    "Set CLOUDFLARE_API_TOKEN environment variable "
+                    "or configure via credential store. "
+                    "Create a token at https://dash.cloudflare.com/profile/api-tokens"
+                ),
+            }
+        return _CloudflareClient(token)
+
+    # --- Zones ---
+
+    @mcp.tool()
+    def cloudflare_list_zones(
+        name: str | None = None,
+        status: str | None = None,
+        page: int = 1,
+        per_page: int = 20,
+    ) -> dict:
+        """
+        List zones (domains) in the Cloudflare account.
+
+        Use this to find zone IDs needed for DNS and cache operations.
+
+        Args:
+            name: Filter by domain name (e.g. "example.com")
+            status: Filter by status ("active", "pending", "initializing")
+            page: Page number for pagination (default 1)
+            per_page: Results per page (1-50, default 20)
+
+        Returns:
+            Dict with list of zones or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_zones(name=name, status=status, page=page, per_page=per_page)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def cloudflare_get_zone(zone_id: str) -> dict:
+        """
+        Get details about a specific zone (domain).
+
+        Returns zone status, nameservers, plan, and settings.
+
+        Args:
+            zone_id: The zone identifier (use cloudflare_list_zones to find it)
+
+        Returns:
+            Dict with zone details or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.get_zone(zone_id)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    # --- DNS Records ---
+
+    @mcp.tool()
+    def cloudflare_list_dns_records(
+        zone_id: str,
+        record_type: str | None = None,
+        name: str | None = None,
+        page: int = 1,
+        per_page: int = 20,
+    ) -> dict:
+        """
+        List DNS records for a zone.
+
+        Use this to see all records (A, AAAA, CNAME, MX, TXT, etc.) for a domain.
+
+        Args:
+            zone_id: The zone identifier
+            record_type: Filter by record type ("A", "AAAA", "CNAME", "MX", "TXT", etc.)
+            name: Filter by record name (e.g. "blog.example.com")
+            page: Page number for pagination (default 1)
+            per_page: Results per page (1-100, default 20)
+
+        Returns:
+            Dict with list of DNS records or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.list_dns_records(
+                zone_id, record_type=record_type, name=name, page=page, per_page=per_page
+            )
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def cloudflare_create_dns_record(
+        zone_id: str,
+        record_type: str,
+        name: str,
+        content: str,
+        ttl: int = 1,
+        proxied: bool = False,
+        priority: int | None = None,
+    ) -> dict:
+        """
+        Create a new DNS record for a zone.
+
+        Common record types:
+        - A: Points to an IPv4 address (e.g. "192.0.2.1")
+        - AAAA: Points to an IPv6 address
+        - CNAME: Alias to another domain (e.g. "example.netlify.app")
+        - MX: Mail server (requires priority)
+        - TXT: Text record (e.g. SPF, DKIM, verification strings)
+
+        Args:
+            zone_id: The zone identifier
+            record_type: DNS record type ("A", "AAAA", "CNAME", "MX", "TXT")
+            name: Record name (e.g. "blog" for blog.example.com, or "@" for root)
+            content: Record value (IP address, domain, or text)
+            ttl: Time to live in seconds (1 = automatic, default 1)
+            proxied: Whether to proxy through Cloudflare (orange cloud, default False)
+            priority: Required for MX records (e.g. 10)
+
+        Returns:
+            Dict with created record details or error
+        """
+        valid_types = {"A", "AAAA", "CNAME", "MX", "TXT", "NS", "SRV", "CAA", "PTR"}
+        if record_type.upper() not in valid_types:
+            return {
+                "error": f"Invalid record type '{record_type}'",
+                "valid_types": sorted(valid_types),
+            }
+
+        if record_type.upper() == "MX" and priority is None:
+            return {"error": "MX records require a priority value (e.g. 10)"}
+
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.create_dns_record(
+                zone_id,
+                record_type=record_type.upper(),
+                name=name,
+                content=content,
+                ttl=ttl,
+                proxied=proxied,
+                priority=priority,
+            )
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def cloudflare_update_dns_record(
+        zone_id: str,
+        record_id: str,
+        record_type: str,
+        name: str,
+        content: str,
+        ttl: int = 1,
+        proxied: bool = False,
+        priority: int | None = None,
+    ) -> dict:
+        """
+        Update an existing DNS record.
+
+        All fields are required since Cloudflare replaces the entire record.
+        Use cloudflare_list_dns_records to find the record_id.
+
+        Args:
+            zone_id: The zone identifier
+            record_id: The DNS record identifier
+            record_type: DNS record type ("A", "AAAA", "CNAME", "MX", "TXT")
+            name: Record name (e.g. "blog.example.com")
+            content: New record value
+            ttl: Time to live in seconds (1 = automatic)
+            proxied: Whether to proxy through Cloudflare (default False)
+            priority: Required for MX records
+
+        Returns:
+            Dict with updated record details or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.update_dns_record(
+                zone_id,
+                record_id=record_id,
+                record_type=record_type.upper(),
+                name=name,
+                content=content,
+                ttl=ttl,
+                proxied=proxied,
+                priority=priority,
+            )
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def cloudflare_delete_dns_record(
+        zone_id: str,
+        record_id: str,
+    ) -> dict:
+        """
+        Delete a DNS record from a zone.
+
+        Use cloudflare_list_dns_records to find the record_id.
+
+        Args:
+            zone_id: The zone identifier
+            record_id: The DNS record identifier to delete
+
+        Returns:
+            Dict with success status or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.delete_dns_record(zone_id, record_id)
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    # --- Cache ---
+
+    @mcp.tool()
+    def cloudflare_purge_cache(
+        zone_id: str,
+        purge_everything: bool = False,
+        files: list[str] | None = None,
+        tags: list[str] | None = None,
+    ) -> dict:
+        """
+        Purge cached content for a zone.
+
+        Use after deploying a new version of your site to ensure fresh content.
+        Choose one of: purge_everything, files, or tags.
+
+        Args:
+            zone_id: The zone identifier
+            purge_everything: If True, purge all cached files (use sparingly)
+            files: List of URLs to purge (e.g. ["https://example.com/style.css"])
+            tags: List of cache tags to purge (Enterprise only)
+
+        Returns:
+            Dict with purge result or error
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+        try:
+            return client.purge_cache(
+                zone_id,
+                purge_everything=purge_everything,
+                files=files,
+                tags=tags,
+            )
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}

--- a/tools/tests/tools/test_cloudflare_tool.py
+++ b/tools/tests/tools/test_cloudflare_tool.py
@@ -1,0 +1,450 @@
+"""
+Tests for Cloudflare tool.
+
+Covers:
+- _CloudflareClient methods (zones, DNS records, cache purge)
+- Error handling (401, 403, 404, 429, API-level errors)
+- Credential retrieval (CredentialStoreAdapter vs env var)
+- All 7 MCP tool functions
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aden_tools.tools.cloudflare_tool import (
+    _CloudflareClient,
+    register_tools,
+)
+
+
+# --- Helper to build Cloudflare-style API responses ---
+
+
+def _cf_ok(result: dict | list) -> dict:
+    """Build a successful Cloudflare API response body."""
+    return {"success": True, "errors": [], "messages": [], "result": result}
+
+
+def _cf_error(code: int, message: str) -> dict:
+    """Build a Cloudflare API error response body."""
+    return {"success": False, "errors": [{"code": code, "message": message}]}
+
+
+def _mock_response(status_code: int = 200, json_data: dict | list | None = None) -> MagicMock:
+    """Create a mock httpx.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.text = str(json_data or "")
+    return resp
+
+
+# --- _CloudflareClient unit tests ---
+
+
+class TestCloudflareClient:
+    def setup_method(self):
+        self.client = _CloudflareClient("test-token-abc")
+
+    def test_headers(self):
+        headers = self.client._headers
+        assert headers["Authorization"] == "Bearer test-token-abc"
+        assert headers["Content-Type"] == "application/json"
+
+    def test_handle_response_success(self):
+        zone = {"id": "z1", "name": "example.com", "status": "active"}
+        resp = _mock_response(200, _cf_ok(zone))
+        result = self.client._handle_response(resp)
+        assert result["success"] is True
+        assert result["data"]["name"] == "example.com"
+
+    def test_handle_response_401(self):
+        resp = _mock_response(401)
+        result = self.client._handle_response(resp)
+        assert "error" in result
+        assert "Invalid" in result["error"]
+
+    def test_handle_response_403(self):
+        resp = _mock_response(403)
+        result = self.client._handle_response(resp)
+        assert "error" in result
+        assert "Forbidden" in result["error"]
+
+    def test_handle_response_404(self):
+        resp = _mock_response(404)
+        result = self.client._handle_response(resp)
+        assert "error" in result
+        assert "not found" in result["error"]
+
+    def test_handle_response_429(self):
+        resp = _mock_response(429)
+        result = self.client._handle_response(resp)
+        assert "error" in result
+        assert "Rate limit" in result["error"]
+
+    def test_handle_response_api_error(self):
+        resp = _mock_response(200, _cf_error(1003, "Invalid zone identifier"))
+        result = self.client._handle_response(resp)
+        assert "error" in result
+        assert "Invalid zone identifier" in result["error"]
+
+    def test_handle_response_server_error(self):
+        resp = _mock_response(500, {"errors": [{"message": "Internal error"}]})
+        result = self.client._handle_response(resp)
+        assert "error" in result
+        assert "500" in result["error"]
+
+    # --- Zone operations ---
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.get")
+    def test_list_zones(self, mock_get):
+        zones = [
+            {"id": "z1", "name": "example.com", "status": "active"},
+            {"id": "z2", "name": "test.io", "status": "pending"},
+        ]
+        mock_get.return_value = _mock_response(200, _cf_ok(zones))
+        result = self.client.list_zones()
+        assert result["success"] is True
+        assert len(result["data"]) == 2
+        assert result["data"][0]["name"] == "example.com"
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.get")
+    def test_list_zones_with_filters(self, mock_get):
+        mock_get.return_value = _mock_response(200, _cf_ok([]))
+        self.client.list_zones(name="example.com", status="active", page=2, per_page=10)
+        _, kwargs = mock_get.call_args
+        assert kwargs["params"]["name"] == "example.com"
+        assert kwargs["params"]["status"] == "active"
+        assert kwargs["params"]["page"] == 2
+        assert kwargs["params"]["per_page"] == 10
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.get")
+    def test_get_zone(self, mock_get):
+        zone = {"id": "z1", "name": "example.com", "status": "active", "name_servers": ["ns1"]}
+        mock_get.return_value = _mock_response(200, _cf_ok(zone))
+        result = self.client.get_zone("z1")
+        assert result["success"] is True
+        assert result["data"]["id"] == "z1"
+
+    # --- DNS record operations ---
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.get")
+    def test_list_dns_records(self, mock_get):
+        records = [
+            {"id": "r1", "type": "A", "name": "example.com", "content": "1.2.3.4"},
+            {"id": "r2", "type": "CNAME", "name": "www.example.com", "content": "example.com"},
+        ]
+        mock_get.return_value = _mock_response(200, _cf_ok(records))
+        result = self.client.list_dns_records("z1")
+        assert result["success"] is True
+        assert len(result["data"]) == 2
+        assert result["data"][0]["type"] == "A"
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.get")
+    def test_list_dns_records_with_type_filter(self, mock_get):
+        mock_get.return_value = _mock_response(200, _cf_ok([]))
+        self.client.list_dns_records("z1", record_type="MX", name="example.com")
+        _, kwargs = mock_get.call_args
+        assert kwargs["params"]["type"] == "MX"
+        assert kwargs["params"]["name"] == "example.com"
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.post")
+    def test_create_dns_record(self, mock_post):
+        record = {"id": "r10", "type": "A", "name": "blog.example.com", "content": "1.2.3.4"}
+        mock_post.return_value = _mock_response(200, _cf_ok(record))
+        result = self.client.create_dns_record("z1", "A", "blog.example.com", "1.2.3.4")
+        assert result["success"] is True
+        assert result["data"]["name"] == "blog.example.com"
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.post")
+    def test_create_dns_record_with_priority(self, mock_post):
+        mock_post.return_value = _mock_response(200, _cf_ok({"id": "r11", "type": "MX"}))
+        self.client.create_dns_record(
+            "z1", "MX", "example.com", "mail.example.com", priority=10
+        )
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"]["priority"] == 10
+        assert kwargs["json"]["type"] == "MX"
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.patch")
+    def test_update_dns_record(self, mock_patch):
+        record = {"id": "r1", "type": "A", "name": "example.com", "content": "5.6.7.8"}
+        mock_patch.return_value = _mock_response(200, _cf_ok(record))
+        result = self.client.update_dns_record("z1", "r1", "A", "example.com", "5.6.7.8")
+        assert result["success"] is True
+        assert result["data"]["content"] == "5.6.7.8"
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.delete")
+    def test_delete_dns_record(self, mock_delete):
+        mock_delete.return_value = _mock_response(200, _cf_ok({"id": "r1"}))
+        result = self.client.delete_dns_record("z1", "r1")
+        assert result["success"] is True
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.delete")
+    def test_delete_dns_record_not_found(self, mock_delete):
+        mock_delete.return_value = _mock_response(404)
+        result = self.client.delete_dns_record("z1", "bad-id")
+        assert "error" in result
+
+    # --- Cache purge ---
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.post")
+    def test_purge_cache_everything(self, mock_post):
+        mock_post.return_value = _mock_response(200, _cf_ok({"id": "purge-1"}))
+        result = self.client.purge_cache("z1", purge_everything=True)
+        assert result["success"] is True
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"]["purge_everything"] is True
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.post")
+    def test_purge_cache_specific_files(self, mock_post):
+        mock_post.return_value = _mock_response(200, _cf_ok({"id": "purge-2"}))
+        urls = ["https://example.com/style.css", "https://example.com/app.js"]
+        result = self.client.purge_cache("z1", files=urls)
+        assert result["success"] is True
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"]["files"] == urls
+
+    def test_purge_cache_no_target(self):
+        result = self.client.purge_cache("z1")
+        assert "error" in result
+        assert "Specify" in result["error"]
+
+
+# --- Tool registration and MCP function tests ---
+
+
+class TestCloudflareListZonesTool:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.fns = []
+        self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
+        cred = MagicMock()
+        cred.get.return_value = "test-cf-token"
+        register_tools(self.mcp, credentials=cred)
+
+    def _fn(self, name):
+        return next(f for f in self.fns if f.__name__ == name)
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.get")
+    def test_list_zones_success(self, mock_get):
+        zones = [{"id": "z1", "name": "example.com", "status": "active"}]
+        mock_get.return_value = _mock_response(200, _cf_ok(zones))
+        result = self._fn("cloudflare_list_zones")()
+        assert result["success"] is True
+        assert result["data"][0]["name"] == "example.com"
+
+    def test_list_zones_no_credentials(self):
+        mcp = MagicMock()
+        fns = []
+        mcp.tool.return_value = lambda fn: fns.append(fn) or fn
+        register_tools(mcp, credentials=None)
+        with patch.dict("os.environ", {"CLOUDFLARE_API_TOKEN": ""}, clear=False):
+            result = next(f for f in fns if f.__name__ == "cloudflare_list_zones")()
+        assert "error" in result
+        assert "not configured" in result["error"]
+        assert "help" in result
+
+
+class TestCloudflareGetZoneTool:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.fns = []
+        self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
+        cred = MagicMock()
+        cred.get.return_value = "test-cf-token"
+        register_tools(self.mcp, credentials=cred)
+
+    def _fn(self, name):
+        return next(f for f in self.fns if f.__name__ == name)
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.get")
+    def test_get_zone_success(self, mock_get):
+        zone = {"id": "z1", "name": "example.com", "status": "active"}
+        mock_get.return_value = _mock_response(200, _cf_ok(zone))
+        result = self._fn("cloudflare_get_zone")("z1")
+        assert result["success"] is True
+        assert result["data"]["id"] == "z1"
+
+
+class TestCloudflareListDnsRecordsTool:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.fns = []
+        self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
+        cred = MagicMock()
+        cred.get.return_value = "test-cf-token"
+        register_tools(self.mcp, credentials=cred)
+
+    def _fn(self, name):
+        return next(f for f in self.fns if f.__name__ == name)
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.get")
+    def test_list_dns_records_success(self, mock_get):
+        records = [{"id": "r1", "type": "A", "name": "example.com", "content": "1.2.3.4"}]
+        mock_get.return_value = _mock_response(200, _cf_ok(records))
+        result = self._fn("cloudflare_list_dns_records")("z1")
+        assert result["success"] is True
+        assert len(result["data"]) == 1
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.get")
+    def test_list_dns_records_with_type_filter(self, mock_get):
+        mock_get.return_value = _mock_response(200, _cf_ok([]))
+        self._fn("cloudflare_list_dns_records")("z1", record_type="TXT")
+        _, kwargs = mock_get.call_args
+        assert kwargs["params"]["type"] == "TXT"
+
+
+class TestCloudflareCreateDnsRecordTool:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.fns = []
+        self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
+        cred = MagicMock()
+        cred.get.return_value = "test-cf-token"
+        register_tools(self.mcp, credentials=cred)
+
+    def _fn(self, name):
+        return next(f for f in self.fns if f.__name__ == name)
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.post")
+    def test_create_a_record(self, mock_post):
+        record = {"id": "r10", "type": "A", "name": "blog.example.com", "content": "1.2.3.4"}
+        mock_post.return_value = _mock_response(200, _cf_ok(record))
+        result = self._fn("cloudflare_create_dns_record")(
+            "z1", record_type="A", name="blog.example.com", content="1.2.3.4"
+        )
+        assert result["success"] is True
+
+    def test_create_invalid_record_type(self):
+        result = self._fn("cloudflare_create_dns_record")(
+            "z1", record_type="INVALID", name="x.example.com", content="1.2.3.4"
+        )
+        assert "error" in result
+        assert "Invalid record type" in result["error"]
+
+    def test_create_mx_without_priority(self):
+        result = self._fn("cloudflare_create_dns_record")(
+            "z1", record_type="MX", name="example.com", content="mail.example.com"
+        )
+        assert "error" in result
+        assert "priority" in result["error"].lower()
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.post")
+    def test_create_mx_with_priority(self, mock_post):
+        record = {"id": "r11", "type": "MX", "name": "example.com"}
+        mock_post.return_value = _mock_response(200, _cf_ok(record))
+        result = self._fn("cloudflare_create_dns_record")(
+            "z1", record_type="MX", name="example.com", content="mail.example.com", priority=10
+        )
+        assert result["success"] is True
+
+
+class TestCloudflareUpdateDnsRecordTool:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.fns = []
+        self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
+        cred = MagicMock()
+        cred.get.return_value = "test-cf-token"
+        register_tools(self.mcp, credentials=cred)
+
+    def _fn(self, name):
+        return next(f for f in self.fns if f.__name__ == name)
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.patch")
+    def test_update_record_success(self, mock_patch):
+        record = {"id": "r1", "type": "A", "name": "example.com", "content": "9.8.7.6"}
+        mock_patch.return_value = _mock_response(200, _cf_ok(record))
+        result = self._fn("cloudflare_update_dns_record")(
+            "z1", record_id="r1", record_type="A", name="example.com", content="9.8.7.6"
+        )
+        assert result["success"] is True
+        assert result["data"]["content"] == "9.8.7.6"
+
+
+class TestCloudflareDeleteDnsRecordTool:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.fns = []
+        self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
+        cred = MagicMock()
+        cred.get.return_value = "test-cf-token"
+        register_tools(self.mcp, credentials=cred)
+
+    def _fn(self, name):
+        return next(f for f in self.fns if f.__name__ == name)
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.delete")
+    def test_delete_record_success(self, mock_delete):
+        mock_delete.return_value = _mock_response(200, _cf_ok({"id": "r1"}))
+        result = self._fn("cloudflare_delete_dns_record")("z1", record_id="r1")
+        assert result["success"] is True
+
+
+class TestCloudflarePurgeCacheTool:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.fns = []
+        self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
+        cred = MagicMock()
+        cred.get.return_value = "test-cf-token"
+        register_tools(self.mcp, credentials=cred)
+
+    def _fn(self, name):
+        return next(f for f in self.fns if f.__name__ == name)
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.post")
+    def test_purge_everything(self, mock_post):
+        mock_post.return_value = _mock_response(200, _cf_ok({"id": "purge-1"}))
+        result = self._fn("cloudflare_purge_cache")("z1", purge_everything=True)
+        assert result["success"] is True
+
+    @patch("aden_tools.tools.cloudflare_tool.cloudflare_tool.httpx.post")
+    def test_purge_specific_files(self, mock_post):
+        mock_post.return_value = _mock_response(200, _cf_ok({"id": "purge-2"}))
+        result = self._fn("cloudflare_purge_cache")(
+            "z1", files=["https://example.com/style.css"]
+        )
+        assert result["success"] is True
+
+    def test_purge_no_target_returns_error(self):
+        result = self._fn("cloudflare_purge_cache")("z1")
+        assert "error" in result
+        assert "Specify" in result["error"]
+
+
+# --- Credential spec tests ---
+
+
+class TestCredentialSpec:
+    def test_cloudflare_credential_spec_exists(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        assert "cloudflare" in CREDENTIAL_SPECS
+
+    def test_cloudflare_spec_env_var(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["cloudflare"]
+        assert spec.env_var == "CLOUDFLARE_API_TOKEN"
+
+    def test_cloudflare_spec_tools(self):
+        from aden_tools.credentials import CREDENTIAL_SPECS
+
+        spec = CREDENTIAL_SPECS["cloudflare"]
+        expected = [
+            "cloudflare_list_zones",
+            "cloudflare_get_zone",
+            "cloudflare_list_dns_records",
+            "cloudflare_create_dns_record",
+            "cloudflare_update_dns_record",
+            "cloudflare_delete_dns_record",
+            "cloudflare_purge_cache",
+        ]
+        for tool in expected:
+            assert tool in spec.tools
+        assert len(spec.tools) == 7


### PR DESCRIPTION
## What
Adds a new Cloudflare tool with 7 MCP tools for DNS and cache management.

## Tools Added
- `cloudflare_list_zones` — List all zones in the account
- `cloudflare_get_zone` — Get zone details by ID
- `cloudflare_list_dns_records` — List DNS records for a zone
- `cloudflare_create_dns_record` — Create a new DNS record
- `cloudflare_update_dns_record` — Update an existing DNS record
- `cloudflare_delete_dns_record` — Delete a DNS record
- `cloudflare_purge_cache` — Purge cache (all or specific URLs/tags)

## Supported Record Types
A, AAAA, CNAME, MX, TXT, NS, SRV, CAA, PTR

## Files
- `tools/src/aden_tools/tools/cloudflare_tool/` — Tool implementation + README
- `tools/src/aden_tools/credentials/cloudflare.py` — Credential spec
- `tools/tests/tools/test_cloudflare_tool.py` — 38 tests (all passing)
- Registration in `tools/__init__.py` and `credentials/__init__.py`

## Testing
All 38 tests pass: `uv run pytest tests/tools/test_cloudflare_tool.py -v`