### PR TITLE
feat: Add Agent Template Library/Community Marketplace

### DIFF
--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -14,6 +14,13 @@ Testing commands:
     hive test-debug <agent_path> <test_name>
     hive test-list <agent_path>
     hive test-stats <agent_path>
+
+Template commands:
+    hive template list [--category <cat>] [--tag <tag>] [--search <query>]
+    hive template show <template_id>
+    hive template copy <template_id> [destination] [--name <name>]
+    hive template categories
+    hive template tags
 """
 
 import argparse
@@ -44,7 +51,7 @@ def _configure_paths():
         if exports_str not in sys.path:
             sys.path.insert(0, exports_str)
 
-    # Add examples/templates/ to sys.path so template agents are importable
+    # Add examples/templates/ to sys.path so template agents are importable as top-level packages
     templates_dir = project_root / "examples" / "templates"
     if templates_dir.is_dir():
         templates_str = str(templates_dir)
@@ -83,6 +90,11 @@ def main():
     from framework.runner.cli import register_commands
 
     register_commands(subparsers)
+
+    # Register template commands (template list, show, copy, categories, tags)
+    from framework.templates.cli import register_commands as register_template_commands
+
+    register_template_commands(subparsers)
 
     # Register testing commands (test-run, test-debug, test-list, test-stats)
     from framework.testing.cli import register_testing_commands

--- a/core/framework/templates/__init__.py
+++ b/core/framework/templates/__init__.py
@@ -1,0 +1,29 @@
+"""Hive Template Library.
+
+Browse, search, and copy agent templates from the Hive community library.
+
+Example usage:
+    from framework.templates import TemplateRegistry, TemplateCategory
+
+    registry = TemplateRegistry()
+    templates = registry.discover_templates()
+
+    # Filter by category
+    sales_templates = registry.list_by_category(TemplateCategory.SALES)
+
+    # Search templates
+    results = registry.search("email")
+
+    # Get a specific template
+    template = registry.get_template("job_hunter")
+"""
+
+from framework.templates.models import TemplateCategory, TemplateMetadata
+from framework.templates.registry import TemplateRegistry, get_template_registry
+
+__all__ = [
+    "TemplateCategory",
+    "TemplateMetadata",
+    "TemplateRegistry",
+    "get_template_registry",
+]

--- a/core/framework/templates/cli.py
+++ b/core/framework/templates/cli.py
@@ -1,0 +1,283 @@
+"""CLI commands for the Hive template library."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from framework.templates.models import TemplateCategory
+from framework.templates.registry import TemplateRegistry, get_template_registry
+
+
+def register_commands(subparsers: argparse._SubParsersAction) -> None:
+    """Register template commands with the main CLI."""
+
+    template_parser = subparsers.add_parser(
+        "template",
+        help="Manage agent templates",
+        description="Browse, search, and copy agent templates from the Hive library.",
+    )
+    template_subparsers = template_parser.add_subparsers(dest="template_command", required=True)
+
+    list_parser = template_subparsers.add_parser(
+        "list",
+        help="List available templates",
+        description="List all templates or filter by category/tag.",
+    )
+    list_parser.add_argument(
+        "--category",
+        "-c",
+        type=str,
+        help="Filter by category (sales, support, ops, research, growth, productivity, development, hr, finance, marketing)",
+    )
+    list_parser.add_argument(
+        "--tag",
+        "-t",
+        type=str,
+        help="Filter by tag",
+    )
+    list_parser.add_argument(
+        "--search",
+        "-s",
+        type=str,
+        help="Search templates by name, description, or tags",
+    )
+    list_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    list_parser.set_defaults(func=cmd_template_list)
+
+    show_parser = template_subparsers.add_parser(
+        "show",
+        help="Show template details",
+        description="Display detailed information about a specific template.",
+    )
+    show_parser.add_argument(
+        "template_id",
+        type=str,
+        help="Template ID (directory name)",
+    )
+    show_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    show_parser.set_defaults(func=cmd_template_show)
+
+    copy_parser = template_subparsers.add_parser(
+        "copy",
+        help="Copy a template",
+        description="Copy a template to your exports directory or a custom location.",
+    )
+    copy_parser.add_argument(
+        "template_id",
+        type=str,
+        help="Template ID to copy",
+    )
+    copy_parser.add_argument(
+        "destination",
+        type=str,
+        nargs="?",
+        default="exports",
+        help="Destination directory (default: exports)",
+    )
+    copy_parser.add_argument(
+        "--name",
+        "-n",
+        type=str,
+        help="New name for the copied template",
+    )
+    copy_parser.set_defaults(func=cmd_template_copy)
+
+    categories_parser = template_subparsers.add_parser(
+        "categories",
+        help="List template categories",
+        description="List all available template categories.",
+    )
+    categories_parser.set_defaults(func=cmd_template_categories)
+
+    tags_parser = template_subparsers.add_parser(
+        "tags",
+        help="List template tags",
+        description="List all unique tags used across templates.",
+    )
+    tags_parser.set_defaults(func=cmd_template_tags)
+
+
+def cmd_template_list(args: argparse.Namespace) -> int:
+    """List available templates."""
+    registry = get_template_registry()
+
+    templates = []
+
+    if args.search:
+        templates = registry.search(args.search)
+    elif args.category:
+        try:
+            category = TemplateCategory.from_string(args.category)
+            templates = registry.list_by_category(category)
+        except ValueError:
+            print(f"Invalid category: {args.category}", file=sys.stderr)
+            print(f"Valid categories: {', '.join(c.value for c in TemplateCategory)}")
+            return 1
+    elif args.tag:
+        templates = registry.list_by_tag(args.tag)
+    else:
+        templates = registry.discover_templates()
+
+    if not templates:
+        print("No templates found.")
+        return 0
+
+    if args.json:
+        import json
+
+        output = [t.to_dict() for t in templates]
+        print(json.dumps(output, indent=2))
+        return 0
+
+    print(f"\nFound {len(templates)} template(s):\n")
+
+    for template in templates:
+        print(f"  {template.name} ({template.id})")
+        print(f"    Category: {template.category.display_name()}")
+        desc = template.description
+        if len(desc) > 60:
+            desc = desc[:60] + "..."
+        print(f"    Description: {desc}")
+        if template.tags:
+            tags_str = ", ".join(template.tags[:5])
+            if len(template.tags) > 5:
+                tags_str += f" (+{len(template.tags) - 5} more)"
+            print(f"    Tags: {tags_str}")
+        print(f"    Nodes: {template.node_count}, Tools: {template.tool_count}")
+        print()
+
+    return 0
+
+
+def cmd_template_show(args: argparse.Namespace) -> int:
+    """Show details for a specific template."""
+    registry = get_template_registry()
+    template = registry.get_template(args.template_id)
+
+    if template is None:
+        print(f"Template not found: {args.template_id}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        import json
+
+        print(json.dumps(template.to_dict(), indent=2))
+        return 0
+
+    print(f"\n{template.name}")
+    print("=" * len(template.name))
+    print(f"\nID: {template.id}")
+    print(f"Category: {template.category.display_name()}")
+    print(f"Version: {template.version}")
+    print(f"Author: {template.author}")
+    print(f"\nDescription:\n  {template.description}")
+
+    if template.tags:
+        print(f"\nTags: {', '.join(template.tags)}")
+
+    print(f"\nStructure:")
+    print(f"  Nodes: {template.node_count}")
+    print(f"  Tools: {template.tool_count}")
+
+    if template.required_tools:
+        print(f"\nRequired Tools:")
+        for tool in template.required_tools:
+            print(f"  - {tool}")
+
+    if template.path:
+        print(f"\nPath: {template.path}")
+        print(f"\nUsage:")
+        print(f"  hive run {template.path}")
+        print(f"  hive template copy {template.id}")
+
+    print()
+
+    return 0
+
+
+def cmd_template_copy(args: argparse.Namespace) -> int:
+    """Copy a template to a new location."""
+    import shutil
+
+    registry = get_template_registry()
+    template = registry.get_template(args.template_id)
+
+    if template is None:
+        print(f"Template not found: {args.template_id}", file=sys.stderr)
+        return 1
+
+    destination = Path(args.destination)
+
+    if not destination.is_absolute():
+        project_root = Path.cwd()
+        while project_root.parent != project_root:
+            if (project_root / "core").is_dir():
+                break
+            project_root = project_root.parent
+        destination = project_root / destination
+
+    try:
+        dest_path = registry.copy_template(args.template_id, destination, args.name)
+        if dest_path is None:
+            print(f"Failed to copy template: {args.template_id}", file=sys.stderr)
+            return 1
+
+        print(f"Copied template to: {dest_path}")
+        print(f"\nYou can now customize and run it:")
+        print(f"  cd {dest_path}")
+        print(f'  hive run . --input \'{{"key": "value"}}\'')
+
+        return 0
+
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"Failed to copy template: {e}", file=sys.stderr)
+        return 1
+
+
+def cmd_template_categories(args: argparse.Namespace) -> int:
+    """List all template categories."""
+    registry = get_template_registry()
+    categories = registry.get_categories()
+
+    print("\nAvailable Categories:\n")
+
+    for category in categories:
+        count = len(registry.list_by_category(category))
+        print(f"  {category.display_name():<15} ({count} templates)")
+
+    print()
+
+    return 0
+
+
+def cmd_template_tags(args: argparse.Namespace) -> int:
+    """List all template tags."""
+    registry = get_template_registry()
+    tags = registry.get_all_tags()
+
+    if not tags:
+        print("No tags found.")
+        return 0
+
+    print("\nAvailable Tags:\n")
+
+    for tag in tags:
+        count = len(registry.list_by_tag(tag))
+        print(f"  {tag} ({count} templates)")
+
+    print()
+
+    return 0

