### PR TITLE
feat(tools): add Country Info Tool using restcountries.com

### DIFF
--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -46,6 +46,7 @@ from .calendar_tool import register_tools as register_calendar
 from .calendly_tool import register_tools as register_calendly
 from .cloudinary_tool import register_tools as register_cloudinary
 from .confluence_tool import register_tools as register_confluence
+from .country_info_tool import register_tools as register_country_info
 from .csv_tool import register_tools as register_csv
 from .databricks_tool import register_tools as register_databricks
 from .discord_tool import register_tools as register_discord
@@ -232,6 +233,7 @@ def _register_unverified(
 ) -> None:
     """Register unverified (new/community) tools."""
     # --- No credentials ---
+    register_country_info(mcp)
     register_duckduckgo(mcp)
     register_yahoo_finance(mcp)
     register_youtube_transcript(mcp)

--- a/tools/src/aden_tools/tools/country_info_tool/__init__.py
+++ b/tools/src/aden_tools/tools/country_info_tool/__init__.py
@@ -1,0 +1,5 @@
+"""Country Info Tool package."""
+
+from .country_info_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/country_info_tool/country_info_tool.py
+++ b/tools/src/aden_tools/tools/country_info_tool/country_info_tool.py
@@ -1,0 +1,154 @@
+"""
+Country Info Tool - Free country data via restcountries.com.
+
+Provides country data including currencies, languages, timezones,
+calling codes, and flags. No API key required.
+"""
+
+from __future__ import annotations
+
+import httpx
+from fastmcp import FastMCP
+
+_BASE_URL = "https://restcountries.com/v3.1"
+_FIELDS = (
+    "name,cca2,cca3,currencies,languages,timezones,idd,flags,population,"
+    "capital,region,subregion"
+)
+
+
+def _simplify_country(data: dict) -> dict:
+    """Extract the most useful fields from a restcountries response object."""
+    currencies = {
+        code: info.get("name", code)
+        for code, info in (data.get("currencies") or {}).items()
+    }
+    languages = list((data.get("languages") or {}).values())
+    calling_codes: list[str] = []
+    idd = data.get("idd") or {}
+    root = idd.get("root", "")
+    suffixes = idd.get("suffixes") or []
+    if root and suffixes:
+        calling_codes = [f"{root}{s}" for s in suffixes]
+    elif root:
+        calling_codes = [root]
+
+    return {
+        "name": (data.get("name") or {}).get("common", ""),
+        "official_name": (data.get("name") or {}).get("official", ""),
+        "cca2": data.get("cca2", ""),
+        "cca3": data.get("cca3", ""),
+        "capital": (data.get("capital") or [None])[0],
+        "region": data.get("region", ""),
+        "subregion": data.get("subregion", ""),
+        "population": data.get("population", 0),
+        "currencies": currencies,
+        "languages": languages,
+        "timezones": data.get("timezones") or [],
+        "calling_codes": calling_codes,
+        "flag_emoji": (data.get("flags") or {}).get("alt", ""),
+        "flag_png": (data.get("flags") or {}).get("png", ""),
+    }
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register country info tools with the MCP server."""
+
+    @mcp.tool()
+    def country_get_by_name(name: str, full_text: bool = False) -> dict:
+        """
+        Get country data by country name.
+
+        Args:
+            name: Country name to search for (e.g. "Germany", "United States").
+            full_text: If True, only exact full-name matches are returned.
+                       If False (default), partial matches are included.
+
+        Returns:
+            Dictionary with a "countries" list. Each entry contains:
+            - name, official_name: common and official country names
+            - cca2, cca3: ISO 2- and 3-letter codes
+            - capital, region, subregion, population
+            - currencies: {code: name} mapping
+            - languages: list of language names
+            - timezones: list of timezone strings
+            - calling_codes: list of phone prefixes
+            - flag_emoji, flag_png: flag description and PNG URL
+        """
+        try:
+            params = {"fields": _FIELDS}
+            if full_text:
+                params["fullText"] = "true"
+            resp = httpx.get(
+                f"{_BASE_URL}/name/{name}",
+                params=params,
+                timeout=10.0,
+            )
+            if resp.status_code == 404:
+                return {"error": f"No country found matching name: {name!r}"}
+            resp.raise_for_status()
+            return {"countries": [_simplify_country(c) for c in resp.json()]}
+        except httpx.HTTPStatusError as exc:
+            return {"error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}"}
+        except Exception as exc:
+            return {"error": str(exc)}
+
+    @mcp.tool()
+    def country_get_by_code(code: str) -> dict:
+        """
+        Get country data by ISO alpha-2 or alpha-3 code.
+
+        Args:
+            code: ISO 3166-1 alpha-2 (e.g. "DE") or alpha-3 (e.g. "DEU") country code.
+                  Case-insensitive.
+
+        Returns:
+            Dictionary with a "country" key containing the same fields as
+            country_get_by_name, or an "error" key on failure.
+        """
+        try:
+            resp = httpx.get(
+                f"{_BASE_URL}/alpha/{code}",
+                params={"fields": _FIELDS},
+                timeout=10.0,
+            )
+            if resp.status_code == 404:
+                return {"error": f"No country found for code: {code!r}"}
+            resp.raise_for_status()
+            data = resp.json()
+            # API returns a list when given /alpha/{code}
+            if isinstance(data, list):
+                data = data[0]
+            return {"country": _simplify_country(data)}
+        except httpx.HTTPStatusError as exc:
+            return {"error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}"}
+        except Exception as exc:
+            return {"error": str(exc)}
+
+    @mcp.tool()
+    def country_get_by_currency(currency_code: str) -> dict:
+        """
+        Find all countries that use a specific currency.
+
+        Args:
+            currency_code: ISO 4217 currency code (e.g. "EUR", "USD", "GBP").
+                           Case-insensitive.
+
+        Returns:
+            Dictionary with a "countries" list of country objects that use the
+            specified currency, or an "error" key on failure.
+        """
+        try:
+            resp = httpx.get(
+                f"{_BASE_URL}/currency/{currency_code}",
+                params={"fields": _FIELDS},
+                timeout=10.0,
+            )
+            if resp.status_code == 404:
+                return {"error": f"No countries found using currency: {currency_code!r}"}
+            resp.raise_for_status()
+            return {"countries": [_simplify_country(c) for c in resp.json()]}
+        except httpx.HTTPStatusError as exc:
+            return {"error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}"}
+        except Exception as exc:
+            return {"error": str(exc)}


### PR DESCRIPTION
## Description
Adds a Country Info Tool that wraps the free [restcountries.com](https://restcountries.com) API (no API key, no signup, Mozilla Public License 2.0). Provides rich country data for agents handling international workflows, e-commerce, travel, or localization.

## Type of Change
- [x] New feature (new tool integration)

## Related Issues
Fixes #6138

## Changes Made
- `tools/src/aden_tools/tools/country_info_tool/country_info_tool.py` — three MCP tools:
  - `country_get_by_name(name, full_text?)` — search by country name, returns list of matches
  - `country_get_by_code(code)` — lookup by ISO alpha-2 ("DE") or alpha-3 ("DEU") code
  - `country_get_by_currency(currency_code)` — find all countries using a currency ("EUR", "USD")
- `tools/src/aden_tools/tools/country_info_tool/__init__.py` — package init
- `tools/src/aden_tools/tools/__init__.py` — registered in `_register_unverified()`

Each tool returns: name, official_name, ISO codes, capital, region, population, currencies, languages, timezones, calling codes, flag emoji/PNG.

## Testing
- [x] Lint passes (`ruff check` clean)
- [x] httpx already a project dependency (no new deps)

## Checklist
- [x] Self-review done
- [x] No new warnings introduced
- [x] No API key required