### PR TITLE
Docs: Manual Testing without Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,32 @@ Now you can run an agent by selectiing the agent (either an existing agent or ex
 
 <img width="2500" height="1214" alt="Image" src="https://github.com/user-attachments/assets/71c38206-2ad5-49aa-bde8-6698d0bc55f5" />
 
+### Test Your Agent
+
+You can test agents with or without Claude Code.
+
+**With Claude Code (recommended):**
+
+```bash
+claude> /hive-test
+```
+
+**Manual testing (no Claude Code required):**
+
+```bash
+# Run all tests
+PYTHONPATH=exports uv run python -m my_agent test
+
+# Test specific criteria
+PYTHONPATH=exports uv run python -m my_agent test --type success
+PYTHONPATH=exports uv run python -m my_agent test --type constraint
+
+# Run agent without API calls (mock mode)
+PYTHONPATH=exports uv run python -m my_agent run --mock --input '{"task": "example"}'
+```
+
+Replace `my_agent` with your agent's package name. See [Testing Guide](docs/testing.md) for writing custom tests and advanced workflows.
+
 ## Features
 
 - **Browser-Use** - Control the browser on your computer to achieve hard tasks
@@ -209,6 +235,7 @@ flowchart LR
 
 - **[Developer Guide](docs/developer-guide.md)** - Comprehensive guide for developers
 - [Getting Started](docs/getting-started.md) - Quick setup instructions
+- [Testing Guide](docs/testing.md) - Test agents with or without Claude Code
 - [Configuration Guide](docs/configuration.md) - All configuration options
 - [Architecture Overview](docs/architecture/README.md) - System design and structure
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -165,16 +165,19 @@ Get your API keys:
 ## Testing Your Agent
 
 ```bash
-# Using Claude Code
+# With Claude Code (recommended)
 claude> /hive-test
 
-# Or manually
+# Manual testing (no Claude Code required)
 PYTHONPATH=exports uv run python -m my_agent test
-
-# Run with specific test type
 PYTHONPATH=exports uv run python -m my_agent test --type constraint
 PYTHONPATH=exports uv run python -m my_agent test --type success
+
+# Run without API calls (mock mode)
+PYTHONPATH=exports uv run python -m my_agent run --mock --input '{"task": "example"}'
 ```
+
+See [Testing Guide](testing.md) for writing custom tests and advanced workflows.
 
 ## Next Steps
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,111 @@
+# Testing Guide
+
+This guide covers how to test Hive agents with or without Claude Code. All testing features work without a Claude Code subscription.
+
+## Quick Reference
+
+| Method              | Command                                                       | Use Case                          |
+| ------------------- | ------------------------------------------------------------- | --------------------------------- |
+| Claude Code         | `claude> /hive-test`                                         | Interactive test loop with Claude |
+| Test suite          | `PYTHONPATH=exports uv run python -m my_agent test`           | Run all pytest tests              |
+| Mock run            | `PYTHONPATH=exports uv run python -m my_agent run --mock ...` | Validate structure, no API calls  |
+| Hive CLI            | `hive run exports/my_agent --input '{}'`                      | Run agent with real LLM           |
+
+Replace `my_agent` with your agent's package name.
+
+## Manual Testing (No Claude Code)
+
+### Run the Test Suite
+
+Agents created with `/hive-create` or from templates include a `tests/` directory. Run them with:
+
+```bash
+# Run all tests
+PYTHONPATH=exports uv run python -m my_agent test
+
+# Test specific criteria
+PYTHONPATH=exports uv run python -m my_agent test --type success
+PYTHONPATH=exports uv run python -m my_agent test --type constraint
+
+# Parallel execution (faster)
+PYTHONPATH=exports uv run python -m my_agent test --parallel 4
+
+# Stop on first failure
+PYTHONPATH=exports uv run python -m my_agent test --fail-fast
+```
+
+### Mock Mode
+
+Mock mode runs the agent without calling real LLM APIs. Use it to:
+
+- Validate graph structure (nodes, edges, connections)
+- Verify the agent loads and is importable
+- Test locally without API keys or credits
+
+```bash
+PYTHONPATH=exports uv run python -m my_agent run --mock --input '{"task": "example"}'
+```
+
+**Limitation:** Mock mode only validates structure. It does not test LLM reasoning, content quality, or real API integrations. For goal-achievement testing, use real credentials.
+
+### Run with Real LLM
+
+```bash
+# Via hive CLI
+hive run exports/my_agent --input '{"task": "your input"}'
+
+# Via agent module (if agent has run command)
+PYTHONPATH=exports uv run python -m my_agent run --input '{"task": "your input"}'
+```
+
+Ensure `ANTHROPIC_API_KEY` (or your LLM provider key) is set.
+
+## Writing Custom Tests
+
+### Test File Structure
+
+```
+exports/my_agent/
+├── agent.py
+├── nodes/
+└── tests/
+    ├── conftest.py           # Shared fixtures
+    ├── test_constraints.py    # Constraint tests
+    └── test_success_criteria.py
+```
+
+### Key Patterns
+
+- Every test must be `async` with `@pytest.mark.asyncio`
+- Use `runner` and `auto_responder` fixtures (provided by framework)
+- Use `await runner.run(input_dict)` — not `default_agent.run()`
+- Access output via `result.output.get("key")` — never `result.output["key"]`
+- `result.success=True` means no exception, not goal achieved — always check output
+
+See [developer-guide.md](developer-guide.md#testing-agents) for a basic example and [.claude/skills/hive-test/SKILL.md](../.claude/skills/hive-test/SKILL.md) for the full iterative testing workflow, safe patterns, and credential requirements.
+
+## Framework Test Commands
+
+For advanced workflows (test generation, debugging, checkpoint resume):
+
+```bash
+# List tests for an agent
+uv run python -m framework test-list exports/my_agent --goal <goal_id>
+
+# Run tests for a specific goal
+uv run python -m framework test-run exports/my_agent --goal <goal_id>
+
+# Debug a failing test
+uv run python -m framework test-debug exports/my_agent <test_name>
+```
+
+See [core/README.md](../core/README.md) for details.
+
+## Credentials
+
+Testing with real LLMs requires:
+
+1. **LLM API key** — e.g. `ANTHROPIC_API_KEY`
+2. **Tool credentials** — if the agent uses tools (HubSpot, Brave Search, etc.)
+
+Use `/hive-credentials` in Claude Code or configure credentials manually. See [hive-test skill](../.claude/skills/hive-test/SKILL.md#credential-requirements) for the full credential checklist.


### PR DESCRIPTION
# Description

Improves testing documentation so users without Claude Code can discover and use manual testing. The README previously only showed Claude Code testing; it now documents manual testing, the `test` CLI, and `--mock` mode.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #1591 

## Changes Made

- **README.md**: Added "Test Your Agent" section with Claude Code (`/hive-test`) and manual testing (test suite, `--type success`/`constraint`, mock mode), plus a link to the Testing Guide
- **docs/testing.md**: New Testing Guide with quick reference table, manual testing commands, mock mode usage and limits, custom test patterns, framework test commands, and credential notes
- **docs/getting-started.md**: Updated testing section with mock mode example and link to Testing Guide
- **README.md**: Added Testing Guide to the Documentation section

## Testing

Describe the tests you ran to verify your changes:

- [x] `cd core && pytest tests/`
- [x] `cd core && ruff check .`
- [x] Manual testing performed (verified markdown links and command syntax)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A — documentation-only changes.
