### PR TITLE
micro-fix: fix wrong credential path and env var in docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,8 +66,8 @@ export EXA_API_KEY="..."
 # Run agents without LLM calls (structure-only validation)
 export MOCK_MODE=1
 
-# Custom credentials storage path (default: ~/.aden/credentials)
-export ADEN_CREDENTIALS_PATH="/custom/path"
+# Encryption key for credential store (default: ~/.hive/credentials)
+export HIVE_CREDENTIAL_KEY="your-fernet-key"
 
 # Custom agent storage path (default: /tmp)
 export AGENT_STORAGE_PATH="/custom/storage"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,7 +66,7 @@ export EXA_API_KEY="..."
 # Run agents without LLM calls (structure-only validation)
 export MOCK_MODE=1
 
-# Encryption key for credential store (default: ~/.hive/credentials)
+# Fernet encryption key for credential store at ~/.hive/credentials
 export HIVE_CREDENTIAL_KEY="your-fernet-key"
 
 # Custom agent storage path (default: /tmp)

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -521,7 +521,7 @@ export ANTHROPIC_API_KEY="sk-ant-..."
 ### Optional Configuration
 
 ```bash
-# Encryption key for credential store (default: ~/.hive/credentials)
+# Fernet encryption key for credential store at ~/.hive/credentials
 export HIVE_CREDENTIAL_KEY="your-fernet-key"
 
 # Agent storage location (default: /tmp)

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -521,8 +521,8 @@ export ANTHROPIC_API_KEY="sk-ant-..."
 ### Optional Configuration
 
 ```bash
-# Credentials storage location (default: ~/.aden/credentials)
-export ADEN_CREDENTIALS_PATH="/custom/path"
+# Encryption key for credential store (default: ~/.hive/credentials)
+export HIVE_CREDENTIAL_KEY="your-fernet-key"
 
 # Agent storage location (default: /tmp)
 export AGENT_STORAGE_PATH="/custom/storage"


### PR DESCRIPTION
Closes #5460

## Summary

- **docs/configuration.md line 69-70** and **docs/environment-setup.md line 524-525** both reference a non-existent `ADEN_CREDENTIALS_PATH` env var and wrong default path `~/.aden/credentials`.
- The actual env var is `HIVE_CREDENTIAL_KEY` (a Fernet encryption key) and the default credential storage path is `~/.hive/credentials`.

## Proof

- `ADEN_CREDENTIALS_PATH` appears nowhere in the Python codebase — only in these two docs files.
- `EncryptedFileStorage.DEFAULT_PATH` is defined as `"~/.hive/credentials"` in `core/framework/credentials/storage.py:119`.
- The encryption key env var is `HIVE_CREDENTIAL_KEY` per `storage.py:125`, `setup.py:250-300`, and `validation.py:24`.

## Changes

2 files changed, 4 insertions, 4 deletions — documentation only.