### PR TITLE
micro-fix: docs(agents): remove dangling bullet point

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,6 @@ Shared agent instructions for this workspace.
 
 ## Coding Agent Notes
 
-- 
 - When working on a GitHub Issue or PR, print the full URL at the end of the task.
 - When answering questions, respond with high-confidence answers only: verify in code; do not guess.
 - Do not update dependencies casually. Version bumps, patched dependencies, overrides, or vendored dependency changes require explicit approval.


### PR DESCRIPTION
## Description

Removed an empty, dangling bullet point under the Coding Agent Notes section in `agents.md` to clean up the formatting.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

N/A (Micro-fix bypass)

## Changes Made

- Removed stray `- ` bullet point in `agents.md`

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed (Verified markdown formatting)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A