### PR TITLE
micro-fix(runtime): tighten executor Callable annotation to Callable[[], Any]

### DIFF
--- a/core/framework/runtime/core.py
+++ b/core/framework/runtime/core.py
@@ -319,7 +319,7 @@ class Runtime:
         options: list[dict[str, Any]],
         chosen: str,
         reasoning: str,
-        executor: Callable,
+        executor: Callable[[], Any],
         **kwargs,
     ) -> tuple[str, Any]:
         """


### PR DESCRIPTION
## Description
The `executor` parameter in `decide_and_execute()` is always called as `executor()` (no arguments), but was typed as the generic `Callable`. This allows any callable to pass static type checking even if its signature is incompatible. Tightening to `Callable[[], Any]` catches mismatches at analysis time without changing runtime behaviour.

## Type of Change
- [x] Micro-fix (type annotation only, no logic change)

## Related Issues
Fixes #1201

## Changes Made
- `core/framework/runtime/core.py:322` — `Callable` → `Callable[[], Any]`

## Testing
- [x] Lint passes (`ruff check`)
- [x] No runtime behaviour changed

## Checklist
- [x] Self-review done
- [x] No new warnings introduced