### PR TITLE
[Integration] feat(tools): add VirusTotal threat intelligence tool

### DIFF
--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -139,6 +139,7 @@ from .vercel import VERCEL_CREDENTIALS
 from .youtube import YOUTUBE_CREDENTIALS
 from .zendesk import ZENDESK_CREDENTIALS
 from .zoho_crm import ZOHO_CRM_CREDENTIALS
+from .virustotal import VIRUSTOTAL_CREDENTIALS
 from .zoom import ZOOM_CREDENTIALS
 
 # Merged registry of all credentials
@@ -217,6 +218,7 @@ CREDENTIAL_SPECS = {
     **ZENDESK_CREDENTIALS,
     **ZOHO_CRM_CREDENTIALS,
     **ZOOM_CREDENTIALS,
+    **VIRUSTOTAL_CREDENTIALS,
 }
 
 __all__ = [
@@ -309,4 +311,5 @@ __all__ = [
     "ZENDESK_CREDENTIALS",
     "ZOHO_CRM_CREDENTIALS",
     "ZOOM_CREDENTIALS",
+    "VIRUSTOTAL_CREDENTIALS",
 ]

--- a/tools/src/aden_tools/credentials/virustotal.py
+++ b/tools/src/aden_tools/credentials/virustotal.py
@@ -1,0 +1,36 @@
+"""
+VirusTotal tool credentials.
+Contains credentials for VirusTotal threat intelligence integration.
+"""
+
+from .base import CredentialSpec
+
+VIRUSTOTAL_CREDENTIALS = {
+    "virustotal": CredentialSpec(
+        env_var="VIRUSTOTAL_API_KEY",
+        tools=[
+            "vt_scan_ip",
+            "vt_scan_domain",
+            "vt_scan_hash",
+        ],
+        required=True,
+        startup_required=False,
+        help_url="https://www.virustotal.com/gui/join-us",
+        description="API key for VirusTotal Threat Intelligence",
+        # Auth method support
+        aden_supported=False,
+        direct_api_key_supported=True,
+        api_key_instructions="""To get your VirusTotal API key:
+1. Go to https://www.virustotal.com/gui/join-us and create a free community account.
+2. Verify your email address and log in.
+3. Click on your profile icon in the top right corner and select "API Key".
+4. Copy the alphanumeric API key provided.""",
+        # Health check configuration
+        health_check_endpoint="https://www.virustotal.com/api/v3/domains/google.com",
+        health_check_method="GET",
+        # Credential store mapping
+        credential_id="virustotal",
+        credential_key="api_key",
+        credential_group="",
+    ),
+}

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -140,6 +140,7 @@ from .youtube_tool import register_tools as register_youtube
 from .youtube_transcript_tool import register_tools as register_youtube_transcript
 from .zendesk_tool import register_tools as register_zendesk
 from .zoho_crm_tool import register_tools as register_zoho_crm
+from .virustotal_tool import register_tools as register_virustotal
 from .zoom_tool import register_tools as register_zoom
 
 
@@ -298,6 +299,7 @@ def _register_unverified(
     register_youtube(mcp, credentials=credentials)
     register_zendesk(mcp, credentials=credentials)
     register_zoho_crm(mcp, credentials=credentials)
+    register_virustotal(mcp, credentials=credentials)
     register_zoom(mcp, credentials=credentials)
 
 

--- a/tools/src/aden_tools/tools/virustotal_tool/README.md
+++ b/tools/src/aden_tools/tools/virustotal_tool/README.md
@@ -1,0 +1,39 @@
+# VirusTotal Tool
+
+Threat intelligence and security scanning via the [VirusTotal API v3](https://docs.virustotal.com/reference/overview).
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `vt_scan_ip` | Scan an IPv4 address for reputation and threat data |
+| `vt_scan_domain` | Analyze a domain for security threats and DNS records |
+| `vt_scan_hash` | Look up a file hash (MD5/SHA1/SHA256) for malware detection |
+
+## Setup
+
+1. Create a free VirusTotal account at https://www.virustotal.com/gui/join-us
+2. Verify your email and log in
+3. Click your profile icon → "API Key"
+4. Copy the API key
+
+```bash
+export VIRUSTOTAL_API_KEY=your_api_key_here
+```
+
+## Rate Limits
+
+Free tier: 4 requests/minute, 500 requests/day.
+
+## Example Usage
+
+```python
+# Scan an IP address
+vt_scan_ip(ip="8.8.8.8")
+
+# Analyze a domain
+vt_scan_domain(domain="example.com")
+
+# Look up a file hash
+vt_scan_hash(file_hash="d41d8cd98f00b204e9800998ecf8427e")
+```

--- a/tools/src/aden_tools/tools/virustotal_tool/__init__.py
+++ b/tools/src/aden_tools/tools/virustotal_tool/__init__.py
@@ -1,0 +1,5 @@
+"""VirusTotal tool — Threat Intelligence & Security Scanning."""
+
+from .virustotal_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/virustotal_tool/virustotal_tool.py
+++ b/tools/src/aden_tools/tools/virustotal_tool/virustotal_tool.py
@@ -1,0 +1,272 @@
+"""
+VirusTotal Tool - Threat intelligence & security scanning via VirusTotal API.
+
+Supports:
+- API key authentication (VIRUSTOTAL_API_KEY)
+
+Use Cases:
+- Scan IP addresses for malicious activity and reputation
+- Analyze domains for security threats and DNS records
+- Look up file hashes (MD5/SHA1/SHA256) for malware detection
+
+API Reference: https://docs.virustotal.com/reference/overview
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import TYPE_CHECKING, Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from aden_tools.credentials import CredentialStoreAdapter
+
+_VT_BASE = "https://www.virustotal.com/api/v3"
+
+
+class _VirusTotalClient:
+    """Internal client wrapping VirusTotal API v3 calls."""
+
+    def __init__(self, api_key: str):
+        self._api_key = api_key
+
+    def _request(self, path: str) -> dict[str, Any]:
+        """Make an authenticated GET request to VT API."""
+        url = f"{_VT_BASE}{path}"
+        req = Request(url, headers={"x-apikey": self._api_key})
+        try:
+            with urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read().decode())
+        except HTTPError as exc:
+            body = exc.read().decode() if exc.fp else ""
+            if exc.code == 401:
+                return {"error": "Invalid API key. Check your VIRUSTOTAL_API_KEY."}
+            if exc.code == 404:
+                return {"error": f"Resource not found: {path}"}
+            if exc.code == 429:
+                return {"error": "Rate limit exceeded. Free tier: 4 req/min, 500 req/day."}
+            return {"error": f"HTTP {exc.code}: {body[:500]}"}
+        except URLError as exc:
+            return {"error": f"Connection error: {exc.reason}"}
+
+    # --- IP Address ---
+
+    def scan_ip(self, ip: str) -> dict[str, Any]:
+        """Get IP address report including reputation and analysis stats."""
+        data = self._request(f"/ip_addresses/{ip}")
+        if "error" in data:
+            return data
+        return self._format_ip(data)
+
+    def _format_ip(self, raw: dict[str, Any]) -> dict[str, Any]:
+        attrs = raw.get("data", {}).get("attributes", {})
+        stats = attrs.get("last_analysis_stats", {})
+        return {
+            "ip": raw.get("data", {}).get("id", ""),
+            "reputation": attrs.get("reputation", 0),
+            "country": attrs.get("country", "unknown"),
+            "as_owner": attrs.get("as_owner", "unknown"),
+            "network": attrs.get("network", ""),
+            "analysis_stats": {
+                "malicious": stats.get("malicious", 0),
+                "suspicious": stats.get("suspicious", 0),
+                "harmless": stats.get("harmless", 0),
+                "undetected": stats.get("undetected", 0),
+            },
+            "total_votes": {
+                "malicious": attrs.get("total_votes", {}).get("malicious", 0),
+                "harmless": attrs.get("total_votes", {}).get("harmless", 0),
+            },
+        }
+
+    # --- Domain ---
+
+    def scan_domain(self, domain: str) -> dict[str, Any]:
+        """Get domain report including reputation, DNS records, and analysis."""
+        data = self._request(f"/domains/{domain}")
+        if "error" in data:
+            return data
+        return self._format_domain(data)
+
+    def _format_domain(self, raw: dict[str, Any]) -> dict[str, Any]:
+        attrs = raw.get("data", {}).get("attributes", {})
+        stats = attrs.get("last_analysis_stats", {})
+        return {
+            "domain": raw.get("data", {}).get("id", ""),
+            "reputation": attrs.get("reputation", 0),
+            "registrar": attrs.get("registrar", "unknown"),
+            "creation_date": attrs.get("creation_date", 0),
+            "last_dns_records": [
+                {"type": r.get("type", ""), "value": r.get("value", "")}
+                for r in attrs.get("last_dns_records", [])[:10]
+            ],
+            "categories": attrs.get("categories", {}),
+            "analysis_stats": {
+                "malicious": stats.get("malicious", 0),
+                "suspicious": stats.get("suspicious", 0),
+                "harmless": stats.get("harmless", 0),
+                "undetected": stats.get("undetected", 0),
+            },
+            "total_votes": {
+                "malicious": attrs.get("total_votes", {}).get("malicious", 0),
+                "harmless": attrs.get("total_votes", {}).get("harmless", 0),
+            },
+        }
+
+    # --- File Hash ---
+
+    def scan_hash(self, file_hash: str) -> dict[str, Any]:
+        """Get file report by hash (MD5, SHA1, or SHA256)."""
+        data = self._request(f"/files/{file_hash}")
+        if "error" in data:
+            return data
+        return self._format_file(data)
+
+    def _format_file(self, raw: dict[str, Any]) -> dict[str, Any]:
+        attrs = raw.get("data", {}).get("attributes", {})
+        stats = attrs.get("last_analysis_stats", {})
+        return {
+            "sha256": attrs.get("sha256", ""),
+            "sha1": attrs.get("sha1", ""),
+            "md5": attrs.get("md5", ""),
+            "file_type": attrs.get("type_description", "unknown"),
+            "file_size": attrs.get("size", 0),
+            "meaningful_name": attrs.get("meaningful_name", ""),
+            "reputation": attrs.get("reputation", 0),
+            "analysis_stats": {
+                "malicious": stats.get("malicious", 0),
+                "suspicious": stats.get("suspicious", 0),
+                "harmless": stats.get("harmless", 0),
+                "undetected": stats.get("undetected", 0),
+                "failure": stats.get("type-unsupported", 0),
+            },
+            "popular_threat_classification": attrs.get("popular_threat_classification", {}),
+            "tags": attrs.get("tags", [])[:20],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Input validation helpers
+# ---------------------------------------------------------------------------
+
+_IP_RE = re.compile(r"^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)$")
+_DOMAIN_RE = re.compile(r"^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$")
+_HASH_RE = re.compile(r"^[a-fA-F0-9]{32}$|^[a-fA-F0-9]{40}$|^[a-fA-F0-9]{64}$")
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+
+
+def register_tools(
+    mcp: FastMCP,
+    *,
+    credentials: CredentialStoreAdapter | None = None,
+) -> None:
+    """Register VirusTotal tools with the MCP server."""
+
+    def _get_api_key() -> str | None:
+        if credentials is not None:
+            key = credentials.get("virustotal")
+            if key:
+                return key
+        return os.getenv("VIRUSTOTAL_API_KEY")
+
+    @mcp.tool()
+    def vt_scan_ip(ip: str) -> str:
+        """
+        Scan an IP address using VirusTotal for threat intelligence.
+
+        Returns reputation score, geolocation, network owner, and
+        aggregated anti-virus vendor analysis results.
+
+        Args:
+            ip: IPv4 address to scan (e.g., "8.8.8.8")
+
+        Returns:
+            JSON string with IP reputation data and analysis statistics
+        """
+        if not _IP_RE.match(ip):
+            return json.dumps({"error": f"Invalid IPv4 address: {ip}"})
+
+        api_key = _get_api_key()
+        if not api_key:
+            return json.dumps(
+                {
+                    "error": "VIRUSTOTAL_API_KEY not set. Get one at https://www.virustotal.com/gui/join-us"
+                }
+            )
+
+        client = _VirusTotalClient(api_key)
+        result = client.scan_ip(ip)
+        return json.dumps(result, indent=2)
+
+    @mcp.tool()
+    def vt_scan_domain(domain: str) -> str:
+        """
+        Scan a domain using VirusTotal for threat intelligence.
+
+        Returns reputation score, registrar, DNS records, category
+        classifications, and aggregated analysis results.
+
+        Args:
+            domain: Domain name to scan (e.g., "example.com")
+
+        Returns:
+            JSON string with domain reputation data and analysis statistics
+        """
+        if not _DOMAIN_RE.match(domain):
+            return json.dumps({"error": f"Invalid domain format: {domain}"})
+
+        api_key = _get_api_key()
+        if not api_key:
+            return json.dumps(
+                {
+                    "error": "VIRUSTOTAL_API_KEY not set. Get one at https://www.virustotal.com/gui/join-us"
+                }
+            )
+
+        client = _VirusTotalClient(api_key)
+        result = client.scan_domain(domain)
+        return json.dumps(result, indent=2)
+
+    @mcp.tool()
+    def vt_scan_hash(file_hash: str) -> str:
+        """
+        Look up a file hash on VirusTotal for malware detection.
+
+        Accepts MD5 (32 chars), SHA1 (40 chars), or SHA256 (64 chars)
+        hashes. Returns file metadata, threat classification, and
+        aggregated anti-virus vendor scan results.
+
+        Args:
+            file_hash: MD5, SHA1, or SHA256 hash of the file
+
+        Returns:
+            JSON string with file analysis data and threat classification
+        """
+        if not _HASH_RE.match(file_hash):
+            return json.dumps(
+                {
+                    "error": f"Invalid hash format. Expected MD5 (32), SHA1 (40), "
+                    f"or SHA256 (64) hex chars, got: {file_hash}"
+                }
+            )
+
+        api_key = _get_api_key()
+        if not api_key:
+            return json.dumps(
+                {
+                    "error": "VIRUSTOTAL_API_KEY not set. Get one at https://www.virustotal.com/gui/join-us"
+                }
+            )
+
+        client = _VirusTotalClient(api_key)
+        result = client.scan_hash(file_hash)
+        return json.dumps(result, indent=2)

--- a/tools/tests/tools/test_virustotal_tool.py
+++ b/tools/tests/tools/test_virustotal_tool.py
@@ -1,0 +1,344 @@
+"""
+Tests for VirusTotal threat intelligence tool.
+
+Covers:
+- _VirusTotalClient methods (scan_ip, scan_domain, scan_hash)
+- Error handling (invalid API key, rate limiting, not found)
+- Input validation (IPv4, domain, hash format)
+- Credential retrieval (CredentialStoreAdapter vs env var)
+- All 3 MCP tool functions
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.virustotal_tool.virustotal_tool import (
+    _VirusTotalClient,
+    register_tools,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mcp():
+    return FastMCP("test-server")
+
+
+@pytest.fixture
+def vt_client():
+    return _VirusTotalClient("test-api-key")
+
+
+# ---------------------------------------------------------------------------
+# Sample API responses
+# ---------------------------------------------------------------------------
+
+SAMPLE_IP_RESPONSE = {
+    "data": {
+        "id": "8.8.8.8",
+        "type": "ip_address",
+        "attributes": {
+            "reputation": 74,
+            "country": "US",
+            "as_owner": "GOOGLE",
+            "network": "8.8.8.0/24",
+            "last_analysis_stats": {
+                "malicious": 0,
+                "suspicious": 0,
+                "harmless": 80,
+                "undetected": 10,
+            },
+            "total_votes": {"malicious": 0, "harmless": 25},
+        },
+    }
+}
+
+SAMPLE_DOMAIN_RESPONSE = {
+    "data": {
+        "id": "google.com",
+        "type": "domain",
+        "attributes": {
+            "reputation": 211,
+            "registrar": "MarkMonitor Inc.",
+            "creation_date": 874296000,
+            "last_dns_records": [
+                {"type": "A", "value": "142.250.80.46"},
+                {"type": "AAAA", "value": "2607:f8b0:4004:800::200e"},
+            ],
+            "categories": {"Forcepoint ThreatSeeker": "search engines and portals"},
+            "last_analysis_stats": {
+                "malicious": 0,
+                "suspicious": 0,
+                "harmless": 89,
+                "undetected": 4,
+            },
+            "total_votes": {"malicious": 0, "harmless": 50},
+        },
+    }
+}
+
+SAMPLE_FILE_RESPONSE = {
+    "data": {
+        "id": "abc123",
+        "type": "file",
+        "attributes": {
+            "sha256": "a" * 64,
+            "sha1": "b" * 40,
+            "md5": "c" * 32,
+            "type_description": "PE32 executable",
+            "size": 123456,
+            "meaningful_name": "test.exe",
+            "reputation": -50,
+            "last_analysis_stats": {
+                "malicious": 45,
+                "suspicious": 3,
+                "harmless": 10,
+                "undetected": 15,
+                "type-unsupported": 2,
+            },
+            "popular_threat_classification": {
+                "suggested_threat_label": "trojan.generic",
+            },
+            "tags": ["peexe", "overlay", "signed"],
+        },
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# _VirusTotalClient tests
+# ---------------------------------------------------------------------------
+
+
+class TestVirusTotalClient:
+    """Tests for the _VirusTotalClient class."""
+
+    @patch("aden_tools.tools.virustotal_tool.virustotal_tool.urlopen")
+    def test_scan_ip_success(self, mock_urlopen, vt_client):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(SAMPLE_IP_RESPONSE).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        result = vt_client.scan_ip("8.8.8.8")
+
+        assert result["ip"] == "8.8.8.8"
+        assert result["reputation"] == 74
+        assert result["country"] == "US"
+        assert result["as_owner"] == "GOOGLE"
+        assert result["analysis_stats"]["malicious"] == 0
+        assert result["analysis_stats"]["harmless"] == 80
+
+    @patch("aden_tools.tools.virustotal_tool.virustotal_tool.urlopen")
+    def test_scan_domain_success(self, mock_urlopen, vt_client):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(SAMPLE_DOMAIN_RESPONSE).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        result = vt_client.scan_domain("google.com")
+
+        assert result["domain"] == "google.com"
+        assert result["reputation"] == 211
+        assert result["registrar"] == "MarkMonitor Inc."
+        assert len(result["last_dns_records"]) == 2
+        assert result["analysis_stats"]["harmless"] == 89
+
+    @patch("aden_tools.tools.virustotal_tool.virustotal_tool.urlopen")
+    def test_scan_hash_success(self, mock_urlopen, vt_client):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(SAMPLE_FILE_RESPONSE).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        result = vt_client.scan_hash("c" * 32)
+
+        assert result["md5"] == "c" * 32
+        assert result["file_type"] == "PE32 executable"
+        assert result["analysis_stats"]["malicious"] == 45
+        assert result["reputation"] == -50
+        assert "trojan.generic" in str(result["popular_threat_classification"])
+
+    @patch("aden_tools.tools.virustotal_tool.virustotal_tool.urlopen")
+    def test_http_401_returns_error(self, mock_urlopen, vt_client):
+        from urllib.error import HTTPError
+
+        mock_urlopen.side_effect = HTTPError(
+            url="https://www.virustotal.com/api/v3/ip_addresses/1.1.1.1",
+            code=401,
+            msg="Unauthorized",
+            hdrs=None,
+            fp=MagicMock(read=lambda: b"Unauthorized"),
+        )
+
+        result = vt_client.scan_ip("1.1.1.1")
+        assert "error" in result
+        assert "Invalid API key" in result["error"]
+
+    @patch("aden_tools.tools.virustotal_tool.virustotal_tool.urlopen")
+    def test_http_429_returns_rate_limit_error(self, mock_urlopen, vt_client):
+        from urllib.error import HTTPError
+
+        mock_urlopen.side_effect = HTTPError(
+            url="https://www.virustotal.com/api/v3/domains/test.com",
+            code=429,
+            msg="Too Many Requests",
+            hdrs=None,
+            fp=MagicMock(read=lambda: b"Rate limit"),
+        )
+
+        result = vt_client.scan_domain("test.com")
+        assert "error" in result
+        assert "Rate limit" in result["error"]
+
+    @patch("aden_tools.tools.virustotal_tool.virustotal_tool.urlopen")
+    def test_http_404_returns_not_found(self, mock_urlopen, vt_client):
+        from urllib.error import HTTPError
+
+        mock_urlopen.side_effect = HTTPError(
+            url="https://www.virustotal.com/api/v3/files/abc",
+            code=404,
+            msg="Not Found",
+            hdrs=None,
+            fp=MagicMock(read=lambda: b"Not found"),
+        )
+
+        result = vt_client.scan_hash("a" * 64)
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Input validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    """Tests for input validation in MCP tool functions."""
+
+    def test_invalid_ip_rejected(self, mcp):
+        register_tools(mcp)
+        tool = mcp._tool_manager._tools["vt_scan_ip"]
+        # Call with invalid IP
+        result = json.loads(tool.fn(ip="999.999.999.999"))
+        assert "error" in result
+        assert "Invalid IPv4" in result["error"]
+
+    def test_invalid_domain_rejected(self, mcp):
+        register_tools(mcp)
+        tool = mcp._tool_manager._tools["vt_scan_domain"]
+        result = json.loads(tool.fn(domain="not a domain!!"))
+        assert "error" in result
+        assert "Invalid domain" in result["error"]
+
+    def test_invalid_hash_rejected(self, mcp):
+        register_tools(mcp)
+        tool = mcp._tool_manager._tools["vt_scan_hash"]
+        result = json.loads(tool.fn(file_hash="xyz-not-a-hash"))
+        assert "error" in result
+        assert "Invalid hash" in result["error"]
+
+    def test_valid_md5_accepted(self, mcp):
+        register_tools(mcp)
+        tool = mcp._tool_manager._tools["vt_scan_hash"]
+        # Valid MD5 format but no API key
+        result = json.loads(tool.fn(file_hash="d" * 32))
+        # Should pass validation, fail on missing API key
+        assert "VIRUSTOTAL_API_KEY" in result.get("error", "")
+
+    def test_valid_sha1_accepted(self, mcp):
+        register_tools(mcp)
+        tool = mcp._tool_manager._tools["vt_scan_hash"]
+        result = json.loads(tool.fn(file_hash="e" * 40))
+        assert "VIRUSTOTAL_API_KEY" in result.get("error", "")
+
+    def test_valid_sha256_accepted(self, mcp):
+        register_tools(mcp)
+        tool = mcp._tool_manager._tools["vt_scan_hash"]
+        result = json.loads(tool.fn(file_hash="f" * 64))
+        assert "VIRUSTOTAL_API_KEY" in result.get("error", "")
+
+
+# ---------------------------------------------------------------------------
+# Tool registration tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolRegistration:
+    """Tests for MCP tool registration."""
+
+    def test_all_three_tools_registered(self, mcp):
+        register_tools(mcp)
+        tools = list(mcp._tool_manager._tools.keys())
+        assert "vt_scan_ip" in tools
+        assert "vt_scan_domain" in tools
+        assert "vt_scan_hash" in tools
+
+    def test_tools_registered_with_credentials(self, mcp):
+        from aden_tools.credentials import CredentialStoreAdapter
+
+        creds = CredentialStoreAdapter.for_testing({"virustotal": "test-key"})
+        register_tools(mcp, credentials=creds)
+        tools = list(mcp._tool_manager._tools.keys())
+        assert len(tools) == 3
+
+
+# ---------------------------------------------------------------------------
+# Credential resolution tests
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialResolution:
+    """Tests for credential retrieval."""
+
+    def test_missing_credentials_returns_error(self, mcp):
+        register_tools(mcp)
+        tool = mcp._tool_manager._tools["vt_scan_ip"]
+        result = json.loads(tool.fn(ip="8.8.8.8"))
+        assert "error" in result
+        assert "VIRUSTOTAL_API_KEY" in result["error"]
+
+    @patch("aden_tools.tools.virustotal_tool.virustotal_tool.urlopen")
+    def test_env_var_credential(self, mock_urlopen, mcp):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(SAMPLE_IP_RESPONSE).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        register_tools(mcp)
+        tool = mcp._tool_manager._tools["vt_scan_ip"]
+
+        with patch.dict("os.environ", {"VIRUSTOTAL_API_KEY": "test-key"}):
+            result = json.loads(tool.fn(ip="8.8.8.8"))
+        assert result["ip"] == "8.8.8.8"
+        assert "error" not in result
+
+    @patch("aden_tools.tools.virustotal_tool.virustotal_tool.urlopen")
+    def test_credential_store_adapter(self, mock_urlopen, mcp):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(SAMPLE_DOMAIN_RESPONSE).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        from aden_tools.credentials import CredentialStoreAdapter
+
+        creds = CredentialStoreAdapter.for_testing({"virustotal": "test-key-from-store"})
+        register_tools(mcp, credentials=creds)
+        tool = mcp._tool_manager._tools["vt_scan_domain"]
+
+        result = json.loads(tool.fn(domain="google.com"))
+        assert result["domain"] == "google.com"
+        assert "error" not in result


### PR DESCRIPTION
## Description

Add VirusTotal integration tool enabling agents to access global threat intelligence by retrieving aggregate anti-virus vendor reports and reputation scores for suspicious indicators of compromise (IoCs).

Follows the existing FastMCP/CredentialStoreAdapter patterns (matching `stripe_tool`, `email_tool`).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Closes #6292

## Changes Made

### New files
- `tools/src/aden_tools/tools/virustotal_tool/virustotal_tool.py` — Three MCP tools: `vt_scan_ip` (IP reputation), `vt_scan_domain` (domain analysis), `vt_scan_hash` (file hash malware lookup)
- `tools/src/aden_tools/tools/virustotal_tool/__init__.py` — Package init
- `tools/src/aden_tools/tools/virustotal_tool/README.md` — Usage docs and setup guide
- `tools/src/aden_tools/credentials/virustotal.py` — `CredentialSpec` for `VIRUSTOTAL_API_KEY` with health check endpoint
- `tools/tests/tools/test_virustotal_tool.py` — 17 tests covering client methods, input validation, error handling, and credential resolution

### Modified files
- `tools/src/aden_tools/tools/__init__.py` — Registered virustotal tool in `_register_unverified`
- `tools/src/aden_tools/credentials/__init__.py` — Registered `VIRUSTOTAL_CREDENTIALS` into `CREDENTIAL_SPECS`

### Design decisions
- **stdlib-only HTTP**: Uses `urllib.request` instead of `requests` to avoid adding a dependency. VT API v3 is simple GET requests with API key header.
- **Input validation**: Regex validation for IPv4, domain format, and hash length (MD5/SHA1/SHA256) before making API calls.
- **Structured output**: Raw API responses are formatted into clean, consistent dictionaries with only the most useful fields.
- **Graceful error handling**: HTTP 401 (invalid key), 404 (not found), 429 (rate limit) return descriptive error messages instead of raising exceptions.

## Testing

- [x] Unit tests pass (`uv run pytest tools/tests/tools/test_virustotal_tool.py` — 17 passed)
- [x] Lint passes (`uv run ruff check` — 0 errors)
- [x] Format passes (`uv run ruff format --check` — 0 reformatted)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Environment Variables

| Variable | Required | Description |
|----------|----------|-------------|
| `VIRUSTOTAL_API_KEY` | Yes | VirusTotal API key ([get one here](https://www.virustotal.com/gui/join-us)) |

## Rate Limits

Free tier: 4 requests/minute, 500 requests/day — suitable for non-commercial security agents.