### PR TITLE
feat(runtime): propagate execution quality metrics to structured runtime logs

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -587,6 +587,7 @@ class GraphExecutor:
             )
 
         try:
+            _reached_end = False  # Track whether the loop exited via break (legitimate)
             while steps < graph.max_steps:
                 steps += 1
 
@@ -667,6 +668,7 @@ class GraphExecutor:
                     )
                     if next_node is None:
                         self.logger.info("   → No more edges after visit limit, ending")
+                        _reached_end = True
                         break
                     current_node_id = next_node
                     continue
@@ -1065,6 +1067,7 @@ class GraphExecutor:
                 # Check if this is a terminal node - if so, we're done
                 if node_spec.id in graph.terminal_nodes:
                     self.logger.info(f"✓ Reached terminal node: {node_spec.name}")
+                    _reached_end = True
                     break
 
                 # Determine next node
@@ -1097,6 +1100,7 @@ class GraphExecutor:
 
                     if not traversable_edges:
                         self.logger.info("   → No more edges, ending execution")
+                        _reached_end = True
                         break  # No valid edge, end execution
 
                     # Check for fan-out (multiple traversable edges)
@@ -1144,6 +1148,7 @@ class GraphExecutor:
                         else:
                             # No convergence point - branches are terminal
                             self.logger.info("   → Parallel branches completed (no convergence)")
+                            _reached_end = True
                             break
                     else:
                         # Sequential: follow single edge (existing logic via _follow_edges)
@@ -1157,6 +1162,7 @@ class GraphExecutor:
                         )
                         if next_node is None:
                             self.logger.info("   → No more edges, ending execution")
+                            _reached_end = True
                             break
                         next_spec = graph.get_node(next_node)
                         self.logger.info(f"   → Next: {next_spec.name if next_spec else next_node}")
@@ -1337,7 +1343,9 @@ class GraphExecutor:
             # Collect output
             output = memory.read_all()
 
-            self.logger.info("\n✓ Execution complete!")
+            _status = "complete" if _reached_end else "truncated"
+            _icon = "\u2713" if _reached_end else "\u26a0"
+            self.logger.info(f"\n{_icon} Execution {_status}!")
             self.logger.info(f"   Steps: {steps}")
             self.logger.info(f"   Path: {' → '.join(path)}")
             self.logger.info(f"   Total tokens: {total_tokens}")
@@ -1346,11 +1354,27 @@ class GraphExecutor:
             # Calculate execution quality metrics
             total_retries_count = sum(node_retry_counts.values())
             nodes_failed = [nid for nid, count in node_retry_counts.items() if count > 0]
-            exec_quality = "degraded" if total_retries_count > 0 else "clean"
+
+            # Detect max_steps exhaustion: the loop exited without reaching
+            # a terminal node or running out of edges.  This means the agent
+            # consumed its entire step budget — likely stuck in a feedback
+            # loop — so treat as truncated, not successful.
+            if not _reached_end:
+                exec_quality = "truncated"
+                self.logger.warning(
+                    f"   ⚠ Execution exhausted max_steps ({graph.max_steps}) "
+                    f"without reaching a terminal node.  Last node: {current_node_id}"
+                )
+            elif total_retries_count > 0:
+                exec_quality = "degraded"
+            else:
+                exec_quality = "clean"
 
             # Update narrative to reflect execution quality
             quality_suffix = ""
-            if exec_quality == "degraded":
+            if exec_quality == "truncated":
+                quality_suffix = f" (TRUNCATED at step {steps}/{graph.max_steps})"
+            elif exec_quality == "degraded":
                 retries = total_retries_count
                 failed = len(nodes_failed)
                 quality_suffix = f" ({retries} retries across {failed} nodes)"
@@ -1369,6 +1393,11 @@ class GraphExecutor:
                     duration_ms=total_latency,
                     node_path=path,
                     execution_quality=exec_quality,
+                    total_retries=total_retries_count,
+                    nodes_with_failures=nodes_failed,
+                    retry_details=dict(node_retry_counts),
+                    had_partial_failures=len(nodes_failed) > 0,
+                    node_visit_counts=dict(node_visit_counts),
                 )
 
             return ExecutionResult(

--- a/core/framework/runtime/runtime_log_schemas.py
+++ b/core/framework/runtime/runtime_log_schemas.py
@@ -117,7 +117,13 @@ class RunSummaryLog(BaseModel):
     attention_reasons: list[str] = Field(default_factory=list)
     started_at: str = ""  # ISO timestamp
     duration_ms: int = 0
-    execution_quality: str = ""  # "clean"|"degraded"|"failed"
+    execution_quality: str = ""  # "clean"|"degraded"|"failed"|"truncated"
+    # Execution quality details (populated by GraphExecutor):
+    total_retries: int = 0
+    nodes_with_failures: list[str] = Field(default_factory=list)
+    retry_details: dict[str, int] = Field(default_factory=dict)  # {node_id: count}
+    had_partial_failures: bool = False
+    node_visit_counts: dict[str, int] = Field(default_factory=dict)  # {node_id: visits}
     # OTel / trace context (from observability; empty if not set):
     trace_id: str = ""
     execution_id: str = ""

--- a/core/framework/runtime/runtime_logger.py
+++ b/core/framework/runtime/runtime_logger.py
@@ -270,6 +270,12 @@ class RuntimeLogger:
         duration_ms: int,
         node_path: list[str] | None = None,
         execution_quality: str = "",
+        # Execution quality details (from GraphExecutor):
+        total_retries: int = 0,
+        nodes_with_failures: list[str] | None = None,
+        retry_details: dict[str, int] | None = None,
+        had_partial_failures: bool = False,
+        node_visit_counts: dict[str, int] | None = None,
     ) -> None:
         """Read L2 from disk, aggregate into L1, write summary.json.
 
@@ -288,6 +294,13 @@ class RuntimeLogger:
             attention_reasons: list[str] = []
             for nd in node_details:
                 attention_reasons.extend(nd.attention_reasons)
+
+            # Flag truncated executions for operator attention
+            if execution_quality == "truncated":
+                needs_attention = True
+                attention_reasons.append(
+                    "Execution truncated: max_steps exhausted"
+                )
 
             # OTel / trace context for L1 correlation
             ctx = get_trace_context()
@@ -308,6 +321,11 @@ class RuntimeLogger:
                 started_at=self._started_at,
                 duration_ms=duration_ms,
                 execution_quality=execution_quality,
+                total_retries=total_retries,
+                nodes_with_failures=nodes_with_failures or [],
+                retry_details=retry_details or {},
+                had_partial_failures=had_partial_failures,
+                node_visit_counts=node_visit_counts or {},
                 trace_id=trace_id,
                 execution_id=execution_id,
             )


### PR DESCRIPTION
Closes #5661

## Changes

- Add 5 new fields to `RunSummaryLog`: `total_retries`, `nodes_with_failures`, `retry_details`, `had_partial_failures`, `node_visit_counts`
- Extend `RuntimeLogger.end_run()` to accept and propagate metrics
- Auto-flag truncated executions with `needs_attention=True`
- Wire `GraphExecutor` to pass metrics at `end_run()` call site
- Zero breaking changes — all new fields have defaults

Foundation for #5650 (Eval System).

## Verification

150 tests pass, 0 failures. `ruff check` clean.
