### PR TITLE
feat(mcp): add input validation and configurable timeouts to MCP client connection

### DIFF
--- a/core/framework/runner/mcp_client.py
+++ b/core/framework/runner/mcp_client.py
@@ -35,6 +35,10 @@ class MCPServerConfig:
     # Optional metadata
     description: str = ""
 
+    # Configurable timeouts (in seconds)
+    event_loop_timeout: float = 5.0
+    connection_timeout: float = 10.0
+
 
 @dataclass
 class MCPTool:
@@ -133,6 +137,7 @@ class MCPClient:
             return
 
         if self.config.transport == "stdio":
+            self._validate_stdio_config()
             self._connect_stdio()
         elif self.config.transport == "http":
             self._connect_http()
@@ -143,11 +148,41 @@ class MCPClient:
         self._discover_tools()
         self._connected = True
 
+    def _validate_stdio_config(self) -> None:
+        """Validate STDIO transport configuration parameters."""
+        if not self.config.command:
+            raise ValueError(
+                f"command is required for STDIO transport. "
+                f"Server config: name='{self.config.name}', transport='{self.config.transport}'"
+            )
+
+        if not isinstance(self.config.args, list):
+            raise TypeError(
+                f"args must be a list, got {type(self.config.args).__name__}. "
+                f"Server config: name='{self.config.name}'"
+            )
+
+        for i, arg in enumerate(self.config.args):
+            if not isinstance(arg, str):
+                raise TypeError(
+                    f"args[{i}] must be a string, got {type(arg).__name__}. "
+                    f"Server config: name='{self.config.name}', args={self.config.args}"
+                )
+
+        if self.config.cwd is not None:
+            if not isinstance(self.config.cwd, str):
+                raise TypeError(
+                    f"cwd must be a string, got {type(self.config.cwd).__name__}. "
+                    f"Server config: name='{self.config.name}'"
+                )
+            if not os.path.isdir(self.config.cwd):
+                raise ValueError(
+                    f"cwd directory does not exist: '{self.config.cwd}'. "
+                    f"Server config: name='{self.config.name}'"
+                )
+
     def _connect_stdio(self) -> None:
         """Connect to MCP server via STDIO transport using MCP SDK with persistent connection."""
-        if not self.config.command:
-            raise ValueError("command is required for STDIO transport")
-
         try:
             import threading
 
@@ -215,18 +250,31 @@ class MCPClient:
             self._loop_thread.start()
 
             # Wait for loop to start
-            loop_started.wait(timeout=5)
+            loop_started.wait(timeout=self.config.event_loop_timeout)
             if not loop_started.is_set():
-                raise RuntimeError("Event loop failed to start")
+                raise RuntimeError(
+                    f"Event loop failed to start within {self.config.event_loop_timeout}s. "
+                    f"Server config: name='{self.config.name}', command='{self.config.command}'"
+                )
 
             # Wait for connection to be ready
-            connection_ready.wait(timeout=10)
+            connection_ready.wait(timeout=self.config.connection_timeout)
             if connection_error:
                 raise connection_error[0]
+            if not connection_ready.is_set():
+                raise RuntimeError(
+                    f"Connection timed out after {self.config.connection_timeout}s. "
+                    f"Server config: name='{self.config.name}', command='{self.config.command}', "
+                    f"args={self.config.args}, cwd='{self.config.cwd}'"
+                )
 
             logger.info(f"Connected to MCP server '{self.config.name}' via STDIO (persistent)")
         except Exception as e:
-            raise RuntimeError(f"Failed to connect to MCP server: {e}") from e
+            raise RuntimeError(
+                f"Failed to connect to MCP server '{self.config.name}': {e}. "
+                f"Server config: command='{self.config.command}', args={self.config.args}, "
+                f"cwd='{self.config.cwd}'"
+            ) from e
 
     def _connect_http(self) -> None:
         """Connect to MCP server via HTTP transport."""

