### PR TITLE
fix(credentials): allow CompositeStorage fallbacks after load errors

### DIFF
--- a/core/framework/credentials/storage.py
+++ b/core/framework/credentials/storage.py
@@ -20,7 +20,12 @@ from typing import Any
 
 from pydantic import SecretStr
 
-from .models import CredentialDecryptionError, CredentialKey, CredentialObject, CredentialType
+from .models import (
+    CredentialDecryptionError,
+    CredentialKey,
+    CredentialObject,
+    CredentialType,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -488,16 +493,28 @@ class CompositeStorage(CredentialStorage):
 
     def load(self, credential_id: str) -> CredentialObject | None:
         """Load from primary, then fallbacks."""
+        from .models import CredentialError
+
+        primary_error = None
         # Try primary first
-        credential = self._primary.load(credential_id)
-        if credential is not None:
-            return credential
+        try:
+            credential = self._primary.load(credential_id)
+            if credential is not None:
+                return credential
+        except CredentialError as e:
+            primary_error = e
 
         # Try fallbacks
         for fallback in self._fallbacks:
-            credential = fallback.load(credential_id)
-            if credential is not None:
-                return credential
+            try:
+                credential = fallback.load(credential_id)
+                if credential is not None:
+                    return credential
+            except CredentialError:
+                pass
+
+        if primary_error is not None:
+            raise primary_error
 
         return None
 

--- a/core/framework/credentials/tests/test_credential_store.py
+++ b/core/framework/credentials/tests/test_credential_store.py
@@ -375,6 +375,44 @@ class TestCompositeStorage:
         assert primary.exists("test")
         assert not fallback.exists("test")
 
+    def test_fallback_when_primary_raises_error(self):
+        """Test fallback is attempted when primary storage raises CredentialError."""
+        from core.framework.credentials.models import CredentialDecryptionError
+
+        class FailingStorage(InMemoryStorage):
+            def load(self, credential_id: str):
+                raise CredentialDecryptionError("Simulated primary failure")
+
+        primary = FailingStorage()
+        fallback = InMemoryStorage()
+        fallback.save(
+            CredentialObject(
+                id="test", keys={"k": CredentialKey(name="k", value=SecretStr("fallback"))}
+            )
+        )
+
+        storage = CompositeStorage(primary, [fallback])
+        cred = storage.load("test")
+
+        assert cred is not None
+        assert cred.get_key("k") == "fallback"
+
+    def test_raises_original_error_if_no_fallback_succeeds(self):
+        """Test original CredentialError is raised if fallbacks return None."""
+        from core.framework.credentials.models import CredentialDecryptionError
+
+        class FailingStorage(InMemoryStorage):
+            def load(self, credential_id: str):
+                raise CredentialDecryptionError("Simulated primary failure")
+
+        primary = FailingStorage()
+        fallback = InMemoryStorage()  # Empty fallback
+
+        storage = CompositeStorage(primary, [fallback])
+
+        with pytest.raises(CredentialDecryptionError, match="Simulated primary failure"):
+            storage.load("test")
+
 
 class TestStaticProvider:
     """Tests for StaticProvider."""


### PR DESCRIPTION
## Description

`CompositeStorage.load()` was returning the primary backend result directly, but if the primary backend raised a `CredentialError` (e.g., an encrypted credential file was corrupted), it aborted the load path before evaluating any fallback backends. This PR adds a proper `try...except` wrapper to catch decryption errors on the primary backend, iterate through fallbacks, and only re-raise the original error if recovery is impossible. Regression tests were added to guarantee this behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #6396

## Changes Made

- Updated `CompositeStorage.load()` in [storage.py](cci:7://file:///Users/aiyufan/Year/2026%20Spring/hive/core/framework/credentials/storage.py:0:0-0:0) to catch `CredentialError` from the primary storage provider.
- Enabled iteration over secondary configured fallbacks when primary fails.
- Guaranteed the original `CredentialError` is strictly re-raised if all configured fallback layers return `None`.
- Added two regression tests in [test_credential_store.py](cci:7://file:///Users/aiyufan/Year/2026%20Spring/hive/core/framework/credentials/tests/test_credential_store.py:0:0-0:0) ([test_fallback_when_primary_raises_error](cci:1://file:///Users/aiyufan/Year/2026%20Spring/hive/core/framework/credentials/tests/test_credential_store.py:377:4-397:46) and [test_raises_original_error_if_no_fallback_succeeds](cci:1://file:///Users/aiyufan/Year/2026%20Spring/hive/core/framework/credentials/tests/test_credential_store.py:399:4-413:32)).

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A
