### PR TITLE
Fix new session creation when submitting prompt from home page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ exports/*
 .agent-builder-sessions/*
 
 .claude/settings.local.json
+.claude/skills/ship-it/
 
 .venv
 

--- a/core/frontend/src/pages/home.tsx
+++ b/core/frontend/src/pages/home.tsx
@@ -40,7 +40,7 @@ const promptHints = [
 export default function Home() {
   const navigate = useNavigate();
   const [inputValue, setInputValue] = useState("");
-  const textareaRef = useRef<HTMLInputElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [showAgents, setShowAgents] = useState(false);
   const [agents, setAgents] = useState<DiscoverEntry[]>([]);
   const [loading, setLoading] = useState(false);
@@ -106,13 +106,24 @@ export default function Home() {
           {/* Chat input */}
           <form onSubmit={handleSubmit} className="mb-6">
             <div className="relative border border-border/60 rounded-xl bg-card/50 hover:border-primary/30 focus-within:border-primary/40 transition-colors shadow-sm">
-              <input
+              <textarea
                 ref={textareaRef}
-                type="text"
+                rows={1}
                 value={inputValue}
-                onChange={(e) => setInputValue(e.target.value)}
+                onChange={(e) => {
+                  setInputValue(e.target.value);
+                  const ta = e.target;
+                  ta.style.height = "auto";
+                  ta.style.height = `${Math.min(ta.scrollHeight, 160)}px`;
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    handleSubmit(e);
+                  }
+                }}
                 placeholder="Describe a task for the hive..."
-                className="w-full bg-transparent px-5 py-4 pr-12 text-sm text-foreground placeholder:text-muted-foreground/60 focus:outline-none rounded-xl"
+                className="w-full bg-transparent px-5 py-4 pr-12 text-sm text-foreground placeholder:text-muted-foreground/60 focus:outline-none rounded-xl resize-none overflow-y-auto"
               />
               <div className="absolute right-3 bottom-2.5">
                 <button

--- a/core/frontend/src/pages/workspace.tsx
+++ b/core/frontend/src/pages/workspace.tsx
@@ -313,6 +313,16 @@ export default function Workspace() {
       return initial;
     }
 
+    // If the user submitted a new prompt from the home page, always create
+    // a fresh session so the prompt isn't lost into an existing session.
+    if (initialPrompt && hasExplicitAgent) {
+      const newSession = initialAgent === "new-agent"
+        ? createSession("new-agent", "New Agent")
+        : createSession(initialAgent, formatAgentDisplayName(initialAgent));
+      initial[initialAgent] = [...(initial[initialAgent] || []), newSession];
+      return initial;
+    }
+
     if (initial[initialAgent]?.length) {
       return initial;
     }
@@ -332,8 +342,14 @@ export default function Workspace() {
     if (persisted) {
       const restored = { ...persisted.activeSessionByAgent };
       const urlSessions = sessionsByAgent[initialAgent];
-      if (urlSessions?.length && !restored[initialAgent]) {
-        restored[initialAgent] = urlSessions[0].id;
+      if (urlSessions?.length) {
+        // When a prompt was submitted from home, activate the newly created
+        // session (last in array) instead of the previously active one.
+        if (initialPrompt && hasExplicitAgent) {
+          restored[initialAgent] = urlSessions[urlSessions.length - 1].id;
+        } else if (!restored[initialAgent]) {
+          restored[initialAgent] = urlSessions[0].id;
+        }
       }
       return restored;
     }
@@ -480,8 +496,13 @@ export default function Workspace() {
         const prompt = initialPrompt || undefined;
         let liveSession: LiveSession | undefined;
 
+        // Find the active session for this agent type
+        const activeId = activeSessionRef.current[agentType];
+        const activeSess = sessionsRef.current[agentType]?.find(s => s.id === activeId)
+          || sessionsRef.current[agentType]?.[0];
+
         // Try to reconnect to stored backend session (e.g., after browser refresh)
-        const storedId = sessionsRef.current[agentType]?.[0]?.backendSessionId;
+        const storedId = activeSess?.backendSessionId;
         if (storedId) {
           try {
             liveSession = await sessionsApi.get(storedId);
@@ -492,11 +513,11 @@ export default function Workspace() {
 
         if (!liveSession) {
           // Reconnect failed — clear stale cached messages from localStorage restore
-          if (storedId) {
+          if (storedId && activeId) {
             setSessionsByAgent(prev => ({
               ...prev,
-              [agentType]: (prev[agentType] || []).map((s, i) =>
-                i === 0 ? { ...s, messages: [], graphNodes: [] } : s,
+              [agentType]: (prev[agentType] || []).map(s =>
+                s.id === activeId ? { ...s, messages: [], graphNodes: [] } : s,
               ),
             }));
           }
@@ -504,27 +525,29 @@ export default function Workspace() {
           liveSession = await sessionsApi.create(undefined, undefined, undefined, prompt);
 
           // Show the initial prompt as a user message in chat (only on fresh create)
-          if (prompt) {
+          if (prompt && activeId) {
             const userMsg: ChatMessage = {
               id: makeId(), agent: "You", agentColor: "",
               content: prompt, timestamp: "", type: "user", thread: agentType, createdAt: Date.now(),
             };
             setSessionsByAgent(prev => ({
               ...prev,
-              [agentType]: (prev[agentType] || []).map(s => ({
-                ...s, messages: [...s.messages, userMsg],
-              })),
+              [agentType]: (prev[agentType] || []).map(s =>
+                s.id === activeId ? { ...s, messages: [...s.messages, userMsg] } : s,
+              ),
             }));
           }
         }
 
-        // Store backendSessionId on the Session object for persistence
-        setSessionsByAgent(prev => ({
-          ...prev,
-          [agentType]: (prev[agentType] || []).map((s, i) =>
-            i === 0 ? { ...s, backendSessionId: liveSession!.session_id } : s,
-          ),
-        }));
+        // Store backendSessionId on the active Session object for persistence
+        if (activeId) {
+          setSessionsByAgent(prev => ({
+            ...prev,
+            [agentType]: (prev[agentType] || []).map(s =>
+              s.id === activeId ? { ...s, backendSessionId: liveSession!.session_id } : s,
+            ),
+          }));
+        }
 
         updateAgentState(agentType, {
           sessionId: liveSession.session_id,

--- a/uv.lock
+++ b/uv.lock
@@ -800,9 +800,6 @@ dependencies = [
     { name = "litellm" },
     { name = "mcp" },
     { name = "pydantic" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-xdist" },
     { name = "textual" },
     { name = "tools" },
 ]
@@ -810,6 +807,11 @@ dependencies = [
 [package.optional-dependencies]
 server = [
     { name = "aiohttp" },
+]
+testing = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-xdist" },
 ]
 tui = [
     { name = "textual" },
@@ -820,6 +822,9 @@ webhook = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -834,17 +839,20 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.81.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0" },
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "pytest-asyncio", specifier = ">=0.23" },
-    { name = "pytest-xdist", specifier = ">=3.0" },
+    { name = "pytest", marker = "extra == 'testing'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'testing'", specifier = ">=0.23" },
+    { name = "pytest-xdist", marker = "extra == 'testing'", specifier = ">=3.0" },
     { name = "textual", specifier = ">=1.0.0" },
     { name = "textual", marker = "extra == 'tui'", specifier = ">=0.75.0" },
     { name = "tools", editable = "tools" },
 ]
-provides-extras = ["tui", "webhook", "server"]
+provides-extras = ["tui", "webhook", "server", "testing"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "pytest-xdist", specifier = ">=3.0" },
     { name = "ruff", specifier = ">=0.14.14" },
     { name = "ty", specifier = ">=0.0.13" },
 ]


### PR DESCRIPTION
## Summary
- Fix workspace session management so submitting a prompt from the home page always creates and activates a fresh session, preventing prompts from being lost into existing sessions
- Upgrade home page input from `<input>` to auto-resizing `<textarea>` with Enter-to-submit and Shift+Enter-for-newline
- Move pytest dependencies from main deps to `testing` extra and dev dependencies

Closes #5708

## Test Plan
- [ ] Submit a prompt from the home page and verify a new session is created
- [ ] Submit a prompt from the home page when an existing session is already open for that agent — verify a new session is created (not reused)
- [ ] Verify the textarea auto-resizes on multiline input and submits on Enter
- [ ] Refresh the browser and verify session reconnection still works correctly