### PR TITLE
micro-fix: add ty type checking to CI lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
           uv run --project core ruff format --check core/
           uv run --project core ruff format --check tools/
 
+      - name: Type check (ty)
+        continue-on-error: true
+        run: |
+          uv run --project core ty check core/framework/
+
   test:
     name: Test Python Framework
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

- Adds `ty` type checking as a non-blocking step in the CI lint job
- `ty` is already a dev dependency (`ty>=0.0.13`) but was never invoked in CI
- Uses `continue-on-error: true` so diagnostics surface without breaking builds

Closes #5442

## Details

Currently 145 diagnostics exist (58 warnings, 87 errors). Adding this as informational lets the team triage and fix incrementally. Once clean, `continue-on-error` can be removed to enforce type safety.

The step reuses the existing `uv sync --project core --group dev` from the lint job, so no additional install step is needed.

## Test plan

- [x] `ty check core/framework/` runs successfully locally (exits with diagnostics, not crashes)
- [x] `ruff check` passes — no regressions
- [x] `ruff format --check` passes — no regressions
- [x] `pytest tests/ -v` passes — 739 passed, 55 skipped
- [x] YAML indentation verified (no tabs, correct nesting)