### PR TITLE
Fix Python detection on Windows using py launcher

### DIFF
--- a/quickstart.ps1
+++ b/quickstart.ps1
@@ -318,9 +318,14 @@ Write-Step -Number "1" -Text "Step 1: Checking Python..."
 
 # On Windows "python3.x" aliases don't exist; prefer "python" then "python3"
 $PythonCmd = $null
-foreach ($candidate in @("python", "python3", "python3.13", "python3.12", "python3.11")) {
+foreach ($candidate in @("python", "python3", "python3.13", "python3.12", "python3.11", "py")) {
     try {
-        $ver = & $candidate -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>$null
+        if ($candidate -eq "py") {
+            $ver = & py -3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>$null
+        } else {
+            $ver = & $candidate -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>$null
+        }
+
         if ($LASTEXITCODE -eq 0 -and $ver) {
             $parts = $ver.Split(".")
             $major = [int]$parts[0]


### PR DESCRIPTION
Fixes #6082

The quickstart.ps1 script previously only checked commands such as
python and python3. On Windows systems with multiple Python installations,
the Python launcher (py.exe) is commonly used.

This change adds detection using the py launcher (py -3), allowing the
script to correctly locate compatible Python versions (>=3.11) even when
the python command resolves to an older version.

Tested on Windows with multiple Python versions installed:

python -> Python 3.11
py launcher -> Python 3.13

The script successfully detects Python via the launcher.