### PR TITLE
feat(dev): add Docker development environment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,48 @@
+FROM python:3.11-slim
+
+# Install system dependencies required to build Python packages
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    build-essential \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv (Python package manager used by Hive)
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
+
+# Install Node.js 20 to build the React frontend
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs
+
+WORKDIR /app
+
+# Copy the full project into the container
+# (docker-compose sets the build context to the repository root)
+COPY . .
+
+# Install Python dependencies using uv workspace
+RUN uv sync
+
+# Build the React frontend
+WORKDIR /app/core/frontend
+RUN npm install && npm run build
+
+WORKDIR /app
+
+# Copy container startup script
+COPY docker/start.sh /start.sh
+RUN chmod +x /start.sh
+
+# Expose Hive dashboard port
+EXPOSE 8787
+
+# Persist Hive configuration and credentials
+VOLUME ["/root/.hive"]
+
+# Container health check
+HEALTHCHECK CMD curl -f http://localhost:8787/api/health || exit 1
+
+# Start Hive server
+ENTRYPOINT ["/start.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,113 @@
+# Hive Docker Setup
+
+This directory provides a Docker-based environment to run the **Hive Agent Framework** with minimal setup.
+
+It builds the Python runtime, installs the project dependencies using **uv**, compiles the React dashboard, and exposes the Hive API server on port **8787**.
+
+The container also prints the accessible URLs when it starts, making it easy to open the dashboard from the host machine.
+
+---
+
+# Requirements
+
+The setup was tested with the following versions:
+* Docker version 29.1.3
+* Docker Compose version v5.0.0
+
+
+You can verify your installation with:
+
+```bash
+docker --version
+docker compose version
+```
+
+# Project Structure
+
+```
+hive/
+│
+├─ core/
+├─ tools/
+├─ pyproject.toml
+│
+└─ docker/
+   ├─ Dockerfile
+   ├─ docker-compose.yml
+   └─ start.sh
+```
+
+
+
+The start.sh script:
+
+* prints the container IP
+* prints the accessible host URL
+* starts the Hive server bound to 0.0.0.0
+
+Example startup message:
+
+-------------------------------------------------
+ Hive container started
+
+ Container IP:  http://172.18.0.2:8787
+ Local access:  http://localhost:8787
+
+ Dashboard:     http://localhost:8787
+ Healthcheck:   http://localhost:8787/api/health
+--------------------------------------------------
+
+Hive is launched with:
+```bash
+uv run hive serve --host 0.0.0.0 --port 8787
+```
+
+# Running Hive with Docker
+
+Navigate to the docker directory:
+
+```bash
+cd docker
+docker compose up --build
+```
+
+Once the container starts, the Hive dashboard will be available at:
+
+```bash
+http://localhost:8787
+```
+
+Health endpoint:
+
+```bash
+http://localhost:8787/api/health
+```
+
+# Rebuilding the Environment
+
+If the container fails to start or dependencies need to be rebuilt, run:
+```bash
+docker compose down
+docker compose build --no-cache
+docker compose up
+```
+
+# Viewing Logs
+To follow the Hive server logs:
+
+```bash
+docker logs -f hive
+```
+
+# Accessing and Checking the container
+
+To open a shell inside the container without starting the Hive server:
+
+```bash
+docker compose run --service-ports hive bash
+```
+
+
+# Contribution
+
+This Docker setup was created to simplify local development and testing of Hive inside containers. Improvements and suggestions are welcome.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.9"
+
+services:
+
+  hive:
+    container_name: hive
+
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+
+    ports:
+      - "8787:8787"
+
+    volumes:
+      - hive_config:/root/.hive
+
+    restart: unless-stopped
+
+volumes:
+  hive_config:

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+PORT=8787
+
+# obtener IP del contenedor
+CONTAINER_IP=$(hostname -i | awk '{print $1}')
+
+echo ""
+echo "-------------------------------------------------"
+echo " Hive container started ✅"
+echo ""
+echo " Container IP:  http://$CONTAINER_IP:$PORT"
+echo " Local access:  http://localhost:$PORT"
+echo ""
+echo " Dashboard:     http://localhost:$PORT"
+echo " Healthcheck:   http://localhost:$PORT/api/health"
+echo "--------------------------------------------------"
+echo ""
+
+exec uv run hive serve --host 0.0.0.0 --port $PORT


### PR DESCRIPTION
## Description

This PR contributes to the containerization effort discussed in #2241 by adding an optional Docker-based development environment to simplify running Hive locally without manual dependency installation.

The Docker setup installs all required dependencies and builds the frontend automatically.

Once started, the Hive dashboard is available at:

http://localhost:8787

This change does not modify the existing quickstart workflow and is intended as an additional option for contributors who prefer containerized development environments.

---

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

---

## Related Issues

Related to #5368 

---

## Changes Made

- Added Dockerfile for containerized development environment
- Added docker-compose configuration to run Hive locally
- Added container startup script
- Builds frontend automatically during container build
- Exposes Hive dashboard on port `8787`
- Persists Hive configuration using a Docker volume

---

## Testing

Manual testing performed:

- Built container using Docker
- Verified frontend builds successfully
- Verified Hive server starts correctly
- Verified dashboard accessible at `http://localhost:8787`

---

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Manual testing performed

---

## Screenshots

Hive dashboard running locally using Docker:

<img width="1851" height="445" alt="imagen" src="https://github.com/user-attachments/assets/7d284b9b-5c6e-452f-b48d-676a52920e76" />

<img width="1912" height="1030" alt="imagen" src="https://github.com/user-attachments/assets/3a9045fb-1f82-41ff-8276-fa44aee79642" />