### PR TITLE
feat: add GTM Signal Intelligence Agent template (#5817)

### DIFF
--- a/core/framework/graph/event_loop_node.py
+++ b/core/framework/graph/event_loop_node.py
@@ -747,9 +747,12 @@ class EventLoopNode(NodeProtocol):
                 continue  # back to top of for-iteration loop
 
             # 6e'. Feed actual API token count back for accurate estimation
-            turn_input = turn_tokens.get("input", 0)
-            if turn_input > 0:
-                conversation.update_token_count(turn_input)
+            if "turn_tokens" in locals():
+                turn_input = turn_tokens.get("input", 0)
+                if turn_input > 0:
+                    conversation.update_token_count(turn_input)
+            else:
+                turn_tokens = {"input": 0, "output": 0}
 
             # 6e''. Post-turn compaction check (catches tool-result bloat)
             if conversation.needs_compaction():

--- a/examples/templates/gtm_signal_agent/README.md
+++ b/examples/templates/gtm_signal_agent/README.md
@@ -1,0 +1,31 @@
+# GTM Signal Intelligence Agent
+
+A forever-alive pipeline that automates the full top-of-funnel GTM flow:
+
+- **ICP intake**: Collect Ideal Customer Profile, target signals, and outreach preferences.
+- **Signal scanning**: Uses Exa/news/web search to find buying signals from ICP-matched companies.
+- **Lead enrichment**: Finds and enriches decision-makers via Apollo.
+- **Opportunity scoring**: Scores each opportunity (0–100) and routes by score (hot / warm / cold).
+- **Outreach drafting**: Drafts short, signal-specific outreach emails.
+- **Human-in-the-loop approval**: Sales reps can approve, edit, or skip drafts before sending/CRM sync.
+- **Pipeline actions**: Creates/updates HubSpot contacts and deals.
+- **Weekly digest**: Periodic summarization of signals and activity.
+
+## Setup
+
+Requires the following environment variables (if real tools are used):
+- `EXA_API_KEY` (for signal scanning)
+- `APOLLO_API_KEY` (for lead enrichment)
+- `HUBSPOT_ACCESS_TOKEN` (for CRM upsert)
+
+## Usage
+
+Run the agent in TUI mode:
+```bash
+make run-agent template=gtm_signal_agent
+```
+
+Or using the CLI directly:
+```bash
+python -m examples.templates.gtm_signal_agent tui
+```

--- a/examples/templates/gtm_signal_agent/__init__.py
+++ b/examples/templates/gtm_signal_agent/__init__.py
@@ -1,0 +1,23 @@
+"""
+GTM Signal Intelligence Agent - End-to-end signal monitoring, enrichment, and outreach.
+
+Continuously detects GTM signals, enriches leads, scores opportunities,
+drafts outreach, and supports human approval before CRM actions.
+"""
+
+from .agent import GTMSignalAgent, default_agent, goal, nodes, edges
+from .config import RuntimeConfig, AgentMetadata, default_config, metadata
+
+__version__ = "1.0.0"
+
+__all__ = [
+    "GTMSignalAgent",
+    "default_agent",
+    "goal",
+    "nodes",
+    "edges",
+    "RuntimeConfig",
+    "AgentMetadata",
+    "default_config",
+    "metadata",
+]

--- a/examples/templates/gtm_signal_agent/__main__.py
+++ b/examples/templates/gtm_signal_agent/__main__.py
@@ -1,0 +1,175 @@
+"""
+CLI entry point for GTM Signal Intelligence Agent.
+
+Uses AgentRuntime for multi-entrypoint support with HITL pause/resume.
+"""
+
+import asyncio
+import json
+import logging
+import sys
+import click
+
+from .agent import default_agent, GTMSignalAgent
+
+
+def setup_logging(verbose=False, debug=False):
+    """Configure logging for execution visibility."""
+    if debug:
+        level, fmt = logging.DEBUG, "%(asctime)s %(name)s: %(message)s"
+    elif verbose:
+        level, fmt = logging.INFO, "%(message)s"
+    else:
+        level, fmt = logging.WARNING, "%(levelname)s: %(message)s"
+    logging.basicConfig(level=level, format=fmt, stream=sys.stderr)
+    logging.getLogger("framework").setLevel(level)
+
+
+@click.group()
+@click.version_option(version="1.0.0")
+def cli():
+    """GTM Signal Intelligence Agent - End-to-end signal monitoring and outreach."""
+    pass
+
+
+@cli.command()
+@click.option("--quiet", "-q", is_flag=True, help="Only output result JSON")
+@click.option("--verbose", "-v", is_flag=True, help="Show execution details")
+@click.option("--debug", is_flag=True, help="Show debug logging")
+def run(quiet, verbose, debug):
+    """Execute the agent loop."""
+    if not quiet:
+        setup_logging(verbose=verbose, debug=debug)
+
+    context = {}
+
+    result = asyncio.run(default_agent.run(context))
+
+    output_data = {
+        "success": result.success,
+        "steps_executed": result.steps_executed,
+        "output": result.output,
+    }
+    if result.error:
+        output_data["error"] = result.error
+
+    click.echo(json.dumps(output_data, indent=2, default=str))
+    sys.exit(0 if result.success else 1)
+
+
+@cli.command()
+@click.option("--verbose", "-v", is_flag=True, help="Show execution details")
+@click.option("--debug", is_flag=True, help="Show debug logging")
+def tui(verbose, debug):
+    """Launch the TUI dashboard for interactive GTM workflow."""
+    setup_logging(verbose=verbose, debug=debug)
+
+    try:
+        from framework.tui.app import AdenTUI
+    except ImportError:
+        click.echo(
+            "TUI requires the 'textual' package. Install with: pip install textual"
+        )
+        sys.exit(1)
+
+    from pathlib import Path
+
+    from framework.llm import LiteLLMProvider
+    from framework.runner.tool_registry import ToolRegistry
+    from framework.runtime.agent_runtime import create_agent_runtime
+    from framework.runtime.event_bus import EventBus
+    from framework.runtime.execution_stream import EntryPointSpec
+
+    async def run_with_tui():
+        agent = GTMSignalAgent()
+
+        # Build graph and tools
+        agent._event_bus = EventBus()
+        agent._tool_registry = ToolRegistry()
+
+        storage_path = Path.home() / ".hive" / "agents" / "gtm_signal_agent"
+        storage_path.mkdir(parents=True, exist_ok=True)
+
+        mcp_config_path = Path(__file__).parent / "mcp_servers.json"
+        if mcp_config_path.exists():
+            agent._tool_registry.load_mcp_config(mcp_config_path)
+
+        # Discover custom tools from tools.py
+        tools_path = Path(__file__).parent / "tools.py"
+        if tools_path.exists():
+            agent._tool_registry.discover_from_module(tools_path)
+
+        llm = LiteLLMProvider(
+            model=agent.config.model,
+            api_key=agent.config.api_key,
+            api_base=agent.config.api_base,
+        )
+
+        tools = list(agent._tool_registry.get_tools().values())
+        tool_executor = agent._tool_registry.get_executor()
+        graph = agent._build_graph()
+
+        runtime = create_agent_runtime(
+            graph=graph,
+            goal=agent.goal,
+            storage_path=storage_path,
+            entry_points=[
+                EntryPointSpec(
+                    id="start",
+                    name="Start GTM Agent",
+                    entry_node="intake",
+                    trigger_type="manual",
+                    isolation_level="isolated",
+                ),
+            ],
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor,
+        )
+
+        await runtime.start()
+
+        try:
+            app = AdenTUI(runtime)
+            await app.run_async()
+        finally:
+            await runtime.stop()
+
+    asyncio.run(run_with_tui())
+
+
+@cli.command()
+@click.option("--json", "output_json", is_flag=True)
+def info(output_json):
+    """Show agent information."""
+    info_data = default_agent.info()
+    if output_json:
+        click.echo(json.dumps(info_data, indent=2))
+    else:
+        click.echo(f"Agent: {info_data['name']}")
+        click.echo(f"Version: {info_data['version']}")
+        click.echo(f"Description: {info_data['description']}")
+        click.echo(f"\nNodes: {', '.join(info_data['nodes'])}")
+        click.echo(f"Client-facing: {', '.join(info_data['client_facing_nodes'])}")
+        click.echo(f"Entry: {info_data['entry_node']}")
+        click.echo(f"Terminal: {', '.join(info_data['terminal_nodes'])}")
+
+
+@cli.command()
+def validate():
+    """Validate agent structure."""
+    validation = default_agent.validate()
+    if validation["valid"]:
+        click.echo("Agent is valid")
+        if validation["warnings"]:
+            for warning in validation["warnings"]:
+                click.echo(f"  WARNING: {warning}")
+    else:
+        click.echo("Agent has errors:")
+        for error in validation["errors"]:
+            click.echo(f"  ERROR: {error}")
+    sys.exit(0 if validation["valid"] else 1)
+
+
+if __name__ == "__main__":
+    cli()

--- a/examples/templates/gtm_signal_agent/agent.json
+++ b/examples/templates/gtm_signal_agent/agent.json
@@ -1,0 +1,25 @@
+{
+  "agent": {
+    "id": "gtm_signal_agent",
+    "name": "GTM Signal Intelligence Agent",
+    "version": "1.0.0",
+    "description": "Continuously detects GTM signals, enriches leads, scores opportunities, drafts outreach, and supports human approval before CRM actions."
+  },
+  "graph": {
+    "id": "gtm-signal-agent-graph",
+    "goal_id": "gtm-signal-automation",
+    "version": "1.0.0",
+    "entry_node": "intake",
+    "entry_points": {
+      "start": "intake"
+    },
+    "pause_nodes": [],
+    "terminal_nodes": [],
+    "conversation_mode": "continuous"
+  },
+  "required_tools": [
+    "exa_search",
+    "apollo_enrichment",
+    "hubspot_upsert"
+  ]
+}

--- a/examples/templates/gtm_signal_agent/agent.py
+++ b/examples/templates/gtm_signal_agent/agent.py
@@ -1,0 +1,370 @@
+"""Agent graph construction for GTM Signal Intelligence Agent."""
+
+from pathlib import Path
+
+from framework.graph import EdgeSpec, EdgeCondition, Goal, SuccessCriterion, Constraint
+from framework.graph.edge import GraphSpec
+from framework.graph.executor import ExecutionResult
+from framework.graph.checkpoint_config import CheckpointConfig
+from framework.llm import LiteLLMProvider
+from framework.runner.tool_registry import ToolRegistry
+from framework.runtime.agent_runtime import AgentRuntime, create_agent_runtime
+from framework.runtime.execution_stream import EntryPointSpec
+
+from .config import default_config, metadata
+from .nodes import (
+    intake_node,
+    signal_scan_node,
+    lead_enricher_node,
+    opportunity_scorer_node,
+    outreach_drafter_node,
+    outreach_approval_node,
+    hubspot_upsert_node,
+    weekly_digest_node,
+    next_scan_gate_node,
+)
+
+# Goal definition
+goal = Goal(
+    id="gtm-signal-automation",
+    name="GTM Signal Intelligence",
+    description=(
+        "Continuously detects GTM signals, enriches leads, scores opportunities, "
+        "drafts outreach, and supports human approval before CRM actions."
+    ),
+    success_criteria=[
+        SuccessCriterion(
+            id="signal-detected",
+            description="Find at least one valid signal matching ICP",
+            metric="signals_found",
+            target=">=1",
+            weight=0.25,
+        ),
+        SuccessCriterion(
+            id="user-approval",
+            description="User reviews draft before outreach is synced/sent",
+            metric="approval_rate",
+            target="100%",
+            weight=0.25,
+        ),
+    ],
+    constraints=[
+        Constraint(
+            id="rate-limits",
+            description="Respect Apollo and Exa rate limits",
+            constraint_type="technical",
+            category="performance",
+        ),
+        Constraint(
+            id="human-in-the-loop",
+            description="Require user approval for hot leads before CRM sync",
+            constraint_type="functional",
+            category="interaction",
+        ),
+    ],
+)
+
+# Node list
+nodes = [
+    intake_node,
+    signal_scan_node,
+    lead_enricher_node,
+    opportunity_scorer_node,
+    outreach_drafter_node,
+    outreach_approval_node,
+    hubspot_upsert_node,
+    weekly_digest_node,
+    next_scan_gate_node,
+]
+
+# Edge definitions
+edges = [
+    EdgeSpec(
+        id="intake-to-scan",
+        source="intake",
+        target="signal_scan",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="scan-to-enrich",
+        source="signal_scan",
+        target="lead_enricher",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="enrich-to-score",
+        source="lead_enricher",
+        target="opportunity_scorer",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    # Score routing
+    EdgeSpec(
+        id="score-to-draft",
+        source="opportunity_scorer",
+        target="outreach_drafter",
+        condition=EdgeCondition.CONDITIONAL,
+        condition_expr="score_band in ['hot', 'warm']",
+        priority=1,
+    ),
+    EdgeSpec(
+        id="score-to-crm",
+        source="opportunity_scorer",
+        target="hubspot_upsert",
+        condition=EdgeCondition.CONDITIONAL,
+        condition_expr="score_band == 'cold'",
+        priority=2,
+    ),
+    EdgeSpec(
+        id="draft-to-approve",
+        source="outreach_drafter",
+        target="outreach_approval",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    # Approval routing
+    EdgeSpec(
+        id="approve-to-crm",
+        source="outreach_approval",
+        target="hubspot_upsert",
+        condition=EdgeCondition.CONDITIONAL,
+        condition_expr="approval_action in ['approve', 'edit']",
+        priority=1,
+    ),
+    EdgeSpec(
+        id="approve-to-next",
+        source="outreach_approval",
+        target="next_scan_gate",
+        condition=EdgeCondition.CONDITIONAL,
+        condition_expr="approval_action == 'skip'",
+        priority=2,
+    ),
+    EdgeSpec(
+        id="crm-to-digest",
+        source="hubspot_upsert",
+        target="weekly_digest",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="digest-to-next",
+        source="weekly_digest",
+        target="next_scan_gate",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    # Forever loop
+    EdgeSpec(
+        id="next-to-intake",
+        source="next_scan_gate",
+        target="intake",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+]
+
+# Graph configuration
+entry_node = "intake"
+entry_points = {"start": "intake"}
+pause_nodes = []
+terminal_nodes = []
+
+
+class GTMSignalAgent:
+    """
+    GTM Signal Intelligence Agent
+    """
+
+    def __init__(self, config=None):
+        self.config = config or default_config
+        self.goal = goal
+        self.nodes = nodes
+        self.edges = edges
+        self.entry_node = entry_node
+        self.entry_points = entry_points
+        self.pause_nodes = pause_nodes
+        self.terminal_nodes = terminal_nodes
+        self._graph: GraphSpec | None = None
+        self._agent_runtime: AgentRuntime | None = None
+        self._tool_registry: ToolRegistry | None = None
+        self._storage_path: Path | None = None
+
+    def _build_graph(self) -> GraphSpec:
+        """Build the GraphSpec."""
+        return GraphSpec(
+            id="gtm-signal-agent-graph",
+            goal_id=self.goal.id,
+            version="1.0.0",
+            entry_node=self.entry_node,
+            entry_points=self.entry_points,
+            terminal_nodes=self.terminal_nodes,
+            pause_nodes=self.pause_nodes,
+            nodes=self.nodes,
+            edges=self.edges,
+            default_model=self.config.model,
+            max_tokens=self.config.max_tokens,
+            loop_config={
+                "max_iterations": 1000,
+                "max_tool_calls_per_turn": 30,
+                "max_history_tokens": 32000,
+            },
+        )
+
+    def _setup(self, mock_mode: bool = False) -> None:
+        """Set up the executor with all components."""
+        from pathlib import Path
+
+        storage_path = Path.home() / ".hive" / "agents" / "gtm_signal_agent"
+        storage_path.mkdir(parents=True, exist_ok=True)
+
+        self._tool_registry = ToolRegistry()
+
+        mcp_config_path = Path(__file__).parent / "mcp_servers.json"
+        if mcp_config_path.exists():
+            self._tool_registry.load_mcp_config(mcp_config_path)
+
+        llm = None
+        if not mock_mode:
+            llm = LiteLLMProvider(
+                model=self.config.model,
+                api_key=self.config.api_key,
+                api_base=self.config.api_base,
+            )
+
+        # Discover custom tools
+        tools_path = Path(__file__).parent / "tools.py"
+        if tools_path.exists():
+            self._tool_registry.discover_from_module(tools_path)
+            
+        tool_executor = self._tool_registry.get_executor()
+        tools = list(self._tool_registry.get_tools().values())
+
+        self._graph = self._build_graph()
+
+        checkpoint_config = CheckpointConfig(
+            enabled=True,
+            checkpoint_on_node_start=False,
+            checkpoint_on_node_complete=True,
+            checkpoint_max_age_days=7,
+            async_checkpoint=True,
+        )
+
+        entry_point_specs = [
+            EntryPointSpec(
+                id="default",
+                name="Default",
+                entry_node=self.entry_node,
+                trigger_type="manual",
+                isolation_level="shared",
+            )
+        ]
+
+        self._agent_runtime = create_agent_runtime(
+            graph=self._graph,
+            goal=self.goal,
+            storage_path=self._storage_path,
+            entry_points=entry_point_specs,
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor,
+            checkpoint_config=checkpoint_config,
+        )
+
+    async def start(self, mock_mode=False) -> None:
+        """Set up and start the agent runtime."""
+        if self._agent_runtime is None:
+            self._setup(mock_mode=mock_mode)
+        if not self._agent_runtime.is_running:
+            await self._agent_runtime.start()
+
+    async def stop(self) -> None:
+        """Stop the agent runtime and clean up."""
+        if self._agent_runtime and self._agent_runtime.is_running:
+            await self._agent_runtime.stop()
+        self._agent_runtime = None
+
+    async def trigger_and_wait(
+        self,
+        entry_point: str = "default",
+        input_data: dict | None = None,
+        timeout: float | None = None,
+        session_state: dict | None = None,
+    ) -> ExecutionResult | None:
+        """Execute the graph and wait for completion."""
+        if self._agent_runtime is None:
+            raise RuntimeError("Agent not started. Call start() first.")
+
+        return await self._agent_runtime.trigger_and_wait(
+            entry_point_id=entry_point,
+            input_data=input_data or {},
+            session_state=session_state,
+        )
+
+    async def run(
+        self, context: dict, mock_mode=False, session_state=None
+    ) -> ExecutionResult:
+        """Run the agent (convenience method for single execution)."""
+        await self.start(mock_mode=mock_mode)
+        try:
+            result = await self.trigger_and_wait(
+                "default", context, session_state=session_state
+            )
+            return result or ExecutionResult(success=False, error="Execution timeout")
+        finally:
+            await self.stop()
+
+    def info(self):
+        """Get agent information."""
+        return {
+            "name": metadata.name,
+            "version": metadata.version,
+            "description": metadata.description,
+            "goal": {
+                "name": self.goal.name,
+                "description": self.goal.description,
+            },
+            "nodes": [n.id for n in self.nodes],
+            "edges": [e.id for e in self.edges],
+            "entry_node": self.entry_node,
+            "entry_points": self.entry_points,
+            "pause_nodes": self.pause_nodes,
+            "terminal_nodes": self.terminal_nodes,
+            "client_facing_nodes": [n.id for n in self.nodes if n.client_facing],
+        }
+
+    def validate(self):
+        """Validate agent structure."""
+        errors = []
+        warnings = []
+
+        node_ids = {node.id for node in self.nodes}
+        for edge in self.edges:
+            if edge.source not in node_ids:
+                errors.append(f"Edge {edge.id}: source '{edge.source}' not found")
+            if edge.target not in node_ids:
+                errors.append(f"Edge {edge.id}: target '{edge.target}' not found")
+
+        if self.entry_node not in node_ids:
+            errors.append(f"Entry node '{self.entry_node}' not found")
+
+        for terminal in self.terminal_nodes:
+            if terminal not in node_ids:
+                errors.append(f"Terminal node '{terminal}' not found")
+
+        for ep_id, node_id in self.entry_points.items():
+            if node_id not in node_ids:
+                errors.append(
+                    f"Entry point '{ep_id}' references unknown node '{node_id}'"
+                )
+
+        return {
+            "valid": len(errors) == 0,
+            "errors": errors,
+            "warnings": warnings,
+        }
+
+
+# Create default instance
+default_agent = GTMSignalAgent()

--- a/examples/templates/gtm_signal_agent/config.py
+++ b/examples/templates/gtm_signal_agent/config.py
@@ -1,0 +1,25 @@
+"""Runtime configuration."""
+
+from dataclasses import dataclass
+
+from framework.config import RuntimeConfig
+
+default_config = RuntimeConfig()
+
+
+@dataclass
+class AgentMetadata:
+    name: str = "GTM Signal Intelligence Agent"
+    version: str = "1.0.0"
+    description: str = (
+        "Forever-alive agent that monitors GTM signals, enriches leads, "
+        "scores opportunities, and drafts outreach with human-in-the-loop approval."
+    )
+    intro_message: str = (
+        "Hi! I'm your GTM Signal Intelligence Agent. I continuously scan for buying "
+        "signals, enrich leads, and prepare targeted outreach. What is our Ideal "
+        "Customer Profile (ICP) for this session?"
+    )
+
+
+metadata = AgentMetadata()

--- a/examples/templates/gtm_signal_agent/mcp_servers.json
+++ b/examples/templates/gtm_signal_agent/mcp_servers.json
@@ -1,0 +1,9 @@
+{
+  "hive-tools": {
+    "transport": "stdio",
+    "command": "uv",
+    "args": ["run", "python", "mcp_server.py", "--stdio"],
+    "cwd": "../../../tools",
+    "description": "Hive tools MCP server providing web_search, web_scrape, and write_to_file"
+  }
+}

--- a/examples/templates/gtm_signal_agent/nodes/__init__.py
+++ b/examples/templates/gtm_signal_agent/nodes/__init__.py
@@ -1,0 +1,215 @@
+"""Node definitions for GTM Signal Intelligence Agent."""
+
+from framework.graph import NodeSpec
+
+intake_node = NodeSpec(
+    id="intake",
+    name="ICP Intake",
+    description="Collect Ideal Customer Profile, target signals, and preferences.",
+    node_type="event_loop",
+    client_facing=True,
+    max_node_visits=0,
+    input_keys=[],
+    output_keys=["icp_profile", "target_signals"],
+    success_criteria="ICP and target signals are clearly defined and confirmed by the user.",
+    system_prompt="""\
+You are a GTM strategist. Ask the user to define their Ideal Customer Profile (ICP) 
+and the types of buying signals they want to track (e.g., funding rounds, leadership changes).
+
+**STEP 1 — Read and respond (text only, NO tool calls):**
+Ask the user for their ICP and target signals if not provided. Confirm the details.
+
+**STEP 2 — After the user confirms, call set_output:**
+- set_output("icp_profile", "Detailed ICP description")
+- set_output("target_signals", "List of target signals to monitor")
+""",
+    tools=[],
+)
+
+signal_scan_node = NodeSpec(
+    id="signal_scan",
+    name="Signal Scanning",
+    description="Use Exa/news/web search to find buying signals from ICP-matched companies.",
+    node_type="event_loop",
+    max_node_visits=0,
+    input_keys=["icp_profile", "target_signals"],
+    output_keys=["signal_candidates"],
+    success_criteria="Identified at least one relevant buying signal.",
+    system_prompt="""\
+You are a signal researcher. Given an ICP profile and target signals, search for recent news.
+
+Use the `exa_search` tool to find recent signals matching the target signals and ICP.
+
+When done, call set_output:
+- set_output("signal_candidates", "[List of companies and the signals found]")
+""",
+    tools=["exa_search"],
+)
+
+lead_enricher_node = NodeSpec(
+    id="lead_enricher",
+    name="Lead Enrichment",
+    description="Find and enrich decision-makers via Apollo.",
+    node_type="event_loop",
+    max_node_visits=0,
+    input_keys=["signal_candidates"],
+    output_keys=["enriched_leads"],
+    success_criteria="Enriched leads with contact info.",
+    system_prompt="""\
+You are a data enrichment specialist. For the companies in `signal_candidates`, find decision makers.
+
+Process them one-by-one to respect API rate limits. Use the `apollo_enrichment` tool to fetch contacts for the domains identified in the signals.
+
+When done, call set_output:
+- set_output("enriched_leads", "[List of leads with contact info and associated signals]")
+""",
+    tools=["apollo_enrichment"],
+)
+
+opportunity_scorer_node = NodeSpec(
+    id="opportunity_scorer",
+    name="Opportunity Scoring",
+    description="Score each opportunity and route by score.",
+    node_type="event_loop",
+    max_node_visits=0,
+    input_keys=["enriched_leads"],
+    output_keys=["opportunity_score", "score_band", "opportunity_data"],
+    success_criteria="Assigned a score (0-100) and band (hot, warm, cold).",
+    system_prompt="""\
+You are a sales operations analyst. Score the enriched leads based on the strength of the signal and ICP fit.
+
+Rubric:
+- 80-100: Hot (Direct ICP match, clear buying signal like new funding)
+- 50-79: Warm (Partial match or weaker signal)
+- 0-49: Cold (Poor fit or no clear signal)
+
+Pick the highest scoring lead to process next (in a full system, you would iterate).
+Call set_output:
+- set_output("opportunity_score", "<integer score>")
+- set_output("score_band", "<hot, warm, or cold>")
+- set_output("opportunity_data", "<JSON with lead and signal details>")
+""",
+    tools=[],
+)
+
+outreach_drafter_node = NodeSpec(
+    id="outreach_drafter",
+    name="Outreach Drafting",
+    description="Draft short, signal-specific outreach emails.",
+    node_type="event_loop",
+    max_node_visits=0,
+    input_keys=["opportunity_data"],
+    output_keys=["outreach_draft"],
+    success_criteria="Drafted a personalized email.",
+    system_prompt="""\
+You are an expert SDR. Write a concise, personalized outreach email based on the `opportunity_data`.
+Mention the specific signal (e.g., funding, hiring) in the first line. 
+Keep it under 100 words.
+
+Call set_output:
+- set_output("outreach_draft", "<The email text>")
+""",
+    tools=[],
+)
+
+outreach_approval_node = NodeSpec(
+    id="outreach_approval",
+    name="Outreach Approval",
+    description="Human-in-the-loop approval of drafts.",
+    node_type="event_loop",
+    client_facing=True,
+    max_node_visits=0,
+    input_keys=["outreach_draft", "opportunity_data"],
+    output_keys=["approval_action", "approved_outreach"],
+    success_criteria="User reviewed the draft and selected an action.",
+    system_prompt="""\
+Present the drafted outreach to the user for approval.
+
+**STEP 1 — Present (text only, NO tool calls):**
+Show the `opportunity_data` summary and the `outreach_draft`.
+Ask: "Do you want to (1) Approve, (2) Edit, or (3) Skip this opportunity?"
+
+**STEP 2 — After the user responds, call set_output:**
+- If they approve:
+  set_output("approval_action", "approve")
+  set_output("approved_outreach", "<original draft>")
+- If they edit:
+  set_output("approval_action", "edit")
+  set_output("approved_outreach", "<user's edited version>")
+- If they skip:
+  set_output("approval_action", "skip")
+  set_output("approved_outreach", "")
+""",
+    tools=[],
+)
+
+hubspot_upsert_node = NodeSpec(
+    id="hubspot_upsert",
+    name="HubSpot Upsert",
+    description="Create or update contacts/deals in CRM and optional tools.",
+    node_type="event_loop",
+    max_node_visits=0,
+    input_keys=["opportunity_data", "approval_action", "approved_outreach"],
+    nullable_output_keys=["approved_outreach", "approval_action"],
+    output_keys=["crm_status"],
+    success_criteria="Upserted to CRM.",
+    system_prompt="""\
+You are an integration worker.
+If the `approval_action` is "skip" or `score_band` was cold, just log the lead to the CRM as a skipped/nurture lead.
+Otherwise, use `hubspot_upsert` to log the approved lead, and use `create_gmail_draft` with the `approved_outreach`.
+
+Call set_output:
+- set_output("crm_status", "Successfully synced to CRM and created drafts.")
+""",
+    tools=["hubspot_upsert", "create_gmail_draft", "send_slack_notification"],
+)
+
+weekly_digest_node = NodeSpec(
+    id="weekly_digest",
+    name="Weekly Digest",
+    description="Client-facing digest of activity.",
+    node_type="event_loop",
+    client_facing=True,
+    max_node_visits=0,
+    input_keys=["crm_status"],
+    output_keys=["last_digest_ts"],
+    success_criteria="Presented summary to user.",
+    system_prompt="""\
+Present a brief summary of the completed cycle to the user.
+"Here is the status of the latest run: <crm_status>. We've completed the cycle."
+Ask the user if they want to run another scan now.
+
+After they reply, call set_output:
+- set_output("last_digest_ts", "<current_time_string>")
+""",
+    tools=[],
+)
+
+next_scan_gate_node = NodeSpec(
+    id="next_scan_gate",
+    name="Next Scan Gate",
+    description="Prepare state for the next forever-alive cycle.",
+    node_type="event_loop",
+    max_node_visits=0,
+    input_keys=[],
+    output_keys=["skip_to_next_scan"],
+    success_criteria="Reset state.",
+    system_prompt="""\
+We are looping back to the beginning. 
+Call set_output:
+- set_output("skip_to_next_scan", "true")
+""",
+    tools=[],
+)
+
+__all__ = [
+    "intake_node",
+    "signal_scan_node",
+    "lead_enricher_node",
+    "opportunity_scorer_node",
+    "outreach_drafter_node",
+    "outreach_approval_node",
+    "hubspot_upsert_node",
+    "weekly_digest_node",
+    "next_scan_gate_node",
+]

--- a/examples/templates/gtm_signal_agent/tools.py
+++ b/examples/templates/gtm_signal_agent/tools.py
@@ -1,0 +1,87 @@
+"""Tool integrations for GTM Signal Intelligence Agent."""
+
+import json
+from framework.runner.tool_registry import tool
+
+@tool(description="Search Exa for buying signals.")
+def exa_search(query: str, num_results: int = 5) -> str:
+    """
+    Search Exa (or mock if no key) for buying signals based on a query.
+    
+    Args:
+        query: The search query for buying signals (e.g. "company just raised funding").
+        num_results: The number of results to return.
+    """
+    # Hybrid MVP: Simulate Exa call
+    results = [
+        {
+            "title": f"Recent Signal related to: {query}",
+            "url": "https://example.com/signal",
+            "text": "The company just announced a major product launch and is looking to expand their sales team."
+        }
+    ]
+    return json.dumps(results)
+
+@tool(description="Fetch decision-maker contacts for a given domain.")
+def apollo_enrichment(domain: str) -> str:
+    """
+    Fetch decision-maker contacts for a given domain via Apollo.
+    
+    Args:
+        domain: The company domain to enrich (e.g. "example.com").
+    """
+    # Hybrid MVP: Simulate Apollo call
+    contacts = [
+        {
+            "name": "Jane Doe",
+            "title": "VP of Sales",
+            "email": "jane@example.com",
+            "linkedin": "https://linkedin.com/in/janedoe"
+        }
+    ]
+    return json.dumps({"domain": domain, "contacts": contacts})
+
+@tool(description="Create or update a contact and deal in HubSpot.")
+def hubspot_upsert(email: str, company: str, score: int) -> str:
+    """
+    Create or update a contact and deal in HubSpot.
+    
+    Args:
+        email: Contact's email address.
+        company: Company name.
+        score: Opportunity score.
+    """
+    return f"Successfully upserted {email} at {company} into HubSpot with score {score}."
+
+@tool(description="Create a draft email in Gmail.")
+def create_gmail_draft(to_email: str, subject: str, body: str) -> str:
+    """
+    Create a draft email in Gmail.
+    
+    Args:
+        to_email: Recipient email address.
+        subject: Email subject.
+        body: Email body content.
+    """
+    return f"Created Gmail draft for {to_email}."
+
+@tool(description="Send a notification to a Slack channel.")
+def send_slack_notification(channel: str, message: str) -> str:
+    """
+    Send a notification to a Slack channel.
+    
+    Args:
+        channel: Slack channel name.
+        message: Message content.
+    """
+    return f"Sent Slack notification to {channel}."
+
+@tool(description="Generate a Cal.com booking link.")
+def generate_cal_com_link(meeting_type: str = "intro") -> str:
+    """
+    Generate a Cal.com booking link for the given meeting type.
+    
+    Args:
+        meeting_type: Type of meeting (e.g., "intro", "demo").
+    """
+    return f"https://cal.com/sales-team/{meeting_type}"

--- a/uv.lock
+++ b/uv.lock
@@ -800,9 +800,6 @@ dependencies = [
     { name = "litellm" },
     { name = "mcp" },
     { name = "pydantic" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-xdist" },
     { name = "textual" },
     { name = "tools" },
 ]
@@ -810,6 +807,11 @@ dependencies = [
 [package.optional-dependencies]
 server = [
     { name = "aiohttp" },
+]
+testing = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-xdist" },
 ]
 tui = [
     { name = "textual" },
@@ -820,6 +822,9 @@ webhook = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -834,17 +839,20 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.81.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0" },
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "pytest-asyncio", specifier = ">=0.23" },
-    { name = "pytest-xdist", specifier = ">=3.0" },
+    { name = "pytest", marker = "extra == 'testing'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'testing'", specifier = ">=0.23" },
+    { name = "pytest-xdist", marker = "extra == 'testing'", specifier = ">=3.0" },
     { name = "textual", specifier = ">=1.0.0" },
     { name = "textual", marker = "extra == 'tui'", specifier = ">=0.75.0" },
     { name = "tools", editable = "tools" },
 ]
-provides-extras = ["tui", "webhook", "server"]
+provides-extras = ["tui", "webhook", "server", "testing"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "pytest-xdist", specifier = ">=3.0" },
     { name = "ruff", specifier = ">=0.14.14" },
     { name = "ty", specifier = ">=0.0.13" },
 ]


### PR DESCRIPTION

## Summary
This PR implements the GTM Signal Intelligence Agent template as described in issue #5817.

### Changes
- Created the `gtm_signal_agent` template under `examples/templates/`.
- Implemented core integrations (Exa/news, Apollo, HubSpot) with initial mock interfaces.
- Designed a 9-node event loop graph incorporating human-in-the-loop (HITL) points for intake, outreach approval, and weekly digests.
- Fixed a framework bug in `core/framework/graph/event_loop_node.py` causing an `UnboundLocalError` when LLM calls fail early in a turn.

### Testing
- Tested in TUI mode.
- Validated with mock integration data.
