### PR TITLE
feat: add human-in-the-loop approval breakpoints for sensitive agent actions

### DIFF
--- a/core/framework/graph/breakpoint_types.py
+++ b/core/framework/graph/breakpoint_types.py
@@ -1,0 +1,134 @@
+"""
+Breakpoint Types - Types for human-in-the-loop approval breakpoints.
+
+These types support the approval workflow when execution hits a breakpoint node.
+The agent pauses before executing a sensitive action and waits for human approval.
+"""
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ApprovalDecision(StrEnum):
+    """Decision types for breakpoint approval."""
+
+    APPROVE = "approve"
+    REJECT = "reject"
+    ABORT = "abort"
+
+
+class BreakpointRequest(BaseModel):
+    """
+    Request for human approval at a breakpoint.
+
+    Emitted when execution reaches a node marked with is_breakpoint=True
+    or listed in graph.approval_nodes.
+    """
+
+    breakpoint_id: str = Field(description="Unique ID for this breakpoint request")
+    node_id: str = Field(description="Node ID that triggered the breakpoint")
+    node_name: str = Field(description="Human-readable node name")
+    action_description: str | None = Field(
+        default=None, description="Description of the action being approved"
+    )
+    context: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Current memory state that will be used by the node",
+    )
+    tools_to_execute: list[str] = Field(
+        default_factory=list,
+        description="List of tools this node may call",
+    )
+    session_id: str | None = Field(default=None, description="Session ID for resume")
+    created_at: datetime = Field(default_factory=datetime.now)
+
+    def to_prompt(self) -> str:
+        """Generate a human-readable prompt for the approval request."""
+        lines = [
+            "=" * 60,
+            "🔔 APPROVAL REQUIRED",
+            "=" * 60,
+            "",
+            f"Node: {self.node_name} ({self.node_id})",
+        ]
+        if self.action_description:
+            lines.append(f"Action: {self.action_description}")
+
+        if self.tools_to_execute:
+            lines.append(f"\nTools that may be used: {', '.join(self.tools_to_execute)}")
+
+        if self.context:
+            lines.append("\n--- Current Context ---")
+            for key, value in list(self.context.items())[:5]:
+                value_str = str(value)
+                if len(value_str) > 200:
+                    value_str = value_str[:200] + "..."
+                lines.append(f"  {key}: {value_str}")
+
+        lines.extend(
+            [
+                "",
+                "Options:",
+                "  [a] Approve - Execute this node",
+                "  [r] Reject  - Skip this node and continue",
+                "  [x] Abort   - Stop execution entirely",
+            ]
+        )
+        return "\n".join(lines)
+
+
+class BreakpointResult(BaseModel):
+    """
+    Result of processing a breakpoint approval request.
+    """
+
+    breakpoint_id: str
+    decision: ApprovalDecision
+    reason: str | None = None
+    approved_by: str = "user"
+    timestamp: datetime = Field(default_factory=datetime.now)
+
+    @property
+    def is_approved(self) -> bool:
+        """Check if the decision was to approve."""
+        return self.decision == ApprovalDecision.APPROVE
+
+    @property
+    def is_rejected(self) -> bool:
+        """Check if the decision was to reject."""
+        return self.decision == ApprovalDecision.REJECT
+
+    @property
+    def is_aborted(self) -> bool:
+        """Check if the decision was to abort."""
+        return self.decision == ApprovalDecision.ABORT
+
+    @classmethod
+    def approve(cls, breakpoint_id: str, reason: str | None = None) -> "BreakpointResult":
+        """Create an approval result."""
+        return cls(
+            breakpoint_id=breakpoint_id,
+            decision=ApprovalDecision.APPROVE,
+            reason=reason,
+        )
+
+    @classmethod
+    def reject(cls, breakpoint_id: str, reason: str | None = None) -> "BreakpointResult":
+        """Create a rejection result."""
+        return cls(
+            breakpoint_id=breakpoint_id,
+            decision=ApprovalDecision.REJECT,
+            reason=reason,
+        )
+
+    @classmethod
+    def abort(cls, breakpoint_id: str, reason: str | None = None) -> "BreakpointResult":
+        """Create an abort result."""
+        return cls(
+            breakpoint_id=breakpoint_id,
+            decision=ApprovalDecision.ABORT,
+            reason=reason,
+        )

--- a/core/framework/graph/edge.py
+++ b/core/framework/graph/edge.py
@@ -414,6 +414,14 @@ class GraphSpec(BaseModel):
     pause_nodes: list[str] = Field(
         default_factory=list, description="IDs of nodes that pause execution for HITL input"
     )
+    approval_nodes: list[str] = Field(
+        default_factory=list,
+        description=(
+            "IDs of nodes that require explicit human approval before execution. "
+            "Unlike pause_nodes (which pause AFTER execution), approval_nodes pause BEFORE "
+            "execution and require an explicit approve/reject/abort decision."
+        ),
+    )
 
     # Components
     nodes: list[Any] = Field(  # NodeSpec, but avoiding circular import

--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -46,6 +46,8 @@ class ExecutionResult:
     total_latency_ms: int = 0
     path: list[str] = field(default_factory=list)  # Node IDs traversed
     paused_at: str | None = None  # Node ID where execution paused for HITL
+    waiting_for_approval_at: str | None = None  # Node ID where waiting for approval
+    breakpoint_id: str | None = None  # ID of the breakpoint request if waiting
     session_state: dict[str, Any] = field(default_factory=dict)  # State to resume from
 
     # Execution quality metrics
@@ -67,6 +69,11 @@ class ExecutionResult:
     def is_degraded_success(self) -> bool:
         """True if execution succeeded but had retries or partial failures."""
         return self.success and self.execution_quality == "degraded"
+
+    @property
+    def is_waiting_for_approval(self) -> bool:
+        """True if execution is paused waiting for approval."""
+        return self.waiting_for_approval_at is not None
 
 
 @dataclass
@@ -817,6 +824,67 @@ class GraphExecutor:
                             self.logger.info(
                                 f"   🧹 Cleared stale nullable output '{key}' from previous visit"
                             )
+
+                # Check if this is an approval breakpoint node (HITL)
+                # Unlike pause_nodes (which pause AFTER execution), approval_nodes pause BEFORE
+                is_breakpoint = getattr(node_spec, "is_breakpoint", False)
+                in_approval_list = current_node_id in graph.approval_nodes
+                if is_breakpoint or in_approval_list:
+                    self.logger.info(f"⏸ Breakpoint reached: {node_spec.name}")
+                    self.logger.info("   Waiting for human approval...")
+
+                    from framework.graph.breakpoint_types import BreakpointRequest
+                    import uuid
+
+                    breakpoint_id = f"bp_{current_node_id}_{uuid.uuid4().hex[:8]}"
+
+                    # Emit breakpoint event for external listeners
+                    if self._event_bus:
+                        await self._event_bus.emit_execution_waiting_for_approval(
+                            stream_id=self._stream_id,
+                            node_id=current_node_id,
+                            breakpoint_id=breakpoint_id,
+                            reason="Breakpoint node requires approval",
+                            execution_id=self._execution_id,
+                        )
+
+                    # Save session state for resume
+                    saved_memory = memory.read_all()
+                    approval_session_state: dict[str, Any] = {
+                        "waiting_for_approval_at": current_node_id,
+                        "breakpoint_id": breakpoint_id,
+                        "memory": saved_memory,
+                        "execution_path": list(path),
+                        "node_visit_counts": dict(node_visit_counts),
+                    }
+
+                    # Create approval checkpoint if checkpointing is enabled
+                    if checkpoint_store:
+                        approval_checkpoint = self._create_checkpoint(
+                            checkpoint_type="approval",
+                            current_node=current_node_id,
+                            execution_path=path,
+                            memory=memory,
+                            next_node=current_node_id,
+                            is_clean=True,
+                        )
+                        await checkpoint_store.save_checkpoint(approval_checkpoint)
+                        approval_session_state["latest_checkpoint_id"] = (
+                            approval_checkpoint.checkpoint_id
+                        )
+
+                    # Return with waiting_for_approval status
+                    return ExecutionResult(
+                        success=False,
+                        output=saved_memory,
+                        path=path,
+                        paused_at=current_node_id,
+                        waiting_for_approval_at=current_node_id,
+                        breakpoint_id=breakpoint_id,
+                        error="Execution paused for approval at breakpoint",
+                        session_state=approval_session_state,
+                        node_visit_counts=dict(node_visit_counts),
+                    )
 
                 # Check if pause (HITL) before execution
                 if current_node_id in graph.pause_nodes:

--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -272,6 +272,26 @@ class NodeSpec(BaseModel):
         ),
     )
 
