### PR TITLE
docs: update templates/README.md to list all 10 available templates

### DIFF
--- a/examples/templates/README.md
+++ b/examples/templates/README.md
@@ -45,3 +45,10 @@ uv run python -m exports.my_research_agent --input '{"topic": "..."}'
 | [deep_research_agent](deep_research_agent/) | Interactive research agent that searches diverse sources, evaluates findings with user checkpoints, and produces a cited HTML report |
 | [local_business_extractor](local_business_extractor/) | Finds local businesses on Google Maps, scrapes contact details, and syncs to Google Sheets |
 | [tech_news_reporter](tech_news_reporter/) | Researches the latest technology and AI news from the web and produces a well-organized report |
+| [competitive_intel_agent](competitive_intel_agent/) | Monitors competitor websites, news sources, and GitHub repos to deliver structured digests with key insights and trend analysis |
+| [email_inbox_management](email_inbox_management/) | Automatically manages Gmail inbox using user-defined free-text rules — trash junk, mark spam, archive, star, and report actions taken |
+| [email_reply_agent](email_reply_agent/) | Reads and drafts context-aware replies to emails using customizable tone and response guidelines |
+| [job_hunter](job_hunter/) | Searches job boards for matching roles, filters by criteria, and compiles a ranked list of opportunities with application links |
+| [meeting_scheduler](meeting_scheduler/) | Coordinates meeting availability across participants and proposes optimal time slots based on calendar constraints |
+| [twitter_news_agent](twitter_news_agent/) | Monitors Twitter/X for trending topics and news in a target domain and generates a curated daily digest |
+| [vulnerability_assessment](vulnerability_assessment/) | Scans a target codebase or URL for common security vulnerabilities and produces a structured risk report |


### PR DESCRIPTION
## Description

The `examples/templates/README.md` currently lists only 3 of the 10 available templates. This PR updates the "Available templates" table to include all 10 templates that exist in the `examples/templates/` directory.

## Type of Change

- [x] Documentation update
## Changes Made

Added 7 missing templates to the README table:
- `competitive_intel_agent` — Monitors competitor websites, news sources, and GitHub repos
- - `email_inbox_management` — Gmail inbox management with free-text rules
- - `email_reply_agent` — Context-aware email reply drafting
- - `job_hunter` — Job board search and ranking
- - `meeting_scheduler` — Calendar-aware meeting coordination
- - `twitter_news_agent` — Twitter/X topic monitoring and digest generation
- - `vulnerability_assessment` — Security vulnerability scanning and risk reporting
## Why

New contributors and users browsing the `examples/templates/` directory won't know these templates exist unless they explore subdirectories manually. This is a discoverability improvement with zero functional changes — it just keeps the documentation in sync with what's actually in the repo.

No functional changes. Documentation only.