### PR TITLE
fix: validate agent.json before parsing in AgentRunner.load()

### DIFF
--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -956,11 +956,14 @@ class AgentRunner:
 
         # Fallback: load from agent.json (legacy JSON-based agents)
         agent_json_path = agent_path / "agent.json"
-        if not agent_json_path.exists():
+        if not agent_json_path.is_file():
             raise FileNotFoundError(f"No agent.py or agent.json found in {agent_path}")
 
-        with open(agent_json_path, encoding="utf-8") as f:
-            graph, goal = load_agent_export(f.read())
+        content = agent_json_path.read_text(encoding="utf-8").strip()
+        if not content:
+            raise FileNotFoundError(f"agent.json is empty: {agent_json_path}")
+
+        graph, goal = load_agent_export(content)
 
         return cls(
             agent_path=agent_path,


### PR DESCRIPTION
## Description

`AgentRunner.load()` crashes with raw Python tracebacks when `agent.json` is empty or is a directory. This fix validates the file before parsing.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #5787

## Changes Made

- Changed `exists()` to `is_file()` so directories are rejected by the same check as missing files
- Added empty content check before passing to `load_agent_export()`
- Clean error messages, no raw tracebacks

## Testing

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Manual testing performed

Tested manually:
```
# Empty agent.json
Error: agent.json is empty: /tmp/test/empty_agent/agent.json

# Directory agent.json
Error: No agent.py or agent.json found in /tmp/test/dir_agent
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes