### PR TITLE
fix(llm): warn when litellm monkey-patches fail to apply [micro-fix]

### DIFF
--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -45,6 +45,12 @@ def _patch_litellm_anthropic_oauth() -> None:
         from litellm.llms.anthropic.common_utils import AnthropicModelInfo
         from litellm.types.llms.anthropic import ANTHROPIC_OAUTH_TOKEN_PREFIX
     except ImportError:
+        logger.warning(
+            "Could not apply litellm Anthropic OAuth patch — litellm internals may have "
+            "changed. Anthropic OAuth tokens (Claude Code subscriptions) may fail with 401. "
+            "See BerriAI/litellm#19618. Current litellm version: %s",
+            getattr(litellm, "__version__", "unknown"),
+        )
         return
 
     original = AnthropicModelInfo.validate_environment
@@ -86,10 +92,12 @@ def _patch_litellm_metadata_nonetype() -> None:
     """
     import functools
 
+    patched_count = 0
     for fn_name in ("completion", "acompletion", "responses", "aresponses"):
         original = getattr(litellm, fn_name, None)
         if original is None:
             continue
+        patched_count += 1
         if asyncio.iscoroutinefunction(original):
 
             @functools.wraps(original)
@@ -108,6 +116,14 @@ def _patch_litellm_metadata_nonetype() -> None:
                 return _orig(*args, **kwargs)
 
             setattr(litellm, fn_name, _sync_wrapper)
+
+    if patched_count == 0:
+        logger.warning(
+            "Could not apply litellm metadata=None patch — none of the expected entry "
+            "points (completion, acompletion, responses, aresponses) were found. "
+            "metadata=None TypeError may occur. Current litellm version: %s",
+            getattr(litellm, "__version__", "unknown"),
+        )
 
 
 if litellm is not None:


### PR DESCRIPTION
## Summary
- Adds `logger.warning()` when litellm Anthropic OAuth monkey-patch fails due to `ImportError`, including litellm version for debugging
- Adds guard check when metadata=None patch finds zero entry points to patch, warning instead of silently doing nothing

Closes #5753

## Changes
- `_patch_litellm_anthropic_oauth()`: Log warning with litellm version on `ImportError`
- `_patch_litellm_metadata_nonetype()`: Track `patched_count`, warn if zero entry points found

## Test plan
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] Changes are logging-only — no logic, API, or DB modifications
- [x] Under 20 lines changed (16 insertions)
