### PR TITLE
docs(contributing): add LLM provider configuration prerequisites section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,25 @@ You may submit PRs without prior assignment for:
 ./quickstart.sh
 ```
 
+### Prerequisites: Configuring an LLM Provider
+
+Before running `./quickstart.sh`, you must have at least one LLM provider configured. Hive supports 100+ providers through LiteLLM:
+
+**Popular Options:**
+- **OpenAI** (recommended for Claude): `export OPENAI_API_KEY="sk-..."`
+- **Anthropic**: `export ANTHROPIC_API_KEY="sk-ant-..."`
+- **Google Gemini**: `export GOOGLE_API_KEY="AIza..."`
+- **Other providers**: See [Configuration Guide](https://docs.adenhq.com/getting-started/configuration) for setup
+
+**Set your API key before running quickstart:**
+```bash
+export OPENAI_API_KEY="your-key-here"
+# Then run:
+./quickstart.sh
+```
+
+The quickstart script will verify your LLM provider is correctly configured. If you skip this step, agent initialization will fail with unclear error messages.
+
 > **Windows Users:**  
 > If you are on native Windows, it is recommended to use **WSL (Windows Subsystem for Linux)**.  
 > Alternatively, make sure to run PowerShell or Git Bash with Python 3.11+ installed, and disable "App Execution Aliases" in Windows settings.


### PR DESCRIPTION
Addresses issue #6274 - Clarifies that LLM provider configuration is required before running quickstart.sh

Changes:
- Add new "Prerequisites: Configuring an LLM Provider" subsection
- List supported LLM providers (OpenAI, Anthropic, Google Gemini)
- Provide clear examples of environment variable setup
- Link to configuration guide for additional providers
- Explain consequences of missing LLM setup

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.
