### PR TITLE
feat(cli): add hive doctor for environment diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,26 @@ This sets up:
 
 > **Tip:** To reopen the dashboard later, run `hive open` from the project directory.
 
+### Diagnose your environment (`hive doctor`)
+
+Before running agents, you can verify your setup with the built-in environment checker:
+
+```bash
+hive doctor
+```
+
+This runs checks for:
+
+- **Python & Node** — Ensures Python 3.11+ (and optionally Node 20+ for the frontend)
+- **Dependencies** — Confirms `uv` is installed and that `core/.venv` and `tools/.venv` exist
+- **Environment variables** — Verifies at least one LLM API key is set (e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`)
+- **Configuration** — Checks for `core/pyproject.toml`, `tools/pyproject.toml`, and optional `~/.hive/configuration.json`
+- **Network** — Optionally tests connectivity to the LLM API (skip with `--no-network`)
+
+Passed checks show ✓ and failures show ✗ with suggestions to fix. For script-friendly output, use `hive doctor --json`. Use `hive doctor --no-network` to skip the connectivity check (e.g. when offline). Fix any reported issues and run `hive doctor` again until all checks pass.
+
+**Testing and contributing:** To test changes to `hive doctor` locally, run `make check` and `make test` from the repo root (see [CONTRIBUTING.md](CONTRIBUTING.md)). To submit a pull request, get assigned to an issue, create a feature branch, and open a PR with a clear description and proof that checks/tests pass.
+
 <img width="2500" height="1214" alt="home-screen" src="https://github.com/user-attachments/assets/134d897f-5e75-4874-b00b-e0505f6b45c4" />
 
 ### Build Your First Agent

--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -6,6 +6,7 @@ Usage:
     hive info exports/my-agent
     hive validate exports/my-agent
     hive list exports/
+    hive doctor              # Diagnose environment (Python, deps, env vars, config, network)
     hive dispatch exports/ --input '{"key": "value"}'
     hive shell exports/my-agent
 

--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -3,6 +3,8 @@
 import argparse
 import asyncio
 import json
+import os
+import shutil
 import sys
 from pathlib import Path
 
@@ -118,6 +120,25 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         help="Directory to search (default: exports)",
     )
     list_parser.set_defaults(func=cmd_list)
+
+    # doctor command (environment diagnostics)
+    doctor_parser = subparsers.add_parser(
+        "doctor",
+        help="Diagnose environment before running agents",
+        description="Run checks for Python/Node, dependencies, env vars, config files, "
+        "and optional network connectivity. Use to troubleshoot setup issues.",
+    )
+    doctor_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output results as JSON (list of check objects)",
+    )
+    doctor_parser.add_argument(
+        "--no-network",
+        action="store_true",
+        help="Skip network connectivity check (e.g. when offline)",
+    )
+    doctor_parser.set_defaults(func=cmd_doctor)
 
     # dispatch command (multi-agent)
     dispatch_parser = subparsers.add_parser(
@@ -716,6 +737,46 @@ def cmd_list(args: argparse.Namespace) -> int:
             print()
 
     return 0
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    """Run environment diagnostics and print a report with pass/fail and suggestions."""
+    from framework.runner.doctor import run_doctor_checks
+
+    # Resolve project root (same as doctor module: runner -> framework -> core -> root)
+    _runner_dir = Path(__file__).resolve().parent
+    _core_dir = _runner_dir.parent.parent
+    project_root = _core_dir.parent
+
+    results = run_doctor_checks(
+        project_root=project_root,
+        skip_network=getattr(args, "no_network", False),
+    )
+
+    if args.json:
+        output = [r.to_dict() for r in results]
+        print(json.dumps(output, indent=2))
+        return 0 if all(r.passed for r in results) else 1
+
+    # Terminal report: ✓ for passed, ✗ for failed, with suggestions
+    print("Hive Doctor — environment diagnostics")
+    print("=" * 60)
+    failed = 0
+    for r in results:
+        symbol = "✓" if r.passed else "✗"
+        status = "PASS" if r.passed else "FAIL"
+        print(f"  {symbol} [{status}] {r.name}")
+        print(f"      {r.message}")
+        if not r.passed:
+            failed += 1
+            if r.suggestion:
+                print(f"      → {r.suggestion}")
+    print("=" * 60)
+    if failed == 0:
+        print("All checks passed. You should be able to run agents.")
+    else:
+        print(f"{failed} check(s) failed. Address the suggestions above and run `hive doctor` again.")
+    return 0 if failed == 0 else 1
 
 
 def cmd_dispatch(args: argparse.Namespace) -> int:

--- a/core/framework/runner/doctor.py
+++ b/core/framework/runner/doctor.py
@@ -1,0 +1,421 @@
+"""
+Environment diagnostics for Hive (hive doctor).
+
+Runs checks for Python/Node versions, dependencies, env vars, config files,
+and optional network connectivity. Used by the `hive doctor` CLI command to
+help developers diagnose setup issues before running agents.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+# Minimum Python version required by core/pyproject.toml (requires-python = ">=3.11")
+MIN_PYTHON_MAJOR = 3
+MIN_PYTHON_MINOR = 11
+
+# Node is optional (only needed for frontend); minimum from root package.json engines
+MIN_NODE_MAJOR = 20
+
+# LLM env vars: at least one must be set for running agents (see docs/configuration.md)
+LLM_ENV_VARS = [
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "CEREBRAS_API_KEY",
+    "GROQ_API_KEY",
+    "GEMINI_API_KEY",
+]
+
+# Optional env vars (tools, etc.)
+OPTIONAL_ENV_VARS = [
+    "BRAVE_SEARCH_API_KEY",
+    "EXA_API_KEY",
+]
+
+# Endpoint used for optional network check (Anthropic; most users need this for agents)
+NETWORK_CHECK_URL = "https://api.anthropic.com"
+NETWORK_CHECK_TIMEOUT_SEC = 5
+
+
+@dataclass
+class CheckResult:
+    """Result of a single doctor check."""
+
+    name: str
+    passed: bool
+    message: str
+    suggestion: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for JSON output."""
+        return {
+            "name": self.name,
+            "passed": self.passed,
+            "message": self.message,
+            "suggestion": self.suggestion,
+        }
+
+
+def _project_root_from_runner() -> Path:
+    """Resolve project root: runner/doctor.py -> runner -> framework -> core -> project root."""
+    this_file = Path(__file__).resolve()
+    return this_file.parent.parent.parent.parent
+
+
+def _check_python_version(project_root: Path) -> CheckResult:
+    """Verify Python version meets project requirement (>=3.11)."""
+    major, minor = sys.version_info.major, sys.version_info.minor
+    version_str = f"{major}.{minor}.{sys.version_info.micro}"
+    if major > MIN_PYTHON_MAJOR or (major == MIN_PYTHON_MAJOR and minor >= MIN_PYTHON_MINOR):
+        return CheckResult(
+            name="Python version",
+            passed=True,
+            message=f"Python {version_str} (>= {MIN_PYTHON_MAJOR}.{MIN_PYTHON_MINOR} required)",
+        )
+    return CheckResult(
+        name="Python version",
+        passed=False,
+        message=f"Python {version_str} (project requires >= {MIN_PYTHON_MAJOR}.{MIN_PYTHON_MINOR})",
+        suggestion="Install Python 3.11+ from https://www.python.org/downloads/ or use pyenv.",
+    )
+
+
+def _check_python_version_file(project_root: Path) -> CheckResult:
+    """Check .python-version exists and matches current interpreter (informational)."""
+    pv_path = project_root / ".python-version"
+    if not pv_path.exists():
+        return CheckResult(
+            name=".python-version",
+            passed=True,
+            message="Not found (optional; uv/pyenv use it for version pinning)",
+        )
+    try:
+        requested = pv_path.read_text().strip()
+    except OSError:
+        return CheckResult(
+            name=".python-version",
+            passed=False,
+            message="File exists but could not be read",
+        )
+    current = f"{sys.version_info.major}.{sys.version_info.minor}"
+    if requested == current or requested.startswith(current):
+        return CheckResult(
+            name=".python-version",
+            passed=True,
+            message=f"Set to {requested} (current: {current})",
+        )
+    return CheckResult(
+        name=".python-version",
+        passed=False,
+        message=f"File requests {requested} but current Python is {current}",
+        suggestion="Run `uv sync` in core/ and tools/ or switch interpreter to match.",
+    )
+
+
+def _check_node_version(project_root: Path) -> CheckResult:
+    """Check Node.js version if available (optional; required only for frontend)."""
+    node_path = shutil.which("node")
+    if not node_path:
+        return CheckResult(
+            name="Node.js",
+            passed=True,
+            message="Not found (optional; only needed for frontend: npm run frontend:dev)",
+        )
+    try:
+        out = subprocess.run(
+            ["node", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return CheckResult(
+            name="Node.js",
+            passed=False,
+            message="node found but version check failed",
+        )
+    if out.returncode != 0:
+        return CheckResult(
+            name="Node.js",
+            passed=False,
+            message="node found but version check failed",
+        )
+    raw = out.stdout.strip().lstrip("v")
+    parts = raw.split(".")
+    try:
+        major = int(parts[0]) if parts else 0
+    except ValueError:
+        major = 0
+    if major >= MIN_NODE_MAJOR:
+        return CheckResult(
+            name="Node.js",
+            passed=True,
+            message=f"v{raw} (>= {MIN_NODE_MAJOR} required for frontend)",
+        )
+    return CheckResult(
+        name="Node.js",
+        passed=False,
+        message=f"v{raw} (project recommends >= {MIN_NODE_MAJOR} for frontend)",
+        suggestion="Upgrade Node from https://nodejs.org/ or use nvm.",
+    )
+
+
+def _check_uv(project_root: Path) -> CheckResult:
+    """Check that uv is on PATH (required for install/sync)."""
+    if shutil.which("uv"):
+        return CheckResult(
+            name="uv",
+            passed=True,
+            message="Found on PATH (Python package manager)",
+        )
+    return CheckResult(
+        name="uv",
+        passed=False,
+        message="Not found on PATH",
+        suggestion="Install uv: https://docs.astral.sh/uv/getting-started/installation/",
+    )
+
+
+def _check_ripgrep(project_root: Path) -> CheckResult:
+    """Check ripgrep (rg) - optional but recommended for search_files tool."""
+    if shutil.which("rg"):
+        return CheckResult(
+            name="ripgrep (rg)",
+            passed=True,
+            message="Found (used by search_files tool)",
+        )
+    return CheckResult(
+        name="ripgrep (rg)",
+        passed=False,
+        message="Not found",
+        suggestion="Optional. On Windows: winget install BurntSushi.ripgrep or scoop install ripgrep.",
+    )
+
+
+def _check_core_pyproject(project_root: Path) -> CheckResult:
+    """Verify core/pyproject.toml exists."""
+    path = project_root / "core" / "pyproject.toml"
+    if path.is_file():
+        return CheckResult(
+            name="core/pyproject.toml",
+            passed=True,
+            message=f"Found at {path}",
+        )
+    return CheckResult(
+        name="core/pyproject.toml",
+        passed=False,
+        message=f"Not found at {path}",
+        suggestion="Ensure you are in the Hive repo root (clone from https://github.com/adenhq/hive).",
+    )
+
+
+def _check_tools_pyproject(project_root: Path) -> CheckResult:
+    """Verify tools/pyproject.toml exists."""
+    path = project_root / "tools" / "pyproject.toml"
+    if path.is_file():
+        return CheckResult(
+            name="tools/pyproject.toml",
+            passed=True,
+            message=f"Found at {path}",
+        )
+    return CheckResult(
+        name="tools/pyproject.toml",
+        passed=False,
+        message=f"Not found at {path}",
+        suggestion="Ensure you are in the Hive repo root.",
+    )
+
+
+def _check_core_venv(project_root: Path) -> CheckResult:
+    """Check that core virtualenv exists (created by uv sync in core/)."""
+    venv = project_root / "core" / ".venv"
+    if venv.is_dir():
+        return CheckResult(
+            name="core/.venv",
+            passed=True,
+            message="Found (run `uv sync` in core/ if you see import errors)",
+        )
+    return CheckResult(
+        name="core/.venv",
+        passed=False,
+        message="Not found",
+        suggestion="Run: cd core && uv sync (or run ./quickstart.sh from repo root).",
+    )
+
+
+def _check_tools_venv(project_root: Path) -> CheckResult:
+    """Check that tools virtualenv exists (created by uv sync in tools/)."""
+    venv = project_root / "tools" / ".venv"
+    if venv.is_dir():
+        return CheckResult(
+            name="tools/.venv",
+            passed=True,
+            message="Found",
+        )
+    return CheckResult(
+        name="tools/.venv",
+        passed=False,
+        message="Not found",
+        suggestion="Run: cd tools && uv sync (or run ./quickstart.sh from repo root).",
+    )
+
+
+def _check_llm_env_vars(project_root: Path) -> CheckResult:
+    """At least one LLM API key must be set for running agents."""
+    set_vars = [v for v in LLM_ENV_VARS if os.environ.get(v, "").strip()]
+    if set_vars:
+        return CheckResult(
+            name="LLM API key",
+            passed=True,
+            message=f"At least one set: {', '.join(set_vars)}",
+        )
+    return CheckResult(
+        name="LLM API key",
+        passed=False,
+        message="None of ANTHROPIC_API_KEY, OPENAI_API_KEY, etc. are set",
+        suggestion="Set one of: ANTHROPIC_API_KEY, OPENAI_API_KEY, GROQ_API_KEY, GEMINI_API_KEY. See docs/configuration.md.",
+    )
+
+
+def _check_optional_env_vars(project_root: Path) -> CheckResult:
+    """Report status of optional env vars (no fail)."""
+    set_opt = [v for v in OPTIONAL_ENV_VARS if os.environ.get(v, "").strip()]
+    if set_opt:
+        return CheckResult(
+            name="Optional env (search, etc.)",
+            passed=True,
+            message=f"Set: {', '.join(set_opt)}",
+        )
+    return CheckResult(
+        name="Optional env (search, etc.)",
+        passed=True,
+        message="None set (optional: BRAVE_SEARCH_API_KEY, EXA_API_KEY for web search tools)",
+    )
+
+
+def _check_hive_config(project_root: Path) -> CheckResult:
+    """Check ~/.hive/configuration.json (created by quickstart)."""
+    config_path = Path.home() / ".hive" / "configuration.json"
+    if config_path.is_file():
+        try:
+            data = json.loads(config_path.read_text())
+            if isinstance(data, dict) and "llm" in data:
+                return CheckResult(
+                    name="~/.hive/configuration.json",
+                    passed=True,
+                    message="Found and valid (default LLM config)",
+                )
+            return CheckResult(
+                name="~/.hive/configuration.json",
+                passed=False,
+                message="File exists but missing 'llm' key",
+                suggestion="Re-run quickstart.sh or see docs/configuration.md.",
+            )
+        except (json.JSONDecodeError, OSError):
+            return CheckResult(
+                name="~/.hive/configuration.json",
+                passed=False,
+                message="File exists but invalid or unreadable",
+                suggestion="Re-run quickstart.sh to regenerate.",
+            )
+    return CheckResult(
+        name="~/.hive/configuration.json",
+        passed=True,
+        message="Not found (optional; quickstart.sh creates it)",
+    )
+
+
+def _check_exports_dir(project_root: Path) -> CheckResult:
+    """Check exports/ directory exists (agents live here)."""
+    path = project_root / "exports"
+    if path.is_dir():
+        return CheckResult(
+            name="exports/",
+            passed=True,
+            message="Found (agent packages directory)",
+        )
+    return CheckResult(
+        name="exports/",
+        passed=True,
+        message="Not found (create it or run agents from examples/templates)",
+    )
+
+
+def _check_network(skip: bool) -> CheckResult:
+    """Test connectivity to LLM API (optional; can be skipped)."""
+    if skip:
+        return CheckResult(
+            name="Network (LLM API)",
+            passed=True,
+            message="Skipped (use without --no-network to check)",
+        )
+    try:
+        req = urllib.request.Request(
+            NETWORK_CHECK_URL,
+            method="HEAD",
+            headers={"User-Agent": "Hive-Doctor/1.0"},
+        )
+        urllib.request.urlopen(req, timeout=NETWORK_CHECK_TIMEOUT_SEC)
+        return CheckResult(
+            name="Network (LLM API)",
+            passed=True,
+            message=f"Reachable {NETWORK_CHECK_URL}",
+        )
+    except OSError as e:
+        return CheckResult(
+            name="Network (LLM API)",
+            passed=False,
+            message=f"Could not reach {NETWORK_CHECK_URL}: {e!s}",
+            suggestion="Check firewall/proxy or run with --no-network to skip this check.",
+        )
+
+
+def run_doctor_checks(
+    project_root: Path | None = None,
+    skip_network: bool = False,
+) -> list[CheckResult]:
+    """
+    Run all environment diagnostics.
+
+    Args:
+        project_root: Repo root path. If None, inferred from this file's location.
+        skip_network: If True, do not perform the network connectivity check.
+
+    Returns:
+        List of CheckResult in display order.
+    """
+    root = project_root or _project_root_from_runner()
+    results: list[CheckResult] = []
+
+    # Runtime & tooling
+    results.append(_check_python_version(root))
+    results.append(_check_python_version_file(root))
+    results.append(_check_node_version(root))
+    results.append(_check_uv(root))
+    results.append(_check_ripgrep(root))
+
+    # Project structure and dependencies
+    results.append(_check_core_pyproject(root))
+    results.append(_check_tools_pyproject(root))
+    results.append(_check_core_venv(root))
+    results.append(_check_tools_venv(root))
+
+    # Configuration and env
+    results.append(_check_llm_env_vars(root))
+    results.append(_check_optional_env_vars(root))
+    results.append(_check_hive_config(root))
+    results.append(_check_exports_dir(root))
+
+    # Network (optional)
+    results.append(_check_network(skip_network))
+
+    return results

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -1,0 +1,95 @@
+"""Tests for hive doctor environment diagnostics (framework.runner.doctor)."""
+
+from pathlib import Path
+
+import pytest
+
+from framework.runner.doctor import (
+    CheckResult,
+    run_doctor_checks,
+)
+
+
+class TestCheckResult:
+    """Test CheckResult dataclass and serialization."""
+
+    def test_to_dict(self):
+        r = CheckResult(
+            name="test_check",
+            passed=True,
+            message="OK",
+            suggestion=None,
+        )
+        d = r.to_dict()
+        assert d["name"] == "test_check"
+        assert d["passed"] is True
+        assert d["message"] == "OK"
+        assert d["suggestion"] is None
+
+    def test_to_dict_with_suggestion(self):
+        r = CheckResult(
+            name="fail",
+            passed=False,
+            message="Missing",
+            suggestion="Run quickstart.sh",
+        )
+        d = r.to_dict()
+        assert d["suggestion"] == "Run quickstart.sh"
+
+
+class TestRunDoctorChecks:
+    """Test run_doctor_checks with explicit project_root (e.g. tmp or fixture)."""
+
+    def test_returns_list_of_check_results(self, tmp_path):
+        """run_doctor_checks returns a list of CheckResult of expected length."""
+        # Minimal layout: no core/tools so many checks will fail
+        results = run_doctor_checks(project_root=tmp_path, skip_network=True)
+        assert isinstance(results, list)
+        assert all(isinstance(r, CheckResult) for r in results)
+        # We have: Python, .python-version, Node, uv, ripgrep, core pyproject,
+        # tools pyproject, core venv, tools venv, LLM env, optional env,
+        # hive config, exports, network(skipped) = 14
+        assert len(results) >= 12
+
+    def test_python_version_check_passes_with_current_interpreter(self, tmp_path):
+        """Python version check should pass when running on 3.11+."""
+        results = run_doctor_checks(project_root=tmp_path, skip_network=True)
+        python_check = next((r for r in results if r.name == "Python version"), None)
+        assert python_check is not None
+        # Current interpreter is 3.11+ in CI and dev
+        assert python_check.passed is True
+        assert "3." in python_check.message
+
+    def test_core_pyproject_check_fails_when_missing(self, tmp_path):
+        """core/pyproject.toml check fails when file is missing."""
+        results = run_doctor_checks(project_root=tmp_path, skip_network=True)
+        check = next((r for r in results if r.name == "core/pyproject.toml"), None)
+        assert check is not None
+        assert check.passed is False
+        assert "suggestion" in (check.suggestion or "").lower() or "Not found" in check.message
+
+    def test_core_pyproject_check_passes_when_exists(self, tmp_path):
+        """core/pyproject.toml check passes when file exists."""
+        core_dir = tmp_path / "core"
+        core_dir.mkdir()
+        (core_dir / "pyproject.toml").write_text("[project]\nname = \"framework\"")
+        results = run_doctor_checks(project_root=tmp_path, skip_network=True)
+        check = next((r for r in results if r.name == "core/pyproject.toml"), None)
+        assert check is not None
+        assert check.passed is True
+
+    def test_network_check_skipped_when_skip_network_true(self, tmp_path):
+        """Network check is skipped when skip_network=True."""
+        results = run_doctor_checks(project_root=tmp_path, skip_network=True)
+        net_check = next((r for r in results if r.name == "Network (LLM API)"), None)
+        assert net_check is not None
+        assert "kip" in net_check.message.lower() or "Skipped" in net_check.message
+
+    def test_llm_env_check_exists_and_has_suggestion_when_failed(self, tmp_path):
+        """LLM API key check exists; when it fails, a suggestion is provided."""
+        results = run_doctor_checks(project_root=tmp_path, skip_network=True)
+        llm_check = next((r for r in results if r.name == "LLM API key"), None)
+        assert llm_check is not None
+        if not llm_check.passed:
+            assert llm_check.suggestion is not None
+            assert "ANTHROPIC" in llm_check.suggestion or "OPENAI" in llm_check.suggestion

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -539,6 +539,19 @@ chore(deps): update React to 18.2.0
 
 ## Common Tasks
 
+### Testing the `hive doctor` command
+
+The `hive doctor` command runs environment diagnostics (Python/Node versions, dependencies, env vars, config files, optional network). To test it locally:
+
+```bash
+# From repo root (after running quickstart.sh or uv sync in core/)
+hive doctor              # Terminal report with ✓/✗ and suggestions
+hive doctor --json       # JSON output for scripting
+hive doctor --no-network # Skip network connectivity check (e.g. offline)
+```
+
+Ensure `make check` and `make test` pass before submitting changes that touch the doctor logic. See [Pull Request Process](#pull-request-process) and [CONTRIBUTING.md](../CONTRIBUTING.md) for how to submit a PR.
+
 ### Adding Python Dependencies
 
 ```bash


### PR DESCRIPTION
## Summary
Adds a `hive doctor` CLI command for environment diagnostics and local setup validation.

## What it checks
- Python version
- .python-version
- Node.js
- uv
- ripgrep (optional)
- project structure
- core/tools virtualenv presence
- API key presence
- optional environment variables
- Hive configuration file
- exports directory
- network connectivity check

## Validation
Tested locally with:
- uv run hive doctor
- uv run hive serve

The command successfully detected missing dependencies and configuration issues on my machine.

## Notes
Happy to contribute further improvements, issues, or agent templates aligned with the roadmap.