### PR TITLE
fix(server): migrate aiohttp app state keys to typed web.AppKey

### DIFF
--- a/core/framework/server/app.py
+++ b/core/framework/server/app.py
@@ -3,12 +3,20 @@
 import logging
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from aiohttp import web
 
 from framework.server.session_manager import Session, SessionManager
 
+if TYPE_CHECKING:
+    from framework.credentials.store import CredentialStore
+
 logger = logging.getLogger(__name__)
+
+# Typed application-state keys (avoids aiohttp NotAppKeyWarning).
+CREDENTIAL_STORE_KEY: "web.AppKey[CredentialStore]" = web.AppKey("credential_store")
+SESSION_MANAGER_KEY: "web.AppKey[SessionManager]" = web.AppKey("manager")
 
 
 # Anchor to the repository root so allowed roots are independent of CWD.
@@ -74,7 +82,7 @@ def resolve_session(request: web.Request):
 
     Returns (session, None) on success or (None, error_response) on failure.
     """
-    manager: SessionManager = request.app["manager"]
+    manager: SessionManager = request.app[SESSION_MANAGER_KEY]
     sid = request.match_info["session_id"]
     session = manager.get_session(sid)
     if not session:
@@ -171,13 +179,13 @@ async def error_middleware(request: web.Request, handler):
 
 async def _on_shutdown(app: web.Application) -> None:
     """Gracefully unload all agents on server shutdown."""
-    manager: SessionManager = app["manager"]
+    manager: SessionManager = app[SESSION_MANAGER_KEY]
     await manager.shutdown_all()
 
 
 async def handle_health(request: web.Request) -> web.Response:
     """GET /api/health — simple health check."""
-    manager: SessionManager = request.app["manager"]
+    manager: SessionManager = request.app[SESSION_MANAGER_KEY]
     sessions = manager.list_sessions()
     return web.json_response(
         {
@@ -225,8 +233,8 @@ def create_app(model: str | None = None) -> web.Application:
         logger.debug("Encrypted credential store unavailable, using in-memory fallback")
         credential_store = CredentialStore.for_testing({})
 
-    app["credential_store"] = credential_store
-    app["manager"] = SessionManager(model=model, credential_store=credential_store)
+    app[CREDENTIAL_STORE_KEY] = credential_store
+    app[SESSION_MANAGER_KEY] = SessionManager(model=model, credential_store=credential_store)
 
     # Register shutdown hook
     app.on_shutdown.append(_on_shutdown)

--- a/core/framework/server/routes_credentials.py
+++ b/core/framework/server/routes_credentials.py
@@ -8,13 +8,13 @@ from pydantic import SecretStr
 
 from framework.credentials.models import CredentialKey, CredentialObject
 from framework.credentials.store import CredentialStore
-from framework.server.app import validate_agent_path
+from framework.server.app import CREDENTIAL_STORE_KEY, validate_agent_path
 
 logger = logging.getLogger(__name__)
 
 
 def _get_store(request: web.Request) -> CredentialStore:
-    return request.app["credential_store"]
+    return request.app[CREDENTIAL_STORE_KEY]
 
 
 def _credential_to_dict(cred: CredentialObject) -> dict:

--- a/core/framework/server/routes_execution.py
+++ b/core/framework/server/routes_execution.py
@@ -8,7 +8,12 @@ from typing import Any
 from aiohttp import web
 
 from framework.credentials.validation import validate_agent_credentials
-from framework.server.app import resolve_session, safe_path_segment, sessions_dir
+from framework.server.app import (
+    SESSION_MANAGER_KEY,
+    resolve_session,
+    safe_path_segment,
+    sessions_dir,
+)
 from framework.server.routes_sessions import _credential_error_response
 
 logger = logging.getLogger(__name__)
@@ -145,7 +150,7 @@ async def handle_chat(request: web.Request) -> web.Response:
             )
 
     # Queen is dead — try to revive her
-    manager: Any = request.app["manager"]
+    manager: Any = request.app[SESSION_MANAGER_KEY]
     try:
         await manager.revive_queen(session, initial_prompt=message)
         return web.json_response(
@@ -186,7 +191,7 @@ async def handle_queen_context(request: web.Request) -> web.Response:
             return web.json_response({"status": "queued", "delivered": True})
 
     # Queen is dead — try to revive her
-    manager: Any = request.app["manager"]
+    manager: Any = request.app[SESSION_MANAGER_KEY]
     try:
         await manager.revive_queen(session)
         # After revival, deliver the message

--- a/core/framework/server/routes_sessions.py
+++ b/core/framework/server/routes_sessions.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from aiohttp import web
 
 from framework.server.app import (
+    SESSION_MANAGER_KEY,
     cold_sessions_dir,
     resolve_session,
     safe_path_segment,
@@ -45,7 +46,7 @@ logger = logging.getLogger(__name__)
 
 
 def _get_manager(request: web.Request) -> SessionManager:
-    return request.app["manager"]
+    return request.app[SESSION_MANAGER_KEY]
 
 
 def _session_to_live_dict(session) -> dict:


### PR DESCRIPTION
## Description
`core/framework/server/app.py` stored app state with string keys (`app["manager"]`, `app["credential_store"]`), triggering `NotAppKeyWarning` in aiohttp tests and suppressing type-checker inference. Replaced with typed `web.AppKey` constants and updated all read sites.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #6161

## Changes Made
- `core/framework/server/app.py` — added `CREDENTIAL_STORE_KEY` and `SESSION_MANAGER_KEY` as module-level `web.AppKey` constants; updated write sites; added `TYPE_CHECKING` guard for type annotations
- `core/framework/server/routes_credentials.py` — `_get_store()` uses `CREDENTIAL_STORE_KEY`
- `core/framework/server/routes_execution.py` — both `handle_chat`/`handle_resume` manager lookups use `SESSION_MANAGER_KEY`
- `core/framework/server/routes_sessions.py` — `_get_manager()` uses `SESSION_MANAGER_KEY`

## Testing
- [x] Lint passes (`ruff check`)
- [x] `NotAppKeyWarning` no longer emitted for these keys

## Checklist
- [x] Self-review done
- [x] No new warnings introduced