### PR TITLE
fix(core): prevent silent data egress in output cleaning

### DIFF
--- a/core/framework/graph/edge.py
+++ b/core/framework/graph/edge.py
@@ -97,7 +97,9 @@ class EdgeSpec(BaseModel):
     )
 
     # Priority for multiple outgoing edges
-    priority: int = Field(default=0, description="Higher priority edges are evaluated first")
+    priority: int = Field(
+        default=0, description="Higher priority edges are evaluated first"
+    )
 
     # Metadata
     description: str = ""
@@ -198,7 +200,9 @@ class EdgeSpec(BaseModel):
             )
             return result
         except Exception as e:
-            logger.warning(f"      ⚠ Condition evaluation failed: {self.condition_expr}")
+            logger.warning(
+                f"      ⚠ Condition evaluation failed: {self.condition_expr}"
+            )
             logger.warning(f"         Error: {e}")
             logger.warning(f"         Available context keys: {list(context.keys())}")
             return False
@@ -261,7 +265,9 @@ Respond with ONLY a JSON object:
                 reasoning = data.get("reasoning", "")
 
                 # Log the decision (using basic print for now)
-                logger.info(f"      🤔 LLM routing decision: {'PROCEED' if proceed else 'SKIP'}")
+                logger.info(
+                    f"      🤔 LLM routing decision: {'PROCEED' if proceed else 'SKIP'}"
+                )
                 logger.info(f"         Reason: {reasoning}")
 
                 return proceed
@@ -332,9 +338,12 @@ class AsyncEntryPointSpec(BaseModel):
         description="Trigger-specific configuration (e.g., webhook URL, timer interval)",
     )
     isolation_level: str = Field(
-        default="shared", description="State isolation: isolated, shared, or synchronized"
+        default="shared",
+        description="State isolation: isolated, shared, or synchronized",
     )
-    priority: int = Field(default=0, description="Execution priority (higher = more priority)")
+    priority: int = Field(
+        default=0, description="Execution priority (higher = more priority)"
+    )
     max_concurrent: int = Field(
         default=10, description="Maximum concurrent executions for this entry point"
     )
@@ -412,14 +421,17 @@ class GraphSpec(BaseModel):
         default_factory=list, description="IDs of nodes that end execution"
     )
     pause_nodes: list[str] = Field(
-        default_factory=list, description="IDs of nodes that pause execution for HITL input"
+        default_factory=list,
+        description="IDs of nodes that pause execution for HITL input",
     )
 
     # Components
     nodes: list[Any] = Field(  # NodeSpec, but avoiding circular import
         default_factory=list, description="All node specifications"
     )
