### PR TITLE
Condense rate limit retry logs to reduce terminal flooding

### DIFF
--- a/core/framework/graph/event_loop_node.py
+++ b/core/framework/graph/event_loop_node.py
@@ -779,15 +779,34 @@ class EventLoopNode(NodeProtocol):
                             * (2 ** (_stream_retry_count - 1)),
                             self._config.stream_retry_max_delay,
                         )
-                        logger.warning(
-                            "[%s] iter=%d: transient error (%s), retrying in %.1fs (%d/%d): %s",
+                        if _stream_retry_count == 1:
+                            logger.warning(
+                                "[%s] iter=%d: transient error (%s), "
+                                "retrying in %.1fs (%d/%d): %s",
+                                node_id,
+                                iteration,
+                                type(e).__name__,
+                                delay,
+                                _stream_retry_count,
+                                self._config.max_stream_retries,
+                                str(e)[:200],
+                            )
+                        else:
+                            logger.warning(
+                                "[%s] iter=%d: transient error (%s), "
+                                "retrying in %.1fs (%d/%d)",
+                                node_id,
+                                iteration,
+                                type(e).__name__,
+                                delay,
+                                _stream_retry_count,
+                                self._config.max_stream_retries,
+                            )
+                        logger.debug(
+                            "[%s] iter=%d: full transient error: %s",
                             node_id,
                             iteration,
-                            type(e).__name__,
-                            delay,
-                            _stream_retry_count,
-                            self._config.max_stream_retries,
-                            str(e)[:200],
+                            str(e),
                         )
                         if self._event_bus:
                             await self._event_bus.emit_node_retry(

--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -256,6 +256,27 @@ def _compute_retry_delay(
     return min(delay, max_delay)
 
 
+def _brief_error(exc: BaseException, max_len: int = 200) -> str:
+    """Return a short, single-line summary of an exception for log messages.
+
+    LLM provider errors (especially RateLimitError) often include the full
+    HTTP response body, which can be hundreds of lines.  This extracts the
+    first non-empty line and truncates it so retry logs stay readable.
+    """
+    text = str(exc)
+    first_line = ""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped:
+            first_line = stripped
+            break
+    if not first_line:
+        first_line = type(exc).__name__
+    if len(first_line) > max_len:
+        return first_line[:max_len] + "..."
+    return first_line
+
+
 def _is_stream_transient_error(exc: BaseException) -> bool:
     """Classify whether a streaming exception is transient (recoverable).
 
@@ -472,7 +493,6 @@ class LiteLLMProvider(LLMProvider):
 
                 return response
             except RateLimitError as e:
-                # Dump full request to file for debugging
                 messages = kwargs.get("messages", [])
                 token_count, token_method = _estimate_tokens(model, messages)
                 dump_path = _dump_failed_request(
@@ -484,19 +504,27 @@ class LiteLLMProvider(LLMProvider):
                 if attempt == retries:
                     logger.error(
                         f"[retry] GAVE UP on {model} after {retries + 1} "
-                        f"attempts — rate limit error: {e!s}. "
+                        f"attempts — rate limit error: {_brief_error(e)}. "
                         f"~{token_count} tokens ({token_method}). "
                         f"Full request dumped to: {dump_path}"
                     )
                     raise
                 wait = _compute_retry_delay(attempt, exception=e)
-                logger.warning(
-                    f"[retry] {model} rate limited (429): {e!s}. "
-                    f"~{token_count} tokens ({token_method}). "
-                    f"Full request dumped to: {dump_path}. "
-                    f"Retrying in {wait}s "
-                    f"(attempt {attempt + 1}/{retries})"
-                )
+                if attempt == 0:
+                    logger.warning(
+                        f"[retry] {model} rate limited (429): {_brief_error(e)}. "
+                        f"~{token_count} tokens ({token_method}). "
+                        f"Full request dumped to: {dump_path}. "
+                        f"Retrying in {wait}s "
+                        f"(attempt {attempt + 1}/{retries})"
+                    )
+                else:
+                    logger.warning(
+                        f"[retry] {model} rate limited (429). "
+                        f"Retrying in {wait}s "
+                        f"(attempt {attempt + 1}/{retries})"
+                    )
+                logger.debug(f"[retry] Full rate limit error: {e!s}")
                 time.sleep(wait)
         # unreachable, but satisfies type checker
         raise RuntimeError("Exhausted rate limit retries")
@@ -684,19 +712,27 @@ class LiteLLMProvider(LLMProvider):
                 if attempt == retries:
                     logger.error(
                         f"[async-retry] GAVE UP on {model} after {retries + 1} "
-                        f"attempts — rate limit error: {e!s}. "
+                        f"attempts — rate limit error: {_brief_error(e)}. "
                         f"~{token_count} tokens ({token_method}). "
                         f"Full request dumped to: {dump_path}"
                     )
                     raise
                 wait = _compute_retry_delay(attempt, exception=e)
-                logger.warning(
-                    f"[async-retry] {model} rate limited (429): {e!s}. "
-                    f"~{token_count} tokens ({token_method}). "
-                    f"Full request dumped to: {dump_path}. "
-                    f"Retrying in {wait}s "
-                    f"(attempt {attempt + 1}/{retries})"
-                )
+                if attempt == 0:
+                    logger.warning(
+                        f"[async-retry] {model} rate limited (429): {_brief_error(e)}. "
+                        f"~{token_count} tokens ({token_method}). "
+                        f"Full request dumped to: {dump_path}. "
+                        f"Retrying in {wait}s "
+                        f"(attempt {attempt + 1}/{retries})"
+                    )
+                else:
+                    logger.warning(
+                        f"[async-retry] {model} rate limited (429). "
+                        f"Retrying in {wait}s "
+                        f"(attempt {attempt + 1}/{retries})"
+                    )
+                logger.debug(f"[async-retry] Full rate limit error: {e!s}")
                 await asyncio.sleep(wait)
         raise RuntimeError("Exhausted rate limit retries")
 
@@ -1217,11 +1253,20 @@ class LiteLLMProvider(LLMProvider):
             except RateLimitError as e:
                 if attempt < RATE_LIMIT_MAX_RETRIES:
                     wait = _compute_retry_delay(attempt, exception=e)
-                    logger.warning(
-                        f"[stream-retry] {self.model} rate limited (429): {e!s}. "
-                        f"Retrying in {wait:.1f}s "
-                        f"(attempt {attempt + 1}/{RATE_LIMIT_MAX_RETRIES})"
-                    )
+                    if attempt == 0:
+                        logger.warning(
+                            f"[stream-retry] {self.model} rate limited (429): "
+                            f"{_brief_error(e)}. "
+                            f"Retrying in {wait:.1f}s "
+                            f"(attempt {attempt + 1}/{RATE_LIMIT_MAX_RETRIES})"
+                        )
+                    else:
+                        logger.warning(
+                            f"[stream-retry] {self.model} rate limited (429). "
+                            f"Retrying in {wait:.1f}s "
+                            f"(attempt {attempt + 1}/{RATE_LIMIT_MAX_RETRIES})"
+                        )
+                    logger.debug(f"[stream-retry] Full rate limit error: {e!s}")
                     await asyncio.sleep(wait)
                     continue
                 yield StreamErrorEvent(error=str(e), recoverable=False)
@@ -1230,11 +1275,22 @@ class LiteLLMProvider(LLMProvider):
             except Exception as e:
                 if _is_stream_transient_error(e) and attempt < RATE_LIMIT_MAX_RETRIES:
                     wait = _compute_retry_delay(attempt, exception=e)
-                    logger.warning(
-                        f"[stream-retry] {self.model} transient error "
-                        f"({type(e).__name__}): {e!s}. "
-                        f"Retrying in {wait:.1f}s "
-                        f"(attempt {attempt + 1}/{RATE_LIMIT_MAX_RETRIES})"
+                    if attempt == 0:
+                        logger.warning(
+                            f"[stream-retry] {self.model} transient error "
+                            f"({type(e).__name__}): {_brief_error(e)}. "
+                            f"Retrying in {wait:.1f}s "
+                            f"(attempt {attempt + 1}/{RATE_LIMIT_MAX_RETRIES})"
+                        )
+                    else:
+                        logger.warning(
+                            f"[stream-retry] {self.model} transient error "
+                            f"({type(e).__name__}). "
+                            f"Retrying in {wait:.1f}s "
+                            f"(attempt {attempt + 1}/{RATE_LIMIT_MAX_RETRIES})"
+                        )
+                    logger.debug(
+                        f"[stream-retry] Full transient error: {e!s}"
                     )
                     await asyncio.sleep(wait)
                     continue


### PR DESCRIPTION
When LLM API rate limits are hit, the system was logging the full exception (often the entire HTTP response body) on every retry attempt (up to 10), flooding the terminal. This PR condenses retry logs so the first retry logs a brief error summary with context (token count, dump path), subsequent retries log only the retry progress line, and full error details remain available at DEBUG level.

## Description

When LLM API rate limits are hit, the system was logging the full exception (often the entire HTTP response body) on every retry attempt (up to 10), flooding the terminal. This PR condenses retry logs so the first retry logs a brief error summary with context (token count, dump path), subsequent retries log only the retry progress line, and full error details remain available at DEBUG level.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #6285, #6290

## Changes Made

- Added _brief_error() helper in core/framework/llm/litellm.py that extracts the first non-empty line of an exception message, truncated to 200 characters, for readable log output
- Updated sync retry handler (_completion_with_rate_limit_retry): first attempt logs brief error + token count + dump path; subsequent attempts log only retry progress; full error always at DEBUG level
- Updated async retry handler (_acompletion_with_rate_limit_retry): same condensed logging pattern as sync
- Updated stream retry handler (stream()): same pattern for both RateLimitError and transient errors
- Updated event loop node retry handler (event_loop_node.py): first retry logs error excerpt, subsequent retries omit repeated error text; full error at DEBUG level

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
