### PR TITLE
fix: improve tool_registry error handling with stack traces and context

### DIFF
--- a/core/framework/runner/tool_registry.py
+++ b/core/framework/runner/tool_registry.py
@@ -7,6 +7,7 @@ import inspect
 import json
 import logging
 import os
+import traceback
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -278,6 +279,15 @@ class ToolRegistry:
                             r = await result
                             return _wrap_result(tool_use.id, r)
                         except Exception as exc:
+                            logger.error(
+                                "Async tool '%s' execution failed for tool_use_id=%s: %s\n"
+                                "Inputs: %s\nTraceback:\n%s",
+                                tool_use.name,
+                                tool_use.id,
+                                exc,
+                                json.dumps(tool_use.input, default=str),
+                                traceback.format_exc(),
+                            )
                             return ToolResult(
                                 tool_use_id=tool_use.id,
                                 content=json.dumps({"error": str(exc)}),
@@ -288,6 +298,14 @@ class ToolRegistry:
 
                 return _wrap_result(tool_use.id, result)
             except Exception as e:
+                logger.error(
+                    "Tool '%s' execution failed for tool_use_id=%s: %s\nInputs: %s\nTraceback:\n%s",
+                    tool_use.name,
+                    tool_use.id,
+                    e,
+                    json.dumps(tool_use.input, default=str),
+                    traceback.format_exc(),
+                )
                 return ToolResult(
                     tool_use_id=tool_use.id,
                     content=json.dumps({"error": str(e)}),
@@ -588,7 +606,13 @@ class ToolRegistry:
                                 return result[0]
                             return result
                         except Exception as e:
-                            logger.error(f"MCP tool '{tool_name}' execution failed: {e}")
+                            logger.error(
+                                "MCP tool '%s' execution failed: %s\nInputs: %s\nTraceback:\n%s",
+                                tool_name,
+                                e,
+                                json.dumps(inputs, default=str),
+                                traceback.format_exc(),
+                            )
                             return {"error": str(e)}
 
                     return executor

--- a/core/framework/runner/tool_registry.py
+++ b/core/framework/runner/tool_registry.py
@@ -7,7 +7,6 @@ import inspect
 import json
 import logging
 import os
-import traceback
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -16,6 +15,8 @@ from typing import Any
 from framework.llm.provider import Tool, ToolResult, ToolUse
 
 logger = logging.getLogger(__name__)
+
+_INPUT_LOG_MAX_LEN = 500
 
 # Per-execution context overrides.  Each asyncio task (and thus each
 # concurrent graph execution) gets its own copy, so there are no races
@@ -279,14 +280,16 @@ class ToolRegistry:
                             r = await result
                             return _wrap_result(tool_use.id, r)
                         except Exception as exc:
+                            inputs_str = json.dumps(tool_use.input, default=str)
+                            if len(inputs_str) > _INPUT_LOG_MAX_LEN:
+                                inputs_str = inputs_str[:_INPUT_LOG_MAX_LEN] + "...(truncated)"
                             logger.error(
-                                "Async tool '%s' execution failed for tool_use_id=%s: %s\n"
-                                "Inputs: %s\nTraceback:\n%s",
+                                "Async tool '%s' failed (tool_use_id=%s): %s\nInputs: %s",
                                 tool_use.name,
                                 tool_use.id,
                                 exc,
-                                json.dumps(tool_use.input, default=str),
-                                traceback.format_exc(),
+                                inputs_str,
+                                exc_info=True,
                             )
                             return ToolResult(
                                 tool_use_id=tool_use.id,
@@ -298,13 +301,16 @@ class ToolRegistry:
 
                 return _wrap_result(tool_use.id, result)
             except Exception as e:
+                inputs_str = json.dumps(tool_use.input, default=str)
+                if len(inputs_str) > _INPUT_LOG_MAX_LEN:
+                    inputs_str = inputs_str[:_INPUT_LOG_MAX_LEN] + "...(truncated)"
                 logger.error(
-                    "Tool '%s' execution failed for tool_use_id=%s: %s\nInputs: %s\nTraceback:\n%s",
+                    "Tool '%s' execution failed for tool_use_id=%s: %s\nInputs: %s",
                     tool_use.name,
                     tool_use.id,
                     e,
-                    json.dumps(tool_use.input, default=str),
-                    traceback.format_exc(),
+                    inputs_str,
+                    exc_info=True,
                 )
                 return ToolResult(
                     tool_use_id=tool_use.id,
@@ -606,12 +612,15 @@ class ToolRegistry:
                                 return result[0]
                             return result
                         except Exception as e:
+                            inputs_str = json.dumps(inputs, default=str)
+                            if len(inputs_str) > _INPUT_LOG_MAX_LEN:
+                                inputs_str = inputs_str[:_INPUT_LOG_MAX_LEN] + "...(truncated)"
                             logger.error(
-                                "MCP tool '%s' execution failed: %s\nInputs: %s\nTraceback:\n%s",
+                                "MCP tool '%s' execution failed: %s\nInputs: %s",
                                 tool_name,
                                 e,
-                                json.dumps(inputs, default=str),
-                                traceback.format_exc(),
+                                inputs_str,
+                                exc_info=True,
                             )
                             return {"error": str(e)}
 

--- a/core/tests/test_tool_registry.py
+++ b/core/tests/test_tool_registry.py
@@ -6,10 +6,12 @@ ToolResult instances. Historically, invalid JSON in ToolResult.content
 could cause a json.JSONDecodeError and crash execution.
 """
 
+import logging
 import textwrap
 from pathlib import Path
 from types import SimpleNamespace
 
+from framework.llm.provider import Tool, ToolUse
 from framework.runner.tool_registry import ToolRegistry
 
 
@@ -206,3 +208,81 @@ def test_register_mcp_server_direct_client_when_manager_disabled(monkeypatch):
     registry.cleanup()
 
     assert created_clients[0].disconnect_calls == 1
+
+
+def test_tool_execution_error_logs_stack_trace_and_context(caplog):
+    """ToolRegistry should log stack traces and context when tool execution fails."""
+    registry = ToolRegistry()
+
+    def failing_executor(inputs: dict) -> None:
+        raise ValueError("Intentional test failure")
+
+    tool = Tool(
+        name="failing_tool",
+        description="A tool that always fails",
+        parameters={"type": "object", "properties": {}},
+    )
+    registry.register("failing_tool", tool, failing_executor)
+
+    tool_use = ToolUse(
+        id="test_call_123",
+        name="failing_tool",
+        input={"param": "value"},
+    )
+
+    with caplog.at_level(logging.ERROR):
+        executor = registry.get_executor()
+        result = executor(tool_use)
+
+    assert result.is_error is True
+    assert "Intentional test failure" in result.content
+
+    assert any("failing_tool" in record.message for record in caplog.records)
+    assert any("test_call_123" in record.message for record in caplog.records)
+    assert any("Traceback" in record.message for record in caplog.records)
+
+
+def test_tool_execution_error_logs_inputs(caplog):
+    """ToolRegistry should log tool inputs when execution fails."""
+    registry = ToolRegistry()
+
+    def failing_executor(inputs: dict) -> None:
+        raise RuntimeError("Tool failed")
+
+    tool = Tool(
+        name="input_logging_tool",
+        description="Tests input logging",
+        parameters={"type": "object", "properties": {"foo": {"type": "string"}}},
+    )
+    registry.register("input_logging_tool", tool, failing_executor)
+
+    tool_use = ToolUse(
+        id="call_456",
+        name="input_logging_tool",
+        input={"foo": "bar", "nested": {"key": "value"}},
+    )
+
+    with caplog.at_level(logging.ERROR):
+        executor = registry.get_executor()
+        executor(tool_use)
+
+    log_messages = [record.message for record in caplog.records]
+    full_log = " ".join(log_messages)
+    assert '"foo": "bar"' in full_log or "'foo': 'bar'" in full_log
+
+
+def test_unknown_tool_error_returns_proper_result():
+    """ToolRegistry should return proper error for unknown tools."""
+    registry = ToolRegistry()
+    tool_use = ToolUse(
+        id="unknown_call",
+        name="nonexistent_tool",
+        input={},
+    )
+
+    executor = registry.get_executor()
+    result = executor(tool_use)
+
+    assert result.is_error is True
+    assert "Unknown tool" in result.content
+    assert "nonexistent_tool" in result.content

--- a/core/tests/test_tool_registry.py
+++ b/core/tests/test_tool_registry.py
@@ -239,7 +239,7 @@ def test_tool_execution_error_logs_stack_trace_and_context(caplog):
 
     assert any("failing_tool" in record.message for record in caplog.records)
     assert any("test_call_123" in record.message for record in caplog.records)
-    assert any("Traceback" in record.message for record in caplog.records)
+    assert any(record.exc_info is not None for record in caplog.records)
 
 
 def test_tool_execution_error_logs_inputs(caplog):
@@ -286,3 +286,33 @@ def test_unknown_tool_error_returns_proper_result():
     assert result.is_error is True
     assert "Unknown tool" in result.content
     assert "nonexistent_tool" in result.content
+
+
+def test_tool_execution_error_truncates_large_inputs(caplog):
+    """ToolRegistry should truncate large inputs in error logs."""
+    registry = ToolRegistry()
+
+    def failing_executor(inputs: dict) -> None:
+        raise RuntimeError("Tool failed")
+
+    tool = Tool(
+        name="large_input_tool",
+        description="Tests input truncation",
+        parameters={"type": "object", "properties": {}},
+    )
+    registry.register("large_input_tool", tool, failing_executor)
+
+    large_input = {"data": "x" * 1000}
+    tool_use = ToolUse(
+        id="call_789",
+        name="large_input_tool",
+        input=large_input,
+    )
+
+    with caplog.at_level(logging.ERROR):
+        executor = registry.get_executor()
+        executor(tool_use)
+
+    log_messages = [record.message for record in caplog.records]
+    full_log = " ".join(log_messages)
+    assert "...(truncated)" in full_log


### PR DESCRIPTION
## Description

Improves error handling in `tool_registry.py` by adding structured logging with stack traces and execution context when tool execution fails. This makes debugging production issues significantly easier.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #2447

## Changes Made

- Added `exc_info=True` to error logging (codebase convention instead of traceback.format_exc())
- Added `_INPUT_LOG_MAX_LEN = 500` constant to truncate large inputs and prevent log flooding
- Updated `get_executor()` to log stack traces, tool name, tool_use_id, and inputs when tool execution fails
- Updated async tool error handling to include the same detailed logging
- Updated MCP tool executor to log stack traces and inputs on failure
- Added 4 new tests to verify error logging behavior:
  - `test_tool_execution_error_logs_stack_trace_and_context`
  - `test_tool_execution_error_logs_inputs`
  - `test_unknown_tool_error_returns_proper_result`
  - `test_tool_execution_error_truncates_large_inputs`

## Testing

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A
