### PR TITLE
fix(#6649): implement retry-then-degrade for judge failures

### DIFF
--- a/core/framework/graph/conversation_judge.py
+++ b/core/framework/graph/conversation_judge.py
@@ -30,6 +30,45 @@ class PhaseVerdict:
     feedback: str = ""
 
 
+def _handle_judge_failure(
+    phase_name: str,
+    failure_count: int,
+    max_failures: int,
+    reason: str,
+) -> PhaseVerdict:
+    """Handle a judge LLM failure with retry-then-degrade strategy."""
+    attempt = failure_count + 1
+    if attempt >= max_failures:
+        logger.error(
+            "Level 2 judge failed %d/%d times for phase '%s' (%s) "
+            "— accepting with degraded confidence. Quality gate was NOT evaluated.",
+            attempt,
+            max_failures,
+            phase_name,
+            reason,
+        )
+        return PhaseVerdict(
+            action="ACCEPT",
+            confidence=0.0,
+            feedback=(
+                "[SYSTEM] Quality gate skipped — judge LLM failed "
+                f"{attempt} consecutive times ({reason})."
+            ),
+        )
+    logger.warning(
+        "Level 2 judge failed %d/%d for phase '%s' (%s) — requesting retry.",
+        attempt,
+        max_failures,
+        phase_name,
+        reason,
+    )
+    return PhaseVerdict(
+        action="RETRY",
+        confidence=0.0,
+        feedback=f"[SYSTEM] Quality evaluation failed ({reason}). Retrying.",
+    )
+
+
 async def evaluate_phase_completion(
     llm: LLMProvider,
     conversation: NodeConversation,
@@ -38,6 +77,8 @@ async def evaluate_phase_completion(
     success_criteria: str,
     accumulator_state: dict[str, Any],
     max_context_tokens: int = 8_196,
+    _judge_failure_count: int = 0,
+    max_judge_failures: int = 2,
 ) -> PhaseVerdict:
     """Level 2 judge: read the conversation and evaluate quality.
 
@@ -93,16 +134,25 @@ FEEDBACK: (reason if RETRY, empty if ACCEPT)"""
             max_retries=1,
         )
         if not response.content or not response.content.strip():
-            logger.debug("Level 2 judge: empty response, accepting by default")
-            return PhaseVerdict(action="ACCEPT", confidence=0.5, feedback="")
+            return _handle_judge_failure(
+                phase_name,
+                _judge_failure_count,
+                max_judge_failures,
+                reason="empty LLM response",
+            )
         return _parse_verdict(response.content)
     except Exception as e:
-        logger.warning(f"Level 2 judge failed, accepting by default: {e}")
-        # On failure, don't block — Level 0 already passed
-        return PhaseVerdict(action="ACCEPT", confidence=0.5, feedback="")
+        return _handle_judge_failure(
+            phase_name,
+            _judge_failure_count,
+            max_judge_failures,
+            reason=f"{type(e).__name__}: {e}",
+        )
 
 
-def _extract_recent_context(conversation: NodeConversation, max_messages: int = 10) -> str:
+def _extract_recent_context(
+    conversation: NodeConversation, max_messages: int = 10
+) -> str:
     """Extract recent conversation messages for evaluation.
 
     Includes tool-call summaries from assistant messages so the judge

--- a/core/framework/graph/event_loop_node.py
+++ b/core/framework/graph/event_loop_node.py
@@ -90,7 +90,9 @@ class _EscalationReceiver:
         self._response: str | None = None
         self._awaiting_input = True  # So inject_worker_message() can prefer us
 
-    async def inject_event(self, content: str, *, is_client_input: bool = False) -> None:
+    async def inject_event(
+        self, content: str, *, is_client_input: bool = False
+    ) -> None:
         """Called by ExecutionStream.inject_input() when the user responds."""
         self._response = content
         self._event.set()
@@ -168,7 +170,9 @@ class SubagentJudge:
         else:
             urgency = f"Missing output keys: {missing}. Use set_output to provide them."
 
-        return JudgeVerdict(action="RETRY", feedback=f"Your task: {self._task}\n{urgency}")
+        return JudgeVerdict(
+            action="RETRY", feedback=f"Your task: {self._task}\n{urgency}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -326,7 +330,11 @@ class OutputAccumulator:
         if self.max_value_chars <= 0 or not self.spillover_dir:
             return value
 
-        val_str = json.dumps(value, ensure_ascii=False) if not isinstance(value, str) else value
+        val_str = (
+            json.dumps(value, ensure_ascii=False)
+            if not isinstance(value, str)
+            else value
+        )
         if len(val_str) <= self.max_value_chars:
             return value
 
@@ -364,7 +372,9 @@ class OutputAccumulator:
 
     def has_all_keys(self, required: list[str]) -> bool:
         """Check if all required keys have been set (non-None)."""
-        return all(key in self.values and self.values[key] is not None for key in required)
+        return all(
+            key in self.values and self.values[key] is not None for key in required
+        )
 
     @classmethod
     async def restore(cls, store: ConversationStore) -> OutputAccumulator:
@@ -418,7 +428,9 @@ class EventLoopNode(NodeProtocol):
         event_bus: EventBus | None = None,
         judge: JudgeProtocol | None = None,
         config: LoopConfig | None = None,
-        tool_executor: Callable[[ToolUse], ToolResult | Awaitable[ToolResult]] | None = None,
+        tool_executor: (
+            Callable[[ToolUse], ToolResult | Awaitable[ToolResult]] | None
+        ) = None,
         conversation_store: ConversationStore | None = None,
     ) -> None:
         self._event_bus = event_bus
@@ -442,6 +454,8 @@ class EventLoopNode(NodeProtocol):
         self._mark_complete_flag = False
         # Counter for subagent instances (1, 2, 3, ...)
         self._subagent_instance_counter: dict[str, int] = {}
+        # Level 2 judge failure tracking (retry-then-degrade)
+        self._judge_failure_count: int = 0
 
     def validate_input(self, ctx: NodeContext) -> list[str]:
         """Validate hard requirements only.
@@ -668,7 +682,9 @@ class EventLoopNode(NodeProtocol):
                     await conversation.add_user_message(initial_message)
 
                 # Fire session_start hooks (e.g. persona selection)
-                await self._run_hooks("session_start", conversation, trigger=initial_message)
+                await self._run_hooks(
+                    "session_start", conversation, trigger=initial_message
+                )
 
         # 2a. Guard: ensure at least one non-system message exists.
         # A restored conversation may have 0 messages if phase_id filtering
@@ -744,11 +760,15 @@ class EventLoopNode(NodeProtocol):
             and stream_id not in ("queen", "judge")
         ):
             self._action_plan_emitted.add(node_id)
