### PR TITLE
fix(graph): catch duplicate edge IDs, self-loops, and missing condition_expr in validate()

### DIFF
--- a/core/framework/graph/edge.py
+++ b/core/framework/graph/edge.py
@@ -631,11 +631,30 @@ class GraphSpec(BaseModel):
             )
 
         # Check edge references
+        seen_edge_ids: set[str] = set()
         for edge in self.edges:
+            # Duplicate edge IDs
+            if edge.id in seen_edge_ids:
+                errors.append(f"Duplicate edge ID: '{edge.id}'")
+            seen_edge_ids.add(edge.id)
+
             if not self.get_node(edge.source):
                 errors.append(f"Edge '{edge.id}' references missing source '{edge.source}'")
             if not self.get_node(edge.target):
                 errors.append(f"Edge '{edge.id}' references missing target '{edge.target}'")
+
+            # Self-loop with ALWAYS condition is almost certainly unintentional
+            if edge.source == edge.target and edge.condition == EdgeCondition.ALWAYS:
+                errors.append(
+                    f"Edge '{edge.id}' is an unconditional self-loop on node "
+                    f"'{edge.source}' (will loop until max_steps)"
+                )
+
+            # CONDITIONAL edges need an expression
+            if edge.condition == EdgeCondition.CONDITIONAL and not edge.condition_expr:
+                errors.append(
+                    f"Edge '{edge.id}' has condition=CONDITIONAL but no condition_expr"
+                )
 
         # Check for unreachable nodes
         # Start with main entry node and all entry points (for pause/resume architecture)

--- a/core/tests/test_graphspec_validation.py
+++ b/core/tests/test_graphspec_validation.py
@@ -1,0 +1,122 @@
+"""Tests for GraphSpec.validate() — duplicate edge IDs, self-loops, missing condition_expr."""
+
+from framework.graph.edge import EdgeCondition, EdgeSpec, GraphSpec
+from framework.graph.node import NodeSpec
+
+
+def _node(node_id: str) -> NodeSpec:
+    """Helper to create a minimal valid node."""
+    return NodeSpec(
+        id=node_id,
+        name=node_id,
+        description=f"Test node {node_id}",
+        node_type="event_loop",
+        input_keys=[],
+        output_keys=[],
+    )
+
+
+class TestDuplicateEdgeIDs:
+    def test_duplicate_edge_ids_flagged(self):
+        graph = GraphSpec(
+            id="g",
+            goal_id="goal",
+            nodes=[_node("a"), _node("b"), _node("c")],
+            edges=[
+                EdgeSpec(id="e1", source="a", target="b", condition=EdgeCondition.ALWAYS),
+                EdgeSpec(id="e1", source="b", target="c", condition=EdgeCondition.ALWAYS),
+            ],
+            entry_node="a",
+        )
+        result = graph.validate()
+        assert any("Duplicate edge ID" in e and "e1" in e for e in result["errors"])
+
+    def test_unique_edge_ids_pass(self):
+        graph = GraphSpec(
+            id="g",
+            goal_id="goal",
+            nodes=[_node("a"), _node("b"), _node("c")],
+            edges=[
+                EdgeSpec(id="e1", source="a", target="b", condition=EdgeCondition.ALWAYS),
+                EdgeSpec(id="e2", source="b", target="c", condition=EdgeCondition.ALWAYS),
+            ],
+            entry_node="a",
+        )
+        result = graph.validate()
+        assert not any("Duplicate edge ID" in e for e in result["errors"])
+
+
+class TestSelfLoopDetection:
+    def test_always_self_loop_flagged(self):
+        graph = GraphSpec(
+            id="g",
+            goal_id="goal",
+            nodes=[_node("a")],
+            edges=[
+                EdgeSpec(id="loop", source="a", target="a", condition=EdgeCondition.ALWAYS),
+            ],
+            entry_node="a",
+        )
+        result = graph.validate()
+        assert any("self-loop" in e for e in result["errors"])
+
+    def test_conditional_self_loop_allowed(self):
+        """Conditional self-loops are a valid pattern (retry with condition)."""
+        graph = GraphSpec(
+            id="g",
+            goal_id="goal",
+            nodes=[_node("a"), _node("b")],
+            edges=[
+                EdgeSpec(
+                    id="retry",
+                    source="a",
+                    target="a",
+                    condition=EdgeCondition.CONDITIONAL,
+                    condition_expr="retry_count < 3",
+                ),
+                EdgeSpec(id="done", source="a", target="b", condition=EdgeCondition.ON_SUCCESS),
+            ],
+            entry_node="a",
+        )
+        result = graph.validate()
+        assert not any("self-loop" in e for e in result["errors"])
+
+
+class TestConditionalEdgeExpr:
+    def test_conditional_without_expr_flagged(self):
+        graph = GraphSpec(
+            id="g",
+            goal_id="goal",
+            nodes=[_node("a"), _node("b")],
+            edges=[
+                EdgeSpec(
+                    id="bad",
+                    source="a",
+                    target="b",
+                    condition=EdgeCondition.CONDITIONAL,
+                    condition_expr=None,
+                ),
+            ],
+            entry_node="a",
+        )
+        result = graph.validate()
+        assert any("condition_expr" in e for e in result["errors"])
+
+    def test_conditional_with_expr_passes(self):
+        graph = GraphSpec(
+            id="g",
+            goal_id="goal",
+            nodes=[_node("a"), _node("b")],
+            edges=[
+                EdgeSpec(
+                    id="ok",
+                    source="a",
+                    target="b",
+                    condition=EdgeCondition.CONDITIONAL,
+                    condition_expr="confidence > 0.8",
+                ),
+            ],
+            entry_node="a",
+        )
+        result = graph.validate()
+        assert not any("condition_expr" in e for e in result["errors"])


### PR DESCRIPTION
## Description

While writing some test graphs I ran into a few cases where `GraphSpec.validate()` didn't catch mistakes that caused confusing behavior at runtime. This PR adds three checks to the existing edge-reference loop.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #6090

## Changes Made

- **Duplicate edge IDs** — tracks seen edge IDs and flags duplicates. The executor uses edge IDs for logging and checkpoint references, so duplicates make debugging really hard.
- **Unconditional self-loops** — flags edges where `source == target` with `condition=ALWAYS`. These loop a node into itself until `max_steps` kills it, which is almost always a graph authoring mistake.
- **CONDITIONAL edges without `condition_expr`** — if you set the condition to `CONDITIONAL` but forget the expression, the edge silently never fires. Now caught at validation time.

## Testing

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

Added `core/tests/test_graphspec_validation.py` with 6 tests:
- Duplicate edge IDs flagged / unique IDs pass
- ALWAYS self-loops flagged / conditional self-loops allowed (valid retry pattern)
- Missing `condition_expr` flagged / provided expression passes

All 35 existing tests in `test_client_facing_validation.py` and `test_agent_runtime.py` still pass.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes