### PR TITLE
feat(credentials): Add configurable refresh_buffer_seconds to CredentialProvider

### DIFF
--- a/core/framework/credentials/provider.py
+++ b/core/framework/credentials/provider.py
@@ -271,7 +271,7 @@ class BearerTokenProvider(CredentialProvider):
         refresh() will fail. This allows the store to know the
         credential needs attention.
         """
-        buffer = timedelta(minutes=5)
+                buffer = timedelta(seconds=getattr(self, "refresh_buffer_seconds", 300))
         now = datetime.now(UTC)
 
         for key_name in ["access_token", "token"]:


### PR DESCRIPTION
**Summary**

Makes the credential refresh buffer configurable instead of hardcoded at 5 minutes. Addresses #5945.

**Changes**

- Updated `should_refresh()` in `CredentialProvider` to use `getattr(self, "refresh_buffer_seconds", 300)` instead of a hardcoded `timedelta(minutes=5)`
- Backward compatible — defaults to 300 seconds (5 min) if `refresh_buffer_seconds` isn't set on the provider instance
- Providers can now set `self.refresh_buffer_seconds = <int>` in their `__init__` to customize

**Related issue:** Closes #5945

**Test plan**

- Default provider uses 300s buffer (verify `timedelta(seconds=300)` behavior)
- Custom provider with `refresh_buffer_seconds=600` triggers refresh earlier
- Provider with `refresh_buffer_seconds=60` for short-lived SSO tokens
- No regression on existing OAuth2 refresh flows

**Notes**

This unblocks teams using enterprise SSO tokens (15-30 min expiry) and long-lived API keys (24h+) that need different buffer tuning per provider.