### PR TITLE
Add professional_rewriter template example

### DIFF
--- a/examples/templates/professional_rewriter/README.md
+++ b/examples/templates/professional_rewriter/README.md
@@ -1,0 +1,15 @@
+Professional Rewriter
+
+This template demonstrates a simple LLM-only Hive agent that rewrites informal text into more professional communication and returns structured outputs.
+
+Input:
+{"text":"yo vincent, im down to contribute. what should i do first?"}
+
+Run:
+uv run hive run examples/templates/professional_rewriter --input-file input.json --model anthropic/claude-sonnet-4-20250514
+
+Expected outputs:
+rewritten_text
+tone
+changes_made
+final_check

--- a/examples/templates/professional_rewriter/__init__.py
+++ b/examples/templates/professional_rewriter/__init__.py
@@ -1,0 +1,34 @@
+"""Professional Rewriter — Rewrites text professionally while maintaining meaning and improving clarity."""
+
+from .agent import (
+    ProfessionalRewriter,
+    default_agent,
+    goal,
+    nodes,
+    edges,
+    entry_node,
+    entry_points,
+    pause_nodes,
+    terminal_nodes,
+    conversation_mode,
+    identity_prompt,
+    loop_config,
+)
+from .config import default_config, metadata
+
+__all__ = [
+    "ProfessionalRewriter",
+    "default_agent",
+    "goal",
+    "nodes",
+    "edges",
+    "entry_node",
+    "entry_points",
+    "pause_nodes",
+    "terminal_nodes",
+    "conversation_mode",
+    "identity_prompt",
+    "loop_config",
+    "default_config",
+    "metadata",
+]

--- a/examples/templates/professional_rewriter/__main__.py
+++ b/examples/templates/professional_rewriter/__main__.py
@@ -1,0 +1,84 @@
+"""CLI entry point for Professional Rewriter."""
+
+import asyncio, json, logging, sys
+import click
+from .agent import default_agent, ProfessionalRewriter
+
+
+def setup_logging(verbose=False, debug=False):
+    if debug: level, fmt = logging.DEBUG, "%(asctime)s %(name)s: %(message)s"
+    elif verbose: level, fmt = logging.INFO, "%(message)s"
+    else: level, fmt = logging.WARNING, "%(levelname)s: %(message)s"
+    logging.basicConfig(level=level, format=fmt, stream=sys.stderr)
+
+
+@click.group()
+@click.version_option(version="1.0.0")
+def cli():
+    """Professional Rewriter — Rewrites text professionally while maintaining meaning and improving clarity."""
+    pass
+
+
+@cli.command()
+@click.option("--text", "-t", required=True, help="Text to rewrite")
+@click.option("--verbose", "-v", is_flag=True)
+def run(text, verbose):
+    """Execute the agent."""
+    setup_logging(verbose=verbose)
+    result = asyncio.run(default_agent.run({"text": text}))
+    click.echo(json.dumps({"success": result.success, "output": result.output}, indent=2, default=str))
+    sys.exit(0 if result.success else 1)
+
+
+@cli.command()
+def tui():
+    """Launch TUI dashboard."""
+    from pathlib import Path
+    from framework.tui.app import AdenTUI
+    from framework.llm import LiteLLMProvider
+    from framework.runner.tool_registry import ToolRegistry
+    from framework.runtime.agent_runtime import create_agent_runtime
+    from framework.runtime.execution_stream import EntryPointSpec
+
+    async def run_tui():
+        agent = ProfessionalRewriter()
+        agent._tool_registry = ToolRegistry()
+        storage = Path.home() / ".hive" / "agents" / "professional_rewriter"
+        storage.mkdir(parents=True, exist_ok=True)
+        mcp_cfg = Path(__file__).parent / "mcp_servers.json"
+        if mcp_cfg.exists(): agent._tool_registry.load_mcp_config(mcp_cfg)
+        llm = LiteLLMProvider(model=agent.config.model, api_key=agent.config.api_key, api_base=agent.config.api_base)
+        runtime = create_agent_runtime(
+            graph=agent._build_graph(), goal=agent.goal, storage_path=storage,
+            entry_points=[EntryPointSpec(id="start", name="Start", entry_node="rewrite", trigger_type="manual", isolation_level="isolated")],
+            llm=llm, tools=list(agent._tool_registry.get_tools().values()), tool_executor=agent._tool_registry.get_executor())
+        await runtime.start()
+        try:
+            app = AdenTUI(runtime)
+            await app.run_async()
+        finally:
+            await runtime.stop()
+    asyncio.run(run_tui())
+
+
+@cli.command()
+def info():
+    """Show agent info."""
+    data = default_agent.info()
+    click.echo(f"Agent: {data['name']}\nVersion: {data['version']}\nDescription: {data['description']}")
+    click.echo(f"Nodes: {', '.join(data['nodes'])}\nClient-facing: {', '.join(data['client_facing_nodes'])}")
+
+
+@cli.command()
+def validate():
+    """Validate agent structure."""
+    v = default_agent.validate()
+    if v["valid"]: click.echo("Agent is valid")
+    else:
+        click.echo("Errors:")
+        for e in v["errors"]: click.echo(f"  {e}")
+    sys.exit(0 if v["valid"] else 1)
+
+
+if __name__ == "__main__":
+    cli()

