### PR TITLE
feat(executor): Add pre/post node execution hooks to GraphExecutor

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -71,6 +71,38 @@ class ExecutionResult:
 
 
 @dataclass
+class NodeExecutionEvent:
+    """Event data passed to pre-execution hooks."""
+
+    node_id: str
+    node_name: str
+    node_type: str
+    attempt: int
+    max_attempts: int
+    input_data: dict[str, Any]
+    memory_snapshot: dict[str, Any]
+
+
+@dataclass
+class NodeExecutionResult:
+    """Result data passed to post-execution hooks."""
+
+    node_id: str
+    node_name: str
+    node_type: str
+    success: bool
+    output: Any | None
+    error: str | None
+    tokens_used: int
+    latency_ms: int
+    attempt: int
+
+
+PreExecuteHook = Callable[[NodeExecutionEvent], Any]
+PostExecuteHook = Callable[[NodeExecutionResult], Any]
+
+
+@dataclass
 class ParallelBranch:
     """Tracks a single branch in parallel fan-out execution."""
 
@@ -132,13 +164,15 @@ class GraphExecutor:
         event_bus: Any | None = None,
         stream_id: str = "",
         execution_id: str = "",
-        runtime_logger: Any = None,
+        runtime_logger: Any | None = None,
         storage_path: str | Path | None = None,
         loop_config: dict[str, Any] | None = None,
         accounts_prompt: str = "",
         accounts_data: list[dict] | None = None,
         tool_provider_map: dict[str, str] | None = None,
         dynamic_tools_provider: Callable | None = None,
+        pre_execute_hook: PreExecuteHook | None = None,
+        post_execute_hook: PostExecuteHook | None = None,
     ):
         """
         Initialize the executor.
@@ -163,6 +197,8 @@ class GraphExecutor:
             tool_provider_map: Tool name to provider name mapping for account routing
             dynamic_tools_provider: Optional callback returning current
                 tool list (for mode switching)
+            pre_execute_hook: Optional async callback invoked before each node execution
+            post_execute_hook: Optional async callback invoked after each node execution
         """
         self.runtime = runtime
         self.llm = llm
@@ -182,6 +218,8 @@ class GraphExecutor:
         self.accounts_data = accounts_data
         self.tool_provider_map = tool_provider_map
         self.dynamic_tools_provider = dynamic_tools_provider
+        self.pre_execute_hook = pre_execute_hook
+        self.post_execute_hook = post_execute_hook
 
         # Initialize output cleaner
         self.cleansing_config = cleansing_config or CleansingConfig()
@@ -920,9 +958,38 @@ class GraphExecutor:
                         execution_id=self._execution_id,
                     )
 
+                current_attempt = node_retry_counts.get(current_node_id, 0) + 1
+                max_retries = getattr(node_spec, "max_retries", 3)
+
+                if self.pre_execute_hook:
+                    event = NodeExecutionEvent(
+                        node_id=node_spec.id,
+                        node_name=node_spec.name,
+                        node_type=node_spec.node_type,
+                        attempt=current_attempt,
+                        max_attempts=max_retries,
+                        input_data=input_data or {},
+                        memory_snapshot=memory.read_all(),
+                    )
+                    await self.pre_execute_hook(event)
+
                 # Execute node
                 self.logger.info("   Executing...")
                 result = await node_impl.execute(ctx)
+
+                if self.post_execute_hook:
+                    result_event = NodeExecutionResult(
+                        node_id=node_spec.id,
+                        node_name=node_spec.name,
+                        node_type=node_spec.node_type,
+                        success=result.success,
+                        output=result.output,
+                        error=result.error,
+                        tokens_used=result.tokens_used,
+                        latency_ms=result.latency_ms,
+                        attempt=current_attempt,
+                    )
+                    await self.post_execute_hook(result_event)
 
                 # Emit node-completed event (skip event_loop nodes)
                 if self._event_bus and node_spec.node_type != "event_loop":
@@ -2171,11 +2238,37 @@ class GraphExecutor:
                             execution_id=self._execution_id,
                         )
 
+                    if self.pre_execute_hook:
+                        event = NodeExecutionEvent(
+                            node_id=node_spec.id,
+                            node_name=node_spec.name,
+                            node_type=node_spec.node_type,
+                            attempt=attempt + 1,
+                            max_attempts=effective_max_retries,
+                            input_data=mapped,
+                            memory_snapshot=memory.read_all(),
+                        )
+                        await self.pre_execute_hook(event)
+
                     self.logger.info(
                         f"      ▶ Branch {node_spec.name}: executing (attempt {attempt + 1})"
                     )
                     result = await node_impl.execute(ctx)
                     last_result = result
