### PR TITLE
Add ToolGuard security middleware for safe agent tool execution

### DIFF
--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -29,6 +29,7 @@ from framework.runner.tool_registry import ToolRegistry
 from framework.runtime.agent_runtime import AgentRuntime, AgentRuntimeConfig, create_agent_runtime
 from framework.runtime.execution_stream import EntryPointSpec
 from framework.runtime.runtime_log_store import RuntimeLogStore
+from framework.runner.tool_guard import SecurityPolicy
 
 if TYPE_CHECKING:
     from framework.runner.protocol import AgentMessage, CapabilityResponse
@@ -712,6 +713,7 @@ class AgentRunner:
         configure_for_account: Callable | None = None,
         list_accounts: Callable | None = None,
         credential_store: Any | None = None,
+        security_policy: SecurityPolicy | None = None,
     ):
         """
         Initialize the runner (use AgentRunner.load() instead).
@@ -732,6 +734,7 @@ class AgentRunner:
             configure_for_account: Callback(runner, account_dict) to scope tools after selection.
             list_accounts: Callback() -> list[dict] to fetch available accounts.
             credential_store: Optional shared CredentialStore (avoids creating redundant stores).
+            security_policy: Optional security policy for tool execution.
         """
         self.agent_path = agent_path
         self.graph = graph
@@ -746,6 +749,7 @@ class AgentRunner:
         self._configure_for_account = configure_for_account
         self._list_accounts = list_accounts
         self._credential_store = credential_store
+        self.security_policy = security_policy or SecurityPolicy.default()
 
         # Set up storage
         if storage_path:
@@ -764,7 +768,7 @@ class AgentRunner:
         _ensure_credential_key_env()
 
         # Initialize components
-        self._tool_registry = ToolRegistry()
+        self._tool_registry = ToolRegistry(security_policy=self.security_policy)
         self._llm: LLMProvider | None = None
         self._approval_callback: Callable | None = None
 

--- a/core/framework/runner/tool_guard.py
+++ b/core/framework/runner/tool_guard.py
@@ -1,0 +1,89 @@
+from dataclasses import dataclass, field
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class SecurityPolicy:
+    """Configuration for tool execution security."""
+    allowed_tools: list[str] | None = None
+    blocked_keywords: list[str] = field(default_factory=list)
+    allow_destructive_tools: bool = False
+    
+    @classmethod
+    def default(cls) -> "SecurityPolicy":
+        """Returns a default restrictive policy."""
+        return cls(
+            allowed_tools=None,
+            blocked_keywords=["rm -rf", "sudo", "password", "format c:", "mkfs"],
+            allow_destructive_tools=False
+        )
+
+class ToolSecurityError(Exception):
+    """Exception raised when a tool call violates security policy."""
+    def __init__(self, message: str, reason: str):
+        super().__init__(message)
+        self.reason = reason
+
+class ToolGuard:
+    """
+    Middleware layer that validates agent tool calls before execution.
+
+    Purpose:
+    - Mitigates prompt injection attacks by checking tool arguments for blocked keywords.
+    - Prevents unsafe or destructive actions (e.g., repository deletion) unless explicitly allowed.
+    - Enforces an optional tool allowlist to limit the agent's capabilities.
+
+    Integration:
+    - Integrated into `ToolRegistry.get_executor()`, acting as a central choke point for all tool calls.
+    - Captures `ToolSecurityError` and returns structured `ToolResult` errors to the agent.
+    - Configured via `AgentRunner` using a `SecurityPolicy` object.
+    """
+    
+    DESTRUCTIVE_KEYWORDS = ["delete", "remove", "drop", "shutdown", "terminate"]
+
+    def __init__(self, policy: SecurityPolicy | None = None):
+        self.policy = policy or SecurityPolicy.default()
+
+    def validate(self, tool_name: str, tool_input: dict[str, Any]) -> bool:
+        """
+        Validates a tool call against the security policy.
+        
+        Args:
+            tool_name: The name of the tool being called.
+            tool_input: The arguments passed to the tool.
+            
+        Returns:
+            True if the call is valid.
+            
+        Raises:
+            ToolSecurityError: If the call violates the policy.
+        """
+        # 1. Allowlist Check
+        if self.policy.allowed_tools is not None:
+            if tool_name not in self.policy.allowed_tools:
+                reason = f"Tool '{tool_name}' is not in the allowlist."
+                logger.warning(f"Security Block: {reason}")
+                raise ToolSecurityError(f"Tool execution blocked: {reason}", "not_allowed")
+
+        # 2. Destructive Tool Check
+        # Splits the tool name (e.g., "github_delete_repo" -> ["github", "delete", "repo"])
+        # to ensure keywords match specific parts and avoid false positives.
+        if not self.policy.allow_destructive_tools:
+            parts = tool_name.lower().replace(".", "_").split("_")
+            if any(word in parts for word in self.DESTRUCTIVE_KEYWORDS):
+                reason = f"Tool '{tool_name}' is classified as destructive."
+                logger.warning(f"Security Block: {reason}")
+                raise ToolSecurityError(f"Tool execution blocked: {reason}", "destructive_tool")
+
+        # 3. Blocked Keywords Check (in arguments)
+        # Uses str() instead of json.dumps() to handle non-serializable objects safely.
+        input_str = str(tool_input).lower()
+        for keyword in self.policy.blocked_keywords:
+            if keyword.lower() in input_str:
+                reason = f"Blocked keyword '{keyword}' detected in tool arguments."
+                logger.warning(f"Security Block: {reason}")
+                raise ToolSecurityError(f"Tool execution blocked: {reason}", "blocked_keyword")
+
+        return True

