### PR TITLE
fix: align the credential functions to be the same

### DIFF
--- a/core/framework/tools/queen_lifecycle_tools.py
+++ b/core/framework/tools/queen_lifecycle_tools.py
@@ -1312,6 +1312,15 @@ def register_queen_lifecycle_tools(
         Returns credential IDs, aliases, status, and identity metadata.
         Never returns secret values. Optionally filter by credential_id.
         """
+        # Load shell config vars into os.environ — same first step as check-agent.
+        # Ensures keys set in ~/.zshrc/~/.bashrc are visible to is_available() checks.
+        try:
+            from framework.credentials.validation import ensure_credential_key_env
+
+            ensure_credential_key_env()
+        except Exception:
+            pass
+
         try:
             # Primary: CredentialStoreAdapter sees both Aden OAuth and local accounts
             from aden_tools.credentials import CredentialStoreAdapter
@@ -1319,13 +1328,24 @@ def register_queen_lifecycle_tools(
             store = CredentialStoreAdapter.default()
             all_accounts = store.get_all_account_info()
 
-            # Filter by credential_id / provider if requested
+            # Filter by credential_id / provider if requested.
+            # A spec name like "gmail_oauth" maps to provider "google" via
+            # credential_id field — resolve that alias before filtering.
             if credential_id:
+                try:
+                    from aden_tools.credentials import CREDENTIAL_SPECS
+
+                    spec = CREDENTIAL_SPECS.get(credential_id)
+                    resolved_provider = (
+                        (spec.credential_id or credential_id) if spec else credential_id
+                    )
+                except Exception:
+                    resolved_provider = credential_id
                 all_accounts = [
                     a
                     for a in all_accounts
                     if a.get("credential_id", "").startswith(credential_id)
-                    or a.get("provider", "") == credential_id
+                    or a.get("provider", "") in (credential_id, resolved_provider)
                 ]
 
             return json.dumps(
@@ -1342,12 +1362,42 @@ def register_queen_lifecycle_tools(
 
         # Fallback: local encrypted store only
         try:
+            from framework.credentials.local.models import LocalAccountInfo
             from framework.credentials.local.registry import LocalCredentialRegistry
+            from framework.credentials.storage import EncryptedFileStorage
 
             registry = LocalCredentialRegistry.default()
             accounts = registry.list_accounts(
                 credential_id=credential_id or None,
             )
+
+            # Also include flat-file credentials saved by the GUI (no "/" separator).
+            # LocalCredentialRegistry.list_accounts() skips these — read them directly.
+            seen_cred_ids = {info.credential_id for info in accounts}
+            storage = EncryptedFileStorage()
+            for storage_id in storage.list_all():
+                if "/" in storage_id:
+                    continue  # already handled by LocalCredentialRegistry above
+                if credential_id and storage_id != credential_id:
+                    continue
+                if storage_id in seen_cred_ids:
+                    continue
+                try:
+                    cred_obj = storage.load(storage_id)
+                except Exception:
+                    continue
+                if cred_obj is None:
+                    continue
+                accounts.append(
+                    LocalAccountInfo(
+                        credential_id=storage_id,
+                        alias="default",
+                        status="unknown",
+                        identity=cred_obj.identity,
+                        last_validated=cred_obj.last_refreshed,
+                        created_at=cred_obj.created_at,
+                    )
+                )
 
             credentials = []
             for info in accounts:


### PR DESCRIPTION
## Description

Aligns list_credentials with check_agent so both functions follow the same credential resolution steps: loading shell env vars, resolving spec-name aliases, and surfacing flat-file credentials written by the GUI.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #6074

## Changes Made

- Call ensure_credential_key_env() at the start of list_credentials to match check_agent behavior
- Resolve CREDENTIAL_SPECS aliases (e.g. gmail_oauth → google) before filtering accounts by credential_id
- Read flat-file credentials directly from EncryptedFileStorage to include GUI-saved credentials that LocalCredentialRegistry skips

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes