### PR TITLE
fix(security): redact sensitive memory keys before LLM routing prompts

### DIFF
--- a/core/framework/graph/edge.py
+++ b/core/framework/graph/edge.py
@@ -35,6 +35,47 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_TOKENS = 8192
 
+# Key name patterns that must never be sent to external LLM prompts.
+# Matched case-insensitively against each memory key.
+SENSITIVE_KEY_PATTERNS = frozenset({
+    "key",
+    "token",
+    "secret",
+    "password",
+    "credential",
+    "auth",
+    "bearer",
+    "api_key",
+    "access_token",
+    "refresh_token",
+})
+
+
+def _sanitize_memory_for_prompt(
+    memory: dict[str, Any], max_keys: int = 5
+) -> dict[str, str]:
+    """Sanitize shared memory before injection into LLM routing prompts.
+
+    Redacts any key whose name contains a sensitive pattern (e.g.
+    'api_key', 'access_token', 'password') to prevent credential or
+    PII leakage to third-party LLM providers.
+
+    Args:
+        memory: The shared-memory dict.
+        max_keys: Maximum number of keys to include (for prompt size control).
+
+    Returns:
+        Sanitized dict safe for LLM prompt injection.
+    """
+    safe: dict[str, str] = {}
+    for k, v in list(memory.items())[:max_keys]:
+        k_lower = k.lower()
+        if any(pattern in k_lower for pattern in SENSITIVE_KEY_PATTERNS):
+            safe[k] = "[REDACTED]"
+        else:
+            safe[k] = str(v)[:100]
+    return safe
+
 
 class EdgeCondition(StrEnum):
     """When an edge should be traversed."""
@@ -235,7 +276,7 @@ Should we proceed to: {target_node_name or self.target}?
 Edge description: {self.description or "No description"}
 
 **Context from memory**:
-{json.dumps({k: str(v)[:100] for k, v in list(memory.items())[:5]}, indent=2)}
+{json.dumps(_sanitize_memory_for_prompt(memory), indent=2)}
 
 Evaluate whether proceeding to this next node is the right step toward achieving the goal.
 Consider:

--- a/core/tests/test_edge_security.py
+++ b/core/tests/test_edge_security.py
@@ -1,0 +1,103 @@
+"""
+Tests for edge routing security — secret redaction in LLM prompts.
+
+Validates that _sanitize_memory_for_prompt() prevents credential/PII
+leakage when shared memory is injected into LLM routing prompts.
+"""
+
+
+from framework.graph.edge import _sanitize_memory_for_prompt
+
+
+class TestSanitizeMemoryForPrompt:
+    """Verify secret redaction before LLM prompt injection."""
+
+    def test_api_key_redacted(self):
+        memory = {"api_key": "sk-secret-12345", "status": "ready"}
+        result = _sanitize_memory_for_prompt(memory)
+        assert result["api_key"] == "[REDACTED]"
+        assert result["status"] == "ready"
+
+    def test_access_token_redacted(self):
+        memory = {"access_token": "ghp_xxxxxxxxxxxx"}
+        result = _sanitize_memory_for_prompt(memory)
+        assert result["access_token"] == "[REDACTED]"
+
+    def test_refresh_token_redacted(self):
+        memory = {"refresh_token": "rt_xxxxxxxxxxxx"}
+        result = _sanitize_memory_for_prompt(memory)
+        assert result["refresh_token"] == "[REDACTED]"
+
+    def test_password_redacted(self):
+        memory = {"database_password": "hunter2"}
+        result = _sanitize_memory_for_prompt(memory)
+        assert result["database_password"] == "[REDACTED]"
+
+    def test_secret_redacted(self):
+        memory = {"client_secret": "cs_xxx"}
+        result = _sanitize_memory_for_prompt(memory)
+        assert result["client_secret"] == "[REDACTED]"
+
+    def test_credential_redacted(self):
+        memory = {"user_credential": "cred_xxx"}
+        result = _sanitize_memory_for_prompt(memory)
+        assert result["user_credential"] == "[REDACTED]"
+
+    def test_bearer_redacted(self):
+        memory = {"bearer_value": "eyJhbGciOi..."}
+        result = _sanitize_memory_for_prompt(memory)
+        assert result["bearer_value"] == "[REDACTED]"
+
+    def test_auth_redacted(self):
+        memory = {"auth_header": "Basic dXNlcjpwYXNz"}
+        result = _sanitize_memory_for_prompt(memory)
+        assert result["auth_header"] == "[REDACTED]"
+
+    def test_case_insensitive_matching(self):
+        """Key matching must be case-insensitive."""
+        memory = {"API_KEY": "sk-xxx", "Access_Token": "tok-xxx"}
+        result = _sanitize_memory_for_prompt(memory)
+        assert result["API_KEY"] == "[REDACTED]"
+        assert result["Access_Token"] == "[REDACTED]"
+
+    def test_safe_keys_pass_through(self):
+        """Non-sensitive keys should pass through with truncation."""
+        memory = {
+            "customer_name": "Alice",
+            "status": "processing",
+            "confidence": "0.95",
+        }
+        result = _sanitize_memory_for_prompt(memory)
+        assert result["customer_name"] == "Alice"
+        assert result["status"] == "processing"
+        assert result["confidence"] == "0.95"
+
+    def test_value_truncation(self):
+        """Long values should be truncated to 100 chars."""
+        memory = {"description": "x" * 200}
+        result = _sanitize_memory_for_prompt(memory)
+        assert len(result["description"]) == 100
+
+    def test_max_keys_limit(self):
+        """Only max_keys entries should appear in the result."""
+        memory = {f"field_{i}": f"value_{i}" for i in range(20)}
+        result = _sanitize_memory_for_prompt(memory, max_keys=3)
+        assert len(result) == 3
+
+    def test_empty_memory(self):
+        result = _sanitize_memory_for_prompt({})
+        assert result == {}
+
+    def test_mixed_safe_and_sensitive(self):
+        """Mix of safe and sensitive keys."""
+        memory = {
+            "task": "process invoice",
+            "api_key": "sk-super-secret",
+            "result": "invoice #123",
+            "oauth_token": "tok-yyy",
+        }
+        result = _sanitize_memory_for_prompt(memory)
+        assert result["task"] == "process invoice"
+        assert result["api_key"] == "[REDACTED]"
+        assert result["result"] == "invoice #123"
+        assert result["oauth_token"] == "[REDACTED]"


### PR DESCRIPTION
Closes #5657

## Changes

- Add `SENSITIVE_KEY_PATTERNS` frozenset for token/secret/password/api_key/etc.
- Add `_sanitize_memory_for_prompt()` — redacts matching keys to `[REDACTED]`
- Apply sanitization in `_llm_decide()` at line 279

## Tests

14 new tests in `test_edge_security.py`. All pass. `ruff check` clean.
