### PR TITLE
fix: Critical bugs in LLM, MCP server, and storage components (#2183)

### DIFF
--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -344,14 +344,14 @@ class SharedMemory:
         if self._allowed_write and key not in self._allowed_write:
             raise PermissionError(f"Node not allowed to write key: {key}")
 
-        # Ensure key has a lock (double-checked locking pattern)
-        if key not in self._key_locks:
-            async with self._lock:
-                if key not in self._key_locks:
-                    self._key_locks[key] = asyncio.Lock()
+        # Ensure key has a lock - always acquire main lock to prevent race condition
+        async with self._lock:
+            if key not in self._key_locks:
+                self._key_locks[key] = asyncio.Lock()
+            key_lock = self._key_locks[key]
 
         # Acquire per-key lock and write
-        async with self._key_locks[key]:
+        async with key_lock:
             if validate and isinstance(value, str):
                 if len(value) > 5000:
                     if self._contains_code_indicators(value):

--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -419,7 +419,6 @@ class LiteLLMProvider(LLMProvider):
 
                 return response
             except RateLimitError as e:
-                # Dump full request to file for debugging
                 messages = kwargs.get("messages", [])
                 token_count, token_method = _estimate_tokens(model, messages)
                 dump_path = _dump_failed_request(
@@ -445,7 +444,47 @@ class LiteLLMProvider(LLMProvider):
                     f"(attempt {attempt + 1}/{retries})"
                 )
                 time.sleep(wait)
-        # unreachable, but satisfies type checker
+            except Exception as e:
+                messages = kwargs.get("messages", [])
+                token_count, token_method = _estimate_tokens(model, messages)
+                if _is_stream_transient_error(e):
+                    if attempt == retries:
+                        dump_path = _dump_failed_request(
+                            model=model,
+                            kwargs=kwargs,
+                            error_type="transient_error",
+                            attempt=attempt,
+                        )
+                        logger.error(
+                            f"[retry] GAVE UP on {model} after {retries + 1} "
+                            f"attempts — transient error: {type(e).__name__}: {e!s}. "
+                            f"~{token_count} tokens ({token_method}). "
+                            f"Full request dumped to: {dump_path}"
+                        )
+                        raise
+                    wait = _compute_retry_delay(attempt, exception=e)
+                    logger.warning(
+                        f"[retry] {model} transient error "
+                        f"({type(e).__name__}): {e!s}. "
+                        f"~{token_count} tokens ({token_method}). "
+                        f"Retrying in {wait}s "
+                        f"(attempt {attempt + 1}/{retries})"
+                    )
+                    time.sleep(wait)
+                else:
+                    dump_path = _dump_failed_request(
+                        model=model,
+                        kwargs=kwargs,
+                        error_type="api_error",
+                        attempt=attempt,
+                    )
+                    logger.error(
+                        f"[retry] {model} API error ({type(e).__name__}): {e!s}. "
+                        f"~{token_count} tokens ({token_method}). "
+                        f"Full request dumped to: {dump_path}. "
+                        f"Not retrying — non-transient error."
+                    )
+                    raise
         raise RuntimeError("Exhausted rate limit retries")
 
     def complete(
@@ -645,6 +684,47 @@ class LiteLLMProvider(LLMProvider):
                     f"(attempt {attempt + 1}/{retries})"
                 )
                 await asyncio.sleep(wait)
+            except Exception as e:
+                messages = kwargs.get("messages", [])
+                token_count, token_method = _estimate_tokens(model, messages)
+                if _is_stream_transient_error(e):
+                    if attempt == retries:
+                        dump_path = _dump_failed_request(
+                            model=model,
+                            kwargs=kwargs,
+                            error_type="transient_error",
+                            attempt=attempt,
+                        )
+                        logger.error(
+                            f"[async-retry] GAVE UP on {model} after {retries + 1} "
+                            f"attempts — transient error: {type(e).__name__}: {e!s}. "
+                            f"~{token_count} tokens ({token_method}). "
+                            f"Full request dumped to: {dump_path}"
+                        )
+                        raise
+                    wait = _compute_retry_delay(attempt, exception=e)
+                    logger.warning(
+                        f"[async-retry] {model} transient error "
+                        f"({type(e).__name__}): {e!s}. "
+                        f"~{token_count} tokens ({token_method}). "
+                        f"Retrying in {wait}s "
+                        f"(attempt {attempt + 1}/{retries})"
+                    )
+                    await asyncio.sleep(wait)
+                else:
+                    dump_path = _dump_failed_request(
+                        model=model,
+                        kwargs=kwargs,
+                        error_type="api_error",
+                        attempt=attempt,
+                    )
+                    logger.error(
+                        f"[async-retry] {model} API error ({type(e).__name__}): {e!s}. "
+                        f"~{token_count} tokens ({token_method}). "
+                        f"Full request dumped to: {dump_path}. "
+                        f"Not retrying — non-transient error."
+                    )
+                    raise
         raise RuntimeError("Exhausted rate limit retries")
 
     async def acomplete(

--- a/core/framework/mcp/agent_builder_server.py
+++ b/core/framework/mcp/agent_builder_server.py
@@ -653,9 +653,6 @@ def add_node(
         max_node_visits=max_node_visits,
     )
 
-    session.nodes.append(node)
-
-    # Validate
     errors = []
     warnings = []
 
@@ -664,18 +661,15 @@ def add_node(
     if not name:
         errors.append("Node must have a name")
 
-    # Reject removed node types
     if node_type in ("function", "llm_tool_use", "llm_generate"):
         errors.append(f"Node type '{node_type}' is no longer supported. Use 'event_loop' instead.")
 
     if node_type == "router" and not routes_dict:
         errors.append(f"Router node '{node_id}' must specify routes")
 
-    # EventLoopNode validation
     if node_type == "event_loop" and not system_prompt:
         warnings.append(f"Event loop node '{node_id}' should have a system_prompt")
 
-    # Warn about client_facing on nodes with tools (likely autonomous work)
     if node_type == "event_loop" and client_facing and tools_list:
         warnings.append(
             f"Node '{node_id}' is client_facing=True but has tools {tools_list}. "
@@ -683,7 +677,6 @@ def add_node(
             "client_facing=False. Only set True if this node needs user approval."
         )
 
-    # nullable_output_keys must be a subset of output_keys
     if nullable_output_keys_list:
         invalid_nullable = [k for k in nullable_output_keys_list if k not in output_keys_list]
         if invalid_nullable:
@@ -692,12 +685,23 @@ def add_node(
                 f"output_keys {output_keys_list}"
             )
 
-    _save_session(session)  # Auto-save
+    if errors:
+        return json.dumps(
+            {
+                "valid": False,
+                "errors": errors,
+                "warnings": warnings,
+                "node": node.model_dump(),
+            }
+        )
+
+    session.nodes.append(node)
+    _save_session(session)
 
     return json.dumps(
         {
-            "valid": len(errors) == 0,
-            "errors": errors,
+            "valid": True,
+            "errors": [],
             "warnings": warnings,
             "node": node.model_dump(),
             "total_nodes": len(session.nodes),
@@ -764,9 +768,6 @@ def add_edge(
         priority=priority,
     )
 
-    session.edges.append(edge)
-
-    # Validate
     errors = []
     warnings = []
 
@@ -777,7 +778,6 @@ def add_edge(
     if edge_condition == EdgeCondition.CONDITIONAL and not condition_expr:
         errors.append(f"Conditional edge '{edge_id}' needs condition_expr")
 
-    # Feedback edge validation
     if priority < 0:
         target_node = next((n for n in session.nodes if n.id == target), None)
         if target_node and target_node.max_node_visits <= 1:
@@ -788,12 +788,23 @@ def add_edge(
                 "Consider increasing max_node_visits on the target node."
             )
 
-    _save_session(session)  # Auto-save
+    if errors:
+        return json.dumps(
+            {
+                "valid": False,
+                "errors": errors,
+                "warnings": warnings,
+                "edge": edge.model_dump(),
+            }
+        )
+
+    session.edges.append(edge)
+    _save_session(session)
 
     return json.dumps(
         {
-            "valid": len(errors) == 0,
-            "errors": errors,
+            "valid": True,
+            "errors": [],
             "warnings": warnings,
             "edge": edge.model_dump(),
             "total_edges": len(session.edges),


### PR DESCRIPTION
## Description

This PR fixes multiple critical bugs across the codebase affecting LLM integration, MCP server, and storage components. These bugs could cause crashes, data corruption, race conditions, and security issues.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #2183

## Changes Made

### 1. Missing Exception Handling in LLM Provider (`core/framework/llm/litellm.py`)
- Added comprehensive exception handling for API errors beyond just `RateLimitError`
- Transient errors (APIConnectionError, InternalServerError, BadGatewayError, ServiceUnavailableError, TimeoutError, ConnectionError, OSError) are now caught and retried with exponential backoff
- Non-transient errors are logged with full request dumps and re-raised with clear messages
- Applied to both `_completion_with_rate_limit_retry` (sync) and `_acompletion_with_rate_limit_retry` (async) methods
- Uses the existing `_is_stream_transient_error()` helper for error classification

### 2. Node/Edge Validation Order Bug (`core/framework/mcp/agent_builder_server.py`)
- Fixed `add_node()`: Validation now happens BEFORE appending to `session.nodes`
- Fixed `add_edge()`: Validation now happens BEFORE appending to `session.edges`
- Only appends and saves to session if validation passes (no errors)
- Prevents state corruption where invalid nodes/edges were persisted to disk

### 3. Race Condition in SharedMemory Async Lock (`core/framework/graph/node.py`)
- Fixed double-checked locking pattern in `write_async()` method
- Now always acquires the main lock before checking `_key_locks` dictionary
- Gets lock reference while holding the main lock to prevent stale references
- Prevents potential KeyError or race condition issues during concurrent access

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/test_litellm_provider.py tests/test_litellm_streaming.py`) - 60 passed, 9 skipped
- [x] Lint passes (`cd core && ruff check .`) - All checks passed
- [x] Manual testing performed:
  - Verified litellm module imports correctly
  - Verified node module imports correctly
  - Tested SharedMemory concurrent writes work correctly
  - Tested that invalid nodes/edges are NOT added to session when validation fails

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
