### PR TITLE
fix: catch preload validation errors and prevent path traversal in session routes

### DIFF
--- a/core/framework/server/app.py
+++ b/core/framework/server/app.py
@@ -75,10 +75,12 @@ def resolve_session(request: web.Request):
     Returns (session, None) on success or (None, error_response) on failure.
     """
     manager: SessionManager = request.app["manager"]
-    sid = request.match_info["session_id"]
+    sid = safe_path_segment(request.match_info["session_id"])
     session = manager.get_session(sid)
     if not session:
-        return None, web.json_response({"error": f"Session '{sid}' not found"}, status=404)
+        return None, web.json_response(
+            {"error": f"Session '{sid}' not found"}, status=404
+        )
     return session, None
 
 
@@ -211,7 +213,9 @@ def create_app(model: str | None = None) -> web.Application:
         # Auto-generate credential key for web-only users who never ran the TUI
         if not os.environ.get("HIVE_CREDENTIAL_KEY"):
             try:
-                from framework.credentials.key_storage import generate_and_save_credential_key
+                from framework.credentials.key_storage import (
+                    generate_and_save_credential_key,
+                )
 
                 generate_and_save_credential_key()
                 logger.info(
@@ -235,12 +239,18 @@ def create_app(model: str | None = None) -> web.Application:
     app.router.add_get("/api/health", handle_health)
 
     # Register route modules
-    from framework.server.routes_credentials import register_routes as register_credential_routes
+    from framework.server.routes_credentials import (
+        register_routes as register_credential_routes,
+    )
     from framework.server.routes_events import register_routes as register_event_routes
-    from framework.server.routes_execution import register_routes as register_execution_routes
+    from framework.server.routes_execution import (
+        register_routes as register_execution_routes,
+    )
     from framework.server.routes_graphs import register_routes as register_graph_routes
     from framework.server.routes_logs import register_routes as register_log_routes
-    from framework.server.routes_sessions import register_routes as register_session_routes
+    from framework.server.routes_sessions import (
+        register_routes as register_session_routes,
+    )
 
     register_credential_routes(app)
     register_execution_routes(app)

--- a/core/framework/server/routes_sessions.py
+++ b/core/framework/server/routes_sessions.py
@@ -34,6 +34,10 @@ from pathlib import Path
 
 from aiohttp import web
 
+from framework.credentials.models import CredentialError
+from framework.runner.preload_validation import (
+    PreloadValidationError,
+)
 from framework.server.app import (
     cold_sessions_dir,
     resolve_session,
@@ -66,19 +70,22 @@ def _session_to_live_dict(session) -> dict:
         "loaded_at": session.loaded_at,
         "uptime_seconds": round(time.time() - session.loaded_at, 1),
         "intro_message": getattr(session.runner, "intro_message", "") or "",
-        "queen_phase": phase_state.phase
-        if phase_state
-        else ("staging" if session.worker_runtime else "planning"),
+        "queen_phase": (
+            phase_state.phase
+            if phase_state
+            else ("staging" if session.worker_runtime else "planning")
+        ),
     }
 
 
-def _credential_error_response(exc: Exception, agent_path: str | None) -> web.Response | None:
+def _credential_error_response(
+    exc: Exception, agent_path: str | None
+) -> web.Response | None:
     """If *exc* is a CredentialError, return a 424 with structured credential info.
 
     Returns None if *exc* is not a credential error (caller should handle it).
     Uses the CredentialValidationResult attached by validate_agent_credentials.
     """
-    from framework.credentials.models import CredentialError
 
     if not isinstance(exc, CredentialError):
         return None
@@ -160,6 +167,8 @@ async def handle_create_session(request: web.Request) -> web.Response:
                 initial_prompt=initial_prompt,
                 queen_resume_from=queen_resume_from,
             )
+    except PreloadValidationError as e:
+        return web.json_response({"error": str(e)}, status=400)
     except ValueError as e:
         msg = str(e)
         if "currently loading" in msg:
@@ -199,7 +208,7 @@ async def handle_get_live_session(request: web.Request) -> web.Response:
     This lets the frontend detect a server restart and restore message history.
     """
     manager = _get_manager(request)
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
     session = manager.get_session(session_id)
 
     if session is None:
@@ -260,7 +269,7 @@ async def handle_get_live_session(request: web.Request) -> web.Response:
 async def handle_stop_session(request: web.Request) -> web.Response:
     """DELETE /api/sessions/{session_id} — stop a session entirely."""
     manager = _get_manager(request)
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
 
     stopped = await manager.stop_session(session_id)
     if not stopped:
@@ -283,7 +292,7 @@ async def handle_load_worker(request: web.Request) -> web.Response:
     Body: {"agent_path": "...", "worker_id": "..." (optional), "model": "..." (optional)}
     """
     manager = _get_manager(request)
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
     body = await request.json()
 
     agent_path = body.get("agent_path")
@@ -305,10 +314,14 @@ async def handle_load_worker(request: web.Request) -> web.Response:
             worker_id=worker_id,
             model=model,
         )
+    except PreloadValidationError as e:
+        return web.json_response({"error": str(e)}, status=400)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=409)
     except FileNotFoundError:
-        return web.json_response({"error": f"Agent not found: {agent_path}"}, status=404)
+        return web.json_response(
+            {"error": f"Agent not found: {agent_path}"}, status=404
+        )
     except Exception as e:
         resp = _credential_error_response(e, agent_path)
         if resp is not None:
@@ -322,7 +335,7 @@ async def handle_load_worker(request: web.Request) -> web.Response:
 async def handle_unload_worker(request: web.Request) -> web.Response:
     """DELETE /api/sessions/{session_id}/worker — unload worker, keep queen alive."""
     manager = _get_manager(request)
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
 
     removed = await manager.unload_worker(session_id)
     if not removed:
@@ -348,7 +361,7 @@ async def handle_unload_worker(request: web.Request) -> web.Response:
 async def handle_session_stats(request: web.Request) -> web.Response:
     """GET /api/sessions/{session_id}/stats — runtime statistics."""
     manager = _get_manager(request)
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
     session = manager.get_session(session_id)
 
     if session is None:
@@ -364,7 +377,7 @@ async def handle_session_stats(request: web.Request) -> web.Response:
 async def handle_session_entry_points(request: web.Request) -> web.Response:
     """GET /api/sessions/{session_id}/entry-points — list entry points."""
     manager = _get_manager(request)
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
     session = manager.get_session(session_id)
 
     if session is None:
@@ -506,7 +519,9 @@ async def handle_update_trigger_task(request: web.Request) -> web.Response:
         _start_trigger_webhook,
     )
 
-    if "trigger_config" in updates and trigger_id in getattr(session, "active_trigger_ids", set()):
+    if "trigger_config" in updates and trigger_id in getattr(
+        session, "active_trigger_ids", set()
+    ):
         task = session.active_timer_tasks.pop(trigger_id, None)
         if task and not task.done():
             task.cancel()
@@ -525,7 +540,7 @@ async def handle_update_trigger_task(request: web.Request) -> web.Response:
             await _start_trigger_webhook(session, trigger_id, tdef)
 
     if trigger_id in getattr(session, "active_trigger_ids", set()):
-        session_id = request.match_info["session_id"]
+        session_id = safe_path_segment(request.match_info["session_id"])
         await _persist_active_triggers(session, session_id)
 
     _save_trigger_to_agent(session, trigger_id, tdef)
@@ -566,7 +581,7 @@ async def handle_update_trigger_task(request: web.Request) -> web.Response:
 async def handle_session_graphs(request: web.Request) -> web.Response:
     """GET /api/sessions/{session_id}/graphs — list loaded graphs."""
     manager = _get_manager(request)
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
     session = manager.get_session(session_id)
 
     if session is None:
@@ -589,7 +604,7 @@ async def handle_list_worker_sessions(request: web.Request) -> web.Response:
     session, err = resolve_session(request)
     if err:
         # Fall back to cold session lookup from disk
-        sid = request.match_info["session_id"]
+        sid = safe_path_segment(request.match_info["session_id"])
         sess_dir = cold_sessions_dir(sid)
         if sess_dir is None:
             return err
@@ -624,7 +639,9 @@ async def handle_list_worker_sessions(request: web.Request) -> web.Response:
 
         cp_dir = d / "checkpoints"
         if cp_dir.exists():
-            entry["checkpoint_count"] = sum(1 for f in cp_dir.iterdir() if f.suffix == ".json")
+            entry["checkpoint_count"] = sum(
+                1 for f in cp_dir.iterdir() if f.suffix == ".json"
+            )
         else:
             entry["checkpoint_count"] = 0
 
@@ -722,7 +739,9 @@ async def handle_restore_checkpoint(request: web.Request) -> web.Response:
         return err
 
     if not session.worker_runtime:
-        return web.json_response({"error": "No worker loaded in this session"}, status=503)
+        return web.json_response(
+            {"error": "No worker loaded in this session"}, status=503
+        )
 
     ws_id = request.match_info.get("ws_id") or request.match_info.get("session_id", "")
     ws_id = safe_path_segment(ws_id)
@@ -761,7 +780,7 @@ async def handle_messages(request: web.Request) -> web.Response:
     session, err = resolve_session(request)
     if err:
         # Fall back to cold session lookup from disk
-        sid = request.match_info["session_id"]
+        sid = safe_path_segment(request.match_info["session_id"])
         sess_dir = cold_sessions_dir(sid)
         if sess_dir is None:
             return err
@@ -854,7 +873,10 @@ async def handle_messages(request: web.Request) -> web.Response:
                     and not (m["role"] == "assistant" and m.get("tool_calls"))
                     and (
                         (m["role"] == "user" and m.get("is_client_input"))
-                        or (m["role"] == "assistant" and m.get("_node_id") in client_facing_nodes)
+                        or (
+                            m["role"] == "assistant"
+                            and m.get("_node_id") in client_facing_nodes
+                        )
                     )
                 )
             ]
@@ -868,8 +890,7 @@ async def handle_queen_messages(request: web.Request) -> web.Response:
     Reads directly from disk so it works for both live sessions and cold
     (post-server-restart) sessions — no live session required.
     """