-    edges: list[EdgeSpec] = Field(default_factory=list, description="All edge specifications")
+    edges: list[EdgeSpec] = Field(
+        default_factory=list, description="All edge specifications"
+    )
 
     # Shared memory keys
     memory_keys: list[str] = Field(
@@ -430,12 +442,15 @@ class GraphSpec(BaseModel):
     default_model: str = "claude-haiku-4-5-20251001"
     max_tokens: int = Field(default=None)  # resolved by _resolve_max_tokens validator
 
-    # Cleanup LLM for JSON extraction fallback (fast/cheap model preferred)
-    # If not set, uses CEREBRAS_API_KEY -> cerebras/llama-3.3-70b
+    # Cleanup LLM for JSON extraction fallback (fast/cheap model preferred).
+    # If set, uses this model for output repair when standard parsing fails.
+    # If not set, only heuristic local repair is attempted.
     cleanup_llm_model: str | None = None
 
     # Execution limits
-    max_steps: int = Field(default=100, description="Maximum node executions before timeout")
+    max_steps: int = Field(
+        default=100, description="Maximum node executions before timeout"
+    )
     max_retries_per_node: int = 3
 
     # EventLoopNode configuration (from configure_loop)
@@ -520,7 +535,9 @@ class GraphSpec(BaseModel):
         for node in self.nodes:
             outgoing = self.get_outgoing_edges(node.id)
             # Fan-out: multiple edges with ON_SUCCESS condition
-            success_edges = [e for e in outgoing if e.condition == EdgeCondition.ON_SUCCESS]
+            success_edges = [
+                e for e in outgoing if e.condition == EdgeCondition.ON_SUCCESS
+            ]
             if len(success_edges) > 1:
                 fan_outs[node.id] = [e.target for e in success_edges]
         return fan_outs
@@ -621,9 +638,13 @@ class GraphSpec(BaseModel):
         # Check edge references
         for edge in self.edges:
             if not self.get_node(edge.source):
-                errors.append(f"Edge '{edge.id}' references missing source '{edge.source}'")
+                errors.append(
+                    f"Edge '{edge.id}' references missing source '{edge.source}'"
+                )
             if not self.get_node(edge.target):
-                errors.append(f"Edge '{edge.id}' references missing target '{edge.target}'")
+                errors.append(
+                    f"Edge '{edge.id}' references missing target '{edge.target}'"
+                )
 
         # Check for unreachable nodes
         # Start with main entry node and all entry points (for pause/resume architecture)
@@ -675,7 +696,8 @@ class GraphSpec(BaseModel):
             client_facing_targets = [
                 t
                 for t in targets
-                if self.get_node(t) and getattr(self.get_node(t), "client_facing", False)
+                if self.get_node(t)
+                and getattr(self.get_node(t), "client_facing", False)
             ]
             if len(client_facing_targets) > 1:
                 errors.append(
@@ -688,7 +710,8 @@ class GraphSpec(BaseModel):
             event_loop_targets = [
                 t
                 for t in targets
-                if self.get_node(t) and getattr(self.get_node(t), "node_type", "") == "event_loop"
+                if self.get_node(t)
+                and getattr(self.get_node(t), "node_type", "") == "event_loop"
             ]
             if len(event_loop_targets) > 1:
                 seen_keys: dict[str, str] = {}

--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -52,12 +52,18 @@ class ExecutionResult:
     # Execution quality metrics
     total_retries: int = 0  # Total number of retries across all nodes
     nodes_with_failures: list[str] = field(default_factory=list)  # Failed but recovered
-    retry_details: dict[str, int] = field(default_factory=dict)  # {node_id: retry_count}
-    had_partial_failures: bool = False  # True if any node failed but eventually succeeded
+    retry_details: dict[str, int] = field(
+        default_factory=dict
+    )  # {node_id: retry_count}
+    had_partial_failures: bool = (
+        False  # True if any node failed but eventually succeeded
+    )
     execution_quality: str = "clean"  # "clean", "degraded", or "failed"
 
     # Visit tracking (for feedback/callback edges)
-    node_visit_counts: dict[str, int] = field(default_factory=dict)  # {node_id: visit_count}
+    node_visit_counts: dict[str, int] = field(
+        default_factory=dict
+    )  # {node_id: visit_count}
 
     @property
     def is_clean_success(self) -> bool:
@@ -282,7 +288,9 @@ class GraphExecutor:
             if node.tools:
                 missing = set(node.tools) - available_tool_names
                 if missing:
-                    available = sorted(available_tool_names) if available_tool_names else "none"
+                    available = (
+                        sorted(available_tool_names) if available_tool_names else "none"
+                    )
                     errors.append(
                         f"Node '{node.name}' (id={node.id}) requires tools "
                         f"{sorted(missing)} but they are not registered. "
@@ -433,6 +441,22 @@ class GraphExecutor:
         # Add agent_id to trace context for correlation
         set_trace_context(agent_id=graph.id)
 
+        # Update output cleaner with graph-specific repair model if configured.
+        # This prevents silent egress by requiring explicit configuration in GraphSpec.
+        if graph.cleanup_llm_model and not self.output_cleaner.llm:
+            try:
+                from framework.llm.litellm import LiteLLMProvider
+
+                self.output_cleaner.llm = LiteLLMProvider(
+                    model=graph.cleanup_llm_model,
+                )
+                self.output_cleaner.config.fast_model = graph.cleanup_llm_model
+                self.logger.info(
+                    f"✓ Configured output cleaning with {graph.cleanup_llm_model}"
+                )
+            except Exception as e:
+                self.logger.warning(f"⚠ Failed to configure output cleaning LLM: {e}")
+
         # Validate graph
         errors = graph.validate()
         if errors:
@@ -490,7 +514,9 @@ class GraphExecutor:
                 # positives on the code-indicator heuristic.
                 for key, value in memory_data.items():
                     memory.write(key, value, validate=False)
-                self.logger.info(f"📥 Restored session state with {len(memory_data)} memory keys")
+                self.logger.info(
+                    f"📥 Restored session state with {len(memory_data)} memory keys"
+                )
 
         # Write new input data to memory (each key individually).
         # Skip when resuming from a paused session — restored memory already
@@ -502,7 +528,9 @@ class GraphExecutor:
                 memory.write(key, value)
 
         # Detect event-triggered execution (timer/webhook) — no interactive user.
-        _event_triggered = bool(input_data and isinstance(input_data.get("event"), dict))
+        _event_triggered = bool(
+            input_data and isinstance(input_data.get("event"), dict)
+        )
 
         path: list[str] = []
         total_tokens = 0
@@ -534,7 +562,11 @@ class GraphExecutor:
 
         # Determine entry point (may differ if resuming)
         # Check if resuming from checkpoint
-        if session_state and session_state.get("resume_from_checkpoint") and checkpoint_store:
+        if (
+            session_state
+            and session_state.get("resume_from_checkpoint")
+            and checkpoint_store
+        ):
             checkpoint_id = session_state["resume_from_checkpoint"]
             try:
                 checkpoint = await checkpoint_store.load_checkpoint(checkpoint_id)
@@ -551,7 +583,9 @@ class GraphExecutor:
 
                     # Start from checkpoint's next node or current node
                     current_node_id = (
-                        checkpoint.next_node or checkpoint.current_node or graph.entry_node
+                        checkpoint.next_node
+                        or checkpoint.current_node
+                        or graph.entry_node
                     )
 
                     # Restore execution path
@@ -566,7 +600,9 @@ class GraphExecutor:
                         f"Checkpoint {checkpoint_id} not found, resuming from normal entry point"
                     )
                     # Check if resuming from paused_at (fallback to session state)
-                    paused_at = session_state.get("paused_at") if session_state else None
+                    paused_at = (
+                        session_state.get("paused_at") if session_state else None
+                    )
                     if paused_at and graph.get_node(paused_at) is not None:
                         current_node_id = paused_at
                         self.logger.info(f"🔄 Resuming from paused node: {paused_at}")
@@ -755,7 +791,9 @@ class GraphExecutor:
                             is_clean=True,
                         )
                         await checkpoint_store.save_checkpoint(pause_checkpoint)
-                        pause_session_state["latest_checkpoint_id"] = pause_checkpoint.checkpoint_id
+                        pause_session_state["latest_checkpoint_id"] = (
+                            pause_checkpoint.checkpoint_id
+                        )
                         pause_session_state["resume_from_checkpoint"] = (
                             pause_checkpoint.checkpoint_id
                         )
@@ -813,7 +851,9 @@ class GraphExecutor:
                 # from visit 1 triggers even when visit 2 sets "final_summary" instead).
                 # Clearing them ensures only the CURRENT visit's outputs affect routing.
                 if node_visit_counts.get(current_node_id, 0) > 1:
-                    nullable_keys = getattr(node_spec, "nullable_output_keys", None) or []
+                    nullable_keys = (
+                        getattr(node_spec, "nullable_output_keys", None) or []
+                    )
                     for key in nullable_keys:
                         if memory.read(key) is not None:
                             memory.write(key, None, validate=False)
@@ -830,14 +870,19 @@ class GraphExecutor:
                 # Expose current node for external injection routing
                 self.current_node_id = current_node_id
 
-                self.logger.info(f"\n▶ Step {steps}: {node_spec.name} ({node_spec.node_type})")
+                self.logger.info(
+                    f"\n▶ Step {steps}: {node_spec.name} ({node_spec.node_type})"
+                )
                 self.logger.info(f"   Inputs: {node_spec.input_keys}")
                 self.logger.info(f"   Outputs: {node_spec.output_keys}")
 
                 # Continuous mode: accumulate tools and output keys from this node
                 if is_continuous and node_spec.tools:
                     for t in self.tools:
-                        if t.name in node_spec.tools and t.name not in cumulative_tool_names:
+                        if (
+                            t.name in node_spec.tools
+                            and t.name not in cumulative_tool_names
+                        ):
                             cumulative_tools.append(t)
                             cumulative_tool_names.add(t.name)
                 if is_continuous and node_spec.output_keys:
@@ -861,9 +906,13 @@ class GraphExecutor:
                     input_data=input_data or {},
                     max_tokens=graph.max_tokens,
                     continuous_mode=is_continuous,
-                    inherited_conversation=continuous_conversation if is_continuous else None,
+                    inherited_conversation=(
+                        continuous_conversation if is_continuous else None
+                    ),
                     override_tools=cumulative_tools if is_continuous else None,
-                    cumulative_output_keys=cumulative_output_keys if is_continuous else None,
+                    cumulative_output_keys=(
+                        cumulative_output_keys if is_continuous else None
+                    ),
                     event_triggered=_event_triggered,
                     node_registry=node_registry,
                     identity_prompt=getattr(graph, "identity_prompt", ""),
@@ -884,7 +933,9 @@ class GraphExecutor:
                             self.logger.info(f"      {key}: {value_str}")
 
                 # Get or create node implementation
-                node_impl = self._get_node_implementation(node_spec, graph.cleanup_llm_model)
+                node_impl = self._get_node_implementation(
+                    node_spec, graph.cleanup_llm_model
+                )
 
                 # Validate inputs
                 validation_errors = node_impl.validate_input(ctx)
@@ -911,7 +962,9 @@ class GraphExecutor:
 
                     if checkpoint_config.async_checkpoint:
                         # Non-blocking checkpoint save
-                        asyncio.create_task(checkpoint_store.save_checkpoint(checkpoint))
+                        asyncio.create_task(
+                            checkpoint_store.save_checkpoint(checkpoint)
+                        )
                     else:
                         # Blocking checkpoint save
                         await checkpoint_store.save_checkpoint(checkpoint)
@@ -967,7 +1020,9 @@ class GraphExecutor:
                             nullable_keys=node_spec.nullable_output_keys,
                         )
                         if not validation.success:
-                            self.logger.error(f"   ✗ Output validation failed: {validation.error}")
+                            self.logger.error(
+                                f"   ✗ Output validation failed: {validation.error}"
+                            )
                             result = NodeResult(
                                 success=False,
                                 error=f"Output validation failed: {validation.error}",
@@ -1038,7 +1093,9 @@ class GraphExecutor:
                         retry_count = node_retry_counts[current_node_id]
                         # Backoff formula: 1.0 * (2^(retry - 1)) -> 1s, 2s, 4s...
                         delay = 1.0 * (2 ** (retry_count - 1))
-                        self.logger.info(f"   Using backoff: Sleeping {delay}s before retry...")
+                        self.logger.info(
+                            f"   Using backoff: Sleeping {delay}s before retry..."
+                        )
                         await asyncio.sleep(delay)
                         # --------------------------------------
 
@@ -1077,7 +1134,9 @@ class GraphExecutor:
 
                         if next_node:
                             # Found a failure handler - route to it
-                            self.logger.info(f"   → Routing to failure handler: {next_node}")
+                            self.logger.info(
+                                f"   → Routing to failure handler: {next_node}"
+                            )
                             current_node_id = next_node
                             continue  # Continue execution with handler
                         else:
@@ -1171,7 +1230,9 @@ class GraphExecutor:
 
                     # Calculate quality metrics
                     total_retries_count = sum(node_retry_counts.values())
-                    nodes_failed = [nid for nid, count in node_retry_counts.items() if count > 0]
+                    nodes_failed = [
+                        nid for nid, count in node_retry_counts.items() if count > 0
+                    ]
                     exec_quality = "degraded" if total_retries_count > 0 else "clean"
 
                     if self.runtime_logger:
@@ -1220,7 +1281,9 @@ class GraphExecutor:
                         )
 
                     current_node_id = result.next_node
