### PR TITLE
micro-fix(frontend): handle clipboard API rejection in SystemPromptTab

### DIFF
--- a/core/frontend/src/components/NodeDetailPanel.tsx
+++ b/core/frontend/src/components/NodeDetailPanel.tsx
@@ -171,7 +171,7 @@ function SystemPromptTab({ systemPrompt }: { systemPrompt?: string }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = () => {
-    navigator.clipboard.writeText(prompt);
+    navigator.clipboard.writeText(prompt).catch(() => {});
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
   };


### PR DESCRIPTION
## Description
`navigator.clipboard.writeText()` returns a Promise that rejects in non-secure contexts (HTTP) or when the browser denies clipboard access. The unhandled rejection was surfacing as a console error. This adds `.catch(() => {})` so clipboard failures are silently swallowed while the copied UI feedback still works.

## Type of Change
- [x] Micro-fix (1-line change, no logic change)

## Related Issues
Fixes #6306

## Changes Made
- `core/frontend/src/components/NodeDetailPanel.tsx` — added `.catch(() => {})` to `navigator.clipboard.writeText(prompt)` call in `handleCopy`

## Testing
- [x] Lint passes
- [x] No functional change — copied state update is unaffected

## Checklist
- [x] Self-review done
- [x] No new warnings introduced