### PR TITLE
fix: validate --input-file is not a directory before execution

### DIFF
--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -397,6 +397,13 @@ def cmd_run(args: argparse.Namespace) -> int:
             print(f"Error parsing --input JSON: {e}", file=sys.stderr)
             return 1
     elif args.input_file:
+        input_path = Path(args.input_file)
+        if input_path.is_dir():
+            print(
+                f"Error: input file is a directory, not a file: {args.input_file}",
+                file=sys.stderr,
+            )
+            return 1
         try:
             with open(args.input_file, encoding="utf-8") as f:
                 context = json.load(f)


### PR DESCRIPTION
## Description

Add a preflight validation check for the `--input-file` argument in `cmd_run` to detect when a directory path is passed instead of a file path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #6207

## Changes Made

- Added `Path.is_dir()` check before opening `--input-file` in `cmd_run`
- Returns a clear error message (`Error: input file is a directory, not a file: <path>`) and exits with code 1
- Check runs before any agent loading or execution begins (fail-fast)

## Testing

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes