### PR TITLE
fix: use UUID for decision IDs to prevent collisions

### DIFF
--- a/core/framework/runtime/core.py
+++ b/core/framework/runtime/core.py
@@ -207,7 +207,7 @@ class Runtime:
             )
 
         # Create decision
-        decision_id = f"dec_{len(self._current_run.decisions)}"
+        decision_id = f"dec_{uuid.uuid4().hex}"
         decision = Decision(
             id=decision_id,
             node_id=node_id or self._current_node,

--- a/core/tests/test_runtime.py
+++ b/core/tests/test_runtime.py
@@ -71,7 +71,8 @@ class TestDecisionRecording:
             reasoning="More formal",
         )
 
-        assert decision_id == "dec_0"
+        assert decision_id.startswith("dec_")
+        assert len(decision_id) == 36  # "dec_" (4) + 32 hex chars
         assert len(runtime.current_run.decisions) == 1
 
         decision = runtime.current_run.decisions[0]
@@ -111,6 +112,27 @@ class TestDecisionRecording:
 
         decision = runtime.current_run.decisions[0]
         assert decision.node_id == "search-node"
+
+        runtime.end_run(success=True)
+
+    def test_decision_ids_are_unique(self, tmp_path: Path):
+        """Test that decision IDs are globally unique and don't collide."""
+        runtime = Runtime(tmp_path)
+        runtime.start_run("test_goal", "Test")
+
+        decision_ids = set()
+        for i in range(100):
+            decision_id = runtime.decide(
+                intent=f"Decision {i}",
+                options=[{"id": "a", "description": "A"}],
+                chosen="a",
+                reasoning="Test",
+            )
+            assert decision_id not in decision_ids, f"Duplicate decision ID: {decision_id}"
+            decision_ids.add(decision_id)
+
+        assert len(decision_ids) == 100
+        assert all(did.startswith("dec_") for did in decision_ids)
 
         runtime.end_run(success=True)
 


### PR DESCRIPTION
## Summary
- Fixed decision ID generation in `Runtime.decide()` to use `uuid.uuid4().hex` instead of list length
- Updated `test_basic_decision` to verify the UUID format of decision IDs
- Added `test_decision_ids_are_unique` test to ensure no ID collisions occur

## Changes
- `core/framework/runtime/core.py`: Changed `decision_id = f"dec_{len(self._current_run.decisions)}"` to `decision_id = f"dec_{uuid.uuid4().hex}"`
- `core/tests/test_runtime.py`: Updated existing test and added new uniqueness test

## Problem
The previous implementation used list length to generate decision IDs (`dec_0`, `dec_1`, etc.), which could cause ID collisions in:
- Concurrent decision recording
- Replayed runs
- Future refactors where decisions may be removed or reordered

## Solution
Using UUIDs ensures globally unique decision IDs without changing the public API, preventing collisions and maintaining correct decision → outcome linkage.

## Testing
All 15 tests pass (3 skipped as expected):
- `test_basic_decision` - Updated to verify UUID format
- `test_decision_ids_are_unique` - New test verifying 100 unique IDs

Resolves #2161
