### PR TITLE
fix(testing): guard against empty/tool-use content in llm_judge.evaluate()

### DIFF
--- a/core/framework/testing/llm_judge.py
+++ b/core/framework/testing/llm_judge.py
@@ -106,7 +106,12 @@ Respond with JSON: {{"passes": true/false, "explanation": "..."}}"""
                     max_tokens=500,
                     messages=[{"role": "user", "content": prompt}],
                 )
-                return self._parse_json_result(response.content[0].text.strip())
+                text_block = next(
+                    (b for b in (response.content or []) if hasattr(b, "text")),
+                    None,
+                )
+                raw_text = text_block.text.strip() if text_block else ""
+                return self._parse_json_result(raw_text)
             else:
                 # Use env-based fallback (LiteLLM or AnthropicProvider)
                 active_provider = fallback_provider


### PR DESCRIPTION
## Description
`response.content[0].text` in `LLMJudge.evaluate()` raised `IndexError` when content was empty and `AttributeError` when the first block was a `ToolUseBlock`. The fix safely finds the first text block with `next(b for b in content if hasattr(b, "text"), None)`.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #816

## Changes Made
- `core/framework/testing/llm_judge.py:109` — replaced direct `content[0].text` access with a safe `next()` over the content list

## Testing
- [x] Lint passes (`ruff check`)
- [x] No existing tests broken

## Checklist
- [x] Self-review done
- [x] No new warnings introduced