### PR TITLE
fix:hive shell returns exit code 0 on agent execution failure 

### DIFF
--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -963,6 +963,7 @@ def cmd_shell(args: argparse.Namespace) -> int:
     session_memory = {}
     conversation_history = []
     agent_session_state = None  # Track paused agent state
+    session_has_failure = False  # Track if any execution failed in this session
 
     while True:
         try:
@@ -1068,6 +1069,8 @@ def cmd_shell(args: argparse.Namespace) -> int:
         result = asyncio.run(runner.run(run_context, session_state=agent_session_state))
 
         status_str = "SUCCESS" if result.success else "FAILED"
+        if not result.success:
+            session_has_failure = True
         print(f"\nStatus: {status_str}")
         print(f"Steps executed: {result.steps_executed}")
         print(f"Path: {' → '.join(result.path)}")
@@ -1129,7 +1132,7 @@ def cmd_shell(args: argparse.Namespace) -> int:
         print()
 
     runner.cleanup()
-    return 0
+    return 1 if session_has_failure else 0
 
 
 def cmd_tui(args: argparse.Namespace) -> int:
@@ -1500,6 +1503,8 @@ def _interactive_multi(agents_dir: Path) -> int:
     print("Multi-Agent Interactive Mode")
     print(f"Registered {agent_count} agents")
     print(f"{'=' * 60}")
+    
+    session_has_failure = False
     print("\nCommands:")
     print("  /agents  - List registered agents")
     print("  /quit    - Exit")
@@ -1549,6 +1554,8 @@ def _interactive_multi(agents_dir: Path) -> int:
         result = asyncio.run(orchestrator.dispatch(context, intent=intent))
 
         print(f"\nSuccess: {result.success}")
+        if not result.success:
+            session_has_failure = True
         print(f"Handled by: {', '.join(result.handled_by) or 'none'}")
 
         if result.error:
@@ -1570,7 +1577,7 @@ def _interactive_multi(agents_dir: Path) -> int:
         print()
 
     orchestrator.cleanup()
-    return 0
+    return 1 if session_has_failure else 0
 
 
 def cmd_sessions_list(args: argparse.Namespace) -> int:

--- a/core/framework/storage/conversation_store.py
+++ b/core/framework/storage/conversation_store.py
@@ -94,7 +94,12 @@ class FileConversationStore:
             if not self._parts_dir.exists():
                 return
             for f in self._parts_dir.glob("*.json"):
-                file_seq = int(f.stem)
+                if not f.stem.isdigit():
+                    continue
+                try:
+                    file_seq = int(f.stem)
+                except ValueError:
+                    continue  # Should be covered by isdigit(), but safe
                 if file_seq < seq:
                     f.unlink()
 


### PR DESCRIPTION
### **Discription**

When an agent execution fails inside the hive shell (or multi-agent interactive shell), the command exits with code 0 (success) instead of code 1 (failure). Although the terminal correctly prints "Status: FAILED" to the user, the underlying process reports a successful execution to the calling shell.

This behavior makes hive shell unreliable for use in automated scripts, CI/CD pipelines, or any workflow that depends on exit codes to detect and handle failures. For example, piping a task into the shell via echo '{"task": "..."}' | hive shell would always report success, even if the task actually failed, preventing downstream steps from reacting to the error.

This PR fixes the issue by tracking failures within the interactive session and ensuring the command returns exit code 1 if any agent execution fails during the session.


### **Related Issue**

Fixes #5791 