### PR TITLE
fix(runner): replace print() with logger.warning() for credential warnings

### DIFF
--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -1479,20 +1479,26 @@ class AgentRunner:
                 # Get OAuth token from Claude Code subscription
                 api_key = get_claude_code_token()
                 if not api_key:
-                    print("Warning: Claude Code subscription configured but no token found.")
-                    print("Run 'claude' to authenticate, then try again.")
+                    logger.warning(
+                        "Claude Code subscription configured but no token found. "
+                        "Run 'claude' to authenticate, then try again."
+                    )
             elif use_codex:
                 # Get OAuth token from Codex subscription
                 api_key = get_codex_token()
                 if not api_key:
-                    print("Warning: Codex subscription configured but no token found.")
-                    print("Run 'codex' to authenticate, then try again.")
+                    logger.warning(
+                        "Codex subscription configured but no token found. "
+                        "Run 'codex' to authenticate, then try again."
+                    )
             elif use_kimi_code:
                 # Get API key from Kimi Code CLI config (~/.kimi/config.toml)
                 api_key = get_kimi_code_token()
                 if not api_key:
-                    print("Warning: Kimi Code subscription configured but no key found.")
-                    print("Run 'kimi /login' to authenticate, then try again.")
+                    logger.warning(
+                        "Kimi Code subscription configured but no key found. "
+                        "Run 'kimi /login' to authenticate, then try again."
+                    )
             elif use_antigravity:
                 pass  # AntigravityProvider handles credentials internally
 
@@ -1577,8 +1583,12 @@ class AgentRunner:
                             if api_key_env:
                                 os.environ[api_key_env] = api_key
                         elif api_key_env:
-                            print(f"Warning: {api_key_env} not set. LLM calls will fail.")
-                            print(f"Set it with: export {api_key_env}=your-api-key")
+                            logger.warning(
+                                "%s not set. LLM calls will fail. "
+                                "Set it with: export %s=your-api-key",
+                                api_key_env,
+                                api_key_env,
+                            )
 
             # Fail fast if the agent needs an LLM but none was configured
             if self._llm is None:


### PR DESCRIPTION
## Description

Replaces raw `print()` calls with `logger.warning()` for credential warning messages in `core/framework/runner/runner.py`.

Fixes #6484

## Changes

| Lines | Before | After |
|-------|--------|-------|
| 1165-1166 | `print("Warning: Claude Code subscription...")` | `logger.warning(...)` |
| 1171-1172 | `print("Warning: Codex subscription...")` | `logger.warning(...)` |
| 1177-1178 | `print("Warning: Kimi Code subscription...")` | `logger.warning(...)` |
| 1248-1249 | `print(f"Warning: {api_key_env} not set...")` | `logger.warning("%s not set...", api_key_env)` |

## Why This Matters

- Raw `print()` is invisible when agents run headlessly or output is redirected
- The file already has `logger` set up — these prints were overlooked
- Uses lazy `%` formatting instead of f-strings (consistent with best practices)

## Checklist

- [x] Code follows project style guidelines
- [x] Lint passes (`ruff check` / `ruff format`)
- [x] Self-reviewed