### PR TITLE
micro-fix(node): replace unsafe eval() with safe_eval() in NodeProtocol docstring

### DIFF
--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -644,8 +644,9 @@ class NodeProtocol(ABC):
                     reasoning="Direct evaluation"
                 )
 
-                # Do the work
-                result = eval(expression)
+                # Do the work (use safe_eval, never bare eval())
+                from framework.graph.safe_eval import safe_eval
+                result = safe_eval(expression, context={"input": ctx.input_data})
 
                 # Record outcome
                 ctx.runtime.record_outcome(decision_id, success=True, result=result)


### PR DESCRIPTION
## Description
The `NodeProtocol` docstring showed `eval(expression)` as the example pattern. Developers copying this could introduce Remote Code Execution vulnerabilities. The framework already provides `safe_eval()` — this fixes the example to use it.

## Type of Change
- [x] Micro-fix (docstring/example correction)

## Related Issues
Fixes #6323

## Changes Made
- `core/framework/graph/node.py:648` — replace `eval(expression)` with `safe_eval(expression, context={"input": ctx.input_data})` in NodeProtocol docstring example

## Testing
- [x] Lint passes (ruff)
- [x] No runtime change — this is a docstring example only

## Checklist
- [x] Self-review done
- [x] Matches how `edge.py:183` uses safe_eval() for condition evaluation