### PR TITLE
feat(runtime): introduce deterministic execution tracing (opt-in)

### DIFF
--- a/core/framework/runtime/execution_trace.py
+++ b/core/framework/runtime/execution_trace.py
@@ -1,0 +1,385 @@
+"""Structured execution tracing for runtime-level observability.
+
+Execution Intelligence (Phase 1) captures runtime behavior as hierarchical spans
+that can be serialized and later replayed (Phase 2).
+
+Key guarantees:
+- Ordered span capture with deterministic serialization
+- Explicit parent-child relationships
+- Exception-aware status transitions
+- Provider-agnostic instrumentation (LLM + tools)
+"""
+
+from __future__ import annotations
+
+import inspect
+import threading
+import datetime as dt
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any, Literal
+from uuid import UUID, uuid4
+
+from framework.llm.provider import LLMProvider
+
+
+SpanStatus = Literal["success", "error", "running"]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(dt.UTC)
+
+
+@dataclass(slots=True)
+class ExecutionSpan:
+    """A single execution unit within an :class:`ExecutionTrace`.
+
+    Purpose:
+        Represent one observable runtime operation (for example, graph execution,
+        node execution, LLM call, or tool call).
+
+    Lifecycle:
+        1. Created with ``status="running"`` and ``start_time``.
+        2. Closed by the trace context manager with ``end_time``.
+        3. Finalized as ``"success"`` or ``"error"``.
+
+    Status semantics:
+        - ``running``: span has started but not finished.
+        - ``success``: span completed without exception.
+        - ``error``: span completed with exception or explicit error marking.
+    """
+
+    id: UUID = field(default_factory=uuid4)
+    parent_id: UUID | None = None
+    name: str = ""
+    start_time: datetime = field(default_factory=_utcnow)
+    end_time: datetime | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    status: SpanStatus = "running"
+    _order_index: int = field(default=0, repr=False, compare=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": str(self.id),
+            "parent_id": str(self.parent_id) if self.parent_id else None,
+            "name": self.name,
+            "start_time": self.start_time.isoformat(),
+            "end_time": self.end_time.isoformat() if self.end_time else None,
+            "metadata": dict(self.metadata),
+            "status": self.status,
+        }
+
+
+class _SpanContext:
+    """Sync/async context manager that records a span lifecycle."""
+
+    __slots__ = ("_trace", "_name", "_metadata", "_token", "_span")
+
+    def __init__(
+        self,
+        trace: ExecutionTrace,
+        name: str,
+        metadata: dict[str, Any] | None,
+    ) -> None:
+        self._trace = trace
+        self._name = name
+        self._metadata = metadata or {}
+        self._token: Token[tuple[UUID, ...]] | None = None
+        self._span: ExecutionSpan | None = None
+
+    def __enter__(self) -> ExecutionSpan:
+        self._span, self._token = self._trace._start_span(self._name, self._metadata)
+        return self._span
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+        if self._span is not None:
+            self._trace._finish_span(self._span, self._token, exc)
+        return False
+
+    async def __aenter__(self) -> ExecutionSpan:
+        return self.__enter__()
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+        return self.__exit__(exc_type, exc, tb)
+
+
+class ExecutionTrace:
+    """In-memory execution trace with deterministic ordering.
+
+    Purpose:
+        Collect structured span data for observability, debugging, and replay
+        preparation without relying on global mutable state.
+
+    Lifecycle:
+        1. Create one trace per runtime execution.
+        2. Open nested spans via ``trace.span(...)``.
+        3. Serialize via :meth:`to_dict` and persist as execution artifact.
+
+    Deterministic ordering guarantee:
+        Spans are assigned a monotonic insertion index at creation time under
+        lock. ``to_dict()`` serializes spans by this index, producing stable,
+        deterministic output ordering independent of dictionary iteration order.
+    """
+
+    def __init__(self, metadata: dict[str, Any] | None = None) -> None:
+        self.id: UUID = uuid4()
+        self.created_at: datetime = _utcnow()
+        self.metadata: dict[str, Any] = metadata or {}
+        self._lock = threading.Lock()
+        self._spans: dict[UUID, ExecutionSpan] = {}
+        self._ordered_span_ids: list[UUID] = []
+        self._children: dict[UUID | None, list[UUID]] = {None: []}
+        self._next_order = 0
+        self._span_stack: ContextVar[tuple[UUID, ...]] = ContextVar(
+            "execution_trace_stack",
+            default=(),
+        )
+
+    def span(self, name: str, metadata: dict[str, Any] | None = None) -> _SpanContext:
+        return _SpanContext(self, name=name, metadata=metadata)
+
+    def _start_span(
+        self,
+        name: str,
+        metadata: dict[str, Any],
+    ) -> tuple[ExecutionSpan, Token[tuple[UUID, ...]]]:
+        parent_stack = self._span_stack.get()
+        parent_id = parent_stack[-1] if parent_stack else None
+        span = ExecutionSpan(
+            parent_id=parent_id,
+            name=name,
+            metadata=dict(metadata),
+        )
+
+        with self._lock:
+            span._order_index = self._next_order
+            self._next_order += 1
+            self._spans[span.id] = span
+            self._ordered_span_ids.append(span.id)
+            self._children.setdefault(parent_id, []).append(span.id)
+            self._children.setdefault(span.id, [])
+
+        token = self._span_stack.set((*parent_stack, span.id))
+        return span, token
+
+    def _finish_span(
+        self,
+        span: ExecutionSpan,
+        token: Token[tuple[UUID, ...]] | None,
+        exc: BaseException | None,
+    ) -> None:
+        if exc is not None:
+            span.status = "error"
+            span.metadata.setdefault("exception_type", type(exc).__name__)
+            span.metadata.setdefault("exception_message", str(exc))
+        elif span.status == "running":
+            span.status = "success"
+
+        end_time = _utcnow()
+        if end_time <= span.start_time:
+            end_time = span.start_time + timedelta(microseconds=1)
+        span.end_time = end_time
+        if token is not None:
+            self._span_stack.reset(token)
+
+    @property
+    def spans(self) -> list[ExecutionSpan]:
+        with self._lock:
+            return [self._spans[span_id] for span_id in self._ordered_span_ids]
+
+    def children(self, span_id: UUID | None) -> list[ExecutionSpan]:
+        with self._lock:
+            child_ids = list(self._children.get(span_id, []))
+            return [self._spans[cid] for cid in child_ids]
+
+    def to_dict(self) -> dict[str, Any]:
+        ordered_spans = sorted(self.spans, key=lambda span: span._order_index)
+        return {
+            "id": str(self.id),
+            "created_at": self.created_at.isoformat(),
+            "metadata": dict(self.metadata),
+            "spans": [span.to_dict() for span in ordered_spans],
+        }
+
+    def replay(self, *_: Any, **__: Any) -> None:
+        """Phase 2 will replay traces against runtime state transitions."""
+        raise NotImplementedError("Execution trace replay is planned for Phase 2.")
+
+
+class TracingLLMProvider(LLMProvider):
+    """Provider-agnostic LLM wrapper that emits execution spans."""
+
+    def __init__(self, provider: LLMProvider, trace: ExecutionTrace) -> None:
+        self._provider = provider
+        self._trace = trace
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(self._provider, item)
+
+    def complete(
+        self,
+        messages: list[dict[str, Any]],
+        system: str = "",
+        tools: list[Any] | None = None,
+        max_tokens: int = 1024,
+        response_format: dict[str, Any] | None = None,
+        json_mode: bool = False,
+        max_retries: int | None = None,
+    ) -> Any:
+        with self._trace.span(
+            "llm_call",
+            {
+                "method": "complete",
+                "message_count": len(messages),
+                "tool_count": len(tools or []),
+                "max_tokens": max_tokens,
+                "json_mode": json_mode,
+            },
+        ):
+            return self._provider.complete(
+                messages=messages,
+                system=system,
+                tools=tools,
+                max_tokens=max_tokens,
+                response_format=response_format,
+                json_mode=json_mode,
+                max_retries=max_retries,
+            )
+
+    def complete_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        system: str,
+        tools: list[Any],
+        tool_executor: Any,
+        max_iterations: int = 10,
+    ) -> Any:
+        with self._trace.span(
+            "llm_call",
+            {
+                "method": "complete_with_tools",
+                "message_count": len(messages),
+                "tool_count": len(tools),
+                "max_iterations": max_iterations,
+            },
+        ):
+            return self._provider.complete_with_tools(
+                messages=messages,
+                system=system,
+                tools=tools,
+                tool_executor=tool_executor,
+                max_iterations=max_iterations,
+            )
+
+    async def acomplete(
+        self,
+        messages: list[dict[str, Any]],
+        system: str = "",
+        tools: list[Any] | None = None,
+        max_tokens: int = 1024,
+        response_format: dict[str, Any] | None = None,
+        json_mode: bool = False,
+        max_retries: int | None = None,
+    ) -> Any:
+        with self._trace.span(
+            "llm_call",
+            {
+                "method": "acomplete",
+                "message_count": len(messages),
+                "tool_count": len(tools or []),
+                "max_tokens": max_tokens,
+                "json_mode": json_mode,
+            },
+        ):
+            return await self._provider.acomplete(
+                messages=messages,
+                system=system,
+                tools=tools,
+                max_tokens=max_tokens,
+                response_format=response_format,
+                json_mode=json_mode,
+                max_retries=max_retries,
+            )
+
+    async def acomplete_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        system: str,
+        tools: list[Any],
+        tool_executor: Any,
+        max_iterations: int = 10,
+    ) -> Any:
+        with self._trace.span(
+            "llm_call",
+            {
+                "method": "acomplete_with_tools",
+                "message_count": len(messages),
+                "tool_count": len(tools),
+                "max_iterations": max_iterations,
+            },
+        ):
+            return await self._provider.acomplete_with_tools(
+                messages=messages,
+                system=system,
+                tools=tools,
+                tool_executor=tool_executor,
+                max_iterations=max_iterations,
+            )
+
+    async def stream(
+        self,
+        messages: list[dict[str, Any]],
+        system: str = "",
+        tools: list[Any] | None = None,
+        max_tokens: int = 4096,
+    ):
+        async with self._trace.span(
+            "llm_call",
+            {
+                "method": "stream",
+                "message_count": len(messages),
+                "tool_count": len(tools or []),
+                "max_tokens": max_tokens,
+            },
+        ):
+            async for event in self._provider.stream(
+                messages=messages,
+                system=system,
+                tools=tools,
+                max_tokens=max_tokens,
+            ):
+                yield event
+
+
+def wrap_llm_provider(llm: LLMProvider | None, trace: ExecutionTrace | None) -> LLMProvider | None:
+    if llm is None or trace is None:
+        return llm
+    if isinstance(llm, TracingLLMProvider):
+        return llm
+    return TracingLLMProvider(provider=llm, trace=trace)
+
+
+def wrap_tool_executor(tool_executor: Any, trace: ExecutionTrace | None):
+    if tool_executor is None or trace is None:
+        return tool_executor
+
+    async def _traced_tool_executor(tool_use: Any):
+        with trace.span(
+            "tool_execution",
+            {
+                "tool_name": getattr(tool_use, "name", "unknown"),
+                "tool_use_id": getattr(tool_use, "id", ""),
+            },
+        ) as tool_span:
+            result = tool_executor(tool_use)
+            if inspect.isawaitable(result):
+                result = await result
+
+            if getattr(result, "is_error", False):
+                tool_span.status = "error"
+                tool_span.metadata["tool_error"] = getattr(result, "content", "")
+
+            return result
+
+    return _traced_tool_executor

