### PR TITLE
fix: resolve issues #6207, #6234, and #6229

### DIFF
--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -397,6 +397,13 @@ def cmd_run(args: argparse.Namespace) -> int:
             print(f"Error parsing --input JSON: {e}", file=sys.stderr)
             return 1
     elif args.input_file:
+        input_path = Path(args.input_file)
+        if input_path.is_dir():
+            print(
+                f"Error: input file is a directory, not a file: {args.input_file}",
+                file=sys.stderr,
+            )
+            return 1
         try:
             with open(args.input_file, encoding="utf-8") as f:
                 context = json.load(f)

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -1248,12 +1248,17 @@ class AgentRunner:
                             f"(e.g. 'ollama serve' for Ollama)."
                         )
                     api_key_env = self._get_api_key_env_var(self.model)
-                    hint = (
-                        f"Set it with: export {api_key_env}=your-api-key"
-                        if api_key_env
-                        else "Configure an API key for your LLM provider."
-                    )
-                    raise CredentialError(f"LLM API key not found for model '{self.model}'. {hint}")
+                    if api_key_env:
+                        raise CredentialError(
+                            f"{api_key_env} is not configured. "
+                            f"Please set it before running Hive.\n"
+                            f"Set it with: export {api_key_env}=your-api-key"
+                        )
+                    else:
+                        raise CredentialError(
+                            "LLM API key is not configured. "
+                            "Please configure an API key for your LLM provider before running Hive."
+                        )
 
         # For GCU nodes: auto-register GCU MCP server if needed, then expand tool lists
         has_gcu_nodes = any(node.node_type == "gcu" for node in self.graph.nodes)

--- a/core/tests/test_fixes_6207_6229.py
+++ b/core/tests/test_fixes_6207_6229.py
@@ -1,0 +1,161 @@
+"""
+Tests for fixes to issues #6207 and #6229.
+
+#6207 — hive run --input-file crashes with raw traceback when given a directory.
+#6229 — Missing OPENAI_API_KEY produces cryptic LiteLLM error instead of clear message.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fix #6207: --input-file directory validation in cmd_run
+# ---------------------------------------------------------------------------
+
+
+def _make_args(**kwargs) -> argparse.Namespace:
+    defaults = dict(
+        agent_path="some_agent",
+        input=None,
+        input_file=None,
+        output=None,
+        quiet=False,
+        verbose=False,
+        model=None,
+        resume_session=None,
+        checkpoint=None,
+    )
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+class TestInputFileDirectoryValidation:
+    """Issue #6207 — validate --input-file before execution."""
+
+    def test_directory_path_returns_exit_code_1(self, tmp_path, capsys):
+        from framework.runner.cli import cmd_run
+
+        result = cmd_run(_make_args(input_file=str(tmp_path)))
+
+        assert result == 1
+
+    def test_directory_path_prints_friendly_error(self, tmp_path, capsys):
+        from framework.runner.cli import cmd_run
+
+        cmd_run(_make_args(input_file=str(tmp_path)))
+
+        captured = capsys.readouterr()
+        assert "directory" in captured.err
+        assert str(tmp_path) in captured.err
+        # Must not be a raw Python traceback
+        assert "IsADirectoryError" not in captured.err
+        assert "Traceback" not in captured.err
+
+    def test_error_message_matches_expected_format(self, tmp_path, capsys):
+        from framework.runner.cli import cmd_run
+
+        cmd_run(_make_args(input_file=str(tmp_path)))
+
+        captured = capsys.readouterr()
+        assert "Error: input file is a directory, not a file:" in captured.err
+
+    def test_valid_json_file_is_not_blocked(self, tmp_path, capsys):
+        """A real JSON file should not be rejected by the directory check."""
+        f = tmp_path / "ctx.json"
+        f.write_text('{"key": "value"}')
+
+        # AgentRunner is imported locally inside cmd_run, so patch at the source.
+        with patch("framework.runner.runner.AgentRunner.load", side_effect=FileNotFoundError("no agent")):
+            from framework.runner.cli import cmd_run
+
+            result = cmd_run(_make_args(input_file=str(f)))
+
+        # exit 1 is fine here (agent not found), but the error must NOT mention directory
+        captured = capsys.readouterr()
+        assert "is a directory" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Fix #6229: clear CredentialError message when API key is missing
+# ---------------------------------------------------------------------------
+
+
+class _NoopRegistry:
+    def cleanup(self) -> None:
+        pass
+
+
+def _make_runner(model: str = "gpt-4o-mini"):
+    from framework.runner.runner import AgentRunner
+
+    runner = AgentRunner.__new__(AgentRunner)
+    runner._tool_registry = _NoopRegistry()
+    runner._temp_dir = None
+    runner.model = model
+    return runner
+
+
+class TestMissingApiKeyErrorMessage:
+    """Issue #6229 — CredentialError should name the missing key explicitly."""
+
+    def test_openai_key_named_in_error(self):
+        from framework.credentials.models import CredentialError
+        from framework.runner.runner import AgentRunner
+
+        mock_graph = MagicMock()
+        mock_graph.nodes = [MagicMock(node_type="event_loop")]
+
+        runner = _make_runner(model="gpt-4o-mini")
+        runner.graph = mock_graph
+        runner._llm = None
+        runner.mock_mode = False
+
+        with pytest.raises(CredentialError) as exc_info:
+            # Trigger the fail-fast block directly
+            if runner._llm is None:
+                has_llm_nodes = any(
+                    node.node_type in ("event_loop", "gcu") for node in runner.graph.nodes
+                )
+                if has_llm_nodes:
+                    api_key_env = runner._get_api_key_env_var(runner.model)
+                    if api_key_env:
+                        raise CredentialError(
+                            f"{api_key_env} is not configured. "
+                            f"Please set it before running Hive.\n"
+                            f"Set it with: export {api_key_env}=your-api-key"
+                        )
+
+        msg = str(exc_info.value)
+        assert "OPENAI_API_KEY" in msg
+        assert "not configured" in msg.lower() or "Please set it" in msg
+
+    def test_error_message_contains_export_hint(self):
+        from framework.credentials.models import CredentialError
+
+        runner = _make_runner(model="gpt-4o-mini")
+        api_key_env = runner._get_api_key_env_var(runner.model)
+
+        error = CredentialError(
+            f"{api_key_env} is not configured. "
+            f"Please set it before running Hive.\n"
+            f"Set it with: export {api_key_env}=your-api-key"
+        )
+        assert "export OPENAI_API_KEY" in str(error)
+
+    def test_anthropic_key_named_for_claude_model(self):
+        runner = _make_runner(model="claude-3-haiku-20240307")
+        assert runner._get_api_key_env_var(runner.model) == "ANTHROPIC_API_KEY"
+
+    def test_openai_key_named_for_gpt_model(self):
+        runner = _make_runner(model="gpt-4o-mini")
+        assert runner._get_api_key_env_var(runner.model) == "OPENAI_API_KEY"
+
+    def test_local_model_returns_none_key(self):
+        runner = _make_runner(model="ollama/llama3")
+        assert runner._get_api_key_env_var(runner.model) is None

--- a/tools/src/gcu/browser/tools/advanced.py
+++ b/tools/src/gcu/browser/tools/advanced.py
@@ -56,7 +56,8 @@ def register_advanced_tools(mcp: FastMCP) -> None:
                 return {"ok": True, "action": "wait", "condition": "selector", "selector": selector}
             elif text:
                 await page.wait_for_function(
-                    f"document.body.innerText.includes('{text}')",
+                    "text => document.body.innerText.includes(text)",
+                    arg=text,
                     timeout=timeout_ms,
                 )
                 return {"ok": True, "action": "wait", "condition": "text", "text": text}

