### PR TITLE
test(security): add comprehensive unit tests for 7 security scanning tools

### DIFF
--- a/tools/tests/tools/test_dns_security_scanner.py
+++ b/tools/tests/tools/test_dns_security_scanner.py
@@ -1,0 +1,314 @@
+"""Tests for DNS Security Scanner tool."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.dns_security_scanner import register_tools
+
+
+@pytest.fixture
+def dns_tools(mcp: FastMCP):
+    """Register DNS security tools and return tool functions."""
+    register_tools(mcp)
+    tools = mcp._tool_manager._tools
+    return {name: tools[name].fn for name in tools}
+
+
+@pytest.fixture
+def scan_fn(dns_tools):
+    return dns_tools["dns_security_scan"]
+
+
+# ---------------------------------------------------------------------------
+# Input Validation & Cleaning
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    """Test domain input cleaning and validation."""
+
+    def test_strips_https_prefix(self, scan_fn):
+        with patch(
+            "aden_tools.tools.dns_security_scanner.dns_security_scanner._DNS_AVAILABLE", True
+        ):
+            with patch(
+                "aden_tools.tools.dns_security_scanner.dns_security_scanner.dns.resolver.Resolver"
+            ) as MockResolver:
+                import dns.resolver
+
+                mock = MagicMock()
+                mock.resolve.side_effect = dns.resolver.NXDOMAIN()
+                mock.timeout = 10
+                mock.lifetime = 10
+                MockResolver.return_value = mock
+
+                result = scan_fn("https://example.com")
+                assert result["domain"] == "example.com"
+
+    def test_strips_http_prefix(self, scan_fn):
+        with patch(
+            "aden_tools.tools.dns_security_scanner.dns_security_scanner._DNS_AVAILABLE", True
+        ):
+            with patch(
+                "aden_tools.tools.dns_security_scanner.dns_security_scanner.dns.resolver.Resolver"
+            ) as MockResolver:
+                import dns.resolver
+
+                mock = MagicMock()
+                mock.resolve.side_effect = dns.resolver.NXDOMAIN()
+                mock.timeout = 10
+                mock.lifetime = 10
+                MockResolver.return_value = mock
+
+                result = scan_fn("http://example.com")
+                assert result["domain"] == "example.com"
+
+    def test_strips_trailing_slash(self, scan_fn):
+        with patch(
+            "aden_tools.tools.dns_security_scanner.dns_security_scanner._DNS_AVAILABLE", True
+        ):
+            with patch(
+                "aden_tools.tools.dns_security_scanner.dns_security_scanner.dns.resolver.Resolver"
+            ) as MockResolver:
+                import dns.resolver
+
+                mock = MagicMock()
+                mock.resolve.side_effect = dns.resolver.NXDOMAIN()
+                mock.timeout = 10
+                mock.lifetime = 10
+                MockResolver.return_value = mock
+
+                result = scan_fn("example.com/")
+                assert result["domain"] == "example.com"
+
+    def test_strips_path(self, scan_fn):
+        with patch(
+            "aden_tools.tools.dns_security_scanner.dns_security_scanner._DNS_AVAILABLE", True
+        ):
+            with patch(
+                "aden_tools.tools.dns_security_scanner.dns_security_scanner.dns.resolver.Resolver"
+            ) as MockResolver:
+                import dns.resolver
+
+                mock = MagicMock()
+                mock.resolve.side_effect = dns.resolver.NXDOMAIN()
+                mock.timeout = 10
+                mock.lifetime = 10
+                MockResolver.return_value = mock
+
+                result = scan_fn("example.com/path/to/page")
+                assert result["domain"] == "example.com"
+
+    def test_strips_port(self, scan_fn):
+        with patch(
+            "aden_tools.tools.dns_security_scanner.dns_security_scanner._DNS_AVAILABLE", True
+        ):
+            with patch(
+                "aden_tools.tools.dns_security_scanner.dns_security_scanner.dns.resolver.Resolver"
+            ) as MockResolver:
+                import dns.resolver
+
+                mock = MagicMock()
+                mock.resolve.side_effect = dns.resolver.NXDOMAIN()
+                mock.timeout = 10
+                mock.lifetime = 10
+                MockResolver.return_value = mock
+
+                result = scan_fn("example.com:8080")
+                assert result["domain"] == "example.com"
+
+
+# ---------------------------------------------------------------------------
+# DNS Library Availability
+# ---------------------------------------------------------------------------
+
+
+class TestDnsAvailability:
+    """Test behavior when dnspython is not installed."""
+
+    def test_dns_not_available(self, scan_fn):
+        with patch(
+            "aden_tools.tools.dns_security_scanner.dns_security_scanner._DNS_AVAILABLE", False
+        ):
+            result = scan_fn("example.com")
+            assert "error" in result
+            assert "dnspython" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# SPF Record Checks
+# ---------------------------------------------------------------------------
+
+
+class TestSpfChecks:
+    """Test SPF record detection and policy analysis."""
+
+    def _mock_resolver_with_spf(self, spf_record):
+        """Create a mock resolver that returns the given SPF record."""
+        mock_resolver = MagicMock()
+        mock_rdata = MagicMock()
+        mock_rdata.to_text.return_value = f'"{spf_record}"'
+        mock_resolver.resolve.return_value = [mock_rdata]
+        return mock_resolver
+
+    def test_spf_hardfail_detected(self, scan_fn):
+        with patch(
+            "aden_tools.tools.dns_security_scanner.dns_security_scanner._DNS_AVAILABLE", True
+        ):
+            with patch(
+                "aden_tools.tools.dns_security_scanner.dns_security_scanner.dns.resolver.Resolver"
+            ) as MockResolver:
+                mock = MagicMock()
+                mock_rdata = MagicMock()
+                mock_rdata.to_text.return_value = '"v=spf1 include:_spf.google.com -all"'
+                mock.resolve.return_value = [mock_rdata]
+                mock.timeout = 10
+                mock.lifetime = 10
+                MockResolver.return_value = mock
+
+                result = scan_fn("example.com")
+                assert result["spf"]["present"] is True
+                assert result["spf"]["policy"] == "hardfail"
+                assert result["grade_input"]["spf_strict"] is True
+
+    def test_spf_softfail_detected(self, scan_fn):
+        with patch(
+            "aden_tools.tools.dns_security_scanner.dns_security_scanner._DNS_AVAILABLE", True
+        ):
+            with patch(
+                "aden_tools.tools.dns_security_scanner.dns_security_scanner.dns.resolver.Resolver"
+            ) as MockResolver:
+                mock = MagicMock()
+                mock_rdata = MagicMock()
+                mock_rdata.to_text.return_value = '"v=spf1 include:_spf.google.com ~all"'
+                mock.resolve.return_value = [mock_rdata]
+                mock.timeout = 10
+                mock.lifetime = 10
+                MockResolver.return_value = mock
+
+                result = scan_fn("example.com")
+                assert result["spf"]["present"] is True
+                assert result["spf"]["policy"] == "softfail"
+                assert result["grade_input"]["spf_strict"] is False
+
+    def test_spf_pass_all_dangerous(self, scan_fn):
+        with patch(
+            "aden_tools.tools.dns_security_scanner.dns_security_scanner._DNS_AVAILABLE", True
+        ):
+            with patch(
+                "aden_tools.tools.dns_security_scanner.dns_security_scanner.dns.resolver.Resolver"
+            ) as MockResolver:
+                mock = MagicMock()
+                mock_rdata = MagicMock()
+                mock_rdata.to_text.return_value = '"v=spf1 +all"'
+                mock.resolve.return_value = [mock_rdata]
+                mock.timeout = 10
+                mock.lifetime = 10
+                MockResolver.return_value = mock
+
+                result = scan_fn("example.com")
+                assert result["spf"]["policy"] == "pass_all"
+                assert len(result["spf"]["issues"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# DMARC Record Checks
+# ---------------------------------------------------------------------------
+
+
+class TestDmarcChecks:
+    """Test DMARC record detection and policy analysis."""
+
+    def test_dmarc_reject_policy(self, scan_fn):
+        with patch(
+            "aden_tools.tools.dns_security_scanner.dns_security_scanner._DNS_AVAILABLE", True
+        ):
+            with patch(
+                "aden_tools.tools.dns_security_scanner.dns_security_scanner.dns.resolver.Resolver"
+            ) as MockResolver:
+                mock = MagicMock()
+
+                def mock_resolve(domain, record_type):
+                    import dns.resolver
+
+                    if record_type == "TXT" and "_dmarc" in domain:
+                        rdata = MagicMock()
+                        rdata.to_text.return_value = '"v=DMARC1; p=reject"'
+                        return [rdata]
+                    raise dns.resolver.NXDOMAIN()
+
+                mock.resolve = mock_resolve
+                mock.timeout = 10
+                mock.lifetime = 10
+                MockResolver.return_value = mock
+
+                result = scan_fn("example.com")
+                assert result["dmarc"]["present"] is True
+                assert result["dmarc"]["policy"] == "reject"
+                assert result["grade_input"]["dmarc_enforcing"] is True
+
+    def test_dmarc_none_policy(self, scan_fn):
+        with patch(
+            "aden_tools.tools.dns_security_scanner.dns_security_scanner._DNS_AVAILABLE", True
+        ):
+            with patch(
+                "aden_tools.tools.dns_security_scanner.dns_security_scanner.dns.resolver.Resolver"
+            ) as MockResolver:
+                mock = MagicMock()
+
+                def mock_resolve(domain, record_type):
+                    if record_type == "TXT" and "_dmarc" in domain:
+                        rdata = MagicMock()
+                        rdata.to_text.return_value = '"v=DMARC1; p=none"'
+                        return [rdata]
+                    import dns.resolver
+
+                    raise dns.resolver.NXDOMAIN()
+
+                mock.resolve = mock_resolve
+                mock.timeout = 10
+                mock.lifetime = 10
+                MockResolver.return_value = mock
+
+                result = scan_fn("example.com")
+                assert result["dmarc"]["policy"] == "none"
+                assert result["grade_input"]["dmarc_enforcing"] is False
+
+
+# ---------------------------------------------------------------------------
+# Grade Input
+# ---------------------------------------------------------------------------
+
+
+class TestGradeInput:
+    """Test grade_input dict is properly constructed."""
+
+    def test_grade_input_keys_present(self, scan_fn):
+        with patch(
+            "aden_tools.tools.dns_security_scanner.dns_security_scanner._DNS_AVAILABLE", True
+        ):
+            with patch(
+                "aden_tools.tools.dns_security_scanner.dns_security_scanner.dns.resolver.Resolver"
+            ) as MockResolver:
+                mock = MagicMock()
+                import dns.resolver
+
+                mock.resolve.side_effect = dns.resolver.NXDOMAIN()
+                mock.timeout = 10
+                mock.lifetime = 10
+                MockResolver.return_value = mock
+
+                result = scan_fn("example.com")
+                assert "grade_input" in result
+                grade = result["grade_input"]
+                assert "spf_present" in grade
+                assert "spf_strict" in grade
+                assert "dmarc_present" in grade
+                assert "dmarc_enforcing" in grade
+                assert "dkim_found" in grade
+                assert "dnssec_enabled" in grade
+                assert "zone_transfer_blocked" in grade

--- a/tools/tests/tools/test_dns_security_scanner.py
+++ b/tools/tests/tools/test_dns_security_scanner.py
@@ -147,14 +147,6 @@ class TestDnsAvailability:
 class TestSpfChecks:
     """Test SPF record detection and policy analysis."""
 
-    def _mock_resolver_with_spf(self, spf_record):
-        """Create a mock resolver that returns the given SPF record."""
-        mock_resolver = MagicMock()
-        mock_rdata = MagicMock()
-        mock_rdata.to_text.return_value = f'"{spf_record}"'
-        mock_resolver.resolve.return_value = [mock_rdata]
-        return mock_resolver
-
     def test_spf_hardfail_detected(self, scan_fn):
         with patch(
             "aden_tools.tools.dns_security_scanner.dns_security_scanner._DNS_AVAILABLE", True

--- a/tools/tests/tools/test_http_headers_scanner.py
+++ b/tools/tests/tools/test_http_headers_scanner.py
@@ -1,0 +1,315 @@
+"""Tests for HTTP Headers Scanner tool."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.http_headers_scanner import register_tools
+
+
+@pytest.fixture
+def headers_tools(mcp: FastMCP):
+    """Register HTTP headers tools and return tool functions."""
+    register_tools(mcp)
+    tools = mcp._tool_manager._tools
+    return {name: tools[name].fn for name in tools}
+
+
+@pytest.fixture
+def scan_fn(headers_tools):
+    return headers_tools["http_headers_scan"]
+
+
+def _mock_response(
+    status_code: int = 200,
+    headers: dict | None = None,
+    url: str = "https://example.com",
+) -> MagicMock:
+    """Create a mock httpx.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.url = url
+    resp.headers = httpx.Headers(headers or {})
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Input Validation
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    """Test URL input cleaning and validation."""
+
+    @pytest.mark.asyncio
+    async def test_auto_prefix_https(self, scan_fn):
+        mock_resp = _mock_response(headers={"strict-transport-security": "max-age=31536000"})
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_resp
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await scan_fn("example.com")
+            assert "error" not in result
+            # Verify https was prefixed
+            mock_client.get.assert_called_once()
+            call_url = mock_client.get.call_args[0][0]
+            assert call_url.startswith("https://")
+
+
+# ---------------------------------------------------------------------------
+# Connection Errors
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionErrors:
+    """Test error handling for connection failures."""
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self, scan_fn):
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.side_effect = httpx.ConnectError("Connection refused")
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await scan_fn("https://example.com")
+            assert "error" in result
+            assert "Connection failed" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_timeout_error(self, scan_fn):
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.side_effect = httpx.TimeoutException("Request timed out")
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await scan_fn("https://example.com")
+            assert "error" in result
+            assert "timed out" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Security Headers Detection
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityHeaders:
+    """Test detection of OWASP security headers."""
+
+    @pytest.mark.asyncio
+    async def test_all_headers_present(self, scan_fn):
+        headers = {
+            "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+            "Content-Security-Policy": "default-src 'self'",
+            "X-Frame-Options": "DENY",
+            "X-Content-Type-Options": "nosniff",
+            "Referrer-Policy": "strict-origin-when-cross-origin",
+            "Permissions-Policy": "camera=(), microphone=()",
+        }
+        mock_resp = _mock_response(headers=headers)
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_resp
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await scan_fn("https://example.com")
+            assert len(result["headers_present"]) == 6
+            assert len(result["headers_missing"]) == 0
+            assert result["grade_input"]["hsts"] is True
+            assert result["grade_input"]["csp"] is True
+
+    @pytest.mark.asyncio
+    async def test_missing_hsts(self, scan_fn):
+        headers = {
+            "Content-Security-Policy": "default-src 'self'",
+            "X-Frame-Options": "DENY",
+        }
+        mock_resp = _mock_response(headers=headers)
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_resp
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await scan_fn("https://example.com")
+            assert result["grade_input"]["hsts"] is False
+            missing_names = [h["header"] for h in result["headers_missing"]]
+            assert "Strict-Transport-Security" in missing_names
+
+    @pytest.mark.asyncio
+    async def test_missing_csp(self, scan_fn):
+        headers = {
+            "Strict-Transport-Security": "max-age=31536000",
+        }
+        mock_resp = _mock_response(headers=headers)
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_resp
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await scan_fn("https://example.com")
+            assert result["grade_input"]["csp"] is False
+            missing_names = [h["header"] for h in result["headers_missing"]]
+            assert "Content-Security-Policy" in missing_names
+
+
+# ---------------------------------------------------------------------------
+# Leaky Headers Detection
+# ---------------------------------------------------------------------------
+
+
+class TestLeakyHeaders:
+    """Test detection of information-leaking headers."""
+
+    @pytest.mark.asyncio
+    async def test_server_header_leaked(self, scan_fn):
+        headers = {"Server": "Apache/2.4.41 (Ubuntu)"}
+        mock_resp = _mock_response(headers=headers)
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_resp
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await scan_fn("https://example.com")
+            assert len(result["leaky_headers"]) > 0
+            leaky_names = [h["header"] for h in result["leaky_headers"]]
+            assert "Server" in leaky_names
+            assert result["grade_input"]["no_leaky_headers"] is False
+
+    @pytest.mark.asyncio
+    async def test_x_powered_by_leaked(self, scan_fn):
+        headers = {"X-Powered-By": "PHP/8.1.0"}
+        mock_resp = _mock_response(headers=headers)
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_resp
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await scan_fn("https://example.com")
+            leaky_names = [h["header"] for h in result["leaky_headers"]]
+            assert "X-Powered-By" in leaky_names
+
+    @pytest.mark.asyncio
+    async def test_no_leaky_headers(self, scan_fn):
+        headers = {
+            "Strict-Transport-Security": "max-age=31536000",
+            "Content-Type": "text/html",
+        }
+        mock_resp = _mock_response(headers=headers)
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_resp
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await scan_fn("https://example.com")
+            assert len(result["leaky_headers"]) == 0
+            assert result["grade_input"]["no_leaky_headers"] is True
+
+
+# ---------------------------------------------------------------------------
+# Deprecated Headers
+# ---------------------------------------------------------------------------
+
+
+class TestDeprecatedHeaders:
+    """Test detection of deprecated headers."""
+
+    @pytest.mark.asyncio
+    async def test_xss_protection_deprecated(self, scan_fn):
+        headers = {"X-XSS-Protection": "1; mode=block"}
+        mock_resp = _mock_response(headers=headers)
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_resp
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await scan_fn("https://example.com")
+            assert "X-XSS-Protection (deprecated)" in result["headers_present"]
+
+
+# ---------------------------------------------------------------------------
+# Grade Input
+# ---------------------------------------------------------------------------
+
+
+class TestGradeInput:
+    """Test grade_input dict is properly constructed."""
+
+    @pytest.mark.asyncio
+    async def test_grade_input_keys_present(self, scan_fn):
+        mock_resp = _mock_response(headers={})
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_resp
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await scan_fn("https://example.com")
+            assert "grade_input" in result
+            grade = result["grade_input"]
+            assert "hsts" in grade
+            assert "csp" in grade
+            assert "x_frame_options" in grade
+            assert "x_content_type_options" in grade
+            assert "referrer_policy" in grade
+            assert "permissions_policy" in grade
+            assert "no_leaky_headers" in grade
+
+
+# ---------------------------------------------------------------------------
+# Response Metadata
+# ---------------------------------------------------------------------------
+
+
+class TestResponseMetadata:
+    """Test response metadata is captured."""
+
+    @pytest.mark.asyncio
+    async def test_status_code_captured(self, scan_fn):
+        mock_resp = _mock_response(status_code=200, headers={})
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_resp
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await scan_fn("https://example.com")
+            assert result["status_code"] == 200
+
+    @pytest.mark.asyncio
+    async def test_final_url_captured(self, scan_fn):
+        mock_resp = _mock_response(status_code=200, headers={}, url="https://www.example.com/")
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_resp
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await scan_fn("https://example.com")
+            assert result["url"] == "https://www.example.com/"

--- a/tools/tests/tools/test_port_scanner.py
+++ b/tools/tests/tools/test_port_scanner.py
@@ -1,0 +1,281 @@
+"""Tests for Port Scanner tool."""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.port_scanner import register_tools
+
+
+@pytest.fixture
+def port_tools(mcp: FastMCP):
+    """Register port scanner tools and return tool functions."""
+    register_tools(mcp)
+    tools = mcp._tool_manager._tools
+    return {name: tools[name].fn for name in tools}
+
+
+@pytest.fixture
+def scan_fn(port_tools):
+    return port_tools["port_scan"]
+
+
+# ---------------------------------------------------------------------------
+# Input Validation
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    """Test hostname and port input validation."""
+
+    @pytest.mark.asyncio
+    async def test_strips_https_prefix(self, scan_fn):
+        with patch("socket.gethostbyname", return_value="93.184.216.34"):
+            with patch(
+                "aden_tools.tools.port_scanner.port_scanner._check_port",
+                new_callable=AsyncMock,
+            ) as mock_check:
+                mock_check.return_value = {"open": False}
+                result = await scan_fn("https://example.com", ports="80")
+                assert result["hostname"] == "example.com"
+
+    @pytest.mark.asyncio
+    async def test_strips_path(self, scan_fn):
+        with patch("socket.gethostbyname", return_value="93.184.216.34"):
+            with patch(
+                "aden_tools.tools.port_scanner.port_scanner._check_port",
+                new_callable=AsyncMock,
+            ) as mock_check:
+                mock_check.return_value = {"open": False}
+                result = await scan_fn("example.com/path", ports="80")
+                assert result["hostname"] == "example.com"
+
+    @pytest.mark.asyncio
+    async def test_invalid_port_list(self, scan_fn):
+        with patch("socket.gethostbyname", return_value="93.184.216.34"):
+            result = await scan_fn("example.com", ports="invalid,ports")
+            assert "error" in result
+            assert "Invalid port list" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_custom_port_list(self, scan_fn):
+        with patch("socket.gethostbyname", return_value="93.184.216.34"):
+            with patch(
+                "aden_tools.tools.port_scanner.port_scanner._check_port",
+                new_callable=AsyncMock,
+            ) as mock_check:
+                mock_check.return_value = {"open": False}
+                result = await scan_fn("example.com", ports="22,80,443")
+                assert result["ports_scanned"] == 3
+
+    @pytest.mark.asyncio
+    async def test_timeout_clamped(self, scan_fn):
+        with patch("socket.gethostbyname", return_value="93.184.216.34"):
+            with patch(
+                "aden_tools.tools.port_scanner.port_scanner._check_port",
+                new_callable=AsyncMock,
+            ) as mock_check:
+                mock_check.return_value = {"open": False}
+                # Timeout > 10 should be clamped
+                result = await scan_fn("example.com", ports="80", timeout=100.0)
+                assert "error" not in result
+
+
+# ---------------------------------------------------------------------------
+# DNS Resolution Errors
+# ---------------------------------------------------------------------------
+
+
+class TestDnsResolution:
+    """Test DNS resolution error handling."""
+
+    @pytest.mark.asyncio
+    async def test_hostname_not_found(self, scan_fn):
+        with patch("socket.gethostbyname", side_effect=socket.gaierror("not found")):
+            result = await scan_fn("nonexistent.invalid")
+            assert "error" in result
+            assert "resolve hostname" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Port Scanning
+# ---------------------------------------------------------------------------
+
+
+class TestPortScanning:
+    """Test port scanning functionality."""
+
+    @pytest.mark.asyncio
+    async def test_open_port_detected(self, scan_fn):
+        with patch("socket.gethostbyname", return_value="93.184.216.34"):
+            with patch(
+                "aden_tools.tools.port_scanner.port_scanner._check_port",
+                new_callable=AsyncMock,
+            ) as mock_check:
+                mock_check.return_value = {"open": True, "banner": ""}
+                result = await scan_fn("example.com", ports="80")
+                assert len(result["open_ports"]) == 1
+                assert result["open_ports"][0]["port"] == 80
+
+    @pytest.mark.asyncio
+    async def test_closed_port_detected(self, scan_fn):
+        with patch("socket.gethostbyname", return_value="93.184.216.34"):
+            with patch(
+                "aden_tools.tools.port_scanner.port_scanner._check_port",
+                new_callable=AsyncMock,
+            ) as mock_check:
+                mock_check.return_value = {"open": False}
+                result = await scan_fn("example.com", ports="12345")
+                assert len(result["open_ports"]) == 0
+                assert 12345 in result["closed_ports"]
+
+    @pytest.mark.asyncio
+    async def test_banner_captured(self, scan_fn):
+        with patch("socket.gethostbyname", return_value="93.184.216.34"):
+            with patch(
+                "aden_tools.tools.port_scanner.port_scanner._check_port",
+                new_callable=AsyncMock,
+            ) as mock_check:
+                mock_check.return_value = {"open": True, "banner": "SSH-2.0-OpenSSH_8.9"}
+                result = await scan_fn("example.com", ports="22")
+                assert result["open_ports"][0]["banner"] == "SSH-2.0-OpenSSH_8.9"
+
+
+# ---------------------------------------------------------------------------
+# Risky Port Detection
+# ---------------------------------------------------------------------------
+
+
+class TestRiskyPorts:
+    """Test detection of risky exposed ports."""
+
+    @pytest.mark.asyncio
+    async def test_database_port_flagged(self, scan_fn):
+        with patch("socket.gethostbyname", return_value="93.184.216.34"):
+            with patch(
+                "aden_tools.tools.port_scanner.port_scanner._check_port",
+                new_callable=AsyncMock,
+            ) as mock_check:
+                mock_check.return_value = {"open": True, "banner": ""}
+                result = await scan_fn("example.com", ports="3306")  # MySQL
+                assert result["open_ports"][0]["severity"] == "high"
+                assert "MySQL" in result["open_ports"][0]["finding"]
+                assert result["grade_input"]["no_database_ports_exposed"] is False
+
+    @pytest.mark.asyncio
+    async def test_admin_port_flagged(self, scan_fn):
+        with patch("socket.gethostbyname", return_value="93.184.216.34"):
+            with patch(
+                "aden_tools.tools.port_scanner.port_scanner._check_port",
+                new_callable=AsyncMock,
+            ) as mock_check:
+                mock_check.return_value = {"open": True, "banner": ""}
+                result = await scan_fn("example.com", ports="3389")  # RDP
+                assert result["open_ports"][0]["severity"] == "high"
+                assert result["grade_input"]["no_admin_ports_exposed"] is False
+
+    @pytest.mark.asyncio
+    async def test_legacy_port_flagged(self, scan_fn):
+        with patch("socket.gethostbyname", return_value="93.184.216.34"):
+            with patch(
+                "aden_tools.tools.port_scanner.port_scanner._check_port",
+                new_callable=AsyncMock,
+            ) as mock_check:
+                mock_check.return_value = {"open": True, "banner": ""}
+                result = await scan_fn("example.com", ports="23")  # Telnet
+                assert result["open_ports"][0]["severity"] == "medium"
+                assert result["grade_input"]["no_legacy_ports_exposed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Grade Input
+# ---------------------------------------------------------------------------
+
+
+class TestGradeInput:
+    """Test grade_input dict is properly constructed."""
+
+    @pytest.mark.asyncio
+    async def test_grade_input_keys_present(self, scan_fn):
+        with patch("socket.gethostbyname", return_value="93.184.216.34"):
+            with patch(
+                "aden_tools.tools.port_scanner.port_scanner._check_port",
+                new_callable=AsyncMock,
+            ) as mock_check:
+                mock_check.return_value = {"open": False}
+                result = await scan_fn("example.com", ports="80")
+                assert "grade_input" in result
+                grade = result["grade_input"]
+                assert "no_database_ports_exposed" in grade
+                assert "no_admin_ports_exposed" in grade
+                assert "no_legacy_ports_exposed" in grade
+                assert "only_web_ports" in grade
+
+    @pytest.mark.asyncio
+    async def test_only_web_ports_true(self, scan_fn):
+        with patch("socket.gethostbyname", return_value="93.184.216.34"):
+            with patch(
+                "aden_tools.tools.port_scanner.port_scanner._check_port",
+                new_callable=AsyncMock,
+            ) as mock_check:
+                # Only 80 and 443 open
+                async def check_port(ip, port, timeout):
+                    if port in (80, 443):
+                        return {"open": True, "banner": ""}
+                    return {"open": False}
+
+                mock_check.side_effect = check_port
+                result = await scan_fn("example.com", ports="22,80,443")
+                assert result["grade_input"]["only_web_ports"] is True
+
+    @pytest.mark.asyncio
+    async def test_only_web_ports_false(self, scan_fn):
+        with patch("socket.gethostbyname", return_value="93.184.216.34"):
+            with patch(
+                "aden_tools.tools.port_scanner.port_scanner._check_port",
+                new_callable=AsyncMock,
+            ) as mock_check:
+                # SSH port also open
+                async def check_port(ip, port, timeout):
+                    if port in (22, 80, 443):
+                        return {"open": True, "banner": ""}
+                    return {"open": False}
+
+                mock_check.side_effect = check_port
+                result = await scan_fn("example.com", ports="22,80,443")
+                assert result["grade_input"]["only_web_ports"] is False
+
+
+# ---------------------------------------------------------------------------
+# Top20/Top100 Port Lists
+# ---------------------------------------------------------------------------
+
+
+class TestPortLists:
+    """Test predefined port lists."""
+
+    @pytest.mark.asyncio
+    async def test_top20_ports(self, scan_fn):
+        with patch("socket.gethostbyname", return_value="93.184.216.34"):
+            with patch(
+                "aden_tools.tools.port_scanner.port_scanner._check_port",
+                new_callable=AsyncMock,
+            ) as mock_check:
+                mock_check.return_value = {"open": False}
+                result = await scan_fn("example.com", ports="top20")
+                assert result["ports_scanned"] == 20
+
+    @pytest.mark.asyncio
+    async def test_top100_ports(self, scan_fn):
+        with patch("socket.gethostbyname", return_value="93.184.216.34"):
+            with patch(
+                "aden_tools.tools.port_scanner.port_scanner._check_port",
+                new_callable=AsyncMock,
+            ) as mock_check:
+                mock_check.return_value = {"open": False}
+                result = await scan_fn("example.com", ports="top100")
+                assert result["ports_scanned"] > 20

--- a/tools/tests/tools/test_port_scanner.py
+++ b/tools/tests/tools/test_port_scanner.py
@@ -83,6 +83,7 @@ class TestInputValidation:
                 # Timeout > 10 should be clamped
                 result = await scan_fn("example.com", ports="80", timeout=100.0)
                 assert "error" not in result
+                assert mock_check.call_args[0][2] <= 10.0
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tests/tools/test_risk_scorer.py
+++ b/tools/tests/tools/test_risk_scorer.py
@@ -1,0 +1,316 @@
+"""Tests for Risk Scorer tool."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.risk_scorer import register_tools
+from aden_tools.tools.risk_scorer.risk_scorer import (
+    SSL_CHECKS,
+    _parse_json,
+    _score_category,
+    _score_to_grade,
+)
+
+
+@pytest.fixture
+def risk_tools(mcp: FastMCP):
+    """Register risk scorer tools and return tool functions."""
+    register_tools(mcp)
+    tools = mcp._tool_manager._tools
+    return {name: tools[name].fn for name in tools}
+
+
+@pytest.fixture
+def score_fn(risk_tools):
+    return risk_tools["risk_score"]
+
+
+# ---------------------------------------------------------------------------
+# Helper Function Tests
+# ---------------------------------------------------------------------------
+
+
+class TestScoreToGrade:
+    """Test _score_to_grade helper."""
+
+    def test_grade_a(self):
+        assert _score_to_grade(95) == "A"
+        assert _score_to_grade(90) == "A"
+
+    def test_grade_b(self):
+        assert _score_to_grade(85) == "B"
+        assert _score_to_grade(75) == "B"
+
+    def test_grade_c(self):
+        assert _score_to_grade(70) == "C"
+        assert _score_to_grade(60) == "C"
+
+    def test_grade_d(self):
+        assert _score_to_grade(55) == "D"
+        assert _score_to_grade(40) == "D"
+
+    def test_grade_f(self):
+        assert _score_to_grade(39) == "F"
+        assert _score_to_grade(0) == "F"
+
+
+class TestParseJson:
+    """Test _parse_json helper."""
+
+    def test_valid_json(self):
+        result = _parse_json('{"key": "value"}')
+        assert result == {"key": "value"}
+
+    def test_invalid_json(self):
+        result = _parse_json("not json")
+        assert result is None
+
+    def test_empty_string(self):
+        result = _parse_json("")
+        assert result is None
+
+    def test_whitespace_only(self):
+        result = _parse_json("   ")
+        assert result is None
+
+    def test_non_dict_json(self):
+        result = _parse_json("[1, 2, 3]")
+        assert result is None
+
+
+class TestScoreCategory:
+    """Test _score_category helper."""
+
+    def test_perfect_ssl_score(self):
+        grade_input = {
+            "tls_version_ok": True,
+            "cert_valid": True,
+            "cert_expiring_soon": False,  # inverted - False is good
+            "strong_cipher": True,
+            "self_signed": False,  # inverted - False is good
+        }
+        score, findings = _score_category(grade_input, SSL_CHECKS)
+        assert score == 100
+        assert len(findings) == 0
+
+    def test_failing_ssl_score(self):
+        grade_input = {
+            "tls_version_ok": False,
+            "cert_valid": False,
+            "cert_expiring_soon": True,  # inverted - True is bad
+            "strong_cipher": False,
+            "self_signed": True,  # inverted - True is bad
+        }
+        score, findings = _score_category(grade_input, SSL_CHECKS)
+        assert score == 0
+        assert len(findings) == 5
+
+    def test_missing_values_half_credit(self):
+        grade_input = {}  # All values missing
+        score, findings = _score_category(grade_input, SSL_CHECKS)
+        # Should get half credit for missing values
+        assert 45 <= score <= 55
+
+
+# ---------------------------------------------------------------------------
+# Full Scoring Flow
+# ---------------------------------------------------------------------------
+
+
+class TestFullScoring:
+    """Test full risk scoring."""
+
+    def test_empty_inputs_returns_zero(self, score_fn):
+        result = score_fn()
+        assert result["overall_score"] == 0
+        assert result["overall_grade"] == "F"
+
+    def test_all_categories_skipped(self, score_fn):
+        result = score_fn()
+        for cat in result["categories"].values():
+            assert cat["skipped"] is True
+
+    def test_ssl_results_only(self, score_fn):
+        ssl_data = {
+            "grade_input": {
+                "tls_version_ok": True,
+                "cert_valid": True,
+                "cert_expiring_soon": False,
+                "strong_cipher": True,
+                "self_signed": False,
+            }
+        }
+        result = score_fn(ssl_results=json.dumps(ssl_data))
+        assert result["categories"]["ssl_tls"]["score"] == 100
+        assert result["categories"]["ssl_tls"]["grade"] == "A"
+        assert result["categories"]["ssl_tls"]["skipped"] is False
+
+    def test_headers_results_only(self, score_fn):
+        headers_data = {
+            "grade_input": {
+                "hsts": True,
+                "csp": True,
+                "x_frame_options": True,
+                "x_content_type_options": True,
+                "referrer_policy": True,
+                "permissions_policy": True,
+                "no_leaky_headers": True,
+            }
+        }
+        result = score_fn(headers_results=json.dumps(headers_data))
+        assert result["categories"]["http_headers"]["score"] == 100
+        assert result["categories"]["http_headers"]["grade"] == "A"
+
+    def test_combined_results(self, score_fn):
+        ssl_data = {
+            "grade_input": {
+                "tls_version_ok": True,
+                "cert_valid": True,
+                "cert_expiring_soon": False,
+                "strong_cipher": True,
+                "self_signed": False,
+            }
+        }
+        headers_data = {
+            "grade_input": {
+                "hsts": True,
+                "csp": True,
+                "x_frame_options": True,
+                "x_content_type_options": True,
+                "referrer_policy": True,
+                "permissions_policy": True,
+                "no_leaky_headers": True,
+            }
+        }
+        result = score_fn(
+            ssl_results=json.dumps(ssl_data),
+            headers_results=json.dumps(headers_data),
+        )
+        # Both categories have perfect scores
+        assert result["categories"]["ssl_tls"]["score"] == 100
+        assert result["categories"]["http_headers"]["score"] == 100
+        # Overall should be 100 (weighted average of two 100s)
+        assert result["overall_score"] == 100
+        assert result["overall_grade"] == "A"
+
+
+# ---------------------------------------------------------------------------
+# Top Risks
+# ---------------------------------------------------------------------------
+
+
+class TestTopRisks:
+    """Test top_risks list generation."""
+
+    def test_top_risks_generated(self, score_fn):
+        ssl_data = {
+            "grade_input": {
+                "tls_version_ok": False,  # Failing
+                "cert_valid": True,
+                "cert_expiring_soon": False,
+                "strong_cipher": False,  # Failing
+                "self_signed": False,
+            }
+        }
+        result = score_fn(ssl_results=json.dumps(ssl_data))
+        assert len(result["top_risks"]) > 0
+        # Should mention TLS version and cipher issues
+        risks_text = " ".join(result["top_risks"])
+        assert "TLS" in risks_text or "cipher" in risks_text.lower()
+
+    def test_top_risks_limited_to_10(self, score_fn):
+        # Create data with many failures
+        ssl_data = {
+            "grade_input": {
+                "tls_version_ok": False,
+                "cert_valid": False,
+                "cert_expiring_soon": True,
+                "strong_cipher": False,
+                "self_signed": True,
+            }
+        }
+        headers_data = {
+            "grade_input": {
+                "hsts": False,
+                "csp": False,
+                "x_frame_options": False,
+                "x_content_type_options": False,
+                "referrer_policy": False,
+                "permissions_policy": False,
+                "no_leaky_headers": False,
+            }
+        }
+        dns_data = {
+            "grade_input": {
+                "spf_present": False,
+                "spf_strict": False,
+                "dmarc_present": False,
+                "dmarc_enforcing": False,
+                "dkim_found": False,
+                "dnssec_enabled": False,
+                "zone_transfer_blocked": False,
+            }
+        }
+        result = score_fn(
+            ssl_results=json.dumps(ssl_data),
+            headers_results=json.dumps(headers_data),
+            dns_results=json.dumps(dns_data),
+        )
+        # Should be capped at 10
+        assert len(result["top_risks"]) <= 10
+
+
+# ---------------------------------------------------------------------------
+# Grade Scale
+# ---------------------------------------------------------------------------
+
+
+class TestGradeScale:
+    """Test grade_scale is included in output."""
+
+    def test_grade_scale_present(self, score_fn):
+        result = score_fn()
+        assert "grade_scale" in result
+        assert "A" in result["grade_scale"]
+        assert "B" in result["grade_scale"]
+        assert "C" in result["grade_scale"]
+        assert "D" in result["grade_scale"]
+        assert "F" in result["grade_scale"]
+
+
+# ---------------------------------------------------------------------------
+# Category Weights
+# ---------------------------------------------------------------------------
+
+
+class TestCategoryWeights:
+    """Test category weights are applied correctly."""
+
+    def test_weights_included_in_output(self, score_fn):
+        ssl_data = {"grade_input": {"tls_version_ok": True}}
+        result = score_fn(ssl_results=json.dumps(ssl_data))
+        assert result["categories"]["ssl_tls"]["weight"] == 0.20
+
+
+# ---------------------------------------------------------------------------
+# Edge Cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Test edge cases and error handling."""
+
+    def test_invalid_json_ignored(self, score_fn):
+        result = score_fn(ssl_results="not valid json")
+        assert result["categories"]["ssl_tls"]["skipped"] is True
+
+    def test_missing_grade_input_key(self, score_fn):
+        # JSON without grade_input - should use the dict itself
+        data = {"tls_version_ok": True}
+        result = score_fn(ssl_results=json.dumps(data))
+        # Should not error
+        assert "overall_score" in result

--- a/tools/tests/tools/test_ssl_tls_scanner.py
+++ b/tools/tests/tools/test_ssl_tls_scanner.py
@@ -1,0 +1,274 @@
+"""Tests for SSL/TLS Scanner tool."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.ssl_tls_scanner import register_tools
+
+
+@pytest.fixture
+def ssl_tools(mcp: FastMCP):
+    """Register SSL/TLS tools and return tool functions."""
+    register_tools(mcp)
+    tools = mcp._tool_manager._tools
+    return {name: tools[name].fn for name in tools}
+
+
+@pytest.fixture
+def scan_fn(ssl_tools):
+    return ssl_tools["ssl_tls_scan"]
+
+
+def _mock_cert_dict(
+    days_until_expiry: int = 365,
+    subject: str = "example.com",
+    issuer: str = "Let's Encrypt",
+    san: list[str] | None = None,
+):
+    """Create a mock certificate dict."""
+    now = datetime.now(UTC)
+    not_before = now - timedelta(days=30)
+    not_after = now + timedelta(days=days_until_expiry)
+
+    return {
+        "subject": ((("commonName", subject),),),
+        "issuer": ((("commonName", issuer),),),
+        "notBefore": not_before.strftime("%b %d %H:%M:%S %Y GMT"),
+        "notAfter": not_after.strftime("%b %d %H:%M:%S %Y GMT"),
+        "subjectAltName": tuple(("DNS", s) for s in (san or [subject])),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Input Validation
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    """Test hostname input cleaning."""
+
+    def test_strips_https_prefix(self, scan_fn):
+        with patch("ssl.create_default_context") as mock_ctx:
+            mock_ctx.return_value.wrap_socket.side_effect = TimeoutError()
+            result = scan_fn("https://example.com")
+            assert "error" in result or result.get("hostname") == "example.com"
+
+    def test_strips_http_prefix(self, scan_fn):
+        with patch("ssl.create_default_context") as mock_ctx:
+            mock_ctx.return_value.wrap_socket.side_effect = TimeoutError()
+            result = scan_fn("http://example.com")
+            assert "error" in result or result.get("hostname") == "example.com"
+
+    def test_strips_path(self, scan_fn):
+        with patch("ssl.create_default_context") as mock_ctx:
+            mock_ctx.return_value.wrap_socket.side_effect = TimeoutError()
+            result = scan_fn("example.com/path/to/page")
+            assert "error" in result or result.get("hostname") == "example.com"
+
+    def test_strips_port_from_hostname(self, scan_fn):
+        with patch("ssl.create_default_context") as mock_ctx:
+            mock_ctx.return_value.wrap_socket.side_effect = TimeoutError()
+            result = scan_fn("example.com:8443")
+            assert "error" in result or result.get("hostname") == "example.com"
+
+
+# ---------------------------------------------------------------------------
+# Connection Errors
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionErrors:
+    """Test error handling for connection failures."""
+
+    def test_timeout_error(self, scan_fn):
+        with patch("ssl.create_default_context") as mock_ctx:
+            mock_conn = MagicMock()
+            mock_conn.connect.side_effect = TimeoutError()
+            mock_ctx.return_value.wrap_socket.return_value = mock_conn
+
+            result = scan_fn("example.com")
+            assert "error" in result
+            assert "timed out" in result["error"]
+
+    def test_connection_refused(self, scan_fn):
+        with patch("ssl.create_default_context") as mock_ctx:
+            mock_conn = MagicMock()
+            mock_conn.connect.side_effect = ConnectionRefusedError()
+            mock_ctx.return_value.wrap_socket.return_value = mock_conn
+
+            result = scan_fn("example.com")
+            assert "error" in result
+            assert "refused" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# TLS Version Detection
+# ---------------------------------------------------------------------------
+
+
+class TestTlsVersion:
+    """Test TLS version detection and validation."""
+
+    def test_tls13_ok(self, scan_fn):
+        with patch("ssl.create_default_context") as mock_ctx:
+            mock_conn = MagicMock()
+            mock_conn.version.return_value = "TLSv1.3"
+            mock_conn.cipher.return_value = ("TLS_AES_256_GCM_SHA384", "TLSv1.3", 256)
+            mock_conn.getpeercert.return_value = _mock_cert_dict()
+            mock_conn.getpeercert.side_effect = [
+                b"fake_der_cert",
+                _mock_cert_dict(),
+            ]
+            mock_ctx.return_value.wrap_socket.return_value = mock_conn
+
+            result = scan_fn("example.com")
+            assert result["tls_version"] == "TLSv1.3"
+            assert result["grade_input"]["tls_version_ok"] is True
+
+    def test_tls10_insecure(self, scan_fn):
+        with patch("ssl.create_default_context") as mock_ctx:
+            mock_conn = MagicMock()
+            mock_conn.version.return_value = "TLSv1"
+            mock_conn.cipher.return_value = ("AES256-SHA", "TLSv1", 256)
+            mock_conn.getpeercert.return_value = _mock_cert_dict()
+            mock_conn.getpeercert.side_effect = [
+                b"fake_der_cert",
+                _mock_cert_dict(),
+            ]
+            mock_ctx.return_value.wrap_socket.return_value = mock_conn
+
+            result = scan_fn("example.com")
+            assert result["grade_input"]["tls_version_ok"] is False
+            issues = [i["finding"] for i in result.get("issues", [])]
+            assert any("TLS version" in i for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# Cipher Suite Detection
+# ---------------------------------------------------------------------------
+
+
+class TestCipherSuite:
+    """Test cipher suite detection and validation."""
+
+    def test_strong_cipher(self, scan_fn):
+        with patch("ssl.create_default_context") as mock_ctx:
+            mock_conn = MagicMock()
+            mock_conn.version.return_value = "TLSv1.3"
+            mock_conn.cipher.return_value = ("TLS_AES_256_GCM_SHA384", "TLSv1.3", 256)
+            mock_conn.getpeercert.return_value = _mock_cert_dict()
+            mock_conn.getpeercert.side_effect = [
+                b"fake_der_cert",
+                _mock_cert_dict(),
+            ]
+            mock_ctx.return_value.wrap_socket.return_value = mock_conn
+
+            result = scan_fn("example.com")
+            assert result["grade_input"]["strong_cipher"] is True
+
+    def test_weak_cipher_rc4(self, scan_fn):
+        with patch("ssl.create_default_context") as mock_ctx:
+            mock_conn = MagicMock()
+            mock_conn.version.return_value = "TLSv1.2"
+            mock_conn.cipher.return_value = ("RC4-SHA", "TLSv1.2", 128)
+            mock_conn.getpeercert.return_value = _mock_cert_dict()
+            mock_conn.getpeercert.side_effect = [
+                b"fake_der_cert",
+                _mock_cert_dict(),
+            ]
+            mock_ctx.return_value.wrap_socket.return_value = mock_conn
+
+            result = scan_fn("example.com")
+            assert result["grade_input"]["strong_cipher"] is False
+
+
+# ---------------------------------------------------------------------------
+# Certificate Validation
+# ---------------------------------------------------------------------------
+
+
+class TestCertificateValidation:
+    """Test certificate validation checks."""
+
+    def test_valid_certificate(self, scan_fn):
+        with patch("ssl.create_default_context") as mock_ctx:
+            mock_conn = MagicMock()
+            mock_conn.version.return_value = "TLSv1.3"
+            mock_conn.cipher.return_value = ("TLS_AES_256_GCM_SHA384", "TLSv1.3", 256)
+            mock_conn.getpeercert.return_value = _mock_cert_dict(days_until_expiry=365)
+            mock_conn.getpeercert.side_effect = [
+                b"fake_der_cert",
+                _mock_cert_dict(days_until_expiry=365),
+            ]
+            mock_ctx.return_value.wrap_socket.return_value = mock_conn
+
+            result = scan_fn("example.com")
+            assert result["grade_input"]["cert_valid"] is True
+
+    def test_expiring_soon(self, scan_fn):
+        with patch("ssl.create_default_context") as mock_ctx:
+            mock_conn = MagicMock()
+            mock_conn.version.return_value = "TLSv1.3"
+            mock_conn.cipher.return_value = ("TLS_AES_256_GCM_SHA384", "TLSv1.3", 256)
+            mock_conn.getpeercert.return_value = _mock_cert_dict(days_until_expiry=15)
+            mock_conn.getpeercert.side_effect = [
+                b"fake_der_cert",
+                _mock_cert_dict(days_until_expiry=15),
+            ]
+            mock_ctx.return_value.wrap_socket.return_value = mock_conn
+
+            result = scan_fn("example.com")
+            assert result["grade_input"]["cert_expiring_soon"] is True
+
+    def test_self_signed_detected(self, scan_fn):
+        with patch("ssl.create_default_context") as mock_ctx:
+            mock_conn = MagicMock()
+            mock_conn.version.return_value = "TLSv1.3"
+            mock_conn.cipher.return_value = ("TLS_AES_256_GCM_SHA384", "TLSv1.3", 256)
+            # Self-signed: subject == issuer
+            mock_conn.getpeercert.return_value = _mock_cert_dict(
+                subject="example.com", issuer="example.com"
+            )
+            mock_conn.getpeercert.side_effect = [
+                b"fake_der_cert",
+                _mock_cert_dict(subject="example.com", issuer="example.com"),
+            ]
+            mock_ctx.return_value.wrap_socket.return_value = mock_conn
+
+            result = scan_fn("example.com")
+            assert result["grade_input"]["self_signed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Grade Input
+# ---------------------------------------------------------------------------
+
+
+class TestGradeInput:
+    """Test grade_input dict is properly constructed."""
+
+    def test_grade_input_keys_present(self, scan_fn):
+        with patch("ssl.create_default_context") as mock_ctx:
+            mock_conn = MagicMock()
+            mock_conn.version.return_value = "TLSv1.3"
+            mock_conn.cipher.return_value = ("TLS_AES_256_GCM_SHA384", "TLSv1.3", 256)
+            mock_conn.getpeercert.return_value = _mock_cert_dict()
+            mock_conn.getpeercert.side_effect = [
+                b"fake_der_cert",
+                _mock_cert_dict(),
+            ]
+            mock_ctx.return_value.wrap_socket.return_value = mock_conn
+
+            result = scan_fn("example.com")
+            assert "grade_input" in result
+            grade = result["grade_input"]
+            assert "tls_version_ok" in grade
+            assert "cert_valid" in grade
+            assert "cert_expiring_soon" in grade
+            assert "strong_cipher" in grade
+            assert "self_signed" in grade

--- a/tools/tests/tools/test_ssl_tls_scanner.py
+++ b/tools/tests/tools/test_ssl_tls_scanner.py
@@ -56,25 +56,28 @@ class TestInputValidation:
         with patch("ssl.create_default_context") as mock_ctx:
             mock_ctx.return_value.wrap_socket.side_effect = TimeoutError()
             result = scan_fn("https://example.com")
-            assert "error" in result or result.get("hostname") == "example.com"
+            assert "example.com" in result["error"]
+            assert "https://" not in result["error"]
 
     def test_strips_http_prefix(self, scan_fn):
         with patch("ssl.create_default_context") as mock_ctx:
             mock_ctx.return_value.wrap_socket.side_effect = TimeoutError()
             result = scan_fn("http://example.com")
-            assert "error" in result or result.get("hostname") == "example.com"
+            assert "example.com" in result["error"]
+            assert "http://" not in result["error"]
 
     def test_strips_path(self, scan_fn):
         with patch("ssl.create_default_context") as mock_ctx:
             mock_ctx.return_value.wrap_socket.side_effect = TimeoutError()
             result = scan_fn("example.com/path/to/page")
-            assert "error" in result or result.get("hostname") == "example.com"
+            assert "example.com" in result["error"]
+            assert "/path" not in result["error"]
 
     def test_strips_port_from_hostname(self, scan_fn):
         with patch("ssl.create_default_context") as mock_ctx:
             mock_ctx.return_value.wrap_socket.side_effect = TimeoutError()
             result = scan_fn("example.com:8443")
-            assert "error" in result or result.get("hostname") == "example.com"
+            assert "example.com:443" in result["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tests/tools/test_subdomain_enumerator.py
+++ b/tools/tests/tools/test_subdomain_enumerator.py
@@ -1,0 +1,294 @@
+"""Tests for Subdomain Enumerator tool."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.subdomain_enumerator import register_tools
+
+
+@pytest.fixture
+def subdomain_tools(mcp: FastMCP):
+    """Register subdomain enumeration tools and return tool functions."""
+    register_tools(mcp)
+    tools = mcp._tool_manager._tools
+    return {name: tools[name].fn for name in tools}
+
+
+@pytest.fixture
+def enumerate_fn(subdomain_tools):
+    return subdomain_tools["subdomain_enumerate"]
+
+
+def _mock_crtsh_response(subdomains: list[str], status_code: int = 200) -> MagicMock:
+    """Create a mock crt.sh response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = [{"name_value": sub} for sub in subdomains]
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Input Validation
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    """Test domain input cleaning."""
+
+    @pytest.mark.asyncio
+    async def test_strips_https_prefix(self, enumerate_fn):
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = _mock_crtsh_response([])
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await enumerate_fn("https://example.com")
+            assert result["domain"] == "example.com"
+
+    @pytest.mark.asyncio
+    async def test_strips_http_prefix(self, enumerate_fn):
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = _mock_crtsh_response([])
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await enumerate_fn("http://example.com")
+            assert result["domain"] == "example.com"
+
+    @pytest.mark.asyncio
+    async def test_strips_path(self, enumerate_fn):
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = _mock_crtsh_response([])
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await enumerate_fn("example.com/path")
+            assert result["domain"] == "example.com"
+
+    @pytest.mark.asyncio
+    async def test_max_results_clamped(self, enumerate_fn):
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = _mock_crtsh_response([])
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            # max_results should be clamped to 200
+            result = await enumerate_fn("example.com", max_results=500)
+            # Result should not error
+            assert "error" not in result
+
+
+# ---------------------------------------------------------------------------
+# Connection Errors
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionErrors:
+    """Test error handling for crt.sh failures."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_error(self, enumerate_fn):
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.side_effect = httpx.TimeoutException("timeout")
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await enumerate_fn("example.com")
+            assert "error" in result
+            assert "timed out" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_http_error(self, enumerate_fn):
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = _mock_crtsh_response([], status_code=500)
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await enumerate_fn("example.com")
+            assert "error" in result
+            assert "500" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Subdomain Discovery
+# ---------------------------------------------------------------------------
+
+
+class TestSubdomainDiscovery:
+    """Test subdomain extraction from CT logs."""
+
+    @pytest.mark.asyncio
+    async def test_subdomains_extracted(self, enumerate_fn):
+        subdomains = [
+            "www.example.com",
+            "api.example.com",
+            "mail.example.com",
+        ]
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = _mock_crtsh_response(subdomains)
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await enumerate_fn("example.com")
+            assert result["total_found"] == 3
+            assert "www.example.com" in result["subdomains"]
+            assert "api.example.com" in result["subdomains"]
+
+    @pytest.mark.asyncio
+    async def test_wildcards_filtered(self, enumerate_fn):
+        subdomains = [
+            "*.example.com",
+            "www.example.com",
+            "*.api.example.com",
+        ]
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = _mock_crtsh_response(subdomains)
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await enumerate_fn("example.com")
+            # Wildcards should be filtered out
+            assert "*.example.com" not in result["subdomains"]
+            assert "www.example.com" in result["subdomains"]
+
+    @pytest.mark.asyncio
+    async def test_duplicates_removed(self, enumerate_fn):
+        subdomains = [
+            "www.example.com",
+            "www.example.com",
+            "www.example.com",
+        ]
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = _mock_crtsh_response(subdomains)
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await enumerate_fn("example.com")
+            assert result["total_found"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Interesting Subdomain Detection
+# ---------------------------------------------------------------------------
+
+
+class TestInterestingSubdomains:
+    """Test detection of security-relevant subdomains."""
+
+    @pytest.mark.asyncio
+    async def test_staging_flagged(self, enumerate_fn):
+        subdomains = ["staging.example.com", "www.example.com"]
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = _mock_crtsh_response(subdomains)
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await enumerate_fn("example.com")
+            assert len(result["interesting"]) > 0
+            interesting_subs = [i["subdomain"] for i in result["interesting"]]
+            assert "staging.example.com" in interesting_subs
+
+    @pytest.mark.asyncio
+    async def test_admin_flagged(self, enumerate_fn):
+        subdomains = ["admin.example.com", "www.example.com"]
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = _mock_crtsh_response(subdomains)
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await enumerate_fn("example.com")
+            interesting_subs = [i["subdomain"] for i in result["interesting"]]
+            assert "admin.example.com" in interesting_subs
+
+    @pytest.mark.asyncio
+    async def test_dev_flagged(self, enumerate_fn):
+        subdomains = ["dev.example.com", "www.example.com"]
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = _mock_crtsh_response(subdomains)
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await enumerate_fn("example.com")
+            interesting_subs = [i["subdomain"] for i in result["interesting"]]
+            assert "dev.example.com" in interesting_subs
+
+
+# ---------------------------------------------------------------------------
+# Grade Input
+# ---------------------------------------------------------------------------
+
+
+class TestGradeInput:
+    """Test grade_input dict is properly constructed."""
+
+    @pytest.mark.asyncio
+    async def test_grade_input_keys_present(self, enumerate_fn):
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = _mock_crtsh_response([])
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await enumerate_fn("example.com")
+            assert "grade_input" in result
+            grade = result["grade_input"]
+            assert "no_dev_staging_exposed" in grade
+            assert "no_admin_exposed" in grade
+            assert "reasonable_surface_area" in grade
+
+    @pytest.mark.asyncio
+    async def test_no_dev_staging_true_when_clean(self, enumerate_fn):
+        subdomains = ["www.example.com", "api.example.com"]
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = _mock_crtsh_response(subdomains)
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await enumerate_fn("example.com")
+            assert result["grade_input"]["no_dev_staging_exposed"] is True
+
+    @pytest.mark.asyncio
+    async def test_reasonable_surface_area(self, enumerate_fn):
+        # Less than 50 subdomains = reasonable
+        subdomains = [f"sub{i}.example.com" for i in range(30)]
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = _mock_crtsh_response(subdomains)
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await enumerate_fn("example.com")
+            assert result["grade_input"]["reasonable_surface_area"] is True

--- a/tools/tests/tools/test_tech_stack_detector.py
+++ b/tools/tests/tools/test_tech_stack_detector.py
@@ -1,0 +1,269 @@
+"""Tests for Tech Stack Detector tool."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.tech_stack_detector import register_tools
+from aden_tools.tools.tech_stack_detector.tech_stack_detector import (
+    _detect_cdn,
+    _detect_cms_from_html,
+    _detect_js_libraries,
+    _detect_server,
+)
+
+
+@pytest.fixture
+def tech_tools(mcp: FastMCP):
+    """Register tech stack tools and return tool functions."""
+    register_tools(mcp)
+    tools = mcp._tool_manager._tools
+    return {name: tools[name].fn for name in tools}
+
+
+@pytest.fixture
+def detect_fn(tech_tools):
+    return tech_tools["tech_stack_detect"]
+
+
+class FakeHeaders:
+    """Minimal stand-in for httpx.Headers."""
+
+    def __init__(self, headers: dict):
+        self._headers = {k.lower(): v for k, v in headers.items()}
+
+    def get(self, name: str, default=None):
+        return self._headers.get(name.lower(), default)
+
+    def get_list(self, name: str) -> list[str]:
+        val = self._headers.get(name.lower())
+        if val is None:
+            return []
+        if isinstance(val, list):
+            return val
+        return [val]
+
+
+# ---------------------------------------------------------------------------
+# Helper Function Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetectServer:
+    """Test _detect_server helper."""
+
+    def test_server_with_version(self):
+        headers = FakeHeaders({"server": "nginx/1.21.0"})
+        result = _detect_server(headers)
+        assert result["name"] == "nginx"
+        assert result["version"] == "1.21.0"
+
+    def test_server_without_version(self):
+        headers = FakeHeaders({"server": "cloudflare"})
+        result = _detect_server(headers)
+        assert result["name"] == "cloudflare"
+        assert result["version"] is None
+
+    def test_no_server_header(self):
+        headers = FakeHeaders({})
+        result = _detect_server(headers)
+        assert result is None
+
+
+class TestDetectCdn:
+    """Test _detect_cdn helper."""
+
+    def test_cloudflare_detected(self):
+        headers = FakeHeaders({"cf-ray": "123abc"})
+        result = _detect_cdn(headers)
+        assert result == "Cloudflare"
+
+    def test_vercel_detected(self):
+        headers = FakeHeaders({"x-vercel-id": "abc123"})
+        result = _detect_cdn(headers)
+        assert result == "Vercel"
+
+    def test_no_cdn(self):
+        headers = FakeHeaders({"content-type": "text/html"})
+        result = _detect_cdn(headers)
+        assert result is None
+
+
+class TestDetectJsLibraries:
+    """Test _detect_js_libraries helper."""
+
+    def test_react_detected(self):
+        html = '<script src="/static/react.min.js"></script>'
+        result = _detect_js_libraries(html)
+        assert "React" in result
+
+    def test_jquery_detected(self):
+        html = '<script src="https://cdn.example.com/jquery-3.6.0.min.js"></script>'
+        result = _detect_js_libraries(html)
+        assert any("jQuery" in lib for lib in result)
+
+    def test_nextjs_detected(self):
+        html = '<script id="__NEXT_DATA__" type="application/json">{}</script>'
+        result = _detect_js_libraries(html)
+        assert "Next.js" in result
+
+    def test_no_libraries(self):
+        html = "<html><body>Simple page</body></html>"
+        result = _detect_js_libraries(html)
+        assert len(result) == 0
+
+
+class TestDetectCms:
+    """Test _detect_cms_from_html helper."""
+
+    def test_wordpress_detected(self):
+        html = '<link href="/wp-content/themes/theme/style.css">'
+        result = _detect_cms_from_html(html)
+        assert result == "WordPress"
+
+    def test_shopify_detected(self):
+        html = '<script src="https://cdn.shopify.com/s/files/1/theme.js"></script>'
+        result = _detect_cms_from_html(html)
+        assert result == "Shopify"
+
+    def test_drupal_detected(self):
+        html = '<script src="/core/misc/drupal.js"></script>'
+        result = _detect_cms_from_html(html)
+        assert result == "Drupal"
+
+    def test_no_cms(self):
+        html = "<html><body>Custom site</body></html>"
+        result = _detect_cms_from_html(html)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Connection Errors
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionErrors:
+    """Test error handling for connection failures."""
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self, detect_fn):
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.side_effect = httpx.ConnectError("Connection refused")
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await detect_fn("https://example.com")
+            assert "error" in result
+            assert "Connection failed" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_timeout_error(self, detect_fn):
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.side_effect = httpx.TimeoutException("timeout")
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await detect_fn("https://example.com")
+            assert "error" in result
+            assert "timed out" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Full Detection Flow
+# ---------------------------------------------------------------------------
+
+
+class TestFullDetection:
+    """Test full tech stack detection."""
+
+    def _mock_response(
+        self,
+        html: str = "<html></html>",
+        headers: dict | None = None,
+        cookies: dict | None = None,
+    ):
+        resp = MagicMock()
+        resp.text = html
+        resp.url = "https://example.com"
+        resp.headers = httpx.Headers(headers or {})
+        resp.cookies = httpx.Cookies(cookies or {})
+        return resp
+
+    @pytest.mark.asyncio
+    async def test_detects_server(self, detect_fn):
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = self._mock_response(headers={"server": "nginx/1.21.0"})
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await detect_fn("https://example.com")
+            assert result["server"]["name"] == "nginx"
+
+    @pytest.mark.asyncio
+    async def test_detects_framework(self, detect_fn):
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = self._mock_response(headers={"x-powered-by": "Express"})
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await detect_fn("https://example.com")
+            assert result["framework"] == "Express"
+
+
+# ---------------------------------------------------------------------------
+# Grade Input
+# ---------------------------------------------------------------------------
+
+
+class TestGradeInput:
+    """Test grade_input dict is properly constructed."""
+
+    def _mock_response(self, html: str = "<html></html>", headers: dict | None = None):
+        resp = MagicMock()
+        resp.text = html
+        resp.url = "https://example.com"
+        resp.headers = httpx.Headers(headers or {})
+        resp.cookies = httpx.Cookies()
+        return resp
+
+    @pytest.mark.asyncio
+    async def test_grade_input_keys_present(self, detect_fn):
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = self._mock_response()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await detect_fn("https://example.com")
+            assert "grade_input" in result
+            grade = result["grade_input"]
+            assert "server_version_hidden" in grade
+            assert "framework_version_hidden" in grade
+            assert "security_txt_present" in grade
+            assert "cookies_secure" in grade
+            assert "cookies_httponly" in grade
+
+    @pytest.mark.asyncio
+    async def test_server_version_exposed(self, detect_fn):
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = self._mock_response(headers={"server": "Apache/2.4.41"})
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await detect_fn("https://example.com")
+            assert result["grade_input"]["server_version_hidden"] is False


### PR DESCRIPTION
## Description

Adds dedicated unit test files for all 7 security scanning tools as requested in #5920.

Fixes #5920

## Test Files Added

| File | Tests | Tool |
|------|-------|------|
| `test_dns_security_scanner.py` | 12 | DNS security scanner |
| `test_http_headers_scanner.py` | 13 | HTTP headers scanner |
| `test_ssl_tls_scanner.py` | 14 | SSL/TLS scanner |
| `test_subdomain_enumerator.py` | 15 | Subdomain enumerator |
| `test_port_scanner.py` | 17 | Port scanner |
| `test_tech_stack_detector.py` | 20 | Tech stack detector |
| `test_risk_scorer.py` | 24 | Risk scorer |

**Total: 115 new tests**

## Test Coverage

Each test file covers:
- Input validation and URL/domain cleaning
- Connection error handling (timeouts, connection refused)
- Core scanning logic with mocked network responses
- Grade/risk calculation logic
- Edge cases

## Testing
```bash
pytest tools/tests/tools/test_dns_security_scanner.py tools/tests/tools/test_http_headers_scanner.py tools/tests/tools/test_ssl_tls_scanner.py tools/tests/tools/test_subdomain_enumerator.py tools/tests/tools/test_port_scanner.py tools/tests/tools/test_tech_stack_detector.py tools/tests/tools/test_risk_scorer.py -v
# 115 passed
```

## Checklist

- [x] Code follows project style guidelines
- [x] Lint passes (`ruff check` / `ruff format`)
- [x] All 115 tests pass locally
- [x] Self-reviewed