### PR TITLE
fix: moved pytest dependencies from prod to dev

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -12,9 +12,6 @@ dependencies = [
   "mcp>=1.0.0",
   "fastmcp>=2.0.0",
   "textual>=1.0.0",
-  "pytest>=8.0",
-  "pytest-asyncio>=0.23",
-  "pytest-xdist>=3.0",
   "tools",
 ]
 
@@ -63,4 +60,10 @@ lint.isort.section-order = [
 ]
 
 [dependency-groups]
-dev = ["ty>=0.0.13", "ruff>=0.14.14"]
+dev = [
+  "ty>=0.0.13",
+  "ruff>=0.14.14",
+  "pytest>=8.0",
+  "pytest-asyncio>=0.23",
+  "pytest-xdist>=3.0",
+]


### PR DESCRIPTION
## Description

- moved pytest dependencies from prod to dev env in `core/pyproject.toml`
- These are test-only tools and should not be installed in production environments.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #5482 

## Changes Made

- Removed `pytest>=8.0`, `pytest-asyncio>=0.23`, and `pytest-xdist>=3.0` from the `dependencies` block
- Added all three to the `[dependency-groups] dev` section

## Testing

Describe the tests you ran to verify your changes:

- [X] Unit tests pass (`cd core && pytest tests/`)
- [X] Lint passes (`cd core && ruff check .`)
- [X] Manual testing performed

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
