### PR TITLE
fix(runtime): warn and track dropped events when EventBus/SharedStateManager history overflows

### DIFF
--- a/core/framework/runtime/event_bus.py
+++ b/core/framework/runtime/event_bus.py
@@ -231,6 +231,7 @@ class EventBus:
         self._subscriptions: dict[str, Subscription] = {}
         self._event_history: list[AgentEvent] = []
         self._max_history = max_history
+        self._events_dropped: int = 0
         self._semaphore = asyncio.Semaphore(max_concurrent_handlers)
         self._subscription_counter = 0
         self._lock = asyncio.Lock()
@@ -303,6 +304,15 @@ class EventBus:
         async with self._lock:
             self._event_history.append(event)
             if len(self._event_history) > self._max_history:
+                dropped = len(self._event_history) - self._max_history
+                self._events_dropped += dropped
+                if self._events_dropped == dropped:  # first overflow — warn once
+                    logger.warning(
+                        "EventBus history buffer full (%d). "
+                        "Oldest events will be dropped. Increase max_history or "
+                        "enable HIVE_DEBUG_EVENTS for persistent logging.",
+                        self._max_history,
+                    )
                 self._event_history = self._event_history[-self._max_history :]
 
         # Write event to JSONL file (gated by HIVE_DEBUG_EVENTS env var)
@@ -1083,6 +1093,7 @@ class EventBus:
 
         return {
             "total_events": len(self._event_history),
+            "events_dropped": self._events_dropped,
             "subscriptions": len(self._subscriptions),
             "events_by_type": type_counts,
         }

--- a/core/framework/runtime/shared_state.py
+++ b/core/framework/runtime/shared_state.py
@@ -89,6 +89,7 @@ class SharedStateManager:
         # Change history for debugging/auditing
         self._change_history: list[StateChange] = []
         self._max_history = 1000
+        self._changes_dropped: int = 0
 
         # Version tracking
         self._version = 0
@@ -283,6 +284,14 @@ class SharedStateManager:
 
         # Trim history if too long
         if len(self._change_history) > self._max_history:
+            dropped = len(self._change_history) - self._max_history
+            self._changes_dropped += dropped
+            if self._changes_dropped == dropped:  # first overflow — warn once
+                logger.warning(
+                    "SharedStateManager change history buffer full (%d). "
+                    "Oldest changes will be dropped.",
+                    self._max_history,
+                )
             self._change_history = self._change_history[-self._max_history :]
 
     # === BULK OPERATIONS ===
@@ -335,6 +344,7 @@ class SharedStateManager:
             "stream_count": len(self._stream_state),
             "execution_count": len(self._execution_state),
             "total_changes": len(self._change_history),
+            "changes_dropped": self._changes_dropped,
             "version": self._version,
         }
 


### PR DESCRIPTION
## Summary
- Add `_events_dropped` / `_changes_dropped` counter to track silent event loss
- Emit a one-time `logger.warning()` on first buffer overflow so operators know events are being dropped
- Expose `events_dropped` / `changes_dropped` in `get_stats()` for observability

Closes #5752

## Changes

| File | Change |
|------|--------|
| `core/framework/runtime/event_bus.py` | Added overflow counter, warning, and `events_dropped` in `get_stats()` |
| `core/framework/runtime/shared_state.py` | Same pattern: `_changes_dropped` counter, warning, `changes_dropped` in `get_stats()` |

## Why

Both `EventBus` and `SharedStateManager` silently discard oldest entries when the in-memory history buffer (default 1,000) overflows. This makes post-mortem debugging impossible for long-running agents and causes `get_stats()` to report misleading `total_events` / `total_changes` counts.

The fix is purely additive — no existing logic is changed, only warnings added on the overflow path.

## Test plan
- [ ] Existing `pytest core/tests/` passes (no behavior change for normal operation)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] Manually verify: create an `EventBus(max_history=5)`, publish 10 events, confirm warning is logged once and `get_stats()` shows `events_dropped: 5`

