### PR TITLE
fix(frontend): add 404 fallback route for unknown paths

### DIFF
--- a/core/frontend/src/App.tsx
+++ b/core/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from "react-router-dom";
 import Home from "./pages/home";
 import MyAgents from "./pages/my-agents";
 import Workspace from "./pages/workspace";
+import NotFound from "./pages/not-found";
 
 function App() {
   return (
@@ -9,6 +10,7 @@ function App() {
       <Route path="/" element={<Home />} />
       <Route path="/my-agents" element={<MyAgents />} />
       <Route path="/workspace" element={<Workspace />} />
+      <Route path="*" element={<NotFound />} />
     </Routes>
   );
 }

--- a/core/frontend/src/pages/not-found.tsx
+++ b/core/frontend/src/pages/not-found.tsx
@@ -1,0 +1,19 @@
+import { Link } from "react-router-dom";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-background flex flex-col items-center justify-center px-6 text-center">
+      <h1 className="text-5xl font-semibold text-foreground">404</h1>
+      <p className="mt-3 text-sm text-muted-foreground">Page not found</p>
+      <p className="mt-1 text-sm text-muted-foreground/80">
+        The page you’re looking for doesn’t exist.
+      </p>
+      <Link
+        to="/"
+        className="mt-6 inline-flex items-center rounded-lg border border-border/40 px-4 py-2 text-sm font-medium text-foreground hover:bg-muted/40 transition-colors"
+      >
+        Back to Home
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Fix invalid frontend routes showing a blank screen by adding a wildcard route and a dedicated 404 page with a safe navigation path back to home.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #6336

## Changes Made

- Added wildcard route (`path="*"`) in `core/frontend/src/App.tsx`
- Added new `core/frontend/src/pages/not-found.tsx`
- Rendered user-friendly 404 UI with “Back to Home” link

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

- Added screenshot(s) showing invalid route now renders 404 page instead of blank screen.