### PR TITLE
fix(config): log warning when hive config file fails to load [micro-fix]

### DIFF
--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -6,6 +6,7 @@ helper functions.
 """
 
 import json
+import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -13,6 +14,7 @@ from typing import Any
 
 from framework.graph.edge import DEFAULT_MAX_TOKENS
 
+logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Low-level config file access
 # ---------------------------------------------------------------------------
@@ -27,7 +29,8 @@ def get_hive_config() -> dict[str, Any]:
     try:
         with open(HIVE_CONFIG_FILE, encoding="utf-8-sig") as f:
             return json.load(f)
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Failed to load config from %s: %s", HIVE_CONFIG_FILE, e)
         return {}
 
 


### PR DESCRIPTION
## Description
When `~/.hive/configuration.json` is missing, unreadable, or contains invalid 
JSON, `get_hive_config()` silently returned `{}` with no warning. This made it 
hard to debug why user settings weren't being applied. This fix adds a logger 
warning that includes the config file path and the underlying error.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
Fixes #5440

## Changes Made
- Added `import logging` to imports
- Added `logger = logging.getLogger(__name__)`
- Updated `except (json.JSONDecodeError, OSError)` to capture exception as `e`
- Added `logger.warning()` call in the except block before returning `{}`

## Testing
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed — verified warning appears when config file 
      contains invalid JSON (missing closing brace) and when file is unreadable

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings