### PR TITLE
micro-fix(graph): replace unsafe eval() with safe_eval() in NodeProtocol docstring

### DIFF
--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -644,8 +644,9 @@ class NodeProtocol(ABC):
                     reasoning="Direct evaluation"
                 )
 
-                # Do the work
-                result = eval(expression)
+                # Do the work (use safe_eval, never bare eval())
+                from framework.graph.safe_eval import safe_eval
+                result = safe_eval(expression, context={"input": ctx.input_data})
 
                 # Record outcome
                 ctx.runtime.record_outcome(decision_id, success=True, result=result)


### PR DESCRIPTION
## Description
The `NodeProtocol` docstring example used Python's built-in `eval()` to demonstrate how to implement a node. Developers copy patterns from docstring examples, making this a direct Remote Code Execution (RCE) vector — any user-influenced input passed to `eval()` can execute arbitrary code.

The framework already provides `safe_eval()` (AST-based evaluator with whitelisted operators) which is correctly used in edge condition evaluation. The docstring example now mirrors that safe pattern.

## Type of Change
- [x] Micro-fix (docstring only, <20 lines)

## Related Issues
Fixes #6323

## Changes Made
- `core/framework/graph/node.py:648` — replaced `eval(expression)` with `safe_eval(expression, context={"input": ctx.input_data})` in the `NodeProtocol` docstring example

## Testing
- [x] Lint passes (`ruff check`)
- [x] Docstring-only change, no runtime behavior affected

## Checklist
- [x] Self-review done
- [x] No new warnings introduced