### PR TITLE
Inject execution-scope preamble into worker node system prompts

### DIFF
--- a/core/framework/graph/event_loop_node.py
+++ b/core/framework/graph/event_loop_node.py
@@ -518,9 +518,7 @@ class EventLoopNode(NodeProtocol):
                     and ctx.node_spec.node_type in ("event_loop", "gcu")
                     and ctx.node_spec.output_keys
                 ):
-                    system_prompt = (
-                        f"{EXECUTION_SCOPE_PREAMBLE}\n\n{system_prompt}"
-                    )
+                    system_prompt = f"{EXECUTION_SCOPE_PREAMBLE}\n\n{system_prompt}"
                 # Prepend GCU browser best-practices prompt for gcu nodes
                 if ctx.node_spec.node_type == "gcu":
                     from framework.graph.gcu import GCU_BROWSER_SYSTEM_PROMPT

--- a/core/framework/graph/event_loop_node.py
+++ b/core/framework/graph/event_loop_node.py
@@ -504,9 +504,23 @@ class EventLoopNode(NodeProtocol):
                 _restored_tool_fingerprints = []
 
                 # Fresh conversation: either isolated mode or first node in continuous mode.
-                from framework.graph.prompt_composer import _with_datetime
+                from framework.graph.prompt_composer import (
+                    EXECUTION_SCOPE_PREAMBLE,
+                    _with_datetime,
+                )
 
                 system_prompt = _with_datetime(ctx.node_spec.system_prompt or "")
+                # Prepend execution-scope preamble for worker nodes so the
+                # LLM knows it is one step in a pipeline and should not try
+                # to perform work that belongs to other nodes.
+                if (
+                    not ctx.is_subagent_mode
+                    and ctx.node_spec.node_type in ("event_loop", "gcu")
+                    and ctx.node_spec.output_keys
+                ):
+                    system_prompt = (
+                        f"{EXECUTION_SCOPE_PREAMBLE}\n\n{system_prompt}"
+                    )
                 # Prepend GCU browser best-practices prompt for gcu nodes
                 if ctx.node_spec.node_type == "gcu":
                     from framework.graph.gcu import GCU_BROWSER_SYSTEM_PROMPT

--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -1420,6 +1420,7 @@ class GraphExecutor:
                     next_spec = graph.get_node(current_node_id)
                     if next_spec and next_spec.node_type == "event_loop":
                         from framework.graph.prompt_composer import (
+                            EXECUTION_SCOPE_PREAMBLE,
                             build_accounts_prompt,
                             build_narrative,
                             build_transition_marker,
@@ -1459,9 +1460,14 @@ class GraphExecutor:
                             )
 
                         # Compose new system prompt (Layer 1 + 2 + 3 + accounts)
+                        # Prepend scope preamble to focus so the LLM stays
+                        # within this node's responsibility.
+                        _focus = next_spec.system_prompt
+                        if next_spec.output_keys and _focus:
+                            _focus = f"{EXECUTION_SCOPE_PREAMBLE}\n\n{_focus}"
                         new_system = compose_system_prompt(
                             identity_prompt=getattr(graph, "identity_prompt", None),
-                            focus_prompt=next_spec.system_prompt,
+                            focus_prompt=_focus,
                             narrative=narrative,
                             accounts_prompt=_node_accounts,
                         )

--- a/core/framework/graph/prompt_composer.py
+++ b/core/framework/graph/prompt_composer.py
@@ -26,6 +26,16 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Injected into every worker node's system prompt so the LLM understands
+# it is one step in a multi-node pipeline and should not overreach.
+EXECUTION_SCOPE_PREAMBLE = (
+    "EXECUTION SCOPE: You are one node in a multi-step workflow graph. "
+    "Focus ONLY on the task described in your instructions below. "
+    "Call set_output() for each of your declared output keys, then stop. "
+    "Do NOT attempt work that belongs to other nodes — the framework "
+    "routes data between nodes automatically."
+)
+
 
 def _with_datetime(prompt: str) -> str:
     """Append current datetime with local timezone to a system prompt."""
@@ -306,6 +316,12 @@ def build_transition_marker(
     # Next phase
     sections.append(f"\nNow entering: {next_node.name}")
     sections.append(f"  {next_node.description}")
+    if next_node.output_keys:
+        sections.append(
+            f"\nYour ONLY job in this phase: complete the task above and call "
+            f"set_output() for {next_node.output_keys}. Do NOT do work that "
+            f"belongs to later phases."
+        )
 
     # Reflection prompt (engineered metacognition)
     sections.append(


### PR DESCRIPTION
## Summary

- Add `EXECUTION_SCOPE_PREAMBLE` constant to `prompt_composer.py` — a brief guardrail telling the LLM it is one node in a multi-step graph and should only do its own part
- Prepend preamble to fresh conversation system prompts in `event_loop_node.py` (for isolated mode / first continuous node)
- Prepend preamble to focus prompt at continuous-mode phase transitions in `executor.py`
- Add phase-specific scope reminder in transition markers ("Your ONLY job in this phase...")

Closes #6567

## Test plan

- [x] `test_subagent.py` — 32 passed
- [x] `test_event_loop_node*.py` — 104 passed, 4 skipped
- [x] `test_prompt_composer*.py` / transition tests — 5 passed
- [ ] Manual: run a multi-node continuous agent and verify nodes stay in scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)