### PR TITLE
fix: improve LLM provider initialization error messages

### DIFF
--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -1248,12 +1248,21 @@ class AgentRunner:
                             f"(e.g. 'ollama serve' for Ollama)."
                         )
                     api_key_env = self._get_api_key_env_var(self.model)
-                    hint = (
-                        f"Set it with: export {api_key_env}=your-api-key"
-                        if api_key_env
-                        else "Configure an API key for your LLM provider."
-                    )
-                    raise CredentialError(f"LLM API key not found for model '{self.model}'. {hint}")
+                    api_key_url = self._get_api_key_url(self.model)
+                    if api_key_env:
+                        raise CredentialError(
+                            f"LLM provider not configured for model '{self.model}'.\n\n"
+                            f"Please set the {api_key_env} environment variable:\n"
+                            f"  1. Get your API key from: {api_key_url}\n"
+                            f"  2. Run: export {api_key_env}=your-api-key\n"
+                            f"  3. Try again\n"
+                        )
+                    else:
+                        raise CredentialError(
+                            f"LLM provider not configured for model '{self.model}'.\n\n"
+                            f"Please configure an API key for your LLM provider.\n"
+                            f"See {api_key_url} for more information.\n"
+                        )
 
         # For GCU nodes: auto-register GCU MCP server if needed, then expand tool lists
         has_gcu_nodes = any(node.node_type == "gcu" for node in self.graph.nodes)
@@ -1418,6 +1427,45 @@ class AgentRunner:
             "llamacpp/",
         )
         return model.lower().startswith(LOCAL_PREFIXES)
