### PR TITLE
fix: move pytest dependencies to dev group and fix lint

### DIFF
--- a/core/framework/storage/checkpoint_store.py
+++ b/core/framework/storage/checkpoint_store.py
@@ -95,7 +95,9 @@ class CheckpointStore:
                 return None
 
             try:
-                return Checkpoint.model_validate_json(checkpoint_path.read_text(encoding="utf-8"))
+                return Checkpoint.model_validate_json(
+                    checkpoint_path.read_text(encoding="utf-8")
+                )
             except Exception as e:
                 logger.error(f"Failed to load checkpoint {checkpoint_id}: {e}")
                 return None
@@ -123,7 +125,9 @@ class CheckpointStore:
                 return None
 
             try:
-                return CheckpointIndex.model_validate_json(self.index_path.read_text(encoding="utf-8"))
+                return CheckpointIndex.model_validate_json(
+                    self.index_path.read_text(encoding="utf-8")
+                )
             except Exception as e:
                 logger.error(f"Failed to load checkpoint index: {e}")
                 return None
@@ -153,7 +157,9 @@ class CheckpointStore:
 
         # Apply filters
         if checkpoint_type:
-            checkpoints = [cp for cp in checkpoints if cp.checkpoint_type == checkpoint_type]
+            checkpoints = [
+                cp for cp in checkpoints if cp.checkpoint_type == checkpoint_type
+            ]
 
         if is_clean is not None:
             checkpoints = [cp for cp in checkpoints if cp.is_clean == is_clean]
@@ -233,7 +239,9 @@ class CheckpointStore:
                 deleted_count += 1
 
         if deleted_count > 0:
-            logger.info(f"Pruned {deleted_count} checkpoints older than {max_age_days} days")
+            logger.info(
+                f"Pruned {deleted_count} checkpoints older than {max_age_days} days"
+            )
 
         return deleted_count
 
@@ -308,7 +316,9 @@ class CheckpointStore:
             return
 
         # Remove checkpoint from index
-        index.checkpoints = [cp for cp in index.checkpoints if cp.checkpoint_id != checkpoint_id]
+        index.checkpoints = [
+            cp for cp in index.checkpoints if cp.checkpoint_id != checkpoint_id
+        ]
 
         # Update totals
         index.total_checkpoints = len(index.checkpoints)

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -12,9 +12,6 @@ dependencies = [
   "mcp>=1.0.0",
   "fastmcp>=2.0.0",
   "textual>=1.0.0",
-  "pytest>=8.0",
-  "pytest-asyncio>=0.23",
-  "pytest-xdist>=3.0",
   "tools",
 ]
 
@@ -63,4 +60,10 @@ lint.isort.section-order = [
 ]
 
 [dependency-groups]
-dev = ["ty>=0.0.13", "ruff>=0.14.14"]
+dev = [
+  "ty>=0.0.13",
+  "ruff>=0.14.14",
+  "pytest>=8.0",
+  "pytest-asyncio>=0.23",
+  "pytest-xdist>=3.0",
+]


### PR DESCRIPTION
- Moved pytest, pytest-asyncio, and pytest-xdist to [dependency-groups] dev in core/pyproject.toml to prevent production install bloat.
- Fixed E501 line too long in core/framework/storage/checkpoint_store.py.

Fixes #1

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
