### PR TITLE
fix(error-handling): replace bare except clauses with logged exceptions

### DIFF
--- a/core/framework/agents/credential_tester/agent.py
+++ b/core/framework/agents/credential_tester/agent.py
@@ -16,6 +16,7 @@ after the user picks an account programmatically.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -34,6 +35,8 @@ from .nodes import build_tester_node
 
 if TYPE_CHECKING:
     from framework.runner import AgentRunner
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Goal
@@ -108,6 +111,7 @@ def _list_aden_accounts() -> list[dict]:
             if c.status == "active"
         ]
     except Exception:
+        logger.warning("Unexpected error listing Aden integrations", exc_info=True)
         return []
 
 
@@ -120,6 +124,7 @@ def _list_local_accounts() -> list[dict]:
             info.to_account_dict() for info in LocalCredentialRegistry.default().list_accounts()
         ]
     except Exception:
+        logger.warning("Unexpected error listing local accounts", exc_info=True)
         return []
 
 
@@ -141,6 +146,7 @@ def _list_env_fallback_accounts() -> list[dict]:
 
         encrypted_ids: set[str] = set(EncryptedFileStorage().list_all())
     except Exception:
+        logger.warning("Unexpected error reading encrypted credential store", exc_info=True)
         encrypted_ids = set()
 
     def _is_configured(cred_name: str, spec) -> bool:
@@ -301,7 +307,7 @@ def _activate_local_account(credential_id: str, alias: str) -> None:
             if key:
                 os.environ[spec.env_var] = key
     except Exception:
-        pass
+        logger.warning("Unexpected error injecting credential into environment", exc_info=True)
 
 
 def _configure_aden_node(

--- a/core/framework/agents/queen/queen_memory.py
+++ b/core/framework/agents/queen/queen_memory.py
@@ -200,6 +200,7 @@ def read_session_context(session_dir: Path, max_messages: int = 80) -> str:
                     label = "user" if role == "user" else "queen"
                     lines.append(f"[{label}]: {content[:600]}")
             except Exception:
+                logger.debug("Malformed conversation message skipped", exc_info=True)
                 continue
         if lines:
             parts.append("## Conversation\n\n" + "\n".join(lines))
@@ -368,4 +369,4 @@ async def consolidate_queen_memory(
                 encoding="utf-8",
             )
         except Exception:
-            pass
+            logger.debug("Could not write consolidation error to file", exc_info=True)

--- a/core/framework/credentials/setup.py
+++ b/core/framework/credentials/setup.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import getpass
 import json
+import logging
 import os
 import sys
 from collections.abc import Callable
@@ -36,6 +37,8 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from framework.graph import NodeSpec
+
+logger = logging.getLogger(__name__)
 
 
 # ANSI colors for terminal output
@@ -434,7 +437,7 @@ class CredentialSetupSession:
                     if value:
                         os.environ[cred.env_var] = value
                 except Exception:
-                    pass
+                    logger.debug("Could not export Aden credential to env", exc_info=True)
                 return True
             else:
                 self._print(
@@ -458,7 +461,7 @@ class CredentialSetupSession:
                 "details": result.details,
             }
         except Exception:
-            # No health checker available
+            logger.debug("Health check unavailable for credential", exc_info=True)
             return None
 
     def _store_credential(self, cred: MissingCredential, value: str) -> None:
@@ -562,6 +565,7 @@ def _load_nodes_from_python_agent(agent_path: Path) -> list:
         spec.loader.exec_module(module)
         return getattr(module, "nodes", [])
     except Exception:
+        logger.debug("Could not load nodes from Python agent at %s", agent_path, exc_info=True)
         return []
 
 
@@ -589,6 +593,7 @@ def _load_nodes_from_json_agent(agent_json: Path) -> list:
             )
         return nodes
     except Exception:
+        logger.debug("Could not load nodes from JSON agent at %s", agent_json, exc_info=True)
         return []
 
 


### PR DESCRIPTION
## Description
Bare `except Exception: continue/pass` clauses in three files silently swallowed errors, making debugging impossible. This replaces them with `logger.debug(..., exc_info=True)` so errors are captured in logs.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #6481

## Changes Made
- `core/framework/agents/credential_tester/agent.py` — added `import logging` + `logger`; fixed 4 bare excepts (listing integrations, listing local accounts, reading encrypted store, injecting credentials)
- `core/framework/credentials/setup.py` — added `import logging` + `logger`; fixed 4 bare excepts (credential export, health check, load nodes from Python agent, load nodes from JSON agent)
- `core/framework/agents/queen/queen_memory.py` — fixed 2 bare excepts (malformed conversation message, writing consolidation error file)

## Testing
- [x] Lint passes (`ruff check` — 0 errors)
- [x] No new warnings introduced

## Checklist
- [x] Self-review done
- [x] Logger placement follows PEP 8 (after all imports)