### PR TITLE
micro-fix(graph): remove deprecated ast.Index visitor in safe_eval

### DIFF
--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -216,11 +216,6 @@ class SafeEvalVisitor(ast.NodeVisitor):
 
         return func(*args, **keywords)
 
-    def visit_Index(self, node: ast.Index) -> Any:
-        # Python < 3.9
-        return self.visit(node.value)
-
-
 def safe_eval(expr: str, context: dict[str, Any] | None = None) -> Any:
     """
     Safely evaluate a python expression string.


### PR DESCRIPTION
## Description
`ast.Index` was removed in Python 3.9+. The `visit_Index` method in `SafeEvalVisitor` references this nonexistent node type, causing an `AttributeError` on modern Python when subscript expressions are evaluated.

## Type of Change
- [x] Micro-fix

## Related Issues
Fixes #4563

## Changes Made
- `core/framework/graph/safe_eval.py:219-221` — removed `visit_Index` method; in Python 3.9+, subscript slices are visited directly as `Constant`/`Name`/etc. nodes without an intermediate `Index` wrapper

## Testing
- [x] Lint passes
- [x] No new warnings introduced

## Checklist
- [x] Self-review done
- [x] No new warnings introduced