### PR TITLE
Fix LLMJudge OpenAI fallback to use LiteLLM provider

### DIFF
--- a/core/framework/testing/llm_judge.py
+++ b/core/framework/testing/llm_judge.py
@@ -40,18 +40,31 @@ class LLMJudge:
 
     def _get_fallback_provider(self) -> LLMProvider | None:
         """
-        Auto-detects available API keys and returns the appropriate provider.
-        Priority: OpenAI -> Anthropic.
+        Auto-detects available API keys and returns an appropriate provider.
+        Uses LiteLLM for OpenAI (framework has no framework.llm.openai module).
+        Priority:
+        1. OpenAI-compatible models via LiteLLM (OPENAI_API_KEY)
+        2. Anthropic via AnthropicProvider (ANTHROPIC_API_KEY)
         """
+        # OpenAI: use LiteLLM (the framework's standard multi-provider integration)
         if os.environ.get("OPENAI_API_KEY"):
-            from framework.llm.openai import OpenAIProvider
+            try:
+                from framework.llm.litellm import LiteLLMProvider
 
-            return OpenAIProvider(model="gpt-4o-mini")
+                return LiteLLMProvider(model="gpt-4o-mini")
+            except ImportError:
+                # LiteLLM is optional; fall through to Anthropic/None
+                pass
 
+        # Anthropic via dedicated provider (wraps LiteLLM internally)
         if os.environ.get("ANTHROPIC_API_KEY"):
-            from framework.llm.anthropic import AnthropicProvider
+            try:
+                from framework.llm.anthropic import AnthropicProvider
 
-            return AnthropicProvider(model="claude-3-haiku-20240307")
+                return AnthropicProvider(model="claude-haiku-4-5-20251001")
+            except Exception:
+                # If AnthropicProvider cannot be constructed, treat as no fallback
+                return None
 
         return None
 
@@ -77,11 +90,16 @@ SUMMARY TO EVALUATE:
 Respond with JSON: {{"passes": true/false, "explanation": "..."}}"""
 
         try:
+            # Compute fallback provider once so we do not create multiple instances
+            fallback_provider = self._get_fallback_provider()
+
             # 1. Use injected provider
             if self._provider:
                 active_provider = self._provider
-            # 2. Check if _get_client was MOCKED (legacy tests) or use Agnostic Fallback
-            elif hasattr(self._get_client, "return_value") or not self._get_fallback_provider():
+            # 2. Legacy path: anthropic client mocked in tests takes precedence,
+            #    or no fallback provider is available.
+            elif hasattr(self._get_client, "return_value") or fallback_provider is None:
+                # Use legacy Anthropic client (e.g. when tests mock _get_client, or no env keys set)
                 client = self._get_client()
                 response = client.messages.create(
                     model="claude-haiku-4-5-20251001",
@@ -90,7 +108,8 @@ Respond with JSON: {{"passes": true/false, "explanation": "..."}}"""
                 )
                 return self._parse_json_result(response.content[0].text.strip())
             else:
-                active_provider = self._get_fallback_provider()
+                # Use env-based fallback (LiteLLM or AnthropicProvider)
+                active_provider = fallback_provider
 
             response = active_provider.complete(
                 messages=[{"role": "user", "content": prompt}],

--- a/core/tests/test_llm_judge.py
+++ b/core/tests/test_llm_judge.py
@@ -338,6 +338,69 @@ class TestLLMJudgeBackwardCompatibility:
         assert call_kwargs["model"] == "claude-haiku-4-5-20251001"
         assert call_kwargs["max_tokens"] == 500
 
+    def test_openai_fallback_uses_litellm_provider(self, monkeypatch):
+        """When OPENAI_API_KEY is set, evaluate() should use a LiteLLM-based provider."""
+        # Force the OpenAI fallback path (no injected provider, no Anthropic key)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-openai")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        # Stub LiteLLMProvider so we don't call the real API; record what judge passes through
+        captured_calls: list[dict] = []
+
+        class DummyProvider:
+            def __init__(self, model: str = "gpt-4o-mini"):
+                self.model = model
+
+            def complete(
+                self,
+                messages,
+                system="",
+                tools=None,
+                max_tokens=1024,
+                response_format=None,
+                json_mode=False,
+                max_retries=None,
+            ):
+                captured_calls.append(
+                    {
+                        "messages": messages,
+                        "system": system,
+                        "max_tokens": max_tokens,
+                        "json_mode": json_mode,
+                        "model": self.model,
+                    }
+                )
+
+                class _Resp:
+                    def __init__(self, content: str):
+                        self.content = content
+
+                # Minimal response object with a content attribute
+                return _Resp('{"passes": true, "explanation": "OK"}')
+
+        monkeypatch.setattr(
+            "framework.llm.litellm.LiteLLMProvider",
+            DummyProvider,
+        )
+
+        judge = LLMJudge()
+        result = judge.evaluate(
+            constraint="no-hallucination",
+            source_document="The sky is blue.",
+            summary="The sky is blue.",
+            criteria="Summary must only contain facts from source",
+        )
+
+        # Judge should have used our stub once and returned the stub's JSON result
+        assert result["passes"] is True
+        assert result["explanation"] == "OK"
+        assert len(captured_calls) == 1
+
+        call = captured_calls[0]
+        assert call["model"] == "gpt-4o-mini"
+        assert call["max_tokens"] == 500
+        assert call["json_mode"] is True
+
 
 # ============================================================================
 # LLMJudge Integration Pattern Tests


### PR DESCRIPTION
## Description

Fix the `LLMJudge` OpenAI fallback so it uses the existing LiteLLM integration instead of importing a non‑existent `framework.llm.openai` provider, while keeping the Anthropic fallback and legacy behavior intact.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #5675
## Changes Made

- Updated `core/framework/testing/llm_judge.py`:
  - `_get_fallback_provider()` now:
    - Uses `LiteLLMProvider(model="gpt-4o-mini")` when `OPENAI_API_KEY` is set (with ImportError guard so LiteLLM stays optional).
    - Uses `AnthropicProvider(model="claude-haiku-4-5-20251001")` when `ANTHROPIC_API_KEY` is set.
    - Falls back to the existing Anthropic client path when no env-based provider is available.
  - `evaluate()` now computes the fallback provider once and chooses between:
    - injected provider,
    - legacy Anthropic client (for mocked tests / no env keys),
    - env-based fallback provider.

- Added `test_openai_fallback_uses_litellm_provider` in `core/tests/test_llm_judge.py`:
  - Uses `monkeypatch` to set `OPENAI_API_KEY` and clear `ANTHROPIC_API_KEY`.
  - Stubs `framework.llm.litellm.LiteLLMProvider` with a dummy provider to avoid real API calls.
  - Asserts the stub is called once with `max_tokens=500`, `json_mode=True`, and returns the expected parsed JSON result.

## Testing

- [x] Unit tests pass (`cd core && uv run pytest tests/test_llm_judge.py -v`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed (`uv run python examples/manual_agent.py` – greeter → uppercaser → `HELLO, ALICE!`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (on the modified files)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A