+
+    @staticmethod
+    def _get_api_key_url(model: str) -> str:
+        """Get URL to obtain an API key for a given model provider.
+
+        Args:
+            model: Model name (e.g., 'claude-sonnet-4-20250514', 'gpt-4o-mini')
+
+        Returns:
+            URL to the provider's API key management page
+        """
+        model_lower = model.lower()
+
+        if model_lower.startswith("anthropic/") or model_lower.startswith("claude"):
+            return "https://console.anthropic.com/"
+        elif model_lower.startswith("openai/") or model_lower.startswith("gpt-"):
+            return "https://platform.openai.com/api-keys"
+        elif model_lower.startswith("gemini/") or model_lower.startswith("google/"):
+            return "https://aistudio.google.com/apikey"
+        elif model_lower.startswith("mistral/"):
+            return "https://console.mistral.ai/api-keys/"
+        elif model_lower.startswith("groq/"):
+            return "https://console.groq.com/keys"
+        elif model_lower.startswith("cerebras/"):
+            return "https://cloud.cerebras.ai/"
+        elif model_lower.startswith("azure/"):
+            return "https://portal.azure.com/"
+        elif model_lower.startswith("cohere/"):
+            return "https://dashboard.cohere.com/api-keys"
+        elif model_lower.startswith("replicate/"):
+            return "https://replicate.com/account/api-tokens"
+        elif model_lower.startswith("together/"):
+            return "https://api.together.xyz/settings/api-keys"
+        elif model_lower.startswith("minimax/") or model_lower.startswith("minimax-"):
+            return "https://www.minimaxi.com/user-center/basic-information/interface-key"
+        elif model_lower.startswith("kimi/"):
+            return "https://platform.moonshot.cn/console/api-keys"
+        else:
+            return "https://docs.litellm.ai/docs/providers"
 
     def _setup_agent_runtime(
         self,

--- a/core/tests/test_runner_api_key_env_var.py
+++ b/core/tests/test_runner_api_key_env_var.py
@@ -21,3 +21,79 @@ def test_minimax_provider_prefix_maps_to_minimax_api_key():
 def test_minimax_model_name_prefix_maps_to_minimax_api_key():
     runner = _runner_for_unit_test()
     assert runner._get_api_key_env_var("minimax-chat") == "MINIMAX_API_KEY"
+
+
+class TestGetApiKeyUrl:
+    """Tests for the _get_api_key_url helper method."""
+
+    def test_anthropic_provider_returns_anthropic_console(self):
+        url = AgentRunner._get_api_key_url("anthropic/claude-sonnet-4")
+        assert url == "https://console.anthropic.com/"
+
+    def test_claude_model_returns_anthropic_console(self):
+        url = AgentRunner._get_api_key_url("claude-sonnet-4-20250514")
+        assert url == "https://console.anthropic.com/"
+
+    def test_openai_provider_returns_openai_platform(self):
+        url = AgentRunner._get_api_key_url("openai/gpt-4o")
+        assert url == "https://platform.openai.com/api-keys"
+
+    def test_gpt_model_returns_openai_platform(self):
+        url = AgentRunner._get_api_key_url("gpt-4o-mini")
+        assert url == "https://platform.openai.com/api-keys"
+
+    def test_gemini_provider_returns_google_ai_studio(self):
+        url = AgentRunner._get_api_key_url("gemini/gemini-pro")
+        assert url == "https://aistudio.google.com/apikey"
+
+    def test_google_provider_returns_google_ai_studio(self):
+        url = AgentRunner._get_api_key_url("google/gemini-pro")
+        assert url == "https://aistudio.google.com/apikey"
+
+    def test_mistral_provider_returns_mistral_console(self):
+        url = AgentRunner._get_api_key_url("mistral/mistral-large")
+        assert url == "https://console.mistral.ai/api-keys/"
+
+    def test_groq_provider_returns_groq_console(self):
+        url = AgentRunner._get_api_key_url("groq/llama-3-70b")
+        assert url == "https://console.groq.com/keys"
+
+    def test_cerebras_provider_returns_cerebras_cloud(self):
+        url = AgentRunner._get_api_key_url("cerebras/llama-3.3-70b")
+        assert url == "https://cloud.cerebras.ai/"
+
+    def test_azure_provider_returns_azure_portal(self):
+        url = AgentRunner._get_api_key_url("azure/gpt-4")
+        assert url == "https://portal.azure.com/"
+
+    def test_cohere_provider_returns_cohere_dashboard(self):
+        url = AgentRunner._get_api_key_url("cohere/command-r")
+        assert url == "https://dashboard.cohere.com/api-keys"
+
+    def test_replicate_provider_returns_replicate_tokens(self):
+        url = AgentRunner._get_api_key_url("replicate/llama-70b")
+        assert url == "https://replicate.com/account/api-tokens"
+
+    def test_together_provider_returns_together_api_keys(self):
+        url = AgentRunner._get_api_key_url("together/llama-70b")
+        assert url == "https://api.together.xyz/settings/api-keys"
+
+    def test_minimax_provider_returns_minimax_interface_key(self):
+        url = AgentRunner._get_api_key_url("minimax/minimax-text-01")
+        assert url == "https://www.minimaxi.com/user-center/basic-information/interface-key"
+
+    def test_minimax_model_prefix_returns_minimax_interface_key(self):
+        url = AgentRunner._get_api_key_url("minimax-chat")
+        assert url == "https://www.minimaxi.com/user-center/basic-information/interface-key"
+
+    def test_kimi_provider_returns_moonshot_api_keys(self):
+        url = AgentRunner._get_api_key_url("kimi/kimi-chat")
+        assert url == "https://platform.moonshot.cn/console/api-keys"
+
+    def test_unknown_provider_returns_litellm_docs(self):
+        url = AgentRunner._get_api_key_url("unknown-model")
+        assert url == "https://docs.litellm.ai/docs/providers"
+
+    def test_case_insensitive_model_name(self):
+        url = AgentRunner._get_api_key_url("CLAUDE-SONNET-4")
+        assert url == "https://console.anthropic.com/"


### PR DESCRIPTION
## Description

This PR improves the LLM provider initialization error messages to provide clear, actionable guidance when API keys are missing. Previously, when an API key was not configured, users would receive a generic error message. Now they get step-by-step instructions with a direct link to obtain their API key from the correct provider.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #1642

## Changes Made

- Added `_get_api_key_url()` helper method to `AgentRunner` class that returns provider-specific URLs for obtaining API keys
- Improved the `CredentialError` message in `_setup()` to include:
  - Clear identification of the missing configuration
  - Step-by-step instructions to fix the issue
  - Direct link to the provider's API key management page
- Added comprehensive unit tests for the new `_get_api_key_url()` method covering all supported providers

## Testing

- [x] Unit tests pass (`cd core && pytest tests/test_runner_api_key_env_var.py -v`)
- [x] Lint passes (`cd core && ruff check framework/runner/runner.py`)
- [x] Related tests pass (`cd core && pytest tests/ -k "runner or credential"`)

All 20 tests in the test file pass, including 18 new tests for the `_get_api_key_url()` method.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Example Output

Before:
```
CredentialError: LLM API key not found for model 'claude-sonnet-4-20250514'. Set it with: export ANTHROPIC_API_KEY=your-api-key
```

After:
```
CredentialError: LLM provider not configured for model 'claude-sonnet-4-20250514'.

Please set the ANTHROPIC_API_KEY environment variable:
  1. Get your API key from: https://console.anthropic.com/
  2. Run: export ANTHROPIC_API_KEY=your-api-key
  3. Try again
```
