### PR TITLE
docs(notion): add Notion tool README

### DIFF
--- a/tools/src/aden_tools/tools/notion_tool/README.md
+++ b/tools/src/aden_tools/tools/notion_tool/README.md
@@ -1,0 +1,63 @@
+# Notion Tool
+
+Manage Notion pages and databases via the Notion API (search, read pages/databases, create/update/archive pages, append blocks).
+
+## Setup
+
+```bash
+export NOTION_API_TOKEN=secret_your_integration_token
+```
+
+**Get your token:**
+1. Create an internal integration: `https://www.notion.so/my-integrations`
+2. Copy the integration token
+3. Share the target page/database with the integration (otherwise Notion returns 403/404)
+
+Alternatively, configure credentials via the Aden credential store using the key `notion_token`.
+
+## Tools (8)
+
+| Tool | Description |
+|------|-------------|
+| `notion_search` | Search pages/databases by title text |
+| `notion_get_page` | Fetch a page by ID (returns simplified properties + title) |
+| `notion_create_page` | Create a page in a database |
+| `notion_update_page` | Update an existing page (properties/title) |
+| `notion_archive_page` | Archive (soft-delete) a page |
+| `notion_append_blocks` | Append text blocks to a page |
+| `notion_get_database` | Fetch a database by ID |
+| `notion_query_database` | Query a database with filters/sorts |
+
+## Usage
+
+### Search
+
+```python
+result = notion_search(query="runbook", filter_type="page", page_size=10)
+```
+
+### Create a page in a database
+
+```python
+result = notion_create_page(
+    parent_database_id="database_id",
+    title="Incident Review",
+    properties_json='{"Status": {"select": {"name": "Todo"}}}',
+    content="Notes:\n- Timeline\n- Root cause\n",
+)
+```
+
+### Query a database
+
+```python
+result = notion_query_database(
+    database_id="database_id",
+    filter_json='{"property":"Status","status":{"equals":"Todo"}}',
+    page_size=20,
+)
+```
+
+## API Reference
+
+- Notion API docs: `https://developers.notion.com/reference`
+


### PR DESCRIPTION
## Description

Adds a README for the existing Notion tool with setup instructions, a tool list, and a few usage examples.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

N/A (docs-only)

## Changes Made

- Added `tools/src/aden_tools/tools/notion_tool/README.md`
- Documented `NOTION_API_TOKEN` / `notion_token` credential setup and required Notion sharing step
- Listed available Notion tools and added basic examples (search, create page, query database)

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A