### PR TITLE
feat(template): Discord Community Digest agent

### DIFF
--- a/examples/templates/discord_digest/README.md
+++ b/examples/templates/discord_digest/README.md
@@ -1,0 +1,110 @@
+# Discord Community Digest
+
+**Version**: 1.0.0
+**Type**: Multi-node agent
+
+## Overview
+
+Monitor Discord servers, categorize messages by priority, and deliver an actionable summary as a Discord DM. Built for open-source contributors and community managers who need to stay on top of Discord without checking it constantly.
+
+## Architecture
+
+### Execution Flow
+
+```
+configure → scan-channels → generate-digest
+```
+
+### Nodes
+
+1. **configure** (client-facing) — Captures user preferences: servers, channels, lookback window, keywords, and Discord user ID for DM delivery.
+2. **scan-channels** — Pulls messages from target channels, filters by time range, flags mentions/keywords/admin posts. Uses per-channel cursors for incremental fetching.
+3. **generate-digest** — Summarizes flagged messages into 4 categories and delivers as a Discord DM.
+
+### Digest Categories
+
+- **Action Needed** — @mentions, direct replies, questions addressed to you
+- **Interesting Threads** — active discussions matching keywords or with high engagement
+- **Announcements** — admin/moderator posts, roadmap updates, new releases
+- **FYI** — everything else worth knowing
+
+## Setup
+
+### 1. Create a Discord Bot
+
+1. Go to https://discord.com/developers/applications
+2. Create a new application
+3. Go to **Bot** → **Add Bot**
+4. Copy the bot token
+5. Go to **OAuth2** → **URL Generator**
+   - Scopes: `bot`
+   - Permissions: `Send Messages`, `Read Message History`, `View Channels`
+6. Use the generated URL to invite the bot to your server(s)
+
+### 2. Configure Credentials
+
+```bash
+export DISCORD_BOT_TOKEN="your-bot-token-here"
+```
+
+Or configure via the Hive credential store.
+
+### 3. Configure Hive LLM
+
+Make sure you have a model configured in `~/.hive/configuration.json` (run `hive quickstart` if you haven't already).
+
+## Usage
+
+### First Run
+
+```bash
+cd examples/templates
+python -m discord_digest run
+```
+
+The agent will ask for your preferences (servers, channels, keywords, user ID) and save them for future runs.
+
+### Subsequent Runs
+
+```bash
+python -m discord_digest run
+```
+
+Uses saved configuration and cursors — only fetches new messages since the last run.
+
+### Reconfigure
+
+```bash
+python -m discord_digest run --reconfigure
+```
+
+### Other Commands
+
+```bash
+python -m discord_digest info       # Show agent metadata
+python -m discord_digest validate   # Check agent structure
+python -m discord_digest tui        # Launch TUI dashboard
+python -m discord_digest shell      # Interactive CLI session
+```
+
+### Scheduling (cron)
+
+```bash
+# Run every day at 8 PM
+0 20 * * * cd /path/to/hive/examples/templates && DISCORD_BOT_TOKEN="..." python -m discord_digest run -q
+```
+
+## Dedup / Incremental Fetching
+
+The agent tracks a per-channel cursor (`cursors.json`) storing the last-processed message ID. On subsequent runs, it uses Discord's `after` parameter to only fetch messages newer than the cursor — no repeated items across runs.
+
+Cursors are stored at `~/.hive/discord_digest/cursors.json`.
+
+## Required Tools
+
+| Tool | Node | Purpose |
+|------|------|---------|
+| `discord_list_guilds` | scan-channels | Enumerate servers the bot has access to |
+| `discord_list_channels` | scan-channels | List text channels in each server |
+| `discord_get_messages` | scan-channels | Fetch recent messages with pagination |
+| `discord_send_message` | generate-digest | Deliver digest as a DM to the user |

--- a/examples/templates/discord_digest/__init__.py
+++ b/examples/templates/discord_digest/__init__.py
@@ -1,0 +1,23 @@
+"""
+Discord Community Digest - Monitor Discord servers and deliver actionable summaries.
+
+Scans Discord servers, categorizes messages by priority, and delivers
+a digest as a Discord DM so you know what needs your attention.
+"""
+
+from .agent import DiscordDigestAgent, default_agent, goal, nodes, edges
+from .config import RuntimeConfig, AgentMetadata, default_config, metadata
+
+__version__ = "1.0.0"
+
+__all__ = [
+    "DiscordDigestAgent",
+    "default_agent",
+    "goal",
+    "nodes",
+    "edges",
+    "RuntimeConfig",
+    "AgentMetadata",
+    "default_config",
+    "metadata",
+]

--- a/examples/templates/discord_digest/__main__.py
+++ b/examples/templates/discord_digest/__main__.py
@@ -1,0 +1,288 @@
+"""
+CLI entry point for Discord Community Digest.
+
+Uses AgentRuntime for multi-entrypoint support with HITL pause/resume.
+"""
+
+import asyncio
+import json
+import logging
+import sys
+import click
+
+from .agent import default_agent, DiscordDigestAgent
+
+
+def setup_logging(verbose=False, debug=False):
+    """Configure logging for execution visibility."""
+    if debug:
+        level, fmt = logging.DEBUG, "%(asctime)s %(name)s: %(message)s"
+    elif verbose:
+        level, fmt = logging.INFO, "%(message)s"
+    else:
+        level, fmt = logging.WARNING, "%(levelname)s: %(message)s"
+    logging.basicConfig(level=level, format=fmt, stream=sys.stderr)
+    logging.getLogger("framework").setLevel(level)
+
+
+@click.group()
+@click.version_option(version="1.0.0")
+def cli():
+    """Discord Community Digest - Monitor Discord and get actionable summaries."""
+    pass
+
+
+@cli.command()
+@click.option("--quiet", "-q", is_flag=True, help="Only output result JSON")
+@click.option("--verbose", "-v", is_flag=True, help="Show execution details")
+@click.option("--debug", is_flag=True, help="Show debug logging")
+@click.option("--reconfigure", is_flag=True, help="Force re-run of configure step")
+def run(quiet, verbose, debug, reconfigure):
+    """Execute the Discord digest agent."""
+    if not quiet:
+        setup_logging(verbose=verbose, debug=debug)
+
+    from pathlib import Path
+    from .config import load_user_config, save_user_config
+    from .cursor import read_cursors, save_cursors, update_cursors
+
+    storage_path = Path.home() / ".hive" / "discord_digest"
+    context = {}
+
+    # Load saved config if available (skip configure node)
+    if not reconfigure:
+        saved = load_user_config(storage_path)
+        if saved:
+            config_dict = {
+                "servers": saved.servers,
+                "channels": saved.channels,
+                "lookback_days": saved.lookback_days,
+                "keywords": saved.keywords,
+                "user_id": saved.user_id,
+            }
+            # Inject cursors for dedup
+            cursors = read_cursors(storage_path)
+            if cursors:
+                config_dict["cursors"] = cursors
+            context["digest_config"] = json.dumps(config_dict)
+
+    result = asyncio.run(default_agent.run(context))
+
+    # Save cursors on success
+    if result.success and result.output:
+        channel_data = result.output.get("channel_data")
+        if channel_data:
+            try:
+                data = (
+                    json.loads(channel_data)
+                    if isinstance(channel_data, str)
+                    else channel_data
+                )
+                new_cursors = data.get("new_cursors", {})
+                if new_cursors:
+                    existing = read_cursors(storage_path)
+                    merged = update_cursors(existing, new_cursors)
+                    save_cursors(merged, storage_path)
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        # Save user config if it came from configure node
+        digest_config = result.output.get("digest_config")
+        if digest_config:
+            try:
+                data = (
+                    json.loads(digest_config)
+                    if isinstance(digest_config, str)
+                    else digest_config
+                )
+                from .config import UserConfig
+
+                save_user_config(
+                    UserConfig(
+                        servers=data.get("servers", ["all"]),
+                        channels=data.get("channels", ["all"]),
+                        lookback_days=data.get("lookback_days", 3),
+                        keywords=data.get("keywords", []),
+                        user_id=data.get("user_id", ""),
+                    ),
+                    storage_path,
+                )
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+    output_data = {
+        "success": result.success,
+        "steps_executed": result.steps_executed,
+        "output": result.output,
+    }
+    if result.error:
+        output_data["error"] = result.error
+
+    click.echo(json.dumps(output_data, indent=2, default=str))
+    sys.exit(0 if result.success else 1)
+
+
+@cli.command()
+@click.option("--verbose", "-v", is_flag=True, help="Show execution details")
+@click.option("--debug", is_flag=True, help="Show debug logging")
+def tui(verbose, debug):
+    """Launch the TUI dashboard for interactive digest management."""
+    setup_logging(verbose=verbose, debug=debug)
+
+    try:
+        from framework.tui.app import AdenTUI
+    except ImportError:
+        click.echo(
+            "TUI requires the 'textual' package. Install with: pip install textual"
+        )
+        sys.exit(1)
+
+    from pathlib import Path
+
+    from framework.llm import LiteLLMProvider
+    from framework.runner.tool_registry import ToolRegistry
+    from framework.runtime.agent_runtime import create_agent_runtime
+    from framework.runtime.event_bus import EventBus
+    from framework.runtime.execution_stream import EntryPointSpec
+
+    async def run_with_tui():
+        agent = DiscordDigestAgent()
+
+        agent._event_bus = EventBus()
+        agent._tool_registry = ToolRegistry()
+
+        storage_path = Path.home() / ".hive" / "agents" / "discord_digest"
+        storage_path.mkdir(parents=True, exist_ok=True)
+
+        mcp_config_path = Path(__file__).parent / "mcp_servers.json"
+        if mcp_config_path.exists():
+            agent._tool_registry.load_mcp_config(mcp_config_path)
+
+        llm = LiteLLMProvider(
+            model=agent.config.model,
+            api_key=agent.config.api_key,
+            api_base=agent.config.api_base,
+        )
+
+        tools = list(agent._tool_registry.get_tools().values())
+        tool_executor = agent._tool_registry.get_executor()
+        graph = agent._build_graph()
+
+        runtime = create_agent_runtime(
+            graph=graph,
+            goal=agent.goal,
+            storage_path=storage_path,
+            entry_points=[
+                EntryPointSpec(
+                    id="start",
+                    name="Start Digest",
+                    entry_node="configure",
+                    trigger_type="manual",
+                    isolation_level="isolated",
+                ),
+            ],
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor,
+        )
+
+        await runtime.start()
+
+        try:
+            app = AdenTUI(runtime)
+            await app.run_async()
+        finally:
+            await runtime.stop()
+
+    asyncio.run(run_with_tui())
+
+
+@cli.command()
+@click.option("--json", "output_json", is_flag=True)
+def info(output_json):
+    """Show agent information."""
+    info_data = default_agent.info()
+    if output_json:
+        click.echo(json.dumps(info_data, indent=2))
+    else:
+        click.echo(f"Agent: {info_data['name']}")
+        click.echo(f"Version: {info_data['version']}")
+        click.echo(f"Description: {info_data['description']}")
+        click.echo(f"\nNodes: {', '.join(info_data['nodes'])}")
+        click.echo(f"Client-facing: {', '.join(info_data['client_facing_nodes'])}")
+        click.echo(f"Entry: {info_data['entry_node']}")
+        click.echo(f"Terminal: {', '.join(info_data['terminal_nodes'])}")
+
+
+@cli.command()
+def validate():
+    """Validate agent structure."""
+    validation = default_agent.validate()
+    if validation["valid"]:
+        click.echo("Agent is valid")
+        if validation["warnings"]:
+            for warning in validation["warnings"]:
+                click.echo(f"  WARNING: {warning}")
+    else:
+        click.echo("Agent has errors:")
+        for error in validation["errors"]:
+            click.echo(f"  ERROR: {error}")
+    sys.exit(0 if validation["valid"] else 1)
+
+
+@cli.command()
+@click.option("--verbose", "-v", is_flag=True)
+def shell(verbose):
+    """Interactive Discord digest session (CLI, no TUI)."""
+    asyncio.run(_interactive_shell(verbose))
+
+
+async def _interactive_shell(verbose=False):
+    """Async interactive shell."""
+    setup_logging(verbose=verbose)
+
+    click.echo("=== Discord Community Digest ===")
+    click.echo("Press Enter to generate a digest (or 'quit' to exit):\n")
+
+    agent = DiscordDigestAgent()
+    await agent.start()
+
+    try:
+        while True:
+            try:
+                user_input = await asyncio.get_event_loop().run_in_executor(
+                    None, input, "Digest> "
+                )
+                if user_input.lower() in ["quit", "exit", "q"]:
+                    click.echo("Goodbye!")
+                    break
+
+                click.echo("\nScanning Discord channels...\n")
+
+                result = await agent.trigger_and_wait("start", {})
+
+                if result is None:
+                    click.echo("\n[Execution timed out]\n")
+                    continue
+
+                if result.success:
+                    output = result.output
+                    if "digest_report" in output:
+                        click.echo("\nDigest delivered!\n")
+                else:
+                    click.echo(f"\nFailed: {result.error}\n")
+
+            except KeyboardInterrupt:
+                click.echo("\nGoodbye!")
+                break
+            except Exception as e:
+                click.echo(f"Error: {e}", err=True)
+                import traceback
+
+                traceback.print_exc()
+    finally:
+        await agent.stop()
+
+
+if __name__ == "__main__":
+    cli()

--- a/examples/templates/discord_digest/agent.json
+++ b/examples/templates/discord_digest/agent.json
@@ -1,0 +1,132 @@
+{
+  "agent": {
+    "id": "discord_digest",
+    "name": "Discord Community Digest",
+    "version": "1.0.0",
+    "description": "Monitor Discord servers, categorize messages by priority, and deliver an actionable summary as a Discord DM."
+  },
+  "graph": {
+    "id": "discord-digest-graph",
+    "goal_id": "discord-digest",
+    "version": "1.0.0",
+    "entry_node": "configure",
+    "entry_points": {
+      "start": "configure"
+    },
+    "pause_nodes": [],
+    "terminal_nodes": [
+      "generate-digest"
+    ],
+    "nodes": [
+      {
+        "id": "configure",
+        "name": "Configure Digest",
+        "description": "Capture user preferences: servers, channels, lookback window, keywords, and Discord user ID for DM delivery.",
+        "node_type": "event_loop",
+        "input_keys": [],
+        "output_keys": ["digest_config"],
+        "tools": [],
+        "client_facing": true
+      },
+      {
+        "id": "scan-channels",
+        "name": "Scan Channels",
+        "description": "Pull messages from target Discord channels, filter by time range, and flag important messages.",
+        "node_type": "event_loop",
+        "input_keys": ["digest_config"],
+        "output_keys": ["channel_data"],
+        "tools": ["discord_list_guilds", "discord_list_channels", "discord_get_messages"],
+        "client_facing": false
+      },
+      {
+        "id": "generate-digest",
+        "name": "Generate Digest",
+        "description": "Summarize scanned messages into an actionable digest and deliver as a Discord DM.",
+        "node_type": "event_loop",
+        "input_keys": ["digest_config", "channel_data"],
+        "output_keys": ["digest_report"],
+        "tools": ["discord_send_message"],
+        "client_facing": false
+      }
+    ],
+    "edges": [
+      {
+        "id": "configure-to-scan",
+        "source": "configure",
+        "target": "scan-channels",
+        "condition": "on_success",
+        "priority": 1
+      },
+      {
+        "id": "scan-to-digest",
+        "source": "scan-channels",
+        "target": "generate-digest",
+        "condition": "on_success",
+        "priority": 1
+      }
+    ],
+    "max_steps": 100,
+    "description": "Monitor Discord servers, categorize messages by priority, and deliver an actionable summary as a Discord DM."
+  },
+  "goal": {
+    "id": "discord-digest",
+    "name": "Discord Community Digest",
+    "description": "Monitor Discord servers, categorize messages by priority, and deliver an actionable summary as a Discord DM.",
+    "success_criteria": [
+      {
+        "id": "sc-channels-scanned",
+        "description": "At least 5 channels are scanned for messages",
+        "metric": "channels_scanned",
+        "target": ">=5",
+        "weight": 0.20
+      },
+      {
+        "id": "sc-messages-categorized",
+        "description": "Messages are categorized into action/threads/announcements/fyi",
+        "metric": "messages_categorized",
+        "target": "true",
+        "weight": 0.25
+      },
+      {
+        "id": "sc-digest-delivered",
+        "description": "Digest is delivered as a Discord DM to the user",
+        "metric": "digest_delivered",
+        "target": "true",
+        "weight": 0.30
+      },
+      {
+        "id": "sc-dedup",
+        "description": "Digest does not repeat messages from previous runs",
+        "metric": "dedup_applied",
+        "target": "true",
+        "weight": 0.25
+      }
+    ],
+    "constraints": [
+      {
+        "id": "c-no-spam",
+        "description": "Never send unsolicited messages to other users",
+        "constraint_type": "hard",
+        "category": "safety"
+      },
+      {
+        "id": "c-time-range",
+        "description": "Only scan messages within the configured lookback window",
+        "constraint_type": "hard",
+        "category": "correctness"
+      },
+      {
+        "id": "c-rate-limit",
+        "description": "Respect Discord API rate limits",
+        "constraint_type": "hard",
+        "category": "reliability"
+      }
+    ]
+  },
+  "required_tools": [
+    "discord_list_guilds",
+    "discord_list_channels",
+    "discord_get_messages",
+    "discord_send_message"
+  ]
+}

--- a/examples/templates/discord_digest/agent.py
+++ b/examples/templates/discord_digest/agent.py
@@ -1,0 +1,285 @@
+"""Agent graph construction for Discord Community Digest."""
+
+from framework.graph import EdgeSpec, EdgeCondition, Goal, SuccessCriterion, Constraint
+from framework.graph.edge import GraphSpec
+from framework.graph.executor import ExecutionResult, GraphExecutor
+from framework.runtime.event_bus import EventBus
+from framework.runtime.core import Runtime
+from framework.llm import LiteLLMProvider
+from framework.runner.tool_registry import ToolRegistry
+
+from .config import default_config, metadata
+from .nodes import (
+    configure_node,
+    scan_channels_node,
+    generate_digest_node,
+)
+
+# Goal definition
+goal = Goal(
+    id="discord-digest",
+    name="Discord Community Digest",
+    description=(
+        "Monitor Discord servers, categorize messages by priority, "
+        "and deliver an actionable summary as a Discord DM."
+    ),
+    success_criteria=[
+        SuccessCriterion(
+            id="sc-channels-scanned",
+            description="At least 5 channels are scanned for messages",
+            metric="channels_scanned",
+            target=">=5",
+            weight=0.20,
+        ),
+        SuccessCriterion(
+            id="sc-messages-categorized",
+            description="Messages are categorized into action/threads/announcements/fyi",
+            metric="messages_categorized",
+            target="true",
+            weight=0.25,
+        ),
+        SuccessCriterion(
+            id="sc-digest-delivered",
+            description="Digest is delivered as a Discord DM to the user",
+            metric="digest_delivered",
+            target="true",
+            weight=0.30,
+        ),
+        SuccessCriterion(
+            id="sc-dedup",
+            description="Digest does not repeat messages from previous runs",
+            metric="dedup_applied",
+            target="true",
+            weight=0.25,
+        ),
+    ],
+    constraints=[
+        Constraint(
+            id="c-no-spam",
+            description="Never send unsolicited messages to other users",
+            constraint_type="hard",
+            category="safety",
+        ),
+        Constraint(
+            id="c-time-range",
+            description="Only scan messages within the configured lookback window",
+            constraint_type="hard",
+            category="correctness",
+        ),
+        Constraint(
+            id="c-rate-limit",
+            description="Respect Discord API rate limits",
+            constraint_type="hard",
+            category="reliability",
+        ),
+    ],
+)
+
+# Node list
+nodes = [
+    configure_node,
+    scan_channels_node,
+    generate_digest_node,
+]
+
+# Edge definitions
+edges = [
+    EdgeSpec(
+        id="configure-to-scan",
+        source="configure",
+        target="scan-channels",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+        description="After capturing preferences, scan Discord channels",
+    ),
+    EdgeSpec(
+        id="scan-to-digest",
+        source="scan-channels",
+        target="generate-digest",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+        description="After scanning channels, generate and deliver the digest",
+    ),
+]
+
+# Graph configuration
+entry_node = "configure"
+entry_points = {"start": "configure"}
+pause_nodes = []
+terminal_nodes = ["generate-digest"]
+
+
+class DiscordDigestAgent:
+    """
+    Discord Community Digest — 3-node pipeline.
+
+    Flow: configure -> scan-channels -> generate-digest
+    """
+
+    def __init__(self, config=None):
+        self.config = config or default_config
+        self.goal = goal
+        self.nodes = nodes
+        self.edges = edges
+        self.entry_node = entry_node
+        self.entry_points = entry_points
+        self.pause_nodes = pause_nodes
+        self.terminal_nodes = terminal_nodes
+        self._executor: GraphExecutor | None = None
+        self._graph: GraphSpec | None = None
+        self._event_bus: EventBus | None = None
+        self._tool_registry: ToolRegistry | None = None
+
+    def _build_graph(self) -> GraphSpec:
+        """Build the GraphSpec."""
+        return GraphSpec(
+            id="discord-digest-graph",
+            goal_id=self.goal.id,
+            version="1.0.0",
+            entry_node=self.entry_node,
+            entry_points=self.entry_points,
+            terminal_nodes=self.terminal_nodes,
+            pause_nodes=self.pause_nodes,
+            nodes=self.nodes,
+            edges=self.edges,
+            default_model=self.config.model,
+            max_tokens=self.config.max_tokens,
+            loop_config={
+                "max_iterations": 50,
+                "max_tool_calls_per_turn": 10,
+                "max_history_tokens": 32000,
+            },
+        )
+
+    def _setup(self) -> GraphExecutor:
+        """Set up the executor with all components."""
+        from pathlib import Path
+
+        storage_path = Path.home() / ".hive" / "discord_digest"
+        storage_path.mkdir(parents=True, exist_ok=True)
+
+        self._event_bus = EventBus()
+        self._tool_registry = ToolRegistry()
+
+        mcp_config_path = Path(__file__).parent / "mcp_servers.json"
+        if mcp_config_path.exists():
+            self._tool_registry.load_mcp_config(mcp_config_path)
+
+        llm = LiteLLMProvider(
+            model=self.config.model,
+            api_key=self.config.api_key,
+            api_base=self.config.api_base,
+        )
+
+        tool_executor = self._tool_registry.get_executor()
+        tools = list(self._tool_registry.get_tools().values())
+
+        self._graph = self._build_graph()
+        runtime = Runtime(storage_path)
+
+        self._executor = GraphExecutor(
+            runtime=runtime,
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor,
+            event_bus=self._event_bus,
+            storage_path=storage_path,
+            loop_config=self._graph.loop_config,
+        )
+
+        return self._executor
+
+    async def start(self) -> None:
+        """Set up the agent (initialize executor and tools)."""
+        if self._executor is None:
+            self._setup()
+
+    async def stop(self) -> None:
+        """Clean up resources."""
+        self._executor = None
+        self._event_bus = None
+
+    async def trigger_and_wait(
+        self,
+        entry_point: str,
+        input_data: dict,
+        timeout: float | None = None,
+        session_state: dict | None = None,
+    ) -> ExecutionResult | None:
+        """Execute the graph and wait for completion."""
+        if self._executor is None:
+            raise RuntimeError("Agent not started. Call start() first.")
+        if self._graph is None:
+            raise RuntimeError("Graph not built. Call start() first.")
+
+        return await self._executor.execute(
+            graph=self._graph,
+            goal=self.goal,
+            input_data=input_data,
+            session_state=session_state,
+        )
+
+    async def run(self, context: dict, session_state=None) -> ExecutionResult:
+        """Run the agent (convenience method for single execution)."""
+        await self.start()
+        try:
+            result = await self.trigger_and_wait(
+                "start", context, session_state=session_state
+            )
+            return result or ExecutionResult(success=False, error="Execution timeout")
+        finally:
+            await self.stop()
+
+    def info(self):
+        """Get agent information."""
+        return {
+            "name": metadata.name,
+            "version": metadata.version,
+            "description": metadata.description,
+            "goal": {
+                "name": self.goal.name,
+                "description": self.goal.description,
+            },
+            "nodes": [n.id for n in self.nodes],
+            "edges": [e.id for e in self.edges],
+            "entry_node": self.entry_node,
+            "entry_points": self.entry_points,
+            "pause_nodes": self.pause_nodes,
+            "terminal_nodes": self.terminal_nodes,
+            "client_facing_nodes": [n.id for n in self.nodes if n.client_facing],
+        }
+
+    def validate(self):
+        """Validate agent structure."""
+        errors = []
+        warnings = []
+
+        node_ids = {node.id for node in self.nodes}
+        for edge in self.edges:
+            if edge.source not in node_ids:
+                errors.append(f"Edge {edge.id}: source '{edge.source}' not found")
+            if edge.target not in node_ids:
+                errors.append(f"Edge {edge.id}: target '{edge.target}' not found")
+
+        if self.entry_node not in node_ids:
+            errors.append(f"Entry node '{self.entry_node}' not found")
+
+        for terminal in self.terminal_nodes:
+            if terminal not in node_ids:
+                errors.append(f"Terminal node '{terminal}' not found")
+
+        for ep_id, node_id in self.entry_points.items():
+            if node_id not in node_ids:
+                errors.append(
+                    f"Entry point '{ep_id}' references unknown node '{node_id}'"
+                )
+
+        return {
+            "valid": len(errors) == 0,
+            "errors": errors,
+            "warnings": warnings,
+        }
+
+
+# Create default instance
+default_agent = DiscordDigestAgent()

--- a/examples/templates/discord_digest/config.py
+++ b/examples/templates/discord_digest/config.py
@@ -1,0 +1,77 @@
+"""Runtime configuration for Discord Community Digest."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from framework.config import RuntimeConfig
+
+default_config = RuntimeConfig()
+
+DEFAULT_STORAGE = Path.home() / ".hive" / "discord_digest"
+CONFIG_FILENAME = "config.json"
+
+
+@dataclass
+class AgentMetadata:
+    name: str = "Discord Community Digest"
+    version: str = "1.0.0"
+    description: str = (
+        "Monitor Discord servers, categorize messages by priority, "
+        "and deliver an actionable summary as a Discord DM."
+    )
+    intro_message: str = (
+        "Hi! I'm your Discord digest assistant. I'll scan your Discord servers "
+        "and put together a summary of what needs your attention. "
+        "Let me ask a few questions to get set up."
+    )
+
+
+metadata = AgentMetadata()
+
+
+@dataclass
+class UserConfig:
+    """User preferences for digest generation."""
+
+    servers: list[str] = field(default_factory=lambda: ["all"])
+    channels: list[str] = field(default_factory=lambda: ["all"])
+    lookback_days: int = 3
+    keywords: list[str] = field(
+        default_factory=lambda: ["agent", "integration", "PR", "bug", "release"]
+    )
+    user_id: str = ""
+
+
+def save_user_config(config: UserConfig, storage_path: Path | None = None) -> Path:
+    """Save user config to disk. Returns the path written."""
+    path = (storage_path or DEFAULT_STORAGE) / CONFIG_FILENAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(
+            {
+                "servers": config.servers,
+                "channels": config.channels,
+                "lookback_days": config.lookback_days,
+                "keywords": config.keywords,
+                "user_id": config.user_id,
+            },
+            f,
+            indent=2,
+        )
+    return path
+
+
+def load_user_config(storage_path: Path | None = None) -> UserConfig | None:
+    """Load saved user config from disk. Returns None if not found."""
+    path = (storage_path or DEFAULT_STORAGE) / CONFIG_FILENAME
+    if not path.exists():
+        return None
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        return UserConfig(**data)
+    except (json.JSONDecodeError, TypeError, KeyError):
+        return None

--- a/examples/templates/discord_digest/cursor.py
+++ b/examples/templates/discord_digest/cursor.py
@@ -1,0 +1,58 @@
+"""Cursor management for incremental Discord message fetching.
+
+Stores the last-processed message ID per channel so reruns only
+fetch new messages. Message IDs are Discord snowflakes — higher
+values mean newer messages.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+CURSOR_FILENAME = "cursors.json"
+
+
+def read_cursors(storage_path: Path) -> dict[str, str]:
+    """Load per-channel cursors from disk.
+
+    Returns a dict mapping channel_id -> last_message_id.
+    Returns empty dict if file doesn't exist or is invalid.
+    """
+    path = storage_path / CURSOR_FILENAME
+    if not path.exists():
+        return {}
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return {str(k): str(v) for k, v in data.items()}
+    except (json.JSONDecodeError, OSError):
+        pass
+    return {}
+
+
+def save_cursors(cursors: dict[str, str], storage_path: Path) -> Path:
+    """Save per-channel cursors to disk. Returns the path written."""
+    path = storage_path / CURSOR_FILENAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(cursors, f, indent=2)
+    return path
+
+
+def update_cursors(
+    existing: dict[str, str],
+    new_messages: dict[str, str],
+) -> dict[str, str]:
+    """Merge new high-water marks into existing cursors.
+
+    For each channel, keeps the higher message ID (newer message).
+    Preserves channels in existing that aren't in new_messages.
+    """
+    merged = dict(existing)
+    for channel_id, message_id in new_messages.items():
+        old = merged.get(channel_id)
+        if old is None or int(message_id) > int(old):
+            merged[channel_id] = message_id
+    return merged

--- a/examples/templates/discord_digest/mcp_servers.json
+++ b/examples/templates/discord_digest/mcp_servers.json
@@ -1,0 +1,9 @@
+{
+  "hive-tools": {
+    "transport": "stdio",
+    "command": "uv",
+    "args": ["run", "python", "mcp_server.py", "--stdio"],
+    "cwd": "../../../tools",
+    "description": "Hive tools MCP server providing discord_list_guilds, discord_list_channels, discord_get_messages, discord_send_message"
+  }
+}

--- a/examples/templates/discord_digest/nodes/__init__.py
+++ b/examples/templates/discord_digest/nodes/__init__.py
@@ -1,0 +1,181 @@
+"""Node definitions for Discord Community Digest."""
+
+from framework.graph import NodeSpec
+
+# ---------------------------------------------------------------------------
+# Node 1: Configure digest preferences (client-facing)
+# ---------------------------------------------------------------------------
+configure_node = NodeSpec(
+    id="configure",
+    name="Configure Digest",
+    description=(
+        "Capture user preferences: servers, channels, lookback window, "
+        "keywords, and Discord user ID for DM delivery."
+    ),
+    node_type="event_loop",
+    client_facing=True,
+    input_keys=[],
+    output_keys=["digest_config"],
+    system_prompt="""\
+You are a Discord digest assistant helping the user set up their preferences.
+
+**STEP 1 — Greet and ask the user:**
+Ask the user for:
+1. Which Discord servers to monitor (default: all servers the bot can see)
+2. Which channels to focus on, or "all" for all text channels (default: all)
+3. How many days to look back (default: 3)
+4. Keywords or topics of interest (default: agent, integration, PR, bug, release)
+5. Their Discord user ID — so the bot can DM them the digest
+   (they can find it by enabling Developer Mode in Discord settings,
+   then right-clicking their name and selecting "Copy User ID")
+
+Keep it brief and friendly. If the user already provided preferences in their \
+initial message, acknowledge them.
+
+After your greeting, call ask_user() to wait for the user's response.
+
+**STEP 2 — After the user responds, call set_output:**
+set_output("digest_config", <JSON string>) with this structure:
+{
+  "servers": ["all"],
+  "channels": ["all"],
+  "lookback_days": 3,
+  "keywords": ["agent", "integration", "PR", "bug", "release"],
+  "user_id": "<their Discord user ID>"
+}
+
+If they didn't provide a user ID, ask again — it's required for DM delivery.
+""",
+    tools=[],
+    max_retries=2,
+)
+
+# ---------------------------------------------------------------------------
+# Node 2: Scan Discord channels and collect messages
+# ---------------------------------------------------------------------------
+scan_channels_node = NodeSpec(
+    id="scan-channels",
+    name="Scan Channels",
+    description=(
+        "Pull messages from target Discord channels, "
+        "filter by time range, and flag important messages."
+    ),
+    node_type="event_loop",
+    input_keys=["digest_config"],
+    output_keys=["channel_data"],
+    system_prompt="""\
+You are a Discord channel scanner. Your job is to systematically pull messages \
+from Discord and identify what matters.
+
+Using the digest_config provided, do the following steps IN ORDER:
+
+1. Call discord_list_guilds to get all available servers.
+2. For each target server (or all if "all"), call discord_list_channels to get \
+text channels.
+3. For each channel, call discord_get_messages to fetch recent messages.
+   IMPORTANT: If the digest_config contains a "cursors" object, use the cursor \
+value for each channel as the "after" parameter in discord_get_messages. This \
+ensures you only fetch NEW messages since the last digest run. Example:
+   - cursors: {"123456": "999888777"} means call \
+discord_get_messages(channel_id="123456", after="999888777")
+   - If a channel has no cursor, fetch without the "after" parameter.
+4. Filter messages to only those within the lookback window (lookback_days from config).
+5. For each channel scanned, track the HIGHEST (newest) message ID you see. \
+You will include these as "new_cursors" in your output so the next run picks up \
+where this one left off.
+6. Flag messages that:
+   - @mention the user (check for <@USER_ID> where USER_ID is from config)
+   - Are replies to the user's previous messages
+   - Come from server admins or moderators (check for admin/moderator roles)
+   - Contain any of the configured keywords
+   - Have high engagement (many replies or reactions)
+
+Compile all flagged messages with their channel name, author, content, \
+timestamp, and why they were flagged.
+
+Output the results using set_output("channel_data", <JSON string>) with:
+{
+  "channels_scanned": <number>,
+  "messages": [
+    {
+      "channel": "<channel name>",
+      "channel_id": "<channel id>",
+      "author": "<username>",
+      "content": "<message text>",
+      "timestamp": "<ISO timestamp>",
+      "message_id": "<message id>",
+      "flags": ["mention", "keyword:agent", "admin_post", ...]
+    }
+  ],
+  "new_cursors": {
+    "<channel_id>": "<highest message ID seen>"
+  }
+}
+""",
+    tools=[
+        "discord_list_guilds",
+        "discord_list_channels",
+        "discord_get_messages",
+    ],
+    max_retries=2,
+)
+
+# ---------------------------------------------------------------------------
+# Node 3: Generate and deliver the digest
+# ---------------------------------------------------------------------------
+generate_digest_node = NodeSpec(
+    id="generate-digest",
+    name="Generate Digest",
+    description="Summarize scanned messages into an actionable digest and deliver as a Discord DM.",
+    node_type="event_loop",
+    input_keys=["digest_config", "channel_data"],
+    output_keys=["digest_report"],
+    system_prompt="""\
+You are a digest writer. Take the scanned channel data and produce a clear, \
+actionable summary organized into these categories:
+
+1. **Action Needed** — Messages where someone @mentioned the user, replied to \
+their message, or asked them a direct question. These need a response.
+
+2. **Interesting Threads** — Active discussions matching the user's keywords \
+or with high engagement. Worth reading but no response required.
+
+3. **Announcements** — Posts from admins/moderators, roadmap updates, new \
+releases, or official announcements.
+
+4. **FYI** — Everything else worth knowing, briefly summarized.
+
+Format the digest as a readable message. Keep it concise — each item should \
+be 1-2 lines with the channel name and a brief summary.
+
+If a category has no items, omit it entirely.
+
+**Delivery:**
+1. First, get the user's Discord user ID from digest_config.
+2. Call discord_send_message to DM the user. To DM a user, send to the DM \
+channel. The bot needs to create a DM channel first — but since \
+discord_send_message can send to any channel ID, you should note the user_id \
+for delivery.
+3. If the digest is longer than 2000 characters (Discord's limit), split it \
+into multiple messages — send one per category.
+
+After sending, store the full digest text using:
+set_output("digest_report", "<the full digest text>")
+""",
+    tools=["discord_send_message"],
+    max_retries=2,
+)
+
+# All nodes for easy import
+all_nodes = [
+    configure_node,
+    scan_channels_node,
+    generate_digest_node,
+]
+
+__all__ = [
+    "configure_node",
+    "scan_channels_node",
+    "generate_digest_node",
+    "all_nodes",
+]


### PR DESCRIPTION
## Summary

- First agent template using the Discord tool integration (#4247)
- 3-node pipeline: `configure → scan-channels → generate-digest`
- Scans Discord servers, categorizes messages by priority (Action Needed / Interesting / Announcements / FYI), and delivers an actionable digest as a Discord DM
- Per-channel cursor dedup so reruns only fetch new messages
- Uses only existing tools: `discord_list_guilds`, `discord_list_channels`, `discord_get_messages`, `discord_send_message`
- Single credential: `DISCORD_BOT_TOKEN`

## Test plan

- [ ] Unit tests for config save/load
- [ ] Unit tests for cursor read/save/update
- [ ] Unit tests for node definitions and graph wiring
- [ ] Unit tests for agent class (info, validate)
- [ ] End-to-end test with mocked Discord API

Closes #5342