### PR TITLE
fix: handle three production reliability bugs (#5965, #5946, #5931)

### DIFF
--- a/core/framework/credentials/key_storage.py
+++ b/core/framework/credentials/key_storage.py
@@ -149,8 +149,13 @@ def delete_aden_api_key() -> None:
 
         storage = EncryptedFileStorage()
         storage.delete(ADEN_CREDENTIAL_ID)
-    except Exception:
-        logger.debug("Could not delete %s from encrypted store", ADEN_CREDENTIAL_ID)
+    except (ImportError, OSError, ValueError) as exc:
+        logger.warning(
+            "Could not delete %s from encrypted store: %s",
+            ADEN_CREDENTIAL_ID,
+            exc,
+            exc_info=True,
+        )
 
     os.environ.pop(ADEN_ENV_VAR, None)
 
@@ -167,8 +172,8 @@ def _read_credential_key_file() -> str | None:
             value = CREDENTIAL_KEY_PATH.read_text(encoding="utf-8").strip()
             if value:
                 return value
-    except Exception:
-        logger.debug("Could not read %s", CREDENTIAL_KEY_PATH)
+    except (OSError, UnicodeDecodeError) as exc:
+        logger.warning("Could not read %s: %s", CREDENTIAL_KEY_PATH, exc, exc_info=True)
     return None
 
 
@@ -196,6 +201,11 @@ def _read_aden_from_encrypted_store() -> str | None:
         cred = storage.load(ADEN_CREDENTIAL_ID)
         if cred:
             return cred.get_key("api_key")
-    except Exception:
-        logger.debug("Could not load %s from encrypted store", ADEN_CREDENTIAL_ID)
+    except (ImportError, OSError, ValueError) as exc:
+        logger.warning(
+            "Could not load %s from encrypted store: %s",
+            ADEN_CREDENTIAL_ID,
+            exc,
+            exc_info=True,
+        )
     return None

--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -148,8 +148,16 @@ def _dump_failed_request(
     error_type: str,
     attempt: int,
 ) -> str:
-    """Dump failed request to a file for debugging. Returns the file path."""
-    FAILED_REQUESTS_DIR.mkdir(parents=True, exist_ok=True)
+    """Dump failed request to a file for debugging. Returns the file path.
+
+    Gracefully handles read-only filesystems and permission errors —
+    the agent must never crash just because a debug dump cannot be written.
+    """
+    try:
+        FAILED_REQUESTS_DIR.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.debug("Cannot create failed-requests dir %s: %s", FAILED_REQUESTS_DIR, exc)
+        return f"<unavailable: {exc}>"
 
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
     filename = f"{error_type}_{model.replace('/', '_')}_{timestamp}.json"
@@ -170,8 +178,13 @@ def _dump_failed_request(
         "temperature": kwargs.get("temperature"),
     }
 
-    with open(filepath, "w", encoding="utf-8") as f:
-        json.dump(dump_data, f, indent=2, default=str)
+    try:
+        with open(filepath, "w", encoding="utf-8") as f:
+            json.dump(dump_data, f, indent=2, default=str)
+    except OSError as exc:
+        # Read-only FS, disk full, permission denied — log and move on
+        logger.debug("Cannot write failed-request dump to %s: %s", filepath, exc)
+        return f"<unavailable: {exc}>"
 
     return str(filepath)
 

--- a/core/framework/runtime/shared_state.py
+++ b/core/framework/runtime/shared_state.py
@@ -201,30 +201,21 @@ class SharedStateManager:
             isolation: Isolation level
             scope: Where to write (execution, stream, or global)
         """
-        # Get old value for change tracking
-        old_value = await self.read(key, execution_id, stream_id, isolation)
-
         # ISOLATED can only write to execution scope
         if isolation == IsolationLevel.ISOLATED:
             scope = StateScope.EXECUTION
 
         # SYNCHRONIZED requires locks for stream/global writes
         if isolation == IsolationLevel.SYNCHRONIZED and scope != StateScope.EXECUTION:
-            await self._write_with_lock(key, value, execution_id, stream_id, scope)
+            lock = self._get_lock(scope, key, stream_id)
+            async with lock:
+                await self._write_and_record(
+                    key, value, execution_id, stream_id, isolation, scope,
+                )
         else:
-            await self._write_direct(key, value, execution_id, stream_id, scope)
-
-        # Record change
-        self._record_change(
-            StateChange(
-                key=key,
-                old_value=old_value,
-                new_value=value,
-                scope=scope,
-                execution_id=execution_id,
-                stream_id=stream_id,
+            await self._write_and_record(
+                key, value, execution_id, stream_id, isolation, scope,
             )
-        )
 
     async def _write_direct(
         self,
@@ -262,6 +253,33 @@ class SharedStateManager:
         lock = self._get_lock(scope, key, stream_id)
         async with lock:
             await self._write_direct(key, value, execution_id, stream_id, scope)
+
+    async def _write_and_record(
+        self,
+        key: str,
+        value: Any,
+        execution_id: str,
+        stream_id: str,
+        isolation: IsolationLevel,
+        scope: StateScope,
+    ) -> None:
+        """Write a single key and record the change (no locking).
+
+        Shared helper used by both ``write()`` and the locked path
+        in ``write_batch()`` to keep write semantics in one place.
+        """
+        old_value = await self.read(key, execution_id, stream_id, isolation)
+        await self._write_direct(key, value, execution_id, stream_id, scope)
+        self._record_change(
+            StateChange(
+                key=key,
+                old_value=old_value,
+                new_value=value,
+                scope=scope,
+                execution_id=execution_id,
+                stream_id=stream_id,
+            )
+        )
 
     def _get_lock(self, scope: StateScope, key: str, stream_id: str) -> asyncio.Lock:
         """Get appropriate lock for scope and key."""
@@ -322,9 +340,41 @@ class SharedStateManager:
         isolation: IsolationLevel,
         scope: StateScope = StateScope.EXECUTION,
     ) -> None:
-        """Write multiple values atomically."""
-        for key, value in updates.items():
-            await self.write(key, value, execution_id, stream_id, isolation, scope)
+        """Write multiple values atomically.
+
+        Under SYNCHRONIZED isolation with non-EXECUTION scope, all keys
+        are written under a single lock acquisition so that concurrent
+        readers never see a partial batch.  EXECUTION-scoped writes are
+        private to a single execution and need no locking.  ISOLATED and
+        SHARED writes remain lock-free (matching the single-key
+        ``write()`` behaviour).
+        """
+        if isolation == IsolationLevel.SYNCHRONIZED and scope != StateScope.EXECUTION:
+            # Acquire all per-key locks in sorted order to avoid deadlocks,
+            # then perform every write while holding all of them.
+            locks = [
+                self._get_lock(scope, key, stream_id)
+                for key in sorted(updates)
+            ]
+            # Acquire sequentially in deterministic order.  Track which
+            # locks have been acquired so that cancellation or errors
+            # during the loop still release already-held locks.
+            acquired: list[asyncio.Lock] = []
+            try:
+                for lock in locks:
+                    await lock.acquire()
+                    acquired.append(lock)
+                for key, value in updates.items():
+                    await self._write_and_record(
+                        key, value, execution_id, stream_id, isolation, scope,
+                    )
+            finally:
+                for lock in reversed(acquired):
+                    lock.release()
+        else:
+            # Non-synchronized — sequential writes (no atomicity guarantee needed)
+            for key, value in updates.items():
+                await self.write(key, value, execution_id, stream_id, isolation, scope)
 
     # === UTILITY ===
 

--- a/core/tests/test_dump_failed_request.py
+++ b/core/tests/test_dump_failed_request.py
@@ -1,0 +1,83 @@
+"""Tests for _dump_failed_request graceful error handling.
+
+Covers Issue #5965: _dump_failed_request crashes agent on read-only filesystems.
+The fix wraps file I/O in try/except so the agent continues running even when
+debug dumps cannot be written (read-only FS, disk full, permission denied).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _skip_without_litellm():
+    """Skip the entire module if litellm is not installed."""
+    pytest.importorskip("litellm")
+
+
+class TestDumpFailedRequest:
+    """Verify _dump_failed_request never raises on I/O failures."""
+
+    def _get_fn(self):
+        from framework.llm.litellm import _dump_failed_request
+
+        return _dump_failed_request
+
+    def test_returns_path_on_success(self, tmp_path):
+        """Normal case: file is written and path is returned."""
+        dump = self._get_fn()
+        with patch("framework.llm.litellm.FAILED_REQUESTS_DIR", tmp_path):
+            result = dump(
+                model="gpt-4",
+                kwargs={"messages": [{"role": "user", "content": "hi"}]},
+                error_type="rate_limit",
+                attempt=0,
+            )
+        assert tmp_path.as_posix() in result or str(tmp_path) in result
+        # A .json file should have been created
+        json_files = list(tmp_path.glob("*.json"))
+        assert len(json_files) == 1
+
+    def test_readonly_mkdir_fails(self, tmp_path):
+        """When mkdir raises (read-only FS), return a fallback string instead of crashing."""
+        dump = self._get_fn()
+        fake_dir = tmp_path / "nonexistent" / "deep"
+        mkdir_err = OSError("Read-only file system")
+        with patch("framework.llm.litellm.FAILED_REQUESTS_DIR", fake_dir):
+            with patch.object(type(fake_dir), "mkdir", side_effect=mkdir_err):
+                result = dump(
+                    model="gpt-4",
+                    kwargs={"messages": []},
+                    error_type="empty_response",
+                    attempt=1,
+                )
+        assert "<unavailable" in result
+
+    def test_write_permission_denied(self, tmp_path):
+        """When open() raises PermissionError, return fallback instead of crashing."""
+        dump = self._get_fn()
+        with patch("framework.llm.litellm.FAILED_REQUESTS_DIR", tmp_path):
+            with patch("builtins.open", side_effect=PermissionError("Permission denied")):
+                result = dump(
+                    model="claude-3",
+                    kwargs={"messages": [{"role": "user", "content": "test"}]},
+                    error_type="rate_limit",
+                    attempt=2,
+                )
+        assert "<unavailable" in result
+
+    def test_disk_full(self, tmp_path):
+        """When open() raises OSError (disk full), return fallback."""
+        dump = self._get_fn()
+        with patch("framework.llm.litellm.FAILED_REQUESTS_DIR", tmp_path):
+            with patch("builtins.open", side_effect=OSError("No space left on device")):
+                result = dump(
+                    model="gpt-4o",
+                    kwargs={"messages": []},
+                    error_type="empty_response",
+                    attempt=0,
+                )
+        assert "<unavailable" in result

--- a/core/tests/test_key_storage_errors.py
+++ b/core/tests/test_key_storage_errors.py
@@ -1,0 +1,103 @@
+"""Tests for key_storage.py exception handling improvements.
+
+Covers Issue #5931: Bare ``except Exception:`` clauses silently swallow errors.
+The fix narrows exception types and raises log severity from debug to warning.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from unittest.mock import patch
+
+
+class TestDeleteAdenApiKey:
+    """delete_aden_api_key should log a warning on failure, not silently pass."""
+
+    def test_logs_warning_on_storage_error(self, caplog):
+        from framework.credentials.key_storage import delete_aden_api_key
+
+        with patch(
+            "framework.credentials.storage.EncryptedFileStorage",
+            side_effect=OSError("disk error"),
+        ):
+            with caplog.at_level(logging.WARNING):
+                delete_aden_api_key()
+
+        assert any("Could not delete" in r.message for r in caplog.records)
+
+    def test_env_var_removed_even_on_failure(self):
+        from framework.credentials.key_storage import (
+            ADEN_ENV_VAR,
+            delete_aden_api_key,
+        )
+
+        os.environ[ADEN_ENV_VAR] = "test-key"
+        with patch(
+            "framework.credentials.storage.EncryptedFileStorage",
+            side_effect=ValueError("bad key"),
+        ):
+            delete_aden_api_key()
+
+        assert ADEN_ENV_VAR not in os.environ
+
+
+class TestReadCredentialKeyFile:
+    """_read_credential_key_file should log warning on failure."""
+
+    def test_returns_none_on_unicode_error(self, tmp_path, caplog):
+        from framework.credentials.key_storage import _read_credential_key_file
+
+        key_file = tmp_path / "credential_key"
+        key_file.write_bytes(b"\xff\xfe")  # Invalid UTF-8
+
+        with patch("framework.credentials.key_storage.CREDENTIAL_KEY_PATH", key_file):
+            with caplog.at_level(logging.WARNING):
+                result = _read_credential_key_file()
+
+        assert result is None
+        assert any("Could not read" in r.message for r in caplog.records)
+
+    def test_returns_value_on_success(self, tmp_path):
+        from framework.credentials.key_storage import _read_credential_key_file
+
+        key_file = tmp_path / "credential_key"
+        key_file.write_text("my-secret-key", encoding="utf-8")
+
+        with patch("framework.credentials.key_storage.CREDENTIAL_KEY_PATH", key_file):
+            result = _read_credential_key_file()
+
+        assert result == "my-secret-key"
+
+
+class TestReadAdenFromEncryptedStore:
+    """_read_aden_from_encrypted_store should log warning on failure."""
+
+    def test_returns_none_when_no_env_var(self):
+        from framework.credentials.key_storage import (
+            CREDENTIAL_KEY_ENV_VAR,
+            _read_aden_from_encrypted_store,
+        )
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(CREDENTIAL_KEY_ENV_VAR, None)
+            result = _read_aden_from_encrypted_store()
+
+        assert result is None
+
+    def test_logs_warning_on_storage_error(self, caplog):
+        from framework.credentials.key_storage import (
+            CREDENTIAL_KEY_ENV_VAR,
+            _read_aden_from_encrypted_store,
+        )
+
+        with patch.dict(os.environ, {CREDENTIAL_KEY_ENV_VAR: "test-key"}):
+            with patch(
+                "framework.credentials.storage.EncryptedFileStorage",
+                side_effect=OSError("corrupt store"),
+            ):
+                with caplog.at_level(logging.WARNING):
+                    result = _read_aden_from_encrypted_store()
+
+        assert result is None
+        assert any("Could not load" in r.message for r in caplog.records)

--- a/core/tests/test_write_batch_atomicity.py
+++ b/core/tests/test_write_batch_atomicity.py
@@ -1,0 +1,154 @@
+"""Tests for SharedStateManager.write_batch() atomicity fix.
+
+Covers Issue #5946: write_batch() executes sequential writes — not atomic
+under SYNCHRONIZED isolation. The fix acquires all per-key locks before
+writing so concurrent readers never see a partial batch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from framework.runtime.shared_state import (
+    IsolationLevel,
+    SharedStateManager,
+    StateScope,
+)
+
+
+@pytest.fixture
+def manager():
+    return SharedStateManager()
+
+
+class TestWriteBatchAtomicity:
+    """Verify write_batch holds all locks during SYNCHRONIZED writes."""
+
+    @pytest.mark.asyncio
+    async def test_batch_write_synchronized_all_or_nothing(self, manager):
+        """Under SYNCHRONIZED + STREAM scope, a concurrent reader sees either
+        all keys from the batch or none."""
+        exec_id = "exec_1"
+        stream_id = "stream_1"
+
+        # Seed initial state so we can detect partial writes
+        await manager.write(
+            "a", "old_a", exec_id, stream_id,
+            IsolationLevel.SYNCHRONIZED, StateScope.STREAM,
+        )
+        await manager.write(
+            "b", "old_b", exec_id, stream_id,
+            IsolationLevel.SYNCHRONIZED, StateScope.STREAM,
+        )
+
+        snapshots: list[dict] = []
+        stop = asyncio.Event()
+
+        async def reader():
+            """Continuously read both keys and record snapshots."""
+            while not stop.is_set():
+                a = await manager.read("a", exec_id, stream_id, IsolationLevel.SYNCHRONIZED)
+                b = await manager.read("b", exec_id, stream_id, IsolationLevel.SYNCHRONIZED)
+                snapshots.append({"a": a, "b": b})
+                await asyncio.sleep(0)  # yield
+
+        reader_task = asyncio.create_task(reader())
+        # Yield so the reader collects at least one snapshot
+        await asyncio.sleep(0)
+
+        # Perform a batch write
+        await manager.write_batch(
+            {"a": "new_a", "b": "new_b"},
+            exec_id, stream_id,
+            IsolationLevel.SYNCHRONIZED,
+            StateScope.STREAM,
+        )
+
+        # Let reader collect a few more snapshots after the write
+        await asyncio.sleep(0.01)
+        stop.set()
+        await reader_task
+
+        # Ensure the reader actually ran (guards against vacuous pass)
+        assert snapshots, "Reader collected no snapshots — test is inconclusive"
+
+        # Every snapshot should be consistent: either both old or both new
+        for snap in snapshots:
+            assert (
+                (snap["a"] == "old_a" and snap["b"] == "old_b")
+                or (snap["a"] == "new_a" and snap["b"] == "new_b")
+            ), f"Partial batch visible: {snap}"
+
+    @pytest.mark.asyncio
+    async def test_batch_write_isolated_still_works(self, manager):
+        """ISOLATED write_batch should still write all keys (no locks needed)."""
+        exec_id = "exec_2"
+        stream_id = "stream_2"
+
+        await manager.write_batch(
+            {"x": 1, "y": 2, "z": 3},
+            exec_id, stream_id,
+            IsolationLevel.ISOLATED,
+            StateScope.EXECUTION,
+        )
+
+        assert await manager.read("x", exec_id, stream_id, IsolationLevel.ISOLATED) == 1
+        assert await manager.read("y", exec_id, stream_id, IsolationLevel.ISOLATED) == 2
+        assert await manager.read("z", exec_id, stream_id, IsolationLevel.ISOLATED) == 3
+
+    @pytest.mark.asyncio
+    async def test_batch_write_records_changes(self, manager):
+        """write_batch should record a StateChange for every key."""
+        exec_id = "exec_3"
+        stream_id = "stream_3"
+
+        initial_changes = len(manager._change_history)
+
+        await manager.write_batch(
+            {"k1": "v1", "k2": "v2"},
+            exec_id, stream_id,
+            IsolationLevel.SYNCHRONIZED,
+            StateScope.STREAM,
+        )
+
+        new_changes = manager._change_history[initial_changes:]
+        changed_keys = {c.key for c in new_changes}
+        assert "k1" in changed_keys
+        assert "k2" in changed_keys
+
+    @pytest.mark.asyncio
+    async def test_batch_write_no_deadlock_on_sorted_keys(self, manager):
+        """Two concurrent batch writes with overlapping keys must not deadlock.
+        Lock acquisition in sorted key order prevents this."""
+        exec_id = "exec_4"
+        stream_id = "stream_4"
+
+        async def writer_a():
+            await manager.write_batch(
+                {"alpha": 1, "beta": 2},
+                exec_id, stream_id,
+                IsolationLevel.SYNCHRONIZED,
+                StateScope.STREAM,
+            )
+
+        async def writer_b():
+            await manager.write_batch(
+                {"beta": 20, "alpha": 10},
+                exec_id, stream_id,
+                IsolationLevel.SYNCHRONIZED,
+                StateScope.STREAM,
+            )
+
+        # Should complete without deadlock within 2 seconds
+        await asyncio.wait_for(
+            asyncio.gather(writer_a(), writer_b()),
+            timeout=2.0,
+        )
+
+        # Both completed — values should be from whichever ran last
+        a = await manager.read("alpha", exec_id, stream_id, IsolationLevel.SYNCHRONIZED)
+        b = await manager.read("beta", exec_id, stream_id, IsolationLevel.SYNCHRONIZED)
+        assert a in (1, 10)
+        assert b in (2, 20)


### PR DESCRIPTION
## Summary

Three production-reliability bug fixes with full test coverage (14 new tests).

> **Note:** I've commented on all three linked issues to request assignment per the [Issue Assignment Policy](https://github.com/aden-hive/hive/blob/main/CONTRIBUTING.md#issue-assignment-policy). Please assign me and this PR is ready for review.

---

### Fix 1: `_dump_failed_request` crashes on read-only filesystems (#5965)

**Problem:** `_dump_failed_request()` calls `mkdir()` and `open()` without error handling, crashing the retry loop on read-only environments.

**Fix:** Wrap both I/O calls in `try/except OSError`, returning `f'<unavailable: {exc}>'` with the real error for accurate diagnostics.

**Tests:** 4 tests — success path, read-only mkdir, permission denied, disk full.

---

### Fix 2: `write_batch()` not atomic under SYNCHRONIZED isolation (#5946)

**Problem:** `write_batch()` acquires/releases per-key locks individually, allowing concurrent readers to see partial batches.

**Fix:**

- Under SYNCHRONIZED isolation with non-EXECUTION scope, acquire **all** per-key locks (sorted order prevents deadlocks) before writing.
- Locks tracked in `acquired` list — task cancellation during acquisition still releases already-held locks via `finally`.
- Locks released in **reverse** acquisition order to minimize contention windows.
- Extracted `_write_and_record()` helper shared by both `write()` and `write_batch()` so write semantics stay in one place and can't drift.

**Tests:** 4 tests — all-or-nothing consistency (with non-empty snapshot assertion), ISOLATED fallback, change recording, deadlock prevention.

---

### Fix 3: Bare `except Exception:` in key_storage.py (#5931)

**Problem:** Three `except Exception:` clauses silently swallow all errors at `debug` level. Corrupted stores, permission issues, encoding errors are invisible.

**Fix:** Narrow to specific types (`ImportError`, `OSError`, `ValueError`, `UnicodeDecodeError`), raise to `warning` with `exc_info=True` so full tracebacks appear in production logs.

**Tests:** 6 tests — warning logging, env cleanup on failure, unicode decode, success path, missing env var (uses `CREDENTIAL_KEY_ENV_VAR` constant), storage corruption.

---

## Checklist

- [x] Follows conventional commit format
- [x] All new tests pass (14/14)
- [x] Existing tests unaffected (34 passed, 0 failed)
- [x] Lint clean (`ruff check` — 0 errors)
- [x] Each fix is a separate commit with `Closes #XXXX` trailer
- [x] Addresses all review comments from #5972