### PR TITLE
Add Level 2 dummy agent end-to-end tests

### DIFF
--- a/core/tests/dummy_agents/README.md
+++ b/core/tests/dummy_agents/README.md
@@ -1,0 +1,44 @@
+# Dummy Agent Tests (Level 2)
+
+End-to-end tests that run real LLM calls against deterministic graph structures. Not part of CI — run manually to verify the executor works with real providers.
+
+## Quick Start
+
+```bash
+cd core
+uv run python tests/dummy_agents/run_all.py
+```
+
+The script detects available credentials and prompts you to pick a provider. You need at least one of:
+
+- `ANTHROPIC_API_KEY`
+- `OPENAI_API_KEY`
+- `GEMINI_API_KEY`
+- `ZAI_API_KEY`
+- Claude Code / Codex / Kimi subscription
+
+## Verbose Mode
+
+Show live LLM logs (tool calls, judge verdicts, node traversal):
+
+```bash
+uv run python tests/dummy_agents/run_all.py --verbose
+```
+
+## What's Tested
+
+| Agent | Tests | What it covers |
+|-------|-------|----------------|
+| echo | 2 | Single-node lifecycle, basic set_output |
+| pipeline | 4 | Multi-node traversal, input_mapping, conversation modes |
+| branch | 3 | Conditional edges, LLM-driven routing |
+| parallel_merge | 4 | Fan-out/fan-in, failure strategies |
+| retry | 4 | Retry mechanics, exhaustion, ON_FAILURE edges |
+| feedback_loop | 3 | Feedback cycles, max_node_visits |
+| worker | 4 | Real MCP tools (example_tool, get_current_time, save_data/load_data) |
+
+## Notes
+
+- Tests are **auto-skipped** in regular `pytest` runs (no LLM configured)
+- Worker tests start the `hive-tools` MCP server as a subprocess
+- Typical runtime: ~1-3 min depending on provider

--- a/core/tests/dummy_agents/__init__.py
+++ b/core/tests/dummy_agents/__init__.py
@@ -1,0 +1,3 @@
+# Level 2: Dummy Agent Tests
+# End-to-end graph execution tests with real LLM calls.
+# NOT part of regular CI — run manually with: uv run python tests/dummy_agents/run_all.py

--- a/core/tests/dummy_agents/conftest.py
+++ b/core/tests/dummy_agents/conftest.py
@@ -39,6 +39,7 @@ def set_llm_selection(
 
 # ── collection hook: skip entire directory when not configured ───────
 
+
 def pytest_collection_modifyitems(config, items):
     """Skip all dummy_agents tests when no LLM is configured.
 

--- a/core/tests/dummy_agents/conftest.py
+++ b/core/tests/dummy_agents/conftest.py
@@ -1,0 +1,139 @@
+"""Shared fixtures for dummy agent end-to-end tests.
+
+These tests use real LLM providers — they are NOT part of regular CI.
+Run via: cd core && uv run python tests/dummy_agents/run_all.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from framework.graph.executor import GraphExecutor, ParallelExecutionConfig
+from framework.graph.goal import Goal
+from framework.llm.litellm import LiteLLMProvider
+from framework.runtime.core import Runtime
+
+# ── module-level state set by run_all.py ─────────────────────────────
+
+_selected_model: str | None = None
+_selected_api_key: str | None = None
+_selected_extra_headers: dict[str, str] | None = None
+_selected_api_base: str | None = None
+
+
+def set_llm_selection(
+    model: str,
+    api_key: str,
+    extra_headers: dict[str, str] | None = None,
+    api_base: str | None = None,
+) -> None:
+    """Called by run_all.py after user selects a provider."""
+    global _selected_model, _selected_api_key, _selected_extra_headers, _selected_api_base
+    _selected_model = model
+    _selected_api_key = api_key
+    _selected_extra_headers = extra_headers
+    _selected_api_base = api_base
+
+
+# ── collection hook: skip entire directory when not configured ───────
+
+def pytest_collection_modifyitems(config, items):
+    """Skip all dummy_agents tests when no LLM is configured.
+
+    This prevents these tests from running in regular CI. They only run
+    when launched via run_all.py (which calls set_llm_selection first).
+    """
+    if _selected_model is not None:
+        return  # LLM configured, run normally
+
+    skip = pytest.mark.skip(
+        reason="Dummy agent tests require a real LLM. "
+        "Run via: cd core && uv run python tests/dummy_agents/run_all.py"
+    )
+    for item in items:
+        if "dummy_agents" in str(item.fspath):
+            item.add_marker(skip)
+
+
+# ── fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="session")
+def llm_provider():
+    """Real LLM provider using the user-selected model."""
+    if _selected_model is None or _selected_api_key is None:
+        pytest.skip("No LLM selected — run via run_all.py")
+    kwargs = {"model": _selected_model, "api_key": _selected_api_key}
+    if _selected_extra_headers:
+        kwargs["extra_headers"] = _selected_extra_headers
+    if _selected_api_base:
+        kwargs["api_base"] = _selected_api_base
+    return LiteLLMProvider(**kwargs)
+
+
+@pytest.fixture(scope="session")
+def tool_registry():
+    """Load hive-tools MCP server and return a ToolRegistry with real tools.
+
+    Session-scoped so the MCP server is started once and reused across tests.
+    """
+    from framework.runner.tool_registry import ToolRegistry
+
+    registry = ToolRegistry()
+    # Resolve the tools directory relative to the repo root
+    repo_root = Path(__file__).resolve().parents[3]  # core/tests/dummy_agents -> repo root
+    tools_dir = repo_root / "tools"
+
+    mcp_config = {
+        "name": "hive-tools",
+        "transport": "stdio",
+        "command": "uv",
+        "args": ["run", "python", "mcp_server.py", "--stdio"],
+        "cwd": str(tools_dir),
+        "description": "Hive tools MCP server",
+    }
+    registry.register_mcp_server(mcp_config)
+    yield registry
+    registry.cleanup()
+
+
+@pytest.fixture
+def runtime(tmp_path):
+    """Real Runtime backed by a temp directory."""
+    return Runtime(storage_path=tmp_path / "runtime")
+
+
+@pytest.fixture
+def goal():
+    return Goal(id="dummy", name="Dummy Agent Test", description="Level 2 end-to-end testing")
+
+
+def make_executor(
+    runtime: Runtime,
+    llm: LiteLLMProvider,
+    *,
+    enable_parallel: bool = True,
+    parallel_config: ParallelExecutionConfig | None = None,
+    loop_config: dict | None = None,
+    tool_registry=None,
+    storage_path: Path | None = None,
+) -> GraphExecutor:
+    """Factory that creates a GraphExecutor with a real LLM."""
+    tools = []
+    tool_executor = None
+    if tool_registry is not None:
+        tools = list(tool_registry.get_tools().values())
+        tool_executor = tool_registry.get_executor()
+
+    return GraphExecutor(
+        runtime=runtime,
+        llm=llm,
+        tools=tools,
+        tool_executor=tool_executor,
+        enable_parallel_execution=enable_parallel,
+        parallel_config=parallel_config,
+        loop_config=loop_config or {"max_iterations": 10},
+        storage_path=storage_path,
+    )

--- a/core/tests/dummy_agents/nodes.py
+++ b/core/tests/dummy_agents/nodes.py
@@ -1,0 +1,64 @@
+"""Minimal helper nodes for deterministic control-flow tests.
+
+Most tests use real EventLoopNode with real LLM calls. These helpers
+exist only for tests that need predictable failure/success patterns
+(retry, feedback loop, parallel failure modes).
+"""
+
+from __future__ import annotations
+
+from framework.graph.node import NodeContext, NodeProtocol, NodeResult
+
+
+class SuccessNode(NodeProtocol):
+    """Always succeeds with configurable output dict."""
+
+    def __init__(self, output: dict | None = None):
+        self._output = output or {"status": "ok"}
+        self.executed = False
+        self.execute_count = 0
+
+    async def execute(self, ctx: NodeContext) -> NodeResult:
+        self.executed = True
+        self.execute_count += 1
+        return NodeResult(success=True, output=self._output, tokens_used=1, latency_ms=1)
+
+
+class FailNode(NodeProtocol):
+    """Always fails with configurable error."""
+
+    def __init__(self, error: str = "node failed"):
+        self._error = error
+        self.attempt_count = 0
+
+    async def execute(self, ctx: NodeContext) -> NodeResult:
+        self.attempt_count += 1
+        return NodeResult(success=False, error=self._error)
+
+
+class FlakyNode(NodeProtocol):
+    """Fails N times then succeeds. For retry tests."""
+
+    def __init__(self, fail_times: int = 2, output: dict | None = None):
+        self.fail_times = fail_times
+        self._output = output or {"status": "recovered"}
+        self.attempt_count = 0
+
+    async def execute(self, ctx: NodeContext) -> NodeResult:
+        self.attempt_count += 1
+        if self.attempt_count <= self.fail_times:
+            return NodeResult(success=False, error=f"fail #{self.attempt_count}")
+        return NodeResult(success=True, output=self._output, tokens_used=1, latency_ms=1)
+
+
+class StatefulNode(NodeProtocol):
+    """Returns different outputs on successive calls. For feedback loop tests."""
+
+    def __init__(self, outputs: list[NodeResult]):
+        self._outputs = outputs
+        self.call_count = 0
+
+    async def execute(self, ctx: NodeContext) -> NodeResult:
+        idx = min(self.call_count, len(self._outputs) - 1)
+        self.call_count += 1
+        return self._outputs[idx]

--- a/core/tests/dummy_agents/run_all.py
+++ b/core/tests/dummy_agents/run_all.py
@@ -40,6 +40,7 @@ def _detect_claude_code_token() -> str | None:
     """Check if Claude Code subscription credentials are available."""
     try:
         from framework.runner.runner import get_claude_code_token
+
         return get_claude_code_token()
     except Exception:
         return None
@@ -49,6 +50,7 @@ def _detect_codex_token() -> str | None:
     """Check if Codex subscription credentials are available."""
     try:
         from framework.runner.runner import get_codex_token
+
         return get_codex_token()
     except Exception:
         return None
@@ -58,6 +60,7 @@ def _detect_kimi_code_token() -> str | None:
     """Check if Kimi Code subscription credentials are available."""
     try:
         from framework.runner.runner import get_kimi_code_token
+
         return get_kimi_code_token()
     except Exception:
         return None
@@ -73,31 +76,37 @@ def detect_available() -> list[dict]:
     # Subscription-based providers
     token = _detect_claude_code_token()
     if token:
-        available.append({
-            "name": "Claude Code (subscription)",
-            "model": "claude-sonnet-4-20250514",
-            "api_key": token,
-            "source": "claude_code_sub",
-            "extra_headers": {"authorization": f"Bearer {token}"},
-        })
+        available.append(
+            {
+                "name": "Claude Code (subscription)",
+                "model": "claude-sonnet-4-20250514",
+                "api_key": token,
+                "source": "claude_code_sub",
+                "extra_headers": {"authorization": f"Bearer {token}"},
+            }
+        )
 
     token = _detect_codex_token()
     if token:
-        available.append({
-            "name": "Codex (subscription)",
-            "model": "gpt-5-mini",
-            "api_key": token,
-            "source": "codex_sub",
-        })
+        available.append(
+            {
+                "name": "Codex (subscription)",
+                "model": "gpt-5-mini",
+                "api_key": token,
+                "source": "codex_sub",
+            }
+        )
 
     token = _detect_kimi_code_token()
     if token:
-        available.append({
-            "name": "Kimi Code (subscription)",
-            "model": "moonshotai/kimi-k2-instruct-0905",
-            "api_key": token,
-            "source": "kimi_sub",
-        })
+        available.append(
+            {
+                "name": "Kimi Code (subscription)",
+                "model": "moonshotai/kimi-k2-instruct-0905",
+                "api_key": token,
+                "source": "kimi_sub",
+            }
+        )
 
     # API key providers (env vars)
     for env_var, name, default_model in API_KEY_PROVIDERS:
@@ -154,6 +163,7 @@ def prompt_provider_selection() -> dict:
 
 # ── test runner ──────────────────────────────────────────────────────
 
+
 def parse_junit_xml(xml_path: str) -> dict[str, dict]:
     """Parse JUnit XML and group results by agent (test file)."""
     tree = ET.parse(xml_path)
@@ -172,8 +182,11 @@ def parse_junit_xml(xml_path: str) -> dict[str, dict]:
 
             if agent_name not in agents:
                 agents[agent_name] = {
-                    "total": 0, "passed": 0, "failed": 0,
-                    "time": 0.0, "tests": [],
+                    "total": 0,
+                    "passed": 0,
+                    "failed": 0,
+                    "time": 0.0,
+                    "tests": [],
                 }
 
             agents[agent_name]["total"] += 1
@@ -281,7 +294,7 @@ def print_table(agents: dict[str, dict], total_time: float, verbose: bool = Fals
                     if reason:
                         # Wrap long reasons
                         for i in range(0, len(reason), 100):
-                            print(f"    {reason[i:i+100]}")
+                            print(f"    {reason[i : i + 100]}")
         print()
 
 
@@ -297,6 +310,7 @@ def main() -> int:
 
     # Step 2: inject selection into conftest module state
     from tests.dummy_agents.conftest import set_llm_selection
+
     set_llm_selection(
         model=provider["model"],
         api_key=provider["api_key"],

--- a/core/tests/dummy_agents/run_all.py
+++ b/core/tests/dummy_agents/run_all.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Runner for Level 2 dummy agent tests with interactive LLM provider selection.
+
+This is NOT part of regular CI. It makes real LLM API calls.
+
+Usage:
+    cd core && uv run python tests/dummy_agents/run_all.py
+    cd core && uv run python tests/dummy_agents/run_all.py --verbose
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+TESTS_DIR = Path(__file__).parent
+
+# ── provider registry ────────────────────────────────────────────────
+
+# (env_var, display_name, default_model) — models match quickstart.sh defaults
+API_KEY_PROVIDERS = [
+    ("ANTHROPIC_API_KEY", "Anthropic (Claude)", "claude-sonnet-4-20250514"),
+    ("OPENAI_API_KEY", "OpenAI", "gpt-5-mini"),
+    ("GEMINI_API_KEY", "Google Gemini", "gemini/gemini-3-flash-preview"),
+    ("ZAI_API_KEY", "ZAI (GLM)", "openai/glm-5"),
+    ("GROQ_API_KEY", "Groq", "moonshotai/kimi-k2-instruct-0905"),
+    ("MISTRAL_API_KEY", "Mistral", "mistral-large-latest"),
+    ("CEREBRAS_API_KEY", "Cerebras", "cerebras/zai-glm-4.7"),
+    ("TOGETHER_API_KEY", "Together AI", "together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo"),
+    ("DEEPSEEK_API_KEY", "DeepSeek", "deepseek-chat"),
+    ("MINIMAX_API_KEY", "MiniMax", "MiniMax-M2.5"),
+]
+
+
+def _detect_claude_code_token() -> str | None:
+    """Check if Claude Code subscription credentials are available."""
+    try:
+        from framework.runner.runner import get_claude_code_token
+        return get_claude_code_token()
+    except Exception:
+        return None
+
+
+def _detect_codex_token() -> str | None:
+    """Check if Codex subscription credentials are available."""
+    try:
+        from framework.runner.runner import get_codex_token
+        return get_codex_token()
+    except Exception:
+        return None
+
+
+def _detect_kimi_code_token() -> str | None:
+    """Check if Kimi Code subscription credentials are available."""
+    try:
+        from framework.runner.runner import get_kimi_code_token
+        return get_kimi_code_token()
+    except Exception:
+        return None
+
+
+def detect_available() -> list[dict]:
+    """Detect all available LLM providers with valid credentials.
+
+    Returns list of dicts: {name, model, api_key, source}
+    """
+    available = []
+
+    # Subscription-based providers
+    token = _detect_claude_code_token()
+    if token:
+        available.append({
+            "name": "Claude Code (subscription)",
+            "model": "claude-sonnet-4-20250514",
+            "api_key": token,
+            "source": "claude_code_sub",
+            "extra_headers": {"authorization": f"Bearer {token}"},
+        })
+
+    token = _detect_codex_token()
+    if token:
+        available.append({
+            "name": "Codex (subscription)",
+            "model": "gpt-5-mini",
+            "api_key": token,
+            "source": "codex_sub",
+        })
+
+    token = _detect_kimi_code_token()
+    if token:
+        available.append({
+            "name": "Kimi Code (subscription)",
+            "model": "moonshotai/kimi-k2-instruct-0905",
+            "api_key": token,
+            "source": "kimi_sub",
+        })
+
+    # API key providers (env vars)
+    for env_var, name, default_model in API_KEY_PROVIDERS:
+        key = os.environ.get(env_var)
+        if key:
+            entry = {
+                "name": f"{name} (${env_var})",
+                "model": default_model,
+                "api_key": key,
+                "source": env_var,
+            }
+            # ZAI requires an api_base (OpenAI-compatible endpoint)
+            if env_var == "ZAI_API_KEY":
+                entry["api_base"] = "https://api.z.ai/api/coding/paas/v4"
+            available.append(entry)
+
+    return available
+
+
+def prompt_provider_selection() -> dict:
+    """Interactive prompt to select an LLM provider. Returns the chosen provider dict."""
+    available = detect_available()
+
+    if not available:
+        print("\n  No LLM credentials detected.")
+        print("  Set an API key environment variable, e.g.:")
+        print("    export ANTHROPIC_API_KEY=sk-...")
+        print("    export OPENAI_API_KEY=sk-...")
+        print("  Or authenticate with Claude Code: claude")
+        sys.exit(1)
+
+    if len(available) == 1:
+        choice = available[0]
+        print(f"\n  Using: {choice['name']} ({choice['model']})")
+        return choice
+
+    print("\n  Available LLM providers:\n")
+    for i, p in enumerate(available, 1):
+        print(f"    {i}) {p['name']}  [{p['model']}]")
+
+    print()
+    while True:
+        try:
+            raw = input(f"  Select provider [1-{len(available)}]: ").strip()
+            idx = int(raw) - 1
+            if 0 <= idx < len(available):
+                choice = available[idx]
+                print(f"\n  Using: {choice['name']} ({choice['model']})\n")
+                return choice
+        except (ValueError, EOFError):
+            pass
+        print(f"  Please enter a number between 1 and {len(available)}")
+
+
+# ── test runner ──────────────────────────────────────────────────────
+
+def parse_junit_xml(xml_path: str) -> dict[str, dict]:
+    """Parse JUnit XML and group results by agent (test file)."""
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+    agents: dict[str, dict] = {}
+
+    for testsuite in root.iter("testsuite"):
+        for testcase in testsuite.iter("testcase"):
+            classname = testcase.get("classname", "")
+            parts = classname.split(".")
+            agent_name = "unknown"
+            for part in parts:
+                if part.startswith("test_"):
+                    agent_name = part[5:]
+                    break
+
+            if agent_name not in agents:
+                agents[agent_name] = {
+                    "total": 0, "passed": 0, "failed": 0,
+                    "time": 0.0, "tests": [],
+                }
+
+            agents[agent_name]["total"] += 1
+            test_time = float(testcase.get("time", "0"))
+            agents[agent_name]["time"] += test_time
+
+            failures = testcase.findall("failure")
+            errors = testcase.findall("error")
+            test_name = testcase.get("name", "")
+
+            if failures or errors:
+                agents[agent_name]["failed"] += 1
+                # Extract failure reason from the first failure/error element
+                fail_el = (failures or errors)[0]
+                reason = fail_el.get("message", "") or ""
+                # Also grab the text body for more detail
+                body = fail_el.text or ""
+                # Build a concise reason: prefer message, fall back to first line of body
+                if not reason and body:
+                    reason = body.strip().split("\n")[0]
+                agents[agent_name]["tests"].append((test_name, "FAIL", reason))
+            else:
+                agents[agent_name]["passed"] += 1
+                agents[agent_name]["tests"].append((test_name, "PASS", ""))
+
+    return agents
+
+
+def print_table(agents: dict[str, dict], total_time: float, verbose: bool = False) -> None:
+    """Print summary table."""
+    col_agent = 20
+    col_tests = 6
+    col_passed = 8
+    col_time = 12
+
+    def sep(char: str = "═") -> str:
+        return (
+            f"╠{char * (col_agent + 2)}╬{char * (col_tests + 2)}"
+            f"╬{char * (col_passed + 2)}╬{char * (col_time + 2)}╣"
+        )
+
+    header = (
+        f"║ {'Agent':<{col_agent}} ║ {'Tests':>{col_tests}} "
+        f"║ {'Passed':>{col_passed}} ║ {'Time (s)':>{col_time}} ║"
+    )
+    top = (
+        f"╔{'═' * (col_agent + 2)}╦{'═' * (col_tests + 2)}"
+        f"╦{'═' * (col_passed + 2)}╦{'═' * (col_time + 2)}╗"
+    )
+    bottom = (
+        f"╚{'═' * (col_agent + 2)}╩{'═' * (col_tests + 2)}"
+        f"╩{'═' * (col_passed + 2)}╩{'═' * (col_time + 2)}╝"
+    )
+
+    print()
+    print(top)
+    print(header)
+    print(sep())
+
+    total_tests = 0
+    total_passed = 0
+
+    for agent_name in sorted(agents.keys()):
+        data = agents[agent_name]
+        total_tests += data["total"]
+        total_passed += data["passed"]
+        marker = " " if data["failed"] == 0 else "!"
+        row = (
+            f"║{marker}{agent_name:<{col_agent + 1}} ║ {data['total']:>{col_tests}} "
+            f"║ {data['passed']:>{col_passed}} ║ {data['time']:>{col_time}.2f} ║"
+        )
+        print(row)
+
+        if verbose:
+            for test_name, status, reason in data["tests"]:
+                icon = "  ✓" if status == "PASS" else "  ✗"
+                print(
+                    f"║   {icon} {test_name:<{col_agent - 2}}"
+                    f"║{'':>{col_tests + 2}}║{'':>{col_passed + 2}}║{'':>{col_time + 2}}║"
+                )
+                if status == "FAIL" and reason:
+                    # Print failure reason wrapped to fit, indented under the test
+                    reason_short = reason[:120] + ("..." if len(reason) > 120 else "")
+                    print(f"║       {reason_short}")
+                    print("║")
+
+    print(sep())
+    all_pass = total_passed == total_tests
+    status = "ALL PASS" if all_pass else f"{total_tests - total_passed} FAILED"
+    totals = (
+        f"║ {status:<{col_agent}} ║ {total_tests:>{col_tests}} "
+        f"║ {total_passed:>{col_passed}} ║ {total_time:>{col_time}.2f} ║"
+    )
+    print(totals)
+    print(bottom)
+
+    # Always print failure details if any tests failed
+    if not all_pass:
+        print("\n  Failure Details:")
+        print("  " + "─" * 70)
+        for agent_name in sorted(agents.keys()):
+            for test_name, status, reason in agents[agent_name]["tests"]:
+                if status == "FAIL":
+                    print(f"\n  ✗ {agent_name}::{test_name}")
+                    if reason:
+                        # Wrap long reasons
+                        for i in range(0, len(reason), 100):
+                            print(f"    {reason[i:i+100]}")
+        print()
+
+
+def main() -> int:
+    verbose = "--verbose" in sys.argv or "-v" in sys.argv
+
+    print("\n  ╔═══════════════════════════════════════╗")
+    print("  ║   Level 2: Dummy Agent Tests (E2E)    ║")
+    print("  ╚═══════════════════════════════════════╝")
+
+    # Step 1: detect credentials and let user pick
+    provider = prompt_provider_selection()
+
+    # Step 2: inject selection into conftest module state
+    from tests.dummy_agents.conftest import set_llm_selection
+    set_llm_selection(
+        model=provider["model"],
+        api_key=provider["api_key"],
+        extra_headers=provider.get("extra_headers"),
+        api_base=provider.get("api_base"),
+    )
+
+    # Step 3: run pytest
+    with NamedTemporaryFile(suffix=".xml", delete=False) as tmp:
+        xml_path = tmp.name
+
+    start = time.time()
+    import pytest as _pytest
+
+    pytest_args = [
+        str(TESTS_DIR),
+        f"--junitxml={xml_path}",
+        "--tb=short",
+        "--override-ini=asyncio_mode=auto",
+        "--log-cli-level=INFO",  # Stream logs live to terminal
+        "-v",
+    ]
+    if not verbose:
+        # In non-verbose mode, only show warnings and above
+        pytest_args[pytest_args.index("--log-cli-level=INFO")] = "--log-cli-level=WARNING"
+        pytest_args.remove("-v")
+        pytest_args.append("-q")
+
+    exit_code = _pytest.main(pytest_args)
+    elapsed = time.time() - start
+
+    # Step 4: print summary
+    try:
+        agents = parse_junit_xml(xml_path)
+        print_table(agents, elapsed, verbose=verbose)
+    except Exception as e:
+        print(f"\n  Could not parse results: {e}")
+
+    # Clean up
+    Path(xml_path).unlink(missing_ok=True)
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/core/tests/dummy_agents/test_branch.py
+++ b/core/tests/dummy_agents/test_branch.py
@@ -41,8 +41,7 @@ def _build_branch_graph() -> GraphSpec:
                     "1. set_output(key='score', value='<number>') — a score between 0.0 "
                     "and 1.0 where >0.5 means positive\n"
                     "2. set_output(key='label', value='positive') or "
-                    "set_output(key='label', value='negative')\n\n"
-                    + SET_OUTPUT_INSTRUCTION
+                    "set_output(key='label', value='negative')\n\n" + SET_OUTPUT_INSTRUCTION
                 ),
             ),
             NodeSpec(

--- a/core/tests/dummy_agents/test_branch.py
+++ b/core/tests/dummy_agents/test_branch.py
@@ -1,0 +1,133 @@
+"""Branch agent: LLM classifies input, conditional edges route to different paths.
+
+Tests conditional edge evaluation with real LLM output.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework.graph.edge import EdgeCondition, EdgeSpec, GraphSpec
+from framework.graph.node import NodeSpec
+
+from .conftest import make_executor
+
+SET_OUTPUT_INSTRUCTION = (
+    "You MUST call the set_output tool to provide your answer. "
+    "Do not just write text — call set_output with the correct key and value."
+)
+
+
+def _build_branch_graph() -> GraphSpec:
+    return GraphSpec(
+        id="branch-graph",
+        goal_id="dummy",
+        entry_node="classify",
+        entry_points={"start": "classify"},
+        terminal_nodes=["positive", "negative"],
+        conversation_mode="continuous",
+        nodes=[
+            NodeSpec(
+                id="classify",
+                name="Classify",
+                description="Classifies input sentiment",
+                node_type="event_loop",
+                input_keys=["text"],
+                output_keys=["score", "label"],
+                system_prompt=(
+                    "You are a sentiment classifier. Read the 'text' input and determine "
+                    "if the sentiment is positive or negative.\n\n"
+                    "You MUST call set_output TWICE:\n"
+                    "1. set_output(key='score', value='<number>') — a score between 0.0 "
+                    "and 1.0 where >0.5 means positive\n"
+                    "2. set_output(key='label', value='positive') or "
+                    "set_output(key='label', value='negative')\n\n"
+                    + SET_OUTPUT_INSTRUCTION
+                ),
+            ),
+            NodeSpec(
+                id="positive",
+                name="Positive Handler",
+                description="Handles positive sentiment",
+                node_type="event_loop",
+                output_keys=["result"],
+                system_prompt=(
+                    "The input was classified as positive. Call set_output with "
+                    "key='result' and a brief one-sentence acknowledgment. "
+                    + SET_OUTPUT_INSTRUCTION
+                ),
+            ),
+            NodeSpec(
+                id="negative",
+                name="Negative Handler",
+                description="Handles negative sentiment",
+                node_type="event_loop",
+                output_keys=["result"],
+                system_prompt=(
+                    "The input was classified as negative. Call set_output with "
+                    "key='result' and a brief one-sentence acknowledgment. "
+                    + SET_OUTPUT_INSTRUCTION
+                ),
+            ),
+        ],
+        edges=[
+            EdgeSpec(
+                id="classify-to-positive",
+                source="classify",
+                target="positive",
+                condition=EdgeCondition.CONDITIONAL,
+                condition_expr="output.get('label') == 'positive'",
+                priority=1,
+            ),
+            EdgeSpec(
+                id="classify-to-negative",
+                source="classify",
+                target="negative",
+                condition=EdgeCondition.CONDITIONAL,
+                condition_expr="output.get('label') == 'negative'",
+                priority=0,
+            ),
+        ],
+        memory_keys=["text", "score", "label", "result"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_branch_positive_path(runtime, goal, llm_provider):
+    graph = _build_branch_graph()
+    executor = make_executor(runtime, llm_provider)
+
+    result = await executor.execute(
+        graph, goal, {"text": "I love this product, it's amazing!"}, validate_graph=False
+    )
+
+    assert result.success
+    assert result.path == ["classify", "positive"]
+
+
+@pytest.mark.asyncio
+async def test_branch_negative_path(runtime, goal, llm_provider):
+    graph = _build_branch_graph()
+    executor = make_executor(runtime, llm_provider)
+
+    result = await executor.execute(
+        graph, goal, {"text": "This is terrible and broken, I hate it."}, validate_graph=False
+    )
+
+    assert result.success
+    assert result.path == ["classify", "negative"]
+
+
+@pytest.mark.asyncio
+async def test_branch_two_nodes_traversed(runtime, goal, llm_provider):
+    """Regardless of which branch, exactly 2 nodes should execute."""
+    graph = _build_branch_graph()
+    executor = make_executor(runtime, llm_provider)
+
+    result = await executor.execute(
+        graph, goal, {"text": "The weather is nice today."}, validate_graph=False
+    )
+
+    assert result.success
+    assert result.steps_executed == 2
+    assert len(result.path) == 2

--- a/core/tests/dummy_agents/test_echo.py
+++ b/core/tests/dummy_agents/test_echo.py
@@ -1,0 +1,66 @@
+"""Echo agent: single-node worker that echoes input to output.
+
+Tests basic node lifecycle with a real LLM call — simplest possible worker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework.graph.edge import GraphSpec
+from framework.graph.node import NodeSpec
+
+from .conftest import make_executor
+
+
+def _build_echo_graph() -> GraphSpec:
+    return GraphSpec(
+        id="echo-graph",
+        goal_id="dummy",
+        entry_node="echo",
+        entry_points={"start": "echo"},
+        terminal_nodes=["echo"],
+        nodes=[
+            NodeSpec(
+                id="echo",
+                name="Echo",
+                description="Echoes input to output",
+                node_type="event_loop",
+                input_keys=["input"],
+                output_keys=["output"],
+                system_prompt=(
+                    "You are an echo node. Your ONLY job is to read the 'input' value "
+                    "provided in the user message, then immediately call the set_output "
+                    "tool with key='output' and value set to the EXACT same string. "
+                    "Do not add any text or explanation. Just call set_output."
+                ),
+            ),
+        ],
+        edges=[],
+        memory_keys=["input", "output"],
+        conversation_mode="continuous",
+    )
+
+
+@pytest.mark.asyncio
+async def test_echo_basic(runtime, goal, llm_provider):
+    graph = _build_echo_graph()
+    executor = make_executor(runtime, llm_provider)
+
+    result = await executor.execute(graph, goal, {"input": "hello"}, validate_graph=False)
+
+    assert result.success
+    assert result.output.get("output") is not None
+    assert result.path == ["echo"]
+    assert result.steps_executed == 1
+
+
+@pytest.mark.asyncio
+async def test_echo_empty_input(runtime, goal, llm_provider):
+    graph = _build_echo_graph()
+    executor = make_executor(runtime, llm_provider)
+
+    result = await executor.execute(graph, goal, {"input": ""}, validate_graph=False)
+
+    assert result.success
+    assert "output" in result.output

--- a/core/tests/dummy_agents/test_feedback_loop.py
+++ b/core/tests/dummy_agents/test_feedback_loop.py
@@ -81,11 +81,13 @@ async def test_feedback_loop_terminates(runtime, goal, llm_provider):
     executor.register_node("draft", SuccessNode(output={"draft_output": "v1"}))
     executor.register_node(
         "review",
-        StatefulNode([
-            NodeResult(success=True, output={"approved": False}),
-            NodeResult(success=True, output={"approved": False}),
-            NodeResult(success=True, output={"approved": True}),
-        ]),
+        StatefulNode(
+            [
+                NodeResult(success=True, output={"approved": False}),
+                NodeResult(success=True, output={"approved": False}),
+                NodeResult(success=True, output={"approved": True}),
+            ]
+        ),
     )
     executor.register_node("done", SuccessNode(output={"final": "done"}))
 
@@ -103,10 +105,12 @@ async def test_feedback_loop_visit_counts(runtime, goal, llm_provider):
     executor.register_node("draft", SuccessNode(output={"draft_output": "v1"}))
     executor.register_node(
         "review",
-        StatefulNode([
-            NodeResult(success=True, output={"approved": False}),
-            NodeResult(success=True, output={"approved": True}),
-        ]),
+        StatefulNode(
+            [
+                NodeResult(success=True, output={"approved": False}),
+                NodeResult(success=True, output={"approved": True}),
+            ]
+        ),
     )
     executor.register_node("done", SuccessNode(output={"final": "done"}))
 
@@ -125,9 +129,11 @@ async def test_feedback_loop_early_exit(runtime, goal, llm_provider):
     executor.register_node("draft", SuccessNode(output={"draft_output": "perfect"}))
     executor.register_node(
         "review",
-        StatefulNode([
-            NodeResult(success=True, output={"approved": True}),
-        ]),
+        StatefulNode(
+            [
+                NodeResult(success=True, output={"approved": True}),
+            ]
+        ),
     )
     executor.register_node("done", SuccessNode(output={"final": "done"}))
 

--- a/core/tests/dummy_agents/test_feedback_loop.py
+++ b/core/tests/dummy_agents/test_feedback_loop.py
@@ -1,0 +1,138 @@
+"""Feedback loop agent: draft/review cycle with max_node_visits limit.
+
+Uses StatefulNode for review to control loop iterations deterministically.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework.graph.edge import EdgeCondition, EdgeSpec, GraphSpec
+from framework.graph.node import NodeResult, NodeSpec
+
+from .conftest import make_executor
+from .nodes import StatefulNode, SuccessNode
+
+
+def _build_feedback_graph(max_visits: int = 3) -> GraphSpec:
+    return GraphSpec(
+        id="feedback-graph",
+        goal_id="dummy",
+        entry_node="draft",
+        terminal_nodes=["done"],
+        nodes=[
+            NodeSpec(
+                id="draft",
+                name="Draft",
+                description="Produces a draft",
+                node_type="event_loop",
+                output_keys=["draft_output"],
+                max_node_visits=max_visits,
+            ),
+            NodeSpec(
+                id="review",
+                name="Review",
+                description="Reviews the draft",
+                node_type="event_loop",
+                input_keys=["draft_output"],
+                output_keys=["approved"],
+            ),
+            NodeSpec(
+                id="done",
+                name="Done",
+                description="Final node",
+                node_type="event_loop",
+                output_keys=["final"],
+            ),
+        ],
+        edges=[
+            EdgeSpec(
+                id="draft-to-review",
+                source="draft",
+                target="review",
+                condition=EdgeCondition.ON_SUCCESS,
+            ),
+            EdgeSpec(
+                id="review-to-draft",
+                source="review",
+                target="draft",
+                condition=EdgeCondition.CONDITIONAL,
+                condition_expr="output.get('approved') == False",
+                priority=1,
+            ),
+            EdgeSpec(
+                id="review-to-done",
+                source="review",
+                target="done",
+                condition=EdgeCondition.CONDITIONAL,
+                condition_expr="output.get('approved') == True",
+                priority=0,
+            ),
+        ],
+        memory_keys=["draft_output", "approved", "final"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_feedback_loop_terminates(runtime, goal, llm_provider):
+    """Loop should terminate: draft visits are capped, review eventually approves."""
+    graph = _build_feedback_graph(max_visits=3)
+    executor = make_executor(runtime, llm_provider)
+    executor.register_node("draft", SuccessNode(output={"draft_output": "v1"}))
+    executor.register_node(
+        "review",
+        StatefulNode([
+            NodeResult(success=True, output={"approved": False}),
+            NodeResult(success=True, output={"approved": False}),
+            NodeResult(success=True, output={"approved": True}),
+        ]),
+    )
+    executor.register_node("done", SuccessNode(output={"final": "done"}))
+
+    result = await executor.execute(graph, goal, {}, validate_graph=False)
+
+    assert result.success
+    assert result.node_visit_counts.get("draft", 0) == 3
+    assert "done" in result.path
+
+
+@pytest.mark.asyncio
+async def test_feedback_loop_visit_counts(runtime, goal, llm_provider):
+    graph = _build_feedback_graph(max_visits=3)
+    executor = make_executor(runtime, llm_provider)
+    executor.register_node("draft", SuccessNode(output={"draft_output": "v1"}))
+    executor.register_node(
+        "review",
+        StatefulNode([
+            NodeResult(success=True, output={"approved": False}),
+            NodeResult(success=True, output={"approved": True}),
+        ]),
+    )
+    executor.register_node("done", SuccessNode(output={"final": "done"}))
+
+    result = await executor.execute(graph, goal, {}, validate_graph=False)
+
+    assert result.success
+    assert result.node_visit_counts.get("draft", 0) == 2
+    assert result.node_visit_counts.get("review", 0) == 2
+
+
+@pytest.mark.asyncio
+async def test_feedback_loop_early_exit(runtime, goal, llm_provider):
+    """Review approves on first iteration — loop exits before max."""
+    graph = _build_feedback_graph(max_visits=5)
+    executor = make_executor(runtime, llm_provider)
+    executor.register_node("draft", SuccessNode(output={"draft_output": "perfect"}))
+    executor.register_node(
+        "review",
+        StatefulNode([
+            NodeResult(success=True, output={"approved": True}),
+        ]),
+    )
+    executor.register_node("done", SuccessNode(output={"final": "done"}))
+
+    result = await executor.execute(graph, goal, {}, validate_graph=False)
+
+    assert result.success
+    assert result.node_visit_counts.get("draft", 0) == 1
+    assert "done" in result.path

--- a/core/tests/dummy_agents/test_gcu_subagent.py
+++ b/core/tests/dummy_agents/test_gcu_subagent.py
@@ -25,6 +25,7 @@ def _has_gcu_server() -> bool:
     """Check if the GCU MCP server module is available."""
     try:
         import gcu.server  # noqa: F401
+
         return True
     except ImportError:
         return False
@@ -114,15 +115,16 @@ async def test_gcu_subagent_delegation(runtime, llm_provider, tool_registry, tmp
                         node.tools.append(tool_name)
 
     executor = make_executor(
-        runtime, llm_provider,
+        runtime,
+        llm_provider,
         tool_registry=tool_registry,
         storage_path=tmp_path / "storage",
     )
 
     result = await executor.execute(
-        graph, _gcu_goal(),
-        {"task": "Use the browser to navigate to https://example.com and "
-         "report the page title."},
+        graph,
+        _gcu_goal(),
+        {"task": "Use the browser to navigate to https://example.com and report the page title."},
         validate_graph=False,
     )
 
@@ -154,15 +156,19 @@ async def test_gcu_subagent_returns_data(runtime, llm_provider, tool_registry, t
                         node.tools.append(tool_name)
 
     executor = make_executor(
-        runtime, llm_provider,
+        runtime,
+        llm_provider,
         tool_registry=tool_registry,
         storage_path=tmp_path / "storage",
     )
 
     result = await executor.execute(
-        graph, _gcu_goal(),
-        {"task": "Use the browser to visit https://example.com and report "
-         "what domain the page is on."},
+        graph,
+        _gcu_goal(),
+        {
+            "task": "Use the browser to visit https://example.com and report "
+            "what domain the page is on."
+        },
         validate_graph=False,
     )
 

--- a/core/tests/dummy_agents/test_gcu_subagent.py
+++ b/core/tests/dummy_agents/test_gcu_subagent.py
@@ -1,0 +1,173 @@
+"""GCU subagent test: parent event_loop delegates to a GCU subagent.
+
+Tests the subagent delegation pattern where a parent node uses
+delegate_to_sub_agent to invoke a GCU (browser) node for a task.
+The GCU node has access to browser tools via the GCU MCP server.
+
+Note: This test requires the GCU MCP server (gcu.server) to be available.
+If not installed, the test is skipped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from framework.graph.edge import GraphSpec
+from framework.graph.goal import Goal
+from framework.graph.node import NodeSpec
+
+from .conftest import make_executor
+
+
+def _has_gcu_server() -> bool:
+    """Check if the GCU MCP server module is available."""
+    try:
+        import gcu.server  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def _build_gcu_subagent_graph() -> GraphSpec:
+    """Parent event_loop node with a GCU subagent for browser tasks.
+
+    Structure:
+    - parent (event_loop): orchestrator that decides when to delegate
+    - browser_worker (gcu): subagent with browser tools
+    - parent delegates to browser_worker via delegate_to_sub_agent tool
+    - browser_worker is NOT connected by edges (validation rule)
+    """
+    return GraphSpec(
+        id="gcu-subagent-graph",
+        goal_id="gcu-test",
+        entry_node="parent",
+        entry_points={"start": "parent"},
+        terminal_nodes=["parent"],
+        nodes=[
+            NodeSpec(
+                id="parent",
+                name="Orchestrator",
+                description="Orchestrates browser tasks via subagent delegation",
+                node_type="event_loop",
+                input_keys=["task"],
+                output_keys=["result"],
+                sub_agents=["browser_worker"],
+                system_prompt=(
+                    "You are an orchestrator. You have a browser subagent called "
+                    "'browser_worker' available via delegate_to_sub_agent.\n\n"
+                    "Read the 'task' input and delegate the browser work to "
+                    "the browser_worker subagent. When the subagent completes, "
+                    "summarize the result and call set_output with key='result'."
+                ),
+            ),
+            NodeSpec(
+                id="browser_worker",
+                name="Browser Worker",
+                description="GCU browser subagent for web tasks",
+                node_type="gcu",
+                output_keys=["browser_result"],
+                system_prompt=(
+                    "You are a browser worker subagent. Complete the delegated "
+                    "browser task using available browser tools. "
+                    "When done, call set_output with key='browser_result' and "
+                    "the information you found."
+                ),
+            ),
+        ],
+        edges=[],  # GCU subagents must NOT be connected by edges
+        memory_keys=["task", "result", "browser_result"],
+        conversation_mode="continuous",
+    )
+
+
+def _gcu_goal() -> Goal:
+    return Goal(
+        id="gcu-test",
+        name="GCU Subagent Test",
+        description="Test browser subagent delegation",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not _has_gcu_server(), reason="GCU server not installed")
+async def test_gcu_subagent_delegation(runtime, llm_provider, tool_registry, tmp_path):
+    """Parent delegates a simple browser task to GCU subagent."""
+    # Register GCU MCP server tools
+    from framework.graph.gcu import GCU_MCP_SERVER_CONFIG
+
+    repo_root = Path(__file__).resolve().parents[3]
+    gcu_config = dict(GCU_MCP_SERVER_CONFIG)
+    gcu_config["cwd"] = str(repo_root / "tools")
+    tool_registry.register_mcp_server(gcu_config)
+
+    # Expand GCU node tools (mirrors what runner._setup does)
+    graph = _build_gcu_subagent_graph()
+    gcu_tool_names = tool_registry.get_server_tool_names("gcu-tools")
+    if gcu_tool_names:
+        for node in graph.nodes:
+            if node.node_type == "gcu":
+                existing = set(node.tools)
+                for tool_name in sorted(gcu_tool_names):
+                    if tool_name not in existing:
+                        node.tools.append(tool_name)
+
+    executor = make_executor(
+        runtime, llm_provider,
+        tool_registry=tool_registry,
+        storage_path=tmp_path / "storage",
+    )
+
+    result = await executor.execute(
+        graph, _gcu_goal(),
+        {"task": "Use the browser to navigate to https://example.com and "
+         "report the page title."},
+        validate_graph=False,
+    )
+
+    assert result.success
+    assert result.output.get("result") is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not _has_gcu_server(), reason="GCU server not installed")
+async def test_gcu_subagent_returns_data(runtime, llm_provider, tool_registry, tmp_path):
+    """Verify the parent receives structured data from the GCU subagent."""
+    from framework.graph.gcu import GCU_MCP_SERVER_CONFIG
+
+    repo_root = Path(__file__).resolve().parents[3]
+    gcu_config = dict(GCU_MCP_SERVER_CONFIG)
+    gcu_config["cwd"] = str(repo_root / "tools")
+    # Only register if not already registered
+    if not tool_registry.get_server_tool_names("gcu-tools"):
+        tool_registry.register_mcp_server(gcu_config)
+
+    graph = _build_gcu_subagent_graph()
+    gcu_tool_names = tool_registry.get_server_tool_names("gcu-tools")
+    if gcu_tool_names:
+        for node in graph.nodes:
+            if node.node_type == "gcu":
+                existing = set(node.tools)
+                for tool_name in sorted(gcu_tool_names):
+                    if tool_name not in existing:
+                        node.tools.append(tool_name)
+
+    executor = make_executor(
+        runtime, llm_provider,
+        tool_registry=tool_registry,
+        storage_path=tmp_path / "storage",
+    )
+
+    result = await executor.execute(
+        graph, _gcu_goal(),
+        {"task": "Use the browser to visit https://example.com and report "
+         "what domain the page is on."},
+        validate_graph=False,
+    )
+
+    assert result.success
+    assert result.output.get("result") is not None
+    # The result should contain something from the browser
+    result_text = str(result.output["result"]).lower()
+    assert "example" in result_text

--- a/core/tests/dummy_agents/test_parallel_merge.py
+++ b/core/tests/dummy_agents/test_parallel_merge.py
@@ -116,9 +116,7 @@ async def test_parallel_both_succeed(runtime, goal, llm_provider):
     config = ParallelExecutionConfig(on_branch_failure="fail_all")
     executor = make_executor(runtime, llm_provider, parallel_config=config)
 
-    result = await executor.execute(
-        graph, goal, {"topic": "remote work"}, validate_graph=False
-    )
+    result = await executor.execute(graph, goal, {"topic": "remote work"}, validate_graph=False)
 
     assert result.success
     assert "split" in result.path
@@ -134,9 +132,7 @@ async def test_parallel_branch_failure_fail_all(runtime, goal, llm_provider):
     executor = make_executor(runtime, llm_provider, parallel_config=config)
     executor.register_node("analyze_b", FailNode(error="branch B failed"))
 
-    result = await executor.execute(
-        graph, goal, {"topic": "remote work"}, validate_graph=False
-    )
+    result = await executor.execute(graph, goal, {"topic": "remote work"}, validate_graph=False)
 
     assert not result.success
 
@@ -149,9 +145,7 @@ async def test_parallel_branch_failure_continue_others(runtime, goal, llm_provid
     executor = make_executor(runtime, llm_provider, parallel_config=config)
     executor.register_node("analyze_b", FailNode(error="branch B failed"))
 
-    result = await executor.execute(
-        graph, goal, {"topic": "remote work"}, validate_graph=False
-    )
+    result = await executor.execute(graph, goal, {"topic": "remote work"}, validate_graph=False)
 
     # With continue_others, execution can proceed past failed branches
     assert result.output.get("merged") is not None or result.output.get("result_a") is not None

--- a/core/tests/dummy_agents/test_parallel_merge.py
+++ b/core/tests/dummy_agents/test_parallel_merge.py
@@ -1,0 +1,172 @@
+"""Parallel merge agent: fan-out to two branches, fan-in to merge node.
+
+Tests parallel execution with real LLM at each branch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework.graph.edge import EdgeCondition, EdgeSpec, GraphSpec
+from framework.graph.executor import ParallelExecutionConfig
+from framework.graph.node import NodeSpec
+
+from .conftest import make_executor
+from .nodes import FailNode
+
+SET_OUTPUT_INSTRUCTION = (
+    "You MUST call the set_output tool to provide your answer. "
+    "Do not just write text — call set_output with the correct key and value."
+)
+
+
+def _build_parallel_graph() -> GraphSpec:
+    return GraphSpec(
+        id="parallel-graph",
+        goal_id="dummy",
+        entry_node="split",
+        entry_points={"start": "split"},
+        terminal_nodes=["merge"],
+        conversation_mode="continuous",
+        nodes=[
+            NodeSpec(
+                id="split",
+                name="Split",
+                description="Entry point that triggers parallel branches",
+                node_type="event_loop",
+                input_keys=["topic"],
+                output_keys=["split_done"],
+                system_prompt=(
+                    "You are a dispatcher. Read the 'topic' input, then immediately "
+                    "call set_output with key='split_done' and value='true'. "
+                    + SET_OUTPUT_INSTRUCTION
+                ),
+            ),
+            NodeSpec(
+                id="analyze_a",
+                name="Analyze Pros",
+                description="Analyzes positive aspects",
+                node_type="event_loop",
+                output_keys=["result_a"],
+                system_prompt=(
+                    "Analyze the positive aspects of the topic. Then call set_output "
+                    "with key='result_a' and a brief one-sentence analysis. "
+                    + SET_OUTPUT_INSTRUCTION
+                ),
+            ),
+            NodeSpec(
+                id="analyze_b",
+                name="Analyze Cons",
+                description="Analyzes negative aspects",
+                node_type="event_loop",
+                output_keys=["result_b"],
+                system_prompt=(
+                    "Analyze the negative aspects of the topic. Then call set_output "
+                    "with key='result_b' and a brief one-sentence analysis. "
+                    + SET_OUTPUT_INSTRUCTION
+                ),
+            ),
+            NodeSpec(
+                id="merge",
+                name="Merge",
+                description="Combines both analyses",
+                node_type="event_loop",
+                input_keys=["result_a", "result_b"],
+                output_keys=["merged"],
+                system_prompt=(
+                    "Read 'result_a' and 'result_b' from the input, combine them into "
+                    "a one-sentence summary, then call set_output with key='merged' "
+                    "and the summary. " + SET_OUTPUT_INSTRUCTION
+                ),
+            ),
+        ],
+        edges=[
+            EdgeSpec(
+                id="split-to-a",
+                source="split",
+                target="analyze_a",
+                condition=EdgeCondition.ON_SUCCESS,
+            ),
+            EdgeSpec(
+                id="split-to-b",
+                source="split",
+                target="analyze_b",
+                condition=EdgeCondition.ON_SUCCESS,
+            ),
+            EdgeSpec(
+                id="a-to-merge",
+                source="analyze_a",
+                target="merge",
+                condition=EdgeCondition.ON_SUCCESS,
+            ),
+            EdgeSpec(
+                id="b-to-merge",
+                source="analyze_b",
+                target="merge",
+                condition=EdgeCondition.ON_SUCCESS,
+            ),
+        ],
+        memory_keys=["topic", "split_done", "result_a", "result_b", "merged"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_parallel_both_succeed(runtime, goal, llm_provider):
+    graph = _build_parallel_graph()
+    config = ParallelExecutionConfig(on_branch_failure="fail_all")
+    executor = make_executor(runtime, llm_provider, parallel_config=config)
+
+    result = await executor.execute(
+        graph, goal, {"topic": "remote work"}, validate_graph=False
+    )
+
+    assert result.success
+    assert "split" in result.path
+    assert "merge" in result.path
+    assert result.output.get("merged") is not None
+
+
+@pytest.mark.asyncio
+async def test_parallel_branch_failure_fail_all(runtime, goal, llm_provider):
+    """One branch fails with fail_all -> execution fails."""
+    graph = _build_parallel_graph()
+    config = ParallelExecutionConfig(on_branch_failure="fail_all")
+    executor = make_executor(runtime, llm_provider, parallel_config=config)
+    executor.register_node("analyze_b", FailNode(error="branch B failed"))
+
+    result = await executor.execute(
+        graph, goal, {"topic": "remote work"}, validate_graph=False
+    )
+
+    assert not result.success
+
+
+@pytest.mark.asyncio
+async def test_parallel_branch_failure_continue_others(runtime, goal, llm_provider):
+    """One branch fails with continue_others -> surviving branch completes."""
+    graph = _build_parallel_graph()
+    config = ParallelExecutionConfig(on_branch_failure="continue_others")
+    executor = make_executor(runtime, llm_provider, parallel_config=config)
+    executor.register_node("analyze_b", FailNode(error="branch B failed"))
+
+    result = await executor.execute(
+        graph, goal, {"topic": "remote work"}, validate_graph=False
+    )
+
+    # With continue_others, execution can proceed past failed branches
+    assert result.output.get("merged") is not None or result.output.get("result_a") is not None
+
+
+@pytest.mark.asyncio
+async def test_parallel_disjoint_output_keys(runtime, goal, llm_provider):
+    """Verify both branches write to separate memory keys without conflicts."""
+    graph = _build_parallel_graph()
+    executor = make_executor(runtime, llm_provider)
+
+    result = await executor.execute(
+        graph, goal, {"topic": "artificial intelligence"}, validate_graph=False
+    )
+
+    assert result.success
+    assert result.output.get("result_a") is not None
+    assert result.output.get("result_b") is not None

--- a/core/tests/dummy_agents/test_pipeline.py
+++ b/core/tests/dummy_agents/test_pipeline.py
@@ -50,8 +50,7 @@ def _build_pipeline_graph(conversation_mode: str = "continuous") -> GraphSpec:
                 system_prompt=(
                     "You are a transform node. Read the 'value' input from the user "
                     "message, convert it to UPPERCASE, then call set_output with "
-                    "key='transformed' and the uppercased value. "
-                    + SET_OUTPUT_INSTRUCTION
+                    "key='transformed' and the uppercased value. " + SET_OUTPUT_INSTRUCTION
                 ),
             ),
             NodeSpec(
@@ -64,8 +63,7 @@ def _build_pipeline_graph(conversation_mode: str = "continuous") -> GraphSpec:
                 system_prompt=(
                     "You are the output node. Read the 'value' input from the user "
                     "message, prefix it with 'Result: ', then call set_output with "
-                    "key='result' and the prefixed value. "
-                    + SET_OUTPUT_INSTRUCTION
+                    "key='result' and the prefixed value. " + SET_OUTPUT_INSTRUCTION
                 ),
             ),
         ],

--- a/core/tests/dummy_agents/test_pipeline.py
+++ b/core/tests/dummy_agents/test_pipeline.py
@@ -1,0 +1,136 @@
+"""Pipeline agent: linear 3-node chain with real LLM at each step.
+
+Tests input_mapping, conversation modes, and multi-node traversal.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework.graph.edge import EdgeCondition, EdgeSpec, GraphSpec
+from framework.graph.node import NodeSpec
+
+from .conftest import make_executor
+
+SET_OUTPUT_INSTRUCTION = (
+    "You MUST call the set_output tool to provide your answer. "
+    "Do not just write text — call set_output with the correct key and value."
+)
+
+
+def _build_pipeline_graph(conversation_mode: str = "continuous") -> GraphSpec:
+    return GraphSpec(
+        id="pipeline-graph",
+        goal_id="dummy",
+        entry_node="intake",
+        entry_points={"start": "intake"},
+        terminal_nodes=["output"],
+        conversation_mode=conversation_mode,
+        nodes=[
+            NodeSpec(
+                id="intake",
+                name="Intake",
+                description="Captures raw input and passes it along",
+                node_type="event_loop",
+                input_keys=["raw"],
+                output_keys=["captured"],
+                system_prompt=(
+                    "You are the intake node. Read the 'raw' input value from the user "
+                    "message, then call set_output with key='captured' and the same value. "
+                    + SET_OUTPUT_INSTRUCTION
+                ),
+            ),
+            NodeSpec(
+                id="transform",
+                name="Transform",
+                description="Uppercases the input value",
+                node_type="event_loop",
+                input_keys=["value"],
+                output_keys=["transformed"],
+                system_prompt=(
+                    "You are a transform node. Read the 'value' input from the user "
+                    "message, convert it to UPPERCASE, then call set_output with "
+                    "key='transformed' and the uppercased value. "
+                    + SET_OUTPUT_INSTRUCTION
+                ),
+            ),
+            NodeSpec(
+                id="output",
+                name="Output",
+                description="Formats final result",
+                node_type="event_loop",
+                input_keys=["value"],
+                output_keys=["result"],
+                system_prompt=(
+                    "You are the output node. Read the 'value' input from the user "
+                    "message, prefix it with 'Result: ', then call set_output with "
+                    "key='result' and the prefixed value. "
+                    + SET_OUTPUT_INSTRUCTION
+                ),
+            ),
+        ],
+        edges=[
+            EdgeSpec(
+                id="intake-to-transform",
+                source="intake",
+                target="transform",
+                condition=EdgeCondition.ON_SUCCESS,
+                input_mapping={"value": "captured"},
+            ),
+            EdgeSpec(
+                id="transform-to-output",
+                source="transform",
+                target="output",
+                condition=EdgeCondition.ON_SUCCESS,
+                input_mapping={"value": "transformed"},
+            ),
+        ],
+        memory_keys=["raw", "captured", "value", "transformed", "result"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_linear_traversal(runtime, goal, llm_provider):
+    graph = _build_pipeline_graph()
+    executor = make_executor(runtime, llm_provider)
+
+    result = await executor.execute(graph, goal, {"raw": "hello"}, validate_graph=False)
+
+    assert result.success
+    assert result.path == ["intake", "transform", "output"]
+    assert result.steps_executed == 3
+
+
+@pytest.mark.asyncio
+async def test_pipeline_input_mapping(runtime, goal, llm_provider):
+    """Verify input_mapping wires source output keys to target input keys."""
+    graph = _build_pipeline_graph()
+    executor = make_executor(runtime, llm_provider)
+
+    result = await executor.execute(graph, goal, {"raw": "test value"}, validate_graph=False)
+
+    assert result.success
+    assert result.steps_executed == 3
+    assert result.output.get("result") is not None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_continuous_conversation(runtime, goal, llm_provider):
+    graph = _build_pipeline_graph(conversation_mode="continuous")
+    executor = make_executor(runtime, llm_provider)
+
+    result = await executor.execute(graph, goal, {"raw": "data"}, validate_graph=False)
+
+    assert result.success
+    assert len(result.path) == 3
+
+
+@pytest.mark.asyncio
+async def test_pipeline_isolated_conversation(runtime, goal, llm_provider):
+    graph = _build_pipeline_graph(conversation_mode="isolated")
+    executor = make_executor(runtime, llm_provider)
+
+    result = await executor.execute(graph, goal, {"raw": "data"}, validate_graph=False)
+
+    assert result.success
+    assert len(result.path) == 3

--- a/core/tests/dummy_agents/test_retry.py
+++ b/core/tests/dummy_agents/test_retry.py
@@ -1,0 +1,131 @@
+"""Retry agent: flaky node with retry limit and failure edges.
+
+Uses deterministic FlakyNode (not LLM) since we need controlled failure patterns.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework.graph.edge import EdgeCondition, EdgeSpec, GraphSpec
+from framework.graph.node import NodeSpec
+
+from .conftest import make_executor
+from .nodes import FlakyNode, SuccessNode
+
+
+def _build_retry_graph(max_retries: int = 3, with_failure_edge: bool = False) -> GraphSpec:
+    nodes = [
+        NodeSpec(
+            id="flaky",
+            name="Flaky",
+            description="Fails then succeeds",
+            node_type="event_loop",
+            output_keys=["status"],
+            max_retries=max_retries,
+        ),
+        NodeSpec(
+            id="done",
+            name="Done",
+            description="Terminal success node",
+            node_type="event_loop",
+            output_keys=["final"],
+        ),
+    ]
+    edges = [
+        EdgeSpec(
+            id="flaky-to-done",
+            source="flaky",
+            target="done",
+            condition=EdgeCondition.ON_SUCCESS,
+        ),
+    ]
+    terminal_nodes = ["done"]
+
+    if with_failure_edge:
+        nodes.append(
+            NodeSpec(
+                id="error_handler",
+                name="Error Handler",
+                description="Handles exhausted retries",
+                node_type="event_loop",
+                output_keys=["error_handled"],
+            )
+        )
+        edges.append(
+            EdgeSpec(
+                id="flaky-to-error",
+                source="flaky",
+                target="error_handler",
+                condition=EdgeCondition.ON_FAILURE,
+            )
+        )
+        terminal_nodes.append("error_handler")
+
+    return GraphSpec(
+        id="retry-graph",
+        goal_id="dummy",
+        entry_node="flaky",
+        terminal_nodes=terminal_nodes,
+        nodes=nodes,
+        edges=edges,
+        memory_keys=["status", "final", "error_handled"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_retry_succeeds_within_limit(runtime, goal, llm_provider):
+    graph = _build_retry_graph(max_retries=3)
+    flaky = FlakyNode(fail_times=2, output={"status": "recovered"})
+    executor = make_executor(runtime, llm_provider)
+    executor.register_node("flaky", flaky)
+    executor.register_node("done", SuccessNode(output={"final": "complete"}))
+
+    result = await executor.execute(graph, goal, {}, validate_graph=False)
+
+    assert result.success
+    assert result.total_retries >= 2
+    assert flaky.attempt_count == 3  # 2 failures + 1 success
+
+
+@pytest.mark.asyncio
+async def test_retry_exhaustion(runtime, goal, llm_provider):
+    graph = _build_retry_graph(max_retries=3)
+    flaky = FlakyNode(fail_times=10, output={"status": "recovered"})
+    executor = make_executor(runtime, llm_provider)
+    executor.register_node("flaky", flaky)
+    executor.register_node("done", SuccessNode(output={"final": "complete"}))
+
+    result = await executor.execute(graph, goal, {}, validate_graph=False)
+
+    assert not result.success
+
+
+@pytest.mark.asyncio
+async def test_retry_with_on_failure_edge(runtime, goal, llm_provider):
+    graph = _build_retry_graph(max_retries=2, with_failure_edge=True)
+    flaky = FlakyNode(fail_times=10)
+    error_handler = SuccessNode(output={"error_handled": True})
+    executor = make_executor(runtime, llm_provider)
+    executor.register_node("flaky", flaky)
+    executor.register_node("done", SuccessNode(output={"final": "complete"}))
+    executor.register_node("error_handler", error_handler)
+
+    result = await executor.execute(graph, goal, {}, validate_graph=False)
+
+    assert "error_handler" in result.path
+    assert error_handler.executed
+
+
+@pytest.mark.asyncio
+async def test_retry_tracking(runtime, goal, llm_provider):
+    graph = _build_retry_graph(max_retries=3)
+    flaky = FlakyNode(fail_times=2)
+    executor = make_executor(runtime, llm_provider)
+    executor.register_node("flaky", flaky)
+    executor.register_node("done", SuccessNode(output={"final": "complete"}))
+
+    result = await executor.execute(graph, goal, {}, validate_graph=False)
+
+    assert result.success
+    assert result.retry_details.get("flaky", 0) >= 2

--- a/core/tests/dummy_agents/test_worker.py
+++ b/core/tests/dummy_agents/test_worker.py
@@ -61,7 +61,8 @@ async def test_worker_example_tool(runtime, llm_provider, tool_registry):
     executor = make_executor(runtime, llm_provider, tool_registry=tool_registry)
 
     result = await executor.execute(
-        graph, _worker_goal(),
+        graph,
+        _worker_goal(),
         {"task": "Use the example_tool to process the message 'hello world' with uppercase=true"},
         validate_graph=False,
     )
@@ -77,9 +78,12 @@ async def test_worker_time_tool(runtime, llm_provider, tool_registry):
     executor = make_executor(runtime, llm_provider, tool_registry=tool_registry)
 
     result = await executor.execute(
-        graph, _worker_goal(),
-        {"task": "Use get_current_time to find the current time in UTC, "
-         "and report the day of the week as the result"},
+        graph,
+        _worker_goal(),
+        {
+            "task": "Use get_current_time to find the current time in UTC, "
+            "and report the day of the week as the result"
+        },
         validate_graph=False,
     )
 
@@ -92,17 +96,21 @@ async def test_worker_data_tools(runtime, llm_provider, tool_registry, tmp_path)
     """Worker uses save_data and load_data to store and retrieve data."""
     graph = _build_worker_graph(tools=["save_data", "load_data"])
     executor = make_executor(
-        runtime, llm_provider,
+        runtime,
+        llm_provider,
         tool_registry=tool_registry,
         storage_path=tmp_path / "storage",
     )
 
     result = await executor.execute(
-        graph, _worker_goal(),
-        {"task": f"Use save_data to save the text 'test payload' to a file called "
-         f"'test.txt' in the data_dir '{tmp_path}/data'. "
-         f"Then use load_data to read it back from the same data_dir. "
-         f"Report what you loaded as the result."},
+        graph,
+        _worker_goal(),
+        {
+            "task": f"Use save_data to save the text 'test payload' to a file called "
+            f"'test.txt' in the data_dir '{tmp_path}/data'. "
+            f"Then use load_data to read it back from the same data_dir. "
+            f"Report what you loaded as the result."
+        },
         validate_graph=False,
     )
 
@@ -117,10 +125,13 @@ async def test_worker_multi_tool(runtime, llm_provider, tool_registry):
     executor = make_executor(runtime, llm_provider, tool_registry=tool_registry)
 
     result = await executor.execute(
-        graph, _worker_goal(),
-        {"task": "First use get_current_time to find the current day of the week. "
-         "Then use example_tool to process that day name with uppercase=true. "
-         "Report the uppercased day name as the result."},
+        graph,
+        _worker_goal(),
+        {
+            "task": "First use get_current_time to find the current day of the week. "
+            "Then use example_tool to process that day name with uppercase=true. "
+            "Report the uppercased day name as the result."
+        },
         validate_graph=False,
     )
 

--- a/core/tests/dummy_agents/test_worker.py
+++ b/core/tests/dummy_agents/test_worker.py
@@ -1,0 +1,128 @@
+"""Worker agent: single-node event loop with real MCP tools.
+
+Tests the core worker pattern — a single EventLoopNode that uses real
+hive-tools (example_tool, get_current_time, save_data/load_data) to
+accomplish tasks, matching how real agents are structured.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework.graph.edge import GraphSpec
+from framework.graph.goal import Goal
+from framework.graph.node import NodeSpec
+
+from .conftest import make_executor
+
+
+def _build_worker_graph(tools: list[str]) -> GraphSpec:
+    """Single-node worker agent with MCP tools — matches real agent structure."""
+    return GraphSpec(
+        id="worker-graph",
+        goal_id="worker-goal",
+        entry_node="worker",
+        entry_points={"start": "worker"},
+        terminal_nodes=["worker"],
+        nodes=[
+            NodeSpec(
+                id="worker",
+                name="Worker",
+                description="General-purpose worker with tools",
+                node_type="event_loop",
+                input_keys=["task"],
+                output_keys=["result"],
+                tools=tools,
+                system_prompt=(
+                    "You are a worker agent with access to tools. "
+                    "Read the 'task' input and complete it using the available tools. "
+                    "When done, call set_output with key='result' and the final answer."
+                ),
+            ),
+        ],
+        edges=[],
+        memory_keys=["task", "result"],
+        conversation_mode="continuous",
+    )
+
+
+def _worker_goal() -> Goal:
+    return Goal(
+        id="worker-goal",
+        name="Worker Agent",
+        description="Complete a task using available tools",
+    )
+
+
+@pytest.mark.asyncio
+async def test_worker_example_tool(runtime, llm_provider, tool_registry):
+    """Worker uses example_tool to process text."""
+    graph = _build_worker_graph(tools=["example_tool"])
+    executor = make_executor(runtime, llm_provider, tool_registry=tool_registry)
+
+    result = await executor.execute(
+        graph, _worker_goal(),
+        {"task": "Use the example_tool to process the message 'hello world' with uppercase=true"},
+        validate_graph=False,
+    )
+
+    assert result.success
+    assert result.output.get("result") is not None
+
+
+@pytest.mark.asyncio
+async def test_worker_time_tool(runtime, llm_provider, tool_registry):
+    """Worker uses get_current_time to check the current time."""
+    graph = _build_worker_graph(tools=["get_current_time"])
+    executor = make_executor(runtime, llm_provider, tool_registry=tool_registry)
+
+    result = await executor.execute(
+        graph, _worker_goal(),
+        {"task": "Use get_current_time to find the current time in UTC, "
+         "and report the day of the week as the result"},
+        validate_graph=False,
+    )
+
+    assert result.success
+    assert result.output.get("result") is not None
+
+
+@pytest.mark.asyncio
+async def test_worker_data_tools(runtime, llm_provider, tool_registry, tmp_path):
+    """Worker uses save_data and load_data to store and retrieve data."""
+    graph = _build_worker_graph(tools=["save_data", "load_data"])
+    executor = make_executor(
+        runtime, llm_provider,
+        tool_registry=tool_registry,
+        storage_path=tmp_path / "storage",
+    )
+
+    result = await executor.execute(
+        graph, _worker_goal(),
+        {"task": f"Use save_data to save the text 'test payload' to a file called "
+         f"'test.txt' in the data_dir '{tmp_path}/data'. "
+         f"Then use load_data to read it back from the same data_dir. "
+         f"Report what you loaded as the result."},
+        validate_graph=False,
+    )
+
+    assert result.success
+    assert result.output.get("result") is not None
+
+
+@pytest.mark.asyncio
+async def test_worker_multi_tool(runtime, llm_provider, tool_registry):
+    """Worker uses multiple tools in sequence."""
+    graph = _build_worker_graph(tools=["example_tool", "get_current_time"])
+    executor = make_executor(runtime, llm_provider, tool_registry=tool_registry)
+
+    result = await executor.execute(
+        graph, _worker_goal(),
+        {"task": "First use get_current_time to find the current day of the week. "
+         "Then use example_tool to process that day name with uppercase=true. "
+         "Report the uppercased day name as the result."},
+        validate_graph=False,
+    )
+
+    assert result.success
+    assert result.output.get("result") is not None


### PR DESCRIPTION
## Summary

Adds a new test suite under `core/tests/dummy_agents/` that exercises the graph executor end-to-end with real LLM calls and real MCP tools. These are **not** part of regular CI — they're meant to be run manually when validating executor changes or testing provider compatibility.

- Interactive runner (`run_all.py`) that detects available credentials and lets you pick a provider
- 7 test agents covering single-node workers, multi-node pipelines, conditional branching, parallel fan-out/fan-in, retry mechanics, feedback loops, and tool usage
- Worker tests use the actual `hive-tools` MCP server (example_tool, get_current_time, save_data/load_data)
- All tests auto-skip in regular `pytest` runs so they don't break CI
- Verbose mode streams live executor logs (node traversal, tool calls, judge verdicts)

Verified passing with Claude Sonnet, Gemini Flash, and GLM.

## How to run

```bash
cd core
uv run python tests/dummy_agents/run_all.py           # pick a provider
uv run python tests/dummy_agents/run_all.py --verbose  # with live logs
```

## Test plan

- [x] 24/24 pass with Claude Sonnet (~2 min)
- [x] 24/24 pass with Gemini Flash (~1.5 min)
- [x] 20+/24 pass with GLM (3 flaky due to model quality, not test bugs)
- [x] All 24 tests skip cleanly in regular `pytest` (no LLM configured)
- [x] No test imports real LLM providers at module level
- [x] `ruff check` clean