### PR TITLE
feat(mcp): add registry CLI tooling for init, validate, and test

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -92,6 +92,24 @@ uv run python -m framework test-list <agent_path>
 
 For detailed testing workflows, see [developer-guide.md](../docs/developer-guide.md).
 
+### MCP Server Registry Tools
+
+Contributor tooling for creating, validating, and testing MCP server manifests:
+
+```bash
+# Scaffold a new manifest interactively
+hive mcp init
+
+# Scaffold with server introspection (pre-fills tools list)
+hive mcp init --server-url http://localhost:4010
+
+# Validate a manifest against the registry schema
+hive mcp validate path/to/manifest.json
+
+# Test a server against its manifest (starts server, checks tools)
+hive mcp test path/to/manifest.json
+```
+
 ### Analyzing Agent Behavior with Builder
 
 The BuilderQuery interface allows you to analyze agent runs and identify improvements:

--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -14,6 +14,11 @@ Testing commands:
     hive test-debug <agent_path> <test_name>
     hive test-list <agent_path>
     hive test-stats <agent_path>
+
+MCP registry commands:
+    hive mcp init [--server-url URL]
+    hive mcp validate <path>
+    hive mcp test <path>
 """
 
 import argparse

--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -99,7 +99,7 @@ def main():
 
     register_debugger_commands(subparsers)
 
-    # Register MCP registry commands (mcp install, mcp add, ...)
+    # Register MCP registry commands (mcp install, mcp add, mcp init, mcp validate, mcp test)
     from framework.runner.mcp_registry_cli import register_mcp_commands
 
     register_mcp_commands(subparsers)

--- a/core/framework/runner/mcp_manifest_schema.py
+++ b/core/framework/runner/mcp_manifest_schema.py
@@ -1,0 +1,215 @@
+"""JSON Schema and validation helpers for MCP server manifests."""
+
+from __future__ import annotations
+
+import jsonschema
+
+MANIFEST_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": [
+        "name",
+        "display_name",
+        "version",
+        "description",
+        "author",
+        "maintainer",
+        "repository",
+        "license",
+        "status",
+        "transport",
+        "install",
+        "tools",
+    ],
+    "properties": {
+        "name": {"type": "string", "pattern": "^[a-z][a-z0-9-]*$"},
+        "display_name": {"type": "string"},
+        "version": {"type": "string"},
+        "description": {"type": "string"},
+        "author": {
+            "type": "object",
+            "required": ["name", "github"],
+            "properties": {
+                "name": {"type": "string"},
+                "github": {"type": "string"},
+                "url": {"type": "string"},
+            },
+        },
+        "maintainer": {
+            "type": "object",
+            "required": ["github"],
+            "properties": {
+                "github": {"type": "string"},
+                "email": {"type": "string", "format": "email"},
+            },
+        },
+        "repository": {"type": "string"},
+        "license": {"type": "string"},
+        "status": {"type": "string", "enum": ["official", "verified", "community"]},
+        "transport": {
+            "type": "object",
+            "required": ["supported", "default"],
+            "properties": {
+                "supported": {
+                    "type": "array",
+                    "items": {"type": "string", "enum": ["stdio", "http", "unix", "sse"]},
+                },
+                "default": {"type": "string", "enum": ["stdio", "http", "unix", "sse"]},
+            },
+        },
+        "install": {
+            "type": "object",
+            "properties": {
+                "pip": {"type": ["string", "null"]},
+                "docker": {"type": ["string", "null"]},
+                "npm": {"type": ["string", "null"]},
+            },
+        },
+        "tools": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["name", "description"],
+                "properties": {
+                    "name": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$"},
+                    "description": {"type": "string"},
+                },
+            },
+        },
+        "credentials": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["id", "env_var", "description", "required"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "env_var": {"type": "string", "pattern": "^[A-Z][A-Z0-9_]*$"},
+                    "description": {"type": "string"},
+                    "help_url": {"type": "string"},
+                    "required": {"type": "boolean"},
+                },
+            },
+        },
+        "tags": {"type": "array", "items": {"type": "string"}},
+        "categories": {"type": "array", "items": {"type": "string"}},
+        "mcp_protocol_version": {"type": "string"},
+        "docs_url": {"type": "string"},
+        "supported_os": {
+            "type": "array",
+            "items": {"type": "string", "enum": ["linux", "macos", "windows"]},
+        },
+        "example_agent_url": {"type": "string"},
+        "deprecated": {"type": "boolean"},
+        "deprecated_by": {"type": "string"},
+        # Transport config blocks
+        "stdio": {
+            "type": "object",
+            "properties": {
+                "command": {"type": "string"},
+                "args": {"type": "array", "items": {"type": "string"}},
+            },
+        },
+        "http": {
+            "type": "object",
+            "properties": {
+                "default_port": {"type": "integer"},
+                "health_path": {"type": "string"},
+                "command": {"type": "string"},
+                "args": {"type": "array", "items": {"type": "string"}},
+            },
+        },
+        "unix": {
+            "type": "object",
+            "properties": {
+                "socket_template": {"type": "string"},
+                "command": {"type": "string"},
+                "args": {"type": "array", "items": {"type": "string"}},
+            },
+        },
+        # Hive extension block
+        "hive": {
+            "type": "object",
+            "properties": {
+                "min_version": {"type": ["string", "null"]},
+                "max_version": {"type": ["string", "null"]},
+                "profiles": {"type": "array", "items": {"type": "string"}},
+                "tool_namespace": {"type": "string"},
+                "example_agent": {"type": "string"},
+            },
+        },
+    },
+}
+
+
+def _format_path(path: list) -> str:
+    """Convert a jsonschema error path to a human-readable string like 'tools[0].name'."""
+    parts: list[str] = []
+    for segment in path:
+        if isinstance(segment, int):
+            parts.append(f"[{segment}]")
+        elif parts:
+            parts.append(f".{segment}")
+        else:
+            parts.append(segment)
+    return "".join(parts)
+
+
+_FIX_SUGGESTIONS: dict[str, str] = {
+    "name": "Use lowercase letters and hyphens only (e.g., 'my-server')",
+    "tools.name": "Use snake_case (e.g., 'create_issue')",
+    "credentials.env_var": "Use UPPER_SNAKE_CASE (e.g., 'MY_API_KEY')",
+    "status": "Must be one of: official, verified, community",
+    "transport.supported": "Supported transports: stdio, http, unix, sse",
+    "transport.default": "Must be one of: stdio, http, unix, sse",
+}
+
+
+def _suggest_fix(error: jsonschema.ValidationError) -> str | None:
+    """Return a human-readable fix suggestion for a schema validation error, or None."""
+    path_parts = list(error.absolute_path)
+    # Match leaf field name (e.g., "name" inside tools[0])
+    if path_parts:
+        leaf = str(path_parts[-1])
+        # Check compound key first (e.g., "tools.name" for path [tools, 0, name])
+        if len(path_parts) >= 2:
+            parent = (
+                str(path_parts[-2])
+                if not isinstance(path_parts[-2], int)
+                else (str(path_parts[-3]) if len(path_parts) >= 3 else "")
+            )
+            compound = f"{parent}.{leaf}"
+            if compound in _FIX_SUGGESTIONS:
+                return _FIX_SUGGESTIONS[compound]
+        if leaf in _FIX_SUGGESTIONS:
+            return _FIX_SUGGESTIONS[leaf]
+    return None
+
+
+def validate_manifest(data: dict) -> list[str]:
+    """Validate a manifest dict against the schema. Returns a list of error strings.
+
+    Each error string includes context and, where possible, a suggested fix.
+    """
+    validator = jsonschema.Draft202012Validator(MANIFEST_SCHEMA)
+    errors: list[str] = []
+
+    for error in validator.iter_errors(data):
+        path = _format_path(list(error.absolute_path))
+        msg = f"{path}: {error.message}" if path else error.message
+        fix = _suggest_fix(error)
+        if fix:
+            msg += f"\n       Fix: {fix}"
+        errors.append(msg)
+
+    # Cross-validation: each declared transport must have a matching config block
+    transport = data.get("transport", {})
+    supported = transport.get("supported", [])
+    for t in supported:
+        if t not in data:
+            errors.append(
+                f"transport: Config block '{t}' is missing but '{t}' is listed in"
+                f" transport.supported\n"
+                f"       Fix: Add a '{t}' section with the server command and args"
+            )
+
+    return errors

--- a/core/framework/runner/mcp_manifest_schema.py
+++ b/core/framework/runner/mcp_manifest_schema.py
@@ -172,11 +172,12 @@ def _suggest_fix(error: jsonschema.ValidationError) -> str | None:
         leaf = str(path_parts[-1])
         # Check compound key first (e.g., "tools.name" for path [tools, 0, name])
         if len(path_parts) >= 2:
-            parent = (
-                str(path_parts[-2])
-                if not isinstance(path_parts[-2], int)
-                else (str(path_parts[-3]) if len(path_parts) >= 3 else "")
-            )
+            if not isinstance(path_parts[-2], int):
+                parent = str(path_parts[-2])
+            elif len(path_parts) >= 3:
+                parent = str(path_parts[-3])
+            else:
+                parent = ""
             compound = f"{parent}.{leaf}"
             if compound in _FIX_SUGGESTIONS:
                 return _FIX_SUGGESTIONS[compound]

--- a/core/framework/runner/mcp_registry_cli.py
+++ b/core/framework/runner/mcp_registry_cli.py
@@ -13,6 +13,9 @@ Commands:
     hive mcp health [name]            Check server health
     hive mcp update                   Refresh index and update installed servers
     hive mcp update <name>            Update a single installed server
+    hive mcp init                     Scaffold a new MCP server manifest
+    hive mcp validate <path>          Validate an MCP server manifest
+    hive mcp test <path>              Test an MCP server against its manifest
 """
 
 from __future__ import annotations
@@ -392,6 +395,24 @@ def register_mcp_commands(subparsers) -> None:
         help="Server name to update (omit to update all registry servers)",
     )
     update_p.set_defaults(func=cmd_mcp_update)
+
+    # ── init (contributor tooling) ──
+    init_p = mcp_sub.add_parser("init", help="Scaffold a new MCP server manifest")
+    init_p.add_argument(
+        "--server-url", default=None, help="URL of running server to introspect for tools"
+    )
+    init_p.add_argument("--output-dir", default=".", help="Directory to write manifest.json and README.md")
+    init_p.set_defaults(func=cmd_mcp_init)
+
+    # ── validate (contributor tooling) ──
+    validate_p = mcp_sub.add_parser("validate", help="Validate an MCP server manifest")
+    validate_p.add_argument("path", help="Path to manifest.json or directory containing it")
+    validate_p.set_defaults(func=cmd_mcp_validate)
+
+    # ── test (contributor tooling) ──
+    test_p = mcp_sub.add_parser("test", help="Test an MCP server against its manifest")
+    test_p.add_argument("path", help="Path to manifest.json or directory containing it")
+    test_p.set_defaults(func=cmd_mcp_test)
 
 
 # ── P0 command handlers ────────────────────────────────────────────
@@ -904,3 +925,215 @@ def _cmd_mcp_update_server(name: str, registry=None) -> int:
         print(f"✓ Updated {name}: v{old_version} → v{new_version}")
 
     return 0
+
+
+# ── Contributor tooling command handlers ──────────────────────────
+
+
+def cmd_mcp_validate(args) -> int:
+    """Validate an MCP server manifest against the schema."""
+    from framework.runner.mcp_manifest_schema import validate_manifest
+
+    path = Path(args.path)
+    if path.is_dir():
+        path = path / "manifest.json"
+
+    if not path.exists():
+        print(f"Error: {path} not found", file=sys.stderr)
+        return 1
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON in {path}: {e}", file=sys.stderr)
+        return 1
+
+    errors = validate_manifest(data)
+    if not errors:
+        print(f"PASS  {path} is valid")
+        return 0
+
+    print(f"Validating {path}...\n")
+    print(f"FAIL  {len(errors)} error(s) found:\n")
+    for i, error in enumerate(errors, 1):
+        print(f"  {i}. {error}")
+    return 1
+
+
+def cmd_mcp_init(args) -> int:
+    """Scaffold a new MCP server manifest."""
+    import httpx
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Prompt for required fields
+    name = input("Server name (lowercase-hyphenated, e.g. jira-cloud): ")
+    display_name = input("Display name (e.g. Jira Cloud MCP Server): ")
+    description = input("Description: ")
+    default_transport = input("Default transport (stdio/http/unix): ")
+    pip_package = input("Pip package name: ")
+
+    # Discover tools from a running server if --server-url was provided
+    tools: list[dict] = []
+    if args.server_url:
+        try:
+            resp = httpx.post(
+                args.server_url,
+                json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+            )
+            result = resp.json().get("result", {})
+            for tool in result.get("tools", []):
+                tools.append(
+                    {
+                        "name": tool["name"],
+                        "description": tool.get("description", ""),
+                    }
+                )
+        except Exception as e:
+            print(f"Warning: could not introspect server at {args.server_url}: {e}")
+            print("Continuing with empty tools list...")
+
+    # Build manifest with sensible defaults
+    manifest = {
+        "name": name,
+        "display_name": display_name,
+        "version": "0.1.0",
+        "description": description,
+        "author": {"name": "TODO", "github": "TODO"},
+        "maintainer": {"github": "TODO"},
+        "repository": "TODO",
+        "license": "MIT",
+        "status": "community",
+        "transport": {"supported": [default_transport], "default": default_transport},
+        "install": {"pip": pip_package, "docker": None, "npm": None},
+        "tools": tools or [{"name": "example_tool", "description": "TODO: describe this tool"}],
+    }
+
+    # Add transport config block for the chosen transport
+    if default_transport == "stdio":
+        manifest["stdio"] = {"command": "uvx", "args": [pip_package]}
+    elif default_transport == "http":
+        manifest["http"] = {
+            "default_port": 4010,
+            "health_path": "/health",
+            "command": "uvx",
+            "args": [pip_package, "--http", "--port", "{port}"],
+        }
+    elif default_transport == "unix":
+        manifest["unix"] = {
+            "socket_template": f"/tmp/mcp-{name}.sock",
+            "command": "uvx",
+            "args": [pip_package, "--unix", "{socket_path}"],
+        }
+
+    # Write manifest.json
+    manifest_path = output_dir / "manifest.json"
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+    print(f"Created {manifest_path}")
+
+    # Write starter README.md
+    readme_path = output_dir / "README.md"
+    readme_path.write_text(
+        f"# {display_name}\n\n"
+        f"{description}\n\n"
+        f"## Install\n\n"
+        f"```bash\npip install {pip_package}\n```\n\n"
+        f"## Contributing\n\n"
+        f"See the [Hive MCP Registry contributing guide]"
+        f"(https://github.com/aden-hive/hive-mcp-registry/blob/main/CONTRIBUTING.md).\n",
+        encoding="utf-8",
+    )
+    print(f"Created {readme_path}")
+
+    return 0
+
+
+def cmd_mcp_test(args) -> int:
+    """Test an MCP server against its manifest."""
+    from framework.runner.mcp_client import MCPClient, MCPServerConfig
+    from framework.runner.mcp_manifest_schema import validate_manifest
+
+    # Read and validate manifest
+    path = Path(args.path)
+    if path.is_dir():
+        path = path / "manifest.json"
+
+    if not path.exists():
+        print(f"Error: {path} not found", file=sys.stderr)
+        return 1
+
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    errors = validate_manifest(data)
+    if errors:
+        print(f"FAIL  Manifest has {len(errors)} validation error(s):")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+
+    # Build server config from manifest
+    transport = data["transport"]["default"]
+    transport_config = data.get(transport, {})
+
+    config = MCPServerConfig(
+        name=data["name"],
+        transport=transport,
+        command=transport_config.get("command"),
+        args=transport_config.get("args", []),
+        url=f"http://localhost:{transport_config['default_port']}"
+        if transport == "http" and "default_port" in transport_config
+        else None,
+        socket_path=transport_config.get("socket_template") if transport == "unix" else None,
+    )
+
+    # Connect and test
+    client = MCPClient(config)
+    try:
+        client.connect()
+        server_tools = client.list_tools()
+        server_tool_names = {t.name for t in server_tools}
+        manifest_tool_names = {t["name"] for t in data["tools"]}
+
+        missing = manifest_tool_names - server_tool_names
+        extra = server_tool_names - manifest_tool_names
+        matched = manifest_tool_names & server_tool_names
+
+        print(f"\nTool comparison for {data['name']}:")
+        for name in sorted(matched):
+            print(f"  PASS  {name}")
+        for name in sorted(extra):
+            print(f"  WARN  {name} (on server, not in manifest)")
+        for name in sorted(missing):
+            print(f"  FAIL  {name} (in manifest, not on server)")
+
+        # Health check for HTTP transport
+        if transport == "http" and transport_config.get("health_path"):
+            port = transport_config.get("default_port", 4010)
+            health_url = f"http://localhost:{port}{transport_config['health_path']}"
+            try:
+                import httpx
+
+                resp = httpx.get(health_url)
+                if resp.status_code == 200:
+                    print(f"  PASS  health check ({health_url})")
+                else:
+                    print(f"  FAIL  health check returned {resp.status_code}")
+            except Exception as e:
+                print(f"  FAIL  health check error: {e}")
+
+        if missing:
+            print(f"\nFAIL  {len(missing)} tool(s) missing from server")
+            return 1
+
+        print(f"\nPASS  All {len(matched)} manifest tool(s) found on server")
+        return 0
+
+    except Exception as e:
+        print(f"Error: could not test server: {e}", file=sys.stderr)
+        return 1
+    finally:
+        client.disconnect()

