### PR TITLE
Fix 404 response for missing aden_api_key and sanitize 500 errors

### DIFF
--- a/core/framework/credentials/key_storage.py
+++ b/core/framework/credentials/key_storage.py
@@ -142,13 +142,18 @@ def save_aden_api_key(key: str) -> None:
     os.environ[ADEN_ENV_VAR] = key
 
 
-def delete_aden_api_key() -> None:
-    """Remove ADEN_API_KEY from the encrypted store and ``os.environ``."""
+def delete_aden_api_key() -> bool:
+    """Remove ADEN_API_KEY from the encrypted store and ``os.environ``.
+
+    Returns:
+        ``True`` if the key existed and was deleted, ``False`` otherwise.
+    """
+    deleted = False
     try:
         from .storage import EncryptedFileStorage
 
         storage = EncryptedFileStorage()
-        storage.delete(ADEN_CREDENTIAL_ID)
+        deleted = storage.delete(ADEN_CREDENTIAL_ID)
     except (FileNotFoundError, PermissionError) as e:
         logger.debug("Could not delete %s from encrypted store: %s", ADEN_CREDENTIAL_ID, e)
     except Exception:
@@ -159,6 +164,7 @@ def delete_aden_api_key() -> None:
         )
 
     os.environ.pop(ADEN_ENV_VAR, None)
+    return deleted
 
 
 # ---------------------------------------------------------------------------

--- a/core/framework/server/routes_credentials.py
+++ b/core/framework/server/routes_credentials.py
@@ -103,7 +103,11 @@ async def handle_delete_credential(request: web.Request) -> web.Response:
     if credential_id == "aden_api_key":
         from framework.credentials.key_storage import delete_aden_api_key
 
-        delete_aden_api_key()
+        deleted = delete_aden_api_key()
+        if not deleted:
+            return web.json_response(
+                {"error": "Credential 'aden_api_key' not found"}, status=404
+            )
         return web.json_response({"deleted": True})
 
     store = _get_store(request)
@@ -178,7 +182,10 @@ async def handle_check_agent(request: web.Request) -> web.Response:
         )
     except Exception as e:
         logger.exception(f"Error checking agent credentials: {e}")
-        return web.json_response({"error": str(e)}, status=500)
+        return web.json_response(
+            {"error": "Internal server error while checking credentials"},
+            status=500,
+        )
 
 
 def _status_to_dict(c) -> dict:

--- a/core/framework/server/tests/test_api.py
+++ b/core/framework/server/tests/test_api.py
@@ -1504,6 +1504,62 @@ class TestCredentials:
             store = app["credential_store"]
             assert store.get_key("test_cred", "api_key") == "new-value"
 
+    @pytest.mark.asyncio
+    async def test_delete_aden_api_key_not_found(self):
+        """DELETE aden_api_key when the key doesn't exist returns 404."""
+        from unittest.mock import patch
+
+        app = self._make_app()
+        async with TestClient(TestServer(app)) as client:
+            with patch(
+                "framework.credentials.key_storage.delete_aden_api_key",
+                return_value=False,
+            ):
+                resp = await client.delete("/api/credentials/aden_api_key")
+            assert resp.status == 404
+            data = await resp.json()
+            assert "error" in data
+
+    @pytest.mark.asyncio
+    async def test_delete_aden_api_key_success(self):
+        """DELETE aden_api_key when the key exists returns 200 + deleted: true."""
+        from unittest.mock import patch
+
+        app = self._make_app()
+        async with TestClient(TestServer(app)) as client:
+            with patch(
+                "framework.credentials.key_storage.delete_aden_api_key",
+                return_value=True,
+            ):
+                resp = await client.delete("/api/credentials/aden_api_key")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["deleted"] is True
+
+    @pytest.mark.asyncio
+    async def test_check_agent_exception_returns_generic_error(self):
+        """handle_check_agent 500 must NOT leak raw exception text."""
+        from unittest.mock import patch
+
+        app = self._make_app()
+        secret_msg = "secret db password in /opt/hive/creds.json"
+        async with TestClient(TestServer(app)) as client:
+            with patch(
+                "framework.server.routes_credentials.validate_agent_path",
+                return_value=Path("/fake/agent"),
+            ), patch(
+                "framework.credentials.setup.load_agent_nodes",
+                side_effect=RuntimeError(secret_msg),
+            ):
+                resp = await client.post(
+                    "/api/credentials/check-agent",
+                    json={"agent_path": "/fake/agent", "verify": False},
+                )
+            assert resp.status == 500
+            data = await resp.json()
+            assert secret_msg not in json.dumps(data)
+            assert data["error"] == "Internal server error while checking credentials"
+
 
 class TestSSEFormat:
     """Tests for SSE event wire format -- events must be unnamed (data-only)


### PR DESCRIPTION
## Description

Fix two incorrect HTTP response bugs in credential routes: (1) `handle_delete_credential()` always returned `{"deleted": true}` for `aden_api_key` regardless of whether the key existed, and (2) `handle_check_agent()` leaked raw exception text (`str(e)`) in 500 responses, potentially exposing filesystem paths and internal module names.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #6190

## Changes Made

- `core/framework/credentials/key_storage.py`: Changed `delete_aden_api_key()` to return `bool` (`True` if deleted, `False` if not found) instead of `None`, so the route can decide between 404 and 200.
- `core/framework/server/routes_credentials.py`: `handle_delete_credential()` now checks the return value of `delete_aden_api_key()` and returns 404 when the key doesn't exist.
- `core/framework/server/routes_credentials.py`: `handle_check_agent()` now returns a generic `"Internal server error while checking credentials"` message on 500 instead of `str(e)`, while keeping `logger.exception()` for server-side debugging.
- `core/framework/server/tests/test_api.py`: Added three new tests covering delete missing aden_api_key → 404, delete existing aden_api_key → 200, and check-agent exception → 500 with sanitized error.

## Testing

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

All 11 `TestCredentials` tests pass, including the 3 new ones:
- `test_delete_aden_api_key_not_found` — DELETE missing key → 404
- `test_delete_aden_api_key_success` — DELETE existing key → 200 + `{"deleted": true}`
- `test_check_agent_exception_returns_generic_error` — 500 response contains generic message, does NOT include exception text

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes