### PR TITLE
fix: prune ~/.hive/failed_requests/ to prevent unbounded disk growth

### DIFF
--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -126,6 +126,10 @@ EMPTY_STREAM_RETRY_DELAY = 1.0  # seconds
 # Directory for dumping failed requests
 FAILED_REQUESTS_DIR = Path.home() / ".hive" / "failed_requests"
 
+# Maximum number of dump files to retain in ~/.hive/failed_requests/.
+# Older files are pruned automatically to prevent unbounded disk growth.
+MAX_FAILED_REQUEST_DUMPS = 50
+
 
 def _estimate_tokens(model: str, messages: list[dict]) -> tuple[int, str]:
     """Estimate token count for messages. Returns (token_count, method)."""
@@ -140,6 +144,24 @@ def _estimate_tokens(model: str, messages: list[dict]) -> tuple[int, str]:
     # Fallback: rough estimate based on character count (~4 chars per token)
     total_chars = sum(len(str(m.get("content", ""))) for m in messages)
     return total_chars // 4, "estimate"
+
+
+def _prune_failed_request_dumps(max_files: int = MAX_FAILED_REQUEST_DUMPS) -> None:
+    """Remove oldest dump files when the count exceeds *max_files*.
+
+    Best-effort: never raises — a pruning failure must not break retry logic.
+    """
+    try:
+        all_dumps = sorted(
+            FAILED_REQUESTS_DIR.glob("*.json"),
+            key=lambda f: f.stat().st_mtime,
+        )
+        excess = len(all_dumps) - max_files
+        if excess > 0:
+            for old_file in all_dumps[:excess]:
+                old_file.unlink(missing_ok=True)
+    except Exception:
+        pass  # Best-effort — never block the caller
 
 
 def _dump_failed_request(
@@ -172,6 +194,9 @@ def _dump_failed_request(
 
     with open(filepath, "w") as f:
         json.dump(dump_data, f, indent=2, default=str)
+
+    # Prune old dumps to prevent unbounded disk growth
+    _prune_failed_request_dumps()
 
     return str(filepath)
 


### PR DESCRIPTION
## Summary

Fixes #5696

`_dump_failed_request()` was writing a new JSON file on every failed LLM request with no cleanup, causing unbounded disk growth on agents hitting persistent rate limits.

## Changes

- Added `MAX_FAILED_REQUEST_DUMPS = 50` constant in `core/framework/llm/litellm.py`
- Added `_prune_failed_request_dumps()` helper that deletes oldest files when count exceeds the cap
- Called `_prune_failed_request_dumps()` at the end of each `_dump_failed_request()` call

## How It Works

After every dump, files in `~/.hive/failed_requests/` are sorted by modification time. Any files beyond the newest 50 are deleted. The pruning is best-effort — failures are silently swallowed so retry logic is never blocked.

## Testing

Verified locally: creating 60 dumps results in exactly 50 remaining (oldest 10 pruned).