### PR TITLE
feat: support separate LLM model for worker agents

### DIFF
--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -61,6 +61,137 @@ def get_preferred_model() -> str:
     return "anthropic/claude-sonnet-4-20250514"
 
 
+def get_preferred_worker_model() -> str | None:
+    """Return the user's preferred worker LLM model, or None if not configured.
+
+    Reads from the ``worker_llm`` section of ~/.hive/configuration.json.
+    Returns None when no worker-specific model is set, so callers can
+    fall back to the default (queen) model via ``get_preferred_model()``.
+    """
+    worker_llm = get_hive_config().get("worker_llm", {})
+    if worker_llm.get("provider") and worker_llm.get("model"):
+        provider = str(worker_llm["provider"])
+        model = str(worker_llm["model"]).strip()
+        if provider.lower() == "openrouter" and model.lower().startswith("openrouter/"):
+            model = model[len("openrouter/") :]
+        if model:
+            return f"{provider}/{model}"
+    return None
+
+
+def get_worker_api_key() -> str | None:
+    """Return the API key for the worker LLM, falling back to the default key."""
+    worker_llm = get_hive_config().get("worker_llm", {})
+    if not worker_llm:
+        return get_api_key()
+
+    # Worker-specific subscription / env var
+    if worker_llm.get("use_claude_code_subscription"):
+        try:
+            from framework.runner.runner import get_claude_code_token
+
+            token = get_claude_code_token()
+            if token:
+                return token
+        except ImportError:
+            pass
+
+    if worker_llm.get("use_codex_subscription"):
+        try:
+            from framework.runner.runner import get_codex_token
+
+            token = get_codex_token()
+            if token:
+                return token
+        except ImportError:
+            pass
+
+    if worker_llm.get("use_kimi_code_subscription"):
+        try:
+            from framework.runner.runner import get_kimi_code_token
+
+            token = get_kimi_code_token()
+            if token:
+                return token
+        except ImportError:
+            pass
+
+    api_key_env_var = worker_llm.get("api_key_env_var")
+    if api_key_env_var:
+        return os.environ.get(api_key_env_var)
+
+    # Fall back to default key
+    return get_api_key()
+
+
+def get_worker_api_base() -> str | None:
+    """Return the api_base for the worker LLM, falling back to the default."""
+    worker_llm = get_hive_config().get("worker_llm", {})
+    if not worker_llm:
+        return get_api_base()
+
+    if worker_llm.get("use_codex_subscription"):
+        return "https://chatgpt.com/backend-api/codex"
+    if worker_llm.get("use_kimi_code_subscription"):
+        return "https://api.kimi.com/coding"
+    if worker_llm.get("api_base"):
+        return worker_llm["api_base"]
+    if str(worker_llm.get("provider", "")).lower() == "openrouter":
+        return OPENROUTER_API_BASE
+    return None
+
+
+def get_worker_llm_extra_kwargs() -> dict[str, Any]:
+    """Return extra kwargs for the worker LLM provider."""
+    worker_llm = get_hive_config().get("worker_llm", {})
+    if not worker_llm:
+        return get_llm_extra_kwargs()
+
+    if worker_llm.get("use_claude_code_subscription"):
+        api_key = get_worker_api_key()
+        if api_key:
+            return {
+                "extra_headers": {"authorization": f"Bearer {api_key}"},
+            }
+    if worker_llm.get("use_codex_subscription"):
+        api_key = get_worker_api_key()
+        if api_key:
+            headers: dict[str, str] = {
+                "Authorization": f"Bearer {api_key}",
+                "User-Agent": "CodexBar",
+            }
+            try:
+                from framework.runner.runner import get_codex_account_id
+
+                account_id = get_codex_account_id()
+                if account_id:
+                    headers["ChatGPT-Account-Id"] = account_id
+            except ImportError:
+                pass
+            return {
+                "extra_headers": headers,
+                "store": False,
+                "allowed_openai_params": ["store"],
+            }
+    return {}
+
+
+def get_worker_max_tokens() -> int:
+    """Return max_tokens for the worker LLM, falling back to default."""
+    worker_llm = get_hive_config().get("worker_llm", {})
+    if worker_llm and "max_tokens" in worker_llm:
+        return worker_llm["max_tokens"]
+    return get_max_tokens()
+
+
+def get_worker_max_context_tokens() -> int:
+    """Return max_context_tokens for the worker LLM, falling back to default."""
+    worker_llm = get_hive_config().get("worker_llm", {})
+    if worker_llm and "max_context_tokens" in worker_llm:
+        return worker_llm["max_context_tokens"]
+    return get_max_context_tokens()
+
+
 def get_max_tokens() -> int:
     """Return the configured max_tokens, falling back to DEFAULT_MAX_TOKENS."""
     return get_hive_config().get("llm", {}).get("max_tokens", DEFAULT_MAX_TOKENS)

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -1141,7 +1141,10 @@ class AgentRunner:
 
         # Create LLM provider
         # Uses LiteLLM which auto-detects the provider from model name
-        if self.mock_mode:
+        # Skip if already injected (e.g. worker agents with a pre-built LLM)
+        if self._llm is not None:
+            pass  # LLM already configured externally
+        elif self.mock_mode:
             # Use mock LLM for testing without real API calls
             from framework.llm.mock import MockLLMProvider
 

--- a/core/framework/server/session_manager.py
+++ b/core/framework/server/session_manager.py
@@ -289,9 +289,15 @@ class SessionManager:
             loop = asyncio.get_running_loop()
 
             # Prioritize: explicit model arg > worker-specific model > session default
-            from framework.config import get_preferred_worker_model
+            from framework.config import (
+                get_preferred_worker_model,
+                get_worker_api_base,
+                get_worker_api_key,
+                get_worker_llm_extra_kwargs,
+            )
 
-            resolved_model = model or get_preferred_worker_model() or self._model
+            worker_model = get_preferred_worker_model()
+            resolved_model = model or worker_model or self._model
             runner = await loop.run_in_executor(
                 None,
                 lambda: AgentRunner.load(
@@ -302,6 +308,22 @@ class SessionManager:
                     credential_store=self._credential_store,
                 ),
             )
+
+            # If a worker-specific model is configured, build an LLM provider
+            # with the correct worker credentials so _setup() doesn't fall back
+            # to the queen's llm config (which may be a different provider).
+            if worker_model and not model:
+                from framework.llm.litellm import LiteLLMProvider
+
+                worker_api_key = get_worker_api_key()
+                worker_api_base = get_worker_api_base()
+                worker_extra = get_worker_llm_extra_kwargs()
+                runner._llm = LiteLLMProvider(
+                    model=resolved_model,
+                    api_key=worker_api_key,
+                    api_base=worker_api_base,
+                    **worker_extra,
+                )
 
             # Setup with session's event bus
             if runner._agent_runtime is None:
@@ -927,6 +949,7 @@ class SessionManager:
         # then use max+1 as offset so resumed sessions produce monotonically
         # increasing iteration values — preventing frontend message ID collisions.
         iteration_offset = 0
+        last_phase = ""
         events_path = queen_dir / "events.jsonl"
         try:
             if events_path.exists():
@@ -938,17 +961,24 @@ class SessionManager:
                             continue
                         try:
                             evt = json.loads(line)
-                            it = evt.get("data", {}).get("iteration")
+                            data = evt.get("data", {})
+                            it = data.get("iteration")
                             if isinstance(it, int) and it > max_iter:
                                 max_iter = it
+                            # Track the latest queen phase from QUEEN_PHASE_CHANGED events
+                            if evt.get("type") == "queen_phase_changed":
+                                phase = data.get("phase")
+                                if phase:
+                                    last_phase = phase
                         except (json.JSONDecodeError, TypeError):
                             continue
                 if max_iter >= 0:
                     iteration_offset = max_iter + 1
                     logger.info(
-                        "Session '%s' resuming with iteration_offset=%d (from events.jsonl max)",
+                        "Session '%s' resuming with iteration_offset=%d (from events.jsonl max), last phase: %s",
                         session.id,
                         iteration_offset,
+                        last_phase or "unknown",
                     )
         except OSError:
             pass

--- a/core/framework/server/session_manager.py
+++ b/core/framework/server/session_manager.py
@@ -287,7 +287,11 @@ class SessionManager:
         try:
             # Blocking I/O — load in executor
             loop = asyncio.get_running_loop()
