### PR TITLE
feat(templates): add Discord Community Digest agent template

### DIFF
--- a/examples/templates/discord_digest/__init__.py
+++ b/examples/templates/discord_digest/__init__.py
@@ -1,0 +1,34 @@
+"""Discord Community Digest — monitor servers and deliver actionable summaries."""
+
+from .agent import (
+    DiscordDigestAgent,
+    default_agent,
+    goal,
+    nodes,
+    edges,
+    entry_node,
+    entry_points,
+    pause_nodes,
+    terminal_nodes,
+    conversation_mode,
+    identity_prompt,
+    loop_config,
+)
+from .config import default_config, metadata
+
+__all__ = [
+    "DiscordDigestAgent",
+    "default_agent",
+    "goal",
+    "nodes",
+    "edges",
+    "entry_node",
+    "entry_points",
+    "pause_nodes",
+    "terminal_nodes",
+    "conversation_mode",
+    "identity_prompt",
+    "loop_config",
+    "default_config",
+    "metadata",
+]

--- a/examples/templates/discord_digest/__main__.py
+++ b/examples/templates/discord_digest/__main__.py
@@ -1,0 +1,71 @@
+"""CLI entry point for Discord Community Digest."""
+
+import asyncio
+import json
+import logging
+import sys
+
+import click
+
+from .agent import default_agent
+
+
+def setup_logging(verbose=False, debug=False):
+    if debug:
+        level, fmt = logging.DEBUG, "%(asctime)s %(name)s: %(message)s"
+    elif verbose:
+        level, fmt = logging.INFO, "%(message)s"
+    else:
+        level, fmt = logging.WARNING, "%(levelname)s: %(message)s"
+    logging.basicConfig(level=level, format=fmt, stream=sys.stderr)
+
+
+@click.group()
+@click.version_option(version="1.0.0")
+def cli():
+    """Discord Community Digest — scan servers and deliver actionable summaries."""
+    pass
+
+
+@cli.command()
+@click.option("--verbose", "-v", is_flag=True)
+def run(verbose):
+    """Execute the agent."""
+    setup_logging(verbose=verbose)
+    result = asyncio.run(default_agent.run({}))
+    click.echo(
+        json.dumps(
+            {"success": result.success, "output": result.output},
+            indent=2,
+            default=str,
+        )
+    )
+    sys.exit(0 if result.success else 1)
+
+
+@cli.command()
+def info():
+    """Show agent info."""
+    data = default_agent.info()
+    click.echo(f"Agent: {data['name']}")
+    click.echo(f"Version: {data['version']}")
+    click.echo(f"Description: {data['description']}")
+    click.echo(f"Nodes: {', '.join(data['nodes'])}")
+    click.echo(f"Client-facing: {', '.join(data['client_facing_nodes'])}")
+
+
+@cli.command()
+def validate():
+    """Validate agent structure."""
+    v = default_agent.validate()
+    if v["valid"]:
+        click.echo("Agent is valid")
+    else:
+        click.echo("Errors:")
+        for e in v["errors"]:
+            click.echo(f"  {e}")
+    sys.exit(0 if v["valid"] else 1)
+
+
+if __name__ == "__main__":
+    cli()

--- a/examples/templates/discord_digest/agent.py
+++ b/examples/templates/discord_digest/agent.py
@@ -1,0 +1,263 @@
+"""Agent graph construction for Discord Community Digest."""
+
+from pathlib import Path
+
+from framework.graph import EdgeSpec, EdgeCondition, Goal, SuccessCriterion, Constraint
+from framework.graph.edge import GraphSpec
+from framework.graph.executor import ExecutionResult
+from framework.graph.checkpoint_config import CheckpointConfig
+from framework.llm import LiteLLMProvider
+from framework.runner.tool_registry import ToolRegistry
+from framework.runtime.agent_runtime import create_agent_runtime
+from framework.runtime.execution_stream import EntryPointSpec
+
+from .config import default_config, metadata
+from .nodes import (
+    configure_node,
+    scan_channels_node,
+    generate_digest_node,
+)
+
+# Goal definition
+goal = Goal(
+    id="discord-digest-goal",
+    name="Discord Community Digest",
+    description=(
+        "Monitor Discord servers, categorize messages by priority, "
+        "and deliver an actionable summary to a designated channel."
+    ),
+    success_criteria=[
+        SuccessCriterion(
+            id="sc-channels-scanned",
+            description="All target text channels are scanned for messages",
+            metric="channels_scanned",
+            target=">=1",
+            weight=0.3,
+        ),
+        SuccessCriterion(
+            id="sc-messages-categorized",
+            description="Messages categorized into Action Needed / Interesting Threads / Announcements / FYI",
+            metric="categorization_complete",
+            target="true",
+            weight=0.3,
+        ),
+        SuccessCriterion(
+            id="sc-digest-delivered",
+            description="Digest delivered to the configured Discord channel",
+            metric="digest_delivered",
+            target="true",
+            weight=0.4,
+        ),
+    ],
+    constraints=[
+        Constraint(
+            id="c-no-spam",
+            description="Never send unsolicited messages to users or channels not configured for delivery",
+            constraint_type="hard",
+            category="safety",
+        ),
+        Constraint(
+            id="c-lookback-window",
+            description="Only scan messages within the configured lookback window",
+            constraint_type="hard",
+            category="correctness",
+        ),
+        Constraint(
+            id="c-rate-limit",
+            description="Respect Discord API rate limits",
+            constraint_type="hard",
+            category="reliability",
+        ),
+    ],
+)
+
+# Node list
+nodes = [
+    configure_node,
+    scan_channels_node,
+    generate_digest_node,
+]
+
+# Edge definitions
+edges = [
+    EdgeSpec(
+        id="configure-to-scan",
+        source="configure",
+        target="scan-channels",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+    EdgeSpec(
+        id="scan-to-digest",
+        source="scan-channels",
+        target="generate-digest",
+        condition=EdgeCondition.ON_SUCCESS,
+        priority=1,
+    ),
+]
+
+# Graph configuration
+entry_node = "configure"
+entry_points = {"start": "configure"}
+pause_nodes = []
+terminal_nodes = ["generate-digest"]
+
+# Module-level vars read by AgentRunner.load()
+conversation_mode = "continuous"
+identity_prompt = (
+    "You are a Discord community digest assistant. You scan Discord servers, "
+    "categorize messages by urgency and engagement, and deliver concise "
+    "actionable summaries."
+)
+loop_config = {
+    "max_iterations": 100,
+    "max_tool_calls_per_turn": 30,
+    "max_history_tokens": 32000,
+}
+
+
+class DiscordDigestAgent:
+    def __init__(self, config=None):
+        self.config = config or default_config
+        self.goal = goal
+        self.nodes = nodes
+        self.edges = edges
+        self.entry_node = entry_node
+        self.entry_points = entry_points
+        self.pause_nodes = pause_nodes
+        self.terminal_nodes = terminal_nodes
+        self._graph = None
+        self._agent_runtime = None
+        self._tool_registry = None
+        self._storage_path = None
+
+    def _build_graph(self):
+        return GraphSpec(
+            id="discord-digest-graph",
+            goal_id=self.goal.id,
+            version="1.0.0",
+            entry_node=self.entry_node,
+            entry_points=self.entry_points,
+            terminal_nodes=self.terminal_nodes,
+            pause_nodes=self.pause_nodes,
+            nodes=self.nodes,
+            edges=self.edges,
+            default_model=self.config.model,
+            max_tokens=self.config.max_tokens,
+            loop_config=loop_config,
+            conversation_mode=conversation_mode,
+            identity_prompt=identity_prompt,
+        )
+
+    def _setup(self):
+        self._storage_path = Path.home() / ".hive" / "agents" / "discord_digest"
+        self._storage_path.mkdir(parents=True, exist_ok=True)
+        self._tool_registry = ToolRegistry()
+        mcp_config = Path(__file__).parent / "mcp_servers.json"
+        if mcp_config.exists():
+            self._tool_registry.load_mcp_config(mcp_config)
+        llm = LiteLLMProvider(
+            model=self.config.model,
+            api_key=self.config.api_key,
+            api_base=self.config.api_base,
+        )
+        tools = list(self._tool_registry.get_tools().values())
+        tool_executor = self._tool_registry.get_executor()
+        self._graph = self._build_graph()
+        self._agent_runtime = create_agent_runtime(
+            graph=self._graph,
+            goal=self.goal,
+            storage_path=self._storage_path,
+            entry_points=[
+                EntryPointSpec(
+                    id="default",
+                    name="Default",
+                    entry_node=self.entry_node,
+                    trigger_type="manual",
+                    isolation_level="shared",
+                ),
+            ],
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor,
+            checkpoint_config=CheckpointConfig(
+                enabled=True,
+                checkpoint_on_node_complete=True,
+                checkpoint_max_age_days=7,
+                async_checkpoint=True,
+            ),
+        )
+
+    async def start(self):
+        if self._agent_runtime is None:
+            self._setup()
+        if not self._agent_runtime.is_running:
+            await self._agent_runtime.start()
+
+    async def stop(self):
+        if self._agent_runtime and self._agent_runtime.is_running:
+            await self._agent_runtime.stop()
+        self._agent_runtime = None
+
+    async def trigger_and_wait(
+        self,
+        entry_point="default",
+        input_data=None,
+        timeout=None,
+        session_state=None,
+    ):
+        if self._agent_runtime is None:
+            raise RuntimeError("Agent not started. Call start() first.")
+        return await self._agent_runtime.trigger_and_wait(
+            entry_point_id=entry_point,
+            input_data=input_data or {},
+            session_state=session_state,
+        )
+
+    async def run(self, context, session_state=None):
+        await self.start()
+        try:
+            result = await self.trigger_and_wait(
+                "default", context, session_state=session_state
+            )
+            return result or ExecutionResult(success=False, error="Execution timeout")
+        finally:
+            await self.stop()
+
+    def info(self):
+        return {
+            "name": metadata.name,
+            "version": metadata.version,
+            "description": metadata.description,
+            "goal": {
+                "name": self.goal.name,
+                "description": self.goal.description,
+            },
+            "nodes": [n.id for n in self.nodes],
+            "edges": [e.id for e in self.edges],
+            "entry_node": self.entry_node,
+            "entry_points": self.entry_points,
+            "terminal_nodes": self.terminal_nodes,
+            "client_facing_nodes": [n.id for n in self.nodes if n.client_facing],
+        }
+
+    def validate(self):
+        errors, warnings = [], []
+        node_ids = {n.id for n in self.nodes}
+        for e in self.edges:
+            if e.source not in node_ids:
+                errors.append(f"Edge {e.id}: source '{e.source}' not found")
+            if e.target not in node_ids:
+                errors.append(f"Edge {e.id}: target '{e.target}' not found")
+        if self.entry_node not in node_ids:
+            errors.append(f"Entry node '{self.entry_node}' not found")
+        for t in self.terminal_nodes:
+            if t not in node_ids:
+                errors.append(f"Terminal node '{t}' not found")
+        for ep_id, nid in self.entry_points.items():
+            if nid not in node_ids:
+                errors.append(f"Entry point '{ep_id}' references unknown node '{nid}'")
+        return {"valid": len(errors) == 0, "errors": errors, "warnings": warnings}
+
+
+default_agent = DiscordDigestAgent()

--- a/examples/templates/discord_digest/config.py
+++ b/examples/templates/discord_digest/config.py
@@ -1,0 +1,25 @@
+"""Runtime configuration for Discord Community Digest."""
+
+from dataclasses import dataclass
+
+from framework.config import RuntimeConfig
+
+default_config = RuntimeConfig()
+
+
+@dataclass
+class AgentMetadata:
+    name: str = "Discord Community Digest"
+    version: str = "1.0.0"
+    description: str = (
+        "Monitor Discord servers, categorize messages by priority, "
+        "and deliver an actionable summary to a designated channel."
+    )
+    intro_message: str = (
+        "Hi! I'll create a digest of your Discord community activity. "
+        "Tell me which servers to monitor, how far back to look, "
+        "and where to deliver the summary."
+    )
+
+
+metadata = AgentMetadata()

--- a/examples/templates/discord_digest/mcp_servers.json
+++ b/examples/templates/discord_digest/mcp_servers.json
@@ -1,0 +1,9 @@
+{
+  "hive-tools": {
+    "transport": "stdio",
+    "command": "uv",
+    "args": ["run", "python", "mcp_server.py", "--stdio"],
+    "cwd": "../../../tools",
+    "description": "Hive tools MCP server"
+  }
+}

--- a/examples/templates/discord_digest/nodes/__init__.py
+++ b/examples/templates/discord_digest/nodes/__init__.py
@@ -1,0 +1,152 @@
+"""Node definitions for Discord Community Digest."""
+
+from framework.graph import NodeSpec
+
+# Node 1: Configure digest preferences (client-facing)
+configure_node = NodeSpec(
+    id="configure",
+    name="Configure Digest",
+    description="Capture user preferences: servers, channels, lookback window, keywords, and delivery channel.",
+    node_type="event_loop",
+    client_facing=True,
+    max_node_visits=0,
+    input_keys=[],
+    output_keys=["digest_config"],
+    system_prompt="""\
+You are a Discord digest configuration assistant.
+
+**STEP 1 — Ask the user for their preferences (text only, NO tool calls):**
+Collect these details:
+1. Which Discord servers to monitor (server names or "all")
+2. How many days to look back (default: 3, range: 1-7)
+3. Keywords of interest (default: agent, integration, PR, bug, release)
+4. Delivery channel ID — the Discord channel where the digest should be sent
+5. Any channels to skip (optional)
+
+**STEP 2 — After the user responds, call set_output:**
+set_output("digest_config", {
+    "servers": ["all"],
+    "lookback_days": 3,
+    "keywords": ["agent", "integration", "PR", "bug", "release"],
+    "delivery_channel_id": "the_channel_id_user_provided",
+    "skip_channels": []
+})
+""",
+    tools=[],
+)
+
+# Node 2: Scan Discord channels and collect messages
+scan_channels_node = NodeSpec(
+    id="scan-channels",
+    name="Scan Channels",
+    description=(
+        "Discover channels, pull messages within the lookback window, "
+        "flag mentions, keyword matches, admin posts, and high-engagement threads. "
+        "Track per-channel cursor to avoid duplicate messages on reruns."
+    ),
+    node_type="event_loop",
+    client_facing=False,
+    max_node_visits=0,
+    input_keys=["digest_config"],
+    output_keys=["channel_data"],
+    system_prompt="""\
+You are a Discord channel scanner. Systematically pull and analyze messages.
+
+STEP-BY-STEP:
+
+1. Load the dedup cursor by calling load_data("discord_digest_cursors").
+   If the file doesn't exist, start with an empty dict {{}}.
+
+2. Call discord_list_guilds to get all servers the bot can see.
+   Filter to only the servers in digest_config.servers (or all if "all").
+
+3. For each server, call discord_list_channels(guild_id, text_only=True).
+   Skip any channels listed in digest_config.skip_channels.
+
+4. For each channel, call discord_get_messages(channel_id, limit=100).
+   If the cursor has a last_message_id for this channel, pass it as
+   the "after" parameter to skip already-seen messages.
+
+5. Filter messages to only those within the lookback window
+   (compare message timestamp against now - lookback_days).
+
+6. For each message, flag it if:
+   - It @mentions someone, @everyone, or @here
+   - It contains any of digest_config.keywords (case-insensitive)
+   - The author has admin/moderator permissions
+   - It has high engagement (3+ reactions or 5+ replies)
+
+7. Update the cursor: for each channel, record the newest message ID.
+   Call save_data("discord_digest_cursors", updated_cursor_dict).
+
+8. Call set_output("channel_data", {{
+       "messages": [...],
+       "flagged": [...],
+       "channels_scanned": N,
+       "messages_found": M
+   }})
+""",
+    tools=[
+        "discord_list_guilds",
+        "discord_list_channels",
+        "discord_get_messages",
+        "load_data",
+        "save_data",
+    ],
+)
+
+# Node 3: Generate and deliver the digest
+generate_digest_node = NodeSpec(
+    id="generate-digest",
+    name="Generate Digest",
+    description=(
+        "Categorize flagged messages into Action Needed / Interesting Threads / "
+        "Announcements / FYI, format as a readable digest, and send to the "
+        "delivery channel via discord_send_message."
+    ),
+    node_type="event_loop",
+    client_facing=False,
+    max_node_visits=0,
+    input_keys=["digest_config", "channel_data"],
+    output_keys=["digest_report"],
+    system_prompt="""\
+You are a digest writer. Take the scanned channel data and produce a clear,
+actionable summary.
+
+CATEGORIZE messages into these groups:
+
+1. **Action Needed** — @mentions, direct replies, urgent keyword matches,
+   unresolved questions. These need a response.
+
+2. **Interesting Threads** — Active discussions with high engagement
+   (3+ reactions, 5+ replies) or matching user keywords. Worth reading.
+
+3. **Announcements** — Posts from admins/moderators, official announcements,
+   release notes, roadmap updates.
+
+4. **FYI** — Everything else worth knowing, briefly summarized.
+
+FORMAT the digest using Discord markdown:
+- Use ## headers for each category
+- Each item: 1-2 line summary with #channel and message link
+- Message links: https://discord.com/channels/{guild_id}/{channel_id}/{message_id}
+- If a category has no items, omit it entirely
+- Keep the total digest concise and scannable
+
+DELIVER the digest:
+1. Call discord_send_message(channel_id=digest_config.delivery_channel_id,
+   content=formatted_digest)
+2. If the digest exceeds 2000 characters, split into multiple messages
+   (one per category)
+3. If delivery fails, log the error but still set the output
+
+Call set_output("digest_report", full_digest_text)
+""",
+    tools=["discord_send_message"],
+)
+
+__all__ = [
+    "configure_node",
+    "scan_channels_node",
+    "generate_digest_node",
+]


### PR DESCRIPTION
Closes #5342

## Summary
- New 3-node template agent: configure → scan-channels → generate-digest
- Scans Discord servers, categorizes messages by priority (Action Needed / Interesting Threads / Announcements / FYI), and delivers a digest to a designated channel
- Uses repo's built-in discord tools — no custom discord_client.py
- Per-channel dedup cursor (load_data/save_data) to avoid repeating messages on reruns
- One-shot pipeline with configurable lookback window (1-7 days)
- Single credential: DISCORD_BOT_TOKEN

## Test plan
- [x] `ruff check` and `ruff format --check` pass
- [x] `default_agent.validate()` passes
- [x] `GraphSpec.validate()` passes with no errors
- [x] `AgentRunner.load()` succeeds
- [x] All 3 nodes reachable from entry, terminal node correct
- [x] Data flow verified: all node input_keys satisfied by predecessors
- [x] Dedup cursor: scan node has load_data + save_data tools and prompt instructions
- [x] No hardcoded channel IDs, user IDs, or model names
- [x] Code style matches existing template agents
- [x] `hive open --agent examples/templates/discord_digest` loads correctly (health check OK, session created)
- [x] 75 structural tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Discord Community Digest agent template as a complete example
  * Monitor Discord servers, categorize messages by priority, and deliver community activity summaries
  * CLI interface with `run`, `info`, and `validate` commands for agent management and configuration verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->