### PR TITLE
Restore session during server restart | fix unhandled error in event routes

### DIFF
--- a/core/framework/server/routes_events.py
+++ b/core/framework/server/routes_events.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 
 from aiohttp import web
+from aiohttp.client_exceptions import ClientConnectionResetError as _AiohttpConnReset
 
 from framework.runtime.event_bus import EventType
 from framework.server.app import resolve_session
@@ -143,8 +144,15 @@ async def handle_events(request: web.Request) -> web.StreamResponse:
                         "SSE first event: session='%s', type='%s'", session.id, data.get("type")
                     )
             except TimeoutError:
-                await sse.send_keepalive()
-            except (ConnectionResetError, ConnectionError):
+                try:
+                    await sse.send_keepalive()
+                except (ConnectionResetError, ConnectionError, _AiohttpConnReset):
+                    close_reason = "client_disconnected"
+                    break
+                except Exception as exc:
+                    close_reason = f"keepalive_error: {exc}"
+                    break
+            except (ConnectionResetError, ConnectionError, _AiohttpConnReset):
                 close_reason = "client_disconnected"
                 break
             except Exception as exc:

--- a/core/framework/server/routes_sessions.py
+++ b/core/framework/server/routes_sessions.py
@@ -177,7 +177,12 @@ async def handle_list_live_sessions(request: web.Request) -> web.Response:
 
 
 async def handle_get_live_session(request: web.Request) -> web.Response:
-    """GET /api/sessions/{session_id} — get session detail."""
+    """GET /api/sessions/{session_id} — get session detail.
+
+    Falls back to cold session metadata (HTTP 200 with ``cold: true``) when the
+    session is not alive in memory but queen conversation files exist on disk.
+    This lets the frontend detect a server restart and restore message history.
+    """
     manager = _get_manager(request)
     session_id = request.match_info["session_id"]
     session = manager.get_session(session_id)
@@ -188,6 +193,10 @@ async def handle_get_live_session(request: web.Request) -> web.Response:
                 {"session_id": session_id, "loading": True},
                 status=202,
             )
+        # Check if conversation files survived on disk (post-restart scenario)
+        cold_info = SessionManager.get_cold_session_info(session_id)
+        if cold_info is not None:
+            return web.json_response(cold_info)
         return web.json_response(
             {"error": f"Session '{session_id}' not found"},
             status=404,
@@ -611,15 +620,17 @@ async def handle_messages(request: web.Request) -> web.Response:
 
 
 async def handle_queen_messages(request: web.Request) -> web.Response:
-    """GET /api/sessions/{session_id}/queen-messages — get queen conversation."""
-    session, err = resolve_session(request)
-    if err:
-        return err
+    """GET /api/sessions/{session_id}/queen-messages — get queen conversation.
 
-    queen_dir = Path.home() / ".hive" / "queen" / "session" / session.id
+    Reads directly from disk so it works for both live sessions and cold
+    (post-server-restart) sessions — no live session required.
+    """
+    session_id = request.match_info["session_id"]
+
+    queen_dir = Path.home() / ".hive" / "queen" / "session" / session_id
     convs_dir = queen_dir / "conversations"
     if not convs_dir.exists():
-        return web.json_response({"messages": []})
+        return web.json_response({"messages": [], "session_id": session_id})
 
     all_messages: list[dict] = []
     for node_dir in convs_dir.iterdir():
@@ -652,7 +663,26 @@ async def handle_queen_messages(request: web.Request) -> web.Response:
         and not (m["role"] == "assistant" and m.get("tool_calls"))
     ]
 
-    return web.json_response({"messages": all_messages})
+    return web.json_response({"messages": all_messages, "session_id": session_id})
+
+
+async def handle_session_history(request: web.Request) -> web.Response:
+    """GET /api/sessions/history — all queen sessions on disk (live + cold).
+
+    Returns every session directory under ~/.hive/queen/session/, newest first.
+    Live sessions have ``live: true, cold: false``; sessions that survived a
+    server restart have ``live: false, cold: true``.
+    """
+    manager = _get_manager(request)
+    live_ids = {s.id for s in manager.list_sessions()}
+
+    disk_sessions = SessionManager.list_cold_sessions()
+    for s in disk_sessions:
+        if s["session_id"] in live_ids:
+            s["cold"] = False
+            s["live"] = True
+
+    return web.json_response({"sessions": disk_sessions})
 
 
 # ------------------------------------------------------------------
