### PR TITLE
micro-fix(cli): validate --input-file is not a directory before opening

### DIFF
--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -401,6 +401,10 @@ def cmd_run(args: argparse.Namespace) -> int:
             print(f"Error parsing --input JSON: {e}", file=sys.stderr)
             return 1
     elif args.input_file:
+        input_path = Path(args.input_file)
+        if input_path.is_dir():
+            print(f"Error: input file is a directory: {args.input_file}", file=sys.stderr)
+            return 1
         try:
             with open(args.input_file, encoding="utf-8") as f:
                 context = json.load(f)


### PR DESCRIPTION
## Description
`hive run --input-file <dir>` raised a raw `IsADirectoryError` traceback because `open()` was called without checking whether the path is a directory first. The existing handler only caught `FileNotFoundError` and `JSONDecodeError`, so the exception escaped with no user-friendly message.

## Type of Change
- [x] Micro-fix

## Related Issues
Fixes #6207

## Changes Made
- `core/framework/runner/cli.py:403` — added `Path(args.input_file).is_dir()` guard before `open()`, printing `Error: input file is a directory, not a file: <path>` and returning exit code 1

## Testing
- [x] Lint passes
- [x] No new warnings introduced

## Checklist
- [x] Self-review done
- [x] No new warnings introduced