### PR TITLE
docs(getting-started): add first-run troubleshooting for credentials …

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,18 @@ This sets up:
 
 > **Tip:** To reopen the dashboard later, run `hive open` from the project directory.
 
+### First-Run Troubleshooting
+
+A few setup blockers are easy to hit on first run. Checking these before debugging agent behavior can save time:
+
+- **Verify your LLM provider credits/quota first.** Hive can start planning and executing quickly, so free-tier or low-credit accounts may fail before a full run completes.
+- **Connect required tools before testing search-heavy workflows.** Some agents depend on integrations such as web search or external services. If the required tool is not connected, results may be incomplete or the workflow may fail.
+- **Expect some sample agents to require credentials.** Template agents such as inbox, research, or external-data workflows may not be runnable until their required credentials are configured.
+- **Google account setup may vary by account type.** Some Google-managed or workspace accounts may hit OAuth/admin restrictions depending on account policy.
+- **If a run appears stalled, check provider limits before deeper debugging.** Provider rate limits, exhausted quota, or missing credentials can look like product issues on first run.
+
+> **Tip:** If a workflow depends on external tools or provider credits, confirm those are configured before evaluating agent behavior in the UI.
+
 ### Build Your First Agent
 
 Type the agent you want to build in the home input box. The queen is going to ask you questions and work out a solution with you.


### PR DESCRIPTION
## Description

This PR adds a small **First-Run Troubleshooting** subsection to the `README.md` Quick Start flow.

The goal is to reduce first-run evaluation friction by surfacing a few setup blockers that are easy to hit before users start debugging agent behavior, including:
- provider credits / quota exhaustion
- missing required tools or integrations
- credential-dependent sample workflows
- account-specific Google OAuth/admin restrictions
- provider or credential issues that can look like product failures on first run

## Type of Change

- [x] Documentation update

## Related Issues

None linked. This PR is based on first-run onboarding friction observed during live testing.

## Changes Made

- Added a new `### First-Run Troubleshooting` subsection under `## Quick Start` in `README.md`
- Documented common first-run blockers related to provider credits/quota, missing tools, and credential-dependent workflows
- Added guidance that some Google account setups may hit OAuth/admin restrictions and that provider/credential issues can appear like product failures during initial evaluation

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings