### PR TITLE
feat: add Hacker News briefing agent with configurable delivery

### DIFF
--- a/examples/templates/hacker_news_briefing/README.md
+++ b/examples/templates/hacker_news_briefing/README.md
@@ -1,0 +1,176 @@
+# Hacker News Briefing Agent
+
+**Version**: 1.0.0
+**Type**: Multi-node agent with feedback loop
+**Created**: 2026-03-08
+
+## Overview
+
+Collects top Hacker News stories daily, ranks them by relevance and value, produces a concise briefing with "why it matters" notes and source links, and delivers via user-configurable channels (markdown, email, slack).
+
+## Architecture
+
+### Execution Flow
+
+```
+intake-preferences -> collect-hn-candidates -> rank-and-summarize -> review-briefing -> deliver-briefing
+                                              ^                          |
+                                              +--------- (revise) --------+
+```
+
+### Nodes (5 total)
+
+1. **intake-preferences** (event_loop, client-facing)
+   - Collect user preferences for delivery channel, timezone, focus areas, and story count.
+   - Writes: `briefing_config`
+   - Client-facing: Yes (blocks for user input)
+
+2. **collect-hn-candidates** (event_loop)
+   - Scrape Hacker News front page and collect top story candidates with metadata.
+   - Reads: `briefing_config`
+   - Writes: `hn_candidates`
+   - Tools: `web_scrape`
+
+3. **rank-and-summarize** (event_loop)
+   - Rank stories by relevance and engagement, create summaries with "why it matters" notes.
+   - Reads: `briefing_config`, `hn_candidates`
+   - Writes: `ranked_briefing`
+
+4. **review-briefing** (event_loop, client-facing)
+   - Present briefing preview to user, allow approval or revision requests.
+   - Reads: `briefing_config`, `ranked_briefing`
+   - Writes: `review_status`, `revision_feedback` (nullable)
+   - Client-facing: Yes (blocks for user input)
+
+5. **deliver-briefing** (event_loop, client-facing)
+   - Deliver final briefing via configured channel(s).
+   - Reads: `briefing_config`, `ranked_briefing`, `review_status`
+   - Writes: `delivery_result`
+   - Tools: `save_data`, `append_data`, `serve_file_to_user`
+   - Client-facing: Yes
+
+### Edges (5 total)
+
+- `intake-preferences` → `collect-hn-candidates` (condition: on_success, priority=1)
+- `collect-hn-candidates` → `rank-and-summarize` (condition: on_success, priority=1)
+- `rank-and-summarize` → `review-briefing` (condition: on_success, priority=1)
+- `review-briefing` → `deliver-briefing` (condition: conditional, when status="approved", priority=1)
+- `review-briefing` → `rank-and-summarize` (condition: conditional, when status="revise", priority=2) — **feedback loop**
+
+## Goal Criteria
+
+### Success Criteria
+
+**Collects top HN stories with metadata** (weight 0.2)
+- Metric: stories_collected
+- Target: >=5
+
+**Ranks stories by relevance and community engagement** (weight 0.2)
+- Metric: ranking_quality
+- Target: true
+
+**Provides concise summaries with "why it matters" notes** (weight 0.2)
+- Metric: summaries_provided
+- Target: 100%
+
+**Allows user to review and refine the briefing** (weight 0.15)
+- Metric: user_reviewed
+- Target: true
+
+**Delivers briefing via configured channel(s)** (weight 0.25)
+- Metric: delivered
+- Target: true
+
+### Constraints
+
+**Never fabricate stories or URLs** (hard)
+- Category: quality
+
+**Always include source links for every story** (hard)
+- Category: quality
+
+**Always deliver via markdown at minimum** (hard)
+- Category: reliability
+
+**Keep summaries brief and actionable** (soft)
+- Category: quality
+
+## Required Tools
+
+- `web_scrape` — for collecting HN stories
+- `save_data` — for creating the briefing file
+- `append_data` — for building the file in chunks
+- `serve_file_to_user` — for delivering the briefing
+
+## Delivery Channels
+
+The agent supports multiple delivery channels:
+
+1. **markdown** (default, no setup required)
+   - Creates a formatted markdown file
+   - Served via `serve_file_to_user`
+
+2. **email** (requires credentials)
+   - Sends HTML email with the briefing
+   - Requires email configuration
+
+3. **slack** (requires credentials)
+   - Posts to Slack channel
+   - Requires Slack webhook configuration
+
+4. **all**
+   - Attempts delivery via all configured channels
+   - Falls back to markdown for unconfigured channels
+
+## Usage
+
+### Basic Usage
+
+```python
+from framework.runner import AgentRunner
+
+# Load the agent
+runner = AgentRunner.load("examples/templates/hacker_news_briefing")
+
+# Run with input
+result = await runner.run({})
+
+# Access results
+print(result.output)
+print(result.status)
+```
+
+### CLI Usage
+
+```bash
+# Run the agent
+python -m examples.templates.hacker_news_briefing run
+
+# Show agent info
+python -m examples.templates.hacker_news_briefing info
+
+# Validate agent structure
+python -m examples.templates.hacker_news_briefing validate
+
+# Interactive shell
+python -m examples.templates.hacker_news_briefing shell
+```
+
+### Input Schema
+
+The agent's entry node `intake-preferences` accepts initial context but primarily collects preferences via user interaction.
+
+### Output Schema
+
+Terminal node: `deliver-briefing`
+
+Output includes:
+- `delivery_result`: JSON with delivery status, channels used, and file path
+
+## Version History
+
+- **1.0.0** (2026-03-08): Initial release
+  - 5 nodes, 5 edges (including feedback loop)
+  - Goal: Hacker News Briefing
+  - Supports configurable delivery channels
+  - Human-in-the-loop review with revision capability

