### PR TITLE
docs(readme): add Frontend section documenting the web workspace (v0.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,42 @@ flowchart LR
 - [Configuration Guide](docs/configuration.md) - All configuration options
 - [Architecture Overview](docs/architecture/README.md) - System design and structure
 
+## Frontend
+
+Hive includes a modern web interface (React + TypeScript) introduced in v0.6.0 for agent management and real-time monitoring.
+
+### Launch the web UI
+
+```bash
+# Recommended — starts the backend and opens the browser automatically
+hive serve
+
+# Re-open the dashboard without restarting the server
+hive open
+
+# Development server (hot-reload, connects to a running backend)
+cd core/frontend
+npm install
+npm run dev
+```
+
+On Windows use the PowerShell wrapper instead:
+
+```powershell
+.\hive.ps1 serve
+.\hive.ps1 open
+```
+
+### Web UI features
+
+- **Agent Management** — browse, create, configure, and delete agents
+- **Workspace** — interactive chat panel, live execution log, and graph visualizer
+- **Real-time Monitoring** — SSE-streamed node transitions, tool calls, and decisions
+- **Credential Manager** — configure and test API keys directly in the browser
+- **Template Gallery** — one-click launch of pre-built agent templates
+
+The frontend source lives in `core/frontend/` and is built with Vite + React. API communication goes through the aiohttp server in `core/framework/server/`.
+
 ## Roadmap
 
 Aden Hive Agent Framework aims to help developers build outcome-oriented, self-adaptive agents. See [roadmap.md](docs/roadmap.md) for details.


### PR DESCRIPTION
## Description
The v0.6.0 release added a React/TypeScript web workspace, but the main `README.md` had no documentation for it. New users defaulted to the TUI without knowing the browser-based interface existed. This adds a `## Frontend` section with launch instructions, feature overview, and tech-stack pointer.

## Type of Change
- [x] Documentation

## Related Issues
Fixes #5636

## Changes Made
- `README.md` — new `## Frontend` section after `## Documentation`, covering `hive serve`/`hive open`/`npm run dev`, Windows PowerShell equivalents, feature list, and source location

## Testing
- [x] Verified commands against current CLI (`hive serve`, `hive open`, `hive.ps1`)
- [x] No code changes

## Checklist
- [x] Self-review done
- [x] No new warnings introduced