### PR TITLE
security(C-02): add command allowlist to file system sandbox executor

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/execute_command_tool/execute_command_tool.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/execute_command_tool/execute_command_tool.py
@@ -1,9 +1,59 @@
 import os
+import shlex
 import subprocess
 
 from mcp.server.fastmcp import FastMCP
 
 from ..security import WORKSPACES_DIR, get_secure_path
+
+# Allowlist of commands permitted in the sandbox.
+ALLOWED_COMMANDS = frozenset({
+    "python", "python3", "pip", "uv",
+    "pytest", "ruff", "mypy", "black", "isort", "flake8",
+    "node", "npm", "npx", "tsc",
+    "cat", "head", "tail", "ls", "find", "grep", "wc",
+    "echo", "diff", "sort", "uniq", "sed", "awk", "cut", "tr",
+    "make",
+})
+
+# Explicitly blocked commands / patterns.
+BLOCKED_COMMANDS = frozenset({
+    "rm", "rmdir", "mv", "cp",  # Destructive file ops require explicit tools
+    "curl", "wget", "nc", "ncat", "ssh", "scp", "rsync",  # Network access
+    "chmod", "chown", "chgrp",  # Permission changes
+    "kill", "pkill", "killall",  # Process control
+    "sudo", "su", "doas",  # Privilege escalation
+    "dd", "mkfs", "mount", "umount",  # System-level ops
+    "shutdown", "reboot", "poweroff", "halt",
+})
+
+
+def _validate_sandbox_command(command: str) -> str | None:
+    """Validate command for sandbox execution.
+
+    Returns None if allowed, or an error message string.
+    """
+    stripped = command.strip()
+    if not stripped:
+        return "Empty command."
+
+    try:
+        tokens = shlex.split(stripped)
+    except ValueError:
+        return "Command contains invalid shell syntax."
+
+    base_cmd = os.path.basename(tokens[0]) if tokens else ""
+
+    if base_cmd in BLOCKED_COMMANDS:
+        return f"Command '{base_cmd}' is blocked in the sandbox."
+
+    if base_cmd not in ALLOWED_COMMANDS:
+        return (
+            f"Command '{base_cmd}' is not allowed in the sandbox. "
+            f"Allowed: {', '.join(sorted(ALLOWED_COMMANDS))}"
+        )
+
+    return None
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -23,9 +73,10 @@ def register_tools(mcp: FastMCP) -> None:
             Perform controlled maintenance tasks
 
         Rules & Constraints
-            No network access unless explicitly allowed
-            No destructive commands (rm -rf, system modification)
-            Output must be treated as data, not truth
+            Commands are validated against an allowlist before execution.
+            No network access — network tools are blocked.
+            No destructive commands — rm, mv, cp are blocked; use dedicated file tools.
+            Shell operators (;, &&, ||, |) are not supported.
 
         Args:
             command: The shell command to execute
@@ -38,6 +89,14 @@ def register_tools(mcp: FastMCP) -> None:
             Dict with command output and execution details, or error dict
         """
         try:
+            # Validate command against allowlist
+            error = _validate_sandbox_command(command)
+            if error:
+                return {"error": f"Command rejected: {error}"}
+
+            # Parse command into args list — never use shell=True
+            args = shlex.split(command)
+
             # Default cwd is the session root
             session_root = os.path.join(WORKSPACES_DIR, workspace_id, agent_id, session_id)
             os.makedirs(session_root, exist_ok=True)
@@ -48,7 +107,7 @@ def register_tools(mcp: FastMCP) -> None:
                 secure_cwd = session_root
 
             result = subprocess.run(
-                command, shell=True, cwd=secure_cwd, capture_output=True, text=True, timeout=60
+                args, shell=False, cwd=secure_cwd, capture_output=True, text=True, timeout=60
             )
 
             return {


### PR DESCRIPTION
Fixes #5555

## Summary

Adds command validation to the sandboxed `execute_command_tool`, preventing shell injection through the tool interface.

**Severity:** 🔴 Critical — The execute_command_tool accepts arbitrary commands with `shell=True` inside a sandboxed environment. The shell is unrestricted, allowing complete sandbox escape.

## Changes

- Added `ALLOWED_COMMANDS` and `BLOCKED_COMMANDS` frozensets
- Added `_validate_sandbox_command()` validation function
- Changed execution to `shell=False` with `shlex.split()`

## Files Changed

- `tools/src/aden_tools/tools/file_system_toolkits/execute_command_tool/execute_command_tool.py` — 63 insertions, 4 deletions

## Test Plan

- [x] Blocked commands rejected (rm, curl, wget, sudo)
- [x] Allowed commands execute normally
- [x] `shell=False` and `shlex.split()` verified
- [x] All 5 security validation tests pass