### PR TITLE
docs: update Windows guidance to reflect native support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,8 +121,14 @@ uv sync
 6. Make your changes
 7. Run checks and tests:
    ```bash
-   make check    # Lint and format checks (ruff check + ruff format --check)
+   make check    # Lint and format checks
    make test     # Core tests
+   ```
+   On Windows (no make), run directly:
+   ```powershell
+   uv run ruff check core/ tools/
+   uv run ruff format --check core/ tools/
+   uv run pytest core/tests/
    ```
 8. Commit your changes following our commit conventions
 9. Push to your fork and submit a Pull Request
@@ -222,8 +228,7 @@ else:  # linux
 - **Node.js 18+** (optional, for frontend development)
 
 > **Windows Users:**
-> If you are on native Windows, it is recommended to use **WSL (Windows Subsystem for Linux)**.
-> Alternatively, make sure to run PowerShell or Git Bash with Python 3.11+ installed, and disable "App Execution Aliases" in Windows settings.
+> Native Windows is supported. Use `.\quickstart.ps1` for setup and `.\hive.ps1` to run (PowerShell 5.1+). Disable "App Execution Aliases" in Windows settings to avoid Python path conflicts. WSL is also an option but not required.
 
 > **Tip:** Installing Claude Code skills is optional for running existing agents, but required if you plan to **build new agents**.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Use Hive when you need:
 - An LLM provider that powers the agents
 - **ripgrep (optional, recommended on Windows):** The `search_files` tool uses ripgrep for faster file search. If not installed, a Python fallback is used. On Windows: `winget install BurntSushi.ripgrep` or `scoop install ripgrep`
 
-> **Note for Windows Users:** It is strongly recommended to use **WSL (Windows Subsystem for Linux)** or **Git Bash** to run this framework. Some core automation scripts may not execute correctly in standard Command Prompt or PowerShell.
+> **Windows Users:** Native Windows is supported via `quickstart.ps1` and `hive.ps1`. Run these in PowerShell 5.1+. WSL is also an option but not required.
 
 ### Installation
 

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -10,8 +10,7 @@ Complete setup guide for building and running goal-driven agents with the Aden A
 ```
 
 > **Note for Windows Users:**
-> Running the setup script on native Windows shells (PowerShell / Git Bash) may sometimes fail due to Python App Execution Aliases.
-> It is **strongly recommended to use WSL (Windows Subsystem for Linux)** for a smoother setup experience.
+> Native Windows is supported via `quickstart.ps1`. Run it in PowerShell 5.1+. Disable "App Execution Aliases" in Windows settings to avoid Python path conflicts.
 
 This will:
 
@@ -25,13 +24,19 @@ This will:
 
 ## Windows Setup
 
-Windows users should use **WSL (Windows Subsystem for Linux)** to set up and run agents.
+Native Windows is supported. Run the PowerShell quickstart:
 
-1. [Install WSL 2](https://learn.microsoft.com/en-us/windows/wsl/install) if you haven't already:
+```powershell
+.\quickstart.ps1
+```
+
+Alternatively, you can use WSL:
+
+1. [Install WSL 2](https://learn.microsoft.com/en-us/windows/wsl/install):
    ```powershell
    wsl --install
    ```
-2. Open your WSL terminal, clone the repo, and run the quickstart script:
+2. Open your WSL terminal, clone the repo, and run:
    ```bash
    ./quickstart.sh
    ```
@@ -93,7 +98,7 @@ uv run python -c "import litellm; print('✓ litellm OK')"
 ```
 
 > **Windows Tip:**
-> On Windows, if the verification commands fail, ensure you are running them in **WSL** or after **disabling Python App Execution Aliases** in Windows Settings → Apps → App Execution Aliases.
+> If the verification commands fail on Windows, disable "App Execution Aliases" in Windows Settings → Apps → App Execution Aliases.
 
 ## Requirements
 
@@ -108,7 +113,7 @@ uv run python -c "import litellm; print('✓ litellm OK')"
 - pip (latest version)
 - 2GB+ RAM
 - Internet connection (for LLM API calls)
-- For Windows users: WSL 2 is recommended for full compatibility.
+- For Windows users: PowerShell 5.1+ (native) or WSL 2.
 
 ### API Keys
 


### PR DESCRIPTION
## Description

Update docs to stop recommending WSL as the primary Windows path. quickstart.ps1 and hive.ps1 provide full native Windows support.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #3835
Fixes #3839

## Changes Made

- README: replace "strongly recommended WSL" with native Windows guidance
- CONTRIBUTING: add Windows PowerShell alternatives for `make check`/`make test`
- CONTRIBUTING: update Windows Users note to mention quickstart.ps1/hive.ps1
- environment-setup: rewrite Windows Setup section with native path first, WSL as alternative

## Testing

- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings