### PR TITLE
security(H-01): limit exponent and shift operations in safe_eval

### DIFF
--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -2,6 +2,31 @@ import ast
 import operator
 from typing import Any
 
+# ── Computation Limits ────────────────────────────────────────────────────
+# Maximum allowed exponent to prevent DoS via expressions like 2**2**2**30.
+_MAX_EXPONENT = 1000
+# Maximum allowed shift bits to prevent memory exhaustion via 1 << 10**9.
+_MAX_SHIFT_BITS = 64
+
+
+def _safe_pow(base: Any, exp: Any) -> Any:
+    """Power operator with exponent limit to prevent DoS."""
+    if isinstance(exp, (int, float)) and abs(exp) > _MAX_EXPONENT:
+        raise ValueError(
+            f"Exponent {exp} exceeds maximum allowed value of {_MAX_EXPONENT}"
+        )
+    return operator.pow(base, exp)
+
+
+def _safe_lshift(a: Any, b: Any) -> Any:
+    """Left shift with bit limit to prevent memory exhaustion."""
+    if isinstance(b, int) and b > _MAX_SHIFT_BITS:
+        raise ValueError(
+            f"Shift amount {b} exceeds maximum allowed value of {_MAX_SHIFT_BITS}"
+        )
+    return operator.lshift(a, b)
+
+
 # Safe operators whitelist
 SAFE_OPERATORS = {
     ast.Add: operator.add,
@@ -10,8 +35,8 @@ SAFE_OPERATORS = {
     ast.Div: operator.truediv,
     ast.FloorDiv: operator.floordiv,
     ast.Mod: operator.mod,
-    ast.Pow: operator.pow,
-    ast.LShift: operator.lshift,
+    ast.Pow: _safe_pow,
+    ast.LShift: _safe_lshift,
     ast.RShift: operator.rshift,
     ast.BitOr: operator.or_,
     ast.BitXor: operator.xor,


### PR DESCRIPTION
## Summary

Adds resource limits to the `safe_eval` AST evaluator to prevent denial-of-service via exponential computation.

**Severity:** 🟠 High — Expressions like `10**10**10` or `1<<10000000` can consume unbounded CPU and memory. Since `safe_eval` processes edge conditions from graph definitions (potentially user-influenced), this is a DoS vector.

## Changes

- Added `MAX_EXPONENT = 1000` and `MAX_SHIFT = 64` constants
- Added `_safe_pow()` wrapper that raises `ValueError` when exponent exceeds limit
- Added `_safe_lshift()` wrapper that raises `ValueError` when shift exceeds limit
- Integrated both into the safe_eval operator dispatch

## Files Changed

- `core/framework/graph/safe_eval.py` — 27 insertions, 2 deletions

## Test Plan

- [x] Verify MAX_EXPONENT and MAX_SHIFT constants exist
- [x] Verify _safe_pow and _safe_lshift functions exist
- [x] Functional test: _safe_pow allows normal exponents, blocks excessive ones
- [x] Functional test: _safe_lshift allows normal shifts, blocks excessive ones
- [x] All 6 security validation tests pass