### PR TITLE
fix(mcp): close errlog file handle to prevent resource leak

### DIFF
--- a/core/framework/runner/mcp_client.py
+++ b/core/framework/runner/mcp_client.py
@@ -68,6 +68,7 @@ class MCPClient:
         self._read_stream = None
         self._write_stream = None
         self._stdio_context = None  # Context manager for stdio_client
+        self._errlog_handle = None  # Track errlog file handle for cleanup
         self._http_client: httpx.Client | None = None
         self._tools: dict[str, MCPTool] = {}
         self._connected = False
@@ -200,7 +201,8 @@ class MCPClient:
                         if os.name == "nt":
                             errlog = sys.stderr
                         else:
-                            errlog = open(os.devnull, "w")  # noqa: SIM115
+                            self._errlog_handle = open(os.devnull, "w")
+                            errlog = self._errlog_handle
                         self._stdio_context = stdio_client(server_params, errlog=errlog)
                         (
                             self._read_stream,
@@ -475,6 +477,15 @@ class MCPClient:
         finally:
             self._stdio_context = None
 
+        # Third: close errlog file handle if we opened one
+        if self._errlog_handle is not None:
+            try:
+                self._errlog_handle.close()
+            except Exception as e:
+                logger.debug(f"Error closing errlog handle: {e}")
+            finally:
+                self._errlog_handle = None
+
     def disconnect(self) -> None:
         """Disconnect from the MCP server."""
         # Clean up persistent STDIO connection
@@ -545,6 +556,7 @@ class MCPClient:
             self._write_stream = None
             self._loop = None
             self._loop_thread = None
+            self._errlog_handle = None
 
         # Clean up HTTP client
         if self._http_client:


### PR DESCRIPTION
## Description

Fixes a file descriptor leak in `MCPClient` where `errlog` file handle opened on non-Windows systems was never closed.

Fixes #6002

## Problem

On non-Windows systems, `open(os.devnull, "w")` was called to create an errlog file handle, but this handle was never closed during cleanup. Over time with many MCP client connections, this leaks file descriptors.
```python
# Before (leaked handle)
errlog = open(os.devnull, "w")  # noqa: SIM115
```

## Solution

Track the file handle and close it properly during cleanup:

1. Added `_errlog_handle` instance variable in `__init__`
2. Store handle reference when opening `os.devnull`
3. Close handle in `_cleanup_stdio_async()` after other cleanup
4. Clear reference in `disconnect()` for safety

## Changes

- `__init__`: Add `self._errlog_handle = None`
- `_connect_stdio`: Store handle in `self._errlog_handle` when opening
- `_cleanup_stdio_async`: Close handle after session/context cleanup
- `disconnect`: Clear reference for safety

## Testing

- Lint passes (`ruff check` / `ruff format`)
- Change is minimal and follows existing cleanup patterns in the file

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed
- [x] Lint passes