--- a/tools/tests/test_fix_6234_browser_wait.py
+++ b/tools/tests/test_fix_6234_browser_wait.py
@@ -1,0 +1,92 @@
+"""
+Tests for fix to issue #6234.
+
+#6234 — browser_wait(text=...) breaks on quotes and newlines because text was
+embedded directly into a JavaScript f-string. Fix: pass text as `arg` to
+page.wait_for_function() so it is treated as data, not code.
+"""
+
+import pytest
+
+
+class TestBrowserWaitTextInjectionFix:
+    """Issue #6234 — text must be passed as arg, not embedded in JS string."""
+
+    def _get_wait_for_function_calls(self, text_value):
+        """
+        Run browser_wait with the given text and capture how
+        page.wait_for_function() was called.
+        """
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_page = AsyncMock()
+        mock_page.wait_for_function = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.get_page.return_value = mock_page
+
+        with patch(
+            "gcu.browser.tools.advanced.get_session", return_value=mock_session
+        ):
+            import asyncio
+
+            # Import the module to get the registered tool function.
+            # register_advanced_tools patches mcp, so we drive it directly.
+            from fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+
+            from gcu.browser.tools.advanced import register_advanced_tools
+
+            register_advanced_tools(mcp)
+
+            # Find the browser_wait tool
+            tool_fn = None
+            for name, tool in mcp._tool_manager._tools.items():
+                if name == "browser_wait":
+                    tool_fn = tool.fn
+                    break
+
+            assert tool_fn is not None, "browser_wait tool not registered"
+
+            asyncio.run(tool_fn(text=text_value))
+
+        return mock_page.wait_for_function.call_args
+
+    def test_text_passed_as_arg_not_embedded(self):
+        """The JS string must NOT contain the literal text value."""
+        call = self._get_wait_for_function_calls("hello world")
+        js_string = call.args[0] if call.args else call.kwargs.get("expression", "")
+        assert "hello world" not in js_string, (
+            "Text value should not be embedded in the JS string — it should be passed as arg"
+        )
+
+    def test_arg_parameter_is_passed(self):
+        """page.wait_for_function must receive arg= with the text value."""
+        call = self._get_wait_for_function_calls("hello world")
+        assert call.kwargs.get("arg") == "hello world", (
+            "text must be forwarded as the arg= parameter to wait_for_function"
+        )
+
+    def test_single_quote_in_text_does_not_break(self):
+        """Text with single quotes must not cause any exception."""
+        call = self._get_wait_for_function_calls("O'Reilly")
+        assert call.kwargs.get("arg") == "O'Reilly"
+
+    def test_backslash_in_text_does_not_break(self):
+        """Text with backslashes must not cause any exception."""
+        call = self._get_wait_for_function_calls("C:\\Users\\foo")
+        assert call.kwargs.get("arg") == "C:\\Users\\foo"
+
+    def test_newline_in_text_does_not_break(self):
+        """Text with newlines must not cause any exception."""
+        call = self._get_wait_for_function_calls("line1\nline2")
+        assert call.kwargs.get("arg") == "line1\nline2"
+
+    def test_js_expression_uses_arrow_function(self):
+        """The JS expression should use an arrow function that receives text as param."""
+        call = self._get_wait_for_function_calls("test")
+        js_string = call.args[0] if call.args else call.kwargs.get("expression", "")
+        # The pattern should be an arrow function like: text => ...includes(text)
+        assert "=>" in js_string, "JS expression should be an arrow function"
+        assert "includes" in js_string


### PR DESCRIPTION
## Summary

- **fix #6207** — `hive run --input-file` crashes with raw Python traceback when a directory is passed. Added `Path.is_dir()` validation in `cmd_run` (`core/framework/runner/cli.py`) before attempting to open the file, printing a friendly `Error: input file is a directory, not a file: <path>` and exiting with code 1.

- **fix #6234** — `browser_wait(text=...)` unsafely embedded user text into a JavaScript string via f-string, breaking on single quotes, backslashes, and newlines. Fixed in `tools/src/gcu/browser/tools/advanced.py` by passing `text` as the `arg` parameter to `page.wait_for_function()` so it is treated as data, not source code.

- **fix #6229** — When `OPENAI_API_KEY` (or another LLM API key) is not set, users saw a cryptic `litellm.AuthenticationError` at runtime. Improved the `CredentialError` message in `core/framework/runner/runner.py` to explicitly say e.g. `OPENAI_API_KEY is not configured. Please set it before running Hive.` with the exact export command needed.

## Test plan

- [ ] `hive run exports/my_agent --input-file exports/` → prints `Error: input file is a directory, not a file: exports/` and exits 1 (no traceback)
- [ ] `browser_wait(text="O'Reilly")` and `browser_wait(text="line1\nline2")` → work correctly without JS syntax errors
- [ ] Running an agent without `OPENAI_API_KEY` set → prints `OPENAI_API_KEY is not configured. Please set it before running Hive.` instead of a LiteLLM auth error

🤖 Generated with [Claude Code](https://claude.com/claude-code)