### PR TITLE
fix(examples): use __file__ relative path for mcp_servers.json copy (micro-fix)

### DIFF
--- a/core/examples/mcp_integration_example.py
+++ b/core/examples/mcp_integration_example.py
@@ -79,7 +79,7 @@ async def example_3_config_file():
     # Copy example config (in practice, you'd place this in your agent folder)
     import shutil
 
-    shutil.copy("examples/mcp_servers.json", test_agent_path / "mcp_servers.json")
+    shutil.copy(Path(__file__).parent / "mcp_servers.json", test_agent_path / "mcp_servers.json")
 
     # Load agent - MCP servers will be auto-discovered
     runner = AgentRunner.load(test_agent_path)


### PR DESCRIPTION
## Description

Fix wrong relative path in MCP integration example. `shutil.copy("examples/mcp_servers.json", ...)` fails when running from repo root. Use `Path(__file__).parent / "mcp_servers.json"` instead.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #1669

## Changes Made

- Use `Path(__file__).parent` to resolve `mcp_servers.json` path relative to the script

## Testing

- [x] Lint passes
- [x] Path resolution verified

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code