### PR TITLE
docs(core): fix outdated goal-agent path reference in README

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -64,7 +64,7 @@ To use the agent builder with Claude Desktop or other MCP clients, add this to y
     "agent-builder": {
       "command": "python",
       "args": ["-m", "framework.mcp.agent_builder_server"],
-      "cwd": "/path/to/goal-agent"
+      "cwd": "/path/to/hive/core"
     }
   }
 }


### PR DESCRIPTION
## Description

The MCP client configuration example in `core/README.md` references an outdated project name (`goal-agent`) in the `cwd` field. This PR updates it to `hive/core` to match the current repository structure.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #5628

## Changes Made

- Updated `"cwd": "/path/to/goal-agent"` to `"cwd": "/path/to/hive/core"` in the MCP client configuration JSON example (line 67)

## Testing

- [x] Manual testing performed
- Verified the path reference matches the current repo structure

## Checklist

- [x] My changes follow the project's code style
- [x] I have reviewed my own changes
- [x] This is a micro-fix (docs/typo, <20 lines changed)