### PR TITLE
fix(email): guard optional resend import

### DIFF
--- a/tools/src/aden_tools/tools/email_tool/email_tool.py
+++ b/tools/src/aden_tools/tools/email_tool/email_tool.py
@@ -12,7 +12,6 @@ import os
 from typing import TYPE_CHECKING, Literal
 
 import httpx
-import resend
 from fastmcp import FastMCP
 
 if TYPE_CHECKING:
@@ -35,6 +34,16 @@ def register_tools(
         bcc: list[str] | None = None,
     ) -> dict:
         """Send email using Resend API."""
+        try:
+            import resend
+        except ImportError:
+            return {
+                "error": (
+                    "resend not installed. Install with: "
+                    "pip install resend  or  pip install tools[email]"
+                )
+            }
+
         resend.api_key = api_key
         try:
             payload: dict = {


### PR DESCRIPTION
## Description
The email tool currently imports `resend` at module load time. If the `resend` package isn’t installed (which is common in clean environments), the import raises `ModuleNotFoundError` and crashes **all** tool registration. This change defers the import to runtime and returns a helpful error dict instead, matching existing optional‑dependency patterns.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
Fixes #4816

## Changes Made
- Moved `import resend` inside `_send_via_resend()`
- Added an `ImportError` guard that returns a clear install hint (`pip install resend` or `pip install tools[email]`)
- Left all existing API behavior and payload construction unchanged when `resend` is available

## Testing
- [x] Manual testing performed (code review only)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings