### PR TITLE
micro-fix(credentials): stop logging encryption key in plaintext

### DIFF
--- a/core/framework/credentials/storage.py
+++ b/core/framework/credentials/storage.py
@@ -145,18 +145,27 @@ class EncryptedFileStorage(CredentialStorage):
         self._key_env_var = key_env_var
 
         # Get or generate encryption key
+        # Priority: explicit arg > env var > key file > generate & save
+        self._key_file = self.base_path.parent / ".credential_key"
         if encryption_key:
             self._key = encryption_key
         else:
             key_str = os.environ.get(key_env_var)
             if key_str:
                 self._key = key_str.encode()
+            elif self._key_file.exists():
+                self._key = self._key_file.read_text().strip().encode()
+                logger.debug("Loaded encryption key from %s", self._key_file)
             else:
-                # Generate new key
                 self._key = Fernet.generate_key()
-                logger.warning(
-                    f"Generated new encryption key. To persist credentials across restarts, "
-                    f"set {key_env_var}={self._key.decode()}"
+                self._key_file.parent.mkdir(parents=True, exist_ok=True)
+                self._key_file.write_text(self._key.decode())
+                os.chmod(self._key_file, 0o600)
+                logger.info(
+                    "Generated new encryption key and saved to %s. "
+                    "You can also override this by setting the %s environment variable.",
+                    self._key_file,
+                    key_env_var,
                 )
 
         self._fernet = Fernet(self._key)


### PR DESCRIPTION
## Summary

- **Removes plaintext encryption key from log output** in `EncryptedFileStorage.__init__()`
- Auto-saves generated Fernet key to `~/.hive/.credential_key` with `0600` permissions
- Loads key from file on subsequent starts; env var (`HIVE_CREDENTIAL_KEY`) still takes priority
- Logs only the file path and env var name, never the key itself

Closes #6598

## Test plan

- [x] Full test suite passes (833 passed, 55 skipped, 0 failures)
- [x] Verified key auto-generates and saves to file
- [x] Verified credentials persist across restarts using saved key
- [x] Verified actual key value never appears in log output
- [x] Ruff lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)