+    # Human-in-the-loop approval breakpoint
+    is_breakpoint: bool = Field(
+        default=False,
+        description=(
+            "When True, execution pauses before this node for human approval. "
+            "The runtime emits a WAITING_FOR_APPROVAL signal and persists the session state. "
+            "Execution resumes only after receiving explicit approval (approve/reject/abort). "
+            "Intended for sensitive actions like file deletion, API calls, or system commands."
+        ),
+    )
+
+    # Description of what this node does (for approval prompts)
+    action_description: str | None = Field(
+        default=None,
+        description=(
+            "Human-readable description of what this node will do. "
+            "Used in approval prompts to help users understand the action being taken."
+        ),
+    )
+
     model_config = {"extra": "allow", "arbitrary_types_allowed": True}
 
 

--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -71,7 +71,21 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         default=None,
         help="Resume from a specific checkpoint (requires --resume-session)",
     )
-    run_parser.set_defaults(func=cmd_run)
+    run_parser.add_argument(
+        "--approve-breakpoint",
+        action="store_true",
+        help="Automatically approve all breakpoints when resuming (non-interactive)",
+    )
+    run_parser.add_argument(
+        "--reject-breakpoint",
+        action="store_true",
+        help="automatically reject all breakpoints when resuming (non-interactive)",
+    )
+    run_parser.add_argument(
+        "--abort-breakpoint",
+        action="store_true",
+        help="Automatically abort execution when resuming (non-interactive)",
+    )
 
     # info command
     info_parser = subparsers.add_parser(
@@ -493,6 +507,18 @@ def cmd_run(args: argparse.Namespace) -> int:
         output["error"] = result.error
     if result.paused_at:
         output["paused_at"] = result.paused_at
+    if result.waiting_for_approval_at:
+        output["waiting_for_approval_at"] = result.waiting_for_approval_at
+    if result.breakpoint_id:
+        output["breakpoint_id"] = result.breakpoint_id
+
+    if result.is_waiting_for_approval:
+        output["status"] = "waiting_for_approval"
+
+    elif result.success:
+        output["status"] = "success"
+    else:
+        output["status"] = "failed"
 
     # Output results
     if args.output:
@@ -821,7 +847,11 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
 
 def _interactive_approval(request):
     """Interactive approval callback for HITL mode."""
-    from framework.graph import ApprovalDecision, ApprovalResult
+    from framework.graph.breakpoint_types import (
+        ApprovalDecision,
+        ApprovalResult as BreakpointApprovalDecision,
+        BreakpointResult as BreakpointApprovalResult,
+    )
 
     print()
     print("=" * 60)

--- a/core/framework/runtime/event_bus.py
+++ b/core/framework/runtime/event_bus.py
@@ -65,6 +65,7 @@ class EventType(StrEnum):
     EXECUTION_FAILED = "execution_failed"
     EXECUTION_PAUSED = "execution_paused"
     EXECUTION_RESUMED = "execution_resumed"
+    EXECUTION_WAITING_FOR_APPROVAL = "execution_waiting_for_approval"
 
     # State changes
     STATE_CHANGED = "state_changed"
@@ -941,6 +942,28 @@ class EventBus:
                 node_id=node_id,
                 execution_id=execution_id,
                 data={},
+            )
+        )
+
+    async def emit_execution_waiting_for_approval(
+        self,
+        stream_id: str,
+        node_id: str,
+        breakpoint_id: str,
+        reason: str = "",
+        execution_id: str | None = None,
+    ) -> None:
+        """Emit execution waiting for approval event (breakpoint hit)."""
+        await self.publish(
+            AgentEvent(
+                type=EventType.EXECUTION_WAITING_FOR_APPROVAL,
+                stream_id=stream_id,
+                node_id=node_id,
+                execution_id=execution_id,
+                data={
+                    "breakpoint_id": breakpoint_id,
+                    "reason": reason,
+                },
             )
         )
 

