### PR TITLE
micro-fix: migrate aiohttp app state from string keys to typed web.AppKey (#6161)

### DIFF
--- a/core/framework/server/app.py
+++ b/core/framework/server/app.py
@@ -10,6 +10,10 @@ from framework.server.session_manager import Session, SessionManager
 
 logger = logging.getLogger(__name__)
 
+# Typed app-state keys (eliminates NotAppKeyWarning)
+credential_store_key: web.AppKey["CredentialStore"] = web.AppKey("credential_store")
+manager_key: web.AppKey[SessionManager] = web.AppKey("manager", t=SessionManager)
+
 
 # Anchor to the repository root so allowed roots are independent of CWD.
 # app.py lives at core/framework/server/app.py, so four .parent calls
@@ -74,7 +78,7 @@ def resolve_session(request: web.Request):
 
     Returns (session, None) on success or (None, error_response) on failure.
     """
-    manager: SessionManager = request.app["manager"]
+    manager: SessionManager = request.app[manager_key]
     sid = request.match_info["session_id"]
     session = manager.get_session(sid)
     if not session:
@@ -148,13 +152,13 @@ async def error_middleware(request: web.Request, handler):
 
 async def _on_shutdown(app: web.Application) -> None:
     """Gracefully unload all agents on server shutdown."""
-    manager: SessionManager = app["manager"]
+    manager: SessionManager = app[manager_key]
     await manager.shutdown_all()
 
 
 async def handle_health(request: web.Request) -> web.Response:
     """GET /api/health — simple health check."""
-    manager: SessionManager = request.app["manager"]
+    manager: SessionManager = request.app[manager_key]
     sessions = manager.list_sessions()
     return web.json_response(
         {
@@ -202,8 +206,8 @@ def create_app(model: str | None = None) -> web.Application:
         logger.debug("Encrypted credential store unavailable, using in-memory fallback")
         credential_store = CredentialStore.for_testing({})
 
-    app["credential_store"] = credential_store
-    app["manager"] = SessionManager(model=model, credential_store=credential_store)
+    app[credential_store_key] = credential_store
+    app[manager_key] = SessionManager(model=model, credential_store=credential_store)
 
     # Register shutdown hook
     app.on_shutdown.append(_on_shutdown)

--- a/core/framework/server/routes_credentials.py
+++ b/core/framework/server/routes_credentials.py
@@ -8,13 +8,13 @@ from pydantic import SecretStr
 
 from framework.credentials.models import CredentialKey, CredentialObject
 from framework.credentials.store import CredentialStore
-from framework.server.app import validate_agent_path
+from framework.server.app import credential_store_key, validate_agent_path
 
 logger = logging.getLogger(__name__)
 
 
 def _get_store(request: web.Request) -> CredentialStore:
-    return request.app["credential_store"]
+    return request.app[credential_store_key]
 
 
 def _credential_to_dict(cred: CredentialObject) -> dict:

--- a/core/framework/server/routes_execution.py
+++ b/core/framework/server/routes_execution.py
@@ -8,7 +8,7 @@ from typing import Any
 from aiohttp import web
 
 from framework.credentials.validation import validate_agent_credentials
-from framework.server.app import resolve_session, safe_path_segment, sessions_dir
+from framework.server.app import manager_key, resolve_session, safe_path_segment, sessions_dir
 from framework.server.routes_sessions import _credential_error_response
 
 logger = logging.getLogger(__name__)
@@ -133,7 +133,7 @@ async def handle_chat(request: web.Request) -> web.Response:
             )
 
     # Queen is dead — try to revive her
-    manager: Any = request.app["manager"]
+    manager: Any = request.app[manager_key]
     try:
         await manager.revive_queen(session, initial_prompt=message)
         return web.json_response(
@@ -174,7 +174,7 @@ async def handle_queen_context(request: web.Request) -> web.Response:
             return web.json_response({"status": "queued", "delivered": True})
 
     # Queen is dead — try to revive her
-    manager: Any = request.app["manager"]
+    manager: Any = request.app[manager_key]
     try:
         await manager.revive_queen(session)
         # After revival, deliver the message

--- a/core/framework/server/routes_sessions.py
+++ b/core/framework/server/routes_sessions.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from aiohttp import web
 
 from framework.server.app import (
+    manager_key,
     resolve_session,
     safe_path_segment,
     sessions_dir,
@@ -42,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 
 def _get_manager(request: web.Request) -> SessionManager:
-    return request.app["manager"]
+    return request.app[manager_key]
 
 
 def _session_to_live_dict(session) -> dict:


### PR DESCRIPTION
## Description

Resolves #6161

Migrate all aiohttp application state access from deprecated string-based keys (`app["key"]`) to typed `web.AppKey` objects. This eliminates `NotAppKeyWarning` deprecation warnings that currently appear in test output and prepares the codebase for aiohttp 4.0, where string-based access will be removed entirely.

### What changed

Two typed keys are defined in `app.py` and imported wherever they are used:

```python
credential_store_key: web.AppKey["CredentialStore"] = web.AppKey("credential_store")
manager_key: web.AppKey[SessionManager] = web.AppKey("manager", t=SessionManager)
```

**Files modified (4):**

| File | Change |
|------|--------|
| `core/framework/server/app.py` | Define `credential_store_key` and `manager_key`; replace all string-key read/write sites |
| `core/framework/server/routes_execution.py` | Import `manager_key`; replace `request.app["manager"]` |
| `core/framework/server/routes_credentials.py` | Import `credential_store_key`; replace `request.app["credential_store"]` |
| `core/framework/server/routes_sessions.py` | Import `manager_key`; replace `request.app["manager"]` |

### Why this matters

- **Deprecation warnings in CI**: aiohttp 3.x emits `NotAppKeyWarning` every time a string key is used, adding noise to test output
- **Forward compatibility**: aiohttp 4.0 will remove string-based app state access entirely — this migration is required before upgrading
- **Type safety**: `web.AppKey[T]` gives type checkers (mypy, pyright) the concrete type of each stored value, catching misuse at lint time rather than runtime

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Testing

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

This is a mechanical refactor — no runtime behavior changes. The `web.AppKey` constructor receives the same string identifier used previously, so existing serialized state (if any) is unaffected. All existing tests should pass without modification.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added/updated relevant documentation (if applicable)
