### PR TITLE
fix(core): emit GOAL_ADJUSTMENT_NEEDED from OutcomeAggregator

### DIFF
--- a/core/framework/agents/hive_coder/ticket_receiver.py
+++ b/core/framework/agents/hive_coder/ticket_receiver.py
@@ -18,7 +18,7 @@ TICKET_RECEIVER_ENTRY_POINT = AsyncEntryPointSpec(
     entry_node="ticket_triage",
     trigger_type="event",
     trigger_config={
-        "event_types": ["worker_escalation_ticket"],
+        "event_types": ["worker_escalation_ticket", "goal_adjustment_needed"],
         # Do not fire on our own graph's events (prevents loops if queen
         # somehow emits a worker_escalation_ticket for herself)
         "exclude_own_graph": True,

--- a/core/framework/runtime/event_bus.py
+++ b/core/framework/runtime/event_bus.py
@@ -73,6 +73,7 @@ class EventType(StrEnum):
     # Goal tracking
     GOAL_PROGRESS = "goal_progress"
     GOAL_ACHIEVED = "goal_achieved"
+    GOAL_ADJUSTMENT_NEEDED = "goal_adjustment_needed"
     CONSTRAINT_VIOLATION = "constraint_violation"
 
     # Stream lifecycle
@@ -348,7 +349,10 @@ class EventBus:
             return False
 
         # Check execution filter
-        if subscription.filter_execution and subscription.filter_execution != event.execution_id:
+        if (
+            subscription.filter_execution
+            and subscription.filter_execution != event.execution_id
+        ):
             return False
 
         # Check graph filter
@@ -372,7 +376,9 @@ class EventBus:
                     logger.error(f"Handler error for {event.type}: {e}")
 
         # Run all handlers concurrently
-        await asyncio.gather(*[run_handler(h) for h in handlers], return_exceptions=True)
+        await asyncio.gather(
+            *[run_handler(h) for h in handlers], return_exceptions=True
+        )
 
     # === CONVENIENCE PUBLISHERS ===
 
@@ -443,6 +449,26 @@ class EventBus:
                 stream_id=stream_id,
                 data={
                     "progress": progress,
+                    "criteria_status": criteria_status,
+                },
+            )
+        )
+
+    async def emit_goal_adjustment_needed(
+        self,
+        stream_id: str,
+        progress: float,
+        reason: str,
+        criteria_status: dict[str, Any],
+    ) -> None:
+        """Emit goal adjustment needed event."""
+        await self.publish(
+            AgentEvent(
+                type=EventType.GOAL_ADJUSTMENT_NEEDED,
+                stream_id=stream_id,
+                data={
+                    "progress": progress,
+                    "reason": reason,
                     "criteria_status": criteria_status,
                 },
             )

--- a/core/framework/runtime/outcome_aggregator.py
+++ b/core/framework/runtime/outcome_aggregator.py
@@ -177,7 +177,9 @@ class OutcomeAggregator:
             else:
                 self._failed_outcomes += 1
 
-            logger.debug(f"Recorded outcome for {decision_id}: success={outcome.success}")
+            logger.debug(
+                f"Recorded outcome for {decision_id}: success={outcome.success}"
+            )
 
     def record_constraint_violation(
         self,
@@ -291,7 +293,9 @@ class OutcomeAggregator:
                     / max(1, self._successful_outcomes + self._failed_outcomes)
                 ),
                 "streams_active": len({d.stream_id for d in self._decisions}),
-                "executions_total": len({(d.stream_id, d.execution_id) for d in self._decisions}),
+                "executions_total": len(
+                    {(d.stream_id, d.execution_id) for d in self._decisions}
+                ),
             }
 
             # Determine recommendation
@@ -307,6 +311,17 @@ class OutcomeAggregator:
                         progress=result["overall_progress"],
                         criteria_status=result["criteria_status"],
                     )
+
+                    # Check for goal adjustment recommendation
+                    if result.get("recommendation") == "adjust":
+                        await self._event_bus.emit_goal_adjustment_needed(
+                            stream_id=list(stream_ids)[0],
+                            progress=result["overall_progress"],
+                            reason=result.get(
+                                "analysis", "Goal adjustment recommended by evaluator."
+                            ),
+                            criteria_status=result["criteria_status"],
+                        )
 
             return result
 
@@ -388,7 +403,9 @@ class OutcomeAggregator:
         violations = result["constraint_violations"]
 
         # Check for hard constraint violations
-        hard_violations = [v for v in violations if self._is_hard_constraint(v["constraint_id"])]
+        hard_violations = [
+            v for v in violations if self._is_hard_constraint(v["constraint_id"])
+        ]
 
         if hard_violations:
             return "adjust"  # Must address violations

--- a/core/framework/tui/app.py
+++ b/core/framework/tui/app.py
@@ -79,7 +79,9 @@ class StatusBar(Container):
             parts.append(node_str)
 
         if self._state == "running" and self._start_time:
-            parts.append(f"[dim]{self._format_elapsed(time.time() - self._start_time)}[/dim]")
+            parts.append(
+                f"[dim]{self._format_elapsed(time.time() - self._start_time)}[/dim]"
+            )
         elif self._final_elapsed is not None:
             parts.append(f"[dim]{self._format_elapsed(self._final_elapsed)}[/dim]")
 
@@ -267,7 +269,9 @@ class AdenTUI(App):
                 text = widget.copy_selection()
                 if text:
                     widget.clear_selection()
-                    self.notify("Copied to clipboard", severity="information", timeout=2)
+                    self.notify(
+                        "Copied to clipboard", severity="information", timeout=2
+                    )
                     return
 
         self.notify("Press [b]q[/b] to quit", severity="warning", timeout=3)
@@ -393,7 +397,9 @@ class AdenTUI(App):
                 else:
                     accounts = []
             except Exception as e:
-                self.notify(f"Failed to list accounts: {e}", severity="error", timeout=10)
+                self.notify(
+                    f"Failed to list accounts: {e}", severity="error", timeout=10
+                )
                 accounts = []
             if accounts:
                 self._show_account_selection(runner, accounts)
@@ -434,11 +440,15 @@ class AdenTUI(App):
         if self.runtime and not self.runtime.is_running:
             try:
                 agent_loop = self.chat_repl._agent_loop
-                future = asyncio.run_coroutine_threadsafe(self.runtime.start(), agent_loop)
+                future = asyncio.run_coroutine_threadsafe(
+                    self.runtime.start(), agent_loop
+                )
                 await asyncio.wrap_future(future)
             except Exception as e:
                 self.status_bar.set_graph_id("")
-                self.notify(f"Failed to start runtime: {e}", severity="error", timeout=10)
+                self.notify(
+                    f"Failed to start runtime: {e}", severity="error", timeout=10
+                )
                 return
 
         await self._init_runtime_connection()
@@ -479,7 +489,9 @@ class AdenTUI(App):
             QueenModeState,
             register_queen_lifecycle_tools,
         )
-        from framework.tools.worker_monitoring_tools import register_worker_monitoring_tools
+        from framework.tools.worker_monitoring_tools import (
+            register_worker_monitoring_tools,
+        )
 
         log = logging.getLogger("tui.queen")
 
@@ -570,9 +582,15 @@ class AdenTUI(App):
             building_names = set(_QUEEN_BUILDING_TOOLS)
             staging_names = set(_QUEEN_STAGING_TOOLS)
             running_names = set(_QUEEN_RUNNING_TOOLS)
-            mode_state.building_tools = [t for t in queen_tools if t.name in building_names]
-            mode_state.staging_tools = [t for t in queen_tools if t.name in staging_names]
-            mode_state.running_tools = [t for t in queen_tools if t.name in running_names]
+            mode_state.building_tools = [
+                t for t in queen_tools if t.name in building_names
+            ]
+            mode_state.staging_tools = [
+                t for t in queen_tools if t.name in staging_names
+            ]
+            mode_state.running_tools = [
+                t for t in queen_tools if t.name in running_names
+            ]
 
             # Build worker profile for queen's system prompt.
             from framework.tools.queen_lifecycle_tools import build_worker_profile
@@ -592,7 +610,9 @@ class AdenTUI(App):
             node_updates: dict = {}
             if set(available_tools) != set(declared_tools):
                 missing = sorted(set(declared_tools) - registered_tool_names)
-                log.warning("Queen: tools not available (MCP may have failed): %s", missing)
+                log.warning(
+                    "Queen: tools not available (MCP may have failed): %s", missing
+                )
                 node_updates["tools"] = available_tools
             # Always inject worker identity into system prompt.
             base_prompt = _orig_queen_node.system_prompt or ""
@@ -796,11 +816,16 @@ class AdenTUI(App):
 
     def _show_agent_picker_initial(self) -> None:
         """Show the agent picker on initial startup (no agent loaded)."""
-        from framework.tui.screens.agent_picker import AgentPickerScreen, discover_agents
+        from framework.tui.screens.agent_picker import (
+            AgentPickerScreen,
+            discover_agents,
+        )
 
         agents = discover_agents()
         if not agents:
-            self.notify("No agents found in exports/ or examples/", severity="error", timeout=5)
+            self.notify(
+                "No agents found in exports/ or examples/", severity="error", timeout=5
+            )
             self.set_timer(2.0, self.exit)
             return
 
@@ -835,7 +860,10 @@ class AdenTUI(App):
 
     def _show_agent_picker_tab(self, tab_id: str) -> None:
         """Show the agent picker focused on a specific tab (no Get Started)."""
-        from framework.tui.screens.agent_picker import AgentPickerScreen, discover_agents
+        from framework.tui.screens.agent_picker import (
+            AgentPickerScreen,
+            discover_agents,
+        )
 
         agents = discover_agents()
         if not agents:
@@ -879,7 +907,10 @@ class AdenTUI(App):
 
     def action_show_agent_picker(self) -> None:
         """Open the agent picker (Ctrl+A or /agents)."""
-        from framework.tui.screens.agent_picker import AgentPickerScreen, discover_agents
+        from framework.tui.screens.agent_picker import (
+            AgentPickerScreen,
+            discover_agents,
+        )
 
         agents = discover_agents()
         if not agents:
@@ -1000,7 +1031,9 @@ class AdenTUI(App):
         if not coder_runtime.is_running:
             try:
                 agent_loop = self.chat_repl._agent_loop
-                future = asyncio.run_coroutine_threadsafe(coder_runtime.start(), agent_loop)
+                future = asyncio.run_coroutine_threadsafe(
+                    coder_runtime.start(), agent_loop
+                )
                 await asyncio.wrap_future(future)
             except Exception as e:
                 self.notify(f"Failed to start coder runtime: {e}", severity="error")
@@ -1038,7 +1071,9 @@ class AdenTUI(App):
         )
         self.refresh_bindings()
 
-    def _build_escalation_input(self, reason: str, context: str, worker_path: str) -> str:
+    def _build_escalation_input(
+        self, reason: str, context: str, worker_path: str
+    ) -> str:
         """Compose the user_request string for hive_coder."""
         parts = []
         if worker_path:
@@ -1102,7 +1137,9 @@ class AdenTUI(App):
         # 5. Show return in chat (deferred — widgets need a tick to mount)
         def _show_return():
             if self.chat_repl:
-                self.chat_repl._write_history("[bold cyan]Returned from Hive Coder.[/bold cyan]")
+                self.chat_repl._write_history(
+                    "[bold cyan]Returned from Hive Coder.[/bold cyan]"
+                )
                 if summary:
                     self.chat_repl._write_history(f"[dim]{summary}[/dim]")
 
@@ -1188,6 +1225,7 @@ class AdenTUI(App):
         EventType.GOAL_PROGRESS,
         EventType.GOAL_ACHIEVED,
         EventType.CONSTRAINT_VIOLATION,
+        EventType.GOAL_ADJUSTMENT_NEEDED,
         EventType.STATE_CHANGED,
         EventType.NODE_INPUT_BLOCKED,
         EventType.CONTEXT_COMPACTED,
@@ -1297,7 +1335,9 @@ class AdenTUI(App):
                         return
                     elif et == EventType.EXECUTION_FAILED:
                         error = event.data.get("error", "Unknown error")[:200]
