### PR TITLE
docs(onboarding): update legacy repository references in setup/support docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Aden Agent Framework
 
-Thank you for your interest in contributing to the Aden Agent Framework! This document provides guidelines and information for contributors. We’re especially looking for help building tools, integrations ([check #2805](https://github.com/adenhq/hive/issues/2805)), and example agents for the framework. If you’re interested in extending its functionality, this is the perfect place to start. 
+Thank you for your interest in contributing to the Aden Agent Framework! This document provides guidelines and information for contributors. We’re especially looking for help building tools, integrations ([check #2805](https://github.com/aden-hive/hive/issues/2805)), and example agents for the framework. If you’re interested in extending its functionality, this is the perfect place to start. 
 
 ## Code of Conduct
 
@@ -35,7 +35,7 @@ You may submit PRs without prior assignment for:
 
 1. Fork the repository
 2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/hive.git`
-3. Add the upstream repository: `git remote add upstream https://github.com/adenhq/hive.git`
+3. Add the upstream repository: `git remote add upstream https://github.com/aden-hive/hive.git`
 4. Sync with upstream to ensure you're starting from the latest code:
    ```bash
    git fetch upstream

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -62,7 +62,7 @@ git --version       # Any recent version
 
 ```bash
 # 1. Clone the repository
-git clone https://github.com/adenhq/hive.git
+git clone https://github.com/aden-hive/hive.git
 cd hive
 
 # 2. Run automated setup
@@ -681,7 +681,7 @@ echo $ANTHROPIC_API_KEY
 ## Getting Help
 
 - **Documentation**: Check the `/docs` folder
-- **Issues**: Search [existing issues](https://github.com/adenhq/hive/issues)
+- **Issues**: Search [existing issues](https://github.com/aden-hive/hive/issues)
 - **Discord**: Join our [community](https://discord.com/invite/MXE49hrKDk)
 - **Code Review**: Tag a maintainer on your PR
 

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -572,6 +572,6 @@ When contributing agent packages:
 
 ## Support
 
-- **Issues:** https://github.com/adenhq/hive/issues
+- **Issues:** https://github.com/aden-hive/hive/issues
 - **Discord:** https://discord.com/invite/MXE49hrKDk
 - **Documentation:** https://docs.adenhq.com/

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,7 +15,7 @@ The fastest way to get started:
 
 ```bash
 # 1. Clone the repository
-git clone https://github.com/adenhq/hive.git
+git clone https://github.com/aden-hive/hive.git
 cd hive
 
 # 2. Run automated setup
@@ -214,6 +214,6 @@ pip uninstall -y framework tools
 ## Getting Help
 
 - **Documentation**: Check the `/docs` folder
-- **Issues**: [github.com/adenhq/hive/issues](https://github.com/adenhq/hive/issues)
+- **Issues**: [github.com/aden-hive/hive/issues](https://github.com/aden-hive/hive/issues)
 - **Discord**: [discord.com/invite/MXE49hrKDk](https://discord.com/invite/MXE49hrKDk)
 - **Build Agents**: Use the coder-tools workflow to create agents


### PR DESCRIPTION
## Description

This PR updates outdated `adenhq/hive` repository references in contributor-facing documentation to the current `aden-hive/hive` organization path. Although the old GitHub URLs currently redirect successfully, the legacy org reference creates avoidable confusion during clone/upstream setup, especially for first-time contributors following the onboarding flow.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

N/A – documentation-only update

## Changes Made

- Updated the upstream remote URL in `CONTRIBUTING.md`
- Updated the clone URL and issues/getting help URL in `docs/developer-guide.md`
- Updated the clone URL and issues/getting help URL in `docs/getting-started.md`
- Updated the issues/support URL in `docs/environment-setup.md`

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [X] Manual testing performed

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
