### PR TITLE
fix: add minimax provider mapping and stream fallback support

### DIFF
--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -735,6 +735,72 @@ class LiteLLMProvider(LLMProvider):
             },
         }
 
+    def _is_minimax_model(self) -> bool:
+        """Return True when the configured model targets MiniMax."""
+        model = (self.model or "").lower()
+        return model.startswith("minimax/") or model.startswith("minimax-")
+
+    async def _stream_via_nonstream_completion(
+        self,
+        messages: list[dict[str, Any]],
+        system: str,
+        tools: list[Tool] | None,
+        max_tokens: int,
+        response_format: dict[str, Any] | None,
+        json_mode: bool,
+    ) -> AsyncIterator[StreamEvent]:
+        """Fallback path: convert non-stream completion to stream events.
+
+        Some providers currently fail in LiteLLM's chunk parser for stream=True.
+        For those providers we do a regular async completion and emit equivalent
+        stream events so higher layers continue to work.
+        """
+        from framework.llm.stream_events import FinishEvent, StreamErrorEvent, TextDeltaEvent, TextEndEvent
+        from framework.llm.stream_events import ToolCallEvent
+
+        try:
+            response = await self.acomplete(
+                messages=messages,
+                system=system,
+                tools=tools,
+                max_tokens=max_tokens,
+                response_format=response_format,
+                json_mode=json_mode,
+            )
+        except Exception as e:
+            yield StreamErrorEvent(error=str(e), recoverable=False)
+            return
+
+        raw = response.raw_response
+        tool_calls = []
+        if raw and hasattr(raw, "choices") and raw.choices:
+            msg = raw.choices[0].message
+            tool_calls = msg.tool_calls or []
+
+        for tc in tool_calls:
+            parsed_args: Any
+            args = tc.function.arguments if tc.function else ""
+            try:
+                parsed_args = json.loads(args) if args else {}
+            except json.JSONDecodeError:
+                parsed_args = {"_raw": args}
+            yield ToolCallEvent(
+                tool_use_id=getattr(tc, "id", ""),
+                tool_name=tc.function.name if tc.function else "",
+                tool_input=parsed_args,
+            )
+
+        if response.content:
+            yield TextDeltaEvent(content=response.content, snapshot=response.content)
+            yield TextEndEvent(full_text=response.content)
+
+        yield FinishEvent(
+            stop_reason=response.stop_reason or "stop",
+            input_tokens=response.input_tokens,
+            output_tokens=response.output_tokens,
+            model=response.model,
+        )
+
     async def stream(
         self,
         messages: list[dict[str, Any]],
@@ -761,6 +827,20 @@ class LiteLLMProvider(LLMProvider):
             TextEndEvent,
             ToolCallEvent,
         )
+
+        # MiniMax currently fails in litellm's stream chunk parser for some
+        # responses (missing "id" in stream chunks). Use non-stream fallback.
+        if self._is_minimax_model():
+            async for event in self._stream_via_nonstream_completion(
+                messages=messages,
+                system=system,
+                tools=tools,
+                max_tokens=max_tokens,
+                response_format=response_format,
+                json_mode=json_mode,
+            ):
+                yield event
+            return
 
         full_messages: list[dict[str, Any]] = []
         if system:

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -1304,6 +1304,8 @@ class AgentRunner:
             return "REPLICATE_API_KEY"
         elif model_lower.startswith("together/"):
             return "TOGETHER_API_KEY"
+        elif model_lower.startswith("minimax/") or model_lower.startswith("minimax-"):
+            return "MINIMAX_API_KEY"
         else:
             # Default: assume OpenAI-compatible
             return "OPENAI_API_KEY"
@@ -1322,6 +1324,8 @@ class AgentRunner:
         cred_id = None
         if model_lower.startswith("anthropic/") or model_lower.startswith("claude"):
             cred_id = "anthropic"