-            resolved_model = model or self._model
+
+            # Prioritize: explicit model arg > worker-specific model > session default
+            from framework.config import get_preferred_worker_model
+
+            resolved_model = model or get_preferred_worker_model() or self._model
             runner = await loop.run_in_executor(
                 None,
                 lambda: AgentRunner.load(

--- a/core/framework/server/session_manager.py
+++ b/core/framework/server/session_manager.py
@@ -975,7 +975,8 @@ class SessionManager:
                 if max_iter >= 0:
                     iteration_offset = max_iter + 1
                     logger.info(
-                        "Session '%s' resuming with iteration_offset=%d (from events.jsonl max), last phase: %s",
+                        "Session '%s' resuming with iteration_offset=%d"
+                        " (from events.jsonl max), last phase: %s",
                         session.id,
                         iteration_offset,
                         last_phase or "unknown",

--- a/core/frontend/package-lock.json
+++ b/core/frontend/package-lock.json
@@ -60,7 +60,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1557,7 +1556,6 @@
       "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1573,7 +1571,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1786,7 +1783,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3564,7 +3560,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3616,7 +3611,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3629,7 +3623,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4190,7 +4183,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/quickstart.ps1
+++ b/quickstart.ps1
@@ -1880,6 +1880,9 @@ if ($SelectedProviderId) {
         Write-Host " -> " -NoNewline
         Write-Color -Text $SelectedModel -Color DarkGray
     }
+    Write-Color -Text "  To use a different model for worker agents, run:" -Color DarkGray
+    Write-Host "     " -NoNewline
+    Write-Color -Text ".\scripts\setup_worker_model.ps1" -Color Cyan
     Write-Host ""
 }
 

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -1767,6 +1767,8 @@ if [ -n "$SELECTED_PROVIDER_ID" ]; then
     else
         echo -e "  ${CYAN}$SELECTED_PROVIDER_ID${NC} → ${DIM}$SELECTED_MODEL${NC}"
     fi
+    echo -e "  ${DIM}To use a different model for worker agents, run:${NC}"
+    echo -e "     ${CYAN}./scripts/setup_worker_model.sh${NC}"
     echo ""
 fi
 

--- a/scripts/setup_worker_model.ps1
+++ b/scripts/setup_worker_model.ps1
@@ -19,6 +19,7 @@ $ProjectDir = Split-Path -Parent $ScriptDir
 $UvHelperPath = Join-Path $ScriptDir "uv-discovery.ps1"
 $HiveConfigDir = Join-Path $env:USERPROFILE ".hive"
 $HiveConfigFile = Join-Path $HiveConfigDir "configuration.json"
+$HiveLlmEndpoint = "https://api.adenhq.com"
 
 . $UvHelperPath
 
@@ -49,56 +50,186 @@ function Write-Warn {
     Write-Color -Text "$([char]0x2B22) $Text" -Color Yellow
 }
 
+function Write-Fail {
+    param([string]$Text)
+    Write-Color -Text "  X $Text" -Color Red
+}
+
 # ============================================================
-# Provider / model definitions
+# Provider / model data
 # ============================================================
 
-$ProviderEnvVars = @{
-    "ANTHROPIC_API_KEY"  = @{ Name = "Anthropic (Claude)"; Id = "anthropic" }
-    "OPENAI_API_KEY"     = @{ Name = "OpenAI (GPT)"; Id = "openai" }
-    "GEMINI_API_KEY"     = @{ Name = "Google Gemini"; Id = "gemini" }
-    "GROQ_API_KEY"       = @{ Name = "Groq"; Id = "groq" }
-    "CEREBRAS_API_KEY"   = @{ Name = "Cerebras"; Id = "cerebras" }
-    "OPENROUTER_API_KEY" = @{ Name = "OpenRouter"; Id = "openrouter" }
-    "MISTRAL_API_KEY"    = @{ Name = "Mistral"; Id = "mistral" }
-    "TOGETHER_API_KEY"   = @{ Name = "Together AI"; Id = "together" }
-    "DEEPSEEK_API_KEY"   = @{ Name = "DeepSeek"; Id = "deepseek" }
+$ProviderMap = [ordered]@{
+    ANTHROPIC_API_KEY = @{ Name = "Anthropic (Claude)"; Id = "anthropic" }
+    OPENAI_API_KEY    = @{ Name = "OpenAI (GPT)";       Id = "openai" }
+    GEMINI_API_KEY    = @{ Name = "Google Gemini";       Id = "gemini" }
+    GOOGLE_API_KEY    = @{ Name = "Google AI";           Id = "google" }
+    GROQ_API_KEY      = @{ Name = "Groq";               Id = "groq" }
+    CEREBRAS_API_KEY  = @{ Name = "Cerebras";            Id = "cerebras" }
+    OPENROUTER_API_KEY = @{ Name = "OpenRouter";          Id = "openrouter" }
+    MISTRAL_API_KEY   = @{ Name = "Mistral";             Id = "mistral" }
+    TOGETHER_API_KEY  = @{ Name = "Together AI";         Id = "together" }
+    DEEPSEEK_API_KEY  = @{ Name = "DeepSeek";            Id = "deepseek" }
 }
 
 $DefaultModels = @{
-    "anthropic"   = "claude-haiku-4-5-20251001"
-    "openai"      = "gpt-5-mini"
-    "gemini"      = "gemini-3-flash-preview"
-    "groq"        = "moonshotai/kimi-k2-instruct-0905"
-    "cerebras"    = "zai-glm-4.7"
-    "mistral"     = "mistral-large-latest"
-    "together_ai" = "meta-llama/Llama-3.3-70B-Instruct-Turbo"
-    "deepseek"    = "deepseek-chat"
+    anthropic   = "claude-haiku-4-5-20251001"
+    openai      = "gpt-5-mini"
+    gemini      = "gemini-3-flash-preview"
+    groq        = "moonshotai/kimi-k2-instruct-0905"
+    cerebras    = "zai-glm-4.7"
+    mistral     = "mistral-large-latest"
+    together_ai = "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+    deepseek    = "deepseek-chat"
 }
 
+# Model choices: array of hashtables per provider
 $ModelChoices = @{
-    "anthropic" = @(
-        @{ Id = "claude-haiku-4-5-20251001";  Label = "Haiku 4.5 - Fast + cheap (recommended for workers)"; MaxTokens = 8192;  MaxContext = 180000 }
-        @{ Id = "claude-sonnet-4-20250514";   Label = "Sonnet 4 - Fast + capable";                         MaxTokens = 8192;  MaxContext = 180000 }
-        @{ Id = "claude-sonnet-4-5-20250929"; Label = "Sonnet 4.5 - Best balance";                         MaxTokens = 16384; MaxContext = 180000 }
-        @{ Id = "claude-opus-4-6";            Label = "Opus 4.6 - Most capable";                           MaxTokens = 32768; MaxContext = 180000 }
+    anthropic = @(
+        @{ Id = "claude-haiku-4-5-20251001";  Label = "Haiku 4.5 - Fast + cheap (recommended)"; MaxTokens = 8192;  MaxContextTokens = 180000 },
+        @{ Id = "claude-sonnet-4-20250514";   Label = "Sonnet 4 - Fast + capable";              MaxTokens = 8192;  MaxContextTokens = 180000 },
+        @{ Id = "claude-sonnet-4-5-20250929"; Label = "Sonnet 4.5 - Best balance";              MaxTokens = 16384; MaxContextTokens = 180000 },
+        @{ Id = "claude-opus-4-6";            Label = "Opus 4.6 - Most capable";                MaxTokens = 32768; MaxContextTokens = 180000 }
     )
-    "openai" = @(
-        @{ Id = "gpt-5-mini"; Label = "GPT-5 Mini - Fast + cheap (recommended for workers)"; MaxTokens = 16384; MaxContext = 120000 }
-        @{ Id = "gpt-5.2";    Label = "GPT-5.2 - Most capable";                              MaxTokens = 16384; MaxContext = 120000 }
+    openai = @(
+        @{ Id = "gpt-5-mini"; Label = "GPT-5 Mini - Fast + cheap (recommended)"; MaxTokens = 16384; MaxContextTokens = 120000 },
+        @{ Id = "gpt-5.2";   Label = "GPT-5.2 - Most capable";                   MaxTokens = 16384; MaxContextTokens = 120000 }
     )
-    "gemini" = @(
-        @{ Id = "gemini-3-flash-preview";   Label = "Gemini 3 Flash - Fast (recommended for workers)"; MaxTokens = 8192; MaxContext = 900000 }
-        @{ Id = "gemini-3.1-pro-preview";   Label = "Gemini 3.1 Pro - Best quality";                   MaxTokens = 8192; MaxContext = 900000 }
+    gemini = @(
+        @{ Id = "gemini-3-flash-preview"; Label = "Gemini 3 Flash - Fast (recommended)"; MaxTokens = 8192; MaxContextTokens = 900000 },
+        @{ Id = "gemini-3.1-pro-preview";  Label = "Gemini 3.1 Pro - Best quality";       MaxTokens = 8192; MaxContextTokens = 900000 }
     )
-    "groq" = @(
-        @{ Id = "moonshotai/kimi-k2-instruct-0905"; Label = "Kimi K2 - Best quality (recommended)"; MaxTokens = 8192; MaxContext = 120000 }
-        @{ Id = "openai/gpt-oss-120b";              Label = "GPT-OSS 120B - Fast reasoning";        MaxTokens = 8192; MaxContext = 120000 }
+    groq = @(
+        @{ Id = "moonshotai/kimi-k2-instruct-0905"; Label = "Kimi K2 - Best quality (recommended)"; MaxTokens = 8192; MaxContextTokens = 120000 },
+        @{ Id = "openai/gpt-oss-120b";              Label = "GPT-OSS 120B - Fast reasoning";        MaxTokens = 8192; MaxContextTokens = 120000 }
     )
-    "cerebras" = @(
-        @{ Id = "zai-glm-4.7";                     Label = "ZAI-GLM 4.7 - Best quality (recommended)"; MaxTokens = 8192; MaxContext = 120000 }
-        @{ Id = "qwen3-235b-a22b-instruct-2507";   Label = "Qwen3 235B - Frontier reasoning";          MaxTokens = 8192; MaxContext = 120000 }
+    cerebras = @(
+        @{ Id = "zai-glm-4.7";                    Label = "ZAI-GLM 4.7 - Best quality (recommended)"; MaxTokens = 8192; MaxContextTokens = 120000 },
+        @{ Id = "qwen3-235b-a22b-instruct-2507";  Label = "Qwen3 235B - Frontier reasoning";          MaxTokens = 8192; MaxContextTokens = 120000 }
     )
+}
+
+function Normalize-OpenRouterModelId {
+    param([string]$ModelId)
+    $normalized = if ($ModelId) { $ModelId.Trim() } else { "" }
+    if ($normalized -match '(?i)^openrouter/(.+)$') {
+        $normalized = $matches[1]
+    }
+    return $normalized
+}
+
+function Get-ModelSelection {
+    param([string]$ProviderId)
+
+    if ($ProviderId -eq "openrouter") {
+        $defaultModel = ""
+        if ($PrevModel -and $PrevProvider -eq $ProviderId) {
+            $defaultModel = Normalize-OpenRouterModelId $PrevModel
+        }
+        Write-Host ""
+        Write-Color -Text "Enter your OpenRouter model id:" -Color White
+        Write-Color -Text "  Paste from openrouter.ai (example: x-ai/grok-4.20-beta)" -Color DarkGray
+        Write-Color -Text "  If calls fail with guardrail/privacy errors: openrouter.ai/settings/privacy" -Color DarkGray
+        Write-Host ""
+        while ($true) {
+            if ($defaultModel) {
+                $rawModel = Read-Host "Model id [$defaultModel]"
+                if ([string]::IsNullOrWhiteSpace($rawModel)) { $rawModel = $defaultModel }
+            } else {
+                $rawModel = Read-Host "Model id"
+            }
+            $normalizedModel = Normalize-OpenRouterModelId $rawModel
+            if (-not [string]::IsNullOrWhiteSpace($normalizedModel)) {
+                $openrouterKey = $null
+                if ($SelectedEnvVar) {
+                    $openrouterKey = [System.Environment]::GetEnvironmentVariable($SelectedEnvVar, "Process")
+                    if (-not $openrouterKey) {
+                        $openrouterKey = [System.Environment]::GetEnvironmentVariable($SelectedEnvVar, "User")
+                    }
+                }
+
+                if ($openrouterKey) {
+                    Write-Host "  Verifying model id... " -NoNewline
+                    try {
+                        $modelApiBase = if ($SelectedApiBase) { $SelectedApiBase } else { "https://openrouter.ai/api/v1" }
+                        Push-Location $ProjectDir
+                        $hcResult = & $UvCmd run python (Join-Path $ProjectDir "scripts/check_llm_key.py") "openrouter" $openrouterKey $modelApiBase $normalizedModel 2>$null
+                        Pop-Location
+                        $hcJson = $hcResult | ConvertFrom-Json
+                        if ($hcJson.valid -eq $true) {
+                            if ($hcJson.model) {
+                                $normalizedModel = [string]$hcJson.model
+                            }
+                            Write-Color -Text "ok" -Color Green
+                        } elseif ($hcJson.valid -eq $false) {
+                            Write-Color -Text "failed" -Color Red
+                            Write-Warn $hcJson.message
+                            Write-Host ""
+                            continue
+                        } else {
+                            Write-Color -Text "--" -Color Yellow
+                            Write-Color -Text "  Could not verify model id (network issue). Continuing with your selection." -Color DarkGray
+                        }
+                    } catch {
+                        Pop-Location
+                        Write-Color -Text "--" -Color Yellow
+                        Write-Color -Text "  Could not verify model id (network issue). Continuing with your selection." -Color DarkGray
+                    }
+                } else {
+                    Write-Color -Text "  Skipping model verification (OpenRouter key not available in current shell)." -Color DarkGray
+                }
+
+                Write-Host ""
+                Write-Ok "Model: $normalizedModel"
+                return @{ Model = $normalizedModel; MaxTokens = 8192; MaxContextTokens = 120000 }
+            }
+            Write-Color -Text "Model id cannot be empty." -Color Red
+        }
+    }
+
+    $choices = $ModelChoices[$ProviderId]
+    if (-not $choices -or $choices.Count -eq 0) {
+        return @{ Model = $DefaultModels[$ProviderId]; MaxTokens = 8192; MaxContextTokens = 120000 }
+    }
+    if ($choices.Count -eq 1) {
+        return @{ Model = $choices[0].Id; MaxTokens = $choices[0].MaxTokens; MaxContextTokens = $choices[0].MaxContextTokens }
+    }
+
+    # Find default index from previous model (if same provider)
+    $defaultIdx = "1"
+    if ($PrevModel -and $PrevProvider -eq $ProviderId) {
+        for ($j = 0; $j -lt $choices.Count; $j++) {
+            if ($choices[$j].Id -eq $PrevModel) {
+                $defaultIdx = [string]($j + 1)
+                break
+            }
+        }
+    }
+
+    Write-Host ""
+    Write-Color -Text "Select a model:" -Color White
+    Write-Host ""
+    for ($i = 0; $i -lt $choices.Count; $i++) {
+        Write-Color -Text "  $($i + 1)" -Color Cyan -NoNewline
+        Write-Host ") $($choices[$i].Label)  " -NoNewline
+        Write-Color -Text "($($choices[$i].Id))" -Color DarkGray
+    }
+    Write-Host ""
+
+    while ($true) {
+        $raw = Read-Host "Enter choice [$defaultIdx]"
+        if ([string]::IsNullOrWhiteSpace($raw)) { $raw = $defaultIdx }
+        if ($raw -match '^\d+$') {
+            $num = [int]$raw
+            if ($num -ge 1 -and $num -le $choices.Count) {
+                $sel = $choices[$num - 1]
+                Write-Host ""
+                Write-Ok "Model: $($sel.Id)"
+                return @{ Model = $sel.Id; MaxTokens = $sel.MaxTokens; MaxContextTokens = $sel.MaxContextTokens }
+            }
+        }
+        Write-Color -Text "Invalid choice. Please enter 1-$($choices.Count)" -Color Red
+    }
 }
 
 # ============================================================
@@ -127,7 +258,7 @@ if (Test-Path $HiveConfigFile) {
 from framework.config import get_preferred_model, get_preferred_worker_model
 print(f'Queen:  {get_preferred_model()}')
 wm = get_preferred_worker_model()
-print(f'Worker: {wm if wm else chr(34) + \"(same as queen)\" + chr(34)}')
+print(f'Worker: {wm if wm else chr(34) + ""(same as queen)"" + chr(34)}')
 " 2>$null
         Pop-Location
         if ($currentConfig) {
@@ -142,143 +273,668 @@ print(f'Worker: {wm if wm else chr(34) + \"(same as queen)\" + chr(34)}')
     }
 }
 
-# Detect available providers
-$AvailableProviders = @()
-foreach ($envVar in $ProviderEnvVars.Keys) {
-    $val = [System.Environment]::GetEnvironmentVariable($envVar, "User")
-    if (-not $val) { $val = [System.Environment]::GetEnvironmentVariable($envVar) }
-    if ($val) {
-        $AvailableProviders += @{
-            EnvVar = $envVar
-            Name   = $ProviderEnvVars[$envVar].Name
-            Id     = $ProviderEnvVars[$envVar].Id
-        }
-    }
-}
+# ============================================================
+# Configure Worker LLM Provider
+# ============================================================
 
-if ($AvailableProviders.Count -eq 0) {
-    Write-Color -Text "No API keys found." -Color Red
-    Write-Host "Run .\quickstart.ps1 first to set up your LLM provider."
-    exit 1
-}
-
-# Pick provider
-$SelectedProvider = $null
-if ($AvailableProviders.Count -eq 1) {
-    $SelectedProvider = $AvailableProviders[0]
-    Write-Ok "Provider: $($SelectedProvider.Name)"
-} else {
-    Write-Color -Text "Select provider for worker agents:" -Color White
-    Write-Host ""
-    for ($i = 0; $i -lt $AvailableProviders.Count; $i++) {
-        Write-Host "  " -NoNewline
-        Write-Color -Text "$($i+1))" -Color Cyan -NoNewline
-        Write-Host " $($AvailableProviders[$i].Name)"
-    }
-    Write-Host ""
-    while ($true) {
-        $choice = Read-Host "Enter choice (1-$($AvailableProviders.Count))"
-        $idx = [int]$choice - 1
-        if ($idx -ge 0 -and $idx -lt $AvailableProviders.Count) {
-            $SelectedProvider = $AvailableProviders[$idx]
-            Write-Host ""
-            Write-Ok "Provider: $($SelectedProvider.Name)"
-            break
-        }
-        Write-Color -Text "Invalid choice." -Color Red
-    }
-}
-
-$SelectedProviderId = $SelectedProvider.Id
-$SelectedEnvVar = $SelectedProvider.EnvVar
-$SelectedModel = $DefaultModels[$SelectedProviderId]
-$SelectedMaxTokens = 8192
+$SelectedProviderId      = ""
+$SelectedEnvVar          = ""
+$SelectedModel           = ""
+$SelectedMaxTokens       = 8192
 $SelectedMaxContextTokens = 120000
-$SelectedApiBase = ""
+$SelectedApiBase         = ""
+$SubscriptionMode        = ""
 
-if ($SelectedProviderId -eq "openrouter") {
-    $SelectedApiBase = "https://openrouter.ai/api/v1"
+# -- Credential detection (silent -- just set flags) ----------
+$ClaudeCredDetected = $false
+$claudeCredPath = Join-Path $env:USERPROFILE ".claude\.credentials.json"
+if (Test-Path $claudeCredPath) { $ClaudeCredDetected = $true }
+
+$CodexCredDetected = $false
+$codexAuthPath = Join-Path $env:USERPROFILE ".codex\auth.json"
+if (Test-Path $codexAuthPath) { $CodexCredDetected = $true }
+
+$ZaiCredDetected = $false
+$zaiKey = [System.Environment]::GetEnvironmentVariable("ZAI_API_KEY", "User")
+if (-not $zaiKey) { $zaiKey = $env:ZAI_API_KEY }
+if ($zaiKey) { $ZaiCredDetected = $true }
+
+$KimiCredDetected = $false
+$kimiConfigPath = Join-Path $env:USERPROFILE ".kimi\config.toml"
+if (Test-Path $kimiConfigPath) { $KimiCredDetected = $true }
+$kimiKey = [System.Environment]::GetEnvironmentVariable("KIMI_API_KEY", "User")
+if (-not $kimiKey) { $kimiKey = $env:KIMI_API_KEY }
+if ($kimiKey) { $KimiCredDetected = $true }
+
+$HiveCredDetected = $false
+$hiveKey = [System.Environment]::GetEnvironmentVariable("HIVE_API_KEY", "User")
+if (-not $hiveKey) { $hiveKey = $env:HIVE_API_KEY }
+if ($hiveKey) { $HiveCredDetected = $true }
+
+# Detect API key providers
+$ProviderMenuEnvVars  = @("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GROQ_API_KEY", "CEREBRAS_API_KEY", "OPENROUTER_API_KEY")
+$ProviderMenuNames    = @("Anthropic (Claude) - Recommended", "OpenAI (GPT)", "Google Gemini - Free tier available", "Groq - Fast, free tier", "Cerebras - Fast, free tier", "OpenRouter - Bring any OpenRouter model")
+$ProviderMenuIds      = @("anthropic", "openai", "gemini", "groq", "cerebras", "openrouter")
+$ProviderMenuUrls     = @(
+    "https://console.anthropic.com/settings/keys",
+    "https://platform.openai.com/api-keys",
+    "https://aistudio.google.com/apikey",
+    "https://console.groq.com/keys",
+    "https://cloud.cerebras.ai/",
+    "https://openrouter.ai/keys"
+)
+
+# -- Read previous worker_llm configuration (if any) ---------
+$PrevProvider = ""
+$PrevModel = ""
+$PrevEnvVar = ""
+$PrevSubMode = ""
+if (Test-Path $HiveConfigFile) {
+    try {
+        $prevConfig = Get-Content -Path $HiveConfigFile -Raw | ConvertFrom-Json
+        $prevLlm = $prevConfig.worker_llm
+        if ($prevLlm) {
+            $PrevProvider = if ($prevLlm.provider) { $prevLlm.provider } else { "" }
+            $PrevModel = if ($prevLlm.model) { $prevLlm.model } else { "" }
+            $PrevEnvVar = if ($prevLlm.api_key_env_var) { $prevLlm.api_key_env_var } else { "" }
+            if ($prevLlm.use_claude_code_subscription) { $PrevSubMode = "claude_code" }
+            elseif ($prevLlm.use_codex_subscription) { $PrevSubMode = "codex" }
+            elseif ($prevLlm.use_kimi_code_subscription) { $PrevSubMode = "kimi_code" }
+            elseif ($prevLlm.api_base -and $prevLlm.api_base -like "*api.z.ai*") { $PrevSubMode = "zai_code" }
+            elseif ($prevLlm.api_base -and $prevLlm.api_base -like "*api.kimi.com*") { $PrevSubMode = "kimi_code" }
+            elseif ($prevLlm.provider -eq "hive" -or ($prevLlm.api_base -and $prevLlm.api_base -like "*adenhq.com*")) { $PrevSubMode = "hive_llm" }
+        }
+    } catch { }
 }
 
-# Select model
-$choices = $ModelChoices[$SelectedProviderId]
-if ($choices -and $choices.Count -gt 0) {
-    Write-Host ""
-    Write-Color -Text "Select worker model:" -Color White
-    for ($i = 0; $i -lt $choices.Count; $i++) {
-        Write-Host "  " -NoNewline
-        Write-Color -Text "$($i+1))" -Color Cyan -NoNewline
-        Write-Host " $($choices[$i].Label)"
+# Compute default menu number (only if credential is still valid)
+$DefaultChoice = ""
+if ($PrevSubMode -or $PrevProvider) {
+    $prevCredValid = $false
+    switch ($PrevSubMode) {
+        "claude_code" { if ($ClaudeCredDetected) { $prevCredValid = $true } }
+        "zai_code"    { if ($ZaiCredDetected)    { $prevCredValid = $true } }
+        "codex"       { if ($CodexCredDetected)  { $prevCredValid = $true } }
+        "kimi_code"   { if ($KimiCredDetected)   { $prevCredValid = $true } }
+        "hive_llm"    { if ($HiveCredDetected)   { $prevCredValid = $true } }
+        default {
+            if ($PrevEnvVar) {
+                $envVal = [System.Environment]::GetEnvironmentVariable($PrevEnvVar, "Process")
+                if (-not $envVal) { $envVal = [System.Environment]::GetEnvironmentVariable($PrevEnvVar, "User") }
+                if ($envVal) { $prevCredValid = $true }
+            }
+        }
     }
+    if ($prevCredValid) {
+        switch ($PrevSubMode) {
+            "claude_code" { $DefaultChoice = "1" }
+            "zai_code"    { $DefaultChoice = "2" }
+            "codex"       { $DefaultChoice = "3" }
+            "kimi_code"   { $DefaultChoice = "4" }
+            "hive_llm"    { $DefaultChoice = "5" }
+        }
+        if (-not $DefaultChoice) {
+            switch ($PrevProvider) {
+                "anthropic" { $DefaultChoice = "6" }
+                "openai"    { $DefaultChoice = "7" }
+                "gemini"    { $DefaultChoice = "8" }
+                "groq"      { $DefaultChoice = "9" }
+                "cerebras"  { $DefaultChoice = "10" }
+                "openrouter" { $DefaultChoice = "11" }
+                "kimi"      { $DefaultChoice = "4" }
+            }
+        }
+    }
+}
+
+# -- Show unified provider selection menu ---------------------
+Write-Color -Text "Select your worker LLM provider:" -Color White
+Write-Host ""
+Write-Color -Text "  Subscription modes (no API key purchase needed):" -Color Cyan
+
+# 1) Claude Code
+Write-Host "  " -NoNewline
+Write-Color -Text "1" -Color Cyan -NoNewline
+Write-Host ") Claude Code Subscription  " -NoNewline
+Write-Color -Text "(use your Claude Max/Pro plan)" -Color DarkGray -NoNewline
+if ($ClaudeCredDetected) { Write-Color -Text "  (credential detected)" -Color Green } else { Write-Host "" }
+
+# 2) ZAI Code
+Write-Host "  " -NoNewline
+Write-Color -Text "2" -Color Cyan -NoNewline
+Write-Host ") ZAI Code Subscription     " -NoNewline
+Write-Color -Text "(use your ZAI Code plan)" -Color DarkGray -NoNewline
+if ($ZaiCredDetected) { Write-Color -Text "  (credential detected)" -Color Green } else { Write-Host "" }
+
+# 3) Codex
+Write-Host "  " -NoNewline
+Write-Color -Text "3" -Color Cyan -NoNewline
+Write-Host ") OpenAI Codex Subscription  " -NoNewline
+Write-Color -Text "(use your Codex/ChatGPT Plus plan)" -Color DarkGray -NoNewline
+if ($CodexCredDetected) { Write-Color -Text "  (credential detected)" -Color Green } else { Write-Host "" }
+
+# 4) Kimi Code
+Write-Host "  " -NoNewline
+Write-Color -Text "4" -Color Cyan -NoNewline
+Write-Host ") Kimi Code Subscription     " -NoNewline
+Write-Color -Text "(use your Kimi Code plan)" -Color DarkGray -NoNewline
+if ($KimiCredDetected) { Write-Color -Text "  (credential detected)" -Color Green } else { Write-Host "" }
+
+# 5) Hive LLM
+Write-Host "  " -NoNewline
+Write-Color -Text "5" -Color Cyan -NoNewline
+Write-Host ") Hive LLM                   " -NoNewline
+Write-Color -Text "(use your Hive API key)" -Color DarkGray -NoNewline
+if ($HiveCredDetected) { Write-Color -Text "  (credential detected)" -Color Green } else { Write-Host "" }
+
+Write-Host ""
+Write-Color -Text "  API key providers:" -Color Cyan
+
+# 6-11) API key providers
+for ($idx = 0; $idx -lt $ProviderMenuEnvVars.Count; $idx++) {
+    $num = $idx + 6
+    $envVal = [System.Environment]::GetEnvironmentVariable($ProviderMenuEnvVars[$idx], "Process")
+    if (-not $envVal) { $envVal = [System.Environment]::GetEnvironmentVariable($ProviderMenuEnvVars[$idx], "User") }
+    Write-Host "  " -NoNewline
+    Write-Color -Text "$num" -Color Cyan -NoNewline
+    Write-Host ") $($ProviderMenuNames[$idx])" -NoNewline
+    if ($envVal) { Write-Color -Text "  (credential detected)" -Color Green } else { Write-Host "" }
+}
+
+$SkipChoice = 6 + $ProviderMenuEnvVars.Count
+Write-Host "  " -NoNewline
+Write-Color -Text "$SkipChoice" -Color Cyan -NoNewline
+Write-Host ") Skip for now"
+Write-Host ""
+
+if ($DefaultChoice) {
+    Write-Color -Text "  Previously configured: $PrevProvider/$PrevModel. Press Enter to keep." -Color DarkGray
     Write-Host ""
-    while ($true) {
-        $choice = Read-Host "Enter choice (1-$($choices.Count)) [1]"
-        if (-not $choice) { $choice = "1" }
-        $idx = [int]$choice - 1
-        if ($idx -ge 0 -and $idx -lt $choices.Count) {
-            $SelectedModel = $choices[$idx].Id
-            $SelectedMaxTokens = $choices[$idx].MaxTokens
-            $SelectedMaxContextTokens = $choices[$idx].MaxContext
+}
+
+while ($true) {
+    if ($DefaultChoice) {
+        $raw = Read-Host "Enter choice (1-$SkipChoice) [$DefaultChoice]"
+        if ([string]::IsNullOrWhiteSpace($raw)) { $raw = $DefaultChoice }
+    } else {
+        $raw = Read-Host "Enter choice (1-$SkipChoice)"
+    }
+    if ($raw -match '^\d+$') {
+        $num = [int]$raw
+        if ($num -ge 1 -and $num -le $SkipChoice) { break }
+    }
+    Write-Color -Text "Invalid choice. Please enter 1-$SkipChoice" -Color Red
+}
+
+switch ($num) {
+    1 {
+        # Claude Code Subscription
+        if (-not $ClaudeCredDetected) {
             Write-Host ""
-            Write-Ok "Worker model: $SelectedModel"
+            Write-Warn "~/.claude/.credentials.json not found."
+            Write-Host "  Run 'claude' first to authenticate with your Claude subscription,"
+            Write-Host "  then run this script again."
+            Write-Host ""
+            exit 1
+        }
+        $SubscriptionMode        = "claude_code"
+        $SelectedProviderId      = "anthropic"
+        $SelectedModel           = "claude-opus-4-6"
+        $SelectedMaxTokens       = 32768
+        $SelectedMaxContextTokens = 180000
+        Write-Host ""
+        Write-Ok "Using Claude Code subscription"
+    }
+    2 {
+        # ZAI Code Subscription
+        $SubscriptionMode        = "zai_code"
+        $SelectedProviderId      = "openai"
+        $SelectedEnvVar          = "ZAI_API_KEY"
+        $SelectedModel           = "glm-5"
+        $SelectedMaxTokens       = 32768
+        $SelectedMaxContextTokens = 120000
+        Write-Host ""
+        Write-Ok "Using ZAI Code subscription"
+        Write-Color -Text "  Model: glm-5 | API: api.z.ai" -Color DarkGray
+    }
+    3 {
+        # OpenAI Codex Subscription
+        if (-not $CodexCredDetected) {
+            Write-Host ""
+            Write-Warn "Codex credentials not found. Starting OAuth login..."
+            Write-Host ""
+            try {
+                Push-Location $ProjectDir
+                & $UvCmd run python (Join-Path $ProjectDir "core\codex_oauth.py") 2>&1
+                Pop-Location
+                if ($LASTEXITCODE -eq 0) {
+                    $CodexCredDetected = $true
+                } else {
+                    Write-Host ""
+                    Write-Fail "OAuth login failed or was cancelled."
+                    Write-Host ""
+                    Write-Host "  Or run 'codex' to authenticate, then run this script again."
+                    Write-Host ""
+                    $SelectedProviderId = ""
+                }
+            } catch {
+                Pop-Location
+                Write-Fail "OAuth login failed: $($_.Exception.Message)"
+                $SelectedProviderId = ""
+            }
+        }
+        if ($CodexCredDetected) {
+            $SubscriptionMode        = "codex"
+            $SelectedProviderId      = "openai"
+            $SelectedModel           = "gpt-5.3-codex"
+            $SelectedMaxTokens       = 16384
+            $SelectedMaxContextTokens = 120000
+            Write-Host ""
+            Write-Ok "Using OpenAI Codex subscription"
+        }
+    }
+    4 {
+        # Kimi Code Subscription
+        $SubscriptionMode        = "kimi_code"
+        $SelectedProviderId      = "kimi"
+        $SelectedEnvVar          = "KIMI_API_KEY"
+        $SelectedModel           = "kimi-k2.5"
+        $SelectedMaxTokens       = 32768
+        $SelectedMaxContextTokens = 120000
+        Write-Host ""
+        Write-Ok "Using Kimi Code subscription"
+        Write-Color -Text "  Model: kimi-k2.5 | API: api.kimi.com/coding" -Color DarkGray
+    }
+    5 {
+        # Hive LLM
+        $SubscriptionMode        = "hive_llm"
+        $SelectedProviderId      = "hive"
+        $SelectedEnvVar          = "HIVE_API_KEY"
+        $SelectedMaxTokens       = 32768
+        $SelectedMaxContextTokens = 120000
+        Write-Host ""
+        Write-Ok "Using Hive LLM"
+        Write-Host ""
+        Write-Host "  Select a model:"
+        Write-Host "  " -NoNewline; Write-Color -Text "1)" -Color Cyan -NoNewline; Write-Host " queen              " -NoNewline; Write-Color -Text "(default - Hive flagship)" -Color DarkGray
+        Write-Host "  " -NoNewline; Write-Color -Text "2)" -Color Cyan -NoNewline; Write-Host " kimi-2.5"
+        Write-Host "  " -NoNewline; Write-Color -Text "3)" -Color Cyan -NoNewline; Write-Host " GLM-5"
+        Write-Host ""
+        $hiveModelChoice = Read-Host "  Enter model choice (1-3) [1]"
+        if (-not $hiveModelChoice) { $hiveModelChoice = "1" }
+        switch ($hiveModelChoice) {
+            "2" { $SelectedModel = "kimi-2.5" }
+            "3" { $SelectedModel = "GLM-5" }
+            default { $SelectedModel = "queen" }
+        }
+        Write-Color -Text "  Model: $SelectedModel | API: $HiveLlmEndpoint" -Color DarkGray
+    }
+    { $_ -ge 6 -and $_ -le 11 } {
+        # API key providers
+        $provIdx = $num - 6
+        $SelectedEnvVar     = $ProviderMenuEnvVars[$provIdx]
+        $SelectedProviderId = $ProviderMenuIds[$provIdx]
+        $providerName       = $ProviderMenuNames[$provIdx] -replace ' - .*', ''  # strip description
+        $signupUrl          = $ProviderMenuUrls[$provIdx]
+        if ($SelectedProviderId -eq "openrouter") {
+            $SelectedApiBase = "https://openrouter.ai/api/v1"
+        } else {
+            $SelectedApiBase = ""
+        }
+
+        # Prompt for key (allow replacement if already set) with verification + retry
+        while ($true) {
+            $existingKey = [System.Environment]::GetEnvironmentVariable($SelectedEnvVar, "User")
+            if (-not $existingKey) { $existingKey = [System.Environment]::GetEnvironmentVariable($SelectedEnvVar, "Process") }
+
+            if ($existingKey) {
+                $masked = $existingKey.Substring(0, [Math]::Min(4, $existingKey.Length)) + "..." + $existingKey.Substring([Math]::Max(0, $existingKey.Length - 4))
+                Write-Host ""
+                Write-Color -Text "  $([char]0x2B22) Current key: $masked" -Color Green
+                $apiKey = Read-Host "  Press Enter to keep, or paste a new key to replace"
+            } else {
+                Write-Host ""
+                Write-Host "Get your API key from: " -NoNewline
+                Write-Color -Text $signupUrl -Color Cyan
+                Write-Host ""
+                $apiKey = Read-Host "Paste your $providerName API key (or press Enter to skip)"
+            }
+
+            if ($apiKey) {
+                [System.Environment]::SetEnvironmentVariable($SelectedEnvVar, $apiKey, "User")
+                Set-Item -Path "Env:\$SelectedEnvVar" -Value $apiKey
+                Write-Host ""
+                Write-Ok "API key saved as User environment variable: $SelectedEnvVar"
+
+                # Health check the new key
+                Write-Host "  Verifying API key... " -NoNewline
+                try {
+                    Push-Location $ProjectDir
+                    if ($SelectedApiBase) {
+                        $hcResult = & $UvCmd run python (Join-Path $ProjectDir "scripts/check_llm_key.py") $SelectedProviderId $apiKey $SelectedApiBase 2>$null
+                    } else {
+                        $hcResult = & $UvCmd run python (Join-Path $ProjectDir "scripts/check_llm_key.py") $SelectedProviderId $apiKey 2>$null
+                    }
+                    Pop-Location
+                    $hcJson = $hcResult | ConvertFrom-Json
+                    if ($hcJson.valid -eq $true) {
+                        Write-Color -Text "ok" -Color Green
+                        break
+                    } elseif ($hcJson.valid -eq $false) {
+                        Write-Color -Text "failed" -Color Red
+                        Write-Warn $hcJson.message
+                        # Undo the save so user can retry cleanly
+                        [System.Environment]::SetEnvironmentVariable($SelectedEnvVar, $null, "User")
+                        Remove-Item -Path "Env:\$SelectedEnvVar" -ErrorAction SilentlyContinue
+                        Write-Host ""
+                        Read-Host "  Press Enter to try again"
+                        # loop back to key prompt
+                    } else {
+                        Write-Color -Text "--" -Color Yellow
+                        Write-Color -Text "  Could not verify key (network issue). The key has been saved." -Color DarkGray
+                        break
+                    }
+                } catch {
+                    Pop-Location
+                    Write-Color -Text "--" -Color Yellow
+                    Write-Color -Text "  Could not verify key (network issue). The key has been saved." -Color DarkGray
+                    break
+                }
+            } elseif (-not $existingKey) {
+                # No existing key and user skipped
+                Write-Host ""
+                Write-Warn "Skipped. Set the environment variable manually when ready:"
+                Write-Host "  [System.Environment]::SetEnvironmentVariable('$SelectedEnvVar', 'your-key', 'User')"
+                $SelectedEnvVar     = ""
+                $SelectedProviderId = ""
+                break
+            } else {
+                # User pressed Enter with existing key -- keep it
+                break
+            }
+        }
+    }
+    { $_ -eq $SkipChoice } {
+        Write-Host ""
+        Write-Warn "Skipped. A worker LLM provider is required for worker agents."
+        Write-Host "  Run this script again when ready."
+        Write-Host ""
+        $SelectedEnvVar     = ""
+        $SelectedProviderId = ""
+    }
+}
+
+# For ZAI subscription: prompt for API key (allow replacement if already set) with verification + retry
+if ($SubscriptionMode -eq "zai_code") {
+    while ($true) {
+        $existingZai = [System.Environment]::GetEnvironmentVariable("ZAI_API_KEY", "User")
+        if (-not $existingZai) { $existingZai = $env:ZAI_API_KEY }
+
+        if ($existingZai) {
+            $masked = $existingZai.Substring(0, [Math]::Min(4, $existingZai.Length)) + "..." + $existingZai.Substring([Math]::Max(0, $existingZai.Length - 4))
+            Write-Host ""
+            Write-Color -Text "  $([char]0x2B22) Current ZAI key: $masked" -Color Green
+            $apiKey = Read-Host "  Press Enter to keep, or paste a new key to replace"
+        } else {
+            Write-Host ""
+            $apiKey = Read-Host "Paste your ZAI API key (or press Enter to skip)"
+        }
+
+        if ($apiKey) {
+            [System.Environment]::SetEnvironmentVariable("ZAI_API_KEY", $apiKey, "User")
+            $env:ZAI_API_KEY = $apiKey
+            Write-Host ""
+            Write-Ok "ZAI API key saved as User environment variable"
+
+            # Health check the new key
+            Write-Host "  Verifying ZAI API key... " -NoNewline
+            try {
+                Push-Location $ProjectDir
+                $hcResult = & $UvCmd run python (Join-Path $ProjectDir "scripts/check_llm_key.py") "zai" $apiKey "https://api.z.ai/api/coding/paas/v4" 2>$null
+                Pop-Location
+                $hcJson = $hcResult | ConvertFrom-Json
+                if ($hcJson.valid -eq $true) {
+                    Write-Color -Text "ok" -Color Green
+                    break
+                } elseif ($hcJson.valid -eq $false) {
+                    Write-Color -Text "failed" -Color Red
+                    Write-Warn $hcJson.message
+                    # Undo the save so user can retry cleanly
+                    [System.Environment]::SetEnvironmentVariable("ZAI_API_KEY", $null, "User")
+                    Remove-Item -Path "Env:\ZAI_API_KEY" -ErrorAction SilentlyContinue
+                    Write-Host ""
+                    Read-Host "  Press Enter to try again"
+                    # loop back to key prompt
+                } else {
+                    Write-Color -Text "--" -Color Yellow
+                    Write-Color -Text "  Could not verify key (network issue). The key has been saved." -Color DarkGray
+                    break
+                }
+            } catch {
+                Pop-Location
+                Write-Color -Text "--" -Color Yellow
+                Write-Color -Text "  Could not verify key (network issue). The key has been saved." -Color DarkGray
+                break
+            }
+        } elseif (-not $existingZai) {
+            # No existing key and user skipped
+            Write-Host ""
+            Write-Warn "Skipped. Add your ZAI API key later:"
+            Write-Color -Text "  [System.Environment]::SetEnvironmentVariable('ZAI_API_KEY', 'your-key', 'User')" -Color Cyan
+            $SelectedEnvVar     = ""
+            $SelectedProviderId = ""
+            $SubscriptionMode   = ""
+            break
+        } else {
+            # User pressed Enter with existing key -- keep it
             break
         }
-        Write-Color -Text "Invalid choice." -Color Red
     }
-} else {
+}
+
+# For Kimi Code subscription: prompt for API key with verification + retry
+if ($SubscriptionMode -eq "kimi_code") {
+    while ($true) {
+        $existingKimi = [System.Environment]::GetEnvironmentVariable("KIMI_API_KEY", "User")
+        if (-not $existingKimi) { $existingKimi = $env:KIMI_API_KEY }
+
+        if ($existingKimi) {
+            $masked = $existingKimi.Substring(0, [Math]::Min(4, $existingKimi.Length)) + "..." + $existingKimi.Substring([Math]::Max(0, $existingKimi.Length - 4))
+            Write-Host ""
+            Write-Color -Text "  $([char]0x2B22) Current Kimi key: $masked" -Color Green
+            $apiKey = Read-Host "  Press Enter to keep, or paste a new key to replace"
+        } else {
+            Write-Host ""
+            Write-Host "Get your API key from: " -NoNewline
+            Write-Color -Text "https://www.kimi.com/code" -Color Cyan
+            Write-Host ""
+            $apiKey = Read-Host "Paste your Kimi API key (or press Enter to skip)"
+        }
+
+        if ($apiKey) {
+            [System.Environment]::SetEnvironmentVariable("KIMI_API_KEY", $apiKey, "User")
+            $env:KIMI_API_KEY = $apiKey
+            Write-Host ""
+            Write-Ok "Kimi API key saved as User environment variable"
+
+            # Health check the new key
+            Write-Host "  Verifying Kimi API key... " -NoNewline
+            try {
+                Push-Location $ProjectDir
+                $hcResult = & $UvCmd run python (Join-Path $ProjectDir "scripts/check_llm_key.py") "kimi" $apiKey "https://api.kimi.com/coding" 2>$null
+                Pop-Location
+                $hcJson = $hcResult | ConvertFrom-Json
+                if ($hcJson.valid -eq $true) {
+                    Write-Color -Text "ok" -Color Green
+                    break
+                } elseif ($hcJson.valid -eq $false) {
+                    Write-Color -Text "failed" -Color Red
+                    Write-Warn $hcJson.message
+                    [System.Environment]::SetEnvironmentVariable("KIMI_API_KEY", $null, "User")
+                    Remove-Item -Path "Env:\KIMI_API_KEY" -ErrorAction SilentlyContinue
+                    Write-Host ""
+                    Read-Host "  Press Enter to try again"
+                } else {
+                    Write-Color -Text "--" -Color Yellow
+                    Write-Color -Text "  Could not verify key (network issue). The key has been saved." -Color DarkGray
+                    break
+                }
+            } catch {
+                Pop-Location
+                Write-Color -Text "--" -Color Yellow
+                Write-Color -Text "  Could not verify key (network issue). The key has been saved." -Color DarkGray
+                break
+            }
+        } elseif (-not $existingKimi) {
+            Write-Host ""
+            Write-Warn "Skipped. Add your Kimi API key later:"
+            Write-Color -Text "  [System.Environment]::SetEnvironmentVariable('KIMI_API_KEY', 'your-key', 'User')" -Color Cyan
+            $SelectedEnvVar     = ""
+            $SelectedProviderId = ""
+            $SubscriptionMode   = ""
+            break
+        } else {
+            break
+        }
+    }
+}
+
+# For Hive LLM: prompt for API key with verification + retry
+if ($SubscriptionMode -eq "hive_llm") {
+    while ($true) {
+        $existingHive = [System.Environment]::GetEnvironmentVariable("HIVE_API_KEY", "User")
+        if (-not $existingHive) { $existingHive = $env:HIVE_API_KEY }
+
+        if ($existingHive) {
+            $masked = $existingHive.Substring(0, [Math]::Min(4, $existingHive.Length)) + "..." + $existingHive.Substring([Math]::Max(0, $existingHive.Length - 4))
+            Write-Host ""
+            Write-Color -Text "  $([char]0x2B22) Current Hive key: $masked" -Color Green
+            Write-Host ""
+            $apiKey = Read-Host "Paste a new Hive API key (or press Enter to keep current)"
+        } else {
+            Write-Host ""
+            Write-Host "  Get your API key from: " -NoNewline
+            Write-Color -Text "https://discord.com/invite/hQdU7QDkgR" -Color Cyan
+            Write-Host ""
+            $apiKey = Read-Host "Paste your Hive API key (or press Enter to skip)"
+        }
+
+        if ($apiKey) {
+            [System.Environment]::SetEnvironmentVariable("HIVE_API_KEY", $apiKey, "User")
+            $env:HIVE_API_KEY = $apiKey
+            Write-Host ""
+            Write-Ok "Hive API key saved as User environment variable"
+
+            # Health check the new key
+            Write-Host "  Verifying Hive API key... " -NoNewline
+            try {
+                Push-Location $ProjectDir
+                $hcResult = & $UvCmd run python (Join-Path $ProjectDir "scripts/check_llm_key.py") "hive" $apiKey "$HiveLlmEndpoint" 2>$null
+                Pop-Location
+                $hcJson = $hcResult | ConvertFrom-Json
+                if ($hcJson.valid -eq $true) {
+                    Write-Color -Text "ok" -Color Green
+                    break
+                } elseif ($hcJson.valid -eq $false) {
+                    Write-Color -Text "failed" -Color Red
+                    Write-Warn $hcJson.message
+                    [System.Environment]::SetEnvironmentVariable("HIVE_API_KEY", $null, "User")
+                    Remove-Item -Path "Env:\HIVE_API_KEY" -ErrorAction SilentlyContinue
+                    Write-Host ""
+                    Read-Host "  Press Enter to try again"
+                } else {
+                    Write-Color -Text "--" -Color Yellow
+                    Write-Color -Text "  Could not verify key (network issue). The key has been saved." -Color DarkGray
+                    break
+                }
+            } catch {
+                Pop-Location
+                Write-Color -Text "--" -Color Yellow
+                break
+            }
+        } elseif (-not $existingHive) {
+            Write-Host ""
+            Write-Warn "Skipped. Add your Hive API key later:"
+            Write-Color -Text "  [System.Environment]::SetEnvironmentVariable('HIVE_API_KEY', 'your-key', 'User')" -Color Cyan
+            $SelectedEnvVar     = ""
+            $SelectedProviderId = ""
+            $SubscriptionMode   = ""
+            break
+        } else {
+            break
+        }
+    }
+}
+
+# Prompt for model if not already selected (manual provider path)
+if ($SelectedProviderId -and -not $SelectedModel) {
+    $modelSel = Get-ModelSelection $SelectedProviderId
+    $SelectedModel            = $modelSel.Model
+    $SelectedMaxTokens        = $modelSel.MaxTokens
+    $SelectedMaxContextTokens = $modelSel.MaxContextTokens
+}
+
+# ============================================================
+# Save configuration to worker_llm section
+# ============================================================
+
+if ($SelectedProviderId) {
+    if (-not $SelectedModel) {
+        $SelectedModel = $DefaultModels[$SelectedProviderId]
+    }
     Write-Host ""
-    Write-Ok "Worker model: $SelectedModel"
-}
+    Write-Host "  Saving worker model configuration... " -NoNewline
 
-# Confirm and save
-Write-Host ""
-$confirm = Read-Host "Save this worker model configuration? [Y/n]"
-if ($confirm -and $confirm -notmatch "^[Yy]") {
-    Write-Host ""
-    Write-Host "Cancelled. Worker agents will continue using the default model."
-    exit 0
-}
+    if (-not (Test-Path $HiveConfigDir)) {
+        New-Item -ItemType Directory -Path $HiveConfigDir -Force | Out-Null
+    }
 
-Write-Host ""
-Write-Host "  Saving worker model configuration... " -NoNewline
-
-# Read existing config, add worker_llm section
-if (-not (Test-Path $HiveConfigDir)) {
-    New-Item -ItemType Directory -Path $HiveConfigDir -Force | Out-Null
-}
-
-try {
-    if (Test-Path $HiveConfigFile) {
-        $config = Get-Content -Path $HiveConfigFile -Raw | ConvertFrom-Json
-    } else {
+    try {
+        if (Test-Path $HiveConfigFile) {
+            $config = Get-Content -Path $HiveConfigFile -Raw | ConvertFrom-Json
+        } else {
+            $config = @{}
+        }
+    } catch {
         $config = @{}
     }
-} catch {
-    $config = @{}
-}
 
-$workerLlm = @{
-    provider           = $SelectedProviderId
-    model              = $SelectedModel
-    max_tokens         = $SelectedMaxTokens
-    max_context_tokens = $SelectedMaxContextTokens
-}
+    $workerLlm = @{
+        provider           = $SelectedProviderId
+        model              = $SelectedModel
+        max_tokens         = $SelectedMaxTokens
+        max_context_tokens = $SelectedMaxContextTokens
+    }
 
-if ($SelectedEnvVar) {
-    $workerLlm["api_key_env_var"] = $SelectedEnvVar
-}
-if ($SelectedApiBase) {
-    $workerLlm["api_base"] = $SelectedApiBase
-}
+    if ($SubscriptionMode -eq "claude_code") {
+        $workerLlm["use_claude_code_subscription"] = $true
+    } elseif ($SubscriptionMode -eq "codex") {
+        $workerLlm["use_codex_subscription"] = $true
+    } elseif ($SubscriptionMode -eq "zai_code") {
+        $workerLlm["api_base"] = "https://api.z.ai/api/coding/paas/v4"
+        $workerLlm["api_key_env_var"] = $SelectedEnvVar
+    } elseif ($SubscriptionMode -eq "kimi_code") {
+        $workerLlm["api_base"] = "https://api.kimi.com/coding"
+        $workerLlm["api_key_env_var"] = $SelectedEnvVar
+    } elseif ($SubscriptionMode -eq "hive_llm") {
+        $workerLlm["api_base"] = $HiveLlmEndpoint
+        $workerLlm["api_key_env_var"] = $SelectedEnvVar
+    } elseif ($SelectedProviderId -eq "openrouter") {
+        $workerLlm["api_base"] = "https://openrouter.ai/api/v1"
+        $workerLlm["api_key_env_var"] = $SelectedEnvVar
+    } else {
+        $workerLlm["api_key_env_var"] = $SelectedEnvVar
+    }
 
-$config | Add-Member -NotePropertyName "worker_llm" -NotePropertyValue $workerLlm -Force
-$config | ConvertTo-Json -Depth 4 | Set-Content -Path $HiveConfigFile -Encoding UTF8
-Write-Ok "done"
-Write-Color -Text "  ~/.hive/configuration.json (worker_llm section)" -Color DarkGray
+    $config | Add-Member -NotePropertyName "worker_llm" -NotePropertyValue $workerLlm -Force
+    $config | ConvertTo-Json -Depth 4 | Set-Content -Path $HiveConfigFile -Encoding UTF8
+    Write-Ok "done"
+    Write-Color -Text "  ~/.hive/configuration.json (worker_llm section)" -Color DarkGray
 
-Write-Host ""
-Write-Ok "Worker model configured successfully."
-Write-Color -Text "  Worker agents will now use: $SelectedProviderId/$SelectedModel" -Color DarkGray
-Write-Color -Text "  Run this script again to change, or remove the worker_llm section" -Color DarkGray
-Write-Color -Text "  from ~/.hive/configuration.json to revert to the default." -Color DarkGray
-Write-Host ""
+    Write-Host ""
+    Write-Ok "Worker model configured successfully."
+    Write-Color -Text "  Worker agents will now use: $SelectedProviderId/$SelectedModel" -Color DarkGray
+    Write-Color -Text "  Run this script again to change, or remove the worker_llm section" -Color DarkGray
+    Write-Color -Text "  from ~/.hive/configuration.json to revert to the default." -Color DarkGray
+    Write-Host ""
+}

--- a/scripts/setup_worker_model.ps1
+++ b/scripts/setup_worker_model.ps1
@@ -1,0 +1,284 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    setup_worker_model.ps1 - Configure a separate LLM model for worker agents
+
+.DESCRIPTION
+    Worker agents can use a different (e.g. cheaper/faster) model than the
+    queen agent.  This script writes a "worker_llm" section to
+    ~/.hive/configuration.json.  If no worker model is configured, workers
+    fall back to the default (queen) model.
+
+.NOTES
+    Run from the project root: .\scripts\setup_worker_model.ps1
+#>
+
+$ErrorActionPreference = "Continue"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$ProjectDir = Split-Path -Parent $ScriptDir
+$UvHelperPath = Join-Path $ScriptDir "uv-discovery.ps1"
+$HiveConfigDir = Join-Path $env:USERPROFILE ".hive"
+$HiveConfigFile = Join-Path $HiveConfigDir "configuration.json"
+
+. $UvHelperPath
+
+# ============================================================
+# Colors / helpers
+# ============================================================
+
+function Write-Color {
+    param(
+        [string]$Text,
+        [ConsoleColor]$Color = [ConsoleColor]::White,
+        [switch]$NoNewline
+    )
+    $prev = $Host.UI.RawUI.ForegroundColor
+    $Host.UI.RawUI.ForegroundColor = $Color
+    if ($NoNewline) { Write-Host $Text -NoNewline }
+    else { Write-Host $Text }
+    $Host.UI.RawUI.ForegroundColor = $prev
+}
+
+function Write-Ok {
+    param([string]$Text)
+    Write-Color -Text "$([char]0x2B22) $Text" -Color Green
+}
+
+function Write-Warn {
+    param([string]$Text)
+    Write-Color -Text "$([char]0x2B22) $Text" -Color Yellow
+}
+
+# ============================================================
+# Provider / model definitions
+# ============================================================
+
+$ProviderEnvVars = @{
+    "ANTHROPIC_API_KEY"  = @{ Name = "Anthropic (Claude)"; Id = "anthropic" }
+    "OPENAI_API_KEY"     = @{ Name = "OpenAI (GPT)"; Id = "openai" }
+    "GEMINI_API_KEY"     = @{ Name = "Google Gemini"; Id = "gemini" }
+    "GROQ_API_KEY"       = @{ Name = "Groq"; Id = "groq" }
+    "CEREBRAS_API_KEY"   = @{ Name = "Cerebras"; Id = "cerebras" }
+    "OPENROUTER_API_KEY" = @{ Name = "OpenRouter"; Id = "openrouter" }
+    "MISTRAL_API_KEY"    = @{ Name = "Mistral"; Id = "mistral" }
+    "TOGETHER_API_KEY"   = @{ Name = "Together AI"; Id = "together" }
+    "DEEPSEEK_API_KEY"   = @{ Name = "DeepSeek"; Id = "deepseek" }
+}
+
+$DefaultModels = @{
+    "anthropic"   = "claude-haiku-4-5-20251001"
+    "openai"      = "gpt-5-mini"
+    "gemini"      = "gemini-3-flash-preview"
+    "groq"        = "moonshotai/kimi-k2-instruct-0905"
+    "cerebras"    = "zai-glm-4.7"
+    "mistral"     = "mistral-large-latest"
+    "together_ai" = "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+    "deepseek"    = "deepseek-chat"
+}
+
+$ModelChoices = @{
+    "anthropic" = @(
+        @{ Id = "claude-haiku-4-5-20251001";  Label = "Haiku 4.5 - Fast + cheap (recommended for workers)"; MaxTokens = 8192;  MaxContext = 180000 }
+        @{ Id = "claude-sonnet-4-20250514";   Label = "Sonnet 4 - Fast + capable";                         MaxTokens = 8192;  MaxContext = 180000 }
+        @{ Id = "claude-sonnet-4-5-20250929"; Label = "Sonnet 4.5 - Best balance";                         MaxTokens = 16384; MaxContext = 180000 }
+        @{ Id = "claude-opus-4-6";            Label = "Opus 4.6 - Most capable";                           MaxTokens = 32768; MaxContext = 180000 }
+    )
+    "openai" = @(
+        @{ Id = "gpt-5-mini"; Label = "GPT-5 Mini - Fast + cheap (recommended for workers)"; MaxTokens = 16384; MaxContext = 120000 }
+        @{ Id = "gpt-5.2";    Label = "GPT-5.2 - Most capable";                              MaxTokens = 16384; MaxContext = 120000 }
+    )
+    "gemini" = @(
+        @{ Id = "gemini-3-flash-preview";   Label = "Gemini 3 Flash - Fast (recommended for workers)"; MaxTokens = 8192; MaxContext = 900000 }
+        @{ Id = "gemini-3.1-pro-preview";   Label = "Gemini 3.1 Pro - Best quality";                   MaxTokens = 8192; MaxContext = 900000 }
+    )
+    "groq" = @(
+        @{ Id = "moonshotai/kimi-k2-instruct-0905"; Label = "Kimi K2 - Best quality (recommended)"; MaxTokens = 8192; MaxContext = 120000 }
+        @{ Id = "openai/gpt-oss-120b";              Label = "GPT-OSS 120B - Fast reasoning";        MaxTokens = 8192; MaxContext = 120000 }
+    )
+    "cerebras" = @(
+        @{ Id = "zai-glm-4.7";                     Label = "ZAI-GLM 4.7 - Best quality (recommended)"; MaxTokens = 8192; MaxContext = 120000 }
+        @{ Id = "qwen3-235b-a22b-instruct-2507";   Label = "Qwen3 235B - Frontier reasoning";          MaxTokens = 8192; MaxContext = 120000 }
+    )
+}
+
+# ============================================================
+# Main
+# ============================================================
+
+$uvInfo = Find-Uv
+if (-not $uvInfo) {
+    Write-Color -Text "uv not found. Run quickstart.ps1 first." -Color Red
+    exit 1
+}
+$UvCmd = $uvInfo.Path
+
+Write-Host ""
+Write-Color -Text "$([char]0x2B22) Worker Model Setup" -Color Yellow
+Write-Host ""
+Write-Color -Text "Configure a separate LLM model for worker agents." -Color DarkGray
+Write-Color -Text "Worker agents will use this model instead of the default queen model." -Color DarkGray
+Write-Host ""
+
+# Show current configuration
+if (Test-Path $HiveConfigFile) {
+    try {
+        Push-Location $ProjectDir
+        $currentConfig = & $UvCmd run python -c "
+from framework.config import get_preferred_model, get_preferred_worker_model
+print(f'Queen:  {get_preferred_model()}')
+wm = get_preferred_worker_model()
+print(f'Worker: {wm if wm else chr(34) + \"(same as queen)\" + chr(34)}')
+" 2>$null
+        Pop-Location
+        if ($currentConfig) {
+            Write-Color -Text "Current configuration:" -Color White
+            foreach ($line in $currentConfig) {
+                Write-Color -Text "  $line" -Color DarkGray
+            }
+            Write-Host ""
+        }
+    } catch {
+        Pop-Location
+    }
+}
+
+# Detect available providers
+$AvailableProviders = @()
+foreach ($envVar in $ProviderEnvVars.Keys) {
+    $val = [System.Environment]::GetEnvironmentVariable($envVar, "User")
+    if (-not $val) { $val = [System.Environment]::GetEnvironmentVariable($envVar) }
+    if ($val) {
+        $AvailableProviders += @{
+            EnvVar = $envVar
+            Name   = $ProviderEnvVars[$envVar].Name
+            Id     = $ProviderEnvVars[$envVar].Id
+        }
+    }
+}
+
+if ($AvailableProviders.Count -eq 0) {
+    Write-Color -Text "No API keys found." -Color Red
+    Write-Host "Run .\quickstart.ps1 first to set up your LLM provider."
+    exit 1
+}
+
+# Pick provider
+$SelectedProvider = $null
+if ($AvailableProviders.Count -eq 1) {
+    $SelectedProvider = $AvailableProviders[0]
+    Write-Ok "Provider: $($SelectedProvider.Name)"
+} else {
+    Write-Color -Text "Select provider for worker agents:" -Color White
+    Write-Host ""
+    for ($i = 0; $i -lt $AvailableProviders.Count; $i++) {
+        Write-Host "  " -NoNewline
+        Write-Color -Text "$($i+1))" -Color Cyan -NoNewline
+        Write-Host " $($AvailableProviders[$i].Name)"
+    }
+    Write-Host ""
+    while ($true) {
+        $choice = Read-Host "Enter choice (1-$($AvailableProviders.Count))"
+        $idx = [int]$choice - 1
+        if ($idx -ge 0 -and $idx -lt $AvailableProviders.Count) {
+            $SelectedProvider = $AvailableProviders[$idx]
+            Write-Host ""
+            Write-Ok "Provider: $($SelectedProvider.Name)"
+            break
+        }
+        Write-Color -Text "Invalid choice." -Color Red
+    }
+}
+
+$SelectedProviderId = $SelectedProvider.Id
+$SelectedEnvVar = $SelectedProvider.EnvVar
+$SelectedModel = $DefaultModels[$SelectedProviderId]
+$SelectedMaxTokens = 8192
+$SelectedMaxContextTokens = 120000
+$SelectedApiBase = ""
+
+if ($SelectedProviderId -eq "openrouter") {
+    $SelectedApiBase = "https://openrouter.ai/api/v1"
+}
+
+# Select model
+$choices = $ModelChoices[$SelectedProviderId]
+if ($choices -and $choices.Count -gt 0) {
+    Write-Host ""
+    Write-Color -Text "Select worker model:" -Color White
+    for ($i = 0; $i -lt $choices.Count; $i++) {
+        Write-Host "  " -NoNewline
+        Write-Color -Text "$($i+1))" -Color Cyan -NoNewline
+        Write-Host " $($choices[$i].Label)"
+    }
+    Write-Host ""
+    while ($true) {
+        $choice = Read-Host "Enter choice (1-$($choices.Count)) [1]"
+        if (-not $choice) { $choice = "1" }
+        $idx = [int]$choice - 1
+        if ($idx -ge 0 -and $idx -lt $choices.Count) {
+            $SelectedModel = $choices[$idx].Id
+            $SelectedMaxTokens = $choices[$idx].MaxTokens
+            $SelectedMaxContextTokens = $choices[$idx].MaxContext
+            Write-Host ""
+            Write-Ok "Worker model: $SelectedModel"
+            break
+        }
+        Write-Color -Text "Invalid choice." -Color Red
+    }
+} else {
+    Write-Host ""
+    Write-Ok "Worker model: $SelectedModel"
+}
+
+# Confirm and save
+Write-Host ""
+$confirm = Read-Host "Save this worker model configuration? [Y/n]"
+if ($confirm -and $confirm -notmatch "^[Yy]") {
+    Write-Host ""
+    Write-Host "Cancelled. Worker agents will continue using the default model."
+    exit 0
+}
+
+Write-Host ""
+Write-Host "  Saving worker model configuration... " -NoNewline
+
+# Read existing config, add worker_llm section
+if (-not (Test-Path $HiveConfigDir)) {
+    New-Item -ItemType Directory -Path $HiveConfigDir -Force | Out-Null
+}
+
+try {
+    if (Test-Path $HiveConfigFile) {
+        $config = Get-Content -Path $HiveConfigFile -Raw | ConvertFrom-Json
+    } else {
+        $config = @{}
+    }
+} catch {
+    $config = @{}
+}
+
+$workerLlm = @{
+    provider           = $SelectedProviderId
+    model              = $SelectedModel
+    max_tokens         = $SelectedMaxTokens
+    max_context_tokens = $SelectedMaxContextTokens
+}
+
+if ($SelectedEnvVar) {
+    $workerLlm["api_key_env_var"] = $SelectedEnvVar
+}
+if ($SelectedApiBase) {
+    $workerLlm["api_base"] = $SelectedApiBase
+}
+
+$config | Add-Member -NotePropertyName "worker_llm" -NotePropertyValue $workerLlm -Force
+$config | ConvertTo-Json -Depth 4 | Set-Content -Path $HiveConfigFile -Encoding UTF8
+Write-Ok "done"
+Write-Color -Text "  ~/.hive/configuration.json (worker_llm section)" -Color DarkGray
+
+Write-Host ""
+Write-Ok "Worker model configured successfully."
+Write-Color -Text "  Worker agents will now use: $SelectedProviderId/$SelectedModel" -Color DarkGray
+Write-Color -Text "  Run this script again to change, or remove the worker_llm section" -Color DarkGray
+Write-Color -Text "  from ~/.hive/configuration.json to revert to the default." -Color DarkGray
+Write-Host ""

--- a/scripts/setup_worker_model.sh
+++ b/scripts/setup_worker_model.sh
@@ -7,6 +7,8 @@
 # ~/.hive/configuration.json.  If no worker model is configured, workers
 # fall back to the default (queen) model.
 #
+# The provider selection flow is identical to quickstart.sh.
+#
 
 set -e
 
@@ -27,28 +29,36 @@ BOLD='\033[1m'
 DIM='\033[2m'
 NC='\033[0m'
 
+# Hive LLM endpoint
+HIVE_LLM_ENDPOINT="https://api.adenhq.com"
+
 # Get the directory where this script is located, then the project root
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
-HIVE_CONFIG_FILE="$HOME/.hive/configuration.json"
+HIVE_CONFIG_DIR="$HOME/.hive"
+HIVE_CONFIG_FILE="$HIVE_CONFIG_DIR/configuration.json"
 
-# Helper function for prompts
-prompt_yes_no() {
-    local prompt="$1"
-    local default="${2:-y}"
-    local response
-
-    if [ "$default" = "y" ]; then
-        prompt="$prompt [Y/n] "
-    else
-        prompt="$prompt [y/N] "
+# ── Detect Python ─────────────────────────────────────────────────────
+PYTHON_CMD=""
+for CANDIDATE in python3.11 python3.12 python3.13 python3 python; do
+    if command -v "$CANDIDATE" &> /dev/null; then
+        PYTHON_MAJOR=$("$CANDIDATE" -c 'import sys; print(sys.version_info.major)')
+        PYTHON_MINOR=$("$CANDIDATE" -c 'import sys; print(sys.version_info.minor)')
+        if [ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -ge 11 ]; then
+            PYTHON_CMD="$CANDIDATE"
+            break
+        fi
     fi
-    read -r -p "$prompt" response
-    response="${response:-$default}"
-    [[ "$response" =~ ^[Yy] ]]
-}
+done
 
-# ── Provider / model definitions (same as quickstart) ────────────────
+if [ -z "$PYTHON_CMD" ]; then
+    PYTHON_CMD="python3"
+    if ! command -v python3 &> /dev/null; then
+        PYTHON_CMD="python"
+    fi
+fi
+
+# ── Provider / model definitions (identical to quickstart) ────────────
 
 if [ "$USE_ASSOC_ARRAYS" = true ]; then
     declare -A PROVIDER_NAMES=(
@@ -228,42 +238,185 @@ else
     get_model_choice_maxcontexttokens() { local idx=$(_mc_nth "$1" "$2"); echo "${MC_MAXCONTEXTTOKENS[$idx]}"; }
 fi
 
-# ── Model selection prompt ───────────────────────────────────────────
+# ── Detect user's shell rc file ──────────────────────────────────────
 
-select_model() {
+detect_shell_rc() {
+    local shell_name
+    shell_name=$(basename "$SHELL")
+
+    case "$shell_name" in
+        zsh)
+            if [ -f "$HOME/.zshrc" ]; then
+                echo "$HOME/.zshrc"
+            else
+                echo "$HOME/.zshenv"
+            fi
+            ;;
+        bash)
+            if [ -f "$HOME/.bashrc" ]; then
+                echo "$HOME/.bashrc"
+            elif [ -f "$HOME/.bash_profile" ]; then
+                echo "$HOME/.bash_profile"
+            else
+                echo "$HOME/.profile"
+            fi
+            ;;
+        *)
+            echo "$HOME/.profile"
+            ;;
+    esac
+}
+
+SHELL_RC_FILE=$(detect_shell_rc)
+
+# ── Normalize OpenRouter model IDs ───────────────────────────────────
+
+normalize_openrouter_model_id() {
+    local raw="$1"
+    # Trim leading/trailing whitespace
+    raw="${raw#"${raw%%[![:space:]]*}"}"
+    raw="${raw%"${raw##*[![:space:]]}"}"
+    if [[ "$raw" =~ ^[Oo][Pp][Ee][Nn][Rr][Oo][Uu][Tt][Ee][Rr]/(.+)$ ]]; then
+        raw="${BASH_REMATCH[1]}"
+    fi
+    printf '%s' "$raw"
+}
+
+# ── Model selection prompt (identical to quickstart) ─────────────────
+
+prompt_model_selection() {
     local provider_id="$1"
+
+    if [ "$provider_id" = "openrouter" ]; then
+        local default_model=""
+        if [ -n "$PREV_MODEL" ] && [ "$provider_id" = "$PREV_PROVIDER" ]; then
+            default_model="$(normalize_openrouter_model_id "$PREV_MODEL")"
+        fi
+        echo ""
+        echo -e "${BOLD}Enter your OpenRouter model id:${NC}"
+        echo -e "  ${DIM}Paste from openrouter.ai (example: x-ai/grok-4.20-beta)${NC}"
+        echo -e "  ${DIM}If calls fail with guardrail/privacy errors: openrouter.ai/settings/privacy${NC}"
+        echo ""
+        local input_model=""
+        while true; do
+            if [ -n "$default_model" ]; then
+                read -r -p "Model id [$default_model]: " input_model || true
+                input_model="${input_model:-$default_model}"
+            else
+                read -r -p "Model id: " input_model || true
+            fi
+            local normalized_model
+            normalized_model="$(normalize_openrouter_model_id "$input_model")"
+            if [ -n "$normalized_model" ]; then
+                local openrouter_key=""
+                if [ -n "${SELECTED_ENV_VAR:-}" ]; then
+                    openrouter_key="${!SELECTED_ENV_VAR:-}"
+                fi
+
+                if [ -n "$openrouter_key" ]; then
+                    local model_hc_result=""
+                    local model_hc_valid=""
+                    local model_hc_msg=""
+                    local model_hc_canonical=""
+                    local model_hc_base="${SELECTED_API_BASE:-https://openrouter.ai/api/v1}"
+                    echo -n "  Verifying model id... "
+                    model_hc_result="$(cd "$PROJECT_DIR" && uv run python "$PROJECT_DIR/scripts/check_llm_key.py" "openrouter" "$openrouter_key" "$model_hc_base" "$normalized_model" 2>/dev/null)" || true
+                    model_hc_valid="$(echo "$model_hc_result" | $PYTHON_CMD -c "import json,sys; print(json.loads(sys.stdin.read()).get('valid',''))" 2>/dev/null)" || true
+                    model_hc_msg="$(echo "$model_hc_result" | $PYTHON_CMD -c "import json,sys; print(json.loads(sys.stdin.read()).get('message',''))" 2>/dev/null)" || true
+                    model_hc_canonical="$(echo "$model_hc_result" | $PYTHON_CMD -c "import json,sys; print(json.loads(sys.stdin.read()).get('model',''))" 2>/dev/null)" || true
+                    if [ "$model_hc_valid" = "True" ]; then
+                        if [ -n "$model_hc_canonical" ]; then
+                            normalized_model="$model_hc_canonical"
+                        fi
+                        echo -e "${GREEN}ok${NC}"
+                    elif [ "$model_hc_valid" = "False" ]; then
+                        echo -e "${RED}failed${NC}"
+                        echo -e "  ${YELLOW}⚠ $model_hc_msg${NC}"
+                        echo ""
+                        continue
+                    else
+                        echo -e "${YELLOW}--${NC}"
+                        echo -e "  ${DIM}Could not verify model id (network issue). Continuing with your selection.${NC}"
+                    fi
+                else
+                    echo -e "  ${DIM}Skipping model verification (OpenRouter key not available in current shell).${NC}"
+                fi
+
+                SELECTED_MODEL="$normalized_model"
+                SELECTED_MAX_TOKENS=8192
+                SELECTED_MAX_CONTEXT_TOKENS=120000
+                echo ""
+                echo -e "${GREEN}⬢${NC} Model: ${DIM}$SELECTED_MODEL${NC}"
+                return
+            fi
+            echo -e "${RED}Model id cannot be empty.${NC}"
+        done
+    fi
+
     local count
-    count=$(get_model_choice_count "$provider_id")
+    count="$(get_model_choice_count "$provider_id")"
 
     if [ "$count" -eq 0 ]; then
+        # No curated choices for this provider (e.g. Mistral, DeepSeek)
         SELECTED_MODEL="$(get_default_model "$provider_id")"
         SELECTED_MAX_TOKENS=8192
         SELECTED_MAX_CONTEXT_TOKENS=120000
-        echo ""
-        echo -e "${GREEN}⬢${NC} Worker model: ${DIM}$SELECTED_MODEL${NC}"
         return
     fi
 
+    if [ "$count" -eq 1 ]; then
+        # Only one choice — auto-select
+        SELECTED_MODEL="$(get_model_choice_id "$provider_id" 0)"
+        SELECTED_MAX_TOKENS="$(get_model_choice_maxtokens "$provider_id" 0)"
+        SELECTED_MAX_CONTEXT_TOKENS="$(get_model_choice_maxcontexttokens "$provider_id" 0)"
+        return
+    fi
+
+    # Multiple choices — show menu
     echo ""
-    echo -e "${BOLD}Select worker model:${NC}"
+    echo -e "${BOLD}Select a model:${NC}"
+    echo ""
+
+    # Find default index from previous model (if same provider)
+    local default_idx=""
+    if [ -n "$PREV_MODEL" ] && [ "$provider_id" = "$PREV_PROVIDER" ]; then
+        local j=0
+        while [ $j -lt "$count" ]; do
+            if [ "$(get_model_choice_id "$provider_id" "$j")" = "$PREV_MODEL" ]; then
+                default_idx=$((j + 1))
+                break
+            fi
+            j=$((j + 1))
+        done
+    fi
+
     local i=0
-    while [ "$i" -lt "$count" ]; do
-        echo -e "  ${CYAN}$((i+1)))${NC} $(get_model_choice_label "$provider_id" "$i")"
+    while [ $i -lt "$count" ]; do
+        local label
+        label="$(get_model_choice_label "$provider_id" "$i")"
+        local mid
+        mid="$(get_model_choice_id "$provider_id" "$i")"
+        local num=$((i + 1))
+        echo -e "  ${CYAN}$num)${NC} $label  ${DIM}($mid)${NC}"
         i=$((i + 1))
     done
     echo ""
 
+    local choice
     while true; do
-        local default_idx=1
-        read -r -p "Enter choice (1-$count) [$default_idx]: " choice || true
-        choice="${choice:-$default_idx}"
+        if [ -n "$default_idx" ]; then
+            read -r -p "Enter choice (1-$count) [$default_idx]: " choice || true
+            choice="${choice:-$default_idx}"
+        else
+            read -r -p "Enter choice (1-$count): " choice || true
+        fi
         if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "$count" ]; then
             local idx=$((choice - 1))
             SELECTED_MODEL="$(get_model_choice_id "$provider_id" "$idx")"
             SELECTED_MAX_TOKENS="$(get_model_choice_maxtokens "$provider_id" "$idx")"
             SELECTED_MAX_CONTEXT_TOKENS="$(get_model_choice_maxcontexttokens "$provider_id" "$idx")"
             echo ""
-            echo -e "${GREEN}⬢${NC} Worker model: ${DIM}$SELECTED_MODEL${NC}"
+            echo -e "${GREEN}⬢${NC} Model: ${DIM}$SELECTED_MODEL${NC}"
             return
         fi
         echo -e "${RED}Invalid choice. Please enter 1-$count${NC}"
@@ -271,6 +424,7 @@ select_model() {
 }
 
 # ── Save worker_llm section to configuration.json ────────────────────
+# Args: provider_id env_var model max_tokens max_context_tokens [use_claude_code_sub] [api_base] [use_codex_sub]
 
 save_worker_configuration() {
     local provider_id="$1"
@@ -278,7 +432,9 @@ save_worker_configuration() {
     local model="$3"
     local max_tokens="$4"
     local max_context_tokens="$5"
-    local api_base="${6:-}"
+    local use_claude_code_sub="${6:-}"
+    local api_base="${7:-}"
+    local use_codex_sub="${8:-}"
 
     if [ -z "$model" ]; then
         model="$(get_default_model "$provider_id")"
@@ -293,7 +449,9 @@ save_worker_configuration() {
         "$model" \
         "$max_tokens" \
         "$max_context_tokens" \
-        "$api_base" 2>/dev/null <<'PY'
+        "$use_claude_code_sub" \
+        "$api_base" \
+        "$use_codex_sub" 2>/dev/null <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -304,8 +462,10 @@ from pathlib import Path
     model,
     max_tokens,
     max_context_tokens,
+    use_claude_code_sub,
     api_base,
-) = sys.argv[1:7]
+    use_codex_sub,
+) = sys.argv[1:9]
 
 cfg_path = Path.home() / ".hive" / "configuration.json"
 cfg_path.parent.mkdir(parents=True, exist_ok=True)
@@ -321,11 +481,28 @@ config["worker_llm"] = {
     "model": model,
     "max_tokens": int(max_tokens),
     "max_context_tokens": int(max_context_tokens),
+    "api_key_env_var": env_var,
 }
-if env_var:
-    config["worker_llm"]["api_key_env_var"] = env_var
+
+if use_claude_code_sub == "true":
+    config["worker_llm"]["use_claude_code_subscription"] = True
+    config["worker_llm"].pop("api_key_env_var", None)
+else:
+    config["worker_llm"].pop("use_claude_code_subscription", None)
+
+if use_codex_sub == "true":
+    config["worker_llm"]["use_codex_subscription"] = True
+    config["worker_llm"].pop("api_key_env_var", None)
+else:
+    config["worker_llm"].pop("use_codex_subscription", None)
+
 if api_base:
     config["worker_llm"]["api_base"] = api_base
+else:
+    config["worker_llm"].pop("api_base", None)
+
+if not env_var:
+    config["worker_llm"].pop("api_key_env_var", None)
 
 tmp_path = cfg_path.with_name(cfg_path.name + ".tmp")
 with open(tmp_path, "w", encoding="utf-8") as f:
@@ -360,100 +537,579 @@ print(f'Worker: {wm if wm else \"(same as queen)\"}')
     fi
 fi
 
-# Source shell rc to pick up env vars
-SHELL_RC_FILE="$HOME/.bashrc"
-if [ -n "$ZSH_VERSION" ] || [ "$SHELL" = "/bin/zsh" ]; then
-    SHELL_RC_FILE="$HOME/.zshrc"
-fi
+# Source shell rc file to pick up existing env vars (temporarily disable set -e)
 set +e
 if [ -f "$SHELL_RC_FILE" ]; then
     eval "$(grep -E '^export [A-Z_]+=' "$SHELL_RC_FILE" 2>/dev/null)"
 fi
 set -e
 
-# Detect available providers
-AVAIL_PROVIDERS=()
-AVAIL_ENV_VARS=()
+# Find all available API keys
+FOUND_PROVIDERS=()      # Display names for UI
+FOUND_ENV_VARS=()       # Corresponding env var names
+SELECTED_PROVIDER_ID="" # Will hold the chosen provider ID
+SELECTED_ENV_VAR=""     # Will hold the chosen env var
+SELECTED_MODEL=""       # Will hold the chosen model ID
+SELECTED_MAX_TOKENS=8192 # Will hold the chosen max_tokens (output limit)
+SELECTED_MAX_CONTEXT_TOKENS=120000 # Will hold the chosen max_context_tokens (input history budget)
+SUBSCRIPTION_MODE=""    # "claude_code" | "codex" | "zai_code" | ""
 
-ENV_VARS_TO_CHECK=(ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY GOOGLE_API_KEY GROQ_API_KEY CEREBRAS_API_KEY OPENROUTER_API_KEY MISTRAL_API_KEY TOGETHER_API_KEY DEEPSEEK_API_KEY)
+# ── Credential detection (silent — just set flags) ───────────
+CLAUDE_CRED_DETECTED=false
+if command -v security &>/dev/null && security find-generic-password -s "Claude Code-credentials" &>/dev/null 2>&1; then
+    CLAUDE_CRED_DETECTED=true
+elif [ -f "$HOME/.claude/.credentials.json" ]; then
+    CLAUDE_CRED_DETECTED=true
+fi
 
-for ev in "${ENV_VARS_TO_CHECK[@]}"; do
-    if [ -n "${!ev:-}" ]; then
-        AVAIL_PROVIDERS+=("$(get_provider_name "$ev")")
-        AVAIL_ENV_VARS+=("$ev")
+CODEX_CRED_DETECTED=false
+if command -v security &>/dev/null && security find-generic-password -s "Codex Auth" &>/dev/null 2>&1; then
+    CODEX_CRED_DETECTED=true
+elif [ -f "$HOME/.codex/auth.json" ]; then
+    CODEX_CRED_DETECTED=true
+fi
+
+ZAI_CRED_DETECTED=false
+if [ -n "${ZAI_API_KEY:-}" ]; then
+    ZAI_CRED_DETECTED=true
+fi
+
+MINIMAX_CRED_DETECTED=false
+if [ -n "${MINIMAX_API_KEY:-}" ]; then
+    MINIMAX_CRED_DETECTED=true
+fi
+
+KIMI_CRED_DETECTED=false
+if [ -f "$HOME/.kimi/config.toml" ]; then
+    KIMI_CRED_DETECTED=true
+elif [ -n "${KIMI_API_KEY:-}" ]; then
+    KIMI_CRED_DETECTED=true
+fi
+
+HIVE_CRED_DETECTED=false
+if [ -n "${HIVE_API_KEY:-}" ]; then
+    HIVE_CRED_DETECTED=true
+fi
+
+# Detect API key providers
+if [ "$USE_ASSOC_ARRAYS" = true ]; then
+    for env_var in "${!PROVIDER_NAMES[@]}"; do
+        if [ -n "${!env_var}" ]; then
+            FOUND_PROVIDERS+=("$(get_provider_name "$env_var")")
+            FOUND_ENV_VARS+=("$env_var")
+        fi
+    done
+else
+    for env_var in "${PROVIDER_ENV_VARS[@]}"; do
+        if [ -n "${!env_var}" ]; then
+            FOUND_PROVIDERS+=("$(get_provider_name "$env_var")")
+            FOUND_ENV_VARS+=("$env_var")
+        fi
+    done
+fi
+
+# ── Read previous worker configuration (if any) ──────────────────────
+PREV_PROVIDER=""
+PREV_MODEL=""
+PREV_ENV_VAR=""
+PREV_SUB_MODE=""
+if [ -f "$HIVE_CONFIG_FILE" ]; then
+    eval "$(cd "$PROJECT_DIR" && uv run python - 2>/dev/null <<'PY'
+import json
+from pathlib import Path
+
+cfg_path = Path.home() / ".hive" / "configuration.json"
+try:
+    with open(cfg_path, encoding="utf-8-sig") as f:
+        c = json.load(f)
+    llm = c.get("worker_llm", {})
+    print(f"PREV_PROVIDER={llm.get('provider', '')}")
+    print(f"PREV_MODEL={llm.get('model', '')}")
+    print(f"PREV_ENV_VAR={llm.get('api_key_env_var', '')}")
+    sub = ""
+    if llm.get("use_claude_code_subscription"):
+        sub = "claude_code"
+    elif llm.get("use_codex_subscription"):
+        sub = "codex"
+    elif llm.get("use_kimi_code_subscription"):
+        sub = "kimi_code"
+    elif llm.get("provider", "") == "minimax" or "api.minimax.io" in llm.get("api_base", ""):
+        sub = "minimax_code"
+    elif llm.get("provider", "") == "hive" or "adenhq.com" in llm.get("api_base", ""):
+        sub = "hive_llm"
+    elif "api.z.ai" in llm.get("api_base", ""):
+        sub = "zai_code"
+    print(f"PREV_SUB_MODE={sub}")
+except Exception:
+    pass
+PY
+)" || true
+fi
+
+# Compute default menu number from previous config (only if credential is still valid)
+DEFAULT_CHOICE=""
+if [ -n "$PREV_SUB_MODE" ] || [ -n "$PREV_PROVIDER" ]; then
+    PREV_CRED_VALID=false
+    case "$PREV_SUB_MODE" in
+        claude_code) [ "$CLAUDE_CRED_DETECTED" = true ] && PREV_CRED_VALID=true ;;
+        zai_code)    [ "$ZAI_CRED_DETECTED" = true ] && PREV_CRED_VALID=true ;;
+        codex)       [ "$CODEX_CRED_DETECTED" = true ] && PREV_CRED_VALID=true ;;
+        kimi_code)   [ "$KIMI_CRED_DETECTED" = true ] && PREV_CRED_VALID=true ;;
+        hive_llm)    [ "$HIVE_CRED_DETECTED" = true ] && PREV_CRED_VALID=true ;;
+        *)
+            # API key provider — check if the env var is set
+            if [ -n "$PREV_ENV_VAR" ] && [ -n "${!PREV_ENV_VAR}" ]; then
+                PREV_CRED_VALID=true
+            fi
+            ;;
+    esac
+
+    if [ "$PREV_CRED_VALID" = true ]; then
+        case "$PREV_SUB_MODE" in
+            claude_code) DEFAULT_CHOICE=1 ;;
+            zai_code)    DEFAULT_CHOICE=2 ;;
+            codex)       DEFAULT_CHOICE=3 ;;
+            minimax_code) DEFAULT_CHOICE=4 ;;
+            kimi_code)   DEFAULT_CHOICE=5 ;;
+            hive_llm)    DEFAULT_CHOICE=6 ;;
+        esac
+        if [ -z "$DEFAULT_CHOICE" ]; then
+            case "$PREV_PROVIDER" in
+                anthropic) DEFAULT_CHOICE=7 ;;
+                openai)    DEFAULT_CHOICE=8 ;;
+                gemini)    DEFAULT_CHOICE=9 ;;
+                groq)      DEFAULT_CHOICE=10 ;;
+                cerebras)  DEFAULT_CHOICE=11 ;;
+                openrouter) DEFAULT_CHOICE=12 ;;
+                minimax)   DEFAULT_CHOICE=4 ;;
+                kimi)      DEFAULT_CHOICE=5 ;;
+                hive)      DEFAULT_CHOICE=6 ;;
+            esac
+        fi
+    fi
+fi
+
+# ── Show unified provider selection menu ─────────────────────
+echo -e "${BOLD}Select your worker LLM provider:${NC}"
+echo ""
+echo -e "  ${CYAN}${BOLD}Subscription modes (no API key purchase needed):${NC}"
+
+# 1) Claude Code
+if [ "$CLAUDE_CRED_DETECTED" = true ]; then
+    echo -e "  ${CYAN}1)${NC} Claude Code Subscription  ${DIM}(use your Claude Max/Pro plan)${NC}  ${GREEN}(credential detected)${NC}"
+else
+    echo -e "  ${CYAN}1)${NC} Claude Code Subscription  ${DIM}(use your Claude Max/Pro plan)${NC}"
+fi
+
+# 2) ZAI Code
+if [ "$ZAI_CRED_DETECTED" = true ]; then
+    echo -e "  ${CYAN}2)${NC} ZAI Code Subscription     ${DIM}(use your ZAI Code plan)${NC}  ${GREEN}(credential detected)${NC}"
+else
+    echo -e "  ${CYAN}2)${NC} ZAI Code Subscription     ${DIM}(use your ZAI Code plan)${NC}"
+fi
+
+# 3) Codex
+if [ "$CODEX_CRED_DETECTED" = true ]; then
+    echo -e "  ${CYAN}3)${NC} OpenAI Codex Subscription  ${DIM}(use your Codex/ChatGPT Plus plan)${NC}  ${GREEN}(credential detected)${NC}"
+else
+    echo -e "  ${CYAN}3)${NC} OpenAI Codex Subscription  ${DIM}(use your Codex/ChatGPT Plus plan)${NC}"
+fi
+
+# 4) MiniMax
+if [ "$MINIMAX_CRED_DETECTED" = true ]; then
+    echo -e "  ${CYAN}4)${NC} MiniMax Coding Key         ${DIM}(use your MiniMax coding key)${NC}  ${GREEN}(credential detected)${NC}"
+else
+    echo -e "  ${CYAN}4)${NC} MiniMax Coding Key         ${DIM}(use your MiniMax coding key)${NC}"
+fi
+
+# 5) Kimi Code
+if [ "$KIMI_CRED_DETECTED" = true ]; then
+    echo -e "  ${CYAN}5)${NC} Kimi Code Subscription     ${DIM}(use your Kimi Code plan)${NC}  ${GREEN}(credential detected)${NC}"
+else
+    echo -e "  ${CYAN}5)${NC} Kimi Code Subscription     ${DIM}(use your Kimi Code plan)${NC}"
+fi
+
+# 6) Hive LLM
+if [ "$HIVE_CRED_DETECTED" = true ]; then
+    echo -e "  ${CYAN}6)${NC} Hive LLM                   ${DIM}(use your Hive API key)${NC}  ${GREEN}(credential detected)${NC}"
+else
+    echo -e "  ${CYAN}6)${NC} Hive LLM                   ${DIM}(use your Hive API key)${NC}"
+fi
+
+echo ""
+echo -e "  ${CYAN}${BOLD}API key providers:${NC}"
+
+# 7-12) API key providers — show (credential detected) if key already set
+PROVIDER_MENU_ENVS=(ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY GROQ_API_KEY CEREBRAS_API_KEY OPENROUTER_API_KEY)
+PROVIDER_MENU_NAMES=("Anthropic (Claude) - Recommended" "OpenAI (GPT)" "Google Gemini - Free tier available" "Groq - Fast, free tier" "Cerebras - Fast, free tier" "OpenRouter - Bring any OpenRouter model")
+for idx in "${!PROVIDER_MENU_ENVS[@]}"; do
+    num=$((idx + 7))
+    env_var="${PROVIDER_MENU_ENVS[$idx]}"
+    if [ -n "${!env_var}" ]; then
+        echo -e "  ${CYAN}$num)${NC} ${PROVIDER_MENU_NAMES[$idx]}  ${GREEN}(credential detected)${NC}"
+    else
+        echo -e "  ${CYAN}$num)${NC} ${PROVIDER_MENU_NAMES[$idx]}"
     fi
 done
 