-            asyncio.create_task(self._generate_action_plan(ctx, stream_id, node_id, execution_id))
+            asyncio.create_task(
+                self._generate_action_plan(ctx, stream_id, node_id, execution_id)
+            )
 
         # 5. Stall / doom loop detection state (restored from cursor if resuming)
         recent_responses: list[str] = _restored_recent_responses
-        recent_tool_fingerprints: list[list[tuple[str, str]]] = _restored_tool_fingerprints
+        recent_tool_fingerprints: list[list[tuple[str, str]]] = (
+            _restored_tool_fingerprints
+        )
         _consecutive_empty_turns: int = 0
 
         # 6. Main loop
@@ -1087,7 +1107,9 @@ class EventLoopNode(NodeProtocol):
             )
             if truly_empty and accumulator is not None:
                 missing = self._get_missing_output_keys(
-                    accumulator, ctx.node_spec.output_keys, ctx.node_spec.nullable_output_keys
+                    accumulator,
+                    ctx.node_spec.output_keys,
+                    ctx.node_spec.nullable_output_keys,
                 )
                 # Only accept on empty response if the node actually has
                 # output_keys that are all satisfied.  Nodes with NO
@@ -1125,7 +1147,10 @@ class EventLoopNode(NodeProtocol):
                         missing,
                         _consecutive_empty_turns,
                     )
-                    if _consecutive_empty_turns >= self._config.stall_detection_threshold:
+                    if (
+                        _consecutive_empty_turns
+                        >= self._config.stall_detection_threshold
+                    ):
                         # Persistent ghost stream — fail the node.
                         error_msg = (
                             f"Ghost empty stream: {_consecutive_empty_turns} "
@@ -1172,7 +1197,10 @@ class EventLoopNode(NodeProtocol):
                         iteration,
                         _consecutive_empty_turns,
                     )
-                    if _consecutive_empty_turns >= self._config.stall_detection_threshold:
+                    if (
+                        _consecutive_empty_turns
+                        >= self._config.stall_detection_threshold
+                    ):
                         # Persistent ghost — but since this is a forever-alive
                         # node, block for user input instead of crashing.
                         logger.warning(
@@ -1476,7 +1504,12 @@ class EventLoopNode(NodeProtocol):
                         deferred["is_error"],
                         deferred["execution_id"],
                     )
-                logger.info("[%s] iter=%d: unblocked, got_input=%s", node_id, iteration, got_input)
+                logger.info(
+                    "[%s] iter=%d: unblocked, got_input=%s",
+                    node_id,
+                    iteration,
+                    got_input,
+                )
                 if not got_input:
                     await self._publish_loop_completed(
                         stream_id, node_id, iteration + 1, execution_id
@@ -1603,8 +1636,12 @@ class EventLoopNode(NodeProtocol):
                         conversation=conversation if _is_continuous else None,
                     )
 
-                logger.info("[%s] iter=%d: waiting for queen input...", node_id, iteration)
-                got_input = await self._await_user_input(ctx, prompt="", emit_client_request=False)
+                logger.info(
+                    "[%s] iter=%d: waiting for queen input...", node_id, iteration
+                )
+                got_input = await self._await_user_input(
+                    ctx, prompt="", emit_client_request=False
+                )
                 logger.info(
                     "[%s] iter=%d: queen wait unblocked, got_input=%s",
                     node_id,
@@ -1685,7 +1722,9 @@ class EventLoopNode(NodeProtocol):
                 or not real_tool_results  # no real tool calls = natural stop
             )
 
-            logger.info("[%s] iter=%d: 6i should_judge=%s", node_id, iteration, should_judge)
+            logger.info(
+                "[%s] iter=%d: 6i should_judge=%s", node_id, iteration, should_judge
+            )
             if not should_judge:
                 # Gap C: unjudged iteration — log as CONTINUE
                 _continue_count += 1
@@ -1734,7 +1773,9 @@ class EventLoopNode(NodeProtocol):
             if verdict.action == "ACCEPT":
                 # Check for missing output keys
                 missing = self._get_missing_output_keys(
-                    accumulator, ctx.node_spec.output_keys, ctx.node_spec.nullable_output_keys
+                    accumulator,
+                    ctx.node_spec.output_keys,
+                    ctx.node_spec.nullable_output_keys,
                 )
                 if missing and self._judge is not None and not self._mark_complete_flag:
                     hint = (
@@ -1757,7 +1798,9 @@ class EventLoopNode(NodeProtocol):
                             node_type="event_loop",
                             step_index=iteration,
                             verdict="RETRY",
-                            verdict_feedback=(f"Judge accepted but missing output keys: {missing}"),
+                            verdict_feedback=(
+                                f"Judge accepted but missing output keys: {missing}"
+                            ),
                             tool_calls=logged_tool_calls,
                             llm_text=assistant_text,
                             input_tokens=turn_tokens.get("input", 0),
@@ -1771,7 +1814,9 @@ class EventLoopNode(NodeProtocol):
                 for key, value in accumulator.to_dict().items():
                     ctx.memory.write(key, value, validate=False)
 
-                await self._publish_loop_completed(stream_id, node_id, iteration + 1, execution_id)
+                await self._publish_loop_completed(
+                    stream_id, node_id, iteration + 1, execution_id
+                )
                 latency_ms = int((time.time() - start_time) * 1000)
                 _accept_count += 1
                 if ctx.runtime_logger:
@@ -1814,7 +1859,9 @@ class EventLoopNode(NodeProtocol):
 
             elif verdict.action == "ESCALATE":
                 # Exit point 6: Judge ESCALATE — log step + log_node_complete
-                await self._publish_loop_completed(stream_id, node_id, iteration + 1, execution_id)
+                await self._publish_loop_completed(
+                    stream_id, node_id, iteration + 1, execution_id
+                )
                 latency_ms = int((time.time() - start_time) * 1000)
                 _escalate_count += 1
                 if ctx.runtime_logger:
@@ -1903,14 +1950,18 @@ class EventLoopNode(NodeProtocol):
             )
         return NodeResult(
             success=False,
-            error=(f"Max iterations ({self._config.max_iterations}) reached without acceptance"),
+            error=(
+                f"Max iterations ({self._config.max_iterations}) reached without acceptance"
+            ),
             output=accumulator.to_dict(),
             tokens_used=total_input_tokens + total_output_tokens,
             latency_ms=latency_ms,
             conversation=conversation if _is_continuous else None,
         )
 
