### PR TITLE
docs(getting-started): clarify Claude Code agent creation instruction

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,7 +65,7 @@ This is the recommended way to create your first agent.
 # Setup already done via quickstart.sh above
 
 # Start Claude Code and build an agent
-Use the coder-tools initialize_and_build_agent tool
+Start Claude Code and run the `initialize_and_build_agent` tool from the coder-tools skill set.
 ```
 
 Follow the interactive prompts to:


### PR DESCRIPTION
## Description
Clarifies the instruction for creating an agent using Claude Code.

The previous wording appeared inside a bash code block and could be mistaken for a runnable terminal command. This change clarifies that the `initialize_and_build_agent` tool should be run from Claude Code.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

N/A

## Changes Made

- Clarified instruction for using the `initialize_and_build_agent` tool
- Removed wording that could be mistaken for a terminal command
- Improved clarity for new contributors following the guide

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual review performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A