### PR TITLE
fix(email-tool): lazy-import resend to avoid crash when package missing

### DIFF
--- a/tools/src/aden_tools/tools/email_tool/email_tool.py
+++ b/tools/src/aden_tools/tools/email_tool/email_tool.py
@@ -12,7 +12,6 @@ import os
 from typing import TYPE_CHECKING, Literal
 
 import httpx
-import resend
 from fastmcp import FastMCP
 
 if TYPE_CHECKING:
@@ -35,6 +34,8 @@ def register_tools(
         bcc: list[str] | None = None,
     ) -> dict:
         """Send email using Resend API."""
+        import resend  # lazy import — optional dependency
+
         resend.api_key = api_key
         try:
             payload: dict = {


### PR DESCRIPTION
## Description
Top-level `import resend` in `email_tool.py` crashes at import time if the `resend` package is not installed, preventing **all** tool registration from completing — even tools that have nothing to do with email. Moving it inside `_send_via_resend()` makes it a lazy import that only fails when the Resend provider is actually used.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #4816

## Changes Made
- `tools/src/aden_tools/tools/email_tool/email_tool.py:15` — removed top-level `import resend`
- `tools/src/aden_tools/tools/email_tool/email_tool.py:37` — added `import resend` as first line of `_send_via_resend()` (lazy import)

## Testing
- [x] Lint passes
- [ ] Unit tests updated/added

## Checklist
- [x] Self-review done
- [x] No new warnings introduced