--- a/core/framework/runner/mcp_registry_cli.py
+++ b/core/framework/runner/mcp_registry_cli.py
@@ -401,7 +401,9 @@ def register_mcp_commands(subparsers) -> None:
     init_p.add_argument(
         "--server-url", default=None, help="URL of running server to introspect for tools"
     )
-    init_p.add_argument("--output-dir", default=".", help="Directory to write manifest.json and README.md")
+    init_p.add_argument(
+        "--output-dir", default=".", help="Directory to write manifest.json and README.md"
+    )
     init_p.set_defaults(func=cmd_mcp_init)
 
     # ── validate (contributor tooling) ──

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "mcp>=1.0.0",
   "fastmcp>=2.0.0",
   "croniter>=1.4.0",
+  "jsonschema>=4.20.0",
   "tools",
 ]
 

--- a/core/tests/test_mcp_manifest_schema.py
+++ b/core/tests/test_mcp_manifest_schema.py
@@ -1,0 +1,136 @@
+from framework.runner.mcp_manifest_schema import validate_manifest
+
+# Based on the Jira example from PRD section 7.1
+VALID_MANIFEST = {
+    "name": "jira",
+    "display_name": "Jira MCP Server",
+    "version": "1.2.0",
+    "description": "Interact with Jira issues, boards, and sprints",
+    "author": {
+        "name": "Jane Contributor",
+        "github": "janedev",
+        "url": "https://github.com/janedev",
+    },
+    "maintainer": {"github": "janedev", "email": "jane@example.com"},
+    "repository": "https://github.com/janedev/jira-mcp-server",
+    "license": "MIT",
+    "status": "community",
+    "transport": {"supported": ["stdio", "http"], "default": "stdio"},
+    "install": {"pip": "jira-mcp-server", "docker": None, "npm": None},
+    "stdio": {"command": "uvx", "args": ["jira-mcp-server", "--stdio"]},
+    "http": {
+        "default_port": 4010,
+        "health_path": "/health",
+        "command": "uvx",
+        "args": ["jira-mcp-server", "--http", "--port", "{port}"],
+    },
+    "tools": [
+        {"name": "jira_create_issue", "description": "Create a new Jira issue"},
+        {"name": "jira_search", "description": "Search Jira issues with JQL"},
+    ],
+    "credentials": [
+        {
+            "id": "jira_api_token",
+            "env_var": "JIRA_API_TOKEN",
+            "description": "Jira API token",
+            "help_url": "https://id.atlassian.com/manage-profile/security/api-tokens",
+            "required": True,
+        },
+    ],
+    "tags": ["project-management", "atlassian"],
+    "categories": ["productivity"],
+    "mcp_protocol_version": "2024-11-05",
+}
+
+
+def test_valid_manifest_passes():
+    errors = validate_manifest(VALID_MANIFEST)
+    assert errors == []
+
+
+def test_missing_name():
+    manifest = {**VALID_MANIFEST}
+    del manifest["name"]
+    errors = validate_manifest(manifest)
+    assert any("name" in e for e in errors)
+
+
+def test_bad_name_format():
+    manifest = {**VALID_MANIFEST, "name": "My Server"}
+    errors = validate_manifest(manifest)
+    assert any("name" in e and "match" in e for e in errors)
+
+
+def test_bad_tool_name_format():
+    manifest = {**VALID_MANIFEST, "tools": [{"name": "createIssue", "description": "..."}]}
+    errors = validate_manifest(manifest)
+    assert any("name" in e for e in errors)
+
+
+def test_bad_credential_env_var():
+    manifest = {
+        **VALID_MANIFEST,
+        "credentials": [{"id": "x", "env_var": "bad_var", "description": "...", "required": True}],
+    }
+    errors = validate_manifest(manifest)
+    assert any("env_var" in e for e in errors)
+
+
+def test_invalid_status():
+    manifest = {**VALID_MANIFEST, "status": "unknown"}
+    errors = validate_manifest(manifest)
+    assert any("status" in e for e in errors)
+
+
+def test_missing_transport_config():
+    manifest = {**VALID_MANIFEST}
+    manifest["transport"] = {"supported": ["stdio", "http"], "default": "stdio"}
+    manifest.pop("http", None)
+    errors = validate_manifest(manifest)
+    assert any("http" in e for e in errors)
+
+
+def test_minimal_valid_manifest():
+    manifest = {
+        "name": "minimal",
+        "display_name": "Minimal Server",
+        "version": "0.1.0",
+        "description": "A minimal MCP server",
+        "author": {"name": "Test", "github": "testuser"},
+        "maintainer": {"github": "testuser"},
+        "repository": "https://github.com/testuser/minimal",
+        "license": "MIT",
+        "status": "community",
+        "transport": {"supported": ["stdio"], "default": "stdio"},
+        "install": {"pip": "minimal-server"},
+        "stdio": {"command": "uvx", "args": ["minimal-server"]},
+        "tools": [{"name": "do_thing", "description": "Does a thing"}],
+    }
+    errors = validate_manifest(manifest)
+    assert errors == []
+
+
+def test_valid_manifest_with_hive_block():
+    manifest = {**VALID_MANIFEST, "hive": {"min_version": "0.5.0", "profiles": ["core"]}}
+    errors = validate_manifest(manifest)
+    assert errors == []
+
+
+def test_fix_suggestion_for_bad_name():
+    manifest = {**VALID_MANIFEST, "name": "My Server"}
+    errors = validate_manifest(manifest)
+    assert any("Fix:" in e for e in errors)
+
+
+def test_fix_suggestion_for_missing_transport_config():
+    manifest = {**VALID_MANIFEST}
+    manifest["transport"] = {"supported": ["stdio", "http"], "default": "stdio"}
+    manifest.pop("http", None)
+    errors = validate_manifest(manifest)
+    assert any("Fix:" in e for e in errors)
+
+
+def test_example_agent_url_field_accepted():
+    manifest = {**VALID_MANIFEST, "example_agent_url": "https://example.com/agent"}
+    errors = validate_manifest(manifest)
+    assert errors == []

--- a/core/tests/test_mcp_manifest_schema.py
+++ b/core/tests/test_mcp_manifest_schema.py
@@ -1,3 +1,5 @@
+"""Tests for MCP manifest schema validation."""
+
 from framework.runner.mcp_manifest_schema import validate_manifest
 
 # Based on the Jira example from PRD section 7.1

--- a/core/tests/test_mcp_registry_cli.py
+++ b/core/tests/test_mcp_registry_cli.py
@@ -1329,3 +1329,164 @@ def test_security_notice_persisted_on_successful_install(
 
     assert rc == 0
     assert sentinel.exists()
+
+
+# ── Contributor tooling tests (init, validate, test) ──────────────
+
+
+VALID_CONTRIBUTOR_MANIFEST = {
+    "name": "test-server",
+    "display_name": "Test Server",
+    "version": "0.1.0",
+    "description": "A test MCP server",
+    "author": {"name": "Test", "github": "testuser"},
+    "maintainer": {"github": "testuser"},
+    "repository": "https://github.com/testuser/test-server",
+    "license": "MIT",
+    "status": "community",
+    "transport": {"supported": ["stdio"], "default": "stdio"},
+    "install": {"pip": "test-server"},
+    "stdio": {"command": "uvx", "args": ["test-server"]},
+    "tools": [{"name": "do_thing", "description": "Does a thing"}],
+}
+
+
+def test_validate_valid_manifest(tmp_path):
+    from framework.runner.mcp_registry_cli import cmd_mcp_validate
+
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(VALID_CONTRIBUTOR_MANIFEST))
+    args = SimpleNamespace(path=str(path))
+    assert cmd_mcp_validate(args) == 0
+
+
+def test_validate_invalid_manifest(tmp_path):
+    from framework.runner.mcp_registry_cli import cmd_mcp_validate
+
+    manifest = {"name": "BAD NAME"}
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+    args = SimpleNamespace(path=str(path))
+    assert cmd_mcp_validate(args) == 1
+
+
+def test_validate_directory_path(tmp_path):
+    from framework.runner.mcp_registry_cli import cmd_mcp_validate
+
+    (tmp_path / "manifest.json").write_text(json.dumps(VALID_CONTRIBUTOR_MANIFEST))
+    args = SimpleNamespace(path=str(tmp_path))
+    assert cmd_mcp_validate(args) == 0
+
+
+def test_validate_missing_file():
+    from framework.runner.mcp_registry_cli import cmd_mcp_validate
+
+    args = SimpleNamespace(path="/nonexistent/manifest.json")
+    assert cmd_mcp_validate(args) == 1
+
+
+def test_validate_invalid_json(tmp_path):
+    from framework.runner.mcp_registry_cli import cmd_mcp_validate
+
+    path = tmp_path / "manifest.json"
+    path.write_text("not json {{{")
+    args = SimpleNamespace(path=str(path))
+    assert cmd_mcp_validate(args) == 1
+
+
+def test_init_creates_manifest(tmp_path):
+    from framework.runner.mcp_registry_cli import cmd_mcp_init
+
+    user_inputs = ["my-server", "My Server", "A test server", "stdio", "my-server-pkg"]
+    with patch("builtins.input", side_effect=user_inputs):
+        args = SimpleNamespace(server_url=None, output_dir=str(tmp_path))
+        result = cmd_mcp_init(args)
+    assert result == 0
+    assert (tmp_path / "manifest.json").exists()
+    assert (tmp_path / "README.md").exists()
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    from framework.runner.mcp_manifest_schema import validate_manifest
+
+    assert validate_manifest(manifest) == []
+
+
+def test_init_with_server_url(tmp_path):
+    from framework.runner.mcp_registry_cli import cmd_mcp_init
+
+    mock_response_data = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "tools": [{"name": "search", "description": "Search things", "inputSchema": {}}]
+        },
+    }
+    user_inputs = ["my-server", "My Server", "A test server", "http", "my-server-pkg"]
+    with (
+        patch("builtins.input", side_effect=user_inputs),
+        patch("httpx.post") as mock_post,
+    ):
+        mock_post.return_value.json.return_value = mock_response_data
+        mock_post.return_value.status_code = 200
+        args = SimpleNamespace(server_url="http://localhost:4000", output_dir=str(tmp_path))
+        result = cmd_mcp_init(args)
+    assert result == 0
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    assert len(manifest["tools"]) == 1
+    assert manifest["tools"][0]["name"] == "search"
+
+
+def _make_mock_tool(name, description=""):
+    tool = MagicMock()
+    tool.name = name
+    tool.description = description
+    return tool
+
+
+def test_cmd_test_pass(tmp_path):
+    from framework.runner.mcp_registry_cli import cmd_mcp_test
+
+    (tmp_path / "manifest.json").write_text(json.dumps(VALID_CONTRIBUTOR_MANIFEST))
+    mock_client = MagicMock()
+    mock_client.list_tools.return_value = [_make_mock_tool("do_thing")]
+    with patch("framework.runner.mcp_registry_cli.MCPClient", return_value=mock_client):
+        args = SimpleNamespace(path=str(tmp_path))
+        assert cmd_mcp_test(args) == 0
+    mock_client.disconnect.assert_called_once()
+
+
+def test_cmd_test_missing_tool(tmp_path):
+    from framework.runner.mcp_registry_cli import cmd_mcp_test
+
+    manifest = {
+        **VALID_CONTRIBUTOR_MANIFEST,
+        "tools": [
+            {"name": "search", "description": "Search"},
+            {"name": "create", "description": "Create"},
+        ],
+    }
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest))
+    mock_client = MagicMock()
+    mock_client.list_tools.return_value = [_make_mock_tool("search")]
+    with patch("framework.runner.mcp_registry_cli.MCPClient", return_value=mock_client):
+        args = SimpleNamespace(path=str(tmp_path))
+        assert cmd_mcp_test(args) == 1
+
+
+def test_cmd_test_invalid_manifest(tmp_path):
+    from framework.runner.mcp_registry_cli import cmd_mcp_test
+
+    (tmp_path / "manifest.json").write_text('{"name": "BAD"}')
+    args = SimpleNamespace(path=str(tmp_path))
+    assert cmd_mcp_test(args) == 1
+
+
+def test_cmd_test_cleanup_on_failure(tmp_path):
+    from framework.runner.mcp_registry_cli import cmd_mcp_test
+
+    (tmp_path / "manifest.json").write_text(json.dumps(VALID_CONTRIBUTOR_MANIFEST))
+    mock_client = MagicMock()
+    mock_client.list_tools.side_effect = Exception("boom")
+    with patch("framework.runner.mcp_registry_cli.MCPClient", return_value=mock_client):
+        args = SimpleNamespace(path=str(tmp_path))
+        cmd_mcp_test(args)
+    mock_client.disconnect.assert_called_once()

