### PR TITLE
docs(readme): fix hive CLI invocation — use ./hive not hive

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This sets up:
 
 - Finally, it will open the Hive interface in your browser
 
-> **Tip:** To reopen the dashboard later, run `hive open` from the project directory.
+> **Tip:** To reopen the dashboard later, run `./hive open` from the project root directory.
 
 <img width="2500" height="1214" alt="home-screen" src="https://github.com/user-attachments/assets/134d897f-5e75-4874-b00b-e0505f6b45c4" />
 


### PR DESCRIPTION
## Description
README said `hive open` but the shipped wrapper is `./hive` and requires being run from the project root. This was confusing for new users who don't have `hive` on their PATH.

## Type of Change
- [x] Documentation fix (fast-track)

## Related Issues
Fixes #6176

## Changes Made
- `README.md:116` — `hive open` → `./hive open`, added "project root" for clarity

## Checklist
- [x] Self-review done