### PR TITLE
fix: prevent write_to_file from clobbering without force_overwrite

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/write_to_file/write_to_file.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/write_to_file/write_to_file.py
@@ -16,6 +16,7 @@ def register_tools(mcp: FastMCP) -> None:
         agent_id: str,
         session_id: str,
         append: bool = False,
+        force_overwrite: bool = False,
     ) -> dict:
         """
         Purpose
@@ -41,12 +42,16 @@ def register_tools(mcp: FastMCP) -> None:
             agent_id: The ID of the agent
             session_id: The ID of the current session
             append: Whether to append to the file instead of overwriting (default: False)
+            force_overwrite: Whether to allow overwriting an existing file when not
+                appending (default: False)
 
         Returns:
             Dict with success status and path, or error dict
         """
         try:
             secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
+            if not append and not force_overwrite and os.path.exists(secure_path):
+                return {"error": "File exists. Set force_overwrite=True to replace."}
             os.makedirs(os.path.dirname(secure_path), exist_ok=True)
             mode = "a" if append else "w"
             with open(secure_path, mode, encoding="utf-8") as f:

--- a/tools/tests/tools/test_file_system_toolkits.py
+++ b/tools/tests/tools/test_file_system_toolkits.py
@@ -83,7 +83,9 @@ class TestViewFileTool:
         register_tools(mcp)
         return mcp._tool_manager._tools["view_file"].fn
 
-    def test_view_existing_file(self, view_file_fn, mock_workspace, mock_secure_path, tmp_path):
+    def test_view_existing_file(
+        self, view_file_fn, mock_workspace, mock_secure_path, tmp_path
+    ):
         """Viewing an existing file returns content and metadata."""
         test_file = tmp_path / "test.txt"
         test_file.write_text("Hello, World!")
@@ -95,14 +97,18 @@ class TestViewFileTool:
         assert result["size_bytes"] == len(b"Hello, World!")
         assert result["lines"] == 1
 
-    def test_view_nonexistent_file(self, view_file_fn, mock_workspace, mock_secure_path):
+    def test_view_nonexistent_file(
+        self, view_file_fn, mock_workspace, mock_secure_path
+    ):
         """Viewing a non-existent file returns an error."""
         result = view_file_fn(path="nonexistent.txt", **mock_workspace)
 
         assert "error" in result
         assert "not found" in result["error"].lower()
 
-    def test_view_multiline_file(self, view_file_fn, mock_workspace, mock_secure_path, tmp_path):
+    def test_view_multiline_file(
+        self, view_file_fn, mock_workspace, mock_secure_path, tmp_path
+    ):
         """Viewing a multiline file returns correct line count."""
         test_file = tmp_path / "multiline.txt"
         content = "Line 1\nLine 2\nLine 3\nLine 4\n"
@@ -114,7 +120,9 @@ class TestViewFileTool:
         assert result["content"] == content
         assert result["lines"] == 4
 
-    def test_view_empty_file(self, view_file_fn, mock_workspace, mock_secure_path, tmp_path):
+    def test_view_empty_file(
+        self, view_file_fn, mock_workspace, mock_secure_path, tmp_path
+    ):
         """Viewing an empty file returns empty content."""
         test_file = tmp_path / "empty.txt"
         test_file.write_text("")
@@ -126,7 +134,9 @@ class TestViewFileTool:
         assert result["size_bytes"] == 0
         assert result["lines"] == 0
 
-    def test_view_file_with_unicode(self, view_file_fn, mock_workspace, mock_secure_path, tmp_path):
+    def test_view_file_with_unicode(
+        self, view_file_fn, mock_workspace, mock_secure_path, tmp_path
+    ):
         """Viewing a file with unicode characters works correctly."""
         test_file = tmp_path / "unicode.txt"
         content = "Hello 世界! 🌍 émoji"
@@ -138,7 +148,9 @@ class TestViewFileTool:
         assert result["content"] == content
         assert result["size_bytes"] == len(content.encode("utf-8"))
 
-    def test_view_nested_file(self, view_file_fn, mock_workspace, mock_secure_path, tmp_path):
+    def test_view_nested_file(
+        self, view_file_fn, mock_workspace, mock_secure_path, tmp_path
+    ):
         """Viewing a file in a nested directory works correctly."""
         nested = tmp_path / "nested" / "dir"
         nested.mkdir(parents=True)