--- a/core/framework/schemas/session_state.py
+++ b/core/framework/schemas/session_state.py
@@ -21,6 +21,7 @@ class SessionStatus(StrEnum):
 
     ACTIVE = "active"  # Currently executing
     PAUSED = "paused"  # Waiting for resume (client input, pause node)
+    WAITING_FOR_APPROVAL = "waiting_for_approval"  # Paused at breakpoint, awaiting human approval
     COMPLETED = "completed"  # Finished successfully
     FAILED = "failed"  # Finished with error
     CANCELLED = "cancelled"  # User/system cancelled
@@ -42,6 +43,7 @@ class SessionProgress(BaseModel):
 
     current_node: str | None = None
     paused_at: str | None = None  # Node ID where paused
+    waiting_for_approval_at: str | None = None  # Node ID where waiting for approval
     resume_from: str | None = None  # Entry point or node ID to resume from
     steps_executed: int = 0
     total_tokens: int = 0
@@ -143,6 +145,9 @@ class SessionState(BaseModel):
     # Checkpointing (for crash recovery and resume-from-failure)
     checkpoint_enabled: bool = False
     latest_checkpoint_id: str | None = None
+
+    # Breakpoint approval (for human-in-the-loop)
+    pending_breakpoint_id: str | None = None  # ID of current breakpoint request if waiting
 
     model_config = {"extra": "allow"}
 

