### PR TITLE
feat(mcp-registry): add MCPRegistry core module (#6349)

### DIFF
--- a/core/framework/agents/credential_tester/agent.py
+++ b/core/framework/agents/credential_tester/agent.py
@@ -16,6 +16,7 @@ after the user picks an account programmatically.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -25,12 +26,15 @@ from framework.graph.checkpoint_config import CheckpointConfig
 from framework.graph.edge import GraphSpec
 from framework.graph.executor import ExecutionResult
 from framework.llm import LiteLLMProvider
+from framework.runner.mcp_registry import MCPRegistry
 from framework.runner.tool_registry import ToolRegistry
 from framework.runtime.agent_runtime import AgentRuntime, create_agent_runtime
 from framework.runtime.execution_stream import EntryPointSpec
 
 from .config import default_config
 from .nodes import build_tester_node
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from framework.runner import AgentRunner
@@ -562,6 +566,15 @@ class CredentialTesterAgent:
         mcp_config_path = Path(__file__).parent / "mcp_servers.json"
         if mcp_config_path.exists():
             self._tool_registry.load_mcp_config(mcp_config_path)
+
+        try:
+            registry = MCPRegistry()
+            registry.initialize()
+            registry_configs = registry.load_agent_selection(Path(__file__).parent)
+            if registry_configs:
+                self._tool_registry.load_registry_servers(registry_configs)
+        except Exception:
+            logger.warning("MCP registry config failed to load", exc_info=True)
 
         extra_kwargs = getattr(self.config, "extra_kwargs", {}) or {}
         llm = LiteLLMProvider(

--- a/core/framework/observability/logging.py
+++ b/core/framework/observability/logging.py
@@ -30,6 +30,8 @@ from typing import Any
 # ContextVar is thread-safe and async-safe - perfect for concurrent agent execution
 trace_context: ContextVar[dict[str, Any] | None] = ContextVar("trace_context", default=None)
 
+_STANDARD_LOG_RECORD_FIELDS = set(logging.makeLogRecord({}).__dict__)
+
 # ANSI escape code pattern (matches \033[...m or \x1b[...m)
 ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;]*m|\033\[[0-9;]*m")
 
@@ -91,6 +93,14 @@ class StructuredFormatter(logging.Formatter):
         model = getattr(record, "model", None)
         if model is not None:
             log_entry["model"] = model
+
+        # Preserve arbitrary structured fields passed via ``extra=...``.
+        for key, value in record.__dict__.items():
+            if key in _STANDARD_LOG_RECORD_FIELDS or key.startswith("_"):
+                continue
+            if key in log_entry:
+                continue
+            log_entry[key] = value
 
         # Add exception info if present (strip ANSI codes from exception text too)
         if record.exc_info:

--- a/core/framework/runner/__init__.py
+++ b/core/framework/runner/__init__.py
@@ -1,5 +1,6 @@
 """Agent Runner - load and run exported agents."""
 
+from framework.runner.mcp_registry import MCPRegistry
 from framework.runner.orchestrator import AgentOrchestrator
 from framework.runner.protocol import (
     AgentMessage,
@@ -17,6 +18,7 @@ __all__ = [
     "AgentInfo",
     "ValidationResult",
     "ToolRegistry",
+    "MCPRegistry",
     "tool",
     # Multi-agent
     "AgentOrchestrator",

--- a/core/framework/runner/mcp_connection_manager.py
+++ b/core/framework/runner/mcp_connection_manager.py
@@ -2,13 +2,14 @@
 
 import logging
 import threading
-from typing import Any
 
 import httpx
 
 from framework.runner.mcp_client import MCPClient, MCPServerConfig
 
 logger = logging.getLogger(__name__)
+
+_TRANSITION_TIMEOUT = 30.0
 
 
 class MCPConnectionManager:
@@ -22,7 +23,6 @@ class MCPConnectionManager:
         self._refcounts: dict[str, int] = {}
         self._configs: dict[str, MCPServerConfig] = {}
         self._pool_lock = threading.Lock()
-        # Transition events keep callers from racing a connect/reconnect/disconnect.
         self._transitions: dict[str, threading.Event] = {}
 
     @classmethod
@@ -37,6 +37,11 @@ class MCPConnectionManager:
     @staticmethod
     def _is_connected(client: MCPClient | None) -> bool:
         return bool(client and getattr(client, "_connected", False))
+
+    def has_connection(self, server_name: str) -> bool:
+        """Return True when a live pooled connection exists for ``server_name``."""
+        with self._pool_lock:
+            return self._is_connected(self._pool.get(server_name))
 
     def acquire(self, config: MCPServerConfig) -> MCPClient:
         """Get or create a shared connection and increment its refcount."""
@@ -67,13 +72,29 @@ class MCPConnectionManager:
                     should_connect = True
 
             if not should_connect:
-                transition_event.wait()
+                if not transition_event.wait(timeout=_TRANSITION_TIMEOUT):
+                    logger.warning(
+                        "Timed out waiting for transition on MCP server '%s', "
+                        "forcing cleanup and retrying",
+                        server_name,
+                    )
+                    with self._pool_lock:
+                        stuck = self._transitions.get(server_name)
+                        if stuck is transition_event:
+                            self._transitions.pop(server_name, None)
+                            transition_event.set()
                 continue
 
+            logger.info("Connecting to MCP server '%s'", server_name)
             client = MCPClient(config)
             try:
                 client.connect()
             except Exception:
+                logger.warning(
+                    "Failed to connect to MCP server '%s'",
+                    server_name,
+                    exc_info=True,
+                )
                 with self._pool_lock:
                     current = self._transitions.get(server_name)
                     if current is transition_event:
@@ -94,9 +115,21 @@ class MCPConnectionManager:
                     self._configs[server_name] = config
                     self._transitions.pop(server_name, None)
                     transition_event.set()
+                    logger.info(
+                        "Connected to MCP server '%s' (refcount=1)",
+                        server_name,
+                    )
                     return client
 
-            client.disconnect()
+            # Lost the transition race, clean up and retry
+            try:
+                client.disconnect()
+            except Exception:
+                logger.debug(
+                    "Error disconnecting stale client for '%s'",
+                    server_name,
+                    exc_info=True,
+                )
 
     def release(self, server_name: str) -> None:
         """Decrement refcount and disconnect when the last user releases."""
@@ -113,21 +146,46 @@ class MCPConnectionManager:
                         return
                     if refcount > 1:
                         self._refcounts[server_name] = refcount - 1
+                        logger.debug(
+                            "Released MCP server '%s' (refcount=%d)",
+                            server_name,
+                            refcount - 1,
+                        )
                         return
 
                     disconnect_client = self._pool.pop(server_name, None)
                     self._refcounts.pop(server_name, None)
+                    self._configs.pop(server_name, None)
                     transition_event = threading.Event()
                     self._transitions[server_name] = transition_event
                     should_disconnect = True
 
             if not should_disconnect:
-                transition_event.wait()
+                if not transition_event.wait(timeout=_TRANSITION_TIMEOUT):
+                    logger.warning(
+                        "Timed out waiting for transition on '%s' during release, forcing cleanup",
+                        server_name,
+                    )
+                    with self._pool_lock:
+                        stuck = self._transitions.get(server_name)
+                        if stuck is transition_event:
+                            self._transitions.pop(server_name, None)
+                            transition_event.set()
                 continue
 
             try:
                 if disconnect_client is not None:
                     disconnect_client.disconnect()
+                    logger.info(
+                        "Disconnected MCP server '%s' (last reference released)",
+                        server_name,
+                    )
+            except Exception:
+                logger.warning(
+                    "Error disconnecting MCP server '%s' during release",
+                    server_name,
+                    exc_info=True,
+                )
             finally:
                 with self._pool_lock:
                     current = self._transitions.get(server_name)
@@ -146,34 +204,60 @@ class MCPConnectionManager:
                     config = self._configs.get(server_name)
                     break
 
-            transition_event.wait()
+            if not transition_event.wait(timeout=_TRANSITION_TIMEOUT):
+                logger.warning(
+                    "Timed out waiting for transition on '%s' during health check",
+                    server_name,
+                )
+                return False
 
         if client is None or config is None:
             return False
 
         try:
-            if config.transport == "stdio":
-                client.list_tools()
-                return True
-
-            if not config.url:
-                return False
-
-            client_kwargs: dict[str, Any] = {
-                "base_url": config.url,
-                "headers": config.headers,
-                "timeout": 5.0,
-            }
-            if config.transport == "unix":
-                if not config.socket_path:
+            match config.transport:
+                case "stdio":
+                    client.list_tools()
+                    return True
+                case "http":
+                    if not config.url:
+                        return False
+                    with httpx.Client(
+                        base_url=config.url,
+                        headers=config.headers,
+                        timeout=5.0,
+                    ) as http_client:
+                        response = http_client.get("/health")
+                        response.raise_for_status()
+                    return True
+                case "sse":
+                    client.list_tools()
+                    return True
+                case "unix":
+                    if not config.socket_path:
+                        return False
+                    with httpx.Client(
+                        base_url=config.url or "http://localhost",
+                        headers=config.headers,
+                        timeout=5.0,
+                        transport=httpx.HTTPTransport(uds=config.socket_path),
+                    ) as http_client:
+                        response = http_client.get("/health")
+                        response.raise_for_status()
+                    return True
+                case _:
+                    logger.warning(
+                        "Unknown transport '%s' for health check on '%s'",
+                        config.transport,
+                        server_name,
+                    )
                     return False
-                client_kwargs["transport"] = httpx.HTTPTransport(uds=config.socket_path)
-
-            with httpx.Client(**client_kwargs) as http_client:
-                response = http_client.get("/health")
-                response.raise_for_status()
-            return True
         except Exception:
+            logger.debug(
+                "Health check failed for MCP server '%s'",
+                server_name,
+                exc_info=True,
+            )
             return False
 
     def reconnect(self, server_name: str) -> MCPClient:
@@ -189,16 +273,34 @@ class MCPConnectionManager:
                     if config is None:
                         raise KeyError(f"Unknown MCP server: {server_name}")
                     old_client = self._pool.get(server_name)
-                    refcount = self._refcounts.get(server_name, 0)
                     transition_event = threading.Event()
                     self._transitions[server_name] = transition_event
                     break
 
-            transition_event.wait()
+            if not transition_event.wait(timeout=_TRANSITION_TIMEOUT):
+                logger.warning(
+                    "Timed out waiting for transition on '%s' during reconnect, forcing cleanup",
+                    server_name,
+                )
+                with self._pool_lock:
+                    stuck = self._transitions.get(server_name)
+                    if stuck is transition_event:
+                        self._transitions.pop(server_name, None)
+                        transition_event.set()
 
+        # Disconnect old client safely
         if old_client is not None:
-            old_client.disconnect()
+            try:
+                old_client.disconnect()
+                logger.info("Disconnected old client for '%s'", server_name)
+            except Exception:
+                logger.warning(
+                    "Error disconnecting old client for '%s' during reconnect",
+                    server_name,
+                    exc_info=True,
+                )
 
+        logger.info("Reconnecting MCP server '%s'", server_name)
         new_client = MCPClient(config)
         try:
             new_client.connect()
@@ -214,13 +316,50 @@ class MCPConnectionManager:
         with self._pool_lock:
             current = self._transitions.get(server_name)
             if current is transition_event:
+                current_refcount = self._refcounts.get(server_name, 0)
+                if current_refcount <= 0:
+                    # All holders released during reconnect. Discard the
+                    # new client instead of creating a phantom reference.
+                    # Caller should acquire() fresh if needed.
+                    self._transitions.pop(server_name, None)
+                    transition_event.set()
+                    logger.info(
+                        "Reconnected MCP server '%s' but refcount dropped to 0, "
+                        "discarding new client",
+                        server_name,
+                    )
+                    try:
+                        new_client.disconnect()
+                    except Exception:
+                        logger.debug(
+                            "Error disconnecting discarded client for '%s'",
+                            server_name,
+                            exc_info=True,
+                        )
+                    raise KeyError(
+                        f"MCP server '{server_name}' was fully released during reconnect"
+                    )
+
                 self._pool[server_name] = new_client
-                self._refcounts[server_name] = max(refcount, 1)
+                self._configs[server_name] = config
+                self._refcounts[server_name] = current_refcount
                 self._transitions.pop(server_name, None)
                 transition_event.set()
+                logger.info(
+                    "Reconnected MCP server '%s' (refcount=%d)",
+                    server_name,
+                    current_refcount,
+                )
                 return new_client
 
-        new_client.disconnect()
+        try:
+            new_client.disconnect()
+        except Exception:
+            logger.debug(
+                "Error disconnecting stale client for '%s' after reconnect race",
+                server_name,
+                exc_info=True,
+            )
         return self.acquire(config)
 
     def cleanup_all(self) -> None:
@@ -238,14 +377,29 @@ class MCPConnectionManager:
                     self._configs.clear()
                     break
 
-            for event in pending:
-                event.wait()
+            all_resolved = all(event.wait(timeout=_TRANSITION_TIMEOUT) for event in pending)
+            if not all_resolved:
+                logger.warning(
+                    "Timed out waiting for pending transitions during cleanup, "
+                    "forcing cleanup of stuck transitions",
+                )
+                with self._pool_lock:
+                    for sn, evt in list(self._transitions.items()):
+                        if not evt.is_set():
+                            self._transitions.pop(sn, None)
+                            evt.set()
 
-        for _server_name, client in clients:
+        logger.info("Cleaning up %d pooled MCP connections", len(clients))
+        for server_name, client in clients:
             try:
                 client.disconnect()
+                logger.debug("Disconnected MCP server '%s' during cleanup", server_name)
             except Exception:
-                pass
+                logger.warning(
+                    "Error disconnecting MCP server '%s' during cleanup",
+                    server_name,
+                    exc_info=True,
+                )
 
         with self._pool_lock:
             for server_name, event in cleanup_events.items():

--- a/core/framework/runner/mcp_registry.py
+++ b/core/framework/runner/mcp_registry.py
@@ -1,0 +1,815 @@
+"""MCP Server Registry: local state management for installed MCP servers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import tomllib
+from datetime import UTC, datetime
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any, Literal
+
+import httpx
+
+from framework.runner.mcp_client import MCPClient, MCPServerConfig
+from framework.runner.mcp_connection_manager import MCPConnectionManager
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_INDEX_URL = (
+    "https://raw.githubusercontent.com/aden-hive/hive-mcp-registry/main/registry_index.json"
+)
+DEFAULT_REFRESH_INTERVAL_HOURS = 24
+_LAST_FETCHED_FILENAME = "last_fetched"
+_LEGACY_LAST_FETCHED_FILENAME = "last_fetched.json"
+
+_DEFAULT_CONFIG = {
+    "index_url": DEFAULT_INDEX_URL,
+    "refresh_interval_hours": DEFAULT_REFRESH_INTERVAL_HOURS,
+}
+
+
+class MCPRegistry:
+    """Manages local MCP server state in ~/.hive/mcp_registry/."""
+
+    def __init__(self, base_path: Path | None = None):
+        self._base = base_path or Path.home() / ".hive" / "mcp_registry"
+        self._installed_path = self._base / "installed.json"
+        self._config_path = self._base / "config.json"
+        self._cache_dir = self._base / "cache"
+
+    # ── Initialization ──────────────────────────────────────────────
+
+    def initialize(self) -> None:
+        """Create directory structure and default files if missing."""
+        self._base.mkdir(parents=True, exist_ok=True)
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+
+        if not self._config_path.exists():
+            self._write_json(self._config_path, _DEFAULT_CONFIG)
+
+        if not self._installed_path.exists():
+            self._write_json(self._installed_path, {"servers": {}})
+
+    # ── Internal I/O ────────────────────────────────────────────────
+
+    def _read_installed(self) -> dict:
+        """Read installed.json, initializing if needed."""
+        if not self._installed_path.exists():
+            self.initialize()
+        return json.loads(self._installed_path.read_text(encoding="utf-8"))
+
+    def _write_installed(self, data: dict) -> None:
+        """Write installed.json."""
+        self._write_json(self._installed_path, data)
+
+    def _read_config(self) -> dict:
+        """Read config.json."""
+        if not self._config_path.exists():
+            self.initialize()
+        return json.loads(self._config_path.read_text(encoding="utf-8"))
+
+    def _read_cached_index(self) -> dict:
+        """Read cached registry_index.json."""
+        index_path = self._cache_dir / "registry_index.json"
+        if not index_path.exists():
+            return {"servers": {}}
+        return json.loads(index_path.read_text(encoding="utf-8"))
+
+    def _get_effective_manifest(
+        self,
+        name: str,
+        entry: dict,
+        cached_index: dict | None = None,
+    ) -> dict:
+        """Return the manifest currently in effect for an installed entry."""
+        manifest = entry.get("manifest", {})
+        if entry.get("source") != "registry":
+            return manifest
+
+        index = cached_index or self._read_cached_index()
+        cached_manifest = index.get("servers", {}).get(name)
+        if cached_manifest is not None:
+            return cached_manifest
+
+        # Fall back to persisted manifest data when the cache is unavailable.
+        if isinstance(manifest, dict) and manifest:
+            return manifest
+        return {}
+
+    @staticmethod
+    def _write_json(path: Path, data: dict) -> None:
+        """Write JSON to file atomically (write to temp, fsync, rename)."""
+        content = json.dumps(data, indent=2) + "\n"
+        fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(content)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    # ── add_local ───────────────────────────────────────────────────
+
+    def add_local(
+        self,
+        name: str,
+        transport: str | None = None,
+        manifest: dict | None = None,
+        url: str | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+        cwd: str | None = None,
+        socket_path: str | None = None,
+        description: str = "",
+    ) -> dict:
+        """Register a local/running MCP server.
+
+        Can be called with an inline manifest dict, or with individual
+        transport/url/command params that build a manifest automatically.
+        """
+        data = self._read_installed()
+        if name in data["servers"]:
+            raise ValueError(f"Server '{name}' already exists. Use remove first.")
+
+        if manifest is not None:
+            # Inline manifest provided directly
+            manifest = {**manifest, "name": name}
+            transport_config = manifest.get("transport", {})
+            transport = transport or transport_config.get("default", "stdio")
+            if "transport" not in manifest:
+                manifest["transport"] = {"supported": [transport], "default": transport}
+        else:
+            # Build manifest from individual params
+            if not transport:
+                raise ValueError("transport is required when manifest is not provided")
+            manifest = {
+                "name": name,
+                "description": description,
+                "transport": {"supported": [transport], "default": transport},
+            }
+            match transport:
+                case "http":
+                    if not url:
+                        raise ValueError("url is required for http transport")
+                    manifest["http"] = {"url": url, "headers": headers or {}}
+                case "stdio":
+                    if not command:
+                        raise ValueError("command is required for stdio transport")
+                    manifest["stdio"] = {
+                        "command": command,
+                        "args": args or [],
+                        "env": env or {},
+                        "cwd": cwd,
+                    }
+                case "unix":
+                    if not socket_path:
+                        raise ValueError("socket_path is required for unix transport")
+                    manifest["unix"] = {"socket_path": socket_path}
+                    manifest["http"] = {"url": url or "http://localhost"}
+                case "sse":
+                    if not url:
+                        raise ValueError("url is required for sse transport")
+                    manifest["sse"] = {"url": url}
+                case _:
+                    raise ValueError(f"Unsupported transport: {transport}")
+
+        entry = self._make_entry(
+            source="local",
+            manifest=manifest,
+            transport=transport,
+            installed_by="hive mcp add",
+        )
+
+        data["servers"][name] = entry
+        self._write_installed(data)
+        logger.info("Registered local MCP server '%s' (%s)", name, transport)
+        return entry
+
+    # ── install ─────────────────────────────────────────────────────
+
+    def install(self, name: str, transport: str | None = None, version: str | None = None) -> dict:
+        """Install a server from the cached remote registry index."""
+        data = self._read_installed()
+        if name in data["servers"]:
+            raise ValueError(f"Server '{name}' already exists. Remove it first or use update.")
+
+        index = self._read_cached_index()
+        manifest = index.get("servers", {}).get(name)
+        if manifest is None:
+            raise ValueError(
+                f"Server '{name}' not found in registry index. "
+                "Run 'hive mcp update' to refresh the index."
+            )
+
+        # Validate version if specified
+        if version is not None:
+            index_version = manifest.get("version")
+            if index_version is None:
+                raise ValueError(f"Cannot pin version for '{name}': manifest has no version field.")
+            if index_version != version:
+                raise ValueError(
+                    f"Version mismatch for '{name}': requested {version}, "
+                    f"index has {index_version}. "
+                    "Run 'hive mcp update' to refresh the index."
+                )
+
+        transport_config = manifest.get("transport", {})
+        supported = transport_config.get("supported", [])
+        if transport is not None:
+            if supported and transport not in supported:
+                raise ValueError(
+                    f"Transport '{transport}' not supported by '{name}'. Supported: {supported}"
+                )
+            resolved_transport = transport
+        else:
+            resolved_transport = transport_config.get("default", "stdio")
+
+        entry = self._make_entry(
+            source="registry",
+            manifest=self._make_registry_manifest_snapshot(name, manifest),
+            transport=resolved_transport,
+            installed_by="hive mcp install",
+            pinned=version is not None,
+            auto_update=version is None,
+            resolved_package_version=manifest.get("version"),
+        )
+
+        data["servers"][name] = entry
+        self._write_installed(data)
+        logger.info(
+            "Installed MCP server '%s' v%s from registry",
+            name,
+            entry["manifest_version"],
+        )
+        return entry
+
+    # ── remove / enable / disable ───────────────────────────────────
+
+    def remove(self, name: str) -> None:
+        """Remove a server from the registry."""
+        data = self._read_installed()
+        if name not in data["servers"]:
+            raise ValueError(f"Server '{name}' is not installed.")
+        del data["servers"][name]
+        self._write_installed(data)
+        logger.info("Removed MCP server '%s'", name)
+
+    def enable(self, name: str) -> None:
+        """Enable a disabled server."""
+        self._set_enabled(name, enabled=True)
+
+    def disable(self, name: str) -> None:
+        """Disable a server without removing it."""
+        self._set_enabled(name, enabled=False)
+
+    def _set_enabled(self, name: str, *, enabled: bool) -> None:
+        data = self._read_installed()
+        if name not in data["servers"]:
+            raise ValueError(f"Server '{name}' is not installed.")
+        data["servers"][name]["enabled"] = enabled
+        self._write_installed(data)
+        logger.info("%s MCP server '%s'", "Enabled" if enabled else "Disabled", name)
+
+    # ── list / get ──────────────────────────────────────────────────
+
+    def list_installed(self) -> list[dict]:
+        """Return all installed servers as a list of dicts with name included."""
+        data = self._read_installed()
+        return [{"name": name, **entry} for name, entry in data["servers"].items()]
+
+    def get_server(self, name: str) -> dict | None:
+        """Get a single installed server entry by name, or None if not found."""
+        data = self._read_installed()
+        entry = data["servers"].get(name)
+        if entry is None:
+            return None
+        return {"name": name, **entry}
+
+    def list_available(self) -> list[dict]:
+        """List all servers from cached remote index."""
+        index = self._read_cached_index()
+        return [{"name": name, **m} for name, m in index.get("servers", {}).items()]
+
+    # ── set_override ────────────────────────────────────────────────
+
+    def set_override(
+        self,
+        name: str,
+        key: str,
+        value: str,
+        override_type: Literal["env", "headers"] = "env",
+    ) -> None:
+        """Set an env or header override for a server."""
+        data = self._read_installed()
+        if name not in data["servers"]:
+            raise ValueError(f"Server '{name}' is not installed.")
+        if override_type not in ("env", "headers"):
+            raise ValueError(f"Invalid override type: {override_type}")
+        data["servers"][name]["overrides"][override_type][key] = value
+        self._write_installed(data)
+        logger.info("Set %s override %s for MCP server '%s'", override_type, key, name)
+
+    # ── search ──────────────────────────────────────────────────────
+
+    def search(self, query: str) -> list[dict]:
+        """Search registry index by name, tag, description, or tool name."""
+        query_lower = query.lower()
+        index = self._read_cached_index()
+        matches = []
+
+        for name, manifest in index.get("servers", {}).items():
+            if self._matches_query(name, manifest, query_lower):
+                matches.append({"name": name, **manifest})
+
+        return matches
+
+    @staticmethod
+    def _matches_query(name: str, manifest: dict, query: str) -> bool:
+        """Check if a manifest matches a search query."""
+        if query in name.lower():
+            return True
+
+        description = manifest.get("description", "")
+        if query in description.lower():
+            return True
+
+        for tag in manifest.get("tags", []):
+            if query in tag.lower():
+                return True
+
+        for tool in manifest.get("tools", []):
+            tool_name = tool.get("name", "") if isinstance(tool, dict) else str(tool)
+            if query in tool_name.lower():
+                return True
+
+        return False
+
+    # ── update_index ────────────────────────────────────────────────
+
+    def is_index_stale(self) -> bool:
+        """Check if the cached registry index needs refreshing."""
+        last_fetched_path = self._cache_dir / _LAST_FETCHED_FILENAME
+        legacy_path = self._cache_dir / _LEGACY_LAST_FETCHED_FILENAME
+        if not last_fetched_path.exists() and not legacy_path.exists():
+            return True
+
+        try:
+            path = last_fetched_path if last_fetched_path.exists() else legacy_path
+            data = json.loads(path.read_text(encoding="utf-8"))
+            last_fetched = datetime.fromisoformat(data["timestamp"])
+            config = self._read_config()
+            interval_hours = config.get("refresh_interval_hours", DEFAULT_REFRESH_INTERVAL_HOURS)
+            age_hours = (datetime.now(UTC) - last_fetched).total_seconds() / 3600
+            return age_hours >= interval_hours
+        except (KeyError, ValueError, OSError):
+            return True
+
+    def update_index(self) -> int:
+        """Fetch the latest registry index from remote and cache it.
+
+        Returns the number of servers in the index.
+        """
+        config = self._read_config()
+        url = config.get("index_url", DEFAULT_INDEX_URL)
+
+        response = httpx.get(url, timeout=10.0)
+        response.raise_for_status()
+        index = response.json()
+
+        self._write_json(self._cache_dir / "registry_index.json", index)
+        # Write last_fetched atomically too
+        self._write_json(
+            self._cache_dir / _LAST_FETCHED_FILENAME,
+            {"timestamp": datetime.now(UTC).isoformat()},
+        )
+
+        server_count = len(index.get("servers", {}))
+        logger.info("Updated registry index: %d servers available", server_count)
+        return server_count
+
+    # ── load_agent_selection ────────────────────────────────────────
+
+    def load_agent_selection(self, agent_path: Path) -> list[dict[str, Any]]:
+        """Load mcp_registry.json from an agent directory and resolve servers.
+
+        Returns list of plain dicts compatible with ToolRegistry.register_mcp_server().
+        """
+        registry_json_path = agent_path / "mcp_registry.json"
+        if not registry_json_path.exists():
+            return []
+
+        selection = json.loads(registry_json_path.read_text(encoding="utf-8"))
+
+        # Validate types at the JSON boundary. Bad fields are dropped with a
+        # warning so the agent still starts (graceful degradation).
+        expected_types: dict[str, type] = {
+            "include": list,
+            "tags": list,
+            "exclude": list,
+            "profile": str,
+            "max_tools": int,
+            "versions": dict,
+        }
+        validated: dict[str, Any] = {}
+        for field, expected in expected_types.items():
+            value = selection.get(field)
+            if value is None:
+                continue
+            if not isinstance(value, expected):
+                logger.warning(
+                    "mcp_registry.json: '%s' must be %s, got %s; ignoring",
+                    field,
+                    expected.__name__,
+                    type(value).__name__,
+                )
+                continue
+            validated[field] = value
+
+        configs = self.resolve_for_agent(
+            include=validated.get("include"),
+            tags=validated.get("tags"),
+            exclude=validated.get("exclude"),
+            profile=validated.get("profile"),
+            max_tools=validated.get("max_tools"),
+            versions=validated.get("versions"),
+        )
+        return [self._server_config_to_dict(c) for c in configs]
+
+    # ── resolve_for_agent ───────────────────────────────────────────
+
+    def resolve_for_agent(
+        self,
+        include: list[str] | None = None,
+        tags: list[str] | None = None,
+        exclude: list[str] | None = None,
+        profile: str | None = None,
+        max_tools: int | None = None,
+        versions: dict[str, str] | None = None,
+    ) -> list[MCPServerConfig]:
+        """Resolve installed servers matching agent selection criteria.
+
+        Selection precedence per PRD section 7.2:
+        1. profile expands to server names (union with include + tags)
+        2. include adds explicit servers
+        3. tags adds servers whose tags overlap
+        4. exclude removes (always wins)
+        5. Load order: include-order first, then alphabetical for tag/profile matches
+
+        Returns list of MCPServerConfig objects ready for ToolRegistry.
+        """
+        data = self._read_installed()
+        servers = data.get("servers", {})
+        cached_index = self._read_cached_index()
+        exclude_set = set(exclude or [])
+
+        # Phase 1: collect profile-matched servers (alphabetical)
+        profile_matched: list[str] = []
+        if profile:
+            for name, entry in sorted(servers.items()):
+                if name in exclude_set:
+                    continue
+                if profile == "all":
+                    profile_matched.append(name)
+                else:
+                    manifest = self._get_effective_manifest(name, entry, cached_index)
+                    profiles = manifest.get("hive", {}).get("profiles", [])
+                    if profile in profiles:
+                        profile_matched.append(name)
+
+        # Phase 2: collect tag-matched servers (alphabetical)
+        tag_matched: list[str] = []
+        if tags:
+            tag_set = set(tags)
+            for name, entry in sorted(servers.items()):
+                if name in exclude_set:
+                    continue
+                manifest = self._get_effective_manifest(name, entry, cached_index)
+                server_tags = set(manifest.get("tags", []))
+                if tag_set & server_tags:
+                    tag_matched.append(name)
+
+        # Phase 3: build final ordered list
+        # include-order first, then alphabetical for profile/tag matches
+        selected: list[str] = []
+        seen: set[str] = set()
+
+        for name in include or []:
+            if name not in seen and name not in exclude_set:
+                selected.append(name)
+                seen.add(name)
+
+        for name in profile_matched:
+            if name not in seen:
+                selected.append(name)
+                seen.add(name)
+
+        for name in tag_matched:
+            if name not in seen:
+                selected.append(name)
+                seen.add(name)
+
+        # Build configs, tracking aggregate tool count for max_tools cap (FR-56)
+        configs: list[MCPServerConfig] = []
+        total_tools = 0
+        for name in selected:
+            entry = servers.get(name)
+            if entry is None:
+                logger.warning(
+                    "Server '%s' requested but not installed. Run: hive mcp install %s",
+                    name,
+                    name,
+                )
+                continue
+            if not entry.get("enabled", True):
+                continue
+
+            manifest = self._get_effective_manifest(name, entry, cached_index)
+
+            # Check version pin (VC-6)
+            if versions and name in versions:
+                installed_version = entry.get("manifest_version", "0.0.0")
+                pinned_version = versions[name]
+                if installed_version != pinned_version:
+                    logger.warning(
+                        "Server '%s' version mismatch: installed=%s, pinned=%s. "
+                        "Run: hive mcp update %s",
+                        name,
+                        installed_version,
+                        pinned_version,
+                        name,
+                    )
+                    continue
+
+            # Check tool count cap before adding (FR-56)
+            manifest_tools = manifest.get("tools", [])
+            server_tool_count = len(manifest_tools)
+            if max_tools is not None and server_tool_count == 0:
+                logger.debug(
+                    "Server '%s' has no declared tools in manifest, skipping max_tools check",
+                    name,
+                )
+            elif max_tools is not None and total_tools + server_tool_count > max_tools:
+                logger.info(
+                    "Skipping server '%s' (%d tools): would exceed max_tools=%d",
+                    name,
+                    server_tool_count,
+                    max_tools,
+                )
+                continue
+
+            config = self._manifest_to_server_config(
+                name,
+                manifest,
+                entry.get("overrides", {}),
+                transport_override=entry.get("transport"),
+            )
+            if config is not None:
+                configs.append(config)
+                total_tools += server_tool_count
+
+        return configs
+
+    def _manifest_to_server_config(
+        self,
+        name: str,
+        manifest: dict,
+        overrides: dict | None = None,
+        transport_override: str | None = None,
+    ) -> MCPServerConfig | None:
+        """Convert a manifest and overrides to MCPServerConfig."""
+        overrides = overrides or {}
+        transport_config = manifest.get("transport", {})
+        transport = transport_override or transport_config.get("default", "stdio")
+        description = manifest.get("description", "")
+
+        match transport:
+            case "stdio":
+                stdio_config = manifest.get("stdio", {})
+                merged_env = {
+                    **stdio_config.get("env", {}),
+                    **overrides.get("env", {}),
+                }
+                return MCPServerConfig(
+                    name=name,
+                    transport="stdio",
+                    command=stdio_config.get("command"),
+                    args=stdio_config.get("args", []),
+                    env=merged_env,
+                    cwd=stdio_config.get("cwd"),
+                    description=description,
+                )
+            case "http":
+                http_config = manifest.get("http", {})
+                url = http_config.get("url", "")
+                merged_headers = {
+                    **http_config.get("headers", {}),
+                    **overrides.get("headers", {}),
+                }
+                return MCPServerConfig(
+                    name=name,
+                    transport="http",
+                    url=url,
+                    headers=merged_headers,
+                    description=description,
+                )
+            case "unix":
+                unix_config = manifest.get("unix", {})
+                http_config = manifest.get("http", {})
+                merged_headers = {
+                    **http_config.get("headers", {}),
+                    **overrides.get("headers", {}),
+                }
+                return MCPServerConfig(
+                    name=name,
+                    transport="unix",
+                    socket_path=unix_config.get("socket_path"),
+                    url=http_config.get("url") or "http://localhost",
+                    headers=merged_headers,
+                    description=description,
+                )
+            case "sse":
+                sse_config = manifest.get("sse", {})
+                merged_headers = {
+                    **sse_config.get("headers", {}),
+                    **overrides.get("headers", {}),
+                }
+                return MCPServerConfig(
+                    name=name,
+                    transport="sse",
+                    url=sse_config.get("url", ""),
+                    headers=merged_headers,
+                    description=description,
+                )
+            case _:
+                logger.warning(
+                    "Unsupported transport '%s' for server '%s'",
+                    transport,
+                    name,
+                )
+                return None
+
+    @staticmethod
+    def _server_config_to_dict(config: MCPServerConfig) -> dict[str, Any]:
+        """Convert MCPServerConfig to plain dict for ToolRegistry.register_mcp_server()."""
+        return {
+            "name": config.name,
+            "transport": config.transport,
+            "command": config.command,
+            "args": config.args,
+            "env": config.env,
+            "cwd": config.cwd,
+            "url": config.url,
+            "headers": config.headers,
+            "socket_path": config.socket_path,
+            "description": config.description,
+        }
+
+    # ── run_health_check ────────────────────────────────────────────
+
+    def health_check(self, name: str | None = None) -> dict | dict[str, dict]:
+        """Check health of installed server(s). Updates telemetry fields.
+
+        If name is None, checks all installed servers and returns
+        a dict mapping server names to their health results.
+
+        """
+        if name is None:
+            results = {}
+            for server in self.list_installed():
+                results[server["name"]] = self.health_check(server["name"])
+            return results
+
+        data = self._read_installed()
+        if name not in data["servers"]:
+            raise ValueError(f"Server '{name}' is not installed.")
+
+        entry = data["servers"][name]
+        manifest = self._get_effective_manifest(name, entry)
+        config = self._manifest_to_server_config(
+            name,
+            manifest,
+            entry.get("overrides", {}),
+            transport_override=entry.get("transport"),
+        )
+        now = datetime.now(UTC).isoformat()
+
+        result: dict[str, Any] = {
+            "name": name,
+            "status": "unknown",
+            "tools": 0,
+            "error": None,
+        }
+
+        if config is None:
+            transport = entry.get("transport", "unknown")
+            result["status"] = "unhealthy"
+            result["error"] = f"Unsupported transport '{transport}'"
+            entry["last_health_status"] = "unhealthy"
+            entry["last_error"] = result["error"]
+            entry["last_health_check_at"] = now
+            self._write_installed(data)
+            return result
+
+        manager = MCPConnectionManager.get_instance()
+
+        try:
+            if manager.has_connection(name):
+                is_healthy = manager.health_check(name)
+                if not is_healthy:
+                    raise RuntimeError("Shared MCP connection health check failed")
+                pooled_client = manager.acquire(config)
+                try:
+                    tools = pooled_client.list_tools()
+                finally:
+                    manager.release(name)
+            else:
+                with MCPClient(config) as client:
+                    tools = client.list_tools()
+
+            result["status"] = "healthy"
+            result["tools"] = len(tools)
+            entry["last_health_status"] = "healthy"
+            entry["last_error"] = None
+            entry["last_validated_with_hive_version"] = self._get_hive_version()
+        except Exception as exc:
+            result["status"] = "unhealthy"
+            result["error"] = str(exc)
+            entry["last_health_status"] = "unhealthy"
+            entry["last_error"] = str(exc)
+
+        entry["last_health_check_at"] = now
+        self._write_installed(data)
+        return result
+
+    def run_health_check(self, name: str | None = None) -> dict | dict[str, dict]:
+        """Backward-compatible wrapper for the public health_check API."""
+        return self.health_check(name)
+
+    @staticmethod
+    def _get_hive_version() -> str:
+        """Get the current Hive version."""
+        try:
+            return version("framework")
+        except PackageNotFoundError:
+            project_toml = Path(__file__).resolve().parents[2] / "pyproject.toml"
+            if not project_toml.exists():
+                return "unknown"
+            try:
+                with project_toml.open("rb") as f:
+                    data = tomllib.load(f)
+                return data.get("project", {}).get("version", "unknown")
+            except (tomllib.TOMLDecodeError, OSError):
+                return "unknown"
+
+    # ── helpers ──────────────────────────────────────────────────────
+
+    @staticmethod
+    def _make_entry(
+        *,
+        source: str,
+        manifest: dict,
+        transport: str,
+        installed_by: str,
+        pinned: bool = False,
+        auto_update: bool = False,
+        resolved_package_version: str | None = None,
+    ) -> dict:
+        """Build a standard installed server entry."""
+        now = datetime.now(UTC).isoformat()
+        return {
+            "source": source,
+            "manifest_version": manifest.get("version", "0.0.0"),
+            "manifest": manifest,
+            "installed_at": now,
+            "installed_by": installed_by,
+            "transport": transport,
+            "enabled": True,
+            "pinned": pinned,
+            "auto_update": auto_update,
+            "resolved_package_version": resolved_package_version,
+            "overrides": {"env": {}, "headers": {}},
+            "last_health_check_at": None,
+            "last_health_status": None,
+            "last_error": None,
+            "last_used_at": None,
+            "last_validated_with_hive_version": None,
+        }
+
+    @staticmethod
+    def _make_registry_manifest_snapshot(name: str, manifest: dict) -> dict[str, Any]:
+        """Persist a full manifest snapshot for registry-installed servers."""
+        manifest_snapshot = dict(manifest)
+        manifest_snapshot["name"] = name
+        return manifest_snapshot

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -1121,6 +1121,9 @@ class AgentRunner:
         if mcp_config_path.exists():
             self._load_mcp_servers_from_config(mcp_config_path)
 
+        # Auto-discover registry-selected MCP servers from mcp_registry.json
+        self._load_registry_mcp_servers(agent_path)
+
     @staticmethod
     def _import_agent_module(agent_path: Path):
         """Import an agent package from its directory path.
@@ -1423,6 +1426,45 @@ class AgentRunner:
     def _load_mcp_servers_from_config(self, config_path: Path) -> None:
         """Load and register MCP servers from a configuration file."""
         self._tool_registry.load_mcp_config(config_path)
+
+    def _load_registry_mcp_servers(self, agent_path: Path) -> None:
+        """Load and register MCP servers selected via ``mcp_registry.json``."""
+        from framework.runner.mcp_registry import MCPRegistry
+
+        try:
+            registry = MCPRegistry()
+            registry.initialize()
+            server_configs = registry.load_agent_selection(agent_path)
+        except Exception as exc:
+            logger.warning(
+                "Failed to load MCP registry servers for '%s': %s",
+                agent_path.name,
+                exc,
+            )
+            return
+
+        if not server_configs:
+            return
+
+        results = self._tool_registry.load_registry_servers(server_configs)
+        loaded = [result for result in results if result["status"] == "loaded"]
+        skipped = [result for result in results if result["status"] != "loaded"]
+
+        logger.info(
+            "Loaded %d/%d MCP registry server(s) for agent '%s'",
+            len(loaded),
+            len(results),
+            agent_path.name,
+        )
+        if skipped:
+            logger.info(
+                "Skipped MCP registry servers for agent '%s': %s",
+                agent_path.name,
+                [
+                    {"server": result["server"], "reason": result["skipped_reason"]}
+                    for result in skipped
+                ],
+            )
 
     def set_approval_callback(self, callback: Callable) -> None:
         """

--- a/core/framework/runner/tool_registry.py
+++ b/core/framework/runner/tool_registry.py
@@ -462,29 +462,80 @@ class ToolRegistry:
             # Treat top-level keys as server names
             server_list = [{"name": name, **cfg} for name, cfg in config.items()]
 
-        for server_config in server_list:
-            server_config = self._resolve_mcp_server_config(server_config, base_dir)
-            for _attempt in range(2):
-                try:
-                    self.register_mcp_server(server_config)
-                    break
-                except Exception as e:
-                    name = server_config.get("name", "unknown")
-                    if _attempt == 0:
-                        logger.warning(
-                            "MCP server '%s' failed to register, retrying in 2s: %s",
-                            name,
-                            e,
-                        )
-                        import time
-
-                        time.sleep(2)
-                    else:
-                        logger.warning("MCP server '%s' failed after retry: %s", name, e)
+        resolved_server_list = [
+            self._resolve_mcp_server_config(server_config, base_dir)
+            for server_config in server_list
+        ]
+        self.load_registry_servers(resolved_server_list, log_summary=False)
 
         # Snapshot credential files and ADEN_API_KEY so we can detect mid-session changes
         self._mcp_cred_snapshot = self._snapshot_credentials()
         self._mcp_aden_key_snapshot = os.environ.get("ADEN_API_KEY")
+
+    def _register_mcp_server_with_retry(
+        self,
+        server_config: dict[str, Any],
+    ) -> tuple[bool, int, str | None]:
+        """Register a single MCP server with one retry for transient failures."""
+        name = server_config.get("name", "unknown")
+        last_error: str | None = None
+
+        for attempt in range(2):
+            try:
+                count = self.register_mcp_server(server_config)
+                if count > 0:
+                    return True, count, None
+                last_error = "registered 0 tools"
+            except Exception as exc:
+                last_error = str(exc)
+
+            if attempt == 0:
+                logger.warning(
+                    "MCP server '%s' failed to register, retrying in 2s: %s",
+                    name,
+                    last_error,
+                )
+                import time
+
+                time.sleep(2)
+            else:
+                logger.warning("MCP server '%s' failed after retry: %s", name, last_error)
+
+        return False, 0, last_error
+
+    def load_registry_servers(
+        self,
+        server_list: list[dict[str, Any]],
+        *,
+        log_summary: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Register resolved registry-selected MCP servers with retry and status tracking."""
+        results: list[dict[str, Any]] = []
+
+        for server_config in server_list:
+            name = server_config.get("name", "unknown")
+            success, tools_loaded, error = self._register_mcp_server_with_retry(server_config)
+            result = {
+                "server": name,
+                "status": "loaded" if success else "skipped",
+                "tools_loaded": tools_loaded,
+                "skipped_reason": None if success else (error or "unknown error"),
+            }
+            results.append(result)
+
+            if log_summary:
+                logger.info(
+                    "MCP registry server resolution",
+                    extra={
+                        "event": "mcp_registry_server_resolution",
+                        "server": result["server"],
+                        "status": result["status"],
+                        "tools_loaded": result["tools_loaded"],
+                        "skipped_reason": result["skipped_reason"],
+                    },
+                )
+
+        return results
 
     def register_mcp_server(
         self,
@@ -524,6 +575,7 @@ class ToolRegistry:
                 cwd=server_config.get("cwd"),
                 url=server_config.get("url"),
                 headers=server_config.get("headers", {}),
+                socket_path=server_config.get("socket_path"),
                 description=server_config.get("description", ""),
             )
 

--- a/core/framework/server/queen_orchestrator.py
+++ b/core/framework/server/queen_orchestrator.py
@@ -62,6 +62,7 @@ async def create_queen(
     from framework.agents.queen.nodes.thinking_hook import select_expert_persona
     from framework.graph.event_loop_node import HookContext, HookResult
     from framework.graph.executor import GraphExecutor
+    from framework.runner.mcp_registry import MCPRegistry
     from framework.runner.tool_registry import ToolRegistry
     from framework.runtime.core import Runtime
     from framework.runtime.event_bus import AgentEvent, EventType
@@ -85,6 +86,16 @@ async def create_queen(
             logger.info("Queen: loaded MCP tools from %s", mcp_config)
         except Exception:
             logger.warning("Queen: MCP config failed to load", exc_info=True)
+
+    try:
+        registry = MCPRegistry()
+        registry.initialize()
+        registry_configs = registry.load_agent_selection(queen_pkg_dir)
+        if registry_configs:
+            results = queen_registry.load_registry_servers(registry_configs)
+            logger.info("Queen: loaded MCP registry servers: %s", results)
+    except Exception:
+        logger.warning("Queen: MCP registry config failed to load", exc_info=True)
 
     # ---- Phase state --------------------------------------------------
     initial_phase = "staging" if worker_identity else "planning"

--- a/core/tests/test_agent_runner_mcp_registry.py
+++ b/core/tests/test_agent_runner_mcp_registry.py
@@ -1,10 +1,12 @@
 """Tests for AgentRunner MCP registry integration."""
 
+import json
 from pathlib import Path
 
 from framework.graph.edge import GraphSpec
 from framework.graph.goal import Goal
 from framework.graph.node import NodeSpec
+from framework.runner.mcp_registry import MCPRegistry
 from framework.runner.runner import AgentRunner
 
 
@@ -188,3 +190,54 @@ def test_agent_runner_survives_malformed_registry_json(tmp_path, monkeypatch):
     )
 
     assert any("Failed to load MCP registry servers" in w for w in warnings)
+
+
+def test_integration_real_registry_to_agent_runner(tmp_path, monkeypatch):
+    """Integration: real MCPRegistry on disk → mcp_registry.json → AgentRunner."""
+    # Set up a real registry with a local server
+    registry_base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=registry_base)
+    registry.initialize()
+    registry.add_local(name="jira", transport="http", url="http://localhost:4010")
+
+    # Write mcp_registry.json in the agent dir
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    (agent_dir / "mcp_registry.json").write_text(
+        json.dumps({"include": ["jira"]}), encoding="utf-8"
+    )
+
+    # Patch MCPRegistry to use our tmp_path base, but keep real logic
+    original_init = MCPRegistry.__init__
+
+    def patched_init(self, base_path=None):
+        original_init(self, base_path=registry_base)
+
+    monkeypatch.setattr(MCPRegistry, "__init__", patched_init)
+    monkeypatch.setattr(
+        "framework.runner.runner.run_preload_validation",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(AgentRunner, "_resolve_default_model", staticmethod(lambda: "test-model"))
+
+    registered: list[dict] = []
+    monkeypatch.setattr(
+        "framework.runner.tool_registry.ToolRegistry.register_mcp_server",
+        lambda self, server_config, use_connection_manager=True: (
+            registered.append(server_config) or 1
+        ),
+    )
+
+    AgentRunner(
+        agent_path=agent_dir,
+        graph=_make_graph(),
+        goal=Goal(id="goal-1", name="Goal", description="desc"),
+        storage_path=tmp_path / "storage",
+        interactive=False,
+        skip_credential_validation=True,
+    )
+
+    assert len(registered) == 1
+    assert registered[0]["name"] == "jira"
+    assert registered[0]["transport"] == "http"
+    assert registered[0]["url"] == "http://localhost:4010"

--- a/core/tests/test_agent_runner_mcp_registry.py
+++ b/core/tests/test_agent_runner_mcp_registry.py
@@ -1,0 +1,190 @@
+"""Tests for AgentRunner MCP registry integration."""
+
+from pathlib import Path
+
+from framework.graph.edge import GraphSpec
+from framework.graph.goal import Goal
+from framework.graph.node import NodeSpec
+from framework.runner.runner import AgentRunner
+
+
+def _make_graph() -> GraphSpec:
+    return GraphSpec(
+        id="test-graph",
+        goal_id="goal-1",
+        entry_node="start",
+        terminal_nodes=["start"],
+        nodes=[NodeSpec(id="start", name="Start", description="Start node")],
+        edges=[],
+    )
+
+
+class _FakeRegistry:
+    def __init__(self, returned_configs):
+        self._returned_configs = returned_configs
+        self.initialize_calls = 0
+        self.loaded_paths: list[Path] = []
+
+    def initialize(self) -> None:
+        self.initialize_calls += 1
+
+    def load_agent_selection(self, agent_path: Path):
+        self.loaded_paths.append(agent_path)
+        return list(self._returned_configs)
+
+
+def test_agent_runner_loads_registry_selected_servers(tmp_path, monkeypatch):
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    (agent_dir / "mcp_registry.json").write_text('{"include": ["jira"]}', encoding="utf-8")
+
+    fake_registry = _FakeRegistry(
+        [
+            {
+                "name": "jira",
+                "transport": "http",
+                "url": "http://localhost:4010",
+                "headers": {},
+                "description": "Jira",
+            }
+        ]
+    )
+    registered: list[dict] = []
+
+    monkeypatch.setattr("framework.runner.mcp_registry.MCPRegistry", lambda: fake_registry)
+    monkeypatch.setattr(
+        "framework.runner.runner.run_preload_validation",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(AgentRunner, "_resolve_default_model", staticmethod(lambda: "test-model"))
+    monkeypatch.setattr(
+        "framework.runner.tool_registry.ToolRegistry.register_mcp_server",
+        lambda self, server_config, use_connection_manager=True: (
+            registered.append(server_config) or 1
+        ),
+    )
+
+    AgentRunner(
+        agent_path=agent_dir,
+        graph=_make_graph(),
+        goal=Goal(id="goal-1", name="Goal", description="desc"),
+        storage_path=tmp_path / "storage",
+        interactive=False,
+        skip_credential_validation=True,
+    )
+
+    assert fake_registry.initialize_calls == 1
+    assert fake_registry.loaded_paths == [agent_dir]
+    assert [config["name"] for config in registered] == ["jira"]
+
+
+def test_agent_runner_skips_registry_when_no_servers_selected(tmp_path, monkeypatch):
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+
+    fake_registry = _FakeRegistry([])
+    registered: list[dict] = []
+
+    monkeypatch.setattr("framework.runner.mcp_registry.MCPRegistry", lambda: fake_registry)
+    monkeypatch.setattr(
+        "framework.runner.runner.run_preload_validation",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(AgentRunner, "_resolve_default_model", staticmethod(lambda: "test-model"))
+    monkeypatch.setattr(
+        "framework.runner.tool_registry.ToolRegistry.register_mcp_server",
+        lambda self, server_config, use_connection_manager=True: (
+            registered.append(server_config) or 1
+        ),
+    )
+
+    AgentRunner(
+        agent_path=agent_dir,
+        graph=_make_graph(),
+        goal=Goal(id="goal-1", name="Goal", description="desc"),
+        storage_path=tmp_path / "storage",
+        interactive=False,
+        skip_credential_validation=True,
+    )
+
+    assert fake_registry.initialize_calls == 1
+    assert fake_registry.loaded_paths == [agent_dir]
+    assert registered == []
+
+
+def test_agent_runner_logs_actual_registry_load_results(tmp_path, monkeypatch):
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    (agent_dir / "mcp_registry.json").write_text('{"include": ["jira", "slack"]}', encoding="utf-8")
+
+    fake_registry = _FakeRegistry(
+        [
+            {"name": "jira", "transport": "http", "url": "http://localhost:4010"},
+            {"name": "slack", "transport": "http", "url": "http://localhost:4020"},
+        ]
+    )
+    log_messages: list[str] = []
+
+    monkeypatch.setattr("framework.runner.mcp_registry.MCPRegistry", lambda: fake_registry)
+    monkeypatch.setattr(
+        "framework.runner.runner.run_preload_validation",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(AgentRunner, "_resolve_default_model", staticmethod(lambda: "test-model"))
+    monkeypatch.setattr(
+        "framework.runner.tool_registry.ToolRegistry.load_registry_servers",
+        lambda self, server_configs: [
+            {"server": "jira", "status": "loaded", "tools_loaded": 2, "skipped_reason": None},
+            {
+                "server": "slack",
+                "status": "skipped",
+                "tools_loaded": 0,
+                "skipped_reason": "registered 0 tools",
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        "framework.runner.runner.logger.info",
+        lambda message, *args: log_messages.append(message % args if args else str(message)),
+    )
+
+    AgentRunner(
+        agent_path=agent_dir,
+        graph=_make_graph(),
+        goal=Goal(id="goal-1", name="Goal", description="desc"),
+        storage_path=tmp_path / "storage",
+        interactive=False,
+        skip_credential_validation=True,
+    )
+
+    assert any("Loaded 1/2 MCP registry server(s)" in message for message in log_messages)
+    assert any("Skipped MCP registry servers" in message for message in log_messages)
+
+
+def test_agent_runner_survives_malformed_registry_json(tmp_path, monkeypatch):
+    """Agent startup must not crash when mcp_registry.json has invalid JSON."""
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    (agent_dir / "mcp_registry.json").write_text("{bad json", encoding="utf-8")
+
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        "framework.runner.runner.run_preload_validation",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(AgentRunner, "_resolve_default_model", staticmethod(lambda: "test-model"))
+    monkeypatch.setattr(
+        "framework.runner.runner.logger.warning",
+        lambda message, *args: warnings.append(message % args if args else str(message)),
+    )
+
+    AgentRunner(
+        agent_path=agent_dir,
+        graph=_make_graph(),
+        goal=Goal(id="goal-1", name="Goal", description="desc"),
+        storage_path=tmp_path / "storage",
+        interactive=False,
+        skip_credential_validation=True,
+    )
+
+    assert any("Failed to load MCP registry servers" in w for w in warnings)

--- a/core/tests/test_mcp_connection_manager.py
+++ b/core/tests/test_mcp_connection_manager.py
@@ -164,9 +164,157 @@ def test_health_check_returns_false_when_server_is_unreachable(manager, monkeypa
     assert manager.health_check("shared") is False
 
 
+def test_health_check_for_stdio_returns_true_when_healthy(manager):
+    config = MCPServerConfig(name="shared", transport="stdio", command="echo")
+    manager.acquire(config)
+
+    assert manager.health_check("shared") is True
+
+
 def test_health_check_for_stdio_returns_false_on_tools_list_error(manager):
     config = MCPServerConfig(name="shared", transport="stdio", command="echo")
     client = manager.acquire(config)
     client.list_tools_error = RuntimeError("broken")
 
     assert manager.health_check("shared") is False
+
+
+def test_health_check_for_sse_uses_list_tools(manager):
+    config = MCPServerConfig(name="stream", transport="sse", url="http://localhost:9000/sse")
+    client = manager.acquire(config)
+
+    assert manager.health_check("stream") is True
+    assert client.list_tools_calls >= 1
+
+
+def test_health_check_unknown_server_returns_false(manager):
+    assert manager.health_check("nonexistent") is False
+
+
+# ── Failure-path tests ──────────────────────────────────────────────
+
+
+class FailingConnectClient(FakeMCPClient):
+    """Client that raises on connect()."""
+
+    def connect(self) -> None:
+        self.connect_calls += 1
+        raise ConnectionError("connect failed")
+
+
+class FailingDisconnectClient(FakeMCPClient):
+    """Client that raises on disconnect()."""
+
+    def disconnect(self) -> None:
+        self.disconnect_calls += 1
+        self._connected = False
+        raise RuntimeError("disconnect failed")
+
+
+def test_acquire_cleans_up_transition_when_connect_fails(monkeypatch):
+    monkeypatch.setattr(
+        "framework.runner.mcp_connection_manager.MCPClient",
+        FailingConnectClient,
+    )
+    monkeypatch.setattr(MCPConnectionManager, "_instance", None)
+    FailingConnectClient.instances = []
+    mgr = MCPConnectionManager.get_instance()
+
+    config = MCPServerConfig(name="broken", transport="stdio", command="echo")
+
+    with pytest.raises(ConnectionError, match="connect failed"):
+        mgr.acquire(config)
+
+    # Transition should be cleaned up, not stuck
+    assert "broken" not in mgr._transitions  # noqa: SLF001
+    assert "broken" not in mgr._pool  # noqa: SLF001
+
+    monkeypatch.setattr(MCPConnectionManager, "_instance", None)
+
+
+def test_release_handles_disconnect_failure(monkeypatch):
+    monkeypatch.setattr(
+        "framework.runner.mcp_connection_manager.MCPClient",
+        FailingDisconnectClient,
+    )
+    monkeypatch.setattr(MCPConnectionManager, "_instance", None)
+    FailingDisconnectClient.instances = []
+    mgr = MCPConnectionManager.get_instance()
+
+    config = MCPServerConfig(name="flaky", transport="stdio", command="echo")
+    mgr.acquire(config)
+
+    # release should not raise even if disconnect fails
+    mgr.release("flaky")
+
+    # Pool should be cleaned up despite disconnect failure
+    assert "flaky" not in mgr._pool  # noqa: SLF001
+    assert "flaky" not in mgr._refcounts  # noqa: SLF001
+    assert "flaky" not in mgr._transitions  # noqa: SLF001
+
+    monkeypatch.setattr(MCPConnectionManager, "_instance", None)
+
+
+def test_reconnect_handles_old_client_disconnect_failure(monkeypatch):
+    call_count = 0
+
+    class FirstFailsThenWorks(FakeMCPClient):
+        """First instance fails disconnect, second works fine."""
+
+        def disconnect(self) -> None:
+            nonlocal call_count
+            call_count += 1
+            self.disconnect_calls += 1
+            self._connected = False
+            if call_count == 1:
+                raise RuntimeError("old disconnect failed")
+
+    monkeypatch.setattr(
+        "framework.runner.mcp_connection_manager.MCPClient",
+        FirstFailsThenWorks,
+    )
+    monkeypatch.setattr(MCPConnectionManager, "_instance", None)
+    FirstFailsThenWorks.instances = []
+    mgr = MCPConnectionManager.get_instance()
+
+    config = MCPServerConfig(name="flaky", transport="stdio", command="echo")
+    original = mgr.acquire(config)
+
+    # reconnect should succeed even if old client disconnect fails
+    replacement = mgr.reconnect("flaky")
+    assert replacement is not original
+    assert "flaky" in mgr._pool  # noqa: SLF001
+    assert "flaky" not in mgr._transitions  # noqa: SLF001
+
+    mgr.cleanup_all()
+    monkeypatch.setattr(MCPConnectionManager, "_instance", None)
+
+
+def test_cleanup_all_handles_disconnect_failure(monkeypatch):
+    monkeypatch.setattr(
+        "framework.runner.mcp_connection_manager.MCPClient",
+        FailingDisconnectClient,
+    )
+    monkeypatch.setattr(MCPConnectionManager, "_instance", None)
+    FailingDisconnectClient.instances = []
+    mgr = MCPConnectionManager.get_instance()
+
+    mgr.acquire(MCPServerConfig(name="a", transport="stdio", command="echo"))
+    mgr.acquire(MCPServerConfig(name="b", transport="stdio", command="echo"))
+
+    # cleanup_all should not raise even if disconnects fail
+    mgr.cleanup_all()
+
+    assert mgr._pool == {}  # noqa: SLF001
+    assert mgr._refcounts == {}  # noqa: SLF001
+
+    monkeypatch.setattr(MCPConnectionManager, "_instance", None)
+
+
+def test_reconnect_on_fully_released_server_raises(manager):
+    config = MCPServerConfig(name="gone", transport="stdio", command="echo")
+    manager.acquire(config)
+    manager.release("gone")
+
+    with pytest.raises(KeyError, match="Unknown MCP server"):
+        manager.reconnect("gone")

--- a/core/tests/test_mcp_registry.py
+++ b/core/tests/test_mcp_registry.py
@@ -1,0 +1,1172 @@
+"""Tests for MCPRegistry core module."""
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from framework.runner.mcp_registry import MCPRegistry
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _write_mock_index(cache_dir: Path, servers: dict) -> None:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache_dir / "registry_index.json").write_text(
+        json.dumps({"servers": servers}), encoding="utf-8"
+    )
+
+
+def _setup_registry_with_servers(tmp_path: Path) -> MCPRegistry:
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+
+    registry.add_local(name="jira", transport="stdio", command="uvx", args=["jira-mcp"])
+    registry.add_local(name="slack", transport="http", url="http://localhost:4020")
+    registry.add_local(name="github", transport="http", url="http://localhost:4030")
+
+    data = registry._read_installed()
+    data["servers"]["jira"]["manifest"]["tags"] = ["productivity", "pm"]
+    data["servers"]["slack"]["manifest"]["tags"] = ["productivity", "messaging"]
+    data["servers"]["github"]["manifest"]["tags"] = ["dev"]
+    data["servers"]["jira"]["manifest"]["hive"] = {"profiles": ["productivity"]}
+    data["servers"]["slack"]["manifest"]["hive"] = {"profiles": ["productivity"]}
+    data["servers"]["github"]["manifest"]["hive"] = {"profiles": ["developer"]}
+    registry._write_installed(data)
+    return registry
+
+
+# ── Initialization ──────────────────────────────────────────────────
+
+
+def test_init_creates_directory_structure(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    assert (tmp_path / "mcp_registry" / "config.json").exists()
+    assert (tmp_path / "mcp_registry" / "installed.json").exists()
+    assert (tmp_path / "mcp_registry" / "cache").is_dir()
+
+
+def test_init_default_config(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    config = json.loads((tmp_path / "mcp_registry" / "config.json").read_text())
+    assert "index_url" in config
+    assert "refresh_interval_hours" in config
+
+
+def test_init_preserves_existing(tmp_path: Path):
+    base = tmp_path / "mcp_registry"
+    base.mkdir(parents=True)
+    (base / "installed.json").write_text(json.dumps({"servers": {"jira": {"enabled": True}}}))
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    assert "jira" in json.loads((base / "installed.json").read_text())["servers"]
+
+
+# ── add_local ───────────────────────────────────────────────────────
+
+
+def test_add_local_http(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="my-db", transport="http", url="http://localhost:9090")
+    entry = registry._read_installed()["servers"]["my-db"]
+    assert entry["source"] == "local"
+    assert entry["transport"] == "http"
+    assert entry["enabled"] is True
+
+
+def test_add_local_duplicate_raises(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="my-db", transport="http", url="http://localhost:9090")
+    with pytest.raises(ValueError, match="already exists"):
+        registry.add_local(name="my-db", transport="http", url="http://localhost:9090")
+
+
+def test_add_local_stdio(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(
+        name="tools",
+        transport="stdio",
+        command="uvx",
+        args=["my-mcp"],
+        cwd="/opt/tools",
+        description="My tools",
+    )
+    entry = registry._read_installed()["servers"]["tools"]
+    assert entry["manifest"]["stdio"]["command"] == "uvx"
+    assert entry["manifest"]["stdio"]["cwd"] == "/opt/tools"
+    assert entry["manifest"]["description"] == "My tools"
+
+
+def test_add_local_unix(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="db", transport="unix", socket_path="/tmp/mcp.sock")
+    entry = registry._read_installed()["servers"]["db"]
+    assert entry["transport"] == "unix"
+    assert entry["manifest"]["unix"]["socket_path"] == "/tmp/mcp.sock"
+
+
+def test_add_local_sse(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="stream", transport="sse", url="http://localhost:8080/sse")
+    entry = registry._read_installed()["servers"]["stream"]
+    assert entry["transport"] == "sse"
+
+
+def test_add_local_stdio_requires_command(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    with pytest.raises(ValueError, match="command is required"):
+        registry.add_local(name="x", transport="stdio")
+
+
+def test_add_local_http_requires_url(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    with pytest.raises(ValueError, match="url is required"):
+        registry.add_local(name="x", transport="http")
+
+
+def test_add_local_unix_requires_socket_path(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    with pytest.raises(ValueError, match="socket_path is required"):
+        registry.add_local(name="x", transport="unix")
+
+
+def test_add_local_unsupported_transport(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    with pytest.raises(ValueError, match="Unsupported transport"):
+        registry.add_local(name="x", transport="grpc")
+
+
+# ── install ─────────────────────────────────────────────────────────
+
+
+def test_install_from_index(tmp_path: Path):
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    _write_mock_index(
+        base / "cache",
+        {
+            "jira": {
+                "name": "jira",
+                "version": "1.2.0",
+                "transport": {"supported": ["stdio"], "default": "stdio"},
+                "stdio": {"command": "uvx", "args": ["jira-mcp-server"]},
+            }
+        },
+    )
+    registry.install("jira")
+    entry = registry._read_installed()["servers"]["jira"]
+    assert entry["source"] == "registry"
+    assert entry["transport"] == "stdio"
+    assert entry["manifest"]["name"] == "jira"
+    assert entry["manifest"]["version"] == "1.2.0"
+    assert entry["manifest"]["stdio"]["command"] == "uvx"
+
+
+def test_install_not_found_raises(tmp_path: Path):
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    _write_mock_index(base / "cache", {})
+    with pytest.raises(ValueError, match="not found"):
+        registry.install("nonexistent")
+
+
+def test_install_duplicate_raises(tmp_path: Path):
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    _write_mock_index(
+        base / "cache",
+        {
+            "jira": {
+                "name": "jira",
+                "version": "1.0.0",
+                "transport": {"default": "stdio"},
+                "stdio": {"command": "uvx"},
+            }
+        },
+    )
+    registry.install("jira")
+    with pytest.raises(ValueError, match="already exists"):
+        registry.install("jira")
+
+
+def test_install_version_pin(tmp_path: Path):
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    _write_mock_index(
+        base / "cache",
+        {"slack": {"name": "slack", "version": "2.0.0", "transport": {"default": "http"}}},
+    )
+    registry.install("slack", version="2.0.0")
+    entry = registry._read_installed()["servers"]["slack"]
+    assert entry["pinned"] is True
+
+
+def test_install_version_mismatch_raises(tmp_path: Path):
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    _write_mock_index(
+        base / "cache",
+        {"jira": {"name": "jira", "version": "1.2.0", "transport": {"default": "stdio"}}},
+    )
+    with pytest.raises(ValueError, match="Version mismatch"):
+        registry.install("jira", version="2.0.0")
+
+
+# ── remove / enable / disable ──────────────────────────────────────
+
+
+def test_remove(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="db", transport="http", url="http://localhost:9090")
+    registry.remove("db")
+    assert "db" not in registry._read_installed()["servers"]
+
+
+def test_remove_nonexistent_raises(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    with pytest.raises(ValueError, match="not installed"):
+        registry.remove("ghost")
+
+
+def test_enable_disable(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="db", transport="http", url="http://localhost:9090")
+    registry.disable("db")
+    assert registry._read_installed()["servers"]["db"]["enabled"] is False
+    registry.enable("db")
+    assert registry._read_installed()["servers"]["db"]["enabled"] is True
+
+
+# ── list / get / search ─────────────────────────────────────────────
+
+
+def test_list_installed(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="a", transport="http", url="http://localhost:1")
+    registry.add_local(name="b", transport="http", url="http://localhost:2")
+    assert len(registry.list_installed()) == 2
+
+
+def test_get_server(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="jira", transport="http", url="http://localhost:4010")
+    assert registry.get_server("jira") is not None
+    assert registry.get_server("nonexistent") is None
+
+
+def test_search_by_name(tmp_path: Path):
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    _write_mock_index(
+        base / "cache",
+        {
+            "jira": {"name": "jira", "description": "Issues", "tags": []},
+            "slack": {"name": "slack", "description": "Chat", "tags": []},
+        },
+    )
+    assert len(registry.search("jira")) == 1
+
+
+def test_search_by_tag(tmp_path: Path):
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    _write_mock_index(
+        base / "cache",
+        {
+            "jira": {"name": "jira", "tags": ["pm"]},
+            "linear": {"name": "linear", "tags": ["pm"]},
+            "slack": {"name": "slack", "tags": ["chat"]},
+        },
+    )
+    assert len(registry.search("pm")) == 2
+
+
+def test_search_by_description(tmp_path: Path):
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    _write_mock_index(
+        base / "cache",
+        {
+            "jira": {"name": "jira", "description": "Manage issues", "tags": []},
+            "slack": {"name": "slack", "description": "Send messages", "tags": []},
+        },
+    )
+    assert len(registry.search("issues")) == 1
+
+
+def test_search_by_tool_name(tmp_path: Path):
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    _write_mock_index(
+        base / "cache",
+        {
+            "jira": {"name": "jira", "tags": [], "tools": [{"name": "create_issue"}]},
+            "slack": {"name": "slack", "tags": [], "tools": [{"name": "send_message"}]},
+        },
+    )
+    assert len(registry.search("create_issue")) == 1
+
+
+def test_list_available(tmp_path: Path):
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    _write_mock_index(base / "cache", {"a": {"name": "a"}, "b": {"name": "b"}})
+    assert len(registry.list_available()) == 2
+
+
+# ── set_override ────────────────────────────────────────────────────
+
+
+def test_set_override_env(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="jira", transport="http", url="http://localhost:4010")
+    registry.set_override("jira", "TOKEN", "secret")
+    assert registry._read_installed()["servers"]["jira"]["overrides"]["env"]["TOKEN"] == "secret"
+
+
+def test_set_override_headers(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="jira", transport="http", url="http://localhost:4010")
+    registry.set_override("jira", "Authorization", "Bearer x", override_type="headers")
+    entry = registry._read_installed()["servers"]["jira"]
+    assert entry["overrides"]["headers"]["Authorization"] == "Bearer x"
+
+
+def test_set_override_invalid_type(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="jira", transport="http", url="http://localhost:4010")
+    with pytest.raises(ValueError, match="Invalid override type"):
+        registry.set_override("jira", "k", "v", override_type="cookies")
+
+
+# ── update_index ────────────────────────────────────────────────────
+
+
+def test_update_index_writes_cache(tmp_path: Path, monkeypatch):
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+
+    class MockResponse:
+        status_code = 200
+
+        def json(self):
+            return {"servers": {"jira": {"name": "jira"}}}
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr("framework.runner.mcp_registry.httpx.get", lambda *a, **kw: MockResponse())
+    registry.update_index()
+    cached = json.loads((base / "cache" / "registry_index.json").read_text())
+    assert "jira" in cached["servers"]
+    assert (base / "cache" / "last_fetched").exists()
+    assert not (base / "cache" / "last_fetched.json").exists()
+
+
+def test_update_index_network_error(tmp_path: Path, monkeypatch):
+    import httpx as _httpx
+
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    monkeypatch.setattr(
+        "framework.runner.mcp_registry.httpx.get",
+        lambda *a, **kw: (_ for _ in ()).throw(_httpx.ConnectError("fail")),
+    )
+    with pytest.raises(_httpx.ConnectError):
+        registry.update_index()
+
+
+# ── is_index_stale ──────────────────────────────────────────────────
+
+
+def test_is_index_stale_no_cache(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    assert registry.is_index_stale() is True
+
+
+def test_is_index_stale_fresh(tmp_path: Path):
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    MCPRegistry._write_json(
+        base / "cache" / "last_fetched",
+        {"timestamp": datetime.now(UTC).isoformat()},
+    )
+    assert registry.is_index_stale() is False
+
+
+def test_is_index_stale_expired(tmp_path: Path):
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    old = datetime.now(UTC) - timedelta(hours=48)
+    MCPRegistry._write_json(
+        base / "cache" / "last_fetched",
+        {"timestamp": old.isoformat()},
+    )
+    assert registry.is_index_stale() is True
+
+
+def test_is_index_stale_supports_legacy_filename(tmp_path: Path):
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    MCPRegistry._write_json(
+        base / "cache" / "last_fetched.json",
+        {"timestamp": datetime.now(UTC).isoformat()},
+    )
+    assert registry.is_index_stale() is False
+
+
+def test_is_index_stale_missing_timestamp_returns_true(tmp_path: Path):
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    MCPRegistry._write_json(base / "cache" / "last_fetched", {"bad": "data"})
+    assert registry.is_index_stale() is True
+
+
+# ── resolve_for_agent ───────────────────────────────────────────────
+
+
+def test_resolve_include(tmp_path: Path):
+    registry = _setup_registry_with_servers(tmp_path)
+    configs = registry.resolve_for_agent(include=["jira", "slack"])
+    assert [c.name for c in configs] == ["jira", "slack"]
+
+
+def test_resolve_exclude(tmp_path: Path):
+    registry = _setup_registry_with_servers(tmp_path)
+    configs = registry.resolve_for_agent(include=["jira", "slack", "github"], exclude=["github"])
+    assert "github" not in [c.name for c in configs]
+
+
+def test_resolve_tags(tmp_path: Path):
+    registry = _setup_registry_with_servers(tmp_path)
+    configs = registry.resolve_for_agent(tags=["productivity"])
+    names = [c.name for c in configs]
+    assert "jira" in names and "slack" in names and "github" not in names
+
+
+def test_resolve_profile(tmp_path: Path):
+    registry = _setup_registry_with_servers(tmp_path)
+    configs = registry.resolve_for_agent(profile="productivity")
+    names = [c.name for c in configs]
+    assert "jira" in names and "slack" in names
+
+
+def test_resolve_profile_all(tmp_path: Path):
+    registry = _setup_registry_with_servers(tmp_path)
+    assert len(registry.resolve_for_agent(profile="all")) == 3
+
+
+def test_resolve_max_tools(tmp_path: Path):
+    registry = _setup_registry_with_servers(tmp_path)
+    data = registry._read_installed()
+    data["servers"]["jira"]["manifest"]["tools"] = [{"name": "a"}, {"name": "b"}]
+    data["servers"]["slack"]["manifest"]["tools"] = [{"name": "c"}, {"name": "d"}]
+    data["servers"]["github"]["manifest"]["tools"] = [{"name": "e"}]
+    registry._write_installed(data)
+    configs = registry.resolve_for_agent(profile="all", max_tools=3)
+    total = sum(
+        len(registry._read_installed()["servers"][c.name]["manifest"].get("tools", []))
+        for c in configs
+    )
+    assert total <= 3 and len(configs) >= 1
+
+
+def test_resolve_skips_disabled(tmp_path: Path):
+    registry = _setup_registry_with_servers(tmp_path)
+    registry.disable("jira")
+    configs = registry.resolve_for_agent(include=["jira", "slack"])
+    assert "jira" not in [c.name for c in configs]
+
+
+def test_resolve_missing_server_warns(tmp_path: Path):
+    registry = _setup_registry_with_servers(tmp_path)
+    assert len(registry.resolve_for_agent(include=["jira", "ghost"])) == 1
+
+
+def test_resolve_versions_match(tmp_path: Path):
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    _write_mock_index(
+        base / "cache",
+        {
+            "jira": {
+                "name": "jira",
+                "version": "1.2.0",
+                "transport": {"default": "stdio"},
+                "stdio": {"command": "uvx"},
+            }
+        },
+    )
+    registry.install("jira")
+    assert len(registry.resolve_for_agent(include=["jira"], versions={"jira": "1.2.0"})) == 1
+    assert len(registry.resolve_for_agent(include=["jira"], versions={"jira": "9.9.9"})) == 0
+
+
+# ── _manifest_to_server_config ──────────────────────────────────────
+
+
+def test_config_merges_env(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="t", transport="stdio", command="uvx", env={"A": "1"})
+    registry.set_override("t", "B", "2")
+    configs = registry.resolve_for_agent(include=["t"])
+    assert configs[0].env["A"] == "1" and configs[0].env["B"] == "2"
+
+
+def test_config_overrides_win(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="t", transport="stdio", command="uvx", env={"K": "old"})
+    registry.set_override("t", "K", "new")
+    assert registry.resolve_for_agent(include=["t"])[0].env["K"] == "new"
+
+
+def test_config_includes_cwd(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="t", transport="stdio", command="uvx", cwd="/opt")
+    assert registry.resolve_for_agent(include=["t"])[0].cwd == "/opt"
+
+
+def test_config_includes_description(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="t", transport="stdio", command="uvx", description="desc")
+    assert registry.resolve_for_agent(include=["t"])[0].description == "desc"
+
+
+def test_config_unix_transport(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="u", transport="unix", socket_path="/tmp/s.sock")
+    c = registry.resolve_for_agent(include=["u"])[0]
+    assert c.transport == "unix" and c.socket_path == "/tmp/s.sock"
+
+
+def test_config_unsupported_transport_returns_none(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    data = registry._read_installed()
+    data["servers"]["x"] = {
+        "source": "local",
+        "transport": "grpc",
+        "enabled": True,
+        "manifest": {"name": "x", "transport": {"default": "grpc"}},
+        "overrides": {"env": {}, "headers": {}},
+    }
+    registry._write_installed(data)
+    assert len(registry.resolve_for_agent(include=["x"])) == 0
+
+
+# ── _server_config_to_dict ──────────────────────────────────────────
+
+
+def test_server_config_to_dict(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="t", transport="stdio", command="uvx", cwd="/opt", description="d")
+    config = registry.resolve_for_agent(include=["t"])[0]
+    d = MCPRegistry._server_config_to_dict(config)
+    assert d["name"] == "t" and d["transport"] == "stdio"
+    assert d["cwd"] == "/opt" and d["description"] == "d"
+
+
+# ── load_agent_selection ────────────────────────────────────────────
+
+
+def test_load_agent_selection(tmp_path: Path):
+    registry = _setup_registry_with_servers(tmp_path)
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    (agent_dir / "mcp_registry.json").write_text(json.dumps({"include": ["jira", "slack"]}))
+    dicts = registry.load_agent_selection(agent_dir)
+    assert len(dicts) == 2 and all("transport" in d for d in dicts)
+
+
+def test_load_agent_selection_no_file(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    assert registry.load_agent_selection(agent_dir) == []
+
+
+@pytest.mark.parametrize(
+    "field, bad_value",
+    [
+        ("include", "jira"),
+        ("tags", "pm"),
+        ("exclude", "jira"),
+        ("profile", ["all"]),
+        ("max_tools", "50"),
+        ("versions", ["1.0.0"]),
+    ],
+)
+def test_load_agent_selection_rejects_wrong_types(tmp_path: Path, field, bad_value):
+    """Fields with wrong JSON types are dropped with a warning, not silently misused."""
+    registry = _setup_registry_with_servers(tmp_path)
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    (agent_dir / "mcp_registry.json").write_text(json.dumps({field: bad_value}))
+    configs = registry.load_agent_selection(agent_dir)
+    # All bad fields are dropped, so resolve_for_agent gets no criteria and returns []
+    assert configs == []
+
+
+# ── run_health_check ────────────────────────────────────────────────
+
+
+def test_run_health_check_healthy(tmp_path: Path, monkeypatch):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="db", transport="http", url="http://localhost:9090")
+
+    class MockClient:
+        def __init__(self, config):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+        def list_tools(self):
+            return []
+
+    monkeypatch.setattr("framework.runner.mcp_registry.MCPClient", MockClient)
+    result = registry.run_health_check("db")
+    assert result["status"] == "healthy"
+    assert registry._read_installed()["servers"]["db"]["last_health_check_at"] is not None
+
+
+def test_health_check_public_api(tmp_path: Path, monkeypatch):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="db", transport="http", url="http://localhost:9090")
+
+    class MockClient:
+        def __init__(self, config):
+            self.config = config
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def list_tools(self):
+            return []
+
+    monkeypatch.setattr("framework.runner.mcp_registry.MCPClient", MockClient)
+    result = registry.health_check("db")
+    assert result["status"] == "healthy"
+
+
+def test_health_check_prefers_pooled_connection(tmp_path: Path, monkeypatch):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="db", transport="http", url="http://localhost:9090")
+
+    class FakePooledClient:
+        def list_tools(self):
+            return [object(), object()]
+
+    class FakeManager:
+        def __init__(self):
+            self.acquire_calls = 0
+            self.release_calls = 0
+
+        def has_connection(self, server_name: str) -> bool:
+            return server_name == "db"
+
+        def health_check(self, server_name: str) -> bool:
+            return server_name == "db"
+
+        def acquire(self, config):
+            self.acquire_calls += 1
+            return FakePooledClient()
+
+        def release(self, server_name: str) -> None:
+            self.release_calls += 1
+
+    fake_manager = FakeManager()
+    monkeypatch.setattr(
+        "framework.runner.mcp_registry.MCPConnectionManager.get_instance",
+        lambda: fake_manager,
+    )
+
+    class UnexpectedClient:
+        def __init__(self, config):
+            raise AssertionError("fresh MCPClient should not be constructed")
+
+    monkeypatch.setattr("framework.runner.mcp_registry.MCPClient", UnexpectedClient)
+
+    result = registry.health_check("db")
+    assert result["status"] == "healthy"
+    assert result["tools"] == 2
+    assert fake_manager.acquire_calls == 1
+    assert fake_manager.release_calls == 1
+
+
+def test_health_check_uses_installed_transport_preference(tmp_path: Path, monkeypatch):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(
+        name="api",
+        manifest={
+            "transport": {"supported": ["stdio", "http"], "default": "stdio"},
+            "stdio": {"command": "uvx", "args": ["legacy-server"]},
+            "http": {"url": "http://localhost:9001"},
+        },
+        transport="http",
+    )
+
+    seen_transport: list[str] = []
+
+    class MockClient:
+        def __init__(self, config):
+            seen_transport.append(config.transport)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def list_tools(self):
+            return []
+
+    monkeypatch.setattr("framework.runner.mcp_registry.MCPClient", MockClient)
+    result = registry.health_check("api")
+    assert result["status"] == "healthy"
+    assert seen_transport == ["http"]
+
+
+def test_run_health_check_unhealthy(tmp_path: Path, monkeypatch):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="db", transport="http", url="http://localhost:9999")
+
+    class MockClient:
+        def __init__(self, config):
+            pass
+
+        def __enter__(self):
+            raise ConnectionError("refused")
+
+        def __exit__(self, *a):
+            pass
+
+    monkeypatch.setattr("framework.runner.mcp_registry.MCPClient", MockClient)
+    result = registry.run_health_check("db")
+    assert result["status"] == "unhealthy"
+    assert "refused" in result["error"]
+
+
+def test_run_health_check_list_tools_failure(tmp_path: Path, monkeypatch):
+    """Health check where connect succeeds but list_tools fails."""
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="db", transport="http", url="http://localhost:9090")
+
+    class MockClient:
+        def __init__(self, config):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+        def list_tools(self):
+            raise RuntimeError("tools discovery failed")
+
+    monkeypatch.setattr("framework.runner.mcp_registry.MCPClient", MockClient)
+    result = registry.run_health_check("db")
+    assert result["status"] == "unhealthy"
+    assert "tools discovery failed" in result["error"]
+
+
+def test_run_health_check_unsupported_transport(tmp_path: Path):
+    """Health check on server with unsupported transport returns unhealthy."""
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    data = registry._read_installed()
+    data["servers"]["weird"] = {
+        "source": "local",
+        "transport": "grpc",
+        "enabled": True,
+        "manifest": {"name": "weird", "transport": {"default": "grpc"}},
+        "overrides": {"env": {}, "headers": {}},
+        "last_health_check_at": None,
+        "last_health_status": None,
+        "last_error": None,
+        "last_used_at": None,
+        "last_validated_with_hive_version": None,
+    }
+    registry._write_installed(data)
+    result = registry.run_health_check("weird")
+    assert result["status"] == "unhealthy"
+    assert "Unsupported transport" in result["error"]
+
+
+def test_run_health_check_not_installed(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    with pytest.raises(ValueError, match="not installed"):
+        registry.run_health_check("ghost")
+
+
+def test_resolve_for_agent_no_criteria(tmp_path: Path):
+    """resolve_for_agent with no criteria returns empty list."""
+    registry = _setup_registry_with_servers(tmp_path)
+    configs = registry.resolve_for_agent()
+    assert configs == []
+
+
+def test_install_version_pin_no_version_in_manifest(tmp_path: Path):
+    """install with version should fail if manifest has no version field."""
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    _write_mock_index(
+        base / "cache", {"noversion": {"name": "noversion", "transport": {"default": "stdio"}}}
+    )
+    with pytest.raises(ValueError, match="no version field"):
+        registry.install("noversion", version="1.0.0")
+
+
+# ── Scope gap fixes ─────────────────────────────────────────────────
+
+
+def test_add_local_with_inline_manifest(tmp_path: Path):
+    """add_local with manifest dict should register the server directly."""
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+
+    manifest = {
+        "description": "Custom Jira server",
+        "transport": {"supported": ["stdio"], "default": "stdio"},
+        "stdio": {"command": "uvx", "args": ["jira-mcp"], "env": {"TOKEN": "abc"}},
+        "tags": ["pm"],
+    }
+    registry.add_local(name="jira", manifest=manifest)
+
+    entry = registry._read_installed()["servers"]["jira"]
+    assert entry["source"] == "local"
+    assert entry["transport"] == "stdio"
+    assert entry["manifest"]["stdio"]["command"] == "uvx"
+    assert entry["manifest"]["tags"] == ["pm"]
+    assert entry["manifest"]["name"] == "jira"
+
+
+def test_add_local_manifest_without_transport_defaults(tmp_path: Path):
+    """add_local with manifest but no transport key should default to stdio."""
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+
+    manifest = {"stdio": {"command": "echo"}}
+    registry.add_local(name="simple", manifest=manifest)
+
+    entry = registry._read_installed()["servers"]["simple"]
+    assert entry["transport"] == "stdio"
+
+
+def test_add_local_requires_transport_without_manifest(tmp_path: Path):
+    """add_local without manifest or transport should raise."""
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    with pytest.raises(ValueError, match="transport is required"):
+        registry.add_local(name="broken")
+
+
+def test_install_with_transport_override(tmp_path: Path):
+    """install with transport should override the manifest default."""
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    _write_mock_index(
+        base / "cache",
+        {
+            "jira": {
+                "name": "jira",
+                "version": "1.0.0",
+                "transport": {"supported": ["stdio", "http"], "default": "stdio"},
+                "stdio": {"command": "uvx"},
+                "http": {"url": "http://localhost:4010"},
+            }
+        },
+    )
+
+    registry.install("jira", transport="http")
+    entry = registry._read_installed()["servers"]["jira"]
+    assert entry["transport"] == "http"
+    config = registry.resolve_for_agent(include=["jira"])[0]
+    assert config.transport == "http"
+    assert config.url == "http://localhost:4010"
+
+
+def test_install_with_unsupported_transport_raises(tmp_path: Path):
+    """install with transport not in supported list should raise."""
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    _write_mock_index(
+        base / "cache",
+        {
+            "jira": {
+                "name": "jira",
+                "version": "1.0.0",
+                "transport": {"supported": ["stdio"], "default": "stdio"},
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match="not supported"):
+        registry.install("jira", transport="http")
+
+
+def test_install_registry_entry_uses_updated_cached_manifest(tmp_path: Path):
+    """Registry installs should resolve via the current cached index."""
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    _write_mock_index(
+        base / "cache",
+        {
+            "jira": {
+                "name": "jira",
+                "version": "1.0.0",
+                "transport": {"supported": ["stdio"], "default": "stdio"},
+                "stdio": {"command": "uvx", "args": ["jira-v1"]},
+            }
+        },
+    )
+
+    registry.install("jira")
+
+    _write_mock_index(
+        base / "cache",
+        {
+            "jira": {
+                "name": "jira",
+                "version": "1.1.0",
+                "transport": {"supported": ["stdio"], "default": "stdio"},
+                "stdio": {"command": "uvx", "args": ["jira-v2"]},
+            }
+        },
+    )
+
+    config = registry.resolve_for_agent(include=["jira"])[0]
+    assert config.transport == "stdio"
+    assert config.args == ["jira-v2"]
+
+
+def test_install_registry_entry_resolves_without_cache(tmp_path: Path):
+    """Registry installs should remain usable even when the cache is missing."""
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    _write_mock_index(
+        base / "cache",
+        {
+            "jira": {
+                "name": "jira",
+                "version": "1.0.0",
+                "transport": {"supported": ["stdio"], "default": "stdio"},
+                "stdio": {"command": "uvx", "args": ["jira-mcp"]},
+            }
+        },
+    )
+
+    registry.install("jira")
+    (base / "cache" / "registry_index.json").unlink()
+
+    config = registry.resolve_for_agent(include=["jira"])[0]
+    assert config.transport == "stdio"
+    assert config.command == "uvx"
+    assert config.args == ["jira-mcp"]
+
+
+def test_run_health_check_all_servers(tmp_path: Path, monkeypatch):
+    """run_health_check with no name should check all servers."""
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    registry.add_local(name="a", transport="http", url="http://localhost:1")
+    registry.add_local(name="b", transport="http", url="http://localhost:2")
+
+    class MockClient:
+        def __init__(self, config):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+        def list_tools(self):
+            return []
+
+    monkeypatch.setattr("framework.runner.mcp_registry.MCPClient", MockClient)
+
+    results = registry.run_health_check()
+    assert isinstance(results, dict)
+    assert "a" in results
+    assert "b" in results
+    assert results["a"]["status"] == "healthy"
+    assert results["b"]["status"] == "healthy"
+
+
+# ── Edge case coverage ──────────────────────────────────────────────
+
+
+def test_add_local_sse_requires_url(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    with pytest.raises(ValueError, match="url is required"):
+        registry.add_local(name="x", transport="sse")
+
+
+def test_enable_nonexistent_raises(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    with pytest.raises(ValueError, match="not installed"):
+        registry.enable("ghost")
+
+
+def test_disable_nonexistent_raises(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    with pytest.raises(ValueError, match="not installed"):
+        registry.disable("ghost")
+
+
+def test_list_installed_empty(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    assert registry.list_installed() == []
+
+
+def test_list_available_empty_index(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    assert registry.list_available() == []
+
+
+def test_set_override_nonexistent_raises(tmp_path: Path):
+    registry = MCPRegistry(base_path=tmp_path / "mcp_registry")
+    registry.initialize()
+    with pytest.raises(ValueError, match="not installed"):
+        registry.set_override("ghost", "KEY", "val")
+
+
+def test_search_no_results(tmp_path: Path):
+    base = tmp_path / "mcp_registry"
+    registry = MCPRegistry(base_path=base)
+    registry.initialize()
+    _write_mock_index(
+        base / "cache",
+        {
+            "jira": {"name": "jira", "description": "Issues", "tags": []},
+        },
+    )
+    assert registry.search("nonexistent_query_xyz") == []
+
+
+def test_resolve_profile_matches_nothing(tmp_path: Path):
+    registry = _setup_registry_with_servers(tmp_path)
+    configs = registry.resolve_for_agent(profile="nonexistent_profile")
+    assert configs == []
+
+
+# ── _get_hive_version ────────────────────────────────────────────────
+
+
+def test_get_hive_version_section_aware(tmp_path: Path, monkeypatch):
+    """Version must come from [project], not from a [tool.*] section."""
+    from importlib.metadata import PackageNotFoundError
+
+    import framework.runner.mcp_registry as mod
+
+    # Create directory structure so parents[2] of fake file -> tmp_path
+    runner_dir = tmp_path / "framework" / "runner"
+    runner_dir.mkdir(parents=True)
+    fake_file = runner_dir / "mcp_registry.py"
+    fake_file.touch()
+
+    # Put version in [tool.*] before [project] to trigger the old bug
+    toml_content = (
+        '[tool.something]\nversion = "9.9.9"\n\n[project]\nname = "framework"\nversion = "0.7.1"\n'
+    )
+    (tmp_path / "pyproject.toml").write_text(toml_content, encoding="utf-8")
+
+    monkeypatch.setattr(
+        "framework.runner.mcp_registry.version",
+        lambda _pkg: (_ for _ in ()).throw(PackageNotFoundError()),
+    )
+    monkeypatch.setattr(mod, "__file__", str(fake_file))
+
+    assert MCPRegistry._get_hive_version() == "0.7.1"
+
+
+def test_get_hive_version_missing_toml(tmp_path: Path, monkeypatch):
+    """Returns 'unknown' when pyproject.toml does not exist."""
+    from importlib.metadata import PackageNotFoundError
+
+    import framework.runner.mcp_registry as mod
+
+    runner_dir = tmp_path / "framework" / "runner"
+    runner_dir.mkdir(parents=True)
+    fake_file = runner_dir / "mcp_registry.py"
+    fake_file.touch()
+
+    monkeypatch.setattr(
+        "framework.runner.mcp_registry.version",
+        lambda _pkg: (_ for _ in ()).throw(PackageNotFoundError()),
+    )
+    monkeypatch.setattr(mod, "__file__", str(fake_file))
+
+    assert MCPRegistry._get_hive_version() == "unknown"

--- a/core/tests/test_tool_registry.py
+++ b/core/tests/test_tool_registry.py
@@ -206,3 +206,80 @@ def test_register_mcp_server_direct_client_when_manager_disabled(monkeypatch):
     registry.cleanup()
 
     assert created_clients[0].disconnect_calls == 1
+
+
+def test_load_registry_servers_retries_when_registration_returns_zero(monkeypatch):
+    registry = ToolRegistry()
+    attempts = {"count": 0}
+
+    def fake_register(server_config, use_connection_manager=True):
+        attempts["count"] += 1
+        return 0 if attempts["count"] == 1 else 2
+
+    monkeypatch.setattr(registry, "register_mcp_server", fake_register)
+    monkeypatch.setattr("time.sleep", lambda _: None)
+
+    results = registry.load_registry_servers(
+        [{"name": "jira", "transport": "http", "url": "http://localhost:4010"}],
+        log_summary=False,
+    )
+
+    assert attempts["count"] == 2
+    assert results == [
+        {
+            "server": "jira",
+            "status": "loaded",
+            "tools_loaded": 2,
+            "skipped_reason": None,
+        }
+    ]
+
+
+def test_load_registry_servers_marks_failures_as_skipped(monkeypatch):
+    registry = ToolRegistry()
+
+    monkeypatch.setattr(registry, "register_mcp_server", lambda *args, **kwargs: 0)
+    monkeypatch.setattr("time.sleep", lambda _: None)
+
+    results = registry.load_registry_servers(
+        [{"name": "jira", "transport": "http", "url": "http://localhost:4010"}],
+        log_summary=False,
+    )
+
+    assert results == [
+        {
+            "server": "jira",
+            "status": "skipped",
+            "tools_loaded": 0,
+            "skipped_reason": "registered 0 tools",
+        }
+    ]
+
+
+def test_load_registry_servers_emits_structured_log_fields(monkeypatch):
+    registry = ToolRegistry()
+    captured_logs: list[tuple[str, dict | None]] = []
+
+    monkeypatch.setattr(registry, "register_mcp_server", lambda *args, **kwargs: 2)
+    monkeypatch.setattr(
+        "framework.runner.tool_registry.logger.info",
+        lambda message, *args, **kwargs: captured_logs.append((message, kwargs.get("extra"))),
+    )
+
+    registry.load_registry_servers(
+        [{"name": "jira", "transport": "http", "url": "http://localhost:4010"}],
+        log_summary=True,
+    )
+
+    assert captured_logs == [
+        (
+            "MCP registry server resolution",
+            {
+                "event": "mcp_registry_server_resolution",
+                "server": "jira",
+                "status": "loaded",
+                "tools_loaded": 2,
+                "skipped_reason": None,
+            },
+        )
+    ]


### PR DESCRIPTION
## Description

Add `MCPRegistry` core module for local MCP server state management at `~/.hive/mcp_registry/`. This is the foundation for the MCP Server Registry (#6321), providing the Python API that CLI commands (#6350) and agent integration (#6351) will build on top of.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (MCPConnectionManager hardening)

## Related Issues

Closes #6349

## Changes Made

### MCPRegistry core module (`mcp_registry.py`, 815 lines)

- Server lifecycle: `install()` from cached registry index with version validation, `add_local()` for all 4 transports (stdio, http, unix, sse), `remove()`, `enable()`, `disable()`
- Agent selection: `resolve_for_agent()` implementing PRD 7.2 selection precedence (include, tags, exclude, profile, max_tools, versions)
- `load_agent_selection()` loads `mcp_registry.json` with type validation on all 6 JSON fields (rejects wrong types with warnings instead of silently misbehaving)
- `set_override()` supports both env and headers via `override_type` parameter
- Discovery: `search()` by name/tag/description/tool-name, `list_installed()`, `list_available()`, `get_server()`
- Remote index: `update_index()` fetches and caches registry_index.json with configurable refresh interval and legacy filename support
- Health check: delegates to `MCPConnectionManager` for pooled connections, falls back to fresh `MCPClient` with context manager
- `_manifest_to_server_config()` handles all 4 transports with override merging, maps all `MCPServerConfig` fields including `cwd`, `socket_path`, `description`
- `_make_registry_manifest_snapshot()` stores full manifest so registry entries survive cache deletion
- `_get_hive_version()` uses `tomllib` for section-aware TOML parsing
- Atomic JSON writes via tempfile + fsync + os.replace
- Exported from `runner/__init__.py`

### Framework bridge (so the module isn't dead code)

- `_server_config_to_dict()` converts `MCPServerConfig` to the plain dict that `register_mcp_server()` expects
- `AgentRunner._load_registry_mcp_servers()` with try/except error handling and loaded/skipped logging
- Queen orchestrator and credential tester integration with try/except
- `ToolRegistry.load_registry_servers()` with retry and structured DX-4 logging via `extra={}` fields
- `register_mcp_server()` now reads `socket_path`
- `logging.py` preserves arbitrary `extra` fields in JSON log output

### MCPConnectionManager hardening

- 30s transition timeouts to prevent deadlocks (previously `.wait()` with no timeout)
- `has_connection()` for registry health check integration
- SSE health check uses `client.list_tools()` instead of HTTP `/health` (SSE is event-stream, not REST)
- Disconnect failure handling in `release()`, `reconnect()`, and `cleanup_all()`
- `reconnect()` guards against refcount dropping to zero mid-reconnect
- `release()` now cleans up `_configs` alongside `_pool` and `_refcounts`

## Review feedback addressed

All 11 findings from the initial review:

| # | Finding | Resolution |
|---|---|---|
| 1 | Bypasses MCPConnectionManager | `health_check()` delegates to `MCPConnectionManager.get_instance()` for pooled connections |
| 2 | No bridge to ToolRegistry | `_server_config_to_dict()` + `load_agent_selection()` + runner integration |
| 3 | Missing cwd/socket_path/description | All fields mapped in `_manifest_to_server_config()` and `register_mcp_server()` |
| 4 | Only stdio/http | All 4 transports (stdio, http, unix, sse) in `add_local()`, config conversion, and health check |
| 5 | Resource leak in health_check | Uses `with MCPClient(config) as client:` context manager |
| 6 | install() ignores version | Version validation against index, raises on mismatch |
| 7 | No mcp_registry.json loading | `load_agent_selection()` + runner/queen/credential_tester integration |
| 8 | Duplicate health_check naming | `run_health_check()` kept as backward-compat wrapper |
| 9 | set_override env-only | Accepts `override_type: Literal["env", "headers"]` |
| 10 | Manual try/except in tests | All tests use `pytest.raises(match=...)` |
| 11 | Missing test coverage | All paths covered |

## Testing

- [x] 117 tests pass across 4 test files
- [x] 85 MCPRegistry tests (lifecycle, selection precedence, health checks, cache fallback, type validation, edge cases)
- [x] 16 MCPConnectionManager tests (pooling, concurrency, SSE health check, failure paths)
- [x] 4 AgentRunner integration tests (loading, skipping, logging, malformed JSON survival)
- [x] 8 ToolRegistry tests (retry behavior, structured logging, connection manager usage)
- [x] Lint passes
- [x] Existing tests unaffected

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes