### PR TITLE
feat(events): emit GOAL_ACHIEVED on terminal-node success

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -1574,6 +1574,15 @@ class GraphExecutor:
                     execution_quality=exec_quality,
                 )
 
+            if self._event_bus:
+                await self._event_bus.emit_goal_achieved(
+                    stream_id=self._stream_id,
+                    execution_id=self._execution_id,
+                    goal_name=goal.name,
+                    goal_description=goal.description,
+                    output=output,
+                )
+
             return ExecutionResult(
                 success=True,
                 output=output,

--- a/core/framework/runtime/EVENT_TYPES.md
+++ b/core/framework/runtime/EVENT_TYPES.md
@@ -392,7 +392,15 @@ Goal completion progress update.
 
 ### `goal_achieved`
 
-Not currently emitted — reserved for explicit goal completion signals.
+Emitted when a graph execution reaches a terminal node successfully, signalling that the goal has been achieved.
+
+| Data Field         | Type   | Description                              |
+| ------------------ | ------ | ---------------------------------------- |
+| `goal_name`        | `str`  | Name of the achieved goal                |
+| `goal_description` | `str`  | Human-readable description of the goal   |
+| `output`           | `dict` | Final output from the execution          |
+
+**Emitted by:** `GraphExecutor` at terminal-node success, via `emit_goal_achieved()`.
 
 ---
 

--- a/core/framework/runtime/event_bus.py
+++ b/core/framework/runtime/event_bus.py
@@ -619,6 +619,28 @@ class EventBus:
             )
         )
 
