### PR TITLE
fix: use configurable PYTHON variable in Makefile `micro-fix`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: lint format check test install-hooks help frontend-install frontend-dev frontend-build
 
+PYTHON ?= python3
+
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -21,7 +23,7 @@ check: ## Run all checks without modifying files (CI-safe)
 	cd tools && ruff format --check .
 
 test: ## Run all tests
-	cd core && uv run python -m pytest tests/ -v
+	cd core && uv run $(PYTHON) -m pytest tests/ -v
 
 install-hooks: ## Install pre-commit hooks
 	uv pip install pre-commit


### PR DESCRIPTION
## Summary
- Added configurable `PYTHON` variable to Makefile (defaults to `python3`)
- Updated test target to use `$(PYTHON)` instead of hardcoded `python`
- Users can now override with `PYTHON=python3.11 make test`

## Problem
The Makefile previously hardcoded `python` in the test target:
```makefile
test: ## Run all tests
    cd core && uv run python -m pytest tests/ -v
```

This caused build failures on modern systems (macOS, Ubuntu 22.04+) where Python 3 is installed as `python3` and `python` is not aliased by default.

## Solution
```makefile
PYTHON ?= python3

test: ## Run all tests
    cd core && uv run $(PYTHON) -m pytest tests/ -v
```

## Testing
- Verified `make test` works with default `python3`
- Verified PYTHON variable can be overridden: `PYTHON=python3.11 make test`
- All existing tests pass

## Files Changed
- `Makefile`: Added PYTHON variable and updated test target

Resolves #1985
