### PR TITLE
 Add policy-aware vendor onboarding workflow recipe 

### DIFF
--- a/examples/recipes/onboarding_assistance/README.md
+++ b/examples/recipes/onboarding_assistance/README.md
@@ -4,7 +4,9 @@ Helping new clients set up their accounts or sending out "Welcome" kits.
 
 ## Why
 
-First impressions stick. A smooth onboarding experience sets the tone for the entire customer relationship — but walking each new client through the same steps is a time sink. This agent delivers a white-glove experience at scale, making every customer feel personally welcomed.
+First impressions stick. A smooth onboarding experience sets the tone for the entire customer relationship — but walking each new client through setup manually does not scale.
+
+An onboarding assistant automates guidance, reminders, and follow-ups while escalating issues to humans only when necessary.
 
 ## What
 
@@ -29,8 +31,53 @@ First impressions stick. A smooth onboarding experience sets the tone for the en
 
 | Trigger | Action |
 |---------|--------|
-| Client stuck on setup >48 hours | Alert with where they're stuck and offer to schedule call |
+| Client stuck on setup >48 hours | Alert with where they're stuck and offer to schedule a call |
 | Technical blocker during setup | Route to support with context already gathered |
-| High-value client starts onboarding | Notify so you can send personal welcome |
+| High-value client starts onboarding | Notify so you can send a personal welcome |
 | Client expresses frustration | Immediate flag for human intervention |
 | Onboarding incomplete after 7 days | Escalate with churn risk assessment |
+
+---
+
+# Example Agents
+
+## Vendor Onboarding Policy Agent
+
+A **policy-aware vendor onboarding workflow** demonstrating how Hive-style agents can automate compliance-heavy onboarding processes.
+
+Instead of a simple automation, this example models a **real business workflow** with validation, risk scoring, deterministic rules, and human escalation.
+
+### Capabilities
+
+- Validate vendor onboarding requests from structured JSON
+- Classify vendor type (software, consultant, data provider, etc.)
+- Run a deterministic compliance checklist
+- Compute vendor risk scores with explanations
+- Route decisions automatically:
+  - `approved`
+  - `needs_more_info`
+  - `human_review`
+- Escalate high-risk vendors to **human-in-the-loop review**
+- Produce a final **structured decision with a full audit trail**
+
+### Example Location
+examples/recipes/onboarding_assistance/vendor_onboarding_policy/
+
+
+### Demo Scenarios
+
+| Scenario | Result |
+|--------|--------|
+| Low-risk vendor | Approved |
+| Missing documents | Needs more information |
+| High-risk jurisdiction | Human review → Reject |
+
+### What This Demonstrates
+
+This example highlights Hive’s strengths for real-world business workflows:
+
+- branching decision graphs
+- deterministic guardrails
+- auditable decision trails
+- human-in-the-loop escalation
+- structured outputs suitable for downstream systems

--- a/examples/recipes/onboarding_assistance/vendor_onboarding_policy/README.md
+++ b/examples/recipes/onboarding_assistance/vendor_onboarding_policy/README.md
@@ -1,0 +1,32 @@
+# Policy-Aware Vendor Onboarding Agent (MVP)
+
+This recipe demonstrates a production-style vendor onboarding workflow using Hive-style nodes and an auditable decision trail.
+
+## What it does
+
+- Ingests a vendor onboarding request from **structured JSON**
+- Validates **required fields**
+- Classifies vendor type (rule-based v1)
+- Evaluates a **deterministic compliance checklist** (required documents)
+- Computes a **risk score + reasons**
+- Routes outcomes:
+  - **needs_more_info** (missing fields/docs or medium risk)
+  - **human_review** (high risk)
+  - **approved** (low risk + compliant)
+- Produces a final **structured recommendation** with an `audit_trail`
+
+## Out of scope (v1)
+
+- Third-party compliance APIs
+- Email sending
+- OCR/PDF extraction
+- Web UI
+- Multi-tenant auth
+
+## Run
+
+From repo root:
+
+```bash
+python3 -m examples.recipes.onboarding_assistance.vendor_onboarding_policy \
+  --input examples/recipes/onboarding_assistance/vendor_onboarding_policy/input_examples/low_risk_vendor.json

--- a/examples/recipes/onboarding_assistance/vendor_onboarding_policy/__main__.py
+++ b/examples/recipes/onboarding_assistance/vendor_onboarding_policy/__main__.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .agent import run
+
+
+def _load_json(path: str) -> Dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run vendor_onboarding_policy agent (deterministic MVP).")
+    parser.add_argument("--input", required=True, help="Path to input JSON file")
+    parser.add_argument("--human", required=False, help="Optional path to human decision JSON")
+    args = parser.parse_args()
+
+    inp = _load_json(args.input)
+    human: Optional[Dict[str, Any]] = _load_json(args.human) if args.human else None
+
+    result = run(inp, human=human)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/recipes/onboarding_assistance/vendor_onboarding_policy/agent.json
+++ b/examples/recipes/onboarding_assistance/vendor_onboarding_policy/agent.json
@@ -1,0 +1,14 @@
+{
+  "name": "vendor_onboarding_policy",
+  "description": "Policy-Aware Vendor Onboarding Agent that validates vendor onboarding requests, performs compliance checks, calculates risk scores, and escalates high-risk vendors to human review.",
+  "version": "0.1.0",
+  "entry_point": "agent.py",
+  "category": "onboarding_assistance",
+  "tags": [
+    "vendor",
+    "compliance",
+    "risk",
+    "human-in-the-loop",
+    "business-process"
+  ]
+}

--- a/examples/recipes/onboarding_assistance/vendor_onboarding_policy/agent.py
+++ b/examples/recipes/onboarding_assistance/vendor_onboarding_policy/agent.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+from typing import Any, Dict, Optional
+
+from .nodes import intake, validate, classify, compliance, risk, decision, hitl, finalize
+
+
+def run(input_data: Dict[str, Any], human: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """
+    Deterministic MVP runner.
+    This does not rely on LLM calls so it can be tested without API keys.
+    """
+    state: Dict[str, Any] = {}
+
+    # 1) Intake
+    r = intake.run(state, input_data)
+    state = r.data
+
+    # 2) Validate
+    r = validate.run(state)
+    state = r.data
+
+    # 3) If incomplete, still continue to finalize for structured output
+    # 4) Classify
+    r = classify.run(state)
+    state = r.data
+
+    # 5) Compliance
+    r = compliance.run(state)
+    state = r.data
+
+    # 6) Risk
+    r = risk.run(state)
+    state = r.data
+
+    # 7) Decision route
+    r = decision.run(state)
+    state = r.data
+
+    # 8) HITL if needed
+    if state.get("decision_route") == "human_review":
+        r = hitl.run(state, human=human)
+        state = r.data
+
+    # 9) Finalize
+    r = finalize.run(state)
+    state = r.data
+
+    return state["result"]

--- a/examples/recipes/onboarding_assistance/vendor_onboarding_policy/config.py
+++ b/examples/recipes/onboarding_assistance/vendor_onboarding_policy/config.py
@@ -1,0 +1,20 @@
+AGENT_NAME = "vendor_onboarding_policy"
+
+REQUIRED_FIELDS = [
+    "vendor_name",
+    "country",
+    "service_type",
+    "annual_contract_value"
+]
+
+HIGH_RISK_COUNTRIES = [
+    "North Korea",
+    "Iran",
+    "Syria"
+]
+
+RISK_THRESHOLDS = {
+    "low": 30,
+    "medium": 60,
+    "high": 80
+}

--- a/examples/recipes/onboarding_assistance/vendor_onboarding_policy/input_examples/high_risk_vendor.json
+++ b/examples/recipes/onboarding_assistance/vendor_onboarding_policy/input_examples/high_risk_vendor.json
@@ -1,0 +1,6 @@
+{
+  "vendor_name": "Red Flag Imports",
+  "country": "Iran",
+  "service_type": "Import/Export",
+  "annual_contract_value": 200000
+}

--- a/examples/recipes/onboarding_assistance/vendor_onboarding_policy/input_examples/incomplete_vendor.json
+++ b/examples/recipes/onboarding_assistance/vendor_onboarding_policy/input_examples/incomplete_vendor.json
@@ -1,0 +1,5 @@
+{
+  "vendor_name": "Global Consulting",
+  "country": "Kenya",
+  "service_type": "Consulting"
+}

--- a/examples/recipes/onboarding_assistance/vendor_onboarding_policy/input_examples/low_risk_vendor.json
+++ b/examples/recipes/onboarding_assistance/vendor_onboarding_policy/input_examples/low_risk_vendor.json
@@ -1,0 +1,10 @@
+{
+  "vendor_name": "Acme Software Ltd",
+  "country": "Germany",
+  "service_type": "Software Development",
+  "annual_contract_value": 25000,
+  "documents": [
+    "registration_certificate",
+    "tax_certificate"
+  ]
+}

--- a/examples/recipes/onboarding_assistance/vendor_onboarding_policy/input_examples/low_risk_vendor.json
+++ b/examples/recipes/onboarding_assistance/vendor_onboarding_policy/input_examples/low_risk_vendor.json
@@ -5,6 +5,7 @@
   "annual_contract_value": 25000,
   "documents": [
     "registration_certificate",
-    "tax_certificate"
+    "tax_certificate",
+    "privacy_policy"
   ]
 }

--- a/examples/recipes/onboarding_assistance/vendor_onboarding_policy/nodes/__init__.py
+++ b/examples/recipes/onboarding_assistance/vendor_onboarding_policy/nodes/__init__.py
@@ -1,0 +1,1 @@
+# Nodes package for vendor_onboarding_policy

--- a/examples/recipes/onboarding_assistance/vendor_onboarding_policy/nodes/classify.py
+++ b/examples/recipes/onboarding_assistance/vendor_onboarding_policy/nodes/classify.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class NodeResult:
+    ok: bool
+    data: Dict[str, Any]
+    notes: str = ""
+
+
+def _classify(service_type: str) -> tuple[str, str]:
+    s = (service_type or "").lower()
+
+    if any(x in s for x in ["payment", "processor", "fintech", "wallet", "bank"]):
+        return "payment_processor", "Service type indicates payments/financial processing"
+    if any(x in s for x in ["data", "analytics", "intelligence", "insights"]):
+        return "data_provider", "Service type indicates data/analytics"
+    if any(x in s for x in ["security", "pentest", "vulnerability", "soc", "audit"]):
+        return "security_vendor", "Service type indicates security/audit work"
+    if any(x in s for x in ["logistics", "shipping", "transport", "fleet"]):
+        return "logistics_vendor", "Service type indicates logistics"
+    if any(x in s for x in ["consult", "advisory", "contractor", "freelance"]):
+        return "consultant", "Service type indicates consulting services"
+    if any(x in s for x in ["software", "engineering", "development", "saas"]):
+        return "software_vendor", "Service type indicates software development/SaaS"
+
+    return "other", "Could not confidently classify from service_type"
+
+
+def run(state: Dict[str, Any]) -> NodeResult:
+    vendor = (state or {}).get("vendor", {})
+    vendor_type, reason = _classify(vendor.get("service_type", ""))
+
+    new_state = dict(state or {})
+    new_state["vendor_type"] = vendor_type
+    new_state["vendor_type_reason"] = reason
+    new_state["audit"].append({"node": "classify", "event": "classified_vendor_type", "type": vendor_type})
+
+    return NodeResult(ok=True, data=new_state, notes=reason)

--- a/examples/recipes/onboarding_assistance/vendor_onboarding_policy/nodes/compliance.py
+++ b/examples/recipes/onboarding_assistance/vendor_onboarding_policy/nodes/compliance.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+@dataclass
+class NodeResult:
+    ok: bool
+    data: Dict[str, Any]
+    notes: str = ""
+
+
+REQUIRED_DOCS_BY_TYPE = {
+    "payment_processor": ["registration_certificate", "tax_certificate", "aml_policy", "privacy_policy"],
+    "data_provider": ["registration_certificate", "tax_certificate", "privacy_policy", "data_processing_terms"],
+    "security_vendor": ["registration_certificate", "tax_certificate", "security_policy"],
+    "software_vendor": ["registration_certificate", "tax_certificate", "privacy_policy"],
+    "consultant": ["registration_certificate", "tax_certificate"],
+    "logistics_vendor": ["registration_certificate", "tax_certificate"],
+    "other": ["registration_certificate", "tax_certificate"],
+}
+
+
+def run(state: Dict[str, Any]) -> NodeResult:
+    vendor = (state or {}).get("vendor", {})
+    vendor_type = (state or {}).get("vendor_type", "other")
+    docs = set([d.strip().lower() for d in (vendor.get("documents") or []) if isinstance(d, str)])
+
+    required = REQUIRED_DOCS_BY_TYPE.get(vendor_type, REQUIRED_DOCS_BY_TYPE["other"])
+    missing_docs: List[str] = [d for d in required if d.lower() not in docs]
+
+    status = "pass" if not missing_docs else "needs_documents"
+
+    new_state = dict(state or {})
+    new_state["compliance"] = {
+        "status": status,
+        "required_docs": required,
+        "missing_docs": missing_docs,
+    }
+    new_state["audit"].append({"node": "compliance", "event": "checked_documents", "missing_docs": missing_docs})
+
+    notes = "Compliance docs complete" if status == "pass" else f"Missing documents: {', '.join(missing_docs)}"
+    return NodeResult(ok=True, data=new_state, notes=notes)

--- a/examples/recipes/onboarding_assistance/vendor_onboarding_policy/nodes/decision.py
+++ b/examples/recipes/onboarding_assistance/vendor_onboarding_policy/nodes/decision.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+@dataclass
+class NodeResult:
+    ok: bool
+    data: Dict[str, Any]
+    notes: str = ""
+
+
+def run(state: Dict[str, Any]) -> NodeResult:
+    completeness = (state or {}).get("completeness")
+    missing_fields: List[str] = (state or {}).get("missing_fields", [])
+    compliance = (state or {}).get("compliance", {})
+    risk = (state or {}).get("risk", {})
+
+    missing_docs = compliance.get("missing_docs") or []
+    risk_level = risk.get("level", "low")
+
+    # Priority routing:
+    # 1) incomplete → request_more_info
+    # 2) high risk → human_review
+    # 3) missing docs → request_more_info
+    # 4) else → approve
+    if completeness == "incomplete" or missing_fields:
+        route = "request_more_info"
+        reason = "Missing required fields"
+    elif risk_level == "high":
+        route = "human_review"
+        reason = "High risk vendor requires human review"
+    elif missing_docs:
+        route = "request_more_info"
+        reason = "Missing compliance documents"
+    elif risk_level == "medium":
+        route = "request_more_info"
+        reason = "Medium risk — requires additional evidence"
+    else:
+        route = "approve"
+        reason = "Low risk and compliance satisfied"
+
+    new_state = dict(state or {})
+    new_state["decision_route"] = route
+    new_state["decision_reason"] = reason
+    new_state["audit"].append({"node": "decision", "event": "routed", "route": route, "reason": reason})
+
+    return NodeResult(ok=True, data=new_state, notes=f"Route={route}: {reason}")

--- a/examples/recipes/onboarding_assistance/vendor_onboarding_policy/nodes/finalize.py
+++ b/examples/recipes/onboarding_assistance/vendor_onboarding_policy/nodes/finalize.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+@dataclass
+class NodeResult:
+    ok: bool
+    data: Dict[str, Any]
+    notes: str = ""
+
+
+def _decision_from_state(state: Dict[str, Any]) -> str:
+    route = state.get("decision_route")
+    if route == "approve":
+        return "approved"
+    if route == "request_more_info":
+        return "needs_more_info"
+    if route == "human_review":
+        human = state.get("human_review", {}) or {}
+        action = (human.get("action") or "request_more_info").lower()
+        if action == "approve":
+            return "approved"
+        if action == "reject":
+            return "rejected"
+        return "needs_more_info"
+    return "needs_more_info"
+
+
+def run(state: Dict[str, Any]) -> NodeResult:
+    vendor = (state or {}).get("vendor", {})
+    vendor_type = (state or {}).get("vendor_type", "other")
+    completeness = (state or {}).get("completeness", "unknown")
+    missing_fields: List[str] = (state or {}).get("missing_fields", [])
+    compliance = (state or {}).get("compliance", {})
+    risk = (state or {}).get("risk", {})
+    decision = _decision_from_state(state or {})
+
+    output = {
+        "vendor_name": vendor.get("vendor_name"),
+        "country": vendor.get("country"),
+        "service_type": vendor.get("service_type"),
+        "vendor_type": vendor_type,
+        "completeness_status": completeness,
+        "missing_fields": missing_fields,
+        "compliance_status": compliance.get("status"),
+        "missing_documents": compliance.get("missing_docs", []),
+        "risk_level": risk.get("level"),
+        "risk_score": risk.get("score"),
+        "risk_reasons": risk.get("reasons", []),
+        "decision": decision,
+        "decision_reason": (state or {}).get("decision_reason"),
+        "human_review": (state or {}).get("human_review"),
+        "audit_trail": (state or {}).get("audit", []),
+    }
+
+    new_state = dict(state or {})
+    new_state["result"] = output
+    new_state["audit"].append({"node": "finalize", "event": "produced_result", "decision": decision})
+
+    return NodeResult(ok=True, data=new_state, notes=f"Final decision: {decision}")

--- a/examples/recipes/onboarding_assistance/vendor_onboarding_policy/nodes/hitl.py
+++ b/examples/recipes/onboarding_assistance/vendor_onboarding_policy/nodes/hitl.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class NodeResult:
+    ok: bool
+    data: Dict[str, Any]
+    notes: str = ""
+
+
+VALID_CHOICES = {"approve", "reject", "request_more_info"}
+
+
+def run(state: Dict[str, Any], human: Dict[str, Any] | None = None) -> NodeResult:
+    """
+    Human-in-the-loop decision.
+    For v1 MVP: consumes an optional 'human' payload:
+      {"action": "approve|reject|request_more_info", "notes": "..."}
+    If not provided, defaults to request_more_info.
+    """
+    human = human or {}
+    action = (human.get("action") or "request_more_info").strip().lower()
+    notes = (human.get("notes") or "").strip()
+
+    if action not in VALID_CHOICES:
+        action = "request_more_info"
+
+    new_state = dict(state or {})
+    new_state["human_review"] = {"action": action, "notes": notes}
+    new_state["audit"].append({"node": "hitl", "event": "human_review", "action": action})
+
+    return NodeResult(ok=True, data=new_state, notes=f"Human decision: {action}")

--- a/examples/recipes/onboarding_assistance/vendor_onboarding_policy/nodes/intake.py
+++ b/examples/recipes/onboarding_assistance/vendor_onboarding_policy/nodes/intake.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class NodeResult:
+    ok: bool
+    data: Dict[str, Any]
+    notes: str = ""
+
+
+def run(state: Dict[str, Any], inp: Dict[str, Any]) -> NodeResult:
+    """
+    Normalize incoming vendor request into a clean state object.
+    Deterministic: no LLM calls.
+    """
+    vendor = dict(inp or {})
+
+    # Basic normalization
+    for k, v in list(vendor.items()):
+        if isinstance(v, str):
+            vendor[k] = v.strip()
+
+    vendor.setdefault("documents", [])
+    vendor.setdefault("annual_contract_value", None)
+
+    new_state = dict(state or {})
+    new_state["vendor"] = vendor
+    new_state.setdefault("audit", [])
+    new_state["audit"].append({"node": "intake", "event": "normalized_input"})
+
+    return NodeResult(ok=True, data=new_state, notes="Input normalized")

--- a/examples/recipes/onboarding_assistance/vendor_onboarding_policy/nodes/risk.py
+++ b/examples/recipes/onboarding_assistance/vendor_onboarding_policy/nodes/risk.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from ..config import HIGH_RISK_COUNTRIES, RISK_THRESHOLDS
+
+
+@dataclass
+class NodeResult:
+    ok: bool
+    data: Dict[str, Any]
+    notes: str = ""
+
+
+def run(state: Dict[str, Any]) -> NodeResult:
+    vendor = (state or {}).get("vendor", {})
+    vendor_type = (state or {}).get("vendor_type", "other")
+    compliance = (state or {}).get("compliance", {})
+    missing_fields = (state or {}).get("missing_fields", [])
+
+    score = 0
+    reasons: List[str] = []
+
+    # Country risk
+    country = (vendor.get("country") or "").strip()
+    if country in HIGH_RISK_COUNTRIES:
+        score += 60
+        reasons.append(f"High-risk country: {country}")
+
+    # Vendor type risk
+    if vendor_type == "payment_processor":
+        score += 25
+        reasons.append("Payment processing vendor type")
+    elif vendor_type in ("data_provider", "security_vendor"):
+        score += 15
+        reasons.append(f"Sensitive vendor type: {vendor_type}")
+
+    # Missing docs or fields increase risk
+    if missing_fields:
+        score += min(30, 5 * len(missing_fields))
+        reasons.append(f"Missing required fields: {', '.join(missing_fields)}")
+
+    missing_docs = (compliance.get("missing_docs") or [])
+    if missing_docs:
+        score += min(30, 5 * len(missing_docs))
+        reasons.append(f"Missing compliance documents: {', '.join(missing_docs)}")
+
+    # Contract value heuristic
+    acv = vendor.get("annual_contract_value")
+    if isinstance(acv, (int, float)) and acv >= 100000:
+        score += 10
+        reasons.append("High contract value (>= 100k)")
+
+    # Clamp
+    score = max(0, min(100, score))
+
+    # Map to level
+    if score >= RISK_THRESHOLDS["high"]:
+        level = "high"
+    elif score >= RISK_THRESHOLDS["medium"]:
+        level = "medium"
+    else:
+        level = "low"
+
+    new_state = dict(state or {})
+    new_state["risk"] = {"score": score, "level": level, "reasons": reasons}
+    new_state["audit"].append({"node": "risk", "event": "scored_risk", "score": score, "level": level})
+
+    return NodeResult(ok=True, data=new_state, notes=f"Risk={level} ({score})")

--- a/examples/recipes/onboarding_assistance/vendor_onboarding_policy/nodes/validate.py
+++ b/examples/recipes/onboarding_assistance/vendor_onboarding_policy/nodes/validate.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from ..config import REQUIRED_FIELDS
+
+
+@dataclass
+class NodeResult:
+    ok: bool
+    data: Dict[str, Any]
+    notes: str = ""
+
+
+def run(state: Dict[str, Any]) -> NodeResult:
+    vendor = (state or {}).get("vendor", {})
+    missing: List[str] = []
+
+    for field in REQUIRED_FIELDS:
+        v = vendor.get(field)
+        if v is None or (isinstance(v, str) and not v.strip()):
+            missing.append(field)
+
+    new_state = dict(state or {})
+    new_state["missing_fields"] = missing
+    new_state["completeness"] = "incomplete" if missing else "complete"
+    new_state["audit"].append({"node": "validate", "event": "checked_required_fields", "missing": missing})
+
+    return NodeResult(ok=True, data=new_state, notes="Validated required fields")


### PR DESCRIPTION
Fixes #5820

## Summary

This PR adds a new onboarding workflow example demonstrating a policy-aware vendor onboarding process.

The example models a realistic business workflow including validation, compliance checks, risk scoring, and human-in-the-loop escalation.

## What this example demonstrates

- deterministic validation and compliance checks
- vendor classification
- rule-based risk scoring with explanations
- decision routing (approved, needs_more_info, human_review)
- human-in-the-loop escalation
- structured audit trail output

## Example location

examples/recipes/onboarding_assistance/vendor_onboarding_policy/

## Demo scenarios

| Scenario               | Result                 |
|------------------------|------------------------|
| Low-risk vendor        | Approved               |
| Missing documents      | Needs more information |
| High-risk jurisdiction | Human review → Reject  |

## Why this is useful

This example demonstrates how Hive agents can support real compliance workflows rather than simple automations. It highlights:

- branching decision graphs
- deterministic guardrails
- auditability
- human escalation workflows
- structured outputs suitable for downstream systems

## Future extensions

Possible next steps:

- integrate external compliance APIs
- add OCR or document ingestion
- add email notifications
- convert the HITL placeholder into a native Hive intervention node