### PR TITLE
fix: prevent deadlock in ConcurrentStorage by sorting lock keys `micro-fix`

### DIFF
--- a/core/framework/storage/concurrent.py
+++ b/core/framework/storage/concurrent.py
@@ -199,6 +199,10 @@ class ConcurrentStorage:
             for node_id in run.metrics.nodes_executed:
                 index_lock_keys.append(f"index:by_node:{node_id}")
 
+            # Sort lock keys to prevent deadlocks from inconsistent lock acquisition order
+            # This ensures all concurrent operations acquire locks in the same order
+            index_lock_keys = sorted(index_lock_keys)
+
             # Collect index locks
             index_locks = [await get_lock(k) for k in index_lock_keys]
 


### PR DESCRIPTION
## Description

Fixes a critical deadlock vulnerability in `ConcurrentStorage._save_run_locked` method. The previous implementation acquired index locks in the order nodes were executed, which could cause circular dependency deadlocks when two parallel runs executed the same nodes in different orders.

**Deadlock Scenario:**
- Run 1 executed Node A then Node B → attempts to lock `index:by_node:A` then `index:by_node:B`
- Run 2 executed Node B then Node A → attempts to lock `index:by_node:B` then `index:by_node:A`
- If timed closely: Run 1 holds A and waits for B, while Run 2 holds B and waits for A → deadlock

**Impact:**
- `_batch_writer` background task hangs
- `_write_queue` backs up indefinitely
- Memory exhaustion

**Fix:**
Sort the `index_lock_keys` list before converting to lock objects. This ensures all concurrent operations acquire locks in the same consistent order, preventing circular wait conditions.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Resolves #1579

## Changes Made

- Added `sorted()` call on `index_lock_keys` in `core/framework/storage/concurrent.py:_save_run_locked` before lock acquisition
- Added comments explaining the deadlock prevention mechanism

## Testing

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed (verified syntax and logic correctness)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