--- a/examples/templates/professional_rewriter/agent.py
+++ b/examples/templates/professional_rewriter/agent.py
@@ -1,0 +1,162 @@
+"""Agent graph construction for Professional Rewriter."""
+
+from pathlib import Path
+
+from framework.graph import EdgeSpec, EdgeCondition, Goal, SuccessCriterion, Constraint
+from framework.graph.edge import GraphSpec
+from framework.graph.executor import ExecutionResult
+from framework.graph.checkpoint_config import CheckpointConfig
+from framework.llm import LiteLLMProvider
+from framework.runner.tool_registry import ToolRegistry
+from framework.runtime.agent_runtime import AgentRuntime, create_agent_runtime
+from framework.runtime.execution_stream import EntryPointSpec
+
+from .config import default_config, metadata
+from .nodes import rewrite_node, validate_node
+
+# Goal definition
+goal = Goal(
+    id="professional-rewriter-goal",
+    name="Professional Text Rewriting",
+    description="Rewrite text professionally while maintaining meaning and providing structured output.",
+    success_criteria=[
+        SuccessCriterion(id="sc-1", description="Text is rewritten with improved clarity and professionalism", metric="quality_improvement", target="high", weight=0.3),
+        SuccessCriterion(id="sc-2", description="Original meaning is preserved", metric="meaning_preservation", target="exact", weight=0.3),
+        SuccessCriterion(id="sc-3", description="Output is valid JSON with required fields", metric="json_validity", target="100%", weight=0.2),
+        SuccessCriterion(id="sc-4", description="Changes are tracked and documented", metric="change_documentation", target="complete", weight=0.2),
+    ],
+    constraints=[
+        Constraint(id="c-1", description="Rewritten text must be non-empty", constraint_type="hard", category="quality"),
+        Constraint(id="c-2", description="Output must be valid JSON format", constraint_type="hard", category="functional"),
+        Constraint(id="c-3", description="Must preserve original meaning and intent", constraint_type="hard", category="accuracy"),
+    ],
+)
+
+# Node list
+nodes = [rewrite_node, validate_node]
+
+# Edge definitions
+edges = [
+    EdgeSpec(id="rewrite-to-validate", source="rewrite", target="validate",
+             condition=EdgeCondition.ON_SUCCESS, priority=1),
+    # Loop back for next rewriting task (queen sends new input)
+    EdgeSpec(id="validate-done", source="validate", target="rewrite",
+             condition=EdgeCondition.ON_SUCCESS, priority=1),
+]
+
+# Graph configuration — entry is the autonomous rewrite node
+# The queen handles intake and passes the text via run_agent_with_input({"text": "..."})
+entry_node = "rewrite"
+entry_points = {"start": "rewrite"}
+pause_nodes = []
+terminal_nodes = []  # Forever-alive
+
+# Module-level vars read by AgentRunner.load()
+conversation_mode = "continuous"
+identity_prompt = "You are a professional text rewriter focused on clarity and professionalism."
+loop_config = {"max_iterations": 100, "max_tool_calls_per_turn": 20, "max_history_tokens": 32000}
+
+
+class ProfessionalRewriter:
+    def __init__(self, config=None):
+        self.config = config or default_config
+        self.goal = goal
+        self.nodes = nodes
+        self.edges = edges
+        self.entry_node = entry_node  # "rewrite" — autonomous entry
+        self.entry_points = entry_points
+        self.pause_nodes = pause_nodes
+        self.terminal_nodes = terminal_nodes
+        self._graph = None
+        self._agent_runtime = None
+        self._tool_registry = None
+        self._storage_path = None
+
+    def _build_graph(self):
+        return GraphSpec(
+            id="professional-rewriter-graph",
+            goal_id=self.goal.id,
+            version="1.0.0",
+            entry_node=self.entry_node,
+            entry_points=self.entry_points,
+            terminal_nodes=self.terminal_nodes,
+            pause_nodes=self.pause_nodes,
+            nodes=self.nodes,
+            edges=self.edges,
+            default_model=self.config.model,
+            max_tokens=self.config.max_tokens,
+            loop_config=loop_config,
+            conversation_mode=conversation_mode,
+            identity_prompt=identity_prompt,
+        )
+
+    def _setup(self):
+        self._storage_path = Path.home() / ".hive" / "agents" / "professional_rewriter"
+        self._storage_path.mkdir(parents=True, exist_ok=True)
+        self._tool_registry = ToolRegistry()
+        mcp_config = Path(__file__).parent / "mcp_servers.json"
+        if mcp_config.exists():
+            self._tool_registry.load_mcp_config(mcp_config)
+        llm = LiteLLMProvider(model=self.config.model, api_key=self.config.api_key, api_base=self.config.api_base)
+        tools = list(self._tool_registry.get_tools().values())
+        tool_executor = self._tool_registry.get_executor()
+        self._graph = self._build_graph()
+        self._agent_runtime = create_agent_runtime(
+            graph=self._graph, goal=self.goal, storage_path=self._storage_path,
+            entry_points=[EntryPointSpec(id="default", name="Default", entry_node=self.entry_node,
+                                         trigger_type="manual", isolation_level="shared")],
+            llm=llm, tools=tools, tool_executor=tool_executor,
+            checkpoint_config=CheckpointConfig(enabled=True, checkpoint_on_node_complete=True,
+                                                checkpoint_max_age_days=7, async_checkpoint=True),
+        )
+
+    async def start(self):
+        if self._agent_runtime is None:
+            self._setup()
+        if not self._agent_runtime.is_running:
+            await self._agent_runtime.start()
+
+    async def stop(self):
+        if self._agent_runtime and self._agent_runtime.is_running:
+            await self._agent_runtime.stop()
+        self._agent_runtime = None
+
+    async def trigger_and_wait(self, entry_point="default", input_data=None, timeout=None, session_state=None):
+        if self._agent_runtime is None:
+            raise RuntimeError("Agent not started. Call start() first.")
+        return await self._agent_runtime.trigger_and_wait(
+            entry_point_id=entry_point, input_data=input_data or {}, session_state=session_state)
+
+    async def run(self, context, session_state=None):
+        await self.start()
+        try:
+            result = await self.trigger_and_wait("default", context, session_state=session_state)
+            return result or ExecutionResult(success=False, error="Execution timeout")
+        finally:
+            await self.stop()
+
+    def info(self):
+        return {
+            "name": metadata.name, "version": metadata.version, "description": metadata.description,
+            "goal": {"name": self.goal.name, "description": self.goal.description},
+            "nodes": [n.id for n in self.nodes], "edges": [e.id for e in self.edges],
+            "entry_node": self.entry_node, "entry_points": self.entry_points,
+            "terminal_nodes": self.terminal_nodes,
+            "client_facing_nodes": [n.id for n in self.nodes if n.client_facing],
+        }
+
+    def validate(self):
+        errors, warnings = [], []
+        node_ids = {n.id for n in self.nodes}
+        for e in self.edges:
+            if e.source not in node_ids: errors.append(f"Edge {e.id}: source '{e.source}' not found")
+            if e.target not in node_ids: errors.append(f"Edge {e.id}: target '{e.target}' not found")
+        if self.entry_node not in node_ids: errors.append(f"Entry node '{self.entry_node}' not found")
+        for t in self.terminal_nodes:
+            if t not in node_ids: errors.append(f"Terminal node '{t}' not found")
+        for ep_id, nid in self.entry_points.items():
+            if nid not in node_ids: errors.append(f"Entry point '{ep_id}' references unknown node '{nid}'")
+        return {"valid": len(errors) == 0, "errors": errors, "warnings": warnings}
+
+
+default_agent = ProfessionalRewriter()

