### PR TITLE
test: add Agent Skills compatibility suite for anthropic/skills fixtures

### DIFF
--- a/core/tests/fixtures/anthropic_skills/claude-api/SKILL.md
+++ b/core/tests/fixtures/anthropic_skills/claude-api/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: claude-api
+description: "Build apps with the Claude API or Anthropic SDK. TRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`/`claude_agent_sdk`, or user asks to use Claude API, Anthropic SDKs, or Agent SDK. DO NOT TRIGGER when: code imports `openai`/other AI SDK, general programming, or ML/data-science tasks."
+license: Complete terms in LICENSE.txt
+---
+
+# Building LLM-Powered Applications with Claude
+
+This skill helps you build LLM-powered applications with Claude. Choose the right surface based on your needs, detect the project language, then read the relevant language-specific documentation.
+
+## Defaults
+
+Unless the user requests otherwise:
+
+For the Claude model version, please use Claude Opus 4.6, which you can access via the exact model string `claude-opus-4-6`. Please default to using adaptive thinking (`thinking: {type: "adaptive"}`) for anything remotely complicated. And finally, please default to streaming for any request that may involve long input, long output, or high `max_tokens` — it prevents hitting request timeouts. Use the SDK's `.get_final_message()` / `.finalMessage()` helper to get the complete response if you don't need to handle individual stream events
+
+---
+
+## Language Detection
+
+Before reading code examples, determine which language the user is working in:
+
+1. **Look at project files** to infer the language:
+
+   - `*.py`, `requirements.txt`, `pyproject.toml`, `setup.py`, `Pipfile` → **Python** — read from `python/`
+   - `*.ts`, `*.tsx`, `package.json`, `tsconfig.json` → **TypeScript** — read from `typescript/`

--- a/core/tests/fixtures/anthropic_skills/frontend-design/SKILL.md
+++ b/core/tests/fixtures/anthropic_skills/frontend-design/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: frontend-design
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
+license: Complete terms in LICENSE.txt
+---
+
+This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+
+The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+
+## Design Thinking
+
+Before coding, understand the context and commit to a BOLD aesthetic direction:
+- **Purpose**: What problem does this interface solve? Who uses it?
+- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc.
+- **Constraints**: Technical requirements (framework, performance, accessibility).
+- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
+
+**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.

--- a/core/tests/fixtures/anthropic_skills/mcp-builder/SKILL.md
+++ b/core/tests/fixtures/anthropic_skills/mcp-builder/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: mcp-builder
+description: Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
+license: Complete terms in LICENSE.txt
+---
+
+# MCP Server Development Guide
+
+## Overview
+
+Create MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. The quality of an MCP server is measured by how well it enables LLMs to accomplish real-world tasks.
+
+---
+
+# Process
+
+## High-Level Workflow
+
+Creating a high-quality MCP server involves four main phases:
+
+### Phase 1: Deep Research and Planning
+
+#### 1.1 Understand Modern MCP Design
+
+**API Coverage vs. Workflow Tools:**
+Balance comprehensive API endpoint coverage with specialized workflow tools. Workflow tools can be more convenient for specific tasks, while comprehensive coverage gives agents flexibility to compose operations.
+
+**Tool Naming and Discoverability:**
+Clear, descriptive tool names help agents find the right tools quickly. Use consistent prefixes (e.g., `github_create_issue`, `github_list_repos`) and action-oriented naming.

--- a/core/tests/fixtures/anthropic_skills/pdf/SKILL.md
+++ b/core/tests/fixtures/anthropic_skills/pdf/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: pdf
+description: Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.
+license: Proprietary. LICENSE.txt has complete terms
+---
+
+# PDF Processing Guide
+
+## Overview
+
+This guide covers essential PDF processing operations using Python libraries and command-line tools. For advanced features, JavaScript libraries, and detailed examples, see REFERENCE.md. If you need to fill out a PDF form, read FORMS.md and follow its instructions.
+
+## Quick Start
+
+```python
+from pypdf import PdfReader, PdfWriter
+
+# Read a PDF
+reader = PdfReader("document.pdf")
+print(f"Pages: {len(reader.pages)}")
+
+# Extract text
+text = ""
+for page in reader.pages:
+    text += page.extract_text()
+```

