### PR TITLE
fix(cli): handle Windows arrow key scan codes in _read_key()

### DIFF
--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -1271,7 +1271,16 @@ def _getch() -> str:
 def _read_key() -> str:
     """Read a key, handling arrow key escape sequences."""
     ch = _getch()
-    if ch == "\x1b":  # Escape sequence start
+    if sys.platform == "win32":
+        # Windows: msvcrt returns \xe0 (invalid UTF-8, decoded as "")
+        # or \x00, followed by a scan-code byte for extended keys.
+        if ch in ("", "\x00"):
+            scan = _getch()
+            if scan == "M":    # 0x4d — Right arrow
+                return "RIGHT"
+            elif scan == "K":  # 0x4b — Left arrow
+                return "LEFT"
+    elif ch == "\x1b":  # Unix: escape sequence start
         ch2 = _getch()
         if ch2 == "[":
             ch3 = _getch()


### PR DESCRIPTION
## Description
Arrow key navigation in the `hive shell` / `hive tui` agent picker was broken on Windows. On Unix, arrow keys emit `\x1b[C` / `\x1b[D`. On Windows, `msvcrt.getch()` emits `\xe0` (which Python's UTF-8 decoder drops silently, returning `""`) or `\x00` as an extended-key prefix, followed by a scan-code byte. `_read_key()` only handled the Unix path, so Windows users got no response from arrow keys.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #4877

## Changes Made
- `core/framework/runner/cli.py:_read_key()` — added `sys.platform == "win32"` branch: detects `""` / `"\x00"` prefix, reads the second byte, maps `0x4d` → `"RIGHT"` and `0x4b` → `"LEFT"`

## Testing
- [x] Lint passes
- [x] Manual verification: Windows msvcrt sends `b'\xe0\x4d'` for right arrow and `b'\xe0\x4b'` for left arrow

## Checklist
- [x] Self-review done
- [x] No new warnings introduced