### PR TITLE
feat: add block-no-verify PreToolUse hook to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write|NotebookEdit",


### PR DESCRIPTION
## Description

Adds `block-no-verify@1.1.2` as a PreToolUse Bash hook in `.claude/settings.json` to prevent agents from bypassing git hooks via the hook-skip flag.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Fixes #6642

## Changes Made

- `.claude/settings.json` — added `PreToolUse` section with a Bash hook running `npx block-no-verify@1.1.2`. The existing `PostToolUse` ruff hook is preserved unchanged.

## Testing

- [x] Manual testing performed — `git commit --no-verify` is blocked; `git commit` without the flag passes through

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

---

_Disclosure: I am the author and maintainer of `block-no-verify`._
