### PR TITLE
fix: warn users not to use uvx hive tui (closes #5444)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Use Hive when you need:
 > Hive uses a `uv` workspace layout and is not installed with `pip install`.
 > Running `pip install -e .` from the repository root will create a placeholder package and Hive will not function correctly.
 > Please use the quickstart script below to set up the environment.
+>
+> **Warning:** Do **not** run `uvx hive tui`. The name `hive` on PyPI belongs to an unrelated C extension package (EdgeDB's `memhive`), which will fail to compile with `fatal error: errormech.h: No such file or directory`. After running `./quickstart.sh`, use the `hive` CLI symlink installed in `~/.local/bin` directly: `hive tui`.
 
 ```bash
 # Clone the repository

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -1323,6 +1323,9 @@ else
     echo -e "  You can start an example agent or an agent built by yourself:"
     echo -e "     ${CYAN}hive tui${NC}"
     echo ""
+    echo -e "${YELLOW}  Note:${NC} Run ${CYAN}hive tui${NC} directly — do ${BOLD}not${NC} use ${CYAN}uvx hive tui${NC}."
+    echo -e "  ${DIM}('hive' on PyPI is an unrelated EdgeDB package that fails to build)${NC}"
+    echo ""
     echo -e "${DIM}Run ./quickstart.sh again to reconfigure.${NC}"
     echo ""
 fi


### PR DESCRIPTION
`uvx hive tui` fails with `fatal error: errormech.h: No such file or directory` because the name `hive` on PyPI belongs to EdgeDB's unrelated `memhive` C extension package. When users run `uvx hive`, they download EdgeDB's package instead of this framework, and its C extension fails to build due to a missing header file in the source distribution.

This PR adds explicit warnings in both the README and quickstart completion screen to prevent users from making this mistake.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #5444

## Changes Made

- `README.md`: Extended the existing installation `Note` block with an explicit warning that `uvx hive tui` resolves to EdgeDB's `memhive` PyPI package (not this project) and redirects users to the correct command: `hive tui`
- `quickstart.sh`: Added the same warning to the post-setup success screen, directly after the `hive tui` instruction, so users are immediately informed at the point of confusion

## Testing

- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed — confirmed `hive tui` works correctly after `./quickstart.sh`; confirmed `uvx hive tui` reproduces the `errormech.h` build error without this warning

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if applicable)

**Before** — no warning, users hit the build error silently:
```
hive tui
```

**After** — quickstart now prints:
```
hive tui

Note: Run hive tui directly — do not use uvx hive tui.
('hive' on PyPI is an unrelated EdgeDB package that fails to build)
```