-    async def inject_event(self, content: str, *, is_client_input: bool = False) -> None:
+    async def inject_event(
+        self, content: str, *, is_client_input: bool = False
+    ) -> None:
         """Inject an external event or user input into the running loop.
 
         The content becomes a user message prepended to the next iteration.
@@ -2112,7 +2163,9 @@ class EventLoopNode(NodeProtocol):
                     "[%s] Messages end with assistant — injecting continuation prompt",
                     node_id,
                 )
-                await conversation.add_user_message("[Continue working on your current task.]")
+                await conversation.add_user_message(
+                    "[Continue working on your current task.]"
+                )
                 messages = conversation.to_llm_messages()
             final_system_prompt = conversation.system_prompt
             final_messages = messages
@@ -2249,15 +2302,16 @@ class EventLoopNode(NodeProtocol):
             limit_hit = False
             executed_in_batch = 0
             hard_limit = int(
-                self._config.max_tool_calls_per_turn * (1 + self._config.tool_call_overflow_margin)
+                self._config.max_tool_calls_per_turn
+                * (1 + self._config.tool_call_overflow_margin)
             )
 
             # Phase 1: triage — handle framework tools immediately,
             # queue real tools and subagents for parallel execution.
             results_by_id: dict[str, ToolResult] = {}
-            timing_by_id: dict[
-                str, dict[str, Any]
-            ] = {}  # tool_use_id -> {start_timestamp, duration_s}
+            timing_by_id: dict[str, dict[str, Any]] = (
+                {}
+            )  # tool_use_id -> {start_timestamp, duration_s}
             pending_real: list[ToolCallEvent] = []
             pending_subagent: list[ToolCallEvent] = []
 
@@ -2287,7 +2341,9 @@ class EventLoopNode(NodeProtocol):
                     # --- Framework-level set_output handling ---
                     _tc_start = time.time()
                     _tc_ts = datetime.now(UTC).isoformat()
-                    result = self._handle_set_output(tc.tool_input, ctx.node_spec.output_keys)
+                    result = self._handle_set_output(
+                        tc.tool_input, ctx.node_spec.output_keys
+                    )
                     result = ToolResult(
                         tool_use_id=tc.tool_use_id,
                         content=result.content,
@@ -2326,7 +2382,9 @@ class EventLoopNode(NodeProtocol):
                             )
                         self._record_learning(key, stored)
                         outputs_set_this_turn.append(key)
-                        await self._publish_output_key_set(stream_id, node_id, key, execution_id)
+                        await self._publish_output_key_set(
+                            stream_id, node_id, key, execution_id
+                        )
                     logged_tool_calls.append(
                         {
                             "tool_use_id": tc.tool_use_id,
@@ -2384,7 +2442,11 @@ class EventLoopNode(NodeProtocol):
                     # text as a chat message so the user can see it.  When
                     # options are present the QuestionWidget shows the
                     # question, but without options nothing renders it.
-                    if ask_user_options is None and ask_user_prompt and ctx.node_spec.client_facing:
+                    if (
+                        ask_user_options is None
+                        and ask_user_prompt
+                        and ctx.node_spec.client_facing
+                    ):
                         await self._publish_text_delta(
                             stream_id,
                             node_id,
@@ -2530,9 +2592,11 @@ class EventLoopNode(NodeProtocol):
                     logger.info(
                         "🔄 LLM requesting subagent delegation: agent_id='%s', task='%s'",
                         tc.tool_input.get("agent_id", "?"),
-                        (tc.tool_input.get("task", "")[:100] + "...")
-                        if len(tc.tool_input.get("task", "")) > 100
-                        else tc.tool_input.get("task", ""),
+                        (
+                            (tc.tool_input.get("task", "")[:100] + "...")
+                            if len(tc.tool_input.get("task", "")) > 100
+                            else tc.tool_input.get("task", "")
+                        ),
                     )
                     pending_subagent.append(tc)
 
@@ -2568,7 +2632,11 @@ class EventLoopNode(NodeProtocol):
 
                     result = ToolResult(
                         tool_use_id=tc.tool_use_id,
-                        content=response if (wait and response) else "Report sent to parent.",
+                        content=(
+                            response
+                            if (wait and response)
+                            else "Report sent to parent."
+                        ),
                         is_error=False,
                     )
                     results_by_id[tc.tool_use_id] = result
@@ -2645,7 +2713,9 @@ class EventLoopNode(NodeProtocol):
                         )
                     else:
                         result = raw
-                    results_by_id[tc.tool_use_id] = self._truncate_tool_result(result, tc.tool_name)
+                    results_by_id[tc.tool_use_id] = self._truncate_tool_result(
+                        result, tc.tool_name
+                    )
 
             # Phase 2b: execute subagent delegations in parallel.
             if pending_subagent:
@@ -3306,13 +3376,17 @@ class EventLoopNode(NodeProtocol):
                 "conversation_summary": conversation.export_summary(),
                 "output_keys": ctx.node_spec.output_keys,
                 "missing_keys": self._get_missing_output_keys(
-                    accumulator, ctx.node_spec.output_keys, ctx.node_spec.nullable_output_keys
+                    accumulator,
+                    ctx.node_spec.output_keys,
+                    ctx.node_spec.nullable_output_keys,
                 ),
             }
             verdict = await self._judge.evaluate(context)
             # Ensure evaluated RETRY always carries feedback for logging.
             if verdict.action == "RETRY" and not verdict.feedback:
-                return JudgeVerdict(action="RETRY", feedback="Custom judge returned RETRY.")
+                return JudgeVerdict(
+                    action="RETRY", feedback="Custom judge returned RETRY."
+                )
             return verdict
 
         # --- Level 2: implicit judge ---------------------------------------
@@ -3377,7 +3451,14 @@ class EventLoopNode(NodeProtocol):
                 success_criteria=ctx.node_spec.success_criteria,
                 accumulator_state=accumulator.to_dict(),
                 max_context_tokens=self._config.max_context_tokens,
+                _judge_failure_count=self._judge_failure_count,
             )
+            # failure signal from conversation_judge is confidence == 0.0
+            if verdict.confidence == 0.0:
+                self._judge_failure_count += 1
+            else:
+                # successful evaluation (ACCEPT or RETRY based on content)
+                self._judge_failure_count = 0
             if verdict.action != "ACCEPT":
                 return JudgeVerdict(
                     action=verdict.action,
@@ -3477,7 +3558,10 @@ class EventLoopNode(NodeProtocol):
         threshold = self._config.stall_similarity_threshold
         # Every consecutive pair must be similar
         for i in range(1, len(recent_responses)):
-            if self._ngram_similarity(recent_responses[i], recent_responses[i - 1]) < threshold:
+            if (
+                self._ngram_similarity(recent_responses[i], recent_responses[i - 1])
+                < threshold
+            ):
                 return False
         return True
 
@@ -3672,7 +3756,9 @@ class EventLoopNode(NodeProtocol):
         try:
             adapt_path = Path(self._config.spillover_dir) / "adapt.md"
             adapt_path.parent.mkdir(parents=True, exist_ok=True)
-            content = adapt_path.read_text(encoding="utf-8") if adapt_path.exists() else ""
+            content = (
+                adapt_path.read_text(encoding="utf-8") if adapt_path.exists() else ""
+            )
 
             if "## Outputs" not in content:
                 content += "\n\n## Outputs\n"
@@ -3732,7 +3818,9 @@ class EventLoopNode(NodeProtocol):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _extract_json_metadata(parsed: Any, *, _depth: int = 0, _max_depth: int = 3) -> str:
+    def _extract_json_metadata(
+        parsed: Any, *, _depth: int = 0, _max_depth: int = 3
+    ) -> str:
         """Return a concise structural summary of parsed JSON.
 
         Reports key names, value types, and — crucially — array lengths so
@@ -3831,7 +3919,9 @@ class EventLoopNode(NodeProtocol):
             def _minimal_arrays(obj: Any) -> Any:
                 if isinstance(obj, list) and len(obj) > _LARGE_ARRAY_THRESHOLD:
                     n = len(obj)
