### PR TITLE
fix(credentials): use atomic writes in EncryptedFileStorage

### DIFF
--- a/core/framework/credentials/storage.py
+++ b/core/framework/credentials/storage.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 from abc import ABC, abstractmethod
 from datetime import UTC, datetime
 from pathlib import Path
@@ -160,6 +161,7 @@ class EncryptedFileStorage(CredentialStorage):
                 )
 
         self._fernet = Fernet(self._key)
+        self._index_lock = threading.Lock()
 
     def _ensure_dirs(self) -> None:
         """Create directory structure."""
@@ -174,6 +176,8 @@ class EncryptedFileStorage(CredentialStorage):
 
     def save(self, credential: CredentialObject) -> None:
         """Encrypt and save credential."""
+        from framework.utils.io import atomic_write
+
         # Serialize credential
         data = self._serialize_credential(credential)
         json_bytes = json.dumps(data, default=str).encode()
@@ -181,9 +185,9 @@ class EncryptedFileStorage(CredentialStorage):
         # Encrypt
         encrypted = self._fernet.encrypt(json_bytes)
 
-        # Write to file
+        # Write to file atomically (prevents corruption on crash)
         cred_path = self._cred_path(credential.id)
-        with open(cred_path, "wb") as f:
+        with atomic_write(cred_path, mode="wb") as f:
             f.write(encrypted)
 
         # Update index
@@ -264,27 +268,30 @@ class EncryptedFileStorage(CredentialStorage):
         operation: str,
         credential_type: str | None = None,
     ) -> None:
-        """Update the metadata index."""
+        """Update the metadata index atomically with thread safety."""
+        from framework.utils.io import atomic_write
+
         index_path = self.base_path / "metadata" / "index.json"
 
-        if index_path.exists():
-            with open(index_path, encoding="utf-8-sig") as f:
-                index = json.load(f)
-        else:
-            index = {"credentials": {}, "version": "1.0"}
+        with self._index_lock:
+            if index_path.exists():
+                with open(index_path, encoding="utf-8-sig") as f:
+                    index = json.load(f)
+            else:
+                index = {"credentials": {}, "version": "1.0"}
 
-        if operation == "save":
-            index["credentials"][credential_id] = {
-                "updated_at": datetime.now(UTC).isoformat(),
-                "type": credential_type,
-            }
-        elif operation == "delete":
-            index["credentials"].pop(credential_id, None)
+            if operation == "save":
+                index["credentials"][credential_id] = {
+                    "updated_at": datetime.now(UTC).isoformat(),
+                    "type": credential_type,
+                }
+            elif operation == "delete":
+                index["credentials"].pop(credential_id, None)
 
-        index["last_modified"] = datetime.now(UTC).isoformat()
+            index["last_modified"] = datetime.now(UTC).isoformat()
 
-        with open(index_path, "w", encoding="utf-8") as f:
-            json.dump(index, f, indent=2)
+            with atomic_write(index_path) as f:
+                json.dump(index, f, indent=2)
 
 
 class EnvVarStorage(CredentialStorage):

--- a/core/framework/utils/io.py
+++ b/core/framework/utils/io.py
@@ -7,7 +7,10 @@ from pathlib import Path
 def atomic_write(path: Path, mode: str = "w", encoding: str = "utf-8"):
     tmp_path = path.with_suffix(path.suffix + ".tmp")
     try:
-        with open(tmp_path, mode, encoding=encoding) as f:
+        kwargs = {"mode": mode}
+        if "b" not in mode:
+            kwargs["encoding"] = encoding
+        with open(tmp_path, **kwargs) as f:
             yield f
             f.flush()
             os.fsync(f.fileno())


### PR DESCRIPTION
## Summary

- `EncryptedFileStorage.save()` and `_update_index()` used bare `open()` calls for writing `.enc` files and the metadata index, risking data corruption on crash, power loss, or concurrent access
- `atomic_write()` already existed in `utils/io.py` (used by `CheckpointStore`) but was never imported by credential storage
- Added threading lock to `_update_index()` to prevent TOCTOU race conditions

## Changes

- **`core/framework/credentials/storage.py`**:
  - `save()`: Uses `atomic_write(path, mode="wb")` for encrypted credential files
  - `_update_index()`: Wrapped in `threading.Lock`, uses `atomic_write()` for index JSON
  - Added `threading` import and `_index_lock` instance variable

- **`core/framework/utils/io.py`**:
  - `atomic_write()`: Now supports binary mode (`wb`) by conditionally passing `encoding` only for text modes

## Why This Matters

Without atomic writes, a crash during `save()` can:
1. Corrupt the `.enc` file (partial write), making the credential unrecoverable
2. Corrupt `index.json` (partial write), causing `list_all()` to fail
3. Create ghost entries in the index if the `.enc` write succeeds but the index update is interrupted

The `atomic_write` pattern (tmp → fsync → rename) ensures either the old or new version is always on disk.

## Test plan

- [ ] Save a credential and verify the `.enc` file is created correctly
- [ ] Kill the process during `save()` and verify no corruption
- [ ] Concurrent `save()` calls don't produce corrupt index
- [ ] `list_all()` returns consistent results after concurrent modifications
- [ ] Binary mode atomic write preserves encrypted data integrity

Closes #5855