@@ -701,6 +731,8 @@ def register_routes(app: web.Application) -> None:
     # Session lifecycle
     app.router.add_post("/api/sessions", handle_create_session)
     app.router.add_get("/api/sessions", handle_list_live_sessions)
+    # history must be registered before {session_id} so it takes priority
+    app.router.add_get("/api/sessions/history", handle_session_history)
     app.router.add_get("/api/sessions/{session_id}", handle_get_live_session)
     app.router.add_delete("/api/sessions/{session_id}", handle_stop_session)
 

--- a/core/framework/server/session_manager.py
+++ b/core/framework/server/session_manager.py
@@ -709,6 +709,83 @@ class SessionManager:
     def list_sessions(self) -> list[Session]:
         return list(self._sessions.values())
 
+    # ------------------------------------------------------------------
+    # Cold session helpers (disk-only, no live runtime required)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def get_cold_session_info(session_id: str) -> dict | None:
+        """Return disk metadata for a session that is no longer live in memory.
+
+        Checks whether queen conversation files exist at
+        ~/.hive/queen/session/{session_id}/conversations/.  Returns None when
+        no data is found so callers can fall through to a 404.
+        """
+        queen_dir = Path.home() / ".hive" / "queen" / "session" / session_id
+        convs_dir = queen_dir / "conversations"
+        if not convs_dir.exists():
+            return None
+
+        # Check whether any message part files are actually present
+        has_messages = False
+        try:
+            for node_dir in convs_dir.iterdir():
+                if not node_dir.is_dir():
+                    continue
+                parts_dir = node_dir / "parts"
+                if parts_dir.exists() and any(f.suffix == ".json" for f in parts_dir.iterdir()):
+                    has_messages = True
+                    break
+        except OSError:
+            pass
+
+        try:
+            created_at = queen_dir.stat().st_ctime
+        except OSError:
+            created_at = 0.0
+
+        return {
+            "session_id": session_id,
+            "cold": True,
+            "live": False,
+            "has_messages": has_messages,
+            "created_at": created_at,
+        }
+
+    @staticmethod
+    def list_cold_sessions() -> list[dict]:
+        """Return metadata for every queen session directory on disk, newest first."""
+        queen_sessions_dir = Path.home() / ".hive" / "queen" / "session"
+        if not queen_sessions_dir.exists():
+            return []
+
+        results: list[dict] = []
+        try:
+            entries = sorted(
+                queen_sessions_dir.iterdir(),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+        except OSError:
+            return []
+
+        for d in entries:
+            if not d.is_dir():
+                continue
+            try:
+                created_at = d.stat().st_ctime
+            except OSError:
+                created_at = 0.0
+            results.append({
+                "session_id": d.name,
+                "cold": True,   # caller overrides for live sessions
+                "live": False,
+                "has_messages": (d / "conversations").exists(),
+                "created_at": created_at,
+            })
+
+        return results
+
     async def shutdown_all(self) -> None:
         """Gracefully stop all sessions. Called on server shutdown."""
         session_ids = list(self._sessions.keys())

--- a/core/frontend/src/api/sessions.ts
+++ b/core/frontend/src/api/sessions.ts
@@ -66,9 +66,13 @@ export const sessionsApi = {
   graphs: (sessionId: string) =>
     api.get<{ graphs: string[] }>(`/sessions/${sessionId}/graphs`),
 
-  /** Get queen conversation history for a session. */
+  /** Get queen conversation history for a session (works for cold/post-restart sessions too). */
   queenMessages: (sessionId: string) =>
-    api.get<{ messages: Message[] }>(`/sessions/${sessionId}/queen-messages`),
+    api.get<{ messages: Message[]; session_id: string }>(`/sessions/${sessionId}/queen-messages`),
+
+  /** List all queen sessions on disk — live + cold (post-restart). */
+  history: () =>
+    api.get<{ sessions: Array<{ session_id: string; cold: boolean; live: boolean; has_messages: boolean; created_at: number }> }>("/sessions/history"),
 
   // --- Worker session browsing (persisted execution runs) ---
 

--- a/core/frontend/src/api/types.ts
+++ b/core/frontend/src/api/types.ts
@@ -19,6 +19,8 @@ export interface LiveSession {
 export interface LiveSessionDetail extends LiveSession {
   entry_points?: EntryPoint[];
   graphs?: string[];
+  /** True when the session exists on disk but is not live (server restarted). */
+  cold?: boolean;
 }
 
 export interface EntryPoint {

--- a/core/frontend/src/pages/workspace.tsx
+++ b/core/frontend/src/pages/workspace.tsx
@@ -482,29 +482,71 @@ export default function Workspace() {
 
         // Try to reconnect to stored backend session (e.g., after browser refresh)
         const storedId = sessionsRef.current[agentType]?.[0]?.backendSessionId;
+        // When the server restarts the session is "cold" — conversation files
+        // survive on disk but there is no live runtime.  Track the old ID so
+        // we can restore message history after creating a new session.
+        let coldRestoreId: string | undefined;
+
         if (storedId) {
           try {
-            liveSession = await sessionsApi.get(storedId);
+            const sessionData = await sessionsApi.get(storedId);
+            if (sessionData.cold) {
+              // Server restarted — files on disk, no live runtime
+              coldRestoreId = storedId;
+            } else {
+              liveSession = sessionData;
+            }
           } catch {
-            // Session gone — fall through to create new
+            // Session gone entirely (no disk files either)
           }
         }
 
         if (!liveSession) {
-          // Reconnect failed — clear stale cached messages from localStorage restore
-          if (storedId) {
-            setSessionsByAgent(prev => ({
-              ...prev,
-              [agentType]: (prev[agentType] || []).map((s, i) =>
-                i === 0 ? { ...s, messages: [], graphNodes: [] } : s,
-              ),
-            }));
-          }
-
           liveSession = await sessionsApi.create(undefined, undefined, undefined, prompt);
 
-          // Show the initial prompt as a user message in chat (only on fresh create)
-          if (prompt) {
+          // Restore previous conversation from disk when the server restarted
+          // (coldRestoreId) or the session ID was stored but is gone (storedId).
+          const restoreFrom = coldRestoreId ?? storedId;
+          let restoredMessageCount = 0;
+          if (restoreFrom) {
+            try {
+              const { messages: queenMsgs } = await sessionsApi.queenMessages(restoreFrom);
+              if (queenMsgs.length > 0) {
+                const restoredMsgs = (queenMsgs as Message[]).map(m => {
+                  const msg = backendMessageToChatMessage(m, agentType, "Queen Bee");
+                  msg.role = "queen";
+                  return msg;
+                });
+                restoredMsgs.sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0));
+                setSessionsByAgent(prev => ({
+                  ...prev,
+                  [agentType]: (prev[agentType] || []).map((s, i) =>
+                    i === 0 ? { ...s, messages: restoredMsgs, graphNodes: [] } : s,
+                  ),
+                }));
+                restoredMessageCount = restoredMsgs.length;
+              } else {
+                // No messages on disk — wipe stale localStorage cache
+                setSessionsByAgent(prev => ({
+                  ...prev,
+                  [agentType]: (prev[agentType] || []).map((s, i) =>
+                    i === 0 ? { ...s, messages: [], graphNodes: [] } : s,
+                  ),
+                }));
+              }
+            } catch {
+              // Queen messages unavailable — wipe stale cache
+              setSessionsByAgent(prev => ({
+                ...prev,
+                [agentType]: (prev[agentType] || []).map((s, i) =>
+                  i === 0 ? { ...s, messages: [], graphNodes: [] } : s,
+                ),
+              }));
+            }
+          }
+
+          // Show the initial prompt as a user message only on a truly fresh session
+          if (prompt && restoredMessageCount === 0) {
             const userMsg: ChatMessage = {
               id: makeId(), agent: "You", agentColor: "",
               content: prompt, timestamp: "", type: "user", thread: agentType, createdAt: Date.now(),

--- a/uv.lock
+++ b/uv.lock
@@ -800,9 +800,6 @@ dependencies = [
     { name = "litellm" },
     { name = "mcp" },
     { name = "pydantic" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-xdist" },
     { name = "textual" },
     { name = "tools" },
 ]
@@ -810,6 +807,11 @@ dependencies = [
 [package.optional-dependencies]
 server = [
     { name = "aiohttp" },
+]
+testing = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-xdist" },
 ]
 tui = [
     { name = "textual" },
@@ -820,6 +822,9 @@ webhook = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -834,17 +839,20 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.81.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0" },
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "pytest-asyncio", specifier = ">=0.23" },
-    { name = "pytest-xdist", specifier = ">=3.0" },
+    { name = "pytest", marker = "extra == 'testing'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'testing'", specifier = ">=0.23" },
+    { name = "pytest-xdist", marker = "extra == 'testing'", specifier = ">=3.0" },
     { name = "textual", specifier = ">=1.0.0" },
     { name = "textual", marker = "extra == 'tui'", specifier = ">=0.75.0" },
     { name = "tools", editable = "tools" },
 ]
-provides-extras = ["tui", "webhook", "server"]
+provides-extras = ["tui", "webhook", "server", "testing"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "pytest-xdist", specifier = ">=3.0" },
     { name = "ruff", specifier = ">=0.14.14" },
     { name = "ty", specifier = ">=0.0.13" },
 ]


### PR DESCRIPTION
## Summary

Queen conversation files written to `~/.hive/queen/session/{session_id}/conversations/` survive a server restart, but the server had no way to serve them afterwards. `GET /api/sessions/{id}` returned 404 (in-memory dict wiped), `GET /api/sessions/{id}/queen-messages` required a live session object, and the frontend silently created a brand-new session — orphaning the on-disk history forever.

This PR makes cold (post-restart) sessions first-class: the server recognises them from disk, the messages endpoint works without a live runtime, and the frontend restores history into the new session before the user sees anything.

---

## Changes

### `core/framework/server/session_manager.py`

Added two static helper methods that inspect `~/.hive/queen/session/` on disk without requiring a live `Session` object in memory:

- **`get_cold_session_info(session_id)`** — checks whether conversation files exist for a given session ID and returns `{session_id, cold: True, has_messages, created_at}`, or `None` if no data is found.
- **`list_cold_sessions()`** — scans all subdirectories under `~/.hive/queen/session/` and returns them newest-first. Used by the history endpoint.

No SQLite dependency added — the conversation directory itself serves as the index.

---

### `core/framework/server/routes_sessions.py`

**`handle_get_live_session`** — instead of returning 404 immediately when a session is not in memory, it now calls `SessionManager.get_cold_session_info(session_id)` first. If disk data exists it returns HTTP 200 with `{cold: true, has_messages, created_at}`. A genuinely unknown session still returns 404.

**`handle_queen_messages`** — removed the `resolve_session(request)` live-session guard. The endpoint now derives the session directory path directly from the `session_id` URL parameter and reads from disk. Works for both live and cold sessions with no behaviour change for the live case.

**`handle_session_history`** (new) — `GET /api/sessions/history` scans all on-disk queen session directories and returns them as a list with `live`/`cold` flags. Live sessions (present in the in-memory dict) are marked `live: true, cold: false`; everything else is `live: false, cold: true`. Route registered before `{session_id}` so it takes priority.

---

### `core/frontend/src/api/types.ts`

Added `cold?: boolean` to `LiveSessionDetail` so TypeScript knows about the new field without a cast.

---

### `core/frontend/src/api/sessions.ts`

- Updated `queenMessages` return type to include `session_id` in the response shape.
- Added `history()` method for `GET /api/sessions/history`.

---

### `core/frontend/src/pages/workspace.tsx`

Rewrote the reconnect logic in `loadAgentForType` for the `"new-agent"` path:

**Before:** `sessionsApi.get(storedId)` threw 404 → stale messages cleared → new session created → blank chat.

**After:**
1. `sessionsApi.get(storedId)` returns `{cold: true}` → server restarted, files are on disk.
2. New live session is created normally.
3. `sessionsApi.queenMessages(oldSessionId)` is called against the **old** cold session ID — the server reads from disk.
4. Restored messages are injected into the chat panel sorted chronologically.
5. If no messages exist on disk (truly fresh scenario), the cache is cleared as before.
6. The initial prompt is only shown as a user message when zero messages were restored (avoids duplication on restores).

---

## Before / After

| Scenario | Before | After |
|---|---|---|
| Server restarts, user refreshes | Blank chat, history lost | Prior conversation restored |
| `GET /api/sessions/{id}` after restart | 404 | 200 with `cold: true` |
| `GET /api/sessions/{id}/queen-messages` after restart | 404 (live session required) | Returns messages from disk |
| `GET /api/sessions/history` | 404 (no endpoint) | Lists all sessions on disk |
| Normal refresh (server still running) | History restored | No change |

---

Resolves issue #5692 