### PR TITLE
fix: handle broken symlinks in list_dir tool

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/list_dir/list_dir.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/list_dir/list_dir.py
@@ -23,6 +23,7 @@ def register_tools(mcp: FastMCP) -> None:
             Path must point to an existing directory
             Returns file names, types, and sizes
             Does not recurse into subdirectories
+            Broken symlinks are reported as type "broken_symlink"
 
         Args:
             path: The directory path (relative to session root)
@@ -45,12 +46,29 @@ def register_tools(mcp: FastMCP) -> None:
             entries = []
             for item in items:
                 full_path = os.path.join(secure_path, item)
-                is_dir = os.path.isdir(full_path)
-                entry = {
-                    "name": item,
-                    "type": "directory" if is_dir else "file",
-                    "size_bytes": os.path.getsize(full_path) if not is_dir else None,
-                }
+                try:
+                    is_dir = os.path.isdir(full_path)
+                    if is_dir:
+                        entry = {
+                            "name": item,
+                            "type": "directory",
+                            "size_bytes": None,
+                        }
+                    else:
+                        entry = {
+                            "name": item,
+                            "type": "file",
+                            "size_bytes": os.path.getsize(full_path),
+                        }
+                except OSError:
+                    if os.path.islink(full_path):
+                        entry = {
+                            "name": item,
+                            "type": "broken_symlink",
+                            "size_bytes": None,
+                        }
+                    else:
+                        raise
                 entries.append(entry)
 
             return {"success": True, "path": path, "entries": entries, "total_count": len(entries)}

--- a/tools/tests/tools/test_file_system_toolkits.py
+++ b/tools/tests/tools/test_file_system_toolkits.py
@@ -391,6 +391,46 @@ class TestListDirTool:
         assert entries_by_name["subdir"]["type"] == "directory"
         assert entries_by_name["subdir"]["size_bytes"] is None
 
+    def test_list_directory_with_broken_symlink(
+        self, list_dir_fn, mock_workspace, mock_secure_path, tmp_path
+    ):
+        """Listing a directory with broken symlinks does not crash."""
+        (tmp_path / "file1.txt").write_text("content", encoding="utf-8")
+        (tmp_path / "subdir").mkdir()
+        broken_link = tmp_path / "broken_link"
+        broken_link.symlink_to("non_existent_file")
+
+        result = list_dir_fn(path=".", **mock_workspace)
+
+        assert result["success"] is True
+        assert result["total_count"] == 3
+        assert len(result["entries"]) == 3
+
+        entries_by_name = {e["name"]: e for e in result["entries"]}
+
+        assert entries_by_name["file1.txt"]["type"] == "file"
+        assert entries_by_name["subdir"]["type"] == "directory"
+        assert entries_by_name["broken_link"]["type"] == "broken_symlink"
+        assert entries_by_name["broken_link"]["size_bytes"] is None
+
+    def test_list_directory_with_multiple_broken_symlinks(
+        self, list_dir_fn, mock_workspace, mock_secure_path, tmp_path
+    ):
+        """Listing a directory with multiple broken symlinks handles all correctly."""
+        (tmp_path / "normal_file.txt").write_text("content", encoding="utf-8")
+        (tmp_path / "broken1").symlink_to("non_existent_1")
+        (tmp_path / "broken2").symlink_to("non_existent_2")
+
+        result = list_dir_fn(path=".", **mock_workspace)
+
+        assert result["success"] is True
+        assert result["total_count"] == 3
+
+        entries_by_name = {e["name"]: e for e in result["entries"]}
+        assert entries_by_name["normal_file.txt"]["type"] == "file"
+        assert entries_by_name["broken1"]["type"] == "broken_symlink"
+        assert entries_by_name["broken2"]["type"] == "broken_symlink"
+
 
 class TestReplaceFileContentTool:
     """Tests for replace_file_content tool."""


### PR DESCRIPTION
## Description

Fix the `list_dir` tool to gracefully handle broken symbolic links instead of crashing with an unhandled `OSError`. When a directory contains broken symlinks (symlinks pointing to non-existent targets), the tool now reports them as type `"broken_symlink"` and continues listing the rest of the directory contents.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Resolves #2319

## Changes Made

- Modified `list_dir.py` to wrap `os.path.isdir()` and `os.path.getsize()` calls in try-except to catch `OSError` on broken symlinks
- Added detection of broken symlinks using `os.path.islink()` when `OSError` is raised
- Broken symlinks are now reported with type `"broken_symlink"` and `size_bytes: null`
- Updated docstring to document the new behavior
- Added two new unit tests:
  - `test_list_directory_with_broken_symlink`: Tests a directory with a mix of files, directories, and a broken symlink
  - `test_list_directory_with_multiple_broken_symlinks`: Tests a directory with multiple broken symlinks

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd tools && uv run pytest tests/tools/test_file_system_toolkits.py`)
- [x] Lint passes (`cd tools && uv run ruff check src/aden_tools/tools/file_system_toolkits/list_dir/list_dir.py`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A
