### PR TITLE
fix(config): avoid double-prefixing provider in get_preferred_model

### DIFF
--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -47,7 +47,12 @@ def get_preferred_model() -> str:
     """Return the user's preferred LLM model string (e.g. 'anthropic/claude-sonnet-4-20250514')."""
     llm = get_hive_config().get("llm", {})
     if llm.get("provider") and llm.get("model"):
-        return f"{llm['provider']}/{llm['model']}"
+        provider = llm["provider"]
+        model = llm["model"]
+        # Avoid double-prefixing if model already includes the provider (e.g. "ollama/qwen2.5:7b")
+        if model.startswith(f"{provider}/"):
+            return model
+        return f"{provider}/{model}"
     return "anthropic/claude-sonnet-4-20250514"
 
 


### PR DESCRIPTION
## Description
`get_preferred_model()` unconditionally prepended `{provider}/` to the model string, so users who wrote `"model": "ollama/qwen2.5:7b"` (the standard LiteLLM format) got `ollama/ollama/qwen2.5:7b`, causing a 404 on every LLM call. The fix checks whether the model already starts with `{provider}/` before prepending.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #6393

## Changes Made
- `core/framework/config.py` — added guard in `get_preferred_model()` to detect already-prefixed model strings

## Testing
- [x] Lint passes
- [ ] Unit tests updated
- [x] Manual testing: both `"model": "qwen2.5:7b"` and `"model": "ollama/qwen2.5:7b"` now resolve to `ollama/qwen2.5:7b`

## Checklist
- [x] Self-review done
- [x] No new warnings introduced