### PR TITLE
feat(templates): add churn risk agent with HITL retention pipeline

### DIFF
--- a/examples/templates/churn_risk_agent/README.md
+++ b/examples/templates/churn_risk_agent/README.md
@@ -1,0 +1,117 @@
+```markdown
+# Churn Risk Agent
+
+Detects at-risk customers using engagement signals and triggers proactive
+retention actions — with human-in-the-loop approval before any outreach is sent.
+
+## What it does
+
+1. Takes in customer account data (login activity, support tickets, NPS, renewal date)
+2. Scores churn risk 0–100 across 5 criteria
+3. Routes to the right action based on risk level:
+   - **HIGH** → Immediate escalation alert to CSM
+   - **MEDIUM** → Drafts personalised re-engagement email, waits for CSM approval
+   - **LOW** → Silently logs, schedules re-check in 7 days
+4. Produces a full audit trail of every decision
+
+## Pipeline
+```
+
+signal_intake → risk_scoring → routing → escalation ↘
+→ outreach → output_log
+→ monitor ↗
+
+````
+
+## Quickstart
+
+### 1. Set your API key
+
+```bash
+export GROQ_API_KEY=your_key_here
+export LITELLM_MODEL=groq/llama-3.3-70b-versatile
+````
+
+### 2. Run interactively (TUI)
+
+```bash
+uv run python -m examples.templates.churn_risk_agent tui
+```
+
+### 3. Run from CLI
+
+```bash
+uv run python -m examples.templates.churn_risk_agent run \
+  --account "Customer: Acme Corp, Last login: 45 days ago, Usage: monthly, Tickets: 4, NPS: 5, Renewal: 20 days"
+```
+
+### 4. Validate agent structure
+
+```bash
+uv run python -m examples.templates.churn_risk_agent validate
+```
+
+### 5. Show agent info
+
+```bash
+uv run python -m examples.templates.churn_risk_agent info
+```
+
+## Input format
+
+Provide account data as a plain text string or JSON:
+
+```
+Customer: Acme Corp
+Last login: 45 days ago
+Feature usage: monthly
+Support tickets (last 30 days): 4
+NPS score: 5
+Contract renewal: 20 days
+```
+
+## Scoring criteria
+
+| Signal                               | Points |
+| ------------------------------------ | ------ |
+| Last login > 30 days ago             | +30    |
+| Last login 15–30 days ago            | +15    |
+| Feature usage monthly or never       | +20    |
+| Support tickets >= 3 in last 30 days | +20    |
+| NPS score <= 6                       | +20    |
+| Contract renewal < 30 days away      | +10    |
+
+**HIGH** >= 60 · **MEDIUM** 30–59 · **LOW** < 30
+
+## Nodes
+
+| Node          | Type                 | Description                          |
+| ------------- | -------------------- | ------------------------------------ |
+| signal_intake | client-facing        | Collects and confirms account data   |
+| risk_scoring  | internal             | Scores 0–100 with reasoning          |
+| routing       | internal             | Routes based on risk level           |
+| escalation    | client-facing        | HIGH risk alert to CSM               |
+| outreach      | client-facing (HITL) | MEDIUM risk email draft for approval |
+| monitor       | internal             | LOW risk silent log                  |
+| output        | client-facing        | Full audit trail                     |
+
+## Use as a library
+
+```python
+from examples.templates.churn_risk_agent import ChurnRiskAgent
+
+agent = ChurnRiskAgent()
+result = await agent.run({
+    "account_data": "Customer: Acme Corp, Last login: 45 days ago..."
+})
+print(result.output)
+```
+
+## Related issues
+
+- [#5701](https://github.com/aden-hive/hive/issues/5701) — Agent proposal
+- [#2805](https://github.com/aden-hive/hive/issues/2805) — Integrations hub
+
+```
+
+```

--- a/examples/templates/churn_risk_agent/__init__.py
+++ b/examples/templates/churn_risk_agent/__init__.py
@@ -1,0 +1,24 @@
+"""
+Churn Risk Agent — Detect at-risk customers and trigger proactive retention.
+
+Monitors customer engagement signals, scores churn risk (HIGH / MEDIUM / LOW),
+and routes to the correct action: escalation alert, outreach draft with human
+approval, or silent monitoring.
+"""
+
+from .agent import ChurnRiskAgent, default_agent, goal, nodes, edges
+from .config import RuntimeConfig, AgentMetadata, default_config, metadata
+
+__version__ = "1.0.0"
+
+__all__ = [
+    "ChurnRiskAgent",
+    "default_agent",
+    "goal",
+    "nodes",
+    "edges",
+    "RuntimeConfig",
+    "AgentMetadata",
+    "default_config",
+    "metadata",
+]

--- a/examples/templates/churn_risk_agent/__main__.py
+++ b/examples/templates/churn_risk_agent/__main__.py
@@ -1,0 +1,164 @@
+"""CLI entry point for Churn Risk Agent."""
+
+import asyncio
+import json
+import logging
+import sys
+
+import click
+
+from .agent import default_agent, ChurnRiskAgent
+
+
+def setup_logging(verbose=False, debug=False):
+    if debug:
+        level, fmt = logging.DEBUG, "%(asctime)s %(name)s: %(message)s"
+    elif verbose:
+        level, fmt = logging.INFO, "%(message)s"
+    else:
+        level, fmt = logging.WARNING, "%(levelname)s: %(message)s"
+    logging.basicConfig(level=level, format=fmt, stream=sys.stderr)
+
+
+@click.group()
+@click.version_option(version="1.0.0")
+def cli():
+    """Churn Risk Agent — detect at-risk customers and trigger retention actions."""
+    pass
+
+
+@cli.command()
+@click.option("--account", "-a", "account_data", help="Customer account data string")
+@click.option("--verbose", "-v", is_flag=True)
+@click.option("--debug", is_flag=True)
+def run(account_data, verbose, debug):
+    """Assess churn risk for a customer account."""
+    setup_logging(verbose=verbose, debug=debug)
+    result = asyncio.run(
+        default_agent.run({"account_data": account_data or ""})
+    )
+    click.echo(
+        json.dumps(
+            {"success": result.success, "output": result.output},
+            indent=2,
+            default=str,
+        )
+    )
+    sys.exit(0 if result.success else 1)
+
+
+@cli.command()
+def shell():
+    """Interactive shell session for churn risk assessment."""
+
+    async def run_shell():
+        agent = ChurnRiskAgent()
+        await agent.start()
+        try:
+            print("\n🔍 Churn Risk Agent — Interactive Shell")
+            print("=" * 50)
+            account = input("Enter customer account data: ").strip()
+            if not account:
+                print("No input provided. Exiting.")
+                return
+            print("\n⏳ Analysing churn risk...\n")
+            result = await agent.trigger_and_wait(
+                "default",
+                {"account_data": account},
+            )
+            if result and result.output:
+                print("\n✅ Result:")
+                print(json.dumps(result.output, indent=2, default=str))
+            else:
+                print("No output returned.")
+        finally:
+            await agent.stop()
+
+    asyncio.run(run_shell())
+
+
+@cli.command()
+def tui():
+    """Launch the TUI dashboard for interactive churn risk assessment."""
+    from pathlib import Path
+    from framework.tui.app import AdenTUI
+    from framework.llm import LiteLLMProvider
+    from framework.runner.tool_registry import ToolRegistry
+    from framework.runtime.agent_runtime import create_agent_runtime
+    from framework.runtime.execution_stream import EntryPointSpec
+    from framework.graph.checkpoint_config import CheckpointConfig
+
+    async def run_tui():
+        agent = ChurnRiskAgent()
+        agent._tool_registry = ToolRegistry()
+        storage = Path.home() / ".hive" / "agents" / "churn_risk_agent"
+        storage.mkdir(parents=True, exist_ok=True)
+        mcp_cfg = Path(__file__).parent / "mcp_servers.json"
+        if mcp_cfg.exists():
+            agent._tool_registry.load_mcp_config(mcp_cfg)
+        llm = LiteLLMProvider(
+            model=agent.config.model,
+            api_key=agent.config.api_key,
+            api_base=agent.config.api_base,
+        )
+        runtime = create_agent_runtime(
+            graph=agent._build_graph(),
+            goal=agent.goal,
+            storage_path=storage,
+            entry_points=[
+                EntryPointSpec(
+                    id="start",
+                    name="Start",
+                    entry_node="signal_intake",
+                    trigger_type="manual",
+                    isolation_level="isolated",
+                )
+            ],
+            llm=llm,
+            tools=list(agent._tool_registry.get_tools().values()),
+            tool_executor=agent._tool_registry.get_executor(),
+            checkpoint_config=CheckpointConfig(
+                enabled=True,
+                checkpoint_on_node_complete=True,
+                checkpoint_max_age_days=7,
+                async_checkpoint=True,
+            ),
+        )
+        await runtime.start()
+        try:
+            app = AdenTUI(runtime)
+            await app.run_async()
+        finally:
+            await runtime.stop()
+
+    asyncio.run(run_tui())
+
+
+@cli.command()
+def info():
+    """Show agent information."""
+    data = default_agent.info()
+    click.echo(f"Agent:         {data['name']}")
+    click.echo(f"Version:       {data['version']}")
+    click.echo(f"Description:   {data['description']}")
+    click.echo(f"Nodes:         {', '.join(data['nodes'])}")
+    click.echo(f"Client-facing: {', '.join(data['client_facing_nodes'])}")
+    click.echo(f"Entry node:    {data['entry_node']}")
+    click.echo(f"Terminal:      {', '.join(data['terminal_nodes'])}")
+
+
+@cli.command()
+def validate():
+    """Validate the agent structure."""
+    v = default_agent.validate()
+    if v["valid"]:
+        click.echo("✅ Agent structure is valid")
+    else:
+        click.echo("❌ Errors found:")
+        for e in v["errors"]:
+            click.echo(f"  - {e}")
+    sys.exit(0 if v["valid"] else 1)
+
+
+if __name__ == "__main__":
+    cli()

--- a/examples/templates/churn_risk_agent/agent.py
+++ b/examples/templates/churn_risk_agent/agent.py
@@ -1,0 +1,325 @@
+"""Agent graph construction for Churn Risk Agent."""
+
+from pathlib import Path
+
+from framework.graph import EdgeSpec, EdgeCondition, Goal, SuccessCriterion, Constraint
+from framework.graph.edge import GraphSpec
+from framework.graph.executor import ExecutionResult
+from framework.graph.checkpoint_config import CheckpointConfig
+from framework.llm import LiteLLMProvider
+from framework.runner.tool_registry import ToolRegistry
+from framework.runtime.agent_runtime import create_agent_runtime
+from framework.runtime.execution_stream import EntryPointSpec
+
+from .config import default_config, metadata
+from .nodes import (
+    signal_intake_node,
+    risk_scoring_node,
+    routing_node,
+    escalation_node,
+    outreach_node,
+    monitor_node,
+    output_node,
+)
+
+# Goal definition
+goal = Goal(
+    id="churn-risk-detection",
+    name="Churn Risk Detection and Retention",
+    description=(
+        "Monitor customer engagement signals, detect churn risk, "
+        "and trigger appropriate retention actions with human-in-the-loop approval."
+    ),
+    success_criteria=[
+        SuccessCriterion(
+            id="risk-scored",
+            description="Every account receives a risk score with criterion-by-criterion reasoning",
+            metric="risk_score_produced",
+            target="true",
+            weight=0.30,
+        ),
+        SuccessCriterion(
+            id="correct-routing",
+            description="Account is routed to the correct action based on risk level",
+            metric="routing_matches_risk_level",
+            target="true",
+            weight=0.25,
+        ),
+        SuccessCriterion(
+            id="hitl-gate",
+            description="No outreach is sent without human review and approval",
+            metric="human_approved_before_send",
+            target="true",
+            weight=0.25,
+        ),
+        SuccessCriterion(
+            id="audit-trail",
+            description="A complete audit log is produced for every run",
+            metric="audit_log_produced",
+            target="true",
+            weight=0.20,
+        ),
+    ],
+    constraints=[
+        Constraint(
+            id="no-send-without-approval",
+            description="Never send outreach without explicit human approval",
+            constraint_type="hard",
+            category="functional",
+        ),
+        Constraint(
+            id="reasoning-required",
+            description="Every risk score must include criterion-by-criterion reasoning",
+            constraint_type="hard",
+            category="accuracy",
+        ),
+        Constraint(
+            id="signal-based-only",
+            description="Risk assessment must be based only on provided account signals",
+            constraint_type="hard",
+            category="accuracy",
+        ),
+    ],
+)
+
+# Node list
+nodes = [
+    signal_intake_node,
+    risk_scoring_node,
+    routing_node,
+    escalation_node,
+    outreach_node,
+    monitor_node,
+    output_node,
+]
+
+# Edge definitions
+edges = [
+    EdgeSpec(
+        id="intake-to-scoring",
+        source="signal_intake",
+        target="risk_scoring",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="scoring-to-routing",
+        source="risk_scoring",
+        target="routing",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="routing-to-escalation",
+        source="routing",
+        target="escalation",
+        condition=EdgeCondition.CONDITIONAL,
+        condition_expr="routing_decision == 'escalate'",
+        priority=1,
+    ),
+    EdgeSpec(
+        id="routing-to-outreach",
+        source="routing",
+        target="outreach",
+        condition=EdgeCondition.CONDITIONAL,
+        condition_expr="routing_decision == 'outreach'",
+        priority=1,
+    ),
+    EdgeSpec(
+        id="routing-to-monitor",
+        source="routing",
+        target="monitor",
+        condition=EdgeCondition.CONDITIONAL,
+        condition_expr="routing_decision == 'monitor'",
+        priority=1,
+    ),
+    EdgeSpec(
+        id="escalation-to-output",
+        source="escalation",
+        target="output",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="outreach-to-output",
+        source="outreach",
+        target="output",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="monitor-to-output",
+        source="monitor",
+        target="output",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+]
+
+# Graph configuration
+entry_node = "signal_intake"
+entry_points = {"start": "signal_intake"}
+pause_nodes = []
+terminal_nodes = ["output"]
+
+# Module-level vars
+conversation_mode = "continuous"
+identity_prompt = (
+    "You are a churn risk detection agent that analyses customer engagement signals, "
+    "scores churn risk, and triggers retention actions with human approval."
+)
+loop_config = {
+    "max_iterations": 10,
+    "max_tool_calls_per_turn": 5,
+    "max_history_tokens": 16000,
+}
+
+
+
+class ChurnRiskAgent:
+    def __init__(self, config=None):
+        self.config = config or default_config
+        self.goal = goal
+        self.nodes = nodes
+        self.edges = edges
+        self.entry_node = entry_node
+        self.entry_points = entry_points
+        self.pause_nodes = pause_nodes
+        self.terminal_nodes = terminal_nodes
+        self._graph = None
+        self._agent_runtime = None
+        self._tool_registry = None
+        self._storage_path = None
+
+    def _build_graph(self):
+        return GraphSpec(
+            id="churn-risk-agent-graph",
+            goal_id=self.goal.id,
+            version="1.0.0",
+            entry_node=self.entry_node,
+            entry_points=self.entry_points,
+            terminal_nodes=self.terminal_nodes,
+            pause_nodes=self.pause_nodes,
+            nodes=self.nodes,
+            edges=self.edges,
+            default_model=self.config.model,
+            max_tokens=self.config.max_tokens,
+            loop_config=loop_config,
+            conversation_mode=conversation_mode,
+            identity_prompt=identity_prompt,
+        )
+
+    def _setup(self):
+        self._storage_path = Path.home() / ".hive" / "agents" / "churn_risk_agent"
+        self._storage_path.mkdir(parents=True, exist_ok=True)
+        self._tool_registry = ToolRegistry()
+        mcp_config = Path(__file__).parent / "mcp_servers.json"
+        if mcp_config.exists():
+            self._tool_registry.load_mcp_config(mcp_config)
+        llm = LiteLLMProvider(
+            model=self.config.model,
+            api_key=self.config.api_key,
+            api_base=self.config.api_base,
+        )
+        tools = list(self._tool_registry.get_tools().values())
+        tool_executor = self._tool_registry.get_executor()
+        self._graph = self._build_graph()
+        self._agent_runtime = create_agent_runtime(
+            graph=self._graph,
+            goal=self.goal,
+            storage_path=self._storage_path,
+            entry_points=[
+                EntryPointSpec(
+                    id="default",
+                    name="Default",
+                    entry_node=self.entry_node,
+                    trigger_type="manual",
+                    isolation_level="shared",
+                ),
+            ],
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor,
+            checkpoint_config=CheckpointConfig(
+                enabled=True,
+                checkpoint_on_node_complete=True,
+                checkpoint_max_age_days=7,
+                async_checkpoint=True,
+            ),
+        )
+
+    async def start(self):
+        if self._agent_runtime is None:
+            self._setup()
+        if not self._agent_runtime.is_running:
+            await self._agent_runtime.start()
+
+    async def stop(self):
+        if self._agent_runtime and self._agent_runtime.is_running:
+            await self._agent_runtime.stop()
+        self._agent_runtime = None
+
+    async def trigger_and_wait(
+        self,
+        entry_point="default",
+        input_data=None,
+        timeout=None,
+        session_state=None,
+    ):
+        if self._agent_runtime is None:
+            raise RuntimeError("Agent not started. Call start() first.")
+        return await self._agent_runtime.trigger_and_wait(
+            entry_point_id=entry_point,
+            input_data=input_data or {},
+            session_state=session_state,
+        )
+
+    async def run(self, context, session_state=None):
+        await self.start()
+        try:
+            result = await self.trigger_and_wait(
+                "default",
+                context,
+                session_state=session_state,
+            )
+            return result or ExecutionResult(success=False, error="Execution timeout")
+        finally:
+            await self.stop()
+
+    def info(self):
+        return {
+            "name": metadata.name,
+            "version": metadata.version,
+            "description": metadata.description,
+            "goal": {
+                "name": self.goal.name,
+                "description": self.goal.description,
+            },
+            "nodes": [n.id for n in self.nodes],
+            "edges": [e.id for e in self.edges],
+            "entry_node": self.entry_node,
+            "entry_points": self.entry_points,
+            "terminal_nodes": self.terminal_nodes,
+            "client_facing_nodes": [n.id for n in self.nodes if n.client_facing],
+        }
+
+    def validate(self):
+        errors, warnings = [], []
+        node_ids = {n.id for n in self.nodes}
+        for e in self.edges:
+            if e.source not in node_ids:
+                errors.append(f"Edge {e.id}: source '{e.source}' not found")
+            if e.target not in node_ids:
+                errors.append(f"Edge {e.id}: target '{e.target}' not found")
+        if self.entry_node not in node_ids:
+            errors.append(f"Entry node '{self.entry_node}' not found")
+        for t in self.terminal_nodes:
+            if t not in node_ids:
+                errors.append(f"Terminal node '{t}' not found")
+        for ep_id, nid in self.entry_points.items():
+            if nid not in node_ids:
+                errors.append(f"Entry point '{ep_id}' references unknown node '{nid}'")
+        return {"valid": len(errors) == 0, "errors": errors, "warnings": warnings}
+
+
+default_agent = ChurnRiskAgent()

--- a/examples/templates/churn_risk_agent/config.py
+++ b/examples/templates/churn_risk_agent/config.py
@@ -1,0 +1,25 @@
+"""Runtime configuration for Churn Risk Agent."""
+
+from dataclasses import dataclass
+
+from framework.config import RuntimeConfig
+
+default_config = RuntimeConfig()
+
+
+@dataclass
+class AgentMetadata:
+    name: str = "Churn Risk Agent"
+    version: str = "1.0.0"
+    description: str = (
+        "Monitors customer engagement signals, detects churn risk, "
+        "and triggers proactive retention actions with human approval."
+    )
+    intro_message: str = (
+        "Hi! I'm your Churn Risk Agent. Provide customer account data "
+        "and I'll assess churn risk, escalate high-risk accounts, and "
+        "draft re-engagement messages for your review."
+    )
+
+
+metadata = AgentMetadata()

--- a/examples/templates/churn_risk_agent/mcp_servers.json
+++ b/examples/templates/churn_risk_agent/mcp_servers.json
@@ -1,0 +1,3 @@
+{
+  "mcpServers": {}
+}

--- a/examples/templates/churn_risk_agent/nodes/__init__.py
+++ b/examples/templates/churn_risk_agent/nodes/__init__.py
@@ -1,0 +1,211 @@
+"""Node definitions for Churn Risk Agent."""
+
+from framework.graph import NodeSpec
+
+# Node 1: Signal Intake
+signal_intake_node = NodeSpec(
+    id="signal_intake",
+    name="Signal Intake",
+    description="Process customer account data",
+    node_type="event_loop",
+    client_facing=False,
+    max_node_visits=1,
+    input_keys=["account_data"],
+    output_keys=["confirmed_account_data"],
+    nullable_output_keys=[],
+    success_criteria="confirmed_account_data has been set with the account data.",
+    system_prompt="""\
+You are a data processor. Account data has been provided in account_data.
+
+IMMEDIATELY call set_output — do NOT ask questions, do NOT wait:
+set_output("confirmed_account_data", "py the exact account_data value here>")
+""",
+    tools=[],
+)
+
+# Node 2: Risk Scoring
+risk_scoring_node = NodeSpec(
+    id="risk_scoring",
+    name="Risk Scoring",
+    description="Score churn risk based on account signals",
+    node_type="event_loop",
+    client_facing=False,
+    max_node_visits=1,
+    input_keys=["confirmed_account_data"],
+    output_keys=["risk_level", "risk_score", "risk_reasoning"],
+    nullable_output_keys=[],
+    success_criteria="risk_level, risk_score, and risk_reasoning have all been set.",
+    system_prompt="""\
+You are a churn risk scorer. Score the account immediately.
+
+Scoring rules (add points for each that applies):
+- Last login > 30 days ago: +30
+- Last login 15-30 days ago: +15
+- Feature usage monthly or never: +20
+- Support tickets >= 3 in last 30 days: +20
+- NPS score <= 6: +20
+- Contract renewal < 30 days away: +10
+
+Risk levels: HIGH >= 60, MEDIUM 30-59, LOW < 30
+
+Compute the score from the account data, then call set_output three times:
+set_output("risk_score", "<number>")
+set_output("risk_level", "<HIGH or MEDIUM or LOW>")
+set_output("risk_reasoning", "<bullet list of criteria applied and points>")
+""",
+    tools=[],
+)
+
+# Node 3: Routing
+routing_node = NodeSpec(
+    id="routing",
+    name="Routing Decision",
+    description="Route based on risk level",
+    node_type="event_loop",
+    client_facing=False,
+    max_node_visits=1,
+    input_keys=["risk_level", "risk_score", "risk_reasoning", "confirmed_account_data"],
+    output_keys=["routing_decision"],
+    nullable_output_keys=[],
+    success_criteria="routing_decision has been set.",
+    system_prompt="""\
+Look at risk_level and IMMEDIATELY call set_output:
+
+If risk_level is HIGH: set_output("routing_decision", "escalate")
+If risk_level is MEDIUM: set_output("routing_decision", "outreach")
+If risk_level is LOW: set_output("routing_decision", "monitor")
+
+Call set_output now. No explanation needed.
+""",
+    tools=[],
+)
+
+# Node 4: Escalation — HIGH risk
+escalation_node = NodeSpec(
+    id="escalation",
+    name="Escalation Alert",
+    description="Alert CSM for HIGH risk accounts",
+    node_type="event_loop",
+    client_facing=True,
+    max_node_visits=1,
+    input_keys=["confirmed_account_data", "risk_score", "risk_reasoning"],
+    output_keys=["escalation_status"],
+    nullable_output_keys=["escalation_status"],
+    success_criteria="Escalation alert presented and escalation_status set.",
+    system_prompt="""\
+Present this escalation alert to the CSM, then call set_output.
+
+🚨 HIGH CHURN RISK ALERT
+Account: [from confirmed_account_data]
+Risk Score: [risk_score]/100
+Reasoning: [risk_reasoning]
+
+Recommended action:
+- Schedule emergency call if renewal < 14 days
+- Send check-in within 24 hours if usage dropped
+- Loop in support lead if tickets are high
+
+Then IMMEDIATELY call:
+set_output("escalation_status", "acknowledged")
+""",
+    tools=[],
+)
+
+# Node 5: Outreach Draft — MEDIUM risk
+outreach_node = NodeSpec(
+    id="outreach",
+    name="Outreach Draft",
+    description="Draft re-engagement email for CSM approval",
+    node_type="event_loop",
+    client_facing=True,
+    max_node_visits=0,
+    input_keys=["confirmed_account_data", "risk_score", "risk_reasoning"],
+    output_keys=["outreach_approved", "outreach_draft"],
+    nullable_output_keys=["outreach_approved", "outreach_draft"],
+    success_criteria="outreach_approved and outreach_draft have been set.",
+    system_prompt="""\
+Draft a re-engagement email and ask the CSM to approve it.
+
+Present:
+📧 DRAFT EMAIL — approve, edit, or reject?
+To: [customer from confirmed_account_data]
+Subject: Checking in — how can we help?
+
+[Write a 3-paragraph personalised email based on their usage signals]
+
+Risk context: [risk_reasoning]
+
+After CSM responds:
+If approved: set_output("outreach_approved", "true") then set_output("outreach_draft", "<email text>")
+If rejected: set_output("outreach_approved", "false") then set_output("outreach_draft", "REJECTED")
+""",
+    tools=[],
+)
+
+# Node 6: Monitor — LOW risk
+monitor_node = NodeSpec(
+    id="monitor",
+    name="Monitor",
+    description="Log low risk account",
+    node_type="event_loop",
+    client_facing=False,
+    max_node_visits=1,
+    input_keys=["confirmed_account_data", "risk_score", "risk_reasoning"],
+    output_keys=["monitor_status"],
+    nullable_output_keys=["monitor_status"],
+    success_criteria="monitor_status has been set.",
+    system_prompt="""\
+IMMEDIATELY call set_output:
+set_output("monitor_status", "low_risk_logged — re-check in 7 days")
+""",
+    tools=[],
+)
+
+# Node 7: Output Log
+output_node = NodeSpec(
+    id="output",
+    name="Output Log",
+    description="Present audit trail",
+    node_type="event_loop",
+    client_facing=True,
+    max_node_visits=1,
+    input_keys=[
+        "confirmed_account_data",
+        "risk_level",
+        "risk_score",
+        "risk_reasoning",
+        "routing_decision",
+    ],
+    output_keys=["audit_log"],
+    nullable_output_keys=[
+        "escalation_status",
+        "outreach_approved",
+        "outreach_draft",
+        "monitor_status",
+    ],
+    success_criteria="audit_log has been set.",
+    system_prompt="""\
+Present the final assessment summary and call set_output.
+
+✅ CHURN RISK ASSESSMENT COMPLETE
+Account: [confirmed_account_data]
+Risk Level: [risk_level] ([risk_score]/100)
+Action: [routing_decision]
+Reasoning: [risk_reasoning]
+
+Then IMMEDIATELY call:
+set_output("audit_log", "account=[confirmed_account_data] risk=[risk_level] score=[risk_score] action=[routing_decision]")
+""",
+    tools=[],
+)
+
+
+__all__ = [
+    "signal_intake_node",
+    "risk_scoring_node",
+    "routing_node",
+    "escalation_node",
+    "outreach_node",
+    "monitor_node",
+    "output_node",
+]


### PR DESCRIPTION
## Summary

Adds a Churn Risk Agent to `examples/templates/` that detects at-risk 
customers using engagement signals and triggers proactive retention 
actions with human-in-the-loop approval.

Closes #5701

## Pipeline

signal_intake → risk_scoring → routing → escalation (HIGH)
                                       → outreach + HITL (MEDIUM)  
                                       → monitor (LOW)
                                       → output_log

## Nodes (7)

- signal_intake — processes customer account data
- risk_scoring — scores 0-100 across 5 criteria with reasoning
- routing — routes based on HIGH / MEDIUM / LOW
- escalation — immediate CSM alert for HIGH risk accounts
- outreach — drafts re-engagement email, waits for human approval
- monitor — silently logs LOW risk accounts
- output — full audit trail of every decision

## Scoring Criteria

- Last login > 30 days: +30
- Feature usage monthly/never: +20  
- Support tickets >= 3 in 30 days: +20
- NPS score <= 6: +20
- Contract renewal < 30 days: +10

## Testing

Agent structure validated:
- `validate` passes with no errors
- All 7 nodes wired correctly
- HITL gate confirmed on outreach node
- Tested with llama-3.1-8b-instant via Groq

## Related

- Issue: #5701