--- a/core/tests/fixtures/anthropic_skills/slack-gif-creator/SKILL.md
+++ b/core/tests/fixtures/anthropic_skills/slack-gif-creator/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: slack-gif-creator
+description: Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make me a GIF of X doing Y for Slack."
+license: Complete terms in LICENSE.txt
+---
+
+# Slack GIF Creator
+
+A toolkit providing utilities and knowledge for creating animated GIFs optimized for Slack.
+
+## Slack Requirements
+
+**Dimensions:**
+- Emoji GIFs: 128x128 (recommended)
+- Message GIFs: 480x480
+
+**Parameters:**
+- FPS: 10-30 (lower is smaller file size)
+- Colors: 48-128 (fewer = smaller file size)
+- Duration: Keep under 3 seconds for emoji GIFs
+
+## Core Workflow
+
+```python
+from core.gif_builder import GIFBuilder
+from PIL import Image, ImageDraw
+
+# 1. Create builder
+builder = GIFBuilder(width=128, height=128, fps=10)
+```

--- a/core/tests/fixtures/anthropic_skills/xlsx/SKILL.md
+++ b/core/tests/fixtures/anthropic_skills/xlsx/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: xlsx
+description: "Use this skill any time a spreadsheet file is the primary input or output. This means any task where the user wants to: open, read, edit, or fix an existing .xlsx, .xlsm, .csv, or .tsv file (e.g., adding columns, computing formulas, formatting, charting, cleaning messy data); create a new spreadsheet from scratch or from other data sources; or convert between tabular file formats. Trigger especially when the user references a spreadsheet file by name or path — even casually (like \"the xlsx in my downloads\") — and wants something done to it or produced from it. Also trigger for cleaning or restructuring messy tabular data files (malformed rows, misplaced headers, junk data) into proper spreadsheets. The deliverable must be a spreadsheet file. Do NOT trigger when the primary deliverable is a Word document, HTML report, standalone Python script, database pipeline, or Google Sheets API integration, even if tabular data is involved."
+license: Proprietary. LICENSE.txt has complete terms
+---
+
+# Requirements for Outputs
+
+## All Excel files
+
+### Professional Font
+- Use a consistent, professional font (e.g., Arial, Times New Roman) for all deliverables unless otherwise instructed by the user
+
+### Zero Formula Errors
+- Every Excel model MUST be delivered with ZERO formula errors (#REF!, #DIV/0!, #VALUE!, #N/A, #NAME?)
+
+### Preserve Existing Templates (when updating templates)
+- Study and EXACTLY match existing format, style, and conventions when modifying files
+- Never impose standardized formatting on files with established patterns
+- Existing template conventions ALWAYS override these guidelines

--- a/core/tests/test_skill_compatibility.py
+++ b/core/tests/test_skill_compatibility.py
@@ -1,0 +1,177 @@
+"""Compatibility tests: Anthropic skills in Hive, and Hive skills against the spec."""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from framework.skills.catalog import SkillCatalog
+from framework.skills.discovery import DiscoveryConfig, SkillDiscovery
+from framework.skills.parser import parse_skill_md
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "anthropic_skills"
+
+ANTHROPIC_SKILLS = [
+    "claude-api",
+    "pdf",
+    "xlsx",
+    "slack-gif-creator",
+    "mcp-builder",
+    "frontend-design",
+]
+
+# Expected substrings in each skill's description
+EXPECTED_DESCRIPTION_SUBSTRINGS = {
+    "claude-api": "Claude API",
+    "pdf": "PDF",
+    "xlsx": "spreadsheet",
+    "slack-gif-creator": "GIF",
+    "mcp-builder": "MCP",
+    "frontend-design": "frontend",
+}
+
+
+# =============================================================================
+# Section A: Anthropic Skills → Hive
+# =============================================================================
+
+
+@pytest.mark.parametrize("skill_name", ANTHROPIC_SKILLS)
+def test_parse_without_errors(skill_name):
+    path = FIXTURES_DIR / skill_name / "SKILL.md"
+    result = parse_skill_md(path)
+    assert result is not None, f"parse_skill_md returned None for {skill_name}"
+
+
+@pytest.mark.parametrize("skill_name", ANTHROPIC_SKILLS)
+def test_name_extracted_correctly(skill_name):
+    path = FIXTURES_DIR / skill_name / "SKILL.md"
+    result = parse_skill_md(path)
+    assert result is not None
+    assert result.name == skill_name
+
+
+@pytest.mark.parametrize("skill_name", ANTHROPIC_SKILLS)
+def test_description_extracted_correctly(skill_name):
+    path = FIXTURES_DIR / skill_name / "SKILL.md"
+    result = parse_skill_md(path)
+    assert result is not None
+    assert result.description, "description should not be empty"
+    expected = EXPECTED_DESCRIPTION_SUBSTRINGS[skill_name]
+    assert expected in result.description, (
+        f"Expected '{expected}' in description: {result.description[:80]}..."
+    )
+
+
+@pytest.mark.parametrize("skill_name", ANTHROPIC_SKILLS)
+def test_body_is_nonempty(skill_name):
+    path = FIXTURES_DIR / skill_name / "SKILL.md"
+    result = parse_skill_md(path)
+    assert result is not None
+    assert result.body, "body should not be empty"
+    assert "#" in result.body, "body should contain at least one markdown heading"
+
+
+@pytest.mark.parametrize("skill_name", ANTHROPIC_SKILLS)
+def test_optional_fields_handled(skill_name):
+    path = FIXTURES_DIR / skill_name / "SKILL.md"
+    result = parse_skill_md(path)
+    assert result is not None
+    # All 6 fixtures have a license field
+    assert result.license is not None, f"{skill_name} should have a license field"
+
+
+@pytest.mark.parametrize("skill_name", ANTHROPIC_SKILLS)
+def test_discovery_finds_skill(skill_name, tmp_path):
+    # Set up directory structure that discovery expects
+    skills_dir = tmp_path / ".agents" / "skills" / skill_name
+    skills_dir.mkdir(parents=True)
+    shutil.copy(FIXTURES_DIR / skill_name / "SKILL.md", skills_dir / "SKILL.md")
+
+    config = DiscoveryConfig(project_root=tmp_path, skip_user_scope=True, skip_framework_scope=True)
+    discovery = SkillDiscovery(config)
+    results = discovery.discover()
+
+    found_names = [s.name for s in results]
+    assert skill_name in found_names, f"{skill_name} not found by discovery"
+
+
+@pytest.mark.parametrize("skill_name", ANTHROPIC_SKILLS)
+def test_catalog_xml_output(skill_name):
+    path = FIXTURES_DIR / skill_name / "SKILL.md"
+    # Must use "project" scope — catalog.to_prompt() filters out "framework" scope
+    result = parse_skill_md(path, source_scope="project")
+    assert result is not None
+
+    catalog = SkillCatalog(skills=[result])
+    prompt = catalog.to_prompt()
+
+    assert f"<name>{skill_name}</name>" in prompt
+    assert "<description>" in prompt
+
+
+@pytest.mark.parametrize("skill_name", ANTHROPIC_SKILLS)
+def test_pre_activation_loads_body(skill_name):
+    path = FIXTURES_DIR / skill_name / "SKILL.md"
+    result = parse_skill_md(path, source_scope="project")
+    assert result is not None
+
+    catalog = SkillCatalog(skills=[result])
+    prompt = catalog.build_pre_activated_prompt([skill_name])
+
+    assert f"Pre-Activated Skill: {skill_name}" in prompt
+    assert result.body[:50] in prompt, "body content should appear in pre-activated prompt"
+
+
+# =============================================================================
+# Section B: Hive Default Skills → Spec
+# =============================================================================
+
+_DEFAULT_SKILLS_DIR = Path(__file__).parent.parent / "framework" / "skills" / "_default_skills"
+
+# From defaults.py SKILL_REGISTRY
+DEFAULT_SKILLS = {
+    "hive.note-taking": "note-taking",
+    "hive.batch-ledger": "batch-ledger",
+    "hive.context-preservation": "context-preservation",
+    "hive.quality-monitor": "quality-monitor",
+    "hive.error-recovery": "error-recovery",
+    "hive.task-decomposition": "task-decomposition",
+}
+
+
+@pytest.mark.parametrize("skill_name,dir_name", DEFAULT_SKILLS.items())
+def test_default_skills_parse(skill_name, dir_name):
+    path = _DEFAULT_SKILLS_DIR / dir_name / "SKILL.md"
+    result = parse_skill_md(path, source_scope="framework")
+    assert result is not None, f"Failed to parse default skill {skill_name}"
+
+
+@pytest.mark.parametrize("skill_name,dir_name", DEFAULT_SKILLS.items())
+def test_default_skills_have_required_fields(skill_name, dir_name):
+    path = _DEFAULT_SKILLS_DIR / dir_name / "SKILL.md"
+    result = parse_skill_md(path, source_scope="framework")
+    assert result is not None
+    assert result.name, "name should not be empty"
+    assert result.description, "description should not be empty"
+    assert result.body, "body should not be empty"
+
+
+@pytest.mark.parametrize("skill_name,dir_name", DEFAULT_SKILLS.items())
+def test_default_skills_name_convention(skill_name, dir_name):
+    path = _DEFAULT_SKILLS_DIR / dir_name / "SKILL.md"
+    result = parse_skill_md(path, source_scope="framework")
+    assert result is not None
+    assert result.name.startswith("hive."), (
+        f"Default skill name should start with 'hive.': {result.name}"
+    )
+
+
+@pytest.mark.parametrize("skill_name,dir_name", DEFAULT_SKILLS.items())
+def test_default_skills_metadata(skill_name, dir_name):
+    path = _DEFAULT_SKILLS_DIR / dir_name / "SKILL.md"
+    result = parse_skill_md(path, source_scope="framework")
+    assert result is not None
+    assert result.metadata is not None, f"{skill_name} should have metadata"
+    assert "author" in result.metadata, f"{skill_name} metadata missing 'author'"
+    assert "type" in result.metadata, f"{skill_name} metadata missing 'type'"


### PR DESCRIPTION
## Summary

- Vendor 6 SKILL.md fixtures from `anthropics/skills` (claude-api, pdf, xlsx, slack-gif-creator, mcp-builder, frontend-design)
- Add parametrized compatibility test suite covering parse, name/description extraction, body loading, discovery, catalog XML, and pre-activation
- Add bidirectional tests verifying Hive's 6 default skills conform to the Agent Skills spec (required fields, naming convention, metadata)

All 6 chosen fixtures have a `license` field, so `test_optional_fields_handled` only validates presence — not absence. Skills without `license` (e.g. `doc-coauthoring`, `skill-creator`) still parse correctly; they just aren't in the fixture set.

Closes #6368

## Test plan

- [x] 72 tests pass (48 Anthropic skill tests + 24 default skill tests)
- [x] Full suite (1268 tests) passes with no regressions
- [x] `uv run ruff check` and `uv run ruff format --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five new skill specifications: Claude API integration, frontend UI design, MCP server development, PDF processing, and spreadsheet management—each with detailed guidance and default configurations.

* **Tests**
  * Added comprehensive test suite validating skill specification parsing, discovery, catalog generation, and default skill requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->