### PR TITLE
micro-fix(tech-news-reporter): set compile-report node client_facing to true

### DIFF
--- a/examples/templates/tech_news_reporter/agent.json
+++ b/examples/templates/tech_news_reporter/agent.json
@@ -98,7 +98,7 @@
         "max_node_visits": 1,
         "output_model": null,
         "max_validation_retries": 2,
-        "client_facing": false
+        "client_facing": true
       }
     ],
     "edges": [


### PR DESCRIPTION
## Description
The `compile-report` node in `tech_news_reporter` had `client_facing: false` despite its system prompt explicitly instructing the agent to present output directly to the user. This is a misconfiguration that could hide the node's output in UIs that use `client_facing` to route messages.

## Type of Change
- [x] Micro-fix

## Related Issues
Fixes #4907

## Changes Made
- `examples/templates/tech_news_reporter/agent.json` — changed `compile-report` node `client_facing` from `false` to `true`

## Testing
- [x] Change is a single field correction in an example config
- [x] No logic changes introduced

## Checklist
- [x] Self-review done
- [x] No new warnings introduced