-                    return obj[:1] + [f"... ({n - 1} more items omitted, {n} total) ..."]
+                    return obj[:1] + [
+                        f"... ({n - 1} more items omitted, {n} total) ..."
+                    ]
                 if isinstance(obj, dict):
                     return {k: _minimal_arrays(v) for k, v in obj.items()}
                 return obj
@@ -3882,7 +3972,9 @@ class EventLoopNode(NodeProtocol):
             try:
                 parsed_ld = json.loads(result.content)
                 metadata_str = self._extract_json_metadata(parsed_ld)
-                smart_preview = self._build_json_preview(parsed_ld, max_chars=PREVIEW_CAP)
+                smart_preview = self._build_json_preview(
+                    parsed_ld, max_chars=PREVIEW_CAP
+                )
             except (json.JSONDecodeError, TypeError, ValueError):
                 pass
 
@@ -3944,7 +4036,9 @@ class EventLoopNode(NodeProtocol):
                 smart_preview: str | None = None
                 if parsed_json is not None:
                     metadata_str = self._extract_json_metadata(parsed_json)
-                    smart_preview = self._build_json_preview(parsed_json, max_chars=PREVIEW_CAP)
+                    smart_preview = self._build_json_preview(
+                        parsed_json, max_chars=PREVIEW_CAP
+                    )
 
                 if smart_preview is not None:
                     preview_block = smart_preview
@@ -3997,7 +4091,9 @@ class EventLoopNode(NodeProtocol):
             try:
                 parsed_inline = json.loads(result.content)
                 metadata_str = self._extract_json_metadata(parsed_inline)
-                smart_preview = self._build_json_preview(parsed_inline, max_chars=PREVIEW_CAP)
+                smart_preview = self._build_json_preview(
+                    parsed_inline, max_chars=PREVIEW_CAP
+                )
             except (json.JSONDecodeError, TypeError, ValueError):
                 pass
 
@@ -4153,7 +4249,9 @@ class EventLoopNode(NodeProtocol):
         from framework.graph.conversation import extract_tool_call_history
 
         if _depth > self._LLM_COMPACT_MAX_DEPTH:
-            raise RuntimeError(f"LLM compaction recursion limit ({self._LLM_COMPACT_MAX_DEPTH})")
+            raise RuntimeError(
+                f"LLM compaction recursion limit ({self._LLM_COMPACT_MAX_DEPTH})"
+            )
 
         formatted = self._format_messages_for_summary(messages)
 
@@ -4307,7 +4405,9 @@ class EventLoopNode(NodeProtocol):
             if m.tool_calls:
                 for tc in m.tool_calls:
                     args = tc.get("function", {}).get("arguments", "")
-                    tc_chars += len(args) if isinstance(args, str) else len(json.dumps(args))
+                    tc_chars += (
+                        len(args) if isinstance(args, str) else len(json.dumps(args))
+                    )
                 names = [tc.get("function", {}).get("name", "?") for tc in m.tool_calls]
                 tool_name = ", ".join(names)
             elif m.role == "tool" and m.tool_use_id:
@@ -4400,7 +4500,9 @@ class EventLoopNode(NodeProtocol):
 
         # Write detailed debug log to ~/.hive/compaction_log/ when enabled
         if _os.environ.get("HIVE_COMPACTION_DEBUG"):
-            self._write_compaction_debug_log(ctx, before_pct, after_pct, level, pre_inventory)
+            self._write_compaction_debug_log(
+                ctx, before_pct, after_pct, level, pre_inventory
+            )
 
     @staticmethod
     def _write_compaction_debug_log(
@@ -4431,7 +4533,8 @@ class EventLoopNode(NodeProtocol):
 
         if inventory:
             total_chars = sum(
-                e.get("content_chars", 0) + e.get("tool_call_args_chars", 0) for e in inventory
+                e.get("content_chars", 0) + e.get("tool_call_args_chars", 0)
+                for e in inventory
             )
             lines.append(
                 f"## Pre-Compaction Message Inventory "
@@ -4440,13 +4543,16 @@ class EventLoopNode(NodeProtocol):
             lines.append("")
             ranked = sorted(
                 inventory,
-                key=lambda e: e.get("content_chars", 0) + e.get("tool_call_args_chars", 0),
+                key=lambda e: e.get("content_chars", 0)
+                + e.get("tool_call_args_chars", 0),
                 reverse=True,
             )
             lines.append("| # | seq | role | tool | chars | % of total | flags |")
             lines.append("|---|-----|------|------|------:|------------|-------|")
             for i, entry in enumerate(ranked, 1):
-                chars = entry.get("content_chars", 0) + entry.get("tool_call_args_chars", 0)
+                chars = entry.get("content_chars", 0) + entry.get(
+                    "tool_call_args_chars", 0
+                )
                 pct = (chars / total_chars * 100) if total_chars else 0
                 tool = entry.get("tool", "")
                 flags = []
@@ -4549,10 +4655,14 @@ class EventLoopNode(NodeProtocol):
                             parts.append(f"AGENT MEMORY (adapt.md):\n{adapt_text}")
 
                     all_files = sorted(
-                        f.name for f in data_dir.iterdir() if f.is_file() and f.name != "adapt.md"
+                        f.name
+                        for f in data_dir.iterdir()
+                        if f.is_file() and f.name != "adapt.md"
                     )
                     # Separate conversation history files from regular data files
-                    conv_files = [f for f in all_files if re.match(r"conversation_\d+\.md$", f)]
+                    conv_files = [
+                        f for f in all_files if re.match(r"conversation_\d+\.md$", f)
+                    ]
                     data_files = [f for f in all_files if f not in conv_files]
 
                     if conv_files:
@@ -4561,14 +4671,17 @@ class EventLoopNode(NodeProtocol):
                         )
                         parts.append(
                             "CONVERSATION HISTORY (freeform messages saved during compaction — "
-                            "use load_data('<filename>') to review earlier dialogue):\n" + conv_list
+                            "use load_data('<filename>') to review earlier dialogue):\n"
+                            + conv_list
                         )
                     if data_files:
                         file_list = "\n".join(
-                            f"  - {f}  (full path: {data_dir / f})" for f in data_files[:30]
+                            f"  - {f}  (full path: {data_dir / f})"
+                            for f in data_files[:30]
                         )
                         parts.append(
-                            "DATA FILES (use load_data('<filename>') to read):\n" + file_list
+                            "DATA FILES (use load_data('<filename>') to read):\n"
+                            + file_list
                         )
                     if not all_files:
                         parts.append(
@@ -4641,11 +4754,12 @@ class EventLoopNode(NodeProtocol):
         start_iteration = cursor.get("iteration", 0) + 1 if cursor else 0
 
         # Restore stall/doom-loop detection state
-        recent_responses: list[str] = cursor.get("recent_responses", []) if cursor else []
+        recent_responses: list[str] = (
+            cursor.get("recent_responses", []) if cursor else []
+        )
         raw_fps = cursor.get("recent_tool_fingerprints", []) if cursor else []
         recent_tool_fingerprints: list[list[tuple[str, str]]] = [
-            [tuple(pair) for pair in fps]  # type: ignore[misc]
-            for fps in raw_fps
+            [tuple(pair) for pair in fps] for fps in raw_fps  # type: ignore[misc]
         ]
 
         logger.info(
@@ -4740,7 +4854,9 @@ class EventLoopNode(NodeProtocol):
             task = t.payload.get("task", "")
             task_line = f"\nTask: {task}" if task else ""
             payload_str = json.dumps(t.payload, default=str)
-            parts.append(f"[TRIGGER: {t.trigger_type}/{t.source_id}]{task_line}\n{payload_str}")
+            parts.append(
+                f"[TRIGGER: {t.trigger_type}/{t.source_id}]{task_line}\n{payload_str}"
+            )
 
         combined = "\n\n".join(parts)
         logger.info("[drain] %d trigger(s): %s", len(triggers), combined[:200])
@@ -4761,8 +4877,12 @@ class EventLoopNode(NodeProtocol):
         """
         # Check executor-level pause event (for /pause command, Ctrl+Z)
         if ctx.pause_event and ctx.pause_event.is_set():
-            completed = iteration  # 0-indexed: iteration=3 means 3 iterations completed (0,1,2)
-            logger.info(f"⏸ Pausing after {completed} iteration(s) completed (executor-level)")
+            completed = (
+                iteration  # 0-indexed: iteration=3 means 3 iterations completed (0,1,2)
+            )
+            logger.info(
+                f"⏸ Pausing after {completed} iteration(s) completed (executor-level)"
+            )
             return True
 
         # Check context-level pause flags (legacy/alternative methods)
@@ -4774,7 +4894,9 @@ class EventLoopNode(NodeProtocol):
                 pause_requested = False
         if pause_requested:
             completed = iteration
-            logger.info(f"⏸ Pausing after {completed} iteration(s) completed (context-level)")
+            logger.info(
+                f"⏸ Pausing after {completed} iteration(s) completed (context-level)"
+            )
             return True
 
         return False
@@ -4839,7 +4961,9 @@ class EventLoopNode(NodeProtocol):
                     execution_id=execution_id,
                 )
         except Exception as e:
-            logger.warning("Action plan generation failed for node '%s': %s", node_id, e)
+            logger.warning(
+                "Action plan generation failed for node '%s': %s", node_id, e
+            )
 
     async def _run_hooks(
         self,
@@ -4989,7 +5113,9 @@ class EventLoopNode(NodeProtocol):
                 execution_id=execution_id,
             )
 
-    async def _publish_stalled(self, stream_id: str, node_id: str, execution_id: str = "") -> None:
+    async def _publish_stalled(
+        self, stream_id: str, node_id: str, execution_id: str = ""
+    ) -> None:
         if self._event_bus:
             await self._event_bus.emit_node_stalled(
                 stream_id=stream_id,
@@ -5160,7 +5286,11 @@ class EventLoopNode(NodeProtocol):
                     {
                         "message": f"Sub-agent '{agent_id}' not found in registry",
                         "data": None,
-                        "metadata": {"agent_id": agent_id, "success": False, "error": "not_found"},
+                        "metadata": {
+                            "agent_id": agent_id,
+                            "success": False,
+                            "error": "not_found",
+                        },
                     }
                 ),
                 is_error=True,
@@ -5216,7 +5346,9 @@ class EventLoopNode(NodeProtocol):
             *,
             wait_for_response: bool = False,
         ) -> str | None:
-            subagent_reports.append({"message": message, "data": data, "timestamp": time.time()})
+            subagent_reports.append(
+                {"message": message, "data": data, "timestamp": time.time()}
+            )
             if self._event_bus:
                 await self._event_bus.emit_subagent_report(
                     stream_id=ctx.node_id,
@@ -5276,7 +5408,9 @@ class EventLoopNode(NodeProtocol):
         # has the original empty list.  When a GCU subagent has no declared
         # tools, include all catalog tools so browser tools are available.
         if subagent_spec.node_type == "gcu" and not subagent_tool_names:
-            subagent_tools = [t for t in tool_source if t.name != "delegate_to_sub_agent"]
+            subagent_tools = [
+                t for t in tool_source if t.name != "delegate_to_sub_agent"
+            ]
         else:
             subagent_tools = [
                 t
@@ -5298,9 +5432,12 @@ class EventLoopNode(NodeProtocol):
             "   - Tools available (%d): %s\n"
             "   - Memory keys inherited: %s",
             agent_id,
-            (subagent_spec.system_prompt[:200] + "...")
-            if subagent_spec.system_prompt and len(subagent_spec.system_prompt) > 200
-            else subagent_spec.system_prompt,
+            (
+                (subagent_spec.system_prompt[:200] + "...")
+                if subagent_spec.system_prompt
+                and len(subagent_spec.system_prompt) > 200
+                else subagent_spec.system_prompt
+            ),
             len(subagent_tools),
             [t.name for t in subagent_tools],
             list(parent_data.keys()),
@@ -5350,7 +5487,9 @@ class EventLoopNode(NodeProtocol):
                 conversations_dir = parent_base.parent  # e.g. conversations/
                 subagent_dir_name = f"{agent_id}-{subagent_instance}"
                 subagent_store_path = conversations_dir / subagent_dir_name
-                subagent_conv_store = FileConversationStore(base_path=subagent_store_path)
+                subagent_conv_store = FileConversationStore(
+                    base_path=subagent_store_path
+                )
 
         # Derive a subagent-scoped spillover dir so large tool results
         # (e.g. browser_snapshot) get written to disk instead of being
@@ -5477,7 +5616,9 @@ class EventLoopNode(NodeProtocol):
                             input={"profile": _subagent_profile},
                         )
                         _stop_result = self._tool_executor(_stop_use)
-                        if asyncio.iscoroutine(_stop_result) or asyncio.isfuture(_stop_result):
+                        if asyncio.iscoroutine(_stop_result) or asyncio.isfuture(
+                            _stop_result
+                        ):
                             await _stop_result
                     except Exception as _gcu_exc:
                         logger.warning(

--- a/core/tests/test_conversation_judge.py
+++ b/core/tests/test_conversation_judge.py
@@ -38,7 +38,9 @@ from framework.runtime.core import Runtime
 class MockStreamingLLM(LLMProvider):
     """Mock LLM that yields pre-programmed StreamEvent sequences."""
 
-    def __init__(self, scenarios: list[list] | None = None, complete_response: str = ""):
+    def __init__(
+        self, scenarios: list[list] | None = None, complete_response: str = ""
+    ):
         self.scenarios = scenarios or []
         self._call_index = 0
         self.stream_calls: list[dict] = []
@@ -52,7 +54,9 @@ class MockStreamingLLM(LLMProvider):
         tools: list[Tool] | None = None,
         max_tokens: int = 4096,
     ) -> AsyncIterator:
-        self.stream_calls.append({"messages": messages, "system": system, "tools": tools})
+        self.stream_calls.append(
+            {"messages": messages, "system": system, "tools": tools}
+        )
         if not self.scenarios:
             return
         events = self.scenarios[self._call_index % len(self.scenarios)]
@@ -60,9 +64,17 @@ class MockStreamingLLM(LLMProvider):
         for event in events:
             yield event
 
+    async def acomplete(self, messages, system="", **kwargs) -> LLMResponse:
+        self.complete_calls.append({"messages": messages, "system": system})
+        return LLMResponse(
+            content=self.complete_response, model="mock", stop_reason="stop"
+        )
+
     def complete(self, messages, system="", **kwargs) -> LLMResponse:
         self.complete_calls.append({"messages": messages, "system": system})
-        return LLMResponse(content=self.complete_response, model="mock", stop_reason="stop")
+        return LLMResponse(
+            content=self.complete_response, model="mock", stop_reason="stop"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -77,7 +89,9 @@ def _set_output_scenario(key: str, value: str) -> list:
             tool_name="set_output",
             tool_input={"key": key, "value": value},
         ),
-        FinishEvent(stop_reason="tool_calls", input_tokens=10, output_tokens=5, model="mock"),
+        FinishEvent(
+            stop_reason="tool_calls", input_tokens=10, output_tokens=5, model="mock"
+        ),
     ]
 
 
@@ -89,7 +103,9 @@ def _text_then_set_output(text: str, key: str, value: str) -> list:
             tool_name="set_output",
             tool_input={"key": key, "value": value},
         ),
-        FinishEvent(stop_reason="tool_calls", input_tokens=10, output_tokens=5, model="mock"),
+        FinishEvent(
+            stop_reason="tool_calls", input_tokens=10, output_tokens=5, model="mock"
+        ),
     ]
 
 
@@ -128,7 +144,9 @@ class TestParseVerdict:
         assert v.feedback == ""
 
     def test_retry_with_feedback(self):
-        v = _parse_verdict("ACTION: RETRY\nCONFIDENCE: 0.6\nFEEDBACK: Research is too shallow.")
+        v = _parse_verdict(
+            "ACTION: RETRY\nCONFIDENCE: 0.6\nFEEDBACK: Research is too shallow."
+        )
         assert v.action == "RETRY"
         assert v.confidence == 0.6
         assert "shallow" in v.feedback
@@ -152,7 +170,9 @@ class TestEvaluatePhaseCompletion:
     @pytest.mark.asyncio
     async def test_accept_on_good_response(self):
         """LLM says ACCEPT → verdict is ACCEPT."""
-        llm = MockStreamingLLM(complete_response="ACTION: ACCEPT\nCONFIDENCE: 0.95\nFEEDBACK:")
+        llm = MockStreamingLLM(
+            complete_response="ACTION: ACCEPT\nCONFIDENCE: 0.95\nFEEDBACK:"
+        )
         conv = NodeConversation(system_prompt="test")
         await conv.add_user_message("Do research on topic X")
         await conv.add_assistant_message("I found 5 high-quality sources on X.")
@@ -192,25 +212,39 @@ class TestEvaluatePhaseCompletion:
         assert "1 source" in verdict.feedback
 
     @pytest.mark.asyncio
-    async def test_llm_failure_defaults_to_accept(self):
-        """When LLM fails, Level 2 should not block (Level 0 already passed)."""
+    async def test_llm_failure_retries_then_accepts(self):
+        """1st failure -> RETRY, 2nd failure -> ACCEPT with 0.0 confidence."""
         llm = MockStreamingLLM()
-        # Make complete() raise an exception
-        llm.complete = MagicMock(side_effect=RuntimeError("LLM unavailable"))
+        llm.acomplete = MagicMock(side_effect=RuntimeError("LLM unavailable"))
 
         conv = NodeConversation(system_prompt="test")
         await conv.add_assistant_message("Done.")
 
-        verdict = await evaluate_phase_completion(
+        # 1st attempt
+        v1 = await evaluate_phase_completion(
             llm=llm,
             conversation=conv,
-            phase_name="Test",
-            phase_description="Test phase",
-            success_criteria="Do the thing",
-            accumulator_state={"result": "done"},
+            phase_name="T",
+            phase_description="D",
+            success_criteria="C",
+            accumulator_state={},
+            _judge_failure_count=0,
         )
-        assert verdict.action == "ACCEPT"
-        assert verdict.confidence == 0.5
+        assert v1.action == "RETRY"
+        assert v1.confidence == 0.0
+
+        # 2nd attempt
+        v2 = await evaluate_phase_completion(
+            llm=llm,
+            conversation=conv,
+            phase_name="T",
+            phase_description="D",
+            success_criteria="C",
+            accumulator_state={},
+            _judge_failure_count=1,
+        )
+        assert v2.action == "ACCEPT"
+        assert v2.confidence == 0.0
 
 
 # ===========================================================================
@@ -299,7 +333,7 @@ class TestLevel2InImplicitJudge:
         call_count = [0]
 
         class SequentialLLM(MockStreamingLLM):
-            def complete(self, messages, system="", **kwargs):
+            async def acomplete(self, messages, system="", **kwargs):
                 idx = call_count[0]
                 call_count[0] += 1
                 resp = complete_responses[idx % len(complete_responses)]
@@ -311,7 +345,9 @@ class TestLevel2InImplicitJudge:
                 _text_then_set_output("Brief research.", "result", "brief"),
                 _text_finish(""),  # triggers judge → Level 2 RETRY
                 # Turn 2: after retry feedback, set output again, stop → Level 2 ACCEPT
-                _text_then_set_output("Much more detailed research.", "result", "detailed"),
+                _text_then_set_output(
+                    "Much more detailed research.", "result", "detailed"
+                ),
                 _text_finish(""),  # triggers judge → Level 2 ACCEPT
             ]
         )


### PR DESCRIPTION
## Problem
Fixes #6649 — Judge LLM failures silently bypass quality gates.

## Root Cause
In `core/framework/graph/conversation_judge.py`, the exception handler and empty response check for the Level 2 judge returned a default `ACCEPT` verdict. This allowed agents to proceed even when the quality evaluation infrastructure was failing.

## Fix
- Implemented a **retry-then-degrade** strategy for judge failures.
- **1st Failure**: Returns `RETRY` with `confidence=0.0`, giving the LLM another chance.
- **2nd Consecutive Failure**: Returns `ACCEPT` with `confidence=0.0`, ensuring progress while logging a clear error.
- Updated `EventLoopNode` to track `_judge_failure_count` and reset it upon successful evaluation.
- `confidence=0.0` is used as a system signal to distinguish infrastructure failures from real judge assessments.

## Validation
- [x] `make lint` — passed
- [x] `make check` — passed
- [x] `test_conversation_judge.py` — 11/11 passed (including new retry logic coverage).
- [x] Manual reproduction verified failure-to-retry transition.

## Risk Assessment
- Blast radius: Limited to Level 2 judge evaluations.
- Rollback: `git revert` this commit.
