### PR TITLE
fix(country-info): add Country Info Tool using restcountries.com

### DIFF
--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -46,6 +46,7 @@ from .calendar_tool import register_tools as register_calendar
 from .calendly_tool import register_tools as register_calendly
 from .cloudinary_tool import register_tools as register_cloudinary
 from .confluence_tool import register_tools as register_confluence
+from .country_info_tool import register_tools as register_country_info
 from .csv_tool import register_tools as register_csv
 from .databricks_tool import register_tools as register_databricks
 from .discord_tool import register_tools as register_discord
@@ -153,6 +154,7 @@ def _register_verified(
     register_web_scrape(mcp)
     register_pdf_read(mcp)
     register_time(mcp)
+    register_country_info(mcp)
     register_runtime_logs(mcp)
     register_wikipedia(mcp)
     register_arxiv(mcp)

--- a/tools/src/aden_tools/tools/country_info_tool/__init__.py
+++ b/tools/src/aden_tools/tools/country_info_tool/__init__.py
@@ -1,0 +1,5 @@
+"""Country Info Tool package."""
+
+from .country_info_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/country_info_tool/country_info_tool.py
+++ b/tools/src/aden_tools/tools/country_info_tool/country_info_tool.py
@@ -1,0 +1,98 @@
+"""
+Country Info Tool — Free country data via restcountries.com.
+
+No API key required. Provides country details including currencies,
+languages, timezones, calling codes, flags, and population.
+
+API: https://restcountries.com/v3.1/ (Mozilla Public License 2.0)
+"""
+
+from __future__ import annotations
+
+import httpx
+from fastmcp import FastMCP
+
+_BASE_URL = "https://restcountries.com/v3.1"
+_TIMEOUT = 15.0
+_FIELDS = "name,cca2,cca3,currencies,languages,timezones,callingCodes,idd,flags,population,region,subregion,capital"  # noqa: E501
+
+
+def _fetch(path: str) -> list[dict]:
+    """Fetch from restcountries.com and return parsed JSON."""
+    url = f"{_BASE_URL}/{path}?fields={_FIELDS}"
+    resp = httpx.get(url, timeout=_TIMEOUT)
+    resp.raise_for_status()
+    data = resp.json()
+    return data if isinstance(data, list) else [data]
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register country info tools with the MCP server."""
+
+    @mcp.tool()
+    def country_get_by_name(name: str) -> dict:
+        """
+        Get country data by country name (full or partial).
+
+        Args:
+            name: Country name to search for (e.g., "Germany", "United States").
+
+        Returns:
+            List of matching countries with currency, languages, timezones,
+            calling codes, flag URLs, population, region, and capital.
+        """
+        try:
+            results = _fetch(f"name/{name}")
+            return {"countries": results, "count": len(results)}
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return {"error": f"No country found for name: {name}", "countries": []}
+            return {"error": str(e), "countries": []}
+        except Exception as e:
+            return {"error": str(e), "countries": []}
+
+    @mcp.tool()
+    def country_get_by_code(code: str) -> dict:
+        """
+        Get country data by ISO 2-letter (e.g., "DE") or 3-letter (e.g., "DEU") code.
+
+        Args:
+            code: ISO 3166-1 alpha-2 or alpha-3 country code.
+
+        Returns:
+            Country data with currency, languages, timezones, calling codes,
+            flag URLs, population, region, and capital.
+        """
+        try:
+            results = _fetch(f"alpha/{code}")
+            return {"countries": results, "count": len(results)}
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return {"error": f"No country found for code: {code}", "countries": []}
+            return {"error": str(e), "countries": []}
+        except Exception as e:
+            return {"error": str(e), "countries": []}
+
+    @mcp.tool()
+    def country_get_by_currency(currency_code: str) -> dict:
+        """
+        Find all countries that use a specific currency.
+
+        Args:
+            currency_code: ISO 4217 currency code (e.g., "EUR", "USD", "GBP").
+
+        Returns:
+            List of countries using that currency, with full country details.
+        """
+        try:
+            results = _fetch(f"currency/{currency_code}")
+            return {"countries": results, "count": len(results)}
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return {
+                    "error": f"No countries found for currency: {currency_code}",
+                    "countries": [],
+                }
+            return {"error": str(e), "countries": []}
+        except Exception as e:
+            return {"error": str(e), "countries": []}


### PR DESCRIPTION
## Description
Adds three country data lookup tools using the free restcountries.com API (no API key required, Mozilla Public License 2.0). Useful for international workflows, e-commerce, travel, and localization agents.

## Type of Change
- [x] New tool integration

## Related Issues
Fixes #6138

## Changes Made
- `tools/src/aden_tools/tools/country_info_tool/__init__.py` — package entry point
- `tools/src/aden_tools/tools/country_info_tool/country_info_tool.py` — 3 tools:
  - `country_get_by_name(name)` — full country data by name
  - `country_get_by_code(code)` — data by ISO 2/3-letter code
  - `country_get_by_currency(currency_code)` — all countries using a currency
- `tools/src/aden_tools/tools/__init__.py` — registered under `_register_verified()` (no credentials needed)

## Testing
- [x] Lint passes (ruff)
- [x] No credentials required — API is open/free
- [x] Gracefully returns `{"error": ..., "countries": []}` on 404 or network error

## Checklist
- [x] Self-review done
- [x] Follows time_tool pattern for no-auth tools