### PR TITLE
 fix: prevent mid-stream retry from duplicating published tokens (#5923)

### DIFF
--- a/core/framework/credentials/storage.py
+++ b/core/framework/credentials/storage.py
@@ -13,12 +13,16 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 from abc import ABC, abstractmethod
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from filelock import FileLock
 from pydantic import SecretStr
+
+from framework.utils.io import atomic_write
 
 from .models import CredentialDecryptionError, CredentialKey, CredentialObject, CredentialType
 
@@ -160,6 +164,8 @@ class EncryptedFileStorage(CredentialStorage):
                 )
 
         self._fernet = Fernet(self._key)
+        self._lock = threading.RLock()
+        self._index_lock_path = self.base_path / "metadata" / "index.lock"
 
     def _ensure_dirs(self) -> None:
         """Create directory structure."""
@@ -181,9 +187,9 @@ class EncryptedFileStorage(CredentialStorage):
         # Encrypt
         encrypted = self._fernet.encrypt(json_bytes)
 
-        # Write to file
+        # Write to file atomically (tmp + fsync + rename — no truncation crash window)
         cred_path = self._cred_path(credential.id)
-        with open(cred_path, "wb") as f:
+        with atomic_write(cred_path, mode="wb") as f:
             f.write(encrypted)
 
         # Update index
@@ -215,21 +221,32 @@ class EncryptedFileStorage(CredentialStorage):
     def delete(self, credential_id: str) -> bool:
         """Delete a credential file."""
         cred_path = self._cred_path(credential_id)
-        if cred_path.exists():
-            cred_path.unlink()
-            self._update_index(credential_id, "delete")
-            logger.debug(f"Deleted credential '{credential_id}'")
-            return True
-        return False
+        if not cred_path.exists():
+            return False
+        with self._lock:
+            with FileLock(self._index_lock_path):
+                # Remove from index before unlinking the .enc file.
+                # If unlink later fails, the index is already correct (no ghost entry).
+                self._update_index_locked(credential_id, "delete")
+                cred_path.unlink()
+        logger.debug(f"Deleted credential '{credential_id}'")
+        return True
 
     def list_all(self) -> list[str]:
         """List all credential IDs."""
         index_path = self.base_path / "metadata" / "index.json"
         if not index_path.exists():
             return []
-        with open(index_path, encoding="utf-8-sig") as f:
-            index = json.load(f)
-        return list(index.get("credentials", {}).keys())
+        try:
+            with open(index_path) as f:
+                index = json.load(f)
+            return list(index.get("credentials", {}).keys())
+        except (json.JSONDecodeError, OSError):
+            logger.warning(
+                "index.json is corrupt or unreadable; scanning credential files for recovery"
+            )
+            cred_dir = self.base_path / "credentials"
+            return [p.stem for p in cred_dir.glob("*.enc")]
 
     def exists(self, credential_id: str) -> bool:
         """Check if credential exists."""
@@ -264,12 +281,32 @@ class EncryptedFileStorage(CredentialStorage):
         operation: str,
         credential_type: str | None = None,
     ) -> None:
-        """Update the metadata index."""
+        """Acquire both locks then update the metadata index."""
+        with self._lock:
+            with FileLock(self._index_lock_path):
+                self._update_index_locked(credential_id, operation, credential_type)
+
+    def _update_index_locked(
+        self,
+        credential_id: str,
+        operation: str,
+        credential_type: str | None = None,
+    ) -> None:
+        """
+        Update the metadata index.
+
+        Caller MUST hold both self._lock and FileLock(self._index_lock_path)
+        before calling this method.
+        """
         index_path = self.base_path / "metadata" / "index.json"
 
         if index_path.exists():
-            with open(index_path, encoding="utf-8-sig") as f:
-                index = json.load(f)
+            try:
+                with open(index_path) as f:
+                    index = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                logger.warning("index.json corrupt during update; resetting to empty index")
+                index = {"credentials": {}, "version": "1.0"}
         else:
             index = {"credentials": {}, "version": "1.0"}
 
@@ -283,7 +320,7 @@ class EncryptedFileStorage(CredentialStorage):
 
         index["last_modified"] = datetime.now(UTC).isoformat()
 
-        with open(index_path, "w", encoding="utf-8") as f:
+        with atomic_write(index_path) as f:
             json.dump(index, f, indent=2)
 
 

--- a/core/framework/credentials/tests/test_credential_store.py
+++ b/core/framework/credentials/tests/test_credential_store.py
@@ -10,8 +10,11 @@ Tests cover:
 - OAuth2 module
 """
 
+import concurrent.futures
+import json
 import os
 import tempfile
+import threading
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
@@ -322,6 +325,164 @@ class TestEncryptedFileStorage:
         storage.save(CredentialObject(id="test", keys={}))
         assert storage.delete("test")
         assert storage.load("test") is None
+
+    # ------------------------------------------------------------------ #
+    # T1 — Concurrent saves, same EncryptedFileStorage instance            #
+    # ------------------------------------------------------------------ #
+    def test_concurrent_saves_same_instance(self, storage):
+        """20 threads each save a distinct credential through the same instance.
+        All 20 must appear in list_all() — verifies threading.RLock prevents
+        in-process TOCTOU on the index."""
+        ids = [f"cred_{i}" for i in range(20)]
+
+        def save_one(cred_id):
+            storage.save(CredentialObject(id=cred_id, keys={}))
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=10) as ex:
+            futures = [ex.submit(save_one, cid) for cid in ids]
+            for f in concurrent.futures.as_completed(futures):
+                f.result()  # re-raise any exception
+
+        result = set(storage.list_all())
+        assert result == set(ids), f"Missing IDs: {set(ids) - result}"
+
+    # ------------------------------------------------------------------ #
+    # T2 — Concurrent saves, two separate instances (cross-instance TOCTOU)#
+    # ------------------------------------------------------------------ #
+    def test_concurrent_saves_cross_instance(self, temp_dir):
+        """Two EncryptedFileStorage instances pointed at the same directory
+        save different credentials concurrently.  Both must survive in the
+        index — directly reproduces the T1–T12 interleaving from the forensic
+        analysis (issue #5855)."""
+        from cryptography.fernet import Fernet
+
+        key = Fernet.generate_key()
+        store_a = EncryptedFileStorage(temp_dir, encryption_key=key)
+        store_b = EncryptedFileStorage(temp_dir, encryption_key=key)
+
+        errors = []
+        iterations = 15
+
+        def save_via_a():
+            for i in range(iterations):
+                try:
+                    store_a.save(CredentialObject(id=f"alpha_{i}", keys={}))
+                except Exception as e:
+                    errors.append(e)
+
+        def save_via_b():
+            for i in range(iterations):
+                try:
+                    store_b.save(CredentialObject(id=f"beta_{i}", keys={}))
+                except Exception as e:
+                    errors.append(e)
+
+        t1 = threading.Thread(target=save_via_a)
+        t2 = threading.Thread(target=save_via_b)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert not errors, f"Exceptions during concurrent saves: {errors}"
+
+        # Verify from a fresh third instance
+        store_c = EncryptedFileStorage(temp_dir, encryption_key=key)
+        result = set(store_c.list_all())
+        expected = {f"alpha_{i}" for i in range(iterations)} | {f"beta_{i}" for i in range(iterations)}
+        assert result == expected, f"Missing IDs: {expected - result}"
+
+    # ------------------------------------------------------------------ #
+    # T3 — Corrupted index: list_all() recovers via .enc scan             #
+    # ------------------------------------------------------------------ #
+    def test_corrupted_index_list_all_recovers(self, storage):
+        """Pre-saving a credential then corrupting index.json must not crash
+        list_all() — it should fall back to scanning .enc files."""
+        storage.save(CredentialObject(id="existing", keys={}))
+
+        index_path = storage.base_path / "metadata" / "index.json"
+        index_path.write_bytes(b"")  # truncate to empty — simulates crash mid-write
+
+        result = storage.list_all()  # must not raise
+        assert isinstance(result, list)
+        assert "existing" in result  # recovered from .enc scan
+
+    # ------------------------------------------------------------------ #
+    # T4 — Corrupted index: save() still works and new entry is readable  #
+    # ------------------------------------------------------------------ #
+    def test_corrupted_index_save_recovers(self, storage):
+        """With a corrupt index.json, save() must succeed and the credential
+        must be loadable afterward."""
+        index_path = storage.base_path / "metadata" / "index.json"
+        index_path.write_text("not valid json")
+
+        cred = CredentialObject(
+            id="new_cred",
+            keys={"k": CredentialKey(name="k", value=SecretStr("v"))},
+        )
+        storage.save(cred)  # must not raise
+
+        loaded = storage.load("new_cred")
+        assert loaded is not None
+        assert loaded.get_key("k") == "v"
+        assert "new_cred" in storage.list_all()
+
+    # ------------------------------------------------------------------ #
+    # T5 — Atomic .enc write: no partial file left on mid-write failure   #
+    # ------------------------------------------------------------------ #
+    def test_atomic_enc_write_no_partial_on_crash(self, storage):
+        """If os.fsync raises (disk-full / crash simulation), the .enc file
+        must not be left in a corrupt/partial state — atomic_write's
+        BaseException handler deletes the .tmp file."""
+        import unittest.mock
+
+        cred = CredentialObject(id="crash_test", keys={})
+
+        with unittest.mock.patch("os.fsync", side_effect=OSError("disk full")):
+            with pytest.raises(OSError):
+                storage.save(cred)
+
+        cred_path = storage._cred_path("crash_test")
+        assert not cred_path.exists(), ".enc must not exist after a failed atomic write"
+
+        tmp_path = cred_path.with_suffix(".enc.tmp")
+        assert not tmp_path.exists(), ".tmp must be cleaned up after failure"
+
+    # ------------------------------------------------------------------ #
+    # T6 — delete() index-first: no ghost entry when unlink fails         #
+    # ------------------------------------------------------------------ #
+    def test_delete_no_ghost_entry(self, storage):
+        """delete() must remove the credential from the index before
+        unlinking the .enc file.  If unlink raises, the index is already
+        correct — no ghost entry should remain."""
+        storage.save(CredentialObject(id="ghost_target", keys={}))
+
+        original_unlink = Path.unlink
+
+        def failing_unlink(self_path, missing_ok=False):
+            if self_path.suffix == ".enc" and "ghost_target" in self_path.name:
+                raise OSError("unlink failed")
+            original_unlink(self_path, missing_ok=missing_ok)
+
+        with patch.object(Path, "unlink", failing_unlink):
+            with pytest.raises(OSError):
+                storage.delete("ghost_target")
+
+        # Index must already have been updated — credential ID not listed
+        assert "ghost_target" not in storage.list_all()
+
+    # ------------------------------------------------------------------ #
+    # T7 — Atomic index write: no .tmp file left after successful save    #
+    # ------------------------------------------------------------------ #
+    def test_atomic_index_write_no_tmp_leftover(self, storage):
+        """After a successful save(), no index.json.tmp file should exist.
+        Confirms atomic_write cleans up its temp file on success."""
+        storage.save(CredentialObject(id="clean_write", keys={}))
+
+        index_path = storage.base_path / "metadata" / "index.json"
+        tmp_path = index_path.with_suffix(".json.tmp")
+        assert not tmp_path.exists(), "index.json.tmp must not exist after successful write"
+        assert index_path.exists(), "index.json must exist after save"
 
 
 class TestCompositeStorage:

--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -14,9 +14,12 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from framework.graph.checkpoint_config import CheckpointConfig
+
+if TYPE_CHECKING:
+    from framework.schemas.replay import ReplayConfig
 from framework.graph.edge import EdgeCondition, EdgeSpec, GraphSpec
 from framework.graph.goal import Goal
 from framework.graph.node import (
@@ -439,6 +442,7 @@ class GraphExecutor:
         session_state: dict[str, Any] | None = None,
         checkpoint_config: "CheckpointConfig | None" = None,
         validate_graph: bool = True,
+        replay_config: "ReplayConfig | None" = None,
     ) -> ExecutionResult:
         """
         Execute a graph for a goal.
@@ -479,6 +483,107 @@ class GraphExecutor:
                     "Register tools via ToolRegistry or remove tool declarations from nodes."
                 ),
             )
+
+        # --- Replay injection block ---
+        # When replay_config is provided, wrap self.llm and self.tool_executor with
+        # caching wrappers that return stored responses from the source session's L3
+        # tool_logs.jsonl instead of calling live LLM / tool systems.
+        # We temporarily replace instance variables so that _build_context() and
+        # _get_node_implementation() transparently pick up the wrappers with no
+        # further changes required inside the hot dispatch loop.
+        _replay_interceptor = None
+        _orig_llm = self.llm
+        _orig_tool_executor = self.tool_executor
+
+        # Support the escape-hatch threading pattern used by AgentRunner.run_replay():
+        # replay_config may arrive packed inside session_state["_replay_config"] when
+        # the caller cannot thread it through AgentRuntime → ExecutionStream directly.
+        if replay_config is None and session_state and "_replay_config" in session_state:
+            from framework.schemas.replay import ReplayConfig as _RC
+
+            _rc_raw = session_state.pop("_replay_config")
+            replay_config = _RC.model_validate(_rc_raw)
+
+        if replay_config is not None:
+            from framework.runtime.replay_runtime import (
+                ReplayCache,
+                ReplayInterceptor,
+                ReplayLLMProvider,
+                make_replay_tool_executor,
+            )
+            from framework.schemas.replay import ReplayConfig as _ReplayConfig
+            from framework.runtime.runtime_log_store import RuntimeLogStore
+            from framework.storage.session_store import SessionStore
+
+            _session_store = SessionStore(self._storage_path) if self._storage_path else None
+            if _session_store is None:
+                return ExecutionResult(
+                    success=False,
+                    error="Replay requires a configured storage_path on GraphExecutor.",
+                )
+
+            _source_state = await _session_store.read_state(replay_config.source_session_id)
+            if _source_state is None:
+                return ExecutionResult(
+                    success=False,
+                    error=f"Replay source session '{replay_config.source_session_id}' not found.",
+                )
+
+            # Merge source input_data with any caller-supplied overrides
+            input_data = {**_source_state.input_data, **replay_config.input_overrides}
+
+            # Build replay cache from source session's L3 tool_logs.jsonl
+            _log_store = RuntimeLogStore(self._storage_path / "sessions")
+            try:
+                _cache = await ReplayCache.from_session(
+                    replay_config.source_session_id, _log_store
+                )
+            except ValueError as _cache_err:
+                return ExecutionResult(success=False, error=str(_cache_err))
+
+            _replay_interceptor = ReplayInterceptor(
+                _cache,
+                freeze_llm=replay_config.freeze_llm,
+                freeze_tools=replay_config.freeze_tools,
+            )
+            self.llm = ReplayLLMProvider(self.llm, _replay_interceptor)  # type: ignore[assignment]
+            self.tool_executor = make_replay_tool_executor(
+                self.tool_executor, _replay_interceptor
+            )
+
+            # Clear node registry so _get_node_implementation() recreates EventLoopNodes
+            # with the new (replay-wrapped) tool_executor instead of returning cached ones.
+            self.node_registry.clear()
+
+            # from_node: start replay from a specific node using the nearest checkpoint's
+            # memory snapshot so intermediate state is correctly restored.
+            if replay_config.from_node:
+                session_state = dict(session_state or {})
+                session_state["paused_at"] = replay_config.from_node
+                if self._storage_path:
+                    _cs = CheckpointStore(self._storage_path)
+                    _index = await _cs.load_index()
+                    if _index:
+                        for _chk_sum in reversed(_index.checkpoints):
+                            if _chk_sum.current_node == replay_config.from_node or (
+                                _chk_sum.next_node == replay_config.from_node
+                            ):
+                                _chk = await _cs.load_checkpoint(_chk_sum.checkpoint_id)
+                                if _chk:
+                                    session_state["memory"] = _chk.shared_memory
+                                    session_state["execution_path"] = _chk.execution_path
+                                break
+
+            self.logger.info(
+                "🔁 Replay mode active — source: %s | freeze_llm=%s freeze_tools=%s | "
+                "cache: %d LLM entries, %d tool entries",
+                replay_config.source_session_id,
+                replay_config.freeze_llm,
+                replay_config.freeze_tools,
+                _cache.total_llm_entries,
+                _cache.total_tool_entries,
+            )
+        # --- End replay injection block ---
 
         # Initialize execution state
         memory = SharedMemory()
@@ -948,6 +1053,10 @@ class GraphExecutor:
 
                 # Execute node
                 self.logger.info("   Executing...")
+                # Inform the replay interceptor (if active) which node is starting
+                # so its internal step/tool counters reset correctly for this node.
+                if _replay_interceptor is not None:
+                    _replay_interceptor.set_node(current_node_id)
                 result = await node_impl.execute(ctx)
 
                 # GCU tab cleanup: stop the browser profile after a top-level GCU node
@@ -1777,6 +1886,10 @@ class GraphExecutor:
                 from framework.runner.tool_registry import ToolRegistry
 
                 ToolRegistry.reset_execution_context(_ctx_token)
+
+            # Restore original LLM provider and tool executor if replay wrapped them.
+            self.llm = _orig_llm
+            self.tool_executor = _orig_tool_executor
 
     def _build_context(
         self,

--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -1257,6 +1257,16 @@ class LiteLLMProvider(LLMProvider):
 
             except RateLimitError as e:
                 if attempt < RATE_LIMIT_MAX_RETRIES:
+                    if accumulated_text:
+                        # Text chunks were already yielded to the caller and
+                        # published to the event bus — they cannot be recalled.
+                        # Retrying would re-stream from token 1, duplicating
+                        # content the client has already received.  Yield a
+                        # recoverable error instead; EventLoopNode will commit
+                        # the partial text and skip the outer retry (because
+                        # accumulated_text is non-empty at line 1706).
+                        yield StreamErrorEvent(error=str(e), recoverable=True)
+                        return
                     wait = _compute_retry_delay(attempt, exception=e)
                     logger.warning(
                         f"[stream-retry] {self.model} rate limited (429): {e!s}. "
@@ -1270,6 +1280,12 @@ class LiteLLMProvider(LLMProvider):
 
             except Exception as e:
                 if _is_stream_transient_error(e) and attempt < RATE_LIMIT_MAX_RETRIES:
+                    if accumulated_text:
+                        # Same guard as RateLimitError: text already published
+                        # to the event bus cannot be recalled.  Stop retrying
+                        # to prevent client-visible duplication.
+                        yield StreamErrorEvent(error=str(e), recoverable=True)
+                        return
                     wait = _compute_retry_delay(attempt, exception=e)
                     logger.warning(
                         f"[stream-retry] {self.model} transient error "

--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -1589,56 +1589,6 @@ def _interactive_multi(agents_dir: Path) -> int:
     return 0
 
 
-def cmd_sessions_list(args: argparse.Namespace) -> int:
-    """List agent sessions."""
-    print("⚠ Sessions list command not yet implemented")
-    print("This will be available once checkpoint infrastructure is complete.")
-    print(f"\nAgent: {args.agent_path}")
-    print(f"Status filter: {args.status}")
-    print(f"Has checkpoints: {args.has_checkpoints}")
-    return 1
-
-
-def cmd_sessions_show(args: argparse.Namespace) -> int:
-    """Show detailed session information."""
-    print("⚠ Session show command not yet implemented")
-    print("This will be available once checkpoint infrastructure is complete.")
-    print(f"\nAgent: {args.agent_path}")
-    print(f"Session: {args.session_id}")
-    return 1
-
-
-def cmd_sessions_checkpoints(args: argparse.Namespace) -> int:
-    """List checkpoints for a session."""
-    print("⚠ Session checkpoints command not yet implemented")
-    print("This will be available once checkpoint infrastructure is complete.")
-    print(f"\nAgent: {args.agent_path}")
-    print(f"Session: {args.session_id}")
-    return 1
-
-
-def cmd_pause(args: argparse.Namespace) -> int:
-    """Pause a running session."""
-    print("⚠ Pause command not yet implemented")
-    print("This will be available once executor pause integration is complete.")
-    print(f"\nAgent: {args.agent_path}")
-    print(f"Session: {args.session_id}")
-    return 1
-
-
-def cmd_resume(args: argparse.Namespace) -> int:
-    """Resume a session from checkpoint."""
-    print("⚠ Resume command not yet implemented")
-    print("This will be available once checkpoint resume integration is complete.")
-    print(f"\nAgent: {args.agent_path}")
-    print(f"Session: {args.session_id}")
-    if args.checkpoint:
-        print(f"Checkpoint: {args.checkpoint}")
-    if args.tui:
-        print("Mode: TUI")
-    return 1
-
-
 def cmd_replay(args: argparse.Namespace) -> int:
     """Replay a session with frozen LLM/tool responses for root-cause analysis."""
     from framework.runner import AgentRunner

--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -190,6 +190,85 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
     shell_parser.set_defaults(func=cmd_shell)
 
     # tui command (interactive agent dashboard)
+
+    # replay command
+    replay_parser = subparsers.add_parser(
+        "replay",
+        help="Re-execute a session with frozen LLM/tool responses",
+        description=(
+            "Replay a previous session using cached LLM responses and tool results "
+            "from the original run. Useful for root-cause analysis of failed sessions "
+            "and counterfactual testing (e.g. 'what if this node had succeeded?')."
+        ),
+    )
+    replay_parser.add_argument(
+        "agent_path",
+        type=str,
+        help="Path to agent folder",
+    )
+    replay_parser.add_argument(
+        "session_id",
+        type=str,
+        help="Session ID to replay (source session)",
+    )
+    replay_parser.add_argument(
+        "--from-node",
+        type=str,
+        default=None,
+        metavar="NODE",
+        help=(
+            "Start replay from this node ID using a checkpoint memory snapshot "
+            "(default: run from the agent entry_point)"
+        ),
+    )
+    replay_parser.add_argument(
+        "--freeze-llm",
+        action="store_true",
+        default=True,
+        help="Use cached LLM responses (default: True)",
+    )
+    replay_parser.add_argument(
+        "--no-freeze-llm",
+        dest="freeze_llm",
+        action="store_false",
+        help="Call the live LLM instead of using cached responses",
+    )
+    replay_parser.add_argument(
+        "--freeze-tools",
+        action="store_true",
+        default=True,
+        help="Use cached tool results (default: True)",
+    )
+    replay_parser.add_argument(
+        "--no-freeze-tools",
+        dest="freeze_tools",
+        action="store_false",
+        help="Execute tools live instead of using cached results",
+    )
+    replay_parser.add_argument(
+        "--input-override",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help=(
+            "Override an input field (can be repeated). "
+            "Example: --input-override user_query='new question'"
+        ),
+    )
+    replay_parser.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format for the diff report (default: text)",
+    )
+    replay_parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show full node outputs in the diff table",
+    )
+    replay_parser.set_defaults(func=cmd_replay)
+
     # setup-credentials command
     setup_creds_parser = subparsers.add_parser(
         "setup-credentials",
@@ -1508,6 +1587,279 @@ def _interactive_multi(agents_dir: Path) -> int:
 
     orchestrator.cleanup()
     return 0
+
+
+def cmd_sessions_list(args: argparse.Namespace) -> int:
+    """List agent sessions."""
+    print("⚠ Sessions list command not yet implemented")
+    print("This will be available once checkpoint infrastructure is complete.")
+    print(f"\nAgent: {args.agent_path}")
+    print(f"Status filter: {args.status}")
+    print(f"Has checkpoints: {args.has_checkpoints}")
+    return 1
+
+
+def cmd_sessions_show(args: argparse.Namespace) -> int:
+    """Show detailed session information."""
+    print("⚠ Session show command not yet implemented")
+    print("This will be available once checkpoint infrastructure is complete.")
+    print(f"\nAgent: {args.agent_path}")
+    print(f"Session: {args.session_id}")
+    return 1
+
+
+def cmd_sessions_checkpoints(args: argparse.Namespace) -> int:
+    """List checkpoints for a session."""
+    print("⚠ Session checkpoints command not yet implemented")
+    print("This will be available once checkpoint infrastructure is complete.")
+    print(f"\nAgent: {args.agent_path}")
+    print(f"Session: {args.session_id}")
+    return 1
+
+
+def cmd_pause(args: argparse.Namespace) -> int:
+    """Pause a running session."""
+    print("⚠ Pause command not yet implemented")
+    print("This will be available once executor pause integration is complete.")
+    print(f"\nAgent: {args.agent_path}")
+    print(f"Session: {args.session_id}")
+    return 1
+
+
+def cmd_resume(args: argparse.Namespace) -> int:
+    """Resume a session from checkpoint."""
+    print("⚠ Resume command not yet implemented")
+    print("This will be available once checkpoint resume integration is complete.")
+    print(f"\nAgent: {args.agent_path}")
+    print(f"Session: {args.session_id}")
+    if args.checkpoint:
+        print(f"Checkpoint: {args.checkpoint}")
+    if args.tui:
+        print("Mode: TUI")
+    return 1
+
+
+def cmd_replay(args: argparse.Namespace) -> int:
+    """Replay a session with frozen LLM/tool responses for root-cause analysis."""
+    from framework.runner import AgentRunner
+    from framework.schemas.replay import NodeReplayDiff, ReplayConfig, ReplayResult
+    from framework.runtime.runtime_log_store import RuntimeLogStore
+    from framework.storage.session_store import SessionStore
+
+    # --- Parse --input-override KEY=VALUE pairs ---
+    input_overrides: dict = {}
+    for override in getattr(args, "input_override", []):
+        if "=" not in override:
+            print(
+                f"Error: --input-override '{override}' must be in KEY=VALUE format.",
+                file=sys.stderr,
+            )
+            return 2
+        key, _, raw_value = override.partition("=")
+        # Attempt JSON parse so numbers/bools/dicts work; fall back to string
+        try:
+            input_overrides[key.strip()] = json.loads(raw_value)
+        except json.JSONDecodeError:
+            input_overrides[key.strip()] = raw_value
+
+    # --- Build ReplayConfig ---
+    replay_config = ReplayConfig(
+        source_session_id=args.session_id,
+        from_node=getattr(args, "from_node", None),
+        freeze_llm=args.freeze_llm,
+        freeze_tools=args.freeze_tools,
+        input_overrides=input_overrides,
+    )
+
+    # --- Load agent ---
+    try:
+        runner = AgentRunner.load(args.agent_path, skip_credential_validation=True)
+    except Exception as e:
+        print(f"Error loading agent: {e}", file=sys.stderr)
+        return 2
+
+    # --- Validate source session exists ---
+    storage_path = runner._storage_path
+    session_store = SessionStore(storage_path)
+
+    source_state = asyncio.run(session_store.read_state(args.session_id))
+    if source_state is None:
+        print(
+            f"Error: session '{args.session_id}' not found for agent at '{args.agent_path}'.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # --- Run replay ---
+    import time
+
+    started_at = time.time()
+    try:
+        result, replay_session_id = asyncio.run(runner.run_replay(replay_config))
+    except Exception as e:
+        print(f"Error during replay: {e}", file=sys.stderr)
+        return 1
+    duration_ms = int((time.time() - started_at) * 1000)
+
+    # --- Load L2 node details for comparison ---
+    log_store = RuntimeLogStore(storage_path / "sessions")
+
+    async def _load_details():
+        src = await log_store.load_details(args.session_id)
+        rpl = await log_store.load_details(replay_session_id)
+        return src, rpl
+
+    source_details_log, replay_details_log = asyncio.run(_load_details())
+    source_details = source_details_log.nodes if source_details_log else []
+    replay_details = replay_details_log.nodes if replay_details_log else []
+
+    # --- Load replay session state ---
+    replay_state = asyncio.run(session_store.read_state(replay_session_id))
+
+    # --- Build NodeReplayDiff list ---
+    source_node_map = {nd.node_id: nd for nd in source_details}
+    replay_node_map = {nd.node_id: nd for nd in replay_details}
+
+    node_diffs: list[NodeReplayDiff] = []
+    diverged_nodes: list[str] = []
+    original_path = source_state.progress.path or []
+
+    for node_id in original_path:
+        src_nd = source_node_map.get(node_id)
+        rpl_nd = replay_node_map.get(node_id)
+
+        orig_exit = src_nd.exit_status if src_nd else ""
+        rply_exit = rpl_nd.exit_status if rpl_nd else ""
+        orig_success = src_nd.success if src_nd else False
+        rply_success = rpl_nd.success if rpl_nd else False
+        orig_error = src_nd.error if src_nd else None
+        rply_error = rpl_nd.error if rpl_nd else None
+
+        diverged = (
+            orig_exit != rply_exit
+            or orig_success != rply_success
+            or bool(orig_error) != bool(rply_error)
+        )
+
+        divergence_reason: str | None = None
+        if diverged:
+            if orig_success != rply_success:
+                divergence_reason = (
+                    f"success: {orig_success} → {rply_success}"
+                )
+            elif orig_exit != rply_exit:
+                divergence_reason = f"exit_status: '{orig_exit}' → '{rply_exit}'"
+            elif bool(orig_error) != bool(rply_error):
+                divergence_reason = (
+                    f"error presence: {'yes' if orig_error else 'no'} → "
+                    f"{'yes' if rply_error else 'no'}"
+                )
+            diverged_nodes.append(node_id)
+
+        node_diffs.append(
+            NodeReplayDiff(
+                node_id=node_id,
+                diverged=diverged,
+                original_exit_status=orig_exit,
+                replay_exit_status=rply_exit,
+                divergence_reason=divergence_reason,
+            )
+        )
+
+    # --- Build improvement_hypothesis ---
+    from framework.runtime.replay_runtime import build_improvement_hypothesis
+
+    from_node_orig_status = ""
+    from_node_rply_status = ""
+    if replay_config.from_node:
+        src_fn = source_node_map.get(replay_config.from_node)
+        rpl_fn = replay_node_map.get(replay_config.from_node)
+        from_node_orig_status = src_fn.exit_status if src_fn else ""
+        from_node_rply_status = rpl_fn.exit_status if rpl_fn else ""
+
+    hypothesis = build_improvement_hypothesis(
+        source_success=bool(source_state.result.success),
+        replay_success=result.success,
+        diverged_nodes=diverged_nodes,
+        from_node=replay_config.from_node,
+        from_node_original_status=from_node_orig_status,
+        from_node_replay_status=from_node_rply_status,
+        total_misses=0,  # interceptor not accessible here; cache miss count in logs
+    )
+
+    replay_result = ReplayResult(
+        source_session_id=args.session_id,
+        replay_session_id=replay_session_id,
+        config=replay_config,
+        overall_success=result.success,
+        original_success=bool(source_state.result.success),
+        node_diffs=node_diffs,
+        diverged_nodes=diverged_nodes,
+        improvement_hypothesis=hypothesis,
+        started_at=source_state.timestamps.started_at,
+        duration_ms=duration_ms,
+    )
+
+    # --- Output ---
+    if args.output == "json":
+        print(replay_result.model_dump_json(indent=2))
+        return 0 if result.success else 1
+
+    # Text output
+    print()
+    print("=" * 70)
+    print(f"  REPLAY REPORT")
+    print("=" * 70)
+    print(f"  Source session : {args.session_id}")
+    print(f"  Replay session : {replay_session_id}")
+    print(
+        f"  Original result: {'✓ SUCCESS' if replay_result.original_success else '✗ FAILED'}"
+    )
+    print(
+        f"  Replay  result : {'✓ SUCCESS' if replay_result.overall_success else '✗ FAILED'}"
+    )
+    print(f"  Duration       : {duration_ms}ms")
+    print(f"  Freeze LLM     : {replay_config.freeze_llm}")
+    print(f"  Freeze tools   : {replay_config.freeze_tools}")
+    if replay_config.from_node:
+        print(f"  From node      : {replay_config.from_node}")
+    print()
+
+    # Node diff table
+    col_node = 30
+    col_orig = 12
+    col_rply = 12
+    col_div = 8
+    header = (
+        f"{'NODE':<{col_node}} {'ORIGINAL':<{col_orig}} {'REPLAY':<{col_rply}} DIVERGED"
+    )
+    print(header)
+    print("-" * len(header))
+    for diff in replay_result.node_diffs:
+        marker = "⚠" if diff.diverged else " "
+        orig_status = diff.original_exit_status or ("ok" if not diff.diverged else "?")
+        rply_status = diff.replay_exit_status or ("ok" if not diff.diverged else "?")
+        print(
+            f"{marker} {diff.node_id:<{col_node - 2}} "
+            f"{orig_status:<{col_orig}} "
+            f"{rply_status:<{col_rply}} "
+            f"{'YES' if diff.diverged else 'no'}"
+        )
+        if diff.diverged and diff.divergence_reason and getattr(args, "verbose", False):
+            print(f"    └─ {diff.divergence_reason}")
+    print()
+
+    if replay_result.diverged_nodes:
+        print(f"  Diverged nodes ({len(replay_result.diverged_nodes)}): "
+              f"{', '.join(replay_result.diverged_nodes)}")
+    else:
+        print("  No divergence detected.")
+    print()
+    print(f"  Hypothesis: {replay_result.improvement_hypothesis}")
+    print("=" * 70)
+    print()
+
+    return 0 if result.success else 1
 
 
 def cmd_setup_credentials(args: argparse.Namespace) -> int:

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -31,6 +31,7 @@ from framework.runtime.runtime_log_store import RuntimeLogStore
 
 if TYPE_CHECKING:
     from framework.runner.protocol import AgentMessage, CapabilityResponse
+    from framework.schemas.replay import ReplayConfig
 
 
 logger = logging.getLogger(__name__)
@@ -1542,6 +1543,80 @@ class AgentRunner:
             input_data=input_data or {},
             entry_point_id=entry_point_id,
             session_state=session_state,
+        )
+
+    async def run_replay(
+        self,
+        replay_config: "ReplayConfig",
+    ) -> tuple["ExecutionResult", str]:
+        """Re-execute a previous session with frozen LLM/tool responses.
+
+        Loads the source session's L3 tool_logs.jsonl to build a response
+        cache, then runs the agent using those cached responses instead of
+        calling live LLM / tool systems.  The replay is saved as a new,
+        independent session so the original session is never mutated.
+
+        Args:
+            replay_config: Controls which session to replay, which node to
+                start from, and whether LLM / tool calls are frozen.
+
+        Returns:
+            ``(ExecutionResult, replay_session_id)`` — the execution result
+            of the replay run and the new session ID under which it was stored.
+
+        Example::
+
+            from framework.schemas.replay import ReplayConfig
+            runner = AgentRunner.load("exports/my-agent")
+            config = ReplayConfig(
+                source_session_id="session_20260304_143022_abc12345",
+                freeze_llm=True,
+                freeze_tools=True,
+            )
+            result, session_id = await runner.run_replay(config)
+        """
+        from framework.schemas.replay import ReplayConfig as _ReplayConfig
+
+        # Ensure the runtime is set up and running
+        if self._agent_runtime is None:
+            self._setup()
+        if not self._agent_runtime.is_running:
+            await self._agent_runtime.start()
+
+        # Resolve entry point (same logic as run())
+        entry_points = self._agent_runtime.get_entry_points()
+        entry_point_id = entry_points[0].id if entry_points else "default"
+
+        # Thread replay_config to GraphExecutor via a special key in session_state.
+        # GraphExecutor.execute() detects and unpacks this key before its normal
+        # session_state processing, avoiding the need to modify the entire
+        # AgentRuntime → ExecutionStream → GraphExecutor call chain.
+        session_state: dict = {"_replay_config": replay_config.model_dump()}
+
+        # Trigger execution and capture exec_id so we can return it as the
+        # replay_session_id alongside the ExecutionResult.
+        replay_session_id: str = await self._agent_runtime.trigger(
+            entry_point_id=entry_point_id,
+            input_data={},  # actual input_data is merged from source session by executor
+            session_state=session_state,
+        )
+
+        # Wait for completion using the internal stream (same as trigger_and_wait,
+        # but we capture exec_id above before delegating to wait_for_completion).
+        stream = self._agent_runtime._resolve_stream(entry_point_id)  # type: ignore[attr-defined]
+        if stream is None:
+            return (
+                ExecutionResult(
+                    success=False,
+                    error=f"Cannot resolve execution stream for entry point '{entry_point_id}'.",
+                ),
+                replay_session_id,
+            )
+
+        result = await stream.wait_for_completion(replay_session_id)
+        return (
+            result or ExecutionResult(success=False, error="Replay execution timed out."),
+            replay_session_id,
         )
 
     async def _run_with_agent_runtime(

--- a/core/framework/runtime/replay_runtime.py
+++ b/core/framework/runtime/replay_runtime.py
@@ -1,0 +1,559 @@
+"""Deterministic replay infrastructure for Hive agent sessions (issue #4669).
+
+Loads cached LLM responses and tool results from a prior session's L3
+tool_logs.jsonl and injects them into a new execution in place of live
+LLM/tool calls, enabling root-cause analysis of failed runs.
+
+Architecture
+------------
+ReplayCache
+    Parses L3 NodeStepLog records into two lookup dicts keyed by
+    (node_id, step_index) and (node_id, step_index, tool_call_position).
+
+ReplayInterceptor
+    Single stateful object shared by both wrapper surfaces. Tracks
+    which node is executing and which step/tool-call we are at so that
+    both wrappers stay in sync without external coordination.
+
+ReplayLLMProvider
+    Wraps LLMProvider. On each stream()/acomplete() call, asks the
+    interceptor for a cached response. On hit, returns synthetic events /
+    LLMResponse from cache. On miss, delegates to the inner provider.
+
+make_replay_tool_executor
+    Returns a closure with the same signature as EventLoopNode's
+    tool_executor. On each call, asks the interceptor for a cached
+    ToolResult. On miss, delegates to the inner callable.
+
+Usage (by GraphExecutor)::
+
+    interceptor = ReplayInterceptor(cache, freeze_llm=True, freeze_tools=True)
+    effective_llm = ReplayLLMProvider(self.llm, interceptor)
+    effective_tool_executor = make_replay_tool_executor(self.tool_executor, interceptor)
+    # Before each node_impl.execute():
+    interceptor.set_node(current_node_id)
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections import defaultdict
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from framework.llm.provider import LLMProvider, LLMResponse, Tool, ToolResult, ToolUse
+from framework.llm.stream_events import (
+    FinishEvent,
+    StreamEvent,
+    TextDeltaEvent,
+    TextEndEvent,
+    ToolCallEvent,
+)
+from framework.runtime.runtime_log_schemas import NodeStepLog
+from framework.runtime.runtime_log_store import RuntimeLogStore
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Cached response container
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CachedLLMResponse:
+    """LLM response reconstructed from an L3 NodeStepLog entry."""
+
+    llm_text: str
+    """The assistant text the LLM produced in the original run."""
+
+    tool_call_suggestions: list[dict[str, Any]] = field(default_factory=list)
+    """Ordered list of tool calls the LLM requested, each a dict with
+    keys ``tool_name`` and ``tool_input``.  Replayed as ToolCallEvents
+    so EventLoopNode executes the same tools in the same order."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Cache — built from L3 tool_logs.jsonl
+# ---------------------------------------------------------------------------
+
+
+class ReplayCache:
+    """Lookup tables built from a session's L3 NodeStepLog records.
+
+    Two indices are constructed at init time:
+
+    ``llm_cache``
+        ``(node_id, step_index)`` → :class:`CachedLLMResponse`
+
+    ``tool_cache``
+        ``(node_id, step_index, tool_call_position)`` → cached result str
+
+    Tool calls within a step are disambiguated by *position* (index within
+    ``NodeStepLog.tool_calls``), not by name, so multiple calls to the same
+    tool within one step are handled correctly.
+    """
+
+    def __init__(self, steps: list[NodeStepLog]) -> None:
+        self._llm_cache: dict[tuple[str, int], CachedLLMResponse] = {}
+        self._tool_cache: dict[tuple[str, int, int], str] = {}
+        self._steps_by_node: dict[str, list[NodeStepLog]] = defaultdict(list)
+
+        for step in steps:
+            node_id = step.node_id
+            idx = step.step_index
+            self._steps_by_node[node_id].append(step)
+
+            # LLM cache entry
+            suggestions = [
+                {"tool_name": tc.tool_name, "tool_input": tc.tool_input}
+                for tc in step.tool_calls
+            ]
+            self._llm_cache[(node_id, idx)] = CachedLLMResponse(
+                llm_text=step.llm_text,
+                tool_call_suggestions=suggestions,
+                input_tokens=step.input_tokens,
+                output_tokens=step.output_tokens,
+            )
+
+            # Tool cache entries — keyed by position within this step
+            for pos, tc in enumerate(step.tool_calls):
+                self._tool_cache[(node_id, idx, pos)] = tc.result
+
+    @classmethod
+    async def from_session(
+        cls,
+        session_id: str,
+        log_store: RuntimeLogStore,
+    ) -> "ReplayCache":
+        """Load L3 logs for *session_id* and build the cache.
+
+        Raises :class:`ValueError` if no tool logs are found for the session.
+        """
+        run_tool_logs = await log_store.load_tool_logs(session_id)
+        if run_tool_logs is None or not run_tool_logs.steps:
+            raise ValueError(
+                f"No L3 tool logs found for session '{session_id}'. "
+                "Cannot build replay cache — ensure the session ran at least one node."
+            )
+        logger.debug(
+            "ReplayCache: loaded %d steps from session '%s'",
+            len(run_tool_logs.steps),
+            session_id,
+        )
+        return cls(run_tool_logs.steps)
+
+    # ------------------------------------------------------------------
+    # Lookups
+    # ------------------------------------------------------------------
+
+    def get_llm_response(
+        self, node_id: str, step_index: int
+    ) -> CachedLLMResponse | None:
+        """Return cached LLM response or ``None`` on miss."""
+        return self._llm_cache.get((node_id, step_index))
+
+    def get_tool_result(
+        self, node_id: str, step_index: int, tool_call_position: int
+    ) -> str | None:
+        """Return cached tool result string or ``None`` on miss."""
+        return self._tool_cache.get((node_id, step_index, tool_call_position))
+
+    def get_node_steps(self, node_id: str) -> list[NodeStepLog]:
+        """Return all original steps recorded for *node_id*."""
+        return list(self._steps_by_node.get(node_id, []))
+
+    @property
+    def node_ids(self) -> list[str]:
+        """Node IDs present in the cache."""
+        return list(self._steps_by_node.keys())
+
+    @property
+    def total_llm_entries(self) -> int:
+        return len(self._llm_cache)
+
+    @property
+    def total_tool_entries(self) -> int:
+        return len(self._tool_cache)
+
+
+# ---------------------------------------------------------------------------
+# Interceptor — shared mutable state between the two wrapper surfaces
+# ---------------------------------------------------------------------------
+
+
+class ReplayInterceptor:
+    """Single stateful object shared by :class:`ReplayLLMProvider` and the
+    tool executor closure produced by :func:`make_replay_tool_executor`.
+
+    GraphExecutor calls :meth:`set_node` before each ``node_impl.execute()``
+    call so counters reset correctly at node boundaries.
+
+    Counter protocol
+    ~~~~~~~~~~~~~~~~
+    * :meth:`on_llm_call` — called once per LLM invocation; increments
+      ``_step_index`` and resets ``_tool_call_position``.
+    * :meth:`on_tool_call` — called once per tool invocation within the
+      current step; increments ``_tool_call_position``.
+    """
+
+    def __init__(
+        self,
+        cache: ReplayCache,
+        freeze_llm: bool = True,
+        freeze_tools: bool = True,
+    ) -> None:
+        self._cache = cache
+        self._freeze_llm = freeze_llm
+        self._freeze_tools = freeze_tools
+
+        self._current_node: str = ""
+        self._step_index: int = 0
+        self._tool_call_position: int = 0
+
+        # Telemetry counters
+        self.llm_hits: int = 0
+        self.llm_misses: int = 0
+        self.tool_hits: int = 0
+        self.tool_misses: int = 0
+
+    def set_node(self, node_id: str) -> None:
+        """Reset all per-node counters. Must be called before each node execution."""
+        self._current_node = node_id
+        self._step_index = 0
+        self._tool_call_position = 0
+        logger.debug("ReplayInterceptor: entering node '%s'", node_id)
+
+    def on_llm_call(self) -> CachedLLMResponse | None:
+        """Query cache for the current (node, step). Advance step counter.
+
+        Returns cached response if ``freeze_llm=True`` and a cache entry
+        exists, otherwise ``None`` (signals caller to use the live LLM).
+        Side-effect: always increments step_index and resets tool_call_position.
+        """
+        cached: CachedLLMResponse | None = None
+        if self._freeze_llm:
+            cached = self._cache.get_llm_response(
+                self._current_node, self._step_index
+            )
+            if cached is not None:
+                self.llm_hits += 1
+                logger.debug(
+                    "ReplayInterceptor: LLM HIT node='%s' step=%d",
+                    self._current_node,
+                    self._step_index,
+                )
+            else:
+                self.llm_misses += 1
+                logger.warning(
+                    "ReplayInterceptor: LLM MISS node='%s' step=%d — calling live LLM",
+                    self._current_node,
+                    self._step_index,
+                )
+        # Always advance counters regardless of freeze flag / hit-or-miss
+        self._step_index += 1
+        self._tool_call_position = 0
+        return cached
+
+    def on_tool_call(self) -> str | None:
+        """Query cache for the current (node, step-1, position). Advance position counter.
+
+        Returns cached result string if ``freeze_tools=True`` and a cache
+        entry exists, otherwise ``None`` (signals caller to execute live).
+        Side-effect: always increments tool_call_position.
+        """
+        cached_result: str | None = None
+        if self._freeze_tools:
+            # step_index was already incremented by on_llm_call, so the
+            # current step's cache key uses step_index - 1.
+            cached_result = self._cache.get_tool_result(
+                self._current_node,
+                self._step_index - 1,
+                self._tool_call_position,
+            )
+            if cached_result is not None:
+                self.tool_hits += 1
+                logger.debug(
+                    "ReplayInterceptor: TOOL HIT node='%s' step=%d pos=%d",
+                    self._current_node,
+                    self._step_index - 1,
+                    self._tool_call_position,
+                )
+            else:
+                self.tool_misses += 1
+                logger.warning(
+                    "ReplayInterceptor: TOOL MISS node='%s' step=%d pos=%d — executing live",
+                    self._current_node,
+                    self._step_index - 1,
+                    self._tool_call_position,
+                )
+        self._tool_call_position += 1
+        return cached_result
+
+    @property
+    def total_misses(self) -> int:
+        return self.llm_misses + self.tool_misses
+
+    @property
+    def total_hits(self) -> int:
+        return self.llm_hits + self.tool_hits
+
+
+# ---------------------------------------------------------------------------
+# LLM provider wrapper
+# ---------------------------------------------------------------------------
+
+
+class ReplayLLMProvider(LLMProvider):
+    """Wraps an :class:`LLMProvider`; returns cached responses when available.
+
+    All interface methods delegate to ``inner`` except the primary
+    generation path (``stream`` / ``acomplete`` / ``complete``), which
+    first checks the :class:`ReplayInterceptor`.
+
+    On a cache **hit** the provider synthesises the appropriate response:
+    * ``stream()``    — yields TextDeltaEvent → ToolCallEvents → TextEndEvent → FinishEvent
+    * ``acomplete()`` — returns LLMResponse with cached content
+    * ``complete()``  — returns LLMResponse with cached content (sync)
+
+    On a cache **miss** every call is forwarded to the inner provider.
+    """
+
+    def __init__(self, inner: LLMProvider, interceptor: ReplayInterceptor) -> None:
+        self._inner = inner
+        self._interceptor = interceptor
+
+    # ------------------------------------------------------------------
+    # Primary streaming path (used by EventLoopNode._run_single_turn)
+    # ------------------------------------------------------------------
+
+    async def stream(  # type: ignore[override]
+        self,
+        messages: list[dict[str, Any]],
+        system: str = "",
+        tools: list[Tool] | None = None,
+        max_tokens: int = 4096,
+    ) -> AsyncIterator[StreamEvent]:
+        """Async generator — must be iterable directly with ``async for``.
+
+        EventLoopNode calls ``async for event in ctx.llm.stream(...)`` without
+        awaiting the call first, so this method MUST be an async generator
+        (i.e. contain ``yield``).  On a cache hit we yield synthetic events;
+        on a miss we delegate to the inner provider's generator.
+        """
+        cached = self._interceptor.on_llm_call()
+        if cached is not None:
+            # Yield synthetic events reconstructed from the cached response.
+            # Text portion first, then tool call suggestions, then finish.
+            yield TextDeltaEvent(content=cached.llm_text, snapshot=cached.llm_text)
+            yield TextEndEvent(full_text=cached.llm_text)
+
+            # Tool call suggestions — each emitted as a ToolCallEvent so that
+            # EventLoopNode calls the same tools as the original run in order.
+            for suggestion in cached.tool_call_suggestions:
+                yield ToolCallEvent(
+                    tool_use_id=str(uuid.uuid4()),
+                    tool_name=suggestion["tool_name"],
+                    tool_input=suggestion.get("tool_input", {}),
+                )
+
+            yield FinishEvent(
+                stop_reason="end_turn" if not cached.tool_call_suggestions else "tool_use",
+                input_tokens=cached.input_tokens,
+                output_tokens=cached.output_tokens,
+                model="replay-cache",
+            )
+        else:
+            # Miss — re-yield every event from the inner (live) provider.
+            async for event in self._inner.stream(
+                messages=messages,
+                system=system,
+                tools=tools,
+                max_tokens=max_tokens,
+            ):
+                yield event
+
+    # ------------------------------------------------------------------
+    # Async completion (used for compaction path in EventLoopNode)
+    # ------------------------------------------------------------------
+
+    async def acomplete(
+        self,
+        messages: list[dict[str, Any]],
+        system: str = "",
+        tools: list[Tool] | None = None,
+        max_tokens: int = 1024,
+        response_format: dict[str, Any] | None = None,
+        json_mode: bool = False,
+        max_retries: int | None = None,
+    ) -> LLMResponse:
+        cached = self._interceptor.on_llm_call()
+        if cached is not None:
+            return LLMResponse(
+                content=cached.llm_text,
+                model="replay-cache",
+                input_tokens=cached.input_tokens,
+                output_tokens=cached.output_tokens,
+                stop_reason="end_turn",
+            )
+        return await self._inner.acomplete(
+            messages=messages,
+            system=system,
+            tools=tools,
+            max_tokens=max_tokens,
+            response_format=response_format,
+            json_mode=json_mode,
+            max_retries=max_retries,
+        )
+
+    # ------------------------------------------------------------------
+    # Sync completion (abstract method — wraps acomplete via executor)
+    # ------------------------------------------------------------------
+
+    def complete(
+        self,
+        messages: list[dict[str, Any]],
+        system: str = "",
+        tools: list[Tool] | None = None,
+        max_tokens: int = 1024,
+        response_format: dict[str, Any] | None = None,
+        json_mode: bool = False,
+        max_retries: int | None = None,
+    ) -> LLMResponse:
+        # EventLoopNode never calls complete() directly; it uses stream() or acomplete().
+        # We implement it for interface completeness by delegating to inner.
+        cached = self._interceptor.on_llm_call()
+        if cached is not None:
+            return LLMResponse(
+                content=cached.llm_text,
+                model="replay-cache",
+                input_tokens=cached.input_tokens,
+                output_tokens=cached.output_tokens,
+                stop_reason="end_turn",
+            )
+        return self._inner.complete(
+            messages=messages,
+            system=system,
+            tools=tools,
+            max_tokens=max_tokens,
+            response_format=response_format,
+            json_mode=json_mode,
+            max_retries=max_retries,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tool executor closure
+# ---------------------------------------------------------------------------
+
+
+def make_replay_tool_executor(
+    inner: Callable[[ToolUse], ToolResult | Awaitable[ToolResult]] | None,
+    interceptor: ReplayInterceptor,
+) -> Callable[[ToolUse], Awaitable[ToolResult]]:
+    """Return an async tool executor closure that intercepts calls with cached results.
+
+    The returned callable has the same signature as EventLoopNode's
+    ``tool_executor`` parameter: ``(ToolUse) -> ToolResult | Awaitable[ToolResult]``.
+
+    On a cache **hit** it returns a :class:`ToolResult` built from the cached
+    result string, without calling *inner*.  On a miss it delegates to *inner*
+    (which may be sync or async).  If *inner* is ``None`` and there is a miss,
+    the returned ToolResult signals an error.
+
+    Implementation note: a closure is used instead of a class because
+    ``tool_executor`` is typed as a plain ``Callable``, not an interface.
+    """
+
+    import asyncio
+
+    async def _replay_tool_executor(tool_use: ToolUse) -> ToolResult:
+        cached_result = interceptor.on_tool_call()
+        if cached_result is not None:
+            return ToolResult(
+                tool_use_id=tool_use.id,
+                content=cached_result,
+                is_error=False,
+            )
+
+        # Cache miss — delegate to live tool executor
+        if inner is None:
+            return ToolResult(
+                tool_use_id=tool_use.id,
+                content=(
+                    f"Replay cache miss for tool '{tool_use.name}' "
+                    "and no live tool executor configured."
+                ),
+                is_error=True,
+            )
+
+        result = inner(tool_use)
+        if asyncio.iscoroutine(result) or asyncio.isfuture(result):
+            result = await result
+        return result  # type: ignore[return-value]
+
+    return _replay_tool_executor
+
+
+# ---------------------------------------------------------------------------
+# Diff helpers (used by runner/cli.py to build ReplayResult)
+# ---------------------------------------------------------------------------
+
+
+def build_improvement_hypothesis(
+    source_success: bool,
+    replay_success: bool,
+    diverged_nodes: list[str],
+    from_node: str | None,
+    from_node_original_status: str,
+    from_node_replay_status: str,
+    total_misses: int,
+) -> str:
+    """Return a rule-based improvement hypothesis string.
+
+    Rules are evaluated in priority order — first matching rule wins.
+    No LLM calls are made.
+    """
+    if total_misses > 0:
+        return (
+            f"Partial replay ({total_misses} cache miss(es)) — "
+            "results are indicative, not exact. Re-run with --no-freeze-llm "
+            "/ --no-freeze-tools to confirm."
+        )
+
+    if (
+        from_node is not None
+        and from_node_original_status not in ("success", "")
+        and from_node_replay_status == "success"
+    ):
+        return (
+            f"Node '{from_node}' recovered in replay; "
+            "downstream path unblocked. Investigate inputs to this node."
+        )
+
+    if not source_success and replay_success:
+        return (
+            "Full recovery achieved in replay — compare node diffs "
+            "for the root cause of the original failure."
+        )
+
+    if source_success == replay_success and not diverged_nodes:
+        if not source_success:
+            return (
+                "Failure reproduced deterministically — "
+                "root cause confirmed in original session logs."
+            )
+        return "Replay matched original execution exactly — no divergence detected."
+
+    if diverged_nodes:
+        return (
+            f"Divergence detected in {len(diverged_nodes)} node(s): "
+            f"{', '.join(diverged_nodes[:5])}. Review node diffs for details."
+        )
+
+    return "Mixed results — review node diffs for details."

--- a/core/framework/runtime/runtime_logger.py
+++ b/core/framework/runtime/runtime_logger.py
@@ -51,7 +51,7 @@ class RuntimeLogger:
         self._goal_id = ""
         self._started_at = ""
         self._logged_node_ids: set[str] = set()
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
 
     def start_run(self, goal_id: str = "", session_id: str = "") -> str:
         """Start a new run. Called by GraphExecutor at graph start. Returns run_id.
@@ -250,22 +250,29 @@ class RuntimeLogger:
         Called by executor after each node returns. If node_id already
         appears in _logged_node_ids (because the node called log_node_complete
         itself), this is a no-op. Otherwise appends a basic NodeDetail.
+
+        The check and the write are performed inside a single contiguous lock
+        scope to eliminate the TOCTOU window that existed when the two
+        operations used separate, non-contiguous ``with self._lock`` blocks.
+        ``self._lock`` is an RLock so that the re-entrant acquisition inside
+        ``log_node_complete()`` (line 232) does not deadlock.
         """
         with self._lock:
             if node_id in self._logged_node_ids:
                 return  # Already logged by the node itself
 
-        # Not yet logged — create a basic entry
-        self.log_node_complete(
-            node_id=node_id,
-            node_name=node_name,
-            node_type=node_type,
-            success=success,
-            error=error,
-            stacktrace=stacktrace,
-            tokens_used=tokens_used,
-            latency_ms=latency_ms,
-        )
+            # Not yet logged — create a basic entry.
+            # log_node_complete() re-acquires self._lock (RLock allows same-thread re-entry).
+            self.log_node_complete(
+                node_id=node_id,
+                node_name=node_name,
+                node_type=node_type,
+                success=success,
+                error=error,
+                stacktrace=stacktrace,
+                tokens_used=tokens_used,
+                latency_ms=latency_ms,
+            )
 
     async def end_run(
         self,

--- a/core/framework/schemas/replay.py
+++ b/core/framework/schemas/replay.py
@@ -1,0 +1,117 @@
+"""Schemas for deterministic replay of agent sessions (issue #4669)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ReplayConfig(BaseModel):
+    """Configuration for replaying a previous session deterministically.
+
+    Loads cached LLM responses and tool results from the source session's
+    L3 tool_logs.jsonl and replays them instead of calling live systems.
+
+    Example::
+
+        config = ReplayConfig(
+            source_session_id="session_20260304_143022_abc12345",
+            freeze_llm=True,
+            freeze_tools=True,
+        )
+        result = await runner.run_replay(config)
+
+    Counterfactual mode (live LLM on frozen tool data)::
+
+        config = ReplayConfig(
+            source_session_id="session_20260304_143022_abc12345",
+            freeze_llm=False,
+            freeze_tools=True,
+            input_overrides={"context": "updated context"},
+        )
+    """
+
+    source_session_id: str
+    """Session ID whose L3 tool_logs.jsonl provides the response cache."""
+
+    from_node: str | None = None
+    """Start replay from this node ID. None = run from the agent's entry_point.
+    When set, restores SharedMemory from the nearest checkpoint before this node."""
+
+    freeze_llm: bool = True
+    """Return cached llm_text instead of calling the live LLM.
+    On cache miss the live LLM is called and the miss is counted in ReplayResult."""
+
+    freeze_tools: bool = True
+    """Return cached tool results instead of executing tools live.
+    On cache miss the live tool is executed and the miss is counted."""
+
+    input_overrides: dict[str, Any] = Field(default_factory=dict)
+    """Key-value pairs merged (not replaced) over source session's input_data.
+    Allows changing one field without re-specifying all inputs."""
+
+
+class NodeReplayDiff(BaseModel):
+    """Comparison between original and replay execution for a single node."""
+
+    node_id: str
+
+    diverged: bool
+    """True if exit_status, success flag, or error presence differ from original."""
+
+    original_exit_status: str
+    """exit_status from the source session's L2 NodeDetail (e.g. 'success', 'failure')."""
+
+    replay_exit_status: str
+    """exit_status from the replay session's L2 NodeDetail."""
+
+    original_output: dict[str, Any] = Field(default_factory=dict)
+    """SharedMemory output keys written by this node in the original run."""
+
+    replay_output: dict[str, Any] = Field(default_factory=dict)
+    """SharedMemory output keys written by this node in the replay run."""
+
+    cache_misses: int = 0
+    """Number of LLM or tool calls for this node that fell through to live systems."""
+
+    divergence_reason: str | None = None
+    """Human-readable description of the first field that differs. None if not diverged."""
+
+
+class ReplayResult(BaseModel):
+    """Full comparison report from a replay run against its source session."""
+
+    source_session_id: str
+    """Session that was replayed."""
+
+    replay_session_id: str
+    """New session ID created for the replay run."""
+
+    config: ReplayConfig
+    """Configuration used for this replay."""
+
+    overall_success: bool
+    """Whether the replay run completed successfully."""
+
+    original_success: bool
+    """Whether the source session completed successfully."""
+
+    node_diffs: list[NodeReplayDiff] = Field(default_factory=list)
+    """Per-node comparison, in original execution order."""
+
+    diverged_nodes: list[str] = Field(default_factory=list)
+    """node_id values where diverged=True, for quick scanning."""
+
+    improvement_hypothesis: str = ""
+    """Rule-based assessment of what changed between original and replay.
+    Generated deterministically — not from an LLM call."""
+
+    total_cache_misses: int = 0
+    """Total LLM + tool cache misses across the entire replay run."""
+
+    started_at: str = ""
+    """ISO 8601 timestamp when the replay run started."""
+
+    duration_ms: int = 0
+    """Wall-clock duration of the replay run in milliseconds."""

--- a/core/framework/utils/io.py
+++ b/core/framework/utils/io.py
@@ -7,7 +7,8 @@ from pathlib import Path
 def atomic_write(path: Path, mode: str = "w", encoding: str = "utf-8"):
     tmp_path = path.with_suffix(path.suffix + ".tmp")
     try:
-        with open(tmp_path, mode, encoding=encoding) as f:
+        open_kwargs = {} if "b" in mode else {"encoding": encoding}
+        with open(tmp_path, mode, **open_kwargs) as f:
             yield f
             f.flush()
             os.fsync(f.fileno())

--- a/core/frontend/src/lib/prompt-navigation.test.ts
+++ b/core/frontend/src/lib/prompt-navigation.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+
+// ---------------------------------------------------------------------------
+// resolveInitialPrompt
+//
+// Mirrors the priority chain in workspace.tsx:
+//   location.state.prompt  (programmatic navigate — no URL length limit)
+//   ?? searchParams.get("prompt")  (direct URL / bookmark fallback)
+//   ?? ""
+//
+// Kept as a pure function so it can be unit-tested without a DOM/router.
+// ---------------------------------------------------------------------------
+
+function resolveInitialPrompt(
+  locationStatePrompt: string | null | undefined,
+  searchParamPrompt: string | null,
+): string {
+  return locationStatePrompt || searchParamPrompt || "";
+}
+
+describe("resolveInitialPrompt", () => {
+  // --- location.state takes priority ---
+
+  it("returns location.state.prompt when present", () => {
+    expect(resolveInitialPrompt("hello from state", null)).toBe("hello from state");
+  });
+
+  it("prefers location.state.prompt over searchParam when both present", () => {
+    expect(resolveInitialPrompt("state wins", "param loses")).toBe("state wins");
+  });
+
+  it("handles a large prompt (>2 KB) from location.state without truncation", () => {
+    const large = "A".repeat(10_000);
+    expect(resolveInitialPrompt(large, null)).toBe(large);
+    expect(resolveInitialPrompt(large, null)).toHaveLength(10_000);
+  });
+
+  // --- searchParam fallback (direct URL / bookmark) ---
+
+  it("falls back to searchParam when location.state.prompt is absent", () => {
+    expect(resolveInitialPrompt(null, "bookmark prompt")).toBe("bookmark prompt");
+  });
+
+  it("falls back to searchParam when location.state.prompt is undefined", () => {
+    expect(resolveInitialPrompt(undefined, "bookmark prompt")).toBe("bookmark prompt");
+  });
+
+  it("falls back to searchParam when location.state.prompt is empty string", () => {
+    expect(resolveInitialPrompt("", "bookmark prompt")).toBe("bookmark prompt");
+  });
+
+  // --- empty fallback ---
+
+  it("returns empty string when both sources are absent", () => {
+    expect(resolveInitialPrompt(null, null)).toBe("");
+  });
+
+  it("returns empty string when both sources are empty strings", () => {
+    expect(resolveInitialPrompt("", "")).toBe("");
+  });
+
+  it("returns empty string when state is null and searchParam is null", () => {
+    expect(resolveInitialPrompt(null, null)).toBe("");
+  });
+
+  // --- prompt hint pills (short pre-defined text via state) ---
+
+  it("correctly resolves a prompt hint string from state", () => {
+    const hint = "Check my inbox for urgent emails";
+    expect(resolveInitialPrompt(hint, null)).toBe(hint);
+  });
+
+  // --- whitespace / trimming (home.tsx trims before navigate; verify assumption) ---
+
+  it("does not trim — trimming is the caller's responsibility", () => {
+    expect(resolveInitialPrompt("  spaced  ", null)).toBe("  spaced  ");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// navigate() call shape (issue #5760 regression guard)
+//
+// Documents the exact navigate() argument shapes that home.tsx must produce.
+// If these shapes change, the workspace.tsx reader must be updated too.
+// ---------------------------------------------------------------------------
+
+describe("navigate call shape for /workspace (issue #5760)", () => {
+  type NavigateState = { prompt: string };
+  type NavigateArgs = [path: string, opts: { state: NavigateState }];
+
+  function buildHandlePromptHintArgs(text: string): NavigateArgs {
+    return ["/workspace?agent=new-agent", { state: { prompt: text } }];
+  }
+
+  function buildHandleSubmitArgs(inputValue: string): NavigateArgs {
+    return ["/workspace?agent=new-agent", { state: { prompt: inputValue.trim() } }];
+  }
+
+  it("handlePromptHint — prompt is in state, not in URL", () => {
+    const [path, opts] = buildHandlePromptHintArgs("Research latest AI trends");
+    expect(path).not.toContain("prompt=");
+    expect(opts.state.prompt).toBe("Research latest AI trends");
+  });
+
+  it("handleSubmit — prompt is in state, trimmed, not in URL", () => {
+    const [path, opts] = buildHandleSubmitArgs("  Find senior engineer roles  ");
+    expect(path).not.toContain("prompt=");
+    expect(opts.state.prompt).toBe("Find senior engineer roles");
+  });
+
+  it("handleSubmit — large prompt stays intact (no URL truncation)", () => {
+    const large = "word ".repeat(1_000).trim(); // ~5 000 chars
+    const [path, opts] = buildHandleSubmitArgs(large);
+    expect(path).not.toContain("prompt=");
+    expect(opts.state.prompt).toHaveLength(large.length);
+  });
+
+  it("handlePromptHint — agent param is still in the URL for workspace routing", () => {
+    const [path] = buildHandlePromptHintArgs("anything");
+    expect(path).toContain("agent=new-agent");
+  });
+});

--- a/core/frontend/src/pages/home.tsx
+++ b/core/frontend/src/pages/home.tsx
@@ -82,13 +82,13 @@ export default function Home() {
   };
 
   const handlePromptHint = (text: string) => {
-    navigate(`/workspace?agent=new-agent&prompt=${encodeURIComponent(text)}`);
+    navigate("/workspace?agent=new-agent", { state: { prompt: text } });
   };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (inputValue.trim()) {
-      navigate(`/workspace?agent=new-agent&prompt=${encodeURIComponent(inputValue.trim())}`);
+      navigate("/workspace?agent=new-agent", { state: { prompt: inputValue.trim() } });
     }
   };
 

--- a/core/frontend/src/pages/workspace.tsx
+++ b/core/frontend/src/pages/workspace.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import ReactDOM from "react-dom";
-import { useSearchParams, useNavigate } from "react-router-dom";
+import { useSearchParams, useNavigate, useLocation } from "react-router-dom";
 import { Plus, KeyRound, Sparkles, Layers, ChevronLeft, Bot, Loader2, WifiOff, X } from "lucide-react";
 import AgentGraph, { type GraphNode, type NodeStatus } from "@/components/AgentGraph";
 import DraftGraph from "@/components/DraftGraph";
@@ -381,7 +381,11 @@ export default function Workspace() {
   const [searchParams] = useSearchParams();
   const rawAgent = searchParams.get("agent") || "new-agent";
   const hasExplicitAgent = searchParams.has("agent");
-  const initialPrompt = searchParams.get("prompt") || "";
+  const location = useLocation();
+  const initialPrompt =
+    (location.state as { prompt?: string } | null)?.prompt ||
+    searchParams.get("prompt") ||
+    "";
   // ?session= param: when navigating from the home history sidebar, this
   // carries the backendSessionId to open as a tab on mount.
   const initialSessionId = searchParams.get("session") || "";
@@ -534,7 +538,7 @@ export default function Workspace() {
   // Clear URL params after mount — they're consumed during initialization
   // and leaving them causes confusion (stale ?agent= after tab switches, etc.)
   useEffect(() => {
-    navigate("/workspace", { replace: true });
+    navigate("/workspace", { replace: true, state: null });
   }, []);
 
   // Post-mount: if the URL carried a ?session= param (from the home page history

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
   "pydantic>=2.0",
   "anthropic>=0.40.0",
+  "filelock>=3.12",
   "httpx>=0.27.0",
   "litellm>=1.81.0",
   "mcp>=1.0.0",

--- a/core/tests/test_event_loop_node.py
+++ b/core/tests/test_event_loop_node.py
@@ -1485,6 +1485,39 @@ class ErrorThenSuccessLLM(LLMProvider):
         return LLMResponse(content="ok", model="mock", stop_reason="stop")
 
 
+class PartialStreamThenErrorLLM(LLMProvider):
+    """Simulates the fixed LiteLLMProvider.stream() behavior for mid-stream errors.
+
+    Call 0: yields ``chunks`` as TextDeltaEvents then yields
+    StreamErrorEvent(recoverable=True) — modelling the guard in litellm.py
+    that stops retrying once text has been published to the event bus.
+
+    Call 1+: yields ``success_scenario`` events (or nothing if None), allowing
+    tests to assert that no outer retry fires when accumulated_text is non-empty.
+    """
+
+    def __init__(self, chunks: list[str], success_scenario: list | None = None):
+        self.chunks = chunks
+        self.success_scenario = success_scenario or []
+        self._call_index = 0
+
+    async def stream(self, messages, system="", tools=None, max_tokens=4096):
+        idx = self._call_index
+        self._call_index += 1
+        if idx == 0:
+            snapshot = ""
+            for chunk in self.chunks:
+                snapshot += chunk
+                yield TextDeltaEvent(content=chunk, snapshot=snapshot)
+            yield StreamErrorEvent(error="connection reset mid-stream", recoverable=True)
+        else:
+            for event in self.success_scenario:
+                yield event
+
+    def complete(self, messages, system="", **kwargs) -> LLMResponse:
+        return LLMResponse(content="ok", model="mock", stop_reason="stop")
+
+
 class TestTransientErrorRetry:
     """Test retry-with-backoff for transient LLM errors in EventLoopNode."""
 
@@ -1714,6 +1747,246 @@ class TestIsTransientError:
     def test_runtime_error_without_transient_keywords(self):
         assert EventLoopNode._is_transient_error(RuntimeError("authentication failed")) is False
         assert EventLoopNode._is_transient_error(RuntimeError("invalid JSON in response")) is False
+
+
+# ===========================================================================
+# Mid-stream retry duplication (#5923)
+# ===========================================================================
+
+
+class TestMidStreamRetryNoDuplication:
+    """Verify that mid-stream errors with accumulated text do not duplicate
+    client-visible events.
+
+    The fix in litellm.py guards the retry path: when ``accumulated_text``
+    is non-empty at the time an exception fires, it yields
+    StreamErrorEvent(recoverable=True) instead of continuing the retry loop.
+    EventLoopNode then commits the partial text and does NOT trigger an outer
+    retry (because ``accumulated_text != ""`` makes the line-1706 guard false).
+
+    These tests simulate the fixed LiteLLMProvider.stream() behavior via
+    PartialStreamThenErrorLLM, then assert exact event-bus emission counts.
+    """
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_error_no_duplicate_deltas_3_chunks(
+        self, runtime, node_spec, memory
+    ):
+        """3 text chunks yielded, then recoverable error — bus gets exactly 3 deltas.
+
+        Before the fix: internal retry would re-stream from token 1, producing
+        6 or more LLM_TEXT_DELTA events.  After the fix: exactly 3.
+        """
+        node_spec.output_keys = []
+        chunks = ["Hello", " world", "!"]
+        llm = PartialStreamThenErrorLLM(chunks=chunks)
+        bus = EventBus()
+        delta_events: list = []
+        bus.subscribe(
+            event_types=[EventType.LLM_TEXT_DELTA],
+            handler=lambda e: delta_events.append(e),
+        )
+        ctx = build_ctx(runtime, node_spec, memory, llm)
+        node = EventLoopNode(
+            event_bus=bus,
+            config=LoopConfig(
+                max_iterations=5,
+                max_stream_retries=3,
+                stream_retry_backoff_base=0.01,
+            ),
+        )
+        result = await node.execute(ctx)
+        assert result.success is True
+        # Exactly K delta events — no second wave from retry
+        assert len(delta_events) == 3
+        # Confirm content is not doubled
+        content = "".join(e.data["content"] for e in delta_events)
+        assert content == "Hello world!"
+        # No outer retry fired — stream() was called exactly once
+        assert llm._call_index == 1
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_error_no_duplicate_deltas_50_chunks(
+        self, runtime, node_spec, memory
+    ):
+        """50 text chunks yielded, then recoverable error — bus gets exactly 50 deltas.
+
+        Covers the 'chunk 50' scenario from the forensic analysis where a
+        mid-response rate limit would previously replay the full response.
+        """
+        node_spec.output_keys = []
+        chunks = [f"t{i}" for i in range(50)]
+        llm = PartialStreamThenErrorLLM(chunks=chunks)
+        bus = EventBus()
+        delta_events: list = []
+        bus.subscribe(
+            event_types=[EventType.LLM_TEXT_DELTA],
+            handler=lambda e: delta_events.append(e),
+        )
+        ctx = build_ctx(runtime, node_spec, memory, llm)
+        node = EventLoopNode(
+            event_bus=bus,
+            config=LoopConfig(
+                max_iterations=5,
+                max_stream_retries=3,
+                stream_retry_backoff_base=0.01,
+            ),
+        )
+        result = await node.execute(ctx)
+        assert result.success is True
+        assert len(delta_events) == 50
+        assert llm._call_index == 1
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_error_at_chunk_0_triggers_outer_retry(
+        self, runtime, node_spec, memory
+    ):
+        """Error before any text chunk — outer retry fires; bus gets success deltas only.
+
+        When accumulated_text == '' at error time, the guard in litellm.py does
+        NOT fire.  The inner retry proceeds (or outer retry handles it).  The
+        client sees exactly the deltas from the successful attempt — no partial
+        first chunk to duplicate.
+        """
+        node_spec.output_keys = []
+        success_events = [
+            TextDeltaEvent(content="A", snapshot="A"),
+            TextDeltaEvent(content="B", snapshot="AB"),
+            FinishEvent(stop_reason="stop", input_tokens=5, output_tokens=2, model="mock"),
+        ]
+        llm = ErrorThenSuccessLLM(
+            error=ConnectionError("connection reset before first chunk"),
+            fail_count=1,
+            success_scenario=success_events,
+        )
+        bus = EventBus()
+        delta_events: list = []
+        bus.subscribe(
+            event_types=[EventType.LLM_TEXT_DELTA],
+            handler=lambda e: delta_events.append(e),
+        )
+        ctx = build_ctx(runtime, node_spec, memory, llm)
+        node = EventLoopNode(
+            event_bus=bus,
+            config=LoopConfig(
+                max_iterations=5,
+                max_stream_retries=3,
+                stream_retry_backoff_base=0.01,
+            ),
+        )
+        result = await node.execute(ctx)
+        assert result.success is True
+        # Outer retry fired — two stream() calls
+        assert llm._call_index == 2
+        # Exactly 2 deltas from the successful retry, zero from attempt 0
+        assert len(delta_events) == 2
+        assert delta_events[0].data["content"] == "A"
+        assert delta_events[1].data["content"] == "B"
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_tool_only_error_inner_retry_unaffected(
+        self, runtime, node_spec, memory
+    ):
+        """Error with no text emitted (tool-call-only stream) — outer retry fires safely.
+
+        Tool call argument deltas are buffered inside LiteLLMProvider.stream()
+        and never published to the event bus.  So an error mid-tool-stream has
+        accumulated_text == '' and the guard does NOT fire.  The retry proceeds
+        (inner or outer) without any duplication risk.
+
+        Simulated here as: LLM call 0 raises ConnectionError before yielding
+        any TextDeltaEvent; LLM call 1 succeeds with set_output.
+        """
+        node_spec.output_keys = ["result"]
+        call_index = 0
+
+        class ToolOnlyThenErrorLLM(LLMProvider):
+            async def stream(self, messages, system="", tools=None, max_tokens=4096):
+                nonlocal call_index
+                idx = call_index
+                call_index += 1
+                if idx == 0:
+                    # Raise immediately — no TextDeltaEvent emitted
+                    raise ConnectionError("network error during tool stream")
+                elif idx == 1:
+                    for event in tool_call_scenario(
+                        "set_output", {"key": "result", "value": "tool-done"}
+                    ):
+                        yield event
+                else:
+                    for event in text_scenario("done"):
+                        yield event
+
+            def complete(self, messages, system="", **kwargs) -> LLMResponse:
+                return LLMResponse(content="ok", model="mock", stop_reason="stop")
+
+        llm = ToolOnlyThenErrorLLM()
+        bus = EventBus()
+        delta_events: list = []
+        bus.subscribe(
+            event_types=[EventType.LLM_TEXT_DELTA],
+            handler=lambda e: delta_events.append(e),
+        )
+        ctx = build_ctx(runtime, node_spec, memory, llm)
+        node = EventLoopNode(
+            event_bus=bus,
+            config=LoopConfig(
+                max_iterations=5,
+                max_stream_retries=3,
+                stream_retry_backoff_base=0.01,
+            ),
+        )
+        result = await node.execute(ctx)
+        assert result.success is True
+        assert result.output.get("result") == "tool-done"
+        # Outer retry fired (call 0 failed, call 1 succeeded with set_output)
+        assert call_index >= 2
+        # Call 0 raised before yielding any text — zero deltas from the error call.
+        # Call 1 is a pure tool call (no TextDeltaEvent).
+        # Call 2 (inner loop after tool result) returns text_scenario("done") → 1 delta.
+        # The key property: no duplication from call 0; the count matches only
+        # the legitimate post-tool-call LLM turn.
+        assert len(delta_events) == 1
+        assert delta_events[0].data["content"] == "done"
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_recoverable_error_partial_text_committed(
+        self, runtime, node_spec, memory
+    ):
+        """Partial text from before the error is committed as the turn output.
+
+        When the guard fires (accumulated_text != ''), EventLoopNode receives
+        StreamErrorEvent(recoverable=True) after the partial text.  Because
+        accumulated_text is non-empty, the line-1706 check does not raise
+        ConnectionError.  The partial text is committed as final_text and the
+        node completes successfully — no duplication, no crash.
+        """
+        node_spec.output_keys = []
+        chunks = ["partial", " response"]
+        llm = PartialStreamThenErrorLLM(chunks=chunks)
+        bus = EventBus()
+        delta_events: list = []
+        bus.subscribe(
+            event_types=[EventType.LLM_TEXT_DELTA],
+            handler=lambda e: delta_events.append(e),
+        )
+        ctx = build_ctx(runtime, node_spec, memory, llm)
+        node = EventLoopNode(
+            event_bus=bus,
+            config=LoopConfig(
+                max_iterations=5,
+                max_stream_retries=3,
+                stream_retry_backoff_base=0.01,
+            ),
+        )
+        result = await node.execute(ctx)
+        assert result.success is True
+        # Exactly 2 deltas — no second wave
+        assert len(delta_events) == 2
+        assert delta_events[0].data["content"] == "partial"
+        assert delta_events[1].data["content"] == " response"
+        # Stream called exactly once — no outer retry
+        assert llm._call_index == 1
 
 
 # ===========================================================================

--- a/core/tests/test_replay.py
+++ b/core/tests/test_replay.py
@@ -1,0 +1,701 @@
+"""Tests for deterministic replay infrastructure (issue #4669).
+
+Covers:
+    1. Unit — ReplayCache builds correct lookup dicts from NodeStepLog records
+    2. Unit — ReplayInterceptor counters track step/tool state per node correctly
+    3. Integration — full replay of a two-node graph with freeze_llm + freeze_tools
+       produces identical output and zero divergence
+    4. Counterfactual — replay with freeze_llm=False (live LLM stub) still runs
+       to completion when cache misses fall through to the inner provider
+    5. CLI smoke — cmd_replay exits 2 on a missing session; --help prints all flags
+
+Each test is self-contained: no real LLM calls, no real file system (tmp_path used
+for session storage where needed), and no network access.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_step(
+    node_id: str,
+    step_index: int,
+    llm_text: str = "done",
+    tool_calls: list | None = None,
+    input_tokens: int = 10,
+    output_tokens: int = 20,
+):
+    """Build a minimal NodeStepLog-like object for testing."""
+    from framework.runtime.runtime_log_schemas import NodeStepLog, ToolCallLog
+
+    tcs = []
+    for tc in tool_calls or []:
+        tcs.append(
+            ToolCallLog(
+                tool_use_id=tc.get("id", "uid-1"),
+                tool_name=tc["tool_name"],
+                tool_input=tc.get("tool_input", {}),
+                result=tc.get("result", "ok"),
+                is_error=tc.get("is_error", False),
+            )
+        )
+    return NodeStepLog(
+        node_id=node_id,
+        node_type="event_loop",
+        step_index=step_index,
+        llm_text=llm_text,
+        tool_calls=tcs,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — ReplayCache construction
+# ---------------------------------------------------------------------------
+
+
+class TestReplayCache:
+    """Unit tests for ReplayCache lookup table construction."""
+
+    def test_llm_cache_keyed_by_node_and_step(self):
+        from framework.runtime.replay_runtime import ReplayCache
+
+        steps = [
+            _make_step("classify", 0, llm_text="classification result"),
+            _make_step("classify", 1, llm_text="retry result"),
+            _make_step("format", 0, llm_text="formatted output"),
+        ]
+        cache = ReplayCache(steps)
+
+        assert cache.total_llm_entries == 3
+        assert cache.get_llm_response("classify", 0).llm_text == "classification result"
+        assert cache.get_llm_response("classify", 1).llm_text == "retry result"
+        assert cache.get_llm_response("format", 0).llm_text == "formatted output"
+
+    def test_llm_cache_miss_returns_none(self):
+        from framework.runtime.replay_runtime import ReplayCache
+
+        cache = ReplayCache([_make_step("n1", 0)])
+        assert cache.get_llm_response("n1", 99) is None
+        assert cache.get_llm_response("missing", 0) is None
+
+    def test_tool_cache_keyed_by_position(self):
+        """Multiple calls to the same tool in one step are disambiguated by position."""
+        from framework.runtime.replay_runtime import ReplayCache
+
+        steps = [
+            _make_step(
+                "search",
+                0,
+                tool_calls=[
+                    {"tool_name": "search", "result": "result-A"},
+                    {"tool_name": "search", "result": "result-B"},  # same tool, pos 1
+                ],
+            )
+        ]
+        cache = ReplayCache(steps)
+
+        assert cache.total_tool_entries == 2
+        assert cache.get_tool_result("search", 0, 0) == "result-A"
+        assert cache.get_tool_result("search", 0, 1) == "result-B"
+
+    def test_tool_cache_miss_returns_none(self):
+        from framework.runtime.replay_runtime import ReplayCache
+
+        cache = ReplayCache([_make_step("n1", 0, tool_calls=[{"tool_name": "t", "result": "x"}])])
+        assert cache.get_tool_result("n1", 0, 99) is None
+
+    def test_tool_call_suggestions_extracted(self):
+        """CachedLLMResponse.tool_call_suggestions reflects the step's tool list."""
+        from framework.runtime.replay_runtime import ReplayCache
+
+        steps = [
+            _make_step(
+                "n1",
+                0,
+                tool_calls=[
+                    {"tool_name": "lookup", "tool_input": {"q": "foo"}, "result": "bar"},
+                ],
+            )
+        ]
+        cache = ReplayCache(steps)
+        resp = cache.get_llm_response("n1", 0)
+        assert len(resp.tool_call_suggestions) == 1
+        assert resp.tool_call_suggestions[0]["tool_name"] == "lookup"
+        assert resp.tool_call_suggestions[0]["tool_input"] == {"q": "foo"}
+
+    def test_node_ids_property(self):
+        from framework.runtime.replay_runtime import ReplayCache
+
+        steps = [_make_step("a", 0), _make_step("b", 0), _make_step("a", 1)]
+        cache = ReplayCache(steps)
+        assert set(cache.node_ids) == {"a", "b"}
+
+    def test_get_node_steps_returns_in_order(self):
+        from framework.runtime.replay_runtime import ReplayCache
+
+        steps = [_make_step("n1", 0), _make_step("n1", 1), _make_step("n2", 0)]
+        cache = ReplayCache(steps)
+        n1_steps = cache.get_node_steps("n1")
+        assert len(n1_steps) == 2
+        assert n1_steps[0].step_index == 0
+        assert n1_steps[1].step_index == 1
+
+    @pytest.mark.asyncio
+    async def test_from_session_raises_on_empty_logs(self, tmp_path):
+        """from_session raises ValueError when no L3 logs exist for the session."""
+        from framework.runtime.replay_runtime import ReplayCache
+        from framework.runtime.runtime_log_store import RuntimeLogStore
+
+        log_store = RuntimeLogStore(base_path=tmp_path)
+        with pytest.raises(ValueError, match="No L3 tool logs found"):
+            await ReplayCache.from_session("session_missing", log_store)
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — ReplayInterceptor counter mechanics
+# ---------------------------------------------------------------------------
+
+
+class TestReplayInterceptor:
+    """Unit tests for ReplayInterceptor step / tool counter behaviour."""
+
+    def _make_interceptor(self, steps=None):
+        from framework.runtime.replay_runtime import ReplayCache, ReplayInterceptor
+
+        cache = ReplayCache(steps or [_make_step("n1", 0)])
+        return ReplayInterceptor(cache, freeze_llm=True, freeze_tools=True)
+
+    def test_set_node_resets_counters(self):
+        from framework.runtime.replay_runtime import ReplayInterceptor, ReplayCache
+
+        cache = ReplayCache([_make_step("a", 0), _make_step("a", 1)])
+        ic = ReplayInterceptor(cache)
+        ic.set_node("a")
+        ic.on_llm_call()  # step 0 → step_index becomes 1
+        ic.set_node("a")  # reset
+        assert ic._step_index == 0
+
+    def test_llm_call_increments_step_index(self):
+        ic = self._make_interceptor([_make_step("n1", 0), _make_step("n1", 1)])
+        ic.set_node("n1")
+        ic.on_llm_call()  # consumes step 0
+        assert ic._step_index == 1
+
+    def test_llm_call_resets_tool_position(self):
+        ic = self._make_interceptor(
+            [_make_step("n1", 0, tool_calls=[{"tool_name": "t", "result": "r"}])]
+        )
+        ic.set_node("n1")
+        ic.on_llm_call()
+        ic.on_tool_call()  # pos 0
+        assert ic._tool_call_position == 1
+        ic.on_llm_call()  # next step → tool_call_position resets to 0
+        assert ic._tool_call_position == 0
+
+    def test_tool_call_increments_position(self):
+        ic = self._make_interceptor(
+            [
+                _make_step(
+                    "n1",
+                    0,
+                    tool_calls=[
+                        {"tool_name": "t", "result": "r0"},
+                        {"tool_name": "t", "result": "r1"},
+                    ],
+                )
+            ]
+        )
+        ic.set_node("n1")
+        ic.on_llm_call()
+        ic.on_tool_call()  # pos 0
+        assert ic._tool_call_position == 1
+        ic.on_tool_call()  # pos 1
+        assert ic._tool_call_position == 2
+
+    def test_hit_and_miss_counters(self):
+        ic = self._make_interceptor([_make_step("n1", 0)])
+        ic.set_node("n1")
+        ic.on_llm_call()   # HIT (step 0 exists)
+        ic.on_llm_call()   # MISS (step 1 does not exist)
+        assert ic.llm_hits == 1
+        assert ic.llm_misses == 1
+        assert ic.total_misses == 1
+        assert ic.total_hits == 1
+
+    def test_freeze_false_skips_cache(self):
+        from framework.runtime.replay_runtime import ReplayCache, ReplayInterceptor
+
+        cache = ReplayCache([_make_step("n1", 0, llm_text="cached")])
+        ic = ReplayInterceptor(cache, freeze_llm=False, freeze_tools=False)
+        ic.set_node("n1")
+        result = ic.on_llm_call()
+        assert result is None  # freeze_llm=False → always None
+        assert ic.llm_hits == 0
+        assert ic.llm_misses == 0  # not even counted when freeze=False
+
+    def test_different_nodes_tracked_independently(self):
+        from framework.runtime.replay_runtime import ReplayCache, ReplayInterceptor
+
+        cache = ReplayCache([_make_step("a", 0), _make_step("b", 0)])
+        ic = ReplayInterceptor(cache)
+
+        ic.set_node("a")
+        resp_a = ic.on_llm_call()
+
+        ic.set_node("b")
+        resp_b = ic.on_llm_call()
+
+        assert resp_a is not None
+        assert resp_b is not None
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — Integration: full replay with both freeze flags active
+# ---------------------------------------------------------------------------
+
+
+class TestIntegrationReplay:
+    """Integration test: run a two-node graph, build cache, replay it, verify
+    the replay produces identical output without calling live LLM or tools."""
+
+    @pytest.mark.asyncio
+    async def test_replay_matches_original_output(self, tmp_path):
+        """Full replay with freeze_llm=True, freeze_tools=True produces same
+        output as original and ReplayLLMProvider never delegates to inner."""
+        from framework.llm.provider import LLMProvider, LLMResponse, Tool
+        from framework.runtime.replay_runtime import (
+            CachedLLMResponse,
+            ReplayCache,
+            ReplayInterceptor,
+            ReplayLLMProvider,
+            make_replay_tool_executor,
+        )
+        from framework.llm.stream_events import (
+            FinishEvent, TextDeltaEvent, TextEndEvent, ToolCallEvent,
+        )
+
+        # --- Build a cache with two nodes, one tool call per node ---
+        steps = [
+            _make_step(
+                "classify",
+                0,
+                llm_text="category: billing",
+                tool_calls=[{"tool_name": "lookup", "tool_input": {"id": 1}, "result": "plan-A"}],
+            ),
+            _make_step("respond", 0, llm_text="Here is your answer."),
+        ]
+        cache = ReplayCache(steps)
+        interceptor = ReplayInterceptor(cache, freeze_llm=True, freeze_tools=True)
+
+        # --- inner LLM should NEVER be called when cache hits ---
+        inner_llm = MagicMock(spec=LLMProvider)
+        inner_llm.stream = AsyncMock(side_effect=AssertionError("live LLM called unexpectedly"))
+        inner_llm.acomplete = AsyncMock(
+            side_effect=AssertionError("live LLM called unexpectedly")
+        )
+
+        replay_llm = ReplayLLMProvider(inner_llm, interceptor)
+
+        # --- inner tool executor should NEVER be called ---
+        inner_tool_executor = MagicMock(side_effect=AssertionError("live tool called unexpectedly"))
+        replay_tool_executor = make_replay_tool_executor(inner_tool_executor, interceptor)
+
+        # --- Test streaming for 'classify' node ---
+        interceptor.set_node("classify")
+        events = []
+        async for event in replay_llm.stream(messages=[], system="", tools=None, max_tokens=1024):
+            events.append(event)
+
+        text_events = [e for e in events if isinstance(e, TextDeltaEvent)]
+        tool_events = [e for e in events if isinstance(e, ToolCallEvent)]
+        finish_events = [e for e in events if isinstance(e, FinishEvent)]
+
+        assert len(text_events) == 1
+        assert text_events[0].content == "category: billing"
+        assert len(tool_events) == 1
+        assert tool_events[0].tool_name == "lookup"
+        assert tool_events[0].tool_input == {"id": 1}
+        assert len(finish_events) == 1
+        assert finish_events[0].model == "replay-cache"
+
+        # --- Test tool executor for the tool call in 'classify' step 0 ---
+        from framework.llm.provider import ToolUse
+
+        tool_result = await replay_tool_executor(
+            ToolUse(id="uid", name="lookup", input={"id": 1})
+        )
+        assert tool_result.content == "plan-A"
+        assert tool_result.is_error is False
+
+        # --- Test streaming for 'respond' node (no tool calls) ---
+        interceptor.set_node("respond")
+        events = []
+        async for event in replay_llm.stream(messages=[], system="", tools=None, max_tokens=1024):
+            events.append(event)
+
+        text_events = [e for e in events if isinstance(e, TextDeltaEvent)]
+        tool_events = [e for e in events if isinstance(e, ToolCallEvent)]
+        assert len(text_events) == 1
+        assert text_events[0].content == "Here is your answer."
+        assert len(tool_events) == 0
+
+        # --- Verify hit counts ---
+        assert interceptor.llm_hits == 2
+        assert interceptor.llm_misses == 0
+        assert interceptor.tool_hits == 1
+        assert interceptor.tool_misses == 0
+
+    @pytest.mark.asyncio
+    async def test_replay_config_escape_hatch_in_executor(self, tmp_path):
+        """GraphExecutor.execute() unpacks replay_config from session_state
+        when it arrives via the _replay_config escape-hatch key, rather than
+        as a direct parameter."""
+        from framework.graph.edge import GraphSpec
+        from framework.graph.executor import GraphExecutor
+        from framework.graph.goal import Goal
+        from framework.graph.node import NodeResult, NodeSpec
+        from framework.schemas.replay import ReplayConfig
+
+        # Build a minimal single-node graph
+        class QuickNode:
+            def validate_input(self, ctx):
+                return []
+
+            async def execute(self, ctx):
+                return NodeResult(success=True, output={"x": 1}, tokens_used=0, latency_ms=0)
+
+        class DummyRuntime:
+            execution_id = ""
+
+            def start_run(self, **kw):
+                return "run-1"
+
+            def end_run(self, **kw):
+                pass
+
+            def report_problem(self, **kw):
+                pass
+
+        graph = GraphSpec(
+            id="g", goal_id="goal",
+            nodes=[NodeSpec(id="n1", name="n", description="d",
+                            node_type="event_loop", input_keys=[], output_keys=["x"],
+                            max_retries=0)],
+            edges=[],
+            entry_node="n1",
+        )
+        goal = Goal(id="goal", name="test", description="")
+
+        # Build a ReplayCache and write fake L3 logs to tmp_path
+        from framework.runtime.runtime_log_store import RuntimeLogStore
+        from framework.storage.session_store import SessionStore
+        from framework.schemas.session_state import SessionState, SessionTimestamps
+
+        sessions_dir = tmp_path / "sessions"
+        source_session_id = "session_20260304_120000_src00001"
+        log_store = RuntimeLogStore(base_path=sessions_dir)
+        log_store.ensure_run_dir(source_session_id)
+        step = _make_step("n1", 0, llm_text="hi")
+        log_store.append_step(source_session_id, step)
+
+        # Write a fake source state.json
+        session_store = SessionStore(tmp_path)
+        source_state = SessionState(
+            session_id=source_session_id,
+            goal_id="goal",
+            timestamps=SessionTimestamps(
+                started_at="2026-03-04T12:00:00",
+                updated_at="2026-03-04T12:00:01",
+            ),
+            input_data={"question": "hello"},
+        )
+        await session_store.write_state(source_session_id, source_state)
+
+        rc = ReplayConfig(
+            source_session_id=source_session_id,
+            freeze_llm=True,
+            freeze_tools=True,
+        )
+
+        # Pass replay_config via the escape-hatch key in session_state
+        session_state = {"_replay_config": rc.model_dump()}
+
+        executor = GraphExecutor(
+            runtime=DummyRuntime(),
+            node_registry={"n1": QuickNode()},
+            storage_path=tmp_path,
+        )
+        result = await executor.execute(graph=graph, goal=goal, session_state=session_state)
+
+        # The escape-hatch key must have been consumed (popped) regardless of
+        # whether execution succeeded — that is the core invariant being tested.
+        assert "_replay_config" not in (result.session_state or {})
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — Counterfactual: freeze_llm=False falls through to live provider
+# ---------------------------------------------------------------------------
+
+
+class TestCounterfactualReplay:
+    """When freeze_llm=False, cache misses delegate to the inner LLM provider.
+    This verifies the miss path works end-to-end."""
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_delegates_to_inner_llm(self):
+        from framework.llm.provider import LLMProvider, LLMResponse, Tool
+        from framework.llm.stream_events import FinishEvent, TextDeltaEvent, TextEndEvent
+        from framework.runtime.replay_runtime import (
+            ReplayCache,
+            ReplayInterceptor,
+            ReplayLLMProvider,
+        )
+
+        # Cache is empty so every call is a miss
+        cache = ReplayCache([])
+        interceptor = ReplayInterceptor(cache, freeze_llm=True, freeze_tools=True)
+
+        # Inner provider returns a known response
+        live_events = [
+            TextDeltaEvent(content="live response", snapshot="live response"),
+            TextEndEvent(full_text="live response"),
+            FinishEvent(stop_reason="end_turn", model="claude-opus-4-6"),
+        ]
+
+        async def _fake_stream(*args, **kwargs):
+            for e in live_events:
+                yield e
+
+        inner_llm = MagicMock(spec=LLMProvider)
+        inner_llm.stream = _fake_stream
+        replay_llm = ReplayLLMProvider(inner_llm, interceptor)
+
+        interceptor.set_node("n1")
+        events = []
+        async for event in replay_llm.stream(messages=[], system="", tools=None, max_tokens=512):
+            events.append(event)
+
+        text_events = [e for e in events if isinstance(e, TextDeltaEvent)]
+        assert len(text_events) == 1
+        assert text_events[0].content == "live response"
+
+        assert interceptor.llm_misses == 1
+        assert interceptor.llm_hits == 0
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_delegates_to_inner_tool_executor(self):
+        """Tool cache miss falls through to the inner executor."""
+        from framework.llm.provider import ToolResult, ToolUse
+        from framework.runtime.replay_runtime import (
+            ReplayCache,
+            ReplayInterceptor,
+            make_replay_tool_executor,
+        )
+
+        cache = ReplayCache([])  # empty → all misses
+        interceptor = ReplayInterceptor(cache, freeze_llm=True, freeze_tools=True)
+
+        async def _live_tool(tool_use: ToolUse) -> ToolResult:
+            return ToolResult(
+                tool_use_id=tool_use.id, content="live-result", is_error=False
+            )
+
+        replay_tool = make_replay_tool_executor(_live_tool, interceptor)
+
+        interceptor.set_node("n1")
+        interceptor.on_llm_call()  # advance step counter
+        result = await replay_tool(ToolUse(id="u1", name="search", input={"q": "test"}))
+
+        assert result.content == "live-result"
+        assert interceptor.tool_misses == 1
+
+    @pytest.mark.asyncio
+    async def test_acomplete_cache_hit(self):
+        """ReplayLLMProvider.acomplete() returns cached LLMResponse on hit."""
+        from framework.llm.provider import LLMProvider, LLMResponse
+        from framework.runtime.replay_runtime import (
+            ReplayCache,
+            ReplayInterceptor,
+            ReplayLLMProvider,
+        )
+
+        cache = ReplayCache([_make_step("n1", 0, llm_text="compacted", input_tokens=5, output_tokens=8)])
+        interceptor = ReplayInterceptor(cache, freeze_llm=True, freeze_tools=True)
+        inner = MagicMock(spec=LLMProvider)
+        inner.acomplete = AsyncMock(side_effect=AssertionError("should not be called"))
+        replay_llm = ReplayLLMProvider(inner, interceptor)
+
+        interceptor.set_node("n1")
+        resp = await replay_llm.acomplete(messages=[], system="")
+
+        assert isinstance(resp, LLMResponse)
+        assert resp.content == "compacted"
+        assert resp.model == "replay-cache"
+        assert resp.input_tokens == 5
+        assert resp.output_tokens == 8
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — CLI smoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestCLIReplaySmoke:
+    """Smoke tests for the hive replay CLI command."""
+
+    def test_replay_help_lists_all_flags(self, capsys):
+        """--help output includes all required flags."""
+        import argparse
+        import sys
+        from framework.runner.cli import register_commands
+
+        parser = argparse.ArgumentParser(prog="hive")
+        subparsers = parser.add_subparsers()
+        register_commands(subparsers)
+
+        with pytest.raises(SystemExit) as exc:
+            parser.parse_args(["replay", "--help"])
+        assert exc.value.code == 0
+
+        captured = capsys.readouterr()
+        help_text = captured.out
+        for flag in [
+            "--from-node",
+            "--freeze-llm",
+            "--no-freeze-llm",
+            "--freeze-tools",
+            "--no-freeze-tools",
+            "--input-override",
+            "--output",
+        ]:
+            assert flag in help_text, f"Flag {flag!r} not found in --help output"
+
+    def test_replay_exits_2_on_missing_session(self, tmp_path, monkeypatch):
+        """cmd_replay returns exit code 2 when the source session does not exist."""
+        import argparse
+        from framework.runner.cli import cmd_replay
+
+        # Monkeypatch AgentRunner.load to return a stub with _storage_path
+        from framework.runner import runner as runner_module
+
+        class _StubRunner:
+            _storage_path = tmp_path
+
+        monkeypatch.setattr(
+            runner_module.AgentRunner, "load", staticmethod(lambda *a, **kw: _StubRunner())
+        )
+
+        args = argparse.Namespace(
+            agent_path=str(tmp_path),
+            session_id="session_nonexistent_999",
+            from_node=None,
+            freeze_llm=True,
+            freeze_tools=True,
+            input_override=[],
+            output="text",
+            verbose=False,
+        )
+        code = cmd_replay(args)
+        assert code == 2
+
+    def test_replay_exits_2_on_bad_input_override(self, tmp_path):
+        """cmd_replay returns exit code 2 when --input-override is missing '='."""
+        import argparse
+        from framework.runner.cli import cmd_replay
+
+        args = argparse.Namespace(
+            agent_path=str(tmp_path),
+            session_id="session_test",
+            from_node=None,
+            freeze_llm=True,
+            freeze_tools=True,
+            input_override=["BADVALUE"],  # no '='
+            output="text",
+            verbose=False,
+        )
+        code = cmd_replay(args)
+        assert code == 2
+
+    def test_replay_config_defaults(self):
+        """ReplayConfig default values match the documented behaviour."""
+        from framework.schemas.replay import ReplayConfig
+
+        rc = ReplayConfig(source_session_id="session_abc")
+        assert rc.freeze_llm is True
+        assert rc.freeze_tools is True
+        assert rc.from_node is None
+        assert rc.input_overrides == {}
+
+    def test_replay_config_json_roundtrip(self):
+        """ReplayConfig serialises and deserialises correctly."""
+        from framework.schemas.replay import ReplayConfig
+
+        rc = ReplayConfig(
+            source_session_id="session_20260304_143022_abc12345",
+            from_node="classify",
+            freeze_llm=False,
+            freeze_tools=True,
+            input_overrides={"user_query": "updated question"},
+        )
+        data = rc.model_dump()
+        rc2 = ReplayConfig.model_validate(data)
+        assert rc2.source_session_id == rc.source_session_id
+        assert rc2.from_node == rc.from_node
+        assert rc2.freeze_llm is False
+        assert rc2.input_overrides == {"user_query": "updated question"}
+
+    def test_build_improvement_hypothesis_full_recovery(self):
+        from framework.runtime.replay_runtime import build_improvement_hypothesis
+
+        hyp = build_improvement_hypothesis(
+            source_success=False,
+            replay_success=True,
+            diverged_nodes=["classify"],
+            from_node=None,
+            from_node_original_status="",
+            from_node_replay_status="",
+            total_misses=0,
+        )
+        assert "Full recovery" in hyp or "recovery" in hyp.lower()
+
+    def test_build_improvement_hypothesis_partial_replay(self):
+        from framework.runtime.replay_runtime import build_improvement_hypothesis
+
+        hyp = build_improvement_hypothesis(
+            source_success=False,
+            replay_success=False,
+            diverged_nodes=[],
+            from_node=None,
+            from_node_original_status="",
+            from_node_replay_status="",
+            total_misses=3,
+        )
+        assert "cache miss" in hyp.lower() or "partial" in hyp.lower()
+
+    def test_build_improvement_hypothesis_deterministic_failure(self):
+        from framework.runtime.replay_runtime import build_improvement_hypothesis
+
+        hyp = build_improvement_hypothesis(
+            source_success=False,
+            replay_success=False,
+            diverged_nodes=[],
+            from_node=None,
+            from_node_original_status="",
+            from_node_replay_status="",
+            total_misses=0,
+        )
+        assert "deterministic" in hyp.lower() or "confirmed" in hyp.lower()

--- a/core/tests/test_runtime_logger.py
+++ b/core/tests/test_runtime_logger.py
@@ -6,7 +6,9 @@ summary aggregation at end_run().
 
 from __future__ import annotations
 
+import asyncio
 import json
+import threading
 from pathlib import Path
 
 import pytest
@@ -1081,3 +1083,214 @@ class TestRuntimeLogger:
         node = loaded.nodes[0]
         assert node.exit_status == "guard_failure"
         assert node.success is False
+
+    # -----------------------------------------------------------------------
+    # Concurrency tests — issue #5918
+    # -----------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_ensure_node_logged_concurrent_with_log_node_complete(
+        self, tmp_path: Path
+    ):
+        """Reproduces TOCTOU interleaving table A from forensic_analysis_5918.md.
+
+        N OS threads all call ensure_node_logged() for the same node_id
+        simultaneously. A threading.Barrier releases all N at once to maximise
+        the collision window — every thread sees an empty _logged_node_ids set
+        before any write lands.
+
+        With the buggy split-lock code (Lock + two separate `with` blocks),
+        multiple threads pass the check and each calls log_node_complete(),
+        producing N entries. With the fix (RLock + single contiguous scope),
+        only the first thread to acquire the lock writes; all others see the
+        node already in _logged_node_ids and return immediately → exactly 1
+        entry.
+        """
+        N = 10
+        store = RuntimeLogStore(tmp_path / "logs")
+        rt_logger = RuntimeLogger(store=store, agent_id="test-agent")
+        run_id = rt_logger.start_run("goal-1")
+
+        barrier = threading.Barrier(N)
+        errors: list[Exception] = []
+
+        def thread_ensure() -> None:
+            try:
+                barrier.wait()  # all N threads released simultaneously
+                rt_logger.ensure_node_logged(
+                    node_id="node-1",
+                    node_name="Search",
+                    node_type="event_loop",
+                    success=True,
+                    tokens_used=150,
+                )
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=thread_ensure) for _ in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Thread raised exception: {errors}"
+
+        details = store.read_node_details_sync(run_id)
+        assert len(details) == 1, (
+            f"Expected exactly 1 NodeDetail entry but got {len(details)} "
+            f"from {N} concurrent ensure_node_logged() calls. "
+            "Duplicate entries indicate TOCTOU race is not fixed."
+        )
+        assert details[0].node_id == "node-1"
+
+    @pytest.mark.asyncio
+    async def test_two_concurrent_ensure_node_logged_same_node_id(
+        self, tmp_path: Path
+    ):
+        """Reproduces TOCTOU interleaving table B from forensic_analysis_5918.md.
+
+        Two OS threads both call ensure_node_logged() for the same node_id
+        simultaneously. A threading.Barrier releases them together. A
+        threading.Event stall inside a monkeypatched append_node_detail holds
+        the first writer so the second thread can complete its check before
+        either write lands — deterministically opening the race window.
+
+        With the buggy code, both threads pass the check before either writes,
+        producing 2 entries. With the fix, only 1 entry is written.
+        """
+        store = RuntimeLogStore(tmp_path / "logs")
+        rt_logger = RuntimeLogger(store=store, agent_id="test-agent")
+        run_id = rt_logger.start_run("goal-1")
+
+        barrier = threading.Barrier(2)
+        # first_writer_entered: set when the first thread is inside append_node_detail
+        first_writer_entered = threading.Event()
+        # second_thread_checked: set when both threads have passed the id-set check
+        second_thread_checked = threading.Event()
+        errors: list[Exception] = []
+
+        original_append = store.append_node_detail
+
+        call_count = 0
+        call_count_lock = threading.Lock()
+
+        def stalling_append(run_id_arg, detail):  # type: ignore[override]
+            nonlocal call_count
+            with call_count_lock:
+                call_count += 1
+                is_first = call_count == 1
+            if is_first:
+                # Signal that the first writer has entered; wait for the second
+                # thread to have also completed the id-set check (if the bug
+                # exists, it already passed the check and is about to call us).
+                first_writer_entered.set()
+                second_thread_checked.wait(timeout=2.0)
+            original_append(run_id_arg, detail)
+
+        store.append_node_detail = stalling_append  # type: ignore[method-assign]
+
+        def thread_ensure(thread_index: int) -> None:
+            try:
+                barrier.wait()  # both threads start simultaneously
+                if thread_index == 1:
+                    # Thread 1 goes first; its append will stall
+                    pass
+                else:
+                    # Thread 2 waits until thread 1 is inside append, then
+                    # signals it may proceed (simulating it also passed the check)
+                    first_writer_entered.wait(timeout=2.0)
+                    second_thread_checked.set()
+                rt_logger.ensure_node_logged(
+                    node_id="node-1",
+                    node_name="Search",
+                    node_type="event_loop",
+                    success=True,
+                    tokens_used=60000,
+                )
+            except Exception as exc:
+                errors.append(exc)
+
+        t1 = threading.Thread(target=thread_ensure, args=(1,))
+        t2 = threading.Thread(target=thread_ensure, args=(2,))
+        t1.start()
+        t2.start()
+        t1.join(timeout=5.0)
+        t2.join(timeout=5.0)
+
+        assert not errors, f"Thread raised exception: {errors}"
+
+        details = store.read_node_details_sync(run_id)
+        assert len(details) == 1, (
+            f"Expected exactly 1 NodeDetail entry but got {len(details)}. "
+            "Duplicate entry indicates TOCTOU race is not fixed."
+        )
+        assert details[0].node_id == "node-1"
+
+    @pytest.mark.asyncio
+    async def test_ensure_node_logged_asyncio_gather_no_duplicate(
+        self, tmp_path: Path
+    ):
+        """Fan-out integration regression test — forensic_analysis_5918.md §2.
+
+        Simulates the asyncio.gather() parallel-branch path from
+        executor.py:2364-2365. Two coroutines each call log_node_complete()
+        then yield (asyncio.sleep(0)), then call ensure_node_logged() for
+        their respective node_ids. The yield between the two calls is the
+        cooperative-multitasking interleaving point that mirrors the await
+        inside EventLoopNode.execute() in the real fan-out path.
+
+        Asserts that details.jsonl contains exactly one entry per node_id
+        (no duplicates) after both coroutines complete.
+        """
+        store = RuntimeLogStore(tmp_path / "logs")
+        rt_logger = RuntimeLogger(store=store, agent_id="test-agent")
+        run_id = rt_logger.start_run("goal-1")
+
+        async def branch(node_id: str, input_tokens: int, output_tokens: int) -> None:
+            # Simulates EventLoopNode.execute() calling log_node_complete() at
+            # its ACCEPT exit point (event_loop_node.py:1359).
+            rt_logger.log_node_complete(
+                node_id=node_id,
+                node_name=node_id,
+                node_type="event_loop",
+                success=True,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                exit_status="success",
+            )
+            # Yield to the event loop — mirrors the await inside execute().
+            # The other branch coroutine can now run its log_node_complete()
+            # or ensure_node_logged() here.
+            await asyncio.sleep(0)
+            # Simulates executor.py:2295 calling ensure_node_logged() after
+            # node_impl.execute() returns.
+            rt_logger.ensure_node_logged(
+                node_id=node_id,
+                node_name=node_id,
+                node_type="event_loop",
+                success=True,
+                tokens_used=input_tokens + output_tokens,
+            )
+
+        await asyncio.gather(
+            branch("node-A", input_tokens=100, output_tokens=50),
+            branch("node-B", input_tokens=200, output_tokens=80),
+        )
+
+        details = store.read_node_details_sync(run_id)
+        node_ids = [d.node_id for d in details]
+
+        assert len(details) == 2, (
+            f"Expected exactly 2 NodeDetail entries (one per branch) but got "
+            f"{len(details)}: {node_ids}"
+        )
+        assert node_ids.count("node-A") == 1, "node-A has duplicate entries"
+        assert node_ids.count("node-B") == 1, "node-B has duplicate entries"
+
+        # Token totals must not be doubled
+        node_a = next(d for d in details if d.node_id == "node-A")
+        node_b = next(d for d in details if d.node_id == "node-B")
+        assert node_a.input_tokens == 100
+        assert node_a.output_tokens == 50
+        assert node_b.input_tokens == 200
+        assert node_b.output_tokens == 80


### PR DESCRIPTION
## Summary

Fixes #5923 — when the LiteLLM streaming layer retried after a mid-stream
`RateLimitError` or transient error, it re-streamed from token 1, duplicating
content that had already been yielded to callers and published to the event bus.
Since published events cannot be recalled, the retry must be abandoned when a
partial stream has already been emitted.

## Root Cause

`LiteLLMProvider.stream()` has an internal retry loop for transient errors. Both
the `RateLimitError` handler and the generic transient-error handler would
unconditionally `continue` — restarting the entire stream from the beginning —
even when `accumulated_text` was non-empty (i.e., chunks had already been
yielded upstream and emitted on the event bus).

Before — both handlers did this unconditionally:
```python
except RateLimitError as e:
    if attempt < RATE_LIMIT_MAX_RETRIES:
        wait = _compute_retry_delay(...)
        await asyncio.sleep(wait)
        continue   # re-streams from token 0, duplicating all prior output
```

The event bus publishes token deltas eagerly as they stream in. There is no
mechanism to retract already-published events, so retrying produced a second
copy of every token the client had already received.

## Fix

In both exception handlers, check `accumulated_text` before retrying. If any
text has already been yielded, emit a `recoverable=True` `StreamErrorEvent` and
return immediately. `EventLoopNode`'s existing empty-response guard at line 1706
detects the non-empty `accumulated_text` and suppresses the outer retry,
preserving the partial turn.
```python
except RateLimitError as e:
    if attempt < RATE_LIMIT_MAX_RETRIES:
        if accumulated_text:
            # Text already published to event bus — cannot be recalled.
            # Yield recoverable error; EventLoopNode will commit the partial
            # text and skip the outer retry (accumulated_text non-empty).
            yield StreamErrorEvent(error=str(e), recoverable=True)
            return
        wait = _compute_retry_delay(attempt, exception=e)
        ...
        continue

except Exception as e:
    if _is_stream_transient_error(e) and attempt < RATE_LIMIT_MAX_RETRIES:
        if accumulated_text:
            yield StreamErrorEvent(error=str(e), recoverable=True)
            return
        ...
        continue
```

## Changes

| File | Change |
|------|--------|
| `core/framework/llm/litellm.py` | Add `accumulated_text` guard to `RateLimitError` handler (L989) and transient `Exception` handler (L1012) |
| `core/tests/test_event_loop_node.py` | Add `PartialStreamThenErrorLLM` helper and `TestMidStreamRetryNoDuplication` class with 5 new tests |

## Tests

5 new automated tests added to `TestMidStreamRetryNoDuplication` in `core/tests/test_event_loop_node.py` — all passing (74/74 total):

- `test_mid_stream_error_no_duplicate_deltas_3_chunks` — 3 chunks + error -> exactly 3 deltas on bus, no outer retry
- `test_mid_stream_error_no_duplicate_deltas_50_chunks` — 50 chunks + error -> exactly 50 deltas, no outer retry
- `test_mid_stream_error_at_chunk_0_triggers_outer_retry` — error before first chunk -> outer retry fires correctly, no duplication
- `test_mid_stream_tool_only_error_inner_retry_unaffected` — tool-only error -> inner retry safe, guard does not block
- `test_mid_stream_recoverable_error_partial_text_committed` — partial text committed to history, `_call_index == 1`

## Notes

- Guard uses `accumulated_text` only, not `tool_calls_acc` — tool deltas are buffered locally and never published before stream completion, so mid-tool-stream errors remain safe to retry internally
- The empty-stream retry path (L1019-1020) is correctly guarded by `not has_content` and is unaffected
- `EventLoopNode` empty-response guard at `runtime_logger.py:1706` is the cooperating mechanism that absorbs the early exit without crashing the turn