+
+                    if self.post_execute_hook:
+                        result_event = NodeExecutionResult(
+                            node_id=node_spec.id,
+                            node_name=node_spec.name,
+                            node_type=node_spec.node_type,
+                            success=result.success,
+                            output=result.output,
+                            error=result.error,
+                            tokens_used=result.tokens_used,
+                            latency_ms=result.latency_ms,
+                            attempt=attempt + 1,
+                        )
+                        await self.post_execute_hook(result_event)
 
                     # Ensure L2 entry for this branch node
                     if self.runtime_logger:

--- a/core/tests/test_executor_hooks.py
+++ b/core/tests/test_executor_hooks.py
@@ -1,0 +1,370 @@
+"""
+Test node execution hooks (pre/post) for GraphExecutor.
+
+This test verifies Issue #877: Add Node Execution Hooks (Pre/Post) to GraphExecutor.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from framework.graph.edge import GraphSpec
+from framework.graph.executor import (
+    GraphExecutor,
+    NodeExecutionEvent,
+    NodeExecutionResult,
+)
+from framework.graph.goal import Goal
+from framework.graph.node import NodeContext, NodeProtocol, NodeResult, NodeSpec
+from framework.runtime.core import Runtime
+
+
+class SimpleTestNode(NodeProtocol):
+    """A simple test node that returns a fixed result."""
+
+    def __init__(self, output: dict | None = None):
+        self.output = output or {"result": "success"}
+        self.execute_count = 0
+
+    async def execute(self, ctx: NodeContext) -> NodeResult:
+        self.execute_count += 1
+        return NodeResult(success=True, output=self.output)
+
+
+@pytest.fixture
+def runtime():
+    """Create a mock Runtime for testing."""
+    runtime = MagicMock(spec=Runtime)
+    runtime.start_run = MagicMock(return_value="test_run_id")
+    runtime.decide = MagicMock(return_value="test_decision_id")
+    runtime.record_outcome = MagicMock()
+    runtime.end_run = MagicMock()
+    runtime.report_problem = MagicMock()
+    runtime.set_node = MagicMock()
+    return runtime
+
+
+@pytest.mark.asyncio
+async def test_pre_execute_hook_is_called(runtime):
+    """Test that pre_execute_hook is called before node execution."""
+
+    hook_calls = []
+
+    async def pre_hook(event: NodeExecutionEvent):
+        hook_calls.append(("pre", event))
+
+    node_spec = NodeSpec(
+        id="test_node",
+        name="Test Node",
+        description="A test node",
+        node_type="event_loop",
+        output_keys=["result"],
+    )
+
+    graph = GraphSpec(
+        id="test_graph",
+        goal_id="test_goal",
+        name="Test Graph",
+        entry_node="test_node",
+        nodes=[node_spec],
+        edges=[],
+        terminal_nodes=["test_node"],
+    )
+
+    goal = Goal(id="test_goal", name="Test Goal", description="Test pre hook")
+
+    executor = GraphExecutor(runtime=runtime, pre_execute_hook=pre_hook)
+    test_node = SimpleTestNode()
+    executor.register_node("test_node", test_node)
+
+    result = await executor.execute(graph, goal, {"input": "test"})
+
+    assert result.success
+    assert len(hook_calls) == 1
+    event = hook_calls[0][1]
+    assert isinstance(event, NodeExecutionEvent)
+    assert event.node_id == "test_node"
+    assert event.node_name == "Test Node"
+    assert event.node_type == "event_loop"
+    assert event.attempt == 1
+    assert event.input_data == {"input": "test"}
+
+
+@pytest.mark.asyncio
+async def test_post_execute_hook_is_called(runtime):
+    """Test that post_execute_hook is called after node execution."""
+
+    hook_calls = []
+
+    async def post_hook(event: NodeExecutionResult):
+        hook_calls.append(("post", event))
+
+    node_spec = NodeSpec(
+        id="test_node",
+        name="Test Node",
+        description="A test node",
+        node_type="event_loop",
+        output_keys=["result"],
+    )
+
+    graph = GraphSpec(
+        id="test_graph",
+        goal_id="test_goal",
+        name="Test Graph",
+        entry_node="test_node",
+        nodes=[node_spec],
+        edges=[],
+        terminal_nodes=["test_node"],
+    )
+
+    goal = Goal(id="test_goal", name="Test Goal", description="Test post hook")
+
+    executor = GraphExecutor(runtime=runtime, post_execute_hook=post_hook)
+    test_node = SimpleTestNode(output={"result": "success_value"})
+    executor.register_node("test_node", test_node)
+
+    result = await executor.execute(graph, goal, {})
+
+    assert result.success
+    assert len(hook_calls) == 1
+    event = hook_calls[0][1]
+    assert isinstance(event, NodeExecutionResult)
+    assert event.node_id == "test_node"
+    assert event.node_name == "Test Node"
+    assert event.success is True
+    assert event.output == {"result": "success_value"}
+
+
+@pytest.mark.asyncio
+async def test_both_hooks_are_called_in_order(runtime):
+    """Test that pre and post hooks are called in correct order."""
+
+    hook_order = []
+
+    async def pre_hook(event: NodeExecutionEvent):
+        hook_order.append("pre")
+
+    async def post_hook(event: NodeExecutionResult):
+        hook_order.append("post")
+
+    node_spec = NodeSpec(
+        id="test_node",
+        name="Test Node",
+        description="A test node",
+        node_type="event_loop",
+        output_keys=["result"],
+    )
+
+    graph = GraphSpec(
+        id="test_graph",
+        goal_id="test_goal",
+        name="Test Graph",
+        entry_node="test_node",
+        nodes=[node_spec],
+        edges=[],
+        terminal_nodes=["test_node"],
+    )
+
+    goal = Goal(id="test_goal", name="Test Goal", description="Test both hooks")
+
+    executor = GraphExecutor(
+        runtime=runtime,
+        pre_execute_hook=pre_hook,
+        post_execute_hook=post_hook,
+    )
+    test_node = SimpleTestNode()
+    executor.register_node("test_node", test_node)
+
+    result = await executor.execute(graph, goal, {})
+
+    assert result.success
+    assert hook_order == ["pre", "post"]
+
+
+@pytest.mark.asyncio
+async def test_hooks_receive_correct_attempt_number_on_retry(
+    runtime, monkeypatch: pytest.MonkeyPatch
+):
+    """Test that hooks receive correct attempt numbers during retries."""
+
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+    hook_attempts = []
+
+    async def pre_hook(event: NodeExecutionEvent):
+        hook_attempts.append(("pre", event.attempt))
+
+    async def post_hook(event: NodeExecutionResult):
+        hook_attempts.append(("post", event.attempt, event.success))
+
+    class FlakyNode(NodeProtocol):
+        def __init__(self, fail_times: int = 2):
+            self.fail_times = fail_times
+            self.attempt_count = 0
+
+        async def execute(self, ctx: NodeContext) -> NodeResult:
+            self.attempt_count += 1
+            if self.attempt_count <= self.fail_times:
+                return NodeResult(success=False, error=f"Failed attempt {self.attempt_count}")
+            return NodeResult(success=True, output={"result": "ok"})
+
+    node_spec = NodeSpec(
+        id="flaky_node",
+        name="Flaky Node",
+        description="A node that fails before succeeding",
+        max_retries=5,
+        node_type="event_loop",
+        output_keys=["result"],
+    )
+
+    graph = GraphSpec(
+        id="test_graph",
+        goal_id="test_goal",
+        name="Test Graph",
+        entry_node="flaky_node",
+        nodes=[node_spec],
+        edges=[],
+        terminal_nodes=["flaky_node"],
+    )
+
+    goal = Goal(id="test_goal", name="Test Goal", description="Test retry hooks")
+
+    executor = GraphExecutor(
+        runtime=runtime,
+        pre_execute_hook=pre_hook,
+        post_execute_hook=post_hook,
+    )
+    flaky_node = FlakyNode(fail_times=2)
+    executor.register_node("flaky_node", flaky_node)
+
+    result = await executor.execute(graph, goal, {})
+
+    assert result.success
+    assert hook_attempts == [
+        ("pre", 1),
+        ("post", 1, False),
+        ("pre", 2),
+        ("post", 2, False),
+        ("pre", 3),
+        ("post", 3, True),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_hooks_not_called_when_none(runtime):
+    """Test that no hooks are called when None is passed."""
+
+    node_spec = NodeSpec(
+        id="test_node",
+        name="Test Node",
+        description="A test node",
+        node_type="event_loop",
+        output_keys=["result"],
+    )
+
+    graph = GraphSpec(
+        id="test_graph",
+        goal_id="test_goal",
+        name="Test Graph",
+        entry_node="test_node",
+        nodes=[node_spec],
+        edges=[],
+        terminal_nodes=["test_node"],
+    )
+
+    goal = Goal(id="test_goal", name="Test Goal", description="Test no hooks")
+
+    executor = GraphExecutor(
+        runtime=runtime,
+        pre_execute_hook=None,
+        post_execute_hook=None,
+    )
+    test_node = SimpleTestNode()
+    executor.register_node("test_node", test_node)
+
+    result = await executor.execute(graph, goal, {})
+
+    assert result.success
+
+
+@pytest.mark.asyncio
+async def test_pre_hook_receives_memory_snapshot(runtime):
+    """Test that pre_hook receives a snapshot of memory."""
+
+    memory_snapshots = []
+
+    async def pre_hook(event: NodeExecutionEvent):
+        memory_snapshots.append(event.memory_snapshot)
+
+    node_spec = NodeSpec(
+        id="test_node",
+        name="Test Node",
+        description="A test node",
+        node_type="event_loop",
+        input_keys=["input_key"],
+        output_keys=["result"],
+    )
+
+    graph = GraphSpec(
+        id="test_graph",
+        goal_id="test_goal",
+        name="Test Graph",
+        entry_node="test_node",
+        nodes=[node_spec],
+        edges=[],
+        terminal_nodes=["test_node"],
+    )
+
+    goal = Goal(id="test_goal", name="Test Goal", description="Test memory snapshot")
+
+    executor = GraphExecutor(runtime=runtime, pre_execute_hook=pre_hook)
+    test_node = SimpleTestNode()
+    executor.register_node("test_node", test_node)
+
+    result = await executor.execute(graph, goal, {"input_key": "input_value"})
+
+    assert result.success
+    assert len(memory_snapshots) == 1
+    assert "input_key" in memory_snapshots[0]
+    assert memory_snapshots[0]["input_key"] == "input_value"
+
+
+@pytest.mark.asyncio
+async def test_post_hook_receives_tokens_and_latency(runtime):
+    """Test that post_hook receives tokens_used and latency_ms."""
+
+    results = []
+
+    async def post_hook(event: NodeExecutionResult):
+        results.append(event)
+
+    node_spec = NodeSpec(
+        id="test_node",
+        name="Test Node",
+        description="A test node",
+        node_type="event_loop",
+        output_keys=["result"],
+    )
+
+    graph = GraphSpec(
+        id="test_graph",
+        goal_id="test_goal",
+        name="Test Graph",
+        entry_node="test_node",
+        nodes=[node_spec],
+        edges=[],
+        terminal_nodes=["test_node"],
+    )
+
+    goal = Goal(id="test_goal", name="Test Goal", description="Test metrics")
+
+    executor = GraphExecutor(runtime=runtime, post_execute_hook=post_hook)
+    test_node = SimpleTestNode()
+    executor.register_node("test_node", test_node)
+
+    result = await executor.execute(graph, goal, {})
+
+    assert result.success
+    assert len(results) == 1
+    assert results[0].tokens_used >= 0
+    assert results[0].latency_ms >= 0


### PR DESCRIPTION
## Description

Add optional `pre_execute_hook` and `post_execute_hook` callbacks to `GraphExecutor` that are invoked before and after each node execution. This enables users to inject custom logic for logging, metrics collection, caching, and observability without modifying the core executor.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Fixes #877

## Changes Made

- **NodeExecutionEvent dataclass**: Contains node metadata (id, name, type, attempt, max_attempts, input_data, memory_snapshot) passed to pre-execution hooks
- **NodeExecutionResult dataclass**: Contains execution result data (node_id, node_name, node_type, success, output, error, tokens_used, latency_ms, attempt) passed to post-execution hooks
- **GraphExecutor.__init__**: Added `pre_execute_hook` and `post_execute_hook` optional parameters
- **execute() method**: Invoke hooks around node execution in both main loop and parallel branches
- **Unit tests**: 7 comprehensive tests covering hook invocation, order, retry handling, and data passed to hooks

## Usage Example

```python
from framework.graph.executor import GraphExecutor, NodeExecutionResult

metrics = {"total_tokens": 0, "node_latencies": {}}

async def track_metrics(result: NodeExecutionResult):
    metrics["total_tokens"] += result.tokens_used
    metrics["node_latencies"][result.node_id] = result.latency_ms

executor = GraphExecutor(
    runtime=runtime,
    llm=llm,
    post_execute_hook=track_metrics,
)
```

## Testing

- [x] Unit tests pass (`cd core && pytest tests/test_executor_hooks.py`)
  - 7 tests covering all hook scenarios
- [x] Existing tests pass (`cd core && pytest tests/test_executor_max_retries.py tests/test_executor_feedback_edges.py`)
  - 13 tests confirming no regressions
- [x] Lint passes (`cd core && ruff check framework/graph/executor.py tests/test_executor_hooks.py`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (docstrings updated)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
