### PR TITLE
test: fix internal DeprecationWarnings for legacy run_ids

### DIFF
--- a/core/framework/runtime/runtime_logger.py
+++ b/core/framework/runtime/runtime_logger.py
@@ -69,7 +69,7 @@ class RuntimeLogger:
         else:
             ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
             short_uuid = uuid.uuid4().hex[:8]
-            self._run_id = f"{ts}_{short_uuid}"
+            self._run_id = f"session_{ts}_{short_uuid}"
 
         self._goal_id = goal_id
         self._started_at = datetime.now(UTC).isoformat()


### PR DESCRIPTION
## **Description**

This **PR** fixes internal **`DeprecationWarnings`** emitted during the test suite execution. The 🐍 **`RuntimeLogStore`** expects 🐍 **`run_id`**s to follow the new **`session_*`** convention (e.g., **`session_{YYYYMMDD}_{HHMMSS}_{uuid}`**) and warns when old directory formats are accessed. Many tests in 🐍 **`core/tests/test_runtime_logger.py`** were using legacy hardcoded mocks like **`run_ok`** or **`test_run_1`**.

Additionally, while fixing the mock IDs, I updated **`RuntimeLogger.start_run()`** to natively generate 🐍 **`run_id`**s with the **`session_`** prefix by default, removing the warnings originating from dynamically generated instances.

## **Type of Change**

- [x] **Bug fix (non-breaking change that fixes an issue - `micro-fix`)**

## **Changes Made**

* Replaced hard-coded 🐍 **`run_id`** mocks in 🐍 **`test_runtime_logger.py`** with **`session_*`** equivalents.
* Updated path assertions in 🐍 **`test_runtime_logger.py`** to check the **`sessions/.../logs`** directory instead of the deprecated 🐍 **`runs/`** directory.
* Updated **`RuntimeLogger.start_run()`** to construct default IDs using the **`session_{ts}_{uuid}`** format.

## **Testing**

- [x] **Unit tests pass (`make test`) -> `DeprecationWarning`s for 🐍 `run_id` usage eliminated.**
- [x] **Lint passes (`make check`)**

## **Checklist**

- [x] **My code follows the project's style guidelines**
- [x] **I have performed a self-review of my code**
- [x] **My changes generate no new warnings**