--- a/core/tests/test_mcp_client.py
+++ b/core/tests/test_mcp_client.py
@@ -1,0 +1,187 @@
+"""
+Unit tests for MCP client input validation.
+"""
+
+import pytest
+
+from framework.runner.mcp_client import MCPClient, MCPServerConfig
+
+
+class TestMCPServerConfigDefaults:
+    """Tests for MCPServerConfig default values."""
+
+    def test_default_timeouts(self):
+        """Test that timeout defaults are set correctly."""
+        config = MCPServerConfig(name="test", transport="stdio", command="python")
+        assert config.event_loop_timeout == 5.0
+        assert config.connection_timeout == 10.0
+
+    def test_custom_timeouts(self):
+        """Test that custom timeouts can be set."""
+        config = MCPServerConfig(
+            name="test",
+            transport="stdio",
+            command="python",
+            event_loop_timeout=15.0,
+            connection_timeout=30.0,
+        )
+        assert config.event_loop_timeout == 15.0
+        assert config.connection_timeout == 30.0
+
+
+class TestMCPServerConfigValidation:
+    """Tests for MCPServerConfig validation."""
+
+    def test_valid_config(self):
+        """Test that a valid config passes validation."""
+        config = MCPServerConfig(
+            name="test-server",
+            transport="stdio",
+            command="python",
+            args=["script.py", "--flag"],
+        )
+        client = MCPClient(config)
+        client._validate_stdio_config()
+
+    def test_missing_command_raises_error(self):
+        """Test that missing command raises ValueError with helpful message."""
+        config = MCPServerConfig(name="test", transport="stdio")
+        client = MCPClient(config)
+        with pytest.raises(ValueError) as exc_info:
+            client._validate_stdio_config()
+        assert "command is required" in str(exc_info.value)
+        assert "test" in str(exc_info.value)
+
+    def test_args_not_list_raises_error(self):
+        """Test that non-list args raises TypeError."""
+        config = MCPServerConfig(
+            name="test",
+            transport="stdio",
+            command="python",
+            args="not-a-list",
+        )
+        client = MCPClient(config)
+        with pytest.raises(TypeError) as exc_info:
+            client._validate_stdio_config()
+        assert "args must be a list" in str(exc_info.value)
+        assert "str" in str(exc_info.value)
+
+    def test_args_non_string_item_raises_error(self):
+        """Test that non-string items in args raises TypeError with index info."""
+        config = MCPServerConfig(
+            name="test",
+            transport="stdio",
+            command="python",
+            args=["script.py", 123, "--flag"],
+        )
+        client = MCPClient(config)
+        with pytest.raises(TypeError) as exc_info:
+            client._validate_stdio_config()
+        assert "args[1]" in str(exc_info.value)
+        assert "int" in str(exc_info.value)
+        assert "test" in str(exc_info.value)
+
+    def test_args_multiple_non_string_items(self):
+        """Test that first non-string item is reported."""
+        config = MCPServerConfig(
+            name="test",
+            transport="stdio",
+            command="python",
+            args=[123, 456],
+        )
+        client = MCPClient(config)
+        with pytest.raises(TypeError) as exc_info:
+            client._validate_stdio_config()
+        assert "args[0]" in str(exc_info.value)
+
+    def test_cwd_non_string_raises_error(self):
+        """Test that non-string cwd raises TypeError."""
+        config = MCPServerConfig(
+            name="test",
+            transport="stdio",
+            command="python",
+            cwd=12345,
+        )
+        client = MCPClient(config)
+        with pytest.raises(TypeError) as exc_info:
+            client._validate_stdio_config()
+        assert "cwd must be a string" in str(exc_info.value)
+
+    def test_cwd_nonexistent_directory_raises_error(self):
+        """Test that non-existent cwd directory raises ValueError."""
+        config = MCPServerConfig(
+            name="test",
+            transport="stdio",
+            command="python",
+            cwd="/nonexistent/path/that/does/not/exist",
+        )
+        client = MCPClient(config)
+        with pytest.raises(ValueError) as exc_info:
+            client._validate_stdio_config()
+        assert "cwd directory does not exist" in str(exc_info.value)
+        assert "/nonexistent/path/that/does/not/exist" in str(exc_info.value)
+
+    def test_cwd_file_not_directory_raises_error(self, tmp_path):
+        """Test that cwd pointing to a file (not directory) raises ValueError."""
+        file_path = tmp_path / "notadir.txt"
+        file_path.write_text("test")
+        config = MCPServerConfig(
+            name="test",
+            transport="stdio",
+            command="python",
+            cwd=str(file_path),
+        )
+        client = MCPClient(config)
+        with pytest.raises(ValueError) as exc_info:
+            client._validate_stdio_config()
+        assert "cwd directory does not exist" in str(exc_info.value)
+
+    def test_cwd_valid_directory(self, tmp_path):
+        """Test that valid existing cwd passes validation."""
+        config = MCPServerConfig(
+            name="test",
+            transport="stdio",
+            command="python",
+            cwd=str(tmp_path),
+        )
+        client = MCPClient(config)
+        client._validate_stdio_config()
+
+    def test_empty_args_list_is_valid(self):
+        """Test that empty args list is valid."""
+        config = MCPServerConfig(
+            name="test",
+            transport="stdio",
+            command="python",
+            args=[],
+        )
+        client = MCPClient(config)
+        client._validate_stdio_config()
+
+    def test_none_cwd_is_valid(self):
+        """Test that None cwd is valid (uses default)."""
+        config = MCPServerConfig(
+            name="test",
+            transport="stdio",
+            command="python",
+            cwd=None,
+        )
+        client = MCPClient(config)
+        client._validate_stdio_config()
+
+
+class TestMCPClientConnectValidation:
+    """Tests that connect() properly validates config before connecting."""
+
+    def test_connect_validates_args_before_connection(self):
+        """Test that connect() calls validation before attempting connection."""
+        config = MCPServerConfig(
+            name="test",
+            transport="stdio",
+            command="python",
+            args=["script.py", 123],
+        )
+        client = MCPClient(config)
+        with pytest.raises(TypeError) as exc_info:
+            client.connect()
+        assert "args[1]" in str(exc_info.value)


### PR DESCRIPTION
## Description

This PR adds comprehensive input validation and configurable timeouts to the MCP client connection, improving developer experience by catching configuration errors early with clear, actionable error messages.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Fixes #1335

## Changes Made

- Added `_validate_stdio_config()` method to `MCPClient` with comprehensive validation:
  - Validates `args` is a list containing only strings
  - Validates `cwd` is an existing directory if provided
  - Validates `command` is provided for STDIO transport
  - Provides clear error messages with full config context

- Added configurable timeout fields to `MCPServerConfig`:
  - `event_loop_timeout` (default: 5.0 seconds) - timeout for event loop startup
  - `connection_timeout` (default: 10.0 seconds) - timeout for connection establishment

- Improved error messages with full config context when connection fails

- Added 14 unit tests covering all validation scenarios

## Testing

- [x] Unit tests pass (`cd core && pytest tests/test_mcp_client.py`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Existing MCP tests pass (`cd core && pytest tests/test_mcp_server.py`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (code comments)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
