### PR TITLE
docs(contributing): add frontend development workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -332,6 +332,30 @@ make test-live     # Run live API integration tests (requires credentials)
 - **React 18+** with TypeScript
 - **WebSocket** for real-time updates
 - **Tailwind CSS** for styling
+- **Vite** for the local frontend dev server
+
+Frontend setup and workflow:
+
+```bash
+# Fastest way to launch the browser UI from the repo root
+hive open
+
+# Start the API server without opening the browser
+hive serve
+
+# Frontend-only development loop
+cd core/frontend
+npm install
+npm run dev
+
+# Frontend verification
+npm run build
+npm run test
+```
+
+- `hive open` is the easiest way to work on the full dashboard locally.
+- `hive serve` serves the API and built frontend on `http://127.0.0.1:8787` by default.
+- `npm run dev` starts the Vite dev server for frontend-only iteration inside `core/frontend/`.
 
 ### Frontend Dev Workflow
 


### PR DESCRIPTION
## Description
Adds the missing frontend development workflow to `CONTRIBUTING.md`, following the latest direction on #5636 to document this in contributor docs instead of `README.md`.

## Type of Change
- [x] Documentation update

## Related Issues
Fixes #5636

## Changes Made
- Added `hive open` and `hive serve` commands for local dashboard development
- Added `core/frontend` setup and dev workflow commands (`npm install`, `npm run dev`)
- Added frontend verification commands (`npm run build`, `npm run test`)
- Documented the default local URL served by `hive serve`

## Testing
- [x] Manual testing performed (verified against current CLI commands and frontend package scripts)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded contribution guide with step-by-step local frontend development workflow.
  * Added clear command sequences for running the local dashboard/API and a frontend-only hot-reload dev server.
  * Documented verification steps (build/test) for frontend changes.
  * Clarified expected local URLs and the roles of the repository-level versus frontend-only development commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aden-hive/hive/pull/6657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->