### PR TITLE
feat: add unix and sse MCP transports

### DIFF
--- a/core/framework/runner/mcp_client.py
+++ b/core/framework/runner/mcp_client.py
@@ -1,7 +1,7 @@
 """MCP Client for connecting to Model Context Protocol servers.
 
 This module provides a client for connecting to MCP servers and invoking their tools.
-Supports both STDIO and HTTP transports using the official MCP Python SDK.
+Supports STDIO, HTTP, UNIX socket, and SSE transports using the official MCP Python SDK.
 """
 
 import asyncio
@@ -22,7 +22,7 @@ class MCPServerConfig:
     """Configuration for an MCP server connection."""
 
     name: str
-    transport: Literal["stdio", "http"]
+    transport: Literal["stdio", "http", "unix", "sse"]
 
     # For STDIO transport
     command: str | None = None
@@ -33,6 +33,7 @@ class MCPServerConfig:
     # For HTTP transport
     url: str | None = None
     headers: dict[str, str] = field(default_factory=dict)
+    socket_path: str | None = None
 
     # Optional metadata
     description: str = ""
@@ -52,7 +53,7 @@ class MCPClient:
     """
     Client for communicating with MCP servers.
 
-    Supports both STDIO and HTTP transports using the official MCP SDK.
+    Supports STDIO, HTTP, UNIX socket, and SSE transports using the official MCP SDK.
     Manages the connection lifecycle and provides methods to list and invoke tools.
     """
 
@@ -68,6 +69,7 @@ class MCPClient:
         self._read_stream = None
         self._write_stream = None
         self._stdio_context = None  # Context manager for stdio_client
+        self._sse_context = None  # Context manager for sse_client
         self._errlog_handle = None  # Track errlog file handle for cleanup
         self._http_client: httpx.Client | None = None
         self._tools: dict[str, MCPTool] = {}
@@ -141,6 +143,10 @@ class MCPClient:
             self._connect_stdio()
         elif self.config.transport == "http":
             self._connect_http()
+        elif self.config.transport == "unix":
+            self._connect_unix()
+        elif self.config.transport == "sse":
+            self._connect_sse()
         else:
             raise ValueError(f"Unsupported transport: {self.config.transport}")
 
@@ -266,10 +272,94 @@ class MCPClient:
             logger.warning(f"Health check failed for MCP server '{self.config.name}': {e}")
             # Continue anyway, server might not have health endpoint
 
+    def _connect_unix(self) -> None:
+        """Connect to MCP server via UNIX domain socket transport."""
+        if not self.config.url:
+            raise ValueError("url is required for UNIX transport")
+        if not self.config.socket_path:
+            raise ValueError("socket_path is required for UNIX transport")
+
+        self._http_client = httpx.Client(
+            base_url=self.config.url,
+            headers=self.config.headers,
+            timeout=30.0,
+            transport=httpx.HTTPTransport(uds=self.config.socket_path),
+        )
+
+        try:
+            response = self._http_client.get("/health")
+            response.raise_for_status()
+            logger.info(
+                "Connected to MCP server '%s' via UNIX socket at %s",
+                self.config.name,
+                self.config.socket_path,
+            )
+        except Exception as e:
+            logger.warning(f"Health check failed for MCP server '{self.config.name}': {e}")
+            # Continue anyway, server might not have health endpoint
+
+    def _connect_sse(self) -> None:
+        """Connect to MCP server via SSE transport using MCP SDK with persistent session."""
+        if not self.config.url:
+            raise ValueError("url is required for SSE transport")
+
+        try:
+            loop_started = threading.Event()
+            connection_ready = threading.Event()
+            connection_error = []
+
+            def run_event_loop():
+                """Run event loop in background thread."""
+                self._loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(self._loop)
+                loop_started.set()
+
+                async def init_connection():
+                    try:
+                        from mcp import ClientSession
+                        from mcp.client.sse import sse_client
+
+                        self._sse_context = sse_client(
+                            self.config.url,
+                            headers=self.config.headers,
+                            timeout=30.0,
+                        )
+                        (
+                            self._read_stream,
+                            self._write_stream,
+                        ) = await self._sse_context.__aenter__()
+
+                        self._session = ClientSession(self._read_stream, self._write_stream)
+                        await self._session.__aenter__()
+                        await self._session.initialize()
+
+                        connection_ready.set()
+                    except Exception as e:
+                        connection_error.append(e)
+                        connection_ready.set()
+
+                self._loop.create_task(init_connection())
+                self._loop.run_forever()
+
+            self._loop_thread = threading.Thread(target=run_event_loop, daemon=True)
+            self._loop_thread.start()
+
+            loop_started.wait(timeout=5)
+            if not loop_started.is_set():
+                raise RuntimeError("Event loop failed to start")
+
+            connection_ready.wait(timeout=10)
+            if connection_error:
+                raise connection_error[0]
+
+            logger.info(f"Connected to MCP server '{self.config.name}' via SSE")
+        except Exception as e:
+            raise RuntimeError(f"Failed to connect to MCP server: {e}") from e
+
     def _discover_tools(self) -> None:
         """Discover available tools from the MCP server."""
         try:
-            if self.config.transport == "stdio":
+            if self.config.transport in {"stdio", "sse"}:
                 tools_list = self._run_async(self._list_tools_stdio_async())
             else:
                 tools_list = self._list_tools_http()
@@ -371,8 +461,36 @@ class MCPClient:
         if self.config.transport == "stdio":
             with self._stdio_call_lock:
                 return self._run_async(self._call_tool_stdio_async(tool_name, arguments))
+        elif self.config.transport == "sse":
+            return self._call_tool_with_retry(
+                lambda: self._run_async(self._call_tool_stdio_async(tool_name, arguments))
+            )
+        elif self.config.transport == "unix":
+            return self._call_tool_with_retry(lambda: self._call_tool_http(tool_name, arguments))
         else:
             return self._call_tool_http(tool_name, arguments)
+
+    def _call_tool_with_retry(self, call: Any) -> Any:
+        """Retry transient MCP transport failures once after reconnecting."""
+        if self.config.transport == "stdio":
+            return call()
+
+        if self.config.transport not in {"unix", "sse"}:
+            return call()
+
+        try:
+            return call()
+        except (httpx.ConnectError, httpx.ReadTimeout) as original_error:
+            logger.warning(
+                "Retrying MCP tool call after transport error from '%s': %s",
+                self.config.name,
+                original_error,
+            )
+            self._reconnect()
+            try:
+                return call()
+            except (httpx.ConnectError, httpx.ReadTimeout) as retry_error:
+                raise original_error from retry_error
 
     async def _call_tool_stdio_async(self, tool_name: str, arguments: dict[str, Any]) -> Any:
         """Call tool via STDIO protocol using persistent session."""
@@ -433,18 +551,24 @@ class MCPClient:
         except Exception as e:
             raise RuntimeError(f"Failed to call tool via HTTP: {e}") from e
 
+    def _reconnect(self) -> None:
+        """Reconnect to the configured MCP server."""
+        logger.info(f"Reconnecting to MCP server '{self.config.name}'...")
+        self.disconnect()
+        self.connect()
+
     _CLEANUP_TIMEOUT = 10
     _THREAD_JOIN_TIMEOUT = 12
 
     async def _cleanup_stdio_async(self) -> None:
-        """Async cleanup for STDIO session and context managers.
+        """Async cleanup for persistent MCP session and context managers.
 
         Cleanup order is critical:
-        - The session must be closed BEFORE the stdio_context because the session
-          depends on the streams provided by stdio_context.
-        - This mirrors the initialization order in _connect_stdio(), where
-          stdio_context is entered first (providing streams), then the session is
-          created with those streams and entered.
+        - The session must be closed BEFORE the transport context manager because the
+          session depends on the streams provided by that context.
+        - This mirrors the initialization order in _connect_stdio() / _connect_sse(),
+          where the transport context is entered first (providing streams), then the
+          session is created with those streams and entered.
         - Do not change this ordering without carefully considering these dependencies.
         """
         # First: close session (depends on stdio_context streams)
@@ -476,6 +600,18 @@ class MCPClient:
                 logger.warning(f"Error closing STDIO context: {e}")
         finally:
             self._stdio_context = None
+
+        try:
+            if self._sse_context:
+                await self._sse_context.__aexit__(None, None, None)
+        except asyncio.CancelledError:
+            logger.debug(
+                "SSE context cleanup was cancelled; proceeding with best-effort shutdown"
+            )
+        except Exception as e:
+            logger.warning(f"Error closing SSE context: {e}")
+        finally:
+            self._sse_context = None
 
         # Third: close errlog file handle if we opened one
         if self._errlog_handle is not None:
@@ -552,6 +688,7 @@ class MCPClient:
             # Setting None to None is safe and ensures clean state.
             self._session = None
             self._stdio_context = None
+            self._sse_context = None
             self._read_stream = None
             self._write_stream = None
             self._loop = None

--- a/core/framework/runner/mcp_client.py
+++ b/core/framework/runner/mcp_client.py
@@ -605,9 +605,7 @@ class MCPClient:
             if self._sse_context:
                 await self._sse_context.__aexit__(None, None, None)
         except asyncio.CancelledError:
-            logger.debug(
-                "SSE context cleanup was cancelled; proceeding with best-effort shutdown"
-            )
+            logger.debug("SSE context cleanup was cancelled; proceeding with best-effort shutdown")
         except Exception as e:
             logger.warning(f"Error closing SSE context: {e}")
         finally:

--- a/core/tests/test_mcp_client.py
+++ b/core/tests/test_mcp_client.py
@@ -1,0 +1,228 @@
+"""Unit tests for MCP client transport and reconnect behavior."""
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from framework.runner import mcp_client as mcp_client_module
+from framework.runner.mcp_client import MCPClient, MCPServerConfig, MCPTool
+
+
+class _FakeResponse:
+    def __init__(self, payload=None):
+        self._payload = payload or {}
+
+    def raise_for_status(self) -> None:
+        """Pretend the request succeeded."""
+
+    def json(self):
+        return self._payload
+
+
+class _FakeHttpClient:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.get_calls: list[str] = []
+        self.closed = False
+
+    def get(self, path: str) -> _FakeResponse:
+        self.get_calls.append(path)
+        return _FakeResponse()
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_connect_unix_transport_uses_socket_path(monkeypatch):
+    created = {}
+
+    class FakeHTTPTransport:
+        def __init__(self, *, uds: str):
+            created["uds"] = uds
+            self.uds = uds
+
+    def fake_client_factory(**kwargs):
+        client = _FakeHttpClient(**kwargs)
+        created["client"] = client
+        return client
+
+    monkeypatch.setattr(mcp_client_module.httpx, "HTTPTransport", FakeHTTPTransport)
+    monkeypatch.setattr(mcp_client_module.httpx, "Client", fake_client_factory)
+    monkeypatch.setattr(MCPClient, "_discover_tools", lambda self: None)
+
+    client = MCPClient(
+        MCPServerConfig(
+            name="unix-server",
+            transport="unix",
+            url="http://localhost",
+            socket_path="/tmp/test.sock",
+        )
+    )
+
+    client.connect()
+
+    assert created["uds"] == "/tmp/test.sock"
+    assert client._http_client is created["client"]  # noqa: SLF001 - direct unit test
+    assert created["client"].kwargs["base_url"] == "http://localhost"
+    assert created["client"].get_calls == ["/health"]
+
+    client.disconnect()
+    assert created["client"].closed is True
+
+
+def test_connect_sse_and_list_tools(monkeypatch):
+    pytest.importorskip("mcp")
+    sse_module = pytest.importorskip("mcp.client.sse")
+    import mcp
+
+    contexts = []
+
+    class FakeSSEContext:
+        def __init__(self, url: str, headers: dict[str, str] | None, timeout: float):
+            self.url = url
+            self.headers = headers
+            self.timeout = timeout
+            self.exited = False
+
+        async def __aenter__(self):
+            return "read-stream", "write-stream"
+
+        async def __aexit__(self, exc_type, exc, tb):
+            self.exited = True
+
+    class FakeSession:
+        def __init__(self, read_stream, write_stream):
+            self.read_stream = read_stream
+            self.write_stream = write_stream
+            self.closed = False
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            self.closed = True
+
+        async def initialize(self):
+            """Pretend session initialization succeeded."""
+
+        async def list_tools(self):
+            return SimpleNamespace(
+                tools=[
+                    SimpleNamespace(
+                        name="search",
+                        description="Search docs",
+                        inputSchema={"type": "object"},
+                    )
+                ]
+            )
+
+    def fake_sse_client(url: str, headers=None, timeout=5, **_kwargs):
+        context = FakeSSEContext(url=url, headers=headers, timeout=timeout)
+        contexts.append(context)
+        return context
+
+    monkeypatch.setattr(sse_module, "sse_client", fake_sse_client)
+    monkeypatch.setattr(mcp, "ClientSession", FakeSession)
+
+    client = MCPClient(
+        MCPServerConfig(
+            name="sse-server",
+            transport="sse",
+            url="http://localhost/sse",
+            headers={"Authorization": "Bearer token"},
+        )
+    )
+
+    client.connect()
+    tools = client.list_tools()
+
+    assert [tool.name for tool in tools] == ["search"]
+    assert tools[0].description == "Search docs"
+    assert contexts[0].url == "http://localhost/sse"
+    assert contexts[0].headers == {"Authorization": "Bearer token"}
+    assert contexts[0].timeout == 30.0
+
+    client.disconnect()
+    assert contexts[0].exited is True
+
+
+def test_call_tool_retries_once_on_connect_error_for_unix(monkeypatch):
+    client = MCPClient(MCPServerConfig(name="unix-server", transport="unix"))
+    client._connected = True  # noqa: SLF001 - direct unit test
+    client._tools = {  # noqa: SLF001 - direct unit test
+        "ping": MCPTool("ping", "Ping tool", {}, "unix-server")
+    }
+
+    first_error = httpx.ConnectError("first failure")
+    calls = {"count": 0}
+    reconnects = []
+
+    def fake_call_tool_http(tool_name, arguments):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise first_error
+        return [{"type": "text", "text": f"{tool_name}:{arguments['value']}"}]
+
+    monkeypatch.setattr(client, "_call_tool_http", fake_call_tool_http)
+    monkeypatch.setattr(client, "_reconnect", lambda: reconnects.append("reconnected"))
+
+    result = client.call_tool("ping", {"value": "ok"})
+
+    assert result == [{"type": "text", "text": "ping:ok"}]
+    assert calls["count"] == 2
+    assert reconnects == ["reconnected"]
+
+
+def test_call_tool_retry_exhausted_raises_original_error_for_unix(monkeypatch):
+    client = MCPClient(MCPServerConfig(name="unix-server", transport="unix"))
+    client._connected = True  # noqa: SLF001 - direct unit test
+    client._tools = {  # noqa: SLF001 - direct unit test
+        "ping": MCPTool("ping", "Ping tool", {}, "unix-server")
+    }
+
+    first_error = httpx.ConnectError("first failure")
+    second_error = httpx.ConnectError("second failure")
+    calls = {"count": 0}
+    reconnects = []
+
+    def fake_call_tool_http(_tool_name, _arguments):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise first_error
+        raise second_error
+
+    monkeypatch.setattr(client, "_call_tool_http", fake_call_tool_http)
+    monkeypatch.setattr(client, "_reconnect", lambda: reconnects.append("reconnected"))
+
+    with pytest.raises(httpx.ConnectError) as exc_info:
+        client.call_tool("ping", {"value": "ok"})
+
+    assert exc_info.value is first_error
+    assert calls["count"] == 2
+    assert reconnects == ["reconnected"]
+
+
+def test_call_tool_http_preserves_runtime_error_wrapping(monkeypatch):
+    client = MCPClient(MCPServerConfig(name="http-server", transport="http"))
+    client._connected = True  # noqa: SLF001 - direct unit test
+    client._tools = {  # noqa: SLF001 - direct unit test
+        "ping": MCPTool("ping", "Ping tool", {}, "http-server")
+    }
+
+    connect_error = httpx.ConnectError("first failure")
+
+    class FailingHttpClient:
+        def post(self, _path, json):
+            raise connect_error
+
+    client._http_client = FailingHttpClient()  # noqa: SLF001 - direct unit test
+    reconnects = []
+    monkeypatch.setattr(client, "_reconnect", lambda: reconnects.append("reconnected"))
+
+    with pytest.raises(RuntimeError) as exc_info:
+        client.call_tool("ping", {"value": "ok"})
+
+    assert "Failed to call tool via HTTP" in str(exc_info.value)
+    assert exc_info.value.__cause__ is connect_error
+    assert reconnects == []


### PR DESCRIPTION
Implements unix socket and SSE MCP transports, adds reconnect-once retry for unix/SSE, and adds focused unit coverage.

## Description

Adds unix socket and SSE transport support to the MCP client, introduces reconnect-once retry behavior for unix/SSE transient connection failures, and adds focused unit tests for the new transport and retry paths.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)


## Related Issues

Fixes #6347

Part of #6321

## Changes Made

- Added `unix` and `sse` transport options to `MCPServerConfig`
- Added `socket_path` support and unix socket connection handling via `httpx.HTTPTransport(uds=...)`
- Added SSE connection support using the MCP Python SDK session lifecycle
- Added reconnect-once retry logic for unix and SSE tool calls on transient connection failures
- Added unit tests for unix transport, SSE transport, retry success, retry exhaustion, and preserved HTTP behavior

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`uv run --package framework pytest core/tests/test_mcp_client.py core/tests/test_tool_registry.py core/tests/test_mcp_server.py`)
- [x] Lint passes (`uv run --package framework ruff check core/framework/runner/mcp_client.py core/tests/test_mcp_client.py`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A
