### PR TITLE
fix(windows): add browser opening support and fix file encoding corru…

### DIFF
--- a/core/codex_oauth.py
+++ b/core/codex_oauth.py
@@ -16,9 +16,7 @@ import hashlib
 import http.server
 import json
 import os
-import platform
 import secrets
-import subprocess
 import sys
 import threading
 import time
@@ -159,17 +157,10 @@ def save_credentials(token_data: dict, account_id: str) -> None:
 
 def open_browser(url: str) -> bool:
     """Open the URL in the user's default browser."""
-    system = platform.system()
+    import webbrowser
     try:
-        devnull = subprocess.DEVNULL
-        if system == "Darwin":
-            subprocess.Popen(["open", url], stdout=devnull, stderr=devnull)
-        elif system == "Windows":
-            subprocess.Popen(["cmd", "/c", "start", url], stdout=devnull, stderr=devnull)
-        else:
-            subprocess.Popen(["xdg-open", url], stdout=devnull, stderr=devnull)
-        return True
-    except OSError:
+        return webbrowser.open(url)
+    except Exception:
         return False
 
 

--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -1937,6 +1937,9 @@ def _open_browser(url: str) -> None:
             subprocess.Popen(
                 ["xdg-open", url], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
             )
+        elif sys.platform == "win32":
+            import os
+            os.startfile(url)
     except Exception:
         pass  # Best-effort — don't crash if browser can't open
 

--- a/tools/src/aden_tools/credentials/shell_config.py
+++ b/tools/src/aden_tools/credentials/shell_config.py
@@ -84,7 +84,7 @@ def check_env_var_in_shell_config(
     if not config_path.exists():
         return False, None
 
-    content = config_path.read_text()
+    content = config_path.read_text(encoding="utf-8")
 
     # Look for export ENV_VAR=value or export ENV_VAR="value"
     pattern = rf"^export\s+{re.escape(env_var)}=(.+)$"
@@ -130,7 +130,7 @@ def add_env_var_to_shell_config(
 
     try:
         if config_path.exists():
-            content = config_path.read_text()
+            content = config_path.read_text(encoding="utf-8")
 
             # Check if already exists
             pattern = rf"^export\s+{re.escape(env_var)}=.*$"
@@ -142,11 +142,11 @@ def add_env_var_to_shell_config(
                     content,
                     flags=re.MULTILINE,
                 )
-                config_path.write_text(new_content)
+                config_path.write_text(new_content, encoding="utf-8")
                 return True, str(config_path)
 
         # Append to file
-        with open(config_path, "a") as f:
+        with open(config_path, "a", encoding="utf-8") as f:
             f.write(f"\n# {comment}\n")
             f.write(f"{export_line}\n")
 
@@ -178,7 +178,7 @@ def remove_env_var_from_shell_config(
         return True, "Config file does not exist"
 
     try:
-        content = config_path.read_text()
+        content = config_path.read_text(encoding="utf-8")
         lines = content.split("\n")
 
         new_lines = []
@@ -206,7 +206,7 @@ def remove_env_var_from_shell_config(
 
             new_lines.append(line)
 
-        config_path.write_text("\n".join(new_lines))
+        config_path.write_text("\n".join(new_lines), encoding="utf-8")
         return True, str(config_path)
 
     except PermissionError:


### PR DESCRIPTION
Fixes #5739

## Summary

Windows users cannot complete the quickstart and use OAuth flows due to three related issues. This PR fixes all three root causes identified in the issue.

## Changes

### 1. File encoding — `tools/src/aden_tools/credentials/shell_config.py`

Added `encoding="utf-8"` parameter to all `read_text()`, `write_text()`, and `open()` calls. On Windows, Python defaults to `cp1252` encoding, which can corrupt non-ASCII characters in shell configuration files.

### 2. Browser opening — `core/framework/runner/cli.py`

Added `win32` platform support to `_open_browser()` using `os.startfile()`. The function previously handled only `darwin` (macOS) and `linux`, ignoring Windows.

### 3. OAuth browser opening — `core/codex_oauth.py`

Replaced unsafe `subprocess.Popen(["cmd", "/c", "start", url])` with Python’s standard `webbrowser.open()` module. The `cmd /c start` approach fails with URLs containing spaces, query parameters, or special characters common in OAuth flows.

Also removed the now-unused `platform` and `subprocess` imports.

## Testing

* Uses only Python standard library (no new dependencies)
* Verified syntax compilation for all modified files
* Tested on Windows 11
