### PR TITLE
micro-fix(runner): replace print() with logger.warning() for credential warnings

### DIFF
--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -1145,20 +1145,26 @@ class AgentRunner:
                 # Get OAuth token from Claude Code subscription
                 api_key = get_claude_code_token()
                 if not api_key:
-                    print("Warning: Claude Code subscription configured but no token found.")
-                    print("Run 'claude' to authenticate, then try again.")
+                    logger.warning(
+                        "Claude Code subscription configured but no token found. "
+                        "Run 'claude' to authenticate, then try again."
+                    )
             elif use_codex:
                 # Get OAuth token from Codex subscription
                 api_key = get_codex_token()
                 if not api_key:
-                    print("Warning: Codex subscription configured but no token found.")
-                    print("Run 'codex' to authenticate, then try again.")
+                    logger.warning(
+                        "Codex subscription configured but no token found. "
+                        "Run 'codex' to authenticate, then try again."
+                    )
             elif use_kimi_code:
                 # Get API key from Kimi Code CLI config (~/.kimi/config.toml)
                 api_key = get_kimi_code_token()
                 if not api_key:
-                    print("Warning: Kimi Code subscription configured but no key found.")
-                    print("Run 'kimi /login' to authenticate, then try again.")
+                    logger.warning(
+                        "Kimi Code subscription configured but no key found. "
+                        "Run 'kimi /login' to authenticate, then try again."
+                    )
 
             if api_key and use_claude_code:
                 # Use litellm's built-in Anthropic OAuth support.
@@ -1228,8 +1234,12 @@ class AgentRunner:
                             if api_key_env:
                                 os.environ[api_key_env] = api_key
                         elif api_key_env:
-                            print(f"Warning: {api_key_env} not set. LLM calls will fail.")
-                            print(f"Set it with: export {api_key_env}=your-api-key")
+                            logger.warning(
+                                "%s not set. LLM calls will fail. "
+                                "Set it with: export %s=your-api-key",
+                                api_key_env,
+                                api_key_env,
+                            )
 
             # Fail fast if the agent needs an LLM but none was configured
             if self._llm is None:


### PR DESCRIPTION
## Description
Six `print()` calls in `runner.py` that warn about missing OAuth tokens and API keys are replaced with `logger.warning()` so they are captured by the logging framework and visible in log files and headless agent runs. The file already has `logger = logging.getLogger(__name__)` at line 36.

## Type of Change
- [x] Bug fix / Micro-fix

## Related Issues
Fixes #6484

## Changes Made
- `core/framework/runner/runner.py:1148-1149` — Claude Code subscription no-token warning
- `core/framework/runner/runner.py:1154-1155` — Codex subscription no-token warning
- `core/framework/runner/runner.py:1160-1161` — Kimi Code subscription no-key warning
- `core/framework/runner/runner.py:1231-1232` — env-var not set warning

## Testing
- [x] Lint passes (`ruff check` clean)

## Checklist
- [x] Self-review done
- [x] No new warnings introduced