### PR TITLE
fix(storage): keep strong references for ConcurrentStorage index locks

### DIFF
--- a/core/framework/storage/concurrent.py
+++ b/core/framework/storage/concurrent.py
@@ -131,29 +131,30 @@ class ConcurrentStorage:
         lock = self._file_locks.get(lock_key)
 
         if lock is not None:
-            # OPTIMIZATION: Only update LRU for "run" locks.
-            # This prevents high-frequency "index" locks from flushing out
-            # the actual run locks we want to keep cached.
-            if lock_key.startswith("run:"):
-                if lock_key in self._lru_tracking:
-                    self._lru_tracking.move_to_end(lock_key)
+            # Touch LRU for all locks to keep an active strong reference.
+            # This prevents index locks from being garbage-collected while
+            # they are still in active use by concurrent tasks.
+            if lock_key in self._lru_tracking:
+                self._lru_tracking.move_to_end(lock_key)
+            else:
+                if len(self._lru_tracking) >= self._max_locks:
+                    self._lru_tracking.popitem(last=False)
+                self._lru_tracking[lock_key] = lock
             return lock
 
         # 2. Create new lock
         lock = asyncio.Lock()
         self._file_locks[lock_key] = lock
 
-        # CRITICAL: Only add "run:" locks to the strong-ref LRU tracking.
-        # Index locks live exclusively in WeakValueDictionary and are GC'd immediately.
-        if lock_key.startswith("run:"):
-            # Manage capacity only for run locks
-            if len(self._lru_tracking) >= self._max_locks:
-                # Remove oldest tracked lock (strong ref)
-                # WeakValueDictionary will auto-remove the lock once no longer in use
-                self._lru_tracking.popitem(last=False)
+        # Keep a strong reference for all lock types (run + index).
+        # Without this, index locks can be reclaimed immediately because
+        # _file_locks is weakly referenced, which can break mutual exclusion.
+        if len(self._lru_tracking) >= self._max_locks:
+            # Remove oldest tracked lock (strong ref)
+            # WeakValueDictionary will auto-remove the lock once no longer in use
+            self._lru_tracking.popitem(last=False)
 
-            # Add strong reference to keep run lock alive
-            self._lru_tracking[lock_key] = lock
+        self._lru_tracking[lock_key] = lock
 
         return lock
 

--- a/core/tests/test_storage.py
+++ b/core/tests/test_storage.py
@@ -5,6 +5,7 @@ New sessions use unified storage at sessions/{session_id}/state.json.
 These tests are kept for backward compatibility verification only.
 """
 
+import gc
 import json
 import time
 from pathlib import Path
@@ -327,6 +328,36 @@ class TestCacheEntry:
         old_timestamp = time.time() - 120  # 2 minutes ago
         entry = CacheEntry(value="test", timestamp=old_timestamp)
         assert entry.is_expired(ttl=60.0) is True
+
+
+class TestConcurrentStorageLockTracking:
+    """Lock lifecycle tests for ConcurrentStorage lock tracking internals."""
+
+    @pytest.mark.asyncio
+    async def test_index_lock_is_strongly_referenced(self, tmp_path: Path):
+        """Index locks should survive GC while tracked in LRU."""
+        storage = ConcurrentStorage(tmp_path, max_locks=10)
+
+        lock = await storage._get_lock("index:by_goal:test-goal")
+        lock_id = id(lock)
+
+        del lock
+        gc.collect()
+
+        same_lock = await storage._get_lock("index:by_goal:test-goal")
+        assert id(same_lock) == lock_id
+        assert "index:by_goal:test-goal" in storage._lru_tracking
+
+    @pytest.mark.asyncio
+    async def test_lru_tracks_both_run_and_index_locks(self, tmp_path: Path):
+        """Both run and index locks should be tracked with strong refs."""
+        storage = ConcurrentStorage(tmp_path, max_locks=10)
+
+        await storage._get_lock("run:run-1")
+        await storage._get_lock("index:by_status:completed")
+
+        assert "run:run-1" in storage._lru_tracking
+        assert "index:by_status:completed" in storage._lru_tracking
 
 
 # === CONCURRENTSTORAGE TESTS ===


### PR DESCRIPTION
## Summary
- keep strong LRU references for **all** lock keys in `ConcurrentStorage._get_lock`, not only `run:*` keys
- touch existing lock keys in LRU regardless of lock type so active index locks stay strongly referenced
- add regression tests that verify index lock identity survives GC and that both run/index lock keys are tracked

## Problem
`ConcurrentStorage` stored index locks only in a `WeakValueDictionary`. Under GC pressure this can drop index lock objects, allowing a second lock object to be created for the same key and breaking mutual exclusion semantics.

## Validation
- `source .venv/bin/activate && cd core && pytest tests/test_storage.py -k 'LockTracking or CacheEntry' -v`
- `source .venv/bin/activate && cd core && pytest tests/test_storage.py -v`

Closes #1928