### PR TITLE
fix(core): add LoopConfig validation to reject invalid configurations

### DIFF
--- a/core/framework/graph/event_loop_node.py
+++ b/core/framework/graph/event_loop_node.py
@@ -317,6 +317,32 @@ class LoopConfig:
         if self.hooks is None:
             object.__setattr__(self, "hooks", {})
 
+        # Validate numeric fields to catch misconfigurations early instead of
+        # producing silent misbehaviour at runtime (infinite loops, broken tool
+        # execution, etc.).
+        if self.max_iterations < 1:
+            raise ValueError(f"max_iterations must be >= 1, got {self.max_iterations}")
+        if self.max_tool_calls_per_turn < 1:
+            raise ValueError(
+                f"max_tool_calls_per_turn must be >= 1, got {self.max_tool_calls_per_turn}"
+            )
+        if self.tool_call_overflow_margin < 0.0:
+            raise ValueError(
+                f"tool_call_overflow_margin must be >= 0.0, got {self.tool_call_overflow_margin}"
+            )
+        if self.stall_detection_threshold < 1:
+            raise ValueError(
+                f"stall_detection_threshold must be >= 1, got {self.stall_detection_threshold}"
+            )
+        if self.max_context_tokens < 1:
+            raise ValueError(f"max_context_tokens must be >= 1, got {self.max_context_tokens}")
+        if self.max_stream_retries < 0:
+            raise ValueError(f"max_stream_retries must be >= 0, got {self.max_stream_retries}")
+        if self.tool_doom_loop_threshold < 1:
+            raise ValueError(
+                f"tool_doom_loop_threshold must be >= 1, got {self.tool_doom_loop_threshold}"
+            )
+
 
 # ---------------------------------------------------------------------------
 # Hook types

--- a/core/tests/test_event_loop_node.py
+++ b/core/tests/test_event_loop_node.py
@@ -2392,3 +2392,64 @@ class TestSubagentAccumulatorMemory:
         # Should return None (not raise PermissionError)
         assert scoped.read("tweet_content") is None
         assert scoped.read("user_request") == "hi"
+
+
+# ---------------------------------------------------------------------------
+# LoopConfig validation
+# ---------------------------------------------------------------------------
+
+
+class TestLoopConfigValidation:
+    """Verify that LoopConfig rejects invalid values at construction time."""
+
+    def test_default_config_valid(self):
+        """Default values must pass validation."""
+        config = LoopConfig()
+        assert config.max_iterations == 50
+
+    def test_custom_valid_config(self):
+        config = LoopConfig(max_iterations=10, max_tool_calls_per_turn=5)
+        assert config.max_iterations == 10
+        assert config.max_tool_calls_per_turn == 5
+
+    def test_max_iterations_zero_rejected(self):
+        with pytest.raises(ValueError, match="max_iterations"):
+            LoopConfig(max_iterations=0)
+
+    def test_max_iterations_negative_rejected(self):
+        with pytest.raises(ValueError, match="max_iterations"):
+            LoopConfig(max_iterations=-1)
+
+    def test_max_tool_calls_per_turn_zero_rejected(self):
+        with pytest.raises(ValueError, match="max_tool_calls_per_turn"):
+            LoopConfig(max_tool_calls_per_turn=0)
+
+    def test_tool_call_overflow_margin_negative_rejected(self):
+        with pytest.raises(ValueError, match="tool_call_overflow_margin"):
+            LoopConfig(tool_call_overflow_margin=-0.1)
+
+    def test_tool_call_overflow_margin_zero_allowed(self):
+        """Zero margin is valid — means no overflow tolerance."""
+        config = LoopConfig(tool_call_overflow_margin=0.0)
+        assert config.tool_call_overflow_margin == 0.0
+
+    def test_stall_detection_threshold_zero_rejected(self):
+        with pytest.raises(ValueError, match="stall_detection_threshold"):
+            LoopConfig(stall_detection_threshold=0)
+
+    def test_max_context_tokens_zero_rejected(self):
+        with pytest.raises(ValueError, match="max_context_tokens"):
+            LoopConfig(max_context_tokens=0)
+
+    def test_max_stream_retries_negative_rejected(self):
+        with pytest.raises(ValueError, match="max_stream_retries"):
+            LoopConfig(max_stream_retries=-1)
+
+    def test_max_stream_retries_zero_allowed(self):
+        """Zero retries is valid — disables retry logic."""
+        config = LoopConfig(max_stream_retries=0)
+        assert config.max_stream_retries == 0
+
+    def test_tool_doom_loop_threshold_zero_rejected(self):
+        with pytest.raises(ValueError, match="tool_doom_loop_threshold"):
+            LoopConfig(tool_doom_loop_threshold=0)


### PR DESCRIPTION
## Summary

- `LoopConfig` is a plain `@dataclass` with no input validation on numeric fields
- Invalid values cause silent misbehaviour: `max_iterations=0` makes the loop never execute, `max_iterations=-1` causes an infinite loop, `tool_call_overflow_margin=-1.0` discards all tool calls, `max_stream_retries=-1` retries forever
- These misconfigurations can arise from programmatic graph construction, self-evolving agents modifying configs, or user error — and are extremely hard to debug because there is no error message

### Changes

Extend `__post_init__` with bounds validation for all numeric fields:

| Field | Constraint | Rationale |
|-------|-----------|-----------|
| `max_iterations` | >= 1 | 0 = never executes; <0 = infinite loop |
| `max_tool_calls_per_turn` | >= 1 | 0 = all tools blocked |
| `tool_call_overflow_margin` | >= 0.0 | <0 = negative threshold |
| `stall_detection_threshold` | >= 1 | 0 = immediate stall |
| `max_context_tokens` | >= 1 | 0 = no context retained |
| `max_stream_retries` | >= 0 | <0 = infinite retries (0 = disabled) |
| `tool_doom_loop_threshold` | >= 1 | 0 = immediate doom loop |

12 new tests in `TestLoopConfigValidation` covering valid defaults, custom valid configs, boundary values, and rejection of each invalid case.

Closes #6703

## Test plan

- [x] All 12 new `TestLoopConfigValidation` tests pass
- [x] `ruff check` and `ruff format --check` pass
- [ ] Verify existing tests are not broken (default LoopConfig values all pass validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)