### PR TITLE
fix: parallel branch execution hides failures and produces nondeterministic results

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -2059,13 +2059,20 @@ class GraphExecutor:
 
         async def execute_single_branch(
             branch: ParallelBranch,
-        ) -> tuple[ParallelBranch, NodeResult | Exception]:
-            """Execute a single branch with retry logic."""
+        ) -> tuple[ParallelBranch, NodeResult | Exception, dict[str, Any]]:
+            """Execute a single branch with retry logic.
+
+            Returns:
+                Tuple of (branch, result_or_exception, output_dict)
+                output_dict contains the branch's outputs to be merged with
+                conflict resolution after all branches complete.
+            """
+            branch_outputs: dict[str, Any] = {}
             node_spec = graph.get_node(branch.node_id)
             if node_spec is None:
                 branch.status = "failed"
                 branch.error = f"Node {branch.node_id} not found in graph"
-                return branch, RuntimeError(branch.error)
+                return branch, RuntimeError(branch.error), branch_outputs
 
             # Get node implementation to check its type
             branch_impl = self._get_node_implementation(node_spec, graph.cleanup_llm_model)
@@ -2143,17 +2150,14 @@ class GraphExecutor:
                         )
 
                     if result.success:
-                        # Write outputs to shared memory using async write
-                        for key, value in result.output.items():
-                            await memory.write_async(key, value)
-
+                        branch_outputs = dict(result.output)
                         branch.result = result
                         branch.status = "completed"
                         self.logger.info(
                             f"      ✓ Branch {node_spec.name}: success "
                             f"(tokens: {result.tokens_used}, latency: {result.latency_ms}ms)"
                         )
-                        return branch, result
+                        return branch, result, branch_outputs
 
                     self.logger.warning(
                         f"      ↻ Branch {node_spec.name}: "
@@ -2168,7 +2172,7 @@ class GraphExecutor:
                     f"      ✗ Branch {node_spec.name}: "
                     f"failed after {effective_max_retries} attempts"
                 )
-                return branch, last_result
+                return branch, last_result, branch_outputs
 
             except Exception as e:
                 import traceback
@@ -2189,19 +2193,31 @@ class GraphExecutor:
                         stacktrace=stack_trace,
                     )
 
-                return branch, e
+                return branch, e, branch_outputs
 
-        # Execute all branches concurrently
+        # Execute all branches concurrently with return_exceptions=True
+        # to collect all results including exceptions
         tasks = [execute_single_branch(b) for b in branches.values()]
-        results = await asyncio.gather(*tasks, return_exceptions=False)
+        raw_results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        # Process results
+        # Process results - handle exceptions from gather itself
+        results: list[tuple[ParallelBranch, NodeResult | Exception, dict[str, Any]]] = []
+        for i, raw in enumerate(raw_results):
+            if isinstance(raw, Exception):
+                branch = list(branches.values())[i]
+                branch.status = "failed"
+                branch.error = str(raw)
+                results.append((branch, raw, {}))
+            else:
+                results.append(raw)
+
         total_tokens = 0
         total_latency = 0
         branch_results: dict[str, NodeResult] = {}
         failed_branches: list[ParallelBranch] = []
+        branch_outputs_list: list[tuple[str, dict[str, Any]]] = []
 
-        for branch, result in results:
+        for branch, result, outputs in results:
             path.append(branch.node_id)
 
             if isinstance(result, Exception):
@@ -2212,6 +2228,32 @@ class GraphExecutor:
                 total_tokens += result.tokens_used
                 total_latency += result.latency_ms
                 branch_results[branch.branch_id] = result
+                branch_outputs_list.append((branch.branch_id, outputs))
+
+        # Apply memory conflict resolution for successful branch outputs
+        if branch_outputs_list:
+            conflict_strategy = self._parallel_config.memory_conflict_strategy
+            merged_outputs: dict[str, Any] = {}
+            key_sources: dict[str, str] = {}
+
+            for branch_id, outputs in branch_outputs_list:
+                for key, value in outputs.items():
+                    if key in merged_outputs:
+                        existing_source = key_sources[key]
+                        if conflict_strategy == "error":
+                            raise RuntimeError(
+                                f"Memory conflict: key '{key}' written by multiple branches "
+                                f"({existing_source}, {branch_id})"
+                            )
+                        elif conflict_strategy == "first_wins":
+                            continue
+                        # else: last_wins (default) - overwrite
+                    merged_outputs[key] = value
+                    key_sources[key] = branch_id
+
+            # Write merged outputs to shared memory
+            for key, value in merged_outputs.items():
+                await memory.write_async(key, value)
 
         # Handle failures based on config
         if failed_branches:

