### PR TITLE
docs: Add Project Structure section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ Use Hive when you need:
 - **[Report Issues](https://github.com/adenhq/hive/issues)** - Bug reports and feature requests
 - **[Contributing](CONTRIBUTING.md)** - How to contribute and submit PRs
 
+
+## Project Structure
+
+The Hive repository is organized into the following main directories:
+
+- **`core/`** – Core runtime for the Hive multi-agent framework
+- **`tools/`** – MCP tool integrations used by agents
+- **`docs/`** – Framework documentation and guides
+- **`scripts/`** – Development and setup scripts
+- **`examples/`** – Example agents and use cases
+
 ## Quick Start
 
 ### Prerequisites


### PR DESCRIPTION
## Overview

This PR adds a **Project Structure** section to the README to help new contributors quickly understand the repository organization.

## Changes

Added a new section between "Quick Links" and "Quick Start" that describes the main directories:

- **`core/`** – Core runtime for the Hive multi-agent framework
- **`tools/`** – MCP tool integrations used by agents
- **`docs/`** – Framework documentation and guides
- **`scripts/`** – Development and setup scripts
- **`examples/`** – Example agents and use cases

## Benefits

- ✅ Helps new contributors understand the repository faster
- ✅ Improves onboarding experience
- ✅ Makes the README more informative
- ✅ Minimal, non-breaking change

## Testing

- Verified the section appears in the correct location
- Confirmed all directory names match the actual repository structure
- No functional code changes

Closes #5981