### PR TITLE
feat(tools): add YouTube Data API integration

### DIFF
--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -93,6 +93,7 @@ from .slack import SLACK_CREDENTIALS
 from .store_adapter import CredentialStoreAdapter
 from .stripe import STRIPE_CREDENTIALS
 from .telegram import TELEGRAM_CREDENTIALS
+from .youtube import YOUTUBE_CREDENTIALS
 
 # Merged registry of all credentials
 CREDENTIAL_SPECS = {
@@ -119,6 +120,7 @@ CREDENTIAL_SPECS = {
     **STRIPE_CREDENTIALS,
     **BREVO_CREDENTIALS,
     **POSTGRES_CREDENTIALS,
+    **YOUTUBE_CREDENTIALS,
 }
 
 __all__ = [
@@ -168,4 +170,5 @@ __all__ = [
     "STRIPE_CREDENTIALS",
     "BREVO_CREDENTIALS",
     "POSTGRES_CREDENTIALS",
+    "YOUTUBE_CREDENTIALS",
 ]

--- a/tools/src/aden_tools/credentials/youtube.py
+++ b/tools/src/aden_tools/credentials/youtube.py
@@ -1,0 +1,19 @@
+"""YouTube Data API credentials."""
+
+from .base import CredentialSpec
+
+YOUTUBE_CREDENTIALS = {
+    "youtube": CredentialSpec(
+        env_var="YOUTUBE_API_KEY",
+        tools=[
+            "youtube_search_videos",
+            "youtube_get_video_details",
+            "youtube_get_channel_info",
+            "youtube_list_channel_videos",
+            "youtube_get_playlist_items",
+            "youtube_search_channels",
+        ],
+        help_url="https://console.cloud.google.com/apis/credentials",
+        description="YouTube Data API v3 key",
+    ),
+}

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -81,6 +81,7 @@ from .web_search_tool import register_tools as register_web_search
 
 # Web and PDF tools
 from .wikipedia_tool import register_tools as register_wikipedia
+from .youtube_tool import register_tools as register_youtube
 
 
 def register_all_tools(
@@ -160,6 +161,9 @@ def register_all_tools(
 
     # Postgres tool
     register_postgres(mcp, credentials=credentials)
+
+    # YouTube tool
+    register_youtube(mcp, credentials=credentials)
 
     # Return the list of all registered tool names
     return list(mcp._tool_manager._tools.keys())

--- a/tools/src/aden_tools/tools/youtube_tool/README.md
+++ b/tools/src/aden_tools/tools/youtube_tool/README.md
@@ -1,0 +1,130 @@
+# YouTube Data API Tool
+
+Search and retrieve video/channel information from YouTube.
+
+## Description
+
+Provides comprehensive access to YouTube's public data including video search, channel statistics, playlists, and detailed metadata. Use when you need to find YouTube content, analyze video statistics, or retrieve channel information.
+
+## Tools (6)
+
+| Tool | Description |
+|------|-------------|
+| `youtube_search_videos` | Search for videos by query with sorting options |
+| `youtube_get_video_details` | Get detailed information about a specific video |
+| `youtube_get_channel_info` | Get channel statistics and information |
+| `youtube_list_channel_videos` | List videos from a specific channel |
+| `youtube_get_playlist_items` | Get videos from a playlist |
+| `youtube_search_channels` | Search for channels by query |
+
+## Setup
+
+Requires a YouTube Data API v3 key from [Google Cloud Console](https://console.cloud.google.com/apis/credentials).
+
+### Steps:
+1. Create a project in Google Cloud Console
+2. Enable YouTube Data API v3
+3. Create an API key
+4. Set the `YOUTUBE_API_KEY` environment variable
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `YOUTUBE_API_KEY` | Yes | YouTube Data API v3 key from Google Cloud Console |
+
+## Parameters
+
+### `youtube_search_videos`
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | `str` | - | Search query string |
+| `max_results` | `int` | `10` | Number of results (1-50) |
+| `order` | `str` | `"relevance"` | Sort order: date, rating, relevance, title, viewCount |
+
+### `youtube_get_video_details`
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `video_id` | `str` | - | YouTube video ID (e.g., "dQw4w9WgXcQ") |
+
+### `youtube_get_channel_info`
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `channel_id` | `str` | - | YouTube channel ID |
+
+### `youtube_list_channel_videos`
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `channel_id` | `str` | - | YouTube channel ID |
+| `max_results` | `int` | `10` | Number of results (1-50) |
+| `order` | `str` | `"date"` | Sort order: date, rating, relevance, title, viewCount |
+
+### `youtube_get_playlist_items`
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `playlist_id` | `str` | - | YouTube playlist ID |
+| `max_results` | `int` | `10` | Number of results (1-50) |
+
+### `youtube_search_channels`
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | `str` | - | Search query string |
+| `max_results` | `int` | `10` | Number of results (1-50) |
+
+## Example Usage
+
+```python
+# Search for videos
+youtube_search_videos(
+    query="Python tutorial",
+    max_results=5,
+    order="viewCount"
+)
+
+# Get video details
+youtube_get_video_details(video_id="dQw4w9WgXcQ")
+
+# Search for a channel, then list its videos (tool chaining)
+channels = youtube_search_channels(query="Fireship", max_results=1)
+channel_id = channels["items"][0]["id"]["channelId"]
+
+videos = youtube_list_channel_videos(
+    channel_id=channel_id,
+    max_results=20,
+    order="date"
+)
+
+# Get channel statistics
+youtube_get_channel_info(channel_id="UCsBjURrPoezykLs9EqgamOA")
+
+# Get playlist videos
+youtube_get_playlist_items(
+    playlist_id="PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf",
+    max_results=25
+)
+```
+
+## Response Format
+
+All tools return JSON responses following YouTube Data API v3 schema:
+
+- **Search results**: Contains `items` array with video/channel data
+- **Video details**: Includes `snippet`, `statistics`, and `contentDetails`
+- **Channel info**: Includes `snippet`, `statistics`, and `contentDetails`
+- **Errors**: Returns `{"error": "message", "help": "..."}`
+
+## API Quota
+
+YouTube Data API v3 has daily quota limits (10,000 units/day default). Each operation costs different units:
+- Search: 100 units
+- Video details: 1 unit
+- Channel info: 1 unit
+- Playlist items: 1 unit
+
+Monitor usage in [Google Cloud Console](https://console.cloud.google.com/apis/api/youtube.googleapis.com/quotas).
+
+## Reference
+
+- [YouTube Data API v3 Documentation](https://developers.google.com/youtube/v3/docs)
+- [API Key Setup Guide](https://developers.google.com/youtube/registering_an_application)
+- [Quota Calculator](https://developers.google.com/youtube/v3/determine_quota_cost)

--- a/tools/src/aden_tools/tools/youtube_tool/__init__.py
+++ b/tools/src/aden_tools/tools/youtube_tool/__init__.py
@@ -1,0 +1,5 @@
+"""YouTube Data API tool for searching and retrieving video/channel information."""
+
+from .youtube_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/youtube_tool/youtube_tool.py
+++ b/tools/src/aden_tools/tools/youtube_tool/youtube_tool.py
@@ -1,0 +1,426 @@
+"""
+YouTube Data API Tool - Search and retrieve video/channel information.
+
+Supports:
+- API key authentication (YOUTUBE_API_KEY)
+
+Use Cases:
+- Search for videos by query
+- Get detailed video information (title, description, views, likes)
+- Get channel information and statistics
+- List videos from a specific channel
+- Get playlist items
+- Search for channels
+
+API Reference: https://developers.google.com/youtube/v3/docs
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialStoreAdapter
+
+logger = logging.getLogger(__name__)
+
+# YouTube Data API base URL
+YOUTUBE_API_BASE = "https://www.googleapis.com/youtube/v3"
+
+
+class _YouTubeClient:
+    """Internal client for YouTube Data API v3 calls."""
+
+    def __init__(self, api_key: str):
+        self._api_key = api_key
+        self._client = httpx.Client(timeout=30.0)
+
+    def _request(
+        self,
+        endpoint: str,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Make a request to the YouTube Data API.
+
+        Args:
+            endpoint: API endpoint (e.g., "search", "videos")
+            params: Query parameters
+
+        Returns:
+            JSON response as dict
+        """
+        # Add API key to params
+        params["key"] = self._api_key
+
+        url = f"{YOUTUBE_API_BASE}/{endpoint}"
+
+        try:
+            response = self._client.get(url, params=params)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            error_data = {}
+            try:
+                error_data = e.response.json()
+            except Exception:
+                pass
+            return {
+                "error": f"YouTube API error: {e.response.status_code}",
+                "details": error_data,
+            }
+        except httpx.RequestError as e:
+            return {"error": f"Request failed: {str(e)}"}
+
+    def search_videos(
+        self,
+        query: str,
+        max_results: int = 10,
+        order: str = "relevance",
+    ) -> dict[str, Any]:
+        """Search for videos.
+
+        Args:
+            query: Search query
+            max_results: Number of results (1-50)
+            order: Sort order (date, rating, relevance, title, viewCount)
+
+        Returns:
+            Dict with video search results
+        """
+        params = {
+            "part": "snippet",
+            "q": query,
+            "type": "video",
+            "maxResults": min(max(max_results, 1), 50),
+            "order": order,
+        }
+        return self._request("search", params)
+
+    def get_video_details(self, video_id: str) -> dict[str, Any]:
+        """Get detailed information about a video.
+
+        Args:
+            video_id: YouTube video ID
+
+        Returns:
+            Dict with video details (snippet, statistics, contentDetails)
+        """
+        params = {
+            "part": "snippet,statistics,contentDetails",
+            "id": video_id,
+        }
+        return self._request("videos", params)
+
+    def get_channel_info(self, channel_id: str) -> dict[str, Any]:
+        """Get channel information and statistics.
+
+        Args:
+            channel_id: YouTube channel ID
+
+        Returns:
+            Dict with channel details
+        """
+        params = {
+            "part": "snippet,statistics,contentDetails",
+            "id": channel_id,
+        }
+        return self._request("channels", params)
+
+    def list_channel_videos(
+        self,
+        channel_id: str,
+        max_results: int = 10,
+        order: str = "date",
+    ) -> dict[str, Any]:
+        """List videos from a channel.
+
+        Args:
+            channel_id: YouTube channel ID
+            max_results: Number of results (1-50)
+            order: Sort order (date, rating, relevance, title, viewCount)
+
+        Returns:
+            Dict with video list
+        """
+        params = {
+            "part": "snippet",
+            "channelId": channel_id,
+            "type": "video",
+            "maxResults": min(max(max_results, 1), 50),
+            "order": order,
+        }
+        return self._request("search", params)
+
+    def get_playlist_items(
+        self,
+        playlist_id: str,
+        max_results: int = 10,
+    ) -> dict[str, Any]:
+        """Get videos from a playlist.
+
+        Args:
+            playlist_id: YouTube playlist ID
+            max_results: Number of results (1-50)
+
+        Returns:
+            Dict with playlist items
+        """
+        params = {
+            "part": "snippet,contentDetails",
+            "playlistId": playlist_id,
+            "maxResults": min(max(max_results, 1), 50),
+        }
+        return self._request("playlistItems", params)
+
+    def search_channels(
+        self,
+        query: str,
+        max_results: int = 10,
+    ) -> dict[str, Any]:
+        """Search for channels.
+
+        Args:
+            query: Search query
+            max_results: Number of results (1-50)
+
+        Returns:
+            Dict with channel search results
+        """
+        params = {
+            "part": "snippet",
+            "q": query,
+            "type": "channel",
+            "maxResults": min(max(max_results, 1), 50),
+        }
+        return self._request("search", params)
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        self._client.close()
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: CredentialStoreAdapter | None = None,
+) -> None:
+    """Register YouTube Data API tools with the MCP server."""
+
+    def _get_api_key() -> str | dict[str, str]:
+        """Get YouTube API key from credential manager or environment."""
+        if credentials is not None:
+            api_key = credentials.get("youtube")
+            if api_key and isinstance(api_key, str):
+                return api_key
+
+        import os
+
+        api_key = os.getenv("YOUTUBE_API_KEY")
+        if api_key:
+            return api_key
+
+        return {
+            "error": "YouTube API key not configured",
+            "help": (
+                "Set YOUTUBE_API_KEY environment variable. "
+                "Get your API key at https://console.cloud.google.com/apis/credentials"
+            ),
+        }
+
+    def _get_client() -> _YouTubeClient | dict[str, str]:
+        """Get a YouTube client, or return an error dict if no API key."""
+        key = _get_api_key()
+        if isinstance(key, dict):
+            return key
+        return _YouTubeClient(key)
+
+    @mcp.tool()
+    def youtube_search_videos(
+        query: str,
+        max_results: int = 10,
+        order: str = "relevance",
+    ) -> dict:
+        """
+        Search for YouTube videos.
+
+        Args:
+            query: Search query string
+            max_results: Number of results to return (1-50, default: 10)
+            order: Sort order - one of: date, rating, relevance, title, viewCount
+                (default: relevance)
+
+        Returns:
+            Dict with search results including video ID, title, description,
+                channel info, and thumbnails
+
+        Example:
+            youtube_search_videos(query="Python tutorial", max_results=5, order="viewCount")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+
+        if not query or not query.strip():
+            return {"error": "Query parameter is required and cannot be empty"}
+
+        try:
+            return client.search_videos(query, max_results, order)
+        finally:
+            client.close()
+
+    @mcp.tool()
+    def youtube_get_video_details(video_id: str) -> dict:
+        """
+        Get detailed information about a specific YouTube video.
+
+        Args:
+            video_id: YouTube video ID (e.g., "dQw4w9WgXcQ")
+
+        Returns:
+            Dict with video details including title, description, view count,
+                like count, duration, and more
+
+        Example:
+            youtube_get_video_details(video_id="dQw4w9WgXcQ")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+
+        if not video_id or not video_id.strip():
+            return {"error": "video_id parameter is required and cannot be empty"}
+
+        try:
+            return client.get_video_details(video_id)
+        finally:
+            client.close()
+
+    @mcp.tool()
+    def youtube_get_channel_info(channel_id: str) -> dict:
+        """
+        Get information and statistics about a YouTube channel.
+
+        Args:
+            channel_id: YouTube channel ID (e.g., "UCuAXFkgsw1L7xaCfnd5JJOw")
+
+        Returns:
+            Dict with channel details including title, description,
+                subscriber count, video count, and view count
+
+        Example:
+            youtube_get_channel_info(channel_id="UCuAXFkgsw1L7xaCfnd5JJOw")
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+
+        if not channel_id or not channel_id.strip():
+            return {"error": "channel_id parameter is required and cannot be empty"}
+
+        try:
+            return client.get_channel_info(channel_id)
+        finally:
+            client.close()
+
+    @mcp.tool()
+    def youtube_list_channel_videos(
+        channel_id: str,
+        max_results: int = 10,
+        order: str = "date",
+    ) -> dict:
+        """
+        List videos from a specific YouTube channel.
+
+        Args:
+            channel_id: YouTube channel ID
+            max_results: Number of results to return (1-50, default: 10)
+            order: Sort order - one of: date, rating, relevance, title, viewCount (default: date)
+
+        Returns:
+            Dict with list of videos from the channel
+
+        Example:
+            youtube_list_channel_videos(
+                channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
+                max_results=20,
+                order="viewCount"
+            )
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+
+        if not channel_id or not channel_id.strip():
+            return {"error": "channel_id parameter is required and cannot be empty"}
+
+        try:
+            return client.list_channel_videos(channel_id, max_results, order)
+        finally:
+            client.close()
+
+    @mcp.tool()
+    def youtube_get_playlist_items(
+        playlist_id: str,
+        max_results: int = 10,
+    ) -> dict:
+        """
+        Get videos from a YouTube playlist.
+
+        Args:
+            playlist_id: YouTube playlist ID
+            max_results: Number of results to return (1-50, default: 10)
+
+        Returns:
+            Dict with playlist items including video details
+
+        Example:
+            youtube_get_playlist_items(
+                playlist_id="PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf",
+                max_results=25
+            )
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+
+        if not playlist_id or not playlist_id.strip():
+            return {"error": "playlist_id parameter is required and cannot be empty"}
+
+        try:
+            return client.get_playlist_items(playlist_id, max_results)
+        finally:
+            client.close()
+
+    @mcp.tool()
+    def youtube_search_channels(
+        query: str,
+        max_results: int = 10,
+    ) -> dict:
+        """
+        Search for YouTube channels.
+
+        Args:
+            query: Search query string
+            max_results: Number of results to return (1-50, default: 10)
+
+        Returns:
+            Dict with channel search results including channel ID, title,
+                description, and thumbnails
+
+        Example:
+            youtube_search_channels(query="Python programming", max_results=5)
+        """
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+
+        if not query or not query.strip():
+            return {"error": "Query parameter is required and cannot be empty"}
+
+        try:
+            return client.search_channels(query, max_results)
+        finally:
+            client.close()

--- a/tools/tests/tools/test_youtube_tool.py
+++ b/tools/tests/tools/test_youtube_tool.py
@@ -1,0 +1,433 @@
+"""
+Tests for YouTube Data API tool.
+
+Covers:
+- All 6 YouTube API tools
+- Error handling (missing API key, empty params, HTTP errors)
+- Credential retrieval (CredentialStoreAdapter vs env var)
+- Input validation (empty query/IDs, max_results clamping)
+- HTTP response mocking
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.youtube_tool.youtube_tool import register_tools
+
+
+@pytest.fixture
+def youtube_tools(mcp: FastMCP):
+    """Register YouTube tools and return dict of tool functions."""
+    register_tools(mcp)
+    tools = mcp._tool_manager._tools
+    return {
+        "search_videos": tools["youtube_search_videos"].fn,
+        "get_video_details": tools["youtube_get_video_details"].fn,
+        "get_channel_info": tools["youtube_get_channel_info"].fn,
+        "list_channel_videos": tools["youtube_list_channel_videos"].fn,
+        "get_playlist_items": tools["youtube_get_playlist_items"].fn,
+        "search_channels": tools["youtube_search_channels"].fn,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Credential Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCredentials:
+    """Test credential retrieval logic."""
+
+    def test_no_credentials_returns_error(self, youtube_tools, monkeypatch):
+        """All tools should return error when no API key is configured."""
+        monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
+
+        result = youtube_tools["search_videos"](query="test")
+
+        assert "error" in result
+        assert "YouTube API key not configured" in result["error"]
+        assert "help" in result
+        assert "YOUTUBE_API_KEY" in result["help"]
+
+    def test_env_var_credential(self, youtube_tools, monkeypatch):
+        """Tools should work with YOUTUBE_API_KEY environment variable."""
+        monkeypatch.setenv("YOUTUBE_API_KEY", "test-api-key")
+
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"items": []}
+            mock_response.raise_for_status.return_value = None
+            mock_client.return_value.get.return_value = mock_response
+
+            result = youtube_tools["search_videos"](query="test")
+
+            assert "error" not in result
+
+
+# ---------------------------------------------------------------------------
+# Search Videos Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSearchVideos:
+    """Test youtube_search_videos tool."""
+
+    def test_empty_query_returns_error(self, youtube_tools, monkeypatch):
+        """Empty query should return error."""
+        monkeypatch.setenv("YOUTUBE_API_KEY", "test-key")
+
+        result = youtube_tools["search_videos"](query="")
+
+        assert "error" in result
+        assert "required" in result["error"].lower()
+
+    def test_whitespace_query_returns_error(self, youtube_tools, monkeypatch):
+        """Whitespace-only query should return error."""
+        monkeypatch.setenv("YOUTUBE_API_KEY", "test-key")
+
+        result = youtube_tools["search_videos"](query="   ")
+
+        assert "error" in result
+        assert "required" in result["error"].lower()
+
+    def test_search_success(self, youtube_tools, monkeypatch):
+        """Successful search returns video results."""
+        monkeypatch.setenv("YOUTUBE_API_KEY", "test-key")
+
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "items": [
+                    {
+                        "id": {"videoId": "video123"},
+                        "snippet": {
+                            "title": "Test Video",
+                            "description": "Test description",
+                            "channelTitle": "Test Channel",
+                        },
+                    }
+                ]
+            }
+            mock_response.raise_for_status.return_value = None
+            mock_client.return_value.get.return_value = mock_response
+
+            result = youtube_tools["search_videos"](
+                query="Python tutorial", max_results=5, order="viewCount"
+            )
+
+            assert "items" in result
+            assert len(result["items"]) == 1
+            assert result["items"][0]["id"]["videoId"] == "video123"
+
+    def test_http_error_handling(self, youtube_tools, monkeypatch):
+        """HTTP errors should be caught and returned as error dict."""
+        monkeypatch.setenv("YOUTUBE_API_KEY", "test-key")
+
+        with patch("httpx.Client") as mock_client:
+            import httpx
+
+            mock_response = MagicMock()
+            mock_response.status_code = 403
+            mock_response.json.return_value = {
+                "error": {"message": "API key invalid"}
+            }
+            mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+                "403 Forbidden", request=MagicMock(), response=mock_response
+            )
+            mock_client.return_value.get.return_value = mock_response
+
+            result = youtube_tools["search_videos"](query="test")
+
+            assert "error" in result
+            assert "403" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Get Video Details Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetVideoDetails:
+    """Test youtube_get_video_details tool."""
+
+    def test_empty_video_id_returns_error(self, youtube_tools, monkeypatch):
+        """Empty video_id should return error."""
+        monkeypatch.setenv("YOUTUBE_API_KEY", "test-key")
+
+        result = youtube_tools["get_video_details"](video_id="")
+
+        assert "error" in result
+        assert "required" in result["error"].lower()
+
+    def test_get_video_details_success(self, youtube_tools, monkeypatch):
+        """Successful video details fetch returns video data."""
+        monkeypatch.setenv("YOUTUBE_API_KEY", "test-key")
+
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "items": [
+                    {
+                        "id": "video123",
+                        "snippet": {
+                            "title": "Test Video",
+                            "description": "Test description",
+                        },
+                        "statistics": {
+                            "viewCount": "1000",
+                            "likeCount": "100",
+                        },
+                        "contentDetails": {"duration": "PT5M30S"},
+                    }
+                ]
+            }
+            mock_response.raise_for_status.return_value = None
+            mock_client.return_value.get.return_value = mock_response
+
+            result = youtube_tools["get_video_details"](video_id="video123")
+
+            assert "items" in result
+            assert result["items"][0]["id"] == "video123"
+            assert "statistics" in result["items"][0]
+            assert result["items"][0]["statistics"]["viewCount"] == "1000"
+
+
+# ---------------------------------------------------------------------------
+# Get Channel Info Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetChannelInfo:
+    """Test youtube_get_channel_info tool."""
+
+    def test_empty_channel_id_returns_error(self, youtube_tools, monkeypatch):
+        """Empty channel_id should return error."""
+        monkeypatch.setenv("YOUTUBE_API_KEY", "test-key")
+
+        result = youtube_tools["get_channel_info"](channel_id="")
+
+        assert "error" in result
+        assert "required" in result["error"].lower()
+
+    def test_get_channel_info_success(self, youtube_tools, monkeypatch):
+        """Successful channel info fetch returns channel data."""
+        monkeypatch.setenv("YOUTUBE_API_KEY", "test-key")
+
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "items": [
+                    {
+                        "id": "channel123",
+                        "snippet": {
+                            "title": "Test Channel",
+                            "description": "Channel description",
+                        },
+                        "statistics": {
+                            "subscriberCount": "10000",
+                            "videoCount": "50",
+                            "viewCount": "100000",
+                        },
+                    }
+                ]
+            }
+            mock_response.raise_for_status.return_value = None
+            mock_client.return_value.get.return_value = mock_response
+
+            result = youtube_tools["get_channel_info"](channel_id="channel123")
+
+            assert "items" in result
+            assert result["items"][0]["id"] == "channel123"
+            assert result["items"][0]["statistics"]["subscriberCount"] == "10000"
+
+
+# ---------------------------------------------------------------------------
+# List Channel Videos Tests
+# ---------------------------------------------------------------------------
+
+
+class TestListChannelVideos:
+    """Test youtube_list_channel_videos tool."""
+
+    def test_empty_channel_id_returns_error(self, youtube_tools, monkeypatch):
+        """Empty channel_id should return error."""
+        monkeypatch.setenv("YOUTUBE_API_KEY", "test-key")
+
+        result = youtube_tools["list_channel_videos"](channel_id="")
+
+        assert "error" in result
+        assert "required" in result["error"].lower()
+
+    def test_list_channel_videos_success(self, youtube_tools, monkeypatch):
+        """Successful channel videos list returns video data."""
+        monkeypatch.setenv("YOUTUBE_API_KEY", "test-key")
+
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "items": [
+                    {
+                        "id": {"videoId": "video1"},
+                        "snippet": {"title": "Video 1", "publishedAt": "2024-01-01"},
+                    },
+                    {
+                        "id": {"videoId": "video2"},
+                        "snippet": {"title": "Video 2", "publishedAt": "2024-01-02"},
+                    },
+                ]
+            }
+            mock_response.raise_for_status.return_value = None
+            mock_client.return_value.get.return_value = mock_response
+
+            result = youtube_tools["list_channel_videos"](
+                channel_id="channel123", max_results=20, order="viewCount"
+            )
+
+            assert "items" in result
+            assert len(result["items"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Get Playlist Items Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlaylistItems:
+    """Test youtube_get_playlist_items tool."""
+
+    def test_empty_playlist_id_returns_error(self, youtube_tools, monkeypatch):
+        """Empty playlist_id should return error."""
+        monkeypatch.setenv("YOUTUBE_API_KEY", "test-key")
+
+        result = youtube_tools["get_playlist_items"](playlist_id="")
+
+        assert "error" in result
+        assert "required" in result["error"].lower()
+
+    def test_get_playlist_items_success(self, youtube_tools, monkeypatch):
+        """Successful playlist items fetch returns video data."""
+        monkeypatch.setenv("YOUTUBE_API_KEY", "test-key")
+
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "items": [
+                    {
+                        "snippet": {
+                            "title": "Playlist Video 1",
+                            "resourceId": {"videoId": "plvideo1"},
+                        },
+                        "contentDetails": {"videoId": "plvideo1"},
+                    }
+                ]
+            }
+            mock_response.raise_for_status.return_value = None
+            mock_client.return_value.get.return_value = mock_response
+
+            result = youtube_tools["get_playlist_items"](
+                playlist_id="playlist123", max_results=25
+            )
+
+            assert "items" in result
+            assert len(result["items"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Search Channels Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSearchChannels:
+    """Test youtube_search_channels tool."""
+
+    def test_empty_query_returns_error(self, youtube_tools, monkeypatch):
+        """Empty query should return error."""
+        monkeypatch.setenv("YOUTUBE_API_KEY", "test-key")
+
+        result = youtube_tools["search_channels"](query="")
+
+        assert "error" in result
+        assert "required" in result["error"].lower()
+
+    def test_search_channels_success(self, youtube_tools, monkeypatch):
+        """Successful channel search returns channel results."""
+        monkeypatch.setenv("YOUTUBE_API_KEY", "test-key")
+
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "items": [
+                    {
+                        "id": {"channelId": "channel123"},
+                        "snippet": {
+                            "title": "Test Channel",
+                            "description": "Channel about Python",
+                        },
+                    }
+                ]
+            }
+            mock_response.raise_for_status.return_value = None
+            mock_client.return_value.get.return_value = mock_response
+
+            result = youtube_tools["search_channels"](
+                query="Python programming", max_results=5
+            )
+
+            assert "items" in result
+            assert len(result["items"]) == 1
+            assert result["items"][0]["id"]["channelId"] == "channel123"
+
+
+# ---------------------------------------------------------------------------
+# Client Lifecycle Tests
+# ---------------------------------------------------------------------------
+
+
+class TestClientLifecycle:
+    """Test that HTTP client is properly closed after each call."""
+
+    def test_client_close_on_success(self, youtube_tools, monkeypatch):
+        """Client should be closed even on successful calls."""
+        monkeypatch.setenv("YOUTUBE_API_KEY", "test-key")
+
+        with patch("httpx.Client") as mock_client:
+            mock_instance = MagicMock()
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"items": []}
+            mock_response.raise_for_status.return_value = None
+            mock_instance.get.return_value = mock_response
+            mock_client.return_value = mock_instance
+
+            youtube_tools["search_videos"](query="test")
+
+            # Verify close was called
+            mock_instance.close.assert_called_once()
+
+    def test_client_close_on_error(self, youtube_tools, monkeypatch):
+        """Client should be closed even when HTTP errors occur."""
+        monkeypatch.setenv("YOUTUBE_API_KEY", "test-key")
+
+        with patch("httpx.Client") as mock_client:
+            import httpx
+
+            mock_instance = MagicMock()
+            mock_response = MagicMock()
+            mock_response.status_code = 500
+            mock_response.json.return_value = {}
+            mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+                "500 Internal Server Error",
+                request=MagicMock(),
+                response=mock_response,
+            )
+            mock_instance.get.return_value = mock_response
+            mock_client.return_value = mock_instance
+
+            result = youtube_tools["search_videos"](query="test")
+
+            # Verify close was called even after error
+            mock_instance.close.assert_called_once()
+            assert "error" in result


### PR DESCRIPTION
Closes #5603 

Implements YouTube Data API v3 integration with 6 tools for searching and retrieving video/channel information.

Changes
- ✅ 6 YouTube API tools implemented (search videos, get video/channel details, list channel videos, get playlist items, search channels)
- ✅ YOUTUBE_API_KEY credential spec with help URL
- ✅ Comprehensive test coverage (18 unit tests, all passing)
- ✅ Detailed README with setup instructions and examples
- ✅ Real API integration testing verified
- ✅ All lint checks passed (ruff)

Configuration
Users need to provide a YouTube Data API v3 key. Set `YOUTUBE_API_KEY` environment variable or use Hive's credential store. Get an API key at https://console.cloud.google.com/apis/credentials

Testing

cd tools
uv run pytest tests/tools/test_youtube_tool.py -v

 
All 18 tests pass ✅