### PR TITLE
fix make test compatibility on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
-.PHONY: lint format check test install-hooks help frontend-install frontend-dev frontend-build
+.PHONY: lint format check test test-tools test-live test-all install-hooks help frontend-install frontend-dev frontend-build
+
+# ── Ensure uv is findable in Git Bash on Windows ──────────────────────────────
+# uv installs to ~/.local/bin on Windows/Linux/macOS. Git Bash may not include
+# this in PATH by default, so we prepend it here.
+export PATH := $(HOME)/.local/bin:$(PATH)
+
+# ── Targets ───────────────────────────────────────────────────────────────────
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \


### PR DESCRIPTION
## Description
Fix `make test` (and all other `make` targets) failing on Windows when using Git Bash. `uv` installs itself to `~/.local/bin`, which Git Bash does not include in `PATH` by default, causing every `uv run` command to fail with `'uv' is not recognized`.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
Fixes #6270

## Changes Made
- Prepend `~/.local/bin` to `PATH` in the Makefile so `uv` is discoverable by Git Bash on Windows
- Removed the previous over-engineered OS detection block (`ifeq ($(OS),Windows_NT)`) that introduced `cd /d` — a cmd.exe-only flag that broke Git Bash
- Restored plain `cd` for all targets, which works correctly across Git Bash, macOS, and Linux

## Testing
Describe the tests you ran to verify your changes:
- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed — ran `make test` successfully in Git Bash on Windows after the fix; confirmed the previous `'uv' is not recognized` error is gone

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Before: `make test` fails with `'uv' is not recognized as an internal or external command`
<img width="825" height="509" alt="image" src="https://github.com/user-attachments/assets/7d35908d-4a68-439c-a142-4f3e2237b570" />

After: `make test` runs all pytest suites successfully in powershell on Windows.
<img width="1218" height="463" alt="image" src="https://github.com/user-attachments/assets/169cc141-5b1d-4b9c-91cf-c0ebb17d030e" />
