### PR TITLE
fix(config): avoid double-prefixing provider in get_preferred_model

### DIFF
--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -56,6 +56,9 @@ def get_preferred_model() -> str:
         # OpenRouter quickstart stores raw model IDs; tolerate pasted "openrouter/<id>" too.
         if provider.lower() == "openrouter" and model.lower().startswith("openrouter/"):
             model = model[len("openrouter/") :]
+        # Avoid double-prefixing for any provider (e.g. "ollama/qwen2.5:7b" + provider="ollama")
+        if model.startswith(f"{provider}/"):
+            return model
         if model:
             return f"{provider}/{model}"
     return "anthropic/claude-sonnet-4-20250514"

--- a/core/tests/test_config.py
+++ b/core/tests/test_config.py
@@ -1,6 +1,9 @@
 """Tests for framework/config.py - Hive configuration loading."""
 
+import json
 import logging
+
+import pytest
 
 from framework.config import get_api_base, get_hive_config, get_preferred_model
 
@@ -65,3 +68,44 @@ class TestOpenRouterConfig:
         monkeypatch.setattr("framework.config.HIVE_CONFIG_FILE", config_file)
 
         assert get_api_base() == "https://proxy.example/v1"
+
+
+class TestGetPreferredModel:
+    """Test get_preferred_model() provider/model resolution."""
+
+    @pytest.fixture()
+    def _config_file(self, tmp_path, monkeypatch):
+        """Provide a helper that writes a config and patches the path."""
+        config_file = tmp_path / "configuration.json"
+        monkeypatch.setattr("framework.config.HIVE_CONFIG_FILE", config_file)
+        return config_file
+
+    def test_returns_default_when_no_config(self, _config_file):
+        """No config file → default Anthropic model."""
+        assert get_preferred_model() == "anthropic/claude-sonnet-4-20250514"
+
+    def test_prepends_provider_when_model_has_no_prefix(self, _config_file):
+        """model='qwen2.5:7b' + provider='ollama' → 'ollama/qwen2.5:7b'."""
+        _config_file.write_text(json.dumps({"llm": {"provider": "ollama", "model": "qwen2.5:7b"}}))
+        assert get_preferred_model() == "ollama/qwen2.5:7b"
+
+    def test_no_double_prefix_when_model_already_includes_provider(self, _config_file):
+        """model='ollama/qwen2.5:7b' + provider='ollama' → 'ollama/qwen2.5:7b' (not doubled)."""
+        _config_file.write_text(
+            json.dumps({"llm": {"provider": "ollama", "model": "ollama/qwen2.5:7b"}})
+        )
+        assert get_preferred_model() == "ollama/qwen2.5:7b"
+
+    def test_anthropic_provider_with_full_model_string(self, _config_file):
+        """model='anthropic/claude-sonnet-4-20250514' + provider='anthropic' → no double prefix."""
+        _config_file.write_text(
+            json.dumps(
+                {"llm": {"provider": "anthropic", "model": "anthropic/claude-sonnet-4-20250514"}}
+            )
+        )
+        assert get_preferred_model() == "anthropic/claude-sonnet-4-20250514"
+
+    def test_returns_default_when_provider_missing(self, _config_file):
+        """Only model set, no provider → default."""
+        _config_file.write_text(json.dumps({"llm": {"model": "qwen2.5:7b"}}))
+        assert get_preferred_model() == "anthropic/claude-sonnet-4-20250514"


### PR DESCRIPTION
## Summary
- `get_preferred_model()` now checks if the model string already starts with `{provider}/` before prepending it, preventing `ollama/ollama/qwen2.5:7b`
- Added 5 tests covering prefixed/unprefixed model strings and fallback defaults

## Test plan
- [x] `uv run pytest tests/test_config.py -v` — all 6 tests pass
- [x] `make check` — linting clean
- [x] Manual: set `"model": "ollama/qwen2.5:7b"` in config, verify LLM calls use correct model string

Closes #6393