### PR TITLE
fix(cli): return exit code 1 from hive shell when any run fails

### DIFF
--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -984,6 +984,7 @@ def cmd_shell(args: argparse.Namespace) -> int:
     session_memory = {}
     conversation_history = []
     agent_session_state = None  # Track paused agent state
+    had_failure = False  # Track any failed run to set exit code
 
     while True:
         try:
@@ -1089,6 +1090,8 @@ def cmd_shell(args: argparse.Namespace) -> int:
         result = asyncio.run(runner.run(run_context, session_state=agent_session_state))
 
         status_str = "SUCCESS" if result.success else "FAILED"
+        if not result.success:
+            had_failure = True
         print(f"\nStatus: {status_str}")
         print(f"Steps executed: {result.steps_executed}")
         print(f"Path: {' → '.join(result.path)}")
@@ -1150,7 +1153,7 @@ def cmd_shell(args: argparse.Namespace) -> int:
         print()
 
     runner.cleanup()
-    return 0
+    return 1 if had_failure else 0
 
 
 def _get_framework_agents_dir() -> Path:


### PR DESCRIPTION
## Description
`hive shell` always exited with code 0 regardless of whether agent runs succeeded or failed, making it useless in scripts and CI that check `$?`. `hive run` already returns exit code 1 on failure — this PR aligns `hive shell` with that behaviour.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #5791

## Changes Made
- `core/framework/runner/cli.py:986` — added `had_failure = False` before the session loop
- `core/framework/runner/cli.py:1092` — set `had_failure = True` when `not result.success`
- `core/framework/runner/cli.py:1155` — changed `return 0` to `return 1 if had_failure else 0`

## Testing
- [x] Lint passes
- [ ] Unit tests updated/added

## Checklist
- [x] Self-review done
- [x] No new warnings introduced