### PR TITLE
Add loading indicator when Queen agent runs

### DIFF
--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -943,6 +943,8 @@ class AgentRunner:
 
         try:
             # Trigger and wait for result
+
+            logging.info("Queen is working on your request...")
             result = await self._agent_runtime.trigger_and_wait(
                 entry_point_id=entry_point_id,
                 input_data=input_data,


### PR DESCRIPTION
## Description
Adds a simple loading indicator message when the Queen agent starts processing a request.

Previously the UI appeared idle while the agent was working. This change logs a message so users know that the agent is actively processing the request.

## Type of Change
[x] New feature (non-breaking change that adds functionality)

## Related Issues
Fixes #6024

## Changes Made
- Added logging message when Queen agent starts processing
- Improves feedback to users during execution