### PR TITLE
fix(runtime): emit GOAL_ADJUSTMENT_NEEDED event when recommendation is adjust

### DIFF
--- a/core/framework/runtime/event_bus.py
+++ b/core/framework/runtime/event_bus.py
@@ -73,6 +73,7 @@ class EventType(StrEnum):
     # Goal tracking
     GOAL_PROGRESS = "goal_progress"
     GOAL_ACHIEVED = "goal_achieved"
+    GOAL_ADJUSTMENT_NEEDED = "goal_adjustment_needed"
     CONSTRAINT_VIOLATION = "constraint_violation"
 
     # Stream lifecycle
@@ -614,6 +615,37 @@ class EventBus:
                 stream_id=stream_id,
                 data={
                     "progress": progress,
+                    "criteria_status": criteria_status,
+                },
+            )
+        )
+
+    async def emit_goal_adjustment_needed(
+        self,
+        stream_id: str,
+        overall_progress: float,
+        reason: str,
+        criteria_status: dict[str, Any],
+    ) -> None:
+        """Emit a goal-adjustment-needed event.
+
+        Published when OutcomeAggregator determines that the running agent
+        requires course correction (stagnation or hard-constraint violation).
+        Subscribers such as Guardian can react autonomously without polling.
+
+        Args:
+            stream_id: ID of the stream that triggered evaluation.
+            overall_progress: Current overall progress score (0.0–1.0).
+            reason: ``"constraint_violation"`` or ``"low_progress_stall"``.
+            criteria_status: Per-criterion status dict from evaluate_goal_progress.
+        """
+        await self.publish(
+            AgentEvent(
+                type=EventType.GOAL_ADJUSTMENT_NEEDED,
+                stream_id=stream_id,
+                data={
+                    "overall_progress": overall_progress,
+                    "reason": reason,
                     "criteria_status": criteria_status,
                 },
             )

--- a/core/framework/runtime/outcome_aggregator.py
+++ b/core/framework/runtime/outcome_aggregator.py
@@ -302,11 +302,30 @@ class OutcomeAggregator:
                 # Get any stream ID for the event
                 stream_ids = {d.stream_id for d in self._decisions}
                 if stream_ids:
+                    stream_id = list(stream_ids)[0]
                     await self._event_bus.emit_goal_progress(
-                        stream_id=list(stream_ids)[0],
+                        stream_id=stream_id,
                         progress=result["overall_progress"],
                         criteria_status=result["criteria_status"],
                     )
+                    # Emit dedicated adjustment signal so Guardian and other
+                    # subscribers can react autonomously without polling.
+                    if result["recommendation"] == "adjust":
+                        violations = result.get("constraint_violations", [])
+                        hard_violations = [
+                            v
+                            for v in violations
+                            if self._is_hard_constraint(v["constraint_id"])
+                        ]
+                        reason = (
+                            "constraint_violation" if hard_violations else "low_progress_stall"
+                        )
+                        await self._event_bus.emit_goal_adjustment_needed(
+                            stream_id=stream_id,
+                            overall_progress=result["overall_progress"],
+                            reason=reason,
+                            criteria_status=result["criteria_status"],
+                        )
 
             return result
 


### PR DESCRIPTION
## Description
`OutcomeAggregator._get_recommendation()` correctly identifies when a running agent needs course correction (stagnation or hard-constraint violation) but the `"adjust"` recommendation was silently dropped — never included in the `GOAL_PROGRESS` event payload, never emitted as a dedicated event. Guardian and other subscribers could not react autonomously; the only way to observe an `"adjust"` signal was to manually poll `get_goal_progress()`.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #5447

## Changes Made
- `core/framework/runtime/event_bus.py` — Added `EventType.GOAL_ADJUSTMENT_NEEDED` to the enum; added `EventBus.emit_goal_adjustment_needed()` helper with `stream_id`, `overall_progress`, `reason`, and `criteria_status` fields
- `core/framework/runtime/outcome_aggregator.py:evaluate_goal_progress()` — After emitting `GOAL_PROGRESS`, also emit `GOAL_ADJUSTMENT_NEEDED` when `recommendation == "adjust"`, with `reason` set to `"constraint_violation"` or `"low_progress_stall"` accordingly

## Testing
- [x] Lint passes (`ruff check` clean)
- [x] Purely additive — no existing behavior changes
- [x] Follows the same publish/subscribe pattern as existing event types

## Checklist
- [x] Self-review done
- [x] No new warnings introduced