-                    self._write_progress(current_node_id, path, memory, node_visit_counts)
+                    self._write_progress(
+                        current_node_id, path, memory, node_visit_counts
+                    )
                 else:
                     # Get all traversable edges for fan-out detection
                     traversable_edges = await self._get_all_traversable_edges(
@@ -1249,9 +1312,11 @@ class GraphExecutor:
                                     stream_id=self._stream_id,
                                     source_node=current_node_id,
                                     target_node=edge.target,
-                                    edge_condition=edge.condition.value
-                                    if hasattr(edge.condition, "value")
-                                    else str(edge.condition),
+                                    edge_condition=(
+                                        edge.condition.value
+                                        if hasattr(edge.condition, "value")
+                                        else str(edge.condition)
+                                    ),
                                     execution_id=self._execution_id,
                                 )
 
@@ -1276,12 +1341,18 @@ class GraphExecutor:
 
                         # Continue from fan-in node
                         if fan_in_node:
-                            self.logger.info(f"   ⑃ Fan-in: converging at {fan_in_node}")
+                            self.logger.info(
+                                f"   ⑃ Fan-in: converging at {fan_in_node}"
+                            )
                             current_node_id = fan_in_node
-                            self._write_progress(current_node_id, path, memory, node_visit_counts)
+                            self._write_progress(
+                                current_node_id, path, memory, node_visit_counts
+                            )
                         else:
                             # No convergence point - branches are terminal
-                            self.logger.info("   → Parallel branches completed (no convergence)")
+                            self.logger.info(
+                                "   → Parallel branches completed (no convergence)"
+                            )
                             break
                     else:
                         # Sequential: follow single edge (existing logic via _follow_edges)
@@ -1297,7 +1368,9 @@ class GraphExecutor:
                             self.logger.info("   → No more edges, ending execution")
                             break
                         next_spec = graph.get_node(next_node)
-                        self.logger.info(f"   → Next: {next_spec.name if next_spec else next_node}")
+                        self.logger.info(
+                            f"   → Next: {next_spec.name if next_spec else next_node}"
+                        )
 
                         # Emit edge traversed event for sequential edge
                         if self._event_bus:
@@ -1324,7 +1397,9 @@ class GraphExecutor:
                             )
 
                             if checkpoint_config.async_checkpoint:
-                                asyncio.create_task(checkpoint_store.save_checkpoint(checkpoint))
+                                asyncio.create_task(
+                                    checkpoint_store.save_checkpoint(checkpoint)
+                                )
                             else:
                                 await checkpoint_store.save_checkpoint(checkpoint)
 
@@ -1401,7 +1476,11 @@ class GraphExecutor:
                         continuous_conversation.update_system_prompt(new_system)
 
                         # Insert transition marker into conversation
-                        data_dir = str(self._storage_path / "data") if self._storage_path else None
+                        data_dir = (
+                            str(self._storage_path / "data")
+                            if self._storage_path
+                            else None
+                        )
                         marker = build_transition_marker(
                             previous_node=node_spec,
                             next_node=next_spec,
@@ -1430,7 +1509,9 @@ class GraphExecutor:
                                 _phase_ratio * 100,
                             )
                             _data_dir = (
-                                str(self._storage_path / "data") if self._storage_path else None
+                                str(self._storage_path / "data")
+                                if self._storage_path
+                                else None
                             )
                             # Step 1: Structural compaction (>=80%)
                             if _data_dir:
@@ -1505,7 +1586,9 @@ class GraphExecutor:
 
             # Calculate execution quality metrics
             total_retries_count = sum(node_retry_counts.values())
-            nodes_failed = [nid for nid, count in node_retry_counts.items() if count > 0]
+            nodes_failed = [
+                nid for nid, count in node_retry_counts.items() if count > 0
+            ]
             exec_quality = "degraded" if total_retries_count > 0 else "clean"
 
             # Update narrative to reflect execution quality
