### PR TITLE
Improve indirect variable expansion in quickstart.sh

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -845,7 +845,8 @@ PROVIDER_MENU_ENVS=(ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY GROQ_API_KEY
 PROVIDER_MENU_NAMES=("Anthropic (Claude) - Recommended" "OpenAI (GPT)" "Google Gemini - Free tier available" "Groq - Fast, free tier" "Cerebras - Fast, free tier")
 for idx in 0 1 2 3 4; do
     num=$((idx + 4))
-    if [ -n "${!PROVIDER_MENU_ENVS[$idx]}" ]; then
+    env_var="${PROVIDER_MENU_ENVS[$idx]}"
+    if [ -n "${!env_var}" ]; then
         echo -e "  ${CYAN}$num)${NC} ${PROVIDER_MENU_NAMES[$idx]}  ${GREEN}(credential detected)${NC}"
     else
         echo -e "  ${CYAN}$num)${NC} ${PROVIDER_MENU_NAMES[$idx]}"


### PR DESCRIPTION
This updates the provider API key detection logic
to use a temporary variable for indirect expansion:

env_var="${PROVIDER_MENU_ENVS[$idx]}"
if [ -n "${!env_var}" ]; then

This improves clarity and robustness while preserving behavior.
<img width="1809" height="701" alt="Screenshot 2026-02-28 102345" src="https://github.com/user-attachments/assets/b19fe7cf-b338-421b-bb1f-11cb4637da0d" />

