### PR TITLE
fix: prevent path traversal in session history endpoints (micro-fix)

### DIFF
--- a/core/framework/server/app.py
+++ b/core/framework/server/app.py
@@ -102,6 +102,10 @@ def cold_sessions_dir(session_id: str) -> Path | None:
     Returns None if meta.json is missing or has no agent_path.
     """
     import json
+    
+    # Must validate the injected argument since it comes directly from a URL path template
+    # inside handle_list_worker_sessions / handle_messages / etc via request.match_info
+    session_id = safe_path_segment(session_id)
 
     meta_path = Path.home() / ".hive" / "queen" / "session" / session_id / "meta.json"
     if not meta_path.exists():

--- a/core/framework/server/routes_sessions.py
+++ b/core/framework/server/routes_sessions.py
@@ -868,7 +868,7 @@ async def handle_queen_messages(request: web.Request) -> web.Response:
     Reads directly from disk so it works for both live sessions and cold
     (post-server-restart) sessions — no live session required.
     """
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
 
     queen_dir = Path.home() / ".hive" / "queen" / "session" / session_id
     convs_dir = queen_dir / "conversations"
@@ -924,7 +924,7 @@ async def handle_session_events_history(request: web.Request) -> web.Response:
     replays these events through ``sseEventToChatMessage`` to fully reconstruct
     the UI state on resume.
     """
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
 
     queen_dir = Path.home() / ".hive" / "queen" / "session" / session_id
     events_path = queen_dir / "events.jsonl"
@@ -981,7 +981,7 @@ async def handle_delete_history_session(request: web.Request) -> web.Response:
     This is the frontend 'delete from history' action.
     """
     manager = _get_manager(request)
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
 
     # Stop the live session if it exists (best-effort)
     if manager.get_session(session_id):

--- a/core/framework/server/session_manager.py
+++ b/core/framework/server/session_manager.py
@@ -950,6 +950,9 @@ class SessionManager:
         ~/.hive/queen/session/{session_id}/conversations/.  Returns None when
         no data is found so callers can fall through to a 404.
         """
+        from framework.server.app import safe_path_segment
+        session_id = safe_path_segment(session_id)
+        
         queen_dir = Path.home() / ".hive" / "queen" / "session" / session_id
         convs_dir = queen_dir / "conversations"
         if not convs_dir.exists():


### PR DESCRIPTION
Fixes #6553. Validates \session_id\ with \safe_path_segment\ in \outes_sessions.py\, \pp.py\ (\cold_sessions_dir\), and \session_manager.py\ (\get_cold_session_info\).