### PR TITLE
fix(scripts): add DeepSeek, OpenRouter, Together AI, Mistral, xAI, Perplexity to check_llm_key.py

### DIFF
--- a/scripts/check_llm_key.py
+++ b/scripts/check_llm_key.py
@@ -135,6 +135,25 @@ PROVIDERS = {
     "kimi": lambda key, **kw: check_anthropic_compatible(
         key, "https://api.kimi.com/coding/v1/messages", "Kimi"
     ),
+    # OpenAI-compatible providers
+    "deepseek": lambda key, **kw: check_openai_compatible(
+        key, "https://api.deepseek.com/v1/models", "DeepSeek"
+    ),
+    "openrouter": lambda key, **kw: check_openai_compatible(
+        key, "https://openrouter.ai/api/v1/models", "OpenRouter"
+    ),
+    "together": lambda key, **kw: check_openai_compatible(
+        key, "https://api.together.xyz/v1/models", "Together AI"
+    ),
+    "mistral": lambda key, **kw: check_openai_compatible(
+        key, "https://api.mistral.ai/v1/models", "Mistral"
+    ),
+    "xai": lambda key, **kw: check_openai_compatible(
+        key, "https://api.x.ai/v1/models", "xAI"
+    ),
+    "perplexity": lambda key, **kw: check_openai_compatible(
+        key, "https://api.perplexity.ai/models", "Perplexity"
+    ),
 }
 
 


### PR DESCRIPTION
## Description
`check_llm_key.py` only supported 5 providers. This PR adds the 6 most-requested OpenAI-compatible providers by reusing the existing `check_openai_compatible()` helper — no new logic needed.

## Type of Change
- [x] Feature / enhancement

## Related Issues
Fixes #6063

## Changes Made
`scripts/check_llm_key.py` — added to `PROVIDERS`:

| Provider | Endpoint |
|----------|----------|
| `deepseek` | `https://api.deepseek.com/v1/models` |
| `openrouter` | `https://openrouter.ai/api/v1/models` |
| `together` | `https://api.together.xyz/v1/models` |
| `mistral` | `https://api.mistral.ai/v1/models` |
| `xai` | `https://api.x.ai/v1/models` |
| `perplexity` | `https://api.perplexity.ai/models` |

## Testing
- [x] Lint passes (`ruff check`)
- [x] All use the existing `check_openai_compatible()` path (GET /models + Bearer auth)

## Checklist
- [x] Self-review done
- [x] No new warnings introduced