### PR TITLE
docs: add Windows quickstart.ps1 to getting-started guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,9 +19,12 @@ git clone https://github.com/adenhq/hive.git
 cd hive
 
 # 2. Run automated setup
+# On macOS/Linux:
 ./quickstart.sh
+# On Windows (PowerShell):
+.\quickstart.ps1
 
-# 3. Verify installation (optional, quickstart.sh already verifies)
+# 3. Verify installation (optional, quickstart already verifies)
 uv run python -c "import framework; import aden_tools; print('✓ Setup complete')"
 ```
 


### PR DESCRIPTION
Summary
Added reference to Windows quickstart script `quickstart.ps1` in the Quick Start section of `getting-started.md`.

Root cause
The Windows `quickstart.ps1` script existed but wasn't mentioned in the guide, creating friction for Windows users.

Solution (minimal)
Updated `docs/getting-started.md` to explicitly list `.\quickstart.ps1` alongside the macOS/Linux command.

Validation (commands + results)
`make check` - Passed (lint/format green)

Risk / edge cases
None.

Fixes #5660
