### PR TITLE
fix: E501 line too long in coder_tools_server.py

### DIFF
--- a/tools/coder_tools_server.py
+++ b/tools/coder_tools_server.py
@@ -1321,7 +1321,9 @@ def validate_agent_package(agent_name: str) -> str:
             result = json.loads(proc.stdout.strip())
             steps["node_completeness"] = {
                 "passed": result["valid"],
-                "output": "; ".join(result["errors"]) if result["errors"] else "All defined nodes are in the graph",
+                "output": "; ".join(result["errors"])
+                if result["errors"]
+                else "All defined nodes are in the graph",
             }
             if not result["valid"]:
                 steps["node_completeness"]["errors"] = result["errors"]


### PR DESCRIPTION
fix: E501 line too  
   long in coder_tools_server.py" --body "## Summary                                                                             
                                                                          
   - Fixes `ruff check` E501 failure on `tools/coder_tools_server.py:1324` (116 > 100 chars)                                     
   - Breaks ternary expression across multiple lines                                                                           

   ## Test plan

   - [x] `uv run ruff check tools/coder_tools_server.py` passes
   - [x] No functional change — formatting only

   Fixes #6043"