### PR TITLE
micro-fix: normalize module input in check_requirements script

### DIFF
--- a/scripts/check_requirements.py
+++ b/scripts/check_requirements.py
@@ -54,7 +54,21 @@ def main():
         print(json.dumps({"error": "No modules specified"}), file=sys.stderr)
         sys.exit(1)
 
-    modules_to_check = sys.argv[1:]
+    raw_tokens = sys.argv[1:]
+    modules_to_check: list[str] = []
+    seen = set()
+
+    for token in raw_tokens:
+        for part in token.split(","):
+            name = part.strip()
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            modules_to_check.append(name)
+
+    if not modules_to_check:
+        print(json.dumps({"error": "No modules specified"}), file=sys.stderr)
+        sys.exit(1)
     results = check_imports(modules_to_check)
 
     # Print results as JSON


### PR DESCRIPTION
Fixes #6685

This PR improves scripts/check_requirements.py by normalizing CLI input.

Changes:
- Support comma-separated module names
- Trim whitespace
- Remove duplicates while preserving order
- Keep existing behavior unchanged

All tests pass:
python3 scripts/test_check_requirements.py