--- a/core/tests/test_fanout.py
+++ b/core/tests/test_fanout.py
@@ -77,6 +77,18 @@ class TimingNode(NodeProtocol):
         )
 
 
+class ExceptionNode(NodeProtocol):
+    """Raises an exception during execution."""
+
+    def __init__(self, message: str = "Branch crashed"):
+        self.executed = False
+        self.message = message
+
+    async def execute(self, ctx: NodeContext) -> NodeResult:
+        self.executed = True
+        raise RuntimeError(self.message)
+
+
 # --- Fixtures ---
 
 
@@ -492,3 +504,267 @@ async def test_parallel_disabled_uses_sequential(runtime, goal):
     # Only one branch should have executed (sequential follows first edge)
     executed_count = sum([b1_impl.executed, b2_impl.executed])
     assert executed_count == 1
+
+
+# === 12. All branches execute even when one raises exception ===
+
+
+@pytest.mark.asyncio
+async def test_all_branches_execute_despite_exception(runtime, goal):
+    """All branches should execute even when one raises an exception."""
+    b1 = NodeSpec(
+        id="b1", name="B1", description="ok", node_type="event_loop", output_keys=["b1_out"]
+    )
+    b2 = NodeSpec(
+        id="b2",
+        name="B2",
+        description="crashes",
+        node_type="event_loop",
+        output_keys=["b2_out"],
+        max_retries=1,
+    )
+    b3 = NodeSpec(
+        id="b3", name="B3", description="ok", node_type="event_loop", output_keys=["b3_out"]
+    )
+
+    graph = _make_fanout_graph([b1, b2, b3])
+
+    config = ParallelExecutionConfig(on_branch_failure="continue_others")
+    executor = GraphExecutor(
+        runtime=runtime, enable_parallel_execution=True, parallel_config=config
+    )
+    executor.register_node("source", SuccessNode({"data": "x"}))
+    b1_impl = SuccessNode({"b1_out": "ok"})
+    b2_impl = ExceptionNode("Branch B2 crashed!")
+    b3_impl = SuccessNode({"b3_out": "ok"})
+    executor.register_node("b1", b1_impl)
+    executor.register_node("b2", b2_impl)
+    executor.register_node("b3", b3_impl)
+
+    result = await executor.execute(graph, goal, {})
+
+    assert b1_impl.executed, "Branch B1 should have executed"
+    assert b2_impl.executed, "Branch B2 should have executed (despite exception)"
+    assert b3_impl.executed, "Branch B3 should have executed"
+    assert result.success, "Execution should succeed with continue_others strategy"
+
+
+# === 13. Memory conflict strategy: error ===
+
+
+@pytest.mark.asyncio
+async def test_memory_conflict_error_strategy(runtime, goal):
+    """memory_conflict_strategy='error' should raise when branches write same key."""
+    b1 = NodeSpec(
+        id="b1", name="B1", description="branch 1", node_type="event_loop", output_keys=["b1_key"]
+    )
+    b2 = NodeSpec(
+        id="b2", name="B2", description="branch 2", node_type="event_loop", output_keys=["b2_key"]
+    )
+
+    graph = _make_fanout_graph([b1, b2])
+
+    config = ParallelExecutionConfig(
+        on_branch_failure="continue_others", memory_conflict_strategy="error"
+    )
+    executor = GraphExecutor(
+        runtime=runtime, enable_parallel_execution=True, parallel_config=config
+    )
+    executor.register_node("source", SuccessNode({"data": "x"}))
+    executor.register_node("b1", SuccessNode({"shared": "value1", "b1_key": "b1"}))
+    executor.register_node("b2", SuccessNode({"shared": "value2", "b2_key": "b2"}))
+
+    result = await executor.execute(graph, goal, {})
+
+    assert not result.success
+    assert "conflict" in result.error.lower() or "shared" in result.error.lower()
+
+
+# === 14. Memory conflict strategy: first_wins ===
+
+
+@pytest.mark.asyncio
+async def test_memory_conflict_first_wins_strategy(runtime, goal):
+    """memory_conflict_strategy='first_wins' should keep first value for conflicting keys."""
+    b1 = NodeSpec(
+        id="b1", name="B1", description="branch 1", node_type="event_loop", output_keys=["b1_key"]
+    )
+    b2 = NodeSpec(
+        id="b2", name="B2", description="branch 2", node_type="event_loop", output_keys=["b2_key"]
+    )
+    merge = NodeSpec(
+        id="merge",
+        name="Merge",
+        description="fan-in",
+        node_type="event_loop",
+        input_keys=["shared"],
+        output_keys=["merged"],
+    )
+
+    graph = _make_fanout_graph([b1, b2], fan_in_node=merge)
+
+    config = ParallelExecutionConfig(
+        on_branch_failure="continue_others", memory_conflict_strategy="first_wins"
+    )
+    executor = GraphExecutor(
+        runtime=runtime, enable_parallel_execution=True, parallel_config=config
+    )
+
+    captured_memory = {}
+    execution_order = []
+
+    class OrderTrackingSuccessNode(NodeProtocol):
+        def __init__(self, output: dict, label: str):
+            self._output = output
+            self.label = label
+
+        async def execute(self, ctx: NodeContext) -> NodeResult:
+            execution_order.append(self.label)
+            return NodeResult(success=True, output=self._output, tokens_used=10, latency_ms=5)
+
+    class MemoryCaptureNode(NodeProtocol):
+        def __init__(self, output: dict):
+            self._output = output
+
+        async def execute(self, ctx: NodeContext) -> NodeResult:
+            captured_memory.update(ctx.memory.read_all())
+            execution_order.append("merge")
+            return NodeResult(success=True, output=self._output, tokens_used=10, latency_ms=5)
+
+    executor.register_node("source", OrderTrackingSuccessNode({"data": "x"}, "source"))
+    executor.register_node("b1", OrderTrackingSuccessNode({"shared": "first_value"}, "b1"))
+    executor.register_node("b2", OrderTrackingSuccessNode({"shared": "second_value"}, "b2"))
+    executor.register_node("merge", MemoryCaptureNode({"merged": "done"}))
+
+    result = await executor.execute(graph, goal, {})
+
+    assert result.success, f"Execution failed: {result.error}"
+    assert "b1" in execution_order, "Branch B1 should have executed"
+    assert "b2" in execution_order, "Branch B2 should have executed"
+    assert "merge" in execution_order, "Merge node should have executed"
+    assert captured_memory.get("shared") == "first_value", (
+        f"First value should win, got: {captured_memory.get('shared')}"
+    )
+
+
+# === 15. Memory conflict strategy: last_wins (default) ===
+
+
+@pytest.mark.asyncio
+async def test_memory_conflict_last_wins_strategy(runtime, goal):
+    """memory_conflict_strategy='last_wins' should keep last value for conflicting keys."""
+    b1 = NodeSpec(
+        id="b1", name="B1", description="branch 1", node_type="event_loop", output_keys=["b1_key"]
+    )
+    b2 = NodeSpec(
+        id="b2", name="B2", description="branch 2", node_type="event_loop", output_keys=["b2_key"]
+    )
+    merge = NodeSpec(
+        id="merge",
+        name="Merge",
+        description="fan-in",
+        node_type="event_loop",
+        input_keys=["shared"],
+        output_keys=["merged"],
+    )
+
+    graph = _make_fanout_graph([b1, b2], fan_in_node=merge)
+
+    config = ParallelExecutionConfig(
+        on_branch_failure="continue_others", memory_conflict_strategy="last_wins"
+    )
+    executor = GraphExecutor(
+        runtime=runtime, enable_parallel_execution=True, parallel_config=config
+    )
+
+    captured_memory = {}
+    execution_order = []
+
+    class OrderTrackingSuccessNode(NodeProtocol):
+        def __init__(self, output: dict, label: str):
+            self._output = output
+            self.label = label
+
+        async def execute(self, ctx: NodeContext) -> NodeResult:
+            execution_order.append(self.label)
+            return NodeResult(success=True, output=self._output, tokens_used=10, latency_ms=5)
+
+    class MemoryCaptureNode(NodeProtocol):
+        def __init__(self, output: dict):
+            self._output = output
+
+        async def execute(self, ctx: NodeContext) -> NodeResult:
+            captured_memory.update(ctx.memory.read_all())
+            execution_order.append("merge")
+            return NodeResult(success=True, output=self._output, tokens_used=10, latency_ms=5)
+
+    executor.register_node("source", OrderTrackingSuccessNode({"data": "x"}, "source"))
+    executor.register_node("b1", OrderTrackingSuccessNode({"shared": "first_value"}, "b1"))
+    executor.register_node("b2", OrderTrackingSuccessNode({"shared": "second_value"}, "b2"))
+    executor.register_node("merge", MemoryCaptureNode({"merged": "done"}))
+
+    result = await executor.execute(graph, goal, {})
+
+    assert result.success, f"Execution failed: {result.error}"
+    assert "b1" in execution_order, "Branch B1 should have executed"
+    assert "b2" in execution_order, "Branch B2 should have executed"
+    assert "merge" in execution_order, "Merge node should have executed"
+    assert captured_memory.get("shared") == "second_value", (
+        f"Last value should win, got: {captured_memory.get('shared')}"
+    )
+
+
+# === 16. Exception in one branch doesn't hide other branch results ===
+
+
+@pytest.mark.asyncio
+async def test_exception_doesnt_hide_other_branch_results(runtime, goal):
+    """When one branch raises an exception, successful branch outputs should still be available."""
+    b1 = NodeSpec(
+        id="b1", name="B1", description="ok", node_type="event_loop", output_keys=["b1_out"]
+    )
+    b2 = NodeSpec(
+        id="b2",
+        name="B2",
+        description="crashes",
+        node_type="event_loop",
+        output_keys=["b2_out"],
+        max_retries=1,
+    )
+    merge = NodeSpec(
+        id="merge",
+        name="Merge",
+        description="fan-in",
+        node_type="event_loop",
+        input_keys=["b1_out"],
+        output_keys=["merged"],
+    )
+
+    graph = _make_fanout_graph([b1, b2], fan_in_node=merge)
+
+    config = ParallelExecutionConfig(on_branch_failure="continue_others")
+    executor = GraphExecutor(
+        runtime=runtime, enable_parallel_execution=True, parallel_config=config
+    )
+
+    captured_memory = {}
+
+    class MemoryCaptureNode(NodeProtocol):
+        def __init__(self, output: dict):
+            self._output = output
+
+        async def execute(self, ctx: NodeContext) -> NodeResult:
+            captured_memory.update(ctx.memory.read_all())
+            return NodeResult(success=True, output=self._output, tokens_used=10, latency_ms=5)
+
+    executor.register_node("source", SuccessNode({"data": "x"}))
+    executor.register_node("b1", SuccessNode({"b1_out": "successful_output"}))
+    executor.register_node("b2", ExceptionNode("Branch B2 crashed!"))
+    executor.register_node("merge", MemoryCaptureNode({"merged": "done"}))
+
+    result = await executor.execute(graph, goal, {})
+
+    assert result.success
+    assert captured_memory.get("b1_out") == "successful_output", (
+        "Successful branch output should be available"
+    )