--- a/core/tests/test_mcp_registry_cli.py
+++ b/core/tests/test_mcp_registry_cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from io import StringIO
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -1448,7 +1448,7 @@ def test_cmd_test_pass(tmp_path):
     (tmp_path / "manifest.json").write_text(json.dumps(VALID_CONTRIBUTOR_MANIFEST))
     mock_client = MagicMock()
     mock_client.list_tools.return_value = [_make_mock_tool("do_thing")]
-    with patch("framework.runner.mcp_registry_cli.MCPClient", return_value=mock_client):
+    with patch("framework.runner.mcp_client.MCPClient", return_value=mock_client):
         args = SimpleNamespace(path=str(tmp_path))
         assert cmd_mcp_test(args) == 0
     mock_client.disconnect.assert_called_once()
@@ -1467,7 +1467,7 @@ def test_cmd_test_missing_tool(tmp_path):
     (tmp_path / "manifest.json").write_text(json.dumps(manifest))
     mock_client = MagicMock()
     mock_client.list_tools.return_value = [_make_mock_tool("search")]
-    with patch("framework.runner.mcp_registry_cli.MCPClient", return_value=mock_client):
+    with patch("framework.runner.mcp_client.MCPClient", return_value=mock_client):
         args = SimpleNamespace(path=str(tmp_path))
         assert cmd_mcp_test(args) == 1
 