--- a/core/framework/runner/tool_registry.py
+++ b/core/framework/runner/tool_registry.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from framework.llm.provider import Tool, ToolResult, ToolUse
+from framework.runner.tool_guard import ToolGuard, SecurityPolicy, ToolSecurityError
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +52,7 @@ class ToolRegistry:
     # Credential directory used for change detection
     _CREDENTIAL_DIR = Path("~/.hive/credentials/credentials").expanduser()
 
-    def __init__(self):
+    def __init__(self, security_policy: SecurityPolicy | None = None):
         self._tools: dict[str, RegisteredTool] = {}
         self._mcp_clients: list[Any] = []  # List of MCPClient instances
         self._session_context: dict[str, Any] = {}  # Auto-injected context for tools
@@ -62,6 +63,10 @@ class ToolRegistry:
         self._mcp_cred_snapshot: set[str] = set()  # Credential filenames at MCP load time
         self._mcp_aden_key_snapshot: str | None = None  # ADEN_API_KEY value at MCP load time
         self._mcp_server_tools: dict[str, set[str]] = {}  # server name -> tool names
+        
+        # Security
+        self.security_policy = security_policy or SecurityPolicy.default()
+        self._guard = ToolGuard(self.security_policy)
 
     def register(
         self,
@@ -254,6 +259,19 @@ class ToolRegistry:
                 return ToolResult(
                     tool_use_id=tool_use.id,
                     content=json.dumps({"error": f"Unknown tool: {tool_use.name}"}),
+                    is_error=True,
+                )
+
+            # Security Validation
+            try:
+                self._guard.validate(tool_use.name, tool_use.input)
+            except ToolSecurityError as e:
+                return ToolResult(
+                    tool_use_id=tool_use.id,
+                    content=json.dumps({
+                        "error": f"Tool execution blocked by security policy: {str(e)}",
+                        "security_reason": e.reason
+                    }),
                     is_error=True,
                 )
 


### PR DESCRIPTION
This PR introduces ToolGuard, a lightweight security middleware
for validating tool calls before execution.

Motivation
AI agents interacting with external tools are vulnerable to
prompt injection and unintended destructive actions.

Key Features
- optional allowlist for permitted tools
- keyword filtering in tool arguments
- destructive tool protection
- centralized enforcement via ToolRegistry.get_executor()

Design
ToolGuard intercepts tool calls inside ToolRegistry.get_executor(),
ensuring every tool invocation passes through a single validation layer.

Security violations return a structured ToolResult with is_error=True,
allowing agents to handle blocked actions gracefully.

The implementation is configurable through SecurityPolicy and
remains backward-compatible with existing workflows.
micro-fix
Fixes #6066 