--- a/core/framework/runtime/tests/test_execution_trace.py
+++ b/core/framework/runtime/tests/test_execution_trace.py
@@ -1,0 +1,49 @@
+import pytest
+
+from framework.runtime.execution_trace import ExecutionTrace
+
+
+def test_span_nesting_parent_child_relationships():
+    trace = ExecutionTrace()
+
+    with trace.span("root") as root_span:
+        with trace.span("child") as child_span:
+            assert child_span.parent_id == root_span.id
+
+    spans = trace.spans
+    assert len(spans) == 2
+
+    root_children = trace.children(root_span.id)
+    assert len(root_children) == 1
+    assert root_children[0].id == child_span.id
+
+
+def test_span_ordering_is_deterministic():
+    trace = ExecutionTrace()
+
+    with trace.span("first"):
+        pass
+    with trace.span("second"):
+        pass
+    with trace.span("third"):
+        pass
+
+    payload = trace.to_dict()
+    ordered_names = [span["name"] for span in payload["spans"]]
+    assert ordered_names == ["first", "second", "third"]
+
+
+def test_span_exception_sets_error_status_and_metadata():
+    trace = ExecutionTrace()
+
+    with pytest.raises(ValueError):
+        with trace.span("fails"):
+            raise ValueError("boom")
+
+    payload = trace.to_dict()
+    assert len(payload["spans"]) == 1
+
+    span = payload["spans"][0]
+    assert span["status"] == "error"
+    assert span["metadata"]["exception_type"] == "ValueError"
+    assert span["metadata"]["exception_message"] == "boom"

--- a/core/tests/test_execution_trace_integration.py
+++ b/core/tests/test_execution_trace_integration.py
@@ -1,0 +1,152 @@
+"""Integration tests for Execution Intelligence runtime wiring."""
+
+import asyncio
+import json
+from datetime import datetime
+
+import pytest
+
+from framework.graph.edge import GraphSpec
+from framework.graph.goal import Goal
+from framework.graph.node import NodeSpec
+from framework.llm.mock import MockLLMProvider
+from framework.runtime.agent_runtime import AgentRuntime, AgentRuntimeConfig
+from framework.runtime.execution_stream import EntryPointSpec
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _build_minimal_graph() -> GraphSpec:
+    node = NodeSpec(
+        id="single",
+        name="Single Node",
+        description="Single-node deterministic test graph",
+        node_type="event_loop",
+        input_keys=["prompt"],
+        output_keys=[],
+        system_prompt="Reply briefly.",
+        max_retries=0,
+    )
+
+    return GraphSpec(
+        id="trace-int-graph",
+        goal_id="trace-int-goal",
+        version="1.0.0",
+        entry_node="single",
+        entry_points={"start": "single"},
+        terminal_nodes=["single"],
+        pause_nodes=[],
+        nodes=[node],
+        edges=[],
+        max_steps=5,
+        max_tokens=128,
+    )
+
+
+def _build_goal() -> Goal:
+    return Goal(
+        id="trace-int-goal",
+        name="Trace Integration Goal",
+        description="Validate execution trace integration end-to-end",
+    )
+
+
+async def _run_runtime_once(tmp_path, monkeypatch=None, force_node_exception: bool = False):
+    graph = _build_minimal_graph()
+    goal = _build_goal()
+
+    if force_node_exception:
+        from framework.graph.event_loop_node import EventLoopNode
+
+        async def _failing_execute(self, ctx):
+            raise RuntimeError("forced-node-error")
+
+        monkeypatch.setattr(EventLoopNode, "execute", _failing_execute)
+
+    runtime = AgentRuntime(
+        graph=graph,
+        goal=goal,
+        storage_path=tmp_path,
+        llm=MockLLMProvider(),
+        config=AgentRuntimeConfig(enable_execution_trace=True),
+    )
+
+    runtime.register_entry_point(
+        EntryPointSpec(
+            id="manual",
+            name="Manual",
+            entry_node="single",
+            trigger_type="manual",
+        )
+    )
+
+    await runtime.start()
+    try:
+        execution_id = await runtime.trigger("manual", {"prompt": "hello"})
+        stream = runtime.get_stream("manual")
+        assert stream is not None
+        result = await stream.wait_for_completion(execution_id, timeout=5)
+        assert result is not None
+        return execution_id, result.success
+    finally:
+        await runtime.stop()
+
+
+def _load_trace_payload(tmp_path, execution_id: str) -> dict:
+    trace_path = tmp_path / "sessions" / execution_id / "execution_trace.json"
+    assert trace_path.exists(), f"Trace file missing: {trace_path}"
+    return json.loads(trace_path.read_text(encoding="utf-8"))
+
+
+def _parse_iso(ts: str) -> datetime:
+    return datetime.fromisoformat(ts)
+
+
+def test_execution_trace_integration_success(tmp_path):
+    execution_id, was_success = _run(_run_runtime_once(tmp_path))
+    assert was_success is True
+
+    payload = _load_trace_payload(tmp_path, execution_id)
+
+    assert isinstance(payload.get("execution_id"), str)
+    assert payload["execution_id"] == execution_id
+    assert isinstance(payload.get("spans"), list)
+
+    spans = payload["spans"]
+    assert spans, "Expected at least one span"
+
+    root_spans = [s for s in spans if s["parent_id"] is None]
+    assert len(root_spans) == 1
+    graph_span = root_spans[0]
+    assert graph_span["name"] == "graph_execution"
+
+    node_spans = [s for s in spans if s["name"] == "node_execution"]
+    assert len(node_spans) == 1
+    node_span = node_spans[0]
+    assert node_span["parent_id"] == graph_span["id"]
+
+    llm_spans = [s for s in spans if s["name"] == "llm_call"]
+    assert len(llm_spans) >= 1
+    assert any(s["parent_id"] == node_span["id"] for s in llm_spans)
+
+    for span in spans:
+        assert span["status"] == "success"
+        assert _parse_iso(span["start_time"]) < _parse_iso(span["end_time"])
+
+
+def test_execution_trace_integration_failure_sets_error_status(tmp_path, monkeypatch):
+    execution_id, was_success = _run(
+        _run_runtime_once(tmp_path, monkeypatch=monkeypatch, force_node_exception=True)
+    )
+    assert was_success is False
+
+    payload = _load_trace_payload(tmp_path, execution_id)
+    spans = payload["spans"]
+
+    node_spans = [s for s in spans if s["name"] == "node_execution"]
+    assert len(node_spans) == 1
+    assert node_spans[0]["status"] == "error"
+
+    assert any(s["status"] == "error" for s in spans)

