### PR TITLE
fix(core): resolve race condition in event_bus debug log initialization

### DIFF
--- a/core/framework/runtime/event_bus.py
+++ b/core/framework/runtime/event_bus.py
@@ -52,8 +52,63 @@ def _open_event_log() -> IO[str] | None:
     return open(path, "a", encoding="utf-8")  # noqa: SIM115
 
 
-_event_log_file: IO[str] | None = None
-_event_log_ready = False  # lazy init guard
+class _EventDebugLog:
+    """Async-safe singleton for the debug event log file.
+
+    Replaces the previous module-level globals that were vulnerable to a race
+    condition: multiple concurrent ``publish()`` coroutines could both see the
+    ``_event_log_ready`` flag as ``False`` and open duplicate file handles,
+    leaking the first one.
+
+    The singleton uses an ``asyncio.Lock`` to guarantee one-time initialisation,
+    and exposes a ``close()`` method for orderly shutdown.
+    """
+
+    _instance: "_EventDebugLog | None" = None
+    _init_lock: asyncio.Lock | None = None
+
+    def __init__(self) -> None:
+        self._file: IO[str] | None = None
+
+    @classmethod
+    async def get(cls) -> "_EventDebugLog":
+        """Return the singleton, lazily opening the log file on first call."""
+        if cls._init_lock is None:
+            cls._init_lock = asyncio.Lock()
+        async with cls._init_lock:
+            if cls._instance is None:
+                inst = cls()
+                inst._file = _open_event_log()
+                cls._instance = inst
+            return cls._instance
+
+    def write_event(self, event: "AgentEvent") -> None:
+        """Serialise and append *event* to the debug log."""
+        if self._file is None:
+            return
+        try:
+            line = json.dumps(event.to_dict(), default=str)
+            self._file.write(line + "\n")
+            self._file.flush()
+        except Exception:
+            pass  # never break event delivery
+
+    def close(self) -> None:
+        """Flush and close the underlying file handle."""
+        if self._file is not None:
+            try:
+                self._file.close()
+            except Exception:
+                pass
+            self._file = None
+
+    @classmethod
+    def reset(cls) -> None:
+        """Close and discard the singleton (for testing)."""
+        if cls._instance is not None:
+            cls._instance.close()
+            cls._instance = None
+        cls._init_lock = None
 
 
 class EventType(StrEnum):
@@ -289,7 +344,7 @@ class EventBus:
         logger.info("Session event log → %s (iteration_offset=%d)", path, iteration_offset)
 
     def close_session_log(self) -> None:
-        """Close the per-session event log file."""
+        """Close the per-session event log file and the debug event log."""
         # Flush any pending output snapshots before closing
         self._flush_pending_snapshots()
         if self._session_log is not None:
@@ -298,6 +353,8 @@ class EventBus:
             except Exception:
                 pass
             self._session_log = None
+        # Also close the debug event log to avoid leaking file handles.
+        _EventDebugLog.reset()
 
     # Event types that are high-frequency streaming deltas — accumulated rather
     # than written individually to the session log.
@@ -466,19 +523,12 @@ class EventBus:
             if len(self._event_history) > self._max_history:
                 self._event_history = self._event_history[-self._max_history :]
 
-        # Write event to JSONL file (gated by HIVE_DEBUG_EVENTS env var)
+        # Write event to JSONL debug log (gated by HIVE_DEBUG_EVENTS env var).
+        # Uses an async-safe singleton to avoid the race condition where
+        # concurrent publish() calls could open duplicate file handles.
         if _DEBUG_EVENTS_ENABLED:
-            global _event_log_file, _event_log_ready  # noqa: PLW0603
-            if not _event_log_ready:
-                _event_log_file = _open_event_log()
-                _event_log_ready = True
-            if _event_log_file is not None:
-                try:
-                    line = json.dumps(event.to_dict(), default=str)
-                    _event_log_file.write(line + "\n")
-                    _event_log_file.flush()
-                except Exception:
-                    pass  # never break event delivery
+            debug_log = await _EventDebugLog.get()
+            debug_log.write_event(event)
 
         # Per-session persistent log (always-on when set_session_log was called).
         # Streaming deltas are coalesced: client_output_delta and llm_text_delta