-    session_id = request.match_info["session_id"]
-
+    session_id = safe_path_segment(request.match_info["session_id"])
     queen_dir = Path.home() / ".hive" / "queen" / "session" / session_id
     convs_dir = queen_dir / "conversations"
     if not convs_dir.exists():
@@ -924,8 +945,7 @@ async def handle_session_events_history(request: web.Request) -> web.Response:
     replays these events through ``sseEventToChatMessage`` to fully reconstruct
     the UI state on resume.
     """
-    session_id = request.match_info["session_id"]
-
+    session_id = safe_path_segment(request.match_info["session_id"])
     queen_dir = Path.home() / ".hive" / "queen" / "session" / session_id
     events_path = queen_dir / "events.jsonl"
     if not events_path.exists():
@@ -981,7 +1001,7 @@ async def handle_delete_history_session(request: web.Request) -> web.Response:
     This is the frontend 'delete from history' action.
     """
     manager = _get_manager(request)
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
 
     # Stop the live session if it exists (best-effort)
     if manager.get_session(session_id):
@@ -993,8 +1013,12 @@ async def handle_delete_history_session(request: web.Request) -> web.Response:
         try:
             shutil.rmtree(queen_session_dir)
         except OSError as e:
-            logger.warning("Failed to delete session directory %s: %s", queen_session_dir, e)
-            return web.json_response({"error": f"Failed to delete session: {e}"}, status=500)
+            logger.warning(
+                "Failed to delete session directory %s: %s", queen_session_dir, e
+            )
+            return web.json_response(
+                {"error": f"Failed to delete session: {e}"}, status=500
+            )
 
     return web.json_response({"deleted": session_id})
 
@@ -1009,7 +1033,9 @@ async def handle_discover(request: web.Request) -> web.Response:
     from framework.agents.discovery import discover_agents
 
     manager = _get_manager(request)
-    loaded_paths = {str(s.worker_path) for s in manager.list_sessions() if s.worker_path}
+    loaded_paths = {
+        str(s.worker_path) for s in manager.list_sessions() if s.worker_path
+    }
 
     groups = discover_agents()
     result = {}
@@ -1048,7 +1074,9 @@ def register_routes(app: web.Application) -> None:
     app.router.add_get("/api/sessions", handle_list_live_sessions)
     # history must be registered before {session_id} so it takes priority
     app.router.add_get("/api/sessions/history", handle_session_history)
-    app.router.add_delete("/api/sessions/history/{session_id}", handle_delete_history_session)
+    app.router.add_delete(
+        "/api/sessions/history/{session_id}", handle_delete_history_session
+    )
     app.router.add_get("/api/sessions/{session_id}", handle_get_live_session)
     app.router.add_delete("/api/sessions/{session_id}", handle_stop_session)
 
@@ -1058,21 +1086,30 @@ def register_routes(app: web.Application) -> None:
 
     # Session info
     app.router.add_get("/api/sessions/{session_id}/stats", handle_session_stats)
-    app.router.add_get("/api/sessions/{session_id}/entry-points", handle_session_entry_points)
+    app.router.add_get(
+        "/api/sessions/{session_id}/entry-points", handle_session_entry_points
+    )
     app.router.add_patch(
         "/api/sessions/{session_id}/triggers/{trigger_id}", handle_update_trigger_task
     )
     app.router.add_get("/api/sessions/{session_id}/graphs", handle_session_graphs)
-    app.router.add_get("/api/sessions/{session_id}/queen-messages", handle_queen_messages)
-    app.router.add_get("/api/sessions/{session_id}/events/history", handle_session_events_history)
+    app.router.add_get(
+        "/api/sessions/{session_id}/queen-messages", handle_queen_messages
+    )
+    app.router.add_get(
+        "/api/sessions/{session_id}/events/history", handle_session_events_history
+    )
 
     # Worker session browsing (session-primary)
-    app.router.add_get("/api/sessions/{session_id}/worker-sessions", handle_list_worker_sessions)
+    app.router.add_get(
+        "/api/sessions/{session_id}/worker-sessions", handle_list_worker_sessions
+    )
     app.router.add_get(
         "/api/sessions/{session_id}/worker-sessions/{ws_id}", handle_get_worker_session
     )
     app.router.add_delete(
-        "/api/sessions/{session_id}/worker-sessions/{ws_id}", handle_delete_worker_session
+        "/api/sessions/{session_id}/worker-sessions/{ws_id}",
+        handle_delete_worker_session,
     )
     app.router.add_get(
         "/api/sessions/{session_id}/worker-sessions/{ws_id}/checkpoints",

--- a/core/framework/server/session_manager.py
+++ b/core/framework/server/session_manager.py
@@ -146,11 +146,15 @@ class SessionManager:
         """
         # Reuse the original session ID when cold-restoring
         resolved_session_id = queen_resume_from or session_id
-        session = await self._create_session_core(session_id=resolved_session_id, model=model)
+        session = await self._create_session_core(
+            session_id=resolved_session_id, model=model
+        )
         session.queen_resume_from = queen_resume_from
 
         # Start queen immediately (queen-only, no worker tools yet)
-        await self._start_queen(session, worker_identity=None, initial_prompt=initial_prompt)
+        await self._start_queen(
+            session, worker_identity=None, initial_prompt=initial_prompt
+        )
 
         logger.info(
             "Session '%s' created (queen-only, resume_from=%s)",
@@ -185,7 +189,12 @@ class SessionManager:
         if queen_resume_from:
             _resume_phase = None
             _meta_path = (
-                Path.home() / ".hive" / "queen" / "session" / queen_resume_from / "meta.json"
+                Path.home()
+                / ".hive"
+                / "queen"
+                / "session"
+                / queen_resume_from
+                / "meta.json"
             )
             if _meta_path.exists():
                 try:
@@ -277,11 +286,15 @@ class SessionManager:
         resolved_worker_id = worker_id or agent_path.name
 
         if session.worker_runtime is not None:
-            raise ValueError(f"Session '{session.id}' already has worker '{session.worker_id}'")
+            raise ValueError(
+                f"Session '{session.id}' already has worker '{session.worker_id}'"
+            )
 
         async with self._lock:
             if session.id in self._loading:
-                raise ValueError(f"Session '{session.id}' is currently loading a worker")
+                raise ValueError(
+                    f"Session '{session.id}' is currently loading a worker"
+                )
             self._loading.add(session.id)
 
         try:
@@ -322,10 +335,14 @@ class SessionManager:
                         description=tdata.get("name", tid),
                         task=tdata.get("task", ""),
                     )
-                    logger.info("Loaded trigger '%s' (%s) from triggers.json", tid, ttype)
+                    logger.info(
+                        "Loaded trigger '%s' (%s) from triggers.json", tid, ttype
+                    )
 
             if session.available_triggers:
-                await self._emit_trigger_events(session, "available", session.available_triggers)
+                await self._emit_trigger_events(
+                    session, "available", session.available_triggers
+                )
 
             # Start runtime on event loop
             if runtime and not runtime.is_running:
@@ -411,11 +428,17 @@ class SessionManager:
                     continue
 
                 state["status"] = "cancelled"
-                state.setdefault("result", {})["error"] = "Stale session: runtime restarted"
-                state.setdefault("timestamps", {})["updated_at"] = datetime.now().isoformat()
+                state.setdefault("result", {})[
+                    "error"
+                ] = "Stale session: runtime restarted"
+                state.setdefault("timestamps", {})[
+                    "updated_at"
+                ] = datetime.now().isoformat()
                 state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
                 logger.info(
-                    "Marked stale session '%s' as cancelled for agent '%s'", d.name, agent_path.name
+                    "Marked stale session '%s' as cancelled for agent '%s'",
+                    d.name,
+                    agent_path.name,
                 )
             except (json.JSONDecodeError, OSError) as e:
                 logger.warning("Failed to clean up stale session %s: %s", d.name, e)
@@ -448,7 +471,9 @@ class SessionManager:
                 return False
             return True
 
-    async def _restore_active_triggers(self, session: "Session", session_id: str) -> None:
+    async def _restore_active_triggers(
+        self, session: "Session", session_id: str
+    ) -> None:
         """Restore previously active triggers from persisted session state.
 
         Called after worker loading to restart any timer/webhook triggers
@@ -523,7 +548,14 @@ class SessionManager:
 
         # Update meta.json so cold-restore can discover this session by agent_path
         storage_session_id = session.queen_resume_from or session.id
-        meta_path = Path.home() / ".hive" / "queen" / "session" / storage_session_id / "meta.json"
+        meta_path = (
+            Path.home()
+            / ".hive"
+            / "queen"
+            / "session"
+            / storage_session_id
+            / "meta.json"
+        )
         try:
             _agent_name = (
                 session.worker_info.name
@@ -580,7 +612,9 @@ class SessionManager:
 
         # Clean up triggers
         if session.available_triggers:
-            await self._emit_trigger_events(session, "removed", session.available_triggers)
+            await self._emit_trigger_events(
+                session, "removed", session.available_triggers
+            )
             session.available_triggers.clear()
 
         if session.worker_digest_sub is not None:
@@ -617,7 +651,11 @@ class SessionManager:
 
         # Capture session data for memory consolidation before teardown
         _llm = getattr(session, "llm", None)
-        _storage_id = getattr(session, "queen_resume_from", None) or session_id
+        from .app import safe_path_segment
+
+        _storage_id = safe_path_segment(
+            getattr(session, "queen_resume_from", None) or session_id
+        )
         _session_dir = Path.home() / ".hive" / "queen" / "session" / _storage_id
 
         if session.worker_handoff_sub is not None:
@@ -693,7 +731,9 @@ class SessionManager:
     # Queen startup
     # ------------------------------------------------------------------
 
-    async def _handle_worker_handoff(self, session: Session, executor: Any, event: Any) -> None:
+    async def _handle_worker_handoff(
+        self, session: Session, executor: Any, event: Any
+    ) -> None:
         """Route worker escalation events into the queen conversation."""
         if event.stream_id == "queen":
             return
@@ -766,7 +806,9 @@ class SessionManager:
             from framework.agents.worker_memory import digest_path
 
             try:
-                content = digest_path(_agent_name, run_id).read_text(encoding="utf-8").strip()
+                content = (
+                    digest_path(_agent_name, run_id).read_text(encoding="utf-8").strip()
+                )
             except OSError:
                 return
             if not content:
@@ -948,7 +990,9 @@ class SessionManager:
                     )
         except OSError:
             pass
-        session.event_bus.set_session_log(events_path, iteration_offset=iteration_offset)
+        session.event_bus.set_session_log(
+            events_path, iteration_offset=iteration_offset
+        )
 
         session.queen_task = await create_queen(
             session=session,
@@ -973,22 +1017,35 @@ class SessionManager:
                             # Agent fully built — load worker and resume
                             await self.load_worker(session.id, _agent_path)
                             if session.phase_state:
-                                await session.phase_state.switch_to_staging(source="auto")
+                                await session.phase_state.switch_to_staging(
+                                    source="auto"
+                                )
                             # Emit flowchart overlay so frontend can display it
                             await self._emit_flowchart_on_restore(session, _agent_path)
-                            logger.info("Cold restore: auto-loaded worker from %s", _agent_path)
+                            logger.info(
+                                "Cold restore: auto-loaded worker from %s", _agent_path
+                            )
                         elif _phase == "building":
                             # Agent folder exists but incomplete — resume building
                             if session.phase_state:
                                 session.phase_state.agent_path = _agent_path
-                                await session.phase_state.switch_to_building(source="auto")
-                            logger.info("Cold restore: resumed BUILDING phase for %s", _agent_path)
+                                await session.phase_state.switch_to_building(
+                                    source="auto"
+                                )
+                            logger.info(
+                                "Cold restore: resumed BUILDING phase for %s",
+                                _agent_path,
+                            )
                         elif _phase == "planning":
                             if session.phase_state:
                                 session.phase_state.agent_path = _agent_path
-                            logger.info("Cold restore: PLANNING phase for %s", _agent_path)
+                            logger.info(
+                                "Cold restore: PLANNING phase for %s", _agent_path
+                            )
                 except Exception:
-                    logger.warning("Cold restore: failed to auto-load worker", exc_info=True)
+                    logger.warning(
+                        "Cold restore: failed to auto-load worker", exc_info=True
+                    )
 
         # Memory consolidation — triggered by context compaction events.
         # Compaction is a natural signal that "enough has happened to be worth remembering".
@@ -1024,7 +1081,9 @@ class SessionManager:
         if node is None or not hasattr(node, "inject_event"):
             return
 
-        profile = build_worker_profile(session.worker_runtime, agent_path=session.worker_path)
+        profile = build_worker_profile(
+            session.worker_runtime, agent_path=session.worker_path
+        )
 
         # Append available trigger info so the queen knows what's schedulable
         trigger_lines = ""
@@ -1032,8 +1091,12 @@ class SessionManager:
             parts = []
             for t in session.available_triggers.values():
                 cfg = t.trigger_config
-                detail = cfg.get("cron") or f"every {cfg.get('interval_minutes', '?')} min"
-                task_info = f' -> task: "{t.task}"' if t.task else " (no task configured)"
+                detail = (
+                    cfg.get("cron") or f"every {cfg.get('interval_minutes', '?')} min"
+                )
+                task_info = (
+                    f' -> task: "{t.task}"' if t.task else " (no task configured)"
+                )
                 parts.append(f"  - {t.id} ({t.trigger_type}: {detail}){task_info}")
             trigger_lines = (
                 "\n\nAvailable triggers (inactive — use set_trigger to activate):\n"
@@ -1054,14 +1117,18 @@ class SessionManager:
                 data={
                     "worker_id": session.worker_id,
                     "worker_name": info.name if info else session.worker_id,
-                    "agent_path": str(session.worker_path) if session.worker_path else "",
+                    "agent_path": (
+                        str(session.worker_path) if session.worker_path else ""
+                    ),
                     "goal": info.goal_name if info else "",
                     "node_count": info.node_count if info else 0,
                 },
             )
         )
 
-    async def _emit_flowchart_on_restore(self, session: Session, agent_path: str | Path) -> None:
+    async def _emit_flowchart_on_restore(
+        self, session: Session, agent_path: str | Path
+    ) -> None:
         """Emit FLOWCHART_MAP_UPDATED from persisted flowchart file on cold restore."""
         from framework.runtime.event_bus import AgentEvent, EventType
         from framework.tools.flowchart_utils import load_flowchart_file
@@ -1109,7 +1176,9 @@ class SessionManager:
         from framework.runtime.event_bus import AgentEvent, EventType
 
         event_type = (
-            EventType.TRIGGER_AVAILABLE if kind == "available" else EventType.TRIGGER_REMOVED
+            EventType.TRIGGER_AVAILABLE
+            if kind == "available"
+            else EventType.TRIGGER_REMOVED
         )
         # Resolve graph entry node for trigger target
         runner = getattr(session, "runner", None)
@@ -1130,7 +1199,9 @@ class SessionManager:
                 )
             )
 
-    async def revive_queen(self, session: Session, initial_prompt: str | None = None) -> None:
+    async def revive_queen(
+        self, session: Session, initial_prompt: str | None = None
+    ) -> None:
         """Revive a dead queen executor on an existing session.
 
         Restarts the queen with the same session context (worker profile, tools, etc.).
@@ -1193,6 +1264,9 @@ class SessionManager:
         ~/.hive/queen/session/{session_id}/conversations/.  Returns None when
         no data is found so callers can fall through to a 404.
         """
+        from .app import safe_path_segment
+
+        session_id = safe_path_segment(session_id)
         queen_dir = Path.home() / ".hive" / "queen" / "session" / session_id
         convs_dir = queen_dir / "conversations"
         if not convs_dir.exists():
@@ -1203,7 +1277,9 @@ class SessionManager:
         try:
             # Flat layout: conversations/parts/*.json
             flat_parts = convs_dir / "parts"
-            if flat_parts.exists() and any(f.suffix == ".json" for f in flat_parts.iterdir()):
+            if flat_parts.exists() and any(
+                f.suffix == ".json" for f in flat_parts.iterdir()
+            ):
                 has_messages = True
             else:
                 # Node-based layout: conversations/<node_id>/parts/*.json
@@ -1211,7 +1287,9 @@ class SessionManager:
                     if not node_dir.is_dir() or node_dir.name == "parts":
                         continue
                     parts_dir = node_dir / "parts"
