### PR TITLE
fix: log exception details in bare except clauses in key_storage.py

### DIFF
--- a/core/framework/credentials/key_storage.py
+++ b/core/framework/credentials/key_storage.py
@@ -149,8 +149,8 @@ def delete_aden_api_key() -> None:
 
         storage = EncryptedFileStorage()
         storage.delete(ADEN_CREDENTIAL_ID)
-    except Exception:
-        logger.debug("Could not delete %s from encrypted store", ADEN_CREDENTIAL_ID)
+    except Exception as e:
+        logger.debug("Could not delete %s from encrypted store: %s", ADEN_CREDENTIAL_ID, e)
 
     os.environ.pop(ADEN_ENV_VAR, None)
 
@@ -167,8 +167,8 @@ def _read_credential_key_file() -> str | None:
             value = CREDENTIAL_KEY_PATH.read_text(encoding="utf-8").strip()
             if value:
                 return value
-    except Exception:
-        logger.debug("Could not read %s", CREDENTIAL_KEY_PATH)
+    except Exception as e:
+        logger.debug("Could not read %s: %s", CREDENTIAL_KEY_PATH, e)
     return None
 
 
@@ -196,6 +196,6 @@ def _read_aden_from_encrypted_store() -> str | None:
         cred = storage.load(ADEN_CREDENTIAL_ID)
         if cred:
             return cred.get_key("api_key")
-    except Exception:
-        logger.debug("Could not load %s from encrypted store", ADEN_CREDENTIAL_ID)
+    except Exception as e:
+        logger.debug("Could not load %s from encrypted store: %s", ADEN_CREDENTIAL_ID, e)
     return None


### PR DESCRIPTION
Fixes issue #5931. Replace bare except Exception: clauses with except Exception as e: and include the exception message in the debug log output so failures are visible when debug logging is enabled.

- delete_aden_api_key: log exception when encrypted store delete fails
- _read_credential_key_file: log exception when credential file read fails
- _read_aden_from_encrypted_store: log exception when encrypted store load fails

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


