### PR TITLE
fix(graph): raise on NameError in conditional edge eval instead of silent False

### DIFF
--- a/core/framework/graph/edge.py
+++ b/core/framework/graph/edge.py
@@ -197,6 +197,14 @@ class EdgeSpec(BaseModel):
                 expr_vars or "none matched",
             )
             return result
+        except NameError as e:
+            # A NameError almost always means a typo in condition_expr.
+            # Raise immediately so the developer sees a clear error rather
+            # than the edge silently evaluating to False.
+            raise ValueError(
+                f"Edge '{self.id}' condition references undefined variable: {e}. "
+                f"Available context keys: {sorted(context.keys())}"
+            ) from e
         except Exception as e:
             logger.warning(f"      ⚠ Condition evaluation failed: {self.condition_expr}")
             logger.warning(f"         Error: {e}")


### PR DESCRIPTION
## Description
A typo in `condition_expr` (referencing a variable that doesn't exist in the edge context) caused a `NameError` that was silently swallowed, making the edge always evaluate to `False` with no visible error. Developers had no way to detect the bug without adding extra logging themselves.

This PR catches `NameError` separately and raises a descriptive `ValueError` that includes the available context keys, making typos immediately visible. Other exceptions (e.g. `ValueError` from `safe_eval`) continue to log a warning and return `False` as before.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #6324

## Changes Made
- `core/framework/graph/edge.py:200-211` — added `except NameError` block before the broad `except Exception` handler; raises `ValueError` with the condition and available context keys

## Testing
- [x] Lint passes
- [ ] Unit tests updated/added

## Checklist
- [x] Self-review done
- [x] No new warnings introduced