@@ -1566,7 +1649,9 @@ class GraphExecutor:
 
                     cursor_path = self._storage_path / "conversations" / "cursor.json"
                     if cursor_path.exists():
-                        cursor_data = _json.loads(cursor_path.read_text(encoding="utf-8"))
+                        cursor_data = _json.loads(
+                            cursor_path.read_text(encoding="utf-8")
+                        )
                         wip_outputs = cursor_data.get("outputs", {})
                         for key, value in wip_outputs.items():
                             if value is not None:
@@ -1593,7 +1678,9 @@ class GraphExecutor:
 
             # Calculate quality metrics
             total_retries_count = sum(node_retry_counts.values())
-            nodes_failed = [nid for nid, count in node_retry_counts.items() if count > 0]
+            nodes_failed = [
+                nid for nid, count in node_retry_counts.items() if count > 0
+            ]
             exec_quality = "degraded" if total_retries_count > 0 else "clean"
 
             if self.runtime_logger:
@@ -1667,7 +1754,9 @@ class GraphExecutor:
 
                     cursor_path = self._storage_path / "conversations" / "cursor.json"
                     if cursor_path.exists():
-                        cursor_data = _json.loads(cursor_path.read_text(encoding="utf-8"))
+                        cursor_data = _json.loads(
+                            cursor_path.read_text(encoding="utf-8")
+                        )
                         for key, value in cursor_data.get("outputs", {}).items():
                             if value is not None:
                                 memory.write(key, value, validate=False)
@@ -1706,7 +1795,9 @@ class GraphExecutor:
                                     f"💾 Marked checkpoint for resume: {latest_clean.checkpoint_id}"
                                 )
                 except Exception as checkpoint_err:
-                    self.logger.warning(f"Failed to mark checkpoint for resume: {checkpoint_err}")
+                    self.logger.warning(
+                        f"Failed to mark checkpoint for resume: {checkpoint_err}"
+                    )
 
             return ExecutionResult(
                 success=False,
@@ -1909,8 +2000,12 @@ class GraphExecutor:
                 memory=memory.read_all(),
                 llm=self.llm,
                 goal=goal,
-                source_node_name=current_node_spec.name if current_node_spec else current_node_id,
-                target_node_name=target_node_spec.name if target_node_spec else edge.target,
+                source_node_name=(
+                    current_node_spec.name if current_node_spec else current_node_id
+                ),
+                target_node_name=(
+                    target_node_spec.name if target_node_spec else edge.target
+                ),
             ):
                 # Validate and clean output before mapping inputs.
                 # Use full memory state (not just result.output) because
@@ -1926,7 +2021,9 @@ class GraphExecutor:
                     )
 
                     if not validation.valid:
-                        self.logger.warning(f"⚠ Output validation failed: {validation.errors}")
+                        self.logger.warning(
+                            f"⚠ Output validation failed: {validation.errors}"
+                        )
 
                         # Clean the output
                         cleaned_output = await self.output_cleaner.clean_output(
@@ -1951,7 +2048,9 @@ class GraphExecutor:
                         )
 
                         if revalidation.valid:
-                            self.logger.info("✓ Output cleaned and validated successfully")
+                            self.logger.info(
+                                "✓ Output cleaned and validated successfully"
+                            )
                         else:
                             self.logger.error(
                                 f"✗ Cleaning failed, errors remain: {revalidation.errors}"
@@ -1993,8 +2092,12 @@ class GraphExecutor:
                 memory=memory.read_all(),
                 llm=self.llm,
                 goal=goal,
-                source_node_name=current_node_spec.name if current_node_spec else current_node_id,
-                target_node_name=target_node_spec.name if target_node_spec else edge.target,
+                source_node_name=(
+                    current_node_spec.name if current_node_spec else current_node_id
+                ),
+                target_node_name=(
+                    target_node_spec.name if target_node_spec else edge.target
+                ),
             ):
                 traversable.append(edge)
 
