### PR TITLE
fix(graph): raise ValueError on NameError in conditional edge evaluation

### DIFF
--- a/core/framework/graph/edge.py
+++ b/core/framework/graph/edge.py
@@ -197,6 +197,15 @@ class EdgeSpec(BaseModel):
                 expr_vars or "none matched",
             )
             return result
+        except NameError as e:
+            # Undefined variable — most likely a typo in condition_expr.
+            # Raise so the developer gets a clear error immediately rather
+            # than silently routing the agent down the wrong path.
+            raise ValueError(
+                f"Edge '{self.id}' condition references undefined variable: {e}. "
+                f"Expression: '{self.condition_expr}'. "
+                f"Available context keys: {list(context.keys())}"
+            ) from e
         except Exception as e:
             logger.warning(f"      ⚠ Condition evaluation failed: {self.condition_expr}")
             logger.warning(f"         Error: {e}")


### PR DESCRIPTION
## Description
When a CONDITIONAL edge's `condition_expr` referenced an undefined variable (e.g. a typo), `safe_eval()` raised `NameError` which was silently caught and returned `False`. The agent silently took the wrong path with no actionable error for the developer.

This adds an explicit `except NameError` handler that raises `ValueError` with the expression, the undefined name, and the available context keys — giving developers immediate, actionable feedback.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #6324

## Changes Made
- `core/framework/graph/edge.py:200-210` — add `except NameError as e:` before `except Exception as e:` in `_evaluate_condition()`, raising `ValueError` with full context

## Testing
- [x] Lint passes (ruff)
- [x] `NameError` (undefined variable) → immediate `ValueError` with clear message
- [x] Other exceptions (e.g. `AttributeError`) still fall through to the existing `logger.warning + return False` path

## Checklist
- [x] Self-review done
- [x] No new warnings introduced