### PR TITLE
micro-fix: Windows compat — guard os.fchmod and remove deleted LLM_CREDENTI…

### DIFF
--- a/tools/src/aden_tools/file_ops.py
+++ b/tools/src/aden_tools/file_ops.py
@@ -969,7 +969,8 @@ def register_file_tools(
             fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(resolved))
             fd_open = True
             try:
-                os.fchmod(fd, original_mode)
+                if hasattr(os, "fchmod"):
+                    os.fchmod(fd, original_mode)
                 with os.fdopen(fd, "w", encoding=encoding, newline="") as f:
                     fd_open = False
                     f.write(joined)

--- a/tools/src/aden_tools/tools/file_system_toolkits/hashline_edit/hashline_edit.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/hashline_edit/hashline_edit.py
@@ -384,7 +384,8 @@ def register_tools(mcp: FastMCP) -> None:
             fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(secure_path))
             fd_open = True
             try:
-                os.fchmod(fd, original_mode)
+                if hasattr(os, "fchmod"):
+                    os.fchmod(fd, original_mode)
                 with os.fdopen(fd, "w", encoding=encoding, newline="") as f:
                     fd_open = False
                     f.write(joined)


### PR DESCRIPTION
…ALS import

os.fchmod does not exist on Windows; guard with hasattr check. Remove LLM_CREDENTIALS reference from test (module deleted in e1db3a4).

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
