### PR TITLE
fix(cli): validate --output path before agent execution in cmd_run

### DIFF
--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -522,6 +522,22 @@ def cmd_run(args: argparse.Namespace) -> int:
         except (FileNotFoundError, json.JSONDecodeError) as e:
             print(f"Error reading input file: {e}", file=sys.stderr)
             return 1
+     # Validate --output path before execution begins (fail fast, before agent loads)
+    if args.output:
+        import os
+        output_parent = Path(args.output).parent
+        if not output_parent.exists():
+            print(
+                f"Error: output directory does not exist: {output_parent}/",
+                file=sys.stderr,
+            )
+            return 1
+        if not os.access(output_parent, os.W_OK):
+            print(
+                f"Error: output directory is not writable: {output_parent}/",
+                file=sys.stderr,
+            )
+            return 1
 
     # Run the agent (with TUI or standard)
     if getattr(args, "tui", False):

--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -522,9 +522,10 @@ def cmd_run(args: argparse.Namespace) -> int:
         except (FileNotFoundError, json.JSONDecodeError) as e:
             print(f"Error reading input file: {e}", file=sys.stderr)
             return 1
-     # Validate --output path before execution begins (fail fast, before agent loads)
+    # Validate --output path before execution begins (fail fast, before agent loads)
     if args.output:
         import os
+
         output_parent = Path(args.output).parent
         if not output_parent.exists():
             print(


### PR DESCRIPTION

Fixes #5788

## What
Adds early validation of the `--output` path in `cmd_run` before 
`AgentRunner.load()` is called.

## Why
Previously, if the output directory didn't exist or lacked write 
permissions, the agent would fully execute before crashing with a raw 
`FileNotFoundError`. This wastes time and gives a poor user experience.

## Changes
- Validates `--output` parent directory exists before execution begins
- Validates write permission on the output directory
- Prints a clean error message and exits with code 1 on failure
- Only `core/framework/runner/cli.py` modified (~10 lines)