### PR TITLE
fix: handleKeyError in slack _get_user_token for unregistered credential

### DIFF
--- a/tools/src/aden_tools/tools/slack_tool/slack_tool.py
+++ b/tools/src/aden_tools/tools/slack_tool/slack_tool.py
@@ -1164,7 +1164,10 @@ def register_tools(
     def _get_user_token() -> str | None:
         """Get Slack user token for search API."""
         if credentials is not None:
-            return credentials.get("slack_user")
+            try:
+                return credentials.get("slack_user")
+            except KeyError:
+                return os.getenv("SLACK_USER_TOKEN")
         return os.getenv("SLACK_USER_TOKEN")
 
     def _get_client(account: str = "") -> _SlackClient | dict[str, str]:


### PR DESCRIPTION
#6041 
## Summary                                             
  
   - `_get_user_token()` in `slack_tool.py` calls `credentials.get("slack_user")`, but `"slack_user"` is not registered in       
   `CREDENTIAL_SPECS` (only `"slack"` is)                                                                                        
   - `CredentialStoreAdapter.get()` raises `KeyError` for unregistered credential names, crashing any code path that calls
   `_get_user_token()` (e.g. `slack_search`)
   - Added `try/except KeyError` to gracefully fall back to `SLACK_USER_TOKEN` env var, matching the existing fallback pattern

   ## Root Cause

   `CREDENTIAL_SPECS` in `slack.py` only defines `"slack"` (bot token). The `"slack_user"` name was never registered, so
   `credentials.get("slack_user")` hits the unknown-name guard in `store_adapter.py` (line 108-109) and raises `KeyError`.

   Confirmed this pattern is unique to the Slack tool — all other tools only call `credentials.get()` with registered
   credential names.


   Fixes #6041 