### PR TITLE
Implement safe exponentiation in safe_eval.py

### DIFF
--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -2,6 +2,25 @@ import ast
 import operator
 from typing import Any
 
+# Maximum allowed exponent to prevent resource exhaustion.
+# Edge conditions are evaluated by the graph executor and may originate
+# from LLM-generated code, so we cap the exponent to a safe range.
+_MAX_SAFE_EXPONENT = 1000
+
+
+def _safe_pow(base: Any, exp: Any) -> Any:
+    """Power operator with bounds to prevent denial-of-service.
+
+    Without limits, expressions like ``10 ** 10 ** 10`` consume unbounded
+    CPU and memory, freezing the graph executor for all agents on the runtime.
+    """
+    if isinstance(exp, (int, float)) and abs(exp) > _MAX_SAFE_EXPONENT:
+        raise ValueError(
+            f"Exponent {exp} exceeds safe limit ({_MAX_SAFE_EXPONENT})"
+        )
+    return operator.pow(base, exp)
+
+
 # Safe operators whitelist
 SAFE_OPERATORS = {
     ast.Add: operator.add,
@@ -10,7 +29,7 @@ SAFE_OPERATORS = {
     ast.Div: operator.truediv,
     ast.FloorDiv: operator.floordiv,
     ast.Mod: operator.mod,
-    ast.Pow: operator.pow,
+    ast.Pow: _safe_pow,
     ast.LShift: operator.lshift,
     ast.RShift: operator.rshift,
     ast.BitOr: operator.or_,
@@ -115,11 +134,25 @@ class SafeEvalVisitor(ast.NodeVisitor):
         return True
 
     def visit_BoolOp(self, node: ast.BoolOp) -> Any:
-        values = [self.visit(v) for v in node.values]
+        # Use lazy evaluation to match Python's short-circuit semantics.
+        # Without this, ``False and (10 ** 10 ** 10)`` would still evaluate
+        # the right side, and guard patterns like
+        # ``x is not None and len(x) > 0`` would raise on the right side
+        # when the left side is falsy.
         if isinstance(node.op, ast.And):
-            return all(values)
+            result: Any = True
+            for v in node.values:
+                result = self.visit(v)
+                if not result:
+                    return result
+            return result
         elif isinstance(node.op, ast.Or):
-            return any(values)
+            result = False
+            for v in node.values:
+                result = self.visit(v)
+                if result:
+                    return result
+            return result
         raise ValueError(f"Boolean operator {type(node.op).__name__} is not allowed")
 
     def visit_IfExp(self, node: ast.IfExp) -> Any:


### PR DESCRIPTION
## Description

Harden `safe_eval` against denial-of-service via unbounded `**` operator and fix `BoolOp` to use short-circuit evaluation matching Python semantics. Both issues affect edge condition evaluation in the graph executor, where expressions can originate from LLM-generated code.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #6269 

## Changes Made

- Add bounded `_safe_pow()` wrapper that rejects exponents exceeding 1,000 — prevents `10 ** 10 ** 10` from freezing the graph executor
- Replace eager `BoolOp` evaluation (list comprehension + `all()`/`any()`) with lazy loop that stops on first falsy/truthy value, matching Python's short-circuit semantics
- Add `core/tests/test_safe_eval.py` with 21 test cases covering both fixes and regression tests for existing behavior

## Testing

- [x] Unit tests pass (`cd core && pytest tests/test_safe_eval.py -v`) — 21/21 passing
- [x] Lint passes (`ruff check core/framework/graph/safe_eval.py`)
- [x] Manual testing performed

```
$ cd core && PYTHONPATH=. pytest tests/test_safe_eval.py -v

tests/test_safe_eval.py::TestPowBounds::test_pow_normal_usage PASSED
tests/test_safe_eval.py::TestPowBounds::test_pow_at_limit PASSED
tests/test_safe_eval.py::TestPowBounds::test_pow_rejects_large_exponent PASSED
tests/test_safe_eval.py::TestPowBounds::test_pow_rejects_large_negative_exponent PASSED
tests/test_safe_eval.py::TestPowBounds::test_pow_with_context_variable PASSED
tests/test_safe_eval.py::TestPowBounds::test_pow_rejects_context_variable_large_exp PASSED
tests/test_safe_eval.py::TestBoolOpShortCircuit::test_and_basic PASSED
tests/test_safe_eval.py::TestBoolOpShortCircuit::test_or_basic PASSED
tests/test_safe_eval.py::TestBoolOpShortCircuit::test_and_short_circuits_on_falsy PASSED
tests/test_safe_eval.py::TestBoolOpShortCircuit::test_or_short_circuits_on_truthy PASSED
tests/test_safe_eval.py::TestBoolOpShortCircuit::test_and_evaluates_all_when_truthy PASSED
tests/test_safe_eval.py::TestBoolOpShortCircuit::test_or_evaluates_all_when_falsy PASSED
tests/test_safe_eval.py::TestBoolOpShortCircuit::test_and_returns_first_falsy_value PASSED
tests/test_safe_eval.py::TestBoolOpShortCircuit::test_combined_short_circuit_prevents_dos PASSED
tests/test_safe_eval.py::TestSafeEvalRegression::test_arithmetic PASSED
tests/test_safe_eval.py::TestSafeEvalRegression::test_comparisons PASSED
tests/test_safe_eval.py::TestSafeEvalRegression::test_context_variables PASSED
tests/test_safe_eval.py::TestSafeEvalRegression::test_safe_functions PASSED
tests/test_safe_eval.py::TestSafeEvalRegression::test_ternary PASSED
tests/test_safe_eval.py::TestSafeEvalRegression::test_rejects_unsafe_operations PASSED
tests/test_safe_eval.py::TestSafeEvalRegression::test_rejects_private_attributes PASSED

============================== 21 passed in 0.91s ==============================
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes