### PR TITLE
fix(runtime): add early validation in AgentRuntime.__init__ for required args

### DIFF
--- a/core/framework/runtime/agent_runtime.py
+++ b/core/framework/runtime/agent_runtime.py
@@ -154,6 +154,15 @@ class AgentRuntime:
                 this bus instead of creating its own. Used by SessionManager to
                 share a single bus between queen, worker, and judge.
         """
+        if graph is None:
+            raise ValueError("AgentRuntime requires a graph; got None.")
+        if goal is None:
+            raise ValueError("AgentRuntime requires a goal; got None.")
+        if storage_path is None:
+            raise ValueError("AgentRuntime requires a storage_path; got None.")
+        if isinstance(storage_path, str) and not storage_path.strip():
+            raise ValueError("AgentRuntime requires a non-empty storage_path.")
+
         self.graph = graph
         self.goal = goal
         self._config = config or AgentRuntimeConfig()


### PR DESCRIPTION
## Description
`AgentRuntime.__init__` accepted `None` for `graph`, `goal`, and `storage_path` without complaint, deferring failures to deep async execution paths that are hard to debug. This PR adds explicit `ValueError` guards at the top of `__init__` so callers get an immediate, actionable error message.

## Type of Change
- [x] Bug fix / defensive improvement

## Related Issues
Fixes #1014

## Changes Made
- `core/framework/runtime/agent_runtime.py:157-164` — Added four guard checks before any assignments:
  - `graph is None` → ValueError
  - `goal is None` → ValueError
  - `storage_path is None` → ValueError
  - `storage_path` is a blank string → ValueError

## Testing
- [x] Lint passes (`ruff check`)
- [x] No existing tests broken

## Checklist
- [x] Self-review done
- [x] No new warnings introduced