--- a/core/framework/templates/models.py
+++ b/core/framework/templates/models.py
@@ -1,0 +1,90 @@
+"""Template metadata models for the Hive template library."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+
+class TemplateCategory(Enum):
+    """Categories for organizing templates."""
+
+    SALES = "sales"
+    SUPPORT = "support"
+    OPS = "ops"
+    RESEARCH = "research"
+    GROWTH = "growth"
+    PRODUCTIVITY = "productivity"
+    DEVELOPMENT = "development"
+    HR = "hr"
+    FINANCE = "finance"
+    MARKETING = "marketing"
+    GENERAL = "general"
+
+    @classmethod
+    def from_string(cls, value: str | None) -> TemplateCategory:
+        """Convert a string to a TemplateCategory, defaulting to GENERAL."""
+        if value is None:
+            return cls.GENERAL
+        try:
+            return cls(value.lower())
+        except ValueError:
+            return cls.GENERAL
+
+    def display_name(self) -> str:
+        """Return a human-readable category name."""
+        special_cases = {"hr": "HR", "ops": "Ops"}
+        return special_cases.get(self.value, self.value.title())
+
+
+@dataclass
+class TemplateMetadata:
+    """Metadata for a template agent."""
+
+    id: str
+    name: str
+    description: str
+    category: TemplateCategory
+    tags: list[str] = field(default_factory=list)
+    author: str = "Hive Team"
+    version: str = "1.0.0"
+    node_count: int = 0
+    tool_count: int = 0
+    required_tools: list[str] = field(default_factory=list)
+    popularity: int = 0
+    path: Path | None = None
+
+    def to_dict(self) -> dict:
+        """Convert metadata to a dictionary for serialization."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "category": self.category.value,
+            "tags": self.tags,
+            "author": self.author,
+            "version": self.version,
+            "node_count": self.node_count,
+            "tool_count": self.tool_count,
+            "required_tools": self.required_tools,
+            "popularity": self.popularity,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict, path: Path | None = None) -> TemplateMetadata:
+        """Create TemplateMetadata from a dictionary."""
+        return cls(
+            id=data.get("id", ""),
+            name=data.get("name", ""),
+            description=data.get("description", ""),
+            category=TemplateCategory.from_string(data.get("category", "general")),
+            tags=data.get("tags", []),
+            author=data.get("author", "Hive Team"),
+            version=data.get("version", "1.0.0"),
+            node_count=data.get("node_count", 0),
+            tool_count=data.get("tool_count", 0),
+            required_tools=data.get("required_tools", []),
+            popularity=data.get("popularity", 0),
+            path=path,
+        )

--- a/core/framework/templates/registry.py
+++ b/core/framework/templates/registry.py
@@ -1,0 +1,259 @@
+"""Template registry for discovering and querying Hive templates."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from framework.templates.models import TemplateCategory, TemplateMetadata
+
+
+class TemplateRegistry:
+    """Registry for discovering and querying Hive agent templates."""
+
+    def __init__(self, templates_dir: Path | None = None):
+        """Initialize the template registry.
+
+        Args:
+            templates_dir: Directory containing templates. Defaults to
+                examples/templates/ relative to this file.
+        """
+        if templates_dir is None:
+            framework_dir = Path(__file__).resolve().parent.parent
+            templates_dir = framework_dir.parent.parent / "examples" / "templates"
+        self.templates_dir = templates_dir
+        self._cache: list[TemplateMetadata] | None = None
+
+    def discover_templates(self, force_reload: bool = False) -> list[TemplateMetadata]:
+        """Discover all available templates.
+
+        Args:
+            force_reload: Force reload from disk, ignoring cache.
+
+        Returns:
+            List of TemplateMetadata for all discovered templates.
+        """
+        if self._cache is not None and not force_reload:
+            return self._cache
+
+        templates: list[TemplateMetadata] = []
+
+        if not self.templates_dir.exists():
+            return templates
+
+        for template_path in sorted(self.templates_dir.iterdir()):
+            if not template_path.is_dir():
+                continue
+
+            metadata = self._load_template_metadata(template_path)
+            if metadata:
+                templates.append(metadata)
+
+        self._cache = templates
+        return templates
+
+    def _load_template_metadata(self, template_path: Path) -> TemplateMetadata | None:
+        """Load metadata for a single template.
+
+        Args:
+            template_path: Path to the template directory.
+
+        Returns:
+            TemplateMetadata if valid template, None otherwise.
+        """
+        agent_json = template_path / "agent.json"
+        agent_py = template_path / "agent.py"
+        template_json = template_path / "template.json"
+
+        if not (agent_json.exists() or agent_py.exists()):
+            return None
+
+        template_id = template_path.name
+        name = template_id.replace("_", " ").title()
+        description = ""
+        category = TemplateCategory.GENERAL
+        tags: list[str] = []
+        author = "Hive Team"
+        version = "1.0.0"
+        node_count = 0
+        tool_count = 0
+        required_tools: list[str] = []
+
+        if template_json.exists():
+            try:
+                data = json.loads(template_json.read_text(encoding="utf-8"))
+                name = data.get("name", name)
+                description = data.get("description", "")
+                category = TemplateCategory.from_string(data.get("category", "general"))
+                tags = data.get("tags", [])
+                author = data.get("author", author)
+                version = data.get("version", version)
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        if agent_json.exists():
+            try:
+                data = json.loads(agent_json.read_text(encoding="utf-8"))
+                agent_data = data.get("agent", {})
+                graph_data = data.get("graph", {})
+
+                if not name or name == template_id.replace("_", " ").title():
+                    name = agent_data.get("name", name)
+                if not description:
+                    description = agent_data.get("description", "")
+
+                nodes = graph_data.get("nodes", [])
+                node_count = len(nodes)
+
+                tools: set[str] = set()
+                for node in nodes:
+                    node_tools = node.get("tools", [])
+                    if isinstance(node_tools, list):
+                        tools.update(node_tools)
+                tool_count = len(tools)
+                required_tools = list(tools)
+
+                if not tags:
+                    tags = agent_data.get("tags", [])
+
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        if not description:
+            description = f"A {category.display_name().lower()} agent template."
+
+        return TemplateMetadata(
+            id=template_id,
+            name=name,
+            description=description,
+            category=category,
+            tags=tags,
+            author=author,
+            version=version,
+            node_count=node_count,
+            tool_count=tool_count,
+            required_tools=required_tools,
+            path=template_path,
+        )
+
+    def get_template(self, template_id: str) -> TemplateMetadata | None:
+        """Get a specific template by ID.
+
+        Args:
+            template_id: The template identifier (directory name).
+
+        Returns:
+            TemplateMetadata if found, None otherwise.
+        """
+        templates = self.discover_templates()
+        for template in templates:
+            if template.id == template_id:
+                return template
+        return None
+
+    def list_by_category(self, category: TemplateCategory) -> list[TemplateMetadata]:
+        """List templates filtered by category.
+
+        Args:
+            category: The category to filter by.
+
+        Returns:
+            List of templates in the specified category.
+        """
+        templates = self.discover_templates()
+        return [t for t in templates if t.category == category]
+
+    def list_by_tag(self, tag: str) -> list[TemplateMetadata]:
+        """List templates filtered by tag.
+
+        Args:
+            tag: The tag to filter by.
+
+        Returns:
+            List of templates with the specified tag.
+        """
+        templates = self.discover_templates()
+        tag_lower = tag.lower()
+        return [t for t in templates if tag_lower in [t.lower() for t in t.tags]]
+
+    def search(self, query: str) -> list[TemplateMetadata]:
+        """Search templates by name, description, or tags.
+
+        Args:
+            query: Search query string.
+
+        Returns:
+            List of matching templates.
+        """
+        templates = self.discover_templates()
+        query_lower = query.lower()
+
+        results = []
+        for template in templates:
+            if (
+                query_lower in template.name.lower()
+                or query_lower in template.description.lower()
+                or any(query_lower in tag.lower() for tag in template.tags)
+            ):
+                results.append(template)
+
+        return results
+
+    def get_categories(self) -> list[TemplateCategory]:
+        """Get list of categories that have templates.
+
+        Returns:
+            List of categories with at least one template.
+        """
+        templates = self.discover_templates()
+        categories = set(t.category for t in templates)
+        return sorted(categories, key=lambda c: c.value)
+
+    def get_all_tags(self) -> list[str]:
+        """Get list of all unique tags across templates.
+
+        Returns:
+            Sorted list of unique tags.
+        """
+        templates = self.discover_templates()
+        tags = set()
+        for template in templates:
+            tags.update(template.tags)
+        return sorted(tags)
+
+    def copy_template(
+        self, template_id: str, destination: Path, new_name: str | None = None
+    ) -> Path | None:
+        """Copy a template to a new location.
+
+        Args:
+            template_id: The template to copy.
+            destination: Destination directory.
+            new_name: Optional new name for the copied template.
+
+        Returns:
+            Path to the copied template, or None if template not found.
+        """
+        import shutil
+
+        template = self.get_template(template_id)
+        if template is None or template.path is None:
+            return None
+
+        dest_name = new_name or template_id
+        dest_path = destination / dest_name
+
+        if dest_path.exists():
+            raise ValueError(f"Destination already exists: {dest_path}")
+
+        shutil.copytree(template.path, dest_path)
+        return dest_path
+
+
+def get_template_registry() -> TemplateRegistry:
+    """Get the global template registry instance.
+
+    Returns:
+        TemplateRegistry instance.
+    """
+    return TemplateRegistry()

--- a/core/tests/framework/templates/test_templates.py
+++ b/core/tests/framework/templates/test_templates.py
@@ -1,0 +1,212 @@
+"""Tests for the Hive template library."""
+
+from __future__ import annotations
+
+import pytest
+from pathlib import Path
+
+from framework.templates.models import TemplateCategory, TemplateMetadata
+from framework.templates.registry import TemplateRegistry
+
+
+class TestTemplateModels:
+    """Tests for template metadata models."""
+
+    def test_template_category_from_string(self):
+        assert TemplateCategory.from_string("sales") == TemplateCategory.SALES
+        assert TemplateCategory.from_string("SUPPORT") == TemplateCategory.SUPPORT
+        assert TemplateCategory.from_string("research") == TemplateCategory.RESEARCH
+        assert TemplateCategory.from_string("unknown") == TemplateCategory.GENERAL
+
+        assert TemplateCategory.from_string("OPS") == TemplateCategory.OPS
+        assert TemplateCategory.from_string("Productivity") == TemplateCategory.PRODUCTIVITY
+
+        assert TemplateCategory.from_string("HR") == TemplateCategory.HR
+
+        assert TemplateCategory.from_string("Finance") == TemplateCategory.FINANCE
+        assert TemplateCategory.from_string("Marketing") == TemplateCategory.MARKETING
+
+        assert TemplateCategory.from_string("Growth") == TemplateCategory.GROWTH
+        assert TemplateCategory.from_string("Development") == TemplateCategory.DEVELOPMENT
+
+        assert TemplateCategory.from_string("") == TemplateCategory.GENERAL
+        assert TemplateCategory.from_string(None) == TemplateCategory.GENERAL
+
+    def test_template_category_display_name(self):
+        assert TemplateCategory.SALES.display_name() == "Sales"
+        assert TemplateCategory.RESEARCH.display_name() == "Research"
+        assert TemplateCategory.OPS.display_name() == "Ops"
+        assert TemplateCategory.GROWTH.display_name() == "Growth"
+        assert TemplateCategory.PRODUCTIVITY.display_name() == "Productivity"
+        assert TemplateCategory.DEVELOPMENT.display_name() == "Development"
+        assert TemplateCategory.HR.display_name() == "HR"
+        assert TemplateCategory.FINANCE.display_name() == "Finance"
+        assert TemplateCategory.MARKETING.display_name() == "Marketing"
+
+        assert TemplateCategory.GENERAL.display_name() == "General"
+
+    def test_template_metadata_to_dict(self):
+        metadata = TemplateMetadata(
+            id="test_agent",
+            name="Test Agent",
+            description="A test agent",
+            category=TemplateCategory.RESEARCH,
+            tags=["test", "demo"],
+            author="Test Author",
+            version="1.0.0",
+            node_count=3,
+            tool_count=2,
+            required_tools=["web_search", "save_data"],
+            popularity=100,
+        )
+
+        result = metadata.to_dict()
+
+        assert result["id"] == "test_agent"
+        assert result["name"] == "Test Agent"
+        assert result["category"] == "research"
+        assert result["tags"] == ["test", "demo"]
+        assert result["node_count"] == 3
+        assert result["tool_count"] == 2
+
+        assert result["author"] == "Test Author"
+        assert result["version"] == "1.0.0"
+        assert result["popularity"] == 100
+
+        assert result["required_tools"] == ["web_search", "save_data"]
+
+    def test_template_metadata_from_dict(self):
+        data = {
+            "id": "from_dict_test",
+            "name": "From Dict Test",
+            "description": "Testing from_dict",
+            "category": "productivity",
+            "tags": ["unit-test"],
+            "node_count": 1,
+        }
+
+        metadata = TemplateMetadata.from_dict(data)
+
+        assert metadata.id == "from_dict_test"
+        assert metadata.name == "From Dict Test"
+        assert metadata.category == TemplateCategory.PRODUCTIVITY
+        assert metadata.tags == ["unit-test"]
+        assert metadata.node_count == 1
+        assert metadata.author == "Hive Team"
+        assert metadata.version == "1.0.0"
+
+    def test_template_metadata_from_dict_with_none(self):
+        metadata = TemplateMetadata.from_dict({})
+        assert metadata.id == ""
+        assert metadata.name == ""
+        assert metadata.category == TemplateCategory.GENERAL
+
+        assert metadata.tags == []
+
+
+class TestTemplateRegistry:
+    """Tests for TemplateRegistry class."""
+
+    @pytest.fixture
+    def registry(self, tmp_path: Path) -> TemplateRegistry:
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir(parents=True)
+
+        valid_template = templates_dir / "valid_agent"
+        valid_template.mkdir()
+        (valid_template / "agent.json").write_text(
+            '{"agent": {"name": "Valid Agent", "description": "A valid test agent"}}',
+            encoding="utf-8",
+        )
+        (valid_template / "template.json").write_text(
+            '{"name": "Valid Agent", "description": "A valid test agent", "category": "research", "tags": ["test"]}',
+            encoding="utf-8",
+        )
+
+        empty_template = templates_dir / "empty_agent"
+        empty_template.mkdir()
+        (empty_template / "agent.json").write_text("{}", encoding="utf-8")
+
+        no_metadata_template = templates_dir / "no_meta_agent"
+        no_metadata_template.mkdir()
+        (no_metadata_template / "agent.py").write_text("# placeholder", encoding="utf-8")
+
+        template_with_tags = templates_dir / "tagged_agent"
+        template_with_tags.mkdir()
+        (template_with_tags / "agent.json").write_text(
+            '{"agent": {"name": "Tagged Agent"}}',
+            encoding="utf-8",
+        )
+        (template_with_tags / "template.json").write_text(
+            '{"name": "Tagged Agent", "description": "Agent with tags", "category": "sales", "tags": ["sales", "lead-gen", "automation"]}',
+            encoding="utf-8",
+        )
+
+        yield TemplateRegistry(templates_dir)
+
+    def test_discover_templates(self, registry: TemplateRegistry):
+        templates = registry.discover_templates()
+        assert len(templates) == 4
+        valid = next(t for t in templates if t.id == "valid_agent")
+        assert valid is not None
+        assert valid.name == "Valid Agent"
+        assert valid.category == TemplateCategory.RESEARCH
+
+        assert valid.tags == ["test"]
+        tagged = next(t for t in templates if t.id == "tagged_agent")
+        assert tagged is not None
+        assert tagged.category == TemplateCategory.SALES
+        assert set(tagged.tags) == {"sales", "lead-gen", "automation"}
+
+    def test_get_template(self, registry: TemplateRegistry):
+        template = registry.get_template("valid_agent")
+        assert template is not None
+        assert template.id == "valid_agent"
+        assert registry.get_template("nonexistent") is None
+
+    def test_list_by_category(self, registry: TemplateRegistry):
+        research_templates = registry.list_by_category(TemplateCategory.RESEARCH)
+        assert len(research_templates) == 1
+        assert research_templates[0].id == "valid_agent"
+        sales_templates = registry.list_by_category(TemplateCategory.SALES)
+        assert len(sales_templates) == 1
+        assert sales_templates[0].id == "tagged_agent"
+        general_templates = registry.list_by_category(TemplateCategory.GENERAL)
+        assert len(general_templates) == 2
+
+    def test_list_by_tag(self, registry: TemplateRegistry):
+        test_templates = registry.list_by_tag("test")
+        assert len(test_templates) == 1
+        assert test_templates[0].id == "valid_agent"
+        sales_templates = registry.list_by_tag("sales")
+        assert len(sales_templates) == 1
+        assert sales_templates[0].id == "tagged_agent"
+        assert len(registry.list_by_tag("nonexistent")) == 0
+        automation_templates = registry.list_by_tag("automation")
+        assert len(automation_templates) == 1
+
+    def test_search(self, registry: TemplateRegistry):
+        results = registry.search("valid")
+        assert len(results) == 1
+        assert results[0].id == "valid_agent"
+        results = registry.search("test")
+        assert len(results) == 1
+        results = registry.search("sales")
+        assert len(results) == 1
+        assert results[0].id == "tagged_agent"
+        assert len(registry.search("nonexistentxyz")) == 0
+
+    def test_get_categories(self, registry: TemplateRegistry):
+        categories = registry.get_categories()
+        assert TemplateCategory.RESEARCH in categories
+        assert TemplateCategory.SALES in categories
+        assert TemplateCategory.GENERAL in categories
+        assert len(categories) == 3
+
+    def test_get_all_tags(self, registry: TemplateRegistry):
+        tags = registry.get_all_tags()
+        assert "test" in tags
+        assert "sales" in tags
+        assert "lead-gen" in tags
+        assert "automation" in tags
+        assert len(tags) == 4

--- a/examples/templates/README.md
+++ b/examples/templates/README.md
@@ -2,46 +2,115 @@
 
 A template is a working agent scaffold that follows the standard Hive export structure. Copy it, rename it, customize the goal/nodes/edges, and run it.
 
-## What's in a template
+## Quick Start
+
+```bash
+# List all available templates
+hive template list
+
+# List templates by category
+hive template list --category research
+# Search for templates
+hive template list --search "email"
+# Show details for a specific template
+hive template show job_hunter
+# Copy a template to your exports directory
+hive template copy job_hunter
+# List available categories
+hive template categories
+# List all tags
+hive template tags
+```
+
+## What's in a Template
 
 Each template is a complete agent package:
-
 ```
 template_name/
 ├── __init__.py       # Package exports
 ├── __main__.py       # CLI entry point
 ├── agent.py          # Goal, edges, graph spec, agent class
 ├── agent.json        # Agent definition (used by build-from-template)
+├── template.json     # Template metadata (category, tags, author)
 ├── config.py         # Runtime configuration
 ├── nodes/
 │   └── __init__.py   # Node definitions (NodeSpec instances)
 └── README.md         # What this template demonstrates
 ```
+### Template Metadata (template.json)
 
-## How to use a template
-
-### Option 1: Build from template (recommended)
-
-Use the `coder-tools` `initialize_and_build_agent` tool and select "From a template" to interactively pick a template, customize the goal/nodes/graph, and export a new agent.
-
-### Option 2: Manual copy
-
-```bash
-# 1. Copy to your exports directory
-cp -r examples/templates/deep_research_agent exports/my_research_agent
-
-# 2. Update the module references in __main__.py and __init__.py
-
-# 3. Customize goal, nodes, edges, and prompts
-
-# 4. Run it
-uv run python -m exports.my_research_agent --input '{"topic": "..."}'
+The `template.json` file contains metadata for the template library:
+```json
+{
+  "name": "Job Hunter",
+  "description": "Analyze resumes and find matching job opportunities.",
+  "category": "productivity",
+  "tags": ["career", "job-search", "resume", "automation"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}
 ```
 
-## Available templates
-
-| Template | Description |
+## Categories
+| Category | Description |
 |----------|-------------|
-| [deep_research_agent](deep_research_agent/) | Interactive research agent that searches diverse sources, evaluates findings with user checkpoints, and produces a cited HTML report |
-| [local_business_extractor](local_business_extractor/) | Finds local businesses on Google Maps, scrapes contact details, and syncs to Google Sheets |
-| [tech_news_reporter](tech_news_reporter/) | Researches the latest technology and AI news from the web and produces a well-organized report |
+| `sales` | Sales and lead generation agents |
+| `support` | Customer support and issue triage |
+| `ops` | Operations and infrastructure |
+| `research` | Research and information gathering |
+| `growth` | Growth and marketing automation |
+| `productivity` | Personal and team productivity tools |
+| `development` | Development and DevOps tools |
+| `hr` | Human resources and employee management |
+| `finance` | Finance and accounting automation |
+| `marketing` | Marketing and campaign management |
+| `general` | General-purpose agents |
+
+## Available Templates
+| Template | Category | Description |
+|----------|----------|-------------|
+| [deep_research_agent](deep_research_agent/) | Research | Interactive research agent that searches diverse sources, evaluates findings with user checkpoints, and produces a cited HTML report |
+| [local_business_extractor](local_business_extractor/) | Sales | Finds local businesses on Google Maps, scrapes contact details, and syncs to Google Sheets |
+| [tech_news_reporter](tech_news_reporter/) | Research | Researches the latest technology and AI news from the web and produces a well-organized report |
+| [job_hunter](job_hunter/) | Productivity | Analyzes resumes, finds matching job opportunities, generates customized application materials |
+| [support_debugger](support_debugger/) | Support | Helps debug and resolve customer support issues |
+| [meeting_scheduler](meeting_scheduler/) | Productivity | Automates meeting scheduling by coordinating calendars and sending invitations |
+| [email_reply_agent](email_reply_agent/) | Productivity | Automatically drafts replies to emails based on context and user preferences |
+| [hr_onboarding_orchestrator](hr_onboarding_orchestrator/) | HR | Orchestrates employee onboarding process by coordinating tasks, documentation, and communications |
+| [mcp_toolsmith](mcp_toolsmith/) | Development | Helps create and manage MCP tools for extending agent capabilities |
+| [hacker_news_briefing](hacker_news_briefing/) | Research | Curates and summarizes top stories from Hacker News for daily briefings |
+| [interview_prep_assistant](interview_prep_assistant/) | Productivity | Helps prepare for job interviews by researching companies and generating practice questions |
+| [dependency_vulnerability_auditor](dependency_vulnerability_auditor/) | Development | Scans project dependencies for known security vulnerabilities and suggests updates |
+| [twitter_news_agent](twitter_news_agent/) | Research | Monitors Twitter for news and trends, curating relevant content for users |
+| [vulnerability_assessment](vulnerability_assessment/) | Development | Performs security vulnerability assessments on systems and applications |
+| [invoice_ap_agent](invoice_ap_agent/) | Finance | Automates accounts payable processes including invoice processing and payment scheduling |
+| [marketing_ops_traffic_controller](marketing_ops_traffic_controller/) | Marketing | Manages and routes marketing operations tasks, coordinating campaigns and content distribution |
+| [sales_call_news_researcher](sales_call_news_researcher/) | Sales | Researches prospects before sales calls, gathering relevant news and insights |
+| [content_research_swarm](content_research_swarm/) | Research | Multi-agent system that researches and curates content from multiple sources |
+| [competitive_intel_agent](competitive_intel_agent/) | Research | Gathers and analyzes competitive intelligence from various sources |
+| [agent_qa_pipeline](agent_qa_pipeline/) | Development | Automated quality assurance pipeline for testing and validating agents |
+| [contract_intelligence_agent](contract_intelligence_agent/) | Finance | Analyzes contracts to extract key terms, risks, and compliance requirements |
+| [financial_ledger_agent](financial_ledger_agent/) | Finance | Automates financial ledger management and transaction reconciliation |
+| [issue_triage_agent](issue_triage_agent/) | Support | Automatically triages and categorizes issues from various sources for efficient handling |
+| [oss_lead_intelligence](oss_lead_intelligence/) | Sales | Identifies and qualifies open-source leads for business development opportunities |
+| [email_inbox_management](email_inbox_management/) | Productivity | Automates email inbox organization, filtering, and response prioritization |
+
+## Programmatic Access
+
+You from framework.templates import TemplateRegistry, get_template_registry
+
+    registry = get_template_registry()
+    
+    # Discover all templates
+    templates = registry.discover_templates()
+    
+    # Filter by category
+    from framework.templates import TemplateCategory
+    research_templates = registry.list_by_category(TemplateCategory.RESEARCH)
+    
+    # Search templates
+    results = registry.search("email")
+    
+    # Get a specific template
+    template = registry.get_template("job_hunter")
+```

--- a/examples/templates/agent_qa_pipeline/template.json
+++ b/examples/templates/agent_qa_pipeline/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Agent QA Pipeline",
+  "description": "Automated quality assurance pipeline for testing and validating agents.",
+  "category": "development",
+  "tags": ["testing", "qa", "automation", "agents"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/competitive_intel_agent/template.json
+++ b/examples/templates/competitive_intel_agent/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Competitive Intel Agent",
+  "description": "Gathers and analyzes competitive intelligence from various sources.",
+  "category": "research",
+  "tags": ["competitive-intelligence", "research", "analysis", "market"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/content_research_swarm/template.json
+++ b/examples/templates/content_research_swarm/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Content Research Swarm",
+  "description": "Multi-agent system that researches and curates content from multiple sources.",
+  "category": "research",
+  "tags": ["content", "research", "multi-agent", "curation"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/contract_intelligence_agent/template.json
+++ b/examples/templates/contract_intelligence_agent/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Contract Intelligence Agent",
+  "description": "Analyzes contracts to extract key terms, risks, and compliance requirements.",
+  "category": "finance",
+  "tags": ["contracts", "legal", "analysis", "compliance"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/deep_research_agent/template.json
+++ b/examples/templates/deep_research_agent/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Deep Research Agent",
+  "description": "Interactive research agent that searches diverse sources, evaluates findings with user checkpoints, and produces a cited HTML report.",
+  "category": "research",
+  "tags": ["research", "web-search", "analysis", "reporting"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/dependency_vulnerability_auditor/template.json
+++ b/examples/templates/dependency_vulnerability_auditor/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Dependency Vulnerability Auditor",
+  "description": "Scans project dependencies for known security vulnerabilities and suggests updates.",
+  "category": "development",
+  "tags": ["security", "dependencies", "vulnerability", "audit"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/email_inbox_management/template.json
+++ b/examples/templates/email_inbox_management/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Email Inbox Management",
+  "description": "Automates email inbox organization, filtering, and response prioritization.",
+  "category": "productivity",
+  "tags": ["email", "inbox", "automation", "productivity"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/email_reply_agent/template.json
+++ b/examples/templates/email_reply_agent/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Email Reply Agent",
+  "description": "Automatically drafts replies to emails based on context and user preferences.",
+  "category": "productivity",
+  "tags": ["email", "communication", "automation", "gmail"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/financial_ledger_agent/template.json
+++ b/examples/templates/financial_ledger_agent/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Financial Ledger Agent",
+  "description": "Automates financial ledger management and transaction reconciliation.",
+  "category": "finance",
+  "tags": ["finance", "ledger", "accounting", "reconciliation"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/hacker_news_briefing/template.json
+++ b/examples/templates/hacker_news_briefing/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Hacker News Briefing",
+  "description": "Curates and summarizes top stories from Hacker News for daily briefings.",
+  "category": "research",
+  "tags": ["news", "hacker-news", "research", "briefing"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/hr_onboarding_orchestrator/template.json
+++ b/examples/templates/hr_onboarding_orchestrator/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "HR Onboarding Orchestrator",
+  "description": "Orchestrates the employee onboarding process by coordinating tasks, documentation, and communications.",
+  "category": "hr",
+  "tags": ["hr", "onboarding", "employee", "automation"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/interview_prep_assistant/template.json
+++ b/examples/templates/interview_prep_assistant/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Interview Prep Assistant",
+  "description": "Helps prepare for job interviews by researching companies and generating practice questions.",
+  "category": "productivity",
+  "tags": ["interview", "career", "preparation", "research"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/invoice_ap_agent/template.json
+++ b/examples/templates/invoice_ap_agent/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Invoice AP Agent",
+  "description": "Automates accounts payable processes including invoice processing and payment scheduling.",
+  "category": "finance",
+  "tags": ["finance", "invoice", "accounts-payable", "automation"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/issue_triage_agent/template.json
+++ b/examples/templates/issue_triage_agent/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Issue Triage Agent",
+  "description": "Automatically triages and categorizes issues from various sources for efficient handling.",
+  "category": "support",
+  "tags": ["support", "triage", "automation", "issues"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/job_hunter/template.json
+++ b/examples/templates/job_hunter/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Job Hunter",
+  "description": "Analyze a user's resume to identify their strongest role fits, find 10 matching job opportunities, let the user select which to pursue, then generate a resume customization list and cold outreach email for each selected job.",
+  "category": "productivity",
+  "tags": ["career", "job-search", "resume", "email", "automation"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/local_business_extractor/template.json
+++ b/examples/templates/local_business_extractor/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Local Business Extractor",
+  "description": "Finds local businesses on Google Maps, scrapes contact details, and syncs to Google Sheets.",
+  "category": "sales",
+  "tags": ["lead-generation", "sales", "google-maps", "web-scraping"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/marketing_ops_traffic_controller/template.json
+++ b/examples/templates/marketing_ops_traffic_controller/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Marketing Ops Traffic Controller",
+  "description": "Manages and routes marketing operations tasks, coordinating campaigns and content distribution.",
+  "category": "marketing",
+  "tags": ["marketing", "campaigns", "automation", "operations"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/mcp_toolsmith/template.json
+++ b/examples/templates/mcp_toolsmith/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "MCP Toolsmith",
+  "description": "Helps create and manage MCP (Model Context Protocol) tools for extending agent capabilities.",
+  "category": "development",
+  "tags": ["mcp", "tools", "development", "automation"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/meeting_scheduler/template.json
+++ b/examples/templates/meeting_scheduler/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Meeting Scheduler",
+  "description": "Automates meeting scheduling by coordinating calendars and sending invitations.",
+  "category": "productivity",
+  "tags": ["calendar", "scheduling", "meetings", "automation"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/oss_lead_intelligence/template.json
+++ b/examples/templates/oss_lead_intelligence/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "OSS Lead Intelligence",
+  "description": "Identifies and qualifies open-source leads for business development opportunities.",
+  "category": "sales",
+  "tags": ["sales", "leads", "open-source", "business-development"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/sales_call_news_researcher/template.json
+++ b/examples/templates/sales_call_news_researcher/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Sales Call News Researcher",
+  "description": "Researches prospects before sales calls, gathering relevant news and insights.",
+  "category": "sales",
+  "tags": ["sales", "research", "prospecting", "news"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/support_debugger/template.json
+++ b/examples/templates/support_debugger/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Support Debugger",
+  "description": "Helps debug and resolve customer support issues by analyzing logs and suggesting solutions.",
+  "category": "support",
+  "tags": ["support", "debugging", "customer-service", "troubleshooting"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/tech_news_reporter/template.json
+++ b/examples/templates/tech_news_reporter/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Tech News Reporter",
+  "description": "Researches the latest technology and AI news from the web and produces a well-organized report.",
+  "category": "research",
+  "tags": ["news", "technology", "ai", "research", "reporting"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/twitter_news_agent/template.json
+++ b/examples/templates/twitter_news_agent/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Twitter News Agent",
+  "description": "Monitors Twitter for news and trends, curating relevant content for users.",
+  "category": "research",
+  "tags": ["twitter", "social-media", "news", "monitoring"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}

--- a/examples/templates/vulnerability_assessment/template.json
+++ b/examples/templates/vulnerability_assessment/template.json
@@ -1,0 +1,8 @@
+{
+  "name": "Vulnerability Assessment",
+  "description": "Performs security vulnerability assessments on systems and applications.",
+  "category": "development",
+  "tags": ["security", "vulnerability", "assessment", "scanning"],
+  "author": "Hive Team",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
## Summary

Implements an **Agent Template Library/Community Marketplace** feature for the Hive framework, enabling users to discover, filter, and deploy reusable agent workflows.

Closes #1918

## Changes

### Core Implementation
- **New module** `core/framework/templates/` with:
  - `models.py` - `TemplateCategory` enum and `TemplateMetadata` dataclass
  - `registry.py` - `TemplateRegistry` class for template discovery and querying
  - `cli.py` - CLI commands for template management
  - `__init__.py` - Module exports

### CLI Commands
- `hive template list [--category <cat>] [--tag <tag>] [--search <query>] [--json]` - Browse templates with filtering
- `hive template show <template_id> [--json]` - Display template details
- `hive template copy <template_id> [destination] [--name <name>]` - Clone a template
- `hive template categories` - List available categories
- `hive template tags` - List all tags

### Template Metadata
- Added `template.json` metadata files to 25+ existing templates in `examples/templates/`
- Categories: SALES, SUPPORT, OPS, RESEARCH, GROWTH, PRODUCTIVITY, DEVELOPMENT, HR, FINANCE, MARKETING, GENERAL

### Tests
- Unit tests in `core/tests/framework/templates/test_templates.py`

### Documentation
- Updated `examples/templates/README.md` with new CLI commands and usage examples

## Usage Examples

```bash
# List all templates
hive template list

# Filter by category
hive template list --category sales

# Search by tag
hive template list --tag automation

# Search templates
hive template list --search "email"

# Show template details
hive template show job_hunter

# Copy template to new project
hive template copy job_hunter ./my_job_hunter --name "My Job Hunter"

# List categories
hive template categories
```

## Testing

```bash
# Run template tests
uv run pytest core/tests/framework/templates/test_templates.py -v
```
