### PR TITLE
fix(security): prevent symlink-based sandbox escape in get_secure_path (closes #1167)

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/security.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/security.py
@@ -10,7 +10,7 @@ def get_secure_path(path: str, workspace_id: str, agent_id: str, session_id: str
         raise ValueError("workspace_id, agent_id, and session_id are all required")
 
     # Ensure session directory exists
-    session_dir = os.path.abspath(os.path.join(WORKSPACES_DIR, workspace_id, agent_id, session_id))
+    session_dir = os.path.realpath(os.path.join(WORKSPACES_DIR, workspace_id, agent_id, session_id))
     os.makedirs(session_dir, exist_ok=True)
 
     # Normalize whitespace to prevent bypass via leading spaces/tabs
@@ -21,9 +21,9 @@ def get_secure_path(path: str, workspace_id: str, agent_id: str, session_id: str
         # Strip exactly one leading separator to make path relative to session_dir,
         # preserving any subsequent separators (e.g. UNC paths like //server/share)
         rel_path = path[1:] if path and path[0] in ("/", "\\") else path
-        final_path = os.path.abspath(os.path.join(session_dir, rel_path))
+        final_path = os.path.realpath(os.path.join(session_dir, rel_path))
     else:
-        final_path = os.path.abspath(os.path.join(session_dir, path))
+        final_path = os.path.realpath(os.path.join(session_dir, path))
 
     # Verify path is within session_dir
     try:

--- a/tools/tests/tools/test_security.py
+++ b/tools/tests/tools/test_security.py
@@ -1,6 +1,5 @@
 """Tests for security.py - get_secure_path() function."""
 
-
 from unittest.mock import patch
 
 import pytest

--- a/tools/tests/tools/test_security.py
+++ b/tools/tests/tools/test_security.py
@@ -1,6 +1,6 @@
 """Tests for security.py - get_secure_path() function."""
 
-import os
+
 from unittest.mock import patch
 
 import pytest
@@ -242,19 +242,14 @@ class TestGetSecurePath:
         symlink_path = session_dir / "link_to_target"
         symlink_path.symlink_to(target_file)
 
-        # Path through symlink should resolve
+        # Path through symlink should resolve to the real target path
         result = get_secure_path("link_to_target", **ids)
 
-        assert result == str(symlink_path)
+        # realpath resolves the symlink, so result points to the real file
+        assert result == str(target_file.resolve())
 
-    def test_symlink_escape_detected_with_realpath(self, ids):
-        """Symlinks pointing outside sandbox can be detected using realpath.
-
-        Note: get_secure_path uses abspath (not realpath), so it validates the
-        lexical path. To fully protect against symlink attacks, callers should
-        verify realpath(result) is still within the sandbox before file I/O.
-        This test documents that pattern.
-        """
+    def test_symlink_escape_blocked(self, ids):
+        """Symlinks pointing outside sandbox are blocked by get_secure_path."""
         from aden_tools.tools.file_system_toolkits.security import get_secure_path
 
         # Create session directory
@@ -267,10 +262,22 @@ class TestGetSecurePath:
         symlink_path = session_dir / "escape_link"
         symlink_path.symlink_to(outside_target)
 
-        # get_secure_path accepts the lexical path (symlink is inside session)
-        result = get_secure_path("escape_link", **ids)
-        assert result == str(symlink_path)
+        # get_secure_path now resolves symlinks and blocks the escape
+        with pytest.raises(ValueError, match="outside the session sandbox"):
+            get_secure_path("escape_link", **ids)
 
-        # However, realpath reveals the escape - callers should check this
-        real_path = os.path.realpath(result)
-        assert os.path.commonpath([real_path, str(session_dir)]) != str(session_dir)
+    def test_symlink_to_root_escape_blocked(self, ids):
+        """Symlink to / inside sandbox then traversing through it is blocked."""
+        from aden_tools.tools.file_system_toolkits.security import get_secure_path
+
+        # Create session directory
+        session_dir = self.workspaces_dir / "test-workspace" / "test-agent" / "test-session"
+        session_dir.mkdir(parents=True, exist_ok=True)
+
+        # Create a symlink to root filesystem inside the sandbox
+        symlink_path = session_dir / "root"
+        symlink_path.symlink_to("/")
+
+        # Attempting to access files through the symlink should be blocked
+        with pytest.raises(ValueError, match="outside the session sandbox"):
+            get_secure_path("root/etc/passwd", **ids)


### PR DESCRIPTION

## Description

This PR fixes a high-severity sandbox escape vulnerability in `get_secure_path()`.

Previously, the function used `os.path.abspath()` to normalize paths before performing a sandbox boundary check using `os.path.commonpath()`. However, `abspath()` does not resolve symbolic links, which allowed an attacker to create a symlink inside the sandbox pointing outside (e.g., `/`) and bypass the boundary validation.

This PR replaces `os.path.abspath()` with `os.path.realpath()` to ensure all symbolic links are fully resolved before validating that the path remains inside the session sandbox.

This closes Issue #1167.

---

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)

---

## Related Issues

Closes #1167

---

## Changes Made

* Replaced all usages of `os.path.abspath()` with `os.path.realpath()` in `get_secure_path()`
* Ensured both `session_dir` and `final_path` are resolved before boundary validation
* Updated symlink-related tests to reflect secure behavior
* Added test coverage for symlink-to-root escape attempt
* Renamed vulnerable test case to reflect fixed behavior

---

## Security Impact

This fix prevents:

* Symlink-based sandbox escape
* Arbitrary file read/write outside the session directory
* Root filesystem traversal via symbolic links

Severity: High → Resolved

---

## Testing

Verified locally with:

```
uv run pytest tools/tests/tools/test_security.py -v
```

Results:

* 20/20 tests passing
* Symlink escape blocked
* Symlink to `/` escape blocked
* Path traversal blocked
* No regressions in normal path handling

---

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [x] My changes generate no new warnings
* [x] I have added/updated tests to verify the fix
* [x] New and existing unit tests pass locally