+        elif model_lower.startswith("minimax/") or model_lower.startswith("minimax-"):
+            cred_id = "minimax"
         # Add more mappings as providers are added to LLM_CREDENTIALS
 
         if cred_id is None:

--- a/core/tests/test_litellm_provider.py
+++ b/core/tests/test_litellm_provider.py
@@ -14,7 +14,7 @@ import os
 import threading
 import time
 from datetime import UTC, datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -629,6 +629,43 @@ class TestAsyncComplete:
         assert call_thread_ids[0] != main_thread_id, (
             "Base acomplete() should offload sync complete() to a thread pool"
         )
+
+
+class TestMiniMaxStreamFallback:
+    """MiniMax models should use non-stream fallback due to parser incompatibility."""
+
+    @pytest.mark.asyncio
+    async def test_stream_uses_nonstream_fallback_for_minimax(self):
+        """stream() should call acomplete() and synthesize stream events for MiniMax."""
+        from framework.llm.stream_events import FinishEvent, TextDeltaEvent
+
+        provider = LiteLLMProvider(model="minimax-text-01", api_key="test-key")
+
+        mock_response = LLMResponse(
+            content="hello from minimax",
+            model="minimax-text-01",
+            input_tokens=7,
+            output_tokens=4,
+            stop_reason="stop",
+            raw_response=None,
+        )
+        provider.acomplete = AsyncMock(return_value=mock_response)
+
+        events = []
+        async for event in provider.stream(messages=[{"role": "user", "content": "hi"}]):
+            events.append(event)
+
+        assert provider.acomplete.await_count == 1
+        assert any(isinstance(e, TextDeltaEvent) for e in events)
+        finish = [e for e in events if isinstance(e, FinishEvent)]
+        assert len(finish) == 1
+        assert finish[0].model == "minimax-text-01"
+
+    def test_is_minimax_model_variants(self):
+        """Recognize both prefixed and plain MiniMax model names."""
+        assert LiteLLMProvider(model="minimax-text-01", api_key="x")._is_minimax_model()
+        assert LiteLLMProvider(model="minimax/minimax-text-01", api_key="x")._is_minimax_model()
+        assert not LiteLLMProvider(model="gpt-4o-mini", api_key="x")._is_minimax_model()
 
 
 # ---------------------------------------------------------------------------

--- a/core/tests/test_runner_api_key_env_var.py
+++ b/core/tests/test_runner_api_key_env_var.py
@@ -1,0 +1,23 @@
+from framework.runner.runner import AgentRunner
+
+
+class _NoopRegistry:
+    def cleanup(self) -> None:
+        pass
+
+
+def _runner_for_unit_test() -> AgentRunner:
+    runner = AgentRunner.__new__(AgentRunner)
+    runner._tool_registry = _NoopRegistry()
+    runner._temp_dir = None
+    return runner
+
+
+def test_minimax_provider_prefix_maps_to_minimax_api_key():
+    runner = _runner_for_unit_test()
+    assert runner._get_api_key_env_var("minimax/minimax-text-01") == "MINIMAX_API_KEY"
+
+
+def test_minimax_model_name_prefix_maps_to_minimax_api_key():
+    runner = _runner_for_unit_test()
+    assert runner._get_api_key_env_var("minimax-chat") == "MINIMAX_API_KEY"


### PR DESCRIPTION
## Description

This PR adds MiniMax support in Hive’s LLM path by wiring provider-specific API key/env mapping and adding a safe non-stream fallback for MiniMax responses when LiteLLM stream chunk parsing fails.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Fixes #5642

## Changes Made

- Added MiniMax API key/env mapping support in runner config resolution.
- Added MiniMax stream fallback path in LiteLLM provider to avoid stream parser failures.
- Added/updated tests for:
  - MiniMax env var mapping
  - MiniMax stream fallback behavior

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Manual testing performed

### Executed
- `uv run --project core pytest -q core/tests/test_runner_api_key_env_var.py core/tests/test_litellm_provider.py -k minimax`
- Result: `4 passed, 60 deselected`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



