### PR TITLE
micro-fix: GitGuardian alert: derive credential IDs from fixtures instead of hardcoding

### DIFF
--- a/core/framework/credentials/aden/tests/test_aden_sync.py
+++ b/core/framework/credentials/aden/tests/test_aden_sync.py
@@ -391,9 +391,10 @@ class TestAdenSyncProvider:
 
     def test_sync_all(self, provider, mock_client, aden_response):
         """Test syncing all credentials."""
+        active_id = aden_response.integration_id
         mock_client.list_integrations.return_value = [
             AdenIntegrationInfo(
-                integration_id="aHVic3BvdDp0ZXN0OjEzNjExOjExNTI1",
+                integration_id=active_id,
                 provider="hubspot",
                 alias="My HubSpot",
                 status="active",
@@ -411,7 +412,7 @@ class TestAdenSyncProvider:
         synced = provider.sync_all(store)
 
         assert synced == 1  # Only active one was synced
-        assert store.get_credential("aHVic3BvdDp0ZXN0OjEzNjExOjExNTI1") is not None
+        assert store.get_credential(active_id) is not None
 
     def test_validate_via_aden(self, provider, mock_client):
         """Test validation via Aden introspection."""


### PR DESCRIPTION
**Fixes #5682**

**Summary**
When forking the repository, GitGuardian reported hardcoded credential-like strings in the Aden sync tests. This PR removes those hardcoded values and derives them from fixtures instead.
**Problem**
In test_sync_all, the credential ID "aHVic3BvdDp0ZXN0OjEzNjExOjExNTI1" was hardcoded in both the mock data and the assertion. GitGuardian flagged this as a potential secret.
**Solution**
Use aden_response.integration_id as the single source of truth for the credential ID. The mock and assertion now reference this value instead of repeating the string. Behavior is unchanged; only the way the ID is obtained is different.
**Changes**
test_sync_all: Replace hardcoded credential ID with aden_response.integration_id in both the mock and the assertion.