+    async def emit_goal_achieved(
+        self,
+        stream_id: str,
+        execution_id: str,
+        goal_name: str,
+        goal_description: str,
+        output: dict[str, Any] | None = None,
+    ) -> None:
+        """Emit goal achieved event."""
+        await self.publish(
+            AgentEvent(
+                type=EventType.GOAL_ACHIEVED,
+                stream_id=stream_id,
+                execution_id=execution_id,
+                data={
+                    "goal_name": goal_name,
+                    "goal_description": goal_description,
+                    "output": output or {},
+                },
+            )
+        )
+
     async def emit_constraint_violation(
         self,
         stream_id: str,

--- a/core/tests/test_goal_achieved_event.py
+++ b/core/tests/test_goal_achieved_event.py
@@ -1,0 +1,213 @@
+"""
+Tests for GOAL_ACHIEVED event emission.
+
+Covers:
+- emit_goal_achieved() publishes correct AgentEvent
+- GraphExecutor emits GOAL_ACHIEVED on terminal-node success
+- Event data contains goal_name, goal_description, and output
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from framework.graph.edge import EdgeCondition, EdgeSpec, GraphSpec
+from framework.graph.executor import GraphExecutor
+from framework.graph.goal import Goal
+from framework.graph.node import NodeContext, NodeProtocol, NodeResult, NodeSpec
+from framework.runtime.core import Runtime
+from framework.runtime.event_bus import AgentEvent, EventBus, EventType
+
+# --- Test node implementations ---
+
+
+class SuccessNode(NodeProtocol):
+    """Always succeeds with configurable output."""
+
+    def __init__(self, output: dict | None = None):
+        self._output = output or {"result": "ok"}
+
+    async def execute(self, ctx: NodeContext) -> NodeResult:
+        return NodeResult(success=True, output=self._output, tokens_used=10, latency_ms=5)
+
+
+# --- EventBus unit tests ---
+
+
+@pytest.mark.asyncio
+async def test_emit_goal_achieved_publishes_correct_event():
+    """emit_goal_achieved() publishes an AgentEvent with correct type and data."""
+    bus = EventBus()
+    received: list[AgentEvent] = []
+
+    async def handler(event: AgentEvent) -> None:
+        received.append(event)
+
+    bus.subscribe(event_types=[EventType.GOAL_ACHIEVED], handler=handler)
+
+    await bus.emit_goal_achieved(
+        stream_id="s1",
+        execution_id="e1",
+        goal_name="Build feature",
+        goal_description="Implement the widget",
+        output={"widget": "done"},
+    )
+
+    assert len(received) == 1
+    event = received[0]
+    assert event.type == EventType.GOAL_ACHIEVED
+    assert event.stream_id == "s1"
+    assert event.execution_id == "e1"
+    assert event.data["goal_name"] == "Build feature"
+    assert event.data["goal_description"] == "Implement the widget"
+    assert event.data["output"] == {"widget": "done"}
+
+
+@pytest.mark.asyncio
+async def test_emit_goal_achieved_defaults_output_to_empty_dict():
+    """When output is None, data['output'] should be an empty dict."""
+    bus = EventBus()
+    received: list[AgentEvent] = []
+
+    async def handler(event: AgentEvent) -> None:
+        received.append(event)
+
+    bus.subscribe(event_types=[EventType.GOAL_ACHIEVED], handler=handler)
+
+    await bus.emit_goal_achieved(
+        stream_id="s1",
+        execution_id="e1",
+        goal_name="Test",
+        goal_description="Desc",
+    )
+
+    assert received[0].data["output"] == {}
+
+
+# --- Executor integration tests ---
+
+
+@pytest.fixture
+def runtime():
+    rt = MagicMock(spec=Runtime)
+    rt.start_run = MagicMock(return_value="run_id")
+    rt.decide = MagicMock(return_value="decision_id")
+    rt.record_outcome = MagicMock()
+    rt.end_run = MagicMock()
+    rt.report_problem = MagicMock()
+    rt.set_node = MagicMock()
+    return rt
+
+
+@pytest.fixture
+def goal():
+    return Goal(id="g1", name="Test Goal", description="A test goal for events")
+
+
+@pytest.fixture
+def event_bus():
+    bus = EventBus()
+    bus.emit_goal_achieved = AsyncMock(wraps=bus.emit_goal_achieved)
+    return bus
+
+
+def _make_linear_graph(node: NodeSpec) -> GraphSpec:
+    """Build a simple two-node linear graph: source → terminal."""
+    source = NodeSpec(
+        id="source",
+        name="Source",
+        description="entry",
+        node_type="event_loop",
+        output_keys=["data"],
+    )
+    return GraphSpec(
+        id="test_graph",
+        goal_id="g1",
+        name="Test Graph",
+        entry_node="source",
+        nodes=[source, node],
+        edges=[
+            EdgeSpec(
+                id="source_to_terminal",
+                source="source",
+                target=node.id,
+                condition=EdgeCondition.ON_SUCCESS,
+            ),
+        ],
+        terminal_nodes=[node.id],
+    )
+
+
+@pytest.mark.asyncio
+async def test_executor_emits_goal_achieved_on_success(runtime, goal, event_bus):
+    """GraphExecutor emits GOAL_ACHIEVED when execution completes successfully."""
+    terminal = SuccessNode(output={"answer": 42})
+    terminal_spec = NodeSpec(
+        id="terminal",
+        name="Terminal",
+        description="terminal node",
+        node_type="event_loop",
+        output_keys=["answer"],
+    )
+    graph = _make_linear_graph(terminal_spec)
+
+    source_node = SuccessNode(output={"data": "input"})
+    node_registry = {
+        "source": source_node,
+        "terminal": terminal,
+    }
+
+    executor = GraphExecutor(
+        runtime=runtime,
+        llm=MagicMock(),
+        tools=[],
+        tool_executor=None,
+        node_registry=node_registry,
+        event_bus=event_bus,
+        stream_id="stream_1",
+        execution_id="exec_1",
+    )
+
+    result = await executor.execute(graph, goal)
+
+    assert result.success
+    event_bus.emit_goal_achieved.assert_awaited_once()
+    call_kwargs = event_bus.emit_goal_achieved.call_args.kwargs
+    assert call_kwargs["stream_id"] == "stream_1"
+    assert call_kwargs["execution_id"] == "exec_1"
+    assert call_kwargs["goal_name"] == "Test Goal"
+    assert call_kwargs["goal_description"] == "A test goal for events"
+
+
+@pytest.mark.asyncio
+async def test_executor_no_goal_achieved_without_event_bus(runtime, goal):
+    """GraphExecutor does not crash when event_bus is None."""
+    terminal = SuccessNode()
+    terminal_spec = NodeSpec(
+        id="terminal",
+        name="Terminal",
+        description="terminal node",
+        node_type="event_loop",
+        output_keys=["result"],
+    )
+    graph = _make_linear_graph(terminal_spec)
+
+    source_node = SuccessNode(output={"data": "input"})
+    node_registry = {
+        "source": source_node,
+        "terminal": terminal,
+    }
+
+    executor = GraphExecutor(
+        runtime=runtime,
+        llm=MagicMock(),
+        tools=[],
+        tool_executor=None,
+        node_registry=node_registry,
+        event_bus=None,
+        stream_id="stream_1",
+        execution_id="exec_1",
+    )
+
+    result = await executor.execute(graph, goal)
+    assert result.success

--- a/core/tests/test_graph_executor.py
+++ b/core/tests/test_graph_executor.py
@@ -159,6 +159,9 @@ class FakeEventBus:
     async def emit_node_retry(self, **kwargs):
         self.events.append(("node_retry", kwargs))
 
+    async def emit_goal_achieved(self, **kwargs):
+        self.events.append(("goal_achieved", kwargs))
+
 
 @pytest.mark.asyncio
 
@@ -207,8 +210,10 @@ async def test_executor_skips_events_for_event_loop_nodes():
     result = await executor.execute(graph=graph, goal=goal)
 
     assert result.success is True
-    # No events should have been emitted — event_loop nodes are skipped
-    assert len(event_bus.events) == 0
+    # No node-level events should have been emitted — event_loop nodes are skipped.
+    # Only the graph-level goal_achieved event is expected.
+    node_events = [e for e in event_bus.events if e[0] != "goal_achieved"]
+    assert len(node_events) == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add `emit_goal_achieved()` convenience method to `EventBus`, mirroring the pattern of existing emitters like `emit_constraint_violation()`
- Emit `GOAL_ACHIEVED` from `GraphExecutor` when execution completes at a terminal node successfully
- Update `EVENT_TYPES.md` to document the payload shape and emission point
- Add unit + integration tests for the new emission

The `GOAL_ACHIEVED` `EventType` was already defined in the enum and fully handled by the TUI (subscription, `chat_repl` handler, `log_pane` formatting), but no backend code ever emitted it. This completes the agent lifecycle observability story.

Fixes #5736

## Test plan

- [x] `emit_goal_achieved()` publishes an `AgentEvent` with correct type, stream_id, execution_id, and data
- [x] Default output is `{}` when None is passed
- [x] `GraphExecutor` calls `emit_goal_achieved` on successful terminal-node completion
- [x] `GraphExecutor` works without crash when `event_bus` is None
- [x] Existing `test_executor_skips_events_for_event_loop_nodes` updated to distinguish node-level vs graph-level events
- [x] All 774 existing tests pass (no regressions)
- [x] `ruff check` passes on all modified files