### PR TITLE
feat: Field Service Dispatch agent template

### DIFF
--- a/examples/templates/field_service_dispatch/README.md
+++ b/examples/templates/field_service_dispatch/README.md
@@ -1,0 +1,79 @@
+# Field Service Dispatch Agent
+
+AI-powered field service dispatch agent that handles the complete dispatch workflow:
+service request intake, priority triage, technician matching, and coordinated
+notification with human-in-the-loop dispatcher approval.
+
+## Use Cases
+
+- **HVAC/Plumbing/Electrical service companies** dispatching technicians to customer sites
+- **Property management** coordinating maintenance crews across multiple properties
+- **Emergency repair services** with SLA-driven priority routing
+- **Fleet management** optimizing technician routes and workload balance
+
+## Graph Flow
+
+```
+intake (client_facing) → triage_and_plan → dispatch → notify (client_facing)
+                              ↑                |
+                              └── reassign ────┘  (if no suitable tech)
+```
+
+### Nodes
+
+| Node | Type | Description |
+|------|------|-------------|
+| `intake` | Client-facing | Collects service request details from customer/dispatcher |
+| `triage_and_plan` | Autonomous | Classifies priority (P1-P4), determines skills, calculates SLA |
+| `dispatch` | Autonomous | Matches best technician by skills, proximity, availability |
+| `notify` | Client-facing | Presents plan for dispatcher approval, coordinates notifications |
+
+### Priority Levels
+
+| Priority | Label | SLA | Examples |
+|----------|-------|-----|----------|
+| P1 | Emergency | 1 hour | Gas leak, flooding, electrical hazard |
+| P2 | Urgent | 4 hours | No hot water, HVAC down, security failure |
+| P3 | Standard | 24 hours | Equipment malfunction, performance issues |
+| P4 | Low | 72 hours | Scheduled maintenance, minor adjustments |
+
+## Setup
+
+```bash
+# From the hive repository root
+cd examples/templates/field_service_dispatch
+
+# Run the agent
+uv run python -m examples.templates.field_service_dispatch run \
+  --request "AC unit not cooling at 123 Main St, Phoenix AZ"
+
+# Validate the agent structure
+uv run python -m examples.templates.field_service_dispatch validate
+
+# Show agent info
+uv run python -m examples.templates.field_service_dispatch info
+
+# Interactive TUI mode
+uv run python -m examples.templates.field_service_dispatch tui
+```
+
+## Tools Used
+
+| Tool | Node | Purpose |
+|------|------|---------|
+| `get_current_time` | triage, dispatch | SLA deadline calculation, scheduling |
+| `web_search` | triage, dispatch | Equipment specs, known issues lookup |
+| `send_email` | notify | Customer/technician notifications |
+
+## Customization
+
+To adapt this template for your organization:
+
+1. **Technician database** — Replace the simulated dispatch logic in the `dispatch` node
+   with queries to your fleet management system or technician API
+2. **Priority rules** — Adjust the SLA windows and classification criteria in `triage_and_plan`
+   to match your service level agreements
+3. **Notification channels** — Extend the `notify` node to use SMS, push notifications,
+   or your preferred communication platform
+4. **Skill taxonomy** — Update the skill categories in `triage_and_plan` to match your
+   team's certifications and specializations

--- a/examples/templates/field_service_dispatch/__init__.py
+++ b/examples/templates/field_service_dispatch/__init__.py
@@ -1,0 +1,24 @@
+"""
+Field Service Dispatch Agent - AI-powered field service dispatch with dispatcher approval.
+
+Handles end-to-end dispatch workflow: service request intake, priority triage,
+technician matching based on skills and proximity, and coordinated notification
+with human-in-the-loop dispatcher approval.
+"""
+
+from .agent import FieldServiceDispatchAgent, default_agent, goal, nodes, edges
+from .config import RuntimeConfig, AgentMetadata, default_config, metadata
+
+__version__ = "1.0.0"
+
+__all__ = [
+    "FieldServiceDispatchAgent",
+    "default_agent",
+    "goal",
+    "nodes",
+    "edges",
+    "RuntimeConfig",
+    "AgentMetadata",
+    "default_config",
+    "metadata",
+]

--- a/examples/templates/field_service_dispatch/__main__.py
+++ b/examples/templates/field_service_dispatch/__main__.py
@@ -1,0 +1,234 @@
+"""
+CLI entry point for Field Service Dispatch Agent.
+
+Uses AgentRuntime for multi-entrypoint support with HITL pause/resume.
+"""
+
+import asyncio
+import json
+import logging
+import sys
+
+import click
+
+from .agent import default_agent, FieldServiceDispatchAgent
+
+
+def setup_logging(verbose=False, debug=False):
+    """Configure logging for execution visibility."""
+    if debug:
+        level, fmt = logging.DEBUG, "%(asctime)s %(name)s: %(message)s"
+    elif verbose:
+        level, fmt = logging.INFO, "%(message)s"
+    else:
+        level, fmt = logging.WARNING, "%(levelname)s: %(message)s"
+    logging.basicConfig(level=level, format=fmt, stream=sys.stderr)
+    logging.getLogger("framework").setLevel(level)
+
+
+@click.group()
+@click.version_option(version="1.0.0")
+def cli():
+    """Field Service Dispatch Agent - AI-powered dispatch with HITL approval."""
+    pass
+
+
+@cli.command()
+@click.option(
+    "--request",
+    "-r",
+    type=str,
+    required=True,
+    help="Service request description",
+)
+@click.option("--quiet", "-q", is_flag=True, help="Only output result JSON")
+@click.option("--verbose", "-v", is_flag=True, help="Show execution details")
+@click.option("--debug", is_flag=True, help="Show debug logging")
+def run(request, quiet, verbose, debug):
+    """Execute dispatch for a service request."""
+    if not quiet:
+        setup_logging(verbose=verbose, debug=debug)
+
+    context = {"request": request}
+
+    result = asyncio.run(default_agent.run(context))
+
+    output_data = {
+        "success": result.success,
+        "steps_executed": result.steps_executed,
+        "output": result.output,
+    }
+    if result.error:
+        output_data["error"] = result.error
+
+    click.echo(json.dumps(output_data, indent=2, default=str))
+    sys.exit(0 if result.success else 1)
+
+
+@cli.command()
+@click.option("--verbose", "-v", is_flag=True, help="Show execution details")
+@click.option("--debug", is_flag=True, help="Show debug logging")
+def tui(verbose, debug):
+    """Launch the TUI dashboard for interactive dispatch."""
+    setup_logging(verbose=verbose, debug=debug)
+
+    try:
+        from framework.tui.app import AdenTUI
+    except ImportError:
+        click.echo(
+            "TUI requires the 'textual' package. Install with: pip install textual"
+        )
+        sys.exit(1)
+
+    from pathlib import Path
+
+    from framework.llm import LiteLLMProvider
+    from framework.runner.tool_registry import ToolRegistry
+    from framework.runtime.agent_runtime import create_agent_runtime
+    from framework.runtime.event_bus import EventBus
+    from framework.runtime.execution_stream import EntryPointSpec
+
+    async def run_with_tui():
+        agent = FieldServiceDispatchAgent()
+
+        agent._event_bus = EventBus()
+        agent._tool_registry = ToolRegistry()
+
+        storage_path = Path.home() / ".hive" / "agents" / "field_service_dispatch"
+        storage_path.mkdir(parents=True, exist_ok=True)
+
+        mcp_config_path = Path(__file__).parent / "mcp_servers.json"
+        if mcp_config_path.exists():
+            agent._tool_registry.load_mcp_config(mcp_config_path)
+
+        llm = LiteLLMProvider(
+            model=agent.config.model,
+            api_key=agent.config.api_key,
+            api_base=agent.config.api_base,
+        )
+
+        tools = list(agent._tool_registry.get_tools().values())
+        tool_executor = agent._tool_registry.get_executor()
+        graph = agent._build_graph()
+
+        runtime = create_agent_runtime(
+            graph=graph,
+            goal=agent.goal,
+            storage_path=storage_path,
+            entry_points=[
+                EntryPointSpec(
+                    id="start",
+                    name="Start Dispatch",
+                    entry_node="intake",
+                    trigger_type="manual",
+                    isolation_level="isolated",
+                ),
+            ],
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor,
+        )
+
+        await runtime.start()
+
+        try:
+            app = AdenTUI(runtime)
+            await app.run_async()
+        finally:
+            await runtime.stop()
+
+    asyncio.run(run_with_tui())
+
+
+@cli.command()
+@click.option("--json", "output_json", is_flag=True)
+def info(output_json):
+    """Show agent information."""
+    info_data = default_agent.info()
+    if output_json:
+        click.echo(json.dumps(info_data, indent=2))
+    else:
+        click.echo(f"Agent: {info_data['name']}")
+        click.echo(f"Version: {info_data['version']}")
+        click.echo(f"Description: {info_data['description']}")
+        click.echo(f"\nNodes: {', '.join(info_data['nodes'])}")
+        click.echo(f"Client-facing: {', '.join(info_data['client_facing_nodes'])}")
+        click.echo(f"Entry: {info_data['entry_node']}")
+        click.echo(f"Terminal: {', '.join(info_data['terminal_nodes'])}")
+
+
+@cli.command()
+def validate():
+    """Validate agent structure."""
+    validation = default_agent.validate()
+    if validation["valid"]:
+        click.echo("Agent is valid")
+        if validation["warnings"]:
+            for warning in validation["warnings"]:
+                click.echo(f"  WARNING: {warning}")
+    else:
+        click.echo("Agent has errors:")
+        for error in validation["errors"]:
+            click.echo(f"  ERROR: {error}")
+    sys.exit(0 if validation["valid"] else 1)
+
+
+@cli.command()
+@click.option("--verbose", "-v", is_flag=True)
+def shell(verbose):
+    """Interactive dispatch session (CLI, no TUI)."""
+    asyncio.run(_interactive_shell(verbose))
+
+
+async def _interactive_shell(verbose=False):
+    """Async interactive shell."""
+    setup_logging(verbose=verbose)
+
+    click.echo("=== Field Service Dispatch Agent ===")
+    click.echo("Describe a service request (or 'quit' to exit):\n")
+
+    agent = FieldServiceDispatchAgent()
+    await agent.start()
+
+    try:
+        while True:
+            try:
+                request = await asyncio.get_event_loop().run_in_executor(
+                    None, input, "Request> "
+                )
+                if request.lower() in ["quit", "exit", "q"]:
+                    click.echo("Goodbye!")
+                    break
+
+                if not request.strip():
+                    continue
+
+                click.echo("\nProcessing dispatch...\n")
+
+                result = await agent.trigger_and_wait("start", {"request": request})
+
+                if result is None:
+                    click.echo("\n[Execution timed out]\n")
+                    continue
+
+                if result.success:
+                    output = result.output
+                    status = output.get("dispatch_confirmation", "unknown")
+                    click.echo(f"\nDispatch complete (status: {status})\n")
+                else:
+                    click.echo(f"\nDispatch failed: {result.error}\n")
+
+            except KeyboardInterrupt:
+                click.echo("\nGoodbye!")
+                break
+            except Exception as e:
+                click.echo(f"Error: {e}", err=True)
+                import traceback
+
+                traceback.print_exc()
+    finally:
+        await agent.stop()
+
+
+if __name__ == "__main__":
+    cli()

--- a/examples/templates/field_service_dispatch/agent.py
+++ b/examples/templates/field_service_dispatch/agent.py
@@ -1,0 +1,340 @@
+"""Agent graph construction for Field Service Dispatch Agent."""
+
+from pathlib import Path
+
+from framework.graph import EdgeSpec, EdgeCondition, Goal, SuccessCriterion, Constraint
+from framework.graph.edge import GraphSpec
+from framework.graph.executor import ExecutionResult
+from framework.graph.checkpoint_config import CheckpointConfig
+from framework.llm import LiteLLMProvider
+from framework.runner.tool_registry import ToolRegistry
+from framework.runtime.agent_runtime import AgentRuntime, create_agent_runtime
+from framework.runtime.execution_stream import EntryPointSpec
+
+from .config import default_config, metadata
+from .nodes import (
+    intake_node,
+    triage_node,
+    dispatch_node,
+    notify_node,
+)
+
+# Goal definition
+goal = Goal(
+    id="efficient-field-dispatch",
+    name="Efficient Field Service Dispatch",
+    description=(
+        "Handle end-to-end field service dispatch: collect service requests, "
+        "triage by priority, match the best technician based on skills and "
+        "proximity, and coordinate dispatch with dispatcher approval."
+    ),
+    success_criteria=[
+        SuccessCriterion(
+            id="request-completeness",
+            description="Service request captured with all required details",
+            metric="request_captured",
+            target="complete",
+            weight=0.3,
+        ),
+        SuccessCriterion(
+            id="triage-accuracy",
+            description="Correct priority classification and skill matching",
+            metric="triage_accuracy",
+            target="correct",
+            weight=0.3,
+        ),
+        SuccessCriterion(
+            id="dispatch-quality",
+            description="Best technician matched with feasible schedule within SLA",
+            metric="dispatch_quality",
+            target="within_sla",
+            weight=0.25,
+        ),
+        SuccessCriterion(
+            id="notification-sent",
+            description="Customer and technician informed of dispatch details",
+            metric="notification_sent",
+            target="true",
+            weight=0.15,
+        ),
+    ],
+    constraints=[
+        Constraint(
+            id="sla-compliance",
+            description="Dispatch must be planned within the SLA window for the priority level",
+            constraint_type="functional",
+            category="timeliness",
+        ),
+        Constraint(
+            id="skill-match",
+            description="Assigned technician must have all required skills/certifications",
+            constraint_type="quality",
+            category="safety",
+        ),
+        Constraint(
+            id="dispatcher-approval",
+            description="Dispatch plan must be approved by dispatcher before execution",
+            constraint_type="functional",
+            category="interaction",
+        ),
+    ],
+)
+
+# Node list
+nodes = [
+    intake_node,
+    triage_node,
+    dispatch_node,
+    notify_node,
+]
+
+# Edge definitions
+edges = [
+    # intake -> triage_and_plan (always after intake completes)
+    EdgeSpec(
+        id="intake-to-triage",
+        source="intake",
+        target="triage_and_plan",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    # triage_and_plan -> dispatch (triage complete)
+    EdgeSpec(
+        id="triage-to-dispatch",
+        source="triage_and_plan",
+        target="dispatch",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    # dispatch -> notify (dispatch plan ready)
+    EdgeSpec(
+        id="dispatch-to-notify",
+        source="dispatch",
+        target="notify",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    # dispatch -> triage_and_plan (reassignment needed — no suitable tech found)
+    EdgeSpec(
+        id="dispatch-to-triage-reassign",
+        source="dispatch",
+        target="triage_and_plan",
+        condition=EdgeCondition.CONDITIONAL,
+        condition_expr="'needs_reassignment: true' in str(dispatch_plan).lower()",
+        priority=2,
+    ),
+    # notify -> intake (new dispatch cycle after completion)
+    EdgeSpec(
+        id="notify-to-intake",
+        source="notify",
+        target="intake",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+]
+
+# Graph configuration
+entry_node = "intake"
+entry_points = {"start": "intake"}
+pause_nodes = []
+terminal_nodes = []
+
+
+class FieldServiceDispatchAgent:
+    """
+    Field Service Dispatch Agent — 4-node pipeline with dispatcher approval.
+
+    Flow: intake -> triage_and_plan -> dispatch -> notify
+                        ^                  |
+                        +-- reassign loop --+ (if no suitable tech)
+
+    Uses AgentRuntime for proper session management:
+    - Session-scoped storage (sessions/{session_id}/)
+    - Checkpointing for resume capability
+    - Runtime logging
+    """
+
+    def __init__(self, config=None):
+        self.config = config or default_config
+        self.goal = goal
+        self.nodes = nodes
+        self.edges = edges
+        self.entry_node = entry_node
+        self.entry_points = entry_points
+        self.pause_nodes = pause_nodes
+        self.terminal_nodes = terminal_nodes
+        self._graph: GraphSpec | None = None
+        self._agent_runtime: AgentRuntime | None = None
+        self._tool_registry: ToolRegistry | None = None
+        self._storage_path: Path | None = None
+
+    def _build_graph(self) -> GraphSpec:
+        """Build the GraphSpec."""
+        return GraphSpec(
+            id="field-service-dispatch-graph",
+            goal_id=self.goal.id,
+            version="1.0.0",
+            entry_node=self.entry_node,
+            entry_points=self.entry_points,
+            terminal_nodes=self.terminal_nodes,
+            pause_nodes=self.pause_nodes,
+            nodes=self.nodes,
+            edges=self.edges,
+            default_model=self.config.model,
+            max_tokens=self.config.max_tokens,
+            loop_config={
+                "max_iterations": 50,
+                "max_tool_calls_per_turn": 10,
+                "max_history_tokens": 32000,
+            },
+        )
+
+    def _setup(self, mock_mode: bool = False) -> None:
+        """Set up the executor with all components."""
+        self._storage_path = Path.home() / ".hive" / "agents" / "field_service_dispatch"
+        self._storage_path.mkdir(parents=True, exist_ok=True)
+
+        self._tool_registry = ToolRegistry()
+
+        mcp_config_path = Path(__file__).parent / "mcp_servers.json"
+        if mcp_config_path.exists():
+            self._tool_registry.load_mcp_config(mcp_config_path)
+
+        llm = None
+        if not mock_mode:
+            llm = LiteLLMProvider(
+                model=self.config.model,
+                api_key=self.config.api_key,
+                api_base=self.config.api_base,
+            )
+
+        tool_executor = self._tool_registry.get_executor()
+        tools = list(self._tool_registry.get_tools().values())
+
+        self._graph = self._build_graph()
+
+        checkpoint_config = CheckpointConfig(
+            enabled=True,
+            checkpoint_on_node_start=False,
+            checkpoint_on_node_complete=True,
+            checkpoint_max_age_days=7,
+            async_checkpoint=True,
+        )
+
+        entry_point_specs = [
+            EntryPointSpec(
+                id="default",
+                name="Default",
+                entry_node=self.entry_node,
+                trigger_type="manual",
+                isolation_level="shared",
+            )
+        ]
+
+        self._agent_runtime = create_agent_runtime(
+            graph=self._graph,
+            goal=self.goal,
+            storage_path=self._storage_path,
+            entry_points=entry_point_specs,
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor,
+            checkpoint_config=checkpoint_config,
+        )
+
+    async def start(self, mock_mode=False) -> None:
+        """Set up and start the agent runtime."""
+        if self._agent_runtime is None:
+            self._setup(mock_mode=mock_mode)
+        if not self._agent_runtime.is_running:
+            await self._agent_runtime.start()
+
+    async def stop(self) -> None:
+        """Stop the agent runtime and clean up."""
+        if self._agent_runtime and self._agent_runtime.is_running:
+            await self._agent_runtime.stop()
+        self._agent_runtime = None
+
+    async def trigger_and_wait(
+        self,
+        entry_point: str = "default",
+        input_data: dict | None = None,
+        timeout: float | None = None,
+        session_state: dict | None = None,
+    ) -> ExecutionResult | None:
+        """Execute the graph and wait for completion."""
+        if self._agent_runtime is None:
+            raise RuntimeError("Agent not started. Call start() first.")
+
+        return await self._agent_runtime.trigger_and_wait(
+            entry_point_id=entry_point,
+            input_data=input_data or {},
+            session_state=session_state,
+        )
+
+    async def run(
+        self, context: dict, mock_mode=False, session_state=None
+    ) -> ExecutionResult:
+        """Run the agent (convenience method for single execution)."""
+        await self.start(mock_mode=mock_mode)
+        try:
+            result = await self.trigger_and_wait(
+                "default", context, session_state=session_state
+            )
+            return result or ExecutionResult(success=False, error="Execution timeout")
+        finally:
+            await self.stop()
+
+    def info(self):
+        """Get agent information."""
+        return {
+            "name": metadata.name,
+            "version": metadata.version,
+            "description": metadata.description,
+            "goal": {
+                "name": self.goal.name,
+                "description": self.goal.description,
+            },
+            "nodes": [n.id for n in self.nodes],
+            "edges": [e.id for e in self.edges],
+            "entry_node": self.entry_node,
+            "entry_points": self.entry_points,
+            "pause_nodes": self.pause_nodes,
+            "terminal_nodes": self.terminal_nodes,
+            "client_facing_nodes": [n.id for n in self.nodes if n.client_facing],
+        }
+
+    def validate(self):
+        """Validate agent structure."""
+        errors = []
+        warnings = []
+
+        node_ids = {node.id for node in self.nodes}
+        for edge in self.edges:
+            if edge.source not in node_ids:
+                errors.append(f"Edge {edge.id}: source '{edge.source}' not found")
+            if edge.target not in node_ids:
+                errors.append(f"Edge {edge.id}: target '{edge.target}' not found")
+
+        if self.entry_node not in node_ids:
+            errors.append(f"Entry node '{self.entry_node}' not found")
+
+        for terminal in self.terminal_nodes:
+            if terminal not in node_ids:
+                errors.append(f"Terminal node '{terminal}' not found")
+
+        for ep_id, node_id in self.entry_points.items():
+            if node_id not in node_ids:
+                errors.append(
+                    f"Entry point '{ep_id}' references unknown node '{node_id}'"
+                )
+
+        return {
+            "valid": len(errors) == 0,
+            "errors": errors,
+            "warnings": warnings,
+        }
+
+
+# Create default instance
+default_agent = FieldServiceDispatchAgent()

--- a/examples/templates/field_service_dispatch/agent.py
+++ b/examples/templates/field_service_dispatch/agent.py
@@ -106,14 +106,6 @@ edges = [
         condition=EdgeCondition.ON_SUCCESS,
         priority=1,
     ),
-    # dispatch -> notify (dispatch plan ready)
-    EdgeSpec(
-        id="dispatch-to-notify",
-        source="dispatch",
-        target="notify",
-        condition=EdgeCondition.ON_SUCCESS,
-        priority=1,
-    ),
     # dispatch -> triage_and_plan (reassignment needed — no suitable tech found)
     EdgeSpec(
         id="dispatch-to-triage-reassign",
@@ -121,6 +113,15 @@ edges = [
         target="triage_and_plan",
         condition=EdgeCondition.CONDITIONAL,
         condition_expr="'needs_reassignment: true' in str(dispatch_plan).lower()",
+        priority=1,
+    ),
+    # dispatch -> notify (dispatch plan ready, no reassignment needed)
+    EdgeSpec(
+        id="dispatch-to-notify",
+        source="dispatch",
+        target="notify",
+        condition=EdgeCondition.CONDITIONAL,
+        condition_expr="'needs_reassignment: true' not in str(dispatch_plan).lower()",
         priority=2,
     ),
     # notify -> intake (new dispatch cycle after completion)

--- a/examples/templates/field_service_dispatch/config.py
+++ b/examples/templates/field_service_dispatch/config.py
@@ -1,0 +1,27 @@
+"""Runtime configuration for Field Service Dispatch Agent."""
+
+from dataclasses import dataclass
+
+from framework.config import RuntimeConfig
+
+default_config = RuntimeConfig()
+
+
+@dataclass
+class AgentMetadata:
+    name: str = "Field Service Dispatch Agent"
+    version: str = "1.0.0"
+    description: str = (
+        "AI-powered field service dispatch agent that handles service request intake, "
+        "priority triage, technician matching with proximity-based routing, and "
+        "automated customer/technician notification — with dispatcher approval at "
+        "the final step."
+    )
+    intro_message: str = (
+        "Hi! I'm your field service dispatch assistant. Describe the service issue "
+        "and I'll handle triage, find the best available technician, and coordinate "
+        "the dispatch. What's the service request?"
+    )
+
+
+metadata = AgentMetadata()

--- a/examples/templates/field_service_dispatch/mcp_servers.json
+++ b/examples/templates/field_service_dispatch/mcp_servers.json
@@ -1,0 +1,14 @@
+{
+  "hive-tools": {
+    "transport": "stdio",
+    "command": "uv",
+    "args": [
+      "run",
+      "python",
+      "mcp_server.py",
+      "--stdio"
+    ],
+    "cwd": "../../../tools",
+    "description": "Hive tools MCP server providing web_search, get_current_time, and send_email for dispatch operations"
+  }
+}

--- a/examples/templates/field_service_dispatch/nodes/__init__.py
+++ b/examples/templates/field_service_dispatch/nodes/__init__.py
@@ -1,0 +1,265 @@
+"""Node definitions for Field Service Dispatch Agent."""
+
+from framework.graph import NodeSpec
+
+# Node 1: Intake (client-facing)
+# Collects service request details from the customer or dispatcher.
+intake_node = NodeSpec(
+    id="intake",
+    name="Service Request Intake",
+    description=(
+        "Collect service request details: location, problem type, urgency, "
+        "and customer contact information"
+    ),
+    node_type="event_loop",
+    client_facing=True,
+    max_node_visits=0,
+    input_keys=[],
+    output_keys=["service_request"],
+    success_criteria=(
+        "A complete service request is captured with: customer name, service address, "
+        "problem description, urgency level, contact phone, and preferred time window."
+    ),
+    system_prompt="""\
+You are a field service intake specialist. Your job is to collect all details needed \
+to dispatch a technician to a service call.
+
+**CRITICAL: You do NOT triage, dispatch, or schedule. You only collect information.**
+
+**STEP 1 — Gather service request details (text only, NO tool calls):**
+
+Collect the following from the user. Ask for missing items — do NOT guess:
+1. **Customer name** — who is requesting service
+2. **Service address** — full street address including city, state, zip
+3. **Problem description** — what equipment/system is affected and symptoms
+4. **Urgency** — is this an emergency (safety/health risk), urgent (same-day needed), \
+standard (within 2-3 days), or low priority (scheduled maintenance)?
+5. **Contact phone** — best number to reach the customer
+6. **Preferred time window** — any scheduling constraints or preferences
+7. **Access instructions** — gate codes, parking, or special access notes (optional)
+
+Keep the conversation natural. If the user provides most details upfront, just confirm \
+and ask for any missing items. Maximum 3 exchanges before finalizing.
+
+**STEP 2 — After all details are collected, call set_output:**
+
+Compile everything into a structured summary:
+- set_output("service_request", "Customer: [name] | Address: [full address] | \
+Problem: [description] | Urgency: [level] | Phone: [number] | \
+Preferred Time: [window] | Access: [notes or 'none']")
+
+That's it. Once you call set_output, the triage node takes over.
+""",
+    tools=[],
+)
+
+# Node 2: Triage and Plan (autonomous)
+# Classifies priority, determines required skills, calculates SLA deadline.
+triage_node = NodeSpec(
+    id="triage_and_plan",
+    name="Triage and Plan",
+    description=(
+        "Classify service priority, determine required technician skills, "
+        "and calculate SLA deadline"
+    ),
+    node_type="event_loop",
+    client_facing=False,
+    max_node_visits=0,
+    input_keys=["service_request"],
+    output_keys=["triage_result"],
+    success_criteria=(
+        "Triage result includes: priority level (P1-P4), required skills list, "
+        "SLA deadline with timestamp, and equipment category."
+    ),
+    system_prompt="""\
+You are a field service triage specialist. Analyze the service request and produce \
+a triage assessment.
+
+**STEP 1 — Get current time:**
+Call get_current_time to establish the current timestamp for SLA calculation.
+
+**STEP 2 — Classify the request:**
+
+Determine priority based on these rules:
+- **P1 Emergency** (1-hour SLA): gas leak, no heat in winter, no AC in extreme heat, \
+flooding, electrical hazard, safety risk
+- **P2 Urgent** (4-hour SLA): no hot water, refrigeration failure, primary HVAC down, \
+security system failure
+- **P3 Standard** (24-hour SLA): equipment malfunction (non-critical), intermittent issues, \
+performance degradation
+- **P4 Low** (72-hour SLA): scheduled maintenance, cosmetic issues, minor adjustments, \
+equipment upgrades
+
+**STEP 3 — Determine required skills:**
+
+Based on the problem description, identify needed technician certifications/skills:
+- HVAC: heating, cooling, ventilation, refrigerant handling (EPA 608)
+- Plumbing: water heaters, pipes, fixtures, backflow prevention
+- Electrical: wiring, panels, circuits, generators (licensed electrician)
+- Appliance: refrigerators, washers, dryers, dishwashers
+- General Maintenance: filters, minor repairs, inspections
+
+If the problem description mentions specific equipment, use web_search to look up \
+the equipment model for any known issues or special tool requirements.
+
+**STEP 4 — Calculate SLA deadline and call set_output:**
+
+Using the current time from Step 1, calculate the SLA deadline based on priority.
+
+- set_output("triage_result", "Priority: [P1-P4] [label] | Skills: [list] | \
+SLA Deadline: [ISO timestamp] | Equipment: [category] | \
+Special Requirements: [any tools or parts needed, or 'none']")
+""",
+    tools=["get_current_time", "web_search"],
+)
+
+# Node 3: Dispatch (autonomous)
+# Matches the best technician and proposes a schedule.
+dispatch_node = NodeSpec(
+    id="dispatch",
+    name="Dispatch Planning",
+    description=(
+        "Match the best available technician based on skills, proximity, "
+        "and availability, then propose a time slot"
+    ),
+    node_type="event_loop",
+    client_facing=False,
+    max_node_visits=0,
+    input_keys=["service_request", "triage_result"],
+    output_keys=["dispatch_plan"],
+    success_criteria=(
+        "A dispatch plan is produced with: assigned technician, estimated arrival time, "
+        "travel distance/duration, and a feasibility assessment."
+    ),
+    system_prompt="""\
+You are a field service dispatch planner. Your job is to create the optimal dispatch plan.
+
+**CONTEXT:** You have the service_request (customer details, address, problem) and \
+triage_result (priority, required skills, SLA deadline).
+
+Since this is a template agent without access to a live technician database, you will \
+simulate the dispatch planning process that would integrate with a real fleet management \
+system. Focus on demonstrating the decision-making logic.
+
+**STEP 1 — Parse requirements:**
+Extract from triage_result:
+- Required skills
+- SLA deadline
+- Priority level
+- Service address from service_request
+
+**STEP 2 — Get current time for scheduling:**
+Call get_current_time to know the current time for availability windows.
+
+**STEP 3 — Build dispatch plan:**
+
+Create a dispatch plan considering:
+1. **Skill match** — technician must have ALL required certifications
+2. **Proximity** — prefer closest technician to minimize travel time
+3. **Availability** — must be available within the SLA window
+4. **Workload balance** — avoid overloading a single technician
+
+For the template, generate a realistic dispatch plan with:
+- Recommended technician profile (skills, current location area)
+- Estimated travel time to service address
+- Proposed arrival window (e.g., "2:00 PM - 3:00 PM")
+- Backup technician recommendation if primary is unavailable
+- Any scheduling conflicts or concerns
+
+**STEP 4 — Assess feasibility:**
+- Can we meet the SLA? If not, flag it and explain why.
+- Are there any risk factors (weather, equipment availability, access issues)?
+- set_output("dispatch_plan", "Technician: [name/profile] | Skills: [matched skills] | \
+Travel: [estimated duration] | Arrival Window: [time range] | \
+SLA Status: [on-track/at-risk/breach] | \
+Backup: [alternative technician] | Notes: [any concerns]")
+
+If the plan is NOT feasible (no qualified tech available within SLA), include \
+"needs_reassignment: true" in the output so the system can loop back to triage \
+for requirement adjustment.
+""",
+    tools=["get_current_time", "web_search"],
+)
+
+# Node 4: Notify (client-facing)
+# Presents the dispatch plan for dispatcher approval and sends notifications.
+notify_node = NodeSpec(
+    id="notify",
+    name="Notify and Confirm",
+    description=(
+        "Present dispatch plan for approval, then notify customer and technician"
+    ),
+    node_type="event_loop",
+    client_facing=True,
+    max_node_visits=0,
+    input_keys=["service_request", "triage_result", "dispatch_plan"],
+    output_keys=["dispatch_confirmation"],
+    success_criteria=(
+        "Dispatcher has reviewed and approved the plan, and confirmation details "
+        "have been presented for customer and technician notification."
+    ),
+    system_prompt="""\
+You are a dispatch coordinator. Present the complete dispatch plan to the dispatcher \
+for approval, then handle notifications.
+
+**STEP 1 — Present dispatch summary (text only, NO tool calls):**
+
+Format the dispatch plan clearly:
+
+📋 **DISPATCH SUMMARY**
+━━━━━━━━━━━━━━━━━━━━
+
+**Service Request:**
+- Customer: [from service_request]
+- Address: [from service_request]
+- Problem: [from service_request]
+
+**Triage Assessment:**
+- Priority: [from triage_result]
+- Required Skills: [from triage_result]
+- SLA Deadline: [from triage_result]
+
+**Dispatch Plan:**
+- Assigned Technician: [from dispatch_plan]
+- Arrival Window: [from dispatch_plan]
+- Travel Time: [from dispatch_plan]
+- SLA Status: [from dispatch_plan]
+- Backup: [from dispatch_plan]
+
+Ask the dispatcher: "Approve this dispatch? (yes/no/modify)"
+
+**STEP 2 — Handle dispatcher response:**
+
+If **approved**:
+- Confirm the dispatch is locked in
+- Present what notifications would be sent:
+  - Customer: appointment confirmation with arrival window
+  - Technician: job assignment with address and problem details
+- Note: In a production system, send_email would deliver these automatically
+
+If **modify requested**:
+- Ask what changes are needed
+- Adjust the plan accordingly
+- Re-present for approval
+
+If **rejected**:
+- Ask for the reason
+- Acknowledge and note it for the next dispatch cycle
+
+**STEP 3 — After dispatcher confirms, call set_output:**
+- set_output("dispatch_confirmation", "Status: [approved/rejected/modified] | \
+Technician: [assigned tech] | Arrival: [confirmed window] | \
+Customer Notified: [yes/pending] | Tech Notified: [yes/pending] | \
+Dispatcher: [approval timestamp]")
+
+The dispatch cycle is complete after set_output is called.
+""",
+    tools=["send_email", "get_current_time"],
+)
+
+__all__ = [
+    "intake_node",
+    "triage_node",
+    "dispatch_node",
+    "notify_node",
+]


### PR DESCRIPTION
Fixes #6381

## Summary

- Adds a **Field Service Dispatch** agent template (`examples/templates/field_service_dispatch/`)
- 4-node event_loop graph: `intake → triage_and_plan → dispatch → notify`
- Handles end-to-end field service workflow: request collection, priority triage (P1-P4 with SLA), technician matching, and dispatcher HITL approval
- Includes reassignment feedback loop when no suitable technician meets SLA requirements

## Use Cases

- HVAC/Plumbing/Electrical service companies dispatching technicians
- Property management coordinating maintenance crews
- Emergency repair services with SLA-driven priority routing

## Design Decisions

- **4 nodes** (not 6) — each has clear single responsibility
- **client_facing** only on intake and notify — autonomous triage/dispatch in the middle
- **Feedback loop** dispatch→triage for reassignment when constraints can't be met
- **Same mcp_servers.json pattern** as deep_research_agent (hive-tools server)
- Tools: `get_current_time`, `web_search`, `send_email`

## Verification

```
✅ ruff check — All checks passed
✅ ruff format --check — 5 files already formatted
✅ Import test — OK
✅ validate() — Valid: True, 0 errors, 0 warnings
✅ Graph: 4 nodes, 5 edges, entry=intake
✅ Existing test suite: 840 passed, 55 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)