### PR TITLE
fix(runtime): add croniter dependency and fix timer drift

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "mcp>=1.0.0",
   "fastmcp>=2.0.0",
   "textual>=1.0.0",
+  "croniter>=1.4.0",
   "pytest>=8.0",
   "pytest-asyncio>=0.23",
   "pytest-xdist>=3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -795,6 +795,7 @@ version = "0.5.1"
 source = { editable = "core" }
 dependencies = [
     { name = "anthropic" },
+    { name = "croniter" },
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "litellm" },
@@ -829,6 +830,7 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'server'", specifier = ">=3.9.0" },
     { name = "aiohttp", marker = "extra == 'webhook'", specifier = ">=3.9.0" },
     { name = "anthropic", specifier = ">=0.40.0" },
+    { name = "croniter", specifier = ">=1.4.0" },
     { name = "fastmcp", specifier = ">=2.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "litellm", specifier = ">=1.81.0" },


### PR DESCRIPTION
Added 'croniter>=1.4.0' to core/pyproject.toml to resolve the silent ImportError that caused timer entry points to be skipped. Refactored the cron timer loop to use a single datetime.now() per iteration, eliminating slight timing drift.
Replaced local imports with a top-level import to ensure failure is loud.

Refs #5353

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