@@ -198,7 +210,9 @@ class TestViewFileTool:
         test_file = tmp_path / "test.txt"
         test_file.write_text("content")
 
-        result = view_file_fn(path="test.txt", encoding="invalid-encoding", **mock_workspace)
+        result = view_file_fn(
+            path="test.txt", encoding="invalid-encoding", **mock_workspace
+        )
 
         assert "error" in result
         assert "Failed to read file" in result["error"]
@@ -214,9 +228,13 @@ class TestWriteToFileTool:
         register_tools(mcp)
         return mcp._tool_manager._tools["write_to_file"].fn
 
-    def test_write_new_file(self, write_to_file_fn, mock_workspace, mock_secure_path, tmp_path):
+    def test_write_new_file(
+        self, write_to_file_fn, mock_workspace, mock_secure_path, tmp_path
+    ):
         """Writing to a new file creates it successfully."""
-        result = write_to_file_fn(path="new_file.txt", content="Test content", **mock_workspace)
+        result = write_to_file_fn(
+            path="new_file.txt", content="Test content", **mock_workspace
+        )
 
         assert result["success"] is True
         assert result["mode"] == "written"
@@ -227,7 +245,9 @@ class TestWriteToFileTool:
         assert created_file.exists()
         assert created_file.read_text() == "Test content"
 
-    def test_write_append_mode(self, write_to_file_fn, mock_workspace, mock_secure_path, tmp_path):
+    def test_write_append_mode(
+        self, write_to_file_fn, mock_workspace, mock_secure_path, tmp_path
+    ):
         """Writing with append=True appends to existing file."""
         test_file = tmp_path / "append_test.txt"
         test_file.write_text("Line 1\n")
@@ -240,24 +260,48 @@ class TestWriteToFileTool:
         assert result["mode"] == "appended"
         assert test_file.read_text() == "Line 1\nLine 2\n"
 