### PR DESCRIPTION
## Description

This PR fixes two critical issues with parallel branch execution in the GraphExecutor:

1. **Hidden Failures**: The previous implementation used `asyncio.gather(*tasks, return_exceptions=False)` which caused the entire execution to raise on the first exception, losing information about other branches. This meant that successful branch results were discarded when any branch failed.

2. **Nondeterministic Memory State**: Branch outputs were written directly to shared memory during parallel execution, causing nondeterministic final state due to race conditions. The declared `memory_conflict_strategy` was not being enforced.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #2285

## Changes Made

### Core Logic (`core/framework/graph/executor.py`)

1. **Changed `return_exceptions=False` to `return_exceptions=True`**: All branch results (success or failure) are now collected before processing.

2. **Deferred Memory Writes**: Branch outputs are collected separately during execution instead of being written immediately to shared memory.

3. **Memory Conflict Resolution**: After all branches complete, outputs are merged according to the configured strategy:
   - `"error"`: Raises `RuntimeError` if multiple branches write to the same key
   - `"first_wins"`: Keeps the first value encountered for each key
   - `"last_wins"` (default): Keeps the last value encountered for each key

4. **Proper Exception Aggregation**: Exceptions from individual branches are captured and reported per branch, not just the first one.

### Tests (`core/tests/test_fanout.py`)

Added 5 new tests:
- `test_all_branches_execute_despite_exception`: Verifies all branches execute even when one raises an exception
- `test_memory_conflict_error_strategy`: Verifies error is raised on key conflict
- `test_memory_conflict_first_wins_strategy`: Verifies first value is kept
- `test_memory_conflict_last_wins_strategy`: Verifies last value is kept deterministically
- `test_exception_doesnt_hide_other_branch_results`: Verifies successful branch outputs are preserved when another branch fails

## Testing

- [x] Unit tests pass (`cd core && pytest tests/ --ignore=tests/test_template_library.py`)
- [x] All 847 existing tests pass
- [x] 16 fanout tests pass (11 existing + 5 new)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
