### PR TITLE
fix(execution): correct session.mode_state typo to phase_state in handle_pause

### DIFF
--- a/core/framework/server/routes_execution.py
+++ b/core/framework/server/routes_execution.py
@@ -357,8 +357,8 @@ async def handle_pause(request: web.Request) -> web.Response:
     runtime.pause_timers()
 
     # Switch to staging (agent still loaded, ready to re-run)
-    if session.mode_state is not None:
-        await session.mode_state.switch_to_staging(source="frontend")
+    if session.phase_state is not None:
+        await session.phase_state.switch_to_staging(source="frontend")
 
     return web.json_response(
         {


### PR DESCRIPTION
## Problem
The handle_pause endpoint in routes_execution.py was referencing session.mode_state instead of session.phase_state, causing an AttributeError on every pause request (issue #5991).

## Analysis
- The Session dataclass defines the field as phase_state (session_manager.py line 44)
- Line 75 and 412 in the same file correctly use session.phase_state
- Line 360-361 incorrectly used session.mode_state (typo)
- This inconsistency caused the pause endpoint to crash with a 500 error

## Solution
Changed line 360-361 to use session.phase_state consistently.

## Verification
- Syntax verified with python -m py_compile
- The fix aligns with existing usage patterns in the same file
- No functional changes beyond fixing the typo

## Notes
This is a micro-fix (< 20 lines, typo correction with no API/logic changes).