-    def test_write_overwrite_existing(
+    def test_write_overwrite_existing_with_force(
         self, write_to_file_fn, mock_workspace, mock_secure_path, tmp_path
     ):
-        """Writing to existing file overwrites it by default."""
+        """Writing to existing file overwrites it when force_overwrite=True."""
         test_file = tmp_path / "overwrite.txt"
         test_file.write_text("Original content")
 
-        result = write_to_file_fn(path="overwrite.txt", content="New content", **mock_workspace)
+        result = write_to_file_fn(
+            path="overwrite.txt",
+            content="New content",
+            force_overwrite=True,
+            **mock_workspace,
+        )
 
         assert result["success"] is True
         assert result["mode"] == "written"
         assert test_file.read_text() == "New content"
 
+    def test_write_overwrite_existing_without_force(
+        self, write_to_file_fn, mock_workspace, mock_secure_path, tmp_path
+    ):
+        """Writing to existing file without force_overwrite=True fails."""
+        test_file = tmp_path / "overwrite_error.txt"
+        test_file.write_text("Original content")
+
+        result = write_to_file_fn(
+            path="overwrite_error.txt",
+            content="New content",
+            **mock_workspace,
+        )
+
+        assert "error" in result
+        assert "File exists. Set force_overwrite=True to replace." in result["error"]
+        assert test_file.read_text() == "Original content"
+
     def test_write_creates_parent_directories(
         self, write_to_file_fn, mock_workspace, mock_secure_path, tmp_path
     ):
         """Writing creates parent directories if they don't exist."""
-        result = write_to_file_fn(path="nested/dir/file.txt", content="Test", **mock_workspace)
+        result = write_to_file_fn(
+            path="nested/dir/file.txt", content="Test", **mock_workspace
+        )
 
         assert result["success"] is True
         created_file = tmp_path / "nested" / "dir" / "file.txt"
@@ -287,7 +331,9 @@ class TestListDirTool:
         register_tools(mcp)
         return mcp._tool_manager._tools["list_dir"].fn
 
-    def test_list_directory(self, list_dir_fn, mock_workspace, mock_secure_path, tmp_path):
+    def test_list_directory(
+        self, list_dir_fn, mock_workspace, mock_secure_path, tmp_path
+    ):
         """Listing a directory returns all entries."""
         # Create test files and directories
         (tmp_path / "file1.txt").write_text("content")
@@ -306,7 +352,9 @@ class TestListDirTool:
             assert "type" in entry
             assert entry["type"] in ["file", "directory"]
 
-    def test_list_empty_directory(self, list_dir_fn, mock_workspace, mock_secure_path, tmp_path):
+    def test_list_empty_directory(
+        self, list_dir_fn, mock_workspace, mock_secure_path, tmp_path
+    ):
         """Listing an empty directory returns empty list."""
         empty_dir = tmp_path / "empty"
         empty_dir.mkdir()
@@ -317,7 +365,9 @@ class TestListDirTool:
         assert result["total_count"] == 0
         assert result["entries"] == []
 
-    def test_list_nonexistent_directory(self, list_dir_fn, mock_workspace, mock_secure_path):
+    def test_list_nonexistent_directory(
+        self, list_dir_fn, mock_workspace, mock_secure_path
+    ):
         """Listing a non-existent directory returns error."""
         result = list_dir_fn(path="nonexistent_dir", **mock_workspace)
 
@@ -356,7 +406,9 @@ class TestReplaceFileContentTool:
 
     @pytest.fixture
     def replace_file_content_fn(self, mcp):
-        from aden_tools.tools.file_system_toolkits.replace_file_content import register_tools
+        from aden_tools.tools.file_system_toolkits.replace_file_content import (
+            register_tools,
+        )
 
         register_tools(mcp)
         return mcp._tool_manager._tools["replace_file_content"].fn
@@ -429,7 +481,9 @@ class TestReplaceFileContentTool:
 
         assert result["success"] is True
         assert result["occurrences_replaced"] == 2
-        assert test_file.read_text() == "Line 1\nDONE: fix this\nLine 3\nDONE: add tests\n"
+        assert (
+            test_file.read_text() == "Line 1\nDONE: fix this\nLine 3\nDONE: add tests\n"
+        )
 
 
 class TestGrepSearchTool:
@@ -449,7 +503,9 @@ class TestGrepSearchTool:
         test_file = tmp_path / "search_test.txt"
         test_file.write_text("Line 1\nLine 2 with pattern\nLine 3")
 
-        result = grep_search_fn(path="search_test.txt", pattern="pattern", **mock_workspace)
+        result = grep_search_fn(
+            path="search_test.txt", pattern="pattern", **mock_workspace
+        )
 
         assert result["success"] is True
         assert result["total_matches"] == 1
@@ -464,7 +520,9 @@ class TestGrepSearchTool:
         test_file = tmp_path / "test.txt"
         test_file.write_text("Hello World")
 
-        result = grep_search_fn(path="test.txt", pattern="nonexistent", **mock_workspace)
+        result = grep_search_fn(
+            path="test.txt", pattern="nonexistent", **mock_workspace
+        )
 
         assert result["success"] is True
         assert result["total_matches"] == 0
@@ -483,7 +541,9 @@ class TestGrepSearchTool:
         nested.mkdir()
         (nested / "nested_file.txt").write_text("pattern in nested")
 
-        result = grep_search_fn(path=".", pattern="pattern", recursive=False, **mock_workspace)
+        result = grep_search_fn(
+            path=".", pattern="pattern", recursive=False, **mock_workspace
+        )
 
         assert result["success"] is True
         assert result["total_matches"] == 1  # Only finds pattern in root, not in nested
@@ -501,7 +561,9 @@ class TestGrepSearchTool:
         nested.mkdir()
         (nested / "nested_file.txt").write_text("pattern in nested")
 
-        result = grep_search_fn(path=".", pattern="pattern", recursive=True, **mock_workspace)
+        result = grep_search_fn(
+            path=".", pattern="pattern", recursive=True, **mock_workspace
+        )
 
         assert result["success"] is True
         assert result["total_matches"] == 2  # Finds pattern in both files
@@ -514,7 +576,9 @@ class TestGrepSearchTool:
         test_file = tmp_path / "regex_test.txt"
         test_file.write_text("foo123bar\nfoo456bar\nbaz789baz\n")
 
-        result = grep_search_fn(path="regex_test.txt", pattern=r"foo\d+bar", **mock_workspace)
+        result = grep_search_fn(
+            path="regex_test.txt", pattern=r"foo\d+bar", **mock_workspace
+        )
 
         assert result["success"] is True
         assert result["total_matches"] == 2
@@ -528,7 +592,9 @@ class TestGrepSearchTool:
         test_file = tmp_path / "multi_match.txt"
         test_file.write_text("hello hello hello\nworld\nhello again")
 
-        result = grep_search_fn(path="multi_match.txt", pattern="hello", **mock_workspace)
+        result = grep_search_fn(
+            path="multi_match.txt", pattern="hello", **mock_workspace
+        )
 
         assert result["success"] is True
         assert result["total_matches"] == 2  # Line 1 and Line 3
@@ -539,12 +605,16 @@ class TestExecuteCommandTool:
 
     @pytest.fixture
     def execute_command_fn(self, mcp):
-        from aden_tools.tools.file_system_toolkits.execute_command_tool import register_tools
+        from aden_tools.tools.file_system_toolkits.execute_command_tool import (
+            register_tools,
+        )
 
         register_tools(mcp)
         return mcp._tool_manager._tools["execute_command_tool"].fn
 
-    def test_execute_simple_command(self, execute_command_fn, mock_workspace, mock_secure_path):
+    def test_execute_simple_command(
+        self, execute_command_fn, mock_workspace, mock_secure_path
+    ):
         """Executing a simple command returns output."""
         result = execute_command_fn(command="echo 'Hello World'", **mock_workspace)
 
@@ -552,7 +622,9 @@ class TestExecuteCommandTool:
         assert result["return_code"] == 0
         assert "Hello World" in result["stdout"]
 
-    def test_execute_failing_command(self, execute_command_fn, mock_workspace, mock_secure_path):
+    def test_execute_failing_command(
+        self, execute_command_fn, mock_workspace, mock_secure_path
+    ):
         """Executing a failing command returns non-zero exit code."""
         result = execute_command_fn(command="exit 1", **mock_workspace)
 
@@ -563,7 +635,9 @@ class TestExecuteCommandTool:
         self, execute_command_fn, mock_workspace, mock_secure_path
     ):
         """Executing a command that writes to stderr captures it."""
