### PR TITLE
docs(getting-started): add Windows quickstart.ps1 instructions to Quick Start

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,6 +13,8 @@ This guide will help you set up the Aden Agent Framework and build your first ag
 
 The fastest way to get started:
 
+**macOS / Linux:**
+
 ```bash
 # 1. Clone the repository
 git clone https://github.com/adenhq/hive.git
@@ -24,6 +26,22 @@ cd hive
 # 3. Verify installation (optional, quickstart.sh already verifies)
 uv run python -c "import framework; import aden_tools; print('✓ Setup complete')"
 ```
+
+**Windows (PowerShell):**
+
+```powershell
+# 1. Clone the repository
+git clone https://github.com/adenhq/hive.git
+cd hive
+
+# 2. Run automated setup
+.\quickstart.ps1
+
+# 3. Verify installation (optional, quickstart.ps1 already verifies)
+uv run python -c "import framework; import aden_tools; print('✓ Setup complete')"
+```
+
+> **Note for Windows Users:** It is strongly recommended to use **PowerShell 5.1+** to run `quickstart.ps1`. If you prefer a Unix-like environment, WSL (Windows Subsystem for Linux) or Git Bash also work with `quickstart.sh`.
 
 ## Building Your First Agent
 


### PR DESCRIPTION
## Description

The Quick Start section in [docs/getting-started.md](cci:7://file:///Users/tushar/Desktop/Open%20Source/hive/docs/getting-started.md:0:0-0:0) only referenced [quickstart.sh](cci:7://file:///Users/tushar/Desktop/Open%20Source/hive/quickstart.sh:0:0-0:0),
leaving Windows users with no setup instructions. Added a clearly labelled
Windows/PowerShell block for [.\quickstart.ps1](cci:7://file:///Users/tushar/Desktop/Open%20Source/hive/quickstart.ps1:0:0-0:0) alongside the existing macOS/Linux block.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #5660

## Changes Made

- Added `macOS / Linux` label above the existing [quickstart.sh](cci:7://file:///Users/tushar/Desktop/Open%20Source/hive/quickstart.sh:0:0-0:0) block
- Added new `Windows (PowerShell)` block with [.\quickstart.ps1](cci:7://file:///Users/tushar/Desktop/Open%20Source/hive/quickstart.ps1:0:0-0:0) instructions
- Added a note about PowerShell 5.1+ requirement and WSL as an alternative

## Testing

- [x] Manual testing performed

> Documentation-only change. No code logic affected. Verified the markdown
> renders correctly and all code blocks are accurate.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings