### PR TITLE
fix(graph): harden safe_eval against DoS, fix BoolOp short-circuit, add depth limit

### DIFF
--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -2,15 +2,44 @@ import ast
 import operator
 from typing import Any
 
+# Limits to prevent resource exhaustion via crafted expressions
+MAX_EXPONENT = 100  # cap for ** operator
+MAX_REPEAT = 10_000  # cap for string/list repetition with *
+
+
+def _safe_pow(base: Any, exp: Any) -> Any:
+    """Bounded power operator to prevent DoS via huge exponents."""
+    if isinstance(exp, (int, float)) and abs(exp) > MAX_EXPONENT:
+        raise ValueError(
+            f"Exponent {exp} exceeds maximum allowed ({MAX_EXPONENT})"
+        )
+    return operator.pow(base, exp)
+
+
+def _safe_mult(a: Any, b: Any) -> Any:
+    """Bounded multiplication that prevents huge string/list repetitions."""
+    if isinstance(a, (str, list, tuple, bytes)) and isinstance(b, int):
+        if b > MAX_REPEAT:
+            raise ValueError(
+                f"Repeat count {b} exceeds maximum allowed ({MAX_REPEAT})"
+            )
+    elif isinstance(b, (str, list, tuple, bytes)) and isinstance(a, int):
+        if a > MAX_REPEAT:
+            raise ValueError(
+                f"Repeat count {a} exceeds maximum allowed ({MAX_REPEAT})"
+            )
+    return operator.mul(a, b)
+
+
 # Safe operators whitelist
 SAFE_OPERATORS = {
     ast.Add: operator.add,
     ast.Sub: operator.sub,
-    ast.Mult: operator.mul,
+    ast.Mult: _safe_mult,
     ast.Div: operator.truediv,
     ast.FloorDiv: operator.floordiv,
     ast.Mod: operator.mod,
-    ast.Pow: operator.pow,
+    ast.Pow: _safe_pow,
     ast.LShift: operator.lshift,
     ast.RShift: operator.rshift,
     ast.BitOr: operator.or_,
@@ -52,16 +81,39 @@ SAFE_FUNCTIONS = {
     "any": any,
 }
 
+# Method whitelist with allowed receiver types.
+# Only these (method, type) combinations are auto-approved.
+SAFE_METHODS: dict[str, tuple[type, ...]] = {
+    "get": (dict,),
+    "keys": (dict,),
+    "values": (dict,),
+    "items": (dict,),
+    "lower": (str,),
+    "upper": (str,),
+    "strip": (str,),
+    "split": (str,),
+}
+
 
 class SafeEvalVisitor(ast.NodeVisitor):
+    MAX_DEPTH = 50  # prevent stack overflow from deeply nested expressions
+
     def __init__(self, context: dict[str, Any]):
         self.context = context
+        self._depth = 0
 
     def visit(self, node: ast.AST) -> Any:
-        # Override visit to prevent default behavior and ensure only explicitly allowed nodes work
-        method = "visit_" + node.__class__.__name__
-        visitor = getattr(self, method, self.generic_visit)
-        return visitor(node)
+        self._depth += 1
+        if self._depth > self.MAX_DEPTH:
+            raise ValueError(
+                f"Expression nesting depth exceeds limit ({self.MAX_DEPTH})"
+            )
+        try:
+            method = "visit_" + node.__class__.__name__
+            visitor = getattr(self, method, self.generic_visit)
+            return visitor(node)
+        finally:
+            self._depth -= 1
 
     def generic_visit(self, node: ast.AST):
         raise ValueError(f"Use of {node.__class__.__name__} is not allowed")
@@ -115,11 +167,23 @@ class SafeEvalVisitor(ast.NodeVisitor):
         return True
 
     def visit_BoolOp(self, node: ast.BoolOp) -> Any:
-        values = [self.visit(v) for v in node.values]
+        # Lazy evaluation matching Python short-circuit semantics.
+        # `x and y` returns x if x is falsy, otherwise y.
+        # `x or y` returns x if x is truthy, otherwise y.
         if isinstance(node.op, ast.And):
-            return all(values)
+            result: Any = True
+            for v in node.values:
+                result = self.visit(v)
+                if not result:
+                    return result
+            return result
         elif isinstance(node.op, ast.Or):
-            return any(values)
+            result = False
+            for v in node.values:
+                result = self.visit(v)
+                if result:
+                    return result
+            return result
         raise ValueError(f"Boolean operator {type(node.op).__name__} is not allowed")
 
     def visit_IfExp(self, node: ast.IfExp) -> Any:
@@ -171,42 +235,29 @@ class SafeEvalVisitor(ast.NodeVisitor):
         raise AttributeError(f"Object has no attribute '{node.attr}'")
 
     def visit_Call(self, node: ast.Call) -> Any:
-        # Only allow calling whitelisted functions
-        func = self.visit(node.func)
-
-        # Check if the function object itself is in our whitelist values
-        # This is tricky because `func` is the actual function object,
-        # but we also want to verify it came from a safe place.
-        # Easier: Check if node.func is a Name and that name is in SAFE_FUNCTIONS.
+        # Only allow calling whitelisted functions or type-checked methods.
 
         is_safe = False
+
         if isinstance(node.func, ast.Name):
             if node.func.id in SAFE_FUNCTIONS:
                 is_safe = True
 
-        # Also allow methods on objects if they are safe?
-        # E.g. "somestring".lower() or list.append() (if we allowed mutation, but we don't for now)
-        # For now, restrict to SAFE_FUNCTIONS whitelist for global calls and deny method calls
-        # unless we explicitly add safe methods.
-        # Allowing method calls on strings/lists (split, join, get) is commonly needed.
-
         if isinstance(node.func, ast.Attribute):
-            # Method call.
-            # Allow basic safe methods?
-            # For security, start strict. Only helper functions.
-            # Re-visiting: User might want 'output.get("key")'.
             method_name = node.func.attr
-            if method_name in [
-                "get",
-                "keys",
-                "values",
-                "items",
-                "lower",
-                "upper",
-                "strip",
-                "split",
-            ]:
-                is_safe = True
+            allowed_types = SAFE_METHODS.get(method_name)
+            if allowed_types:
+                # Evaluate the receiver and check its type before approving
+                receiver = self.visit(node.func.value)
+                if isinstance(receiver, allowed_types):
+                    is_safe = True
+                    # Build the bound method directly so we don't re-visit
+                    func = getattr(receiver, method_name)
+                    args = [self.visit(arg) for arg in node.args]
+                    keywords = {kw.arg: self.visit(kw.value) for kw in node.keywords}
+                    return func(*args, **keywords)
+
+        func = self.visit(node.func)
 
         if not is_safe and func not in SAFE_FUNCTIONS.values():
             raise ValueError("Call to function/method is not allowed")

--- a/core/tests/test_safe_eval.py
+++ b/core/tests/test_safe_eval.py
@@ -1,0 +1,251 @@
+"""Tests for the safe_eval expression evaluator.
+
+Covers resource exhaustion protections (DoS via exponentiation and
+string/list multiplication) and correct short-circuit semantics for
+boolean operators.
+"""
+
+import pytest
+
+from framework.graph.safe_eval import safe_eval
+
+
+# ---------------------------------------------------------------------------
+# Basic functionality (sanity checks)
+# ---------------------------------------------------------------------------
+
+class TestBasicEval:
+    def test_arithmetic(self):
+        assert safe_eval("2 + 3") == 5
+        assert safe_eval("10 - 4") == 6
+        assert safe_eval("5 * 10") == 50
+        assert safe_eval("9 / 3") == 3.0
+
+    def test_comparison(self):
+        assert safe_eval("1 < 2") is True
+        assert safe_eval("2 >= 2") is True
+        assert safe_eval("3 == 4") is False
+
+    def test_variable_lookup(self):
+        assert safe_eval("x + 1", {"x": 10}) == 11
+        assert safe_eval("name", {"name": "alice"}) == "alice"
+
+    def test_function_calls(self):
+        assert safe_eval("len(x)", {"x": [1, 2, 3]}) == 3
+        assert safe_eval("abs(-5)") == 5
+        assert safe_eval("int(3.7)") == 3
+
+    def test_ternary(self):
+        assert safe_eval("'yes' if x else 'no'", {"x": True}) == "yes"
+        assert safe_eval("'yes' if x else 'no'", {"x": False}) == "no"
+
+    def test_moderate_exponentiation(self):
+        assert safe_eval("2 ** 10") == 1024
+        assert safe_eval("3 ** 3") == 27
+        assert safe_eval("10 ** 0") == 1
+
+    def test_small_string_repeat(self):
+        assert safe_eval('"ha" * 3') == "hahaha"
+        assert safe_eval('"x" * 0') == ""
+
+    def test_small_list_repeat(self):
+        assert safe_eval("[0] * 5") == [0, 0, 0, 0, 0]
+
+
+# ---------------------------------------------------------------------------
+# DoS protection: exponentiation bounds
+# ---------------------------------------------------------------------------
+
+class TestExponentiationBounds:
+    def test_huge_exponent_blocked(self):
+        """9 ** 9 ** 9 = 9^387420489, must not hang the process."""
+        with pytest.raises(ValueError, match="exceeds maximum"):
+            safe_eval("9 ** 9 ** 9")
+
+    def test_large_exponent_blocked(self):
+        with pytest.raises(ValueError, match="exceeds maximum"):
+            safe_eval("2 ** 1000")
+
+    def test_negative_huge_exponent_blocked(self):
+        with pytest.raises(ValueError, match="exceeds maximum"):
+            safe_eval("2 ** -1000")
+
+    def test_boundary_exponent_allowed(self):
+        """Exponent exactly at the limit should still work."""
+        result = safe_eval("2 ** 100")
+        assert result == 2**100
+
+    def test_float_exponent_blocked(self):
+        with pytest.raises(ValueError, match="exceeds maximum"):
+            safe_eval("1.5 ** 200.0")
+
+
+# ---------------------------------------------------------------------------
+# DoS protection: string/list multiplication bounds
+# ---------------------------------------------------------------------------
+
+class TestRepetitionBounds:
+    def test_huge_string_repeat_blocked(self):
+        with pytest.raises(ValueError, match="exceeds maximum"):
+            safe_eval('"a" * 100000000')
+
+    def test_huge_list_repeat_blocked(self):
+        with pytest.raises(ValueError, match="exceeds maximum"):
+            safe_eval("[1] * 100000000")
+
+    def test_huge_tuple_repeat_blocked(self):
+        with pytest.raises(ValueError, match="exceeds maximum"):
+            safe_eval("(1,) * 100000000")
+
+    def test_reverse_operand_order_blocked(self):
+        """100000000 * 'a' should also be caught."""
+        with pytest.raises(ValueError, match="exceeds maximum"):
+            safe_eval('100000000 * "a"')
+
+    def test_numeric_multiplication_unaffected(self):
+        """Normal number * number should never be blocked."""
+        assert safe_eval("100000000 * 2") == 200000000
+        assert safe_eval("999999 * 999999") == 999998000001
+
+
+# ---------------------------------------------------------------------------
+# BoolOp short-circuit semantics
+# ---------------------------------------------------------------------------
+
+class TestBoolOpShortCircuit:
+    def test_and_short_circuits_on_falsy(self):
+        """None and len(None) should return None, not raise TypeError."""
+        result = safe_eval("x and len(x) > 0", {"x": None})
+        assert result is None
+
+    def test_and_short_circuits_on_zero(self):
+        result = safe_eval("x and 1 / x", {"x": 0})
+        assert result == 0
+
+    def test_and_evaluates_all_if_truthy(self):
+        result = safe_eval("x and len(x) > 0", {"x": [1, 2, 3]})
+        assert result is True
+
+    def test_and_returns_last_truthy(self):
+        """Python `and` returns the last value if all truthy."""
+        result = safe_eval("1 and 2 and 3")
+        assert result == 3
+
+    def test_and_returns_first_falsy(self):
+        result = safe_eval("1 and 0 and 3")
+        assert result == 0
+
+    def test_or_short_circuits_on_truthy(self):
+        result = safe_eval("x or 1 / 0", {"x": "hello"})
+        assert result == "hello"
+
+    def test_or_evaluates_all_if_falsy(self):
+        result = safe_eval('x or "default"', {"x": ""})
+        assert result == "default"
+
+    def test_or_returns_first_truthy(self):
+        result = safe_eval("0 or '' or 42 or 99")
+        assert result == 42
+
+    def test_or_returns_last_falsy(self):
+        """If all falsy, Python `or` returns the last value."""
+        result = safe_eval("0 or '' or None")
+        assert result is None
+
+    def test_nested_bool_ops(self):
+        result = safe_eval(
+            "(x or 'fallback') and len(x or 'fallback') > 0",
+            {"x": None},
+        )
+        assert result is True
+
+    def test_and_with_empty_list(self):
+        result = safe_eval("x and x[0]", {"x": []})
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Recursion depth limit
+# ---------------------------------------------------------------------------
+
+class TestRecursionDepthLimit:
+    def test_deeply_nested_expression_blocked(self):
+        """Nesting beyond MAX_DEPTH should raise ValueError, not RecursionError."""
+        # Build an expression with 60 levels of nesting: not not not ... True
+        expr = "not " * 60 + "True"
+        with pytest.raises(ValueError, match="nesting depth exceeds"):
+            safe_eval(expr)
+
+    def test_moderate_nesting_allowed(self):
+        # 10 levels of nesting should be fine
+        expr = "not " * 10 + "True"
+        result = safe_eval(expr)
+        assert result is True  # even number of nots → True? No, 10 nots on True = True
+        # Actually: not not not ... True with 10 `not`s = True (even count)
+        assert result is True
+
+    def test_nested_subscripts_allowed(self):
+        ctx = {"x": {"a": {"b": {"c": 42}}}}
+        assert safe_eval('x["a"]["b"]["c"]', ctx) == 42
+
+
+# ---------------------------------------------------------------------------
+# Method type checking
+# ---------------------------------------------------------------------------
+
+class TestMethodTypeChecking:
+    def test_dict_get_allowed(self):
+        assert safe_eval('x.get("key", "default")', {"x": {"key": "val"}}) == "val"
+        assert safe_eval('x.get("missing", "default")', {"x": {}}) == "default"
+
+    def test_str_lower_allowed(self):
+        assert safe_eval('x.lower()', {"x": "HELLO"}) == "hello"
+
+    def test_str_split_allowed(self):
+        assert safe_eval('x.split(",")', {"x": "a,b,c"}) == ["a", "b", "c"]
+
+    def test_dict_keys_allowed(self):
+        result = safe_eval('list(x.keys())', {"x": {"a": 1, "b": 2}})
+        assert sorted(result) == ["a", "b"]
+
+    def test_get_on_non_dict_blocked(self):
+        """Calling .get() on a non-dict type should not be auto-approved."""
+
+        class FakeObj:
+            def get(self):
+                return "escaped!"
+
+        with pytest.raises(ValueError, match="not allowed"):
+            safe_eval("x.get()", {"x": FakeObj()})
+
+    def test_lower_on_non_str_blocked(self):
+        """Calling .lower() on a non-str should not be auto-approved."""
+
+        class FakeObj:
+            def lower(self):
+                return "escaped!"
+
+        with pytest.raises(ValueError, match="not allowed"):
+            safe_eval("x.lower()", {"x": FakeObj()})
+
+
+# ---------------------------------------------------------------------------
+# Security (these should still be blocked)
+# ---------------------------------------------------------------------------
+
+class TestSecurityBlocking:
+    def test_import_blocked(self):
+        with pytest.raises(NameError):
+            safe_eval('__import__("os")')
+
+    def test_eval_blocked(self):
+        with pytest.raises(NameError):
+            safe_eval('eval("1+1")')
+
+    def test_private_attribute_blocked(self):
+        with pytest.raises(ValueError, match="private attribute"):
+            safe_eval("x.__class__", {"x": 1})
+
+    def test_subclass_escape_blocked(self):
+        with pytest.raises(ValueError):
+            safe_eval("().__class__.__bases__[0].__subclasses__()")


### PR DESCRIPTION
## Summary

Addresses all four vulnerabilities reported in #5109. The `safe_eval` expression evaluator used for `CONDITIONAL` edge traversal had no resource limits and no test coverage.

## Changes

### `core/framework/graph/safe_eval.py`

**1. Bounded exponentiation (DoS fix)**
- Replaced `operator.pow` with `_safe_pow` that caps the exponent at 100
- `9 ** 9 ** 9` now raises `ValueError` instead of hanging forever

**2. Bounded string/list repetition (DoS fix)**
- Replaced `operator.mul` with `_safe_mult` that caps repeat count at 10,000
- `"a" * 100_000_000` (100MB in 0.03s) is now blocked

**3. BoolOp short-circuit semantics**
- Rewrote `visit_BoolOp` to evaluate lazily, matching Python behavior
- `x and len(x) > 0` now correctly returns `None` when `x` is `None` instead of crashing with `TypeError`
- `False and expensive()` no longer evaluates `expensive()`

**4. Recursion depth limit**
- Added `MAX_DEPTH = 50` counter to `visit()` 
- Deeply nested expressions raise `ValueError` instead of `RecursionError`

**5. Method receiver type checking**
- Method whitelist now validates the type of the receiver object
- `.get()` only works on `dict`, `.lower()` only on `str`, etc.
- Prevents sandbox escape if context ever contains richer objects

### `core/tests/test_safe_eval.py` (new)

42 tests covering:
- Basic functionality (arithmetic, comparisons, variables, functions)
- Exponentiation bounds (huge, negative, boundary, float)
- Repetition bounds (string, list, tuple, reversed operands, numeric unaffected)
- BoolOp short-circuit (falsy and, zero division, truthy chains, or fallback, nested)
- Recursion depth (blocked at 60 levels, allowed at 10, nested subscripts)
- Method type checking (dict.get, str.lower, str.split, non-dict .get blocked)
- Security baseline (import, eval, private attrs, subclass escape)

## Testing

```bash
uv run pytest core/tests/test_safe_eval.py -v  # 42 passed
uv run pytest core/tests/test_conditional_edge_direct_key.py -v  # 4 passed (existing edge tests)
uv run pytest core/tests/test_executor_feedback_edges.py -v  # 7 passed
uv run pytest core/tests/test_on_failure_edges.py -v  # 5 passed
```

No regressions in existing edge condition tests.

Closes #5109