### PR TITLE
fix(headless): fix agent deadlock and runaway retries in non-TTY mode

### DIFF
--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -117,6 +117,11 @@ if litellm is not None:
 RATE_LIMIT_MAX_RETRIES = 10
 RATE_LIMIT_BACKOFF_BASE = 2  # seconds
 RATE_LIMIT_MAX_DELAY = 120  # seconds - cap to prevent absurd waits
+# Total wall-clock budget for all rate-limit retries in a single stream call.
+# With 10 retries × up to 120 s each the uncapped worst case is ~20 min per
+# call; three node-layer stream retries multiply that to ~60 min.  This cap
+# guarantees the streaming retry loop gives up after at most 5 minutes total.
+RATE_LIMIT_MAX_RETRY_WALL_TIME = 300  # seconds
 MINIMAX_API_BASE = "https://api.minimax.io/v1"
 # Kimi For Coding uses an Anthropic-compatible endpoint (no /v1 suffix).
 # Claude Code integration uses this format; the /v1 OpenAI-compatible endpoint
@@ -927,6 +932,7 @@ class LiteLLMProvider(LLMProvider):
             kwargs.pop("max_tokens", None)
             kwargs.pop("stream_options", None)
 
+        _retry_start = time.monotonic()
         for attempt in range(RATE_LIMIT_MAX_RETRIES + 1):
             # Post-stream events (ToolCall, TextEnd, Finish) are buffered
             # because they depend on the full stream.  TextDeltaEvents are
@@ -1101,26 +1107,39 @@ class LiteLLMProvider(LLMProvider):
                 return
 
             except RateLimitError as e:
-                if attempt < RATE_LIMIT_MAX_RETRIES:
+                elapsed = time.monotonic() - _retry_start
+                if attempt < RATE_LIMIT_MAX_RETRIES and elapsed < RATE_LIMIT_MAX_RETRY_WALL_TIME:
                     wait = _compute_retry_delay(attempt, exception=e)
                     logger.warning(
                         f"[stream-retry] {self.model} rate limited (429): {e!s}. "
                         f"Retrying in {wait:.1f}s "
-                        f"(attempt {attempt + 1}/{RATE_LIMIT_MAX_RETRIES})"
+                        f"(attempt {attempt + 1}/{RATE_LIMIT_MAX_RETRIES}, "
+                        f"elapsed {elapsed:.0f}s/{RATE_LIMIT_MAX_RETRY_WALL_TIME}s)"
                     )
                     await asyncio.sleep(wait)
                     continue
+                if elapsed >= RATE_LIMIT_MAX_RETRY_WALL_TIME:
+                    logger.warning(
+                        f"[stream-retry] {self.model} rate-limit retry budget exhausted "
+                        f"({elapsed:.0f}s >= {RATE_LIMIT_MAX_RETRY_WALL_TIME}s). Giving up."
+                    )
                 yield StreamErrorEvent(error=str(e), recoverable=False)
                 return
 
             except Exception as e:
-                if _is_stream_transient_error(e) and attempt < RATE_LIMIT_MAX_RETRIES:
+                elapsed = time.monotonic() - _retry_start
+                if (
+                    _is_stream_transient_error(e)
+                    and attempt < RATE_LIMIT_MAX_RETRIES
+                    and elapsed < RATE_LIMIT_MAX_RETRY_WALL_TIME
+                ):
                     wait = _compute_retry_delay(attempt, exception=e)
                     logger.warning(
                         f"[stream-retry] {self.model} transient error "
                         f"({type(e).__name__}): {e!s}. "
                         f"Retrying in {wait:.1f}s "
-                        f"(attempt {attempt + 1}/{RATE_LIMIT_MAX_RETRIES})"
+                        f"(attempt {attempt + 1}/{RATE_LIMIT_MAX_RETRIES}, "
+                        f"elapsed {elapsed:.0f}s/{RATE_LIMIT_MAX_RETRY_WALL_TIME}s)"
                     )
                     await asyncio.sleep(wait)
                     continue

--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -71,6 +71,15 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         default=None,
         help="Resume from a specific checkpoint (requires --resume-session)",
     )