@@ -1486,7 +1486,7 @@ def test_cmd_test_cleanup_on_failure(tmp_path):
     (tmp_path / "manifest.json").write_text(json.dumps(VALID_CONTRIBUTOR_MANIFEST))
     mock_client = MagicMock()
     mock_client.list_tools.side_effect = Exception("boom")
-    with patch("framework.runner.mcp_registry_cli.MCPClient", return_value=mock_client):
+    with patch("framework.runner.mcp_client.MCPClient", return_value=mock_client):
         args = SimpleNamespace(path=str(tmp_path))
         cmd_mcp_test(args)
     mock_client.disconnect.assert_called_once()


### PR DESCRIPTION
## Summary

- Add `hive mcp init` command to scaffold MCP server manifests interactively,
  with optional `--server-url` to introspect a running server and pre-fill tools
- Add `hive mcp validate <path>` to validate manifests against the JSON Schema
  with actionable fix suggestions (DX-2)
- Add `hive mcp test <path>` to connect to a server, compare discovered tools
  against the manifest, and run health checks
- Define full MCP manifest JSON Schema (draft-2020-12) covering all PRD fields:
  base layer (FR-10–FR-17), trust metadata (FR-80–FR-85), and hive extension
  block (FR-90–FR-94)

Closes #6353

## Test plan

- [x] `uv run pytest core/tests/test_mcp_manifest_schema.py core/tests/test_mcp_registry_cli.py -v` — 25 tests pass
- [x] `uv run pytest core/tests/ -q` — full suite passes (1221 passed, 80 skipped)
- [x] `uv run ruff check && uv run ruff format --check` — lint clean
- [x] `hive mcp validate` with valid/invalid manifests returns correct exit codes
- [x] `hive mcp init` generates a manifest that passes round-trip validation
- [x] `hive mcp test` fails gracefully when server is unreachable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `hive mcp init` command to scaffold new server manifests with interactive setup and optional server introspection.
  * Added `hive mcp validate` command to validate manifests with detailed error messages and fix suggestions.
  * Added `hive mcp test` command to test servers and verify tool compliance against manifest definitions.

* **Documentation**
  * Updated documentation with new MCP Server Registry Tools contributor commands.

* **Tests**
  * Added comprehensive test coverage for manifest validation and new CLI commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->