### PR TITLE
fix: avoid JS interpolation bug in browser_wait text matching

### DIFF
--- a/tools/src/gcu/browser/tools/advanced.py
+++ b/tools/src/gcu/browser/tools/advanced.py
@@ -56,7 +56,8 @@ def register_advanced_tools(mcp: FastMCP) -> None:
                 return {"ok": True, "action": "wait", "condition": "selector", "selector": selector}
             elif text:
                 await page.wait_for_function(
-                    f"document.body.innerText.includes('{text}')",
+                    "(expected) => document.body.innerText.includes(expected)",
+                    text,
                     timeout=timeout_ms,
                 )
                 return {"ok": True, "action": "wait", "condition": "text", "text": text}


### PR DESCRIPTION
Fix a bug in browser_wait(text=...) where user-provided text was interpolated
directly into a JavaScript string. This caused failures when the text
contained quotes ('), backslashes (\), or newline characters.

The fix passes the text as an argument to page.wait_for_function instead
of embedding it into the JavaScript source.

Fixes #6234