### PR TITLE
fix(graph): implement Goal.check_constraint() with safe expression evaluation

### DIFF
--- a/core/framework/graph/goal.py
+++ b/core/framework/graph/goal.py
@@ -11,11 +11,14 @@ Goals are:
 - Versionable: Can evolve based on runtime feedback
 """
 
+import logging
 from datetime import datetime
 from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
 
 
 class GoalStatus(StrEnum):
@@ -168,11 +171,48 @@ class Goal(BaseModel):
         return met_weight >= total_weight * 0.9  # 90% threshold
 
     def check_constraint(self, constraint_id: str, value: Any) -> bool:
-        """Check if a specific constraint is satisfied."""
+        """Check if a specific constraint is satisfied.
+
+        Evaluates the constraint's ``check`` expression (if set) using
+        :func:`~framework.graph.safe_eval.safe_eval` with ``value`` bound
+        to the name ``value`` in the evaluation context.
+
+        - If ``check`` is empty the constraint is assumed satisfied (True).
+        - If ``check`` is ``"llm_judge"`` or an unresolvable function name,
+          validation is skipped and True is returned with a warning.
+        - Hard constraints that raise during evaluation are treated as
+          *not satisfied* (False); soft constraints fall back to True.
+        """
         for c in self.constraints:
             if c.id == constraint_id:
-                # This would be expanded with actual evaluation logic
-                return True
+                if not c.check:
+                    return True
+
+                if c.check == "llm_judge":
+                    logger.warning(
+                        "Constraint '%s' uses llm_judge which is not yet "
+                        "implemented; treating as satisfied.",
+                        constraint_id,
+                    )
+                    return True
+
+                # Evaluate as a Python expression via safe_eval
+                from framework.graph.safe_eval import safe_eval
+
+                try:
+                    result = safe_eval(c.check, {"value": value})
+                    return bool(result)
+                except Exception as exc:
+                    logger.warning(
+                        "Constraint '%s' evaluation failed (%s); "
+                        "treating as %s.",
+                        constraint_id,
+                        exc,
+                        "not satisfied" if c.constraint_type == "hard" else "satisfied",
+                    )
+                    return c.constraint_type != "hard"
+
+        # Constraint ID not found — nothing to enforce
         return True
 
     def to_prompt_context(self) -> str:


### PR DESCRIPTION
## Description
`Goal.check_constraint()` was a stub that always returned `True`, making constraint validation completely ineffective. This PR implements expression-based evaluation using the existing `safe_eval` utility so constraints with a `check` field are actually enforced.

## Type of Change
- [x] Bug fix / feature implementation

## Related Issues
Fixes #741

## Changes Made
- `core/framework/graph/goal.py` — Replaced the always-True stub with real logic:
  - If `check` is empty → return `True` (no validator defined)
  - If `check == "llm_judge"` → log warning and return `True` (not yet implemented)
  - Otherwise → evaluate `check` as a Python expression via `safe_eval` with `value` in context
  - Hard constraints return `False` on evaluation error; soft constraints fall back to `True`

## Testing
- [x] Lint passes (`ruff check`)
- [x] Expression evaluation tested manually: `"value < 1000"` with `value=500` → True; `value=2000` → False

## Checklist
- [x] Self-review done
- [x] No new warnings introduced