### PR TITLE
[micro-fix] fix(credentials): re-raise CredentialRefreshError instead of returning stale credential

### DIFF
--- a/core/framework/credentials/store.py
+++ b/core/framework/credentials/store.py
@@ -528,9 +528,9 @@ class CredentialStore:
             logger.info(f"Refreshed credential '{credential.id}'")
             return refreshed
 
-        except CredentialRefreshError as e:
-            logger.error(f"Failed to refresh credential '{credential.id}': {e}")
-            return credential
+        except CredentialRefreshError:
+            logger.error(f"Failed to refresh credential '{credential.id}'")
+            raise
 
     def refresh_credential(self, credential_id: str) -> CredentialObject | None:
         """


### PR DESCRIPTION
## Description
`_refresh_credential()` caught `CredentialRefreshError`, logged it, and returned the stale/expired credential. This hid the failure from callers, causing confusing downstream authentication failures with no clear signal about the root cause.

## Type of Change
- [x] Micro-fix (<20 lines, no logic/API change)

## Related Issues
Fixes #5845

## Changes Made
- `core/framework/credentials/store.py:_refresh_credential()` — re-raise `CredentialRefreshError` instead of silently returning the stale credential; removed the exception `as e` binding since the message is now in the exception itself

## Testing
- [x] Lint passes (`ruff check` clean)
- [x] `refresh_credential()` docstring already says "Raises: CredentialRefreshError: If refresh fails" — now actually does so

## Checklist
- [x] Self-review done
- [x] No new warnings introduced