### PR TITLE
Fix Windows browser opening and file encoding issues

### DIFF
--- a/core/codex_oauth.py
+++ b/core/codex_oauth.py
@@ -159,13 +159,15 @@ def save_credentials(token_data: dict, account_id: str) -> None:
 
 def open_browser(url: str) -> bool:
     """Open the URL in the user's default browser."""
+    import webbrowser
     system = platform.system()
     try:
         devnull = subprocess.DEVNULL
         if system == "Darwin":
             subprocess.Popen(["open", url], stdout=devnull, stderr=devnull)
         elif system == "Windows":
-            subprocess.Popen(["cmd", "/c", "start", url], stdout=devnull, stderr=devnull)
+            # Use webbrowser module for Windows to safely handle URLs with special characters
+            return webbrowser.open(url)
         else:
             subprocess.Popen(["xdg-open", url], stdout=devnull, stderr=devnull)
         return True

--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -1929,6 +1929,7 @@ def _open_browser(url: str) -> None:
     """Open URL in the default browser (best-effort, non-blocking)."""
     import subprocess
     import sys
+    import webbrowser
 
     try:
         if sys.platform == "darwin":
@@ -1937,6 +1938,8 @@ def _open_browser(url: str) -> None:
             subprocess.Popen(
                 ["xdg-open", url], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
             )
+        elif sys.platform == "win32":
+            webbrowser.open(url)
     except Exception:
         pass  # Best-effort — don't crash if browser can't open
 

--- a/tools/src/aden_tools/credentials/shell_config.py
+++ b/tools/src/aden_tools/credentials/shell_config.py
@@ -130,7 +130,7 @@ def add_env_var_to_shell_config(
 
     try:
         if config_path.exists():
-            content = config_path.read_text()
+            content = config_path.read_text(encoding="utf-8")
 
             # Check if already exists
             pattern = rf"^export\s+{re.escape(env_var)}=.*$"
@@ -142,11 +142,11 @@ def add_env_var_to_shell_config(
                     content,
                     flags=re.MULTILINE,
                 )
-                config_path.write_text(new_content)
+                config_path.write_text(new_content, encoding="utf-8")
                 return True, str(config_path)
 
         # Append to file
-        with open(config_path, "a") as f:
+        with open(config_path, "a", encoding="utf-8") as f:
             f.write(f"\n# {comment}\n")
             f.write(f"{export_line}\n")
 


### PR DESCRIPTION
- Add UTF-8 encoding to shell config file operations
- Add Windows support to browser opening in CLI
- Use webbrowser module for Windows in OAuth (safer than cmd.exe)

Fixes dashboard not opening in browser on Windows and file corruption when managing environment variables in shell configs.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
