### PR TITLE
fix(templates): align EntryPointSpec id from 'default' to 'start'

### DIFF
--- a/examples/templates/deep_research_agent/agent.py
+++ b/examples/templates/deep_research_agent/agent.py
@@ -236,8 +236,8 @@ class DeepResearchAgent:
 
         entry_point_specs = [
             EntryPointSpec(
-                id="default",
-                name="Default",
+                id="start",
+                name="Start Research",
                 entry_node=self.entry_node,
                 trigger_type="manual",
                 isolation_level="shared",
@@ -292,7 +292,7 @@ class DeepResearchAgent:
         await self.start(mock_mode=mock_mode)
         try:
             result = await self.trigger_and_wait(
-                "default", context, session_state=session_state
+                "start", context, session_state=session_state
             )
             return result or ExecutionResult(success=False, error="Execution timeout")
         finally:

--- a/examples/templates/email_inbox_management/agent.py
+++ b/examples/templates/email_inbox_management/agent.py
@@ -257,8 +257,8 @@ class EmailInboxManagementAgent:
         entry_point_specs = [
             # Primary entry point (user-facing)
             EntryPointSpec(
-                id="default",
-                name="Default",
+                id="start",
+                name="Start Email Management",
                 entry_node=self.entry_node,
                 trigger_type="manual",
                 isolation_level="shared",
@@ -315,7 +315,7 @@ class EmailInboxManagementAgent:
         await self.start(mock_mode=mock_mode)
         try:
             result = await self.trigger_and_wait(
-                "default", context, session_state=session_state
+                "start", context, session_state=session_state
             )
             return result or ExecutionResult(success=False, error="Execution timeout")
         finally:

--- a/examples/templates/job_hunter/agent.py
+++ b/examples/templates/job_hunter/agent.py
@@ -216,8 +216,8 @@ class JobHunterAgent:
 
         entry_point_specs = [
             EntryPointSpec(
-                id="default",
-                name="Default",
+                id="start",
+                name="Start Job Hunt",
                 entry_node=self.entry_node,
                 trigger_type="manual",
                 isolation_level="shared",
@@ -250,7 +250,7 @@ class JobHunterAgent:
 
     async def trigger_and_wait(
         self,
-        entry_point: str = "default",
+        entry_point: str = "start",
         input_data: dict | None = None,
         timeout: float | None = None,
         session_state: dict | None = None,
@@ -272,7 +272,7 @@ class JobHunterAgent:
         await self.start(mock_mode=mock_mode)
         try:
             result = await self.trigger_and_wait(
-                "default", context, session_state=session_state
+                "start", context, session_state=session_state
             )
             return result or ExecutionResult(success=False, error="Execution timeout")
         finally:


### PR DESCRIPTION
## Description
Three template agents (`deep_research_agent`, `job_hunter`, `email_inbox_management`) all declare `entry_points = {"start": "intake"}` and their interactive shell paths call `trigger_and_wait("start", ...)`, but `_setup()` registered `EntryPointSpec(id="default", ...)`. When the shell called `trigger_and_wait("start", ...)`, the runtime raised a KeyError because no entry point with id `"start"` was registered.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #5073

## Changes Made
- `examples/templates/deep_research_agent/agent.py` — changed `EntryPointSpec(id="default")` to `id="start"`, updated `trigger_and_wait()` default and `run()` call
- `examples/templates/job_hunter/agent.py` — same fix
- `examples/templates/email_inbox_management/agent.py` — same fix

## Testing
- [x] Lint passes
- [x] `trigger_and_wait("start", ...)` now resolves to the registered entry point

## Checklist
- [x] Self-review done
- [x] No new warnings introduced