### PR TITLE
fix(cli): return non-zero exit code from hive shell on failure

### DIFF
--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -1190,6 +1190,7 @@ def cmd_shell(args: argparse.Namespace) -> int:
     session_memory = {}
     conversation_history = []
     agent_session_state = None  # Track paused agent state
+    had_failure = False  # Track if any execution failed during session
 
     while True:
         try:
@@ -1294,6 +1295,8 @@ def cmd_shell(args: argparse.Namespace) -> int:
         # Pass agent session state to enable resumption
         result = asyncio.run(runner.run(run_context, session_state=agent_session_state))
 
+        if not result.success:
+            had_failure = True
         status_str = "SUCCESS" if result.success else "FAILED"
         print(f"\nStatus: {status_str}")
         print(f"Steps executed: {result.steps_executed}")
@@ -1356,7 +1359,7 @@ def cmd_shell(args: argparse.Namespace) -> int:
         print()
 
     runner.cleanup()
-    return 0
+    return 1 if had_failure else 0
 
 
 def _get_framework_agents_dir() -> Path:


### PR DESCRIPTION
## Summary

- `hive shell` always returned exit code 0 regardless of agent execution outcomes, making it impossible to detect failures in scripts or CI pipelines
- `hive run` already correctly returns `0 if result.success else 1` (line 776), but `cmd_shell` unconditionally returned 0 (line 1359)
- Added `had_failure` tracking across the REPL loop and return `1` if any execution failed during the session

## Changes

- `core/framework/runner/cli.py`: Track `had_failure` flag, set it when `result.success` is False, return appropriate exit code

## Test plan

- [ ] Run `hive shell` with an agent that succeeds → verify exit code 0
- [ ] Run `hive shell` with an agent that fails → verify exit code 1
- [ ] Run `hive shell` with mixed success/failure → verify exit code 1 (any failure taints the session)
- [ ] Verify `hive run` behavior is unchanged

Closes #5791