### PR TITLE
fix(server): restore /chat worker-first routing, 404 unknown API routes, fix mock drift

### DIFF
--- a/core/framework/server/app.py
+++ b/core/framework/server/app.py
@@ -278,9 +278,22 @@ def _setup_static_serving(app: web.Application) -> None:
 
     logger.info(f"Serving frontend from {dist_dir}")
 
-    async def handle_spa(request: web.Request) -> web.FileResponse:
-        """Serve static files with SPA fallback to index.html."""
+    async def handle_spa(request: web.Request) -> web.Response:
+        """Serve static files with SPA fallback to index.html.
+
+        API paths that don't match a registered route must not be served
+        as HTML — return a JSON 404 so clients get a proper error response
+        instead of unexpected HTML.
+        """
         rel_path = request.match_info.get("path", "")
+
+        # Never serve HTML for unmatched /api/* paths
+        if rel_path.startswith("api/") or rel_path == "api":
+            return web.json_response(
+                {"error": f"API route not found: /{rel_path}"},
+                status=404,
+            )
+
         file_path = (dist_dir / rel_path).resolve()
 
         if file_path.is_file() and file_path.is_relative_to(dist_dir):

--- a/core/framework/server/routes_execution.py
+++ b/core/framework/server/routes_execution.py
@@ -103,10 +103,11 @@ async def handle_inject(request: web.Request) -> web.Response:
 
 
 async def handle_chat(request: web.Request) -> web.Response:
-    """POST /api/sessions/{session_id}/chat — send a message to the queen.
+    """POST /api/sessions/{session_id}/chat — smart-route a message.
 
-    The input box is permanently connected to the queen agent.
-    Worker input is handled separately via /worker-input.
+    Routing priority (documented behavior):
+    1. If the worker runtime has a node awaiting input, inject there.
+    2. Otherwise, send to the queen.
 
     Body: {"message": "hello"}
     """
@@ -120,6 +121,25 @@ async def handle_chat(request: web.Request) -> web.Response:
     if not message:
         return web.json_response({"error": "message is required"}, status=400)
 
+    # 1. Worker-first: inject into a waiting worker node when available
+    if session.worker_runtime is not None:
+        node_id, graph_id = session.worker_runtime.find_awaiting_node()
+        if node_id:
+            delivered = await session.worker_runtime.inject_input(
+                node_id,
+                message,
+                graph_id=graph_id,
+                is_client_input=True,
+            )
+            return web.json_response(
+                {
+                    "status": "worker",
+                    "delivered": delivered,
+                    "node_id": node_id,
+                }
+            )
+
+    # 2. Fall through to the queen
     queen_executor = session.queen_executor
     if queen_executor is not None:
         node = queen_executor.node_registry.get("queen")

--- a/core/framework/server/tests/test_api.py
+++ b/core/framework/server/tests/test_api.py
@@ -81,7 +81,7 @@ class MockStream:
     _active_executors: dict = field(default_factory=dict)
     active_execution_ids: set = field(default_factory=set)
 
-    async def cancel_execution(self, execution_id: str) -> bool:
+    async def cancel_execution(self, execution_id: str, *, reason: str | None = None) -> bool:
         return execution_id in self._execution_tasks
 
 


### PR DESCRIPTION
## Description
Three small server contract bugs from the `test_api.py` regression notes.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #6252

## Changes Made

### 1. `routes_execution.py` — `/chat` worker-first routing
`handle_chat()` was sending every message to the queen without checking the worker. Added the documented priority:
1. If `session.worker_runtime.find_awaiting_node()` returns a node → inject there and return `{"status": "worker", ...}`
2. Otherwise fall through to the queen as before.

### 2. `app.py` — Unknown `/api/*` routes return JSON 404
`handle_spa()` was catching all unmatched GET paths including `/api/nonexistent`, returning `index.html` with status 200. Added a guard: if `rel_path` starts with `api/`, return `{"error": "API route not found: /..."}` with status 404.

### 3. `tests/test_api.py` — `MockStream.cancel_execution` signature
The real `ExecutionStream.cancel_execution` accepts `reason: str | None = None` as a keyword-only arg. Updated the mock to match.

## Testing
- [x] Lint passes (`ruff check`)
- [x] API tests can now match real stream signature

## Checklist
- [x] Self-review done
- [x] No new warnings introduced