### PR TITLE
fix: improve MCP tool partitioning, discovery, and assistant message visibility

### DIFF
--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -9,7 +9,11 @@ from datetime import UTC
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from framework.config import get_hive_config, get_max_context_tokens, get_preferred_model
+from framework.config import (
+    get_hive_config,
+    get_max_context_tokens,
+    get_preferred_model,
+)
 from framework.credentials.validation import (
     ensure_credential_key_env as _ensure_credential_key_env,
 )
@@ -25,7 +29,11 @@ from framework.graph.node import NodeSpec
 from framework.llm.provider import LLMProvider, Tool
 from framework.runner.preload_validation import run_preload_validation
 from framework.runner.tool_registry import ToolRegistry
-from framework.runtime.agent_runtime import AgentRuntime, AgentRuntimeConfig, create_agent_runtime
+from framework.runtime.agent_runtime import (
+    AgentRuntime,
+    AgentRuntimeConfig,
+    create_agent_runtime,
+)
 from framework.runtime.execution_stream import EntryPointSpec
 from framework.runtime.runtime_log_store import RuntimeLogStore
 from framework.tools.flowchart_utils import generate_fallback_flowchart
@@ -351,7 +359,9 @@ def _is_codex_token_expired(auth_data: dict) -> bool:
         # Codex stores last_refresh as an ISO 8601 timestamp string —
         # convert to Unix epoch float for arithmetic.
         try:
-            last_refresh = datetime.fromisoformat(last_refresh.replace("Z", "+00:00")).timestamp()
+            last_refresh = datetime.fromisoformat(
+                last_refresh.replace("Z", "+00:00")
+            ).timestamp()
         except (ValueError, TypeError):
             return True
 
@@ -633,9 +643,13 @@ def load_agent_export(data: str | dict) -> tuple[GraphSpec, Goal]:
         goal_id=graph_data.get("goal_id", ""),
         version=graph_data.get("version", "1.0.0"),
         entry_node=graph_data.get("entry_node", ""),
-        entry_points=graph_data.get("entry_points", {}),  # Support pause/resume architecture
+        entry_points=graph_data.get(
+            "entry_points", {}
+        ),  # Support pause/resume architecture
         terminal_nodes=graph_data.get("terminal_nodes", []),
-        pause_nodes=graph_data.get("pause_nodes", []),  # Support pause/resume architecture
+        pause_nodes=graph_data.get(
+            "pause_nodes", []
+        ),  # Support pause/resume architecture
         nodes=nodes,
         edges=edges,
         max_steps=graph_data.get("max_steps", 100),
@@ -804,9 +818,13 @@ class AgentRunner:
         os.environ["HIVE_STORAGE_PATH"] = str(self._storage_path)
 
         # Auto-discover MCP servers from mcp_servers.json
-        mcp_config_path = agent_path / "mcp_servers.json"
-        if mcp_config_path.exists():
-            self._load_mcp_servers_from_config(mcp_config_path)
+        mcp_config_paths = [
+            agent_path / "mcp_servers.json",
+            agent_path / "nodes" / "mcp_servers.json",
+        ]
+        for mcp_config_path in mcp_config_paths:
+            if mcp_config_path.exists():
+                self._load_mcp_servers_from_config(mcp_config_path)
 
     @staticmethod
     def _import_agent_module(agent_path: Path):
@@ -911,7 +929,9 @@ class AgentRunner:
                 )
             else:
                 hive_config = get_hive_config()
-                max_tokens = hive_config.get("llm", {}).get("max_tokens", DEFAULT_MAX_TOKENS)
+                max_tokens = hive_config.get("llm", {}).get(
+                    "max_tokens", DEFAULT_MAX_TOKENS
+                )
 
             # Resolve max_context_tokens with priority:
             #   1. agent loop_config["max_context_tokens"] (explicit, wins silently)
@@ -921,7 +941,9 @@ class AgentRunner:
             agent_loop_config: dict = dict(getattr(agent_module, "loop_config", {}))
             if "max_context_tokens" not in agent_loop_config:
                 if agent_config and hasattr(agent_config, "max_context_tokens"):
-                    agent_loop_config["max_context_tokens"] = agent_config.max_context_tokens
+                    agent_loop_config["max_context_tokens"] = (
+                        agent_config.max_context_tokens
+                    )
                     logger.info(
                         "Agent default_config overrides max_context_tokens: %d"
                         " (configuration.json value ignored)",
@@ -1012,7 +1034,9 @@ class AgentRunner:
         try:
             graph, goal = load_agent_export(export_data)
         except json.JSONDecodeError as exc:
-            raise ValueError(f"Invalid JSON in agent export file: {agent_json_path}") from exc
+            raise ValueError(
+                f"Invalid JSON in agent export file: {agent_json_path}"
+            ) from exc
 
         # Generate flowchart.json if missing (for legacy JSON-based agents)
         generate_fallback_flowchart(graph, goal, agent_path)
@@ -1162,7 +1186,9 @@ class AgentRunner:
                 # Get OAuth token from Claude Code subscription
                 api_key = get_claude_code_token()
                 if not api_key:
-                    print("Warning: Claude Code subscription configured but no token found.")
+                    print(
+                        "Warning: Claude Code subscription configured but no token found."
+                    )
                     print("Run 'claude' to authenticate, then try again.")
             elif use_codex:
                 # Get OAuth token from Codex subscription
@@ -1174,7 +1200,9 @@ class AgentRunner:
                 # Get API key from Kimi Code CLI config (~/.kimi/config.toml)
                 api_key = get_kimi_code_token()
                 if not api_key:
-                    print("Warning: Kimi Code subscription configured but no key found.")
+                    print(
+                        "Warning: Kimi Code subscription configured but no key found."
+                    )
                     print("Run 'kimi /login' to authenticate, then try again.")
 
             if api_key and use_claude_code:
@@ -1224,9 +1252,9 @@ class AgentRunner:
                 else:
                     # Fall back to environment variable
                     # First check api_key_env_var from config (set by quickstart)
-                    api_key_env = llm_config.get("api_key_env_var") or self._get_api_key_env_var(
-                        self.model
-                    )
+                    api_key_env = llm_config.get(
+                        "api_key_env_var"
+                    ) or self._get_api_key_env_var(self.model)
                     if api_key_env and os.environ.get(api_key_env):
                         self._llm = LiteLLMProvider(
                             model=self.model,
@@ -1245,7 +1273,9 @@ class AgentRunner:
                             if api_key_env:
                                 os.environ[api_key_env] = api_key
                         elif api_key_env:
-                            print(f"Warning: {api_key_env} not set. LLM calls will fail.")
+                            print(
+                                f"Warning: {api_key_env} not set. LLM calls will fail."
+                            )
                             print(f"Set it with: export {api_key_env}=your-api-key")
 
             # Fail fast if the agent needs an LLM but none was configured
@@ -1268,7 +1298,9 @@ class AgentRunner:
                         if api_key_env
                         else "Configure an API key for your LLM provider."
                     )
-                    raise CredentialError(f"LLM API key not found for model '{self.model}'. {hint}")
+                    raise CredentialError(
+                        f"LLM API key not found for model '{self.model}'. {hint}"
+                    )
 
         # For GCU nodes: auto-register GCU MCP server if needed, then expand tool lists
         has_gcu_nodes = any(node.node_type == "gcu" for node in self.graph.nodes)
@@ -1283,7 +1315,9 @@ class AgentRunner:
                 _repo_root = Path(__file__).resolve().parent.parent.parent.parent
                 gcu_config["cwd"] = str(_repo_root / "tools")
                 self._tool_registry.register_mcp_server(gcu_config)
-                gcu_tool_names = self._tool_registry.get_server_tool_names(GCU_SERVER_NAME)
+                gcu_tool_names = self._tool_registry.get_server_tool_names(
+                    GCU_SERVER_NAME
+                )
 
             # Expand each GCU node's tools list to include all GCU server tools
             if gcu_tool_names:
@@ -1295,18 +1329,27 @@ class AgentRunner:
                                 node.tools.append(tool_name)
 
         # For event_loop/gcu nodes: auto-register file tools MCP server, then expand tool lists
-        has_loop_nodes = any(node.node_type in ("event_loop", "gcu") for node in self.graph.nodes)
+        has_loop_nodes = any(
+            node.node_type in ("event_loop", "gcu") for node in self.graph.nodes
+        )
         if has_loop_nodes:
-            from framework.graph.files import FILES_MCP_SERVER_CONFIG, FILES_MCP_SERVER_NAME
+            from framework.graph.files import (
+                FILES_MCP_SERVER_CONFIG,
+                FILES_MCP_SERVER_NAME,
+            )
 
-            files_tool_names = self._tool_registry.get_server_tool_names(FILES_MCP_SERVER_NAME)
+            files_tool_names = self._tool_registry.get_server_tool_names(
+                FILES_MCP_SERVER_NAME
+            )
             if not files_tool_names:
                 # Resolve cwd to repo-level tools/ (not relative to agent_path)
                 files_config = dict(FILES_MCP_SERVER_CONFIG)
                 _repo_root = Path(__file__).resolve().parent.parent.parent.parent
                 files_config["cwd"] = str(_repo_root / "tools")
                 self._tool_registry.register_mcp_server(files_config)
-                files_tool_names = self._tool_registry.get_server_tool_names(FILES_MCP_SERVER_NAME)
+                files_tool_names = self._tool_registry.get_server_tool_names(
+                    FILES_MCP_SERVER_NAME
+                )
 
             if files_tool_names:
                 for node in self.graph.nodes:
@@ -1336,7 +1379,9 @@ class AgentRunner:
             if accounts_data:
                 from framework.graph.prompt_composer import build_accounts_prompt
 
-                accounts_prompt = build_accounts_prompt(accounts_data, tool_provider_map)
+                accounts_prompt = build_accounts_prompt(
+                    accounts_data, tool_provider_map
+                )
         except Exception:
             pass  # Best-effort — agent works without account info
 
@@ -1568,7 +1613,9 @@ class AgentRunner:
             for warning in validation.warnings:
                 if "Missing " in warning:
                     error_lines.append(f"  {warning}")
-            error_lines.append("\nSet the required environment variables and re-run the agent.")
+            error_lines.append(
+                "\nSet the required environment variables and re-run the agent."
+            )
             error_msg = "\n".join(error_lines)
             return ExecutionResult(
                 success=False,
@@ -1852,7 +1899,9 @@ class AgentRunner:
             adapter = CredentialStoreAdapter.default()
 
             # Check tool credentials
-            for _cred_name, spec in adapter.get_missing_for_tools(list(info.required_tools)):
+            for _cred_name, spec in adapter.get_missing_for_tools(
+                list(info.required_tools)
+            ):
                 missing_credentials.append(spec.env_var)
                 affected_tools = [t for t in info.required_tools if t in spec.tools]
                 tools_str = ", ".join(affected_tools)
@@ -1977,7 +2026,9 @@ Respond with JSON only:
                 }
                 return CapabilityResponse(
                     agent_name=info.name,
-                    level=level_map.get(data.get("level", "uncertain"), CapabilityLevel.UNCERTAIN),
+                    level=level_map.get(
+                        data.get("level", "uncertain"), CapabilityLevel.UNCERTAIN
+                    ),
                     confidence=float(data.get("confidence", 0.5)),
                     reasoning=data.get("reasoning", ""),
                     estimated_steps=data.get("estimated_steps"),
@@ -2022,7 +2073,9 @@ Respond with JSON only:
             level=level,
             confidence=confidence,
             reasoning=f"Keyword match ratio: {match_ratio:.2f}",
-            estimated_steps=info.node_count if level != CapabilityLevel.CANNOT_HANDLE else None,
+            estimated_steps=(
+                info.node_count if level != CapabilityLevel.CANNOT_HANDLE else None
+            ),
         )
 
     async def receive_message(self, message: "AgentMessage") -> "AgentMessage":

--- a/core/framework/server/routes_sessions.py
+++ b/core/framework/server/routes_sessions.py
@@ -66,13 +66,17 @@ def _session_to_live_dict(session) -> dict:
         "loaded_at": session.loaded_at,
         "uptime_seconds": round(time.time() - session.loaded_at, 1),
         "intro_message": getattr(session.runner, "intro_message", "") or "",
-        "queen_phase": phase_state.phase
-        if phase_state
-        else ("staging" if session.worker_runtime else "planning"),
+        "queen_phase": (
+            phase_state.phase
+            if phase_state
+            else ("staging" if session.worker_runtime else "planning")
+        ),
     }
 
 
-def _credential_error_response(exc: Exception, agent_path: str | None) -> web.Response | None:
+def _credential_error_response(
+    exc: Exception, agent_path: str | None
+) -> web.Response | None:
     """If *exc* is a CredentialError, return a 424 with structured credential info.
 
     Returns None if *exc* is not a credential error (caller should handle it).
@@ -308,7 +312,9 @@ async def handle_load_worker(request: web.Request) -> web.Response:
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=409)
     except FileNotFoundError:
-        return web.json_response({"error": f"Agent not found: {agent_path}"}, status=404)
+        return web.json_response(
+            {"error": f"Agent not found: {agent_path}"}, status=404
+        )
     except Exception as e:
         resp = _credential_error_response(e, agent_path)
         if resp is not None:
@@ -506,7 +512,9 @@ async def handle_update_trigger_task(request: web.Request) -> web.Response:
         _start_trigger_webhook,
     )
 
-    if "trigger_config" in updates and trigger_id in getattr(session, "active_trigger_ids", set()):
+    if "trigger_config" in updates and trigger_id in getattr(
+        session, "active_trigger_ids", set()
+    ):
         task = session.active_timer_tasks.pop(trigger_id, None)
         if task and not task.done():
             task.cancel()
@@ -624,7 +632,9 @@ async def handle_list_worker_sessions(request: web.Request) -> web.Response:
 
         cp_dir = d / "checkpoints"
         if cp_dir.exists():
-            entry["checkpoint_count"] = sum(1 for f in cp_dir.iterdir() if f.suffix == ".json")
+            entry["checkpoint_count"] = sum(
+                1 for f in cp_dir.iterdir() if f.suffix == ".json"
+            )
         else:
             entry["checkpoint_count"] = 0
 
@@ -722,7 +732,9 @@ async def handle_restore_checkpoint(request: web.Request) -> web.Response:
         return err
 
     if not session.worker_runtime:
-        return web.json_response({"error": "No worker loaded in this session"}, status=503)
+        return web.json_response(
+            {"error": "No worker loaded in this session"}, status=503
+        )
 
     ws_id = request.match_info.get("ws_id") or request.match_info.get("session_id", "")
     ws_id = safe_path_segment(ws_id)
@@ -851,10 +863,17 @@ async def handle_messages(request: web.Request) -> web.Response:
                 or (
                     not m.get("is_transition_marker")
                     and m["role"] != "tool"
-                    and not (m["role"] == "assistant" and m.get("tool_calls"))
+                    and not (
+                        m["role"] == "assistant"
+                        and m.get("tool_calls")
+                        and not m.get("content")
+                    )
                     and (
                         (m["role"] == "user" and m.get("is_client_input"))
-                        or (m["role"] == "assistant" and m.get("_node_id") in client_facing_nodes)
+                        or (
+                            m["role"] == "assistant"
+                            and m.get("_node_id") in client_facing_nodes
+                        )
                     )
                 )
             ]
@@ -910,7 +929,9 @@ async def handle_queen_messages(request: web.Request) -> web.Response:
         for m in all_messages
         if not m.get("is_transition_marker")
         and m["role"] != "tool"
-        and not (m["role"] == "assistant" and m.get("tool_calls"))
+        and not (
+            m["role"] == "assistant" and m.get("tool_calls") and not m.get("content")
+        )
     ]
 
     return web.json_response({"messages": all_messages, "session_id": session_id})
@@ -993,8 +1014,12 @@ async def handle_delete_history_session(request: web.Request) -> web.Response:
         try:
             shutil.rmtree(queen_session_dir)
         except OSError as e:
-            logger.warning("Failed to delete session directory %s: %s", queen_session_dir, e)
-            return web.json_response({"error": f"Failed to delete session: {e}"}, status=500)
+            logger.warning(
+                "Failed to delete session directory %s: %s", queen_session_dir, e
+            )
+            return web.json_response(
+                {"error": f"Failed to delete session: {e}"}, status=500
+            )
 
     return web.json_response({"deleted": session_id})
 
@@ -1009,7 +1034,9 @@ async def handle_discover(request: web.Request) -> web.Response:
     from framework.agents.discovery import discover_agents
 
     manager = _get_manager(request)
-    loaded_paths = {str(s.worker_path) for s in manager.list_sessions() if s.worker_path}
+    loaded_paths = {
+        str(s.worker_path) for s in manager.list_sessions() if s.worker_path
+    }
 
     groups = discover_agents()
     result = {}
@@ -1048,7 +1075,9 @@ def register_routes(app: web.Application) -> None:
     app.router.add_get("/api/sessions", handle_list_live_sessions)
     # history must be registered before {session_id} so it takes priority
     app.router.add_get("/api/sessions/history", handle_session_history)
-    app.router.add_delete("/api/sessions/history/{session_id}", handle_delete_history_session)
+    app.router.add_delete(
+        "/api/sessions/history/{session_id}", handle_delete_history_session
+    )
     app.router.add_get("/api/sessions/{session_id}", handle_get_live_session)
     app.router.add_delete("/api/sessions/{session_id}", handle_stop_session)
 
@@ -1058,21 +1087,30 @@ def register_routes(app: web.Application) -> None:
 
     # Session info
     app.router.add_get("/api/sessions/{session_id}/stats", handle_session_stats)
-    app.router.add_get("/api/sessions/{session_id}/entry-points", handle_session_entry_points)
+    app.router.add_get(
+        "/api/sessions/{session_id}/entry-points", handle_session_entry_points
+    )
     app.router.add_patch(
         "/api/sessions/{session_id}/triggers/{trigger_id}", handle_update_trigger_task
     )
     app.router.add_get("/api/sessions/{session_id}/graphs", handle_session_graphs)
-    app.router.add_get("/api/sessions/{session_id}/queen-messages", handle_queen_messages)
-    app.router.add_get("/api/sessions/{session_id}/events/history", handle_session_events_history)
+    app.router.add_get(
+        "/api/sessions/{session_id}/queen-messages", handle_queen_messages
+    )
+    app.router.add_get(
+        "/api/sessions/{session_id}/events/history", handle_session_events_history
+    )
 
     # Worker session browsing (session-primary)
-    app.router.add_get("/api/sessions/{session_id}/worker-sessions", handle_list_worker_sessions)
+    app.router.add_get(
+        "/api/sessions/{session_id}/worker-sessions", handle_list_worker_sessions
+    )
     app.router.add_get(
         "/api/sessions/{session_id}/worker-sessions/{ws_id}", handle_get_worker_session
     )
     app.router.add_delete(
-        "/api/sessions/{session_id}/worker-sessions/{ws_id}", handle_delete_worker_session
+        "/api/sessions/{session_id}/worker-sessions/{ws_id}",
+        handle_delete_worker_session,
     )
     app.router.add_get(
         "/api/sessions/{session_id}/worker-sessions/{ws_id}/checkpoints",

--- a/core/framework/tools/queen_lifecycle_tools.py
+++ b/core/framework/tools/queen_lifecycle_tools.py
@@ -43,7 +43,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from framework.credentials.models import CredentialError
-from framework.runner.preload_validation import credential_errors_to_json, validate_credentials
+from framework.runner.preload_validation import (
+    credential_errors_to_json,
+    validate_credentials,
+)
 from framework.runtime.event_bus import AgentEvent, EventType
 from framework.server.app import validate_agent_path
 from framework.tools.flowchart_utils import (
@@ -258,7 +261,9 @@ class QueenPhaseState:
             )
 
 
-def build_worker_profile(runtime: AgentRuntime, agent_path: Path | str | None = None) -> str:
+def build_worker_profile(
+    runtime: AgentRuntime, agent_path: Path | str | None = None
+) -> str:
     """Build a worker capability profile from its graph/goal definition.
 
     Injected into the queen's system prompt so it knows what the worker
@@ -291,11 +296,17 @@ def build_worker_profile(runtime: AgentRuntime, agent_path: Path | str | None = 
             lines.append(f"- {node.id}: {node.description or node.name}")
 
     all_tools: set[str] = set()
+    # 1. Static tools from graph definition
     for node in graph.nodes:
         if node.tools:
             all_tools.update(node.tools)
+    # 2. Dynamic/MCP tools from registry
+    if hasattr(runtime, "tool_registry") and runtime.tool_registry:
+        all_tools.update(runtime.tool_registry.list_tools())
+
     if all_tools:
-        lines.append(f"\n## Worker Tools\n{', '.join(sorted(all_tools))}")
+        tools_str = ", ".join(sorted(all_tools))
+        lines.append(f"\n## Worker Tools\n{tools_str}")
 
     lines.append("\nStatus at session start: idle (not started).")
     return "\n".join(lines)
@@ -354,7 +365,9 @@ def _remove_trigger_from_agent(session: Any, trigger_id: str) -> None:
     updated = [t for t in triggers if t.get("id") != trigger_id]
     if len(updated) != len(triggers):
         _write_agent_triggers_json(agent_path, updated)
-        logger.info("Removed trigger '%s' from %s/triggers.json", trigger_id, agent_path)
+        logger.info(
+            "Removed trigger '%s' from %s/triggers.json", trigger_id, agent_path
+        )
 
 
 async def _persist_active_triggers(session: Any, session_id: str) -> None:
@@ -381,7 +394,9 @@ async def _persist_active_triggers(session: Any, session_id: str) -> None:
         await store.write_state(session_id, state)
     except Exception:
         logger.warning(
-            "Failed to persist active triggers for session %s", session_id, exc_info=True
+            "Failed to persist active triggers for session %s",
+            session_id,
+            exc_info=True,
         )
 
 
@@ -411,7 +426,9 @@ async def _start_trigger_timer(session: Any, trigger_id: str, tdef: Any) -> None
                 # Record next fire time for introspection (monotonic, matches routes)
                 fire_times = getattr(session, "trigger_next_fire", None)
                 if fire_times is not None:
-                    _next_delay = float(interval_minutes) * 60 if interval_minutes else 60
+                    _next_delay = (
+                        float(interval_minutes) * 60 if interval_minutes else 60
+                    )
                     fire_times[trigger_id] = time.monotonic() + _next_delay
 
                 # Gate on worker being loaded
@@ -438,7 +455,9 @@ async def _start_trigger_timer(session: Any, trigger_id: str, tdef: Any) -> None
             except asyncio.CancelledError:
                 raise
             except Exception:
-                logger.warning("Timer trigger '%s' tick failed", trigger_id, exc_info=True)
+                logger.warning(
+                    "Timer trigger '%s' tick failed", trigger_id, exc_info=True
+                )
 
     task = asyncio.create_task(_timer_loop(), name=f"trigger_timer_{trigger_id}")
     if not hasattr(session, "active_timer_tasks"):
@@ -449,7 +468,11 @@ async def _start_trigger_timer(session: Any, trigger_id: str, tdef: Any) -> None
 async def _start_trigger_webhook(session: Any, trigger_id: str, tdef: Any) -> None:
     """Subscribe to WEBHOOK_RECEIVED events and route matching ones to the queen."""
     from framework.graph.event_loop_node import TriggerEvent
-    from framework.runtime.webhook_server import WebhookRoute, WebhookServer, WebhookServerConfig
+    from framework.runtime.webhook_server import (
+        WebhookRoute,
+        WebhookServer,
+        WebhookServerConfig,
+    )
 
     bus = session.event_bus
     path = tdef.trigger_config.get("path", "")
@@ -585,10 +608,15 @@ def _dissolve_planning_nodes(
 
         # Decision clause: prefer decision_clause, fall back to description/name
         clause = (
-            d_node.get("decision_clause") or d_node.get("description") or d_node.get("name") or d_id
+            d_node.get("decision_clause")
+            or d_node.get("description")
+            or d_node.get("name")
+            or d_id
         ).strip()
 
-        predecessors = [node_by_id[e["source"]] for e in in_edges if e["source"] in node_by_id]
+        predecessors = [
+            node_by_id[e["source"]] for e in in_edges if e["source"] in node_by_id
+        ]
 
         if not predecessors:
             # Decision at start: convert to regular process node
@@ -618,7 +646,9 @@ def _dissolve_planning_nodes(
                 pred["success_criteria"] = clause
 
             # Remove the edge from predecessor -> decision
-            edges[:] = [e for e in edges if not (e["source"] == pid and e["target"] == d_id)]
+            edges[:] = [
+                e for e in edges if not (e["source"] == pid and e["target"] == d_id)
+            ]
 
             # Wire predecessor -> yes/no targets
             edge_counter = len(edges)
@@ -922,7 +952,9 @@ def register_queen_lifecycle_tools(
             "required": ["task"],
         },
     )
-    registry.register("start_worker", _start_tool, lambda inputs: start_worker(**inputs))
+    registry.register(
+        "start_worker", _start_tool, lambda inputs: start_worker(**inputs)
+    )
     tools_registered += 1
 
     # --- stop_worker ----------------------------------------------------------
@@ -994,7 +1026,9 @@ def register_queen_lifecycle_tools(
         # Switch to building phase
         if phase_state is not None:
             await phase_state.switch_to_building()
-            _update_meta_json(session_manager, manager_session_id, {"phase": "building"})
+            _update_meta_json(
+                session_manager, manager_session_id, {"phase": "building"}
+            )
 
         result = json.loads(stop_result)
         result["phase"] = "building"
@@ -1092,7 +1126,9 @@ def register_queen_lifecycle_tools(
                         )
                     )
                 except Exception:
-                    logger.warning("Failed to re-emit draft during replan", exc_info=True)
+                    logger.warning(
+                        "Failed to re-emit draft during replan", exc_info=True
+                    )
 
         has_draft = phase_state is not None and phase_state.draft_graph is not None
         return json.dumps(
@@ -1219,7 +1255,9 @@ def register_queen_lifecycle_tools(
                 or d_id
             ).strip()
 
-            predecessors = [node_by_id[e["source"]] for e in in_edges if e["source"] in node_by_id]
+            predecessors = [
+                node_by_id[e["source"]] for e in in_edges if e["source"] in node_by_id
+            ]
 
             if not predecessors:
                 # Decision at start: convert to regular process node
@@ -1249,7 +1287,9 @@ def register_queen_lifecycle_tools(
                     pred["success_criteria"] = clause
 
                 # Remove the edge from predecessor → decision
-                edges[:] = [e for e in edges if not (e["source"] == pid and e["target"] == d_id)]
+                edges[:] = [
+                    e for e in edges if not (e["source"] == pid and e["target"] == d_id)
+                ]
 
                 # Wire predecessor → yes/no targets
                 edge_counter = len(edges)
@@ -1332,7 +1372,9 @@ def register_queen_lifecycle_tools(
                 absorbed[pred_id] = prev_absorbed
 
             # Remove sub-agent node and all its edges
-            edges[:] = [e for e in edges if e["source"] != sa_id and e["target"] != sa_id]
+            edges[:] = [
+                e for e in edges if e["source"] != sa_id and e["target"] != sa_id
+            ]
             nodes[:] = [n for n in nodes if n["id"] != sa_id]
             del node_by_id[sa_id]
 
@@ -1359,7 +1401,9 @@ def register_queen_lifecycle_tools(
                     absorbed[n["id"]] = prev_absorbed
 
             # Remove the sub-agent node and its edges
-            edges[:] = [e for e in edges if e["source"] != sa_id and e["target"] != sa_id]
+            edges[:] = [
+                e for e in edges if e["source"] != sa_id and e["target"] != sa_id
+            ]
             nodes[:] = [n for n in nodes if n["id"] != sa_id]
             del node_by_id[sa_id]
 
@@ -1448,14 +1492,18 @@ def register_queen_lifecycle_tools(
         validated_nodes = []
         for i, n in enumerate(nodes):
             if not isinstance(n, dict):
-                return json.dumps({"error": f"Node {i} must be a dict, got {type(n).__name__}"})
+                return json.dumps(
+                    {"error": f"Node {i} must be a dict, got {type(n).__name__}"}
+                )
             node_id = n.get("id", "").strip()
             if not node_id:
                 return json.dumps({"error": f"Node {i} is missing 'id'"})
             validated_nodes.append(
                 {
                     "id": node_id,
-                    "name": n.get("name", node_id.replace("-", " ").replace("_", " ").title()),
+                    "name": n.get(
+                        "name", node_id.replace("-", " ").replace("_", " ").title()
+                    ),
                     "description": n.get("description", ""),
                     "node_type": n.get("node_type", "event_loop"),
                     # Optional business-logic hints (not validated yet)
@@ -1487,9 +1535,13 @@ def register_queen_lifecycle_tools(
                 src = e.get("source", "")
                 tgt = e.get("target", "")
                 if src and src not in node_ids:
-                    return json.dumps({"error": f"Edge {i} source '{src}' references unknown node"})
+                    return json.dumps(
+                        {"error": f"Edge {i} source '{src}' references unknown node"}
+                    )
                 if tgt and tgt not in node_ids:
-                    return json.dumps({"error": f"Edge {i} target '{tgt}' references unknown node"})
+                    return json.dumps(
+                        {"error": f"Edge {i} target '{tgt}' references unknown node"}
+                    )
                 validated_edges.append(
                     {
                         "id": e.get("id", f"edge-{i}"),
@@ -1526,7 +1578,9 @@ def register_queen_lifecycle_tools(
                 ]
                 if not gcu_children:
                     continue
-                d_parents = [e["source"] for e in validated_edges if e["target"] == d_id]
+                d_parents = [
+                    e["source"] for e in validated_edges if e["target"] == d_id
+                ]
                 for gc_edge in gcu_children:
                     gc_id = gc_edge["target"]
                     logger.warning(
@@ -1632,7 +1686,10 @@ def register_queen_lifecycle_tools(
                     validated_edges[:] = [
                         e
                         for e in validated_edges
-                        if not (e["source"] == leaf_id and e["target"] in set(illegal_targets))
+                        if not (
+                            e["source"] == leaf_id
+                            and e["target"] in set(illegal_targets)
+                        )
                     ]
 
                 # Ensure the leaf is in its parent's sub_agents list
@@ -1676,7 +1733,9 @@ def register_queen_lifecycle_tools(
                     f"removed. Add it to a parent node's sub_agents "
                     f"list and re-save the draft."
                 )
-            validated_nodes[:] = [n for n in validated_nodes if n["id"] not in set(orphaned_ids)]
+            validated_nodes[:] = [
+                n for n in validated_nodes if n["id"] not in set(orphaned_ids)
+            ]
             node_by_id_v = {n["id"]: n for n in validated_nodes}
 
         # Synthesize visual edges for sub-agents that are referenced in
@@ -1759,7 +1818,9 @@ def register_queen_lifecycle_tools(
                     for e in validated_edges
                     if e["source"] not in unreachable and e["target"] not in unreachable
                 ]
-                validated_nodes[:] = [n for n in validated_nodes if n["id"] not in unreachable]
+                validated_nodes[:] = [
+                    n for n in validated_nodes if n["id"] not in unreachable
+                ]
 
         # Determine terminal nodes: explicit list, or nodes with no outgoing edges.
         # Sub-agent nodes are leaf helpers, not endpoints — exclude them.
@@ -1859,9 +1920,11 @@ def register_queen_lifecycle_tools(
                         stream_id="queen",
                         data={
                             "map": phase_state.flowchart_map if phase_state else None,
-                            "original_draft": phase_state.original_draft_graph
-                            if phase_state
-                            else draft,
+                            "original_draft": (
+                                phase_state.original_draft_graph
+                                if phase_state
+                                else draft
+                            ),
                         },
                     )
                 )
@@ -1905,7 +1968,8 @@ def register_queen_lifecycle_tools(
                 "Draft graph saved and sent to the visualizer. "
                 "The user can now see the color-coded flowchart. "
                 "Present this design to the user and get their approval. "
-                "When the user confirms, call confirm_and_build() to proceed." + correction_warning
+                "When the user confirms, call confirm_and_build() to proceed."
+                + correction_warning
             )
 
         result: dict = {
@@ -1955,8 +2019,14 @@ def register_queen_lifecycle_tools(
                     "items": {
                         "type": "object",
                         "properties": {
-                            "id": {"type": "string", "description": "Kebab-case node identifier"},
-                            "name": {"type": "string", "description": "Human-readable name"},
+                            "id": {
+                                "type": "string",
+                                "description": "Kebab-case node identifier",
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "Human-readable name",
+                            },
                             "description": {
                                 "type": "string",
                                 "description": "What this node does (business logic)",
@@ -2107,7 +2177,9 @@ def register_queen_lifecycle_tools(
 
         if phase_state.phase != "planning":
             return json.dumps(
-                {"error": f"Cannot confirm_and_build: currently in {phase_state.phase} phase."}
+                {
+                    "error": f"Cannot confirm_and_build: currently in {phase_state.phase} phase."
+                }
             )
 
         if phase_state.draft_graph is None:
@@ -2154,7 +2226,9 @@ def register_queen_lifecycle_tools(
             )
 
         dissolved_count = len(original_nodes) - len(converted.get("nodes", []))
-        decision_count = sum(1 for n in original_nodes if n.get("flowchart_type") == "decision")
+        decision_count = sum(
+            1 for n in original_nodes if n.get("flowchart_type") == "decision"
+        )
         subagent_count = sum(
             1
             for n in original_nodes
@@ -2283,7 +2357,9 @@ def register_queen_lifecycle_tools(
                     if fallback_path:
                         phase_state.agent_path = str(fallback_path)
                     await phase_state.switch_to_building(source="tool")
-                    _update_meta_json(session_manager, manager_session_id, {"phase": "building"})
+                    _update_meta_json(
+                        session_manager, manager_session_id, {"phase": "building"}
+                    )
                     if phase_state.inject_notification:
                         await phase_state.inject_notification(
                             "[PHASE CHANGE] Switched to BUILDING phase. "
@@ -2336,7 +2412,10 @@ def register_queen_lifecycle_tools(
                         # Reset draft state after successful scaffolding
                         phase_state.build_confirmed = False
                         # Persist flowchart now that the agent folder exists
-                        if phase_state.original_draft_graph and phase_state.flowchart_map:
+                        if (
+                            phase_state.original_draft_graph
+                            and phase_state.flowchart_map
+                        ):
                             _save_flowchart_file(
                                 Path("exports") / agent_name,
                                 phase_state.original_draft_graph,
@@ -2400,7 +2479,9 @@ def register_queen_lifecycle_tools(
         ),
         parameters={"type": "object", "properties": {}},
     )
-    registry.register("stop_worker", _stop_worker_tool, lambda inputs: stop_worker_to_staging())
+    registry.register(
+        "stop_worker", _stop_worker_tool, lambda inputs: stop_worker_to_staging()
+    )
     tools_registered += 1
 
     # --- get_worker_status ----------------------------------------------------
@@ -2525,7 +2606,9 @@ def register_queen_lifecycle_tools(
         bus = _get_event_bus()
         if bus:
             if preamble["status"] == "waiting_for_input":
-                input_events = bus.get_history(event_type=EventType.CLIENT_INPUT_REQUESTED, limit=1)
+                input_events = bus.get_history(
+                    event_type=EventType.CLIENT_INPUT_REQUESTED, limit=1
+                )
                 if input_events:
                     prompt = input_events[0].data.get("prompt", "")
                     if prompt:
@@ -2537,7 +2620,9 @@ def register_queen_lifecycle_tools(
                 if target:
                     preamble["current_node"] = target
 
-            iter_events = bus.get_history(event_type=EventType.NODE_LOOP_ITERATION, limit=1)
+            iter_events = bus.get_history(
+                event_type=EventType.NODE_LOOP_ITERATION, limit=1
+            )
             if iter_events:
                 preamble["current_iteration"] = iter_events[0].data.get("iteration")
 
@@ -2583,7 +2668,9 @@ def register_queen_lifecycle_tools(
             parts.append(node_part)
 
         if red_flags:
-            parts.append(f"{red_flags} issue type(s) detected — use focus='issues' for details")
+            parts.append(
+                f"{red_flags} issue type(s) detected — use focus='issues' for details"
+            )
         else:
             parts.append("No issues detected")
 
@@ -2654,7 +2741,9 @@ def register_queen_lifecycle_tools(
             return "No active execution found."
 
         exec_id = exec_ids[0]
-        memory = runtime.state_manager.create_memory(exec_id, stream_id, IsolationLevel.SHARED)
+        memory = runtime.state_manager.create_memory(
+            exec_id, stream_id, IsolationLevel.SHARED
+        )
         state = await memory.read_all()
 
         if not state:
@@ -2678,7 +2767,9 @@ def register_queen_lifecycle_tools(
                 else:
                     old_preview = _preview_value(change.old_value, 40)
                     new_preview = _preview_value(change.new_value, 40)
-                    lines.append(f"  {change.key}: {old_preview} -> {new_preview} ({ago})")
+                    lines.append(
+                        f"  {change.key}: {old_preview} -> {new_preview} ({ago})"
+                    )
 
         return "\n".join(lines)
 
@@ -2687,15 +2778,22 @@ def register_queen_lifecycle_tools(
         lines = []
 
         # Running tools (started but not yet completed)
-        tool_started = bus.get_history(event_type=EventType.TOOL_CALL_STARTED, limit=last_n * 2)
-        tool_completed = bus.get_history(event_type=EventType.TOOL_CALL_COMPLETED, limit=last_n * 2)
+        tool_started = bus.get_history(
+            event_type=EventType.TOOL_CALL_STARTED, limit=last_n * 2
+        )
+        tool_completed = bus.get_history(
+            event_type=EventType.TOOL_CALL_COMPLETED, limit=last_n * 2
+        )
         completed_ids = {
-            evt.data.get("tool_use_id") for evt in tool_completed if evt.data.get("tool_use_id")
+            evt.data.get("tool_use_id")
+            for evt in tool_completed
+            if evt.data.get("tool_use_id")
         }
         running = [
             evt
             for evt in tool_started
-            if evt.data.get("tool_use_id") and evt.data.get("tool_use_id") not in completed_ids
+            if evt.data.get("tool_use_id")
+            and evt.data.get("tool_use_id") not in completed_ids
         ]
 
         if running:
@@ -2827,7 +2925,9 @@ def register_queen_lifecycle_tools(
             )
 
         # Execution outcomes
-        exec_completed = bus.get_history(event_type=EventType.EXECUTION_COMPLETED, limit=5)
+        exec_completed = bus.get_history(
+            event_type=EventType.EXECUTION_COMPLETED, limit=5
+        )
         exec_failed = bus.get_history(event_type=EventType.EXECUTION_FAILED, limit=5)
         completed_n = len(exec_completed)
         failed_n = len(exec_failed)
@@ -2873,15 +2973,22 @@ def register_queen_lifecycle_tools(
                 result[key] = preamble[key]
 
         # Running + completed tool calls
-        tool_started = bus.get_history(event_type=EventType.TOOL_CALL_STARTED, limit=last_n * 2)
-        tool_completed = bus.get_history(event_type=EventType.TOOL_CALL_COMPLETED, limit=last_n * 2)
+        tool_started = bus.get_history(
+            event_type=EventType.TOOL_CALL_STARTED, limit=last_n * 2
+        )
+        tool_completed = bus.get_history(
+            event_type=EventType.TOOL_CALL_COMPLETED, limit=last_n * 2
+        )
         completed_ids = {
-            evt.data.get("tool_use_id") for evt in tool_completed if evt.data.get("tool_use_id")
+            evt.data.get("tool_use_id")
+            for evt in tool_completed
+            if evt.data.get("tool_use_id")
         }
         running = [
             evt
             for evt in tool_started
-            if evt.data.get("tool_use_id") and evt.data.get("tool_use_id") not in completed_ids
+            if evt.data.get("tool_use_id")
+            and evt.data.get("tool_use_id") not in completed_ids
         ]
         if running:
             result["running_tools"] = [
@@ -2996,7 +3103,9 @@ def register_queen_lifecycle_tools(
             }
 
         # Execution outcomes
-        exec_completed = bus.get_history(event_type=EventType.EXECUTION_COMPLETED, limit=5)
+        exec_completed = bus.get_history(
+            event_type=EventType.EXECUTION_COMPLETED, limit=5
+        )
         exec_failed = bus.get_history(event_type=EventType.EXECUTION_FAILED, limit=5)
         if exec_completed or exec_failed:
             result["execution_outcomes"] = []
@@ -3139,7 +3248,15 @@ def register_queen_lifecycle_tools(
             "properties": {
                 "focus": {
                     "type": "string",
-                    "enum": ["diary", "activity", "memory", "tools", "issues", "progress", "full"],
+                    "enum": [
+                        "diary",
+                        "activity",
+                        "memory",
+                        "tools",
+                        "issues",
+                        "progress",
+                        "full",
+                    ],
                     "description": (
                         "Aspect to inspect. Omit for a brief summary. "
                         "Use 'diary' to read persistent run history before checking live logs."
@@ -3155,7 +3272,9 @@ def register_queen_lifecycle_tools(
             "required": [],
         },
     )
-    registry.register("get_worker_status", _status_tool, lambda inputs: get_worker_status(**inputs))
+    registry.register(
+        "get_worker_status", _status_tool, lambda inputs: get_worker_status(**inputs)
+    )
     tools_registered += 1
 
     # --- inject_worker_message ------------------------------------------------
@@ -3181,7 +3300,9 @@ def register_queen_lifecycle_tools(
             waiting = stream.get_waiting_nodes()
             if waiting:
                 target_node_id = waiting[0]["node_id"]
-                ok = await stream.inject_input(target_node_id, content, is_client_input=True)
+                ok = await stream.inject_input(
+                    target_node_id, content, is_client_input=True
+                )
                 if ok:
                     return json.dumps(
                         {
@@ -3196,7 +3317,9 @@ def register_queen_lifecycle_tools(
             injectable = stream.get_injectable_nodes()
             if injectable:
                 target_node_id = injectable[0]["node_id"]
-                ok = await stream.inject_input(target_node_id, content, is_client_input=True)
+                ok = await stream.inject_input(
+                    target_node_id, content, is_client_input=True
+                )
                 if ok:
                     return json.dumps(
                         {
@@ -3231,7 +3354,9 @@ def register_queen_lifecycle_tools(
         },
     )
     registry.register(
-        "inject_worker_message", _inject_tool, lambda inputs: inject_worker_message(**inputs)
+        "inject_worker_message",
+        _inject_tool,
+        lambda inputs: inject_worker_message(**inputs),
     )
     tools_registered += 1
 
@@ -3337,7 +3462,9 @@ def register_queen_lifecycle_tools(
                     "alias": info.alias,
                     "storage_id": info.storage_id,
                     "status": info.status,
-                    "created_at": info.created_at.isoformat() if info.created_at else None,
+                    "created_at": (
+                        info.created_at.isoformat() if info.created_at else None
+                    ),
                     "last_validated": (
                         info.last_validated.isoformat() if info.last_validated else None
                     ),
@@ -3400,8 +3527,12 @@ def register_queen_lifecycle_tools(
                 try:
                     await session_manager.unload_worker(manager_session_id)
                 except Exception as e:
-                    logger.error("Failed to unload existing worker: %s", e, exc_info=True)
-                    return json.dumps({"error": f"Failed to unload existing worker: {e}"})
+                    logger.error(
+                        "Failed to unload existing worker: %s", e, exc_info=True
+                    )
+                    return json.dumps(
+                        {"error": f"Failed to unload existing worker: {e}"}
+                    )
 
             try:
                 resolved_path = validate_agent_path(agent_path)
@@ -3423,13 +3554,19 @@ def register_queen_lifecycle_tools(
                 if parent_dir not in _sys.path:
                     _sys.path.insert(0, parent_dir)
                 # Evict stale cached modules
-                stale = [n for n in _sys.modules if n == pkg_name or n.startswith(f"{pkg_name}.")]
+                stale = [
+                    n
+                    for n in _sys.modules
+                    if n == pkg_name or n.startswith(f"{pkg_name}.")
+                ]
                 for n in stale:
                     del _sys.modules[n]
 
                 mod = importlib.import_module(pkg_name)
                 missing_attrs = [
-                    attr for attr in ("goal", "nodes", "edges") if getattr(mod, attr, None) is None
+                    attr
+                    for attr in ("goal", "nodes", "edges")
+                    if getattr(mod, attr, None) is None
                 ]
                 if missing_attrs:
                     return json.dumps(
@@ -3471,7 +3608,9 @@ def register_queen_lifecycle_tools(
                         if node.tools:
                             missing = set(node.tools) - available_tool_names
                             if missing:
-                                missing_by_node[f"{node.name} (id={node.id})"] = sorted(missing)
+                                missing_by_node[f"{node.name} (id={node.id})"] = sorted(
+                                    missing
+                                )
                     if missing_by_node:
                         # Unload the broken worker
                         try:
@@ -3479,7 +3618,8 @@ def register_queen_lifecycle_tools(
                         except Exception:
                             pass
                         details = "; ".join(
-                            f"Node '{k}' missing {v}" for k, v in missing_by_node.items()
+                            f"Node '{k}' missing {v}"
+                            for k, v in missing_by_node.items()
                         )
                         return json.dumps(
                             {
@@ -3536,13 +3676,17 @@ def register_queen_lifecycle_tools(
                                     )
                                 )
                             except Exception:
-                                logger.warning("Failed to emit flowchart map", exc_info=True)
+                                logger.warning(
+                                    "Failed to emit flowchart map", exc_info=True
+                                )
 
                 # Switch to staging phase after successful load + validation
                 if phase_state is not None:
                     phase_state.agent_path = str(resolved_path)
                     await phase_state.switch_to_staging()
-                    _update_meta_json(session_manager, manager_session_id, {"phase": "staging"})
+                    _update_meta_json(
+                        session_manager, manager_session_id, {"phase": "staging"}
+                    )
 
                 worker_name = info.name if info else updated_session.worker_id
                 return json.dumps(
@@ -3562,7 +3706,9 @@ def register_queen_lifecycle_tools(
                     }
                 )
             except Exception as e:
-                logger.error("load_built_agent failed for '%s'", agent_path, exc_info=True)
+                logger.error(
+                    "load_built_agent failed for '%s'", agent_path, exc_info=True
+                )
                 return json.dumps({"error": f"Failed to load agent: {e}"})
 
         _load_built_tool = Tool(
@@ -3578,7 +3724,9 @@ def register_queen_lifecycle_tools(
                 "properties": {
                     "agent_path": {
                         "type": "string",
-                        "description": ("Path to the agent directory (e.g. 'exports/my_agent')"),
+                        "description": (
+                            "Path to the agent directory (e.g. 'exports/my_agent')"
+                        ),
                     },
                 },
                 "required": ["agent_path"],
@@ -3662,7 +3810,9 @@ def register_queen_lifecycle_tools(
             # Switch to running phase
             if phase_state is not None:
                 await phase_state.switch_to_running()
-                _update_meta_json(session_manager, manager_session_id, {"phase": "running"})
+                _update_meta_json(
+                    session_manager, manager_session_id, {"phase": "running"}
+                )
 
             return json.dumps(
                 {
@@ -3708,7 +3858,9 @@ def register_queen_lifecycle_tools(
         },
     )
     registry.register(
-        "run_agent_with_input", _run_input_tool, lambda inputs: run_agent_with_input(**inputs)
+        "run_agent_with_input",
+        _run_input_tool,
+        lambda inputs: run_agent_with_input(**inputs),
     )
     tools_registered += 1
 
@@ -3786,7 +3938,9 @@ def register_queen_lifecycle_tools(
             invalid = [m.upper() for m in methods if m.upper() not in valid_methods]
             if invalid:
                 return json.dumps(
-                    {"error": f"Invalid HTTP methods: {invalid}. Valid: {sorted(valid_methods)}"}
+                    {
+                        "error": f"Invalid HTTP methods: {invalid}. Valid: {sorted(valid_methods)}"
+                    }
                 )
 
             try:
@@ -3835,17 +3989,25 @@ def register_queen_lifecycle_tools(
                 from croniter import croniter
 
                 if not croniter.is_valid(cron_expr):
-                    return json.dumps({"error": f"Invalid cron expression: {cron_expr}"})
+                    return json.dumps(
+                        {"error": f"Invalid cron expression: {cron_expr}"}
+                    )
             except ImportError:
                 return json.dumps(
-                    {"error": "croniter package not installed — cannot validate cron expression."}
+                    {
+                        "error": "croniter package not installed — cannot validate cron expression."
+                    }
                 )
         elif interval:
             if not isinstance(interval, (int, float)) or interval <= 0:
-                return json.dumps({"error": f"interval_minutes must be > 0, got {interval}"})
+                return json.dumps(
+                    {"error": f"interval_minutes must be > 0, got {interval}"}
+                )
         else:
             return json.dumps(
-                {"error": "Timer trigger needs 'cron' or 'interval_minutes' in trigger_config."}
+                {
+                    "error": "Timer trigger needs 'cron' or 'interval_minutes' in trigger_config."
+                }
             )
 
         # Start timer
@@ -3931,7 +4093,9 @@ def register_queen_lifecycle_tools(
             "required": ["trigger_id"],
         },
     )
-    registry.register("set_trigger", _set_trigger_tool, lambda inputs: set_trigger(**inputs))
+    registry.register(
+        "set_trigger", _set_trigger_tool, lambda inputs: set_trigger(**inputs)
+    )
     tools_registered += 1
 
     # --- remove_trigger --------------------------------------------------------
@@ -4034,7 +4198,9 @@ def register_queen_lifecycle_tools(
             "properties": {},
         },
     )
-    registry.register("list_triggers", _list_triggers_tool, lambda inputs: list_triggers())
+    registry.register(
+        "list_triggers", _list_triggers_tool, lambda inputs: list_triggers()
+    )
     tools_registered += 1
 
     logger.info("Registered %d queen lifecycle tools", tools_registered)


### PR DESCRIPTION
## Problem
This PR addresses three issues related to MCP server integration and session visibility (#6130):
1. **Assistant Message Visibility**: Assistant messages containing both text content and tool calls were being completely filtered out from the conversation history, making the UI feel unresponsive.
2. **MCP Tool Partitioning**: Dynamic and MCP-provided tools were not being correctly included in the Queen's building mode/worker profile, preventing their use during agent design.
3. **MCP Config Discovery**: The system only looked for `mcp_servers.json` in the immediate agent directory, missing configurations in internal structures like `nodes/`.

## Solution
- **Visibility**: Updated filtering logic in `routes_sessions.py` to preserve assistant messages that contain text content, even if they also have tool calls.
- **Tool Partitioning**: Modified `build_worker_profile` in `queen_lifecycle_tools.py` to gather tools from both the static graph definition and the live `runtime.tool_registry`.
- **Discovery**: Enhanced `AgentRunner` to also check `agent_path / "nodes" / "mcp_servers.json"` during initialization.

## Validation
- Verified all session-related API tests pass (matching baseline).
- Verified `make check` and `make lint` pass (ensuring compatibility with Python 3.11+).