### PR TITLE
feat: add json_yaml_tool for JSON/YAML validation and conversion

### DIFF
--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "arxiv>=2.1.0",
     "requests>=2.31.0",
     "psycopg2-binary>=2.9.0",
+    "pyyaml>=6.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -60,6 +60,7 @@ from .google_maps_tool import register_tools as register_google_maps
 from .http_headers_scanner import register_tools as register_http_headers_scanner
 from .hubspot_tool import register_tools as register_hubspot
 from .intercom_tool import register_tools as register_intercom
+from .json_yaml_tool import register_tools as register_json_yaml
 from .news_tool import register_tools as register_news
 from .pdf_read_tool import register_tools as register_pdf_read
 from .port_scanner import register_tools as register_port_scanner
@@ -106,6 +107,7 @@ def register_all_tools(
     register_runtime_logs(mcp)
     register_wikipedia(mcp)
     register_arxiv(mcp)
+    register_json_yaml(mcp)
 
     # Tools that need credentials (pass credentials if provided)
     # web_search supports multiple providers (Google, Brave) with auto-detection

--- a/tools/src/aden_tools/tools/json_yaml_tool/README.md
+++ b/tools/src/aden_tools/tools/json_yaml_tool/README.md
@@ -1,0 +1,102 @@
+# JSON/YAML Validation Tool
+
+A tool for validating and converting JSON and YAML data structures.
+
+## Features
+
+- **JSON Validation**: Validate JSON syntax and optionally against JSON Schema
+- **YAML Validation**: Validate YAML syntax and structure using safe loading
+- **JSON to YAML Conversion**: Convert JSON documents to YAML format
+- **YAML to JSON Conversion**: Convert YAML documents to JSON format
+
+## Tools
+
+### `validate_json`
+
+Validate JSON content and optionally validate against a JSON Schema.
+
+**Parameters:**
+- `content` (str): JSON string to validate
+- `schema` (dict, optional): JSON Schema dictionary to validate against
+
+**Returns:**
+- `valid` (bool): Whether the JSON is valid
+- `data` (dict/list): Parsed JSON data (if valid)
+- `error` (str): Error message (if invalid)
+
+**Example:**
+```python
+result = validate_json(
+    content='{"name": "agent", "version": 1}',
+    schema={"type": "object", "required": ["name"]}
+)
+# Returns: {"valid": True, "data": {"name": "agent", "version": 1}}
+```
+
+### `validate_yaml`
+
+Validate YAML content and parse it.
+
+**Parameters:**
+- `content` (str): YAML string to validate
+
+**Returns:**
+- `valid` (bool): Whether the YAML is valid
+- `data` (dict/list): Parsed YAML data (if valid)
+- `error` (str): Error message (if invalid)
+
+**Example:**
+```python
+result = validate_yaml(content='name: agent\nversion: 1')
+# Returns: {"valid": True, "data": {"name": "agent", "version": 1}}
+```
+
+### `json_to_yaml`
+
+Convert JSON content to YAML format.
+
+**Parameters:**
+- `content` (str): JSON string to convert
+- `indent` (int, optional): Number of spaces for YAML indentation (default: 2)
+- `default_flow_style` (bool, optional): Use flow style for nested structures (default: False)
+
+**Returns:**
+- `success` (bool): Whether conversion was successful
+- `yaml` (str): YAML output (if successful)
+- `error` (str): Error message (if failed)
+
+**Example:**
+```python
+result = json_to_yaml(content='{"key": "value", "nested": {"a": 1}}')
+# Returns: {"success": True, "yaml": "key: value\nnested:\n  a: 1"}
+```
+
+### `yaml_to_json`
+
+Convert YAML content to JSON format.
+
+**Parameters:**
+- `content` (str): YAML string to convert
+- `indent` (int, optional): Number of spaces for JSON indentation (default: 2)
+
+**Returns:**
+- `success` (bool): Whether conversion was successful
+- `json` (str): JSON output (if successful)
+- `error` (str): Error message (if failed)
+
+**Example:**
+```python
+result = yaml_to_json(content='key: value\nnested:\n  a: 1')
+# Returns: {"success": True, "json": '{"key": "value", "nested": {"a": 1}}'}
+```
+
+## Security Considerations
+
+- Uses `yaml.safe_load` for YAML parsing to prevent arbitrary code execution
+- Input size limited to 10MB to prevent DoS attacks
+- Clear error messages without exposing internal details
+
+## Dependencies
+
+- `pyyaml`: YAML parsing and serialization
+- `jsonschema` (optional): JSON Schema validation

--- a/tools/src/aden_tools/tools/json_yaml_tool/__init__.py
+++ b/tools/src/aden_tools/tools/json_yaml_tool/__init__.py
@@ -1,0 +1,5 @@
+"""JSON/YAML Tool package."""
+
+from .json_yaml_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/json_yaml_tool/json_yaml_tool.py
+++ b/tools/src/aden_tools/tools/json_yaml_tool/json_yaml_tool.py
@@ -1,0 +1,162 @@
+"""JSON/YAML Tool - Validate and convert JSON and YAML data."""
+
+from __future__ import annotations
+
+import json
+
+import yaml
+from fastmcp import FastMCP
+
+MAX_CONTENT_SIZE = 10 * 1024 * 1024
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register JSON/YAML tools with the MCP server."""
+
+    @mcp.tool()
+    def validate_json(content: str, schema: dict | None = None) -> dict:
+        """
+        Validate JSON content and optionally validate against a JSON Schema.
+
+        Args:
+            content: JSON string to validate
+            schema: Optional JSON Schema dictionary to validate against
+
+        Returns:
+            dict with validation result:
+            - valid: bool indicating if JSON is valid
+            - data: parsed JSON data (if valid)
+            - error: error message (if invalid)
+        """
+        if len(content) > MAX_CONTENT_SIZE:
+            return {
+                "valid": False,
+                "error": f"Content exceeds maximum size of {MAX_CONTENT_SIZE} bytes",
+            }
+
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as e:
+            return {"valid": False, "error": f"JSON parsing error: {str(e)}"}
+
+        if schema is not None:
+            try:
+                import jsonschema
+            except ImportError:
+                return {
+                    "valid": False,
+                    "error": "jsonschema not installed. Install with: pip install jsonschema",
+                }
+
+            try:
+                jsonschema.validate(instance=data, schema=schema)
+            except jsonschema.ValidationError as e:
+                return {
+                    "valid": False,
+                    "error": f"Schema validation error: {e.message}",
+                    "path": list(e.absolute_path),
+                }
+            except jsonschema.SchemaError as e:
+                return {"valid": False, "error": f"Invalid schema: {e.message}"}
+
+        return {"valid": True, "data": data}
+
+    @mcp.tool()
+    def validate_yaml(content: str) -> dict:
+        """
+        Validate YAML content and parse it.
+
+        Args:
+            content: YAML string to validate
+
+        Returns:
+            dict with validation result:
+            - valid: bool indicating if YAML is valid
+            - data: parsed YAML data (if valid)
+            - error: error message (if invalid)
+        """
+        if len(content) > MAX_CONTENT_SIZE:
+            return {
+                "valid": False,
+                "error": f"Content exceeds maximum size of {MAX_CONTENT_SIZE} bytes",
+            }
+
+        try:
+            data = yaml.safe_load(content)
+        except yaml.YAMLError as e:
+            return {"valid": False, "error": f"YAML parsing error: {str(e)}"}
+
+        return {"valid": True, "data": data}
+
+    @mcp.tool()
+    def json_to_yaml(content: str, indent: int = 2, default_flow_style: bool = False) -> dict:
+        """
+        Convert JSON content to YAML format.
+
+        Args:
+            content: JSON string to convert
+            indent: Number of spaces for YAML indentation (default: 2)
+            default_flow_style: Use flow style for nested structures (default: False)
+
+        Returns:
+            dict with conversion result:
+            - success: bool indicating if conversion was successful
+            - yaml: YAML string (if successful)
+            - error: error message (if failed)
+        """
+        if len(content) > MAX_CONTENT_SIZE:
+            return {
+                "success": False,
+                "error": f"Content exceeds maximum size of {MAX_CONTENT_SIZE} bytes",
+            }
+
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as e:
+            return {"success": False, "error": f"JSON parsing error: {str(e)}"}
+
+        try:
+            yaml_output = yaml.dump(
+                data,
+                indent=indent,
+                default_flow_style=default_flow_style,
+                allow_unicode=True,
+                sort_keys=False,
+            )
+        except yaml.YAMLError as e:
+            return {"success": False, "error": f"YAML serialization error: {str(e)}"}
+
+        return {"success": True, "yaml": yaml_output.rstrip("\n")}
+
+    @mcp.tool()
+    def yaml_to_json(content: str, indent: int = 2) -> dict:
+        """
+        Convert YAML content to JSON format.
+
+        Args:
+            content: YAML string to convert
+            indent: Number of spaces for JSON indentation (default: 2)
+
+        Returns:
+            dict with conversion result:
+            - success: bool indicating if conversion was successful
+            - json: JSON string (if successful)
+            - error: error message (if failed)
+        """
+        if len(content) > MAX_CONTENT_SIZE:
+            return {
+                "success": False,
+                "error": f"Content exceeds maximum size of {MAX_CONTENT_SIZE} bytes",
+            }
+
+        try:
+            data = yaml.safe_load(content)
+        except yaml.YAMLError as e:
+            return {"success": False, "error": f"YAML parsing error: {str(e)}"}
+
+        try:
+            json_output = json.dumps(data, indent=indent, ensure_ascii=False)
+        except (TypeError, ValueError) as e:
+            return {"success": False, "error": f"JSON serialization error: {str(e)}"}
+
+        return {"success": True, "json": json_output}

--- a/tools/src/aden_tools/tools/json_yaml_tool/tests/__init__.py
+++ b/tools/src/aden_tools/tools/json_yaml_tool/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for JSON/YAML Tool package."""

--- a/tools/src/aden_tools/tools/json_yaml_tool/tests/test_json_yaml_tool.py
+++ b/tools/src/aden_tools/tools/json_yaml_tool/tests/test_json_yaml_tool.py
@@ -1,0 +1,234 @@
+"""Tests for JSON/YAML Tool."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from aden_tools.tools.json_yaml_tool.json_yaml_tool import register_tools
+
+
+class TestValidateJson:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.fns = []
+        self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
+        register_tools(self.mcp)
+
+    def _fn(self, name):
+        return next(f for f in self.fns if f.__name__ == name)
+
+    def test_validate_json_valid(self):
+        result = self._fn("validate_json")(content='{"name": "test", "value": 123}')
+        assert result["valid"] is True
+        assert result["data"] == {"name": "test", "value": 123}
+
+    def test_validate_json_invalid_syntax(self):
+        result = self._fn("validate_json")(content='{"name": invalid}')
+        assert result["valid"] is False
+        assert "JSON parsing error" in result["error"]
+
+    def test_validate_json_empty_string(self):
+        result = self._fn("validate_json")(content="")
+        assert result["valid"] is False
+        assert "JSON parsing error" in result["error"]
+
+    def test_validate_json_array(self):
+        result = self._fn("validate_json")(content="[1, 2, 3]")
+        assert result["valid"] is True
+        assert result["data"] == [1, 2, 3]
+
+    def test_validate_json_with_schema_valid(self):
+        result = self._fn("validate_json")(
+            content='{"name": "agent", "version": 1}',
+            schema={"type": "object", "required": ["name"]},
+        )
+        assert result["valid"] is True
+        assert result["data"]["name"] == "agent"
+
+    def test_validate_json_with_schema_missing_required(self):
+        result = self._fn("validate_json")(
+            content='{"version": 1}',
+            schema={"type": "object", "required": ["name"]},
+        )
+        assert result["valid"] is False
+        assert "Schema validation error" in result["error"]
+
+    def test_validate_json_with_schema_wrong_type(self):
+        result = self._fn("validate_json")(
+            content='{"name": "agent", "count": "not_a_number"}',
+            schema={"type": "object", "properties": {"count": {"type": "number"}}},
+        )
+        assert result["valid"] is False
+        assert "Schema validation error" in result["error"]
+
+    def test_validate_json_with_invalid_schema(self):
+        result = self._fn("validate_json")(
+            content='{"name": "agent"}',
+            schema={"type": "invalid_type"},
+        )
+        assert result["valid"] is False
+        assert "Invalid schema" in result["error"]
+
+    def test_validate_json_exceeds_size_limit(self):
+        large_content = "x" * (11 * 1024 * 1024)
+        result = self._fn("validate_json")(content=large_content)
+        assert result["valid"] is False
+        assert "exceeds maximum size" in result["error"]
+
+
+class TestValidateYaml:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.fns = []
+        self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
+        register_tools(self.mcp)
+
+    def _fn(self, name):
+        return next(f for f in self.fns if f.__name__ == name)
+
+    def test_validate_yaml_valid(self):
+        result = self._fn("validate_yaml")(content="name: test\nvalue: 123")
+        assert result["valid"] is True
+        assert result["data"] == {"name": "test", "value": 123}
+
+    def test_validate_yaml_invalid_syntax(self):
+        result = self._fn("validate_yaml")(content="name: test\n  bad_indent: value")
+        assert result["valid"] is False
+        assert "YAML parsing error" in result["error"]
+
+    def test_validate_yaml_empty_string(self):
+        result = self._fn("validate_yaml")(content="")
+        assert result["valid"] is True
+        assert result["data"] is None
+
+    def test_validate_yaml_list(self):
+        result = self._fn("validate_yaml")(content="- item1\n- item2\n- item3")
+        assert result["valid"] is True
+        assert result["data"] == ["item1", "item2", "item3"]
+
+    def test_validate_yaml_nested(self):
+        result = self._fn("validate_yaml")(
+            content="parent:\n  child: value\n  nested:\n    deep: true"
+        )
+        assert result["valid"] is True
+        assert result["data"]["parent"]["nested"]["deep"] is True
+
+    def test_validate_yaml_exceeds_size_limit(self):
+        large_content = "x" * (11 * 1024 * 1024)
+        result = self._fn("validate_yaml")(content=large_content)
+        assert result["valid"] is False
+        assert "exceeds maximum size" in result["error"]
+
+
+class TestJsonToYaml:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.fns = []
+        self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
+        register_tools(self.mcp)
+
+    def _fn(self, name):
+        return next(f for f in self.fns if f.__name__ == name)
+
+    def test_json_to_yaml_simple(self):
+        result = self._fn("json_to_yaml")(content='{"key": "value"}')
+        assert result["success"] is True
+        assert result["yaml"] == "key: value"
+
+    def test_json_to_yaml_nested(self):
+        result = self._fn("json_to_yaml")(content='{"parent": {"child": "value"}}')
+        assert result["success"] is True
+        assert "parent:" in result["yaml"]
+        assert "child: value" in result["yaml"]
+
+    def test_json_to_yaml_array(self):
+        result = self._fn("json_to_yaml")(content="[1, 2, 3]")
+        assert result["success"] is True
+        assert "- 1" in result["yaml"]
+        assert "- 2" in result["yaml"]
+        assert "- 3" in result["yaml"]
+
+    def test_json_to_yaml_custom_indent(self):
+        result = self._fn("json_to_yaml")(content='{"parent": {"child": "value"}}', indent=4)
+        assert result["success"] is True
+        assert "    child: value" in result["yaml"]
+
+    def test_json_to_yaml_invalid_json(self):
+        result = self._fn("json_to_yaml")(content="{invalid json}")
+        assert result["success"] is False
+        assert "JSON parsing error" in result["error"]
+
+    def test_json_to_yaml_unicode(self):
+        result = self._fn("json_to_yaml")(content='{"greeting": "hello world"}')
+        assert result["success"] is True
+        assert "greeting: hello world" in result["yaml"]
+
+    def test_json_to_yaml_exceeds_size_limit(self):
+        large_content = "x" * (11 * 1024 * 1024)
+        result = self._fn("json_to_yaml")(content=large_content)
+        assert result["success"] is False
+        assert "exceeds maximum size" in result["error"]
+
+
+class TestYamlToJson:
+    def setup_method(self):
+        self.mcp = MagicMock()
+        self.fns = []
+        self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
+        register_tools(self.mcp)
+
+    def _fn(self, name):
+        return next(f for f in self.fns if f.__name__ == name)
+
+    def test_yaml_to_json_simple(self):
+        result = self._fn("yaml_to_json")(content="key: value")
+        assert result["success"] is True
+        assert result["json"] == '{"key": "value"}'
+
+    def test_yaml_to_json_nested(self):
+        result = self._fn("yaml_to_json")(content="parent:\n  child: value")
+        assert result["success"] is True
+        assert '"parent"' in result["json"]
+        assert '"child": "value"' in result["json"]
+
+    def test_yaml_to_json_array(self):
+        result = self._fn("yaml_to_json")(content="- item1\n- item2")
+        assert result["success"] is True
+        assert result["json"] == '["item1", "item2"]'
+
+    def test_yaml_to_json_custom_indent(self):
+        result = self._fn("yaml_to_json")(content="key: value", indent=4)
+        assert result["success"] is True
+        assert "    " in result["json"]
+
+    def test_yaml_to_json_compact(self):
+        result = self._fn("yaml_to_json")(content="key: value", indent=None)
+        assert result["success"] is True
+        assert result["json"] == '{"key": "value"}'
+
+    def test_yaml_to_json_invalid_yaml(self):
+        result = self._fn("yaml_to_json")(content="key: value\n  bad: indent")
+        assert result["success"] is False
+        assert "YAML parsing error" in result["error"]
+
+    def test_yaml_to_json_numbers(self):
+        result = self._fn("yaml_to_json")(content="integer: 42\nfloat: 3.14")
+        assert result["success"] is True
+        assert '"integer": 42' in result["json"]
+        assert '"float": 3.14' in result["json"]
+
+    def test_yaml_to_json_exceeds_size_limit(self):
+        large_content = "x" * (11 * 1024 * 1024)
+        result = self._fn("yaml_to_json")(content=large_content)
+        assert result["success"] is False
+        assert "exceeds maximum size" in result["error"]
+
+
+class TestToolRegistration:
+    def test_register_tools_registers_all_tools(self):
+        mcp = MagicMock()
+        mcp.tool.return_value = lambda fn: fn
+        register_tools(mcp)
+        assert mcp.tool.call_count == 4


### PR DESCRIPTION
Implements #1564 - Add JSON/YAML Validation Tool for Data Processing Agents

Core functions:
- validate_json: Validate JSON syntax and optionally against JSON Schema
- validate_yaml: Validate YAML syntax using safe_load
- json_to_yaml: Convert JSON to YAML format
- yaml_to_json: Convert YAML to JSON format

Files added:
- tools/src/aden_tools/tools/json_yaml_tool/json_yaml_tool.py
- tools/src/aden_tools/tools/json_yaml_tool/__init__.py
- tools/src/aden_tools/tools/json_yaml_tool/README.md
- tools/src/aden_tools/tools/json_yaml_tool/tests/test_json_yaml_tool.py
- tools/src/aden_tools/tools/json_yaml_tool/tests/__init__.py

Files modified:
- tools/pyproject.toml: Added pyyaml>=6.0.0 dependency
- tools/src/aden_tools/tools/__init__.py: Registered json_yaml_tool

Security considerations:
- Uses yaml.safe_load to prevent arbitrary code execution
- Input size limited to 10MB to prevent DoS attacks