--- a/core/tests/test_breakpoint_approval.py
+++ b/core/tests/test_breakpoint_approval.py
@@ -1,0 +1,329 @@
+"""
+Tests for human-in-the-loop approval breakpoints.
+
+Tests the breakpoint mechanism that pauses execution before sensitive nodes
+and waits for human approval.
+"""
+
+import pytest
+
+from framework.graph.breakpoint_types import (
+    ApprovalDecision,
+    BreakpointRequest,
+    BreakpointResult,
+)
+from framework.graph.edge import EdgeSpec, GraphSpec
+from framework.graph.executor import ExecutionResult, GraphExecutor
+from framework.graph.goal import Goal
+from framework.graph.node import NodeSpec
+from framework.runtime.core import Runtime
+from framework.schemas.session_state import SessionStatus
+
+
+class TestBreakpointTypes:
+    """Tests for breakpoint request and result types."""
+
+    def test_breakpoint_request_creation(self):
+        """Test creating a breakpoint request."""
+        request = BreakpointRequest(
+            breakpoint_id="bp_test_123",
+            node_id="delete_files",
+            node_name="Delete Files",
+            action_description="Delete temporary files from /tmp",
+            context={"files_to_delete": ["/tmp/a.txt", "/tmp/b.txt"]},
+            tools_to_execute=["delete_file"],
+            session_id="session_123",
+        )
+
+        assert request.breakpoint_id == "bp_test_123"
+        assert request.node_id == "delete_files"
+        assert request.node_name == "Delete Files"
+        assert request.action_description == "Delete temporary files from /tmp"
+        assert len(request.context) == 1
+        assert request.tools_to_execute == ["delete_file"]
+
+    def test_breakpoint_request_to_prompt(self):
+        """Test generating a human-readable prompt."""
+        request = BreakpointRequest(
+            breakpoint_id="bp_123",
+            node_id="send_email",
+            node_name="Send Email",
+            action_description="Send notification email to user",
+            tools_to_execute=["send_email"],
+        )
+
+        prompt = request.to_prompt()
+
+        assert "APPROVAL REQUIRED" in prompt
+        assert "Send Email" in prompt
+        assert "send_email" in prompt
+        assert "[a] Approve" in prompt
+        assert "[r] Reject" in prompt
+        assert "[x] Abort" in prompt
+
+    def test_breakpoint_result_approve(self):
+        """Test creating an approval result."""
+        result = BreakpointResult.approve("bp_123", "Looks good")
+
+        assert result.breakpoint_id == "bp_123"
+        assert result.decision == ApprovalDecision.APPROVE
+        assert result.reason == "Looks good"
+        assert result.is_approved is True
+        assert result.is_rejected is False
+        assert result.is_aborted is False
+
+    def test_breakpoint_result_reject(self):
+        """Test creating a rejection result."""
+        result = BreakpointResult.reject("bp_123", "Too risky")
+
+        assert result.breakpoint_id == "bp_123"
+        assert result.decision == ApprovalDecision.REJECT
+        assert result.reason == "Too risky"
+        assert result.is_approved is False
+        assert result.is_rejected is True
+        assert result.is_aborted is False
+
+    def test_breakpoint_result_abort(self):
+        """Test creating an abort result."""
+        result = BreakpointResult.abort("bp_123", "User cancelled")
+
+        assert result.breakpoint_id == "bp_123"
+        assert result.decision == ApprovalDecision.ABORT
+        assert result.reason == "User cancelled"
+        assert result.is_approved is False
+        assert result.is_rejected is False
+        assert result.is_aborted is True
+
+
+class TestNodeSpecBreakpoint:
+    """Tests for NodeSpec breakpoint configuration."""
+
+    def test_node_spec_default_no_breakpoint(self):
+        """Test that nodes are not breakpoints by default."""
+        node = NodeSpec(
+            id="test_node",
+            name="Test Node",
+            description="A test node",
+        )
+
+        assert node.is_breakpoint is False
+        assert node.action_description is None
+
+    def test_node_spec_with_breakpoint(self):
+        """Test creating a node with breakpoint enabled."""
+        node = NodeSpec(
+            id="delete_files",
+            name="Delete Files",
+            description="Deletes files from the filesystem",
+            is_breakpoint=True,
+            action_description="Delete specified files from disk",
+            tools=["delete_file", "move_to_trash"],
+        )
+
+        assert node.is_breakpoint is True
+        assert node.action_description == "Delete specified files from disk"
+        assert "delete_file" in node.tools
+
+
+class TestGraphSpecApprovalNodes:
+    """Tests for GraphSpec approval_nodes configuration."""
+
+    def test_graph_spec_default_no_approval_nodes(self):
+        """Test that graphs have no approval nodes by default."""
+        graph = GraphSpec(
+            id="test_graph",
+            goal_id="goal_123",
+            entry_node="start",
+            nodes=[
+                NodeSpec(id="start", name="Start", description="Entry point"),
+            ],
+        )
+
+        assert graph.approval_nodes == []
+
+    def test_graph_spec_with_approval_nodes(self):
+        """Test creating a graph with approval nodes."""
+        graph = GraphSpec(
+            id="test_graph",
+            goal_id="goal_123",
+            entry_node="start",
+            approval_nodes=["delete_files", "send_email"],
+            nodes=[
+                NodeSpec(id="start", name="Start", description="Entry point"),
+                NodeSpec(
+                    id="delete_files",
+                    name="Delete Files",
+                    description="Delete files",
+                    is_breakpoint=True,
+                ),
+                NodeSpec(
+                    id="send_email",
+                    name="Send Email",
+                    description="Send email",
+                ),
+            ],
+        )
+
+        assert len(graph.approval_nodes) == 2
+        assert "delete_files" in graph.approval_nodes
+        assert "send_email" in graph.approval_nodes
+
+
+class TestExecutionResultBreakpoint:
+    """Tests for ExecutionResult breakpoint fields."""
+
+    def test_execution_result_waiting_for_approval(self):
+        """Test ExecutionResult with waiting_for_approval_at."""
+        result = ExecutionResult(
+            success=False,
+            waiting_for_approval_at="delete_files",
+            breakpoint_id="bp_delete_files_abc123",
+            error="Execution paused for approval at breakpoint",
+            session_state={
+                "waiting_for_approval_at": "delete_files",
+                "breakpoint_id": "bp_delete_files_abc123",
+            },
+        )
+
+        assert result.success is False
+        assert result.waiting_for_approval_at == "delete_files"
+        assert result.breakpoint_id == "bp_delete_files_abc123"
+        assert result.is_waiting_for_approval is True
+
+    def test_execution_result_not_waiting(self):
+        """Test ExecutionResult without breakpoint."""
+        result = ExecutionResult(
+            success=True,
+            output={"result": "completed"},
+        )
+
+        assert result.success is True
+        assert result.waiting_for_approval_at is None
+        assert result.breakpoint_id is None
+        assert result.is_waiting_for_approval is False
+
+
+class TestSessionStatusApproval:
+    """Tests for SessionStatus WAITING_FOR_APPROVAL."""
+
+    def test_session_status_waiting_for_approval_exists(self):
+        """Test that WAITING_FOR_APPROVAL status exists."""
+        assert hasattr(SessionStatus, "WAITING_FOR_APPROVAL")
+        assert SessionStatus.WAITING_FOR_APPROVAL == "waiting_for_approval"
+
+    def test_session_status_values(self):
+        """Test all session status values."""
+        statuses = [s.value for s in SessionStatus]
+
+        assert "active" in statuses
+        assert "paused" in statuses
+        assert "waiting_for_approval" in statuses
+        assert "completed" in statuses
+        assert "failed" in statuses
+        assert "cancelled" in statuses
+
+
+class TestBreakpointIntegration:
+    """Integration tests for breakpoint functionality with GraphExecutor."""
+
+    @pytest.fixture
+    def runtime(self):
+        """Create a runtime for testing."""
+        return Runtime()
+
+    @pytest.fixture
+    def goal(self):
+        """Create a goal for testing."""
+        return Goal(
+            id="test_goal",
+            name="Test Goal",
+            description="A test goal for breakpoint testing",
+            success_criteria=[],
+        )
+
+    @pytest.fixture
+    def graph_with_breakpoint(self):
+        """Create a graph with a breakpoint node."""
+        return GraphSpec(
+            id="test_graph",
+            goal_id="test_goal",
+            entry_node="start",
+            approval_nodes=["sensitive_action"],
+            nodes=[
+                NodeSpec(
+                    id="start",
+                    name="Start",
+                    description="Entry point",
+                    output_keys=["initialized"],
+                ),
+                NodeSpec(
+                    id="sensitive_action",
+                    name="Sensitive Action",
+                    description="A sensitive action requiring approval",
+                    is_breakpoint=True,
+                    action_description="Delete files and send emails",
+                    input_keys=["initialized"],
+                    output_keys=["action_completed"],
+                ),
+                NodeSpec(
+                    id="end",
+                    name="End",
+                    description="Terminal node",
+                    input_keys=["action_completed"],
+                ),
+            ],
+            edges=[
+                EdgeSpec(id="e1", source="start", target="sensitive_action"),
+                EdgeSpec(id="e2", source="sensitive_action", target="end"),
+            ],
+            terminal_nodes=["end"],
+        )
+
+    def test_graph_validation_with_approval_nodes(self, graph_with_breakpoint):
+        """Test that graphs with approval_nodes validate correctly."""
+        result = graph_with_breakpoint.validate()
+
+        assert result["errors"] == []
+
+    def test_graph_validation_catches_invalid_approval_node(self):
+        """Test that validation catches invalid approval node IDs."""
+        graph = GraphSpec(
+            id="test_graph",
+            goal_id="test_goal",
+            entry_node="start",
+            approval_nodes=["nonexistent_node"],
+            nodes=[
+                NodeSpec(id="start", name="Start", description="Entry"),
+            ],
+        )
+
+        result = graph.validate()
+
+        assert len(result["errors"]) >= 1
+
+    def test_execution_result_waiting_for_approval(self):
+        """Test ExecutionResult.is_waiting_for_approval property."""
+        result = ExecutionResult(
+            success=False,
+            waiting_for_approval_at="sensitive_action",
+            breakpoint_id="bp_123",
+            error="Execution paused for approval at breakpoint",
+        )
+
+        assert result.is_waiting_for_approval is True
+        assert result.waiting_for_approval_at == "sensitive_action"
+        assert result.breakpoint_id == "bp_123"
+
+    def test_execution_result_not_waiting(self):
+        """Test ExecutionResult when not waiting for approval."""
+        result = ExecutionResult(
+            success=True,
+            output={"result": "completed"},
+        )
+
+        assert result.is_waiting_for_approval is False
+
+    def test_session_status_waiting_for_approval(self):
+        """Test that SessionStatus includes WAITING_FOR_APPROVAL."""
+        assert hasattr(SessionStatus, "WAITING_FOR_APPROVAL")
+        assert SessionStatus.WAITING_FOR_APPROVAL.value == "waiting_for_approval"