+    run_parser.add_argument(
+        "--non-interactive",
+        "-n",
+        action="store_true",
+        help=(
+            "Fail immediately if the agent has client_facing nodes that require "
+            "interactive input. Use `hive tui` for interactive agents."
+        ),
+    )
     run_parser.set_defaults(func=cmd_run)
 
     # info command
@@ -434,6 +443,20 @@ def cmd_run(args: argparse.Namespace) -> int:
     except FileNotFoundError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
+
+    # Fail fast if --non-interactive is set and the agent has client_facing nodes
+    if getattr(args, "non_interactive", False):
+        interactive_nodes = [n.name for n in runner.graph.nodes if n.client_facing]
+        if interactive_nodes:
+            nodes_str = ", ".join(interactive_nodes)
+            print(
+                f"Error: This agent has interactive nodes ({nodes_str}) and cannot "
+                "run in non-interactive mode.\n"
+                "  Use `hive tui` for interactive sessions.\n"
+                "  To run headlessly, set client_facing=False in your agent definition.",
+                file=sys.stderr,
+            )
+            return 1
 
     # Prompt before starting (allows credential updates)
     if sys.stdin.isatty() and not args.quiet:

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -1574,7 +1574,14 @@ class AgentRunner:
         has_client_facing = any(n.client_facing for n in self.graph.nodes)
         sub_ids: list[str] = []
 
-        if has_client_facing and sys.stdin.isatty():
+        if has_client_facing and not sys.stdin.isatty():
+            logger.warning(
+                "Agent has client-facing nodes but stdin is not a terminal. "
+                "Input will be read from stdin (pipe/redirect). "
+                "If the agent hangs, it is waiting for user input on stdin."
+            )
+
+        if has_client_facing:
             from framework.runtime.event_bus import EventType
 
             runtime = self._agent_runtime
@@ -1594,10 +1601,15 @@ class AgentRunner:
                     loop = asyncio.get_event_loop()
                     user_input = await loop.run_in_executor(None, input, "\n>>> ")
                 except EOFError:
-                    user_input = ""
+                    logger.warning(
+                        "stdin reached EOF (non-TTY mode). "
+                        "This agent requires interactive input. Use `hive tui` instead."
+                    )
+                    runtime.signal_node_shutdown(node_id)
+                    return
 
                 # Inject into the waiting EventLoopNode via runtime
