### PR TITLE
fix: support slash-separated github branch names

### DIFF
--- a/tools/src/aden_tools/tools/duckduckgo_tool/README.md
+++ b/tools/src/aden_tools/tools/duckduckgo_tool/README.md
@@ -1,0 +1,118 @@
+# DuckDuckGo Tool
+
+Search the web, news, and images through DuckDuckGo without requiring API credentials.
+
+This integration wraps the `duckduckgo_search` Python package so agents can fetch public search results for lightweight research and discovery workflows.
+
+## Setup
+
+No API key is required.
+
+The tool depends on the `duckduckgo_search` package that ships with the tools workspace. Once the Aden tools package is installed, the DuckDuckGo tools are ready to use.
+
+## Tools (3)
+
+| Tool | Description |
+|------|-------------|
+| `duckduckgo_search` | Search general web results and return titles, URLs, and snippets |
+| `duckduckgo_news` | Search DuckDuckGo news results and return titles, source, date, URL, and snippet |
+| `duckduckgo_images` | Search image results and return image URLs, thumbnails, source, and dimensions |
+
+## Usage
+
+### Web Search
+
+```python
+result = duckduckgo_search(
+    query="latest AI agent frameworks",
+    max_results=5,
+    region="us-en",
+    safesearch="moderate",
+    timelimit="w",
+)
+
+# Returns:
+# {
+#   "query": "latest AI agent frameworks",
+#   "results": [
+#     {
+#       "title": "...",
+#       "url": "https://...",
+#       "snippet": "..."
+#     }
+#   ],
+#   "count": 5
+# }
+```
+
+### News Search
+
+```python
+result = duckduckgo_news(
+    query="OpenAI announcements",
+    max_results=5,
+    region="us-en",
+    timelimit="d",
+)
+```
+
+### Image Search
+
+```python
+result = duckduckgo_images(
+    query="honey bee macro photo",
+    max_results=8,
+    region="us-en",
+    safesearch="moderate",
+    size="Large",
+)
+```
+
+## Parameters
+
+### `duckduckgo_search`
+
+- `query`: Search query string. Required.
+- `max_results`: Number of results to return. Clamped to `1-50`.
+- `region`: Region code such as `us-en`, `uk-en`, or `de-de`.
+- `safesearch`: One of `on`, `moderate`, or `off`.
+- `timelimit`: Optional time filter: `d`, `w`, `m`, `y`, or empty for any time.
+
+### `duckduckgo_news`
+
+- `query`: News query string. Required.
+- `max_results`: Number of results to return. Clamped to `1-50`.
+- `region`: Region code such as `us-en`.
+- `timelimit`: Optional time filter: `d`, `w`, `m`, or empty for any time.
+
+### `duckduckgo_images`
+
+- `query`: Image query string. Required.
+- `max_results`: Number of results to return. Clamped to `1-50`.
+- `region`: Region code such as `us-en`.
+- `safesearch`: One of `on`, `moderate`, or `off`.
+- `size`: Optional image size filter such as `Small`, `Medium`, `Large`, or `Wallpaper`.
+
+## Error Handling
+
+Each tool returns an error object instead of raising exceptions:
+
+```python
+{"error": "..."}
+```
+
+Common error cases:
+
+- Missing `query`
+- Temporary DuckDuckGo request failures
+- Upstream library/runtime errors
+
+## Scope
+
+- Public web search without account setup
+- News discovery with basic regional and time filtering
+- Image lookup with safe search and size filtering
+
+## API Reference
+
+- [duckduckgo-search on PyPI](https://pypi.org/project/duckduckgo-search/)

--- a/tools/src/aden_tools/tools/github_tool/github_tool.py
+++ b/tools/src/aden_tools/tools/github_tool/github_tool.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 import httpx
 from fastmcp import FastMCP
@@ -39,6 +40,18 @@ def _sanitize_path_param(param: str, param_name: str = "parameter") -> str:
     if "/" in param or ".." in param:
         raise ValueError(f"Invalid {param_name}: cannot contain '/' or '..'")
     return param
+
+
+def _encode_branch_path_param(branch: str) -> str:
+    """Encode branch names for GitHub path segments.
+
+    Git branch names commonly contain forward slashes, e.g. ``feature/foo``.
+    GitHub's branch endpoint expects those slashes to be URL-encoded rather
+    than rejected as path traversal.
+    """
+    if ".." in branch:
+        raise ValueError("Invalid branch: cannot contain '..'")
+    return quote(branch, safe="")
 
 
 def _sanitize_error_message(error: Exception) -> str:
@@ -396,7 +409,7 @@ class _GitHubClient:
         """Get a specific branch."""
         owner = _sanitize_path_param(owner, "owner")
         repo = _sanitize_path_param(repo, "repo")
-        branch = _sanitize_path_param(branch, "branch")
+        branch = _encode_branch_path_param(branch)
         response = httpx.get(
             f"{GITHUB_API_BASE}/repos/{owner}/{repo}/branches/{branch}",
             headers=self._headers,

--- a/tools/tests/tools/test_github_tool.py
+++ b/tools/tests/tools/test_github_tool.py
@@ -18,6 +18,7 @@ from fastmcp import FastMCP
 
 from aden_tools.tools.github_tool.github_tool import (
     _GitHubClient,
+    _encode_branch_path_param,
     register_tools,
 )
 
@@ -69,6 +70,13 @@ class TestGitHubClient:
         result = self.client._handle_response(response)
         assert "error" in result
         assert "Validation" in result["error"]
+
+    def test_encode_branch_path_param_encodes_slashes(self):
+        assert _encode_branch_path_param("feature/test-branch") == "feature%2Ftest-branch"
+
+    def test_encode_branch_path_param_rejects_path_traversal(self):
+        with pytest.raises(ValueError, match="cannot contain '\\.\\.'"):
+            _encode_branch_path_param("../main")
 
     @patch("aden_tools.tools.github_tool.github_tool.httpx.get")
     def test_list_repos(self, mock_get):
@@ -622,3 +630,20 @@ class TestGitHubBranches:
             result = get_branch(owner="owner", repo="repo", branch="main")
 
             assert result["success"] is True
+
+    @patch("aden_tools.tools.github_tool.github_tool.httpx.get")
+    def test_get_branch_encodes_slash_in_branch_name(self, mock_get, mcp):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"name": "feature/test-branch", "protected": False}
+        mock_get.return_value = mock_response
+
+        with patch("os.getenv", return_value="ghp_test"):
+            register_tools(mcp, credentials=None)
+            get_branch = mcp._tool_manager._tools["github_get_branch"].fn
+
+            result = get_branch(owner="owner", repo="repo", branch="feature/test-branch")
+
+            assert result["success"] is True
+            request_url = mock_get.call_args.args[0]
+            assert request_url.endswith("/branches/feature%2Ftest-branch")


### PR DESCRIPTION
## Description
Fixes #6289

Fix `github_get_branch` so branch names containing `/` are URL-encoded instead of rejected.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
- #6289

## Changes Made
- added branch-specific encoding for GitHub branch path parameters
- preserved rejection for `..` to avoid traversal-like input
- added tests for slash-separated branch names and invalid traversal input

## Testing
- [ ] Unit tests pass (`cd tools && uv run python -m pytest tests/tools/test_github_tool.py`)
- [ ] Lint passes
- [x] Manual testing performed

Notes:
- I could not run the automated test suite locally because `pytest` / `uv` were not available in my environment.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [ ] New and existing unit tests pass locally with my changes
