### PR TITLE
Add unit tests for account_info_tool and mssql_tool

### DIFF
--- a/tools/tests/tools/test_account_info_tool.py
+++ b/tools/tests/tools/test_account_info_tool.py
@@ -1,0 +1,57 @@
+"""Tests for account_info_tool - Account listing and filtering."""
+
+from unittest.mock import patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.account_info_tool.account_info_tool import register_tools
+
+
+@pytest.fixture
+def tool_fns(mcp: FastMCP):
+    register_tools(mcp, credentials=None)
+    tools = mcp._tool_manager._tools
+    return {name: tools[name].fn for name in tools}
+
+
+class TestAccountInfoTool:
+    def test_list_accounts(self, tool_fns):
+        mock_accounts = [
+            {"id": "acc1", "provider": "aws", "name": "AWS Account"},
+            {"id": "acc2", "provider": "gcp", "name": "GCP Account"},
+        ]
+
+        with patch(
+            "aden_tools.tools.account_info_tool.account_info_tool.get_accounts",
+            return_value=mock_accounts,
+        ):
+            result = tool_fns["account_info_tool"]()
+
+        assert result["count"] == 2
+        assert result["accounts"][0]["provider"] == "aws"
+
+    def test_filter_by_provider(self, tool_fns):
+        mock_accounts = [
+            {"id": "acc1", "provider": "aws"},
+            {"id": "acc2", "provider": "gcp"},
+        ]
+
+        with patch(
+            "aden_tools.tools.account_info_tool.account_info_tool.get_accounts",
+            return_value=mock_accounts,
+        ):
+            result = tool_fns["account_info_tool"](provider="aws")
+
+        assert result["count"] == 1
+        assert result["accounts"][0]["provider"] == "aws"
+
+    def test_no_accounts(self, tool_fns):
+        with patch(
+            "aden_tools.tools.account_info_tool.account_info_tool.get_accounts",
+            return_value=[],
+        ):
+            result = tool_fns["account_info_tool"]()
+
+        assert result["count"] == 0
+        assert result["accounts"] == []

--- a/tools/tests/tools/test_mssql_tool.py
+++ b/tools/tests/tools/test_mssql_tool.py
@@ -1,0 +1,54 @@
+"""Tests for mssql_tool - Microsoft SQL Server query execution."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.mssql_tool.mssql_tool import register_tools
+
+
+@pytest.fixture
+def tool_fns(mcp: FastMCP):
+    register_tools(mcp, credentials=None)
+    tools = mcp._tool_manager._tools
+    return {name: tools[name].fn for name in tools}
+
+
+class TestMssqlTool:
+
+    def test_missing_params(self, tool_fns):
+        result = tool_fns["mssql_query"](server="", database="", query="")
+        assert "error" in result
+
+    def test_connection_error(self, tool_fns):
+        with patch(
+            "aden_tools.tools.mssql_tool.mssql_tool.pyodbc.connect",
+            side_effect=Exception("connection failed"),
+        ):
+            result = tool_fns["mssql_query"](
+                server="localhost",
+                database="test",
+                query="SELECT 1",
+            )
+
+        assert "error" in result
+
+    def test_successful_query(self, tool_fns):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = [(1, "test")]
+
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        with patch(
+            "aden_tools.tools.mssql_tool.mssql_tool.pyodbc.connect",
+            return_value=mock_conn,
+        ):
+            result = tool_fns["mssql_query"](
+                server="localhost",
+                database="test",
+                query="SELECT 1",
+            )
+
+        assert result["rows"][0][0] == 1


### PR DESCRIPTION
This PR adds dedicated unit tests for two utility tools that previously did not have test coverage:

account_info_tool

mssql_tool

The tests follow the same structure and patterns used by existing tool tests in the repository.

Test Coverage Added
account_info_tool

Test listing all accounts

Test filtering accounts by provider

Test handling of empty account lists

mssql_tool

Test connection error handling

Test successful query execution with mocked database connection

External dependencies such as database connections and account retrieval are mocked to ensure reliable and isolated unit tests.