### PR TITLE
fix: SubagentJudge and implicit judge return feedback=None on ACCEPT

### DIFF
--- a/core/framework/graph/event_loop_node.py
+++ b/core/framework/graph/event_loop_node.py
@@ -134,7 +134,7 @@ class SubagentJudge:
     async def evaluate(self, context: dict[str, Any]) -> JudgeVerdict:
         missing = context.get("missing_keys", [])
         if not missing:
-            return JudgeVerdict(action="ACCEPT")
+            return JudgeVerdict(action="ACCEPT", feedback="")
 
         iteration = context.get("iteration", 0)
         remaining = self._max_iterations - iteration - 1
@@ -2921,7 +2921,7 @@ class EventLoopNode(NodeProtocol):
                     feedback=verdict.feedback or "Phase criteria not met.",
                 )
 
-        return JudgeVerdict(action="ACCEPT")
+        return JudgeVerdict(action="ACCEPT", feedback="")
 
     # -------------------------------------------------------------------
     # Helpers

--- a/tools/tests/credentials/test_google_analytics_credentials.py
+++ b/tools/tests/credentials/test_google_analytics_credentials.py
@@ -21,13 +21,16 @@ class TestGoogleAnalyticsCredentials:
         assert spec.env_var == "GOOGLE_APPLICATION_CREDENTIALS"
 
     def test_tools_list(self):
-        """Spec lists all four GA tool names."""
+        """Spec lists all seven GA tool names."""
         spec = GOOGLE_ANALYTICS_CREDENTIALS["google_analytics"]
         expected = [
             "ga_run_report",
             "ga_get_realtime",
             "ga_get_top_pages",
             "ga_get_traffic_sources",
+            "ga_get_user_demographics",
+            "ga_get_conversion_events",
+            "ga_get_landing_pages",
         ]
         assert spec.tools == expected
 

--- a/tools/tests/integrations/conftest.py
+++ b/tools/tests/integrations/conftest.py
@@ -137,6 +137,13 @@ def get_all_credential_tool_names() -> list[str]:
     return names
 
 
