### PR TITLE
feat(rss-twitter): migrate Playwright agent to v0.6 template layout

### DIFF
--- a/examples/template/rss_twitter_agent/run.py
+++ b/examples/template/rss_twitter_agent/run.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+"""Backward-compatible wrapper to run the v0.6 RSS template package."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "core"))
+sys.path.insert(0, str(REPO_ROOT / "examples" / "templates"))
+
+from rss_twitter_agent.run import run_interactive  # noqa: E402
+
+
+if __name__ == "__main__":
+    result = asyncio.run(run_interactive())
+    print(json.dumps(result, indent=2, default=str))

--- a/examples/templates/rss_twitter_agent/README.md
+++ b/examples/templates/rss_twitter_agent/README.md
@@ -1,0 +1,53 @@
+# RSS-to-Twitter Agent (Playwright)
+
+This template keeps the original behavior:
+
+1. Fetch RSS news
+2. Summarize with Ollama
+3. Ask you `y/n/q` per thread
+4. If `y`, auto-open Twitter/X and post via Playwright
+
+Updated for Hive v0.6+ project layout and credential namespace support.
+
+## Run
+
+From repo root:
+
+```bash
+cd /Users/vasu/Desktop/hive
+export PYTHONPATH=core:examples/templates
+
+python -m rss_twitter_agent run \
+  --feed-url "https://news.ycombinator.com/rss" \
+  --max-articles 3
+```
+
+Optional credential ref (v0.6 format):
+
+```bash
+python -m rss_twitter_agent run \
+  --feed-url "https://news.ycombinator.com/rss" \
+  --max-articles 3 \
+  --twitter-credential-ref twitter/default
+```
+
+## Validate / Info
+
+```bash
+python -m rss_twitter_agent validate
+python -m rss_twitter_agent info
+```
+
+## Ollama prerequisites
+
+```bash
+ollama serve
+ollama pull llama3.2
+```
+
+## Behavior notes
+
+- First posting run opens browser login and stores session.
+- Later runs reuse session automatically.
+- You can override session path with `HIVE_TWITTER_SESSION_DIR`.
+- Credential reference uses `{name}/{alias}` (example: `twitter/default`).

--- a/examples/templates/rss_twitter_agent/__init__.py
+++ b/examples/templates/rss_twitter_agent/__init__.py
@@ -1,0 +1,5 @@
+"""RSS-to-Twitter Playwright agent (Hive v0.6-compatible package)."""
+
+from .agent import RSSTwitterAgent, default_agent
+
+__all__ = ["RSSTwitterAgent", "default_agent"]

--- a/examples/templates/rss_twitter_agent/__main__.py
+++ b/examples/templates/rss_twitter_agent/__main__.py
@@ -1,0 +1,72 @@
+"""CLI for RSS-to-Twitter Playwright agent."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+
+import click
+
+from .agent import default_agent
+from .run import run_interactive
+
+
+@click.group()
+@click.version_option(version="1.1.0")
+def cli() -> None:
+    """RSS-to-Twitter Playwright agent."""
+
+
+@cli.command()
+@click.option("--feed-url", default="https://news.ycombinator.com/rss", show_default=True)
+@click.option("--max-articles", default=3, show_default=True, type=int)
+@click.option(
+    "--twitter-credential-ref",
+    default=None,
+    help="Hive credential reference in {name}/{alias} format (example: twitter/default).",
+)
+def run(feed_url: str, max_articles: int, twitter_credential_ref: str | None) -> None:
+    """Run the interactive RSS -> summarize -> approve -> post flow."""
+    summary = asyncio.run(
+        run_interactive(
+            feed_url=feed_url,
+            max_articles=max_articles,
+            twitter_credential_ref=twitter_credential_ref,
+        )
+    )
+    click.echo(json.dumps(summary, indent=2, default=str))
+    sys.exit(0)
+
+
+@cli.command()
+def validate() -> None:
+    """Validate basic graph structure metadata."""
+    result = default_agent.validate()
+    if result["valid"]:
+        click.echo("Agent is valid")
+        return
+    click.echo("Agent has errors:")
+    for err in result["errors"]:
+        click.echo(f"  ERROR: {err}")
+    sys.exit(1)
+
+
+@cli.command()
+@click.option("--json", "output_json", is_flag=True)
+def info(output_json: bool) -> None:
+    """Show agent metadata."""
+    data = default_agent.info()
+    if output_json:
+        click.echo(json.dumps(data, indent=2))
+        return
+    click.echo(f"Agent: {data['name']}")
+    click.echo(f"Version: {data['version']}")
+    click.echo(f"Description: {data['description']}")
+    click.echo(f"Nodes: {', '.join(data['nodes'])}")
+    click.echo(f"Entry: {data['entry_node']}")
+    click.echo(f"Terminal: {', '.join(data['terminal_nodes'])}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/examples/templates/rss_twitter_agent/agent.py
+++ b/examples/templates/rss_twitter_agent/agent.py
@@ -1,0 +1,174 @@
+"""Agent metadata + simple execution wrapper for RSS-to-Twitter Playwright flow."""
+
+from __future__ import annotations
+
+from framework.graph import Constraint, EdgeCondition, EdgeSpec, Goal, SuccessCriterion
+from framework.graph.executor import ExecutionResult
+
+from .config import metadata, validate_ollama
+from .fetch import approve_threads, fetch_rss, generate_tweets, post_to_twitter, summarize_articles
+from .nodes import approve_node, fetch_node, generate_node, post_node, process_node
+
+
+goal = Goal(
+    id="rss-to-twitter",
+    name="RSS-to-Twitter Content Repurposing",
+    description=(
+        "Fetch articles from RSS feeds, summarize them, generate engaging Twitter threads, "
+        "ask for explicit user approval, and post approved threads via Playwright."
+    ),
+    success_criteria=[
+        SuccessCriterion(
+            id="feed-parsing",
+            description="Agent fetches and parses at least one feed item",
+            metric="article_count",
+            target=">=1",
+            weight=0.3,
+        ),
+        SuccessCriterion(
+            id="thread-quality",
+            description="Generated threads contain structured tweets with CTA and link",
+            metric="thread_count",
+            target=">=1",
+            weight=0.35,
+        ),
+        SuccessCriterion(
+            id="approval-gate",
+            description="User explicitly approves/rejects each thread",
+            metric="approval_present",
+            target="true",
+            weight=0.2,
+        ),
+        SuccessCriterion(
+            id="posting",
+            description="Approved threads are posted through Playwright",
+            metric="post_success",
+            target="true when approved",
+            weight=0.15,
+        ),
+    ],
+    constraints=[
+        Constraint(
+            id="human-approval-required",
+            description="Posting requires explicit human y/n decision",
+            constraint_type="safety",
+            category="approval",
+        ),
+        Constraint(
+            id="source-attribution",
+            description="Threads should include source links",
+            constraint_type="quality",
+            category="content",
+        ),
+    ],
+)
+
+nodes = [fetch_node, process_node, generate_node, approve_node, post_node]
+edges = [
+    EdgeSpec(
+        id="fetch-to-process",
+        source="fetch",
+        target="process",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="process-to-generate",
+        source="process",
+        target="generate",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="generate-to-approve",
+        source="generate",
+        target="approve",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="approve-to-post",
+        source="approve",
+        target="post",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+]
+
+entry_node = "fetch"
+entry_points = {"start": "fetch"}
+terminal_nodes = ["post"]
+
+
+class RSSTwitterAgent:
+    """Lightweight wrapper preserving the original interactive Playwright workflow."""
+
+    def __init__(self):
+        self.goal = goal
+        self.nodes = nodes
+        self.edges = edges
+        self.entry_node = entry_node
+        self.entry_points = entry_points
+        self.terminal_nodes = terminal_nodes
+
+    async def start(self) -> None:
+        ok, msg = validate_ollama()
+        if not ok:
+            raise RuntimeError(msg)
+
+    async def stop(self) -> None:
+        return None
+
+    async def trigger_and_wait(self, entry_point: str, input_data: dict, timeout: float | None = None) -> ExecutionResult:
+        feed_url = str(input_data.get("feed_url") or "https://news.ycombinator.com/rss")
+        max_articles = int(input_data.get("max_articles") or 3)
+        articles_json = fetch_rss(feed_url=feed_url, max_articles=max_articles)
+        processed_json = summarize_articles(articles_json)
+        threads_json = generate_tweets(processed_json)
+        approved_json = approve_threads(threads_json)
+        results_json = await post_to_twitter(approved_json)
+
+        return ExecutionResult(
+            success=True,
+            output={
+                "articles_json": articles_json,
+                "processed_json": processed_json,
+                "threads_json": threads_json,
+                "approved_json": approved_json,
+                "results_json": results_json,
+            },
+            steps_executed=5,
+        )
+
+    async def run(self, context: dict) -> ExecutionResult:
+        await self.start()
+        try:
+            return await self.trigger_and_wait("start", context)
+        finally:
+            await self.stop()
+
+    def info(self) -> dict:
+        return {
+            "name": metadata.name,
+            "version": metadata.version,
+            "description": metadata.description,
+            "goal": {"name": self.goal.name, "description": self.goal.description},
+            "nodes": [n.id for n in self.nodes],
+            "entry_node": self.entry_node,
+            "terminal_nodes": self.terminal_nodes,
+        }
+
+    def validate(self) -> dict:
+        errors: list[str] = []
+        node_ids = {n.id for n in self.nodes}
+        if self.entry_node not in node_ids:
+            errors.append(f"Entry node '{self.entry_node}' not found")
+        for edge in self.edges:
+            if edge.source not in node_ids:
+                errors.append(f"Edge {edge.id}: source '{edge.source}' not found")
+            if edge.target not in node_ids:
+                errors.append(f"Edge {edge.id}: target '{edge.target}' not found")
+        return {"valid": not errors, "errors": errors, "warnings": []}
+
+
+default_agent = RSSTwitterAgent()

--- a/examples/templates/rss_twitter_agent/config.py
+++ b/examples/templates/rss_twitter_agent/config.py
@@ -1,0 +1,59 @@
+"""Runtime configuration for RSS-to-Twitter Agent with Ollama."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+import httpx
+
+OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434")
+DEFAULT_MODEL = os.environ.get("LLM_MODEL", "ollama/llama3.2")
+
+
+def _check_ollama_running() -> bool:
+    """Check if Ollama is running locally."""
+    try:
+        with httpx.Client() as client:
+            resp = client.get(f"{OLLAMA_URL}/api/tags", timeout=2.0)
+            return resp.status_code == 200
+    except Exception:
+        return False
+
+
+def _get_model() -> str:
+    return DEFAULT_MODEL
+
+
+@dataclass
+class RuntimeConfig:
+    model: str = field(default_factory=_get_model)
+    temperature: float = 0.7
+    max_tokens: int = 8000
+    api_key: str | None = os.environ.get("LLM_API_KEY")
+    api_base: str | None = os.environ.get("LLM_API_BASE")
+
+
+default_config = RuntimeConfig()
+
+
+@dataclass
+class AgentMetadata:
+    name: str = "RSS-to-Twitter Agent"
+    version: str = "1.1.0"
+    description: str = (
+        "Automated content repurposing from RSS feeds to Twitter threads. "
+        "Uses Ollama for local LLM inference and Playwright for automated posting."
+    )
+
+
+metadata = AgentMetadata()
+
+
+def validate_ollama() -> tuple[bool, str]:
+    if not _check_ollama_running():
+        return (
+            False,
+            "Ollama is not running. Start it with `ollama serve` and ensure your model is pulled.",
+        )
+    return True, ""

--- a/examples/templates/rss_twitter_agent/credentials.py
+++ b/examples/templates/rss_twitter_agent/credentials.py
@@ -1,0 +1,57 @@
+"""Credential helpers for RSS Twitter Playwright agent (Hive v0.6+)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def _extract_session_dir(payload: Any) -> str | None:
+    if isinstance(payload, dict):
+        for key in (
+            "session_dir",
+            "user_data_dir",
+            "twitter_session_dir",
+            "playwright_user_data_dir",
+            "path",
+            "value",
+        ):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    elif isinstance(payload, str):
+        raw = payload.strip()
+        if not raw:
+            return None
+        if raw.startswith("{"):
+            try:
+                obj = json.loads(raw)
+                return _extract_session_dir(obj)
+            except json.JSONDecodeError:
+                return None
+        return raw
+    return None
+
+
+def resolve_twitter_session_dir(credential_ref: str | None = None) -> str:
+    """Resolve session dir from env first, then Hive credential store."""
+    env_dir = os.environ.get("HIVE_TWITTER_SESSION_DIR")
+    if env_dir:
+        return str(Path(env_dir).expanduser())
+
+    ref = credential_ref or os.environ.get("TWITTER_CREDENTIAL_REF")
+    if ref and "/" in ref:
+        try:
+            from framework.credentials.store import CredentialStore
+
+            store = CredentialStore.with_encrypted_storage(Path.home() / ".hive" / "credentials")
+            value = store.get(ref)
+            resolved = _extract_session_dir(value)
+            if resolved:
+                return str(Path(resolved).expanduser())
+        except Exception:
+            pass
+
+    return str(Path.home() / ".hive" / "twitter_session")

--- a/examples/templates/rss_twitter_agent/fetch.py
+++ b/examples/templates/rss_twitter_agent/fetch.py
@@ -1,0 +1,241 @@
+"""RSS fetch + LLM summarization + approval + post helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import xml.etree.ElementTree as ET
+
+import httpx
+
+
+def fetch_rss(feed_url: str = "https://news.ycombinator.com/rss", max_articles: int = 3) -> str:
+    """Fetch RSS feed and return parsed articles as JSON string."""
+    try:
+        with httpx.Client() as client:
+            resp = client.get(feed_url, timeout=10.0, follow_redirects=True)
+            resp.raise_for_status()
+            xml_content = resp.text
+    except Exception:
+        return json.dumps([])
+
+    try:
+        root = ET.fromstring(xml_content)
+    except ET.ParseError:
+        return json.dumps([])
+
+    articles = []
+    for item in root.findall(".//item")[:max_articles]:
+        title_elem = item.find("title")
+        link_elem = item.find("link")
+        desc_elem = item.find("description")
+
+        article = {
+            "title": title_elem.text if title_elem is not None else "",
+            "link": link_elem.text if link_elem is not None else "",
+            "summary": (
+                desc_elem.text[:150] if desc_elem is not None and desc_elem.text else ""
+            ),
+            "source": "Hacker News",
+        }
+        articles.append(article)
+
+    return json.dumps(articles)
+
+
+def _call_ollama(prompt: str, max_tokens: int = 800) -> str:
+    """Call Ollama API directly via HTTP."""
+    model = os.environ.get("OLLAMA_MODEL", "llama3.2")
+    try:
+        with httpx.Client() as client:
+            resp = client.post(
+                "http://localhost:11434/api/generate",
+                json={
+                    "model": model,
+                    "prompt": prompt,
+                    "stream": False,
+                    "options": {"num_predict": max_tokens, "temperature": 0.75},
+                },
+                timeout=90.0,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("response", "[]")
+    except Exception as e:
+        print(f"Ollama error: {e}")
+        return "[]"
+
+
+def summarize_articles(articles_json: str) -> str:
+    """Summarize articles into rich tweet-ready format using Ollama."""
+    articles = json.loads(articles_json) if articles_json else []
+    if not articles:
+        return json.dumps([])
+
+    prompt = f"""You are a tech journalist. For each article below, extract rich context for Twitter threads.
+Return ONLY a JSON array — one object per article — with this exact format:
+[
+  {{
+    "title": "article title",
+    "url": "article url",
+    "hook": "one punchy sentence that grabs attention — a surprising fact, bold claim, or question",
+    "points": ["key insight 1", "key insight 2", "key insight 3"],
+    "why_it_matters": "one sentence on why this is important or interesting",
+    "hashtags": ["#Tag1", "#Tag2", "#Tag3"]
+  }}
+]
+
+Articles:
+{json.dumps(articles, indent=2)}
+
+Return ONLY the JSON array, no other text:"""
+
+    text = _call_ollama(prompt, 900)
+
+    start = text.find("[")
+    end = text.rfind("]") + 1
+    if start >= 0 and end > start:
+        try:
+            parsed = json.loads(text[start:end])
+            if isinstance(parsed, list) and parsed:
+                return json.dumps(parsed)
+        except json.JSONDecodeError:
+            pass
+
+    return json.dumps([
+        {
+            "title": a["title"],
+            "url": a["link"],
+            "hook": a["title"],
+            "points": [a.get("summary", "")[:150]],
+            "why_it_matters": "",
+            "hashtags": ["#Tech"],
+        }
+        for a in articles
+    ])
+
+
+def _generate_thread_for_article(summary: dict) -> dict | None:
+    """Generate one high-quality Twitter thread for a single article."""
+    title = summary.get("title", "News")
+    url = summary.get("url", "")
+    hook = summary.get("hook", title)
+    points = summary.get("points", [])
+    why = summary.get("why_it_matters", "")
+    hashtags = " ".join(summary.get("hashtags", ["#Tech"])[:3])
+
+    prompt = f"""You are a viral tech Twitter personality. Write an engaging 4-tweet thread about this article.
+
+Article: {title}
+URL: {url}
+Hook: {hook}
+Key points: {json.dumps(points)}
+Why it matters: {why}
+Hashtags to use: {hashtags}
+
+Rules:
+- Tweet 1: Start with 🧵 and a PUNCHY hook — a bold claim, surprising fact, or provocative question. Max 240 chars.
+- Tweet 2: Start with \"1/\" — explain the core idea in plain English. Conversational, not corporate. Max 260 chars.
+- Tweet 3: Start with \"2/\" — give the most interesting insight or implication. Use an emoji. Max 260 chars.
+- Tweet 4: Start with \"3/\" — why this matters + call to action + the URL + hashtags. Max 280 chars.
+- Sound like a real person, not a press release.
+
+Return ONLY a JSON object with this exact structure (no other text):
+{{"title": "{title[:60]}", "tweets": ["tweet1", "tweet2", "tweet3", "tweet4"]}}"""
+
+    text = _call_ollama(prompt, 700)
+
+    start = text.find("{")
+    end = text.rfind("}") + 1
+    if start >= 0 and end > start:
+        try:
+            obj = json.loads(text[start:end])
+            if isinstance(obj, dict) and "tweets" in obj and len(obj["tweets"]) >= 3:
+                return obj
+        except json.JSONDecodeError:
+            pass
+
+    tweets = [
+        f"🧵 {hook[:220]}",
+        f"1/ {points[0][:250]}" if points else f"1/ {title[:250]}",
+        f"2/ {points[1][:240]} 💡" if len(points) > 1 else f"2/ {why[:240]} 💡",
+        f"3/ Why it matters: {why[:150]}\n\n{url}\n\n{hashtags}",
+    ]
+    return {"title": title[:60], "tweets": tweets}
+
+
+def generate_tweets(processed_json: str) -> str:
+    """Generate one engaging Twitter thread per article."""
+    summaries = json.loads(processed_json) if processed_json else []
+    if not summaries:
+        return json.dumps([])
+
+    threads = []
+    for i, summary in enumerate(summaries):
+        print(f"   Generating thread {i + 1}/{len(summaries)}: {summary.get('title', '')[:50]}...")
+        thread = _generate_thread_for_article(summary)
+        if thread:
+            threads.append(thread)
+
+    return json.dumps(threads)
+
+
+def approve_threads(threads_json: str) -> str:
+    """Display threads and ask user which ones to post."""
+    threads = json.loads(threads_json) if threads_json else []
+    if not threads:
+        print("No threads to review.")
+        return json.dumps([])
+
+    print("\n" + "=" * 60)
+    print("GENERATED TWEET THREADS")
+    print("=" * 60 + "\n")
+
+    approved = []
+    for i, thread in enumerate(threads, 1):
+        title = thread.get("title", "Untitled")
+        tweets = thread.get("tweets", [])
+
+        print(f"\n--- Thread {i}: {title[:50]}{'...' if len(title) > 50 else ''} ---\n")
+
+        for j, tweet in enumerate(tweets, 1):
+            prefix = "🧵" if j == 1 else f"{j}/"
+            print(f"  {prefix} {tweet}")
+            if len(tweet) > 280:
+                print(f"     WARNING: {len(tweet)} chars (over 280)")
+
+        print()
+        response = input("Post this thread? (y/n): ").strip().lower()
+
+        if response == "y":
+            approved.append(thread)
+            print("  Approved")
+        else:
+            print("  Skipped")
+
+    print("\n" + "=" * 60)
+    print(f"APPROVED: {len(approved)}/{len(threads)} threads")
+    print("=" * 60 + "\n")
+
+    return json.dumps(approved)
+
+
+async def post_to_twitter(approved_json: str) -> str:
+    """Post approved threads via Playwright automation."""
+    threads = json.loads(approved_json) if approved_json else []
+    if not threads:
+        print("No threads to post.")
+        return json.dumps({"success": False, "error": "No threads"})
+
+    print(f"\nPosting {len(threads)} thread(s) via Playwright automation...")
+    print("Browser will open. First run requires manual login.\n")
+
+    from .twitter import post_threads_impl
+
+    credential_ref = os.environ.get("TWITTER_CREDENTIAL_REF")
+    result = await post_threads_impl(approved_json, None, credential_ref=credential_ref)
+    return (
+        json.dumps(result)
+        if isinstance(result, dict)
+        else json.dumps({"success": False, "error": str(result)})
+    )

--- a/examples/templates/rss_twitter_agent/nodes/__init__.py
+++ b/examples/templates/rss_twitter_agent/nodes/__init__.py
@@ -1,0 +1,61 @@
+"""Node definitions for RSS-to-Twitter Agent - simple function nodes."""
+
+from framework.graph import NodeSpec
+
+fetch_node = NodeSpec(
+    id="fetch",
+    name="Fetch RSS",
+    description="Fetch and parse RSS feeds",
+    node_type="function",
+    client_facing=False,
+    input_keys=[],
+    output_keys=["articles_json"],
+)
+
+process_node = NodeSpec(
+    id="process",
+    name="Summarize",
+    description="Summarize articles into key points",
+    node_type="function",
+    client_facing=False,
+    input_keys=["articles_json"],
+    output_keys=["processed_json"],
+)
+
+generate_node = NodeSpec(
+    id="generate",
+    name="Generate Tweets",
+    description="Generate tweet drafts",
+    node_type="function",
+    client_facing=False,
+    input_keys=["processed_json"],
+    output_keys=["threads_json"],
+)
+
+approve_node = NodeSpec(
+    id="approve",
+    name="Approve Threads",
+    description="Show threads and get user approval",
+    node_type="function",
+    client_facing=False,
+    input_keys=["threads_json"],
+    output_keys=["approved_json"],
+)
+
+post_node = NodeSpec(
+    id="post",
+    name="Post to Twitter",
+    description="Post approved threads via Playwright",
+    node_type="function",
+    client_facing=False,
+    input_keys=["approved_json"],
+    output_keys=["results_json"],
+)
+
+__all__ = [
+    "fetch_node",
+    "process_node",
+    "generate_node",
+    "approve_node",
+    "post_node",
+]

--- a/examples/templates/rss_twitter_agent/run.py
+++ b/examples/templates/rss_twitter_agent/run.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+"""RSS-to-Twitter interactive workflow runner (legacy behavior preserved)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+from .fetch import _generate_thread_for_article, fetch_rss, post_to_twitter, summarize_articles
+
+
+async def run_interactive(
+    feed_url: str = "https://news.ycombinator.com/rss",
+    max_articles: int = 3,
+    twitter_credential_ref: str | None = None,
+) -> dict:
+    """Run fetch -> summarize -> per-thread y/n -> post (Playwright)."""
+    if twitter_credential_ref:
+        os.environ["TWITTER_CREDENTIAL_REF"] = twitter_credential_ref
+
+    print("=" * 60)
+    print("RSS-to-Twitter Agent")
+    print("=" * 60 + "\n")
+
+    print("Generates tweets from RSS feeds and posts automatically.\n")
+    print("Uses Playwright for browser automation.\n")
+
+    print("1. Fetching RSS...")
+    articles_json = fetch_rss(feed_url=feed_url, max_articles=max_articles)
+    articles = json.loads(articles_json)
+    print(f"   Fetched {len(articles)} articles\n")
+
+    print("2. Summarizing articles...")
+    summaries_json = summarize_articles(articles_json)
+    summaries = json.loads(summaries_json)
+    print(f"   Summarized {len(summaries)} articles\n")
+
+    total_posted = 0
+    reviewed = 0
+    results = []
+
+    for i, summary in enumerate(summaries):
+        article_title = summary.get("title", "Untitled")
+
+        print(f"\n{'=' * 60}")
+        print(
+            f"Article {i + 1}/{len(summaries)}: "
+            f"{article_title[:50]}{'...' if len(article_title) > 50 else ''}"
+        )
+        print("=" * 60)
+
+        print("  Generating thread...")
+        thread = _generate_thread_for_article(summary)
+        if not thread:
+            print("  Could not generate thread, skipping.")
+            continue
+
+        tweets = thread.get("tweets", [])
+
+        print()
+        for j, tweet in enumerate(tweets, 1):
+            tweet_text = tweet.get("text", tweet) if isinstance(tweet, dict) else tweet
+            prefix = "🧵" if j == 1 else f"{j}/"
+            print(f"  {prefix} {tweet_text}")
+            if len(tweet_text) > 280:
+                print(f"     WARNING: {len(tweet_text)} chars (over 280)")
+
+        print()
+        try:
+            response = input("Post this thread? (y/n/q): ").strip().lower()
+        except EOFError:
+            response = "n"
+
+        reviewed += 1
+        if response == "q":
+            print("  Quitting...")
+            break
+        if response != "y":
+            print("  Skipped")
+            continue
+
+        print("  Posting...\n")
+        result_json = await post_to_twitter(json.dumps([thread]))
+        result = json.loads(result_json)
+        results.append(result)
+        if isinstance(result, dict) and result.get("success"):
+            total_posted += 1
+            print("  Posted")
+        else:
+            err = result.get("error", "Unknown error") if isinstance(result, dict) else result
+            print(f"  Error: {err}")
+
+        if i < len(summaries) - 1:
+            try:
+                input("\nPress Enter for next thread...")
+            except EOFError:
+                pass
+
+    print(f"\n{'=' * 60}")
+    print(f"Done! Posted {total_posted}/{reviewed} reviewed threads.")
+    print("=" * 60)
+
+    return {
+        "success": True,
+        "feed_url": feed_url,
+        "articles_fetched": len(articles),
+        "threads_reviewed": reviewed,
+        "threads_posted": total_posted,
+        "post_results": results,
+    }
+
+
+if __name__ == "__main__":
+    output = asyncio.run(run_interactive())
+    print(json.dumps(output, indent=2, default=str))

--- a/examples/templates/rss_twitter_agent/test_flow.py
+++ b/examples/templates/rss_twitter_agent/test_flow.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+"""Quick flow test for RSS-to-Twitter interactive runner."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from .run import run_interactive
+
+
+async def test_full_flow() -> None:
+    result = await run_interactive(max_articles=1)
+    print(json.dumps(result, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    asyncio.run(test_full_flow())

--- a/examples/templates/rss_twitter_agent/twitter.py
+++ b/examples/templates/rss_twitter_agent/twitter.py
@@ -1,0 +1,250 @@
+"""Twitter posting via Playwright with persistent session support."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from .credentials import resolve_twitter_session_dir
+
+TwitterConfig = Any
+
+
+def _session_dir() -> Path:
+    configured = resolve_twitter_session_dir(os.environ.get("TWITTER_CREDENTIAL_REF"))
+    return Path(configured).expanduser()
+
+
+def _session_marker() -> Path:
+    return _session_dir() / ".logged_in"
+
+
+def _is_logged_in() -> bool:
+    return _session_marker().exists()
+
+
+async def _post_thread_with_playwright(thread: dict) -> dict:
+    from playwright.async_api import TimeoutError as PlaywrightTimeout
+    from playwright.async_api import async_playwright
+
+    tweets = thread.get("thread") or thread.get("tweets") or []
+    title = thread.get("article_title") or thread.get("title", "Untitled")
+
+    if not tweets:
+        return {"title": title, "posted": 0, "error": "No tweets in thread"}
+
+    session_dir = _session_dir()
+    session_marker = _session_marker()
+    session_dir.mkdir(parents=True, exist_ok=True)
+    first_run = not _is_logged_in()
+
+    print(f"\n{'=' * 60}")
+    print(f"Thread: {title[:55]}{'...' if len(title) > 55 else ''}")
+    print(f"Tweets: {len(tweets)}")
+    print("=" * 60)
+
+    if first_run:
+        print("\nFIRST RUN — Browser will open for manual login.")
+        print("Log in to X/Twitter, then press Enter here to continue.\n")
+
+    async with async_playwright() as p:
+        context = await p.chromium.launch_persistent_context(
+            user_data_dir=str(session_dir),
+            headless=False,
+            slow_mo=80,
+            args=[
+                "--disable-blink-features=AutomationControlled",
+                "--no-sandbox",
+                "--disable-dev-shm-usage",
+            ],
+            viewport={"width": 1280, "height": 800},
+        )
+
+        page = await context.new_page()
+
+        if first_run:
+            await page.goto("https://x.com/login", wait_until="domcontentloaded")
+            loop = asyncio.get_event_loop()
+            await loop.run_in_executor(
+                None,
+                lambda: input("   -> Log in to X in the browser, then press Enter here: "),
+            )
+            await page.goto("https://x.com/home", wait_until="domcontentloaded")
+            await asyncio.sleep(2)
+            if "login" in page.url or "i/flow" in page.url:
+                await context.close()
+                return {
+                    "title": title,
+                    "posted": 0,
+                    "error": "Login not detected. Please try again.",
+                }
+            session_marker.touch()
+            print("Session saved — future runs will be fully automatic.\n")
+
+        posted = 0
+        first_tweet_url = None
+
+        for i, tweet_text in enumerate(tweets):
+            if isinstance(tweet_text, dict):
+                tweet_text = tweet_text.get("text", "")
+            tweet_text = tweet_text.strip()
+            if not tweet_text:
+                continue
+
+            print(f"\n  Posting tweet {i + 1}/{len(tweets)}...")
+
+            try:
+                if i == 0:
+                    await page.goto("https://x.com/compose/tweet", wait_until="domcontentloaded")
+                    await asyncio.sleep(1.5)
+
+                    if "login" in page.url or "i/flow" in page.url:
+                        session_marker.unlink(missing_ok=True)
+                        await context.close()
+                        return {
+                            "title": title,
+                            "posted": posted,
+                            "error": "Session expired. Re-login and run again.",
+                        }
+
+                    textarea = page.locator(
+                        "[data-testid='tweetTextarea_0'], "
+                        "div[role='textbox'][data-testid='tweetTextarea_0'], "
+                        "div.public-DraftEditor-content"
+                    ).first
+                    await textarea.wait_for(timeout=10000)
+                    await textarea.click()
+                    await asyncio.sleep(0.5)
+                    await page.keyboard.type(tweet_text, delay=30)
+                    await asyncio.sleep(0.8)
+
+                    post_btn = page.locator(
+                        "[data-testid='tweetButtonInline'], "
+                        "[data-testid='tweetButton']"
+                    ).first
+                    await post_btn.wait_for(timeout=8000)
+                    await post_btn.click()
+                    await asyncio.sleep(2.5)
+
+                    first_tweet_url = page.url
+                    posted += 1
+                    print("  Posted tweet 1")
+
+                else:
+                    if first_tweet_url and "status" in first_tweet_url:
+                        await page.goto(first_tweet_url, wait_until="domcontentloaded")
+                        await asyncio.sleep(1.5)
+
+                        reply_btn = page.locator("[data-testid='reply']").first
+                        await reply_btn.wait_for(timeout=8000)
+                        await reply_btn.click()
+                        await asyncio.sleep(1.0)
+                    else:
+                        await page.goto("https://x.com/compose/tweet", wait_until="domcontentloaded")
+                        await asyncio.sleep(1.5)
+
+                    textarea = page.locator(
+                        "div[data-testid='tweetTextarea_0'], "
+                        "div[role='textbox']"
+                    ).last
+                    await textarea.wait_for(timeout=10000)
+                    await textarea.click()
+                    await asyncio.sleep(0.5)
+                    await page.keyboard.type(tweet_text, delay=30)
+                    await asyncio.sleep(0.8)
+
+                    post_btn = page.locator(
+                        "[data-testid='tweetButtonInline'], "
+                        "[data-testid='tweetButton']"
+                    ).first
+                    await post_btn.wait_for(timeout=8000)
+                    await post_btn.click()
+                    await asyncio.sleep(2.5)
+
+                    posted += 1
+                    print(f"  Posted tweet {i + 1}")
+
+            except PlaywrightTimeout as e:
+                print(f"  Timeout on tweet {i + 1}: {e}")
+            except Exception as e:
+                print(f"  Error on tweet {i + 1}: {e}")
+
+        await context.close()
+
+    return {
+        "title": title,
+        "posted": posted,
+        "total": len(tweets),
+        "url": first_tweet_url,
+    }
+
+
+async def post_threads_impl(
+    threads_json: str,
+    config: TwitterConfig,
+    credential_ref: str | None = None,
+) -> str | dict[str, Any]:
+    if credential_ref:
+        os.environ["TWITTER_CREDENTIAL_REF"] = credential_ref
+
+    try:
+        threads = json.loads(threads_json)
+    except (json.JSONDecodeError, TypeError) as e:
+        return f"Invalid threads_json: {e!s}"
+
+    if not isinstance(threads, list):
+        return "threads_json must be a JSON array of thread objects."
+
+    if not threads:
+        return "No threads to post."
+
+    results = []
+    total_posted = 0
+
+    for thread in threads:
+        if not isinstance(thread, dict):
+            continue
+        result = await _post_thread_with_playwright(thread)
+        results.append(result)
+        total_posted += result.get("posted", 0)
+
+    return {
+        "success": True,
+        "threads": results,
+        "message": f"Posted {total_posted} tweets across {len(results)} threads",
+    }
+
+
+def register_twitter_tool(registry: Any, config: TwitterConfig) -> None:
+    from framework.llm.provider import Tool
+
+    tool = Tool(
+        name="post_to_twitter",
+        description="Post threads to Twitter/X using Playwright automation.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "threads_json": {
+                    "type": "string",
+                    "description": "JSON string of the threads array.",
+                },
+                "twitter_credential_ref": {
+                    "type": "string",
+                    "description": "Optional credential ref in {name}/{alias} format.",
+                },
+            },
+            "required": ["threads_json"],
+        },
+    )
+    registry.register(
+        "post_to_twitter",
+        tool,
+        lambda inputs: post_threads_impl(
+            inputs["threads_json"],
+            config,
+            inputs.get("twitter_credential_ref"),
+        ),
+    )


### PR DESCRIPTION
## Description

Migrates the RSS-to-Twitter Playwright workflow into a Hive v0.6-compatible template layout while preserving the original behavior: fetch RSS news, summarize, ask for per-thread `y/n/q` approval, and post approved threads via Playwright.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update


## Related Issues

Fixes #4406

## Changes Made

- Added v0.6-compatible RSS template package at `examples/templates/rss_twitter_agent/`.
- Kept original interactive Playwright flow (approval prompt and automated posting) through updated runner/CLI paths.
- Added credential namespace support for Twitter session path (`{name}/{alias}` style references).
- Added backward-compatible wrapper for legacy run path usage.
- Updated README and quick test flow script for current Hive layout.

## Testing

Describe the tests you ran to verify your changes:

- [x] Manual testing performed

Additional verification run for this PR:
- [x] `PYTHONPATH=core:examples/templates python -m rss_twitter_agent validate`
- [x] `PYTHONPATH=core:examples/templates python -m rss_twitter_agent info`
- [x] `PYTHONPATH=core:examples/templates python -m rss_twitter_agent run --feed-url "https://news.ycombinator.com/rss" --max-articles 3`
- [x] Verified interactive approval prompt and Playwright posting flow manually

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Demo Video

Demo recording: https://www.youtube.com/watch?v=1cLnFnPfmKA

