### PR TITLE
fix(tui): make action_show_agent_picker async

### DIFF
--- a/core/framework/tui/app.py
+++ b/core/framework/tui/app.py
@@ -845,7 +845,7 @@ class AdenTUI(App):
         # Re-show picker so user can still select an agent
         self._show_agent_picker_initial()
 
-    def action_show_agent_picker(self) -> None:
+    async def action_show_agent_picker(self) -> None:
         """Open the agent picker (Ctrl+A or /agents)."""
         from framework.tui.screens.agent_picker import AgentPickerScreen, discover_agents
 


### PR DESCRIPTION
## Description

Fix crash in TUI when `/agents` is invoked. The `AdenTUI.action_show_agent_picker` method is now defined as `async def` to match the awaited call in the chat REPL. This prevents `TypeError: object NoneType cannot be used in 'await' expression`.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)


## Related Issues

Fixes #5627 


## Changes Made

* Declared `AdenTUI.action_show_agent_picker` as `async def`.

---

## Testing

Describe the tests you ran to verify your changes:

* [x] Manual verification:

  1. Launch Hive TUI (`hive tui --model ollama/llama2` or set `HIVE_MODEL`).
  2. Enter `/agents`.
  3. Agent picker appears without exception.
  4. Selecting an agent works normally.

* [x] Existing unit tests pass (no TUI tests currently exist for this flow).

* [x] Lint passes (`ruff check .`).

---

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [ ] My changes include unit tests where applicable (manual verification used)
* [x] New and existing unit tests pass locally with my changes

---

## Screenshots (if applicable)

N/A — no UI changes, only TUI behavior fix.