-if [ ${#AVAIL_PROVIDERS[@]} -eq 0 ]; then
-    echo -e "${RED}No API keys found.${NC}"
-    echo -e "Run ${CYAN}./quickstart.sh${NC} first to set up your LLM provider."
-    exit 1
+SKIP_CHOICE=$((7 + ${#PROVIDER_MENU_ENVS[@]}))
+echo -e "  ${CYAN}$SKIP_CHOICE)${NC} Skip for now"
+echo ""
+
+if [ -n "$DEFAULT_CHOICE" ]; then
+    echo -e "  ${DIM}Previously configured: ${PREV_PROVIDER}/${PREV_MODEL}. Press Enter to keep.${NC}"
+    echo ""
 fi
 
-# Pick provider
-SELECTED_PROVIDER_ID=""
-SELECTED_ENV_VAR=""
-SELECTED_MODEL=""
-SELECTED_MAX_TOKENS=8192
-SELECTED_MAX_CONTEXT_TOKENS=120000
-SELECTED_API_BASE=""
+while true; do
+    if [ -n "$DEFAULT_CHOICE" ]; then
+        read -r -p "Enter choice (1-$SKIP_CHOICE) [$DEFAULT_CHOICE]: " choice || true
+        choice="${choice:-$DEFAULT_CHOICE}"
+    else
+        read -r -p "Enter choice (1-$SKIP_CHOICE): " choice || true
+    fi
+    if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "$SKIP_CHOICE" ]; then
+        break
+    fi
+    echo -e "${RED}Invalid choice. Please enter 1-$SKIP_CHOICE${NC}"
+done
 
-if [ ${#AVAIL_PROVIDERS[@]} -eq 1 ]; then
-    SELECTED_ENV_VAR="${AVAIL_ENV_VARS[0]}"
-    SELECTED_PROVIDER_ID="$(get_provider_id "$SELECTED_ENV_VAR")"
-    echo -e "${GREEN}⬢${NC} Provider: $(get_provider_name "$SELECTED_ENV_VAR")"
-else
-    echo -e "${BOLD}Select provider for worker agents:${NC}"
-    echo ""
-    local_i=1
-    for prov in "${AVAIL_PROVIDERS[@]}"; do
-        echo -e "  ${CYAN}${local_i})${NC} $prov"
-        local_i=$((local_i + 1))
-    done
-    echo ""
-    while true; do
-        read -r -p "Enter choice (1-${#AVAIL_PROVIDERS[@]}): " choice || true
-        if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#AVAIL_PROVIDERS[@]}" ]; then
-            idx=$((choice - 1))
-            SELECTED_ENV_VAR="${AVAIL_ENV_VARS[$idx]}"
-            SELECTED_PROVIDER_ID="$(get_provider_id "$SELECTED_ENV_VAR")"
+case $choice in
+    1)
+        # Claude Code Subscription
+        if [ "$CLAUDE_CRED_DETECTED" = false ]; then
             echo ""
-            echo -e "${GREEN}⬢${NC} Provider: ${AVAIL_PROVIDERS[$idx]}"
+            echo -e "${YELLOW}  ~/.claude/.credentials.json not found.${NC}"
+            echo -e "  Run ${CYAN}claude${NC} first to authenticate with your Claude subscription,"
+            echo -e "  then run this script again."
+            echo ""
+            exit 1
+        else
+            SUBSCRIPTION_MODE="claude_code"
+            SELECTED_PROVIDER_ID="anthropic"
+            SELECTED_MODEL="claude-opus-4-6"
+            SELECTED_MAX_TOKENS=32768
+            SELECTED_MAX_CONTEXT_TOKENS=960000  # Claude — 1M context window
+            echo ""
+            echo -e "${GREEN}⬢${NC} Using Claude Code subscription"
+        fi
+        ;;
+    2)
+        # ZAI Code Subscription
+        SUBSCRIPTION_MODE="zai_code"
+        SELECTED_PROVIDER_ID="openai"
+        SELECTED_ENV_VAR="ZAI_API_KEY"
+        SELECTED_MODEL="glm-5"
+        SELECTED_MAX_TOKENS=32768
+        SELECTED_MAX_CONTEXT_TOKENS=180000  # GLM-5 — 200k context window
+        PROVIDER_NAME="ZAI"
+        echo ""
+        echo -e "${GREEN}⬢${NC} Using ZAI Code subscription"
+        echo -e "  ${DIM}Model: glm-5 | API: api.z.ai${NC}"
+        ;;
+    3)
+        # OpenAI Codex Subscription
+        if [ "$CODEX_CRED_DETECTED" = false ]; then
+            echo ""
+            echo -e "${YELLOW}  Codex credentials not found. Starting OAuth login...${NC}"
+            echo ""
+            if cd "$PROJECT_DIR" && uv run python "$PROJECT_DIR/core/codex_oauth.py"; then
+                CODEX_CRED_DETECTED=true
+            else
+                echo ""
+                echo -e "${RED}  OAuth login failed or was cancelled.${NC}"
+                echo ""
+                echo -e "  To authenticate manually, visit:"
+                echo -e "  ${CYAN}https://auth.openai.com/authorize?client_id=app_EMoamEEZ73f0CkXaXp7hrann&response_type=code&redirect_uri=http://localhost:1455/auth/callback&scope=openid%20profile%20email%20offline_access${NC}"
+                echo ""
+                echo -e "  Or run ${CYAN}codex${NC} to authenticate, then run this script again."
+                echo ""
+                SELECTED_PROVIDER_ID=""
+            fi
+        fi
+        if [ "$CODEX_CRED_DETECTED" = true ]; then
+            SUBSCRIPTION_MODE="codex"
+            SELECTED_PROVIDER_ID="openai"
+            SELECTED_MODEL="gpt-5.3-codex"
+            SELECTED_MAX_TOKENS=16384
+            SELECTED_MAX_CONTEXT_TOKENS=120000  # GPT Codex — 128k context window
+            echo ""
+            echo -e "${GREEN}⬢${NC} Using OpenAI Codex subscription"
+        fi
+        ;;
+    4)
+        # MiniMax Coding Key
+        SUBSCRIPTION_MODE="minimax_code"
+        SELECTED_ENV_VAR="MINIMAX_API_KEY"
+        SELECTED_PROVIDER_ID="minimax"
+        SELECTED_MODEL="MiniMax-M2.5"
+        SELECTED_MAX_TOKENS=32768
+        SELECTED_MAX_CONTEXT_TOKENS=900000  # MiniMax M2.5 — 1M context window
+        SELECTED_API_BASE="https://api.minimax.io/v1"
+        PROVIDER_NAME="MiniMax"
+        SIGNUP_URL="https://platform.minimax.io/user-center/basic-information/interface-key"
+        echo ""
+        echo -e "${GREEN}⬢${NC} Using MiniMax coding key"
+        echo -e "  ${DIM}Model: MiniMax-M2.5 | API: api.minimax.io${NC}"
+        ;;
+    5)
+        # Kimi Code Subscription
+        SUBSCRIPTION_MODE="kimi_code"
+        SELECTED_PROVIDER_ID="kimi"
+        SELECTED_ENV_VAR="KIMI_API_KEY"
+        SELECTED_MODEL="kimi-k2.5"
+        SELECTED_MAX_TOKENS=32768
+        SELECTED_MAX_CONTEXT_TOKENS=240000  # Kimi K2.5 — 256k context window
+        SELECTED_API_BASE="https://api.kimi.com/coding"
+        PROVIDER_NAME="Kimi"
+        SIGNUP_URL="https://www.kimi.com/code"
+        echo ""
+        echo -e "${GREEN}⬢${NC} Using Kimi Code subscription"
+        echo -e "  ${DIM}Model: kimi-k2.5 | API: api.kimi.com/coding${NC}"
+        ;;
+    6)
+        # Hive LLM
+        SUBSCRIPTION_MODE="hive_llm"
+        SELECTED_PROVIDER_ID="hive"
+        SELECTED_ENV_VAR="HIVE_API_KEY"
+        SELECTED_MAX_TOKENS=32768
+        SELECTED_MAX_CONTEXT_TOKENS=180000
+        SELECTED_API_BASE="$HIVE_LLM_ENDPOINT"
+        PROVIDER_NAME="Hive"
+        SIGNUP_URL="https://discord.com/invite/hQdU7QDkgR"
+        echo ""
+        echo -e "${GREEN}⬢${NC} Using Hive LLM"
+        echo ""
+        echo -e "  Select a model:"
+        echo -e "  ${CYAN}1)${NC} queen              ${DIM}(default — Hive flagship)${NC}"
+        echo -e "  ${CYAN}2)${NC} kimi-2.5"
+        echo -e "  ${CYAN}3)${NC} GLM-5"
+        echo ""
+        read -r -p "  Enter model choice (1-3) [1]: " hive_model_choice || true
+        hive_model_choice="${hive_model_choice:-1}"
+        case "$hive_model_choice" in
+            2) SELECTED_MODEL="kimi-2.5" ;;
+            3) SELECTED_MODEL="GLM-5" ;;
+            *) SELECTED_MODEL="queen" ;;
+        esac
+        echo -e "  ${DIM}Model: $SELECTED_MODEL | API: ${HIVE_LLM_ENDPOINT}${NC}"
+        ;;
+    7)
+        SELECTED_ENV_VAR="ANTHROPIC_API_KEY"
+        SELECTED_PROVIDER_ID="anthropic"
+        PROVIDER_NAME="Anthropic"
+        SIGNUP_URL="https://console.anthropic.com/settings/keys"
+        ;;
+    8)
+        SELECTED_ENV_VAR="OPENAI_API_KEY"
+        SELECTED_PROVIDER_ID="openai"
+        PROVIDER_NAME="OpenAI"
+        SIGNUP_URL="https://platform.openai.com/api-keys"
+        ;;
+    9)
+        SELECTED_ENV_VAR="GEMINI_API_KEY"
+        SELECTED_PROVIDER_ID="gemini"
+        PROVIDER_NAME="Google Gemini"
+        SIGNUP_URL="https://aistudio.google.com/apikey"
+        ;;
+    10)
+        SELECTED_ENV_VAR="GROQ_API_KEY"
+        SELECTED_PROVIDER_ID="groq"
+        PROVIDER_NAME="Groq"
+        SIGNUP_URL="https://console.groq.com/keys"
+        ;;
+    11)
+        SELECTED_ENV_VAR="CEREBRAS_API_KEY"
+        SELECTED_PROVIDER_ID="cerebras"
+        PROVIDER_NAME="Cerebras"
+        SIGNUP_URL="https://cloud.cerebras.ai/"
+        ;;
+    12)
+        SELECTED_ENV_VAR="OPENROUTER_API_KEY"
+        SELECTED_PROVIDER_ID="openrouter"
+        SELECTED_API_BASE="https://openrouter.ai/api/v1"
+        PROVIDER_NAME="OpenRouter"
+        SIGNUP_URL="https://openrouter.ai/keys"
+        ;;
+    "$SKIP_CHOICE")
+        echo ""
+        echo -e "${YELLOW}Skipped.${NC} Worker model not configured."
+        echo -e "Run this script again when ready."
+        echo ""
+        exit 0
+        ;;
+esac
+
+# For API-key providers: prompt for key (allow replacement if already set)
+if { [ -z "$SUBSCRIPTION_MODE" ] || [ "$SUBSCRIPTION_MODE" = "minimax_code" ] || [ "$SUBSCRIPTION_MODE" = "kimi_code" ] || [ "$SUBSCRIPTION_MODE" = "hive_llm" ]; } && [ -n "$SELECTED_ENV_VAR" ]; then
+    while true; do
+        CURRENT_KEY="${!SELECTED_ENV_VAR}"
+        if [ -n "$CURRENT_KEY" ]; then
+            # Key exists — offer to keep or replace
+            MASKED_KEY="${CURRENT_KEY:0:4}...${CURRENT_KEY: -4}"
+            echo ""
+            echo -e "  ${GREEN}⬢${NC} Current key: ${DIM}$MASKED_KEY${NC}"
+            read -r -p "  Press Enter to keep, or paste a new key to replace: " API_KEY
+        else
+            # No key — prompt for one
+            echo ""
+            echo -e "Get your API key from: ${CYAN}$SIGNUP_URL${NC}"
+            echo ""
+            read -r -p "Paste your $PROVIDER_NAME API key (or press Enter to skip): " API_KEY
+        fi
+
+        if [ -n "$API_KEY" ]; then
+            # Remove old export line(s) for this env var from shell rc, then append new
+            sed -i.bak "/^export ${SELECTED_ENV_VAR}=/d" "$SHELL_RC_FILE" && rm -f "${SHELL_RC_FILE}.bak"
+            echo "" >> "$SHELL_RC_FILE"
+            echo "# Hive Agent Framework - $PROVIDER_NAME API key" >> "$SHELL_RC_FILE"
+            echo "export $SELECTED_ENV_VAR=\"$API_KEY\"" >> "$SHELL_RC_FILE"
+            export "$SELECTED_ENV_VAR=$API_KEY"
+            echo ""
+            echo -e "${GREEN}⬢${NC} API key saved to $SHELL_RC_FILE"
+            # Health check the new key
+            echo -n "  Verifying API key... "
+            if [ -n "${SELECTED_API_BASE:-}" ]; then
+                HC_RESULT=$(cd "$PROJECT_DIR" && uv run python "$PROJECT_DIR/scripts/check_llm_key.py" "$SELECTED_PROVIDER_ID" "$API_KEY" "$SELECTED_API_BASE" 2>/dev/null) || true
+            else
+                HC_RESULT=$(cd "$PROJECT_DIR" && uv run python "$PROJECT_DIR/scripts/check_llm_key.py" "$SELECTED_PROVIDER_ID" "$API_KEY" 2>/dev/null) || true
+            fi
+            HC_VALID=$(echo "$HC_RESULT" | $PYTHON_CMD -c "import json,sys; print(json.loads(sys.stdin.read()).get('valid',''))" 2>/dev/null) || true
+            HC_MSG=$(echo "$HC_RESULT" | $PYTHON_CMD -c "import json,sys; print(json.loads(sys.stdin.read()).get('message',''))" 2>/dev/null) || true
+            if [ "$HC_VALID" = "True" ]; then
+                echo -e "${GREEN}ok${NC}"
+                break
+            elif [ "$HC_VALID" = "False" ]; then
+                echo -e "${RED}failed${NC}"
+                echo -e "  ${YELLOW}⚠ $HC_MSG${NC}"
+                # Undo the save so the user can retry cleanly
+                sed -i.bak "/^export ${SELECTED_ENV_VAR}=/d" "$SHELL_RC_FILE" && rm -f "${SHELL_RC_FILE}.bak"
+                # Remove the comment line we just added
+                sed -i.bak "/^# Hive Agent Framework - $PROVIDER_NAME API key$/d" "$SHELL_RC_FILE" && rm -f "${SHELL_RC_FILE}.bak"
+                unset "$SELECTED_ENV_VAR"
+                echo ""
+                read -r -p "  Press Enter to try again: " _
+                # Loop back to key prompt
+            else
+                echo -e "${YELLOW}--${NC}"
+                echo -e "  ${DIM}Could not verify key (network issue). The key has been saved.${NC}"
+                break
+            fi
+        elif [ -z "$CURRENT_KEY" ]; then
+            # No existing key and user skipped — abort provider
+            echo ""
+            echo -e "${YELLOW}Skipped.${NC} Add your API key to $SHELL_RC_FILE when ready."
+            SELECTED_ENV_VAR=""
+            SELECTED_PROVIDER_ID=""
+            break
+        else
+            # User pressed Enter with existing key — keep it, proceed normally
             break
         fi
