### PR TITLE
fix: handle empty or directory agent.json in AgentRunner.load

### DIFF
--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC
@@ -869,9 +870,22 @@ class AgentRunner:
         if not agent_json_path.exists():
             raise FileNotFoundError(f"No agent.py or agent.json found in {agent_path}")
 
-        with open(agent_json_path) as f:
-            graph, goal = load_agent_export(f.read())
+        if not agent_json_path.is_file():
+             print("Error: agent.json is not a file")
+             sys.exit(1)
+        content = agent_json_path.read_text().strip()
+        
+        if not content:
+            print("Error: agent.json is empty")
+            sys.exit(1)
 
+        try:
+            graph, goal = load_agent_export(content)
+        except json.JSONDecodeError:
+             print("Error: agent.json contains invalid JSON")
+             sys.exit(1)
+
+        
         return cls(
             agent_path=agent_path,
             graph=graph,


### PR DESCRIPTION
## Description

Fixes an issue where `hive validate` and `hive info` crashed with a raw Python traceback when `agent.json` was empty or when it was mistakenly created as a directory instead of a file.

Previously, `AgentRunner.load()` attempted to parse `agent.json` without validating the file first, which resulted in `JSONDecodeError` or `IsADirectoryError` being shown to users.  

This PR adds validation checks before parsing the file so that clear, user-friendly CLI error messages are shown instead of Python tracebacks.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #5787

## Changes Made

- Added validation to ensure `agent.json` exists and is a file (not a directory)
- Added a check to detect an empty `agent.json`
- Added graceful error handling for invalid JSON
- Prevented raw Python tracebacks and replaced them with user-friendly CLI error messages

#Manual tests performed:

1. Empty file case
   New-Item exports/empty_agent/agent.json -Force
   hive validate exports/empty_agent

   Output:
   Error: agent.json is empty

2. Directory instead of file
   mkdir exports/weird_agent
   mkdir exports/weird_agent/agent.json
   hive validate exports/weird_agent

   Output:
   Error: agent.json is not a file
