### PR TITLE
fix(credentials): remove plaintext encryption key from log output

### DIFF
--- a/core/framework/credentials/storage.py
+++ b/core/framework/credentials/storage.py
@@ -155,8 +155,10 @@ class EncryptedFileStorage(CredentialStorage):
                 # Generate new key
                 self._key = Fernet.generate_key()
                 logger.warning(
-                    f"Generated new encryption key. To persist credentials across restarts, "
-                    f"set {key_env_var}={self._key.decode()}"
+                    "Generated new encryption key. Credentials will not persist across "
+                    "restarts until %s is set. Run 'hive setup-credentials' or export "
+                    "the key from this session's credential store.",
+                    key_env_var,
                 )
 
         self._fernet = Fernet(self._key)


### PR DESCRIPTION
## Summary

- Removes raw Fernet encryption key from `logger.warning()` output in `EncryptedFileStorage.__init__()`
- Replaces with a setup instruction that doesn't leak secret material

Closes #5449

## Problem

When `HIVE_CREDENTIAL_KEY` is not set, the constructor logs the full key:

```
set HIVE_CREDENTIAL_KEY=bQS7RzVL2xCI3OVcuu_lzLJ-rkbN2pWOu42dslOQxhE=
```

This exposes the key in application logs, enabling decryption of all stored credentials.

## Verification

**Before (vulnerability confirmed):**
```
$ python -c "from framework.credentials.storage import EncryptedFileStorage; EncryptedFileStorage('/tmp/test')"
framework.credentials.storage: Generated new encryption key. To persist credentials across restarts, set HIVE_CREDENTIAL_KEY=bQS7RzVL2xCI3OVcuu_lzLJ-rkbN2pWOu42dslOQxhE=
```

**After (key removed from output):**
```
framework.credentials.storage: Generated new encryption key. Credentials will not persist across restarts until HIVE_CREDENTIAL_KEY is set. Run 'hive setup-credentials' or export the key from this session's credential store.
```

## Test plan

- [x] Verified key no longer appears in log output
- [x] Verified credential save/load/exists/list_all still works with generated key
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] Full test suite: 739 passed, 55 skipped, 0 failures