### PR TITLE
fix: guard optional resend import in email_tool to prevent registration crash

### DIFF
--- a/tools/src/aden_tools/tools/email_tool/email_tool.py
+++ b/tools/src/aden_tools/tools/email_tool/email_tool.py
@@ -12,7 +12,6 @@ import os
 from typing import TYPE_CHECKING, Literal
 
 import httpx
-import resend
 from fastmcp import FastMCP
 
 if TYPE_CHECKING:
@@ -35,6 +34,15 @@ def register_tools(
         bcc: list[str] | None = None,
     ) -> dict:
         """Send email using Resend API."""
+        try:
+            import resend
+        except ImportError:
+            return {
+                "error": (
+                    "resend not installed. "
+                    "Install with: pip install resend  or  pip install tools[email]"
+                )
+            }
         resend.api_key = api_key
         try:
             payload: dict = {


### PR DESCRIPTION
## What
Guards the optional `resend` import in `email_tool.py` to prevent it from crashing the entire MCP tool registration pipeline.

## Why
Fixes #4816. The bare `import resend` at module level raises `ModuleNotFoundError` when `resend` is not installed, propagating through `register_all_tools()` and preventing ALL tools from registering.

## How
- Removed top-level `import resend` (line 15)
- Added lazy import with `try/except ImportError` inside `_send_via_resend()`  
- Returns a clear error dict when resend is missing
- Follows the established pattern in `excel_tool.py` (lines 43-51)

## Testing
- All 38 existing tests pass (`pytest tools/tests/tools/test_email_tool.py -v`)
- Verified email tool returns helpful error message when `resend` is missing
- Verified email tool works correctly when `resend` IS installed