-                        self._inject_worker_status_into_queen(f"Worker execution failed: {error}")
+                        self._inject_worker_status_into_queen(
+                            f"Worker execution failed: {error}"
+                        )
                         return
                     elif et in (
                         EventType.LLM_TEXT_DELTA,
@@ -1367,7 +1407,9 @@ class AdenTUI(App):
             elif et == EventType.EXECUTION_COMPLETED:
                 self.chat_repl.handle_execution_completed(event.data.get("output", {}))
             elif et == EventType.EXECUTION_FAILED:
-                self.chat_repl.handle_execution_failed(event.data.get("error", "Unknown error"))
+                self.chat_repl.handle_execution_failed(
+                    event.data.get("error", "Unknown error")
+                )
             elif et == EventType.CLIENT_INPUT_REQUESTED:
                 self.chat_repl.handle_input_requested(
                     event.node_id or event.data.get("node_id", ""),
@@ -1405,6 +1447,11 @@ class AdenTUI(App):
                 self.chat_repl.handle_goal_achieved(event.data)
             elif et == EventType.CONSTRAINT_VIOLATION:
                 self.chat_repl.handle_constraint_violation(event.data)
+            elif et == EventType.GOAL_ADJUSTMENT_NEEDED:
+                # Goal adjustment needed — notify queen
+                self._inject_worker_status_into_queen(
+                    f"Goal adjustment needed: {event.data.get('reason', 'Goal adjustment recommended by evaluator.')}"
+                )
 
             # --- Graph view events ---
             if self.graph_view is not None:
@@ -1470,13 +1517,17 @@ class AdenTUI(App):
                 name = node.name if node else _ext_names.get(nid, nid)
                 self.status_bar.set_active_node(name, "thinking...")
             elif et == EventType.NODE_LOOP_ITERATION:
-                self.status_bar.set_node_detail(f"step {event.data.get('iteration', '?')}")
+                self.status_bar.set_node_detail(
+                    f"step {event.data.get('iteration', '?')}"
+                )
             elif et == EventType.TOOL_CALL_STARTED:
                 self.status_bar.set_node_detail(f"{event.data.get('tool_name', '')}...")
             elif et == EventType.TOOL_CALL_COMPLETED:
                 self.status_bar.set_node_detail("thinking...")
             elif et == EventType.NODE_STALLED:
-                self.status_bar.set_node_detail(f"stalled: {event.data.get('reason', '')}")
+                self.status_bar.set_node_detail(
+                    f"stalled: {event.data.get('reason', '')}"
+                )
             elif et == EventType.CONTEXT_COMPACTED:
                 before = event.data.get("usage_before", "?")
                 after = event.data.get("usage_after", "?")

--- a/core/framework/tui/app.py
+++ b/core/framework/tui/app.py
@@ -1449,8 +1449,11 @@ class AdenTUI(App):
                 self.chat_repl.handle_constraint_violation(event.data)
             elif et == EventType.GOAL_ADJUSTMENT_NEEDED:
                 # Goal adjustment needed — notify queen
+                reason = event.data.get(
+                    "reason", "Goal adjustment recommended by evaluator."
+                )
                 self._inject_worker_status_into_queen(
-                    f"Goal adjustment needed: {event.data.get('reason', 'Goal adjustment recommended by evaluator.')}"
+                    f"Goal adjustment needed: {reason}"
                 )
 
             # --- Graph view events ---

--- a/core/framework/tui/widgets/log_pane.py
+++ b/core/framework/tui/widgets/log_pane.py
@@ -31,6 +31,7 @@ EVENT_FORMAT: dict[EventType, tuple[str, str]] = {
     EventType.GOAL_PROGRESS: ("%%", "blue"),
     EventType.GOAL_ACHIEVED: ("**", "bold green"),
     EventType.CONSTRAINT_VIOLATION: ("!!", "bold red"),
+    EventType.GOAL_ADJUSTMENT_NEEDED: ("!!", "bold yellow"),
     EventType.STATE_CHANGED: ("~~", "dim"),
     EventType.CLIENT_INPUT_REQUESTED: ("??", "magenta"),
 }
@@ -84,6 +85,8 @@ def extract_event_text(event: AgentEvent) -> str:
         return "Goal achieved"
     elif et == EventType.CONSTRAINT_VIOLATION:
         return f"Constraint violated: {data.get('description', 'unknown')}"
+    elif et == EventType.GOAL_ADJUSTMENT_NEEDED:
+        return f"Goal adjustment needed: {data.get('reason', 'unknown')}"
     elif et == EventType.STATE_CHANGED:
         return f"State changed: {data.get('key', 'unknown')}"
     elif et == EventType.CLIENT_INPUT_REQUESTED:


### PR DESCRIPTION
Summary
When OutcomeAggregator.evaluate_goal_progress() recommends 'adjust', it now emits a GOAL_ADJUSTMENT_NEEDED event.
Guardian (hive_coder) is updated to subscribe to this event alongside existing triggers.
TUI is updated to display the event and inject it into the queen's conversation when active.

Root cause
The 'adjust' recommendation was computed but never emitted as an event, making it invisible to other components like the Guardian or TUI.

Solution
1. Add `GOAL_ADJUSTMENT_NEEDED` to `EventType`.
2. Add `emit_goal_adjustment_needed` to `EventBus`.
3. Modify `OutcomeAggregator.evaluate_goal_progress()` to emit the event when recommendation is 'adjust'.
4. Update `ticket_receiver.py` in `hive_coder` to subscribe to the new event.
5. Update TUI (`app.py` and `log_pane.py`) to display and route the event.

Validation
Passed `make check` and `uv run pytest tests/`.
827 passed, 54 skipped, 63 warnings.

Fixes #5447