-                    if parts_dir.exists() and any(f.suffix == ".json" for f in parts_dir.iterdir()):
+                    if parts_dir.exists() and any(
+                        f.suffix == ".json" for f in parts_dir.iterdir()
+                    ):
                         has_messages = True
                         break
         except OSError:
@@ -1291,7 +1369,9 @@ class SessionManager:
                 try:
                     all_parts: list[dict] = []
 
-                    def _collect_parts(parts_dir: Path, _dest: list[dict] = all_parts) -> None:
+                    def _collect_parts(
+                        parts_dir: Path, _dest: list[dict] = all_parts
+                    ) -> None:
                         if not parts_dir.exists():
                             return
                         for part_file in sorted(parts_dir.iterdir()):


### PR DESCRIPTION
## Problem
1. **Preload Validation 500 Error (#6570)**: When an agent fails preload validation (e.g., GCU node constraints), the server returns a 500 Internal Server Error instead of a descriptive 400 error.
2. **Session ID Path Traversal (#6553)**: Several session history and disk lookup endpoints built filesystem paths using raw `session_id` values from the URL, bypassing safety checks.

## Solution
- **Error Handling**: Updated `handle_create_session` and `handle_load_worker` in `routes_sessions.py` to explicitly catch `PreloadValidationError` and return a 400 response with the error details.
- **Path Validation**:
    - Applied `safe_path_segment()` to all `session_id` and `sid` extractions from `request.match_info` in `routes_sessions.py`.
    - Integrated `safe_path_segment()` into `SessionManager.stop_session()` and `SessionManager.get_cold_session_info()`.
    - Resolved a circular import by moving the `safe_path_segment` import inside the relevant `SessionManager` methods.

## Validation
- Created and successfully ran a reproduction test suite for both `handle_create_session` and `handle_load_worker`.
- Verified that all existing session-related API tests pass.
- Verified that `make check` and `make lint` pass.