### PR TITLE
fix(credentials): aden_api_key delete returns 404 when not found, san…

### DIFF
--- a/core/framework/credentials/key_storage.py
+++ b/core/framework/credentials/key_storage.py
@@ -144,18 +144,23 @@ def save_aden_api_key(key: str) -> None:
 
 def delete_aden_api_key() -> bool:
     """Remove ADEN_API_KEY from the encrypted store and ``os.environ``.
-    
+
     Returns True if the key existed and was deleted, False otherwise.
     """
     deleted = False
     try:
         from .storage import EncryptedFileStorage
+
         storage = EncryptedFileStorage()
         deleted = storage.delete(ADEN_CREDENTIAL_ID)
     except (FileNotFoundError, PermissionError) as e:
         logger.debug("Could not delete %s from encrypted store: %s", ADEN_CREDENTIAL_ID, e)
     except Exception:
-        pass
+        logger.warning(
+            "Unexpected error deleting %s from encrypted store",
+            ADEN_CREDENTIAL_ID,
+            exc_info=True,
+        )
     os.environ.pop(ADEN_ENV_VAR, None)
     return deleted
 

--- a/core/framework/credentials/key_storage.py
+++ b/core/framework/credentials/key_storage.py
@@ -142,23 +142,22 @@ def save_aden_api_key(key: str) -> None:
     os.environ[ADEN_ENV_VAR] = key
 
 
-def delete_aden_api_key() -> None:
-    """Remove ADEN_API_KEY from the encrypted store and ``os.environ``."""
+def delete_aden_api_key() -> bool:
+    """Remove ADEN_API_KEY from the encrypted store and ``os.environ``.
+    
+    Returns True if the key existed and was deleted, False otherwise.
+    """
+    deleted = False
     try:
         from .storage import EncryptedFileStorage
-
         storage = EncryptedFileStorage()
-        storage.delete(ADEN_CREDENTIAL_ID)
+        deleted = storage.delete(ADEN_CREDENTIAL_ID)
     except (FileNotFoundError, PermissionError) as e:
         logger.debug("Could not delete %s from encrypted store: %s", ADEN_CREDENTIAL_ID, e)
     except Exception:
-        logger.warning(
-            "Unexpected error deleting %s from encrypted store",
-            ADEN_CREDENTIAL_ID,
-            exc_info=True,
-        )
-
+        pass
     os.environ.pop(ADEN_ENV_VAR, None)
+    return deleted
 
 
 # ---------------------------------------------------------------------------

--- a/core/framework/server/routes_credentials.py
+++ b/core/framework/server/routes_credentials.py
@@ -102,11 +102,10 @@ async def handle_delete_credential(request: web.Request) -> web.Response:
 
     if credential_id == "aden_api_key":
         from framework.credentials.key_storage import delete_aden_api_key
+
         deleted = delete_aden_api_key()
         if not deleted:
-            return web.json_response(
-                {"error": "Credential 'aden_api_key' not found"}, status=404
-            )
+            return web.json_response({"error": "Credential 'aden_api_key' not found"}, status=404)
         return web.json_response({"deleted": True})
 
     store = _get_store(request)

--- a/core/framework/server/routes_credentials.py
+++ b/core/framework/server/routes_credentials.py
@@ -102,8 +102,11 @@ async def handle_delete_credential(request: web.Request) -> web.Response:
 
     if credential_id == "aden_api_key":
         from framework.credentials.key_storage import delete_aden_api_key
-
-        delete_aden_api_key()
+        deleted = delete_aden_api_key()
+        if not deleted:
+            return web.json_response(
+                {"error": "Credential 'aden_api_key' not found"}, status=404
+            )
         return web.json_response({"deleted": True})
 
     store = _get_store(request)
@@ -178,7 +181,10 @@ async def handle_check_agent(request: web.Request) -> web.Response:
         )
     except Exception as e:
         logger.exception(f"Error checking agent credentials: {e}")
-        return web.json_response({"error": str(e)}, status=500)
+        return web.json_response(
+            {"error": "Internal server error while checking credentials"},
+            status=500,
+        )
 
 
 def _status_to_dict(c) -> dict:


### PR DESCRIPTION
Closes #6190

## Changes

`core/framework/credentials/key_storage.py`
- `delete_aden_api_key()` now returns `bool` — `True` if deleted, `False` if not found, using the existing return value from `storage.delete()`

`core/framework/server/routes_credentials.py`
- `handle_delete_credential()` now returns 404 when `aden_api_key` does not exist, consistent with the regular credential delete path
- `handle_check_agent()` now returns a generic 500 message instead of `str(e)`, full error still logged server-side via `logger.exception()`