### PR TITLE
micro-fix: remove vestigial duplicate Step 3 header in quickstart.sh

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -301,17 +301,10 @@ if [ "$NODE_AVAILABLE" = true ]; then
 fi
 
 # ============================================================
-# Step 3: Configure LLM API Key
-# ============================================================
-
-echo -e "${YELLOW}⬢${NC} ${BLUE}${BOLD}Step 3: Configuring LLM provider...${NC}"
-echo ""
-
-# ============================================================
 # Step 3: Verify Python Imports
 # ============================================================
 
-echo -e "${BLUE}Step 3: Verifying Python imports...${NC}"
+echo -e "${YELLOW}⬢${NC} ${BLUE}${BOLD}Step 3: Verifying Python imports...${NC}"
 echo ""
 
 IMPORT_ERRORS=0


### PR DESCRIPTION
## Bug
[#6015](https://github.com/aden-hive/hive/issues/6015) — Quickstart setup output lists "Step 3" twice.

## Fix
Removed the vestigial "Step 3: Configuring LLM provider..." header that no longer had any associated code. This was causing duplicate Step 3 output:

```
Step 3: Configuring LLM provider...
Step 3: Verifying Python imports...
```

After this fix:
```
Step 3: Verifying Python imports...
```

Also updated the styling of the remaining Step 3 to match the consistent bold yellow/blue format used by other steps.

Greetings, saschabuehrle