--- a/docs/execution_intelligence.md
+++ b/docs/execution_intelligence.md
@@ -1,0 +1,61 @@
+# Execution Intelligence
+
+Execution Intelligence introduces structured runtime tracing for agent executions.
+
+## Phase 1 Overview
+
+Phase 1 adds a lightweight `ExecutionTrace` system that records:
+
+- Graph execution spans
+- Per-node execution spans
+- LLM call spans (provider-agnostic)
+- Tool execution spans
+
+Each span includes:
+
+- `id` (uuid)
+- `parent_id` (optional)
+- `name`
+- `start_time`
+- `end_time`
+- `metadata`
+- `status` (`running`, `success`, `error`)
+
+Traces are persisted to:
+
+- `sessions/<execution_id>/execution_trace.json`
+
+This artifact is deterministic and replay-ready (Phase 2 stub).
+
+## Configuration
+
+Execution tracing is opt-in and disabled by default:
+
+```python
+from framework.runtime.agent_runtime import AgentRuntimeConfig
+
+config = AgentRuntimeConfig(
+    enable_execution_trace=True,
+)
+```
+
+When `enable_execution_trace=False`, runtime behavior remains unchanged and does not allocate trace wrappers.
+
+## Runtime Integration
+
+Tracing is integrated at runtime boundaries without changing public APIs:
+
+- `framework.runtime.execution_stream.ExecutionStream`
+  - Creates per-execution trace instances
+  - Wraps LLM providers and tool executors only when enabled
+  - Persists trace artifacts at execution completion
+
+- `framework.graph.executor.GraphExecutor`
+  - Records node execution spans for each node step
+
+## Design Notes
+
+- No global trace state is used.
+- Trace nesting relies on `contextvars` and works in async execution.
+- Serialization uses deterministic insertion ordering for stable replay input.
+- Replay entrypoint is present (`ExecutionTrace.replay`) and intentionally deferred to Phase 2.


### PR DESCRIPTION
Description

This PR introduces a deterministic execution tracing layer to the runtime.

It provides structured, hierarchical span tracing for:

graph_execution

node_execution

llm_call

tool_execution

Tracing is fully opt-in via enable_execution_trace flag in AgentRuntime. Default behavior remains unchanged.

No breaking changes.

Why

Enables runtime-level observability without affecting existing execution paths

Produces deterministic, JSON-serializable traces

Designed for future replay / execution intelligence capabilities

Zero overhead when disabled

What’s Included

ExecutionTrace and ExecutionSpan implementation

Deterministic parent-child span model

Error-aware span lifecycle

Trace persistence to sessions/<execution_id>/execution_trace.json

Unit tests for:

nesting correctness

deterministic ordering

exception capture

Integration test verifying persisted trace structure

Backward Compatibility

Default tracing flag is disabled

No existing API contracts changed

No modifications to runtime behavior when tracing is off

Tests

Executed locally:

pytest test_execution_trace.py -q
pytest test_execution_trace_integration.py -q

All tests passing.