-        echo -e "${RED}Invalid choice.${NC}"
     done
 fi
 
-# OpenRouter: custom api_base
-if [ "$SELECTED_PROVIDER_ID" = "openrouter" ]; then
-    SELECTED_API_BASE="https://openrouter.ai/api/v1"
+# For ZAI subscription: prompt for API key (allow replacement if already set)
+if [ "$SUBSCRIPTION_MODE" = "zai_code" ]; then
+    while true; do
+        if [ "$ZAI_CRED_DETECTED" = true ] && [ -n "$ZAI_API_KEY" ]; then
+            # Key exists — offer to keep or replace
+            MASKED_KEY="${ZAI_API_KEY:0:4}...${ZAI_API_KEY: -4}"
+            echo ""
+            echo -e "  ${GREEN}⬢${NC} Current ZAI key: ${DIM}$MASKED_KEY${NC}"
+            read -r -p "  Press Enter to keep, or paste a new key to replace: " API_KEY
+        else
+            # No key — prompt for one
+            echo ""
+            read -r -p "Paste your ZAI API key (or press Enter to skip): " API_KEY
+        fi
+
+        if [ -n "$API_KEY" ]; then
+            sed -i.bak "/^export ZAI_API_KEY=/d" "$SHELL_RC_FILE" && rm -f "${SHELL_RC_FILE}.bak"
+            echo "" >> "$SHELL_RC_FILE"
+            echo "# Hive Agent Framework - ZAI Code subscription API key" >> "$SHELL_RC_FILE"
+            echo "export ZAI_API_KEY=\"$API_KEY\"" >> "$SHELL_RC_FILE"
+            export ZAI_API_KEY="$API_KEY"
+            echo ""
+            echo -e "${GREEN}⬢${NC} ZAI API key saved to $SHELL_RC_FILE"
+            # Health check the new key
+            echo -n "  Verifying ZAI API key... "
+            HC_RESULT=$(cd "$PROJECT_DIR" && uv run python "$PROJECT_DIR/scripts/check_llm_key.py" "zai" "$API_KEY" "https://api.z.ai/api/coding/paas/v4" 2>/dev/null) || true
+            HC_VALID=$(echo "$HC_RESULT" | $PYTHON_CMD -c "import json,sys; print(json.loads(sys.stdin.read()).get('valid',''))" 2>/dev/null) || true
+            HC_MSG=$(echo "$HC_RESULT" | $PYTHON_CMD -c "import json,sys; print(json.loads(sys.stdin.read()).get('message',''))" 2>/dev/null) || true
+            if [ "$HC_VALID" = "True" ]; then
+                echo -e "${GREEN}ok${NC}"
+                break
+            elif [ "$HC_VALID" = "False" ]; then
+                echo -e "${RED}failed${NC}"
+                echo -e "  ${YELLOW}⚠ $HC_MSG${NC}"
+                # Undo the save so the user can retry cleanly
+                sed -i.bak "/^export ZAI_API_KEY=/d" "$SHELL_RC_FILE" && rm -f "${SHELL_RC_FILE}.bak"
+                sed -i.bak "/^# Hive Agent Framework - ZAI Code subscription API key$/d" "$SHELL_RC_FILE" && rm -f "${SHELL_RC_FILE}.bak"
+                unset ZAI_API_KEY
+                ZAI_CRED_DETECTED=false
+                echo ""
+                read -r -p "  Press Enter to try again: " _
+                # Loop back to key prompt
+            else
+                echo -e "${YELLOW}--${NC}"
+                echo -e "  ${DIM}Could not verify key (network issue). The key has been saved.${NC}"
+                break
+            fi
+        elif [ "$ZAI_CRED_DETECTED" = false ] || [ -z "$ZAI_API_KEY" ]; then
+            # No existing key and user skipped — abort provider
+            echo ""
+            echo -e "${YELLOW}Skipped.${NC} Add your ZAI API key to $SHELL_RC_FILE when ready:"
+            echo -e "  ${CYAN}echo 'export ZAI_API_KEY=\"your-key\"' >> $SHELL_RC_FILE${NC}"
+            SELECTED_ENV_VAR=""
+            SELECTED_PROVIDER_ID=""
+            SUBSCRIPTION_MODE=""
+            break
+        else
+            # User pressed Enter with existing key — keep it, proceed normally
+            break
+        fi
+    done
 fi
 
-# Select model
-select_model "$SELECTED_PROVIDER_ID"
+# Prompt for model if not already selected (manual provider path)
+if [ -n "$SELECTED_PROVIDER_ID" ] && [ -z "$SELECTED_MODEL" ]; then
+    prompt_model_selection "$SELECTED_PROVIDER_ID"
+fi
 
-# Option to clear worker model
-echo ""
-if prompt_yes_no "Save this worker model configuration?"; then
+# Save worker configuration if a provider was selected
+if [ -n "$SELECTED_PROVIDER_ID" ]; then
     echo ""
     echo -n "  Saving worker model configuration... "
-    if save_worker_configuration "$SELECTED_PROVIDER_ID" "$SELECTED_ENV_VAR" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "$SELECTED_API_BASE" > /dev/null; then
-        echo -e "${GREEN}done${NC}"
-        echo -e "  ${DIM}~/.hive/configuration.json (worker_llm section)${NC}"
+    SAVE_OK=true
+    if [ "$SUBSCRIPTION_MODE" = "claude_code" ]; then
+        save_worker_configuration "$SELECTED_PROVIDER_ID" "" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "true" "" > /dev/null || SAVE_OK=false
+    elif [ "$SUBSCRIPTION_MODE" = "codex" ]; then
+        save_worker_configuration "$SELECTED_PROVIDER_ID" "" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "" "" "true" > /dev/null || SAVE_OK=false
+    elif [ "$SUBSCRIPTION_MODE" = "zai_code" ]; then
+        save_worker_configuration "$SELECTED_PROVIDER_ID" "$SELECTED_ENV_VAR" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "" "https://api.z.ai/api/coding/paas/v4" > /dev/null || SAVE_OK=false
+    elif [ "$SUBSCRIPTION_MODE" = "minimax_code" ]; then
+        save_worker_configuration "$SELECTED_PROVIDER_ID" "$SELECTED_ENV_VAR" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "" "$SELECTED_API_BASE" > /dev/null || SAVE_OK=false
+    elif [ "$SUBSCRIPTION_MODE" = "kimi_code" ]; then
+        save_worker_configuration "$SELECTED_PROVIDER_ID" "$SELECTED_ENV_VAR" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "" "$SELECTED_API_BASE" > /dev/null || SAVE_OK=false
+    elif [ "$SUBSCRIPTION_MODE" = "hive_llm" ]; then
+        save_worker_configuration "$SELECTED_PROVIDER_ID" "$SELECTED_ENV_VAR" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "" "$SELECTED_API_BASE" > /dev/null || SAVE_OK=false
+    elif [ "$SELECTED_PROVIDER_ID" = "openrouter" ]; then
+        save_worker_configuration "$SELECTED_PROVIDER_ID" "$SELECTED_ENV_VAR" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "" "$SELECTED_API_BASE" > /dev/null || SAVE_OK=false
     else
