### PR TITLE
fix(codex_oauth): add utf-8 encoding to prevent UnicodeEncodeError on Windows

### DIFF
--- a/core/codex_oauth.py
+++ b/core/codex_oauth.py
@@ -153,7 +153,7 @@ def save_credentials(token_data: dict, account_id: str) -> None:
 
     CODEX_AUTH_FILE.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     fd = os.open(CODEX_AUTH_FILE, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "w") as f:
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
         json.dump(auth_data, f, indent=2)
 
 


### PR DESCRIPTION
## Description
`os.fdopen(fd, "w")` uses the system default encoding (cp1252 on Windows), which cannot encode Unicode characters like ✗ (U+2717) present in the auth JSON. Adding `encoding=\"utf-8\"` ensures the file is always written as UTF-8.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #1161

## Changes Made
- `core/codex_oauth.py:156` — added `encoding="utf-8"` to `os.fdopen(fd, "w")`

## Testing
- [x] Lint passes (`ruff check`)
- [x] Runtime tests pass (`pytest tests/test_runtime.py`)

## Checklist
- [x] Self-review done
- [x] No new warnings introduced