### PR TITLE
Fix duplicate Step 3 in quickstart scripts

### DIFF
--- a/quickstart.ps1
+++ b/quickstart.ps1
@@ -711,10 +711,10 @@ if (-not $checkResult.DefenderEnabled) {
 
 
 # ============================================================
-# Step 3: Verify Python Imports
+# Step 4: Verify Python Imports
 # ============================================================
 
-Write-Step -Number "3" -Text "Step 3: Verifying Python imports..."
+Write-Step -Number "4" -Text "Step 4: Verifying Python imports..."
 
 $importErrors = 0
 
@@ -773,10 +773,10 @@ if ($importErrors -gt 0) {
 Write-Host ""
 
 # ============================================================
-# Step 4: Verify Claude Code Skills
+# Step 5: Verify Claude Code Skills
 # ============================================================
 
-Write-Step -Number "4" -Text "Step 4: Verifying Claude Code skills..."
+Write-Step -Number "5" -Text "Step 5: Verifying Claude Code skills..."
 
 # (skills check is informational only, shown in final verification)
 
@@ -1298,7 +1298,7 @@ if ($SelectedProviderId) {
 Write-Host ""
 
 # ============================================================
-# Step 5b: Browser Automation (GCU) — always enabled
+# Step 6b: Browser Automation (GCU) — always enabled
 # ============================================================
 
 Write-Host ""
@@ -1323,10 +1323,10 @@ if (Test-Path $HiveConfigFile) {
 Write-Host ""
 
 # ============================================================
-# Step 6: Initialize Credential Store
+# Step 7: Initialize Credential Store
 # ============================================================
 
-Write-Step -Number "5" -Text "Step 5: Initializing credential store..."
+Write-Step -Number "7" -Text "Step 7: Initializing credential store..."
 Write-Color -Text "The credential store encrypts API keys and secrets for your agents." -Color DarkGray
 Write-Host ""
 
@@ -1422,10 +1422,10 @@ if ($credKey) {
 Write-Host ""
 
 # ============================================================
-# Step 6: Verify Setup
+# Step 8: Verify Setup
 # ============================================================
 
-Write-Step -Number "6" -Text "Step 6: Verifying installation..."
+Write-Step -Number "8" -Text "Step 8: Verifying installation..."
 
 $verifyErrors = 0
 
@@ -1529,10 +1529,10 @@ if ($verifyErrors -gt 0) {
 }
 
 # ============================================================
-# Step 7: Install hive CLI wrapper
+# Step 9: Install hive CLI wrapper
 # ============================================================
 
-Write-Step -Number "7" -Text "Step 7: Installing hive CLI..."
+Write-Step -Number "9" -Text "Step 9: Installing hive CLI..."
 
 # Verify hive.ps1 wrapper exists in project root
 $hivePs1Path = Join-Path $ScriptDir "hive.ps1"

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -312,10 +312,10 @@ echo -e "${YELLOW}⬢${NC} ${BLUE}${BOLD}Step 3: Configuring LLM provider...${NC
 echo ""
 
 # ============================================================
-# Step 3: Verify Python Imports
+# Step 4: Verify Python Imports
 # ============================================================
 
-echo -e "${BLUE}Step 3: Verifying Python imports...${NC}"
+echo -e "${BLUE}Step 4: Verifying Python imports...${NC}"
 echo ""
 
 IMPORT_ERRORS=0
@@ -372,10 +372,10 @@ fi
 echo ""
 
 # ============================================================
-# Step 4: Verify Claude Code Skills
+# Step 5: Verify Claude Code Skills
 # ============================================================
 
-echo -e "${BLUE}Step 4: Verifying Claude Code skills...${NC}"
+echo -e "${BLUE}Step 5: Verifying Claude Code skills...${NC}"
 echo ""
 
 # Provider configuration - use associative arrays (Bash 4+) or indexed arrays (Bash 3.2)
@@ -1248,7 +1248,7 @@ fi
 echo ""
 
 # ============================================================
-# Step 4b: Browser Automation (GCU) — always enabled
+# Step 5b: Browser Automation (GCU) — always enabled
 # ============================================================
 
 echo -e "${GREEN}⬢${NC} Browser automation enabled"
@@ -1276,10 +1276,10 @@ fi
 echo ""
 
 # ============================================================
-# Step 5: Initialize Credential Store
+# Step 6: Initialize Credential Store
 # ============================================================
 
-echo -e "${YELLOW}⬢${NC} ${BLUE}${BOLD}Step 5: Initializing credential store...${NC}"
+echo -e "${YELLOW}⬢${NC} ${BLUE}${BOLD}Step 6: Initializing credential store...${NC}"
 echo ""
 echo -e "${DIM}The credential store encrypts API keys and secrets for your agents.${NC}"
 echo ""
@@ -1346,10 +1346,10 @@ fi
 echo ""
 
 # ============================================================
-# Step 6: Verify Setup
+# Step 7: Verify Setup
 # ============================================================
 
-echo -e "${YELLOW}⬢${NC} ${BLUE}${BOLD}Step 6: Verifying installation...${NC}"
+echo -e "${YELLOW}⬢${NC} ${BLUE}${BOLD}Step 7: Verifying installation...${NC}"
 echo ""
 
 ERRORS=0
@@ -1410,10 +1410,10 @@ if [ $ERRORS -gt 0 ]; then
 fi
 
 # ============================================================
-# Step 7: Install hive CLI globally
+# Step 8: Install hive CLI globally
 # ============================================================
 
-echo -e "${YELLOW}⬢${NC} ${BLUE}${BOLD}Step 7: Installing hive CLI...${NC}"
+echo -e "${YELLOW}⬢${NC} ${BLUE}${BOLD}Step 8: Installing hive CLI...${NC}"
 echo ""
 
 # Ensure ~/.local/bin exists and is in PATH


### PR DESCRIPTION
Fixes #6015

## Problem
The quickstart.sh and quickstart.ps1 scripts both had two sections labeled "Step 3", which could confuse users running the setup wizard.

## Solution
Renumbered the steps to be sequential:

| Old | New | Description |
|-----|-----|-------------|
| Step 3 | Step 3 | Configure LLM API Key (unchanged) |
| Step 3 | Step 4 | Verify Python Imports |
| Step 4 | Step 5 | Verify Claude Code Skills |
| Step 5 | Step 6 | Initialize Credential Store |
| Step 6 | Step 7 | Verify Setup |
| Step 7 | Step 8/9 | Install hive CLI |

## Files Changed
- quickstart.sh
- quickstart.ps1