### PR TITLE
feat: add interactive prompt for missing API keys

### DIFF
--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -17,8 +17,8 @@ from pathlib import Path
 from typing import Any
 
 try:
-    import litellm
-    from litellm.exceptions import RateLimitError
+    import litellm  # type: ignore
+    from litellm.exceptions import RateLimitError  # type: ignore
 except ImportError:
     litellm = None  # type: ignore[assignment]
     RateLimitError = Exception  # type: ignore[assignment, misc]

--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -520,16 +520,22 @@ def cmd_run(args: argparse.Namespace) -> int:
             print("No key provided. Exiting.", file=sys.stderr)
             return 1
             
-        # Infer a likely key name from the model
-        key_name = "ANTHROPIC_API_KEY"
+        # Infer a likely key name from the model (used as a suggestion only)
+        suggested_key_name = "ANTHROPIC_API_KEY"
         if args.model:
             model_lower = args.model.lower()
             if "gpt" in model_lower or "openai" in model_lower:
-                key_name = "OPENAI_API_KEY"
+                suggested_key_name = "OPENAI_API_KEY"
             elif "gemini" in model_lower or "google" in model_lower:
-                key_name = "GEMINI_API_KEY"
+                suggested_key_name = "GEMINI_API_KEY"
             elif "claude" in model_lower or "anthropic" in model_lower:
-                key_name = "ANTHROPIC_API_KEY"
+                suggested_key_name = "ANTHROPIC_API_KEY"
+        
+        # Let the user confirm or override the environment variable name
+        user_key_name = input(
+            f"Environment variable name to store this key [{suggested_key_name}]: "
+        ).strip()
+        key_name = user_key_name or suggested_key_name
         
         # 4. Set current process environment variables
         os.environ[key_name] = api_key

--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -485,7 +485,84 @@ def cmd_run(args: argparse.Namespace) -> int:
         print("=" * 60)
         print()
 
-    result = asyncio.run(runner.run(context, session_state=session_state))
+    while True:
+        try:
+            result = asyncio.run(runner.run(context, session_state=session_state))
+            
+            # If the error is returned in result.error instead of raising directly
+            error_str = str(result.error) if not result.success and result.error else ""
+            is_auth_error = "AuthenticationError" in error_str or "API key" in error_str
+            
+            if not is_auth_error:
+                break
+                
+        except Exception as e:
+            error_str = str(e)
+            if "AuthenticationError" not in type(e).__name__ and "AuthenticationError" not in error_str:
+                raise
+        
+        # --- Interactive Fallback ---
+        if not sys.stdin.isatty():
+            if 'result' not in locals():
+                raise RuntimeError(error_str)
+            break
+            
+        print(f"\n[!] Authentication Error: {error_str.splitlines()[-1] if error_str else 'Missing or invalid API Key'}", file=sys.stderr)
+        
+        import getpass
+        import os
+        from pathlib import Path
+        
+        print("\nIt looks like your API key is missing or invalid.")
+        api_key = getpass.getpass("Please paste your API key to continue: ").strip()
+        
+        if not api_key:
+            print("No key provided. Exiting.", file=sys.stderr)
+            return 1
+            
+        # Infer a likely key name from the model
+        key_name = "ANTHROPIC_API_KEY"
+        if args.model:
+            model_lower = args.model.lower()
+            if "gpt" in model_lower or "openai" in model_lower:
+                key_name = "OPENAI_API_KEY"
+            elif "gemini" in model_lower or "google" in model_lower:
+                key_name = "GEMINI_API_KEY"
+            elif "claude" in model_lower or "anthropic" in model_lower:
+                key_name = "ANTHROPIC_API_KEY"
+        
+        # 4. Set current process environment variables
+        os.environ[key_name] = api_key
+        
+        # 3. Persist to ~/.hive/configuration.json
+        config_path = Path("~/.hive/configuration.json").expanduser()
+        config_data = {}
+        if config_path.exists():
+            try:
+                with open(config_path, "r", encoding="utf-8") as f:
+                    config_data = json.load(f)
+            except json.JSONDecodeError:
+                pass
+                
+        if "credentials" not in config_data:
+            config_data["credentials"] = {}
+        # Ensure we don't accidentally wipe existing configs
+        config_data["credentials"][key_name] = api_key
+        
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(config_path, "w", encoding="utf-8") as f:
+            json.dump(config_data, f, indent=2)
+            
+        print(f"\nSaved {key_name} to {config_path}")
+        print("Retrying agent execution...\n")
+        
+        # Reload the runner so it picks up the new credentials
+        try:
+            from framework.runner import AgentRunner
+            runner = AgentRunner.load(args.agent_path, model=args.model)
+        except Exception as e:
+            print(f"Error reloading agent: {e}", file=sys.stderr)
+            return 1
 
     # Format output
     output = {


### PR DESCRIPTION

## Description

Added an interactive, secure prompt to handle missing API keys gracefully. Previously, running an agent without valid credentials would cause a hard error. This update intercepts `AuthenticationError` exceptions, prompts the user to securely paste their key via `getpass`, saves the configuration to the `~/.hive/configuration.json` storage, and dynamically reloads the agent—all without forcing the user to exit and restart the CLI.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #6275

## Changes Made

- Wrapped the primary `asyncio.run(runner.run(...))` execution block in cli.py with a retry loop.
- Added a fallback path that catches `AuthenticationError` and uses `getpass.getpass()` for secure CLI input when `sys.stdin.isatty()` is true.
- Automatically determines the most likely API key environment variable (e.g. `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`) based on the requested model name.
- Wires the newly inputted credential into the current process's `os.environ` map and permanently saves it to the `~/.hive/configuration.json` credentials block safely.
- Included type hinting fixes (`# type: ignore`) for missing static resolution in litellm.py.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
``` it should look like this ```
<img width="940" height="171" alt="image" src="https://github.com/user-attachments/assets/f0192ed2-f990-4018-9f27-a79b1d1deb8d" />