### PR TITLE
[micro-fix] fix(config): add DEFAULT_HIVE_MODEL to align CLI and runtime defaults

### DIFF
--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -20,6 +20,8 @@ import argparse
 import sys
 from pathlib import Path
 
+from framework.config import DEFAULT_HIVE_MODEL
+
 
 def _configure_paths():
     """Auto-configure sys.path so agents in exports/ are discoverable.
@@ -73,8 +75,8 @@ def main():
     )
     parser.add_argument(
         "--model",
-        default="claude-haiku-4-5-20251001",
-        help="Anthropic model to use",
+        default=DEFAULT_HIVE_MODEL,
+        help="LLM model to use (any LiteLLM-compatible name)",
     )
 
     subparsers = parser.add_subparsers(dest="command", required=True)

--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -21,6 +21,11 @@ from framework.graph.edge import DEFAULT_MAX_TOKENS
 HIVE_CONFIG_FILE = Path.home() / ".hive" / "configuration.json"
 logger = logging.getLogger(__name__)
 
+# Single source of truth for the fallback model used when no configuration exists.
+# Both the CLI (framework/cli.py --model default) and get_preferred_model() reference
+# this constant so they always agree when the user has no ~/.hive/configuration.json.
+DEFAULT_HIVE_MODEL = "anthropic/claude-haiku-4-5-20251001"
+
 
 def get_hive_config() -> dict[str, Any]:
     """Load hive configuration from ~/.hive/configuration.json."""
@@ -44,11 +49,15 @@ def get_hive_config() -> dict[str, Any]:
 
 
 def get_preferred_model() -> str:
-    """Return the user's preferred LLM model string (e.g. 'anthropic/claude-sonnet-4-20250514')."""
+    """Return the user's preferred LLM model string (e.g. 'anthropic/claude-haiku-4-5-20251001').
+
+    Falls back to DEFAULT_HIVE_MODEL when no configuration file is present,
+    matching the default used by the hive CLI --model flag.
+    """
     llm = get_hive_config().get("llm", {})
     if llm.get("provider") and llm.get("model"):
         return f"{llm['provider']}/{llm['model']}"
-    return "anthropic/claude-sonnet-4-20250514"
+    return DEFAULT_HIVE_MODEL
 
 
 def get_max_tokens() -> int:


### PR DESCRIPTION
## Description
`framework/cli.py` defaulted `--model` to `claude-haiku-4-5-20251001` while `get_preferred_model()` fell back to `anthropic/claude-sonnet-4-20250514` — two different models and formats. This caused confusing behaviour where `hive run` would silently use a different model than the CLI indicated.

## Type of Change
- [x] Micro-fix (<20 lines, no logic/API change)

## Related Issues
Fixes #5417

## Changes Made
- `core/framework/config.py` — added `DEFAULT_HIVE_MODEL = "anthropic/claude-haiku-4-5-20251001"` constant; updated `get_preferred_model()` to use it as the fallback instead of hardcoded sonnet string
- `core/framework/cli.py` — import and use `DEFAULT_HIVE_MODEL` for the `--model` default; updated help text to say "LiteLLM-compatible name"

## Testing
- [x] Lint passes (`ruff check` clean)
- [x] Existing tests unaffected

## Checklist
- [x] Self-review done
- [x] Single source of truth for default model