-                await runtime.inject_input(node_id, user_input)
+                await runtime.inject_input(node_id, user_input, is_client_input=True)
 
             sub_ids.append(
                 runtime.subscribe_to_events(

--- a/core/framework/runtime/agent_runtime.py
+++ b/core/framework/runtime/agent_runtime.py
@@ -1442,6 +1442,25 @@ class AgentRuntime:
                     return True
         return False
 
+    def signal_node_shutdown(self, node_id: str) -> bool:
+        """Signal a specific node to exit its loop cleanly.
+
+        Used when stdin hits EOF in non-TTY mode to avoid degraded empty-string loops.
+        Returns True if the node was found and signaled.
+        """
+        target = self._active_graph_id
+        if target in self._graphs:
+            for stream in self._graphs[target].streams.values():
+                if stream.signal_node_shutdown(node_id):
+                    return True
+        for gid, reg in self._graphs.items():
+            if gid == target:
+                continue
+            for stream in reg.streams.values():
+                if stream.signal_node_shutdown(node_id):
+                    return True
+        return False
+
     async def get_goal_progress(self) -> dict[str, Any]:
         """
         Evaluate goal progress across all streams.

--- a/core/framework/runtime/execution_stream.py
+++ b/core/framework/runtime/execution_stream.py
@@ -425,6 +425,18 @@ class ExecutionStream:
                 return True
         return False
 
+    def signal_node_shutdown(self, node_id: str) -> bool:
+        """Signal a specific EventLoopNode to exit cleanly (e.g. on EOF).
+
+        Returns True if the node was found and signaled, False otherwise.
+        """
+        for executor in self._active_executors.values():
+            node = executor.node_registry.get(node_id)
+            if node is not None and hasattr(node, "signal_shutdown"):
+                node.signal_shutdown()
+                return True
+        return False
+
     async def execute(
         self,
         input_data: dict[str, Any],

--- a/core/tests/test_headless_input_fix.py
+++ b/core/tests/test_headless_input_fix.py
@@ -1,0 +1,504 @@
+"""Tests for the headless (non-TTY) input deadlock fix.
+
+Bug: runner.py gated stdin handler registration behind sys.stdin.isatty().
+In non-TTY environments (CI, piped stdin, WSL2), the handler was never
+registered, so CLIENT_INPUT_REQUESTED had no responder and _await_user_input()
+blocked on an asyncio.Event that was never set — deadlock.
+
+Fix: remove the isatty() guard so the handler is always registered for
+client_facing agents, and pass is_client_input=True so injected stdin input
+is treated as a real user message rather than an external event.
+
+These tests operate at the EventLoopNode + EventBus level (no AgentRuntime
+needed) to deterministically verify the blocking/unblocking behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from framework.graph.edge import GraphSpec
+from framework.graph.event_loop_node import EventLoopNode, LoopConfig
+from framework.graph.node import NodeContext, NodeSpec, SharedMemory
+from framework.llm.provider import LLMProvider, LLMResponse, Tool
+from framework.llm.stream_events import FinishEvent, TextDeltaEvent, ToolCallEvent
+from framework.runner.runner import AgentRunner, ExecutionResult
+from framework.runtime.core import Runtime
+from framework.runtime.event_bus import EventBus, EventType
+
+
+# ---------------------------------------------------------------------------
+# Minimal mock LLM (same pattern as test_event_loop_node.py)
+# ---------------------------------------------------------------------------
+
+
+class MockStreamingLLM(LLMProvider):
+    def __init__(self, scenarios: list[list] | None = None):
+        self.scenarios = scenarios or []
+        self._call_index = 0
+        self.stream_calls: list[dict] = []
+
+    async def stream(
+        self,
+        messages: list[dict[str, Any]],
+        system: str = "",
+        tools: list[Tool] | None = None,
+        max_tokens: int = 4096,
+    ) -> AsyncIterator:
+        self.stream_calls.append({"messages": messages, "system": system, "tools": tools})
+        if not self.scenarios:
+            return
+        events = self.scenarios[self._call_index % len(self.scenarios)]
+        self._call_index += 1
+        for event in events:
+            yield event
+
+    def complete(self, messages, system="", **kwargs) -> LLMResponse:
+        return LLMResponse(content="summary", model="mock", stop_reason="stop")
+
+
+def text_scenario(text: str) -> list:
+    return [
+        TextDeltaEvent(content=text, snapshot=text),
+        FinishEvent(stop_reason="stop", input_tokens=10, output_tokens=5, model="mock"),
+    ]
+
+
+def tool_call_scenario(tool_name: str, tool_input: dict, tool_use_id: str = "tc_1") -> list:
+    return [
+        ToolCallEvent(tool_use_id=tool_use_id, tool_name=tool_name, tool_input=tool_input),
+        FinishEvent(stop_reason="tool_calls", input_tokens=10, output_tokens=5, model="mock"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runtime():
+    rt = MagicMock(spec=Runtime)
+    rt.start_run = MagicMock(return_value="session_headless_test")
+    rt.decide = MagicMock(return_value="dec_1")
+    rt.record_outcome = MagicMock()
+    rt.end_run = MagicMock()
+    rt.report_problem = MagicMock()
+    rt.set_node = MagicMock()
+    return rt
+
+
+@pytest.fixture
+def memory():
+    return SharedMemory()
+
+
+@pytest.fixture
+def client_spec():
+    return NodeSpec(
+        id="intake",
+        name="Intake",
+        description="client-facing intake node",
+        node_type="event_loop",
+        output_keys=[],
+        client_facing=True,
+    )
+
+
+def build_ctx(runtime, node_spec, memory, llm):
+    return NodeContext(
+        runtime=runtime,
+        node_id=node_spec.id,
+        node_spec=node_spec,
+        memory=memory,
+        input_data={},
+        llm=llm,
+        available_tools=[],
+        stream_id="queen",  # ask_user requires stream_id="queen" for free-text input
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestHeadlessInputFix:
+    @pytest.mark.asyncio
+    async def test_deadlock_without_handler(self, runtime, memory, client_spec):
+        """Regression: without a CLIENT_INPUT_REQUESTED handler the node blocks forever.
+
+        This reproduces the pre-fix behaviour. asyncio.wait_for() with a short
+        timeout stands in for the real-world symptom of an infinite hang.
+        """
+        llm = MockStreamingLLM(
+            scenarios=[
+                tool_call_scenario("ask_user", {"question": "What file should I analyse?"}),
+            ]
+        )
+        bus = EventBus()
+        # No handler subscribed — nothing will ever call inject_event()
+        node = EventLoopNode(event_bus=bus, config=LoopConfig(max_iterations=3))
+        ctx = build_ctx(runtime, client_spec, memory, llm)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(node.execute(ctx), timeout=0.5)
+
+    @pytest.mark.asyncio
+    async def test_node_unblocks_when_handler_injects(self, runtime, memory, client_spec):
+        """Fix: with the runner's CLIENT_INPUT_REQUESTED handler registered, the
+        node receives stdin input and completes normally.
+        """
+        client_spec.output_keys = ["answer"]
+        llm = MockStreamingLLM(
+            scenarios=[
+                # Turn 1: node asks the user for input
+                tool_call_scenario(
+                    "ask_user",
+                    {"question": "What file should I analyse?"},
+                    tool_use_id="ask_1",
+                ),
+                # Turn 2: after input received, set the output
+                tool_call_scenario(
+                    "set_output",
+                    {"key": "answer", "value": "analysis complete"},
+                    tool_use_id="set_1",
+                ),
+                # Turn 3: finish
+                text_scenario("Done."),
+            ]
+        )
+        bus = EventBus()
+        node = EventLoopNode(event_bus=bus, config=LoopConfig(max_iterations=5))
+
+        # Simulate what runner._handle_input_requested does after the fix:
+        # subscribe unconditionally (no isatty() guard) and inject with is_client_input=True
+        async def handler(event):
+            await node.inject_event("/tmp/test_data.csv", is_client_input=True)
+
+        bus.subscribe(event_types=[EventType.CLIENT_INPUT_REQUESTED], handler=handler)
+
+        ctx = build_ctx(runtime, client_spec, memory, llm)
+        result = await asyncio.wait_for(node.execute(ctx), timeout=5.0)
+
+        assert result.success is True
+        assert result.output.get("answer") == "analysis complete"
+
+    @pytest.mark.asyncio
+    async def test_injected_input_is_client_input_not_external_event(
+        self, runtime, memory, client_spec
+    ):
+        """Fix: is_client_input=True means the LLM sees the raw user message,
+        not one prefixed with '[External event]:'.
+
+        Before the fix, inject_input() defaulted to is_client_input=False which
+        caused _drain_injection_queue to prepend '[External event]: ' — confusing
+        the LLM into treating the user's stdin response as a system notification.
+        """
+        llm = MockStreamingLLM(
+            scenarios=[
+                tool_call_scenario("ask_user", {"question": "Say hi"}, tool_use_id="ask_1"),
+                text_scenario("Hi back!"),
+            ]
+        )
+        bus = EventBus()
+        node = EventLoopNode(event_bus=bus, config=LoopConfig(max_iterations=5))
+
+        async def handler(event):
+            await node.inject_event("hello from user", is_client_input=True)
+
+        bus.subscribe(event_types=[EventType.CLIENT_INPUT_REQUESTED], handler=handler)
+
+        ctx = build_ctx(runtime, client_spec, memory, llm)
+        await asyncio.wait_for(node.execute(ctx), timeout=5.0)
+
+        # Inspect the messages the LLM received on the turn after the user responded.
+        # The user's message should be plain text, not wrapped with [External event]: prefix.
+        all_user_contents = [
+            str(m["content"])
+            for call in llm.stream_calls
+            for m in call["messages"]
+            if m.get("role") == "user"
+        ]
+        assert any("hello from user" in c for c in all_user_contents), (
+            "User's stdin input was never delivered to the LLM"
+        )
+        assert not any("[External event]" in c for c in all_user_contents), (
+            "User's stdin input was incorrectly prefixed with '[External event]:' "
+            "(is_client_input was False)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_eof_stdin_signals_clean_shutdown(self, runtime, memory, client_spec):
+        """Fix: when stdin hits EOF in non-TTY mode, the node should exit cleanly
+        (success=False) rather than looping on empty strings up to max_iterations.
+
+        Simulates what runner._handle_input_requested does on EOFError:
+        calls node.signal_shutdown() instead of injecting "".
+        """
+        llm = MockStreamingLLM(
+            scenarios=[
+                tool_call_scenario("ask_user", {"question": "What file?"}),
+            ]
+        )
+        bus = EventBus()
+        node = EventLoopNode(event_bus=bus, config=LoopConfig(max_iterations=50))
+
+        async def eof_handler(event):
+            # Simulates runtime.signal_node_shutdown(node_id) on EOFError
+            node.signal_shutdown()
+            await asyncio.sleep(0)  # yield to event loop; required by EventHandler protocol
+
+        bus.subscribe(event_types=[EventType.CLIENT_INPUT_REQUESTED], handler=eof_handler)
+
+        ctx = build_ctx(runtime, client_spec, memory, llm)
+        result = await asyncio.wait_for(node.execute(ctx), timeout=2.0)
+
+        # Clean shutdown returns success=True (no error), but with empty output
+        # because no set_output() was ever called before EOF.
+        assert result.error is None
+        assert result.output == {}
+        # LLM called only once — no degraded loop of empty-string injections
+        assert len(llm.stream_calls) == 1, (
+            f"Expected 1 LLM call (clean exit), got {len(llm.stream_calls)} "
+            "(EOF triggered a degraded loop)"
+        )
+
+
+class TestRunnerHandlerRegistration:
+    """Runner-level tests: verify _run_with_agent_runtime registers the
+    CLIENT_INPUT_REQUESTED handler regardless of sys.stdin.isatty().
+
+    These tests prove the isatty() guard removal in runner.py:1584 actually
+    wires up the handler — closing the gap the EventLoopNode-level tests leave.
+    """
+
+    def _make_runner(self, client_facing: bool) -> AgentRunner:
+        """Build a minimal AgentRunner without triggering __init__."""
+        node = NodeSpec(
+            id="intake",
+            name="Intake",
+            description="intake node",
+            node_type="event_loop",
+            output_keys=[],
+            client_facing=client_facing,
+        )
+        graph = GraphSpec(
+            id="test-graph",
+            goal_id="test-goal",
+            name="Test Graph",
+            entry_node="intake",
+            nodes=[node],
+            edges=[],
+            terminal_nodes=["intake"],
+        )
+        runner = AgentRunner.__new__(AgentRunner)
+        runner.graph = graph
+        # __new__ skips __init__; stub out attributes touched by __del__ / cleanup
+        runner._tool_registry = MagicMock()
+        runner._temp_dir = None
+        return runner
+
+    def _make_mock_runtime(self) -> MagicMock:
+        """Build a mock AgentRuntime that satisfies _run_with_agent_runtime."""
+        runtime = MagicMock()
+        runtime.is_running = True
+        runtime.subscribe_to_events = MagicMock(side_effect=["sub-output", "sub-input"])
+        runtime.get_entry_points = MagicMock(return_value=[])
+        runtime.trigger_and_wait = AsyncMock(
+            return_value=ExecutionResult(success=True, output={})
+        )
+        runtime.unsubscribe_from_events = MagicMock()
+        return runtime
+
+    @pytest.mark.asyncio
+    async def test_handler_registered_in_non_tty(self):
+        """With isatty()=False (CI/pipe/WSL2), CLIENT_INPUT_REQUESTED handler
+        must still be registered — this is the core of the bug fix."""
+        runner = self._make_runner(client_facing=True)
+        mock_runtime = self._make_mock_runtime()
+        runner._agent_runtime = mock_runtime
+
+        fake_stdin = io.StringIO("some piped input\n")
+        with patch("sys.stdin", fake_stdin):
+            await runner._run_with_agent_runtime({})
+
+        subscribed_event_types = [
+            c.kwargs.get("event_types") or c.args[0]
+            for c in mock_runtime.subscribe_to_events.call_args_list
+        ]
+        assert any(
+            EventType.CLIENT_INPUT_REQUESTED in et for et in subscribed_event_types
+        ), "CLIENT_INPUT_REQUESTED handler was not registered in non-TTY mode"
+
+    @pytest.mark.asyncio
+    async def test_handler_registered_in_tty(self):
+        """With isatty()=True (normal terminal), handler is also registered —
+        the fix must not break the interactive (TTY) path."""
+        runner = self._make_runner(client_facing=True)
+        mock_runtime = self._make_mock_runtime()
+        runner._agent_runtime = mock_runtime
+
+        fake_tty = MagicMock()
+        fake_tty.isatty = MagicMock(return_value=True)
+        with patch("sys.stdin", fake_tty):
+            await runner._run_with_agent_runtime({})
+
+        subscribed_event_types = [
+            c.kwargs.get("event_types") or c.args[0]
+            for c in mock_runtime.subscribe_to_events.call_args_list
+        ]
+        assert any(
+            EventType.CLIENT_INPUT_REQUESTED in et for et in subscribed_event_types
+        ), "CLIENT_INPUT_REQUESTED handler was not registered in TTY mode"
+
+    @pytest.mark.asyncio
+    async def test_handler_not_registered_when_no_client_facing_nodes(self):
+        """When no nodes are client_facing, no I/O handlers should be registered —
+        the has_client_facing guard must remain intact."""
+        runner = self._make_runner(client_facing=False)
+        mock_runtime = self._make_mock_runtime()
+        runner._agent_runtime = mock_runtime
+
+        fake_stdin = io.StringIO("")
+        with patch("sys.stdin", fake_stdin):
+            await runner._run_with_agent_runtime({})
+
+        assert mock_runtime.subscribe_to_events.call_count == 0, (
+            "subscribe_to_events should not be called when no client-facing nodes exist"
+        )
+
+
+class TestInjectionPathRouting:
+    """Prove that ExecutionStream.inject_input correctly routes to node.inject_event.
+
+    This closes the gap between the runner-level tests (which only verify that
+    subscribe_to_events is called) and the node-level tests (which call
+    node.inject_event directly).  Here we test the actual routing code in
+    execution_stream.py:421-425.
+    """
+
+    @pytest.mark.asyncio
+    async def test_execution_stream_inject_routes_to_node(self):
+        """ExecutionStream.inject_input finds the node in _active_executors and
+        calls inject_event, setting _input_ready so _await_user_input unblocks."""
+        from framework.runtime.execution_stream import ExecutionStream
+
+        node = EventLoopNode(config=LoopConfig(max_iterations=3))
+
+        # Build a minimal executor stub — only node_registry is needed
+        mock_executor = MagicMock()
+        mock_executor.node_registry = {"intake": node}
+
+        # Instantiate ExecutionStream without __init__ (heavy dependencies)
+        # and wire only what inject_input touches
+        stream = ExecutionStream.__new__(ExecutionStream)
+        stream._active_executors = {"exec_1": mock_executor}
+
+        result = await stream.inject_input("intake", "hello from stdin", is_client_input=True)
+
+        assert result is True, "inject_input should return True when node is found"
+        assert not node._injection_queue.empty(), "content should be in node's injection queue"
+        content, is_client = node._injection_queue.get_nowait()
+        assert content == "hello from stdin"
+        assert is_client is True, "is_client_input flag must be preserved through the routing chain"
+
+    @pytest.mark.asyncio
+    async def test_execution_stream_inject_returns_false_for_unknown_node(self):
+        """inject_input returns False (not silently deadlocking) when the node_id
+        is not found — e.g. if the executor hasn't registered the node yet."""
+        from framework.runtime.execution_stream import ExecutionStream
+
+        stream = ExecutionStream.__new__(ExecutionStream)
+        stream._active_executors = {}  # no executors registered
+
+        result = await stream.inject_input("unknown_node", "hello")
+
+        assert result is False
+
+
+class TestRateLimitRetryCap:
+    """Prove that the streaming retry loop stops after RATE_LIMIT_MAX_RETRY_WALL_TIME.
+
+    Before the fix: 10 retries × up to 120 s each = ~20 min per LLM call.
+    After the fix: total retry time is capped at RATE_LIMIT_MAX_RETRY_WALL_TIME.
+    """
+
+    @pytest.mark.asyncio
+    async def test_retry_budget_stops_retries_after_wall_time_exceeded(self):
+        """With a tiny wall-time budget, the loop stops after the first retry
+        even though RATE_LIMIT_MAX_RETRIES has not been exhausted."""
+        from litellm.exceptions import RateLimitError
+        import framework.llm.litellm as litellm_module
+        from framework.llm.litellm import LiteLLMProvider
+
+        provider = LiteLLMProvider(model="mock-model")
+
+        call_count = 0
+
+        async def fake_acompletion(**_kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise RateLimitError("rate limited", llm_provider="mock", model="mock-model")
+
+        # Patch: tiny budget + zero backoff so the second attempt immediately
+        # exceeds the wall-time budget without sleeping 2 s in the test.
+        with (
+            patch.object(litellm_module, "RATE_LIMIT_MAX_RETRY_WALL_TIME", 0.01),
+            patch.object(litellm_module, "RATE_LIMIT_BACKOFF_BASE", 0),
+            patch("litellm.acompletion", fake_acompletion),
+        ):
+            events = []
+            async for event in provider.stream(messages=[{"role": "user", "content": "hi"}]):
+                events.append(event)
+
+        from framework.llm.stream_events import StreamErrorEvent
+
+        # Budget check fires after the sleep on attempt 0, so attempt 1 is the
+        # one that sees elapsed > budget and stops — 2 total LLM calls.
+        assert call_count == 2, (
+            f"Expected 2 LLM calls (initial + 1 retry before budget cut-off), got {call_count}"
+        )
+        assert len(events) == 1 and isinstance(events[0], StreamErrorEvent), (
+            "Should yield a StreamErrorEvent when budget is exhausted"
+        )
+
+    @pytest.mark.asyncio
+    async def test_retry_proceeds_within_budget(self):
+        """Within the budget, retries still happen normally."""
+        from litellm.exceptions import RateLimitError
+        import framework.llm.litellm as litellm_module
+        from framework.llm.litellm import LiteLLMProvider
+        from framework.llm.stream_events import StreamErrorEvent
+
+        provider = LiteLLMProvider(model="mock-model")
+
+        call_count = 0
+
+        async def fake_acompletion(**_kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise RateLimitError("rate limited", llm_provider="mock", model="mock-model")
+
+        # Large budget (1000 s) but only 2 max retries → stops after 3 calls
+        with (
+            patch.object(litellm_module, "RATE_LIMIT_MAX_RETRIES", 2),
+            patch.object(litellm_module, "RATE_LIMIT_MAX_RETRY_WALL_TIME", 1000),
+            patch.object(litellm_module, "RATE_LIMIT_BACKOFF_BASE", 0),  # no sleep
+            patch("litellm.acompletion", fake_acompletion),
+        ):
+            events = []
+            async for event in provider.stream(messages=[{"role": "user", "content": "hi"}]):
+                events.append(event)
+
+        assert call_count == 3, (
+            f"Expected 3 calls (initial + 2 retries), got {call_count}"
+        )
+        assert isinstance(events[0], StreamErrorEvent)

--- a/core/tests/test_headless_input_fix.py
+++ b/core/tests/test_headless_input_fix.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import asyncio
 import io
 from collections.abc import AsyncIterator
-from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -32,7 +31,6 @@ from framework.llm.stream_events import FinishEvent, TextDeltaEvent, ToolCallEve
 from framework.runner.runner import AgentRunner, ExecutionResult
 from framework.runtime.core import Runtime
 from framework.runtime.event_bus import EventBus, EventType
-
 
 # ---------------------------------------------------------------------------
 # Minimal mock LLM (same pattern as test_event_loop_node.py)
@@ -436,6 +434,7 @@ class TestRateLimitRetryCap:
         """With a tiny wall-time budget, the loop stops after the first retry
         even though RATE_LIMIT_MAX_RETRIES has not been exhausted."""
         from litellm.exceptions import RateLimitError
+
         import framework.llm.litellm as litellm_module
         from framework.llm.litellm import LiteLLMProvider
 
@@ -474,6 +473,7 @@ class TestRateLimitRetryCap:
     async def test_retry_proceeds_within_budget(self):
         """Within the budget, retries still happen normally."""
         from litellm.exceptions import RateLimitError
+
         import framework.llm.litellm as litellm_module
         from framework.llm.litellm import LiteLLMProvider
         from framework.llm.stream_events import StreamErrorEvent

--- a/docs/server-cli-arch.md
+++ b/docs/server-cli-arch.md
@@ -225,6 +225,43 @@ The differences are in the **access pattern**, not the runtime behavior.
 
 ---
 
+## Run Modes and `client_facing` Nodes
+
+A node with `client_facing=True` streams its LLM output to the end user in real time and can call `ask_user()` to block and wait for a reply. Whether that works depends on how the agent is launched:
+
+| Run mode | stdin available | `client_facing` works? |
+|---|---|---|
+| `hive tui` | yes (TUI widget) | yes — intended use case |
+| `hive run` (interactive terminal) | yes (shell prompt) | yes — reads from terminal |
+| `hive run -f file.json` (headless) | no (pipe/redirect) | partial — reads from stdin if pipe attached; fails cleanly on EOF |
+| `hive run ... --non-interactive` | n/a | no — fails immediately with clear error before any LLM calls |
+| HTTP server (`POST /chat`) | n/a | yes — injected via `/inject` endpoint |
+| CI / Docker (no stdin) | EOF | no — signals clean shutdown after EOF with warning |
+
+### Headless execution with `client_facing` agents
+
+Running a `client_facing` agent headlessly (e.g., `hive run -f input.json` in CI or Docker) will either:
+
+- **Read from stdin** if a pipe is attached: `echo "my answer" | hive run my_agent/ -f input.json`
+- **Signal clean shutdown** if stdin hits EOF, logging: `stdin reached EOF (non-TTY mode). This agent requires interactive input. Use hive tui instead.`
+
+To detect incompatibility early — before any LLM calls are made — use `--non-interactive`:
+
+```bash
+hive run my_agent/ -f input.json --non-interactive
+# Error: This agent has interactive nodes (intake) and cannot run in non-interactive mode.
+#   Use `hive tui` for interactive sessions.
+#   To run headlessly, set client_facing=False in your agent definition.
+```
+
+This exits immediately with code 1, consuming no API credits.
+
+### Designing agents for headless execution
+
+If your agent needs to run in CI or other non-interactive environments, set `client_facing=False` on all nodes and pass inputs via `--input` / `--input-file`. The node logic should read from `input_data` directly rather than calling `ask_user()`.
+
+---
+
 ## The AgentManager Bridge
 
 The only component unique to the HTTP server. It manages the lifecycle of multiple loaded agents within a single process.


### PR DESCRIPTION
## Description

Fixes a permanent deadlock and runaway API cost when running agents with
`client_facing=True` nodes in headless/non-TTY mode (`run -f`, CI, Docker).

The stdin handler was gated behind `sys.stdin.isatty()` — returning False in
piped environments — so `CLIENT_INPUT_REQUESTED` had no responder and the node
blocked forever. When rate-limited during the deadlock, the retry loop had no
time cap, allowing ~$5 USD in credits to be consumed over 1.5 hours.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Related Issues

Fixes #6193

## Changes Made

- `runner.py` — remove `isatty()` guard; `CLIENT_INPUT_REQUESTED` handler now always registered for `client_facing` agents
- `runner.py` — add `is_client_input=True` on stdin injection (was prepending `[External event]:` to user messages)
- `runner.py` — on `EOFError`, call `runtime.signal_node_shutdown()` instead of injecting `""` to prevent degraded loop up to `max_iterations`
- `litellm.py` — add `RATE_LIMIT_MAX_RETRY_WALL_TIME = 300s` cap on streaming retries (was uncapped, worst case ~20 min per call)
- `execution_stream.py` / `agent_runtime.py` — add `signal_node_shutdown(node_id)` mirroring the existing `inject_input` path
- `cli.py` — add `--non-interactive` / `-n` flag: exits with code 1 and clear error before any LLM calls if agent has `client_facing` nodes
- `docs/server-cli-arch.md` — add "Run Modes and `client_facing` Nodes" section documenting compatibility across all run modes

## Testing

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

New test file: `core/tests/test_headless_input_fix.py` — 11 tests across 4 classes:

- `TestHeadlessInputFix` — deadlock regression, handler-unblocks-node, `is_client_input` flag, EOF clean shutdown
- `TestRunnerHandlerRegistration` — handler registered in non-TTY, TTY, and no-client-facing cases
- `TestInjectionPathRouting` — full `ExecutionStream` → `node_registry` → `inject_event` path
- `TestRateLimitRetryCap` — budget stops retries after 300s, normal retries work within budget

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
