### PR TITLE
fix: escape browser_wait text matching

### DIFF
--- a/tools/src/gcu/browser/tools/advanced.py
+++ b/tools/src/gcu/browser/tools/advanced.py
@@ -56,7 +56,8 @@ def register_advanced_tools(mcp: FastMCP) -> None:
                 return {"ok": True, "action": "wait", "condition": "selector", "selector": selector}
             elif text:
                 await page.wait_for_function(
-                    f"document.body.innerText.includes('{text}')",
+                    "(text) => document.body.innerText.includes(text)",
+                    arg=text,
                     timeout=timeout_ms,
                 )
                 return {"ok": True, "action": "wait", "condition": "text", "text": text}

--- a/tools/tests/test_browser_advanced_tools.py
+++ b/tools/tests/test_browser_advanced_tools.py
@@ -1,0 +1,42 @@
+"""Tests for browser advanced tools."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from gcu.browser.tools.advanced import register_advanced_tools
+
+
+@pytest.fixture
+def mcp() -> FastMCP:
+    """Create a fresh FastMCP instance for testing."""
+    return FastMCP("test-browser-advanced")
+
+
+@pytest.fixture
+def browser_wait_fn(mcp):
+    """Register browser tools and return the browser_wait function."""
+    register_advanced_tools(mcp)
+    return mcp._tool_manager._tools["browser_wait"].fn
+
+
+@pytest.mark.asyncio
+async def test_browser_wait_passes_text_as_function_argument(browser_wait_fn):
+    """Quoted and multiline text should be passed as data, not JS source."""
+    text = "O'Reilly\nMedia"
+    page = MagicMock()
+    page.wait_for_function = AsyncMock()
+
+    session = MagicMock()
+    session.get_page.return_value = page
+
+    with patch("gcu.browser.tools.advanced.get_session", return_value=session):
+        result = await browser_wait_fn(text=text, timeout_ms=1234)
+
+    assert result == {"ok": True, "action": "wait", "condition": "text", "text": text}
+    page.wait_for_function.assert_awaited_once_with(
+        "(text) => document.body.innerText.includes(text)",
+        arg=text,
+        timeout=1234,
+    )


### PR DESCRIPTION
Closes #6234.

## Summary
- pass `browser_wait(text=...)` values to Playwright as a function argument instead of interpolating them into JavaScript source
- preserve correct waiting behavior for quoted and multiline text values
- add a focused regression test for the quoted/multiline case

## Test plan
- `python3 -m py_compile tools/src/gcu/browser/tools/advanced.py tools/tests/test_browser_advanced_tools.py`
- `pytest` could not be run locally because this environment does not have `pytest` or `fastmcp` installed

Made with [Cursor](https://cursor.com)