### PR TITLE
fix(cli): use webbrowser.open() for browser launching on all platforms

### DIFF
--- a/core/codex_oauth.py
+++ b/core/codex_oauth.py
@@ -16,9 +16,7 @@ import hashlib
 import http.server
 import json
 import os
-import platform
 import secrets
-import subprocess
 import sys
 import threading
 import time
@@ -159,17 +157,13 @@ def save_credentials(token_data: dict, account_id: str) -> None:
 
 def open_browser(url: str) -> bool:
     """Open the URL in the user's default browser."""
-    system = platform.system()
+    import webbrowser
+
     try:
-        devnull = subprocess.DEVNULL
-        if system == "Darwin":
-            subprocess.Popen(["open", url], stdout=devnull, stderr=devnull)
-        elif system == "Windows":
-            subprocess.Popen(["cmd", "/c", "start", url], stdout=devnull, stderr=devnull)
-        else:
-            subprocess.Popen(["xdg-open", url], stdout=devnull, stderr=devnull)
-        return True
-    except OSError:
+        # webbrowser.open handles URL escaping correctly on all platforms,
+        # including Windows where 'cmd /c start <url>' fails with special chars.
+        return webbrowser.open(url)
+    except Exception:
         return False
 
 

--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -1534,29 +1534,12 @@ def cmd_setup_credentials(args: argparse.Namespace) -> int:
 
 def _open_browser(url: str) -> None:
     """Open URL in the default browser (best-effort, non-blocking)."""
-    import subprocess
+    import webbrowser
 
     try:
-        if sys.platform == "darwin":
-            subprocess.Popen(
-                ["open", url],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                encoding="utf-8",
-            )
-        elif sys.platform == "win32":
-            subprocess.Popen(
-                ["cmd", "/c", "start", "", url],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-        elif sys.platform == "linux":
-            subprocess.Popen(
-                ["xdg-open", url],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                encoding="utf-8",
-            )
+        # webbrowser.open handles URL escaping and platform differences
+        # (macOS, Linux, Windows) without requiring subprocess shenanigans.
+        webbrowser.open(url)
     except Exception:
         pass  # Best-effort — don't crash if browser can't open
 


### PR DESCRIPTION
## Description
Two places in the codebase used `cmd /c start <url>` on Windows to open a browser:
1. `codex_oauth.py:open_browser()` — used `["cmd", "/c", "start", url]` which fails when the URL contains `&` or other special characters (common in OAuth redirect URLs)
2. `core/framework/runner/cli.py:_open_browser()` — same issue with `["cmd", "/c", "start", "", url]`

The standard library `webbrowser.open()` handles URL encoding, platform detection, and subprocess spawning correctly on all platforms (macOS, Linux, Windows) without custom subprocess plumbing.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #5739
Fixes #5779

## Changes Made
- `core/codex_oauth.py:open_browser` — replaced platform-specific subprocess logic with `webbrowser.open(url)`; removed now-unused `platform` and `subprocess` imports
- `core/framework/runner/cli.py:_open_browser` — replaced platform-specific subprocess logic with `webbrowser.open(url)`

## Testing
- [x] Lint passes
- [x] `webbrowser.open()` is stdlib and works on macOS, Linux, Windows without additional dependencies

## Checklist
- [x] Self-review done
- [x] No new warnings introduced