### PR TITLE
micro-fix(tests): remove __init__.py from test dirs to fix root pytest collection

### DIFF
--- a/core/tests/__init__.py
+++ b/core/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Tests for framework runtime."""

--- a/tools/tests/__init__.py
+++ b/tools/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Aden Tools test suite."""


### PR DESCRIPTION
## Description
Running `pytest -q` from the repo root fails with `ModuleNotFoundError: No module named 'tests.conftest'` because both `core/tests/` and `tools/tests/` have `__init__.py`, causing Python to register them both as the `tests` package — a name collision. Removing the `__init__.py` files lets pytest use root-relative path discovery instead of package imports, resolving the collision.

## Type of Change
- [x] Micro-fix

## Related Issues
Fixes #5006

## Changes Made
- `core/tests/__init__.py` — removed (no tests imported from this as a package)
- `tools/tests/__init__.py` — removed (no tests imported from this as a package)

## Testing
- [x] Verified no test files use `from tests.` cross-package imports
- [x] Each test suite remains runnable via `uv run python -m pytest` in its own directory

## Checklist
- [x] Self-review done
- [x] No new warnings introduced