### PR TITLE
Handled root_cause to be always a string

### DIFF
--- a/core/framework/builder/query.py
+++ b/core/framework/builder/query.py
@@ -186,7 +186,11 @@ class BuilderQuery:
         else:
             first_failure = failed_decisions[0]
             failure_point = first_failure.summary_for_builder()
-            root_cause = first_failure.outcome.error if first_failure.outcome else "Unknown"
+            root_cause = (
+                first_failure.outcome.error
+                if first_failure.outcome and first_failure.outcome.error
+                else "Unknown"
+            )
 
         # Build the decision chain leading to failure
         decision_chain = []


### PR DESCRIPTION
Description
Fixed a bug issue number #6003 where BuilderQuery.analyze_failure() could set root_cause to None when outcome.error is None, causing misleading output ("Root Cause: None") and violating the type contract that expects a string.

Type of Change
 Bug fix (non-breaking change that fixes an issue)
Changes Made
Updated root_cause assignment in BuilderQuery.analyze_failure() to check both outcome and outcome.error before using the value
Now returns "Unknown" as a fallback when the error message is missing, ensuring root_cause is always a valid string
Testing
 No syntax or type errors in the modified file
 Code follows the existing pattern used elsewhere in the same file (line 254)
 Unit tests pass (cd core && uv run pytest tests/)
 Lint passes cd core && ruff check .
Checklist
 Code follows the project's style guidelines
 Self-review completed
 No new warnings generated