### PR TITLE
fix(credentials): re-raise CredentialRefreshError on refresh failure

### DIFF
--- a/core/framework/credentials/store.py
+++ b/core/framework/credentials/store.py
@@ -530,7 +530,7 @@ class CredentialStore:
 
         except CredentialRefreshError as e:
             logger.error(f"Failed to refresh credential '{credential.id}': {e}")
-            return credential
+            raise
 
     def refresh_credential(self, credential_id: str) -> CredentialObject | None:
         """

--- a/core/framework/credentials/tests/test_credential_store.py
+++ b/core/framework/credentials/tests/test_credential_store.py
@@ -332,14 +332,16 @@ class TestCompositeStorage:
         primary = InMemoryStorage()
         primary.save(
             CredentialObject(
-                id="test", keys={"k": CredentialKey(name="k", value=SecretStr("primary"))}
+                id="test",
+                keys={"k": CredentialKey(name="k", value=SecretStr("primary"))},
             )
         )
 
         fallback = InMemoryStorage()
         fallback.save(
             CredentialObject(
-                id="test", keys={"k": CredentialKey(name="k", value=SecretStr("fallback"))}
+                id="test",
+                keys={"k": CredentialKey(name="k", value=SecretStr("fallback"))},
             )
         )
 
@@ -355,7 +357,8 @@ class TestCompositeStorage:
         fallback = InMemoryStorage()
         fallback.save(
             CredentialObject(
-                id="test", keys={"k": CredentialKey(name="k", value=SecretStr("fallback"))}
+                id="test",
+                keys={"k": CredentialKey(name="k", value=SecretStr("fallback"))},
             )
         )
 
@@ -634,6 +637,42 @@ class TestCredentialStore:
         # Should not find in cache now
         assert store.get_credential("test") is None
 
+    def test_refresh_credential_failure_raises(self):
+        """Test that refresh failure raises CredentialRefreshError instead of returning stale."""
+        from unittest.mock import MagicMock
+
+        from core.framework.credentials.provider import (
+            CredentialProvider,
+            CredentialRefreshError,
+        )
+
+        # 1. Setup expired credential
+        past = datetime.now(UTC) - timedelta(hours=1)
+        cred = CredentialObject(
+            id="test_cred",
+            credential_type=CredentialType.CUSTOM,
+            keys={
+                "token": CredentialKey(name="token", value=SecretStr("test-value"), expires_at=past)
+            },
+            auto_refresh=True,
+            provider_id="mock",
+        )
+
+        # 2. Setup mock provider that fails
+        mock_provider = MagicMock(spec=CredentialProvider)
+        mock_provider.provider_id = "mock"
+        mock_provider.refresh.side_effect = CredentialRefreshError("Refresh failed")
+        mock_provider.should_refresh.return_value = True
+        mock_provider.can_handle.return_value = True
+
+        # 3. Setup store
+        store = CredentialStore(storage=InMemoryStorage({"test_cred": cred}))
+        store.register_provider(mock_provider)
+
+        # 4. Verify it raises instead of returning stale
+        with pytest.raises(CredentialRefreshError, match="Refresh failed"):
+            store.get_credential("test_cred")
+
 
 class TestOAuth2Module:
     """Tests for OAuth2 module."""
@@ -687,7 +726,9 @@ class TestOAuth2Module:
 
         # Valid config
         config = OAuth2Config(
-            token_url="https://example.com/token", client_id="id", client_secret="secret"
+            token_url="https://example.com/token",
+            client_id="id",
+            client_secret="secret",
         )
         assert config.token_url == "https://example.com/token"
 


### PR DESCRIPTION
Summary
Modified `CredentialStore._refresh_credential` to re-raise `CredentialRefreshError` when a credential refresh operation fails, instead of silently returning the stale/expired credential.

Root cause
The previous implementation caught `CredentialRefreshError`, logged it, and returned the original (stale) credential. Callers (like `get_credential`) would then return this invalid credential to the user without indicating that the refresh had failed.

Solution (minimal)
Changed `return credential` to `raise` in the `except CredentialRefreshError` block of `_refresh_credential`.

Validation (commands + results)
1. Created a reproduction script that mocks a failing provider and verified `get_credential` returns stale instead of raising.
2. Verified the fix causes `get_credential` to correctly bubble up the exception.
3. Added a new test case `test_refresh_credential_failure_raises` to `core/framework/credentials/tests/test_credential_store.py`.
4. Ran `make check` and `make test` (5000+ tests passed).

Risk / edge cases
Callers of `get_credential` or `get_key` will now need to handle `CredentialRefreshError` if they want to recover from refresh failures. However, this is preferred over silently using expired credentials.

Fixes #5845
