### PR TITLE
fix(safe-eval): short-circuit evaluation in visit_BoolOp

### DIFF
--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -115,11 +115,20 @@ class SafeEvalVisitor(ast.NodeVisitor):
         return True
 
     def visit_BoolOp(self, node: ast.BoolOp) -> Any:
-        values = [self.visit(v) for v in node.values]
         if isinstance(node.op, ast.And):
-            return all(values)
+            result: Any = True
+            for v in node.values:
+                result = self.visit(v)
+                if not result:
+                    return result
+            return result
         elif isinstance(node.op, ast.Or):
-            return any(values)
+            result = False
+            for v in node.values:
+                result = self.visit(v)
+                if result:
+                    return result
+            return result
         raise ValueError(f"Boolean operator {type(node.op).__name__} is not allowed")
 
     def visit_IfExp(self, node: ast.IfExp) -> Any:


### PR DESCRIPTION
## Description
`visit_BoolOp` was evaluating all boolean operands eagerly (via list comprehension) before applying `all()` / `any()`. This broke guard patterns like `x is not None and x.value > 0` — when `x` is `None`, the right-hand side `x.value > 0` raised `AttributeError` even though `and` should short-circuit after the first falsy value. Python's `and` / `or` operators guarantee left-to-right short-circuit evaluation.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #4010

## Changes Made
- `core/framework/graph/safe_eval.py:visit_BoolOp` — replaced eager list comprehension + `all()`/`any()` with lazy iteration that returns immediately on the first deciding value, matching Python semantics

## Testing
- [x] Lint passes
- [x] `x is not None and x["key"]` no longer crashes when `x` is `None`
- [x] `False or some_value` correctly returns `some_value`

## Checklist
- [x] Self-review done
- [x] No new warnings introduced