### PR TITLE
docs: improve MCP session tool partitioning and assistant message visibility

### DIFF
--- a/core/framework/server/queen_orchestrator.py
+++ b/core/framework/server/queen_orchestrator.py
@@ -133,7 +133,18 @@ async def create_queen(
     logger.info("Queen: registered tools: %s", sorted(registered_names))
 
     phase_state.planning_tools = [t for t in queen_tools if t.name in planning_names]
-    phase_state.building_tools = [t for t in queen_tools if t.name in building_names]
+    
+    # Partition tools into mode-specific sets.
+    # In building mode, we allow all standard building tools PLUS any dynamic/MCP tools.
+    # Dynamic tools are those NOT specifically whitelisted for other modes.
+    all_hardcoded = building_names | staging_names | running_names
+    phase_state.building_tools = [
+        t
+        for t in queen_tools
+        if t.name in building_names or t.name not in all_hardcoded
+    ]
+
+    # Staging and running sets remain strictly whitelisted for safety.
     phase_state.staging_tools = [t for t in queen_tools if t.name in staging_names]
     phase_state.running_tools = [t for t in queen_tools if t.name in running_names]
 

--- a/core/framework/server/routes_sessions.py
+++ b/core/framework/server/routes_sessions.py
@@ -667,7 +667,8 @@ async def handle_queen_messages(request: web.Request) -> web.Response:
         for m in all_messages
         if not m.get("is_transition_marker")
         and m["role"] != "tool"
-        and not (m["role"] == "assistant" and m.get("tool_calls"))
+        # Permit assistant messages with tool_calls IF they have content (text for the user)
+        and not (m["role"] == "assistant" and m.get("tool_calls") and not m.get("content"))
     ]
 
     return web.json_response({"messages": all_messages, "session_id": session_id})

--- a/tools/coder_tools_server.py
+++ b/tools/coder_tools_server.py
@@ -364,6 +364,7 @@ def list_agent_tools(
     # Resolve config path
     if not server_config_path:
         candidates = [
+            os.path.join(PROJECT_ROOT, "core", "framework", "agents", "hive_coder", "mcp_servers.json"),
             os.path.join(PROJECT_ROOT, "tools", "mcp_servers.json"),
             os.path.join(PROJECT_ROOT, "mcp_servers.json"),
         ]


### PR DESCRIPTION
## Description

This PR isolates the core logic improvements for session management and MCP tool tracking from previous feedback (#5927). It fixes bugs related to the Queen's tool accessibility during the building phase, ensures assistant messages with tool calls remain visible if they contain text, and improves MCP config discovery. 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #6130

## Changes Made

- **Assistant Message Visibility:** Fixed the filtering logic so that assistant messages containing tool_calls are now displayed to the user if they also include text `content`.
- **MCP Tool Partitioning:** Modified the tool allocation logic to ensure that dynamic and MCP tools are actively available during the `building` mode.
- **MCP Config Discovery:** Expanded the configuration discovery candidates to properly locate MCP config files within internal agent directories.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed (Verified MCP tools appear in building mode and assistant messages don't disappear when using tools).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
A full video demonstration of these fixes in action—including live MCP tool orchestration and multi-agent terminal tracking—can be found in the related feature PR: #6134