--- a/examples/templates/professional_rewriter/config.py
+++ b/examples/templates/professional_rewriter/config.py
@@ -1,0 +1,43 @@
+"""Runtime configuration."""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+def _load_preferred_model() -> str:
+    """Load preferred model from ~/.hive/configuration.json."""
+    config_path = Path.home() / ".hive" / "configuration.json"
+    if config_path.exists():
+        try:
+            with open(config_path) as f:
+                config = json.load(f)
+            llm = config.get("llm", {})
+            if llm.get("provider") and llm.get("model"):
+                return f"{llm['provider']}/{llm['model']}"
+        except Exception:
+            pass
+    return "anthropic/claude-sonnet-4-20250514"
+
+
+@dataclass
+class RuntimeConfig:
+    model: str = field(default_factory=_load_preferred_model)
+    temperature: float = 0.7
+    max_tokens: int = 40000
+    api_key: str | None = None
+    api_base: str | None = None
+
+
+default_config = RuntimeConfig()
+
+
+@dataclass
+class AgentMetadata:
+    name: str = "Professional Rewriter"
+    version: str = "1.0.0"
+    description: str = "Rewrites text professionally while maintaining meaning and improving clarity."
+    intro_message: str = "Welcome! I'll help you rewrite text professionally. Provide the text you'd like me to rewrite."
+
+
+metadata = AgentMetadata()

--- a/examples/templates/professional_rewriter/mcp_servers.json
+++ b/examples/templates/professional_rewriter/mcp_servers.json
@@ -1,0 +1,9 @@
+{
+  "hive-tools": {
+    "transport": "stdio",
+    "command": "uv",
+    "args": ["run", "python", "mcp_server.py", "--stdio"],
+    "cwd": "../../tools",
+    "description": "Hive tools MCP server"
+  }
+}

--- a/examples/templates/professional_rewriter/nodes/__init__.py
+++ b/examples/templates/professional_rewriter/nodes/__init__.py
@@ -1,0 +1,78 @@
+"""Node definitions for Professional Rewriter."""
+
+from framework.graph import NodeSpec
+
+# Node 1: Rewrite (autonomous entry node)
+# The queen handles intake and passes text via run_agent_with_input({"text": "..."})
+rewrite_node = NodeSpec(
+    id="rewrite",
+    name="Professional Rewriter",
+    description="Rewrite text professionally with tone analysis and change tracking",
+    node_type="event_loop",
+    max_node_visits=0,  # Unlimited for forever-alive
+    input_keys=["text"],
+    output_keys=["rewritten_text", "tone", "changes_made", "final_check"],
+    success_criteria="Text is rewritten professionally with valid JSON output.",
+    system_prompt="""\
+You are a professional text rewriter. Your task is to rewrite the provided text to improve clarity, professionalism, and readability while preserving the original meaning.
+
+The text to rewrite is in memory under "text".
+
+Work in phases:
+1. **Analyze the original text**: Identify tone, style, and key points
+2. **Rewrite professionally**: Improve clarity, grammar, structure, and flow
+3. **Track changes**: Note specific improvements made
+4. **Validate output**: Ensure the rewrite maintains original meaning
+
+Call set_output in a SEPARATE turn with these exact keys:
+- set_output("rewritten_text", "the professionally rewritten version")
+- set_output("tone", "description of the tone used (e.g., 'formal business', 'academic', 'conversational professional')")  
+- set_output("changes_made", "JSON array of specific changes as strings")
+- set_output("final_check", "true if rewrite maintains original meaning and is professional, false otherwise")
+
+Requirements:
+- rewritten_text must be non-empty
+- tone should be a concise description
+- changes_made must be a valid JSON array of strings describing improvements
+- final_check must be "true" or "false" as a string
+""",
+    tools=[],
+)
+
+# Node 2: Validate (validation step)
+validate_node = NodeSpec(
+    id="validate",
+    name="Output Validator",
+    description="Validate that output is valid JSON and meets requirements",
+    node_type="event_loop",
+    max_node_visits=0,
+    input_keys=["rewritten_text", "tone", "changes_made", "final_check"],
+    output_keys=["validation_result", "final_output"],
+    success_criteria="Output is validated as proper JSON with non-empty rewritten_text.",
+    system_prompt="""\
+You are a validation specialist. Your task is to validate the rewriting output and format it as valid JSON.
+
+Check the following requirements:
+1. rewritten_text must be non-empty
+2. tone should be a meaningful description
+3. changes_made must be parseable as a JSON array
+4. final_check should be "true" or "false"
+
+If all validations pass, create the final JSON output. If any fail, set validation_result to describe the issue.
+
+Call set_output in a SEPARATE turn:
+- set_output("validation_result", "valid" if all checks pass, otherwise describe the issue)
+- set_output("final_output", "complete JSON object as string" if valid, otherwise "null")
+
+Final JSON format:
+{
+  "rewritten_text": "...",
+  "tone": "...",
+  "changes_made": [...],
+  "final_check": true/false
+}
+""",
+    tools=[],
+)
+
+__all__ = ["rewrite_node", "validate_node"]

