### PR TITLE
Fix/consistent default model

### DIFF
--- a/core/framework/agents/hive_coder/config.py
+++ b/core/framework/agents/hive_coder/config.py
@@ -1,28 +1,13 @@
 """Runtime configuration for Hive Coder agent."""
 
-import json
 from dataclasses import dataclass, field
-from pathlib import Path
 
-
-def _load_preferred_model() -> str:
-    """Load preferred model from ~/.hive/configuration.json."""
-    config_path = Path.home() / ".hive" / "configuration.json"
-    if config_path.exists():
-        try:
-            with open(config_path) as f:
-                config = json.load(f)
-            llm = config.get("llm", {})
-            if llm.get("provider") and llm.get("model"):
-                return f"{llm['provider']}/{llm['model']}"
-        except Exception:
-            pass
-    return "anthropic/claude-sonnet-4-20250514"
+from framework.config import get_preferred_model
 
 
 @dataclass
 class RuntimeConfig:
-    model: str = field(default_factory=_load_preferred_model)
+    model: str = field(default_factory=get_preferred_model)
     temperature: float = 0.7
     max_tokens: int = 40000
     api_key: str | None = None

--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -20,6 +20,11 @@ import argparse
 import sys
 from pathlib import Path
 
+# Imported at module level so the --model default is evaluated once,
+# after sys.path has been configured by _configure_paths().
+# (The actual import is deferred into main() to avoid a circular-import
+# chicken-and-egg with _configure_paths; see below.)
+
 
 def _configure_paths():
     """Auto-configure sys.path so agents in exports/ are discoverable.
@@ -67,14 +72,17 @@ def _configure_paths():
 def main():
     _configure_paths()
 
+    # Import here (after _configure_paths) so framework is on sys.path.
+    from framework.config import get_preferred_model
+
     parser = argparse.ArgumentParser(
         prog="hive",
         description="Aden Hive - Build and run goal-driven agents",
     )
     parser.add_argument(
         "--model",
-        default="claude-haiku-4-5-20251001",
-        help="Anthropic model to use",
+        default=get_preferred_model(),
+        help="LLM model to use (default: from ~/.hive/configuration.json, or anthropic/claude-sonnet-4-20250514)",
     )
 
     subparsers = parser.add_subparsers(dest="command", required=True)

--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -82,7 +82,7 @@ def main():
     parser.add_argument(
         "--model",
         default=get_preferred_model(),
-        help="LLM model to use (default: from ~/.hive/configuration.json, or anthropic/claude-sonnet-4-20250514)",
+        help="LLM Model(default:~/.hive/configuration.json, or anthropic/claude-sonnet-4-20250514)",
     )
 
     subparsers = parser.add_subparsers(dest="command", required=True)

--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -14,6 +14,15 @@ from typing import Any
 from framework.graph.edge import DEFAULT_MAX_TOKENS
 
 # ---------------------------------------------------------------------------
+# Canonical default model
+# ---------------------------------------------------------------------------
+
+#: The default LLM model used by every Hive component when no
+#: ~/.hive/configuration.json is present or it contains no ``llm`` block.
+#: Import this constant instead of hard-coding a model string.
+DEFAULT_MODEL: str = "anthropic/claude-sonnet-4-20250514"
+
+# ---------------------------------------------------------------------------
 # Low-level config file access
 # ---------------------------------------------------------------------------
 
@@ -37,11 +46,14 @@ def get_hive_config() -> dict[str, Any]:
 
 
 def get_preferred_model() -> str:
-    """Return the user's preferred LLM model string (e.g. 'anthropic/claude-sonnet-4-20250514')."""
+    """Return the user's preferred LLM model string (e.g. 'anthropic/claude-sonnet-4-20250514').
+
+    Reads ``~/.hive/configuration.json``; falls back to :data:`DEFAULT_MODEL`.
+    """
     llm = get_hive_config().get("llm", {})
     if llm.get("provider") and llm.get("model"):
         return f"{llm['provider']}/{llm['model']}"
-    return "anthropic/claude-sonnet-4-20250514"
+    return DEFAULT_MODEL
 
 
 def get_max_tokens() -> int:


### PR DESCRIPTION
## Description

The CLI --model flag defaulted to claude-haiku-4-5-20251001 while get_preferred_model() fell back to anthropic/claude-sonnet-4-20250514, causing the CLI and runtime to silently use different models when no ~/.hive/configuration.json exists.

- Add DEFAULT_MODEL constant to framework/config.py as single source of truth
- cli.py --model now calls get_preferred_model() instead of hardcoding a string
- hive_coder/config.py drops its duplicate _load_preferred_model() and delegates to the shared get_preferred_model()

## Type of Change

- [✅ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #5417

## Changes Made

- Add DEFAULT_MODEL constant to framework/config.py as single source of truth
- cli.py --model now calls get_preferred_model() instead of hardcoding a string
- hive_coder/config.py drops its duplicate _load_preferred_model() and delegates to the shared get_preferred_model()

## Testing

Describe the tests you ran to verify your changes:

- [✅ ] Unit tests pass (`cd core && pytest tests/`)
- [✅ ] Lint passes (`cd core && ruff check .`)
- [ ✅] Manual testing performed

## Checklist

- [✅ ] My code follows the project's style guidelines
- [✅ ] I have performed a self-review of my code
- [ ✅] I have commented my code, particularly in hard-to-understand areas
- [✅ ] I have made corresponding changes to the documentation
- [✅ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [✅ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