+        save_worker_configuration "$SELECTED_PROVIDER_ID" "$SELECTED_ENV_VAR" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" > /dev/null || SAVE_OK=false
+    fi
+    if [ "$SAVE_OK" = false ]; then
         echo -e "${RED}failed${NC}"
+        echo -e "${YELLOW}  Could not write ~/.hive/configuration.json. Please rerun this script.${NC}"
         exit 1
     fi
-else
+    echo -e "${GREEN}done${NC}"
+    echo -e "  ${DIM}~/.hive/configuration.json (worker_llm section)${NC}"
     echo ""
-    echo "Cancelled. Worker agents will continue using the default model."
-    exit 0
+    echo -e "${GREEN}⬢${NC} Worker model configured successfully."
+    echo -e "  ${DIM}Worker agents will now use: ${SELECTED_PROVIDER_ID}/${SELECTED_MODEL}${NC}"
+    echo -e "  ${DIM}Run this script again to change, or remove the worker_llm section${NC}"
+    echo -e "  ${DIM}from ~/.hive/configuration.json to revert to the default.${NC}"
+    echo ""
 fi
-
-echo ""
-echo -e "${GREEN}⬢${NC} Worker model configured successfully."
-echo -e "  ${DIM}Worker agents will now use: ${SELECTED_PROVIDER_ID}/${SELECTED_MODEL}${NC}"
-echo -e "  ${DIM}Run this script again to change, or remove the worker_llm section${NC}"
-echo -e "  ${DIM}from ~/.hive/configuration.json to revert to the default.${NC}"
-echo ""

