### PR TITLE
feat: add light/dark mode toggle to web UI

### DIFF
--- a/core/frontend/src/components/ThemeToggle.tsx
+++ b/core/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,16 @@
+import { Sun, Moon } from "lucide-react";
+import { useTheme } from "../context/ThemeContext";
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors flex-shrink-0"
+      aria-label="Toggle dark mode"
+    >
+      {theme === "dark" ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+    </button>
+  );
+}

--- a/core/frontend/src/components/TopBar.tsx
+++ b/core/frontend/src/components/TopBar.tsx
@@ -1,8 +1,9 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
-import { Crown, X, Sun, Moon } from "lucide-react";
+import { Crown, X } from "lucide-react";
 import { loadPersistedTabs, savePersistedTabs, TAB_STORAGE_KEY, type PersistedTabState } from "@/lib/tab-persistence";
 import { sessionsApi } from "@/api/sessions";
+import { ThemeToggle } from "./ThemeToggle";
 
 export interface TopBarTab {
   agentType: string;
@@ -24,38 +25,6 @@ interface TopBarProps {
   afterTabs?: React.ReactNode;
   /** Right-side slot for page-specific controls (e.g. credentials). */
   children?: React.ReactNode;
-}
-
-function ThemeToggle() {
-  const [isDark, setIsDark] = useState(() => {
-    if (typeof window !== "undefined") {
-      return (
-        localStorage.theme === "dark" ||
-        (!("theme" in localStorage) && window.matchMedia("(prefers-color-scheme: dark)").matches)
-      );
-    }
-    return false;
-  });
-
-  useEffect(() => {
-    if (isDark) {
-      document.documentElement.classList.add("dark");
-      localStorage.setItem("theme", "dark");
-    } else {
-      document.documentElement.classList.remove("dark");
-      localStorage.setItem("theme", "light");
-    }
-  }, [isDark]);
-
-  return (
-    <button
-      onClick={() => setIsDark(!isDark)}
-      className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors flex-shrink-0"
-      aria-label="Toggle dark mode"
-    >
-      {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
-    </button>
-  );
 }
 
 export default function TopBar({ tabs: tabsProp, onTabClick, onCloseTab, canCloseTabs, afterTabs, children }: TopBarProps) {

--- a/core/frontend/src/components/TopBar.tsx
+++ b/core/frontend/src/components/TopBar.tsx
@@ -1,6 +1,6 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { Crown, X } from "lucide-react";
+import { Crown, X, Sun, Moon } from "lucide-react";
 import { loadPersistedTabs, savePersistedTabs, TAB_STORAGE_KEY, type PersistedTabState } from "@/lib/tab-persistence";
 import { sessionsApi } from "@/api/sessions";
 
@@ -24,6 +24,38 @@ interface TopBarProps {
   afterTabs?: React.ReactNode;
   /** Right-side slot for page-specific controls (e.g. credentials). */
   children?: React.ReactNode;
+}
+
+function ThemeToggle() {
+  const [isDark, setIsDark] = useState(() => {
+    if (typeof window !== "undefined") {
+      return (
+        localStorage.theme === "dark" ||
+        (!("theme" in localStorage) && window.matchMedia("(prefers-color-scheme: dark)").matches)
+      );
+    }
+    return false;
+  });
+
+  useEffect(() => {
+    if (isDark) {
+      document.documentElement.classList.add("dark");
+      localStorage.setItem("theme", "dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+      localStorage.setItem("theme", "light");
+    }
+  }, [isDark]);
+
+  return (
+    <button
+      onClick={() => setIsDark(!isDark)}
+      className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors flex-shrink-0"
+      aria-label="Toggle dark mode"
+    >
+      {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+    </button>
+  );
 }
 
 export default function TopBar({ tabs: tabsProp, onTabClick, onCloseTab, canCloseTabs, afterTabs, children }: TopBarProps) {
@@ -51,13 +83,13 @@ export default function TopBar({ tabs: tabsProp, onTabClick, onCloseTab, canClos
       onCloseTab(agentType);
       return;
     }
-    // Kill the backend session (queen/judge/worker) even outside workspace
+     // Kill the backend session (queen/judge/worker) even outside workspace
     sessionsApi.list()
       .then(({ sessions }) => {
         const match = sessions.find(s => s.agent_path === agentType);
         if (match) return sessionsApi.stop(match.session_id);
       })
-      .catch(() => {});  // fire-and-forget
+      .catch(() => {}); // fire-and-forget
 
     // Fallback: update localStorage directly (non-workspace pages)
     setPersisted(prev => {
@@ -129,11 +161,14 @@ export default function TopBar({ tabs: tabsProp, onTabClick, onCloseTab, canClos
         )}
       </div>
 
-      {children && (
-        <div className="flex items-center gap-1 flex-shrink-0">
-          {children}
-        </div>
-      )}
+      <div className="flex items-center gap-2 flex-shrink-0">
+        <ThemeToggle />
+        {children && (
+          <div className="flex items-center gap-1 flex-shrink-0">
+            {children}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/core/frontend/src/context/ThemeContext.tsx
+++ b/core/frontend/src/context/ThemeContext.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window !== "undefined") {
+      const saved = localStorage.getItem("theme") as Theme | null;
+      if (saved === "light" || saved === "dark") return saved;
+      return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+    return "light";
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    root.classList.remove("light", "dark");
+    root.classList.add(theme);
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((prev) => (prev === "light" ? "dark" : "light"));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within a ThemeProvider");
+  return ctx;
+}

--- a/core/frontend/src/main.tsx
+++ b/core/frontend/src/main.tsx
@@ -1,10 +1,13 @@
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import { ThemeProvider } from "./context/ThemeContext";
 import App from "./App";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>
+  <ThemeProvider>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </ThemeProvider>
 );


### PR DESCRIPTION
## Description
Added a native Light/Dark mode toggle to the `TopBar` component to handle UI theming.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Related Issues
Fixes #6035

## Changes Made
- Created a `<ThemeToggle />` component inside `TopBar.tsx`.
- Integrated `lucide-react` Sun/Moon icons for the UI.
- Added state management to toggle the `.dark` class on the document root.
- Persisted user theme preference in `localStorage`.
- Added fallback to respect system-level `prefers-color-scheme` on initial load.

## Testing
- [x] Manual testing performed: Verified toggle successfully updates DOM class, switches icons, and persists in localStorage across reloads.
- [ ] Lint passes (Pending CI)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code