### PR TITLE
feat(setup): add OpenRouter as a first-class provider in quickstart scripts

### DIFF
--- a/quickstart.ps1
+++ b/quickstart.ps1
@@ -786,6 +786,7 @@ $ProviderMap = [ordered]@{
     MISTRAL_API_KEY   = @{ Name = "Mistral";             Id = "mistral" }
     TOGETHER_API_KEY  = @{ Name = "Together AI";         Id = "together" }
     DEEPSEEK_API_KEY  = @{ Name = "DeepSeek";            Id = "deepseek" }
+    OPENROUTER_API_KEY = @{ Name = "OpenRouter";         Id = "openrouter" }
 }
 
 $DefaultModels = @{
@@ -797,6 +798,7 @@ $DefaultModels = @{
     mistral     = "mistral-large-latest"
     together_ai = "meta-llama/Llama-3.3-70B-Instruct-Turbo"
     deepseek    = "deepseek-chat"
+    openrouter  = "openrouter/auto"
 }
 
 # Model choices: array of hashtables per provider

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -388,6 +388,7 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
         ["MISTRAL_API_KEY"]="Mistral"
         ["TOGETHER_API_KEY"]="Together AI"
         ["DEEPSEEK_API_KEY"]="DeepSeek"
+        ["OPENROUTER_API_KEY"]="OpenRouter"
     )
 
     declare -A PROVIDER_IDS=(
@@ -401,6 +402,7 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
         ["MISTRAL_API_KEY"]="mistral"
         ["TOGETHER_API_KEY"]="together"
         ["DEEPSEEK_API_KEY"]="deepseek"
+        ["OPENROUTER_API_KEY"]="openrouter"
     )
 
     declare -A DEFAULT_MODELS=(
@@ -413,6 +415,7 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
         ["mistral"]="mistral-large-latest"
         ["together_ai"]="meta-llama/Llama-3.3-70B-Instruct-Turbo"
         ["deepseek"]="deepseek-chat"
+        ["openrouter"]="openrouter/auto"
     )
 
     # Model choices per provider: composite-key associative arrays
@@ -521,13 +524,13 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
     }
 else
     # Bash 3.2 - use parallel indexed arrays
-    PROVIDER_ENV_VARS=(ANTHROPIC_API_KEY OPENAI_API_KEY MINIMAX_API_KEY GEMINI_API_KEY GOOGLE_API_KEY GROQ_API_KEY CEREBRAS_API_KEY MISTRAL_API_KEY TOGETHER_API_KEY DEEPSEEK_API_KEY)
+    PROVIDER_ENV_VARS=(ANTHROPIC_API_KEY OPENAI_API_KEY MINIMAX_API_KEY GEMINI_API_KEY GOOGLE_API_KEY GROQ_API_KEY CEREBRAS_API_KEY MISTRAL_API_KEY TOGETHER_API_KEY DEEPSEEK_API_KEY OPENROUTER_API_KEY)
     PROVIDER_DISPLAY_NAMES=("Anthropic (Claude)" "OpenAI (GPT)" "MiniMax" "Google Gemini" "Google AI" "Groq" "Cerebras" "Mistral" "Together AI" "DeepSeek")
-    PROVIDER_ID_LIST=(anthropic openai minimax gemini google groq cerebras mistral together deepseek)
+    PROVIDER_ID_LIST=(anthropic openai minimax gemini google groq cerebras mistral together deepseek openrouter)
 
     # Default models by provider id (parallel arrays)
-    MODEL_PROVIDER_IDS=(anthropic openai minimax gemini groq cerebras mistral together_ai deepseek)
-    MODEL_DEFAULTS=("claude-haiku-4-5-20251001" "gpt-5-mini" "MiniMax-M2.5" "gemini-3-flash-preview" "moonshotai/kimi-k2-instruct-0905" "zai-glm-4.7" "mistral-large-latest" "meta-llama/Llama-3.3-70B-Instruct-Turbo" "deepseek-chat")
+    MODEL_PROVIDER_IDS=(anthropic openai minimax gemini groq cerebras mistral together_ai deepseek openrouter)
+    MODEL_DEFAULTS=("claude-haiku-4-5-20251001" "gpt-5-mini" "MiniMax-M2.5" "gemini-3-flash-preview" "moonshotai/kimi-k2-instruct-0905" "zai-glm-4.7" "mistral-large-latest" "meta-llama/Llama-3.3-70B-Instruct-Turbo" "deepseek-chat" "openrouter/auto")
 
     # Helper: get provider display name for an env var
     get_provider_name() {


### PR DESCRIPTION
## Description
Registers `OPENROUTER_API_KEY` in the provider detection and configuration arrays of both `quickstart.sh` and `quickstart.ps1`, so users who have an OpenRouter key can use it in the setup wizard just like any other provider.

## Type of Change
- [x] Feature / enhancement

## Related Issues
Fixes #6305

## Changes Made

**`quickstart.sh`**
- Added `["OPENROUTER_API_KEY"]="OpenRouter"` to `PROVIDER_NAMES`
- Added `["OPENROUTER_API_KEY"]="openrouter"` to `PROVIDER_IDS`
- Added `["openrouter"]="openrouter/auto"` to `DEFAULT_MODELS`
- Added `OPENROUTER_API_KEY` to `PROVIDER_ENV_VARS`
- Added `openrouter` to `PROVIDER_ID_LIST` and `MODEL_PROVIDER_IDS`
- Added `"openrouter/auto"` to `MODEL_DEFAULTS`

**`quickstart.ps1`**
- Added `OPENROUTER_API_KEY` entry to `$Providers`
- Added `openrouter = "openrouter/auto"` to `$DefaultModels`

**Existing infrastructure already covered:**
- `scripts/check_llm_key.py` — OpenRouter key validation (PR #6467)
- LiteLLM natively handles `openrouter/*` model strings — no provider code changes needed

## Testing
- [x] No tests broken (setup scripts are not unit-tested in CI)

## Checklist
- [x] Self-review done