@@ -2004,13 +2107,16 @@ class GraphExecutor:
         # forward vs. feedback) from incorrectly triggering fan-out.
         # ON_SUCCESS / other edge types are unaffected.
         if len(traversable) > 1:
-            conditionals = [e for e in traversable if e.condition == EdgeCondition.CONDITIONAL]
+            conditionals = [
+                e for e in traversable if e.condition == EdgeCondition.CONDITIONAL
+            ]
             if len(conditionals) > 1:
                 max_prio = max(e.priority for e in conditionals)
                 traversable = [
                     e
                     for e in traversable
-                    if e.condition != EdgeCondition.CONDITIONAL or e.priority == max_prio
+                    if e.condition != EdgeCondition.CONDITIONAL
+                    or e.priority == max_prio
                 ]
 
         return traversable
@@ -2086,10 +2192,14 @@ class GraphExecutor:
                 edge=edge,
             )
 
-        self.logger.info(f"   ⑂ Fan-out: executing {len(branches)} branches in parallel")
+        self.logger.info(
+            f"   ⑂ Fan-out: executing {len(branches)} branches in parallel"
+        )
         for branch in branches.values():
             target_spec = graph.get_node(branch.node_id)
-            self.logger.info(f"      • {target_spec.name if target_spec else branch.node_id}")
+            self.logger.info(
+                f"      • {target_spec.name if target_spec else branch.node_id}"
+            )
 
         async def execute_single_branch(
             branch: ParallelBranch,
@@ -2102,7 +2212,9 @@ class GraphExecutor:
                 return branch, RuntimeError(branch.error)
 
             # Get node implementation to check its type
-            branch_impl = self._get_node_implementation(node_spec, graph.cleanup_llm_model)
+            branch_impl = self._get_node_implementation(
+                node_spec, graph.cleanup_llm_model
+            )
 
             effective_max_retries = node_spec.max_retries
             # Only override for actual EventLoopNode instances, not custom NodeProtocol impls
@@ -2126,7 +2238,9 @@ class GraphExecutor:
                     mem_snapshot = memory.read_all()
                     validation = self.output_cleaner.validate_output(
                         output=mem_snapshot,
-                        source_node_id=source_node_spec.id if source_node_spec else "unknown",
+                        source_node_id=(
+                            source_node_spec.id if source_node_spec else "unknown"
+                        ),
                         target_node_spec=node_spec,
                     )
 
@@ -2137,7 +2251,9 @@ class GraphExecutor:
                         )
                         cleaned_output = await self.output_cleaner.clean_output(
                             output=mem_snapshot,
-                            source_node_id=source_node_spec.id if source_node_spec else "unknown",
+                            source_node_id=(
+                                source_node_spec.id if source_node_spec else "unknown"
+                            ),
                             target_node_spec=node_spec,
                             validation_errors=validation.errors,
                         )
@@ -2165,7 +2281,9 @@ class GraphExecutor:
                         node_registry=node_registry,
                         graph=graph,
                     )
-                    node_impl = self._get_node_implementation(node_spec, graph.cleanup_llm_model)
+                    node_impl = self._get_node_implementation(
+                        node_spec, graph.cleanup_llm_model
+                    )
 
                     # Emit node-started event (skip event_loop nodes)
                     if self._event_bus and node_spec.node_type != "event_loop":
@@ -2277,7 +2395,9 @@ class GraphExecutor:
         if failed_branches:
             failed_names = [graph.get_node(b.node_id).name for b in failed_branches]
             if self._parallel_config.on_branch_failure == "fail_all":
