### PR TITLE
fix(server): use session.phase_state instead of session.mode_state in…

### DIFF
--- a/core/framework/server/routes_execution.py
+++ b/core/framework/server/routes_execution.py
@@ -357,8 +357,8 @@ async def handle_pause(request: web.Request) -> web.Response:
     runtime.pause_timers()
 
     # Switch to staging (agent still loaded, ready to re-run)
-    if session.mode_state is not None:
-        await session.mode_state.switch_to_staging(source="frontend")
+    if session.phase_state is not None:
+        await session.phase_state.switch_to_staging(source="frontend")
 
     return web.json_response(
         {


### PR DESCRIPTION

for issue  #5991
… handle_pause

The handle_pause endpoint referenced session.mode_state (lines 360-361), which does not exist on the Session dataclass. This caused an AttributeError every time the pause endpoint reached the phase transition step, preventing the queen phase from transitioning to staging and returning a 500 error to the frontend.

Changed to session.phase_state, consistent with handle_stop (line 412), handle_run (line 75), and the Session dataclass definition (session_manager.py line 44).

## Description

Brief description of the changes in this PR.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
