### PR TITLE
Fixed  Missing __init__.py in file_system_toolkits package directory #6055

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/__init__.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/__init__.py
@@ -1,0 +1,1 @@
+"""File system toolkits for Aden Tools."""


### PR DESCRIPTION
## Description

Adds missing __init__.py file to file_system_toolkits directory to ensure proper Python module resolution.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
## Related Issues

Fixes #6055 )

## Changes Made

- Added __init__.py to file_system_toolkits for package consistency
- File contains a minimal docstring matching the convention used in sibling directories

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A