### PR TITLE
feat(executor): add NodeEvaluator hook for execution-time evaluation

### DIFF
--- a/core/framework/graph/__init__.py
+++ b/core/framework/graph/__init__.py
@@ -9,6 +9,7 @@ from framework.graph.client_io import (
 from framework.graph.context_handoff import ContextHandoff, HandoffContext
 from framework.graph.conversation import ConversationStore, Message, NodeConversation
 from framework.graph.edge import DEFAULT_MAX_TOKENS, EdgeCondition, EdgeSpec, GraphSpec
+from framework.graph.evaluator import NodeEvaluator
 from framework.graph.event_loop_node import (
     EventLoopNode,
     JudgeProtocol,
@@ -36,6 +37,8 @@ __all__ = [
     "EdgeCondition",
     "GraphSpec",
     "DEFAULT_MAX_TOKENS",
+    # Evaluator
+    "NodeEvaluator",
     # Executor
     "GraphExecutor",
     # Conversation

--- a/core/framework/graph/evaluator.py
+++ b/core/framework/graph/evaluator.py
@@ -1,0 +1,28 @@
+"""NodeEvaluator protocol for execution-time quality evaluation."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from framework.graph.node import NodeResult, NodeSpec
+from framework.schemas.eval_report import EvalReport
+
+
+@runtime_checkable
+class NodeEvaluator(Protocol):
+    """Structural protocol for node-level quality evaluation.
+
+    Implementations receive the node specification, its execution result,
+    and the current shared-memory snapshot.  They return an ``EvalReport``
+    with per-dimension scores.
+
+    The protocol is ``runtime_checkable`` so callers can use
+    ``isinstance(obj, NodeEvaluator)`` if needed.
+    """
+
+    async def evaluate(
+        self,
+        node_spec: NodeSpec,
+        node_result: NodeResult,
+        memory: dict[str, Any],
+    ) -> EvalReport: ...

--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -152,6 +152,7 @@ class GraphExecutor:
         dynamic_tools_provider: Callable | None = None,
         dynamic_prompt_provider: Callable | None = None,
         iteration_metadata_provider: Callable | None = None,
+        node_evaluator: Any | None = None,
     ):
         """
         Initialize the executor.
@@ -177,6 +178,9 @@ class GraphExecutor:
                 tool list (for mode switching)
             dynamic_prompt_provider: Optional callback returning current
                 system prompt (for phase switching)
+            node_evaluator: Optional NodeEvaluator for execution-time quality
+                evaluation.  When set, called after each successful node and
+                the resulting EvalReport is attached to runtime logs.
         """
         self.runtime = runtime
         self.llm = llm
@@ -198,6 +202,7 @@ class GraphExecutor:
         self.dynamic_tools_provider = dynamic_tools_provider
         self.dynamic_prompt_provider = dynamic_prompt_provider
         self.iteration_metadata_provider = iteration_metadata_provider
+        self.node_evaluator = node_evaluator
 
         # Parallel execution settings
         self.enable_parallel_execution = enable_parallel_execution
@@ -1043,6 +1048,37 @@ class GraphExecutor:
                             if len(value_str) > 200:
                                 value_str = value_str[:200] + "..."
                             self.logger.info(f"      {key}: {value_str}")
+
+                    # Run NodeEvaluator if configured (non-blocking)
+                    if self.node_evaluator:
+                        try:
+                            eval_report = await self.node_evaluator.evaluate(
+                                node_spec=node_spec,
+                                node_result=result,
+                                memory=dict(memory.items()) if hasattr(memory, "items") else {},
+                            )
+                            self.logger.info(
+                                f"   📊 Eval: faithfulness={eval_report.faithfulness:.2f} "
+                                f"relevance={eval_report.relevance:.2f} "
+                                f"completeness={eval_report.completeness:.2f} "
+                                f"cost_efficiency={eval_report.cost_efficiency:.2f}"
+                            )
+                            if eval_report.weak_dimensions:
+                                self.logger.warning(
+                                    f"   ⚠ Weak dimensions: {eval_report.weak_dimensions}"
+                                )
+                            can_log = self.runtime_logger and hasattr(
+                                self.runtime_logger, "log_eval_report"
+                            )
+                            if can_log:
+                                self.runtime_logger.log_eval_report(
+                                    node_id=node_spec.id,
+                                    eval_report=eval_report,
+                                )
+                        except Exception as eval_err:
+                            self.logger.debug(
+                                f"   NodeEvaluator failed for {node_spec.id}: {eval_err}"
+                            )
 
                     # Write node outputs to memory BEFORE edge evaluation
                     # This enables direct key access in conditional expressions (e.g., "score > 80")

--- a/core/framework/runtime/runtime_logger.py
+++ b/core/framework/runtime/runtime_logger.py
@@ -267,6 +267,27 @@ class RuntimeLogger:
             latency_ms=latency_ms,
         )
 
+    def log_eval_report(self, node_id: str, eval_report: Any) -> None:
+        """Persist an EvalReport as a JSON file alongside L2 logs.
+
+        Best-effort: failures are silently ignored so evaluation never
+        blocks graph execution.
+        """
+        try:
+            import json
+
+            report_dict = (
+                eval_report.model_dump()
+                if hasattr(eval_report, "model_dump")
+                else vars(eval_report)
+            )
+            run_dir = self._store._get_run_dir(self._run_id)
+            eval_path = run_dir / "eval_reports.jsonl"
+            with open(eval_path, "a") as f:
+                f.write(json.dumps({"node_id": node_id, **report_dict}) + "\n")
+        except Exception:
+            pass  # Non-blocking; never fail the execution
+
     async def end_run(
         self,
         status: str,

--- a/core/framework/schemas/__init__.py
+++ b/core/framework/schemas/__init__.py
@@ -1,6 +1,7 @@
 """Schema definitions for runtime data."""
 
 from framework.schemas.decision import Decision, DecisionEvaluation, Option, Outcome
+from framework.schemas.eval_report import EvalReport
 from framework.schemas.run import Problem, Run, RunSummary
 
 __all__ = [
@@ -8,6 +9,7 @@ __all__ = [
     "Option",
     "Outcome",
     "DecisionEvaluation",
+    "EvalReport",
     "Run",
     "RunSummary",
     "Problem",

--- a/core/framework/schemas/eval_report.py
+++ b/core/framework/schemas/eval_report.py
@@ -1,0 +1,25 @@
+"""Multi-dimensional evaluation report for node execution quality."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class EvalReport(BaseModel):
+    """Structured quality report produced by a NodeEvaluator after each node runs.
+
+    Each dimension is scored 0.0–1.0.  ``weak_dimensions`` lists any
+    dimension below a caller-defined threshold so downstream policies
+    (e.g. DegradationPolicy from #6214) can react without re-parsing scores.
+    """
+
+    node_id: str
+    faithfulness: float = Field(default=1.0, ge=0.0, le=1.0)
+    relevance: float = Field(default=1.0, ge=0.0, le=1.0)
+    completeness: float = Field(default=1.0, ge=0.0, le=1.0)
+    cost_efficiency: float = Field(default=1.0, ge=0.0, le=1.0)
+    weak_dimensions: list[str] = Field(default_factory=list)
+    tokens_used: int = 0
+    evaluator_model: str | None = None
+
+    model_config = {"extra": "allow"}

--- a/core/tests/test_node_evaluator.py
+++ b/core/tests/test_node_evaluator.py
@@ -1,0 +1,229 @@
+"""Tests for NodeEvaluator protocol and executor integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from framework.graph.edge import GraphSpec
+from framework.graph.evaluator import NodeEvaluator
+from framework.graph.executor import GraphExecutor
+from framework.graph.goal import Goal
+from framework.graph.node import NodeResult, NodeSpec
+from framework.schemas.eval_report import EvalReport
+
+
+# ---- Dummy runtime (no real logging) ----
+class DummyRuntime:
+    execution_id = ""
+
+    def start_run(self, **kwargs):
+        return "run-1"
+
+    def end_run(self, **kwargs):
+        pass
+
+    def report_problem(self, **kwargs):
+        pass
+
+
+# ---- Fake node that always succeeds ----
+class SuccessNode:
+    def validate_input(self, ctx):
+        return []
+
+    async def execute(self, ctx):
+        return NodeResult(
+            success=True,
+            output={"result": "hello"},
+            tokens_used=50,
+            latency_ms=100,
+        )
+
+
+# ---- Fake node that always fails ----
+class FailingNode:
+    def validate_input(self, ctx):
+        return []
+
+    async def execute(self, ctx):
+        return NodeResult(success=False, error="intentional failure")
+
+
+# ---- Concrete NodeEvaluator for testing ----
+class MockEvaluator:
+    """Satisfies the NodeEvaluator protocol."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def evaluate(
+        self,
+        node_spec: NodeSpec,
+        node_result: NodeResult,
+        memory: dict[str, Any],
+    ) -> EvalReport:
+        self.calls.append(
+            {
+                "node_id": node_spec.id,
+                "output": node_result.output,
+                "memory_keys": list(memory.keys()),
+            }
+        )
+        return EvalReport(
+            node_id=node_spec.id,
+            faithfulness=0.9,
+            relevance=0.8,
+            completeness=0.7,
+            cost_efficiency=0.95,
+            weak_dimensions=["completeness"],
+            tokens_used=node_result.tokens_used,
+        )
+
+
+class FailingEvaluator:
+    """Evaluator that raises to test non-blocking error handling."""
+
+    async def evaluate(
+        self,
+        node_spec: NodeSpec,
+        node_result: NodeResult,
+        memory: dict[str, Any],
+    ) -> EvalReport:
+        raise RuntimeError("Evaluator crashed")
+
+
+# ---- Helper to build a simple one-node graph ----
+def _one_node_graph(node_id: str = "n1") -> GraphSpec:
+    return GraphSpec(
+        id="graph-1",
+        goal_id="g1",
+        nodes=[
+            NodeSpec(
+                id=node_id,
+                name="test-node",
+                description="a test node",
+                node_type="event_loop",
+                input_keys=[],
+                output_keys=["result"],
+                max_retries=0,
+            )
+        ],
+        edges=[],
+        entry_node=node_id,
+        terminal_nodes=[node_id],
+    )
+
+
+def _goal() -> Goal:
+    return Goal(id="g1", name="test-goal", description="test")
+
+
+# ---- Schema tests ----
+
+
+class TestEvalReport:
+    def test_defaults(self):
+        report = EvalReport(node_id="n1")
+        assert report.faithfulness == 1.0
+        assert report.relevance == 1.0
+        assert report.completeness == 1.0
+        assert report.cost_efficiency == 1.0
+        assert report.weak_dimensions == []
+        assert report.tokens_used == 0
+        assert report.evaluator_model is None
+
+    def test_custom_scores(self):
+        report = EvalReport(
+            node_id="n1",
+            faithfulness=0.5,
+            relevance=0.3,
+            weak_dimensions=["faithfulness", "relevance"],
+            evaluator_model="gpt-4o",
+        )
+        assert report.faithfulness == 0.5
+        assert report.relevance == 0.3
+        assert report.weak_dimensions == ["faithfulness", "relevance"]
+        assert report.evaluator_model == "gpt-4o"
+
+    def test_score_bounds(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            EvalReport(node_id="n1", faithfulness=1.5)
+        with pytest.raises(ValidationError):
+            EvalReport(node_id="n1", relevance=-0.1)
+
+    def test_extra_fields_allowed(self):
+        report = EvalReport(node_id="n1", custom_metric=0.42)
+        assert report.model_dump()["custom_metric"] == 0.42
+
+
+# ---- Protocol tests ----
+
+
+class TestNodeEvaluatorProtocol:
+    def test_mock_evaluator_satisfies_protocol(self):
+        evaluator = MockEvaluator()
+        assert isinstance(evaluator, NodeEvaluator)
+
+    def test_failing_evaluator_satisfies_protocol(self):
+        evaluator = FailingEvaluator()
+        assert isinstance(evaluator, NodeEvaluator)
+
+
+# ---- Executor integration tests ----
+
+
+class TestExecutorEvaluatorHook:
+    @pytest.mark.asyncio
+    async def test_evaluator_called_on_success(self):
+        evaluator = MockEvaluator()
+        executor = GraphExecutor(
+            runtime=DummyRuntime(),
+            node_registry={"n1": SuccessNode()},
+            node_evaluator=evaluator,
+        )
+        result = await executor.execute(graph=_one_node_graph(), goal=_goal())
+
+        assert result.success is True
+        assert len(evaluator.calls) == 1
+        assert evaluator.calls[0]["node_id"] == "n1"
+        assert evaluator.calls[0]["output"] == {"result": "hello"}
+
+    @pytest.mark.asyncio
+    async def test_evaluator_not_called_on_failure(self):
+        evaluator = MockEvaluator()
+        executor = GraphExecutor(
+            runtime=DummyRuntime(),
+            node_registry={"n1": FailingNode()},
+            node_evaluator=evaluator,
+        )
+        result = await executor.execute(graph=_one_node_graph(), goal=_goal())
+
+        assert result.success is False
+        assert len(evaluator.calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_evaluator_failure_is_non_blocking(self):
+        executor = GraphExecutor(
+            runtime=DummyRuntime(),
+            node_registry={"n1": SuccessNode()},
+            node_evaluator=FailingEvaluator(),
+        )
+        result = await executor.execute(graph=_one_node_graph(), goal=_goal())
+
+        # Execution should succeed even though evaluator crashed
+        assert result.success is True
+        assert result.path == ["n1"]
+
+    @pytest.mark.asyncio
+    async def test_no_evaluator_is_default(self):
+        executor = GraphExecutor(
+            runtime=DummyRuntime(),
+            node_registry={"n1": SuccessNode()},
+        )
+        # No evaluator set — should work exactly as before
+        result = await executor.execute(graph=_one_node_graph(), goal=_goal())
+        assert result.success is True


### PR DESCRIPTION
## Description

Wires a `NodeEvaluator` protocol into `GraphExecutor.execute()` so every successful node produces a structured `EvalReport` (faithfulness, relevance, completeness, cost_efficiency, weak_dimensions) alongside its `NodeResult`. Zero breaking changes — `node_evaluator=None` is the default.

## Type of Change

- [x] New feature (non-breaking)

## Related Issues

Fixes #6542

## Changes Made

| File | What |
|------|------|
| `core/framework/schemas/eval_report.py` | New `EvalReport` Pydantic schema — four 0.0–1.0 dimensions + `weak_dimensions` list |
| `core/framework/graph/evaluator.py` | New `NodeEvaluator` Protocol (runtime_checkable, structural typing) |
| `core/framework/graph/executor.py` | Hook after output validation, before memory writes. Non-blocking `try/except`. +1 constructor param |
| `core/framework/runtime/runtime_logger.py` | `log_eval_report()` method — persists eval reports as JSONL |
| `core/framework/schemas/__init__.py` | Export `EvalReport` |
| `core/framework/graph/__init__.py` | Export `NodeEvaluator` |
| `core/tests/test_node_evaluator.py` | 10 tests: schema validation, protocol conformance, executor integration |

## Design Decisions

- **Protocol, not ABC**: Matches existing `JudgeProtocol` pattern. Structural typing means any class with `async evaluate(node_spec, node_result, memory) -> EvalReport` works without inheritance.
- **Non-blocking**: Evaluator failures are caught and logged at DEBUG level. Never blocks graph execution.
- **`model_config = {"extra": "allow"}`**: Follows `DecisionEvaluation` pattern — lets users attach custom dimensions without schema changes.
- **JSONL persistence**: `eval_reports.jsonl` sits alongside existing L2 logs. No schema migration needed.

## Testing

- [x] 10 new tests pass (`uv run pytest core/tests/test_node_evaluator.py -v`)
- [x] Existing executor tests pass (`uv run pytest core/tests/test_graph_executor.py -v`)
- [x] Lint passes (`uv run ruff check core/`)
- [x] Format passes (`uv run ruff format --check core/`)

## Checklist

- [x] Self-review completed
- [x] No warnings introduced
- [x] Tests added for new functionality
- [x] Zero breaking changes — default `node_evaluator=None` preserves existing behavior