### PR TITLE
fix: validate duplicate edge IDs, unconditional self-loops, and missing condition_expr

### DIFF
--- a/core/framework/graph/edge.py
+++ b/core/framework/graph/edge.py
@@ -630,12 +630,33 @@ class GraphSpec(BaseModel):
                 "Consider adding a termination point where execution ends."
             )
 
+        # Check for duplicate edge IDs
+        seen_edge_ids: set[str] = set()
+        for edge in self.edges:
+            if edge.id in seen_edge_ids:
+                errors.append(f"Duplicate edge ID: '{edge.id}'")
+            seen_edge_ids.add(edge.id)
+
         # Check edge references
         for edge in self.edges:
             if not self.get_node(edge.source):
                 errors.append(f"Edge '{edge.id}' references missing source '{edge.source}'")
             if not self.get_node(edge.target):
                 errors.append(f"Edge '{edge.id}' references missing target '{edge.target}'")
+
+            # Warn on unconditional self-loops
+            if edge.source == edge.target and edge.condition == EdgeCondition.ALWAYS:
+                warnings.append(
+                    f"Edge '{edge.id}' is an unconditional self-loop on '{edge.source}'. "
+                    "This will loop until max_steps is reached."
+                )
+
+            # Error on CONDITIONAL edges without condition_expr
+            if edge.condition == EdgeCondition.CONDITIONAL and not edge.condition_expr:
+                errors.append(
+                    f"Edge '{edge.id}' has condition=CONDITIONAL but no condition_expr. "
+                    "The edge will never fire."
+                )
 
         # Check for unreachable nodes
         # Start with main entry node and all entry points (for pause/resume architecture)

--- a/core/tests/test_edge_validation.py
+++ b/core/tests/test_edge_validation.py
@@ -1,0 +1,127 @@
+"""
+Tests for edge validation checks in GraphSpec.validate().
+
+Validates three rules:
+1. Duplicate edge IDs are flagged as errors.
+2. Unconditional self-loops (source == target, condition=ALWAYS) produce a warning.
+3. CONDITIONAL edges without condition_expr are flagged as errors.
+"""
+
+from framework.graph.edge import EdgeCondition, EdgeSpec, GraphSpec
+from framework.graph.node import NodeSpec
+
+
+def _make_nodes(*ids: str) -> list[NodeSpec]:
+    return [NodeSpec(id=nid, name=nid, description="test") for nid in ids]
+
+
+class TestDuplicateEdgeIds:
+    """Duplicate edge IDs should be flagged."""
+
+    def test_duplicate_edge_ids_error(self):
+        graph = GraphSpec(
+            id="g",
+            goal_id="goal",
+            entry_node="a",
+            nodes=_make_nodes("a", "b"),
+            edges=[
+                EdgeSpec(id="e1", source="a", target="b", condition=EdgeCondition.ALWAYS),
+                EdgeSpec(id="e1", source="b", target="a", condition=EdgeCondition.ALWAYS),
+            ],
+        )
+        errors = graph.validate()["errors"]
+        dup_errors = [e for e in errors if "Duplicate edge ID" in e]
+        assert len(dup_errors) == 1
+        assert "'e1'" in dup_errors[0]
+
+    def test_unique_edge_ids_pass(self):
+        graph = GraphSpec(
+            id="g",
+            goal_id="goal",
+            entry_node="a",
+            nodes=_make_nodes("a", "b"),
+            edges=[
+                EdgeSpec(id="e1", source="a", target="b", condition=EdgeCondition.ALWAYS),
+                EdgeSpec(id="e2", source="b", target="a", condition=EdgeCondition.ALWAYS),
+            ],
+        )
+        errors = graph.validate()["errors"]
+        dup_errors = [e for e in errors if "Duplicate edge ID" in e]
+        assert len(dup_errors) == 0
+
+
+class TestUnconditionalSelfLoop:
+    """Unconditional self-loops should produce a warning."""
+
+    def test_always_self_loop_warning(self):
+        graph = GraphSpec(
+            id="g",
+            goal_id="goal",
+            entry_node="a",
+            nodes=_make_nodes("a"),
+            edges=[
+                EdgeSpec(id="loop", source="a", target="a", condition=EdgeCondition.ALWAYS),
+            ],
+        )
+        warnings = graph.validate()["warnings"]
+        loop_warnings = [w for w in warnings if "unconditional self-loop" in w]
+        assert len(loop_warnings) == 1
+        assert "'a'" in loop_warnings[0]
+
+    def test_conditional_self_loop_no_warning(self):
+        graph = GraphSpec(
+            id="g",
+            goal_id="goal",
+            entry_node="a",
+            nodes=_make_nodes("a"),
+            edges=[
+                EdgeSpec(
+                    id="loop",
+                    source="a",
+                    target="a",
+                    condition=EdgeCondition.CONDITIONAL,
+                    condition_expr="output.retry == true",
+                ),
+            ],
+        )
+        warnings = graph.validate()["warnings"]
+        loop_warnings = [w for w in warnings if "unconditional self-loop" in w]
+        assert len(loop_warnings) == 0
+
+
+class TestConditionalWithoutExpr:
+    """CONDITIONAL edges without condition_expr should be flagged."""
+
+    def test_conditional_no_expr_error(self):
+        graph = GraphSpec(
+            id="g",
+            goal_id="goal",
+            entry_node="a",
+            nodes=_make_nodes("a", "b"),
+            edges=[
+                EdgeSpec(id="e", source="a", target="b", condition=EdgeCondition.CONDITIONAL),
+            ],
+        )
+        errors = graph.validate()["errors"]
+        expr_errors = [e for e in errors if "no condition_expr" in e]
+        assert len(expr_errors) == 1
+
+    def test_conditional_with_expr_pass(self):
+        graph = GraphSpec(
+            id="g",
+            goal_id="goal",
+            entry_node="a",
+            nodes=_make_nodes("a", "b"),
+            edges=[
+                EdgeSpec(
+                    id="e",
+                    source="a",
+                    target="b",
+                    condition=EdgeCondition.CONDITIONAL,
+                    condition_expr="output.confidence < 0.8",
+                ),
+            ],
+        )
+        errors = graph.validate()["errors"]
+        expr_errors = [e for e in errors if "no condition_expr" in e]
+        assert len(expr_errors) == 0


### PR DESCRIPTION
## Summary
- **Duplicate edge IDs**: Flag as error — executor uses edge IDs for logging and checkpoints, so duplicates cause confusion
- **Unconditional self-loops**: Warn when `source == target` with `condition=ALWAYS` — almost always a typo that loops until `max_steps`
- **CONDITIONAL without `condition_expr`**: Flag as error — the edge silently never fires, which is confusing to debug

All three checks are added to the existing edge-reference loop in `GraphSpec.validate()`.

Closes #6090

## Test plan
- [x] 6 new tests in `core/tests/test_edge_validation.py` (all pass)
- [x] Duplicate edge IDs detected
- [x] Unique edge IDs pass cleanly
- [x] ALWAYS self-loop produces warning
- [x] CONDITIONAL self-loop does NOT produce warning
- [x] CONDITIONAL without expr flagged as error
- [x] CONDITIONAL with expr passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)