### PR TITLE
docs: add Windows setup guide and troubleshooting (refs #3840, #5660)

### DIFF
--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -250,6 +250,62 @@ This step verifies that the agent meets its goals before production use.
 
 ## Troubleshooting
 
+### Windows-Specific Issues
+
+#### "uv: command not found"
+
+**Cause:** The `uv` package manager is not installed or not in your system PATH.
+
+**Solution:** Install it via PowerShell and verify:
+
+```powershell
+irm https://astral.sh/uv/install.ps1 | iex
+uv --version
+```
+
+#### PowerShell: "running scripts is disabled on this system"
+
+**Cause:** PowerShell's default execution policy restricts running scripts like `quickstart.ps1`.
+
+**Solution:** Run this command once per session to bypass the restriction:
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+```
+
+#### PYTHONPATH Path Separator Issues
+
+**Cause:** Windows uses a semicolon (`;`) to separate paths in environment variables, unlike macOS/Linux which uses a colon (`:`).
+
+**Solution:** When setting `PYTHONPATH` manually in PowerShell, use a semicolon:
+
+```powershell
+$env:PYTHONPATH="core;exports"
+```
+
+#### Line Ending Issues (.sh scripts in Git Bash)
+
+**Cause:** Git for Windows may checkout files with CRLF line endings, causing `\r: command not found` errors when running `.sh` scripts in WSL or Git Bash.
+
+**Solution:** Force the script to use Unix line endings (LF):
+
+```bash
+sed -i 's/\r$//' quickstart.sh
+./quickstart.sh
+```
+
+#### Virtual Environment Activation Failures
+
+**Cause:** The activation command differs between PowerShell and Unix shells.
+
+**Solution:** Ensure you use the correct path for Windows:
+
+```powershell
+.venv\Scripts\activate
+```
+
+---
+
 ### "externally-managed-environment" error (PEP 668)
 
 **Cause:** Python 3.12+ on macOS/Homebrew, WSL, or some Linux distros prevents system-wide pip installs.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,11 +19,16 @@ git clone https://github.com/adenhq/hive.git
 cd hive
 
 # 2. Run automated setup
+# On macOS/Linux:
 ./quickstart.sh
+# On Windows (PowerShell):
+.\quickstart.ps1
 
-# 3. Verify installation (optional, quickstart.sh already verifies)
+# 3. Verify installation (optional, quickstart already verifies)
 uv run python -c "import framework; import aden_tools; print('✓ Setup complete')"
 ```
+
+> **Windows Tip:** If you encounter errors like `uv: command not found` or PowerShell execution policy issues, see the [Windows Troubleshooting section in environment-setup.md](./environment-setup.md#windows-specific-issues).
 
 ## Building Your First Agent
 


### PR DESCRIPTION
Summary: Added a Windows-specific setup guide to getting-started.md and a detailed Troubleshooting section to environment-setup.md.\n\nRoot cause: Documentation was missing Windows-specific onboarding steps and common error solutions, causing friction.\n\nSolution: \n- Added `quickstart.ps1` to Quick Start.\n- Added a new 'Windows-Specific Issues' section to Troubleshooting covering uv, execution policy, PYTHONPATH separators, line endings, and venv activation.\n\nValidation: Verified locally and via fork PR gate.\n\nFixes #3840\nFixes #5660