--- a/examples/templates/professional_rewriter/tests/conftest.py
+++ b/examples/templates/professional_rewriter/tests/conftest.py
@@ -1,0 +1,28 @@
+"""Test fixtures."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_repo_root = Path(__file__).resolve().parents[3]
+for _p in ["exports", "core"]:
+    _path = str(_repo_root / _p)
+    if _path not in sys.path:
+        sys.path.insert(0, _path)
+
+AGENT_PATH = str(Path(__file__).resolve().parents[1])
+
+
+@pytest.fixture(scope="session")
+def agent_module():
+    """Import the agent package for structural validation."""
+    import importlib
+    return importlib.import_module(Path(AGENT_PATH).name)
+
+
+@pytest.fixture(scope="session")
+def runner_loaded():
+    """Load the agent through AgentRunner (structural only, no LLM needed)."""
+    from framework.runner.runner import AgentRunner
+    return AgentRunner.load(AGENT_PATH)

--- a/examples/templates/professional_rewriter/tests/test_professional_rewriter.py
+++ b/examples/templates/professional_rewriter/tests/test_professional_rewriter.py
@@ -1,0 +1,103 @@
+"""Tests for Professional Rewriter agent."""
+
+import pytest
+from professional_rewriter import default_agent, goal, nodes, edges
+
+
+def test_agent_structure():
+    """Test basic agent structure."""
+    assert default_agent.goal.id == "professional-rewriter-goal"
+    assert len(default_agent.nodes) == 2
+    assert len(default_agent.edges) == 2
+    assert default_agent.entry_node == "rewrite"
+
+
+def test_goal_definition():
+    """Test goal has required success criteria and constraints."""
+    assert len(goal.success_criteria) == 4
+    assert len(goal.constraints) == 3
+    
+    # Check success criteria weights sum to 1.0
+    total_weight = sum(sc.weight for sc in goal.success_criteria)
+    assert abs(total_weight - 1.0) < 0.001
+
+
+def test_node_configuration():
+    """Test node specifications."""
+    node_ids = {n.id for n in nodes}
+    assert node_ids == {"rewrite", "validate"}
+    
+    # Find nodes
+    rewrite_node = next(n for n in nodes if n.id == "rewrite")
+    validate_node = next(n for n in nodes if n.id == "validate")
+    
+    # Test rewrite node
+    assert rewrite_node.node_type == "event_loop"
+    assert "text" in rewrite_node.input_keys
+    assert "rewritten_text" in rewrite_node.output_keys
+    assert "tone" in rewrite_node.output_keys
+    assert "changes_made" in rewrite_node.output_keys
+    assert "final_check" in rewrite_node.output_keys
+    assert rewrite_node.tools == []  # LLM only
+    
+    # Test validate node
+    assert validate_node.node_type == "event_loop"
+    assert "rewritten_text" in validate_node.input_keys
+    assert "validation_result" in validate_node.output_keys
+    assert "final_output" in validate_node.output_keys
+    assert validate_node.tools == []  # LLM only
+
+
+def test_edge_configuration():
+    """Test edge specifications."""
+    edge_specs = {(e.source, e.target): e for e in edges}
+    
+    # Should have rewrite -> validate -> rewrite loop
+    assert ("rewrite", "validate") in edge_specs
+    assert ("validate", "rewrite") in edge_specs
+    
+    # Check edge conditions
+    rewrite_to_validate = edge_specs[("rewrite", "validate")]
+    assert rewrite_to_validate.condition.name == "ON_SUCCESS"
+    
+    validate_done = edge_specs[("validate", "rewrite")]
+    assert validate_done.condition.name == "ON_SUCCESS"
+
+
+def test_agent_validation():
+    """Test agent passes internal validation."""
+    validation = default_agent.validate()
+    assert validation["valid"] is True
+    assert len(validation["errors"]) == 0
+
+
+def test_forever_alive_configuration():
+    """Test agent is configured as forever-alive."""
+    assert default_agent.terminal_nodes == []
+    assert default_agent.entry_points == {"start": "rewrite"}
+
+
+def test_system_prompts():
+    """Test nodes have appropriate system prompts."""
+    rewrite_node = next(n for n in nodes if n.id == "rewrite")
+    validate_node = next(n for n in nodes if n.id == "validate")
+    
+    # Check key instructions are present
+    assert "set_output" in rewrite_node.system_prompt
+    assert "rewritten_text" in rewrite_node.system_prompt
+    assert "changes_made" in rewrite_node.system_prompt
+    assert "JSON" in validate_node.system_prompt
+    assert "validation_result" in validate_node.system_prompt
+
+
+def test_import_agent_package(agent_module):
+    """Test that the agent package can be imported."""
+    assert hasattr(agent_module, "default_agent")
+    assert hasattr(agent_module, "goal")
+    assert hasattr(agent_module, "nodes")
+    assert hasattr(agent_module, "edges")
+
+
+def test_agent_runner_loads(runner_loaded):
+    """Test that AgentRunner can load the agent."""
+    assert runner_loaded is not None


### PR DESCRIPTION
Fixes #6039
Description

Adds a new LLM-only template agent, professional_rewriter, to examples/templates. The agent rewrites informal text into professional communication and returns structured outputs including rewritten_text, tone, changes_made, and final_check.

Type of Change

New feature (non-breaking change that adds functionality)
Documentation update

Related Issues

Related to the Windows runtime cleanup / MCP issue discussed separately.

Changes Made

Added examples/templates/professional_rewriter
Included agent files for an LLM-only structured output example
Added documentation explaining how to run the template

Testing

Manual testing performed.

Tested on Windows using VSCode PowerShell.
Ran the template with:

uv run hive run examples/templates/professional_rewriter --input-file input.json --model anthropic/claude-sonnet-4-20250514

The agent executed and produced the expected structured outputs