### PR TITLE
fix(server): prevent "Session already exists" error on agent re-open / cold-restore

### DIFF
--- a/core/framework/server/session_manager.py
+++ b/core/framework/server/session_manager.py
@@ -103,6 +103,16 @@ class SessionManager:
 
         async with self._lock:
             if resolved_id in self._sessions:
+                if session_id is not None:
+                    # Caller explicitly requested an existing session ID (e.g. a
+                    # cold-restore that races with the still-alive in-memory
+                    # session).  Return the live session instead of erroring so
+                    # the frontend can reconnect without a 409.
+                    logger.warning(
+                        "Session '%s' already exists in memory; returning existing session.",
+                        resolved_id,
+                    )
+                    return self._sessions[resolved_id]
                 raise ValueError(f"Session '{resolved_id}' already exists")
 
         # Load LLM config from ~/.hive/configuration.json
@@ -676,6 +686,15 @@ class SessionManager:
         history accumulates in one place across server restarts.
         """
         from framework.server.queen_orchestrator import create_queen
+
+        # If the queen is already running (e.g. we returned an existing in-memory
+        # session instead of creating a new one), do not start a second queen.
+        if session.queen_task is not None and not session.queen_task.done():
+            logger.debug(
+                "Session '%s' queen already running; skipping _start_queen.",
+                session.id,
+            )
+            return
 
         hive_home = Path.home() / ".hive"
 


### PR DESCRIPTION
## Description
After navigating between multiple agents, opening an existing agent could raise `"Session 'session_...' already exists"` (HTTP 409), displayed in the UI as *"Backend unavailable"*. This happened when a cold-restore request passed a `session_id` that was still alive in memory.

Two-part fix:
1. **`_create_session_core`** — when the caller explicitly provides a `session_id` that already exists in memory, return the live session rather than raising a `ValueError`. Auto-generated IDs (no explicit `session_id`) still raise on collision (essentially impossible with UUID).
2. **`_start_queen`** — guard against starting a duplicate queen task if the session's queen is already running (guards the case where we returned an existing live session).

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #6334

## Changes Made
- `core/framework/server/session_manager.py:_create_session_core` — return existing session on explicit ID conflict (with warning log)
- `core/framework/server/session_manager.py:_start_queen` — skip if `queen_task` is already running

## Testing
- [x] Lint passes (`ruff check`)
- [x] Reproduces scenario: explicitly passing an existing `session_id` no longer raises

## Checklist
- [x] Self-review done
- [x] No new warnings introduced