### PR TITLE
fix: add timeout to clean_output() LLM call to prevent infinite hang

### DIFF
--- a/core/framework/graph/output_cleaner.py
+++ b/core/framework/graph/output_cleaner.py
@@ -7,6 +7,7 @@ to clean malformed outputs before they flow to the next node.
 This prevents cascading failures and dramatically improves execution success rates.
 """
 
+import asyncio
 import json
 import logging
 import re
@@ -70,6 +71,7 @@ class CleansingConfig:
     cache_successful_patterns: bool = True
     fallback_to_raw: bool = True  # If cleaning fails, pass raw output
     log_cleanings: bool = True  # Log when cleansing happens
+    timeout: float = 30.0  # Timeout in seconds for LLM cleaning calls
 
 
 @dataclass
@@ -288,12 +290,16 @@ Return ONLY valid JSON matching the expected schema. No explanations, no markdow
                     f"🧹 Cleaning output from '{source_node_id}' using {self.config.fast_model}"
                 )
 
-            response = await self.llm.acomplete(
-                messages=[{"role": "user", "content": prompt}],
-                system=(
-                    "You clean malformed agent outputs. Return only valid JSON matching the schema."
+            response = await asyncio.wait_for(
+                self.llm.acomplete(
+                    messages=[{"role": "user", "content": prompt}],
+                    system=(
+                        "You clean malformed agent outputs. "
+                        "Return only valid JSON matching the schema."
+                    ),
+                    max_tokens=2048,  # Sufficient for cleaning most outputs
                 ),
-                max_tokens=2048,  # Sufficient for cleaning most outputs
+                timeout=self.config.timeout,
             )
 
             # Parse cleaned output
@@ -324,6 +330,16 @@ Return ONLY valid JSON matching the expected schema. No explanations, no markdow
             logger.error(f"✗ Failed to parse cleaned JSON: {e}")
             if self.config.fallback_to_raw:
                 logger.info("↩ Falling back to raw output")
+                return output
+            else:
+                raise
+
+        except TimeoutError:
+            logger.error(
+                f"✗ Cleaning LLM timed out after {self.config.timeout}s for '{source_node_id}'"
+            )
+            if self.config.fallback_to_raw:
+                logger.info("↩ Falling back to raw output due to timeout")
                 return output
             else:
                 raise

--- a/core/tests/test_output_cleaner.py
+++ b/core/tests/test_output_cleaner.py
@@ -1,0 +1,178 @@
+"""Tests for OutputCleaner timeout handling.
+
+Validates:
+  - clean_output() respects the configured timeout
+  - TimeoutError triggers fallback_to_raw when enabled
+  - TimeoutError is raised when fallback_to_raw is disabled
+  - Default timeout is 30 seconds
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from framework.graph.node import NodeSpec
+from framework.graph.output_cleaner import CleansingConfig, OutputCleaner
+
+
+class MockLLMProvider:
+    """Mock LLM provider for testing timeout behavior."""
+
+    def __init__(self, delay: float = 0.0, response: str = '{"result": "cleaned"}'):
+        self.delay = delay
+        self.response = response
+        self.acomplete_calls: list[dict] = []
+
+    async def acomplete(
+        self,
+        messages: list[dict[str, Any]],
+        system: str = "",
+        tools: list | None = None,
+        max_tokens: int = 1024,
+        **kwargs,
+    ):
+        self.acomplete_calls.append({"messages": messages, "system": system})
+        if self.delay > 0:
+            await asyncio.sleep(self.delay)
+        return MagicMock(content=self.response)
+
+
+class SlowMockLLMProvider:
+    """Mock LLM provider that never returns (simulates hung LLM)."""
+
+    def __init__(self):
+        self.acomplete_calls: list[dict] = []
+
+    async def acomplete(
+        self,
+        messages: list[dict[str, Any]],
+        system: str = "",
+        tools: list | None = None,
+        max_tokens: int = 1024,
+        **kwargs,
+    ):
+        self.acomplete_calls.append({"messages": messages, "system": system})
+        await asyncio.sleep(1000)
+
+
+def _make_target_spec() -> NodeSpec:
+    """Create a simple target NodeSpec for testing."""
+    return NodeSpec(
+        id="target-node",
+        name="Target Node",
+        description="Test target",
+        input_keys=["data"],
+        output_keys=["result"],
+        input_schema={
+            "data": {"type": "dict", "required": True},
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_clean_output_timeout_fallback_to_raw():
+    """Test that timeout triggers fallback_to_raw when enabled."""
+    slow_llm = SlowMockLLMProvider()
+    config = CleansingConfig(
+        enabled=True,
+        timeout=0.1,
+        fallback_to_raw=True,
+    )
+    cleaner = OutputCleaner(config=config, llm_provider=slow_llm)
+
+    output = {"data": "malformed content that needs LLM repair"}
+    target_spec = _make_target_spec()
+
+    result = await cleaner.clean_output(
+        output=output,
+        source_node_id="source",
+        target_node_spec=target_spec,
+        validation_errors=["Test error"],
+    )
+
+    assert result == output, "Should return raw output on timeout when fallback_to_raw=True"
+    assert len(slow_llm.acomplete_calls) == 1, "Should have attempted one LLM call"
+
+
+@pytest.mark.asyncio
+async def test_clean_output_timeout_raises_without_fallback():
+    """Test that timeout raises when fallback_to_raw is disabled."""
+    slow_llm = SlowMockLLMProvider()
+    config = CleansingConfig(
+        enabled=True,
+        timeout=0.1,
+        fallback_to_raw=False,
+    )
+    cleaner = OutputCleaner(config=config, llm_provider=slow_llm)
+
+    output = {"data": "malformed content that needs LLM repair"}
+    target_spec = _make_target_spec()
+
+    with pytest.raises(asyncio.TimeoutError):
+        await cleaner.clean_output(
+            output=output,
+            source_node_id="source",
+            target_node_spec=target_spec,
+            validation_errors=["Test error"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_clean_output_completes_within_timeout():
+    """Test that clean_output succeeds when LLM responds within timeout."""
+    fast_llm = MockLLMProvider(delay=0.01, response='{"data": {"nested": "value"}}')
+    config = CleansingConfig(
+        enabled=True,
+        timeout=5.0,
+        fallback_to_raw=True,
+    )
+    cleaner = OutputCleaner(config=config, llm_provider=fast_llm)
+
+    output = {"data": "malformed"}
+    target_spec = _make_target_spec()
+
+    result = await cleaner.clean_output(
+        output=output,
+        source_node_id="source",
+        target_node_spec=target_spec,
+        validation_errors=["Test error"],
+    )
+
+    assert "data" in result, "Should return cleaned output"
+
+
+def test_default_timeout_is_30_seconds():
+    """Test that default timeout is 30 seconds as per issue recommendation."""
+    config = CleansingConfig()
+    assert config.timeout == 30.0, "Default timeout should be 30 seconds"
+
+
+def test_timeout_is_configurable():
+    """Test that timeout can be configured."""
+    config = CleansingConfig(timeout=60.0)
+    assert config.timeout == 60.0, "Timeout should be configurable"
+
+
+@pytest.mark.asyncio
+async def test_heuristic_repair_bypasses_llm():
+    """Test that heuristic repair bypasses LLM call entirely."""
+    config = CleansingConfig(enabled=True, timeout=0.1)
+    mock_llm = MockLLMProvider(delay=100)
+    cleaner = OutputCleaner(config=config, llm_provider=mock_llm)
+
+    output = {"data": '{"nested": "value"}'}
+    target_spec = _make_target_spec()
+
+    result = await cleaner.clean_output(
+        output=output,
+        source_node_id="source",
+        target_node_spec=target_spec,
+        validation_errors=["Test error"],
+    )
+
+    assert len(mock_llm.acomplete_calls) == 0, "Heuristic repair should bypass LLM"
+    assert result.get("data") == {"nested": "value"}, "Should apply heuristic repair"


### PR DESCRIPTION
## Description

This PR fixes the issue where `clean_output()` method in the OutputCleaner class could hang indefinitely if the LLM provider becomes slow or unresponsive. The fix adds a configurable timeout to the LLM call with proper error handling.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #2171

## Changes Made

- Added `timeout` parameter to `CleansingConfig` dataclass with a default value of 30 seconds
- Wrapped the `llm.acomplete()` call in `asyncio.wait_for()` to enforce the timeout
- Added explicit `TimeoutError` handling with support for `fallback_to_raw` configuration
- Added comprehensive unit tests for timeout behavior

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/test_output_cleaner.py`)
- [x] Lint passes (`cd core && ruff check framework/graph/output_cleaner.py tests/test_output_cleaner.py`)
- [x] Manual testing performed (verified timeout behavior with slow mock LLM)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
