### PR TITLE
docs: clarify hive open requires repo root and PATH setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This sets up:
 
 - At last, it will initiate the open hive interface in your browser
 
-> **Tip:** To reopen the dashboard later, run `hive open` from the project directory.
+> **Tip:** To reopen the dashboard later, run `hive open` from the repo root directory. If `hive` is not found, run `source $HOME/.local/bin/env` first.
 
 <img width="2500" height="1214" alt="home-screen" src="https://github.com/user-attachments/assets/134d897f-5e75-4874-b00b-e0505f6b45c4" />
 


### PR DESCRIPTION
Fixes #6176

## What changed
Updated README tip to clarify that `hive open` must be 
run from the repo root directory, and added a note about 
PATH setup if `hive` command is not found.

## Before
"run `hive open` from the project directory"

## After  
"run `hive open` from the repo root directory. 
If `hive` is not found, run `source $HOME/.local/bin/env` first"

## Type
- [x] Documentation fix