### PR TITLE
fix: restore server api routing contracts

### DIFF
--- a/core/framework/server/app.py
+++ b/core/framework/server/app.py
@@ -258,6 +258,9 @@ def _setup_static_serving(app: web.Application) -> None:
     async def handle_spa(request: web.Request) -> web.FileResponse:
         """Serve static files with SPA fallback to index.html."""
         rel_path = request.match_info.get("path", "")
+        if rel_path == "api" or rel_path.startswith("api/"):
+            return web.json_response({"error": "API route not found"}, status=404)
+
         file_path = (dist_dir / rel_path).resolve()
 
         if file_path.is_file() and file_path.is_relative_to(dist_dir):

--- a/core/framework/server/routes_execution.py
+++ b/core/framework/server/routes_execution.py
@@ -103,10 +103,12 @@ async def handle_inject(request: web.Request) -> web.Response:
 
 
 async def handle_chat(request: web.Request) -> web.Response:
-    """POST /api/sessions/{session_id}/chat — send a message to the queen.
+    """POST /api/sessions/{session_id}/chat — route a chat message.
 
-    The input box is permanently connected to the queen agent.
-    Worker input is handled separately via /worker-input.
+    Priority:
+    1. If a worker node is awaiting input, inject into that node.
+    2. Otherwise deliver the message to the queen.
+    3. If neither is available, return 503.
 
     Body: {"message": "hello"}
     """
@@ -119,6 +121,23 @@ async def handle_chat(request: web.Request) -> web.Response:
 
     if not message:
         return web.json_response({"error": "message is required"}, status=400)
+
+    if session.worker_runtime:
+        node_id, graph_id = session.worker_runtime.find_awaiting_node()
+        if node_id:
+            delivered = await session.worker_runtime.inject_input(
+                node_id,
+                message,
+                graph_id=graph_id,
+                is_client_input=True,
+            )
+            return web.json_response(
+                {
+                    "status": "injected",
+                    "node_id": node_id,
+                    "delivered": delivered,
+                }
+            )
 
     queen_executor = session.queen_executor
     if queen_executor is not None:

--- a/core/framework/server/tests/test_api.py
+++ b/core/framework/server/tests/test_api.py
@@ -78,7 +78,7 @@ class MockStream:
     _active_executors: dict = field(default_factory=dict)
     active_execution_ids: set = field(default_factory=set)
 
-    async def cancel_execution(self, execution_id: str) -> bool:
+    async def cancel_execution(self, execution_id: str, *, reason: str | None = None) -> bool:
         return execution_id in self._execution_tasks
 
 


### PR DESCRIPTION
Closes #6252.

## Summary
- restore worker-first smart routing in `/api/sessions/{session_id}/chat` so waiting worker nodes receive chat input before the queen
- prevent unknown `/api/*` routes from falling through to the frontend SPA and returning `index.html` with `200`
- update the stop-route test mock to match the current `cancel_execution(..., reason=...)` signature

## Test plan
- `uv run pytest framework/server/tests/test_api.py`

Made with [Cursor](https://cursor.com)