### PR TITLE
fix: update default storage path from `/tmp` to `~/.hive/agents/{agent_name}/`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,7 +69,7 @@ export MOCK_MODE=1
 # Fernet encryption key for credential store at ~/.hive/credentials
 export HIVE_CREDENTIAL_KEY="your-fernet-key"
 
-# Custom agent storage path (default: /tmp)
+# Custom agent storage path (default: ~/.hive/agents/{agent_name}/)
 export AGENT_STORAGE_PATH="/custom/storage"
 ```
 
@@ -84,7 +84,7 @@ CONFIG = {
     "max_tokens": 8192,  # default: DEFAULT_MAX_TOKENS from framework.graph
     "temperature": 0.7,
     "tools": ["web_search", "pdf_read"],   # MCP tools to enable
-    "storage_path": "/tmp/my_agent",       # Runtime data location
+    "storage_path": "~/.hive/agents/my_agent/",  # Runtime data location (default)
 }
 ```
 

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -523,7 +523,7 @@ export ANTHROPIC_API_KEY="sk-ant-..."
 # Fernet encryption key for credential store at ~/.hive/credentials
 export HIVE_CREDENTIAL_KEY="your-fernet-key"
 
-# Agent storage location (default: /tmp)
+# Agent storage location (default: ~/.hive/agents/{agent_name}/)
 export AGENT_STORAGE_PATH="/custom/storage"
 ```
 


### PR DESCRIPTION
## Description

Update outdated documentation references to the default agent storage path. The code uses `~/.hive/agents/{agent_name}/` as the default persistent storage location, but the docs still referenced `/tmp`.

## Resolves

Fixes #6266 

## Changes

- Updated `docs/configuration.md`:
  - Changed comment from `(default: /tmp)` to `(default: ~/.hive/agents/{agent_name}/)`
  - Updated example `storage_path` from `"/tmp/my_agent"` to `"~/.hive/agents/my_agent/"`

- Updated `docs/environment-setup.md`:
  - Changed comment from `(default: /tmp)` to `(default: ~/.hive/agents/{agent_name}/)`

## Testing

- [x] Documentation reviewed against actual implementation in `runner.py`
- [x] Changes reflect current default storage behavior

