### PR TITLE
fix: read nodes from graph object in discovery.py for correct node count

### DIFF
--- a/core/framework/agents/discovery.py
+++ b/core/framework/agents/discovery.py
@@ -79,7 +79,7 @@ def _extract_agent_stats(agent_path: Path) -> tuple[int, int, list[str]]:
     if agent_json.exists():
         try:
             data = json.loads(agent_json.read_text(encoding="utf-8"))
-            json_nodes = data.get("nodes", [])
+            json_nodes = data.get("graph", {}).get("nodes", []) or data.get("nodes", [])
             if node_count == 0:
                 node_count = len(json_nodes)
             tools: set[str] = set()


### PR DESCRIPTION
## Description

Fixes the Competitive Intelligence Agent missing node count badge 
in the sample agents UI. The _extract_agent_stats function was 
looking for nodes at the top level of agent.json, but some agents 
store nodes nested inside the "graph" object.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #6226

## Fix
Updated to check inside `"graph"` first, then fall back to top level:
```python
json_nodes = data.get("graph", {}).get("nodes", []) or data.get("nodes", [])
```

## Changes Made

- Updated _extract_agent_stats in discovery.py to first look for 
  nodes inside the "graph" object, then fall back to top level
- Before: data.get("nodes", [])
- After: data.get("graph", {}).get("nodes", []) or data.get("nodes", [])

## Testing

- Manual testing performed locally via quickstart.sh
- Competitive Intelligence Agent now correctly shows "7 nodes" badge
- Verified all other agents (Deep Research, Job Hunter, etc.) 
  still display their node counts correctly


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
<img width="1151" height="803" alt="Screenshot 2026-03-11 at 7 34 13 PM" src="https://github.com/user-attachments/assets/f306b9b7-856d-4f38-9e92-a2fa6cae8bab" />
<img width="1337" height="811" alt="Screenshot 2026-03-11 at 7 35 48 PM" src="https://github.com/user-attachments/assets/6858ebf3-ae20-42aa-a7ba-9633572aa23a" />