--- a/scripts/setup_worker_model.sh
+++ b/scripts/setup_worker_model.sh
@@ -1,0 +1,459 @@
+#!/bin/bash
+#
+# setup_worker_model.sh - Configure a separate LLM model for worker agents
+#
+# Worker agents can use a different (e.g. cheaper/faster) model than the
+# queen agent.  This script writes a "worker_llm" section to
+# ~/.hive/configuration.json.  If no worker model is configured, workers
+# fall back to the default (queen) model.
+#
+
+set -e
+
+# Detect Bash version for compatibility
+BASH_MAJOR_VERSION="${BASH_VERSINFO[0]}"
+USE_ASSOC_ARRAYS=false
+if [ "$BASH_MAJOR_VERSION" -ge 4 ]; then
+    USE_ASSOC_ARRAYS=true
+fi
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+DIM='\033[2m'
+NC='\033[0m'
+
+# Get the directory where this script is located, then the project root
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
+HIVE_CONFIG_FILE="$HOME/.hive/configuration.json"
+
+# Helper function for prompts
+prompt_yes_no() {
+    local prompt="$1"
+    local default="${2:-y}"
+    local response
+
+    if [ "$default" = "y" ]; then
+        prompt="$prompt [Y/n] "
+    else
+        prompt="$prompt [y/N] "
+    fi
+    read -r -p "$prompt" response
+    response="${response:-$default}"
+    [[ "$response" =~ ^[Yy] ]]
+}
+
+# ── Provider / model definitions (same as quickstart) ────────────────
+
+if [ "$USE_ASSOC_ARRAYS" = true ]; then
+    declare -A PROVIDER_NAMES=(
+        ["ANTHROPIC_API_KEY"]="Anthropic (Claude)"
+        ["OPENAI_API_KEY"]="OpenAI (GPT)"
+        ["MINIMAX_API_KEY"]="MiniMax"
+        ["GEMINI_API_KEY"]="Google Gemini"
+        ["GOOGLE_API_KEY"]="Google AI"
+        ["GROQ_API_KEY"]="Groq"
+        ["CEREBRAS_API_KEY"]="Cerebras"
+        ["OPENROUTER_API_KEY"]="OpenRouter"
+        ["MISTRAL_API_KEY"]="Mistral"
+        ["TOGETHER_API_KEY"]="Together AI"
+        ["DEEPSEEK_API_KEY"]="DeepSeek"
+    )
+
+    declare -A PROVIDER_IDS=(
+        ["ANTHROPIC_API_KEY"]="anthropic"
+        ["OPENAI_API_KEY"]="openai"
+        ["MINIMAX_API_KEY"]="minimax"
+        ["GEMINI_API_KEY"]="gemini"
+        ["GOOGLE_API_KEY"]="google"
+        ["GROQ_API_KEY"]="groq"
+        ["CEREBRAS_API_KEY"]="cerebras"
+        ["OPENROUTER_API_KEY"]="openrouter"
+        ["MISTRAL_API_KEY"]="mistral"
+        ["TOGETHER_API_KEY"]="together"
+        ["DEEPSEEK_API_KEY"]="deepseek"
+    )
+
+    declare -A DEFAULT_MODELS=(
+        ["anthropic"]="claude-haiku-4-5-20251001"
+        ["openai"]="gpt-5-mini"
+        ["minimax"]="MiniMax-M2.5"
+        ["gemini"]="gemini-3-flash-preview"
+        ["groq"]="moonshotai/kimi-k2-instruct-0905"
+        ["cerebras"]="zai-glm-4.7"
+        ["mistral"]="mistral-large-latest"
+        ["together_ai"]="meta-llama/Llama-3.3-70B-Instruct-Turbo"
+        ["deepseek"]="deepseek-chat"
+    )
+
+    declare -A MODEL_CHOICES_ID=(
+        ["anthropic:0"]="claude-haiku-4-5-20251001"
+        ["anthropic:1"]="claude-sonnet-4-20250514"
+        ["anthropic:2"]="claude-sonnet-4-5-20250929"
+        ["anthropic:3"]="claude-opus-4-6"
+        ["openai:0"]="gpt-5-mini"
+        ["openai:1"]="gpt-5.2"
+        ["gemini:0"]="gemini-3-flash-preview"
+        ["gemini:1"]="gemini-3.1-pro-preview"
+        ["groq:0"]="moonshotai/kimi-k2-instruct-0905"
+        ["groq:1"]="openai/gpt-oss-120b"
+        ["cerebras:0"]="zai-glm-4.7"
+        ["cerebras:1"]="qwen3-235b-a22b-instruct-2507"
+    )
+
+    declare -A MODEL_CHOICES_LABEL=(
+        ["anthropic:0"]="Haiku 4.5 - Fast + cheap (recommended for workers)"
+        ["anthropic:1"]="Sonnet 4 - Fast + capable"
+        ["anthropic:2"]="Sonnet 4.5 - Best balance"
+        ["anthropic:3"]="Opus 4.6 - Most capable"
+        ["openai:0"]="GPT-5 Mini - Fast + cheap (recommended for workers)"
+        ["openai:1"]="GPT-5.2 - Most capable"
+        ["gemini:0"]="Gemini 3 Flash - Fast (recommended for workers)"
+        ["gemini:1"]="Gemini 3.1 Pro - Best quality"
+        ["groq:0"]="Kimi K2 - Best quality (recommended)"
+        ["groq:1"]="GPT-OSS 120B - Fast reasoning"
+        ["cerebras:0"]="ZAI-GLM 4.7 - Best quality (recommended)"
+        ["cerebras:1"]="Qwen3 235B - Frontier reasoning"
+    )
+
+    declare -A MODEL_CHOICES_MAXTOKENS=(
+        ["anthropic:0"]=8192
+        ["anthropic:1"]=8192
+        ["anthropic:2"]=16384
+        ["anthropic:3"]=32768
+        ["openai:0"]=16384
+        ["openai:1"]=16384
+        ["gemini:0"]=8192
+        ["gemini:1"]=8192
+        ["groq:0"]=8192
+        ["groq:1"]=8192
+        ["cerebras:0"]=8192
+        ["cerebras:1"]=8192
+    )
+
+    declare -A MODEL_CHOICES_MAXCONTEXTTOKENS=(
+        ["anthropic:0"]=180000
+        ["anthropic:1"]=180000
+        ["anthropic:2"]=180000
+        ["anthropic:3"]=180000
+        ["openai:0"]=120000
+        ["openai:1"]=120000
+        ["gemini:0"]=900000
+        ["gemini:1"]=900000
+        ["groq:0"]=120000
+        ["groq:1"]=120000
+        ["cerebras:0"]=120000
+        ["cerebras:1"]=120000
+    )
+
+    declare -A MODEL_CHOICES_COUNT=(
+        ["anthropic"]=4
+        ["openai"]=2
+        ["gemini"]=2
+        ["groq"]=2
+        ["cerebras"]=2
+    )
+
+    get_provider_name()  { echo "${PROVIDER_NAMES[$1]}"; }
+    get_provider_id()    { echo "${PROVIDER_IDS[$1]}"; }
+    get_default_model()  { echo "${DEFAULT_MODELS[$1]}"; }
+    get_model_choice_count() { echo "${MODEL_CHOICES_COUNT[$1]:-0}"; }
+    get_model_choice_id()    { echo "${MODEL_CHOICES_ID[$1:$2]}"; }
+    get_model_choice_label() { echo "${MODEL_CHOICES_LABEL[$1:$2]}"; }
+    get_model_choice_maxtokens()       { echo "${MODEL_CHOICES_MAXTOKENS[$1:$2]}"; }
+    get_model_choice_maxcontexttokens() { echo "${MODEL_CHOICES_MAXCONTEXTTOKENS[$1:$2]}"; }
+else
+    # Bash 3.2 fallback
+    PROVIDER_ENV_VARS=(ANTHROPIC_API_KEY OPENAI_API_KEY MINIMAX_API_KEY GEMINI_API_KEY GOOGLE_API_KEY GROQ_API_KEY CEREBRAS_API_KEY OPENROUTER_API_KEY MISTRAL_API_KEY TOGETHER_API_KEY DEEPSEEK_API_KEY)
+    PROVIDER_DISPLAY_NAMES=("Anthropic (Claude)" "OpenAI (GPT)" "MiniMax" "Google Gemini" "Google AI" "Groq" "Cerebras" "OpenRouter" "Mistral" "Together AI" "DeepSeek")
+    PROVIDER_ID_LIST=(anthropic openai minimax gemini google groq cerebras openrouter mistral together deepseek)
+
+    MODEL_PROVIDER_IDS=(anthropic openai minimax gemini groq cerebras mistral together_ai deepseek)
+    MODEL_DEFAULTS=("claude-haiku-4-5-20251001" "gpt-5-mini" "MiniMax-M2.5" "gemini-3-flash-preview" "moonshotai/kimi-k2-instruct-0905" "zai-glm-4.7" "mistral-large-latest" "meta-llama/Llama-3.3-70B-Instruct-Turbo" "deepseek-chat")
+
+    get_provider_name() {
+        local env_var="$1"; local i=0
+        while [ $i -lt ${#PROVIDER_ENV_VARS[@]} ]; do
+            if [ "${PROVIDER_ENV_VARS[$i]}" = "$env_var" ]; then echo "${PROVIDER_DISPLAY_NAMES[$i]}"; return; fi
+            i=$((i + 1))
+        done
+    }
+    get_provider_id() {
+        local env_var="$1"; local i=0
+        while [ $i -lt ${#PROVIDER_ENV_VARS[@]} ]; do
+            if [ "${PROVIDER_ENV_VARS[$i]}" = "$env_var" ]; then echo "${PROVIDER_ID_LIST[$i]}"; return; fi
+            i=$((i + 1))
+        done
+    }
+    get_default_model() {
+        local provider_id="$1"; local i=0
+        while [ $i -lt ${#MODEL_PROVIDER_IDS[@]} ]; do
+            if [ "${MODEL_PROVIDER_IDS[$i]}" = "$provider_id" ]; then echo "${MODEL_DEFAULTS[$i]}"; return; fi
+            i=$((i + 1))
+        done
+    }
+
+    MC_PROVIDERS=(anthropic anthropic anthropic anthropic openai openai gemini gemini groq groq cerebras cerebras)
+    MC_IDS=("claude-haiku-4-5-20251001" "claude-sonnet-4-20250514" "claude-sonnet-4-5-20250929" "claude-opus-4-6" "gpt-5-mini" "gpt-5.2" "gemini-3-flash-preview" "gemini-3.1-pro-preview" "moonshotai/kimi-k2-instruct-0905" "openai/gpt-oss-120b" "zai-glm-4.7" "qwen3-235b-a22b-instruct-2507")
+    MC_LABELS=("Haiku 4.5 - Fast + cheap (recommended for workers)" "Sonnet 4 - Fast + capable" "Sonnet 4.5 - Best balance" "Opus 4.6 - Most capable" "GPT-5 Mini - Fast + cheap (recommended for workers)" "GPT-5.2 - Most capable" "Gemini 3 Flash - Fast (recommended for workers)" "Gemini 3.1 Pro - Best quality" "Kimi K2 - Best quality (recommended)" "GPT-OSS 120B - Fast reasoning" "ZAI-GLM 4.7 - Best quality (recommended)" "Qwen3 235B - Frontier reasoning")
+    MC_MAXTOKENS=(8192 8192 16384 32768 16384 16384 8192 8192 8192 8192 8192 8192)
+    MC_MAXCONTEXTTOKENS=(180000 180000 180000 180000 120000 120000 900000 900000 120000 120000 120000 120000)
+
+    get_model_choice_count() {
+        local p="$1"; local cnt=0; local i=0
+        while [ $i -lt ${#MC_PROVIDERS[@]} ]; do
+            if [ "${MC_PROVIDERS[$i]}" = "$p" ]; then cnt=$((cnt + 1)); fi
+            i=$((i + 1))
+        done
+        echo "$cnt"
+    }
+    _mc_nth() {
+        local p="$1"; local n="$2"; local cnt=0; local i=0
+        while [ $i -lt ${#MC_PROVIDERS[@]} ]; do
+            if [ "${MC_PROVIDERS[$i]}" = "$p" ]; then
+                if [ "$cnt" -eq "$n" ]; then echo "$i"; return; fi
+                cnt=$((cnt + 1))
+            fi
+            i=$((i + 1))
+        done
+    }
+    get_model_choice_id()    { local idx=$(_mc_nth "$1" "$2"); echo "${MC_IDS[$idx]}"; }
+    get_model_choice_label() { local idx=$(_mc_nth "$1" "$2"); echo "${MC_LABELS[$idx]}"; }
+    get_model_choice_maxtokens()       { local idx=$(_mc_nth "$1" "$2"); echo "${MC_MAXTOKENS[$idx]}"; }
+    get_model_choice_maxcontexttokens() { local idx=$(_mc_nth "$1" "$2"); echo "${MC_MAXCONTEXTTOKENS[$idx]}"; }
+fi
+
+# ── Model selection prompt ───────────────────────────────────────────
+
+select_model() {
+    local provider_id="$1"
+    local count
+    count=$(get_model_choice_count "$provider_id")
+
+    if [ "$count" -eq 0 ]; then
+        SELECTED_MODEL="$(get_default_model "$provider_id")"
+        SELECTED_MAX_TOKENS=8192
+        SELECTED_MAX_CONTEXT_TOKENS=120000
+        echo ""
+        echo -e "${GREEN}⬢${NC} Worker model: ${DIM}$SELECTED_MODEL${NC}"
+        return
+    fi
+
+    echo ""
+    echo -e "${BOLD}Select worker model:${NC}"
+    local i=0
+    while [ "$i" -lt "$count" ]; do
+        echo -e "  ${CYAN}$((i+1)))${NC} $(get_model_choice_label "$provider_id" "$i")"
+        i=$((i + 1))
+    done
+    echo ""
+
+    while true; do
+        local default_idx=1
+        read -r -p "Enter choice (1-$count) [$default_idx]: " choice || true
+        choice="${choice:-$default_idx}"
+        if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "$count" ]; then
+            local idx=$((choice - 1))
+            SELECTED_MODEL="$(get_model_choice_id "$provider_id" "$idx")"
+            SELECTED_MAX_TOKENS="$(get_model_choice_maxtokens "$provider_id" "$idx")"
+            SELECTED_MAX_CONTEXT_TOKENS="$(get_model_choice_maxcontexttokens "$provider_id" "$idx")"
+            echo ""
+            echo -e "${GREEN}⬢${NC} Worker model: ${DIM}$SELECTED_MODEL${NC}"
+            return
+        fi
+        echo -e "${RED}Invalid choice. Please enter 1-$count${NC}"
+    done
+}
+
+# ── Save worker_llm section to configuration.json ────────────────────
+
+save_worker_configuration() {
+    local provider_id="$1"
+    local env_var="$2"
+    local model="$3"
+    local max_tokens="$4"
+    local max_context_tokens="$5"
+    local api_base="${6:-}"
+
+    if [ -z "$model" ]; then
+        model="$(get_default_model "$provider_id")"
+    fi
+    if [ -z "$max_tokens" ]; then max_tokens=8192; fi
+    if [ -z "$max_context_tokens" ]; then max_context_tokens=120000; fi
+
+    cd "$PROJECT_DIR"
+    uv run python - \
+        "$provider_id" \
+        "$env_var" \
+        "$model" \
+        "$max_tokens" \
+        "$max_context_tokens" \
+        "$api_base" 2>/dev/null <<'PY'
+import json
+import sys
+from pathlib import Path
+
+(
+    provider_id,
+    env_var,
+    model,
+    max_tokens,
+    max_context_tokens,
+    api_base,
+) = sys.argv[1:7]
+
+cfg_path = Path.home() / ".hive" / "configuration.json"
+cfg_path.parent.mkdir(parents=True, exist_ok=True)
+
+try:
+    with open(cfg_path, encoding="utf-8-sig") as f:
+        config = json.load(f)
+except (OSError, json.JSONDecodeError):
+    config = {}
+
+config["worker_llm"] = {
+    "provider": provider_id,
+    "model": model,
+    "max_tokens": int(max_tokens),
+    "max_context_tokens": int(max_context_tokens),
+}
+if env_var:
+    config["worker_llm"]["api_key_env_var"] = env_var
+if api_base:
+    config["worker_llm"]["api_base"] = api_base
+
+tmp_path = cfg_path.with_name(cfg_path.name + ".tmp")
+with open(tmp_path, "w", encoding="utf-8") as f:
+    json.dump(config, f, indent=2)
+tmp_path.replace(cfg_path)
+print(json.dumps(config.get("worker_llm", {}), indent=2))
+PY
+}
+
+# ── Main ─────────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC} ${BOLD}Worker Model Setup${NC} ${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}"
+echo ""
+echo -e "${DIM}Configure a separate LLM model for worker agents.${NC}"
+echo -e "${DIM}Worker agents will use this model instead of the default queen model.${NC}"
+echo ""
+
+# Show current configuration
+if [ -f "$HIVE_CONFIG_FILE" ]; then
+    CURRENT_QUEEN=$(cd "$PROJECT_DIR" && uv run python -c "
+from framework.config import get_preferred_model, get_preferred_worker_model
+print(f'Queen:  {get_preferred_model()}')
+wm = get_preferred_worker_model()
+print(f'Worker: {wm if wm else \"(same as queen)\"}')
+" 2>/dev/null) || true
+    if [ -n "$CURRENT_QUEEN" ]; then
+        echo -e "${BOLD}Current configuration:${NC}"
+        echo -e "  ${DIM}$CURRENT_QUEEN${NC}" | head -1
+        echo -e "  ${DIM}$(echo "$CURRENT_QUEEN" | tail -1)${NC}"
+        echo ""
+    fi
+fi
+
+# Source shell rc to pick up env vars
+SHELL_RC_FILE="$HOME/.bashrc"
+if [ -n "$ZSH_VERSION" ] || [ "$SHELL" = "/bin/zsh" ]; then
+    SHELL_RC_FILE="$HOME/.zshrc"
+fi
+set +e
+if [ -f "$SHELL_RC_FILE" ]; then
+    eval "$(grep -E '^export [A-Z_]+=' "$SHELL_RC_FILE" 2>/dev/null)"
+fi
+set -e
+
+# Detect available providers
+AVAIL_PROVIDERS=()
+AVAIL_ENV_VARS=()
+
+ENV_VARS_TO_CHECK=(ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY GOOGLE_API_KEY GROQ_API_KEY CEREBRAS_API_KEY OPENROUTER_API_KEY MISTRAL_API_KEY TOGETHER_API_KEY DEEPSEEK_API_KEY)
+
+for ev in "${ENV_VARS_TO_CHECK[@]}"; do
+    if [ -n "${!ev:-}" ]; then
+        AVAIL_PROVIDERS+=("$(get_provider_name "$ev")")
+        AVAIL_ENV_VARS+=("$ev")
+    fi
+done
+
+if [ ${#AVAIL_PROVIDERS[@]} -eq 0 ]; then
+    echo -e "${RED}No API keys found.${NC}"
+    echo -e "Run ${CYAN}./quickstart.sh${NC} first to set up your LLM provider."
+    exit 1
+fi
+
+# Pick provider
+SELECTED_PROVIDER_ID=""
+SELECTED_ENV_VAR=""
+SELECTED_MODEL=""
+SELECTED_MAX_TOKENS=8192
+SELECTED_MAX_CONTEXT_TOKENS=120000
+SELECTED_API_BASE=""
+
+if [ ${#AVAIL_PROVIDERS[@]} -eq 1 ]; then
+    SELECTED_ENV_VAR="${AVAIL_ENV_VARS[0]}"
+    SELECTED_PROVIDER_ID="$(get_provider_id "$SELECTED_ENV_VAR")"
+    echo -e "${GREEN}⬢${NC} Provider: $(get_provider_name "$SELECTED_ENV_VAR")"
+else
+    echo -e "${BOLD}Select provider for worker agents:${NC}"
+    echo ""
+    local_i=1
+    for prov in "${AVAIL_PROVIDERS[@]}"; do
+        echo -e "  ${CYAN}${local_i})${NC} $prov"
+        local_i=$((local_i + 1))
+    done
+    echo ""
+    while true; do
+        read -r -p "Enter choice (1-${#AVAIL_PROVIDERS[@]}): " choice || true
+        if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#AVAIL_PROVIDERS[@]}" ]; then
+            idx=$((choice - 1))
+            SELECTED_ENV_VAR="${AVAIL_ENV_VARS[$idx]}"
+            SELECTED_PROVIDER_ID="$(get_provider_id "$SELECTED_ENV_VAR")"
+            echo ""
+            echo -e "${GREEN}⬢${NC} Provider: ${AVAIL_PROVIDERS[$idx]}"
+            break
+        fi
+        echo -e "${RED}Invalid choice.${NC}"
+    done
+fi
+
+# OpenRouter: custom api_base
+if [ "$SELECTED_PROVIDER_ID" = "openrouter" ]; then
+    SELECTED_API_BASE="https://openrouter.ai/api/v1"
+fi
+
+# Select model
+select_model "$SELECTED_PROVIDER_ID"
+
+# Option to clear worker model
+echo ""
+if prompt_yes_no "Save this worker model configuration?"; then
+    echo ""
+    echo -n "  Saving worker model configuration... "
+    if save_worker_configuration "$SELECTED_PROVIDER_ID" "$SELECTED_ENV_VAR" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "$SELECTED_API_BASE" > /dev/null; then
+        echo -e "${GREEN}done${NC}"
+        echo -e "  ${DIM}~/.hive/configuration.json (worker_llm section)${NC}"
+    else
+        echo -e "${RED}failed${NC}"
+        exit 1
+    fi
+else
+    echo ""
+    echo "Cancelled. Worker agents will continue using the default model."
+    exit 0
+fi
+
+echo ""
+echo -e "${GREEN}⬢${NC} Worker model configured successfully."
+echo -e "  ${DIM}Worker agents will now use: ${SELECTED_PROVIDER_ID}/${SELECTED_MODEL}${NC}"
+echo -e "  ${DIM}Run this script again to change, or remove the worker_llm section${NC}"
+echo -e "  ${DIM}from ~/.hive/configuration.json to revert to the default.${NC}"
+echo ""


### PR DESCRIPTION
## Summary
- Add `worker_llm` configuration section so worker agents can use a different (cheaper/faster) model than the queen agent
- New config helpers, session manager wiring, and runner support for externally injected LLMs
- Interactive setup scripts (`setup_worker_model.sh` / `.ps1`) and quickstart hints

Closes #6614

## Test Plan
- [ ] Configure `worker_llm` in `~/.hive/configuration.json` and verify workers use the specified model
- [ ] Verify workers fall back to the queen model when no `worker_llm` is configured
- [ ] Run `./scripts/setup_worker_model.sh` and confirm it writes the correct config
- [ ] Verify existing queen-only workflows are unaffected