--- a/core/tests/test_event_bus_debug_log.py
+++ b/core/tests/test_event_bus_debug_log.py
@@ -1,0 +1,221 @@
+"""Tests for EventBus debug log race condition fix.
+
+Validates that the _EventDebugLog singleton initializes exactly once under
+concurrent access, properly cleans up file handles, and does not create
+files when debug mode is disabled.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from framework.runtime.event_bus import (
+    AgentEvent,
+    EventBus,
+    EventType,
+    _EventDebugLog,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_debug_log():
+    """Ensure clean singleton state for each test."""
+    _EventDebugLog.reset()
+    yield
+    _EventDebugLog.reset()
+
+
+class TestEventDebugLogSingleton:
+    """Verify the _EventDebugLog singleton initializes safely."""
+
+    @pytest.mark.asyncio
+    async def test_singleton_returns_same_instance(self):
+        """Multiple calls to get() must return the same instance."""
+        with (
+            patch("framework.runtime.event_bus._DEBUG_EVENTS_ENABLED", True),
+            patch(
+                "framework.runtime.event_bus._open_event_log",
+                return_value=None,
+            ),
+        ):
+            inst1 = await _EventDebugLog.get()
+            inst2 = await _EventDebugLog.get()
+            assert inst1 is inst2
+
+    @pytest.mark.asyncio
+    async def test_concurrent_get_initializes_once(self):
+        """Concurrent get() calls must only open the log file once."""
+        open_count = 0
+
+        def counting_open():
+            nonlocal open_count
+            open_count += 1
+            return None
+
+        with (
+            patch("framework.runtime.event_bus._DEBUG_EVENTS_ENABLED", True),
+            patch(
+                "framework.runtime.event_bus._open_event_log",
+                side_effect=counting_open,
+            ),
+        ):
+            # Launch many concurrent get() calls
+            tasks = [asyncio.create_task(_EventDebugLog.get()) for _ in range(20)]
+            instances = await asyncio.gather(*tasks)
+
+            # All must be the same instance
+            assert all(inst is instances[0] for inst in instances)
+            # _open_event_log called exactly once
+            assert open_count == 1
+
+    @pytest.mark.asyncio
+    async def test_reset_allows_reinitialisation(self):
+        """After reset(), the next get() creates a fresh instance."""
+        with (
+            patch("framework.runtime.event_bus._DEBUG_EVENTS_ENABLED", True),
+            patch(
+                "framework.runtime.event_bus._open_event_log",
+                return_value=None,
+            ),
+        ):
+            inst1 = await _EventDebugLog.get()
+            _EventDebugLog.reset()
+            inst2 = await _EventDebugLog.get()
+            assert inst1 is not inst2
+
+
+class TestEventDebugLogWriteAndClose:
+    """Verify write_event and close behaviour."""
+
+    @pytest.mark.asyncio
+    async def test_write_event_to_file(self, tmp_path: Path):
+        """Events are serialised as JSONL to the underlying file."""
+        log_path = tmp_path / "events.jsonl"
+        fh = open(log_path, "a", encoding="utf-8")
+
+        with (
+            patch("framework.runtime.event_bus._DEBUG_EVENTS_ENABLED", True),
+            patch(
+                "framework.runtime.event_bus._open_event_log",
+                return_value=fh,
+            ),
+        ):
+            debug_log = await _EventDebugLog.get()
+
+            event = AgentEvent(
+                type=EventType.EXECUTION_STARTED,
+                stream_id="test-stream",
+                data={"info": "hello"},
+            )
+            debug_log.write_event(event)
+
+        fh.close()
+
+        lines = log_path.read_text(encoding="utf-8").strip().split("\n")
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["type"] == "execution_started"
+        assert parsed["stream_id"] == "test-stream"
+
+    @pytest.mark.asyncio
+    async def test_write_event_noop_when_file_is_none(self):
+        """write_event must not raise when file handle is None."""
+        with (
+            patch("framework.runtime.event_bus._DEBUG_EVENTS_ENABLED", True),
+            patch(
+                "framework.runtime.event_bus._open_event_log",
+                return_value=None,
+            ),
+        ):
+            debug_log = await _EventDebugLog.get()
+            event = AgentEvent(
+                type=EventType.EXECUTION_STARTED,
+                stream_id="s",
+                data={},
+            )
+            # Should not raise
+            debug_log.write_event(event)
+
+    @pytest.mark.asyncio
+    async def test_close_closes_file_handle(self, tmp_path: Path):
+        """close() must close the underlying file handle."""
+        log_path = tmp_path / "events.jsonl"
+        fh = open(log_path, "a", encoding="utf-8")
+
+        with (
+            patch("framework.runtime.event_bus._DEBUG_EVENTS_ENABLED", True),
+            patch(
+                "framework.runtime.event_bus._open_event_log",
+                return_value=fh,
+            ),
+        ):
+            debug_log = await _EventDebugLog.get()
+            debug_log.close()
+            assert fh.closed
+
+
+class TestEventBusDebugIntegration:
+    """Integration: EventBus.publish() uses the debug log correctly."""
+
+    @pytest.mark.asyncio
+    async def test_publish_writes_to_debug_log(self, tmp_path: Path):
+        """publish() should write to the debug log when enabled."""
+        log_path = tmp_path / "events.jsonl"
+        fh = open(log_path, "a", encoding="utf-8")
+
+        with (
+            patch("framework.runtime.event_bus._DEBUG_EVENTS_ENABLED", True),
+            patch(
+                "framework.runtime.event_bus._open_event_log",
+                return_value=fh,
+            ),
+        ):
+            bus = EventBus()
+            event = AgentEvent(
+                type=EventType.EXECUTION_STARTED,
+                stream_id="bus-test",
+                data={"step": 1},
+            )
+            await bus.publish(event)
+
+        fh.close()
+
+        lines = log_path.read_text(encoding="utf-8").strip().split("\n")
+        assert len(lines) == 1
+        assert "bus-test" in lines[0]
+
+    @pytest.mark.asyncio
+    async def test_publish_skips_debug_when_disabled(self):
+        """publish() must not touch the debug log when disabled."""
+        with patch("framework.runtime.event_bus._DEBUG_EVENTS_ENABLED", False):
+            bus = EventBus()
+            event = AgentEvent(
+                type=EventType.EXECUTION_STARTED,
+                stream_id="s",
+                data={},
+            )
+            # Should not raise or create any file
+            await bus.publish(event)
+            assert _EventDebugLog._instance is None
+
+    @pytest.mark.asyncio
+    async def test_close_session_log_resets_debug_log(self, tmp_path: Path):
+        """close_session_log() should also reset the debug log singleton."""
+        with (
+            patch("framework.runtime.event_bus._DEBUG_EVENTS_ENABLED", True),
+            patch(
+                "framework.runtime.event_bus._open_event_log",
+                return_value=None,
+            ),
+        ):
+            bus = EventBus()
+            await bus.publish(AgentEvent(type=EventType.EXECUTION_STARTED, stream_id="s", data={}))
+            assert _EventDebugLog._instance is not None
+
+            bus.close_session_log()
+            assert _EventDebugLog._instance is None


### PR DESCRIPTION
## Summary

- The debug event log (`HIVE_DEBUG_EVENTS=1`) used module-level global variables (`_event_log_file`, `_event_log_ready`) initialized lazily in `publish()` **without any `asyncio.Lock`**
- When multiple coroutines called `publish()` concurrently (normal in multi-stream agents), both could see `_event_log_ready == False`, both call `_open_event_log()`, and the first file handle was leaked (never closed)
- No cleanup path existed — the file handle was never closed on shutdown

### Changes

1. **Replaced global state with `_EventDebugLog` singleton** — uses `asyncio.Lock` to guarantee one-time initialization regardless of concurrent access
2. **Added proper lifecycle management** — `close()` flushes and closes the file handle; `reset()` discards the singleton for testing and shutdown
3. **Integrated cleanup with `EventBus.close_session_log()`** — the debug log is reset when the session log is closed, preventing file handle leaks

### 9 new tests covering:

| Test | What it verifies |
|------|-----------------|
| `test_singleton_returns_same_instance` | `get()` returns same object |
| `test_concurrent_get_initializes_once` | 20 parallel coroutines → 1 file open |
| `test_reset_allows_reinitialisation` | Fresh instance after `reset()` |
| `test_write_event_to_file` | JSONL serialisation works |
| `test_write_event_noop_when_file_is_none` | No crash when disabled |
| `test_close_closes_file_handle` | File handle properly closed |
| `test_publish_writes_to_debug_log` | End-to-end via `EventBus.publish()` |
| `test_publish_skips_debug_when_disabled` | No singleton created when disabled |
| `test_close_session_log_resets_debug_log` | Cleanup integration |

Closes #6701

## Test plan

- [x] All 9 new tests pass
- [x] `ruff check` and `ruff format --check` pass
- [ ] Verify existing event bus consumers are not affected (the public API is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)