### PR TITLE
fix(credentials): align EnvVarStorage exists with load semantics

### DIFF
--- a/core/framework/credentials/storage.py
+++ b/core/framework/credentials/storage.py
@@ -519,7 +519,7 @@ class EnvVarStorage(CredentialStorage):
     def exists(self, credential_id: str) -> bool:
         """Check if credential is available in environment."""
         env_var = self._get_env_var_name(credential_id)
-        return self._read_env_value(env_var) is not None
+        return bool(self._read_env_value(env_var))
 
     def add_mapping(self, credential_id: str, env_var: str) -> None:
         """

--- a/core/framework/credentials/tests/test_credential_store.py
+++ b/core/framework/credentials/tests/test_credential_store.py
@@ -258,6 +258,14 @@ class TestEnvVarStorage:
         with pytest.raises(NotImplementedError):
             storage.delete("test")
 
+    def test_exists_matches_load_for_empty_value(self):
+        """Test exists() and load() stay consistent for empty values."""
+        storage = EnvVarStorage(env_mapping={"empty": "EMPTY_API_KEY"})
+
+        with patch.object(storage, "_read_env_value", return_value=""):
+            assert storage.load("empty") is None
+            assert not storage.exists("empty")
+
 
 class TestEncryptedFileStorage:
     """Tests for EncryptedFileStorage."""


### PR DESCRIPTION
## Description

Fixes an inconsistency in `EnvVarStorage` where `exists()` and `load()` used different truthiness semantics for env values.  
Now `exists()` treats empty values as absent, matching `load()` behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #5388 

## Changes Made

- Updated `EnvVarStorage.exists()` to return `bool(self._read_env_value(env_var))`.
- Kept `load()` semantics unchanged (`if not value: return None`).
- Added regression test `test_exists_matches_load_for_empty_value` to ensure consistency.

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

Manual verification:
- Confirmed `load()` returns `None` for empty values.
- Confirmed `exists()` returns `False` for empty values.
- Confirmed non-empty values remain available.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A (no UI changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in credential storage behavior when handling empty environment variable values—empty values are now uniformly treated as non-existent credentials.

* **Tests**
  * Added test coverage to ensure credential storage load and existence checks behave consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->