### PR TITLE
micro-fix(frontend): add catch-all 404 route to App router

### DIFF
--- a/core/frontend/src/App.tsx
+++ b/core/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route } from "react-router-dom";
 import Home from "./pages/home";
 import MyAgents from "./pages/my-agents";
+import NotFound from "./pages/not-found";
 import Workspace from "./pages/workspace";
 
 function App() {
@@ -9,6 +10,7 @@ function App() {
       <Route path="/" element={<Home />} />
       <Route path="/my-agents" element={<MyAgents />} />
       <Route path="/workspace" element={<Workspace />} />
+      <Route path="*" element={<NotFound />} />
     </Routes>
   );
 }

--- a/core/frontend/src/pages/not-found.tsx
+++ b/core/frontend/src/pages/not-found.tsx
@@ -1,0 +1,17 @@
+import { useNavigate } from "react-router-dom";
+
+export default function NotFound() {
+  const navigate = useNavigate();
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen gap-4">
+      <h1 className="text-4xl font-bold">404</h1>
+      <p className="text-muted-foreground">Page not found</p>
+      <button
+        onClick={() => navigate("/")}
+        className="px-4 py-2 rounded bg-primary text-primary-foreground hover:opacity-90"
+      >
+        Go home
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
The React app had no wildcard route, so navigating to any unknown path rendered a blank page with no feedback. This adds a simple `NotFound` page and wires it up as the catch-all `path="*"` route.

## Type of Change
- [x] Micro-fix

## Related Issues
Fixes #6336

## Changes Made
- `core/frontend/src/pages/not-found.tsx` — new minimal 404 page with a "Go home" button
- `core/frontend/src/App.tsx:5,13` — import NotFound and add `<Route path="*" element={<NotFound />} />`

## Testing
- [x] No new warnings introduced

## Checklist
- [x] Self-review done
- [x] No new warnings introduced