### PR TITLE
feat(tools): add IPInfo tool — IP geolocation and network intelligence

### DIFF
--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -67,6 +67,7 @@ from .azure_sql import AZURE_SQL_CREDENTIALS
 from .base import CredentialError, CredentialSpec
 from .bigquery import BIGQUERY_CREDENTIALS
 from .brevo import BREVO_CREDENTIALS
+from .ipinfo import IPINFO_CREDENTIALS
 from .browser import get_aden_auth_url, get_aden_setup_url, open_browser
 from .calcom import CALCOM_CREDENTIALS
 from .calendly import CALENDLY_CREDENTIALS
@@ -156,6 +157,7 @@ CREDENTIAL_SPECS = {
     **AZURE_SQL_CREDENTIALS,
     **BIGQUERY_CREDENTIALS,
     **BREVO_CREDENTIALS,
+    **IPINFO_CREDENTIALS,
     **CALCOM_CREDENTIALS,
     **CALENDLY_CREDENTIALS,
     **CLOUDINARY_CREDENTIALS,

--- a/tools/src/aden_tools/credentials/ipinfo.py
+++ b/tools/src/aden_tools/credentials/ipinfo.py
@@ -1,0 +1,31 @@
+"""
+IPInfo tool credentials.
+Contains credentials for IPInfo IP geolocation integration.
+"""
+
+from .base import CredentialSpec
+
+IPINFO_CREDENTIALS = {
+    "ipinfo": CredentialSpec(
+        env_var="IPINFO_TOKEN",
+        tools=[
+            "ipinfo_get_ip_details",
+            "ipinfo_get_my_ip",
+        ],
+        required=True,
+        startup_required=False,
+        help_url="https://ipinfo.io/account/token",
+        description="IPInfo API token for IP geolocation and network intelligence",
+        aden_supported=False,
+        direct_api_key_supported=True,
+        api_key_instructions="""To get an IPInfo token:
+1. Sign up for free at https://ipinfo.io/signup
+2. Go to your dashboard at https://ipinfo.io/account/token
+3. Copy your access token
+4. Set it as IPINFO_TOKEN""",
+        health_check_endpoint="https://ipinfo.io/8.8.8.8",
+        health_check_method="GET",
+        credential_id="ipinfo",
+        credential_key="token",
+    ),
+}

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -41,6 +41,7 @@ from .aws_s3_tool import register_tools as register_aws_s3
 from .azure_sql_tool import register_tools as register_azure_sql
 from .bigquery_tool import register_tools as register_bigquery
 from .brevo_tool import register_tools as register_brevo
+from .ipinfo_tool import register_tools as register_ipinfo
 from .calcom_tool import register_tools as register_calcom
 from .calendar_tool import register_tools as register_calendar
 from .calendly_tool import register_tools as register_calendly
@@ -246,6 +247,7 @@ def _register_unverified(
     register_intercom(mcp, credentials=credentials)
     register_apollo(mcp, credentials=credentials)
     register_brevo(mcp, credentials=credentials)
+    register_ipinfo(mcp, credentials=credentials)
     register_bigquery(mcp, credentials=credentials)
     register_calcom(mcp, credentials=credentials)
     register_razorpay(mcp, credentials=credentials)

--- a/tools/src/aden_tools/tools/ipinfo_tool/README.md
+++ b/tools/src/aden_tools/tools/ipinfo_tool/README.md
@@ -1,0 +1,23 @@
+# IPInfo Tool
+
+IP geolocation and network intelligence for Hive agents using ipinfo.io.
+
+## Authentication
+Requires a free IPInfo token. Sign up at https://ipinfo.io/signup.
+Set `IPINFO_TOKEN` environment variable.
+
+## Tools
+
+### ipinfo_get_ip_details
+Get location and network data for any IP address.
+- `ip` (str): IP address e.g. 8.8.8.8
+
+### ipinfo_get_my_ip
+Get location and network data for the current machine's IP.
+
+## Returns
+ip, city, region, country, org, timezone, loc (lat/lon)
+
+## License
+Data provided under CC BY-SA 4.0 (attribution required).
+Free tier: 50,000 requests/month.

--- a/tools/src/aden_tools/tools/ipinfo_tool/__init__.py
+++ b/tools/src/aden_tools/tools/ipinfo_tool/__init__.py
@@ -1,0 +1,3 @@
+from .ipinfo_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/ipinfo_tool/ipinfo_tool.py
+++ b/tools/src/aden_tools/tools/ipinfo_tool/ipinfo_tool.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import httpx
+from fastmcp import FastMCP
+
+
+def register_tools(mcp: FastMCP, credentials: dict | None = None) -> None:
+    """Register IPInfo tools with the MCP server."""
+
+    token = (credentials or {}).get("ipinfo", "")
+
+    @mcp.tool()
+    def ipinfo_get_ip_details(ip: str) -> dict:
+        """Get geolocation and network details for any IP address.
+
+        Args:
+            ip: IP address to look up (e.g. 8.8.8.8)
+
+        Returns:
+            Dictionary with ip, city, region, country, org, timezone, loc
+        """
+        try:
+            url = f"https://ipinfo.io/{ip}"
+            params = {"token": token} if token else {}
+            response = httpx.get(url, params=params, timeout=10)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            return {"error": f"API request failed: {e.response.status_code}"}
+        except Exception as e:
+            return {"error": str(e)}
+
+    @mcp.tool()
+    def ipinfo_get_my_ip() -> dict:
+        """Get geolocation and network details for the current machine's IP address.
+
+        Returns:
+            Dictionary with ip, city, region, country, org, timezone, loc
+        """
+        try:
+            url = "https://ipinfo.io/json"
+            params = {"token": token} if token else {}
+            response = httpx.get(url, params=params, timeout=10)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            return {"error": f"API request failed: {e.response.status_code}"}
+        except Exception as e:
+            return {"error": str(e)}


### PR DESCRIPTION
Closes #6508

## Summary
Adds IPInfo integration using ipinfo.io — free tier, 50k requests/month.

## Tools Added
- `ipinfo_get_ip_details(ip)` — location, org, timezone for any IP
- `ipinfo_get_my_ip()` — details for current machine's IP

## Credential
- IPINFO_TOKEN (free signup at ipinfo.io)

## Testing
- ipinfo_get_ip_details("8.8.8.8") → Google DNS location ✅
- ipinfo_get_my_ip() → current machine location ✅

## Notes
- Follows existing credential pattern (brevo_tool)
- Parent issue: #2805