-        result = execute_command_fn(command="echo 'error message' >&2", **mock_workspace)
+        result = execute_command_fn(
+            command="echo 'error message' >&2", **mock_workspace
+        )
 
         assert result["success"] is True
         assert "error message" in result.get("stderr", "")
@@ -581,9 +655,13 @@ class TestExecuteCommandTool:
         assert result["return_code"] == 0
         assert "testfile.txt" in result["stdout"]
 
-    def test_execute_command_with_pipe(self, execute_command_fn, mock_workspace, mock_secure_path):
+    def test_execute_command_with_pipe(
+        self, execute_command_fn, mock_workspace, mock_secure_path
+    ):
         """Executing a command with pipe works correctly."""
-        result = execute_command_fn(command="echo 'hello world' | tr 'a-z' 'A-Z'", **mock_workspace)
+        result = execute_command_fn(
+            command="echo 'hello world' | tr 'a-z' 'A-Z'", **mock_workspace
+        )
 
         assert result["success"] is True
         assert result["return_code"] == 0
@@ -600,14 +678,20 @@ class TestApplyDiffTool:
         register_tools(mcp)
         return mcp._tool_manager._tools["apply_diff"].fn
 
-    def test_apply_diff_file_not_found(self, apply_diff_fn, mock_workspace, mock_secure_path):
+    def test_apply_diff_file_not_found(
+        self, apply_diff_fn, mock_workspace, mock_secure_path
+    ):
         """Applying diff to non-existent file returns error."""
-        result = apply_diff_fn(path="nonexistent.txt", diff_text="some diff", **mock_workspace)
+        result = apply_diff_fn(
+            path="nonexistent.txt", diff_text="some diff", **mock_workspace
+        )
 
         assert "error" in result
         assert "not found" in result["error"].lower()
 
-    def test_apply_diff_successful(self, apply_diff_fn, mock_workspace, mock_secure_path, tmp_path):
+    def test_apply_diff_successful(
+        self, apply_diff_fn, mock_workspace, mock_secure_path, tmp_path
+    ):
         """Applying a valid diff successfully modifies the file."""
         test_file = tmp_path / "diff_test.txt"
         test_file.write_text("Hello World")
@@ -619,14 +703,18 @@ class TestApplyDiffTool:
         patches = dmp.patch_make("Hello World", "Hello Universe")
         diff_text = dmp.patch_toText(patches)
 
-        result = apply_diff_fn(path="diff_test.txt", diff_text=diff_text, **mock_workspace)
+        result = apply_diff_fn(
+            path="diff_test.txt", diff_text=diff_text, **mock_workspace
+        )
 
         assert result["success"] is True
         assert result["all_successful"] is True
         assert result["patches_applied"] > 0
         assert test_file.read_text() == "Hello Universe"
 
