### PR TITLE
fix(core): detect max_steps exhaustion and report execution as truncated

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -587,6 +587,7 @@ class GraphExecutor:
             )
 
         try:
+            _reached_end = False  # Track whether the loop exited via break (legitimate)
             while steps < graph.max_steps:
                 steps += 1
 
@@ -667,6 +668,7 @@ class GraphExecutor:
                     )
                     if next_node is None:
                         self.logger.info("   → No more edges after visit limit, ending")
+                        _reached_end = True
                         break
                     current_node_id = next_node
                     continue
@@ -1065,6 +1067,7 @@ class GraphExecutor:
                 # Check if this is a terminal node - if so, we're done
                 if node_spec.id in graph.terminal_nodes:
                     self.logger.info(f"✓ Reached terminal node: {node_spec.name}")
+                    _reached_end = True
                     break
 
                 # Determine next node
@@ -1097,6 +1100,7 @@ class GraphExecutor:
 
                     if not traversable_edges:
                         self.logger.info("   → No more edges, ending execution")
+                        _reached_end = True
                         break  # No valid edge, end execution
 
                     # Check for fan-out (multiple traversable edges)
@@ -1144,6 +1148,7 @@ class GraphExecutor:
                         else:
                             # No convergence point - branches are terminal
                             self.logger.info("   → Parallel branches completed (no convergence)")
+                            _reached_end = True
                             break
                     else:
                         # Sequential: follow single edge (existing logic via _follow_edges)
@@ -1157,6 +1162,7 @@ class GraphExecutor:
                         )
                         if next_node is None:
                             self.logger.info("   → No more edges, ending execution")
+                            _reached_end = True
                             break
                         next_spec = graph.get_node(next_node)
                         self.logger.info(f"   → Next: {next_spec.name if next_spec else next_node}")
@@ -1337,7 +1343,9 @@ class GraphExecutor:
             # Collect output
             output = memory.read_all()
 
-            self.logger.info("\n✓ Execution complete!")
+            _status = "complete" if _reached_end else "truncated"
+            _icon = "\u2713" if _reached_end else "\u26a0"
+            self.logger.info(f"\n{_icon} Execution {_status}!")
             self.logger.info(f"   Steps: {steps}")
             self.logger.info(f"   Path: {' → '.join(path)}")
             self.logger.info(f"   Total tokens: {total_tokens}")
@@ -1346,11 +1354,27 @@ class GraphExecutor:
             # Calculate execution quality metrics
             total_retries_count = sum(node_retry_counts.values())
             nodes_failed = [nid for nid, count in node_retry_counts.items() if count > 0]
-            exec_quality = "degraded" if total_retries_count > 0 else "clean"
+
+            # Detect max_steps exhaustion: the loop exited without reaching
+            # a terminal node or running out of edges.  This means the agent
+            # consumed its entire step budget — likely stuck in a feedback
+            # loop — so treat as truncated, not successful.
+            if not _reached_end:
+                exec_quality = "truncated"
+                self.logger.warning(
+                    f"   ⚠ Execution exhausted max_steps ({graph.max_steps}) "
+                    f"without reaching a terminal node.  Last node: {current_node_id}"
+                )
+            elif total_retries_count > 0:
+                exec_quality = "degraded"
+            else:
+                exec_quality = "clean"
 
             # Update narrative to reflect execution quality
             quality_suffix = ""
-            if exec_quality == "degraded":
+            if exec_quality == "truncated":
+                quality_suffix = f" (TRUNCATED at step {steps}/{graph.max_steps})"
+            elif exec_quality == "degraded":
                 retries = total_retries_count
                 failed = len(nodes_failed)
                 quality_suffix = f" ({retries} retries across {failed} nodes)"
@@ -1369,6 +1393,11 @@ class GraphExecutor:
                     duration_ms=total_latency,
                     node_path=path,
                     execution_quality=exec_quality,
+                    total_retries=total_retries_count,
+                    nodes_with_failures=nodes_failed,
+                    retry_details=dict(node_retry_counts),
+                    had_partial_failures=len(nodes_failed) > 0,
+                    node_visit_counts=dict(node_visit_counts),
                 )
 
             return ExecutionResult(

--- a/core/tests/test_executor_truncation.py
+++ b/core/tests/test_executor_truncation.py
@@ -1,0 +1,173 @@
+"""
+Tests for executor max_steps exhaustion detection.
+
+Validates that GraphExecutor correctly reports execution_quality="truncated"
+when the step budget is exhausted without reaching a terminal node,
+and "clean" when a terminal node is properly reached.
+"""
+
+import pytest
+
+from framework.graph.edge import EdgeCondition, EdgeSpec, GraphSpec
+from framework.graph.executor import GraphExecutor
+from framework.graph.goal import Goal
+from framework.graph.node import NodeResult, NodeSpec
+
+
+# ---- Minimal runtime stub (matches test_graph_executor.py pattern) ----
+class DummyRuntime:
+    execution_id = ""
+
+    def start_run(self, **kwargs):
+        return "run-1"
+
+    def end_run(self, **kwargs):
+        pass
+
+    def report_problem(self, **kwargs):
+        pass
+
+
+# ---- Fake node that always succeeds ----
+class SuccessNode:
+    def validate_input(self, ctx):
+        return []
+
+    async def execute(self, ctx):
+        return NodeResult(
+            success=True,
+            output={"result": "done"},
+            tokens_used=1,
+            latency_ms=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_terminal_node_reached_is_clean():
+    """When the executor reaches a terminal node, quality should be 'clean'."""
+    graph = GraphSpec(
+        id="graph-term",
+        goal_id="g1",
+        nodes=[
+            NodeSpec(
+                id="start",
+                name="start",
+                description="entry",
+                node_type="event_loop",
+                input_keys=[],
+                output_keys=["result"],
+                max_retries=0,
+            ),
+            NodeSpec(
+                id="end",
+                name="end",
+                description="terminal",
+                node_type="event_loop",
+                input_keys=[],
+                output_keys=["result"],
+                max_retries=0,
+            ),
+        ],
+        edges=[
+            EdgeSpec(
+                id="e1",
+                source="start",
+                target="end",
+                condition=EdgeCondition.ON_SUCCESS,
+            ),
+        ],
+        entry_node="start",
+        terminal_nodes=["end"],
+        max_steps=10,
+    )
+
+    executor = GraphExecutor(
+        runtime=DummyRuntime(),
+        node_registry={"start": SuccessNode(), "end": SuccessNode()},
+    )
+
+    goal = Goal(id="g1", name="test", description="test")
+    result = await executor.execute(graph=graph, goal=goal)
+
+    assert result.success is True
+    assert result.execution_quality == "clean"
+    assert "end" in result.path
+
+
+@pytest.mark.asyncio
+async def test_no_edges_ends_cleanly():
+    """A single node with no outgoing edges should end with 'clean'."""
+    graph = GraphSpec(
+        id="graph-single",
+        goal_id="g1",
+        nodes=[
+            NodeSpec(
+                id="only",
+                name="only",
+                description="sole node",
+                node_type="event_loop",
+                input_keys=[],
+                output_keys=["result"],
+                max_retries=0,
+            ),
+        ],
+        edges=[],
+        entry_node="only",
+        max_steps=10,
+    )
+
+    executor = GraphExecutor(
+        runtime=DummyRuntime(),
+        node_registry={"only": SuccessNode()},
+    )
+
+    goal = Goal(id="g1", name="test", description="test")
+    result = await executor.execute(graph=graph, goal=goal)
+
+    assert result.success is True
+    assert result.execution_quality == "clean"
+
+
+@pytest.mark.asyncio
+async def test_max_steps_exhaustion_is_truncated():
+    """Exhausting max_steps in a self-loop should report 'truncated'."""
+    graph = GraphSpec(
+        id="graph-loop",
+        goal_id="g1",
+        nodes=[
+            NodeSpec(
+                id="loop_node",
+                name="loop_node",
+                description="loops forever",
+                node_type="event_loop",
+                input_keys=[],
+                output_keys=["result"],
+                max_retries=0,
+            ),
+        ],
+        edges=[
+            EdgeSpec(
+                id="self_loop",
+                source="loop_node",
+                target="loop_node",
+                condition=EdgeCondition.ALWAYS,
+            ),
+        ],
+        entry_node="loop_node",
+        terminal_nodes=[],  # No terminal nodes — loop never ends
+        max_steps=3,  # Small step budget
+    )
+
+    executor = GraphExecutor(
+        runtime=DummyRuntime(),
+        node_registry={"loop_node": SuccessNode()},
+    )
+
+    goal = Goal(id="g1", name="test", description="test")
+    result = await executor.execute(graph=graph, goal=goal)
+
+    # Should still return partial output (not crash)
+    assert result.success is True
+    # But quality should indicate truncation, NOT clean
+    assert result.execution_quality == "truncated"
+    assert result.steps_executed == 3


### PR DESCRIPTION
Closes #5659

## Changes

- Add `_reached_end` flag — set True on all 5 legitimate `break` points
- After loop: if `_reached_end is False`, set `execution_quality="truncated"`
- Log warning with step count and last node for operator visibility
- Pass telemetry metrics to `end_run()` for structured logging

## Tests

3 new tests in `test_executor_truncation.py`. All pass. `ruff check` clean.