--- a/examples/templates/hacker_news_briefing/__init__.py
+++ b/examples/templates/hacker_news_briefing/__init__.py
@@ -1,0 +1,24 @@
+"""
+Hacker News Briefing - Daily HN briefing with configurable delivery.
+
+Collects top Hacker News stories, ranks them by relevance, produces
+a concise briefing with 'why it matters' notes, and delivers via
+user-configurable channels (markdown, email, slack).
+"""
+
+from .agent import HackerNewsBriefingAgent, default_agent, edges, goal, nodes
+from .config import AgentMetadata, RuntimeConfig, default_config, metadata
+
+__version__ = "1.0.0"
+
+__all__ = [
+    "HackerNewsBriefingAgent",
+    "default_agent",
+    "goal",
+    "nodes",
+    "edges",
+    "RuntimeConfig",
+    "AgentMetadata",
+    "default_config",
+    "metadata",
+]

--- a/examples/templates/hacker_news_briefing/__main__.py
+++ b/examples/templates/hacker_news_briefing/__main__.py
@@ -1,0 +1,230 @@
+"""
+CLI entry point for Hacker News Briefing.
+
+Uses AgentRuntime for multi-entrypoint support with HITL pause/resume.
+"""
+
+import asyncio
+import json
+import logging
+import sys
+
+import click
+
+from .agent import HackerNewsBriefingAgent, default_agent
+
+
+def setup_logging(verbose=False, debug=False):
+    """Configure logging for execution visibility."""
+    if debug:
+        level, fmt = logging.DEBUG, "%(asctime)s %(name)s: %(message)s"
+    elif verbose:
+        level, fmt = logging.INFO, "%(message)s"
+    else:
+        level, fmt = logging.WARNING, "%(levelname)s: %(message)s"
+    logging.basicConfig(level=level, format=fmt, stream=sys.stderr)
+    logging.getLogger("framework").setLevel(level)
+
+
+@click.group()
+@click.version_option(version="1.0.0")
+def cli():
+    """Hacker News Briefing - Daily HN briefing with configurable delivery."""
+    pass
+
+
+@cli.command()
+@click.option("--quiet", "-q", is_flag=True, help="Only output result JSON")
+@click.option("--verbose", "-v", is_flag=True, help="Show execution details")
+@click.option("--debug", is_flag=True, help="Show debug logging")
+def run(quiet, verbose, debug):
+    """Execute the Hacker News briefing agent."""
+    if not quiet:
+        setup_logging(verbose=verbose, debug=debug)
+
+    context = {}
+
+    result = asyncio.run(default_agent.run(context))
+
+    output_data = {
+        "success": result.success,
+        "steps_executed": result.steps_executed,
+        "output": result.output,
+    }
+    if result.error:
+        output_data["error"] = result.error
+
+    click.echo(json.dumps(output_data, indent=2, default=str))
+    sys.exit(0 if result.success else 1)
+
+
+@cli.command()
+@click.option("--verbose", "-v", is_flag=True, help="Show execution details")
+@click.option("--debug", is_flag=True, help="Show debug logging")
+def tui(verbose, debug):
+    """Launch the TUI dashboard for interactive briefing."""
+    setup_logging(verbose=verbose, debug=debug)
+
+    try:
+        from framework.tui.app import AdenTUI
+    except ImportError:
+        click.echo(
+            "TUI requires the 'textual' package. Install with: pip install textual"
+        )
+        sys.exit(1)
+
+    from pathlib import Path
+
+    from framework.llm import LiteLLMProvider
+    from framework.runner.tool_registry import ToolRegistry
+    from framework.runtime.agent_runtime import create_agent_runtime
+    from framework.runtime.event_bus import EventBus
+    from framework.runtime.execution_stream import EntryPointSpec
+
+    async def run_with_tui():
+        agent = HackerNewsBriefingAgent()
+
+        agent._event_bus = EventBus()
+        agent._tool_registry = ToolRegistry()
+
+        storage_path = Path.home() / ".hive" / "agents" / "hn_briefing"
+        storage_path.mkdir(parents=True, exist_ok=True)
+
+        mcp_config_path = Path(__file__).parent / "mcp_servers.json"
+        if mcp_config_path.exists():
+            agent._tool_registry.load_mcp_config(mcp_config_path)
+
+        llm = LiteLLMProvider(
+            model=agent.config.model,
+            api_key=agent.config.api_key,
+            api_base=agent.config.api_base,
+        )
+
+        tools = list(agent._tool_registry.get_tools().values())
+        tool_executor = agent._tool_registry.get_executor()
+        graph = agent._build_graph()
+
+        runtime = create_agent_runtime(
+            graph=graph,
+            goal=agent.goal,
+            storage_path=storage_path,
+            entry_points=[
+                EntryPointSpec(
+                    id="start",
+                    name="Start HN Briefing",
+                    entry_node="intake-preferences",
+                    trigger_type="manual",
+                    isolation_level="isolated",
+                ),
+            ],
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor,
+        )
+
+        await runtime.start()
+
+        try:
+            app = AdenTUI(runtime)
+            await app.run_async()
+        finally:
+            await runtime.stop()
+
+    asyncio.run(run_with_tui())
+
+
+@cli.command()
+@click.option("--json", "output_json", is_flag=True)
+def info(output_json):
+    """Show agent information."""
+    info_data = default_agent.info()
+    if output_json:
+        click.echo(json.dumps(info_data, indent=2))
+    else:
+        click.echo(f"Agent: {info_data['name']}")
+        click.echo(f"Version: {info_data['version']}")
+        click.echo(f"Description: {info_data['description']}")
+        click.echo(f"\nNodes: {', '.join(info_data['nodes'])}")
+        click.echo(f"Client-facing: {', '.join(info_data['client_facing_nodes'])}")
+        click.echo(f"Entry: {info_data['entry_node']}")
+        click.echo(f"Terminal: {', '.join(info_data['terminal_nodes'])}")
+
+
+@cli.command()
+def validate():
+    """Validate agent structure."""
+    validation = default_agent.validate()
+    if validation["valid"]:
+        click.echo("Agent is valid")
+        if validation["warnings"]:
+            for warning in validation["warnings"]:
+                click.echo(f"  WARNING: {warning}")
+    else:
+        click.echo("Agent has errors:")
+        for error in validation["errors"]:
+            click.echo(f"  ERROR: {error}")
+    sys.exit(0 if validation["valid"] else 1)
+
+
+@cli.command()
+@click.option("--verbose", "-v", is_flag=True)
+def shell(verbose):
+    """Interactive briefing session (CLI, no TUI)."""
+    asyncio.run(_interactive_shell(verbose))
+
+
+async def _interactive_shell(verbose=False):
+    """Async interactive shell."""
+    setup_logging(verbose=verbose)
+
+    click.echo("=== Hacker News Briefing ===")
+    click.echo("Press Enter to start a briefing (or 'quit' to exit):\n")
+
+    agent = HackerNewsBriefingAgent()
+    await agent.start()
+
+    try:
+        while True:
+            try:
+                user_input = await asyncio.get_event_loop().run_in_executor(
+                    None, input, "HN> "
+                )
+                if user_input.lower() in ["quit", "exit", "q"]:
+                    click.echo("Goodbye!")
+                    break
+
+                click.echo("\nCollecting Hacker News stories...\n")
+
+                result = await agent.trigger_and_wait("start", {})
+
+                if result is None:
+                    click.echo("\n[Execution timed out]\n")
+                    continue
+
+                if result.success:
+                    output = result.output
+                    if "delivery_result" in output:
+                        delivery = output["delivery_result"]
+                        if isinstance(delivery, dict):
+                            click.echo(
+                                f"\nBriefing delivered via: {delivery.get('channels_used', [])}"
+                            )
+                            if "file_path" in delivery:
+                                click.echo(f"File: {delivery['file_path']}\n")
+                else:
+                    click.echo(f"\nFailed: {result.error}\n")
+
+            except KeyboardInterrupt:
+                click.echo("\nGoodbye!")
+                break
+            except Exception as e:
+                click.echo(f"Error: {e}", err=True)
+                import traceback
+
+                traceback.print_exc()
+    finally:
+        await agent.stop()
+
+
+if __name__ == "__main__":
+    cli()

--- a/examples/templates/hacker_news_briefing/agent.py
+++ b/examples/templates/hacker_news_briefing/agent.py
@@ -1,0 +1,322 @@
+"""Agent graph construction for Hacker News Briefing."""
+
+from framework.graph import Constraint, EdgeCondition, EdgeSpec, Goal, SuccessCriterion
+from framework.graph.edge import GraphSpec
+from framework.graph.executor import ExecutionResult, GraphExecutor
+from framework.llm import LiteLLMProvider
+from framework.runner.tool_registry import ToolRegistry
+from framework.runtime.core import Runtime
+from framework.runtime.event_bus import EventBus
+
+from .config import default_config, metadata
+from .nodes import (
+    collect_hn_candidates_node,
+    deliver_briefing_node,
+    intake_preferences_node,
+    rank_and_summarize_node,
+    review_briefing_node,
+)
+
+goal = Goal(
+    id="hn-briefing",
+    name="Hacker News Briefing",
+    description=(
+        "Collect top Hacker News stories daily, rank them by relevance and value, "
+        "produce a concise briefing with 'why it matters' notes and source links, "
+        "and deliver via user-configurable channels (markdown, email, slack)."
+    ),
+    success_criteria=[
+        SuccessCriterion(
+            id="sc-collect-stories",
+            description="Collects top HN stories with metadata",
+            metric="stories_collected",
+            target=">=5",
+            weight=0.2,
+        ),
+        SuccessCriterion(
+            id="sc-rank-relevance",
+            description="Ranks stories by relevance and community engagement",
+            metric="ranking_quality",
+            target="true",
+            weight=0.2,
+        ),
+        SuccessCriterion(
+            id="sc-summaries",
+            description="Provides concise summaries with 'why it matters' notes",
+            metric="summaries_provided",
+            target="100%",
+            weight=0.2,
+        ),
+        SuccessCriterion(
+            id="sc-user-review",
+            description="Allows user to review and refine the briefing",
+            metric="user_reviewed",
+            target="true",
+            weight=0.15,
+        ),
+        SuccessCriterion(
+            id="sc-deliver",
+            description="Delivers briefing via configured channel(s)",
+            metric="delivered",
+            target="true",
+            weight=0.25,
+        ),
+    ],
+    constraints=[
+        Constraint(
+            id="c-no-fabrication",
+            description="Never fabricate stories or URLs",
+            constraint_type="hard",
+            category="quality",
+        ),
+        Constraint(
+            id="c-source-attribution",
+            description="Always include source links for every story",
+            constraint_type="hard",
+            category="quality",
+        ),
+        Constraint(
+            id="c-markdown-fallback",
+            description="Always deliver via markdown at minimum",
+            constraint_type="hard",
+            category="reliability",
+        ),
+        Constraint(
+            id="c-concise",
+            description="Keep summaries brief and actionable",
+            constraint_type="soft",
+            category="quality",
+        ),
+    ],
+)
+
+nodes = [
+    intake_preferences_node,
+    collect_hn_candidates_node,
+    rank_and_summarize_node,
+    review_briefing_node,
+    deliver_briefing_node,
+]
+
+edges = [
+    EdgeSpec(
+        id="intake-to-collect",
+        source="intake-preferences",
+        target="collect-hn-candidates",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="collect-to-rank",
+        source="collect-hn-candidates",
+        target="rank-and-summarize",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="rank-to-review",
+        source="rank-and-summarize",
+        target="review-briefing",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="review-to-deliver",
+        source="review-briefing",
+        target="deliver-briefing",
+        condition=EdgeCondition.CONDITIONAL,
+        condition_expr="str(status).lower() == 'approved'",
+        priority=1,
+    ),
+    EdgeSpec(
+        id="review-feedback-loop",
+        source="review-briefing",
+        target="rank-and-summarize",
+        condition=EdgeCondition.CONDITIONAL,
+        condition_expr="str(status).lower() == 'revise'",
+        priority=2,
+    ),
+]
+
+entry_node = "intake-preferences"
+entry_points = {"start": "intake-preferences"}
+pause_nodes = []
+terminal_nodes = ["deliver-briefing"]
+
+
+class HackerNewsBriefingAgent:
+    """
+    Hacker News Briefing — 5-node pipeline with feedback loop.
+
+    Flow: intake-preferences -> collect-hn-candidates -> rank-and-summarize
+          -> review-briefing -> deliver-briefing
+
+    Feedback loop: review-briefing -> rank-and-summarize (if revision requested)
+    """
+
+    def __init__(self, config=None):
+        self.config = config or default_config
+        self.goal = goal
+        self.nodes = nodes
+        self.edges = edges
+        self.entry_node = entry_node
+        self.entry_points = entry_points
+        self.pause_nodes = pause_nodes
+        self.terminal_nodes = terminal_nodes
+        self._executor: GraphExecutor | None = None
+        self._graph: GraphSpec | None = None
+        self._event_bus: EventBus | None = None
+        self._tool_registry: ToolRegistry | None = None
+
+    def _build_graph(self) -> GraphSpec:
+        """Build the GraphSpec."""
+        return GraphSpec(
+            id="hn-briefing-graph",
+            goal_id=self.goal.id,
+            version="1.0.0",
+            entry_node=self.entry_node,
+            entry_points=self.entry_points,
+            terminal_nodes=self.terminal_nodes,
+            pause_nodes=self.pause_nodes,
+            nodes=self.nodes,
+            edges=self.edges,
+            default_model=self.config.model,
+            max_tokens=self.config.max_tokens,
+            loop_config={
+                "max_iterations": 50,
+                "max_tool_calls_per_turn": 30,
+                "max_history_tokens": 32000,
+            },
+        )
+
+    def _setup(self) -> GraphExecutor:
+        """Set up the executor with all components."""
+        from pathlib import Path
+
+        storage_path = Path.home() / ".hive" / "hn_briefing"
+        storage_path.mkdir(parents=True, exist_ok=True)
+
+        self._event_bus = EventBus()
+        self._tool_registry = ToolRegistry()
+
+        mcp_config_path = Path(__file__).parent / "mcp_servers.json"
+        if mcp_config_path.exists():
+            self._tool_registry.load_mcp_config(mcp_config_path)
+
+        llm = LiteLLMProvider(
+            model=self.config.model,
+            api_key=self.config.api_key,
+            api_base=self.config.api_base,
+        )
+
+        tool_executor = self._tool_registry.get_executor()
+        tools = list(self._tool_registry.get_tools().values())
+
+        self._graph = self._build_graph()
+        runtime = Runtime(storage_path)
+
+        self._executor = GraphExecutor(
+            runtime=runtime,
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor,
+            event_bus=self._event_bus,
+            storage_path=storage_path,
+            loop_config=self._graph.loop_config,
+        )
+
+        return self._executor
+
+    async def start(self) -> None:
+        """Set up the agent (initialize executor and tools)."""
+        if self._executor is None:
+            self._setup()
+
+    async def stop(self) -> None:
+        """Clean up resources."""
+        self._executor = None
+        self._event_bus = None
+
+    async def trigger_and_wait(
+        self,
+        entry_point: str,
+        input_data: dict,
+        timeout: float | None = None,
+        session_state: dict | None = None,
+    ) -> ExecutionResult | None:
+        """Execute the graph and wait for completion."""
+        if self._executor is None:
+            raise RuntimeError("Agent not started. Call start() first.")
+        if self._graph is None:
+            raise RuntimeError("Graph not built. Call start() first.")
+
+        return await self._executor.execute(
+            graph=self._graph,
+            goal=self.goal,
+            input_data=input_data,
+            session_state=session_state,
+        )
+
+    async def run(self, context: dict, session_state=None) -> ExecutionResult:
+        """Run the agent (convenience method for single execution)."""
+        await self.start()
+        try:
+            result = await self.trigger_and_wait(
+                "start", context, session_state=session_state
+            )
+            return result or ExecutionResult(success=False, error="Execution timeout")
+        finally:
+            await self.stop()
+
+    def info(self):
+        """Get agent information."""
+        return {
+            "name": metadata.name,
+            "version": metadata.version,
+            "description": metadata.description,
+            "goal": {
+                "name": self.goal.name,
+                "description": self.goal.description,
+            },
+            "nodes": [n.id for n in self.nodes],
+            "edges": [e.id for e in self.edges],
+            "entry_node": self.entry_node,
+            "entry_points": self.entry_points,
+            "pause_nodes": self.pause_nodes,
+            "terminal_nodes": self.terminal_nodes,
+            "client_facing_nodes": [n.id for n in self.nodes if n.client_facing],
+        }
+
+    def validate(self):
+        """Validate agent structure."""
+        errors = []
+        warnings = []
+
+        node_ids = {node.id for node in self.nodes}
+        for edge in self.edges:
+            if edge.source not in node_ids:
+                errors.append(f"Edge {edge.id}: source '{edge.source}' not found")
+            if edge.target not in node_ids:
+                errors.append(f"Edge {edge.id}: target '{edge.target}' not found")
+
+        if self.entry_node not in node_ids:
+            errors.append(f"Entry node '{self.entry_node}' not found")
+
+        for terminal in self.terminal_nodes:
+            if terminal not in node_ids:
+                errors.append(f"Terminal node '{terminal}' not found")
+
+        for ep_id, node_id in self.entry_points.items():
+            if node_id not in node_ids:
+                errors.append(
+                    f"Entry point '{ep_id}' references unknown node '{node_id}'"
+                )
+
+        return {
+            "valid": len(errors) == 0,
+            "errors": errors,
+            "warnings": warnings,
+        }
+
+
+default_agent = HackerNewsBriefingAgent()

--- a/examples/templates/hacker_news_briefing/config.py
+++ b/examples/templates/hacker_news_briefing/config.py
@@ -1,0 +1,26 @@
+"""Runtime configuration for Hacker News Briefing agent."""
+
+from dataclasses import dataclass
+
+from framework.config import RuntimeConfig
+
+default_config = RuntimeConfig()
+
+
+@dataclass
+class AgentMetadata:
+    name: str = "Hacker News Briefing"
+    version: str = "1.0.0"
+    description: str = (
+        "Collects top Hacker News stories daily, ranks them by relevance, "
+        "and delivers a concise briefing with 'why it matters' notes and source links. "
+        "Supports configurable delivery channels (markdown, email, slack) and schedule."
+    )
+    intro_message: str = (
+        "Hi! I'm your Hacker News briefing agent. I'll collect the top stories "
+        "from Hacker News, rank them by relevance, and deliver a concise summary. "
+        "Let's start by setting up your preferences."
+    )
+
+
+metadata = AgentMetadata()

--- a/examples/templates/hacker_news_briefing/nodes/__init__.py
+++ b/examples/templates/hacker_news_briefing/nodes/__init__.py
@@ -1,0 +1,390 @@
+"""Node definitions for Hacker News Briefing agent."""
+
+from framework.graph import NodeSpec
+
+intake_preferences_node = NodeSpec(
+    id="intake-preferences",
+    name="Intake Preferences",
+    description=(
+        "Collect user preferences for delivery channel, timezone, and briefing focus areas."
+    ),
+    node_type="event_loop",
+    client_facing=True,
+    input_keys=[],
+    output_keys=["briefing_config"],
+    system_prompt="""\
+You are the intake assistant for a Hacker News Briefing agent.
+
+**STEP 1 — Greet and ask for preferences:**
+Greet the user and ask about their briefing preferences. Collect:
+
+1. **Delivery Channel**: How would they like to receive the briefing?
+   - markdown (default, no setup required)
+   - email (requires email configuration)
+   - slack (requires Slack webhook)
+   - all (delivers via all configured channels)
+
+2. **Timezone**: What timezone should the briefing be timestamped in?
+   (e.g., "America/New_York", "Europe/London", "Asia/Tokyo")
+
+3. **Focus Areas** (optional): Are there specific topics they care about?
+   - Technology startups
+   - Programming languages
+   - AI/ML
+   - Security
+   - General tech news
+   - All (no filter)
+
+4. **Number of stories**: How many top stories to include? (default: 10)
+
+Keep it brief and conversational. Use ask_user() to wait for their response.
+
+**STEP 2 — After the user responds, call set_output:**
+- set_output("briefing_config", <JSON string>)
+
+Output format:
+```json
+{
+  "delivery_channel": "markdown",
+  "timezone": "America/New_York",
+  "focus_areas": ["AI/ML", "startups"],
+  "story_count": 10
+}
+```
+
+If the user doesn't specify something, use sensible defaults:
+- delivery_channel: "markdown"
+- timezone: "UTC"
+- focus_areas: ["all"]
+- story_count: 10
+""",
+    tools=[],
+)
+
+collect_hn_candidates_node = NodeSpec(
+    id="collect-hn-candidates",
+    name="Collect HN Candidates",
+    description="Scrape Hacker News front page and collect top story candidates.",
+    node_type="event_loop",
+    input_keys=["briefing_config"],
+    output_keys=["hn_candidates"],
+    system_prompt="""\
+You are a data collector for a Hacker News Briefing agent.
+
+Your task: Collect the top stories from Hacker News.
+
+**Instructions:**
+
+1. Use web_scrape to fetch the Hacker News front page:
+   - https://news.ycombinator.com
+   - Set max_length=10000 and include_links=true
+
+2. Parse the scraped content and extract:
+   - Story titles
+   - Story URLs (the actual article links, not HN discussion links)
+   - HN discussion URLs (the "item?id=..." links)
+   - Points/score
+   - Number of comments
+   - Rank position on the front page
+
+3. Focus on the top N stories based on briefing_config.story_count (default: 10).
+   If focus_areas is specified and not ["all"], prioritize stories matching those topics.
+
+4. For each story, you may optionally scrape the actual article to get a brief snippet
+   (max_length=2000 per article, only for top 5 stories to stay efficient).
+
+**Output format:**
+Use set_output("hn_candidates", <JSON string>) with this structure:
+```json
+{
+  "stories": [
+    {
+      "title": "Story Title",
+      "url": "https://actual-article-url.com/...",
+      "hn_url": "https://news.ycombinator.com/item?id=...",
+      "points": 342,
+      "comments": 127,
+      "rank": 1,
+      "snippet": "Optional brief excerpt from the article...",
+      "topic_hints": ["AI", "startups"]
+    }
+  ],
+  "collected_at": "2026-03-08T10:30:00Z",
+  "total_on_front_page": 30
+}
+```
+
+**Rules:**
+- Only include real stories with real URLs from the scraped content
+- Never fabricate URLs or stories
+- Copy URLs exactly as they appear in the scrape results
+- If the front page fails to load, report an error in the output
+""",
+    tools=["web_scrape"],
+)
+
+rank_and_summarize_node = NodeSpec(
+    id="rank-and-summarize",
+    name="Rank and Summarize",
+    description=(
+        "Rank HN stories by relevance, create concise summaries with 'why it matters' notes."
+    ),
+    node_type="event_loop",
+    input_keys=["briefing_config", "hn_candidates"],
+    output_keys=["ranked_briefing"],
+    system_prompt="""\
+You are an editor for a Hacker News Briefing agent.
+
+Your task: Rank the collected stories and create a concise, valuable briefing.
+
+**Ranking Criteria:**
+1. **Relevance**: Match to user's focus_areas (if specified)
+2. **Engagement**: Higher points and comments indicate community interest
+3. **Impact**: Stories that matter to tech professionals
+4. **Recency**: Fresh news over older discussions
+
+**Instructions:**
+
+1. Review the hn_candidates stories.
+
+2. Rank them by combining:
+   - Points (community signal)
+   - Comments (discussion depth)
+   - Relevance to focus_areas
+   - Your assessment of "why it matters" to a tech professional
+
+3. For each story, write:
+   - A one-sentence summary
+   - A "Why it matters" note (1-2 sentences explaining the significance)
+   - The relevance score (1-10)
+
+4. Select the top N stories (based on briefing_config.story_count).
+
+**Output format:**
+Use set_output("ranked_briefing", <JSON string>) with this structure:
+```json
+{
+  "briefing_date": "2026-03-08",
+  "timezone": "America/New_York",
+  "stories": [
+    {
+      "rank": 1,
+      "title": "Story Title",
+      "url": "https://...",
+      "hn_url": "https://news.ycombinator.com/item?id=...",
+      "points": 342,
+      "comments": 127,
+      "summary": "One sentence summary of the story.",
+      "why_it_matters": "This matters because... (1-2 sentences)",
+      "relevance_score": 9,
+      "topic": "AI"
+    }
+  ],
+  "total_candidates": 30,
+  "selected_count": 10
+}
+```
+
+**Rules:**
+- Keep summaries concise and factual
+- "Why it matters" should explain the significance to a tech professional
+- Don't exaggerate or fabricate information
+- If focus_areas was specified, prioritize matching stories
+""",
+    tools=[],
+)
+
+review_briefing_node = NodeSpec(
+    id="review-briefing",
+    name="Review Briefing",
+    description="Present the briefing to the user for review and allow refinement.",
+    node_type="event_loop",
+    client_facing=True,
+    input_keys=["briefing_config", "ranked_briefing"],
+    output_keys=["review_status"],
+    nullable_output_keys=["revision_feedback"],
+    system_prompt="""\
+You are the review coordinator for a Hacker News Briefing agent.
+
+Your task: Present the briefing to the user and get their feedback.
+
+**STEP 1 — Present the briefing:**
+Show the user a preview of their briefing with:
+- Number of stories
+- Top 3 headlines with their "why it matters" notes
+- Delivery channel that will be used
+
+**STEP 2 — Ask for feedback:**
+Ask the user:
+- Are they happy with this selection?
+- Do they want to add/remove any topics?
+- Do they want to regenerate with different criteria?
+
+Use ask_user() to wait for their response.
+
+**STEP 3 — Handle response:**
+
+If the user approves (e.g., "looks good", "yes", "send it"):
+- set_output("review_status", "approved")
+
+If the user wants changes (e.g., "add more AI stories", "remove that one"):
+- set_output("review_status", "revise")
+- set_output("revision_feedback", "<description of what to change>")
+
+If the user wants to cancel:
+- set_output("review_status", "cancelled")
+
+**Presentation format:**
+```
+📰 **Your Hacker News Briefing Preview**
+
+📅 Date: 2026-03-08 (America/New_York)
+📊 Stories: 10 top picks
+📧 Delivery: markdown
+
+**Top 3 Headlines:**
+
+1. [Story Title] (342 pts, 127 comments)
+   Why it matters: This matters because...
+
+2. [Story Title] (256 pts, 89 comments)
+   Why it matters: This matters because...
+
+3. [Story Title] (198 pts, 45 comments)
+   Why it matters: This matters because...
+
+---
+Does this look good? Reply with:
+- "yes" to proceed with delivery
+- "revise" with feedback to adjust the briefing
+- "cancel" to abort
+```
+""",
+    tools=[],
+)
+
+deliver_briefing_node = NodeSpec(
+    id="deliver-briefing",
+    name="Deliver Briefing",
+    description="Deliver the final briefing via the configured channel(s).",
+    node_type="event_loop",
+    client_facing=True,
+    input_keys=["briefing_config", "ranked_briefing", "review_status"],
+    output_keys=["delivery_result"],
+    system_prompt="""\
+You are the delivery coordinator for a Hacker News Briefing agent.
+
+Your task: Deliver the briefing via the user's configured channel(s).
+
+**Delivery Channels:**
+
+1. **markdown** (always available):
+   - Create a formatted markdown file using save_data and append_data
+   - Use serve_file_to_user to deliver it
+   - This is the default and requires no credentials
+
+2. **email** (requires credentials):
+   - Use send_email if email credentials are configured
+   - If not configured, inform the user and fall back to markdown
+
+3. **slack** (requires credentials):
+   - Use slack_send_message if Slack credentials are configured
+   - If not configured, inform the user and fall back to markdown
+
+4. **all**:
+   - Attempt all channels, use markdown as fallback
+
+**STEP 1 — Build the markdown report:**
+
+CRITICAL: Build the file in multiple append_data calls to avoid token limits.
+
+First, call save_data with the header:
+```
+save_data(filename="hn_briefing.md", data="# Hacker News Briefing\\n\\nDate: ...")
+```
+
+Then, for each story, call append_data:
+```
+append_data(filename="hn_briefing.md", data="\\n## 1. Story Title\\n\\n...")
+```
+
+**Markdown format:**
+```markdown
+# Hacker News Briefing
+
+**Date:** 2026-03-08 (America/New_York)
+**Stories:** 10 top picks
+
+---
+
+## 1. Story Title
+
+**Points:** 342 | **Comments:** 127 | **Topic:** AI
+
+**Summary:** One sentence summary.
+
+**Why it matters:** This matters because...
+
+**Links:**
+- [Article](https://...)
+- [Hacker News Discussion](https://news.ycombinator.com/item?id=...)
+
+---
+
+## 2. Story Title
+...
+```
+
+**STEP 2 — Deliver:**
+
+For markdown:
+```
+serve_file_to_user(filename="hn_briefing.md", label="Hacker News Briefing", open_in_browser=false)
+```
+
+For email (if configured and requested):
+- Format the briefing as HTML email body
+- Use send_email with subject "Your Hacker News Briefing - YYYY-MM-DD"
+
+For Slack (if configured and requested):
+- Format as a condensed Slack message
+- Use slack_send_message
+
+**STEP 3 — Report delivery status:**
+
+Use set_output("delivery_result", <JSON string>):
+```json
+{
+  "status": "success",
+  "channels_used": ["markdown"],
+  "file_path": "/path/to/hn_briefing.md",
+  "delivered_at": "2026-03-08T10:45:00Z"
+}
+```
+
+If delivery fails:
+```json
+{
+  "status": "partial",
+  "channels_used": ["markdown"],
+  "failed_channels": ["email"],
+  "error": "Email credentials not configured",
+  "file_path": "/path/to/hn_briefing.md"
+}
+```
+
+**Rules:**
+- Always deliver via markdown at minimum
+- If external channels fail, inform the user but don't fail the whole delivery
+- Print the file path so user can find the briefing later
+""",
+    tools=["save_data", "append_data", "serve_file_to_user"],
+)
+
+__all__ = [
+    "intake_preferences_node",
+    "collect_hn_candidates_node",
+    "rank_and_summarize_node",
+    "review_briefing_node",
+    "deliver_briefing_node",
+]


### PR DESCRIPTION
## Description

Add a new Hacker News briefing agent that collects top HN stories daily, ranks them by relevance and value, and delivers a concise briefing with "why it matters" notes and source links. The agent supports user-configurable delivery channels (markdown, email, slack) and schedule preferences.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Resolves #5762

## Changes Made

- **New Agent**: `examples/templates/hacker_news_briefing/`
  - 5-node pipeline with feedback loop for iterative refinement
  - `intake-preferences`: Collects user preferences (delivery channel, timezone, focus areas, story count)
  - `collect-hn-candidates`: Scrapes HN front page and extracts story metadata
  - `rank-and-summarize`: Ranks stories by relevance/engagement, creates summaries with "why it matters" notes
  - `review-briefing`: Human-in-the-loop review with revision capability
  - `deliver-briefing`: Delivers via configured channel(s) (markdown by default, email/slack when configured)

- **Features**:
  - Feedback loop from `review-briefing` back to `rank-and-summarize` for iterative refinement
  - Markdown delivery works out-of-the-box (no credentials required)
  - Optional email/slack delivery when credentials are configured
  - Configurable focus areas (AI/ML, startups, security, etc.)
  - Timezone-aware timestamps

## Testing

- [x] Manual testing performed
  - Agent structure validated successfully
  - Lint passes with `ruff check`

```
$ uv run python -c "from examples.templates.hacker_news_briefing.agent import default_agent; print(default_agent.validate())"
{'valid': True, 'errors': [], 'warnings': []}

$ uv run ruff check examples/templates/hacker_news_briefing/
All checks passed!
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
