### PR TITLE
micro-fix: lazy import resend to prevent crash when not installed

### DIFF
--- a/tools/src/aden_tools/tools/email_tool/email_tool.py
+++ b/tools/src/aden_tools/tools/email_tool/email_tool.py
@@ -12,7 +12,6 @@ import os
 from typing import TYPE_CHECKING, Literal
 
 import httpx
-import resend
 from fastmcp import FastMCP
 
 if TYPE_CHECKING:
@@ -35,6 +34,15 @@ def register_tools(
         bcc: list[str] | None = None,
     ) -> dict:
         """Send email using Resend API."""
+        try:
+            import resend
+        except ImportError:
+            return {
+                "error": (
+                    "resend not installed. Install with: "
+                    "pip install resend  or  pip install tools[email]"
+                )
+            }
         resend.api_key = api_key
         try:
             payload: dict = {


### PR DESCRIPTION
Fixes #4816

## Problem
`email_tool.py` has a bare `import resend` at module level (line 17). When `resend` is not installed, importing this module raises an unhandled `ModuleNotFoundError`, which propagates up through `register_all_tools()` and prevents **all** MCP tools from registering.

## Fix
- Removed `import resend` from module-level imports
- Added lazy import with `try/except ImportError` inside `_send_via_resend()`
- Returns a helpful error dict when resend is not installed

This matches the existing pattern used by `excel_tool.py` (openpyxl) and other tools with optional dependencies.

micro-fix