### PR TITLE
feat: Add Plan.from_json validation for duplicate IDs, invalid deps, and cycles

### DIFF
--- a/core/framework/schemas/__init__.py
+++ b/core/framework/schemas/__init__.py
@@ -1,6 +1,14 @@
 """Schema definitions for runtime data."""
 
 from framework.schemas.decision import Decision, DecisionEvaluation, Option, Outcome
+from framework.schemas.plan import (
+    CircularDependencyError,
+    DuplicateStepIdError,
+    InvalidDependencyError,
+    Plan,
+    PlanValidationError,
+    Step,
+)
 from framework.schemas.run import Problem, Run, RunSummary
 
 __all__ = [
@@ -11,4 +19,10 @@ __all__ = [
     "Run",
     "RunSummary",
     "Problem",
+    "Plan",
+    "Step",
+    "PlanValidationError",
+    "DuplicateStepIdError",
+    "InvalidDependencyError",
+    "CircularDependencyError",
 ]

--- a/core/framework/schemas/plan.py
+++ b/core/framework/schemas/plan.py
@@ -1,0 +1,251 @@
+"""
+Plan Schema - Represents an execution plan with steps and dependencies.
+
+A Plan contains steps that can depend on each other, forming a DAG.
+This module provides validation to ensure plan integrity during loading.
+"""
+
+import json
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class PlanValidationError(Exception):
+    """Raised when plan validation fails."""
+
+    pass
+
+
+class DuplicateStepIdError(PlanValidationError):
+    """Raised when duplicate step IDs are detected."""
+
+    pass
+
+
+class InvalidDependencyError(PlanValidationError):
+    """Raised when a dependency references an unknown step."""
+
+    pass
+
+
+class CircularDependencyError(PlanValidationError):
+    """Raised when circular dependencies are detected."""
+
+    pass
+
+
+class Step(BaseModel):
+    """
+    A single step in an execution plan.
+
+    Attributes:
+        id: Unique identifier for this step.
+        name: Human-readable name for the step.
+        description: Optional description of what this step does.
+        dependencies: List of step IDs that must complete before this step.
+        config: Optional configuration for the step execution.
+    """
+
+    id: str
+    name: str = ""
+    description: str = ""
+    dependencies: list[str] = Field(default_factory=list)
+    config: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = {"extra": "allow"}
+
+
+class Plan(BaseModel):
+    """
+    An execution plan consisting of steps with dependencies.
+
+    Plans are loaded from JSON and validated for integrity:
+    - No duplicate step IDs
+    - All dependencies reference existing steps
+    - No circular dependencies between steps
+
+    Attributes:
+        id: Unique identifier for this plan.
+        name: Human-readable name for the plan.
+        description: Optional description of the plan's purpose.
+        steps: List of steps in this plan.
+    """
+
+    id: str
+    name: str = ""
+    description: str = ""
+    steps: list[Step] = Field(default_factory=list)
+
+    model_config = {"extra": "allow"}
+
+    @classmethod
+    def from_json(cls, json_data: str | dict[str, Any]) -> "Plan":
+        """
+        Load a Plan from JSON string or dict with validation.
+
+        Args:
+            json_data: JSON string or dict containing plan data.
+
+        Returns:
+            A validated Plan instance.
+
+        Raises:
+            DuplicateStepIdError: If duplicate step IDs are found.
+            InvalidDependencyError: If a dependency references an unknown step.
+            CircularDependencyError: If circular dependencies are detected.
+            ValueError: If JSON parsing fails.
+        """
+        if isinstance(json_data, str):
+            try:
+                data = json.loads(json_data)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Invalid JSON: {e}") from e
+        else:
+            data = json_data
+
+        steps_data = data.get("steps", [])
+        steps = [Step(**step_data) for step_data in steps_data]
+        data["steps"] = steps
+
+        plan = cls(**data)
+        plan._validate()
+
+        return plan
+
+    def _validate(self) -> None:
+        """
+        Validate the plan for integrity issues.
+
+        Raises:
+            DuplicateStepIdError: If duplicate step IDs are found.
+            InvalidDependencyError: If a dependency references an unknown step.
+            CircularDependencyError: If circular dependencies are detected.
+        """
+        self._validate_no_duplicate_ids()
+        self._validate_dependencies_exist()
+        self._validate_no_cycles()
+
+    def _validate_no_duplicate_ids(self) -> None:
+        """
+        Check for duplicate step IDs.
+
+        Raises:
+            DuplicateStepIdError: If duplicate step IDs are found.
+        """
+        seen_ids: set[str] = set()
+        duplicates: list[str] = []
+
+        for step in self.steps:
+            if step.id in seen_ids:
+                duplicates.append(step.id)
+            seen_ids.add(step.id)
+
+        if duplicates:
+            raise DuplicateStepIdError(
+                f"Duplicate step IDs found: {', '.join(sorted(set(duplicates)))}"
+            )
+
+    def _validate_dependencies_exist(self) -> None:
+        """
+        Check that all dependencies reference existing steps.
+
+        Raises:
+            InvalidDependencyError: If a dependency references an unknown step.
+        """
+        step_ids = {step.id for step in self.steps}
+
+        for step in self.steps:
+            for dep_id in step.dependencies:
+                if dep_id not in step_ids:
+                    raise InvalidDependencyError(
+                        f"Step '{step.id}' references unknown dependency '{dep_id}'"
+                    )
+
+    def _validate_no_cycles(self) -> None:
+        """
+        Check for circular dependencies using DFS.
+
+        Raises:
+            CircularDependencyError: If circular dependencies are detected.
+        """
+        dependency_graph: dict[str, list[str]] = {step.id: step.dependencies for step in self.steps}
+
+        visited: set[str] = set()
+        rec_stack: set[str] = set()
+        path: list[str] = []
+
+        def dfs(step_id: str) -> bool:
+            """Returns True if a cycle is detected."""
+            visited.add(step_id)
+            rec_stack.add(step_id)
+            path.append(step_id)
+
+            for dep_id in dependency_graph.get(step_id, []):
+                if dep_id not in visited:
+                    if dfs(dep_id):
+                        return True
+                elif dep_id in rec_stack:
+                    cycle_start = path.index(dep_id)
+                    cycle = path[cycle_start:] + [dep_id]
+                    raise CircularDependencyError(
+                        f"Circular dependency detected: {' -> '.join(cycle)}"
+                    )
+
+            path.pop()
+            rec_stack.remove(step_id)
+            return False
+
+        for step in self.steps:
+            if step.id not in visited:
+                dfs(step.id)
+
+    def get_step(self, step_id: str) -> Step | None:
+        """
+        Get a step by its ID.
+
+        Args:
+            step_id: The ID of the step to find.
+
+        Returns:
+            The Step if found, None otherwise.
+        """
+        for step in self.steps:
+            if step.id == step_id:
+                return step
+        return None
+
+    def get_execution_order(self) -> list[str]:
+        """
+        Get steps in topologically sorted order for execution.
+
+        Returns:
+            List of step IDs in execution order (dependencies first).
+
+        Raises:
+            CircularDependencyError: If cycles exist (should not happen if validated).
+        """
+        in_degree: dict[str, int] = {step.id: 0 for step in self.steps}
+
+        for step in self.steps:
+            for dep_id in step.dependencies:
+                if dep_id in in_degree:
+                    in_degree[step.id] += 1
+
+        queue = [step_id for step_id, degree in in_degree.items() if degree == 0]
+        result: list[str] = []
+
+        while queue:
+            current = queue.pop(0)
+            result.append(current)
+
+            for step in self.steps:
+                if current in step.dependencies:
+                    in_degree[step.id] -= 1
+                    if in_degree[step.id] == 0:
+                        queue.append(step.id)
+
+        if len(result) != len(self.steps):
+            raise CircularDependencyError("Cannot determine execution order: cycle exists")
+
+        return result

--- a/core/tests/test_plan.py
+++ b/core/tests/test_plan.py
@@ -1,0 +1,447 @@
+"""
+Tests for Plan schema validation.
+
+Tests the Plan.from_json validation for:
+- Duplicate step IDs
+- Invalid dependencies (referencing unknown steps)
+- Circular dependencies
+"""
+
+import json
+
+import pytest
+
+from framework.schemas.plan import (
+    CircularDependencyError,
+    DuplicateStepIdError,
+    InvalidDependencyError,
+    Plan,
+    PlanValidationError,
+    Step,
+)
+
+
+class TestStepModel:
+    """Tests for the Step model."""
+
+    def test_step_minimal(self):
+        """Step should accept minimal required fields."""
+        step = Step(id="step_1")
+        assert step.id == "step_1"
+        assert step.name == ""
+        assert step.dependencies == []
+
+    def test_step_full(self):
+        """Step should accept all fields."""
+        step = Step(
+            id="step_1",
+            name="First Step",
+            description="Do something",
+            dependencies=["step_0"],
+            config={"timeout": 30},
+        )
+        assert step.id == "step_1"
+        assert step.name == "First Step"
+        assert step.dependencies == ["step_0"]
+        assert step.config["timeout"] == 30
+
+
+class TestPlanModel:
+    """Tests for the Plan model."""
+
+    def test_plan_minimal(self):
+        """Plan should accept minimal required fields."""
+        plan = Plan(id="plan_1")
+        assert plan.id == "plan_1"
+        assert plan.steps == []
+
+    def test_plan_with_steps(self):
+        """Plan should accept steps."""
+        plan = Plan(
+            id="plan_1",
+            name="Test Plan",
+            steps=[
+                Step(id="step_1"),
+                Step(id="step_2", dependencies=["step_1"]),
+            ],
+        )
+        assert len(plan.steps) == 2
+        assert plan.steps[1].dependencies == ["step_1"]
+
+    def test_get_step(self):
+        """get_step should find steps by ID."""
+        plan = Plan(
+            id="plan_1",
+            steps=[Step(id="step_1"), Step(id="step_2")],
+        )
+        assert plan.get_step("step_1") is not None
+        assert plan.get_step("step_1").id == "step_1"
+        assert plan.get_step("nonexistent") is None
+
+
+class TestPlanFromJsonBasic:
+    """Basic tests for Plan.from_json."""
+
+    def test_from_json_string(self):
+        """Should load from JSON string."""
+        json_str = json.dumps(
+            {
+                "id": "plan_1",
+                "name": "Test Plan",
+                "steps": [{"id": "step_1"}],
+            }
+        )
+        plan = Plan.from_json(json_str)
+        assert plan.id == "plan_1"
+        assert len(plan.steps) == 1
+
+    def test_from_json_dict(self):
+        """Should load from dict."""
+        data = {
+            "id": "plan_1",
+            "steps": [{"id": "step_1"}, {"id": "step_2"}],
+        }
+        plan = Plan.from_json(data)
+        assert len(plan.steps) == 2
+
+    def test_from_json_invalid_json_string(self):
+        """Should raise ValueError for invalid JSON."""
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            Plan.from_json("{not valid json}")
+
+    def test_from_json_empty_plan(self):
+        """Should handle empty plan."""
+        plan = Plan.from_json({"id": "empty_plan"})
+        assert plan.id == "empty_plan"
+        assert plan.steps == []
+
+
+class TestDuplicateStepIds:
+    """Tests for duplicate step ID validation."""
+
+    def test_duplicate_ids_rejected(self):
+        """Should reject plans with duplicate step IDs."""
+        data = {
+            "id": "plan_1",
+            "steps": [
+                {"id": "step_1"},
+                {"id": "step_2"},
+                {"id": "step_1"},
+            ],
+        }
+        with pytest.raises(DuplicateStepIdError, match="Duplicate step IDs"):
+            Plan.from_json(data)
+
+    def test_multiple_duplicates_reported(self):
+        """Should report all duplicate IDs."""
+        data = {
+            "id": "plan_1",
+            "steps": [
+                {"id": "step_1"},
+                {"id": "step_1"},
+                {"id": "step_2"},
+                {"id": "step_2"},
+            ],
+        }
+        with pytest.raises(DuplicateStepIdError) as exc_info:
+            Plan.from_json(data)
+        error_msg = str(exc_info.value)
+        assert "step_1" in error_msg
+        assert "step_2" in error_msg
+
+    def test_unique_ids_accepted(self):
+        """Should accept plans with unique IDs."""
+        data = {
+            "id": "plan_1",
+            "steps": [
+                {"id": "step_1"},
+                {"id": "step_2"},
+                {"id": "step_3"},
+            ],
+        }
+        plan = Plan.from_json(data)
+        assert len(plan.steps) == 3
+
+
+class TestInvalidDependencies:
+    """Tests for invalid dependency validation."""
+
+    def test_unknown_dependency_rejected(self):
+        """Should reject dependencies to unknown steps."""
+        data = {
+            "id": "plan_1",
+            "steps": [
+                {"id": "step_1", "dependencies": ["nonexistent"]},
+            ],
+        }
+        with pytest.raises(InvalidDependencyError, match="unknown dependency"):
+            Plan.from_json(data)
+
+    def test_multiple_unknown_dependencies(self):
+        """Should report first unknown dependency."""
+        data = {
+            "id": "plan_1",
+            "steps": [
+                {"id": "step_1", "dependencies": ["unknown_1", "unknown_2"]},
+            ],
+        }
+        with pytest.raises(InvalidDependencyError) as exc_info:
+            Plan.from_json(data)
+        error_msg = str(exc_info.value)
+        assert "unknown_1" in error_msg
+
+    def test_valid_dependencies_accepted(self):
+        """Should accept valid dependencies."""
+        data = {
+            "id": "plan_1",
+            "steps": [
+                {"id": "step_1"},
+                {"id": "step_2", "dependencies": ["step_1"]},
+                {"id": "step_3", "dependencies": ["step_1", "step_2"]},
+            ],
+        }
+        plan = Plan.from_json(data)
+        assert len(plan.steps) == 3
+
+    def test_self_dependency_rejected(self):
+        """Should reject self-dependencies as unknown."""
+        data = {
+            "id": "plan_1",
+            "steps": [
+                {"id": "step_1", "dependencies": ["step_1"]},
+            ],
+        }
+        with pytest.raises(CircularDependencyError, match="Circular dependency"):
+            Plan.from_json(data)
+
+
+class TestCircularDependencies:
+    """Tests for circular dependency detection."""
+
+    def test_simple_cycle_rejected(self):
+        """Should detect simple A -> B -> A cycle."""
+        data = {
+            "id": "plan_1",
+            "steps": [
+                {"id": "step_a", "dependencies": ["step_b"]},
+                {"id": "step_b", "dependencies": ["step_a"]},
+            ],
+        }
+        with pytest.raises(CircularDependencyError, match="Circular dependency"):
+            Plan.from_json(data)
+
+    def test_three_node_cycle_rejected(self):
+        """Should detect A -> B -> C -> A cycle."""
+        data = {
+            "id": "plan_1",
+            "steps": [
+                {"id": "step_a", "dependencies": ["step_c"]},
+                {"id": "step_b", "dependencies": ["step_a"]},
+                {"id": "step_c", "dependencies": ["step_b"]},
+            ],
+        }
+        with pytest.raises(CircularDependencyError, match="Circular dependency"):
+            Plan.from_json(data)
+
+    def test_longer_cycle_rejected(self):
+        """Should detect longer cycles."""
+        data = {
+            "id": "plan_1",
+            "steps": [
+                {"id": "step_1", "dependencies": ["step_4"]},
+                {"id": "step_2", "dependencies": ["step_1"]},
+                {"id": "step_3", "dependencies": ["step_2"]},
+                {"id": "step_4", "dependencies": ["step_3"]},
+            ],
+        }
+        with pytest.raises(CircularDependencyError, match="Circular dependency"):
+            Plan.from_json(data)
+
+    def test_dag_accepted(self):
+        """Should accept valid DAG (no cycles)."""
+        data = {
+            "id": "plan_1",
+            "steps": [
+                {"id": "step_1"},
+                {"id": "step_2", "dependencies": ["step_1"]},
+                {"id": "step_3", "dependencies": ["step_1"]},
+                {"id": "step_4", "dependencies": ["step_2", "step_3"]},
+            ],
+        }
+        plan = Plan.from_json(data)
+        assert len(plan.steps) == 4
+
+    def test_disconnected_steps_accepted(self):
+        """Should accept disconnected steps (no dependencies)."""
+        data = {
+            "id": "plan_1",
+            "steps": [
+                {"id": "step_1"},
+                {"id": "step_2"},
+                {"id": "step_3"},
+            ],
+        }
+        plan = Plan.from_json(data)
+        assert len(plan.steps) == 3
+
+    def test_cycle_in_subgraph_rejected(self):
+        """Should detect cycle even in a subgraph."""
+        data = {
+            "id": "plan_1",
+            "steps": [
+                {"id": "step_1"},
+                {"id": "step_2", "dependencies": ["step_1"]},
+                {"id": "step_a", "dependencies": ["step_b"]},
+                {"id": "step_b", "dependencies": ["step_a"]},
+            ],
+        }
+        with pytest.raises(CircularDependencyError, match="Circular dependency"):
+            Plan.from_json(data)
+
+
+class TestGetExecutionOrder:
+    """Tests for topological sort / execution order."""
+
+    def test_linear_dependencies(self):
+        """Should return steps in dependency order for linear deps."""
+        data = {
+            "id": "plan_1",
+            "steps": [
+                {"id": "step_3", "dependencies": ["step_2"]},
+                {"id": "step_1"},
+                {"id": "step_2", "dependencies": ["step_1"]},
+            ],
+        }
+        plan = Plan.from_json(data)
+        order = plan.get_execution_order()
+        assert order.index("step_1") < order.index("step_2")
+        assert order.index("step_2") < order.index("step_3")
+
+    def test_diamond_dependencies(self):
+        """Should handle diamond dependency pattern."""
+        data = {
+            "id": "plan_1",
+            "steps": [
+                {"id": "step_1"},
+                {"id": "step_2", "dependencies": ["step_1"]},
+                {"id": "step_3", "dependencies": ["step_1"]},
+                {"id": "step_4", "dependencies": ["step_2", "step_3"]},
+            ],
+        }
+        plan = Plan.from_json(data)
+        order = plan.get_execution_order()
+        assert order.index("step_1") < order.index("step_2")
+        assert order.index("step_1") < order.index("step_3")
+        assert order.index("step_2") < order.index("step_4")
+        assert order.index("step_3") < order.index("step_4")
+
+    def test_no_dependencies(self):
+        """Should handle steps with no dependencies."""
+        data = {
+            "id": "plan_1",
+            "steps": [
+                {"id": "step_3"},
+                {"id": "step_1"},
+                {"id": "step_2"},
+            ],
+        }
+        plan = Plan.from_json(data)
+        order = plan.get_execution_order()
+        assert set(order) == {"step_1", "step_2", "step_3"}
+
+
+class TestExceptionHierarchy:
+    """Tests for exception hierarchy."""
+
+    def test_duplicate_is_plan_validation_error(self):
+        """DuplicateStepIdError should be a PlanValidationError."""
+        assert issubclass(DuplicateStepIdError, PlanValidationError)
+
+    def test_invalid_dep_is_plan_validation_error(self):
+        """InvalidDependencyError should be a PlanValidationError."""
+        assert issubclass(InvalidDependencyError, PlanValidationError)
+
+    def test_circular_is_plan_validation_error(self):
+        """CircularDependencyError should be a PlanValidationError."""
+        assert issubclass(CircularDependencyError, PlanValidationError)
+
+    def test_can_catch_all_with_base_class(self):
+        """Should be able to catch all validation errors with base class."""
+        errors_to_test = [
+            ({"id": "p", "steps": [{"id": "a"}, {"id": "a"}]}, DuplicateStepIdError),
+            ({"id": "p", "steps": [{"id": "a", "dependencies": ["b"]}]}, InvalidDependencyError),
+            (
+                {
+                    "id": "p",
+                    "steps": [
+                        {"id": "a", "dependencies": ["b"]},
+                        {"id": "b", "dependencies": ["a"]},
+                    ],
+                },
+                CircularDependencyError,
+            ),
+        ]
+
+        for data, _ in errors_to_test:
+            with pytest.raises(PlanValidationError):
+                Plan.from_json(data)
+
+
+class TestEdgeCases:
+    """Tests for edge cases and boundary conditions."""
+
+    def test_empty_dependencies_list(self):
+        """Should handle empty dependencies list."""
+        data = {
+            "id": "plan_1",
+            "steps": [
+                {"id": "step_1", "dependencies": []},
+            ],
+        }
+        plan = Plan.from_json(data)
+        assert plan.steps[0].dependencies == []
+
+    def test_step_with_multiple_dependencies(self):
+        """Should handle steps with multiple dependencies."""
+        data = {
+            "id": "plan_1",
+            "steps": [
+                {"id": "step_1"},
+                {"id": "step_2"},
+                {"id": "step_3"},
+                {"id": "step_4", "dependencies": ["step_1", "step_2", "step_3"]},
+            ],
+        }
+        plan = Plan.from_json(data)
+        assert len(plan.steps[3].dependencies) == 3
+
+    def test_plan_with_extra_fields(self):
+        """Should accept plans with extra fields."""
+        data = {
+            "id": "plan_1",
+            "name": "Test Plan",
+            "description": "A test plan",
+            "metadata": {"version": "1.0"},
+            "steps": [{"id": "step_1"}],
+        }
+        plan = Plan.from_json(data)
+        assert plan.name == "Test Plan"
+        assert plan.description == "A test plan"
+
+    def test_step_with_extra_fields(self):
+        """Should accept steps with extra fields."""
+        data = {
+            "id": "plan_1",
+            "steps": [
+                {
+                    "id": "step_1",
+                    "name": "First Step",
+                    "description": "Do something",
+                    "config": {"timeout": 30},
+                    "custom_field": "custom_value",
+                },
+            ],
+        }
+        plan = Plan.from_json(data)
+        assert plan.steps[0].name == "First Step"
+        assert plan.steps[0].config["timeout"] == 30


### PR DESCRIPTION
## Description

This PR adds a `Plan` schema with robust validation in `Plan.from_json` to catch common plan integrity issues early during loading, preventing subtle runtime errors later in execution.

The validation includes:
- **Duplicate step IDs**: Rejects plans with duplicate step IDs
- **Invalid dependencies**: Raises an error when a step references a dependency that doesn't exist
- **Circular dependencies**: Detects and reports cycles in the dependency graph

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Resolves #1105

## Changes Made

- Added `core/framework/schemas/plan.py` with:
  - `Step` model for individual plan steps with id, name, description, dependencies, and config
  - `Plan` model with `from_json` class method that validates plan integrity
  - `PlanValidationError` base exception and specific exceptions:
    - `DuplicateStepIdError`
    - `InvalidDependencyError`
    - `CircularDependencyError`
  - `get_step()` method to retrieve a step by ID
  - `get_execution_order()` method for topological sort of steps
- Updated `core/framework/schemas/__init__.py` to export new Plan-related classes
- Added `core/tests/test_plan.py` with 33 comprehensive tests covering:
  - Basic model functionality
  - JSON loading (string and dict)
  - Duplicate ID detection
  - Invalid dependency detection
  - Circular dependency detection (simple, 3-node, longer cycles)
  - Execution order calculation
  - Exception hierarchy
  - Edge cases

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && uv run pytest tests/test_plan.py -v`) - 33 tests passed
- [x] Lint passes (`cd core && uv run ruff check framework/schemas/plan.py tests/test_plan.py`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
