### PR TITLE
fix: declare croniter dependency and fail loudly on missing import

### DIFF
--- a/core/framework/runtime/agent_runtime.py
+++ b/core/framework/runtime/agent_runtime.py
@@ -400,11 +400,16 @@ class AgentRuntime:
                     # Cron expression mode — takes priority over interval_minutes
                     try:
                         from croniter import croniter
+                    except ImportError as e:
+                        raise RuntimeError(
+                            "croniter is required for cron-based entry points. "
+                            "Install it with: uv pip install croniter"
+                        ) from e
 
-                        # Validate the expression upfront
+                    try:
                         if not croniter.is_valid(cron_expr):
                             raise ValueError(f"Invalid cron expression: {cron_expr}")
-                    except (ImportError, ValueError) as e:
+                    except ValueError as e:
                         logger.warning(
                             "Entry point '%s' has invalid cron config: %s",
                             ep_id,

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "litellm>=1.81.0",
   "mcp>=1.0.0",
   "fastmcp>=2.0.0",
+  "croniter>=1.4.0",
   "tools",
 ]
 


### PR DESCRIPTION
## Description

croniter is used for cron-based timer entry points but was never declared in pyproject.toml. A fresh install silently skips all cron triggers.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #5353

## Changes Made

- Added `croniter>=1.4.0` to `core/pyproject.toml` dependencies
- Split `except (ImportError, ValueError)` in `agent_runtime.py` so ImportError raises RuntimeError instead of silently continuing

## Testing

- [x] Unit tests pass (`uv run pytest core/framework/runtime/tests/test_agent_runtime.py` - 26 passed)
- [x] Lint passes (`uv run ruff check core/framework/runtime/agent_runtime.py`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes