### PR TITLE
fix(runner): validate agent before executing in hive run and hive shell

### DIFF
--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -439,6 +439,15 @@ def cmd_run(args: argparse.Namespace) -> int:
         print(f"Error: {e}", file=sys.stderr)
         return 1
 
+    # Validate before executing — fail fast on structural errors
+    validation = runner.validate()
+    if not validation.valid:
+        print("✗ Agent validation failed — cannot run:", file=sys.stderr)
+        for error in validation.errors:
+            print(f"  ERROR: {error}", file=sys.stderr)
+        runner.cleanup()
+        return 1
+
     # Prompt before starting (allows credential updates)
     if sys.stdin.isatty() and not args.quiet:
         runner = _prompt_before_start(args.agent_path, runner, args.model)
@@ -950,6 +959,15 @@ def cmd_shell(args: argparse.Namespace) -> int:
         return 1
     except FileNotFoundError as e:
         print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    # Validate before starting the session — fail fast on structural errors
+    validation = runner.validate()
+    if not validation.valid:
+        print("✗ Agent validation failed — cannot start shell session:", file=sys.stderr)
+        for error in validation.errors:
+            print(f"  ERROR: {error}", file=sys.stderr)
+        runner.cleanup()
         return 1
 
     # Set up approval callback by default (unless --no-approve is set)


### PR DESCRIPTION
## Description
`hive run` and `hive shell` loaded an agent and immediately began execution without a pre-flight validation step. Structural errors (missing nodes, invalid entry point, etc.) only surfaced deep in the runtime with a confusing stack trace. `hive validate` already had the correct logic; this PR reuses it in both commands to fail fast with a clear error message.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #5122
Fixes #5124

## Changes Made
- `core/framework/runner/cli.py:cmd_run` — after loading the runner, call `runner.validate()`; if not valid, print all errors and return 1 before executing
- `core/framework/runner/cli.py:cmd_shell` — same pre-flight validation before the interactive session starts

## Testing
- [x] Lint passes
- [x] Agent with empty/invalid `agent.json` now exits with a clear error message instead of a runtime stack trace

## Checklist
- [x] Self-review done
- [x] No new warnings introduced