### PR TITLE
fix(tests): skip symlink tests when creation privileges unavailable on Windows

### DIFF
--- a/tools/tests/tools/test_security.py
+++ b/tools/tests/tools/test_security.py
@@ -240,7 +240,10 @@ class TestGetSecurePath:
         target_file = session_dir / "target.txt"
         target_file.write_text("content", encoding="utf-8")
         symlink_path = session_dir / "link_to_target"
-        symlink_path.symlink_to(target_file)
+        try:
+            symlink_path.symlink_to(target_file)
+        except OSError:
+            pytest.skip("Symlink creation requires elevated privileges on this platform")
 
         # Path through symlink should resolve
         result = get_secure_path("link_to_target", **ids)
@@ -265,7 +268,10 @@ class TestGetSecurePath:
         outside_target = self.workspaces_dir / "outside_file.txt"
         outside_target.write_text("sensitive data", encoding="utf-8")
         symlink_path = session_dir / "escape_link"
-        symlink_path.symlink_to(outside_target)
+        try:
+            symlink_path.symlink_to(outside_target)
+        except OSError:
+            pytest.skip("Symlink creation requires elevated privileges on this platform")
 
         # get_secure_path accepts the lexical path (symlink is inside session)
         result = get_secure_path("escape_link", **ids)


### PR DESCRIPTION
## Description
On Windows without Developer Mode (or without elevated privileges), `symlink_to()` raises `OSError WinError 1314`. Two `TestGetSecurePath` tests were failing with this error instead of being skipped. Wrapped `symlink_to()` calls in `try/except OSError` with `pytest.skip()` so they're skipped on restricted Windows and still run on Linux/macOS and Windows with Developer Mode.

Additionally, the 6 originally reported Windows failures in #6270 (hashline ACL, `search_files` PermissionError fallback, `execute_command` Unix commands) are already resolved in current `main`.

## Type of Change
- [x] Bug fix (test fix)

## Related Issues
Fixes #6270

## Changes Made
- `tools/tests/tools/test_security.py` — added `try/except OSError: pytest.skip(...)` around `symlink_to()` calls in `test_symlink_within_sandbox_works` and `test_symlink_escape_detected_with_realpath`

## Testing
- [x] On Windows without Developer Mode: 2 symlink tests → SKIPPED (not FAILED)
- [x] All other 5723 tests pass, 277 skipped (pre-existing skips unchanged)

## Checklist
- [x] Self-review done
- [x] No new warnings introduced