### PR TITLE
fix: handle clipboard write errors in SystemPromptTab

### DIFF
--- a/core/frontend/src/components/NodeDetailPanel.tsx
+++ b/core/frontend/src/components/NodeDetailPanel.tsx
@@ -170,10 +170,17 @@ function SystemPromptTab({ systemPrompt }: { systemPrompt?: string }) {
   const prompt = systemPrompt || "";
   const [copied, setCopied] = useState(false);
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(prompt);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
+  const handleCopy = async () => {
+    try {
+      if (!navigator.clipboard) {
+        throw new Error("Clipboard API not supported");
+      }
+      await navigator.clipboard.writeText(prompt);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch (err) {
+      console.error("Clipboard copy failed:", err);
+    }
   };
 
   if (!prompt) {


### PR DESCRIPTION
## Description
Add error handling to the clipboard write operation in `SystemPromptTab` 
to prevent false "Copied" feedback when the clipboard operation fails.

## Motivation
The current implementation calls `navigator.clipboard.writeText()` without 
any error handling. If the clipboard write fails (e.g., insecure context, 
browser permission restrictions, or unsupported environments), the failure 
is silent and the UI still shows the "Copied" state, misleading users into 
thinking the copy succeeded.

## Changes
- Wrapped `navigator.clipboard.writeText()` in a `try/catch` block in `NodeDetailPanel.tsx`
- Made `handleCopy` function async
- Moved `setCopied(true)` inside the success path so it only fires on successful copy
- Added `console.error` logging for clipboard failures
- Added guard for environments where `navigator.clipboard` is unavailable

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist
- [x] Code follows style guidelines (ruff)
- [x] Self-review completed
- [ ] Documentation updated
- [x] No breaking changes (or documented if unavoidable)

Closes #6306