### PR TITLE
docs: add Windows PowerShell quickstart instructions

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,6 +13,8 @@ This guide will help you set up the Aden Agent Framework and build your first ag
 
 The fastest way to get started:
 
+### Linux/macOS
+
 ```bash
 # 1. Clone the repository
 git clone https://github.com/adenhq/hive.git
@@ -22,6 +24,20 @@ cd hive
 ./quickstart.sh
 
 # 3. Verify installation (optional, quickstart.sh already verifies)
+uv run python -c "import framework; import aden_tools; print('✓ Setup complete')"
+```
+
+### Windows (PowerShell)
+
+```powershell
+# 1. Clone the repository
+git clone https://github.com/adenhq/hive.git
+cd hive
+
+# 2. Run automated setup
+.\quickstart.ps1
+
+# 3. Verify installation (optional, quickstart.ps1 already verifies)
 uv run python -c "import framework; import aden_tools; print('✓ Setup complete')"
 ```
 


### PR DESCRIPTION
Fixes #5660

## Problem
The Quick Start section in `docs/getting-started.md` only referenced `./quickstart.sh`, leaving Windows users without guidance even though the repo includes a polished `quickstart.ps1`.

## Solution
Added a separate **Windows (PowerShell)** subsection under Quick Start that references `quickstart.ps1`, maintaining parallel structure with the Linux/macOS section.

## Changes
- Split Quick Start into platform-specific subsections
- Added Windows PowerShell instructions using existing `quickstart.ps1`
- Kept verification step consistent across platforms

Tested the formatting locally.