### PR TITLE
feat(agent): add Lead Qualification Agent for ICP-based lead scoring and routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ tmp/
 temp/
 
 exports/*
+!exports/lead_qualification_agent/
 
 .agent-builder-sessions/*
 

--- a/exports/lead_qualification_agent/README.md
+++ b/exports/lead_qualification_agent/README.md
@@ -1,0 +1,204 @@
+# Lead Qualification Agent
+
+Automatically scores, enriches, and routes inbound leads based on Ideal Customer Profile (ICP) criteria — eliminating manual triage and ensuring hot leads never slip through the cracks.
+
+## Overview
+
+This agent handles the complete lead qualification workflow:
+1. **Intake** — Receives lead data (name, email, company, role)
+2. **Enrichment** — Looks up company details via web search (industry, size, funding, location)
+3. **Scoring** — Scores lead 0-100 based on configurable ICP criteria
+4. **Routing** — Routes to appropriate pipeline based on score
+5. **Output** — Logs final decision and updates CRM
+
+## Workflow
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                    LEAD QUALIFICATION AGENT                                 │
+│                                                                             │
+│  Goal: Score, enrich, and route inbound leads based on ICP criteria        │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+    ┌───────────────────────┐
+    │       INTAKE          │
+    │  (client-facing)      │
+    │                       │
+    │  in:  lead_data       │
+    │  out: lead_brief      │
+    └───────────┬───────────┘
+                │ on_success
+                ▼
+    ┌───────────────────────┐
+    │     ENRICHMENT        │
+    │                       │
+    │  tools: web_search,   │
+    │         web_scrape    │
+    │                       │
+    │  in:  lead_brief      │
+    │  out: enriched_lead   │
+    └───────────┬───────────┘
+                │ on_success
+                ▼
+    ┌───────────────────────┐
+    │       SCORING         │
+    │                       │
+    │  in:  enriched_lead   │
+    │  out: score,          │
+    │       score_breakdown │
+    └───────────┬───────────┘
+                │ on_success
+                ▼
+    ┌───────────────────────┐
+    │  ROUTING_DECISION     │
+    │                       │
+    │  in:  score           │
+    │  out: route           │
+    └───────┬───────┬───────┘
+            │       │
+    score>=70│       │score 40-69
+            │       │
+            ▼       ▼
+    ┌───────────┐ ┌───────────┐
+    │ HOT_LEAD  │ │  REVIEW   │ (client-facing)
+    │           │ │           │
+    │ tools:    │ │ in: score │
+    │ hubspot   │ │ out:      │
+    │           │ │ override  │
+    └─────┬─────┘ └─────┬─────┘
+          │             │
+          │    ┌────────┴────────┐
+          │    │                 │
+          │  hot│               nurture
+          │    │                 │
+          │    ▼                 ▼
+          │  ┌───────────┐ ┌───────────┐
+          │  │ HOT_LEAD  │ │  NURTURE  │
+          │  │ (again)   │ │           │
+          │  └─────┬─────┘ │ tools:    │
+          │        │       │ hubspot   │
+          │        │       └─────┬─────┘
+          │        │             │
+          │        ▼             ▼
+          │      ┌───────────────────┐
+          └─────►│      OUTPUT       │
+                 │  (client-facing)  │
+                 │                   │
+                 │ out: final_status │
+                 └─────────┬─────────┘
+                           │
+                           │ loops to INTAKE
+                           ▼
+
+    EDGES:
+    ──────
+    1. intake → enrichment              [on_success, priority: 1]
+    2. enrichment → scoring            [on_success, priority: 1]
+    3. scoring → routing_decision      [on_success, priority: 1]
+    4. routing_decision → hot_lead     [conditional: route == 'hot', priority: 3]
+    5. routing_decision → review       [conditional: route == 'review', priority: 2]
+    6. routing_decision → nurture      [conditional: route == 'nurture', priority: 1]
+    7. hot_lead → output               [on_success, priority: 1]
+    8. review → hot_lead               [conditional: override_route == 'hot', priority: 2]
+    9. review → nurture                [conditional: override_route == 'nurture', priority: 1]
+    10. nurture → output               [on_success, priority: 1]
+    11. output → intake                [conditional: qualification_complete, priority: 1]
+```
+
+## ICP Scoring Framework
+
+The agent uses a configurable ICP scoring framework:
+
+| Category | Max Points | Criteria |
+|----------|------------|----------|
+| Industry Fit | 25 | SaaS/Software (25), Tech Services (20), Finance/Healthcare (15), Other B2B (10) |
+| Company Size | 25 | 10-200 employees (25), 200-500 (20), 500-1000 (15), <10 or >1000 (5-10) |
+| Role Seniority | 25 | C-level/VP (25), Director (20), Manager (15), IC (5-10) |
+| Role Relevance | 25 | Engineering/Product (25), Operations/IT (20), Sales/Marketing (10-15) |
+
+**Modifiers:** +5 for recent funding, +5 for target geography, -10 for bad fit signals
+
+## Routing Thresholds
+
+- **Score >= 70**: Hot Lead → Immediate SDR follow-up
+- **Score 40-69**: Review → Human-in-the-loop review before routing
+- **Score < 40**: Nurture → Automated email sequence
+
+## Usage
+
+### CLI Commands
+
+```bash
+# Validate agent structure
+PYTHONPATH=exports uv run python -m lead_qualification_agent validate
+
+# Show agent info
+PYTHONPATH=exports uv run python -m lead_qualification_agent info
+
+# Run with lead data
+PYTHONPATH=exports uv run python -m lead_qualification_agent run \
+  --name "Jane Smith" \
+  --email "jane@techstartup.io" \
+  --company "TechStartup Inc" \
+  --role "VP of Engineering"
+
+# Interactive shell
+PYTHONPATH=exports uv run python -m lead_qualification_agent shell
+
+# Launch TUI (deprecated - use hive open instead)
+PYTHONPATH=exports uv run python -m lead_qualification_agent tui
+```
+
+### Browser Interface (Recommended)
+
+```bash
+# Start the browser-based interface
+hive open
+
+# Then select "Lead Qualification Agent" from the agent list
+```
+
+## Requirements
+
+### Credentials
+
+The agent requires the following credentials:
+
+1. **LLM API Key** — Set via `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`
+2. **HubSpot Access Token** — Set via `HUBSPOT_ACCESS_TOKEN` or configure via credential store
+
+```bash
+# Set up credentials
+/hive-credentials --agent lead_qualification_agent
+```
+
+### MCP Tools
+
+The agent uses these tools from the Hive tools MCP server:
+- `web_search` — For company enrichment
+- `web_scrape` — For fetching company information
+- `hubspot_search_contacts` — Find existing contacts
+- `hubspot_create_contact` — Create new contacts
+- `hubspot_update_contact` — Update contact with routing tags
+- `hubspot_create_company` — Create company records
+- `hubspot_update_company` — Update company data
+
+## Success Criteria
+
+1. ✅ Lead is enriched with firmographic data from web search
+2. ✅ Lead score is calculated with clear ICP-based breakdown
+3. ✅ Lead is routed to correct pipeline based on score
+4. ✅ Lead data is written to CRM with routing tags
+5. ✅ Agent runs end-to-end in under 30 seconds per lead
+
+## Target Users
+
+- B2B SaaS founders and sales teams
+- Growth/RevOps teams managing HubSpot or similar CRMs
+- SDRs who want to focus on closing, not triaging
+
+## Related
+
+- Issue: #5700 — Lead Qualification Agent — Score, Enrich, and Route Inbound Leads
+- HubSpot Integration: #2848 (completed)
+- Related recipes: `crm_update`, `inquiry_triaging`

--- a/exports/lead_qualification_agent/__init__.py
+++ b/exports/lead_qualification_agent/__init__.py
@@ -1,0 +1,24 @@
+"""
+Lead Qualification Agent - Score, Enrich, and Route Inbound Leads.
+
+Automatically scores, enriches, and routes inbound leads based on Ideal
+Customer Profile (ICP) criteria — eliminating manual triage and ensuring
+hot leads never slip through the cracks.
+"""
+
+from .agent import LeadQualificationAgent, default_agent, edges, goal, nodes
+from .config import AgentMetadata, RuntimeConfig, default_config, metadata
+
+__version__ = "1.0.0"
+
+__all__ = [
+    "LeadQualificationAgent",
+    "default_agent",
+    "goal",
+    "nodes",
+    "edges",
+    "RuntimeConfig",
+    "AgentMetadata",
+    "default_config",
+    "metadata",
+]

--- a/exports/lead_qualification_agent/__main__.py
+++ b/exports/lead_qualification_agent/__main__.py
@@ -1,0 +1,265 @@
+"""
+CLI entry point for Lead Qualification Agent.
+
+Uses AgentRuntime for multi-entrypoint support with HITL pause/resume.
+"""
+
+import asyncio
+import json
+import logging
+import sys
+
+import click
+
+from .agent import LeadQualificationAgent, default_agent
+
+
+def setup_logging(verbose=False, debug=False):
+    if debug:
+        level, fmt = logging.DEBUG, "%(asctime)s %(name)s: %(message)s"
+    elif verbose:
+        level, fmt = logging.INFO, "%(message)s"
+    else:
+        level, fmt = logging.WARNING, "%(levelname)s: %(message)s"
+    logging.basicConfig(level=level, format=fmt, stream=sys.stderr)
+    logging.getLogger("framework").setLevel(level)
+
+
+@click.group()
+@click.version_option(version="1.0.0")
+def cli():
+    """Lead Qualification Agent - Score, Enrich, and Route Inbound Leads."""
+    pass
+
+
+@cli.command()
+@click.option("--name", "-n", type=str, help="Lead contact name")
+@click.option("--email", "-e", type=str, help="Lead email address")
+@click.option("--company", "-c", type=str, help="Company name")
+@click.option("--role", "-r", type=str, help="Lead role/title")
+@click.option("--mock", is_flag=True, help="Run in mock mode")
+@click.option("--quiet", "-q", is_flag=True, help="Only output result JSON")
+@click.option("--verbose", "-v", is_flag=True, help="Show execution details")
+@click.option("--debug", is_flag=True, help="Show debug logging")
+def run(name, email, company, role, mock, quiet, verbose, debug):
+    """Execute lead qualification on provided lead data."""
+    if not quiet:
+        setup_logging(verbose=verbose, debug=debug)
+
+    if name and email and company and role:
+        context = {
+            "lead_data": {
+                "name": name,
+                "email": email,
+                "company": company,
+                "role": role,
+            }
+        }
+    else:
+        context = {}
+
+    result = asyncio.run(default_agent.run(context, mock_mode=mock))
+
+    output_data = {
+        "success": result.success,
+        "steps_executed": result.steps_executed,
+        "output": result.output,
+    }
+    if result.error:
+        output_data["error"] = result.error
+
+    click.echo(json.dumps(output_data, indent=2, default=str))
+    sys.exit(0 if result.success else 1)
+
+
+@cli.command()
+@click.option("--mock", is_flag=True, help="Run in mock mode")
+@click.option("--verbose", "-v", is_flag=True, help="Show execution details")
+@click.option("--debug", is_flag=True, help="Show debug logging")
+def tui(mock, verbose, debug):
+    """Launch the TUI dashboard for interactive lead qualification."""
+    setup_logging(verbose=verbose, debug=debug)
+
+    try:
+        from framework.tui.app import AdenTUI
+    except ImportError:
+        click.echo(
+            "TUI requires the 'textual' package. Install with: pip install textual"
+        )
+        sys.exit(1)
+
+    from pathlib import Path
+
+    from framework.llm import LiteLLMProvider
+    from framework.runner.tool_registry import ToolRegistry
+    from framework.runtime.agent_runtime import create_agent_runtime
+    from framework.runtime.event_bus import EventBus
+    from framework.runtime.execution_stream import EntryPointSpec
+
+    async def run_with_tui():
+        agent = LeadQualificationAgent()
+
+        agent._event_bus = EventBus()
+        agent._tool_registry = ToolRegistry()
+
+        storage_path = Path.home() / ".hive" / "agents" / "lead_qualification_agent"
+        storage_path.mkdir(parents=True, exist_ok=True)
+
+        mcp_config_path = Path(__file__).parent / "mcp_servers.json"
+        if mcp_config_path.exists():
+            agent._tool_registry.load_mcp_config(mcp_config_path)
+
+        llm = None
+        if not mock:
+            llm = LiteLLMProvider(
+                model=agent.config.model,
+                api_key=agent.config.api_key,
+                api_base=agent.config.api_base,
+            )
+
+        tools = list(agent._tool_registry.get_tools().values())
+        tool_executor = agent._tool_registry.get_executor()
+        graph = agent._build_graph()
+
+        runtime = create_agent_runtime(
+            graph=graph,
+            goal=agent.goal,
+            storage_path=storage_path,
+            entry_points=[
+                EntryPointSpec(
+                    id="start",
+                    name="Start Qualification",
+                    entry_node="intake",
+                    trigger_type="manual",
+                    isolation_level="isolated",
+                ),
+            ],
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor,
+        )
+
+        await runtime.start()
+
+        try:
+            app = AdenTUI(runtime)
+            await app.run_async()
+        finally:
+            await runtime.stop()
+
+    asyncio.run(run_with_tui())
+
+
+@cli.command()
+@click.option("--json", "output_json", is_flag=True)
+def info(output_json):
+    """Show agent information."""
+    info_data = default_agent.info()
+    if output_json:
+        click.echo(json.dumps(info_data, indent=2))
+    else:
+        click.echo(f"Agent: {info_data['name']}")
+        click.echo(f"Version: {info_data['version']}")
+        click.echo(f"Description: {info_data['description']}")
+        click.echo(f"\nNodes: {', '.join(info_data['nodes'])}")
+        click.echo(f"Client-facing: {', '.join(info_data['client_facing_nodes'])}")
+        click.echo(f"Entry: {info_data['entry_node']}")
+        click.echo(f"Terminal: {', '.join(info_data['terminal_nodes'])}")
+
+
+@cli.command()
+def validate():
+    """Validate agent structure."""
+    validation = default_agent.validate()
+    if validation["valid"]:
+        click.echo("Agent is valid")
+        if validation["warnings"]:
+            for warning in validation["warnings"]:
+                click.echo(f"  WARNING: {warning}")
+    else:
+        click.echo("Agent has errors:")
+        for error in validation["errors"]:
+            click.echo(f"  ERROR: {error}")
+    sys.exit(0 if validation["valid"] else 1)
+
+
+@cli.command()
+@click.option("--verbose", "-v", is_flag=True)
+def shell(verbose):
+    """Interactive lead qualification session (CLI, no TUI)."""
+    asyncio.run(_interactive_shell(verbose))
+
+
+async def _interactive_shell(verbose=False):
+    setup_logging(verbose=verbose)
+
+    click.echo("=== Lead Qualification Agent ===")
+    click.echo("Enter lead details to qualify (or 'quit' to exit):\n")
+
+    agent = LeadQualificationAgent()
+    await agent.start()
+
+    try:
+        while True:
+            try:
+                name = await asyncio.get_event_loop().run_in_executor(
+                    None, input, "Contact Name> "
+                )
+                if name.lower() in ["quit", "exit", "q"]:
+                    click.echo("Goodbye!")
+                    break
+
+                email = await asyncio.get_event_loop().run_in_executor(
+                    None, input, "Email> "
+                )
+                company = await asyncio.get_event_loop().run_in_executor(
+                    None, input, "Company> "
+                )
+                role = await asyncio.get_event_loop().run_in_executor(
+                    None, input, "Role> "
+                )
+
+                if not all(
+                    [name.strip(), email.strip(), company.strip(), role.strip()]
+                ):
+                    click.echo("\nPlease provide all lead details.\n")
+                    continue
+
+                click.echo("\nQualifying lead...\n")
+
+                lead_data = {
+                    "name": name.strip(),
+                    "email": email.strip(),
+                    "company": company.strip(),
+                    "role": role.strip(),
+                }
+
+                result = await agent.trigger_and_wait(
+                    "default", {"lead_data": lead_data}
+                )
+
+                if result is None:
+                    click.echo("\n[Execution timed out]\n")
+                    continue
+
+                if result.success:
+                    output = result.output
+                    if "final_status" in output:
+                        click.echo(f"\n{output['final_status']}\n")
+                else:
+                    click.echo(f"\nQualification failed: {result.error}\n")
+
+            except KeyboardInterrupt:
+                click.echo("\nGoodbye!")
+                break
+            except Exception as e:
+                click.echo(f"Error: {e}", err=True)
+                import traceback
+
+                traceback.print_exc()
+    finally:
+        await agent.stop()
+
+
+if __name__ == "__main__":
+    cli()

--- a/exports/lead_qualification_agent/agent.py
+++ b/exports/lead_qualification_agent/agent.py
@@ -1,0 +1,397 @@
+"""Agent graph construction for Lead Qualification Agent."""
+
+from pathlib import Path
+
+from framework.graph import Constraint, EdgeCondition, EdgeSpec, Goal, SuccessCriterion
+from framework.graph.checkpoint_config import CheckpointConfig
+from framework.graph.edge import GraphSpec
+from framework.graph.executor import ExecutionResult
+from framework.llm import LiteLLMProvider
+from framework.runner.tool_registry import ToolRegistry
+from framework.runtime.agent_runtime import AgentRuntime, create_agent_runtime
+from framework.runtime.execution_stream import EntryPointSpec
+
+from .config import default_config, metadata
+from .nodes import (
+    enrichment_node,
+    hot_lead_node,
+    intake_node,
+    nurture_node,
+    output_node,
+    review_node,
+    routing_decision_node,
+    scoring_node,
+)
+
+goal = Goal(
+    id="lead-qualification-icp-scoring",
+    name="Lead Qualification with ICP Scoring",
+    description=(
+        "Automatically score, enrich, and route inbound leads based on Ideal Customer "
+        "Profile (ICP) criteria — eliminating manual triage and ensuring hot leads "
+        "receive immediate attention."
+    ),
+    success_criteria=[
+        SuccessCriterion(
+            id="enrichment-completeness",
+            description="Lead is enriched with firmographic data from web search",
+            metric="enrichment_fields",
+            target=">=4 fields",
+            weight=0.20,
+        ),
+        SuccessCriterion(
+            id="scoring-accuracy",
+            description="Lead score is calculated with clear ICP-based breakdown",
+            metric="score_breakdown_completeness",
+            target="100%",
+            weight=0.25,
+        ),
+        SuccessCriterion(
+            id="routing-correctness",
+            description="Lead is routed to correct pipeline based on score",
+            metric="routing_accuracy",
+            target="100%",
+            weight=0.25,
+        ),
+        SuccessCriterion(
+            id="crm-integration",
+            description="Lead data is written to CRM with routing tags",
+            metric="crm_update_success",
+            target="true",
+            weight=0.15,
+        ),
+        SuccessCriterion(
+            id="execution-speed",
+            description="Agent runs end-to-end in under 30 seconds per lead",
+            metric="execution_time_seconds",
+            target="<30",
+            weight=0.15,
+        ),
+    ],
+    constraints=[
+        Constraint(
+            id="no-hallucination",
+            description="Only include company data found through actual web search",
+            constraint_type="quality",
+            category="accuracy",
+        ),
+        Constraint(
+            id="human-checkpoint",
+            description="Borderline leads (40-69 score) require human review before final routing",
+            constraint_type="functional",
+            category="interaction",
+        ),
+        Constraint(
+            id="crm-write-back",
+            description="All qualified leads must be written back to CRM with routing tags",
+            constraint_type="functional",
+            category="integration",
+        ),
+    ],
+)
+
+nodes = [
+    intake_node,
+    enrichment_node,
+    scoring_node,
+    routing_decision_node,
+    hot_lead_node,
+    review_node,
+    nurture_node,
+    output_node,
+]
+
+edges = [
+    EdgeSpec(
+        id="intake-to-enrichment",
+        source="intake",
+        target="enrichment",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="enrichment-to-scoring",
+        source="enrichment",
+        target="scoring",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="scoring-to-routing",
+        source="scoring",
+        target="routing_decision",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="routing-to-hot",
+        source="routing_decision",
+        target="hot_lead",
+        condition=EdgeCondition.CONDITIONAL,
+        condition_expr="route == 'hot'",
+        priority=3,
+    ),
+    EdgeSpec(
+        id="routing-to-review",
+        source="routing_decision",
+        target="review",
+        condition=EdgeCondition.CONDITIONAL,
+        condition_expr="route == 'review'",
+        priority=2,
+    ),
+    EdgeSpec(
+        id="routing-to-nurture",
+        source="routing_decision",
+        target="nurture",
+        condition=EdgeCondition.CONDITIONAL,
+        condition_expr="route == 'nurture'",
+        priority=1,
+    ),
+    EdgeSpec(
+        id="hot-to-output",
+        source="hot_lead",
+        target="output",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="review-to-hot",
+        source="review",
+        target="hot_lead",
+        condition=EdgeCondition.CONDITIONAL,
+        condition_expr="override_route == 'hot'",
+        priority=2,
+    ),
+    EdgeSpec(
+        id="review-to-nurture",
+        source="review",
+        target="nurture",
+        condition=EdgeCondition.CONDITIONAL,
+        condition_expr="override_route == 'nurture'",
+        priority=1,
+    ),
+    EdgeSpec(
+        id="nurture-to-output",
+        source="nurture",
+        target="output",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="output-to-intake",
+        source="output",
+        target="intake",
+        condition=EdgeCondition.CONDITIONAL,
+        condition_expr="qualification_complete == 'true'",
+        priority=1,
+    ),
+]
+
+entry_node = "intake"
+entry_points = {"start": "intake"}
+pause_nodes = []
+terminal_nodes = []
+
+
+class LeadQualificationAgent:
+    """
+    Lead Qualification Agent — 8-node pipeline with human-in-the-loop review.
+
+    Flow: intake -> enrichment -> scoring -> routing_decision
+                                          ├─> hot_lead -> output
+                                          ├─> review -> hot_lead/nurture -> output
+                                          └─> nurture -> output
+
+    Uses AgentRuntime for proper session management:
+    - Session-scoped storage (sessions/{session_id}/)
+    - Checkpointing for resume capability
+    - Runtime logging
+    - Data folder for save_data/load_data
+    """
+
+    def __init__(self, config=None):
+        self.config = config or default_config
+        self.goal = goal
+        self.nodes = nodes
+        self.edges = edges
+        self.entry_node = entry_node
+        self.entry_points = entry_points
+        self.pause_nodes = pause_nodes
+        self.terminal_nodes = terminal_nodes
+        self._graph: GraphSpec | None = None
+        self._agent_runtime: AgentRuntime | None = None
+        self._tool_registry: ToolRegistry | None = None
+        self._storage_path: Path | None = None
+
+    def _build_graph(self) -> GraphSpec:
+        return GraphSpec(
+            id="lead-qualification-agent-graph",
+            goal_id=self.goal.id,
+            version="1.0.0",
+            entry_node=self.entry_node,
+            entry_points=self.entry_points,
+            terminal_nodes=self.terminal_nodes,
+            pause_nodes=self.pause_nodes,
+            nodes=self.nodes,
+            edges=self.edges,
+            default_model=self.config.model,
+            max_tokens=self.config.max_tokens,
+            loop_config={
+                "max_iterations": 100,
+                "max_tool_calls_per_turn": 20,
+                "max_history_tokens": 32000,
+            },
+            conversation_mode="continuous",
+            identity_prompt=(
+                "You are a lead qualification agent for a B2B SaaS company. "
+                "You receive lead information, enrich it with company data from web search, "
+                "score it against Ideal Customer Profile (ICP) criteria, and route it to the "
+                "appropriate pipeline. You ensure hot leads get immediate attention while "
+                "borderline cases receive human review. You never fabricate company data — "
+                "only include information you actually found through web search."
+            ),
+        )
+
+    def _setup(self, mock_mode=False) -> None:
+        self._storage_path = (
+            Path.home() / ".hive" / "agents" / "lead_qualification_agent"
+        )
+        self._storage_path.mkdir(parents=True, exist_ok=True)
+
+        self._tool_registry = ToolRegistry()
+
+        mcp_config_path = Path(__file__).parent / "mcp_servers.json"
+        if mcp_config_path.exists():
+            self._tool_registry.load_mcp_config(mcp_config_path)
+
+        llm = None
+        if not mock_mode:
+            llm = LiteLLMProvider(
+                model=self.config.model,
+                api_key=self.config.api_key,
+                api_base=self.config.api_base,
+            )
+
+        tool_executor = self._tool_registry.get_executor()
+        tools = list(self._tool_registry.get_tools().values())
+
+        self._graph = self._build_graph()
+
+        checkpoint_config = CheckpointConfig(
+            enabled=True,
+            checkpoint_on_node_start=False,
+            checkpoint_on_node_complete=True,
+            checkpoint_max_age_days=7,
+            async_checkpoint=True,
+        )
+
+        entry_point_specs = [
+            EntryPointSpec(
+                id="default",
+                name="Default",
+                entry_node=self.entry_node,
+                trigger_type="manual",
+                isolation_level="shared",
+            )
+        ]
+
+        self._agent_runtime = create_agent_runtime(
+            graph=self._graph,
+            goal=self.goal,
+            storage_path=self._storage_path,
+            entry_points=entry_point_specs,
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor,
+            checkpoint_config=checkpoint_config,
+        )
+
+    async def start(self, mock_mode=False) -> None:
+        if self._agent_runtime is None:
+            self._setup(mock_mode=mock_mode)
+        if not self._agent_runtime.is_running:
+            await self._agent_runtime.start()
+
+    async def stop(self) -> None:
+        if self._agent_runtime and self._agent_runtime.is_running:
+            await self._agent_runtime.stop()
+        self._agent_runtime = None
+
+    async def trigger_and_wait(
+        self,
+        entry_point: str = "default",
+        input_data: dict | None = None,
+        timeout: float | None = None,
+        session_state: dict | None = None,
+    ) -> ExecutionResult | None:
+        if self._agent_runtime is None:
+            raise RuntimeError("Agent not started. Call start() first.")
+
+        return await self._agent_runtime.trigger_and_wait(
+            entry_point_id=entry_point,
+            input_data=input_data or {},
+            session_state=session_state,
+        )
+
+    async def run(
+        self, context: dict, mock_mode=False, session_state=None
+    ) -> ExecutionResult:
+        await self.start(mock_mode=mock_mode)
+        try:
+            result = await self.trigger_and_wait(
+                "default", context, session_state=session_state
+            )
+            return result or ExecutionResult(success=False, error="Execution timeout")
+        finally:
+            await self.stop()
+
+    def info(self):
+        return {
+            "name": metadata.name,
+            "version": metadata.version,
+            "description": metadata.description,
+            "goal": {
+                "name": self.goal.name,
+                "description": self.goal.description,
+            },
+            "nodes": [n.id for n in self.nodes],
+            "edges": [e.id for e in self.edges],
+            "entry_node": self.entry_node,
+            "entry_points": self.entry_points,
+            "pause_nodes": self.pause_nodes,
+            "terminal_nodes": self.terminal_nodes,
+            "client_facing_nodes": [n.id for n in self.nodes if n.client_facing],
+        }
+
+    def validate(self):
+        errors = []
+        warnings = []
+
+        node_ids = {node.id for node in self.nodes}
+        for edge in self.edges:
+            if edge.source not in node_ids:
+                errors.append(f"Edge {edge.id}: source '{edge.source}' not found")
+            if edge.target not in node_ids:
+                errors.append(f"Edge {edge.id}: target '{edge.target}' not found")
+
+        if self.entry_node not in node_ids:
+            errors.append(f"Entry node '{self.entry_node}' not found")
+
+        for terminal in self.terminal_nodes:
+            if terminal not in node_ids:
+                errors.append(f"Terminal node '{terminal}' not found")
+
+        for ep_id, node_id in self.entry_points.items():
+            if node_id not in node_ids:
+                errors.append(
+                    f"Entry point '{ep_id}' references unknown node '{node_id}'"
+                )
+
+        return {
+            "valid": len(errors) == 0,
+            "errors": errors,
+            "warnings": warnings,
+        }
+
+
+default_agent = LeadQualificationAgent()

--- a/exports/lead_qualification_agent/config.py
+++ b/exports/lead_qualification_agent/config.py
@@ -1,0 +1,26 @@
+"""Runtime configuration for Lead Qualification Agent."""
+
+from dataclasses import dataclass
+
+from framework.config import RuntimeConfig
+
+default_config = RuntimeConfig()
+
+
+@dataclass
+class AgentMetadata:
+    name: str = "Lead Qualification Agent"
+    version: str = "1.0.0"
+    description: str = (
+        "Automatically scores, enriches, and routes inbound leads based on "
+        "Ideal Customer Profile (ICP) criteria — eliminating manual triage and "
+        "ensuring hot leads never slip through the cracks."
+    )
+    intro_message: str = (
+        "Hi! I'm your Lead Qualification Agent. Give me a lead (name, email, company, role) "
+        "and I'll enrich it with firmographic data, score it against your ICP, and route it "
+        "to the right pipeline. What lead would you like me to qualify?"
+    )
+
+
+metadata = AgentMetadata()

--- a/exports/lead_qualification_agent/mcp_servers.json
+++ b/exports/lead_qualification_agent/mcp_servers.json
@@ -1,0 +1,9 @@
+{
+  "hive-tools": {
+    "transport": "stdio",
+    "command": "uv",
+    "args": ["run", "python", "mcp_server.py", "--stdio"],
+    "cwd": "../../tools",
+    "description": "Hive tools MCP server providing web_search, web_scrape, and HubSpot CRM tools"
+  }
+}

--- a/exports/lead_qualification_agent/nodes/__init__.py
+++ b/exports/lead_qualification_agent/nodes/__init__.py
@@ -1,0 +1,439 @@
+"""Node definitions for Lead Qualification Agent."""
+
+from framework.graph import NodeSpec
+
+intake_node = NodeSpec(
+    id="intake",
+    name="Lead Intake",
+    description="Receive lead data (name, email, company, role) and prepare for enrichment",
+    node_type="event_loop",
+    client_facing=True,
+    max_node_visits=0,
+    input_keys=["lead_data"],
+    output_keys=["lead_brief"],
+    success_criteria=(
+        "Lead brief contains: contact name, email, company name, and role/title. "
+        "All fields are validated and ready for enrichment."
+    ),
+    system_prompt="""\
+You are a lead intake specialist. The user provides lead information for qualification.
+
+**STEP 1 — Gather lead information (text only, NO tool calls):**
+
+Ask the user for the lead details. You need:
+- Contact name (first and last)
+- Email address
+- Company name
+- Role/Title
+
+If they provide partial information, ask for the missing fields.
+If they provide all fields, confirm the details and ask them to confirm.
+
+**STEP 2 — After the user confirms, call set_output:**
+
+- set_output("lead_brief", JSON object with: name, email, company, role)
+
+Example:
+{
+  "name": "Jane Smith",
+  "email": "jane.smith@techstartup.io",
+  "company": "TechStartup Inc",
+  "role": "VP of Engineering"
+}
+""",
+    tools=[],
+)
+
+enrichment_node = NodeSpec(
+    id="enrichment",
+    name="Company Enrichment",
+    description="Look up company details via web search: industry, headcount, funding, location",
+    node_type="event_loop",
+    max_node_visits=0,
+    input_keys=["lead_brief"],
+    output_keys=["enriched_lead"],
+    success_criteria=(
+        "Enriched lead contains: original lead data plus company industry, "
+        "approximate employee count, funding stage (if available), and location."
+    ),
+    system_prompt="""\
+You are a company research specialist. Given a lead's company name, enrich it
+with firmographic data.
+
+Work in phases:
+1. **Search**: Use web_search to find information about the company
+   - Search for: "{company name} company size employees funding industry"
+   - Also try: "{company name} crunchbase" or "{company name} about"
+2. **Scrape**: Use web_scrape on promising URLs (company website, LinkedIn, Crunchbase, etc.)
+3. **Extract**: Compile the enriched data
+
+Information to find:
+- Industry/Sector
+- Approximate employee count (or company size range)
+- Funding stage (seed, series A, B, etc. if available)
+- Headquarters location
+- Any other relevant firmographics
+
+Important:
+- Work in batches of 3-4 tool calls at a time
+- If information is not available, mark as "unknown"
+- Be accurate — only include verified information
+
+When done, use set_output:
+- set_output("enriched_lead", JSON object combining lead_brief with enrichment data)
+
+Example output structure:
+{
+  "name": "Jane Smith",
+  "email": "jane.smith@techstartup.io",
+  "company": "TechStartup Inc",
+  "role": "VP of Engineering",
+  "enrichment": {
+    "industry": "SaaS / B2B Software",
+    "employee_count": "50-100",
+    "funding_stage": "Series A",
+    "location": "San Francisco, CA",
+    "website": "techstartup.io"
+  }
+}
+""",
+    tools=[
+        "web_search",
+        "web_scrape",
+        "load_data",
+        "save_data",
+        "append_data",
+        "list_data_files",
+    ],
+)
+
+scoring_node = NodeSpec(
+    id="scoring",
+    name="Lead Scoring",
+    description="Score lead 0-100 based on configurable ICP criteria",
+    node_type="event_loop",
+    max_node_visits=0,
+    input_keys=["enriched_lead"],
+    output_keys=["score", "score_breakdown"],
+    success_criteria=(
+        "Score is an integer 0-100. Score breakdown explains the reasoning "
+        "with specific ICP criteria matches."
+    ),
+    system_prompt="""\
+You are a lead scoring expert. Score the enriched lead against typical B2B SaaS ICP criteria.
+
+**ICP Scoring Framework (adjust based on available data):**
+
+Industry Fit (0-25 points):
+- SaaS/Software: 25 pts
+- Technology Services: 20 pts
+- Finance/Healthcare: 15 pts
+- Other relevant B2B: 10 pts
+- Consumer/Unrelated: 0-5 pts
+
+Company Size (0-25 points):
+- 10-200 employees (sweet spot): 25 pts
+- 200-500 employees: 20 pts
+- 500-1000 employees: 15 pts
+- <10 or >1000: 5-10 pts
+
+Role Seniority (0-25 points):
+- C-level/VP: 25 pts
+- Director: 20 pts
+- Manager: 15 pts
+- Individual contributor: 5-10 pts
+
+Role Relevance (0-25 points):
+- Engineering/Product (for technical products): 25 pts
+- Operations/IT: 20 pts
+- Sales/Marketing: 10-15 pts
+- Unrelated: 0-5 pts
+
+Additional Modifiers:
+- +5 if funding recently raised
+- +5 if in target geography
+- -10 if clear bad fit signals
+
+**Output the score and breakdown:**
+
+- set_output("score", integer 0-100)
+- set_output("score_breakdown", JSON with category scores and reasoning)
+
+Example:
+{
+  "industry_score": 25,
+  "size_score": 25,
+  "role_seniority_score": 25,
+  "role_relevance_score": 20,
+  "modifiers": 5,
+  "total": 100,
+  "reasoning": "Perfect ICP fit: SaaS company in sweet spot size range with VP-level tech buyer."
+}
+""",
+    tools=[],
+)
+
+routing_decision_node = NodeSpec(
+    id="routing_decision",
+    name="Routing Decision",
+    description="Route lead based on score: hot (>=70), review (40-69), or nurture (<40)",
+    node_type="event_loop",
+    max_node_visits=0,
+    input_keys=["enriched_lead", "score", "score_breakdown"],
+    output_keys=["route"],
+    success_criteria="Route is set to 'hot', 'review', or 'nurture' based on score thresholds.",
+    system_prompt="""\
+You are a routing decision node. Determine where the lead should go based on its score.
+
+**Routing Rules:**
+- Score >= 70: Route to "hot" (immediate SDR follow-up)
+- Score 40-69: Route to "review" (human-in-the-loop review)
+- Score < 40: Route to "nurture" (automated email sequence)
+
+Set the route using set_output:
+- set_output("route", "hot") or "review" or "nurture"
+
+This is a simple decision node — just apply the routing rules and output the route.
+""",
+    tools=[],
+)
+
+hot_lead_node = NodeSpec(
+    id="hot_lead",
+    name="Hot Lead Processing",
+    description="Format lead summary for SDR follow-up and prepare CRM update",
+    node_type="event_loop",
+    max_node_visits=0,
+    input_keys=["enriched_lead", "score", "score_breakdown"],
+    output_keys=["lead_summary", "crm_update_ready"],
+    success_criteria=(
+        "Lead summary is formatted for SDR review. CRM update is prepared "
+        "with routing tag set to 'hot-lead'."
+    ),
+    system_prompt="""\
+You are processing a hot lead that needs immediate SDR attention.
+
+**STEP 1 — Create a lead summary card:**
+
+Format a clear, actionable summary for the SDR including:
+- Contact: Name, Email, Role
+- Company: Name, Industry, Size, Location
+- Score: Total and breakdown
+- Why it's hot: Key ICP matches
+- Suggested outreach angle
+
+**STEP 2 — Prepare CRM update:**
+
+Use hubspot_update_contact or hubspot_create_contact to tag this lead.
+Set properties:
+- hs_lead_status: "HOT"
+- lead_score: [the score]
+- lead_routing: "hot-lead"
+
+If the contact doesn't exist, create it first with hubspot_create_contact.
+
+**STEP 3 — Output the results:**
+
+- set_output("lead_summary", formatted summary text)
+- set_output("crm_update_ready", "true")
+
+Example lead summary:
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🔥 HOT LEAD ALERT
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Contact: Jane Smith (VP of Engineering)
+Email: jane.smith@techstartup.io
+Company: TechStartup Inc
+Industry: SaaS / B2B Software | Size: 50-100 | Location: San Francisco, CA
+
+Score: 95/100
+├─ Industry Fit: 25/25 ✓
+├─ Company Size: 25/25 ✓
+├─ Role Seniority: 25/25 ✓
+└─ Role Relevance: 20/25
+
+Why Hot: Perfect ICP fit — growing SaaS company with technical decision-maker.
+Suggested Angle: Focus on engineering productivity and team scaling challenges.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+""",
+    tools=[
+        "hubspot_search_contacts",
+        "hubspot_create_contact",
+        "hubspot_update_contact",
+        "hubspot_create_company",
+        "hubspot_update_company",
+    ],
+)
+
+review_node = NodeSpec(
+    id="review",
+    name="Human Review",
+    description="Present borderline leads for human review before routing decision",
+    node_type="event_loop",
+    client_facing=True,
+    max_node_visits=0,
+    input_keys=["enriched_lead", "score", "score_breakdown"],
+    output_keys=["human_decision", "override_route"],
+    nullable_output_keys=["override_route"],
+    success_criteria=(
+        "User has reviewed the lead and made a routing decision: "
+        "approve as hot, send to nurture, or provide custom direction."
+    ),
+    system_prompt="""\
+You are presenting a borderline lead for human review.
+
+**STEP 1 — Present the lead (text only, NO tool calls):**
+
+Show the user:
+- Lead details (contact, company, enrichment)
+- Score and breakdown
+- Why it's borderline (what pushed it into review vs hot)
+- Ask for their decision: Route to Hot, Nurture, or provide specific guidance
+
+Example presentation:
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+📋 LEAD REVIEW REQUIRED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Contact: Alex Johnson (Director of IT)
+Email: alex.johnson@midsize-corp.com
+Company: MidSize Corp
+Industry: Manufacturing | Size: 500-1000 | Location: Chicago, IL
+
+Score: 55/100 (Borderline)
+├─ Industry Fit: 10/25 (not typical SaaS)
+├─ Company Size: 15/25 (larger than sweet spot)
+├─ Role Seniority: 20/25 (Director level)
+└─ Role Relevance: 10/25 (IT, not engineering)
+
+Why Review: Manufacturing is outside core ICP, but company size and
+seniority suggest budget authority. Could be a strategic expansion opportunity.
+
+What would you like to do?
+1. Route to Hot (prioritize for SDR)
+2. Route to Nurture (add to email sequence)
+3. Provide custom guidance
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+**STEP 2 — After the user responds, call set_output:**
+
+- set_output("human_decision", "approved_hot" or "approved_nurture" or "custom")
+- set_output("override_route", "hot" or "nurture" or null if staying with original)
+
+If the user wants to route to hot, set override_route to "hot".
+If the user wants to route to nurture, set override_route to "nurture".
+If the user provides custom guidance, set human_decision to "custom" and explain.
+""",
+    tools=[],
+)
+
+nurture_node = NodeSpec(
+    id="nurture",
+    name="Nurture Sequence",
+    description="Tag lead for automated nurture sequence and prepare CRM update",
+    node_type="event_loop",
+    max_node_visits=0,
+    input_keys=["enriched_lead", "score", "score_breakdown"],
+    output_keys=["nurture_status", "crm_update_ready"],
+    success_criteria=(
+        "Lead is tagged for nurture sequence. CRM update is prepared "
+        "with routing tag set to 'nurture'."
+    ),
+    system_prompt="""\
+You are processing a lead for the nurture sequence.
+
+**STEP 1 — Prepare CRM update:**
+
+Use hubspot_update_contact or hubspot_create_contact to tag this lead.
+Set properties:
+- hs_lead_status: "NURTURE"
+- lead_score: [the score]
+- lead_routing: "nurture"
+
+If the contact doesn't exist, create it first with hubspot_create_contact.
+
+**STEP 2 — Output the results:**
+
+- set_output("nurture_status", "added to nurture sequence")
+- set_output("crm_update_ready", "true")
+
+This is a straightforward processing node — the lead will receive automated
+email sequences to build awareness over time.
+""",
+    tools=[
+        "hubspot_search_contacts",
+        "hubspot_create_contact",
+        "hubspot_update_contact",
+        "hubspot_create_company",
+        "hubspot_update_company",
+    ],
+)
+
+output_node = NodeSpec(
+    id="output",
+    name="Final Output",
+    description="Log final routing decision and complete enrichment data",
+    node_type="event_loop",
+    client_facing=True,
+    max_node_visits=0,
+    input_keys=[
+        "enriched_lead",
+        "score",
+        "score_breakdown",
+        "route",
+        "lead_summary",
+        "nurture_status",
+        "human_decision",
+        "crm_update_ready",
+    ],
+    output_keys=["final_status", "qualification_complete"],
+    nullable_output_keys=["lead_summary", "nurture_status", "human_decision"],
+    success_criteria=(
+        "Final status summarizes the qualification result with routing decision. "
+        "Qualification is marked complete."
+    ),
+    system_prompt="""\
+You are the final output node. Summarize the qualification result for the user.
+
+**STEP 1 — Present the final result (text only, NO tool calls):**
+
+Summarize:
+- Lead: Contact name, company
+- Score: Total with brief breakdown
+- Route: Where it went (hot/review/nurture)
+- Status: CRM update status
+
+Then ask if the user wants to qualify another lead.
+
+**STEP 2 — After the user responds or confirms, call set_output:**
+
+- set_output("final_status", summary of the qualification result)
+- set_output("qualification_complete", "true")
+
+Example output:
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✅ LEAD QUALIFICATION COMPLETE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Lead: Jane Smith @ TechStartup Inc
+Score: 95/100
+Route: 🔥 HOT LEAD — Queued for SDR follow-up
+CRM: Updated with hot-lead tag
+
+The lead has been enriched, scored, and routed. An SDR will receive
+notification for immediate outreach.
+
+Would you like to qualify another lead?
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+""",
+    tools=[],
+)
+
+__all__ = [
+    "intake_node",
+    "enrichment_node",
+    "scoring_node",
+    "routing_decision_node",
+    "hot_lead_node",
+    "review_node",
+    "nurture_node",
+    "output_node",
+]


### PR DESCRIPTION
## Description

Add a new Lead Qualification Agent that automatically scores, enriches, and routes inbound leads based on Ideal Customer Profile (ICP) criteria — eliminating manual triage and ensuring hot leads never slip through the cracks.

This agent implements the complete lead qualification workflow:
1. **Intake** — Receives lead data (name, email, company, role)
2. **Enrichment** — Looks up company details via web search (industry, size, funding, location)
3. **Scoring** — Scores lead 0-100 based on configurable ICP criteria
4. **Routing** — Routes to appropriate pipeline based on score
5. **Output** — Logs final decision and updates CRM

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Fixes #5700

## Changes Made

- Added `exports/lead_qualification_agent/` package with:
  - `agent.py` - Goal, nodes, edges, and agent class definition
  - `nodes/__init__.py` - 8 node specifications (intake, enrichment, scoring, routing_decision, hot_lead, review, nurture, output)
  - `config.py` - Runtime configuration and metadata
  - `__main__.py` - CLI interface with run, validate, info, shell, tui commands
  - `__init__.py` - Package exports
  - `mcp_servers.json` - MCP server configuration
  - `README.md` - Documentation with workflow diagram and usage instructions
- Updated `.gitignore` to include the new agent

## Testing

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check ../exports/lead_qualification_agent/`)
- [x] Agent validates (`PYTHONPATH=exports uv run python -m lead_qualification_agent validate`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation

## Agent Workflow

```
intake → enrichment → scoring → routing_decision
                                ├─> hot_lead → output
                                ├─> review → hot_lead/nurture → output
                                └─> nurture → output
```

## ICP Scoring Framework

| Category | Max Points |
|----------|------------|
| Industry Fit | 25 |
| Company Size | 25 |
| Role Seniority | 25 |
| Role Relevance | 25 |

**Routing Thresholds:**
- Score >= 70: Hot Lead
- Score 40-69: Human Review
- Score < 40: Nurture
