### PR TITLE
fix(memory): use tiered indicator scoring to prevent false positives in code detection

### DIFF
--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -380,6 +380,12 @@ class SharedMemory:
         """
         Check for code patterns in a string using sampling for efficiency.
 
+        Uses a threshold approach: a single keyword like "import" or "class"
+        in natural language shouldn't trigger rejection.  We require multiple
+        distinct indicators to be present, which makes it far more likely
+        that the text is actually code rather than a report that happens to
+        mention "import" once.
+
         For strings under 10KB, checks the entire content.
         For longer strings, samples at strategic positions to balance
         performance with detection accuracy.
@@ -390,36 +396,50 @@ class SharedMemory:
         Returns:
             True if code indicators are found, False otherwise
         """
-        code_indicators = [
-            # Python
+        # Strong indicators — almost never appear in natural prose
+        strong_indicators = [
             "```python",
+            "```javascript",
+            "```typescript",
+            "=> {",
+            "require(",
+            "<script",
+            "<?php",
+            "<%",
+            "async def ",
+        ]
+
+        # Weak indicators — common English words that also appear in code
+        weak_indicators = [
             "def ",
             "class ",
             "import ",
-            "async def ",
             "from ",
-            # JavaScript/TypeScript
             "function ",
             "const ",
             "let ",
-            "=> {",
-            "require(",
             "export ",
-            # SQL
             "SELECT ",
             "INSERT ",
             "UPDATE ",
             "DELETE ",
             "DROP ",
-            # HTML/Script injection
-            "<script",
-            "<?php",
-            "<%",
         ]
+
+        # Threshold: 1 strong indicator OR 3+ distinct weak indicators
+        min_weak_matches = 3
+
+        def _check_text(text: str) -> bool:
+            # Any strong indicator is an immediate match
+            if any(s in text for s in strong_indicators):
+                return True
+            # Count distinct weak indicators found
+            weak_count = sum(1 for w in weak_indicators if w in text)
+            return weak_count >= min_weak_matches
 
         # For strings under 10KB, check the entire content
         if len(value) < 10000:
-            return any(indicator in value for indicator in code_indicators)
+            return _check_text(value)
 
         # For longer strings, sample at strategic positions
         sample_positions = [
@@ -432,7 +452,7 @@ class SharedMemory:
 
         for pos in sample_positions:
             chunk = value[pos : pos + 2000]
-            if any(indicator in chunk for indicator in code_indicators):
+            if _check_text(chunk):
                 return True
 
         return False

--- a/core/tests/test_shared_memory_code_detection.py
+++ b/core/tests/test_shared_memory_code_detection.py
@@ -1,0 +1,96 @@
+"""Tests for SharedMemory code detection — false positives and true positives."""
+
+import pytest
+
+from framework.graph.node import SharedMemory
+
+
+class TestFalsePositives:
+    """Natural language text should NOT be rejected."""
+
+    def test_business_report_with_import(self):
+        """A report mentioning 'import' once should not be flagged."""
+        mem = SharedMemory()
+        report = (
+            "Our analysis shows that we should import data from multiple sources. "
+            "The market dynamics require a comprehensive approach to gathering "
+            "information from various industry sectors. "
+        ) * 30  # ~5400 chars, over the 5000 threshold
+        mem.write("report", report)  # should not raise
+
+    def test_report_with_class_and_from(self):
+        """Words like 'class' and 'from' are normal English."""
+        mem = SharedMemory()
+        report = (
+            "The class of assets defined by their risk profile varies. "
+            "Data collected from regional offices shows growth trends. "
+        ) * 30
+        mem.write("report", report)
+
+    def test_report_with_select_keyword(self):
+        """'SELECT' alone in a business context is not SQL."""
+        mem = SharedMemory()
+        report = (
+            "We need to SELECT the best candidates from the applicant pool. "
+            "The committee will UPDATE their recommendations next quarter. "
+        ) * 25
+        # Two weak indicators is still under threshold
+        mem.write("report", report)
+
+    def test_short_text_never_rejected(self):
+        """Text under 5000 chars is never checked regardless of content."""
+        mem = SharedMemory()
+        mem.write("short", "import os\nclass Foo:\n    def bar(self):\n        pass")
+
+
+class TestTruePositives:
+    """Actual code should still be caught."""
+
+    def test_python_code_block(self):
+        mem = SharedMemory()
+        code = '```python\ndef hello():\n    print("world")\n```' + ("x" * 5000)
+        with pytest.raises(Exception, match="Rejected suspicious"):
+            mem.write("output", code)
+
+    def test_multiple_code_keywords(self):
+        """Text with 3+ code indicators should be caught."""
+        mem = SharedMemory()
+        code = (
+            "import os\n"
+            "from pathlib import Path\n"
+            "class MyClass:\n"
+            "    def method(self):\n"
+            "        const = 42\n"
+        ) * 60  # ~5600 chars, over the 5000 threshold
+        with pytest.raises(Exception, match="Rejected suspicious"):
+            mem.write("output", code)
+
+    def test_javascript_code(self):
+        mem = SharedMemory()
+        code = (
+            "const express = require('express');\n"
+            "function handleRequest(req, res) {\n"
+            "  export default class App => {\n"
+        ) * 80
+        with pytest.raises(Exception, match="Rejected suspicious"):
+            mem.write("output", code)
+
+    def test_script_tag_always_caught(self):
+        """Strong indicators like <script should always trigger."""
+        mem = SharedMemory()
+        text = "Some normal text " * 300 + "<script>alert('xss')</script>"
+        with pytest.raises(Exception, match="Rejected suspicious"):
+            mem.write("output", text)
+
+
+class TestEdgeCases:
+    def test_validate_false_bypasses_check(self):
+        """validate=False should always allow writes."""
+        mem = SharedMemory()
+        code = "```python\nimport os\nclass Foo:\n    def bar(self):\n        pass\n```" * 100
+        mem.write("output", code, validate=False)  # should not raise
+
+    def test_non_string_values_skip_check(self):
+        mem = SharedMemory()
+        mem.write("data", {"import": "from", "class": "def"})  # dict, not str
+        mem.write("items", [1, 2, 3] * 2000)  # list, not str


### PR DESCRIPTION
## Description

Ran into this while testing an agent that writes business reports — text like "We should import data from multiple sources" was getting rejected by `SharedMemory` because `"import "` and `"from "` matched the code detection. These are just normal English words.

This PR splits the flat indicator list into strong vs weak tiers so we stop rejecting legitimate text while still catching actual code.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #6092

## Changes Made

- Split `code_indicators` into `strong_indicators` and `weak_indicators`
- **Strong** (code fences, `<script`, `require(`, `async def`) — immediate match, same behavior as before
- **Weak** (`import`, `class`, `from`, `function`, `const`, SQL keywords etc) — only triggers if 3+ distinct ones appear together
- Applied the same logic to the sampling path for large strings
- No new dependencies, no API changes

## Testing

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

Added `core/tests/test_shared_memory_code_detection.py` with 10 tests:
- **False positive prevention:** business report with "import", text with "class"/"from", text with "SELECT"/"UPDATE" — none rejected
- **True positive detection:** Python code blocks, multi-keyword code, JavaScript, `<script>` injection — all still caught
- **Edge cases:** `validate=False` bypass works, non-string values skip the check

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes