### PR TITLE
fix(llm): warn when litellm monkey-patches fail to apply [micro-fix]

### DIFF
--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -45,6 +45,12 @@ def _patch_litellm_anthropic_oauth() -> None:
         from litellm.llms.anthropic.common_utils import AnthropicModelInfo
         from litellm.types.llms.anthropic import ANTHROPIC_OAUTH_TOKEN_PREFIX
     except ImportError:
+        logger.warning(
+            "Could not apply litellm Anthropic OAuth patch — litellm internals may have "
+            "changed. Anthropic OAuth tokens (Claude Code subscriptions) may fail with 401. "
+            "See BerriAI/litellm#19618. Current litellm version: %s",
+            getattr(litellm, "__version__", "unknown"),
+        )
         return
 
     original = AnthropicModelInfo.validate_environment
@@ -86,10 +92,12 @@ def _patch_litellm_metadata_nonetype() -> None:
     """
     import functools
 
+    patched_count = 0
     for fn_name in ("completion", "acompletion", "responses", "aresponses"):
         original = getattr(litellm, fn_name, None)
         if original is None:
             continue
+        patched_count += 1
         if asyncio.iscoroutinefunction(original):
 
             @functools.wraps(original)
@@ -108,6 +116,14 @@ def _patch_litellm_metadata_nonetype() -> None:
                 return _orig(*args, **kwargs)
 
             setattr(litellm, fn_name, _sync_wrapper)
+
+    if patched_count == 0:
+        logger.warning(
+            "Could not apply litellm metadata=None patch — none of the expected entry "
+            "points (completion, acompletion, responses, aresponses) were found. "
+            "metadata=None TypeError may occur. Current litellm version: %s",
+            getattr(litellm, "__version__", "unknown"),
+        )
 
 
 if litellm is not None:


### PR DESCRIPTION
## Summary
- Add `logger.warning()` to `_patch_litellm_anthropic_oauth()` when `ImportError` is caught, including the current litellm version for diagnostics
- Add a `patched_count` check to `_patch_litellm_metadata_nonetype()` that warns if none of the expected entry points were found

Closes #5753

## Changes

| File | Change |
|------|--------|
| `core/framework/llm/litellm.py` | Added warning with version info on OAuth patch ImportError; added patched_count guard on metadata patch |

## Why

Both `_patch_litellm_anthropic_oauth` and `_patch_litellm_metadata_nonetype` patch litellm's private internal modules. When litellm updates its module structure, the patches silently fail — the agent initializes successfully but encounters cryptic 401 errors (OAuth) or `APIConnectionError` (metadata) at runtime.

Since `pyproject.toml` pins `litellm>=1.81.0` with no upper bound, any future litellm release can trigger this. Adding warnings turns a silent runtime failure into an actionable startup diagnostic.

The fix is purely additive — only adds logging on the failure paths, no existing behavior is changed.

## Test plan
- [ ] Existing `pytest core/tests/` passes (patches still apply normally with current litellm 1.81.5)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] To verify the warning: temporarily rename one of the imported litellm modules and confirm the warning is logged at startup

