### PR TITLE
fix(config): log when hive config file fails to load

### DIFF
--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -6,12 +6,15 @@ helper functions.
 """
 
 import json
+import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from framework.graph.edge import DEFAULT_MAX_TOKENS
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Low-level config file access
@@ -27,7 +30,8 @@ def get_hive_config() -> dict[str, Any]:
     try:
         with open(HIVE_CONFIG_FILE, encoding="utf-8-sig") as f:
             return json.load(f)
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Failed to load config from %s: %s", HIVE_CONFIG_FILE, e)
         return {}
 
 


### PR DESCRIPTION
When ~/.hive/configuration.json is missing, unreadable, or invalid JSON, get_hive_config() used to return {} with no message. This PR adds a logger.warning in the except block so users see the config path and error when the file can’t be loaded, making misconfigurations easier to debug.
