### PR TITLE
feat(tools): add IP Geolocation tool — free real-time IP location data, no API key required

### DIFF
--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -126,6 +126,7 @@ from .tech_stack_detector import register_tools as register_tech_stack_detector
 from .telegram_tool import register_tools as register_telegram
 from .terraform_tool import register_tools as register_terraform
 from .time_tool import register_tools as register_time
+from .ip_geolocation_tool import register_tools as register_ip_geolocation
 from .tines_tool import register_tools as register_tines
 from .trello_tool import register_tools as register_trello
 from .twilio_tool import register_tools as register_twilio
@@ -153,6 +154,7 @@ def _register_verified(
     register_web_scrape(mcp)
     register_pdf_read(mcp)
     register_time(mcp)
+    register_ip_geolocation(mcp)
     register_runtime_logs(mcp)
     register_wikipedia(mcp)
     register_arxiv(mcp)

--- a/tools/src/aden_tools/tools/ip_geolocation_tool/README.md
+++ b/tools/src/aden_tools/tools/ip_geolocation_tool/README.md
@@ -1,0 +1,18 @@
+# IP Geolocation Tool
+
+Free IP geolocation for Hive agents. No API key required.
+
+## Tools
+
+### ip_geolocation_lookup
+Get location data for any IP address.
+- ip (str): IP address e.g. 8.8.8.8
+
+### ip_geolocation_get_my_ip
+Get location data for the current machine IP.
+
+## Returns
+country, city, region, timezone, ISP, latitude, longitude
+
+## Authentication
+None required. Completely free.

--- a/tools/src/aden_tools/tools/ip_geolocation_tool/__init__.py
+++ b/tools/src/aden_tools/tools/ip_geolocation_tool/__init__.py
@@ -1,0 +1,3 @@
+from .ip_geolocation_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/ip_geolocation_tool/ip_geolocation_tool.py
+++ b/tools/src/aden_tools/tools/ip_geolocation_tool/ip_geolocation_tool.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import httpx
+from fastmcp import FastMCP
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register IP Geolocation tools with the MCP server."""
+
+    @mcp.tool()
+    def ip_geolocation_lookup(ip: str) -> dict:
+        """Get geolocation data for any IP address.
+
+        Args:
+            ip: IP address to look up (e.g. 8.8.8.8)
+
+        Returns:
+            Dictionary with country, city, region, timezone, ISP, lat, lon
+        """
+        try:
+            url = f"http://ip-api.com/json/{ip}"
+            response = httpx.get(url, timeout=10)
+            response.raise_for_status()
+            data = response.json()
+            if data.get("status") == "fail":
+                return {"error": data.get("message", "Lookup failed")}
+            return data
+        except httpx.HTTPStatusError as e:
+            return {"error": f"API request failed: {e.response.status_code}"}
+        except Exception as e:
+            return {"error": str(e)}
+
+    @mcp.tool()
+    def ip_geolocation_get_my_ip() -> dict:
+        """Get geolocation data for the current machine IP address.
+
+        Returns:
+            Dictionary with country, city, region, timezone, ISP, lat, lon
+        """
+        try:
+            url = "http://ip-api.com/json"
+            response = httpx.get(url, timeout=10)
+            response.raise_for_status()
+            data = response.json()
+            if data.get("status") == "fail":
+                return {"error": data.get("message", "Lookup failed")}
+            return data
+        except httpx.HTTPStatusError as e:
+            return {"error": f"API request failed: {e.response.status_code}"}
+        except Exception as e:
+            return {"error": str(e)}


### PR DESCRIPTION
Closes #5997

## Summary
Adds IP Geolocation tool using ip-api.com — completely free, no API key required.

## Tools Added
- `ip_geolocation_lookup(ip)` — get country, city, region, timezone, ISP, lat/lon for any IP
- `ip_geolocation_get_my_ip()` — get geolocation for the current machine's IP

## Testing
- Tested against 8.8.8.8 (Google DNS) — returns correct US/Google location data
- Tested ip_geolocation_get_my_ip() — returns correct local IP location

## Notes
- No authentication required
- Free for non-commercial use
- Follows existing tool patterns (time_tool)
- Parent issue: #2805