### PR TITLE
docs(getting-started): clarify ./hive wrapper usage and project-root requirement

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -143,19 +143,30 @@ hive/
 
 ## Running an Agent
 
+> **Note:** All `hive` commands must be run from the **project root** (`hive/`), either using the local wrapper (`./hive`) or via `uv run hive`. Running from a subdirectory will fail with a directory mismatch error.
+
 ```bash
 # Launch the web dashboard in your browser
-hive open
+./hive open
+# or: uv run hive open
 
 # Browse and run agents in terminal
-hive tui
+./hive tui
+# or: uv run hive tui
 
 # Run a specific agent
-hive run exports/my_agent --input '{"task": "Your input here"}'
+./hive run exports/my_agent --input '{"task": "Your input here"}'
+# or: uv run hive run exports/my_agent --input '{"task": "Your input here"}'
 
 # Run with TUI dashboard
-hive run exports/my_agent --tui
+./hive run exports/my_agent --tui
+```
 
+**Windows (PowerShell):** Use `.\hive.ps1` instead of `./hive`:
+
+```powershell
+.\hive.ps1 open
+.\hive.ps1 run exports\my_agent --input '{"task": "Your input here"}'
 ```
 
 ## API Keys Setup


### PR DESCRIPTION
## Description
`docs/getting-started.md` showed plain `hive open` / `hive tui` commands, creating confusion since Hive ships a local `./hive` wrapper that must be invoked from the project root. Users who typed `hive open` from a subdirectory or without `uv run` got a cryptic directory-mismatch error.

## Type of Change
- [x] Documentation

## Related Issues
Fixes #6176

## Changes Made
- `docs/getting-started.md` — updated "Running an Agent" section to use `./hive` (the local wrapper) in all examples, added `uv run hive` alternatives, added an explicit note about the project-root requirement, and added Windows PowerShell equivalents using `.\hive.ps1`

## Checklist
- [x] Self-review done
- [x] No code changes, docs only