### PR TITLE
micro-fix(examples): add missing agent.json to template directories

### DIFF
--- a/examples/templates/email_reply_agent/agent.json
+++ b/examples/templates/email_reply_agent/agent.json
@@ -1,0 +1,197 @@
+{
+  "agent": {
+    "id": "email_reply_agent",
+    "name": "Email Reply Agent",
+    "version": "1.0.0",
+    "description": "Filter unreplied emails by user criteria, confirm recipients, send personalized replies."
+  },
+  "graph": {
+    "id": "email-reply-graph",
+    "goal_id": "email-reply-goal",
+    "version": "1.0.0",
+    "entry_node": "intake",
+    "entry_points": {
+      "start": "intake"
+    },
+    "pause_nodes": [],
+    "terminal_nodes": [],
+    "nodes": [
+      {
+        "id": "intake",
+        "name": "Intake",
+        "description": "Gather email filter criteria from user",
+        "node_type": "event_loop",
+        "input_keys": ["batch_complete", "restart"],
+        "output_keys": ["filter_criteria"],
+        "nullable_output_keys": ["batch_complete", "restart"],
+        "input_schema": {},
+        "output_schema": {},
+        "system_prompt": null,
+        "tools": [],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 0,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": true
+      },
+      {
+        "id": "search",
+        "name": "Search Emails",
+        "description": "Search Gmail for unreplied emails matching filter criteria",
+        "node_type": "event_loop",
+        "input_keys": ["filter_criteria"],
+        "output_keys": ["email_list"],
+        "nullable_output_keys": [],
+        "input_schema": {},
+        "output_schema": {},
+        "system_prompt": null,
+        "tools": ["gmail_list_messages", "gmail_get_message", "gmail_batch_get_messages"],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 0,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": false
+      },
+      {
+        "id": "confirm-draft",
+        "name": "Confirm & Reply",
+        "description": "Present emails for confirmation, send personalized replies",
+        "node_type": "event_loop",
+        "input_keys": ["email_list", "filter_criteria"],
+        "output_keys": ["batch_complete", "restart"],
+        "nullable_output_keys": ["batch_complete", "restart"],
+        "input_schema": {},
+        "output_schema": {},
+        "system_prompt": null,
+        "tools": ["gmail_reply_email"],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 0,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": true
+      }
+    ],
+    "edges": [
+      {
+        "id": "intake-to-search",
+        "source": "intake",
+        "target": "search",
+        "condition": "on_success",
+        "condition_expr": null,
+        "priority": 1,
+        "input_mapping": {}
+      },
+      {
+        "id": "search-to-confirm",
+        "source": "search",
+        "target": "confirm-draft",
+        "condition": "on_success",
+        "condition_expr": null,
+        "priority": 1,
+        "input_mapping": {}
+      },
+      {
+        "id": "confirm-to-intake-on-restart",
+        "source": "confirm-draft",
+        "target": "intake",
+        "condition": "conditional",
+        "condition_expr": "restart == True",
+        "priority": 2,
+        "input_mapping": {}
+      },
+      {
+        "id": "confirm-to-intake-on-complete",
+        "source": "confirm-draft",
+        "target": "intake",
+        "condition": "conditional",
+        "condition_expr": "batch_complete == True",
+        "priority": 1,
+        "input_mapping": {}
+      }
+    ],
+    "max_steps": 100,
+    "max_retries_per_node": 3,
+    "description": "Filter unreplied emails by user criteria, confirm recipients, send personalized replies.",
+    "created_at": "2026-03-15T00:00:00.000000"
+  },
+  "goal": {
+    "id": "email-reply-goal",
+    "name": "Email Reply Agent",
+    "description": "Filter unreplied emails by user criteria, confirm recipients, send personalized replies.",
+    "status": "draft",
+    "success_criteria": [
+      {
+        "id": "sc-filter",
+        "description": "Accurately finds unreplied emails matching user criteria",
+        "metric": "Precision of email filtering",
+        "target": "90%",
+        "weight": 0.35,
+        "met": false
+      },
+      {
+        "id": "sc-confirm",
+        "description": "User confirms recipient list before sending",
+        "metric": "Confirmation rate",
+        "target": "100%",
+        "weight": 0.25,
+        "met": false
+      },
+      {
+        "id": "sc-personalize",
+        "description": "Replies are personalized based on email content and tone guidance",
+        "metric": "User satisfaction with reply relevance",
+        "target": "85%",
+        "weight": 0.40,
+        "met": false
+      }
+    ],
+    "constraints": [
+      {
+        "id": "c-privacy",
+        "description": "Never send emails without explicit user confirmation; always present recipient list and get approval first",
+        "constraint_type": "hard",
+        "category": "functional",
+        "check": ""
+      },
+      {
+        "id": "c-batch",
+        "description": "Process up to 50 emails per batch",
+        "constraint_type": "hard",
+        "category": "functional",
+        "check": ""
+      }
+    ],
+    "context": {},
+    "required_capabilities": [],
+    "input_schema": {},
+    "output_schema": {},
+    "version": "1.0.0",
+    "parent_version": null,
+    "evolution_reason": null,
+    "created_at": "2026-03-15 00:00:00.000000",
+    "updated_at": "2026-03-15 00:00:00.000000"
+  },
+  "required_tools": [
+    "gmail_list_messages",
+    "gmail_get_message",
+    "gmail_batch_get_messages",
+    "gmail_reply_email"
+  ],
+  "metadata": {
+    "created_at": "2026-03-15T00:00:00.000000",
+    "node_count": 3,
+    "edge_count": 4
+  }
+}

--- a/examples/templates/meeting_scheduler/agent.json
+++ b/examples/templates/meeting_scheduler/agent.json
@@ -1,0 +1,214 @@
+{
+  "agent": {
+    "id": "meeting_scheduler",
+    "name": "Meeting Scheduler",
+    "version": "1.0.0",
+    "description": "Schedule meetings by checking Google Calendar availability, booking optimal time slots, recording details in Google Sheets, and sending email confirmations with Google Meet links to attendees."
+  },
+  "graph": {
+    "id": "meeting-scheduler-graph",
+    "goal_id": "meeting-scheduler-goal",
+    "version": "1.0.0",
+    "entry_node": "intake",
+    "entry_points": {
+      "start": "intake"
+    },
+    "pause_nodes": [],
+    "terminal_nodes": [],
+    "nodes": [
+      {
+        "id": "intake",
+        "name": "Intake",
+        "description": "Gather meeting details from the user",
+        "node_type": "event_loop",
+        "input_keys": ["attendee_email", "meeting_duration_minutes"],
+        "output_keys": ["attendee_email", "meeting_duration_minutes", "meeting_title"],
+        "nullable_output_keys": ["attendee_email", "meeting_duration_minutes", "meeting_title"],
+        "input_schema": {},
+        "output_schema": {},
+        "system_prompt": null,
+        "tools": [],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 0,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": true
+      },
+      {
+        "id": "schedule",
+        "name": "Schedule",
+        "description": "Find available time on calendar, book meeting with Google Meet, and log to Google Sheet",
+        "node_type": "event_loop",
+        "input_keys": ["attendee_email", "meeting_duration_minutes", "meeting_title"],
+        "output_keys": ["meeting_time", "booking_confirmed", "spreadsheet_recorded", "email_sent", "meet_link"],
+        "nullable_output_keys": [],
+        "input_schema": {},
+        "output_schema": {},
+        "system_prompt": null,
+        "tools": [
+          "calendar_check_availability",
+          "calendar_create_event",
+          "calendar_list_events",
+          "google_sheets_create_spreadsheet",
+          "google_sheets_get_spreadsheet",
+          "google_sheets_append_values",
+          "send_email"
+        ],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 0,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": false
+      },
+      {
+        "id": "confirm",
+        "name": "Confirm",
+        "description": "Present booking confirmation to user with Google Meet link",
+        "node_type": "event_loop",
+        "input_keys": ["meeting_time", "booking_confirmed", "meet_link"],
+        "output_keys": ["next_action"],
+        "nullable_output_keys": ["next_action"],
+        "input_schema": {},
+        "output_schema": {},
+        "system_prompt": null,
+        "tools": [],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 0,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": true
+      }
+    ],
+    "edges": [
+      {
+        "id": "intake-to-schedule",
+        "source": "intake",
+        "target": "schedule",
+        "condition": "on_success",
+        "condition_expr": null,
+        "priority": 1,
+        "input_mapping": {}
+      },
+      {
+        "id": "schedule-to-confirm",
+        "source": "schedule",
+        "target": "confirm",
+        "condition": "on_success",
+        "condition_expr": null,
+        "priority": 1,
+        "input_mapping": {}
+      },
+      {
+        "id": "confirm-to-intake",
+        "source": "confirm",
+        "target": "intake",
+        "condition": "conditional",
+        "condition_expr": "str(next_action).lower() == 'another'",
+        "priority": 1,
+        "input_mapping": {}
+      }
+    ],
+    "max_steps": 100,
+    "max_retries_per_node": 3,
+    "description": "Check calendar availability, find optimal meeting times, record meetings, and send reminders.",
+    "created_at": "2026-03-15T00:00:00.000000"
+  },
+  "goal": {
+    "id": "meeting-scheduler-goal",
+    "name": "Schedule Meetings",
+    "description": "Check calendar availability, find optimal meeting times, record meetings, and send reminders.",
+    "status": "draft",
+    "success_criteria": [
+      {
+        "id": "sc-1",
+        "description": "Meeting time found within requested duration",
+        "metric": "calendar_availability",
+        "target": "success",
+        "weight": 0.35,
+        "met": false
+      },
+      {
+        "id": "sc-2",
+        "description": "Meeting recorded in spreadsheet accurately",
+        "metric": "data_persistence",
+        "target": "recorded",
+        "weight": 0.30,
+        "met": false
+      },
+      {
+        "id": "sc-3",
+        "description": "Attendee email reminder sent",
+        "metric": "communication",
+        "target": "sent",
+        "weight": 0.25,
+        "met": false
+      },
+      {
+        "id": "sc-4",
+        "description": "User confirms meeting details",
+        "metric": "user_acknowledgment",
+        "target": "confirmed",
+        "weight": 0.10,
+        "met": false
+      }
+    ],
+    "constraints": [
+      {
+        "id": "c-1",
+        "description": "Must use Google Calendar API for availability check",
+        "constraint_type": "hard",
+        "category": "functional",
+        "check": ""
+      },
+      {
+        "id": "c-2",
+        "description": "Meeting duration must match requested time",
+        "constraint_type": "hard",
+        "category": "accuracy",
+        "check": ""
+      },
+      {
+        "id": "c-3",
+        "description": "Spreadsheet record must include date, time, attendee, title",
+        "constraint_type": "hard",
+        "category": "quality",
+        "check": ""
+      }
+    ],
+    "context": {},
+    "required_capabilities": [],
+    "input_schema": {},
+    "output_schema": {},
+    "version": "1.0.0",
+    "parent_version": null,
+    "evolution_reason": null,
+    "created_at": "2026-03-15 00:00:00.000000",
+    "updated_at": "2026-03-15 00:00:00.000000"
+  },
+  "required_tools": [
+    "calendar_check_availability",
+    "calendar_create_event",
+    "calendar_list_events",
+    "google_sheets_create_spreadsheet",
+    "google_sheets_get_spreadsheet",
+    "google_sheets_append_values",
+    "send_email"
+  ],
+  "metadata": {
+    "created_at": "2026-03-15T00:00:00.000000",
+    "node_count": 3,
+    "edge_count": 3
+  }
+}


### PR DESCRIPTION
## Description
`email_reply_agent` and `meeting_scheduler` template directories were missing `agent.json` files, which prevented the runner from loading these agents by directory path. Added both files following the same structure as `competitive_intel_agent/agent.json`.

## Type of Change
- [x] Micro-fix (config files only, no logic changes)

## Related Issues
Fixes #6272

## Changes Made
- `examples/templates/email_reply_agent/agent.json` — created with nodes (intake, search, confirm-draft), edges, goal, and required tools from agent.py
- `examples/templates/meeting_scheduler/agent.json` — created with nodes (intake, schedule, confirm), edges, goal, and required tools from agent.py

## Testing
- [x] JSON is valid
- [x] Structure mirrors competitive_intel_agent/agent.json
- [x] Node IDs, edge source/target, and tool lists match agent.py definitions

## Checklist
- [x] Self-review done
- [x] No new warnings introduced