### PR TITLE
Fix: is_resumable returns False for CANCELLED sessions

### DIFF
--- a/core/framework/schemas/session_state.py
+++ b/core/framework/schemas/session_state.py
@@ -161,11 +161,10 @@ class SessionState(BaseModel):
     def is_resumable(self) -> bool:
         """Can this session be resumed?
 
-        Every non-completed session is resumable. If resume_from/paused_at
-        aren't set, the executor falls back to the graph entry point —
-        so we don't gate on those. Even catastrophic failures are resumable.
+        COMPLETED and CANCELLED sessions are not resumable.
+        Only ACTIVE, PAUSED, and FAILED sessions can be resumed.
         """
-        return self.status != SessionStatus.COMPLETED
+        return self.status not in (SessionStatus.COMPLETED, SessionStatus.CANCELLED)
 
     @computed_field
     @property

--- a/core/framework/schemas/tests/test_session_state.py
+++ b/core/framework/schemas/tests/test_session_state.py
@@ -1,0 +1,36 @@
+import sys
+sys.path.insert(0, "core")
+
+from datetime import datetime
+from framework.schemas.session_state import SessionState, SessionStatus
+
+def make_session(status):
+    return SessionState(
+        session_id="test",
+        goal_id="test",
+        status=status,
+        timestamps={
+            "started_at": datetime.now().isoformat(),
+            "updated_at": datetime.now().isoformat()
+        }
+    )
+
+def test_cancelled_not_resumable():
+    s = make_session(SessionStatus.CANCELLED)
+    assert s.is_resumable == False
+
+def test_completed_not_resumable():
+    s = make_session(SessionStatus.COMPLETED)
+    assert s.is_resumable == False
+
+def test_active_is_resumable():
+    s = make_session(SessionStatus.ACTIVE)
+    assert s.is_resumable == True
+
+def test_paused_is_resumable():
+    s = make_session(SessionStatus.PAUSED)
+    assert s.is_resumable == True
+
+def test_failed_is_resumable():
+    s = make_session(SessionStatus.FAILED)
+    assert s.is_resumable == True


### PR DESCRIPTION
## Description
`is_resumable` was returning `True` for `CANCELLED` sessions. 
CANCELLED sessions are deliberately stopped and should not be resumable.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
Fixes #6145

## Changes Made
- Updated `is_resumable` in `core/framework/schemas/session_state.py` to exclude `CANCELLED` status
- Updated docstring to reflect new behaviour
- Added unit tests for all session states

## Testing
- [x] Unit tests pass
- [x] Manual testing performed

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes