### PR TITLE
fix(credentials): improve exception handling in key_storage.py

### DIFF
--- a/core/framework/credentials/key_storage.py
+++ b/core/framework/credentials/key_storage.py
@@ -149,8 +149,14 @@ def delete_aden_api_key() -> None:
 
         storage = EncryptedFileStorage()
         storage.delete(ADEN_CREDENTIAL_ID)
+    except (FileNotFoundError, PermissionError) as e:
+        logger.debug("Could not delete %s from encrypted store: %s", ADEN_CREDENTIAL_ID, e)
     except Exception:
-        logger.debug("Could not delete %s from encrypted store", ADEN_CREDENTIAL_ID)
+        logger.warning(
+            "Unexpected error deleting %s from encrypted store",
+            ADEN_CREDENTIAL_ID,
+            exc_info=True,
+        )
 
     os.environ.pop(ADEN_ENV_VAR, None)
 
@@ -167,8 +173,10 @@ def _read_credential_key_file() -> str | None:
             value = CREDENTIAL_KEY_PATH.read_text(encoding="utf-8").strip()
             if value:
                 return value
+    except (FileNotFoundError, PermissionError) as e:
+        logger.debug("Could not read %s: %s", CREDENTIAL_KEY_PATH, e)
     except Exception:
-        logger.debug("Could not read %s", CREDENTIAL_KEY_PATH)
+        logger.warning("Unexpected error reading %s", CREDENTIAL_KEY_PATH, exc_info=True)
     return None
 
 
@@ -196,6 +204,12 @@ def _read_aden_from_encrypted_store() -> str | None:
         cred = storage.load(ADEN_CREDENTIAL_ID)
         if cred:
             return cred.get_key("api_key")
+    except (FileNotFoundError, PermissionError, KeyError) as e:
+        logger.debug("Could not load %s from encrypted store: %s", ADEN_CREDENTIAL_ID, e)
     except Exception:
-        logger.debug("Could not load %s from encrypted store", ADEN_CREDENTIAL_ID)
+        logger.warning(
+            "Unexpected error loading %s from encrypted store",
+            ADEN_CREDENTIAL_ID,
+            exc_info=True,
+        )
     return None


### PR DESCRIPTION
## Description

Improves exception handling in `key_storage.py` by replacing bare `except Exception:` clauses with specific exception types and better logging.

Fixes #5931

## Problem

The bare `except Exception:` clauses were silently swallowing errors with only debug-level logging, making credential issues hard to diagnose in production.

## Solution

Replace bare exception handlers with a two-tier approach:

| Function | Expected Errors (DEBUG) | Unexpected Errors (WARNING) |
|----------|------------------------|----------------------------|
| `delete_aden_api_key()` | `FileNotFoundError`, `PermissionError` | All others with `exc_info=True` |
| `_read_credential_key_file()` | `FileNotFoundError`, `PermissionError` | All others with `exc_info=True` |
| `_read_aden_from_encrypted_store()` | `FileNotFoundError`, `PermissionError`, `KeyError` | All others with `exc_info=True` |

## Benefits

- **Unexpected errors are now visible** - logged at WARNING level with full stack trace
- **Expected failures stay quiet** - file not found, permission errors stay at DEBUG
- **Easier debugging** - `exc_info=True` provides full traceback for unexpected issues

## Testing

- Lint passes (`ruff check` / `ruff format`)
- Self-reviewed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed
- [x] Lint passes