-                raise RuntimeError(f"Parallel execution failed: branches {failed_names} failed")
+                raise RuntimeError(
+                    f"Parallel execution failed: branches {failed_names} failed"
+                )
             elif self._parallel_config.on_branch_failure == "continue_others":
                 self.logger.warning(
                     f"⚠ Some branches failed ({failed_names}), continuing with successful ones"

--- a/core/framework/graph/output_cleaner.py
+++ b/core/framework/graph/output_cleaner.py
@@ -65,7 +65,7 @@ class CleansingConfig:
     """Configuration for output cleansing."""
 
     enabled: bool = True
-    fast_model: str = "cerebras/llama-3.3-70b"  # Fast, cheap model for cleaning
+    fast_model: str | None = None  # No default model to prevent silent egress
     max_retries: int = 2
     cache_successful_patterns: bool = True
     fallback_to_raw: bool = True  # If cleaning fails, pass raw output
@@ -106,28 +106,29 @@ class OutputCleaner:
         # Initialize LLM provider for cleaning
         if llm_provider:
             self.llm = llm_provider
-        elif config.enabled:
-            # Create dedicated fast LLM provider for cleaning
+        elif config.enabled and config.fast_model:
+            # Create dedicated fast LLM provider for cleaning ONLY if model is explicit
             try:
-                import os
-
                 from framework.llm.litellm import LiteLLMProvider
 
-                api_key = os.environ.get("CEREBRAS_API_KEY")
-                if api_key:
-                    self.llm = LiteLLMProvider(
-                        api_key=api_key,
-                        model=config.fast_model,
-                    )
-                    logger.info(f"✓ Initialized OutputCleaner with {config.fast_model}")
-                else:
-                    logger.warning("⚠ CEREBRAS_API_KEY not found, output cleaning will be disabled")
-                    self.llm = None
-            except ImportError:
-                logger.warning("⚠ LiteLLMProvider not available, output cleaning disabled")
+                # Note: LiteLLMProvider will check for the appropriate API key
+                # based on the model name (e.g. CEREBRAS_API_KEY for cerebras/*)
+                self.llm = LiteLLMProvider(
+                    model=config.fast_model,
+                )
+                logger.info(f"✓ Initialized OutputCleaner with {config.fast_model}")
+            except Exception as e:
+                logger.warning(
+                    f"⚠ Failed to initialize LLM provider for cleansing: {e}"
+                )
                 self.llm = None
         else:
             self.llm = None
+
+        if config.enabled and not self.llm:
+            logger.info(
+                "ℹ LLM-based output cleaning is disabled (no repair model configured)"
+            )
 
     def validate_output(
         self,
@@ -181,7 +182,10 @@ class OutputCleaner:
                         )
 
             # Check 3: Type validation (if schema provided)
-            if hasattr(target_node_spec, "input_schema") and target_node_spec.input_schema:
+            if (
+                hasattr(target_node_spec, "input_schema")
+                and target_node_spec.input_schema
+            ):
                 expected_schema = target_node_spec.input_schema.get(key)
                 if expected_schema:
                     expected_type = expected_schema.get("type")
@@ -318,7 +322,9 @@ Return ONLY valid JSON matching the expected schema. No explanations, no markdow
                 if self.config.fallback_to_raw:
                     return output
                 else:
-                    raise ValueError(f"Cleaning produced {type(cleaned)}, expected dict")
+                    raise ValueError(
+                        f"Cleaning produced {type(cleaned)}, expected dict"
+                    )
 
         except json.JSONDecodeError as e:
             logger.error(f"✗ Failed to parse cleaned JSON: {e}")


### PR DESCRIPTION
Summary
Removes the silent auto-initialization of the OutputCleaner's LLM from global environment keys (CEREBRAS_API_KEY). 
LLM-based cleaning now requires explicit configuration in the GraphSpec (via cleanup_llm_model) or an explicit provider passed to the constructor.

Root cause
OutputCleaner was automatically creating a LiteLLMProvider using CEREBRAS_API_KEY from the environment if present, even if not explicitly configured by the agent author. This could lead to unauthorized data egress in private deployments.

Solution
1. Removed auto-initialization from environment in `OutputCleaner.__init__`.
2. Updated `GraphExecutor.execute` to configure the cleaner's LLM only if `graph.cleanup_llm_model` is explicitly set.
3. Updated `GraphSpec` documentation to reflect this change.

Validation
Passed reproduction tests verifying that LLM is no longer initialized from environment unless explicit.
Passed full core test suite.

Fixes #2854