+# Parameter names that require specific valid values to pass input validation
+# before the credential check is reached.
+_PARAM_OVERRIDES: dict[str, str] = {
+    "object_type": "contacts",
+}
+
+
 def get_minimal_args(fn: Any) -> dict[str, Any]:
     """Build minimal keyword arguments for a tool function.
 
@@ -149,6 +156,11 @@ def get_minimal_args(fn: Any) -> dict[str, Any]:
     for name, param in sig.parameters.items():
         if param.default is not inspect.Parameter.empty:
             continue  # Skip optional params
+
+        # Check for known parameter overrides first
+        if name in _PARAM_OVERRIDES:
+            args[name] = _PARAM_OVERRIDES[name]
+            continue
 
         # Infer a minimal value from annotation
         annotation = param.annotation

--- a/tools/tests/tools/test_apollo_tool.py
+++ b/tools/tests/tools/test_apollo_tool.py
@@ -394,7 +394,7 @@ class TestToolRegistration:
         mcp = MagicMock()
         mcp.tool.return_value = lambda fn: fn
         register_tools(mcp)
-        assert mcp.tool.call_count == 4
+        assert mcp.tool.call_count == 7
 
     def test_no_credentials_returns_error(self):
         mcp = MagicMock()
@@ -672,4 +672,7 @@ class TestCredentialSpec:
         assert "apollo_enrich_company" in spec.tools
         assert "apollo_search_people" in spec.tools
         assert "apollo_search_companies" in spec.tools
-        assert len(spec.tools) == 4
+        assert "apollo_get_person_activities" in spec.tools
+        assert "apollo_list_email_accounts" in spec.tools
+        assert "apollo_bulk_enrich_people" in spec.tools
+        assert len(spec.tools) == 7

--- a/tools/tests/tools/test_discord_tool.py
+++ b/tools/tests/tools/test_discord_tool.py
@@ -411,4 +411,7 @@ class TestCredentialSpec:
         assert "discord_list_channels" in spec.tools
         assert "discord_send_message" in spec.tools
         assert "discord_get_messages" in spec.tools
-        assert len(spec.tools) == 4
+        assert "discord_get_channel" in spec.tools
+        assert "discord_create_reaction" in spec.tools
+        assert "discord_delete_message" in spec.tools
+        assert len(spec.tools) == 7

--- a/tools/tests/tools/test_google_analytics_tool.py
+++ b/tools/tests/tools/test_google_analytics_tool.py
@@ -723,8 +723,8 @@ class TestGaGetTrafficSources:
 class TestToolRegistration:
     """Tests for tool registration in register_all_tools."""
 
-    def test_register_tools_registers_all_four_tools(self):
-        """register_tools registers exactly 4 GA tool functions."""
+    def test_register_tools_registers_all_seven_tools(self):
+        """register_tools registers exactly 7 GA tool functions."""
         mcp = MagicMock()
         registered_fns = {}
         mcp.tool.return_value = lambda fn: registered_fns.update({fn.__name__: fn}) or fn
@@ -736,6 +736,9 @@ class TestToolRegistration:
             "ga_get_realtime",
             "ga_get_top_pages",
             "ga_get_traffic_sources",
+            "ga_get_user_demographics",
+            "ga_get_conversion_events",
+            "ga_get_landing_pages",
         }
         assert set(registered_fns.keys()) == expected_tools
 
@@ -768,4 +771,4 @@ class TestToolRegistration:
 
         register_tools(mcp, credentials=cred_manager)
 
-        assert len(registered_fns) == 4
+        assert len(registered_fns) == 7

--- a/tools/tests/tools/test_linear_tool.py
+++ b/tools/tests/tools/test_linear_tool.py
@@ -441,8 +441,8 @@ class TestToolRegistration:
         mcp = MagicMock()
         mcp.tool.return_value = lambda fn: fn
         register_tools(mcp)
-        # 18 tools: 6 issue + 4 project + 3 team + 2 label + 3 user
-        assert mcp.tool.call_count == 18
+        # 21 tools: 6 issue + 4 project + 3 team + 2 label + 3 user + 2 cycle + 1 relation
+        assert mcp.tool.call_count == 21
 
     def test_no_credentials_returns_error(self):
         mcp = MagicMock()

--- a/tools/tests/tools/test_stripe_tool.py
+++ b/tools/tests/tools/test_stripe_tool.py
@@ -1089,7 +1089,7 @@ class TestToolRegistration:
         mcp = MagicMock()
         mcp.tool.return_value = lambda fn: fn
         register_tools(mcp)
-        assert mcp.tool.call_count == 51
+        assert mcp.tool.call_count == 54
 
     def test_no_credentials_returns_error(self):
         mcp = MagicMock()
@@ -1596,7 +1596,7 @@ class TestCredentialSpec:
         from aden_tools.credentials import CREDENTIAL_SPECS
 
         spec = CREDENTIAL_SPECS["stripe"]
-        assert len(spec.tools) == 51
+        assert len(spec.tools) == 54
 
     def test_stripe_spec_tools_include_core_methods(self):
         from aden_tools.credentials import CREDENTIAL_SPECS


### PR DESCRIPTION
## Description

Two fixes for failing CI tests on main:

1. `SubagentJudge.evaluate()` and `_judge_turn()` implicit judge returned `JudgeVerdict(action="ACCEPT")` without passing `feedback`, defaulting to `None`. Per `JudgeVerdict` docstring, `None` means "no evaluation happened" while `""` means "evaluated but no feedback". ACCEPT from these paths is a real evaluation, so `feedback=""` is correct.

2. Multiple tool test assertions were outdated after new tools were added to stripe, linear, apollo, discord, and google_analytics.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #6107

## Changes Made

- `SubagentJudge.evaluate()` (L137): `JudgeVerdict(action="ACCEPT")` -> `JudgeVerdict(action="ACCEPT", feedback="")`
- `_judge_turn()` implicit judge final ACCEPT (L2924): same change
- Updated tool counts and expected tool lists in tests for stripe (51->54), linear (18->21), apollo (4->7), discord (4->7), google_analytics (4->7)
- Fixed hubspot_delete_object test input validation in conftest.py

## Testing

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Unit tests pass (`cd tools && pytest tests/`)
- [x] `test_subagent_judge_accepts_when_output_keys_filled` was failing on main, now passes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes