### PR TITLE
Fix Windows UI Launch and Missing Safe Eval Built-ins

### DIFF
--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -50,6 +50,9 @@ SAFE_FUNCTIONS = {
     "round": round,
     "all": all,
     "any": any,
+    "isinstance": isinstance,
+    "issubclass": issubclass,
+    "type": type,
 }
 
 

--- a/quickstart.ps1
+++ b/quickstart.ps1
@@ -2019,7 +2019,7 @@ Write-Host ""
 if ($FrontendBuilt) {
     Write-Color -Text "Launching dashboard..." -Color White
     Write-Host ""
-    & hive open
+    & .\hive.ps1 open
 } else {
     Write-Color -Text "Frontend build was skipped or failed." -Color Yellow -NoNewline
     Write-Host " Launch manually when ready:"


### PR DESCRIPTION
## Description
Resolves #6654 and Resolves #6665.

This PR fixes two separate bugs for initial onboarding and safety functionality:
1. **Windows Web UI Launch**: Replaced the `& hive open` global shorthand with `& .\hive.ps1 open` in [quickstart.ps1](cci:7://file:///c:/Users/ntinu/.gemini/antigravity/scratch/Hive/quickstart.ps1:0:0-0:0). The Windows PowerShell session does not have the local hive script in the system PATH and requires the local execution prefix.
2. **Safe Eval Built-ins**: Added `isinstance`, `issubclass`, and `type` to the `SAFE_FUNCTIONS` allowlist in [core/framework/graph/safe_eval.py](cci:7://file:///c:/Users/ntinu/.gemini/antigravity/scratch/Hive/core/framework/graph/safe_eval.py:0:0-0:0) to prevent the silent `NameError` crash reported during edge condition evaluation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #6654
Fixes #6665

## Changes Made

- Changed `& hive open` to `& .\hive.ps1 open` in [quickstart.ps1](cci:7://file:///c:/Users/ntinu/.gemini/antigravity/scratch/Hive/quickstart.ps1:0:0-0:0).
- Added `isinstance`, `issubclass`, and `type` to `SAFE_FUNCTIONS` in [core/framework/graph/safe_eval.py](cci:7://file:///c:/Users/ntinu/.gemini/antigravity/scratch/Hive/core/framework/graph/safe_eval.py:0:0-0:0).

## Testing

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

*(N/A - backend and script execution changes only)*
