### PR TITLE
fix: add utf-8 encoding to _dump_failed_request to prevent Windows ch…

### DIFF
--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -170,7 +170,7 @@ def _dump_failed_request(
         "temperature": kwargs.get("temperature"),
     }
 
-    with open(filepath, "w") as f:
+    with open(filepath, "w", encoding='utf-8') as f:
         json.dump(dump_data, f, indent=2, default=str)
 
     return str(filepath)


### PR DESCRIPTION
## Summary
Fixes #5779

## Problem
On Windows, the `_dump_failed_request()` function in 
`core/framework/llm/litellm.py` was opening files without 
specifying encoding. Windows defaults to 'charmap' encoding 
which fails to decode certain bytes, causing:

`Backend unavailable: 'charmap' codec can't decode byte 0x90`

## Fix
Added `encoding='utf-8'` to the `open()` call in `_dump_failed_request()`

## Before
with open(filepath, "w") as f:

## After
with open(filepath, "w", encoding='utf-8') as f:

## Testing
Tested on Windows 10 (Version 10.0.26100.7840)
- Python 3.12
- Model: gemini-3-flash-preview