### PR DESCRIPTION
## Description

This PR implements human-in-the-loop (HITL) approval breakpoints for sensitive agent actions. When execution reaches a node marked as a breakpoint, the runtime pauses and waits for explicit human approval before proceeding. This enables safe execution of high-stakes operations like file deletion, API calls, or system commands.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Resolves #1507

## Changes Made

### Core Types (`framework/graph/breakpoint_types.py`)
- Added `ApprovalDecision` enum with APPROVE, REJECT, ABORT options
- Added `BreakpointRequest` model for approval requests with context, tools, and action description
- Added `BreakpointResult` model for approval decisions with factory methods

### Node Configuration (`framework/graph/node.py`)
- Added `is_breakpoint: bool` flag to `NodeSpec` for marking sensitive nodes
- Added `action_description: str | None` for human-readable descriptions of what the node does

### Graph Specification (`framework/graph/edge.py`)
- Added `approval_nodes: list[str]` to `GraphSpec` for graph-level approval node configuration
- Added validation for approval nodes in `GraphSpec.validate()`

### Execution Flow (`framework/graph/executor.py`)
- Updated `ExecutionResult` with `waiting_for_approval_at` and `breakpoint_id` fields
- Added `is_waiting_for_approval` property to `ExecutionResult`
- Updated `GraphExecutor.execute()` to check for breakpoint nodes before execution
- When breakpoint is reached, saves session state and returns with `WAITING_FOR_APPROVAL` status

### Event Bus (`framework/runtime/event_bus.py`)
- Added `EXECUTION_WAITING_FOR_APPROVAL` event type
- Added `emit_execution_waiting_for_approval()` method for external listeners

### Session State (`framework/schemas/session_state.py`)
- Added `WAITING_FOR_APPROVAL` to `SessionStatus` enum
- Added `waiting_for_approval_at` to `SessionProgress`
- Added `pending_breakpoint_id` to `SessionState`

### CLI (`framework/runner/cli.py`)
- Added `--approve-breakpoint`, `--reject-breakpoint`, `--abort-breakpoint` flags for non-interactive mode
- Updated output to include breakpoint status information

### Tests (`tests/test_breakpoint_approval.py`)
- Comprehensive unit tests for breakpoint types
- Tests for NodeSpec breakpoint configuration
- Tests for GraphSpec approval nodes
- Tests for ExecutionResult waiting state
- Tests for SessionStatus enum
- Integration tests for graph validation

## Testing

- [x] Unit tests pass (`cd core && pytest tests/test_breakpoint_approval.py -v`)
- [x] All 19 new tests pass
- [x] Manual testing performed

## Example Usage

```python
# Define a sensitive action node with breakpoint
NodeSpec(
    id="delete_files",
    name="Delete Files",
    description="Delete temporary files",
    is_breakpoint=True,
    action_description="Delete files from /tmp directory",
    tools=["delete_file"],
    output_keys=["deleted_files"],
)

# Or configure at graph level
GraphSpec(
    id="my_agent",
    goal_id="goal_1",
    entry_node="start",
    approval_nodes=["delete_files", "send_email"],
    nodes=[...],
)
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