-    def test_apply_diff_multiline(self, apply_diff_fn, mock_workspace, mock_secure_path, tmp_path):
+    def test_apply_diff_multiline(
+        self, apply_diff_fn, mock_workspace, mock_secure_path, tmp_path
+    ):
         """Applying diff to multiline content works correctly."""
         test_file = tmp_path / "multiline.txt"
         original = "Line 1\nLine 2\nLine 3\n"
@@ -639,7 +727,9 @@ class TestApplyDiffTool:
         patches = dmp.patch_make(original, modified)
         diff_text = dmp.patch_toText(patches)
 
-        result = apply_diff_fn(path="multiline.txt", diff_text=diff_text, **mock_workspace)
+        result = apply_diff_fn(
+            path="multiline.txt", diff_text=diff_text, **mock_workspace
+        )
 
         assert result["success"] is True
         assert result["all_successful"] is True
@@ -654,7 +744,9 @@ class TestApplyDiffTool:
         test_file.write_text(original_content)
 
         # Invalid diff text
-        result = apply_diff_fn(path="test.txt", diff_text="invalid diff format", **mock_workspace)
+        result = apply_diff_fn(
+            path="test.txt", diff_text="invalid diff format", **mock_workspace
+        )
 
         # Should either error or show no patches applied
         if "error" not in result:
@@ -673,9 +765,13 @@ class TestApplyPatchTool:
         register_tools(mcp)
         return mcp._tool_manager._tools["apply_patch"].fn
 
-    def test_apply_patch_file_not_found(self, apply_patch_fn, mock_workspace, mock_secure_path):
+    def test_apply_patch_file_not_found(
+        self, apply_patch_fn, mock_workspace, mock_secure_path
+    ):
         """Applying patch to non-existent file returns error."""
-        result = apply_patch_fn(path="nonexistent.txt", patch_text="some patch", **mock_workspace)
+        result = apply_patch_fn(
+            path="nonexistent.txt", patch_text="some patch", **mock_workspace
+        )
 
         assert "error" in result
         assert "not found" in result["error"].lower()
@@ -694,7 +790,9 @@ class TestApplyPatchTool:
         patches = dmp.patch_make("Hello World", "Hello Python")
         patch_text = dmp.patch_toText(patches)
 
-        result = apply_patch_fn(path="patch_test.txt", patch_text=patch_text, **mock_workspace)
+        result = apply_patch_fn(
+            path="patch_test.txt", patch_text=patch_text, **mock_workspace
+        )
 
         assert result["success"] is True
         assert result["all_successful"] is True
@@ -716,7 +814,9 @@ class TestApplyPatchTool:
         patches = dmp.patch_make(original, modified)
         patch_text = dmp.patch_toText(patches)
 
-        result = apply_patch_fn(path="multiline.txt", patch_text=patch_text, **mock_workspace)
+        result = apply_patch_fn(
+            path="multiline.txt", patch_text=patch_text, **mock_workspace
+        )
 
         assert result["success"] is True
         assert result["all_successful"] is True
@@ -756,7 +856,9 @@ class TestApplyPatchTool:
         patches = dmp.patch_make(original, modified)
         patch_text = dmp.patch_toText(patches)
 
-        result = apply_patch_fn(path="complex.txt", patch_text=patch_text, **mock_workspace)
+        result = apply_patch_fn(
+            path="complex.txt", patch_text=patch_text, **mock_workspace
+        )
 
         assert result["success"] is True
         assert result["all_successful"] is True


### PR DESCRIPTION
Fixes #4059

**Summary**
Added `force_overwrite` parameter to `write_to_file` to prevent agents from unintentionally clobbering existing files when not running in append mode.

**Root cause**
The tool lacked a safety check for existing files before opening them in write (`w`) mode.

**Solution**
Added a `force_overwrite` boolean check and an `os.path.exists()` check. Returns an error message guiding the agent if a file exists and `force_overwrite` is false.

**Validation**
- `pytest tests/tools/test_file_system_toolkits.py`
- `ruff check tools/` and `ruff format tools/`

**Risk / edge cases**
Agents expecting implicit overwrite behavior will now receive an error, which should correctly prompt them to add `force_overwrite=True`.