### PR TITLE
Add light/dark mode toggle to web UI header

### DIFF
--- a/core/frontend/index.html
+++ b/core/frontend/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/core/frontend/src/components/ThemeToggle.tsx
+++ b/core/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,20 @@
+import { Sun, Moon } from "lucide-react";
+import { useTheme } from "../context/ThemeContext";
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <button
+      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      className="px-3 py-1 text-xs border rounded-md flex items-center gap-1.5 text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+      aria-label="Toggle theme"
+    >
+      {theme === "dark" ? (
+        <Sun className="w-3.5 h-3.5" />
+      ) : (
+        <Moon className="w-3.5 h-3.5" />
+      )}
+    </button>
+  );
+}

--- a/core/frontend/src/components/TopBar.tsx
+++ b/core/frontend/src/components/TopBar.tsx
@@ -1,8 +1,14 @@
 import { useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { Crown, X } from "lucide-react";
+import {
+  loadPersistedTabs,
+  savePersistedTabs,
+  TAB_STORAGE_KEY,
+  type PersistedTabState,
+} from "@/lib/tab-persistence";
+import ThemeToggle from "./ThemeToggle";
 import { sessionsApi } from "@/api/sessions";
-import { loadPersistedTabs, savePersistedTabs, TAB_STORAGE_KEY, type PersistedTabState } from "@/lib/tab-persistence";
 import BrowserStatusBadge from "@/components/BrowserStatusBadge";
 
 export interface TopBarTab {
@@ -27,65 +33,89 @@ interface TopBarProps {
   children?: React.ReactNode;
 }
 
-export default function TopBar({ tabs: tabsProp, onTabClick, onCloseTab, canCloseTabs, afterTabs, children }: TopBarProps) {
+export default function TopBar({
+  tabs: tabsProp,
+  onTabClick,
+  onCloseTab,
+  canCloseTabs,
+  afterTabs,
+  children,
+}: TopBarProps) {
   const navigate = useNavigate();
 
   // Fallback: read persisted tabs when no live tabs provided
   const [persisted, setPersisted] = useState<PersistedTabState | null>(() =>
-    tabsProp ? null : loadPersistedTabs()
+    tabsProp ? null : loadPersistedTabs(),
   );
 
   const tabs: TopBarTab[] = tabsProp ?? deriveTabs(persisted);
   const showClose = canCloseTabs ?? true;
 
-  const handleTabClick = useCallback((agentType: string) => {
-    if (onTabClick) {
-      onTabClick(agentType);
-    } else {
-      navigate(`/workspace?agent=${encodeURIComponent(agentType)}`);
-    }
-  }, [onTabClick, navigate]);
-
-  const handleCloseTab = useCallback((agentType: string, e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (onCloseTab) {
-      onCloseTab(agentType);
-      return;
-    }
-    // Kill the backend session (queen/worker) even outside workspace
-    sessionsApi.list()
-      .then(({ sessions }) => {
-        const match = sessions.find(s => s.agent_path.endsWith(agentType));
-        if (match) return sessionsApi.stop(match.session_id);
-      })
-      .catch(() => {});  // fire-and-forget
-
-    // Fallback: update localStorage directly (non-workspace pages)
-    setPersisted(prev => {
-      if (!prev) return null;
-      const nextTabs = prev.tabs.filter(t => t.agentType !== agentType);
-      if (nextTabs.length === 0) {
-        localStorage.removeItem(TAB_STORAGE_KEY);
-        return null;
+  const handleTabClick = useCallback(
+    (agentType: string) => {
+      if (onTabClick) {
+        onTabClick(agentType);
+      } else {
+        navigate(`/workspace?agent=${encodeURIComponent(agentType)}`);
       }
-      const removedIds = new Set(prev.tabs.filter(t => t.agentType === agentType).map(t => t.id));
-      const nextSessions = { ...prev.sessions };
-      for (const id of removedIds) delete nextSessions[id];
-      const nextActiveSession = { ...prev.activeSessionByAgent };
-      delete nextActiveSession[agentType];
-      const nextActiveWorker = prev.activeWorker === agentType
-        ? nextTabs[0].agentType
-        : prev.activeWorker;
-      const nextState: PersistedTabState = {
-        tabs: nextTabs,
-        activeSessionByAgent: nextActiveSession,
-        activeWorker: nextActiveWorker,
-        sessions: nextSessions,
-      };
-      savePersistedTabs(nextState);
-      return nextState;
-    });
-  }, [onCloseTab]);
+    },
+    [onTabClick, navigate],
+  );
+
+  const handleCloseTab = useCallback(
+    (agentType: string, e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (onCloseTab) {
+        onCloseTab(agentType);
+        return;
+      }
+      // Kill the backend session (queen/worker) even outside workspace
+
+      sessionsApi
+        .list()
+        .then(({ sessions }) => {
+          const match = sessions.find((s) => s.agent_path.endsWith(agentType));
+          if (match) return sessionsApi.stop(match.session_id);
+        })
+        .catch(() => {}); // fire-and-forget
+
+      // Fallback: update localStorage directly (non-workspace pages)
+      setPersisted((prev) => {
+        if (!prev) return null;
+        const nextTabs = prev.tabs.filter((t) => t.agentType !== agentType);
+
+        if (nextTabs.length === 0) {
+          localStorage.removeItem(TAB_STORAGE_KEY);
+          return null;
+        }
+
+        const removedIds = new Set(
+          prev.tabs.filter((t) => t.agentType === agentType).map((t) => t.id),
+        );
+        const nextSessions = { ...prev.sessions };
+        for (const id of removedIds) delete nextSessions[id];
+
+        const nextActiveSession = { ...prev.activeSessionByAgent };
+        delete nextActiveSession[agentType];
+
+        const nextActiveWorker =
+          prev.activeWorker === agentType
+            ? nextTabs[0].agentType
+            : prev.activeWorker;
+
+        const nextState: PersistedTabState = {
+          tabs: nextTabs,
+          activeSessionByAgent: nextActiveSession,
+          activeWorker: nextActiveWorker,
+          sessions: nextSessions,
+        };
+
+        savePersistedTabs(nextState);
+        return nextState;
+      });
+    },
+    [onCloseTab],
+  );
 
   return (
     <div className="relative h-12 flex items-center justify-between px-5 border-b border-border/60 bg-card/50 backdrop-blur-sm flex-shrink-0">
@@ -115,6 +145,7 @@ export default function TopBar({ tabs: tabsProp, onTabClick, onCloseTab, canClos
                       <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-primary" />
                     </span>
                   )}
+
                   <span>{tab.label}</span>
                   {showClose && (
                     <X
@@ -125,12 +156,14 @@ export default function TopBar({ tabs: tabsProp, onTabClick, onCloseTab, canClos
                 </button>
               ))}
             </div>
+
             {afterTabs}
           </>
         )}
       </div>
 
       <div className="flex items-center gap-3 flex-shrink-0">
+        <ThemeToggle />
         <BrowserStatusBadge />
         {children && (
           <div className="flex items-center gap-1">
@@ -145,15 +178,23 @@ export default function TopBar({ tabs: tabsProp, onTabClick, onCloseTab, canClos
 /** Derive TopBarTab[] from persisted localStorage state (used outside workspace). */
 function deriveTabs(persisted: PersistedTabState | null): TopBarTab[] {
   if (!persisted) return [];
+
   const seen = new Set<string>();
   const tabs: TopBarTab[] = [];
+
   for (const tab of persisted.tabs) {
     if (seen.has(tab.agentType)) continue;
+
     seen.add(tab.agentType);
+
     const sessionData = persisted.sessions?.[tab.id];
-    const hasRunning = sessionData?.graphNodes?.some(
-      (n) => n.status === "running" || n.status === "looping"
-    ) ?? false;
+
+    const hasRunning =
+      sessionData?.graphNodes?.some(
+        (n) => n.status === "running" || n.status === "looping",
+      ) ?? false;
+
+
     tabs.push({
       agentType: tab.agentType,
       label: tab.label,

--- a/core/frontend/src/context/ThemeContext.tsx
+++ b/core/frontend/src/context/ThemeContext.tsx
@@ -1,0 +1,49 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const stored = localStorage.getItem("theme");
+
+    if (stored === "light" || stored === "dark") {
+      return stored;
+    }
+
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+
+    root.classList.remove("light", "dark");
+    root.classList.add(theme);
+
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const context = useContext(ThemeContext);
+
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+
+  return context;
+}

--- a/core/frontend/src/main.tsx
+++ b/core/frontend/src/main.tsx
@@ -1,10 +1,13 @@
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import { ThemeProvider } from "./context/ThemeContext";
 import App from "./App";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>
+  <ThemeProvider>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </ThemeProvider>,
 );


### PR DESCRIPTION
This PR adds a light/dark theme toggle to the Hive web UI.

Features:
- Toggle button added to the header
- Allows switching between dark and light mode
- Theme preference stored in localStorage
- Theme persists across sessions

Fixes #6035

## Dark Mode
<img width="1916" height="1025" alt="Screenshot 2026-03-09 131957" src="https://github.com/user-attachments/assets/9a2e66f7-5c07-4627-9ffc-3334dbf7cdf3" />

## Light Mode
<img width="1913" height="1022" alt="Screenshot 2026-03-09 132007" src="https://github.com/user-attachments/assets/50647b23-26e4-43ae-b882-a811a681c7ee" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme toggle button added to the top navigation bar for switching between light and dark modes.
  * Theme preferences are automatically saved and persist across sessions.
  * System color scheme preferences are respected on initial app load.
  * Dynamic theme switching updates the visual appearance across the entire application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->