### PR TITLE
fix(runtime): standardize attention reason codes for debugger compatibility

### DIFF
--- a/core/framework/runtime/runtime_logger.py
+++ b/core/framework/runtime/runtime_logger.py
@@ -37,6 +37,20 @@ from framework.runtime.runtime_log_store import RuntimeLogStore
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Stable attention reason codes
+#
+# Use these constants instead of free-text strings so that downstream tooling
+# (debuggers, aggregators, dashboards) can match on stable identifiers rather
+# than parsing human-readable messages.
+# ---------------------------------------------------------------------------
+REASON_NODE_FAILED = "node_failed"
+REASON_HIGH_RETRY_COUNT = "high_retry_count"
+REASON_EXCESSIVE_ESCALATIONS = "excessive_escalations"
+REASON_HIGH_LATENCY = "high_latency"
+REASON_HIGH_TOKEN_USAGE = "high_token_usage"
+REASON_EXCESSIVE_STEPS = "excessive_steps"
+
 
 class RuntimeLogger:
     """Captures runtime data during graph execution.
@@ -175,28 +189,28 @@ class RuntimeLogger:
         needs_attention = not success
         attention_reasons: list[str] = []
         if not success and error:
-            attention_reasons.append(f"Node {node_id} failed: {error}")
+            attention_reasons.append(REASON_NODE_FAILED)
 
         # Enhanced attention flags
         if retry_count > 3:
             needs_attention = True
-            attention_reasons.append(f"Excessive retries: {retry_count}")
+            attention_reasons.append(REASON_HIGH_RETRY_COUNT)
 
         if escalate_count > 2:
             needs_attention = True
-            attention_reasons.append(f"Excessive escalations: {escalate_count}")
+            attention_reasons.append(REASON_EXCESSIVE_ESCALATIONS)
 
         if latency_ms > 60000:  # > 1 minute
             needs_attention = True
-            attention_reasons.append(f"High latency: {latency_ms}ms")
+            attention_reasons.append(REASON_HIGH_LATENCY)
 
         if tokens_used > 100000:  # High token usage
             needs_attention = True
-            attention_reasons.append(f"High token usage: {tokens_used}")
+            attention_reasons.append(REASON_HIGH_TOKEN_USAGE)
 
         if total_steps > 20:  # Many iterations
             needs_attention = True
-            attention_reasons.append(f"Many iterations: {total_steps}")
+            attention_reasons.append(REASON_EXCESSIVE_STEPS)
 
         # OTel / trace context for L2 correlation
         ctx = get_trace_context()
@@ -285,9 +299,12 @@ class RuntimeLogger:
             total_output = sum(nd.output_tokens for nd in node_details)
 
             needs_attention = any(nd.needs_attention for nd in node_details)
-            attention_reasons: list[str] = []
+            all_reasons: list[str] = []
             for nd in node_details:
-                attention_reasons.extend(nd.attention_reasons)
+                all_reasons.extend(nd.attention_reasons)
+            # Deduplicate and sort so the L1 summary lists each code once,
+            # regardless of how many nodes triggered it.
+            attention_reasons = sorted(set(all_reasons))
 
             # OTel / trace context for L1 correlation
             ctx = get_trace_context()

--- a/core/tests/test_runtime_logger.py
+++ b/core/tests/test_runtime_logger.py
@@ -19,7 +19,15 @@ from framework.runtime.runtime_log_schemas import (
     ToolCallLog,
 )
 from framework.runtime.runtime_log_store import RuntimeLogStore
-from framework.runtime.runtime_logger import RuntimeLogger
+from framework.runtime.runtime_logger import (
+    REASON_EXCESSIVE_ESCALATIONS,
+    REASON_EXCESSIVE_STEPS,
+    REASON_HIGH_LATENCY,
+    REASON_HIGH_RETRY_COUNT,
+    REASON_HIGH_TOKEN_USAGE,
+    REASON_NODE_FAILED,
+    RuntimeLogger,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -706,9 +714,7 @@ class TestRuntimeLogger:
         summary = await store.load_summary(run_id)
         assert summary is not None
         assert summary.needs_attention is True
-        assert any(
-            "failed" in r.lower() or "escalat" in r.lower() for r in summary.attention_reasons
-        )
+        assert any(r in (REASON_NODE_FAILED, REASON_EXCESSIVE_ESCALATIONS) for r in summary.attention_reasons)
 
     @pytest.mark.asyncio
     async def test_ensure_node_logged_no_op_if_already_logged(self, tmp_path: Path):
@@ -984,7 +990,7 @@ class TestRuntimeLogger:
         assert loaded is not None
         node = loaded.nodes[0]
         assert node.needs_attention is True
-        assert any("Excessive retries" in reason for reason in node.attention_reasons)
+        assert REASON_HIGH_RETRY_COUNT in node.attention_reasons
 
     @pytest.mark.asyncio
     async def test_attention_flags_high_latency(self, tmp_path: Path):
@@ -1007,7 +1013,7 @@ class TestRuntimeLogger:
         assert loaded is not None
         node = loaded.nodes[0]
         assert node.needs_attention is True
-        assert any("High latency" in reason for reason in node.attention_reasons)
+        assert REASON_HIGH_LATENCY in node.attention_reasons
 
     @pytest.mark.asyncio
     async def test_attention_flags_high_token_usage(self, tmp_path: Path):
@@ -1030,7 +1036,7 @@ class TestRuntimeLogger:
         assert loaded is not None
         node = loaded.nodes[0]
         assert node.needs_attention is True
-        assert any("High token usage" in reason for reason in node.attention_reasons)
+        assert REASON_HIGH_TOKEN_USAGE in node.attention_reasons
 
     @pytest.mark.asyncio
     async def test_attention_flags_many_iterations(self, tmp_path: Path):
@@ -1053,7 +1059,7 @@ class TestRuntimeLogger:
         assert loaded is not None
         node = loaded.nodes[0]
         assert node.needs_attention is True
-        assert any("Many iterations" in reason for reason in node.attention_reasons)
+        assert REASON_EXCESSIVE_STEPS in node.attention_reasons
 
     @pytest.mark.asyncio
     async def test_guard_failure_exit_status(self, tmp_path: Path):
@@ -1078,3 +1084,79 @@ class TestRuntimeLogger:
         node = loaded.nodes[0]
         assert node.exit_status == "guard_failure"
         assert node.success is False
+
+    @pytest.mark.asyncio
+    async def test_end_run_deduplicates_attention_reasons(self, tmp_path: Path):
+        """L1 summary deduplicates attention reason codes across multiple nodes."""
+        store = RuntimeLogStore(tmp_path / "logs")
+        rt_logger = RuntimeLogger(store=store, agent_id="test-agent")
+        run_id = rt_logger.start_run("goal-1")
+
+        # Two nodes both trigger high_retry_count and node-2 also triggers high_latency
+        rt_logger.log_node_complete(
+            node_id="node-1",
+            node_name="Retry Node A",
+            node_type="event_loop",
+            success=True,
+            retry_count=5,  # triggers REASON_HIGH_RETRY_COUNT
+        )
+        rt_logger.log_node_complete(
+            node_id="node-2",
+            node_name="Retry Node B",
+            node_type="event_loop",
+            success=True,
+            retry_count=4,  # also triggers REASON_HIGH_RETRY_COUNT
+            latency_ms=65000,  # also triggers REASON_HIGH_LATENCY
+        )
+
+        await rt_logger.end_run(
+            status="success",
+            duration_ms=70000,
+            node_path=["node-1", "node-2"],
+        )
+
+        summary = await store.load_summary(run_id)
+        assert summary is not None
+        # high_retry_count appeared twice across nodes — must appear exactly once in L1
+        assert summary.attention_reasons.count(REASON_HIGH_RETRY_COUNT) == 1
+        assert REASON_HIGH_LATENCY in summary.attention_reasons
+        # List must be sorted
+        assert summary.attention_reasons == sorted(summary.attention_reasons)
+
+    @pytest.mark.asyncio
+    async def test_attention_reason_codes_are_stable_strings(self, tmp_path: Path):
+        """Emitted attention reasons are the documented stable codes, not free-text."""
+        from framework.runtime import runtime_logger as rl_module
+
+        store = RuntimeLogStore(tmp_path / "logs")
+        rt_logger = RuntimeLogger(store=store, agent_id="test-agent")
+        rt_logger.start_run("goal-1")
+
+        # Trigger every attention flag
+        rt_logger.log_node_complete(
+            node_id="node-1",
+            node_name="All Flags",
+            node_type="event_loop",
+            success=False,
+            error="something went wrong",
+            retry_count=5,
+            escalate_count=3,
+            latency_ms=65000,
+            tokens_used=150000,
+            total_steps=25,
+        )
+
+        details = store.read_node_details_sync(rt_logger._run_id)
+        reasons = set(details[0].attention_reasons)
+
+        expected_codes = {
+            rl_module.REASON_NODE_FAILED,
+            rl_module.REASON_HIGH_RETRY_COUNT,
+            rl_module.REASON_EXCESSIVE_ESCALATIONS,
+            rl_module.REASON_HIGH_LATENCY,
+            rl_module.REASON_HIGH_TOKEN_USAGE,
+            rl_module.REASON_EXCESSIVE_STEPS,
+        }
+        assert reasons == expected_codes, (
+            f"Expected stable codes {expected_codes}, got {reasons}"
+        )

--- a/tools/tests/tools/test_runtime_logs_tool.py
+++ b/tools/tests/tools/test_runtime_logs_tool.py
@@ -138,7 +138,7 @@ def runtime_logs_dir(tmp_path: Path) -> Path:
                 "total_input_tokens": 10000,
                 "total_output_tokens": 5000,
                 "needs_attention": True,
-                "attention_reasons": ["Node node-1 failed: Max iterations exhausted"],
+                "attention_reasons": ["node_failed"],
                 "started_at": "2025-01-01T00:00:02",
                 "duration_ms": 60000,
                 "execution_quality": "failed",
@@ -158,7 +158,7 @@ def runtime_logs_dir(tmp_path: Path) -> Path:
                 "exit_status": "failure",
                 "retry_count": 50,
                 "needs_attention": True,
-                "attention_reasons": ["Node node-1 failed: Max iterations exhausted"],
+                "attention_reasons": ["node_failed"],
             },
         ],
     )


### PR DESCRIPTION
## Summary

Fixes #5617.

`RuntimeLogger.log_node_complete()` was emitting free-text strings like `"Excessive retries: 5"` and `"High latency: 65000ms"` into `attention_reasons`. These are brittle for any downstream tool trying to match or aggregate them.

**Changes:**

- **`runtime_logger.py`** — Introduced six stable module-level constants (`REASON_NODE_FAILED`, `REASON_HIGH_RETRY_COUNT`, `REASON_EXCESSIVE_ESCALATIONS`, `REASON_HIGH_LATENCY`, `REASON_HIGH_TOKEN_USAGE`, `REASON_EXCESSIVE_STEPS`) and replaced all free-text strings with these codes. Thresholds are unchanged.
- **`runtime_logger.py` (`end_run`)** — Aggregates node-level reasons through `sorted(set(...))` so the L1 `RunSummaryLog` lists each code exactly once, regardless of how many nodes triggered it.
- **`test_runtime_logger.py`** — Updated 5 existing assertions to match stable codes; added 2 new tests: `test_end_run_deduplicates_attention_reasons` and `test_attention_reason_codes_are_stable_strings`.
- **`tools/tests/tools/test_runtime_logs_tool.py`** — Updated mock fixture data to use `"node_failed"` instead of the old free-text format.

## Test plan

- [x] All 36 existing `test_runtime_logger.py` tests pass
- [x] 2 new tests cover deduplication and code stability
- [x] `tools/tests/tools/test_runtime_logs_tool.py` mock data aligned with new format

```
36 passed in 1.30s
```