### PR TITLE
docs: add Frontend section to README (v0.6.0 web workspace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,26 @@ hive tui
 hive run exports/your_agent_name --input '{"key": "value"}'
 ```
 
+## Frontend
+
+The v0.6.0 release introduced a new web workspace for visual agent building and monitoring.
+
+### Running the Frontend
+
+```bash
+cd core/frontend
+npm install
+npm run dev
+```
+
+The frontend provides:
+- Visual agent graph builder
+- Real-time session monitoring
+- Credential management UI
+- Chat interface for agent interaction
+
+For more details, see the [Frontend README](core/frontend/README.md).
+
 ## Coding Agent Support
 
 ### Codex CLI


### PR DESCRIPTION
## Summary
Add Frontend section to README documenting how to run and use the web workspace introduced in v0.6.0.

### Changes
- Added ## Frontend section with:
  - Running instructions (npm install, npm run dev)
  - Features overview (visual graph builder, session monitoring, credential management, chat interface)

Closes #5636