### PR TITLE
security(H-04): remove memory dict unpacking from eval context

### DIFF
--- a/core/framework/graph/edge.py
+++ b/core/framework/graph/edge.py
@@ -167,15 +167,17 @@ class EdgeSpec(BaseModel):
         if not self.condition_expr:
             return True
 
-        # Build evaluation context
-        # Include memory keys directly for easier access in conditions
+        # Build evaluation context.
+        # Security: do NOT unpack memory directly into the eval context
+        # via **memory — that would allow adversarial memory keys to shadow
+        # built-in names or inject unexpected variables into the evaluator.
+        # Instead, only expose memory under its own namespace.
         context = {
             "output": output,
             "memory": memory,
             "result": output.get("result"),
             "true": True,  # Allow lowercase true/false in conditions
             "false": False,
-            **memory,  # Unpack memory keys directly into context
         }
 
         try:


### PR DESCRIPTION
## Summary

Removes `**memory` unpacking from the `safe_eval` call context in edge condition evaluation, preventing memory key injection into the evaluation namespace.

**Severity:** 🟠 High — Edge condition evaluation unpacks the full memory dict (`**memory`) into the eval namespace. An adversarial upstream node can write a memory key like `__builtins__` or `result` to override sandbox variables and escape the safe_eval sandbox.

## Changes

- Changed from `safe_eval(condition, **memory)` to `safe_eval(condition, memory=memory)`
- Memory is now accessible as `memory["key"]` in expressions instead of as bare variables
- This prevents memory keys from overriding the evaluation namespace

## Files Changed

- `core/framework/graph/edge.py` — 5 insertions, 3 deletions

## Test Plan

- [x] Verify `**memory` is not used in eval context (excluding comments)
- [x] Security validation test passes