### PR TITLE
fix: enforce 0600 permissions on OAuth token files

### DIFF
--- a/core/codex_oauth.py
+++ b/core/codex_oauth.py
@@ -15,6 +15,7 @@ import base64
 import hashlib
 import http.server
 import json
+import os
 import platform
 import secrets
 import subprocess
@@ -150,8 +151,9 @@ def save_credentials(token_data: dict, account_id: str) -> None:
     if "id_token" in token_data:
         auth_data["tokens"]["id_token"] = token_data["id_token"]
 
-    CODEX_AUTH_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with open(CODEX_AUTH_FILE, "w") as f:
+    CODEX_AUTH_FILE.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    fd = os.open(CODEX_AUTH_FILE, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
         json.dump(auth_data, f, indent=2)
 
 

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -322,8 +322,9 @@ def _save_refreshed_codex_credentials(auth_data: dict, token_data: dict) -> None
         auth_data["tokens"] = tokens
         auth_data["last_refresh"] = datetime.now(UTC).isoformat()
 
-        CODEX_AUTH_FILE.parent.mkdir(parents=True, exist_ok=True)
-        with open(CODEX_AUTH_FILE, "w") as f:
+        CODEX_AUTH_FILE.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        fd = os.open(CODEX_AUTH_FILE, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
             json.dump(auth_data, f, indent=2)
         logger.debug("Codex credentials refreshed successfully")
     except (OSError, KeyError) as exc:

--- a/core/framework/storage/checkpoint_store.py
+++ b/core/framework/storage/checkpoint_store.py
@@ -123,7 +123,8 @@ class CheckpointStore:
                 return None
 
             try:
-                return CheckpointIndex.model_validate_json(self.index_path.read_text(encoding="utf-8"))
+                content = self.index_path.read_text(encoding="utf-8")
+                return CheckpointIndex.model_validate_json(content)
             except Exception as e:
                 logger.error(f"Failed to load checkpoint index: {e}")
                 return None


### PR DESCRIPTION
## Description

OAuth token files (`~/.codex/auth.json`) were written using `open(file, "w")` which relies on system umask for permissions. On systems with permissive umask (e.g. `0o000`), token files could be readable by other users.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #5530

## Changes Made

- `core/codex_oauth.py`: Use `os.open()` with explicit `0o600` mode and `mkdir(mode=0o700)` for new directories
- `core/framework/runner/runner.py`: Same fix for token refresh write path

## Testing

- [x] Manual testing performed

Ran full OAuth flow (`uv run python core/codex_oauth.py`), verified:
- `auth.json` created with `-rw-------` (0o600)
- Token content written and readable correctly
- Overwrite (token refresh) maintains 0o600 permissions

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings