### PR TITLE
fix(sessions): pre-flight LLM key check before creating a session

### DIFF
--- a/core/framework/server/routes_sessions.py
+++ b/core/framework/server/routes_sessions.py
@@ -131,6 +131,29 @@ async def handle_create_session(request: web.Request) -> web.Response:
     # so the full history accumulates in one place across server restarts.
     queen_resume_from = body.get("queen_resume_from")
 
+    # Pre-flight: verify that the configured LLM API key is available.
+    # This surfaces a clear error to the UI instead of letting the queen
+    # start and fail mid-turn with a cryptic AuthenticationError.
+    try:
+        from framework.config import get_api_key, get_preferred_model
+
+        if not get_api_key():
+            configured_model = get_preferred_model()
+            return web.json_response(
+                {
+                    "error": (
+                        f"LLM API key is not configured for model '{configured_model}'. "
+                        "Please set your API key via 'hive credentials set' or the Credentials "
+                        "page in the dashboard before starting a session."
+                    ),
+                    "error_type": "missing_llm_key",
+                    "model": configured_model,
+                },
+                status=400,
+            )
+    except Exception:
+        pass  # Config unavailable — let the session start and fail naturally
+
     if agent_path:
         try:
             agent_path = str(validate_agent_path(agent_path))


### PR DESCRIPTION
## Description
When a user clicks a dashboard sample action (e.g. "Check my inbox for urgent emails") without a configured API key, the queen started and failed mid-turn with a cryptic `litellm.AuthenticationError`. Added a lightweight pre-flight check in `handle_create_session()` that returns a structured 400 before the session is created, so the frontend can surface a helpful configuration message immediately.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #6229

## Changes Made
- `core/framework/server/routes_sessions.py` — added pre-flight `get_api_key()` check in `handle_create_session()` before any session/worker setup; returns 400 with `error_type: "missing_llm_key"`, the configured model string, and a setup instructions message; wrapped in `try/except` so config import errors never block session creation

## Testing
- [x] Lint passes (`ruff check`)
- [x] Fallback to original failure path preserved when config is unavailable

## Checklist
- [x] Self-review done
- [x] No new warnings introduced