### PR TITLE
feat(tools): add centralized aden_tools.logging helper (stderr-safe, idempotent)

### DIFF
--- a/tools/src/aden_tools/__init__.py
+++ b/tools/src/aden_tools/__init__.py
@@ -25,6 +25,7 @@ from .credentials import (
 )
 
 # Utilities (no external dependencies)
+from .logging import configure_logging, get_logger
 from .utils import get_env_var
 
 
@@ -42,6 +43,8 @@ __all__ = [
     "__version__",
     # Utilities
     "get_env_var",
+    "configure_logging",
+    "get_logger",
     # Credentials
     "CredentialStoreAdapter",
     "CredentialSpec",

--- a/tools/src/aden_tools/logging.py
+++ b/tools/src/aden_tools/logging.py
@@ -1,0 +1,90 @@
+"""Centralized logging configuration for aden_tools.
+
+Usage::
+
+    from aden_tools.logging import get_logger
+
+    logger = get_logger(__name__)
+    logger.info("Tool initialised")
+
+Environment variables
+---------------------
+ADEN_TOOLS_LOG_LEVEL  : Log level (default: ``INFO``). Accepts any value
+                        accepted by :func:`logging.getLevelName` (e.g.
+                        ``DEBUG``, ``WARNING``, ``ERROR``).
+ADEN_TOOLS_LOG_FORMAT : Log format string (default: a compact timestamped
+                        format written to *stderr*).
+
+Notes
+-----
+* All handlers write to **stderr** so that stdout remains clean for
+  MCP STDIO / JSON-RPC communication.
+* :func:`configure_logging` is idempotent — calling it multiple times
+  does **not** add duplicate handlers.
+* Avoid passing reserved :class:`logging.LogRecord` field names (such as
+  ``name``, ``message``, ``asctime``) in the ``extra`` dict; use
+  descriptive alternatives like ``file_name`` or ``tool_name`` instead.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+_CONFIGURED = False
+_DEFAULT_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+_LOGGER_NAME = "aden_tools"
+
+
+def configure_logging(
+    level: int | str | None = None,
+    fmt: str | None = None,
+) -> None:
+    """Configure the *aden_tools* root logger.
+
+    Safe to call multiple times — only installs the handler once.
+
+    Args:
+        level: Logging level.  Defaults to ``ADEN_TOOLS_LOG_LEVEL`` env var,
+               falling back to ``INFO``.
+        fmt:   Log format string.  Defaults to ``ADEN_TOOLS_LOG_FORMAT`` env
+               var, falling back to a compact timestamp format.
+    """
+    global _CONFIGURED  # noqa: PLW0603
+    if _CONFIGURED:
+        return
+
+    resolved_level = level or os.environ.get("ADEN_TOOLS_LOG_LEVEL", "INFO")
+    resolved_fmt = fmt or os.environ.get("ADEN_TOOLS_LOG_FORMAT", _DEFAULT_FORMAT)
+
+    root = logging.getLogger(_LOGGER_NAME)
+
+    if not root.handlers:
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter(resolved_fmt))
+        root.addHandler(handler)
+
+    try:
+        root.setLevel(resolved_level)
+    except (ValueError, TypeError):
+        root.setLevel(logging.INFO)
+
+    _CONFIGURED = True
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger namespaced under *aden_tools*.
+
+    Args:
+        name: Typically ``__name__`` of the calling module.
+
+    Returns:
+        A :class:`logging.Logger` configured to write to stderr.
+    """
+    configure_logging()
+    # Ensure the logger is a child of the aden_tools hierarchy so it
+    # inherits the handler installed by configure_logging().
+    if not name.startswith(_LOGGER_NAME):
+        name = f"{_LOGGER_NAME}.{name}"
+    return logging.getLogger(name)

--- a/tools/tests/test_logging.py
+++ b/tools/tests/test_logging.py
@@ -1,0 +1,54 @@
+"""Tests for aden_tools.logging module."""
+
+import logging
+
+
+def test_get_logger_returns_logger():
+    from aden_tools.logging import get_logger
+
+    logger = get_logger(__name__)
+    assert isinstance(logger, logging.Logger)
+
+
+def test_get_logger_namespaced():
+    from aden_tools.logging import get_logger
+
+    logger = get_logger("my_tool")
+    assert logger.name.startswith("aden_tools")
+
+
+def test_configure_logging_idempotent():
+    """Calling configure_logging() multiple times must not add duplicate handlers."""
+    import aden_tools.logging as mod
+
+    # Reset state so we start clean regardless of import order in test suite
+    mod._CONFIGURED = False
+    root = logging.getLogger("aden_tools")
+    root.handlers.clear()
+
+    mod.configure_logging()
+    handlers_after_first = len(root.handlers)
+
+    mod._CONFIGURED = False  # allow re-entry
+    mod.configure_logging()
+    handlers_after_second = len(root.handlers)
+
+    # configure_logging sets _CONFIGURED=True on first call; second call is a no-op
+    assert handlers_after_first == handlers_after_second
+
+
+def test_configure_logging_uses_env_level(monkeypatch):
+    import aden_tools.logging as mod
+
+    monkeypatch.setenv("ADEN_TOOLS_LOG_LEVEL", "DEBUG")
+    mod._CONFIGURED = False
+    root = logging.getLogger("aden_tools")
+    root.handlers.clear()
+
+    mod.configure_logging()
+    assert root.level == logging.DEBUG
+
+    # Cleanup
+    mod._CONFIGURED = False
+    root.handlers.clear()
+    monkeypatch.delenv("ADEN_TOOLS_LOG_LEVEL", raising=False)


### PR DESCRIPTION
## Description
`aden_tools` had no shared logging standard. Tool authors used `logging.getLogger(__name__)` directly, with no guarantee that logs went to stderr (breaking MCP STDIO), and some used reserved `extra` keys like `"name"` that crash with `KeyError`. This PR adds a thin, centralized helper.

## Type of Change
- [x] Feature / enhancement

## Related Issues
Fixes #1477

## Changes Made

### `tools/src/aden_tools/logging.py` (new)
- `get_logger(name)` — returns a namespaced logger under `aden_tools.*`
- `configure_logging()` — idempotent; installs a **stderr** `StreamHandler` once; respects `ADEN_TOOLS_LOG_LEVEL` / `ADEN_TOOLS_LOG_FORMAT` env vars

### `tools/src/aden_tools/__init__.py`
- Exports `get_logger` and `configure_logging`

### `tools/tests/test_logging.py` (new)
- 4 tests: basic logger creation, namespace check, idempotency, env-level override

## Testing
- [x] All 4 new tests pass (`uv run python -m pytest tests/test_logging.py -v`)
- [x] Lint passes (`ruff check`)

## Checklist
- [x] Self-review done
- [x] No new warnings introduced