### PR TITLE
Antigravity subscription support as an LLM provider

### DIFF
--- a/core/antigravity_auth.py
+++ b/core/antigravity_auth.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Antigravity authentication CLI.
+
+Implements OAuth2 flow for Google's Antigravity Code Assist gateway.
+Credentials are stored in ~/.hive/antigravity-accounts.json.
+
+Usage:
+    python -m antigravity_auth auth account add
+    python -m antigravity_auth auth account list
+    python -m antigravity_auth auth account remove <email>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import secrets
+import socket
+import subprocess
+import sys
+import time
+import urllib.parse
+import urllib.request
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+# OAuth endpoints
+_OAUTH_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+# Scopes for Antigravity/Cloud Code Assist
+_OAUTH_SCOPES = [
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/userinfo.email",
+    "https://www.googleapis.com/auth/userinfo.profile",
+]
+
+# Credentials file path in ~/.hive/
+_ACCOUNTS_FILE = Path.home() / ".hive" / "antigravity-accounts.json"
+
+# Default project ID
+_DEFAULT_PROJECT_ID = "rising-fact-p41fc"
+_DEFAULT_REDIRECT_PORT = 51121
+
+# OAuth credentials fetched from the opencode-antigravity-auth project.
+# This project reverse-engineered and published the public OAuth credentials
+# for Google's Antigravity/Cloud Code Assist API.
+# Source: https://github.com/NoeFabris/opencode-antigravity-auth
+_CREDENTIALS_URL = "https://raw.githubusercontent.com/NoeFabris/opencode-antigravity-auth/dev/src/constants.ts"
+
+# Cached credentials fetched from public source
+_cached_client_id: str | None = None
+_cached_client_secret: str | None = None
+
+
+def _fetch_credentials_from_public_source() -> tuple[str | None, str | None]:
+    """Fetch OAuth client ID and secret from the public npm package source on GitHub."""
+    global _cached_client_id, _cached_client_secret
+    if _cached_client_id and _cached_client_secret:
+        return _cached_client_id, _cached_client_secret
+
+    try:
+        req = urllib.request.Request(_CREDENTIALS_URL, headers={"User-Agent": "Hive-Antigravity-Auth/1.0"})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            content = resp.read().decode("utf-8")
+            import re
+            id_match = re.search(r'ANTIGRAVITY_CLIENT_ID\s*=\s*"([^"]+)"', content)
+            secret_match = re.search(r'ANTIGRAVITY_CLIENT_SECRET\s*=\s*"([^"]+)"', content)
+            if id_match:
+                _cached_client_id = id_match.group(1)
+            if secret_match:
+                _cached_client_secret = secret_match.group(1)
+            return _cached_client_id, _cached_client_secret
+    except Exception as e:
+        logger.debug(f"Failed to fetch credentials from public source: {e}")
+    return None, None
+
+
+def get_client_id() -> str:
+    """Get OAuth client ID from env, config, or public source."""
+    env_id = os.environ.get("ANTIGRAVITY_CLIENT_ID")
+    if env_id:
+        return env_id
+
+    # Try hive config
+    hive_cfg = Path.home() / ".hive" / "configuration.json"
+    if hive_cfg.exists():
+        try:
+            with open(hive_cfg) as f:
+                cfg = json.load(f)
+                cfg_id = cfg.get("llm", {}).get("antigravity_client_id")
+                if cfg_id:
+                    return cfg_id
+        except Exception:
+            pass
+
+    # Fetch from public source
+    client_id, _ = _fetch_credentials_from_public_source()
+    if client_id:
+        return client_id
+
+    raise RuntimeError("Could not obtain Antigravity OAuth client ID")
+
+
+def get_client_secret() -> str | None:
+    """Get OAuth client secret from env, config, or public source."""
+    secret = os.environ.get("ANTIGRAVITY_CLIENT_SECRET")
+    if secret:
+        return secret
+
+    # Try to read from hive config
+    hive_cfg = Path.home() / ".hive" / "configuration.json"
+    if hive_cfg.exists():
+        try:
+            with open(hive_cfg) as f:
+                cfg = json.load(f)
+                secret = cfg.get("llm", {}).get("antigravity_client_secret")
+                if secret:
+                    return secret
+        except Exception:
+            pass
+
+    # Fetch from public source (npm package on GitHub)
+    _, secret = _fetch_credentials_from_public_source()
+    return secret
+
+
+def find_free_port() -> int:
+    """Find an available local port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        s.listen(1)
+        return s.getsockname()[1]
+
+
+class OAuthCallbackHandler(BaseHTTPRequestHandler):
+    """Handle OAuth callback from browser."""
+
+    auth_code: str | None = None
+    state: str | None = None
+    error: str | None = None
+
+    def log_message(self, format: str, *args: Any) -> None:
+        pass  # Suppress default logging
+
+    def do_GET(self) -> None:
+        parsed = urllib.parse.urlparse(self.path)
+
+        if parsed.path == "/oauth-callback":
+            query = urllib.parse.parse_qs(parsed.query)
+
+            if "error" in query:
+                self.error = query["error"][0]
+                self._send_response("Authentication failed. You can close this window.")
+                return
+
+            if "code" in query and "state" in query:
+                OAuthCallbackHandler.auth_code = query["code"][0]
+                OAuthCallbackHandler.state = query["state"][0]
+                self._send_response(
+                    "Authentication successful! You can close this window and return to the terminal."
+                )
+                return
+
+        self._send_response("Waiting for authentication...")
+
+    def _send_response(self, message: str) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+        html = f"""<!DOCTYPE html>
+<html>
+<head><title>Antigravity Auth</title></head>
+<body style="font-family: system-ui; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; background: #1a1a2e; color: #eee;">
+    <div style="text-align: center;">
+        <h2>{message}</h2>
+    </div>
+</body>
+</html>"""
+        self.wfile.write(html.encode())
+
+
+def wait_for_callback(port: int, timeout: int = 300) -> tuple[str | None, str | None, str | None]:
+    """Start local server and wait for OAuth callback."""
+    server = HTTPServer(("localhost", port), OAuthCallbackHandler)
+    server.timeout = 1
+
+    start = time.time()
+    while time.time() - start < timeout:
+        if OAuthCallbackHandler.auth_code:
+            return (
+                OAuthCallbackHandler.auth_code,
+                OAuthCallbackHandler.state,
+                OAuthCallbackHandler.error,
+            )
+        server.handle_request()
+
+    return None, None, "timeout"
+
+
+def exchange_code_for_tokens(
+    code: str, redirect_uri: str, client_id: str, client_secret: str | None
+) -> dict[str, Any] | None:
+    """Exchange authorization code for tokens."""
+    data = {
+        "code": code,
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "grant_type": "authorization_code",
+    }
+    if client_secret:
+        data["client_secret"] = client_secret
+
+    body = urllib.parse.urlencode(data).encode()
+
+    req = urllib.request.Request(
+        _OAUTH_TOKEN_URL,
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read())
+    except Exception as e:
+        logger.error(f"Token exchange failed: {e}")
+        return None
+
+
+def get_user_email(access_token: str) -> str | None:
+    """Get user email from Google API."""
+    req = urllib.request.Request(
+        "https://www.googleapis.com/oauth2/v2/userinfo",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+            return data.get("email")
+    except Exception:
+        return None
+
+
+def load_accounts() -> dict[str, Any]:
+    """Load existing accounts from file."""
+    if not _ACCOUNTS_FILE.exists():
+        return {"schemaVersion": 4, "accounts": []}
+    try:
+        with open(_ACCOUNTS_FILE) as f:
+            return json.load(f)
+    except Exception:
+        return {"schemaVersion": 4, "accounts": []}
+
+
+def save_accounts(data: dict[str, Any]) -> None:
+    """Save accounts to file."""
+    _ACCOUNTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(_ACCOUNTS_FILE, "w") as f:
+        json.dump(data, f, indent=2)
+    logger.info(f"Saved credentials to {_ACCOUNTS_FILE}")
+
+
+def cmd_account_add(args: argparse.Namespace) -> int:
+    """Add a new Antigravity account via OAuth2."""
+    client_id = get_client_id()
+    client_secret = get_client_secret()
+
+    if not client_secret:
+        logger.warning(
+            "No client secret configured. Token refresh may fail.\n"
+            "Set ANTIGRAVITY_CLIENT_SECRET env var or add "
+            "'antigravity_client_secret' to ~/.hive/configuration.json"
+        )
+
+    # Use fixed port and path matching Google's expected OAuth redirect URI
+    port = _DEFAULT_REDIRECT_PORT
+    redirect_uri = f"http://localhost:{port}/oauth-callback"
+
+    # Generate state for CSRF protection
+    state = secrets.token_urlsafe(16)
+
+    # Build authorization URL
+    params = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": " ".join(_OAUTH_SCOPES),
+        "state": state,
+        "access_type": "offline",
+        "prompt": "consent",
+    }
+    auth_url = f"{_OAUTH_AUTH_URL}?{urllib.parse.urlencode(params)}"
+
+    logger.info("Opening browser for authentication...")
+    logger.info(f"If the browser doesn't open, visit: {auth_url}\n")
+
+    # Open browser
+    webbrowser.open(auth_url)
+
+    # Wait for callback
+    logger.info(f"Listening for callback on port {port}...")
+    code, received_state, error = wait_for_callback(port)
+
+    if error:
+        logger.error(f"Authentication failed: {error}")
+        return 1
+
+    if not code:
+        logger.error("No authorization code received")
+        return 1
+
+    if received_state != state:
+        logger.error("State mismatch - possible CSRF attack")
+        return 1
+
+    # Exchange code for tokens
+    logger.info("Exchanging authorization code for tokens...")
+    tokens = exchange_code_for_tokens(code, redirect_uri, client_id, client_secret)
+
+    if not tokens:
+        return 1
+
+    access_token = tokens.get("access_token")
+    refresh_token = tokens.get("refresh_token")
+    expires_in = tokens.get("expires_in", 3600)
+
+    if not access_token:
+        logger.error("No access token in response")
+        return 1
+
+    # Get user email
+    email = get_user_email(access_token)
+    if email:
+        logger.info(f"Authenticated as: {email}")
+
+    # Load existing accounts and add/update
+    accounts_data = load_accounts()
+    accounts = accounts_data.get("accounts", [])
+
+    # Build new account entry (V4 schema)
+    expires_ms = int((time.time() + expires_in) * 1000)
+    refresh_entry = f"{refresh_token}|{_DEFAULT_PROJECT_ID}"
+
+    new_account = {
+        "access": access_token,
+        "refresh": refresh_entry,
+        "expires": expires_ms,
+        "email": email,
+        "enabled": True,
+    }
+
+    # Update existing account or add new one
+    existing_idx = next(
+        (i for i, a in enumerate(accounts) if a.get("email") == email), None
+    )
+    if existing_idx is not None:
+        accounts[existing_idx] = new_account
+        logger.info(f"Updated existing account: {email}")
+    else:
+        accounts.append(new_account)
+        logger.info(f"Added new account: {email}")
+
+    accounts_data["accounts"] = accounts
+    accounts_data["schemaVersion"] = 4
+    accounts_data["last_refresh"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    save_accounts(accounts_data)
+    logger.info("\n✓ Authentication complete!")
+    return 0
+
+
+def cmd_account_list(args: argparse.Namespace) -> int:
+    """List all stored accounts."""
+    data = load_accounts()
+    accounts = data.get("accounts", [])
+
+    if not accounts:
+        logger.info("No accounts configured.")
+        logger.info(f"Run 'antigravity auth account add' to add one.")
+        return 0
+
+    logger.info("Configured accounts:\n")
+    for i, account in enumerate(accounts, 1):
+        email = account.get("email", "unknown")
+        enabled = "enabled" if account.get("enabled", True) else "disabled"
+        logger.info(f"  {i}. {email} ({enabled})")
+
+    return 0
+
+
+def cmd_account_remove(args: argparse.Namespace) -> int:
+    """Remove an account by email."""
+    email = args.email
+    data = load_accounts()
+    accounts = data.get("accounts", [])
+
+    original_len = len(accounts)
+    accounts = [a for a in accounts if a.get("email") != email]
+
+    if len(accounts) == original_len:
+        logger.error(f"No account found with email: {email}")
+        return 1
+
+    data["accounts"] = accounts
+    save_accounts(data)
+    logger.info(f"Removed account: {email}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Antigravity authentication CLI",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Commands")
+
+    # auth account add
+    auth_parser = subparsers.add_parser("auth", help="Authentication commands")
+    auth_subparsers = auth_parser.add_subparsers(dest="auth_command")
+
+    account_parser = auth_subparsers.add_parser("account", help="Account management")
+    account_subparsers = account_parser.add_subparsers(dest="account_command")
+
+    add_parser = account_subparsers.add_parser("add", help="Add a new account via OAuth2")
+    add_parser.set_defaults(func=cmd_account_add)
+
+    list_parser = account_subparsers.add_parser("list", help="List configured accounts")
+    list_parser.set_defaults(func=cmd_account_list)
+
+    remove_parser = account_subparsers.add_parser("remove", help="Remove an account")
+    remove_parser.add_argument("email", help="Email of account to remove")
+    remove_parser.set_defaults(func=cmd_account_remove)
+
+    args = parser.parse_args()
+
+    if hasattr(args, "func"):
+        return args.func(args)
+
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/core/antigravity_auth.py
+++ b/core/antigravity_auth.py
@@ -18,7 +18,6 @@ import logging
 import os
 import secrets
 import socket
-import subprocess
 import sys
 import time
 import urllib.parse
@@ -53,7 +52,9 @@ _DEFAULT_REDIRECT_PORT = 51121
 # This project reverse-engineered and published the public OAuth credentials
 # for Google's Antigravity/Cloud Code Assist API.
 # Source: https://github.com/NoeFabris/opencode-antigravity-auth
-_CREDENTIALS_URL = "https://raw.githubusercontent.com/NoeFabris/opencode-antigravity-auth/dev/src/constants.ts"
+_CREDENTIALS_URL = (
+    "https://raw.githubusercontent.com/NoeFabris/opencode-antigravity-auth/dev/src/constants.ts"
+)
 
 # Cached credentials fetched from public source
 _cached_client_id: str | None = None
@@ -67,10 +68,13 @@ def _fetch_credentials_from_public_source() -> tuple[str | None, str | None]:
         return _cached_client_id, _cached_client_secret
 
     try:
-        req = urllib.request.Request(_CREDENTIALS_URL, headers={"User-Agent": "Hive-Antigravity-Auth/1.0"})
+        req = urllib.request.Request(
+            _CREDENTIALS_URL, headers={"User-Agent": "Hive-Antigravity-Auth/1.0"}
+        )
         with urllib.request.urlopen(req, timeout=10) as resp:
             content = resp.read().decode("utf-8")
             import re
+
             id_match = re.search(r'ANTIGRAVITY_CLIENT_ID\s*=\s*"([^"]+)"', content)
             secret_match = re.search(r'ANTIGRAVITY_CLIENT_SECRET\s*=\s*"([^"]+)"', content)
             if id_match:
@@ -165,7 +169,8 @@ class OAuthCallbackHandler(BaseHTTPRequestHandler):
                 OAuthCallbackHandler.auth_code = query["code"][0]
                 OAuthCallbackHandler.state = query["state"][0]
                 self._send_response(
-                    "Authentication successful! You can close this window and return to the terminal."
+                    "Authentication successful! You can close this window "
+                    "and return to the terminal."
                 )
                 return
 
@@ -178,7 +183,9 @@ class OAuthCallbackHandler(BaseHTTPRequestHandler):
         html = f"""<!DOCTYPE html>
 <html>
 <head><title>Antigravity Auth</title></head>
-<body style="font-family: system-ui; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; background: #1a1a2e; color: #eee;">
+<body style="font-family: system-ui; display: flex; align-items: center;
+      justify-content: center; height: 100vh; margin: 0; background: #1a1a2e;
+      color: #eee;">
     <div style="text-align: center;">
         <h2>{message}</h2>
     </div>
@@ -288,7 +295,10 @@ def validate_credentials(access_token: str, project_id: str = _DEFAULT_PROJECT_I
     headers = {
         "Authorization": f"Bearer {access_token}",
         "Content-Type": "application/json",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Antigravity/1.18.3",
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Antigravity/1.18.3"
+        ),
         "X-Goog-Api-Client": "google-cloud-sdk vscode_cloudshelleditor/0.1",
     }
 
@@ -306,7 +316,9 @@ def validate_credentials(access_token: str, project_id: str = _DEFAULT_PROJECT_I
         return False
 
 
-def refresh_access_token(refresh_token: str, client_id: str, client_secret: str | None) -> dict | None:
+def refresh_access_token(
+    refresh_token: str, client_id: str, client_secret: str | None
+) -> dict | None:
     """Refresh the access token using the refresh token."""
     data = {
         "grant_type": "refresh_token",
@@ -349,7 +361,9 @@ def cmd_account_add(args: argparse.Namespace) -> int:
         access_token = account.get("access")
         refresh_token_str = account.get("refresh", "")
         refresh_token = refresh_token_str.split("|")[0] if refresh_token_str else None
-        project_id = refresh_token_str.split("|")[1] if "|" in refresh_token_str else _DEFAULT_PROJECT_ID
+        project_id = (
+            refresh_token_str.split("|")[1] if "|" in refresh_token_str else _DEFAULT_PROJECT_ID
+        )
         email = account.get("email", "unknown")
         expires_ms = account.get("expires", 0)
         expires_at = expires_ms / 1000.0 if expires_ms else 0.0
@@ -360,7 +374,7 @@ def cmd_account_add(args: argparse.Namespace) -> int:
             logger.info(f"Found existing credentials for: {email}")
             logger.info("Validating existing credentials...")
             if validate_credentials(access_token, project_id):
-                logger.info(f"✓ Credentials valid! Skipping OAuth.")
+                logger.info("✓ Credentials valid! Skipping OAuth.")
                 return 0
             else:
                 logger.info("Credentials failed validation, refreshing...")
@@ -376,13 +390,15 @@ def cmd_account_add(args: argparse.Namespace) -> int:
                     # Update the account
                     account["access"] = new_access
                     account["expires"] = int((time.time() + expires_in) * 1000)
-                    accounts_data["last_refresh"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+                    accounts_data["last_refresh"] = time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
+                    )
                     save_accounts(accounts_data)
 
                     # Validate the refreshed token
                     logger.info("Validating refreshed credentials...")
                     if validate_credentials(new_access, project_id):
-                        logger.info(f"✓ Credentials refreshed and validated!")
+                        logger.info("✓ Credentials refreshed and validated!")
                         return 0
                     else:
                         logger.info("Refreshed token failed validation, proceeding with OAuth...")
@@ -475,9 +491,7 @@ def cmd_account_add(args: argparse.Namespace) -> int:
     }
 
     # Update existing account or add new one
-    existing_idx = next(
-        (i for i, a in enumerate(accounts) if a.get("email") == email), None
-    )
+    existing_idx = next((i for i, a in enumerate(accounts) if a.get("email") == email), None)
     if existing_idx is not None:
         accounts[existing_idx] = new_account
         logger.info(f"Updated existing account: {email}")
@@ -501,7 +515,7 @@ def cmd_account_list(args: argparse.Namespace) -> int:
 
     if not accounts:
         logger.info("No accounts configured.")
-        logger.info(f"Run 'antigravity auth account add' to add one.")
+        logger.info("Run 'antigravity auth account add' to add one.")
         return 0
 
     logger.info("Configured accounts:\n")

--- a/core/antigravity_auth.py
+++ b/core/antigravity_auth.py
@@ -268,11 +268,128 @@ def save_accounts(data: dict[str, Any]) -> None:
     logger.info(f"Saved credentials to {_ACCOUNTS_FILE}")
 
 
+def validate_credentials(access_token: str, project_id: str = _DEFAULT_PROJECT_ID) -> bool:
+    """Test if credentials work by making a simple API call to Antigravity.
+
+    Returns True if credentials are valid, False otherwise.
+    """
+    endpoint = "https://daily-cloudcode-pa.sandbox.googleapis.com"
+    body = {
+        "project": project_id,
+        "model": "gemini-3-flash",
+        "request": {
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "generationConfig": {"maxOutputTokens": 10},
+        },
+        "requestType": "agent",
+        "userAgent": "antigravity",
+        "requestId": "validation-test",
+    }
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Antigravity/1.18.3",
+        "X-Goog-Api-Client": "google-cloud-sdk vscode_cloudshelleditor/0.1",
+    }
+
+    try:
+        req = urllib.request.Request(
+            f"{endpoint}/v1internal:generateContent",
+            data=json.dumps(body).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            json.loads(resp.read())
+            return True
+    except Exception:
+        return False
+
+
+def refresh_access_token(refresh_token: str, client_id: str, client_secret: str | None) -> dict | None:
+    """Refresh the access token using the refresh token."""
+    data = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": client_id,
+    }
+    if client_secret:
+        data["client_secret"] = client_secret
+
+    body = urllib.parse.urlencode(data).encode()
+    req = urllib.request.Request(
+        _OAUTH_TOKEN_URL,
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read())
+    except Exception as e:
+        logger.debug(f"Token refresh failed: {e}")
+        return None
+
+
 def cmd_account_add(args: argparse.Namespace) -> int:
-    """Add a new Antigravity account via OAuth2."""
+    """Add a new Antigravity account via OAuth2.
+
+    First checks if valid credentials already exist. If so, validates them
+    and skips OAuth if they work. Otherwise, proceeds with OAuth flow.
+    """
     client_id = get_client_id()
     client_secret = get_client_secret()
 
+    # Check if credentials already exist
+    accounts_data = load_accounts()
+    accounts = accounts_data.get("accounts", [])
+
+    if accounts:
+        account = next((a for a in accounts if a.get("enabled", True) is not False), accounts[0])
+        access_token = account.get("access")
+        refresh_token_str = account.get("refresh", "")
+        refresh_token = refresh_token_str.split("|")[0] if refresh_token_str else None
+        project_id = refresh_token_str.split("|")[1] if "|" in refresh_token_str else _DEFAULT_PROJECT_ID
+        email = account.get("email", "unknown")
+        expires_ms = account.get("expires", 0)
+        expires_at = expires_ms / 1000.0 if expires_ms else 0.0
+
+        # Check if token is expired or near expiry
+        if access_token and expires_at and time.time() < expires_at - 60:
+            # Token still valid, test it
+            logger.info(f"Found existing credentials for: {email}")
+            logger.info("Validating existing credentials...")
+            if validate_credentials(access_token, project_id):
+                logger.info(f"✓ Credentials valid! Skipping OAuth.")
+                return 0
+            else:
+                logger.info("Credentials failed validation, refreshing...")
+        elif refresh_token:
+            logger.info(f"Found expired credentials for: {email}")
+            logger.info("Attempting token refresh...")
+
+            tokens = refresh_access_token(refresh_token, client_id, client_secret)
+            if tokens:
+                new_access = tokens.get("access_token")
+                expires_in = tokens.get("expires_in", 3600)
+                if new_access:
+                    # Update the account
+                    account["access"] = new_access
+                    account["expires"] = int((time.time() + expires_in) * 1000)
+                    accounts_data["last_refresh"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+                    save_accounts(accounts_data)
+
+                    # Validate the refreshed token
+                    logger.info("Validating refreshed credentials...")
+                    if validate_credentials(new_access, project_id):
+                        logger.info(f"✓ Credentials refreshed and validated!")
+                        return 0
+                    else:
+                        logger.info("Refreshed token failed validation, proceeding with OAuth...")
+            else:
+                logger.info("Token refresh failed, proceeding with OAuth...")
+
+    # No valid credentials, proceed with OAuth
     if not client_secret:
         logger.warning(
             "No client secret configured. Token refresh may fail.\n"

--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -116,6 +116,16 @@ def get_worker_api_key() -> str | None:
         except ImportError:
             pass
 
+    if worker_llm.get("use_antigravity_subscription"):
+        try:
+            from framework.runner.runner import get_antigravity_token
+
+            token = get_antigravity_token()
+            if token:
+                return token
+        except ImportError:
+            pass
+
     api_key_env_var = worker_llm.get("api_key_env_var")
     if api_key_env_var:
         return os.environ.get(api_key_env_var)
@@ -134,6 +144,8 @@ def get_worker_api_base() -> str | None:
         return "https://chatgpt.com/backend-api/codex"
     if worker_llm.get("use_kimi_code_subscription"):
         return "https://api.kimi.com/coding"
+    if worker_llm.get("use_antigravity_subscription"):
+        return "http://localhost:8069/v1"
     if worker_llm.get("api_base"):
         return worker_llm["api_base"]
     if str(worker_llm.get("provider", "")).lower() == "openrouter":
@@ -251,6 +263,17 @@ def get_api_key() -> str | None:
         except ImportError:
             pass
 
+    # Antigravity subscription: read OAuth token from accounts JSON
+    if llm.get("use_antigravity_subscription"):
+        try:
+            from framework.runner.runner import get_antigravity_token
+
+            token = get_antigravity_token()
+            if token:
+                return token
+        except ImportError:
+            pass
+
     # Standard env-var path (covers ZAI Code and all API-key providers)
     api_key_env_var = llm.get("api_key_env_var")
     if api_key_env_var:
@@ -280,6 +303,9 @@ def get_api_base() -> str | None:
     if llm.get("use_kimi_code_subscription"):
         # Kimi Code uses an Anthropic-compatible endpoint (no /v1 suffix).
         return "https://api.kimi.com/coding"
+    if llm.get("use_antigravity_subscription"):
+        # Antigravity routes through a local OpenAI-compatible proxy.
+        return "http://localhost:8069/v1"
     if llm.get("api_base"):
         return llm["api_base"]
     if str(llm.get("provider", "")).lower() == "openrouter":

--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -286,7 +286,9 @@ def get_api_key() -> str | None:
 # This project reverse-engineered and published the public OAuth credentials
 # for Google's Antigravity/Cloud Code Assist API.
 # Source: https://github.com/NoeFabris/opencode-antigravity-auth
-_ANTIGRAVITY_CREDENTIALS_URL = "https://raw.githubusercontent.com/NoeFabris/opencode-antigravity-auth/dev/src/constants.ts"
+_ANTIGRAVITY_CREDENTIALS_URL = (
+    "https://raw.githubusercontent.com/NoeFabris/opencode-antigravity-auth/dev/src/constants.ts"
+)
 _antigravity_credentials_cache: tuple[str | None, str | None] = (None, None)
 
 
@@ -300,7 +302,9 @@ def _fetch_antigravity_credentials() -> tuple[str | None, str | None]:
     import urllib.request
 
     try:
-        req = urllib.request.Request(_ANTIGRAVITY_CREDENTIALS_URL, headers={"User-Agent": "Hive/1.0"})
+        req = urllib.request.Request(
+            _ANTIGRAVITY_CREDENTIALS_URL, headers={"User-Agent": "Hive/1.0"}
+        )
         with urllib.request.urlopen(req, timeout=10) as resp:
             content = resp.read().decode("utf-8")
             id_match = re.search(r'ANTIGRAVITY_CLIENT_ID\s*=\s*"([^"]+)"', content)

--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -319,9 +319,11 @@ def _read_antigravity_secret_from_npm() -> str | None:
 
     candidates: list[_Path] = []
     try:
-        npm_root = subprocess.check_output(
-            ["npm", "root", "-g"], stderr=subprocess.DEVNULL, timeout=5
-        ).decode().strip()
+        npm_root = (
+            subprocess.check_output(["npm", "root", "-g"], stderr=subprocess.DEVNULL, timeout=5)
+            .decode()
+            .strip()
+        )
         candidates.append(_Path(npm_root) / "opencode-antigravity-auth/dist/src/constants.js")
     except Exception:
         pass

--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -282,18 +282,46 @@ def get_api_key() -> str | None:
     return None
 
 
+# OAuth credentials for Antigravity are fetched from the opencode-antigravity-auth project.
+# This project reverse-engineered and published the public OAuth credentials
+# for Google's Antigravity/Cloud Code Assist API.
+# Source: https://github.com/NoeFabris/opencode-antigravity-auth
+_ANTIGRAVITY_CREDENTIALS_URL = "https://raw.githubusercontent.com/NoeFabris/opencode-antigravity-auth/dev/src/constants.ts"
+_antigravity_credentials_cache: tuple[str | None, str | None] = (None, None)
+
+
+def _fetch_antigravity_credentials() -> tuple[str | None, str | None]:
+    """Fetch OAuth client ID and secret from the public npm package source on GitHub."""
+    global _antigravity_credentials_cache
+    if _antigravity_credentials_cache[0] and _antigravity_credentials_cache[1]:
+        return _antigravity_credentials_cache
+
+    import re
+    import urllib.request
+
+    try:
+        req = urllib.request.Request(_ANTIGRAVITY_CREDENTIALS_URL, headers={"User-Agent": "Hive/1.0"})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            content = resp.read().decode("utf-8")
+            id_match = re.search(r'ANTIGRAVITY_CLIENT_ID\s*=\s*"([^"]+)"', content)
+            secret_match = re.search(r'ANTIGRAVITY_CLIENT_SECRET\s*=\s*"([^"]+)"', content)
+            client_id = id_match.group(1) if id_match else None
+            client_secret = secret_match.group(1) if secret_match else None
+            if client_id and client_secret:
+                _antigravity_credentials_cache = (client_id, client_secret)
+            return client_id, client_secret
+    except Exception as e:
+        logger.debug("Failed to fetch Antigravity credentials from public source: %s", e)
+    return None, None
+
+
 def get_antigravity_client_id() -> str:
     """Return the Antigravity OAuth application client ID.
 
     Checked in order:
     1. ``ANTIGRAVITY_CLIENT_ID`` environment variable
     2. ``llm.antigravity_client_id`` in ~/.hive/configuration.json
-       (written by quickstart when Antigravity is configured)
-
-    Falls back to the well-known application client ID registered by
-    Google for the Antigravity IDE — same value for every user of the
-    application, analogous to CLAUDE_OAUTH_CLIENT_ID / CODEX_OAUTH_CLIENT_ID
-    in runner.py.
+    3. Fetch from public source (opencode-antigravity-auth project on GitHub)
     """
     env = os.environ.get("ANTIGRAVITY_CLIENT_ID")
     if env:
@@ -301,43 +329,11 @@ def get_antigravity_client_id() -> str:
     cfg_val = get_hive_config().get("llm", {}).get("antigravity_client_id")
     if cfg_val:
         return cfg_val
-    # Well-known Antigravity application client ID (public, not user-specific).
-    # Source: github.com/NoeFabris/opencode-antigravity-auth/blob/dev/src/constants.ts
-    return "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
-
-
-def _read_antigravity_secret_from_npm() -> str | None:
-    """Read the Antigravity OAuth client secret from the globally installed npm package.
-
-    Mirrors the bash ``_read_antigravity_creds_from_npm()`` helper so that users
-    who have ``opencode-antigravity-auth`` installed globally always get the secret
-    at runtime — regardless of whether quickstart wrote it to their config.
-    """
-    import re as _re
-    import subprocess
-    from pathlib import Path as _Path
-
-    candidates: list[_Path] = []
-    try:
-        npm_root = (
-            subprocess.check_output(["npm", "root", "-g"], stderr=subprocess.DEVNULL, timeout=5)
-            .decode()
-            .strip()
-        )
-        candidates.append(_Path(npm_root) / "opencode-antigravity-auth/dist/src/constants.js")
-    except Exception:
-        pass
-    candidates += [
-        _Path("/opt/homebrew/lib/node_modules/opencode-antigravity-auth/dist/src/constants.js"),
-        _Path("/usr/local/lib/node_modules/opencode-antigravity-auth/dist/src/constants.js"),
-        _Path("/usr/lib/node_modules/opencode-antigravity-auth/dist/src/constants.js"),
-    ]
-    for p in candidates:
-        if p.exists():
-            m = _re.search(r'"(GOCSPX-[^"]+)"', p.read_text(errors="ignore"))
-            if m:
-                return m.group(1)
-    return None
+    # Fetch from public source
+    client_id, _ = _fetch_antigravity_credentials()
+    if client_id:
+        return client_id
+    raise RuntimeError("Could not obtain Antigravity OAuth client ID")
 
 
 def get_antigravity_client_secret() -> str | None:
@@ -346,8 +342,7 @@ def get_antigravity_client_secret() -> str | None:
     Checked in order:
     1. ``ANTIGRAVITY_CLIENT_SECRET`` environment variable
     2. ``llm.antigravity_client_secret`` in ~/.hive/configuration.json
-       (written by quickstart when Antigravity is configured)
-    3. Globally installed ``opencode-antigravity-auth`` npm package (runtime fallback)
+    3. Fetch from public source (opencode-antigravity-auth project on GitHub)
 
     Returns None when not found — token refresh will be skipped and
     the caller must use whatever access token is already available.
@@ -358,9 +353,9 @@ def get_antigravity_client_secret() -> str | None:
     cfg_val = get_hive_config().get("llm", {}).get("antigravity_client_secret") or None
     if cfg_val:
         return cfg_val
-    # Runtime fallback: read from globally installed npm package so users who set up
-    # via a path other than the updated quickstart still get the secret automatically.
-    return _read_antigravity_secret_from_npm()
+    # Fetch from public source
+    _, secret = _fetch_antigravity_credentials()
+    return secret
 
 
 def get_gcu_enabled() -> bool:

--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -145,7 +145,8 @@ def get_worker_api_base() -> str | None:
     if worker_llm.get("use_kimi_code_subscription"):
         return "https://api.kimi.com/coding"
     if worker_llm.get("use_antigravity_subscription"):
-        return "http://localhost:8069/v1"
+        # Antigravity uses AntigravityProvider directly — no api_base needed.
+        return None
     if worker_llm.get("api_base"):
         return worker_llm["api_base"]
     if str(worker_llm.get("provider", "")).lower() == "openrouter":
@@ -281,6 +282,47 @@ def get_api_key() -> str | None:
     return None
 
 
+def get_antigravity_client_id() -> str:
+    """Return the Antigravity OAuth application client ID.
+
+    Checked in order:
+    1. ``ANTIGRAVITY_CLIENT_ID`` environment variable
+    2. ``llm.antigravity_client_id`` in ~/.hive/configuration.json
+       (written by quickstart when Antigravity is configured)
+
+    Falls back to the well-known application client ID registered by
+    Google for the Antigravity IDE — same value for every user of the
+    application, analogous to CLAUDE_OAUTH_CLIENT_ID / CODEX_OAUTH_CLIENT_ID
+    in runner.py.
+    """
+    env = os.environ.get("ANTIGRAVITY_CLIENT_ID")
+    if env:
+        return env
+    cfg_val = get_hive_config().get("llm", {}).get("antigravity_client_id")
+    if cfg_val:
+        return cfg_val
+    # Well-known Antigravity application client ID (public, not user-specific).
+    # Source: github.com/NoeFabris/opencode-antigravity-auth/blob/dev/src/constants.ts
+    return "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
+
+
+def get_antigravity_client_secret() -> str | None:
+    """Return the Antigravity OAuth client secret.
+
+    Checked in order:
+    1. ``ANTIGRAVITY_CLIENT_SECRET`` environment variable
+    2. ``llm.antigravity_client_secret`` in ~/.hive/configuration.json
+       (written by quickstart when Antigravity is configured)
+
+    Returns None when not found — token refresh will be skipped and
+    the caller must use whatever access token is already available.
+    """
+    env = os.environ.get("ANTIGRAVITY_CLIENT_SECRET")
+    if env:
+        return env
+    return get_hive_config().get("llm", {}).get("antigravity_client_secret") or None
+
+
 def get_gcu_enabled() -> bool:
     """Return whether GCU (browser automation) is enabled in user config."""
     return get_hive_config().get("gcu_enabled", True)
@@ -304,8 +346,8 @@ def get_api_base() -> str | None:
         # Kimi Code uses an Anthropic-compatible endpoint (no /v1 suffix).
         return "https://api.kimi.com/coding"
     if llm.get("use_antigravity_subscription"):
-        # Antigravity routes through a local OpenAI-compatible proxy.
-        return "http://localhost:8069/v1"
+        # Antigravity uses AntigravityProvider directly — no api_base needed.
+        return None
     if llm.get("api_base"):
         return llm["api_base"]
     if str(llm.get("provider", "")).lower() == "openrouter":

--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -306,6 +306,38 @@ def get_antigravity_client_id() -> str:
     return "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
 
 
+def _read_antigravity_secret_from_npm() -> str | None:
+    """Read the Antigravity OAuth client secret from the globally installed npm package.
+
+    Mirrors the bash ``_read_antigravity_creds_from_npm()`` helper so that users
+    who have ``opencode-antigravity-auth`` installed globally always get the secret
+    at runtime — regardless of whether quickstart wrote it to their config.
+    """
+    import re as _re
+    import subprocess
+    from pathlib import Path as _Path
+
+    candidates: list[_Path] = []
+    try:
+        npm_root = subprocess.check_output(
+            ["npm", "root", "-g"], stderr=subprocess.DEVNULL, timeout=5
+        ).decode().strip()
+        candidates.append(_Path(npm_root) / "opencode-antigravity-auth/dist/src/constants.js")
+    except Exception:
+        pass
+    candidates += [
+        _Path("/opt/homebrew/lib/node_modules/opencode-antigravity-auth/dist/src/constants.js"),
+        _Path("/usr/local/lib/node_modules/opencode-antigravity-auth/dist/src/constants.js"),
+        _Path("/usr/lib/node_modules/opencode-antigravity-auth/dist/src/constants.js"),
+    ]
+    for p in candidates:
+        if p.exists():
+            m = _re.search(r'"(GOCSPX-[^"]+)"', p.read_text(errors="ignore"))
+            if m:
+                return m.group(1)
+    return None
+
+
 def get_antigravity_client_secret() -> str | None:
     """Return the Antigravity OAuth client secret.
 
@@ -313,6 +345,7 @@ def get_antigravity_client_secret() -> str | None:
     1. ``ANTIGRAVITY_CLIENT_SECRET`` environment variable
     2. ``llm.antigravity_client_secret`` in ~/.hive/configuration.json
        (written by quickstart when Antigravity is configured)
+    3. Globally installed ``opencode-antigravity-auth`` npm package (runtime fallback)
 
     Returns None when not found — token refresh will be skipped and
     the caller must use whatever access token is already available.
@@ -320,7 +353,12 @@ def get_antigravity_client_secret() -> str | None:
     env = os.environ.get("ANTIGRAVITY_CLIENT_SECRET")
     if env:
         return env
-    return get_hive_config().get("llm", {}).get("antigravity_client_secret") or None
+    cfg_val = get_hive_config().get("llm", {}).get("antigravity_client_secret") or None
+    if cfg_val:
+        return cfg_val
+    # Runtime fallback: read from globally installed npm package so users who set up
+    # via a path other than the updated quickstart still get the secret automatically.
+    return _read_antigravity_secret_from_npm()
 
 
 def get_gcu_enabled() -> bool:

--- a/core/framework/llm/antigravity.py
+++ b/core/framework/llm/antigravity.py
@@ -1,0 +1,702 @@
+"""Antigravity (Google internal Cloud Code Assist) LLM provider.
+
+Antigravity is Google's unified gateway API that routes requests to Gemini,
+Claude, and GPT-OSS models through a single Gemini-style interface.  It is
+NOT the public ``generativelanguage.googleapis.com`` API.
+
+Authentication uses Google OAuth2.  Token refresh is done directly with the
+OAuth client secret — no local proxy (``antigravity-auth serve``) required.
+
+Credential sources (checked in order):
+  1. ``~/.config/opencode/antigravity-accounts.json``  (written by the
+     opencode-antigravity-auth plugin — V4 schema with proper expiry info)
+  2. Antigravity IDE SQLite state DB  (macOS / Linux)
+
+References:
+  https://github.com/NoeFabris/opencode-antigravity-auth
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+from typing import Any
+
+from framework.llm.provider import LLMProvider, LLMResponse, Tool
+from framework.llm.stream_events import (
+    FinishEvent,
+    StreamErrorEvent,
+    StreamEvent,
+    TextDeltaEvent,
+    TextEndEvent,
+    ToolCallEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+# Fallback order: daily sandbox → autopush sandbox → production
+_ENDPOINTS = [
+    "https://daily-cloudcode-pa.sandbox.googleapis.com",
+    "https://autopush-cloudcode-pa.sandbox.googleapis.com",
+    "https://cloudcode-pa.googleapis.com",
+]
+_DEFAULT_PROJECT_ID = "rising-fact-p41fc"
+_TOKEN_REFRESH_BUFFER_SECS = 60
+
+_ACCOUNTS_FILE = Path.home() / ".config" / "opencode" / "antigravity-accounts.json"
+_IDE_STATE_DB_MAC = (
+    Path.home()
+    / "Library"
+    / "Application Support"
+    / "Antigravity"
+    / "User"
+    / "globalStorage"
+    / "state.vscdb"
+)
+_IDE_STATE_DB_LINUX = (
+    Path.home()
+    / ".config"
+    / "Antigravity"
+    / "User"
+    / "globalStorage"
+    / "state.vscdb"
+)
+_IDE_STATE_DB_KEY = "antigravityUnifiedStateSync.oauthToken"
+
+_BASE_HEADERS: dict[str, str] = {
+    # Mimic the Antigravity Electron app so the API accepts the request.
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Antigravity/1.18.3 Chrome/138.0.7204.235 "
+        "Electron/37.3.1 Safari/537.36"
+    ),
+    "X-Goog-Api-Client": "google-cloud-sdk vscode_cloudshelleditor/0.1",
+    "Client-Metadata": '{"ideType":"ANTIGRAVITY","platform":"MACOS","pluginType":"GEMINI"}',
+}
+
+
+# ---------------------------------------------------------------------------
+# Credential loading helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_from_json_file() -> tuple[str | None, str | None, str, float]:
+    """Read credentials from ``~/.config/opencode/antigravity-accounts.json``.
+
+    Returns ``(access_token | None, refresh_token | None, project_id, expires_at)``.
+    ``expires_at`` is a Unix timestamp (seconds); 0.0 means unknown.
+    """
+    if not _ACCOUNTS_FILE.exists():
+        return None, None, _DEFAULT_PROJECT_ID, 0.0
+    try:
+        with open(_ACCOUNTS_FILE, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.debug("Failed to read Antigravity accounts file: %s", exc)
+        return None, None, _DEFAULT_PROJECT_ID, 0.0
+
+    accounts = data.get("accounts", [])
+    if not accounts:
+        return None, None, _DEFAULT_PROJECT_ID, 0.0
+
+    account = next(
+        (a for a in accounts if a.get("enabled", True) is not False), accounts[0]
+    )
+    schema_version = data.get("schemaVersion", 1)
+
+    if schema_version >= 4:
+        # V4 schema: refresh = "refreshToken|projectId[|managedProjectId]"
+        refresh_str = account.get("refresh", "")
+        parts = refresh_str.split("|") if refresh_str else []
+        refresh_token: str | None = parts[0] if parts else None
+        project_id = parts[1] if len(parts) >= 2 and parts[1] else _DEFAULT_PROJECT_ID
+
+        access_token: str | None = account.get("access")
+        expires_ms: int = account.get("expires", 0)
+        expires_at = float(expires_ms) / 1000.0 if expires_ms else 0.0
+
+        # Treat near-expiry tokens as absent so _ensure_token() triggers a refresh.
+        if access_token and expires_at and time.time() >= expires_at - _TOKEN_REFRESH_BUFFER_SECS:
+            access_token = None
+            expires_at = 0.0
+
+        return access_token, refresh_token, project_id, expires_at
+    else:
+        # V1–V3 schema: plain accessToken / refreshToken fields
+        access_token = account.get("accessToken")
+        refresh_token = account.get("refreshToken")
+        # Estimate expiry from last_refresh + 1 h
+        last_refresh_str: str | None = data.get("last_refresh")
+        expires_at = 0.0
+        if last_refresh_str:
+            try:
+                from datetime import datetime  # noqa: PLC0415
+
+                ts = datetime.fromisoformat(
+                    last_refresh_str.replace("Z", "+00:00")
+                ).timestamp()
+                expires_at = ts + 3600.0
+                if time.time() >= expires_at - _TOKEN_REFRESH_BUFFER_SECS:
+                    access_token = None
+            except (ValueError, TypeError):
+                pass
+        return access_token, refresh_token, _DEFAULT_PROJECT_ID, expires_at
+
+
+def _load_from_ide_db() -> tuple[str | None, str | None, float]:
+    """Extract ``(access_token, refresh_token, expires_at)`` from the IDE SQLite DB."""
+    import base64  # noqa: PLC0415
+    import sqlite3  # noqa: PLC0415
+
+    for db_path in (_IDE_STATE_DB_MAC, _IDE_STATE_DB_LINUX):
+        if not db_path.exists():
+            continue
+        try:
+            con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+            try:
+                row = con.execute(
+                    "SELECT value FROM ItemTable WHERE key = ?",
+                    (_IDE_STATE_DB_KEY,),
+                ).fetchone()
+            finally:
+                con.close()
+            if not row:
+                continue
+
+            blob = base64.b64decode(row[0])
+            candidates = re.findall(rb"[A-Za-z0-9+/=_\-]{40,}", blob)
+            access_token: str | None = None
+            refresh_token: str | None = None
+            for candidate in candidates:
+                try:
+                    padded = candidate + b"=" * (-len(candidate) % 4)
+                    inner = base64.urlsafe_b64decode(padded)
+                except Exception:
+                    continue
+                if not access_token:
+                    m = re.search(rb"ya29\.[A-Za-z0-9_\-\.]+", inner)
+                    if m:
+                        access_token = m.group(0).decode("ascii")
+                if not refresh_token:
+                    m = re.search(rb"1//[A-Za-z0-9_\-\.]+", inner)
+                    if m:
+                        refresh_token = m.group(0).decode("ascii")
+                if access_token and refresh_token:
+                    break
+
+            if access_token:
+                # Estimate expiry from DB mtime (IDE refreshes while running)
+                mtime = db_path.stat().st_mtime
+                expires_at = mtime + 3600.0
+                return access_token, refresh_token, expires_at
+        except Exception as exc:
+            logger.debug("Failed to read Antigravity IDE state DB: %s", exc)
+            continue
+    return None, None, 0.0
+
+
+def _do_token_refresh(refresh_token: str) -> tuple[str, float] | None:
+    """POST to Google OAuth endpoint and return ``(new_access_token, expires_at)``.
+
+    Requires the Antigravity OAuth client secret to be configured via:
+    - ``ANTIGRAVITY_CLIENT_SECRET`` environment variable, or
+    - ``llm.antigravity_client_secret`` in ~/.hive/configuration.json
+
+    Returns None (skips refresh) when the secret is unavailable.
+    """
+    from framework.config import get_antigravity_client_secret  # noqa: PLC0415
+
+    client_secret = get_antigravity_client_secret()
+    if not client_secret:
+        logger.debug(
+            "Antigravity client secret not configured — skipping token refresh. "
+            "Set ANTIGRAVITY_CLIENT_SECRET or run quickstart to configure."
+        )
+        return None
+
+    import urllib.error  # noqa: PLC0415
+    import urllib.parse  # noqa: PLC0415
+    import urllib.request  # noqa: PLC0415
+
+    from framework.config import get_antigravity_client_id  # noqa: PLC0415
+
+    body = urllib.parse.urlencode(
+        {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": get_antigravity_client_id(),
+            "client_secret": client_secret,
+        }
+    ).encode("utf-8")
+
+    req = urllib.request.Request(
+        _TOKEN_URL,
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:  # noqa: S310
+            payload = json.loads(resp.read())
+        access_token: str = payload["access_token"]
+        expires_in: int = payload.get("expires_in", 3600)
+        logger.debug("Antigravity token refreshed successfully")
+        return access_token, time.time() + expires_in
+    except (Exception) as exc:
+        logger.debug("Antigravity token refresh failed: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Message conversion helpers
+# ---------------------------------------------------------------------------
+
+
+def _clean_tool_name(name: str) -> str:
+    """Sanitize a tool name for the Antigravity function-calling schema."""
+    name = re.sub(r"[/\s]", "_", name)
+    if name and not (name[0].isalpha() or name[0] == "_"):
+        name = "_" + name
+    return name[:64]
+
+
+def _to_gemini_contents(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert OpenAI-format messages to Gemini-style ``contents`` array."""
+    # Pre-build a map tool_call_id → function_name from assistant messages.
+    # Tool result messages (role="tool") only carry tool_call_id, not the name,
+    # but Gemini requires functionResponse.name to match the functionCall.name.
+    tc_id_to_name: dict[str, str] = {}
+    for msg in messages:
+        if msg.get("role") == "assistant":
+            for tc in msg.get("tool_calls") or []:
+                tc_id = tc.get("id")
+                fn_name = tc.get("function", {}).get("name", "")
+                if tc_id and fn_name:
+                    tc_id_to_name[tc_id] = fn_name
+
+    contents: list[dict[str, Any]] = []
+    # Consecutive tool-result messages must be batched into one user turn.
+    pending_tool_parts: list[dict[str, Any]] = []
+
+    def _flush_tool_results() -> None:
+        if pending_tool_parts:
+            contents.append({"role": "user", "parts": list(pending_tool_parts)})
+            pending_tool_parts.clear()
+
+    for msg in messages:
+        role = msg.get("role", "user")
+        content = msg.get("content")
+
+        if role == "system":
+            continue  # Handled via systemInstruction, not in contents.
+
+        if role == "tool":
+            # OpenAI tool result → Gemini functionResponse part.
+            result_str = content if isinstance(content, str) else str(content or "")
+            tc_id = msg.get("tool_call_id", "")
+            # Look up function name from the pre-built map; fall back to msg.name.
+            fn_name = tc_id_to_name.get(tc_id) or msg.get("name", "")
+            pending_tool_parts.append({
+                "functionResponse": {
+                    "name": fn_name,
+                    "id": tc_id,
+                    "response": {"content": result_str},
+                }
+            })
+            continue
+
+        _flush_tool_results()
+
+        gemini_role = "model" if role == "assistant" else "user"
+        parts: list[dict[str, Any]] = []
+
+        if isinstance(content, str) and content:
+            parts.append({"text": content})
+        elif isinstance(content, list):
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                if block.get("type") == "text":
+                    text = block.get("text", "")
+                    if text:
+                        parts.append({"text": text})
+                # Other block types (image_url etc.) skipped.
+
+        # Assistant messages may carry OpenAI-style tool_calls.
+        for tc in msg.get("tool_calls") or []:
+            fn = tc.get("function", {})
+            try:
+                args = json.loads(fn.get("arguments", "{}") or "{}")
+            except (json.JSONDecodeError, TypeError):
+                args = {}
+            parts.append({
+                "functionCall": {
+                    "name": fn.get("name", ""),
+                    "args": args,
+                    "id": tc.get("id", str(uuid.uuid4())),
+                }
+            })
+
+        if parts:
+            contents.append({"role": gemini_role, "parts": parts})
+
+    _flush_tool_results()
+
+    # Gemini requires the first turn to be a user turn.  Drop any leading
+    # model messages so the API doesn't reject with a 400.
+    while contents and contents[0].get("role") == "model":
+        contents.pop(0)
+
+    return contents
+
+
+# ---------------------------------------------------------------------------
+# Response parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _map_finish_reason(reason: str) -> str:
+    return {"STOP": "stop", "MAX_TOKENS": "max_tokens", "OTHER": "tool_use"}.get(
+        (reason or "").upper(), "stop"
+    )
+
+
+def _parse_complete_response(raw: dict[str, Any], model: str) -> LLMResponse:
+    """Parse a non-streaming Antigravity response dict → LLMResponse."""
+    payload: dict[str, Any] = raw.get("response", raw)
+    candidates: list[dict[str, Any]] = payload.get("candidates", [])
+    usage: dict[str, Any] = payload.get("usageMetadata", {})
+
+    text_parts: list[str] = []
+    if candidates:
+        for part in candidates[0].get("content", {}).get("parts", []):
+            if "text" in part and not part.get("thought"):
+                text_parts.append(part["text"])
+
+    return LLMResponse(
+        content="".join(text_parts),
+        model=payload.get("modelVersion", model),
+        input_tokens=usage.get("promptTokenCount", 0),
+        output_tokens=usage.get("candidatesTokenCount", 0),
+        stop_reason=_map_finish_reason(
+            candidates[0].get("finishReason", "") if candidates else ""
+        ),
+        raw_response=raw,
+    )
+
+
+def _parse_sse_stream(response: Any, model: str) -> Iterator[StreamEvent]:
+    """Parse Antigravity SSE response line-by-line → StreamEvents.
+
+    Each SSE line looks like::
+
+        data: {"response": {"candidates": [...], "usageMetadata": {...}}, "traceId": "..."}
+    """
+    accumulated = ""
+    input_tokens = 0
+    output_tokens = 0
+    finish_reason = ""
+
+    for raw_line in response:
+        line: str = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
+        if not line.startswith("data:"):
+            continue
+        data_str = line[5:].strip()
+        if not data_str or data_str == "[DONE]":
+            continue
+        try:
+            data: dict[str, Any] = json.loads(data_str)
+        except json.JSONDecodeError:
+            continue
+
+        # The outer envelope is {"response": {...}, "traceId": "..."}.
+        payload: dict[str, Any] = data.get("response", data)
+
+        usage = payload.get("usageMetadata", {})
+        if usage:
+            input_tokens = usage.get("promptTokenCount", input_tokens)
+            output_tokens = usage.get("candidatesTokenCount", output_tokens)
+
+        for candidate in payload.get("candidates", []):
+            fr = candidate.get("finishReason", "")
+            if fr:
+                finish_reason = fr
+
+            for part in candidate.get("content", {}).get("parts", []):
+                if "text" in part and not part.get("thought"):
+                    delta: str = part["text"]
+                    accumulated += delta
+                    yield TextDeltaEvent(content=delta, snapshot=accumulated)
+                elif "functionCall" in part:
+                    fc: dict[str, Any] = part["functionCall"]
+                    args = fc.get("args", {})
+                    if isinstance(args, str):
+                        try:
+                            args = json.loads(args)
+                        except json.JSONDecodeError:
+                            args = {}
+                    yield ToolCallEvent(
+                        tool_use_id=fc.get("id") or str(uuid.uuid4()),
+                        tool_name=fc.get("name", ""),
+                        tool_input=args,
+                    )
+
+    if accumulated:
+        yield TextEndEvent(full_text=accumulated)
+    yield FinishEvent(
+        stop_reason=_map_finish_reason(finish_reason),
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        model=model,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class AntigravityProvider(LLMProvider):
+    """LLM provider for Google's internal Antigravity Code Assist gateway.
+
+    No local proxy required.  Handles OAuth token refresh, Gemini-format
+    request/response conversion, and SSE streaming directly.
+    """
+
+    def __init__(self, model: str = "gemini-3-flash") -> None:
+        # Strip any provider prefix ("openai/gemini-3-flash" → "gemini-3-flash").
+        if "/" in model:
+            model = model.split("/", 1)[1]
+        self.model = model
+
+        self._access_token: str | None = None
+        self._refresh_token: str | None = None
+        self._project_id: str = _DEFAULT_PROJECT_ID
+        self._token_expires_at: float = 0.0
+
+        self._init_credentials()
+
+    # --- Credential management -------------------------------------------- #
+
+    def _init_credentials(self) -> None:
+        """Load credentials from the best available source."""
+        access, refresh, project_id, expires_at = _load_from_json_file()
+        if refresh:
+            self._refresh_token = refresh
+            self._project_id = project_id
+            self._access_token = access
+            self._token_expires_at = expires_at
+            return
+
+        # Fall back to IDE state DB.
+        access, refresh, expires_at = _load_from_ide_db()
+        if access:
+            self._access_token = access
+            self._refresh_token = refresh
+            self._token_expires_at = expires_at
+
+    def has_credentials(self) -> bool:
+        """Return True if any credential is available."""
+        return bool(self._access_token or self._refresh_token)
+
+    def _ensure_token(self) -> str:
+        """Return a valid access token, refreshing via OAuth if needed."""
+        if (
+            self._access_token
+            and self._token_expires_at
+            and time.time() < self._token_expires_at - _TOKEN_REFRESH_BUFFER_SECS
+        ):
+            return self._access_token
+
+        if self._refresh_token:
+            result = _do_token_refresh(self._refresh_token)
+            if result:
+                self._access_token, self._token_expires_at = result
+                return self._access_token
+
+        if self._access_token:
+            logger.warning("Using potentially stale Antigravity access token")
+            return self._access_token
+
+        raise RuntimeError(
+            "No valid Antigravity credentials. Authenticate with the "
+            "opencode-antigravity-auth plugin: "
+            "https://github.com/NoeFabris/opencode-antigravity-auth"
+        )
+
+    # --- Request building -------------------------------------------------- #
+
+    def _build_body(
+        self,
+        messages: list[dict[str, Any]],
+        system: str,
+        tools: list[Tool] | None,
+        max_tokens: int,
+    ) -> dict[str, Any]:
+        contents = _to_gemini_contents(messages)
+        inner: dict[str, Any] = {
+            "contents": contents,
+            "generationConfig": {"maxOutputTokens": max_tokens},
+        }
+        if system:
+            inner["systemInstruction"] = {"parts": [{"text": system}]}
+        if tools:
+            inner["tools"] = [
+                {
+                    "functionDeclarations": [
+                        {
+                            "name": _clean_tool_name(t.name),
+                            "description": t.description,
+                            "parameters": t.parameters or {
+                                "type": "object",
+                                "properties": {},
+                            },
+                        }
+                        for t in tools
+                    ]
+                }
+            ]
+        return {
+            "project": self._project_id,
+            "model": self.model,
+            "request": inner,
+            "requestType": "agent",
+            "userAgent": "antigravity",
+            "requestId": f"agent-{uuid.uuid4()}",
+        }
+
+    # --- HTTP transport ---------------------------------------------------- #
+
+    def _post(self, body: dict[str, Any], *, streaming: bool) -> Any:
+        """POST to the Antigravity endpoint, falling back through the endpoint list."""
+        import urllib.error  # noqa: PLC0415
+        import urllib.request  # noqa: PLC0415
+
+        token = self._ensure_token()
+        body_bytes = json.dumps(body).encode("utf-8")
+        path = (
+            "/v1internal:streamGenerateContent?alt=sse"
+            if streaming
+            else "/v1internal:generateContent"
+        )
+        headers = {
+            **_BASE_HEADERS,
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+        if streaming:
+            headers["Accept"] = "text/event-stream"
+
+        last_exc: Exception | None = None
+        for base_url in _ENDPOINTS:
+            url = f"{base_url}{path}"
+            req = urllib.request.Request(
+                url, data=body_bytes, headers=headers, method="POST"
+            )
+            try:
+                return urllib.request.urlopen(req, timeout=120)  # noqa: S310
+            except urllib.error.HTTPError as exc:
+                if exc.code in (401, 403) and self._refresh_token:
+                    # Token rejected — refresh once and retry this endpoint.
+                    result = _do_token_refresh(self._refresh_token)
+                    if result:
+                        self._access_token, self._token_expires_at = result
+                        headers["Authorization"] = f"Bearer {self._access_token}"
+                        req2 = urllib.request.Request(
+                            url, data=body_bytes, headers=headers, method="POST"
+                        )
+                        try:
+                            return urllib.request.urlopen(req2, timeout=120)  # noqa: S310
+                        except urllib.error.HTTPError as exc2:
+                            last_exc = exc2
+                            continue
+                    last_exc = exc
+                    continue
+                elif exc.code >= 500:
+                    last_exc = exc
+                    continue
+                # Include the API response body in the exception for easier debugging.
+                try:
+                    err_body = exc.read().decode("utf-8", errors="replace")
+                except Exception:
+                    err_body = "(unreadable)"
+                raise RuntimeError(
+                    f"Antigravity HTTP {exc.code} from {url}: {err_body}"
+                ) from exc
+            except (urllib.error.URLError, OSError) as exc:
+                last_exc = exc
+                continue
+
+        raise RuntimeError(
+            f"All Antigravity endpoints failed. Last error: {last_exc}"
+        ) from last_exc
+
+    # --- LLMProvider interface --------------------------------------------- #
+
+    def complete(
+        self,
+        messages: list[dict[str, Any]],
+        system: str = "",
+        tools: list[Tool] | None = None,
+        max_tokens: int = 1024,
+        response_format: dict[str, Any] | None = None,
+        json_mode: bool = False,
+        max_retries: int | None = None,
+    ) -> LLMResponse:
+        if json_mode:
+            suffix = "\n\nPlease respond with a valid JSON object."
+            system = (system + suffix) if system else suffix.strip()
+
+        body = self._build_body(messages, system, tools, max_tokens)
+        resp = self._post(body, streaming=False)
+        return _parse_complete_response(json.loads(resp.read()), self.model)
+
+    async def stream(
+        self,
+        messages: list[dict[str, Any]],
+        system: str = "",
+        tools: list[Tool] | None = None,
+        max_tokens: int = 4096,
+    ) -> AsyncIterator[StreamEvent]:
+        import asyncio  # noqa: PLC0415
+        import concurrent.futures  # noqa: PLC0415
+
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue[StreamEvent | None] = asyncio.Queue()
+
+        def _blocking_work() -> None:
+            try:
+                body = self._build_body(messages, system, tools, max_tokens)
+                http_resp = self._post(body, streaming=True)
+                for event in _parse_sse_stream(http_resp, self.model):
+                    loop.call_soon_threadsafe(queue.put_nowait, event)
+            except Exception as exc:
+                logger.error("Antigravity stream error: %s", exc)
+                loop.call_soon_threadsafe(
+                    queue.put_nowait, StreamErrorEvent(error=str(exc))
+                )
+            finally:
+                loop.call_soon_threadsafe(queue.put_nowait, None)  # sentinel
+
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        fut = loop.run_in_executor(executor, _blocking_work)
+        try:
+            while True:
+                event = await queue.get()
+                if event is None:
+                    break
+                yield event
+        finally:
+            await fut
+            executor.shutdown(wait=False)

--- a/core/framework/llm/antigravity.py
+++ b/core/framework/llm/antigravity.py
@@ -200,21 +200,21 @@ def _load_from_ide_db() -> tuple[str | None, str | None, float]:
 def _do_token_refresh(refresh_token: str) -> tuple[str, float] | None:
     """POST to Google OAuth endpoint and return ``(new_access_token, expires_at)``.
 
-    Requires the Antigravity OAuth client secret to be configured via:
-    - ``ANTIGRAVITY_CLIENT_SECRET`` environment variable, or
-    - ``llm.antigravity_client_secret`` in ~/.hive/configuration.json
+    The client secret is sourced via ``get_antigravity_client_secret()`` (env var,
+    config file, or npm package fallback). When unavailable the refresh is attempted
+    without it — Google will reject it for web-app clients, but the npm fallback in
+    ``get_antigravity_client_secret()`` should ensure the secret is found at runtime.
 
-    Returns None (skips refresh) when the secret is unavailable.
+    Returns None when the HTTP request fails.
     """
     from framework.config import get_antigravity_client_secret  # noqa: PLC0415
 
     client_secret = get_antigravity_client_secret()
     if not client_secret:
         logger.debug(
-            "Antigravity client secret not configured — skipping token refresh. "
+            "Antigravity client secret not configured — attempting refresh without it. "
             "Set ANTIGRAVITY_CLIENT_SECRET or run quickstart to configure."
         )
-        return None
 
     import urllib.error  # noqa: PLC0415
     import urllib.parse  # noqa: PLC0415
@@ -222,14 +222,14 @@ def _do_token_refresh(refresh_token: str) -> tuple[str, float] | None:
 
     from framework.config import get_antigravity_client_id  # noqa: PLC0415
 
-    body = urllib.parse.urlencode(
-        {
-            "grant_type": "refresh_token",
-            "refresh_token": refresh_token,
-            "client_id": get_antigravity_client_id(),
-            "client_secret": client_secret,
-        }
-    ).encode("utf-8")
+    params: dict[str, str] = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": get_antigravity_client_id(),
+    }
+    if client_secret:
+        params["client_secret"] = client_secret
+    body = urllib.parse.urlencode(params).encode("utf-8")
 
     req = urllib.request.Request(
         _TOKEN_URL,

--- a/core/framework/llm/antigravity.py
+++ b/core/framework/llm/antigravity.py
@@ -65,12 +65,7 @@ _IDE_STATE_DB_MAC = (
     / "state.vscdb"
 )
 _IDE_STATE_DB_LINUX = (
-    Path.home()
-    / ".config"
-    / "Antigravity"
-    / "User"
-    / "globalStorage"
-    / "state.vscdb"
+    Path.home() / ".config" / "Antigravity" / "User" / "globalStorage" / "state.vscdb"
 )
 _IDE_STATE_DB_KEY = "antigravityUnifiedStateSync.oauthToken"
 
@@ -110,9 +105,7 @@ def _load_from_json_file() -> tuple[str | None, str | None, str, float]:
     if not accounts:
         return None, None, _DEFAULT_PROJECT_ID, 0.0
 
-    account = next(
-        (a for a in accounts if a.get("enabled", True) is not False), accounts[0]
-    )
+    account = next((a for a in accounts if a.get("enabled", True) is not False), accounts[0])
     schema_version = data.get("schemaVersion", 1)
 
     if schema_version >= 4:
@@ -143,9 +136,7 @@ def _load_from_json_file() -> tuple[str | None, str | None, str, float]:
             try:
                 from datetime import datetime  # noqa: PLC0415
 
-                ts = datetime.fromisoformat(
-                    last_refresh_str.replace("Z", "+00:00")
-                ).timestamp()
+                ts = datetime.fromisoformat(last_refresh_str.replace("Z", "+00:00")).timestamp()
                 expires_at = ts + 3600.0
                 if time.time() >= expires_at - _TOKEN_REFRESH_BUFFER_SECS:
                     access_token = None
@@ -253,7 +244,7 @@ def _do_token_refresh(refresh_token: str) -> tuple[str, float] | None:
         expires_in: int = payload.get("expires_in", 3600)
         logger.debug("Antigravity token refreshed successfully")
         return access_token, time.time() + expires_in
-    except (Exception) as exc:
+    except Exception as exc:
         logger.debug("Antigravity token refresh failed: %s", exc)
         return None
 
@@ -307,13 +298,15 @@ def _to_gemini_contents(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
             tc_id = msg.get("tool_call_id", "")
             # Look up function name from the pre-built map; fall back to msg.name.
             fn_name = tc_id_to_name.get(tc_id) or msg.get("name", "")
-            pending_tool_parts.append({
-                "functionResponse": {
-                    "name": fn_name,
-                    "id": tc_id,
-                    "response": {"content": result_str},
+            pending_tool_parts.append(
+                {
+                    "functionResponse": {
+                        "name": fn_name,
+                        "id": tc_id,
+                        "response": {"content": result_str},
+                    }
                 }
-            })
+            )
             continue
 
         _flush_tool_results()
@@ -340,13 +333,15 @@ def _to_gemini_contents(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 args = json.loads(fn.get("arguments", "{}") or "{}")
             except (json.JSONDecodeError, TypeError):
                 args = {}
-            parts.append({
-                "functionCall": {
-                    "name": fn.get("name", ""),
-                    "args": args,
-                    "id": tc.get("id", str(uuid.uuid4())),
+            parts.append(
+                {
+                    "functionCall": {
+                        "name": fn.get("name", ""),
+                        "args": args,
+                        "id": tc.get("id", str(uuid.uuid4())),
+                    }
                 }
-            })
+            )
 
         if parts:
             contents.append({"role": gemini_role, "parts": parts})
@@ -389,9 +384,7 @@ def _parse_complete_response(raw: dict[str, Any], model: str) -> LLMResponse:
         model=payload.get("modelVersion", model),
         input_tokens=usage.get("promptTokenCount", 0),
         output_tokens=usage.get("candidatesTokenCount", 0),
-        stop_reason=_map_finish_reason(
-            candidates[0].get("finishReason", "") if candidates else ""
-        ),
+        stop_reason=_map_finish_reason(candidates[0].get("finishReason", "") if candidates else ""),
         raw_response=raw,
     )
 
@@ -558,7 +551,8 @@ class AntigravityProvider(LLMProvider):
                         {
                             "name": _clean_tool_name(t.name),
                             "description": t.description,
-                            "parameters": t.parameters or {
+                            "parameters": t.parameters
+                            or {
                                 "type": "object",
                                 "properties": {},
                             },
@@ -601,9 +595,7 @@ class AntigravityProvider(LLMProvider):
         last_exc: Exception | None = None
         for base_url in _ENDPOINTS:
             url = f"{base_url}{path}"
-            req = urllib.request.Request(
-                url, data=body_bytes, headers=headers, method="POST"
-            )
+            req = urllib.request.Request(url, data=body_bytes, headers=headers, method="POST")
             try:
                 return urllib.request.urlopen(req, timeout=120)  # noqa: S310
             except urllib.error.HTTPError as exc:
@@ -631,9 +623,7 @@ class AntigravityProvider(LLMProvider):
                     err_body = exc.read().decode("utf-8", errors="replace")
                 except Exception:
                     err_body = "(unreadable)"
-                raise RuntimeError(
-                    f"Antigravity HTTP {exc.code} from {url}: {err_body}"
-                ) from exc
+                raise RuntimeError(f"Antigravity HTTP {exc.code} from {url}: {err_body}") from exc
             except (urllib.error.URLError, OSError) as exc:
                 last_exc = exc
                 continue
@@ -683,9 +673,7 @@ class AntigravityProvider(LLMProvider):
                     loop.call_soon_threadsafe(queue.put_nowait, event)
             except Exception as exc:
                 logger.error("Antigravity stream error: %s", exc)
-                loop.call_soon_threadsafe(
-                    queue.put_nowait, StreamErrorEvent(error=str(exc))
-                )
+                loop.call_soon_threadsafe(queue.put_nowait, StreamErrorEvent(error=str(exc)))
             finally:
                 loop.call_soon_threadsafe(queue.put_nowait, None)  # sentinel
 

--- a/core/framework/llm/antigravity.py
+++ b/core/framework/llm/antigravity.py
@@ -23,7 +23,7 @@ import logging
 import re
 import time
 import uuid
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator, Callable, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -262,7 +262,10 @@ def _clean_tool_name(name: str) -> str:
     return name[:64]
 
 
-def _to_gemini_contents(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _to_gemini_contents(
+    messages: list[dict[str, Any]],
+    thought_sigs: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
     """Convert OpenAI-format messages to Gemini-style ``contents`` array."""
     # Pre-build a map tool_call_id → function_name from assistant messages.
     # Tool result messages (role="tool") only carry tool_call_id, not the name,
@@ -333,15 +336,19 @@ def _to_gemini_contents(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 args = json.loads(fn.get("arguments", "{}") or "{}")
             except (json.JSONDecodeError, TypeError):
                 args = {}
-            parts.append(
-                {
-                    "functionCall": {
-                        "name": fn.get("name", ""),
-                        "args": args,
-                        "id": tc.get("id", str(uuid.uuid4())),
-                    }
+            tc_id = tc.get("id", str(uuid.uuid4()))
+            fc_part: dict[str, Any] = {
+                "functionCall": {
+                    "name": fn.get("name", ""),
+                    "args": args,
+                    "id": tc_id,
                 }
-            )
+            }
+            if thought_sigs:
+                sig = thought_sigs.get(tc_id, "")
+                if sig:
+                    fc_part["thoughtSignature"] = sig  # part-level, not inside functionCall
+            parts.append(fc_part)
 
         if parts:
             contents.append({"role": gemini_role, "parts": parts})
@@ -389,7 +396,11 @@ def _parse_complete_response(raw: dict[str, Any], model: str) -> LLMResponse:
     )
 
 
-def _parse_sse_stream(response: Any, model: str) -> Iterator[StreamEvent]:
+def _parse_sse_stream(
+    response: Any,
+    model: str,
+    on_thought_signature: Callable[[str, str], None] | None = None,
+) -> Iterator[StreamEvent]:
     """Parse Antigravity SSE response line-by-line → StreamEvents.
 
     Each SSE line looks like::
@@ -433,6 +444,10 @@ def _parse_sse_stream(response: Any, model: str) -> Iterator[StreamEvent]:
                     yield TextDeltaEvent(content=delta, snapshot=accumulated)
                 elif "functionCall" in part:
                     fc: dict[str, Any] = part["functionCall"]
+                    tool_use_id = fc.get("id") or str(uuid.uuid4())
+                    thought_sig = part.get("thoughtSignature", "")  # sibling of functionCall
+                    if thought_sig and on_thought_signature:
+                        on_thought_signature(tool_use_id, thought_sig)
                     args = fc.get("args", {})
                     if isinstance(args, str):
                         try:
@@ -440,7 +455,7 @@ def _parse_sse_stream(response: Any, model: str) -> Iterator[StreamEvent]:
                         except json.JSONDecodeError:
                             args = {}
                     yield ToolCallEvent(
-                        tool_use_id=fc.get("id") or str(uuid.uuid4()),
+                        tool_use_id=tool_use_id,
                         tool_name=fc.get("name", ""),
                         tool_input=args,
                     )
@@ -477,6 +492,7 @@ class AntigravityProvider(LLMProvider):
         self._refresh_token: str | None = None
         self._project_id: str = _DEFAULT_PROJECT_ID
         self._token_expires_at: float = 0.0
+        self._thought_sigs: dict[str, str] = {}  # tool_use_id → thoughtSignature
 
         self._init_credentials()
 
@@ -537,7 +553,7 @@ class AntigravityProvider(LLMProvider):
         tools: list[Tool] | None,
         max_tokens: int,
     ) -> dict[str, Any]:
-        contents = _to_gemini_contents(messages)
+        contents = _to_gemini_contents(messages, self._thought_sigs)
         inner: dict[str, Any] = {
             "contents": contents,
             "generationConfig": {"maxOutputTokens": max_tokens},
@@ -669,7 +685,9 @@ class AntigravityProvider(LLMProvider):
             try:
                 body = self._build_body(messages, system, tools, max_tokens)
                 http_resp = self._post(body, streaming=True)
-                for event in _parse_sse_stream(http_resp, self.model):
+                for event in _parse_sse_stream(
+                    http_resp, self.model, self._thought_sigs.__setitem__
+                ):
                     loop.call_soon_threadsafe(queue.put_nowait, event)
             except Exception as exc:
                 logger.error("Antigravity stream error: %s", exc)

--- a/core/framework/llm/antigravity.py
+++ b/core/framework/llm/antigravity.py
@@ -5,15 +5,11 @@ Claude, and GPT-OSS models through a single Gemini-style interface.  It is
 NOT the public ``generativelanguage.googleapis.com`` API.
 
 Authentication uses Google OAuth2.  Token refresh is done directly with the
-OAuth client secret — no local proxy (``antigravity-auth serve``) required.
+OAuth client secret — no local proxy required.
 
 Credential sources (checked in order):
-  1. ``~/.config/opencode/antigravity-accounts.json``  (written by the
-     opencode-antigravity-auth plugin — V4 schema with proper expiry info)
-  2. Antigravity IDE SQLite state DB  (macOS / Linux)
-
-References:
-  https://github.com/NoeFabris/opencode-antigravity-auth
+  1. ``~/.hive/antigravity-accounts.json`` (native OAuth implementation)
+  2. Antigravity IDE SQLite state DB (macOS / Linux)
 """
 
 from __future__ import annotations
@@ -54,7 +50,8 @@ _ENDPOINTS = [
 _DEFAULT_PROJECT_ID = "rising-fact-p41fc"
 _TOKEN_REFRESH_BUFFER_SECS = 60
 
-_ACCOUNTS_FILE = Path.home() / ".config" / "opencode" / "antigravity-accounts.json"
+# Credentials file in ~/.hive/ (native implementation)
+_ACCOUNTS_FILE = Path.home() / ".hive" / "antigravity-accounts.json"
 _IDE_STATE_DB_MAC = (
     Path.home()
     / "Library"
@@ -87,7 +84,9 @@ _BASE_HEADERS: dict[str, str] = {
 
 
 def _load_from_json_file() -> tuple[str | None, str | None, str, float]:
-    """Read credentials from ``~/.config/opencode/antigravity-accounts.json``.
+    """Read credentials from JSON accounts file.
+
+    Reads from ~/.hive/antigravity-accounts.json.
 
     Returns ``(access_token | None, refresh_token | None, project_id, expires_at)``.
     ``expires_at`` is a Unix timestamp (seconds); 0.0 means unknown.
@@ -539,9 +538,8 @@ class AntigravityProvider(LLMProvider):
             return self._access_token
 
         raise RuntimeError(
-            "No valid Antigravity credentials. Authenticate with the "
-            "opencode-antigravity-auth plugin: "
-            "https://github.com/NoeFabris/opencode-antigravity-auth"
+            "No valid Antigravity credentials. "
+            "Run: uv run python core/antigravity_auth.py auth account add"
         )
 
     # --- Request building -------------------------------------------------- #

--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -525,6 +525,8 @@ class LiteLLMProvider(LLMProvider):
         self._codex_backend = bool(
             self.api_base and "chatgpt.com/backend-api/codex" in self.api_base
         )
+        # Antigravity routes through a local OpenAI-compatible proxy — no patches needed.
+        self._antigravity = bool(self.api_base and "localhost:8069" in self.api_base)
 
         if litellm is None:
             raise ImportError(

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -572,14 +572,10 @@ ANTIGRAVITY_IDE_STATE_DB = (
 ANTIGRAVITY_IDE_STATE_DB_LINUX = (
     Path.home() / ".config" / "Antigravity" / "User" / "globalStorage" / "state.vscdb"
 )
-# antigravity-auth CLI tool stores credentials in JSON files
-ANTIGRAVITY_AUTH_FILE = Path.home() / ".config" / "opencode" / "antigravity-accounts.json"
-ANTIGRAVITY_AUTH_FILE_FALLBACK = Path.home() / ".config" / "antigravity_auth" / "accounts.json"
+# Antigravity credentials stored by native OAuth implementation
+ANTIGRAVITY_AUTH_FILE = Path.home() / ".hive" / "antigravity-accounts.json"
 
 ANTIGRAVITY_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token"
-ANTIGRAVITY_OAUTH_CLIENT_ID = (
-    "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
-)
 _ANTIGRAVITY_TOKEN_LIFETIME_SECS = 3600  # Google access tokens expire in 1 hour
 _ANTIGRAVITY_IDE_STATE_DB_KEY = "antigravityUnifiedStateSync.oauthToken"
 
@@ -665,8 +661,7 @@ def _read_antigravity_credentials() -> dict | None:
 
     Checks in order:
     1. Antigravity IDE SQLite state database (native macOS/Linux app)
-    2. antigravity-auth CLI JSON file (~/.config/opencode/antigravity-accounts.json)
-    3. antigravity-auth CLI fallback (~/.config/antigravity_auth/accounts.json)
+    2. Native OAuth credentials file (~/.hive/antigravity-accounts.json)
 
     Returns:
         Auth data dict with an ``accounts`` list on success, None otherwise.
@@ -676,18 +671,16 @@ def _read_antigravity_credentials() -> dict | None:
     if ide_creds:
         return ide_creds
 
-    # 2 & 3. antigravity-auth CLI tool JSON files
-    for path in (ANTIGRAVITY_AUTH_FILE, ANTIGRAVITY_AUTH_FILE_FALLBACK):
-        if not path.exists():
-            continue
+    # 2. Native OAuth credentials file
+    if ANTIGRAVITY_AUTH_FILE.exists():
         try:
-            with open(path, encoding="utf-8") as f:
+            with open(ANTIGRAVITY_AUTH_FILE, encoding="utf-8") as f:
                 data = json.load(f)
             accounts = data.get("accounts", [])
             if accounts and isinstance(accounts[0], dict):
                 return data
         except (json.JSONDecodeError, OSError):
-            continue
+            pass
     return None
 
 
@@ -717,12 +710,7 @@ def _is_antigravity_token_expired(auth_data: dict) -> bool:
     last_refresh_val: float | str | None = auth_data.get("last_refresh")
     if last_refresh_val is None:
         try:
-            path = (
-                ANTIGRAVITY_AUTH_FILE
-                if ANTIGRAVITY_AUTH_FILE.exists()
-                else ANTIGRAVITY_AUTH_FILE_FALLBACK
-            )
-            last_refresh_val = path.stat().st_mtime
+            last_refresh_val = ANTIGRAVITY_AUTH_FILE.stat().st_mtime
         except OSError:
             return True
     elif isinstance(last_refresh_val, str):
@@ -751,13 +739,14 @@ def _refresh_antigravity_token(refresh_token: str) -> dict | None:
     import urllib.parse
     import urllib.request
 
-    from framework.config import get_antigravity_client_secret
+    from framework.config import get_antigravity_client_id, get_antigravity_client_secret
 
+    client_id = get_antigravity_client_id()
     client_secret = get_antigravity_client_secret()
     params: dict = {
         "grant_type": "refresh_token",
         "refresh_token": refresh_token,
-        "client_id": ANTIGRAVITY_OAUTH_CLIENT_ID,
+        "client_id": client_id,
     }
     if client_secret:
         params["client_secret"] = client_secret
@@ -803,13 +792,8 @@ def _save_refreshed_antigravity_credentials(auth_data: dict, token_data: dict) -
         auth_data["accounts"] = accounts
         auth_data["last_refresh"] = datetime.now(UTC).isoformat()
 
-        target_path = (
-            ANTIGRAVITY_AUTH_FILE
-            if ANTIGRAVITY_AUTH_FILE.exists()
-            else ANTIGRAVITY_AUTH_FILE_FALLBACK
-        )
-        target_path.parent.mkdir(parents=True, exist_ok=True)
-        fd = os.open(target_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        ANTIGRAVITY_AUTH_FILE.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(ANTIGRAVITY_AUTH_FILE, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(auth_data, f, indent=2)
         logger.debug("Antigravity credentials refreshed and saved")
@@ -1559,8 +1543,7 @@ class AgentRunner:
                 if not provider.has_credentials():
                     print(
                         "Warning: Antigravity credentials not found. "
-                        "Install the opencode-antigravity-auth plugin and authenticate: "
-                        "https://github.com/NoeFabris/opencode-antigravity-auth"
+                        "Run: uv run python core/antigravity_auth.py auth account add"
                     )
                 self._llm = provider
             else:

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -751,13 +751,18 @@ def _refresh_antigravity_token(refresh_token: str) -> dict | None:
     import urllib.parse
     import urllib.request
 
-    data = urllib.parse.urlencode(
-        {
-            "grant_type": "refresh_token",
-            "refresh_token": refresh_token,
-            "client_id": ANTIGRAVITY_OAUTH_CLIENT_ID,
-        }
-    ).encode("utf-8")
+    from framework.config import get_antigravity_client_secret
+
+    client_secret = get_antigravity_client_secret()
+    params: dict = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": ANTIGRAVITY_OAUTH_CLIENT_ID,
+    }
+    if client_secret:
+        params["client_secret"] = client_secret
+
+    data = urllib.parse.urlencode(params).encode("utf-8")
 
     req = urllib.request.Request(
         ANTIGRAVITY_OAUTH_TOKEN_URL,
@@ -863,6 +868,17 @@ def get_antigravity_token() -> str | None:
         "Re-open the Antigravity IDE or run 'antigravity-auth accounts add'."
     )
     return access_token
+
+
+def _is_antigravity_proxy_available() -> bool:
+    """Return True if antigravity-auth serve is running on localhost:8069."""
+    import socket
+
+    try:
+        with socket.create_connection(("localhost", 8069), timeout=0.5):
+            return True
+    except (OSError, TimeoutError):
+        return False
 
 
 @dataclass
@@ -1494,11 +1510,7 @@ class AgentRunner:
                     print("Warning: Kimi Code subscription configured but no key found.")
                     print("Run 'kimi /login' to authenticate, then try again.")
             elif use_antigravity:
-                # Get OAuth token from Antigravity subscription (Google OAuth)
-                api_key = get_antigravity_token()
-                if not api_key:
-                    print("Warning: Antigravity subscription configured but no token found.")
-                    print("Run 'antigravity-auth accounts add' to authenticate, then try again.")
+                pass  # AntigravityProvider handles credentials internally
 
             if api_key and use_claude_code:
                 # Use litellm's built-in Anthropic OAuth support.
@@ -1537,15 +1549,20 @@ class AgentRunner:
                     api_key=api_key,
                     api_base=api_base,
                 )
-            elif api_key and use_antigravity:
-                # Antigravity routes through a local OpenAI-compatible proxy
-                # started with 'antigravity-auth serve' on localhost:8069.
-                # No special headers required — the proxy handles auth internally.
-                self._llm = LiteLLMProvider(
-                    model=self.model,
-                    api_key=api_key,
-                    api_base="http://localhost:8069/v1",
-                )
+            elif use_antigravity:
+                # Direct OAuth to Google's internal Cloud Code Assist gateway.
+                # No local proxy required — AntigravityProvider handles token
+                # refresh and Gemini-format request/response conversion natively.
+                from framework.llm.antigravity import AntigravityProvider  # noqa: PLC0415
+
+                provider = AntigravityProvider(model=self.model)
+                if not provider.has_credentials():
+                    print(
+                        "Warning: Antigravity credentials not found. "
+                        "Install the opencode-antigravity-auth plugin and authenticate: "
+                        "https://github.com/NoeFabris/opencode-antigravity-auth"
+                    )
+                self._llm = provider
             else:
                 # Local models (e.g. Ollama) don't need an API key
                 if self._is_local_model(self.model):

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -552,6 +552,319 @@ def get_kimi_code_token() -> str | None:
     return None
 
 
+# ---------------------------------------------------------------------------
+# Antigravity subscription token helpers
+# ---------------------------------------------------------------------------
+
+# Antigravity IDE (native macOS/Linux app) stores OAuth tokens in its
+# VSCode-style SQLite state database under the key
+# "antigravityUnifiedStateSync.oauthToken" as a base64-encoded protobuf blob.
+ANTIGRAVITY_IDE_STATE_DB = (
+    Path.home()
+    / "Library"
+    / "Application Support"
+    / "Antigravity"
+    / "User"
+    / "globalStorage"
+    / "state.vscdb"
+)
+# Linux fallback for the IDE state DB
+ANTIGRAVITY_IDE_STATE_DB_LINUX = (
+    Path.home() / ".config" / "Antigravity" / "User" / "globalStorage" / "state.vscdb"
+)
+# antigravity-auth CLI tool stores credentials in JSON files
+ANTIGRAVITY_AUTH_FILE = Path.home() / ".config" / "opencode" / "antigravity-accounts.json"
+ANTIGRAVITY_AUTH_FILE_FALLBACK = Path.home() / ".config" / "antigravity_auth" / "accounts.json"
+
+ANTIGRAVITY_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token"
+ANTIGRAVITY_OAUTH_CLIENT_ID = (
+    "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
+)
+_ANTIGRAVITY_TOKEN_LIFETIME_SECS = 3600  # Google access tokens expire in 1 hour
+_ANTIGRAVITY_IDE_STATE_DB_KEY = "antigravityUnifiedStateSync.oauthToken"
+
+
+def _read_antigravity_ide_credentials() -> dict | None:
+    """Read credentials from the Antigravity IDE's SQLite state database.
+
+    The Antigravity desktop IDE (VSCode-based) stores its OAuth token as a
+    base64-encoded protobuf blob in a SQLite database.  The access token is
+    a standard Google OAuth ``ya29.*`` bearer token.
+
+    Returns:
+        Dict with ``accessToken`` and optionally ``refreshToken`` keys,
+        plus ``_source: "ide"`` to skip file-based save on refresh.
+        Returns None if the database is absent or the key is not found.
+    """
+    import re
+    import sqlite3
+
+    for db_path in (ANTIGRAVITY_IDE_STATE_DB, ANTIGRAVITY_IDE_STATE_DB_LINUX):
+        if not db_path.exists():
+            continue
+        try:
+            con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+            try:
+                row = con.execute(
+                    "SELECT value FROM ItemTable WHERE key = ?",
+                    (_ANTIGRAVITY_IDE_STATE_DB_KEY,),
+                ).fetchone()
+            finally:
+                con.close()
+
+            if not row:
+                continue
+
+            import base64
+
+            blob = base64.b64decode(row[0])
+
+            # The protobuf blob contains the access token (ya29.*) and
+            # refresh token (1//*) as length-prefixed UTF-8 strings.
+            # Decode the inner base64 layer and extract with regex.
+            inner_b64_candidates = re.findall(rb"[A-Za-z0-9+/=_\-]{40,}", blob)
+            access_token: str | None = None
+            refresh_token: str | None = None
+            for candidate in inner_b64_candidates:
+                try:
+                    padded = candidate + b"=" * (-len(candidate) % 4)
+                    inner = base64.urlsafe_b64decode(padded)
+                except Exception:
+                    continue
+                if not access_token:
+                    m = re.search(rb"ya29\.[A-Za-z0-9_\-\.]+", inner)
+                    if m:
+                        access_token = m.group(0).decode("ascii")
+                if not refresh_token:
+                    m = re.search(rb"1//[A-Za-z0-9_\-\.]+", inner)
+                    if m:
+                        refresh_token = m.group(0).decode("ascii")
+                if access_token and refresh_token:
+                    break
+
+            if access_token:
+                return {
+                    "accounts": [
+                        {
+                            "accessToken": access_token,
+                            "refreshToken": refresh_token or "",
+                        }
+                    ],
+                    "_source": "ide",
+                    "_db_path": str(db_path),
+                }
+        except Exception as exc:
+            logger.debug("Failed to read Antigravity IDE state DB: %s", exc)
+            continue
+
+    return None
+
+
+def _read_antigravity_credentials() -> dict | None:
+    """Read Antigravity auth data from all supported credential sources.
+
+    Checks in order:
+    1. Antigravity IDE SQLite state database (native macOS/Linux app)
+    2. antigravity-auth CLI JSON file (~/.config/opencode/antigravity-accounts.json)
+    3. antigravity-auth CLI fallback (~/.config/antigravity_auth/accounts.json)
+
+    Returns:
+        Auth data dict with an ``accounts`` list on success, None otherwise.
+    """
+    # 1. Native Antigravity IDE (primary on macOS)
+    ide_creds = _read_antigravity_ide_credentials()
+    if ide_creds:
+        return ide_creds
+
+    # 2 & 3. antigravity-auth CLI tool JSON files
+    for path in (ANTIGRAVITY_AUTH_FILE, ANTIGRAVITY_AUTH_FILE_FALLBACK):
+        if not path.exists():
+            continue
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+            accounts = data.get("accounts", [])
+            if accounts and isinstance(accounts[0], dict):
+                return data
+        except (json.JSONDecodeError, OSError):
+            continue
+    return None
+
+
+def _is_antigravity_token_expired(auth_data: dict) -> bool:
+    """Check whether the Antigravity access token is expired or near expiry.
+
+    For IDE-sourced credentials: uses the state DB's mtime as last_refresh
+    since the IDE keeps the DB fresh while it's running.
+    For JSON-sourced credentials: uses the ``last_refresh`` field or file mtime.
+    """
+    import time
+    from datetime import datetime
+
+    now = time.time()
+
+    if auth_data.get("_source") == "ide":
+        # The IDE refreshes tokens automatically while running.
+        # Use the DB file's mtime as a proxy for when the token was last updated.
+        try:
+            db_path = Path(auth_data.get("_db_path", str(ANTIGRAVITY_IDE_STATE_DB)))
+            last_refresh: float = db_path.stat().st_mtime
+        except OSError:
+            return True
+        expires_at = last_refresh + _ANTIGRAVITY_TOKEN_LIFETIME_SECS
+        return now >= (expires_at - _TOKEN_REFRESH_BUFFER_SECS)
+
+    last_refresh_val: float | str | None = auth_data.get("last_refresh")
+    if last_refresh_val is None:
+        try:
+            path = (
+                ANTIGRAVITY_AUTH_FILE
+                if ANTIGRAVITY_AUTH_FILE.exists()
+                else ANTIGRAVITY_AUTH_FILE_FALLBACK
+            )
+            last_refresh_val = path.stat().st_mtime
+        except OSError:
+            return True
+    elif isinstance(last_refresh_val, str):
+        try:
+            last_refresh_val = datetime.fromisoformat(
+                last_refresh_val.replace("Z", "+00:00")
+            ).timestamp()
+        except (ValueError, TypeError):
+            return True
+
+    expires_at = float(last_refresh_val) + _ANTIGRAVITY_TOKEN_LIFETIME_SECS
+    return now >= (expires_at - _TOKEN_REFRESH_BUFFER_SECS)
+
+
+def _refresh_antigravity_token(refresh_token: str) -> dict | None:
+    """Refresh the Antigravity access token via Google OAuth.
+
+    POSTs form-encoded ``grant_type=refresh_token`` to the Google token
+    endpoint using Antigravity's public OAuth client ID.
+
+    Returns:
+        Parsed response dict (containing ``access_token``) on success,
+        None on any error.
+    """
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    data = urllib.parse.urlencode(
+        {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": ANTIGRAVITY_OAUTH_CLIENT_ID,
+        }
+    ).encode("utf-8")
+
+    req = urllib.request.Request(
+        ANTIGRAVITY_OAUTH_TOKEN_URL,
+        data=data,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:  # noqa: S310
+            return json.loads(resp.read())
+    except (urllib.error.URLError, json.JSONDecodeError, TimeoutError, OSError) as exc:
+        logger.debug("Antigravity token refresh failed: %s", exc)
+        return None
+
+
+def _save_refreshed_antigravity_credentials(auth_data: dict, token_data: dict) -> None:
+    """Write refreshed tokens back to the Antigravity JSON credentials file.
+
+    Skipped for IDE-sourced credentials (the IDE manages its own DB).
+    Updates ``accounts[0].accessToken`` (and ``refreshToken`` if present),
+    then persists ``last_refresh`` as an ISO-8601 UTC string.
+    """
+    from datetime import datetime
+
+    # IDE manages its own state — we do not write back to its SQLite DB
+    if auth_data.get("_source") == "ide":
+        return
+
+    try:
+        accounts = auth_data.get("accounts", [])
+        if not accounts:
+            return
+        account = accounts[0]
+        account["accessToken"] = token_data["access_token"]
+        if "refresh_token" in token_data:
+            account["refreshToken"] = token_data["refresh_token"]
+        auth_data["accounts"] = accounts
+        auth_data["last_refresh"] = datetime.now(UTC).isoformat()
+
+        target_path = (
+            ANTIGRAVITY_AUTH_FILE
+            if ANTIGRAVITY_AUTH_FILE.exists()
+            else ANTIGRAVITY_AUTH_FILE_FALLBACK
+        )
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(target_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(auth_data, f, indent=2)
+        logger.debug("Antigravity credentials refreshed and saved")
+    except (OSError, KeyError) as exc:
+        logger.debug("Failed to save refreshed Antigravity credentials: %s", exc)
+
+
+def get_antigravity_token() -> str | None:
+    """Get the OAuth access token from an Antigravity subscription.
+
+    Credential sources checked in order:
+    1. Antigravity IDE SQLite state DB (native app, macOS/Linux)
+    2. antigravity-auth CLI JSON file
+
+    For IDE credentials the token is read directly (the IDE refreshes it
+    automatically while running).  For JSON credentials an automatic OAuth
+    refresh is attempted when the token is near expiry.
+
+    Returns:
+        The ``ya29.*`` Google OAuth access token, or None if unavailable.
+    """
+    auth_data = _read_antigravity_credentials()
+    if not auth_data:
+        return None
+
+    accounts = auth_data.get("accounts", [])
+    if not accounts:
+        return None
+    account = accounts[0]
+
+    access_token = account.get("accessToken")
+    if not access_token:
+        return None
+
+    if not _is_antigravity_token_expired(auth_data):
+        return access_token
+
+    # Token is expired or near expiry — attempt a refresh
+    refresh_token = account.get("refreshToken")
+    if not refresh_token:
+        logger.warning(
+            "Antigravity token expired and no refresh token available. "
+            "Re-open the Antigravity IDE to refresh, or run 'antigravity-auth accounts add'."
+        )
+        return access_token  # return stale token; proxy may still accept it briefly
+
+    logger.info("Antigravity token expired or near expiry, refreshing...")
+    token_data = _refresh_antigravity_token(refresh_token)
+
+    if token_data and "access_token" in token_data:
+        _save_refreshed_antigravity_credentials(auth_data, token_data)
+        return token_data["access_token"]
+
+    logger.warning(
+        "Antigravity token refresh failed. "
+        "Re-open the Antigravity IDE or run 'antigravity-auth accounts add'."
+    )
+    return access_token
+
+
 @dataclass
 class AgentInfo:
     """Information about an exported agent."""
@@ -1158,6 +1471,7 @@ class AgentRunner:
             use_claude_code = llm_config.get("use_claude_code_subscription", False)
             use_codex = llm_config.get("use_codex_subscription", False)
             use_kimi_code = llm_config.get("use_kimi_code_subscription", False)
+            use_antigravity = llm_config.get("use_antigravity_subscription", False)
             api_base = llm_config.get("api_base")
 
             api_key = None
@@ -1179,6 +1493,12 @@ class AgentRunner:
                 if not api_key:
                     print("Warning: Kimi Code subscription configured but no key found.")
                     print("Run 'kimi /login' to authenticate, then try again.")
+            elif use_antigravity:
+                # Get OAuth token from Antigravity subscription (Google OAuth)
+                api_key = get_antigravity_token()
+                if not api_key:
+                    print("Warning: Antigravity subscription configured but no token found.")
+                    print("Run 'antigravity-auth accounts add' to authenticate, then try again.")
 
             if api_key and use_claude_code:
                 # Use litellm's built-in Anthropic OAuth support.
@@ -1216,6 +1536,15 @@ class AgentRunner:
                     model=self.model,
                     api_key=api_key,
                     api_base=api_base,
+                )
+            elif api_key and use_antigravity:
+                # Antigravity routes through a local OpenAI-compatible proxy
+                # started with 'antigravity-auth serve' on localhost:8069.
+                # No special headers required — the proxy handles auth internally.
+                self._llm = LiteLLMProvider(
+                    model=self.model,
+                    api_key=api_key,
+                    api_base="http://localhost:8069/v1",
                 )
             else:
                 # Local models (e.g. Ollama) don't need an API key

--- a/core/framework/server/session_manager.py
+++ b/core/framework/server/session_manager.py
@@ -96,8 +96,7 @@ class SessionManager:
 
         Internal helper — use create_session() or create_session_with_worker().
         """
-        from framework.config import RuntimeConfig
-        from framework.llm.litellm import LiteLLMProvider
+        from framework.config import RuntimeConfig, get_hive_config
         from framework.runtime.event_bus import EventBus
 
         ts = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -111,12 +110,20 @@ class SessionManager:
         rc = RuntimeConfig(model=model or self._model or RuntimeConfig().model)
 
         # Session owns these — shared with queen and worker
-        llm = LiteLLMProvider(
-            model=rc.model,
-            api_key=rc.api_key,
-            api_base=rc.api_base,
-            **rc.extra_kwargs,
-        )
+        llm_config = get_hive_config().get("llm", {})
+        if llm_config.get("use_antigravity_subscription"):
+            from framework.llm.antigravity import AntigravityProvider
+
+            llm = AntigravityProvider(model=rc.model)
+        else:
+            from framework.llm.litellm import LiteLLMProvider
+
+            llm = LiteLLMProvider(
+                model=rc.model,
+                api_key=rc.api_key,
+                api_base=rc.api_base,
+                **rc.extra_kwargs,
+            )
         event_bus = EventBus()
 
         session = Session(
@@ -313,17 +320,25 @@ class SessionManager:
             # with the correct worker credentials so _setup() doesn't fall back
             # to the queen's llm config (which may be a different provider).
             if worker_model and not model:
-                from framework.llm.litellm import LiteLLMProvider
+                from framework.config import get_hive_config
 
-                worker_api_key = get_worker_api_key()
-                worker_api_base = get_worker_api_base()
-                worker_extra = get_worker_llm_extra_kwargs()
-                runner._llm = LiteLLMProvider(
-                    model=resolved_model,
-                    api_key=worker_api_key,
-                    api_base=worker_api_base,
-                    **worker_extra,
-                )
+                worker_llm_cfg = get_hive_config().get("worker_llm", {})
+                if worker_llm_cfg.get("use_antigravity_subscription"):
+                    from framework.llm.antigravity import AntigravityProvider
+
+                    runner._llm = AntigravityProvider(model=resolved_model)
+                else:
+                    from framework.llm.litellm import LiteLLMProvider
+
+                    worker_api_key = get_worker_api_key()
+                    worker_api_base = get_worker_api_base()
+                    worker_extra = get_worker_llm_extra_kwargs()
+                    runner._llm = LiteLLMProvider(
+                        model=resolved_model,
+                        api_key=worker_api_key,
+                        api_base=worker_api_base,
+                        **worker_extra,
+                    )
 
             # Setup with session's event bus
             if runner._agent_runtime is None:

--- a/core/tests/test_antigravity_eventloop.py
+++ b/core/tests/test_antigravity_eventloop.py
@@ -3,10 +3,8 @@
 Run: .venv/bin/python core/tests/test_antigravity_eventloop.py
 
 Requires:
-  - ~/.config/opencode/antigravity-accounts.json with valid credentials
-    (run 'antigravity-auth accounts add' to authenticate)
-  - antigravity-auth serve running on localhost:8069
-    (run 'antigravity-auth serve' in a separate terminal)
+  - ~/.hive/antigravity-accounts.json with valid credentials
+    (run 'uv run python core/antigravity_auth.py auth account add' to authenticate)
 """
 
 import asyncio

--- a/core/tests/test_antigravity_eventloop.py
+++ b/core/tests/test_antigravity_eventloop.py
@@ -1,0 +1,174 @@
+"""Integration test: Run a real EventLoopNode against the Antigravity backend.
+
+Run: .venv/bin/python core/tests/test_antigravity_eventloop.py
+
+Requires:
+  - ~/.config/opencode/antigravity-accounts.json with valid credentials
+    (run 'antigravity-auth accounts add' to authenticate)
+  - antigravity-auth serve running on localhost:8069
+    (run 'antigravity-auth serve' in a separate terminal)
+"""
+
+import asyncio
+import logging
+import sys
+from unittest.mock import MagicMock
+
+sys.path.insert(0, "core")
+
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(name)s: %(message)s")
+# Show our provider's retry/stream logs
+logging.getLogger("framework.llm.litellm").setLevel(logging.DEBUG)
+
+from framework.config import RuntimeConfig  # noqa: E402
+from framework.graph.event_loop_node import EventLoopNode, LoopConfig  # noqa: E402
+from framework.graph.node import NodeContext, NodeResult, NodeSpec, SharedMemory  # noqa: E402
+from framework.llm.litellm import LiteLLMProvider  # noqa: E402
+
+
+def make_provider() -> LiteLLMProvider:
+    cfg = RuntimeConfig()
+    if not cfg.api_key:
+        print("ERROR: No Antigravity token found.")
+        print("  1. Run 'antigravity-auth accounts add' to authenticate.")
+        print("  2. Run 'antigravity-auth serve' to start the local proxy.")
+        print("  3. Configure Hive: run quickstart.sh and select option 7 (Antigravity).")
+        sys.exit(1)
+    print(f"Model       : {cfg.model}")
+    print(f"Base        : {cfg.api_base}")
+    print(f"Antigravity : {'localhost:8069' in (cfg.api_base or '')}")
+    return LiteLLMProvider(
+        model=cfg.model,
+        api_key=cfg.api_key,
+        api_base=cfg.api_base,
+        **cfg.extra_kwargs,
+    )
+
+
+def make_context(
+    llm: LiteLLMProvider,
+    *,
+    node_id: str = "test",
+    system_prompt: str = "You are a helpful assistant.",
+    output_keys: list[str] | None = None,
+) -> NodeContext:
+    if output_keys is None:
+        output_keys = ["answer"]
+
+    spec = NodeSpec(
+        id=node_id,
+        name="Test Node",
+        description="Integration test node",
+        node_type="event_loop",
+        output_keys=output_keys,
+        system_prompt=system_prompt,
+    )
+
+    runtime = MagicMock()
+    runtime.start_run = MagicMock(return_value="run-1")
+    runtime.decide = MagicMock(return_value="dec-1")
+    runtime.record_outcome = MagicMock()
+    runtime.end_run = MagicMock()
+
+    memory = SharedMemory()
+
+    return NodeContext(
+        runtime=runtime,
+        node_id=node_id,
+        node_spec=spec,
+        memory=memory,
+        input_data={},
+        llm=llm,
+        available_tools=[],
+        max_tokens=4096,
+    )
+
+
+async def run_test(
+    name: str, llm: LiteLLMProvider, system: str, output_keys: list[str]
+) -> NodeResult:
+    print(f"\n{'=' * 60}")
+    print(f"TEST: {name}")
+    print(f"{'=' * 60}")
+
+    ctx = make_context(llm, system_prompt=system, output_keys=output_keys)
+    node = EventLoopNode(config=LoopConfig(max_iterations=3))
+
+    try:
+        result = await node.execute(ctx)
+        print(f"  Success : {result.success}")
+        print(f"  Output  : {result.output}")
+        if result.error:
+            print(f"  Error   : {result.error}")
+        return result
+    except Exception as e:
+        print(f"  EXCEPTION: {type(e).__name__}: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return NodeResult(success=False, error=str(e))
+
+
+async def main():
+    llm = make_provider()
+    print()
+
+    # Test 1: Simple text output — the node should call set_output to fill "answer"
+    r1 = await run_test(
+        name="Simple text generation",
+        llm=llm,
+        system=(
+            "You are a helpful assistant. When asked a question, use the "
+            "set_output tool to store your answer in the 'answer' key. "
+            "Keep answers short (1-2 sentences)."
+        ),
+        output_keys=["answer"],
+    )
+
+    # Test 2: If test 1 failed, try bare stream() to isolate the issue
+    if not r1.success:
+        print(f"\n{'=' * 60}")
+        print("FALLBACK: Testing bare provider.stream() directly")
+        print(f"{'=' * 60}")
+        try:
+            from framework.llm.stream_events import (
+                FinishEvent,
+                StreamErrorEvent,
+                TextDeltaEvent,
+                ToolCallEvent,
+            )
+
+            text = ""
+            events = []
+            async for event in llm.stream(
+                messages=[{"role": "user", "content": "Say hello in 3 words."}],
+            ):
+                events.append(type(event).__name__)
+                if isinstance(event, TextDeltaEvent):
+                    text = event.snapshot
+                elif isinstance(event, FinishEvent):
+                    print(
+                        f"  Finish: stop={event.stop_reason}"
+                        f" in={event.input_tokens}"
+                        f" out={event.output_tokens}"
+                    )
+                elif isinstance(event, StreamErrorEvent):
+                    print(f"  StreamError: {event.error} (recoverable={event.recoverable})")
+                elif isinstance(event, ToolCallEvent):
+                    print(f"  ToolCall: {event.tool_name}")
+            print(f"  Text   : {text!r}")
+            print(f"  Events : {events}")
+            print(f"  RESULT : {'OK' if text else 'EMPTY'}")
+        except Exception as e:
+            print(f"  EXCEPTION: {type(e).__name__}: {e}")
+            import traceback
+
+            traceback.print_exc()
+
+    print(f"\n{'=' * 60}")
+    print("DONE")
+    print(f"{'=' * 60}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -846,6 +846,32 @@ prompt_model_selection() {
     done
 }
 
+# Read Antigravity OAuth client credentials from the installed npm package.
+# Exports _AG_CLIENT_SECRET and _AG_CLIENT_ID; returns 1 if package not found.
+_read_antigravity_creds_from_npm() {
+    local constants_js=""
+    local npm_root
+    npm_root="$(npm root -g 2>/dev/null)" && \
+        [ -f "$npm_root/opencode-antigravity-auth/dist/src/constants.js" ] && \
+        constants_js="$npm_root/opencode-antigravity-auth/dist/src/constants.js"
+    if [ -z "$constants_js" ]; then
+        for _candidate in \
+            /opt/homebrew/lib/node_modules/opencode-antigravity-auth/dist/src/constants.js \
+            /usr/local/lib/node_modules/opencode-antigravity-auth/dist/src/constants.js \
+            /usr/lib/node_modules/opencode-antigravity-auth/dist/src/constants.js; do
+            if [ -f "$_candidate" ]; then
+                constants_js="$_candidate"
+                break
+            fi
+        done
+    fi
+    [ -z "$constants_js" ] && return 1
+    _AG_CLIENT_SECRET="$(grep -o '"GOCSPX-[^"]*"' "$constants_js" 2>/dev/null | tr -d '"' | head -1)"
+    _AG_CLIENT_ID="$(grep -o '"[0-9]*-[a-z0-9]*\.apps\.googleusercontent\.com"' "$constants_js" 2>/dev/null | tr -d '"' | head -1)"
+    export _AG_CLIENT_SECRET _AG_CLIENT_ID
+    [ -n "$_AG_CLIENT_SECRET" ] && [ -n "$_AG_CLIENT_ID" ]
+}
+
 # Function to save configuration
 # Args: provider_id env_var model max_tokens max_context_tokens [use_claude_code_sub] [api_base] [use_codex_sub] [use_antigravity_sub]
 save_configuration() {
@@ -868,6 +894,11 @@ save_configuration() {
     fi
     if [ -z "$max_context_tokens" ]; then
         max_context_tokens=120000
+    fi
+
+    if _read_antigravity_creds_from_npm 2>/dev/null; then
+        export ANTIGRAVITY_CLIENT_SECRET="$_AG_CLIENT_SECRET"
+        export ANTIGRAVITY_CLIENT_ID="$_AG_CLIENT_ID"
     fi
 
     uv run python - \
@@ -931,8 +962,19 @@ else:
 if use_antigravity_sub == "true":
     config["llm"]["use_antigravity_subscription"] = True
     config["llm"].pop("api_key_env_var", None)
+    # Store the Antigravity OAuth client secret so token refresh works
+    # without hardcoding it in source code (read at runtime via config.py).
+    import os as _os
+    _secret = _os.environ.get("ANTIGRAVITY_CLIENT_SECRET") or ""
+    if _secret:
+        config["llm"]["antigravity_client_secret"] = _secret
+    _client_id = _os.environ.get("ANTIGRAVITY_CLIENT_ID") or ""
+    if _client_id:
+        config["llm"]["antigravity_client_id"] = _client_id
 else:
     config["llm"].pop("use_antigravity_subscription", None)
+    config["llm"].pop("antigravity_client_secret", None)
+    config["llm"].pop("antigravity_client_id", None)
 
 if api_base:
     config["llm"]["api_base"] = api_base
@@ -1333,12 +1375,112 @@ case $choice in
         # Antigravity Subscription
         if [ "$ANTIGRAVITY_CRED_DETECTED" = false ]; then
             echo ""
-            echo -e "${YELLOW}  Antigravity credentials not found.${NC}"
-            echo -e "  Run ${CYAN}antigravity-auth accounts add${NC} to authenticate,"
-            echo -e "  then run this quickstart again."
+            echo -e "${CYAN}  Setting up Antigravity authentication...${NC}"
             echo ""
-            exit 1
-        else
+
+            # ── Step 1: ensure opencode is installed ────────────────────────
+            if ! command -v opencode &>/dev/null; then
+                echo -e "  Installing ${CYAN}opencode${NC} (required for Antigravity OAuth)..."
+                if command -v npm &>/dev/null; then
+                    npm install -g opencode-ai || { echo -e "${RED}  npm install failed. Install Node.js and retry.${NC}"; exit 1; }
+                else
+                    echo -e "${RED}  Node.js/npm not found. Install Node.js first: https://nodejs.org${NC}"
+                    exit 1
+                fi
+            fi
+
+            # ── Step 2: write opencode.json with the plugin ─────────────────
+            OPENCODE_CFG_DIR="$HOME/.config/opencode"
+            OPENCODE_CFG="$OPENCODE_CFG_DIR/opencode.json"
+            mkdir -p "$OPENCODE_CFG_DIR"
+
+            if [ ! -f "$OPENCODE_CFG" ]; then
+                cat > "$OPENCODE_CFG" <<'JSON'
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["opencode-antigravity-auth@latest"],
+  "provider": {
+    "google": {
+      "models": {
+        "antigravity-gemini-3-flash": {
+          "name": "Gemini 3 Flash (Antigravity)",
+          "limit": { "context": 1048576, "output": 65536 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "antigravity-gemini-3-pro": {
+          "name": "Gemini 3 Pro (Antigravity)",
+          "limit": { "context": 1048576, "output": 65535 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "antigravity-gemini-3.1-pro": {
+          "name": "Gemini 3.1 Pro (Antigravity)",
+          "limit": { "context": 1048576, "output": 65535 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "antigravity-claude-sonnet-4-6": {
+          "name": "Claude Sonnet 4.6 (Antigravity)",
+          "limit": { "context": 200000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "antigravity-claude-opus-4-6-thinking": {
+          "name": "Claude Opus 4.6 Thinking (Antigravity)",
+          "limit": { "context": 200000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        }
+      }
+    }
+  }
+}
+JSON
+            else
+                # Inject plugin entry if not already present
+                uv run python3 - "$OPENCODE_CFG" <<'PY' 2>/dev/null || true
+import json, sys
+p = sys.argv[1]
+try:
+    with open(p) as f:
+        cfg = json.load(f)
+except Exception:
+    cfg = {}
+plugins = cfg.get("plugin", [])
+entry = "opencode-antigravity-auth@latest"
+if entry not in plugins:
+    plugins.append(entry)
+cfg["plugin"] = plugins
+import os
+fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+with os.fdopen(fd, "w") as f:
+    json.dump(cfg, f, indent=2)
+print("plugin entry added")
+PY
+            fi
+
+            echo -e "  ${GREEN}✓${NC} opencode.json configured with antigravity plugin"
+            echo ""
+            echo -e "  ${YELLOW}A browser window will open for Google OAuth.${NC}"
+            echo -e "  Sign in with your Google account that has Antigravity access."
+            echo ""
+
+            # ── Step 3: run opencode auth login ─────────────────────────────
+            opencode auth login || true
+
+            # ── Step 4: re-detect credentials ───────────────────────────────
+            if [ -f "$HOME/.config/opencode/antigravity-accounts.json" ]; then
+                ANTIGRAVITY_CRED_DETECTED=true
+            elif [ -f "$HOME/.config/antigravity_auth/accounts.json" ]; then
+                ANTIGRAVITY_CRED_DETECTED=true
+            fi
+
+            if [ "$ANTIGRAVITY_CRED_DETECTED" = false ]; then
+                echo ""
+                echo -e "${RED}  Authentication did not produce credentials.${NC}"
+                echo -e "  Run ${CYAN}opencode auth login${NC} manually and try again."
+                echo ""
+                exit 1
+            fi
+        fi
+
+        if [ "$ANTIGRAVITY_CRED_DETECTED" = true ]; then
             SUBSCRIPTION_MODE="antigravity"
             SELECTED_PROVIDER_ID="openai"
             SELECTED_MODEL="gemini-3-flash"
@@ -1348,8 +1490,7 @@ case $choice in
             echo -e "${YELLOW}  ⚠ Using Antigravity can technically cause your account suspension. Please use at your own risk.${NC}"
             echo ""
             echo -e "${GREEN}⬢${NC} Using Antigravity subscription"
-            echo -e "  ${DIM}Model: gemini-3-flash | Proxy: localhost:8069/v1${NC}"
-            echo -e "  ${DIM}Ensure 'antigravity-auth serve' is running before starting agents.${NC}"
+            echo -e "  ${DIM}Model: gemini-3-flash | Direct OAuth (no proxy required)${NC}"
         fi
         ;;
     8)

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -847,7 +847,7 @@ prompt_model_selection() {
 }
 
 # Function to save configuration
-# Args: provider_id env_var model max_tokens max_context_tokens [use_claude_code_sub] [api_base] [use_codex_sub]
+# Args: provider_id env_var model max_tokens max_context_tokens [use_claude_code_sub] [api_base] [use_codex_sub] [use_antigravity_sub]
 save_configuration() {
     local provider_id="$1"
     local env_var="$2"
@@ -857,6 +857,7 @@ save_configuration() {
     local use_claude_code_sub="${6:-}"
     local api_base="${7:-}"
     local use_codex_sub="${8:-}"
+    local use_antigravity_sub="${9:-}"
 
     # Fallbacks if not provided
     if [ -z "$model" ]; then
@@ -878,6 +879,7 @@ save_configuration() {
         "$use_claude_code_sub" \
         "$api_base" \
         "$use_codex_sub" \
+        "$use_antigravity_sub" \
         "$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")" 2>/dev/null <<'PY'
 import json
 import sys
@@ -892,8 +894,9 @@ from pathlib import Path
     use_claude_code_sub,
     api_base,
     use_codex_sub,
+    use_antigravity_sub,
     created_at,
-) = sys.argv[1:10]
+) = sys.argv[1:11]
 
 cfg_path = Path.home() / ".hive" / "configuration.json"
 cfg_path.parent.mkdir(parents=True, exist_ok=True)
@@ -924,6 +927,12 @@ if use_codex_sub == "true":
     config["llm"].pop("api_key_env_var", None)
 else:
     config["llm"].pop("use_codex_subscription", None)
+
+if use_antigravity_sub == "true":
+    config["llm"]["use_antigravity_subscription"] = True
+    config["llm"].pop("api_key_env_var", None)
+else:
+    config["llm"].pop("use_antigravity_subscription", None)
 
 if api_base:
     config["llm"]["api_base"] = api_base
@@ -993,6 +1002,19 @@ if [ -n "${HIVE_API_KEY:-}" ]; then
     HIVE_CRED_DETECTED=true
 fi
 
+ANTIGRAVITY_CRED_DETECTED=false
+# Check native Antigravity IDE (macOS/Linux) SQLite state DB first
+if [ -f "$HOME/Library/Application Support/Antigravity/User/globalStorage/state.vscdb" ]; then
+    ANTIGRAVITY_CRED_DETECTED=true
+elif [ -f "$HOME/.config/Antigravity/User/globalStorage/state.vscdb" ]; then
+    ANTIGRAVITY_CRED_DETECTED=true
+# Fallback: antigravity-auth CLI tool JSON files
+elif [ -f "$HOME/.config/opencode/antigravity-accounts.json" ]; then
+    ANTIGRAVITY_CRED_DETECTED=true
+elif [ -f "$HOME/.config/antigravity_auth/accounts.json" ]; then
+    ANTIGRAVITY_CRED_DETECTED=true
+fi
+
 # Detect API key providers
 if [ "$USE_ASSOC_ARRAYS" = true ]; then
     for env_var in "${!PROVIDER_NAMES[@]}"; do
@@ -1035,6 +1057,8 @@ try:
         sub = "codex"
     elif llm.get("use_kimi_code_subscription"):
         sub = "kimi_code"
+    elif llm.get("use_antigravity_subscription"):
+        sub = "antigravity"
     elif llm.get("provider", "") == "minimax" or "api.minimax.io" in llm.get("api_base", ""):
         sub = "minimax_code"
     elif llm.get("provider", "") == "hive" or "adenhq.com" in llm.get("api_base", ""):
@@ -1058,6 +1082,7 @@ if [ -n "$PREV_SUB_MODE" ] || [ -n "$PREV_PROVIDER" ]; then
         codex)       [ "$CODEX_CRED_DETECTED" = true ] && PREV_CRED_VALID=true ;;
         kimi_code)   [ "$KIMI_CRED_DETECTED" = true ] && PREV_CRED_VALID=true ;;
         hive_llm)    [ "$HIVE_CRED_DETECTED" = true ] && PREV_CRED_VALID=true ;;
+        antigravity) [ "$ANTIGRAVITY_CRED_DETECTED" = true ] && PREV_CRED_VALID=true ;;
         *)
             # API key provider — check if the env var is set
             if [ -n "$PREV_ENV_VAR" ] && [ -n "${!PREV_ENV_VAR}" ]; then
@@ -1074,15 +1099,16 @@ if [ -n "$PREV_SUB_MODE" ] || [ -n "$PREV_PROVIDER" ]; then
             minimax_code) DEFAULT_CHOICE=4 ;;
             kimi_code)   DEFAULT_CHOICE=5 ;;
             hive_llm)    DEFAULT_CHOICE=6 ;;
+            antigravity) DEFAULT_CHOICE=7 ;;
         esac
         if [ -z "$DEFAULT_CHOICE" ]; then
             case "$PREV_PROVIDER" in
-                anthropic) DEFAULT_CHOICE=7 ;;
-                openai)    DEFAULT_CHOICE=8 ;;
-                gemini)    DEFAULT_CHOICE=9 ;;
-                groq)      DEFAULT_CHOICE=10 ;;
-                cerebras)  DEFAULT_CHOICE=11 ;;
-                openrouter) DEFAULT_CHOICE=12 ;;
+                anthropic) DEFAULT_CHOICE=8 ;;
+                openai)    DEFAULT_CHOICE=9 ;;
+                gemini)    DEFAULT_CHOICE=10 ;;
+                groq)      DEFAULT_CHOICE=11 ;;
+                cerebras)  DEFAULT_CHOICE=12 ;;
+                openrouter) DEFAULT_CHOICE=13 ;;
                 minimax)   DEFAULT_CHOICE=4 ;;
                 kimi)      DEFAULT_CHOICE=5 ;;
                 hive)      DEFAULT_CHOICE=6 ;;
@@ -1138,14 +1164,21 @@ else
     echo -e "  ${CYAN}6)${NC} Hive LLM                   ${DIM}(use your Hive API key)${NC}"
 fi
 
+# 7) Antigravity
+if [ "$ANTIGRAVITY_CRED_DETECTED" = true ]; then
+    echo -e "  ${CYAN}7)${NC} Antigravity Subscription  ${DIM}(use your Google/Gemini plan)${NC}  ${GREEN}(credential detected)${NC}"
+else
+    echo -e "  ${CYAN}7)${NC} Antigravity Subscription  ${DIM}(use your Google/Gemini plan)${NC}"
+fi
+
 echo ""
 echo -e "  ${CYAN}${BOLD}API key providers:${NC}"
 
-# 7-12) API key providers — show (credential detected) if key already set
+# 8-13) API key providers — show (credential detected) if key already set
 PROVIDER_MENU_ENVS=(ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY GROQ_API_KEY CEREBRAS_API_KEY OPENROUTER_API_KEY)
 PROVIDER_MENU_NAMES=("Anthropic (Claude) - Recommended" "OpenAI (GPT)" "Google Gemini - Free tier available" "Groq - Fast, free tier" "Cerebras - Fast, free tier" "OpenRouter - Bring any OpenRouter model")
 for idx in "${!PROVIDER_MENU_ENVS[@]}"; do
-    num=$((idx + 7))
+    num=$((idx + 8))
     env_var="${PROVIDER_MENU_ENVS[$idx]}"
     if [ -n "${!env_var}" ]; then
         echo -e "  ${CYAN}$num)${NC} ${PROVIDER_MENU_NAMES[$idx]}  ${GREEN}(credential detected)${NC}"
@@ -1154,7 +1187,7 @@ for idx in "${!PROVIDER_MENU_ENVS[@]}"; do
     fi
 done
 
-SKIP_CHOICE=$((7 + ${#PROVIDER_MENU_ENVS[@]}))
+SKIP_CHOICE=$((8 + ${#PROVIDER_MENU_ENVS[@]}))
 echo -e "  ${CYAN}$SKIP_CHOICE)${NC} Skip for now"
 echo ""
 
@@ -1297,36 +1330,59 @@ case $choice in
         echo -e "  ${DIM}Model: $SELECTED_MODEL | API: ${HIVE_LLM_ENDPOINT}${NC}"
         ;;
     7)
+        # Antigravity Subscription
+        if [ "$ANTIGRAVITY_CRED_DETECTED" = false ]; then
+            echo ""
+            echo -e "${YELLOW}  Antigravity credentials not found.${NC}"
+            echo -e "  Run ${CYAN}antigravity-auth accounts add${NC} to authenticate,"
+            echo -e "  then run this quickstart again."
+            echo ""
+            exit 1
+        else
+            SUBSCRIPTION_MODE="antigravity"
+            SELECTED_PROVIDER_ID="openai"
+            SELECTED_MODEL="gemini-3-flash"
+            SELECTED_MAX_TOKENS=32768
+            SELECTED_MAX_CONTEXT_TOKENS=1000000  # Gemini 3 Flash — 1M context window
+            echo ""
+            echo -e "${YELLOW}  ⚠ Using Antigravity can technically cause your account suspension. Please use at your own risk.${NC}"
+            echo ""
+            echo -e "${GREEN}⬢${NC} Using Antigravity subscription"
+            echo -e "  ${DIM}Model: gemini-3-flash | Proxy: localhost:8069/v1${NC}"
+            echo -e "  ${DIM}Ensure 'antigravity-auth serve' is running before starting agents.${NC}"
+        fi
+        ;;
+    8)
         SELECTED_ENV_VAR="ANTHROPIC_API_KEY"
         SELECTED_PROVIDER_ID="anthropic"
         PROVIDER_NAME="Anthropic"
         SIGNUP_URL="https://console.anthropic.com/settings/keys"
         ;;
-    8)
+    9)
         SELECTED_ENV_VAR="OPENAI_API_KEY"
         SELECTED_PROVIDER_ID="openai"
         PROVIDER_NAME="OpenAI"
         SIGNUP_URL="https://platform.openai.com/api-keys"
         ;;
-    9)
+    10)
         SELECTED_ENV_VAR="GEMINI_API_KEY"
         SELECTED_PROVIDER_ID="gemini"
         PROVIDER_NAME="Google Gemini"
         SIGNUP_URL="https://aistudio.google.com/apikey"
         ;;
-    10)
+    11)
         SELECTED_ENV_VAR="GROQ_API_KEY"
         SELECTED_PROVIDER_ID="groq"
         PROVIDER_NAME="Groq"
         SIGNUP_URL="https://console.groq.com/keys"
         ;;
-    11)
+    12)
         SELECTED_ENV_VAR="CEREBRAS_API_KEY"
         SELECTED_PROVIDER_ID="cerebras"
         PROVIDER_NAME="Cerebras"
         SIGNUP_URL="https://cloud.cerebras.ai/"
         ;;
-    12)
+    13)
         SELECTED_ENV_VAR="OPENROUTER_API_KEY"
         SELECTED_PROVIDER_ID="openrouter"
         SELECTED_API_BASE="https://openrouter.ai/api/v1"
@@ -1491,6 +1547,8 @@ if [ -n "$SELECTED_PROVIDER_ID" ]; then
         save_configuration "$SELECTED_PROVIDER_ID" "" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "true" "" > /dev/null || SAVE_OK=false
     elif [ "$SUBSCRIPTION_MODE" = "codex" ]; then
         save_configuration "$SELECTED_PROVIDER_ID" "" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "" "" "true" > /dev/null || SAVE_OK=false
+    elif [ "$SUBSCRIPTION_MODE" = "antigravity" ]; then
+        save_configuration "$SELECTED_PROVIDER_ID" "" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "" "" "" "true" > /dev/null || SAVE_OK=false
     elif [ "$SUBSCRIPTION_MODE" = "zai_code" ]; then
         save_configuration "$SELECTED_PROVIDER_ID" "$SELECTED_ENV_VAR" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "" "https://api.z.ai/api/coding/paas/v4" > /dev/null || SAVE_OK=false
     elif [ "$SUBSCRIPTION_MODE" = "minimax_code" ]; then

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -846,32 +846,6 @@ prompt_model_selection() {
     done
 }
 
-# Read Antigravity OAuth client credentials from the installed npm package.
-# Exports _AG_CLIENT_SECRET and _AG_CLIENT_ID; returns 1 if package not found.
-_read_antigravity_creds_from_npm() {
-    local constants_js=""
-    local npm_root
-    npm_root="$(npm root -g 2>/dev/null)" && \
-        [ -f "$npm_root/opencode-antigravity-auth/dist/src/constants.js" ] && \
-        constants_js="$npm_root/opencode-antigravity-auth/dist/src/constants.js"
-    if [ -z "$constants_js" ]; then
-        for _candidate in \
-            /opt/homebrew/lib/node_modules/opencode-antigravity-auth/dist/src/constants.js \
-            /usr/local/lib/node_modules/opencode-antigravity-auth/dist/src/constants.js \
-            /usr/lib/node_modules/opencode-antigravity-auth/dist/src/constants.js; do
-            if [ -f "$_candidate" ]; then
-                constants_js="$_candidate"
-                break
-            fi
-        done
-    fi
-    [ -z "$constants_js" ] && return 1
-    _AG_CLIENT_SECRET="$(grep -o '"GOCSPX-[^"]*"' "$constants_js" 2>/dev/null | tr -d '"' | head -1)"
-    _AG_CLIENT_ID="$(grep -o '"[0-9]*-[a-z0-9]*\.apps\.googleusercontent\.com"' "$constants_js" 2>/dev/null | tr -d '"' | head -1)"
-    export _AG_CLIENT_SECRET _AG_CLIENT_ID
-    [ -n "$_AG_CLIENT_SECRET" ] && [ -n "$_AG_CLIENT_ID" ]
-}
-
 # Function to save configuration
 # Args: provider_id env_var model max_tokens max_context_tokens [use_claude_code_sub] [api_base] [use_codex_sub] [use_antigravity_sub]
 save_configuration() {
@@ -894,11 +868,6 @@ save_configuration() {
     fi
     if [ -z "$max_context_tokens" ]; then
         max_context_tokens=120000
-    fi
-
-    if _read_antigravity_creds_from_npm 2>/dev/null; then
-        export ANTIGRAVITY_CLIENT_SECRET="$_AG_CLIENT_SECRET"
-        export ANTIGRAVITY_CLIENT_ID="$_AG_CLIENT_ID"
     fi
 
     uv run python - \
@@ -1050,10 +1019,8 @@ if [ -f "$HOME/Library/Application Support/Antigravity/User/globalStorage/state.
     ANTIGRAVITY_CRED_DETECTED=true
 elif [ -f "$HOME/.config/Antigravity/User/globalStorage/state.vscdb" ]; then
     ANTIGRAVITY_CRED_DETECTED=true
-# Fallback: antigravity-auth CLI tool JSON files
-elif [ -f "$HOME/.config/opencode/antigravity-accounts.json" ]; then
-    ANTIGRAVITY_CRED_DETECTED=true
-elif [ -f "$HOME/.config/antigravity_auth/accounts.json" ]; then
+# Native OAuth credentials
+elif [ -f "$HOME/.hive/antigravity-accounts.json" ]; then
     ANTIGRAVITY_CRED_DETECTED=true
 fi
 
@@ -1377,106 +1344,23 @@ case $choice in
             echo ""
             echo -e "${CYAN}  Setting up Antigravity authentication...${NC}"
             echo ""
-
-            # ── Step 1: ensure opencode is installed ────────────────────────
-            if ! command -v opencode &>/dev/null; then
-                echo -e "  Installing ${CYAN}opencode${NC} (required for Antigravity OAuth)..."
-                if command -v npm &>/dev/null; then
-                    npm install -g opencode-ai || { echo -e "${RED}  npm install failed. Install Node.js and retry.${NC}"; exit 1; }
-                else
-                    echo -e "${RED}  Node.js/npm not found. Install Node.js first: https://nodejs.org${NC}"
-                    exit 1
-                fi
-            fi
-
-            # ── Step 2: write opencode.json with the plugin ─────────────────
-            OPENCODE_CFG_DIR="$HOME/.config/opencode"
-            OPENCODE_CFG="$OPENCODE_CFG_DIR/opencode.json"
-            mkdir -p "$OPENCODE_CFG_DIR"
-
-            if [ ! -f "$OPENCODE_CFG" ]; then
-                cat > "$OPENCODE_CFG" <<'JSON'
-{
-  "$schema": "https://opencode.ai/config.json",
-  "plugin": ["opencode-antigravity-auth@latest"],
-  "provider": {
-    "google": {
-      "models": {
-        "antigravity-gemini-3-flash": {
-          "name": "Gemini 3 Flash (Antigravity)",
-          "limit": { "context": 1048576, "output": 65536 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "antigravity-gemini-3-pro": {
-          "name": "Gemini 3 Pro (Antigravity)",
-          "limit": { "context": 1048576, "output": 65535 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "antigravity-gemini-3.1-pro": {
-          "name": "Gemini 3.1 Pro (Antigravity)",
-          "limit": { "context": 1048576, "output": 65535 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "antigravity-claude-sonnet-4-6": {
-          "name": "Claude Sonnet 4.6 (Antigravity)",
-          "limit": { "context": 200000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "antigravity-claude-opus-4-6-thinking": {
-          "name": "Claude Opus 4.6 Thinking (Antigravity)",
-          "limit": { "context": 200000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        }
-      }
-    }
-  }
-}
-JSON
-            else
-                # Inject plugin entry if not already present
-                uv run python3 - "$OPENCODE_CFG" <<'PY' 2>/dev/null || true
-import json, sys
-p = sys.argv[1]
-try:
-    with open(p) as f:
-        cfg = json.load(f)
-except Exception:
-    cfg = {}
-plugins = cfg.get("plugin", [])
-entry = "opencode-antigravity-auth@latest"
-if entry not in plugins:
-    plugins.append(entry)
-cfg["plugin"] = plugins
-import os
-fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
-with os.fdopen(fd, "w") as f:
-    json.dump(cfg, f, indent=2)
-print("plugin entry added")
-PY
-            fi
-
-            echo -e "  ${GREEN}✓${NC} opencode.json configured with antigravity plugin"
-            echo ""
             echo -e "  ${YELLOW}A browser window will open for Google OAuth.${NC}"
             echo -e "  Sign in with your Google account that has Antigravity access."
             echo ""
 
-            # ── Step 3: run opencode auth login ─────────────────────────────
-            opencode auth login || true
-
-            # ── Step 4: re-detect credentials ───────────────────────────────
-            if [ -f "$HOME/.config/opencode/antigravity-accounts.json" ]; then
-                ANTIGRAVITY_CRED_DETECTED=true
-            elif [ -f "$HOME/.config/antigravity_auth/accounts.json" ]; then
-                ANTIGRAVITY_CRED_DETECTED=true
+            # Run native OAuth flow
+            if uv run python "$SCRIPT_DIR/core/antigravity_auth.py" auth account add; then
+                # Re-detect credentials
+                if [ -f "$HOME/.hive/antigravity-accounts.json" ]; then
+                    ANTIGRAVITY_CRED_DETECTED=true
+                fi
             fi
 
             if [ "$ANTIGRAVITY_CRED_DETECTED" = false ]; then
                 echo ""
-                echo -e "${RED}  Authentication did not produce credentials.${NC}"
-                echo -e "  Run ${CYAN}opencode auth login${NC} manually and try again."
+                echo -e "${RED}  Authentication failed or was cancelled.${NC}"
                 echo ""
-                exit 1
+                SELECTED_PROVIDER_ID=""
             fi
         fi
 

--- a/scripts/check_llm_key.py
+++ b/scripts/check_llm_key.py
@@ -33,8 +33,8 @@ OPENROUTER_SEPARATOR_TRANSLATION = str.maketrans(
         "\u2212": "-",
         "\u2044": "/",
         "\u2215": "/",
-        "\u29F8": "/",
-        "\uFF0F": "/",
+        "\u29f8": "/",
+        "\uff0f": "/",
     }
 )
 
@@ -66,9 +66,7 @@ def _sanitize_openrouter_model_id(value: str) -> str:
     """Sanitize pasted OpenRouter model IDs into a comparable slug."""
     normalized = unicodedata.normalize("NFKC", value or "")
     normalized = "".join(
-        ch
-        for ch in normalized
-        if unicodedata.category(ch) not in {"Cc", "Cf"}
+        ch for ch in normalized if unicodedata.category(ch) not in {"Cc", "Cf"}
     )
     normalized = normalized.translate(OPENROUTER_SEPARATOR_TRANSLATION)
     normalized = re.sub(r"\s+", "", normalized)
@@ -183,7 +181,10 @@ def check_openrouter(
         return {"valid": False, "message": "Invalid OpenRouter API key"}
     if r.status_code == 403:
         return {"valid": False, "message": "OpenRouter API key lacks permissions"}
-    return {"valid": False, "message": f"OpenRouter API returned status {r.status_code}"}
+    return {
+        "valid": False,
+        "message": f"OpenRouter API returned status {r.status_code}",
+    }
 
 
 def check_openrouter_model(

--- a/scripts/llm_debug_log_visualizer.py
+++ b/scripts/llm_debug_log_visualizer.py
@@ -876,7 +876,7 @@ def _run_server(
             if self.path == "/":
                 self._respond(200, "text/html; charset=utf-8", html_bytes)
             elif self.path.startswith("/api/session/"):
-                sid = urllib.parse.unquote(self.path[len("/api/session/"):])
+                sid = urllib.parse.unquote(self.path[len("/api/session/") :])
                 records = sessions.get(sid)
                 if records is None:
                     self._respond(404, "application/json", b"[]")
@@ -917,9 +917,7 @@ def _run_server(
 def main() -> int:
     args = _parse_args()
     records = _discover_records(args.logs_dir.expanduser(), args.limit_files)
-    summaries, sessions = _group_sessions(
-        records, include_tests=args.include_tests
-    )
+    summaries, sessions = _group_sessions(records, include_tests=args.include_tests)
 
     initial_session_id = args.session or (
         summaries[0].execution_id if summaries else ""

--- a/scripts/setup_worker_model.sh
+++ b/scripts/setup_worker_model.sh
@@ -424,7 +424,7 @@ prompt_model_selection() {
 }
 
 # ── Save worker_llm section to configuration.json ────────────────────
-# Args: provider_id env_var model max_tokens max_context_tokens [use_claude_code_sub] [api_base] [use_codex_sub]
+# Args: provider_id env_var model max_tokens max_context_tokens [use_claude_code_sub] [api_base] [use_codex_sub] [use_antigravity_sub]
 
 save_worker_configuration() {
     local provider_id="$1"
@@ -435,6 +435,7 @@ save_worker_configuration() {
     local use_claude_code_sub="${6:-}"
     local api_base="${7:-}"
     local use_codex_sub="${8:-}"
+    local use_antigravity_sub="${9:-}"
 
     if [ -z "$model" ]; then
         model="$(get_default_model "$provider_id")"
@@ -451,7 +452,8 @@ save_worker_configuration() {
         "$max_context_tokens" \
         "$use_claude_code_sub" \
         "$api_base" \
-        "$use_codex_sub" 2>/dev/null <<'PY'
+        "$use_codex_sub" \
+        "$use_antigravity_sub" 2>/dev/null <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -465,7 +467,8 @@ from pathlib import Path
     use_claude_code_sub,
     api_base,
     use_codex_sub,
-) = sys.argv[1:9]
+    use_antigravity_sub,
+) = sys.argv[1:10]
 
 cfg_path = Path.home() / ".hive" / "configuration.json"
 cfg_path.parent.mkdir(parents=True, exist_ok=True)
@@ -495,6 +498,12 @@ if use_codex_sub == "true":
     config["worker_llm"].pop("api_key_env_var", None)
 else:
     config["worker_llm"].pop("use_codex_subscription", None)
+
+if use_antigravity_sub == "true":
+    config["worker_llm"]["use_antigravity_subscription"] = True
+    config["worker_llm"].pop("api_key_env_var", None)
+else:
+    config["worker_llm"].pop("use_antigravity_subscription", None)
 
 if api_base:
     config["worker_llm"]["api_base"] = api_base
@@ -591,6 +600,19 @@ if [ -n "${HIVE_API_KEY:-}" ]; then
     HIVE_CRED_DETECTED=true
 fi
 
+ANTIGRAVITY_CRED_DETECTED=false
+# Check native Antigravity IDE (macOS/Linux) SQLite state DB first
+if [ -f "$HOME/Library/Application Support/Antigravity/User/globalStorage/state.vscdb" ]; then
+    ANTIGRAVITY_CRED_DETECTED=true
+elif [ -f "$HOME/.config/Antigravity/User/globalStorage/state.vscdb" ]; then
+    ANTIGRAVITY_CRED_DETECTED=true
+# Fallback: antigravity-auth CLI tool JSON files
+elif [ -f "$HOME/.config/opencode/antigravity-accounts.json" ]; then
+    ANTIGRAVITY_CRED_DETECTED=true
+elif [ -f "$HOME/.config/antigravity_auth/accounts.json" ]; then
+    ANTIGRAVITY_CRED_DETECTED=true
+fi
+
 # Detect API key providers
 if [ "$USE_ASSOC_ARRAYS" = true ]; then
     for env_var in "${!PROVIDER_NAMES[@]}"; do
@@ -633,6 +655,8 @@ try:
         sub = "codex"
     elif llm.get("use_kimi_code_subscription"):
         sub = "kimi_code"
+    elif llm.get("use_antigravity_subscription"):
+        sub = "antigravity"
     elif llm.get("provider", "") == "minimax" or "api.minimax.io" in llm.get("api_base", ""):
         sub = "minimax_code"
     elif llm.get("provider", "") == "hive" or "adenhq.com" in llm.get("api_base", ""):
@@ -656,6 +680,7 @@ if [ -n "$PREV_SUB_MODE" ] || [ -n "$PREV_PROVIDER" ]; then
         codex)       [ "$CODEX_CRED_DETECTED" = true ] && PREV_CRED_VALID=true ;;
         kimi_code)   [ "$KIMI_CRED_DETECTED" = true ] && PREV_CRED_VALID=true ;;
         hive_llm)    [ "$HIVE_CRED_DETECTED" = true ] && PREV_CRED_VALID=true ;;
+        antigravity) [ "$ANTIGRAVITY_CRED_DETECTED" = true ] && PREV_CRED_VALID=true ;;
         *)
             # API key provider — check if the env var is set
             if [ -n "$PREV_ENV_VAR" ] && [ -n "${!PREV_ENV_VAR}" ]; then
@@ -672,15 +697,16 @@ if [ -n "$PREV_SUB_MODE" ] || [ -n "$PREV_PROVIDER" ]; then
             minimax_code) DEFAULT_CHOICE=4 ;;
             kimi_code)   DEFAULT_CHOICE=5 ;;
             hive_llm)    DEFAULT_CHOICE=6 ;;
+            antigravity) DEFAULT_CHOICE=7 ;;
         esac
         if [ -z "$DEFAULT_CHOICE" ]; then
             case "$PREV_PROVIDER" in
-                anthropic) DEFAULT_CHOICE=7 ;;
-                openai)    DEFAULT_CHOICE=8 ;;
-                gemini)    DEFAULT_CHOICE=9 ;;
-                groq)      DEFAULT_CHOICE=10 ;;
-                cerebras)  DEFAULT_CHOICE=11 ;;
-                openrouter) DEFAULT_CHOICE=12 ;;
+                anthropic) DEFAULT_CHOICE=8 ;;
+                openai)    DEFAULT_CHOICE=9 ;;
+                gemini)    DEFAULT_CHOICE=10 ;;
+                groq)      DEFAULT_CHOICE=11 ;;
+                cerebras)  DEFAULT_CHOICE=12 ;;
+                openrouter) DEFAULT_CHOICE=13 ;;
                 minimax)   DEFAULT_CHOICE=4 ;;
                 kimi)      DEFAULT_CHOICE=5 ;;
                 hive)      DEFAULT_CHOICE=6 ;;
@@ -736,14 +762,21 @@ else
     echo -e "  ${CYAN}6)${NC} Hive LLM                   ${DIM}(use your Hive API key)${NC}"
 fi
 
+# 7) Antigravity
+if [ "$ANTIGRAVITY_CRED_DETECTED" = true ]; then
+    echo -e "  ${CYAN}7)${NC} Antigravity Subscription  ${DIM}(use your Google/Gemini plan)${NC}  ${GREEN}(credential detected)${NC}"
+else
+    echo -e "  ${CYAN}7)${NC} Antigravity Subscription  ${DIM}(use your Google/Gemini plan)${NC}"
+fi
+
 echo ""
 echo -e "  ${CYAN}${BOLD}API key providers:${NC}"
 
-# 7-12) API key providers — show (credential detected) if key already set
+# 8-13) API key providers — show (credential detected) if key already set
 PROVIDER_MENU_ENVS=(ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY GROQ_API_KEY CEREBRAS_API_KEY OPENROUTER_API_KEY)
 PROVIDER_MENU_NAMES=("Anthropic (Claude) - Recommended" "OpenAI (GPT)" "Google Gemini - Free tier available" "Groq - Fast, free tier" "Cerebras - Fast, free tier" "OpenRouter - Bring any OpenRouter model")
 for idx in "${!PROVIDER_MENU_ENVS[@]}"; do
-    num=$((idx + 7))
+    num=$((idx + 8))
     env_var="${PROVIDER_MENU_ENVS[$idx]}"
     if [ -n "${!env_var}" ]; then
         echo -e "  ${CYAN}$num)${NC} ${PROVIDER_MENU_NAMES[$idx]}  ${GREEN}(credential detected)${NC}"
@@ -752,7 +785,7 @@ for idx in "${!PROVIDER_MENU_ENVS[@]}"; do
     fi
 done
 
-SKIP_CHOICE=$((7 + ${#PROVIDER_MENU_ENVS[@]}))
+SKIP_CHOICE=$((8 + ${#PROVIDER_MENU_ENVS[@]}))
 echo -e "  ${CYAN}$SKIP_CHOICE)${NC} Skip for now"
 echo ""
 
@@ -895,36 +928,59 @@ case $choice in
         echo -e "  ${DIM}Model: $SELECTED_MODEL | API: ${HIVE_LLM_ENDPOINT}${NC}"
         ;;
     7)
+        # Antigravity Subscription
+        if [ "$ANTIGRAVITY_CRED_DETECTED" = false ]; then
+            echo ""
+            echo -e "${YELLOW}  Antigravity credentials not found.${NC}"
+            echo -e "  Run ${CYAN}antigravity-auth accounts add${NC} to authenticate,"
+            echo -e "  then run this script again."
+            echo ""
+            exit 1
+        else
+            SUBSCRIPTION_MODE="antigravity"
+            SELECTED_PROVIDER_ID="openai"
+            SELECTED_MODEL="gemini-3-flash"
+            SELECTED_MAX_TOKENS=32768
+            SELECTED_MAX_CONTEXT_TOKENS=1000000  # Gemini 3 Flash — 1M context window
+            echo ""
+            echo -e "${YELLOW}  ⚠ Using Antigravity can technically cause your account suspension. Please use at your own risk.${NC}"
+            echo ""
+            echo -e "${GREEN}⬢${NC} Using Antigravity subscription"
+            echo -e "  ${DIM}Model: gemini-3-flash | Proxy: localhost:8069/v1${NC}"
+            echo -e "  ${DIM}Ensure 'antigravity-auth serve' is running before starting agents.${NC}"
+        fi
+        ;;
+    8)
         SELECTED_ENV_VAR="ANTHROPIC_API_KEY"
         SELECTED_PROVIDER_ID="anthropic"
         PROVIDER_NAME="Anthropic"
         SIGNUP_URL="https://console.anthropic.com/settings/keys"
         ;;
-    8)
+    9)
         SELECTED_ENV_VAR="OPENAI_API_KEY"
         SELECTED_PROVIDER_ID="openai"
         PROVIDER_NAME="OpenAI"
         SIGNUP_URL="https://platform.openai.com/api-keys"
         ;;
-    9)
+    10)
         SELECTED_ENV_VAR="GEMINI_API_KEY"
         SELECTED_PROVIDER_ID="gemini"
         PROVIDER_NAME="Google Gemini"
         SIGNUP_URL="https://aistudio.google.com/apikey"
         ;;
-    10)
+    11)
         SELECTED_ENV_VAR="GROQ_API_KEY"
         SELECTED_PROVIDER_ID="groq"
         PROVIDER_NAME="Groq"
         SIGNUP_URL="https://console.groq.com/keys"
         ;;
-    11)
+    12)
         SELECTED_ENV_VAR="CEREBRAS_API_KEY"
         SELECTED_PROVIDER_ID="cerebras"
         PROVIDER_NAME="Cerebras"
         SIGNUP_URL="https://cloud.cerebras.ai/"
         ;;
-    12)
+    13)
         SELECTED_ENV_VAR="OPENROUTER_API_KEY"
         SELECTED_PROVIDER_ID="openrouter"
         SELECTED_API_BASE="https://openrouter.ai/api/v1"
@@ -1086,6 +1142,8 @@ if [ -n "$SELECTED_PROVIDER_ID" ]; then
         save_worker_configuration "$SELECTED_PROVIDER_ID" "" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "true" "" > /dev/null || SAVE_OK=false
     elif [ "$SUBSCRIPTION_MODE" = "codex" ]; then
         save_worker_configuration "$SELECTED_PROVIDER_ID" "" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "" "" "true" > /dev/null || SAVE_OK=false
+    elif [ "$SUBSCRIPTION_MODE" = "antigravity" ]; then
+        save_worker_configuration "$SELECTED_PROVIDER_ID" "" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "" "" "" "true" > /dev/null || SAVE_OK=false
     elif [ "$SUBSCRIPTION_MODE" = "zai_code" ]; then
         save_worker_configuration "$SELECTED_PROVIDER_ID" "$SELECTED_ENV_VAR" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "" "https://api.z.ai/api/coding/paas/v4" > /dev/null || SAVE_OK=false
     elif [ "$SUBSCRIPTION_MODE" = "minimax_code" ]; then

--- a/scripts/setup_worker_model.sh
+++ b/scripts/setup_worker_model.sh
@@ -423,6 +423,32 @@ prompt_model_selection() {
     done
 }
 
+# Read Antigravity OAuth client credentials from the installed npm package.
+# Exports _AG_CLIENT_SECRET and _AG_CLIENT_ID; returns 1 if package not found.
+_read_antigravity_creds_from_npm() {
+    local constants_js=""
+    local npm_root
+    npm_root="$(npm root -g 2>/dev/null)" && \
+        [ -f "$npm_root/opencode-antigravity-auth/dist/src/constants.js" ] && \
+        constants_js="$npm_root/opencode-antigravity-auth/dist/src/constants.js"
+    if [ -z "$constants_js" ]; then
+        for _candidate in \
+            /opt/homebrew/lib/node_modules/opencode-antigravity-auth/dist/src/constants.js \
+            /usr/local/lib/node_modules/opencode-antigravity-auth/dist/src/constants.js \
+            /usr/lib/node_modules/opencode-antigravity-auth/dist/src/constants.js; do
+            if [ -f "$_candidate" ]; then
+                constants_js="$_candidate"
+                break
+            fi
+        done
+    fi
+    [ -z "$constants_js" ] && return 1
+    _AG_CLIENT_SECRET="$(grep -o '"GOCSPX-[^"]*"' "$constants_js" 2>/dev/null | tr -d '"' | head -1)"
+    _AG_CLIENT_ID="$(grep -o '"[0-9]*-[a-z0-9]*\.apps\.googleusercontent\.com"' "$constants_js" 2>/dev/null | tr -d '"' | head -1)"
+    export _AG_CLIENT_SECRET _AG_CLIENT_ID
+    [ -n "$_AG_CLIENT_SECRET" ] && [ -n "$_AG_CLIENT_ID" ]
+}
+
 # ── Save worker_llm section to configuration.json ────────────────────
 # Args: provider_id env_var model max_tokens max_context_tokens [use_claude_code_sub] [api_base] [use_codex_sub] [use_antigravity_sub]
 
@@ -442,6 +468,11 @@ save_worker_configuration() {
     fi
     if [ -z "$max_tokens" ]; then max_tokens=8192; fi
     if [ -z "$max_context_tokens" ]; then max_context_tokens=120000; fi
+
+    if _read_antigravity_creds_from_npm 2>/dev/null; then
+        export ANTIGRAVITY_CLIENT_SECRET="$_AG_CLIENT_SECRET"
+        export ANTIGRAVITY_CLIENT_ID="$_AG_CLIENT_ID"
+    fi
 
     cd "$PROJECT_DIR"
     uv run python - \
@@ -502,8 +533,17 @@ else:
 if use_antigravity_sub == "true":
     config["worker_llm"]["use_antigravity_subscription"] = True
     config["worker_llm"].pop("api_key_env_var", None)
+    import os as _os
+    _secret = _os.environ.get("ANTIGRAVITY_CLIENT_SECRET") or ""
+    if _secret:
+        config["worker_llm"]["antigravity_client_secret"] = _secret
+    _client_id = _os.environ.get("ANTIGRAVITY_CLIENT_ID") or ""
+    if _client_id:
+        config["worker_llm"]["antigravity_client_id"] = _client_id
 else:
     config["worker_llm"].pop("use_antigravity_subscription", None)
+    config["worker_llm"].pop("antigravity_client_secret", None)
+    config["worker_llm"].pop("antigravity_client_id", None)
 
 if api_base:
     config["worker_llm"]["api_base"] = api_base
@@ -931,12 +971,110 @@ case $choice in
         # Antigravity Subscription
         if [ "$ANTIGRAVITY_CRED_DETECTED" = false ]; then
             echo ""
-            echo -e "${YELLOW}  Antigravity credentials not found.${NC}"
-            echo -e "  Run ${CYAN}antigravity-auth accounts add${NC} to authenticate,"
-            echo -e "  then run this script again."
+            echo -e "${CYAN}  Setting up Antigravity authentication...${NC}"
             echo ""
-            exit 1
-        else
+
+            # ── Step 1: ensure opencode is installed ────────────────────────
+            if ! command -v opencode &>/dev/null; then
+                echo -e "  Installing ${CYAN}opencode${NC} (required for Antigravity OAuth)..."
+                if command -v npm &>/dev/null; then
+                    npm install -g opencode-ai || { echo -e "${RED}  npm install failed. Install Node.js and retry.${NC}"; exit 1; }
+                else
+                    echo -e "${RED}  Node.js/npm not found. Install Node.js first: https://nodejs.org${NC}"
+                    exit 1
+                fi
+            fi
+
+            # ── Step 2: write opencode.json with the plugin ─────────────────
+            OPENCODE_CFG_DIR="$HOME/.config/opencode"
+            OPENCODE_CFG="$OPENCODE_CFG_DIR/opencode.json"
+            mkdir -p "$OPENCODE_CFG_DIR"
+
+            if [ ! -f "$OPENCODE_CFG" ]; then
+                cat > "$OPENCODE_CFG" <<'JSON'
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["opencode-antigravity-auth@latest"],
+  "provider": {
+    "google": {
+      "models": {
+        "antigravity-gemini-3-flash": {
+          "name": "Gemini 3 Flash (Antigravity)",
+          "limit": { "context": 1048576, "output": 65536 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "antigravity-gemini-3-pro": {
+          "name": "Gemini 3 Pro (Antigravity)",
+          "limit": { "context": 1048576, "output": 65535 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "antigravity-gemini-3.1-pro": {
+          "name": "Gemini 3.1 Pro (Antigravity)",
+          "limit": { "context": 1048576, "output": 65535 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "antigravity-claude-sonnet-4-6": {
+          "name": "Claude Sonnet 4.6 (Antigravity)",
+          "limit": { "context": 200000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "antigravity-claude-opus-4-6-thinking": {
+          "name": "Claude Opus 4.6 Thinking (Antigravity)",
+          "limit": { "context": 200000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        }
+      }
+    }
+  }
+}
+JSON
+            else
+                uv run python3 - "$OPENCODE_CFG" <<'PY' 2>/dev/null || true
+import json, sys
+p = sys.argv[1]
+try:
+    with open(p) as f:
+        cfg = json.load(f)
+except Exception:
+    cfg = {}
+plugins = cfg.get("plugin", [])
+entry = "opencode-antigravity-auth@latest"
+if entry not in plugins:
+    plugins.append(entry)
+cfg["plugin"] = plugins
+import os
+fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+with os.fdopen(fd, "w") as f:
+    json.dump(cfg, f, indent=2)
+PY
+            fi
+
+            echo -e "  ${GREEN}✓${NC} opencode.json configured with antigravity plugin"
+            echo ""
+            echo -e "  ${YELLOW}A browser window will open for Google OAuth.${NC}"
+            echo -e "  Sign in with your Google account that has Antigravity access."
+            echo ""
+
+            # ── Step 3: run opencode auth login ─────────────────────────────
+            opencode auth login || true
+
+            # ── Step 4: re-detect credentials ───────────────────────────────
+            if [ -f "$HOME/.config/opencode/antigravity-accounts.json" ]; then
+                ANTIGRAVITY_CRED_DETECTED=true
+            elif [ -f "$HOME/.config/antigravity_auth/accounts.json" ]; then
+                ANTIGRAVITY_CRED_DETECTED=true
+            fi
+
+            if [ "$ANTIGRAVITY_CRED_DETECTED" = false ]; then
+                echo ""
+                echo -e "${RED}  Authentication did not produce credentials.${NC}"
+                echo -e "  Run ${CYAN}opencode auth login${NC} manually and try again."
+                echo ""
+                exit 1
+            fi
+        fi
+
+        if [ "$ANTIGRAVITY_CRED_DETECTED" = true ]; then
             SUBSCRIPTION_MODE="antigravity"
             SELECTED_PROVIDER_ID="openai"
             SELECTED_MODEL="gemini-3-flash"
@@ -946,8 +1084,7 @@ case $choice in
             echo -e "${YELLOW}  ⚠ Using Antigravity can technically cause your account suspension. Please use at your own risk.${NC}"
             echo ""
             echo -e "${GREEN}⬢${NC} Using Antigravity subscription"
-            echo -e "  ${DIM}Model: gemini-3-flash | Proxy: localhost:8069/v1${NC}"
-            echo -e "  ${DIM}Ensure 'antigravity-auth serve' is running before starting agents.${NC}"
+            echo -e "  ${DIM}Model: gemini-3-flash | Direct OAuth (no proxy required)${NC}"
         fi
         ;;
     8)

--- a/scripts/setup_worker_model.sh
+++ b/scripts/setup_worker_model.sh
@@ -423,32 +423,6 @@ prompt_model_selection() {
     done
 }
 
-# Read Antigravity OAuth client credentials from the installed npm package.
-# Exports _AG_CLIENT_SECRET and _AG_CLIENT_ID; returns 1 if package not found.
-_read_antigravity_creds_from_npm() {
-    local constants_js=""
-    local npm_root
-    npm_root="$(npm root -g 2>/dev/null)" && \
-        [ -f "$npm_root/opencode-antigravity-auth/dist/src/constants.js" ] && \
-        constants_js="$npm_root/opencode-antigravity-auth/dist/src/constants.js"
-    if [ -z "$constants_js" ]; then
-        for _candidate in \
-            /opt/homebrew/lib/node_modules/opencode-antigravity-auth/dist/src/constants.js \
-            /usr/local/lib/node_modules/opencode-antigravity-auth/dist/src/constants.js \
-            /usr/lib/node_modules/opencode-antigravity-auth/dist/src/constants.js; do
-            if [ -f "$_candidate" ]; then
-                constants_js="$_candidate"
-                break
-            fi
-        done
-    fi
-    [ -z "$constants_js" ] && return 1
-    _AG_CLIENT_SECRET="$(grep -o '"GOCSPX-[^"]*"' "$constants_js" 2>/dev/null | tr -d '"' | head -1)"
-    _AG_CLIENT_ID="$(grep -o '"[0-9]*-[a-z0-9]*\.apps\.googleusercontent\.com"' "$constants_js" 2>/dev/null | tr -d '"' | head -1)"
-    export _AG_CLIENT_SECRET _AG_CLIENT_ID
-    [ -n "$_AG_CLIENT_SECRET" ] && [ -n "$_AG_CLIENT_ID" ]
-}
-
 # ── Save worker_llm section to configuration.json ────────────────────
 # Args: provider_id env_var model max_tokens max_context_tokens [use_claude_code_sub] [api_base] [use_codex_sub] [use_antigravity_sub]
 
@@ -468,11 +442,6 @@ save_worker_configuration() {
     fi
     if [ -z "$max_tokens" ]; then max_tokens=8192; fi
     if [ -z "$max_context_tokens" ]; then max_context_tokens=120000; fi
-
-    if _read_antigravity_creds_from_npm 2>/dev/null; then
-        export ANTIGRAVITY_CLIENT_SECRET="$_AG_CLIENT_SECRET"
-        export ANTIGRAVITY_CLIENT_ID="$_AG_CLIENT_ID"
-    fi
 
     cd "$PROJECT_DIR"
     uv run python - \
@@ -646,10 +615,8 @@ if [ -f "$HOME/Library/Application Support/Antigravity/User/globalStorage/state.
     ANTIGRAVITY_CRED_DETECTED=true
 elif [ -f "$HOME/.config/Antigravity/User/globalStorage/state.vscdb" ]; then
     ANTIGRAVITY_CRED_DETECTED=true
-# Fallback: antigravity-auth CLI tool JSON files
-elif [ -f "$HOME/.config/opencode/antigravity-accounts.json" ]; then
-    ANTIGRAVITY_CRED_DETECTED=true
-elif [ -f "$HOME/.config/antigravity_auth/accounts.json" ]; then
+# Native OAuth credentials
+elif [ -f "$HOME/.hive/antigravity-accounts.json" ]; then
     ANTIGRAVITY_CRED_DETECTED=true
 fi
 
@@ -973,102 +940,21 @@ case $choice in
             echo ""
             echo -e "${CYAN}  Setting up Antigravity authentication...${NC}"
             echo ""
-
-            # ── Step 1: ensure opencode is installed ────────────────────────
-            if ! command -v opencode &>/dev/null; then
-                echo -e "  Installing ${CYAN}opencode${NC} (required for Antigravity OAuth)..."
-                if command -v npm &>/dev/null; then
-                    npm install -g opencode-ai || { echo -e "${RED}  npm install failed. Install Node.js and retry.${NC}"; exit 1; }
-                else
-                    echo -e "${RED}  Node.js/npm not found. Install Node.js first: https://nodejs.org${NC}"
-                    exit 1
-                fi
-            fi
-
-            # ── Step 2: write opencode.json with the plugin ─────────────────
-            OPENCODE_CFG_DIR="$HOME/.config/opencode"
-            OPENCODE_CFG="$OPENCODE_CFG_DIR/opencode.json"
-            mkdir -p "$OPENCODE_CFG_DIR"
-
-            if [ ! -f "$OPENCODE_CFG" ]; then
-                cat > "$OPENCODE_CFG" <<'JSON'
-{
-  "$schema": "https://opencode.ai/config.json",
-  "plugin": ["opencode-antigravity-auth@latest"],
-  "provider": {
-    "google": {
-      "models": {
-        "antigravity-gemini-3-flash": {
-          "name": "Gemini 3 Flash (Antigravity)",
-          "limit": { "context": 1048576, "output": 65536 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "antigravity-gemini-3-pro": {
-          "name": "Gemini 3 Pro (Antigravity)",
-          "limit": { "context": 1048576, "output": 65535 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "antigravity-gemini-3.1-pro": {
-          "name": "Gemini 3.1 Pro (Antigravity)",
-          "limit": { "context": 1048576, "output": 65535 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "antigravity-claude-sonnet-4-6": {
-          "name": "Claude Sonnet 4.6 (Antigravity)",
-          "limit": { "context": 200000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "antigravity-claude-opus-4-6-thinking": {
-          "name": "Claude Opus 4.6 Thinking (Antigravity)",
-          "limit": { "context": 200000, "output": 64000 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        }
-      }
-    }
-  }
-}
-JSON
-            else
-                uv run python3 - "$OPENCODE_CFG" <<'PY' 2>/dev/null || true
-import json, sys
-p = sys.argv[1]
-try:
-    with open(p) as f:
-        cfg = json.load(f)
-except Exception:
-    cfg = {}
-plugins = cfg.get("plugin", [])
-entry = "opencode-antigravity-auth@latest"
-if entry not in plugins:
-    plugins.append(entry)
-cfg["plugin"] = plugins
-import os
-fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
-with os.fdopen(fd, "w") as f:
-    json.dump(cfg, f, indent=2)
-PY
-            fi
-
-            echo -e "  ${GREEN}✓${NC} opencode.json configured with antigravity plugin"
-            echo ""
             echo -e "  ${YELLOW}A browser window will open for Google OAuth.${NC}"
             echo -e "  Sign in with your Google account that has Antigravity access."
             echo ""
 
-            # ── Step 3: run opencode auth login ─────────────────────────────
-            opencode auth login || true
-
-            # ── Step 4: re-detect credentials ───────────────────────────────
-            if [ -f "$HOME/.config/opencode/antigravity-accounts.json" ]; then
-                ANTIGRAVITY_CRED_DETECTED=true
-            elif [ -f "$HOME/.config/antigravity_auth/accounts.json" ]; then
-                ANTIGRAVITY_CRED_DETECTED=true
+            # Run native OAuth flow
+            if uv run python "$PROJECT_DIR/core/antigravity_auth.py" auth account add; then
+                # Re-detect credentials
+                if [ -f "$HOME/.hive/antigravity-accounts.json" ]; then
+                    ANTIGRAVITY_CRED_DETECTED=true
+                fi
             fi
 
             if [ "$ANTIGRAVITY_CRED_DETECTED" = false ]; then
                 echo ""
-                echo -e "${RED}  Authentication did not produce credentials.${NC}"
-                echo -e "  Run ${CYAN}opencode auth login${NC} manually and try again."
+                echo -e "${RED}  Authentication failed or was cancelled.${NC}"
                 echo ""
                 exit 1
             fi


### PR DESCRIPTION
Summary

This PR adds first-class support for Antigravity (Google's unified Cloud Code Assist gateway) as a selectable LLM provider for both the main queen agent and worker models. Antigravity routes requests to Gemini, Claude, and GPT-OSS models through a single Gemini-style API. Authentication is handled via Google OAuth2 directly — no local proxy or antigravity-auth serve required.

---

What changed

New file: core/framework/llm/antigravity.py

A full standalone LLM provider class (AntigravityProvider) implementing the LLMProvider interface. This is not built on LiteLLM — the provider owns the entire request lifecycle:

- Credential loading from two sources in priority order: the opencode-antigravity-auth JSON accounts file (~/.config/opencode/antigravity-accounts.json, V1–V4 schema with expiry support) and the Antigravity IDE's VSCode-style SQLite state database on macOS and Linux as a fallback.
- Token expiry tracking with a 60-second refresh buffer. Refresh is done directly against the Google OAuth2 token endpoint using the client secret read from config or environment.
- Endpoint fallback chain: daily sandbox → autopush sandbox → production, so requests automatically route to the next available endpoint on failure.
- Custom OpenAI-format to Gemini-format message conversion, including tool call/result batching, function name sanitisation (spaces and slashes to underscores, 64-char cap), and handling of Gemini's requirement that the first turn must be a user turn.
- SSE stream parsing that yields TextDeltaEvent, ToolCallEvent, FinishEvent, and StreamErrorEvent objects compatible with the existing event loop infrastructure.
- Thread-executor-backed async stream() to keep blocking HTTP I/O off the event loop.

core/framework/config.py

Added get_antigravity_client_id() and get_antigravity_client_secret() helpers that read from ANTIGRAVITY_CLIENT_ID / ANTIGRAVITY_CLIENT_SECRET environment variables first, then from the antigravity_client_id / antigravity_client_secret fields in configuration.json. The client ID has a well-known public fallback so token refresh works even when the config entry is absent.

core/framework/runner/runner.py

Added Antigravity credential detection and token loading at session initialisation. The runner checks both credential sources, performs an early token refresh if the stored token is close to expiry, and injects the bearer token into the provider at run time. Also added the credential detection flag (ANTIGRAVITY_CRED_DETECTED) used by the quickstart and session manager to decide whether to offer the Antigravity option.

core/framework/server/session_manager.py

Session creation now detects Antigravity credentials and selects AntigravityProvider when the configuration specifies use_antigravity_subscription. The provider is instantiated with the model from configuration.json (defaults to gemini-3-flash).

quickstart.sh and scripts/setup_worker_model.sh

Both scripts gain a new Antigravity option in the provider selection menu (option 8 for the main model, matching the worker model setup):

- If credentials are not yet present, the script guides the user through installing opencode-ai via npm (if not already installed), writing or updating ~/.config/opencode/opencode.json with the opencode-antigravity-auth@latest plugin entry, and running opencode auth login to complete the Google OAuth browser flow.
- After login the script re-checks for the accounts file and exits with a clear message if authentication did not produce credentials.
- The save_configuration / save_worker_configuration Python block writes use_antigravity_subscription, antigravity_client_secret, and antigravity_client_id into configuration.json. The secret and client ID are read from the installed npm package's constants.js at setup time rather than being hardcoded — no literal credentials appear in source.
- The informational display text now reflects the direct OAuth model ("no proxy required") instead of the old antigravity-auth serve instruction.

core/tests/test_antigravity_eventloop.py

Integration smoke test (mirrors the structure of test_codex_eventloop.py) that runs a real EventLoopNode against the live Antigravity backend, validates tool-use output via the set_output mechanism, and includes a fallback bare provider.stream() path for diagnosing streaming issues independently of the event loop.

---

How it works end-to-end

1. User runs quickstart and selects Antigravity.
2. If not already authenticated, the script installs the npm plugin and opens the Google OAuth consent page via opencode auth login.
3. Credentials are saved to ~/.config/opencode/antigravity-accounts.json by the plugin.
4. The quickstart reads the client secret and client ID from the npm package's constants.js and writes them into configuration.json alongside use_antigravity_subscription: true.
5. At agent startup, the runner detects the subscription flag, loads the credential file, refreshes the token if needed, and hands a live bearer token to AntigravityProvider.
6. All LLM calls go directly to the cloudcode-pa.googleapis.com endpoint (or sandbox variants) over HTTPS with no intermediary proxy.

---

Not changed

No existing provider (LiteLLMProvider, AnthropicProvider, OpenRouterProvider) was modified to accommodate this. The new provider is fully additive. The Codex subscription flow, Claude Code subscription flow, and all other provider paths are untouched.

---

Verification

To test manually:
- Authenticate with opencode auth login and confirm ~/.config/opencode/antigravity-accounts.json exists.
- Run quickstart, select option 8, and confirm configuration.json contains use_antigravity_subscription, antigravity_client_id, and antigravity_client_secret.
- Run core/tests/test_antigravity_eventloop.py directly (requires valid credentials) and confirm the EventLoopNode test passes and the stream test produces token counts.
- Confirm that grep for the literal OAuth client secret string returns no results in quickstart.sh or scripts/setup_worker_model.sh.

---

Screen Recording:

https://github.com/user-attachments/assets/69cf228b-6422-4603-b03b-5ba6978ba723

---

solves issue #6632 