### PR TITLE
fix(cli): align --model default with get_preferred_model()

### DIFF
--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -71,10 +71,12 @@ def main():
         prog="hive",
         description="Aden Hive - Build and run goal-driven agents",
     )
+    from framework.config import get_preferred_model
+
     parser.add_argument(
         "--model",
-        default="claude-haiku-4-5-20251001",
-        help="Anthropic model to use",
+        default=get_preferred_model(),
+        help="LLM model to use (default: from ~/.hive/configuration.json or get_preferred_model())",
     )
 
     subparsers = parser.add_subparsers(dest="command", required=True)


### PR DESCRIPTION
## Description
`cli.py` hardcoded `claude-haiku-4-5-20251001` as the `--model` default while `config.get_preferred_model()` returned `anthropic/claude-sonnet-4-20250514`. When no user configuration exists, a command might use one model string for the CLI invocation and a different one once the runtime initialises — causing confusing, unpredictable behaviour.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #5417

## Changes Made
- `core/framework/cli.py:74-80` — replaced hardcoded default with a call to `get_preferred_model()` so CLI and runtime always agree on the default model

## Testing
- [x] Lint passes
- [x] Running `./hive run` with no config now uses the same model as `RuntimeConfig.model`

## Checklist
- [x] Self-review done
- [x] No new warnings introduced