### PR TITLE
fix(session): exclude CANCELLED sessions from is_resumable

### DIFF
--- a/core/framework/schemas/session_state.py
+++ b/core/framework/schemas/session_state.py
@@ -165,7 +165,7 @@ class SessionState(BaseModel):
         aren't set, the executor falls back to the graph entry point —
         so we don't gate on those. Even catastrophic failures are resumable.
         """
-        return self.status != SessionStatus.COMPLETED
+        return self.status not in (SessionStatus.COMPLETED, SessionStatus.CANCELLED)
 
     @computed_field
     @property


### PR DESCRIPTION
## Description
Fix `is_resumable` to return `False` for `CANCELLED` sessions. Previously only `COMPLETED` was excluded, allowing cancelled sessions to be incorrectly resumed.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
Fixes #(issue number)

## Changes Made
- Updated `is_resumable` in `core/framework/schemas/session_state.py` to exclude `CANCELLED` alongside `COMPLETED`

## Testing
Describe the tests you ran to verify your changes:
- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Add screenshots to demonstrate UI changes.