### PR TITLE
docs(tools): add README.md for kafka, redis, and mongodb tools

### DIFF
--- a/tools/src/aden_tools/tools/kafka_tool/README.md
+++ b/tools/src/aden_tools/tools/kafka_tool/README.md
@@ -1,0 +1,32 @@
+# Kafka Tool
+
+Manage Apache Kafka topics, produce messages, and monitor consumer groups via the Confluent REST Proxy v3.
+
+## Supported Actions
+
+- **kafka_list_topics** – List all topics in the cluster with partition and replication metadata
+- **kafka_get_topic** – Get detailed metadata for a specific topic
+- **kafka_create_topic** – Create a new topic with configurable partitions and replication factor
+- **kafka_produce_message** – Produce a message (JSON, STRING, or BINARY) to a topic with optional key
+- **kafka_list_consumer_groups** – List all consumer groups and their states
+- **kafka_get_consumer_group_lag** – Get lag summary for a consumer group (max lag, total lag, lagging partitions)
+
+## Setup
+
+1. Deploy or connect to a [Confluent REST Proxy](https://docs.confluent.io/platform/current/kafka-rest/index.html) instance.
+
+2. Set the required environment variables:
+   ```bash
+   export KAFKA_REST_URL=http://localhost:8082   # REST Proxy URL
+   export KAFKA_CLUSTER_ID=your-cluster-id       # Kafka cluster ID
+   ```
+
+3. For authenticated clusters, also set:
+   ```bash
+   export KAFKA_API_KEY=your-api-key
+   export KAFKA_API_SECRET=your-api-secret
+   ```
+
+## Use Case
+
+Example: "Monitor consumer group lag across all topics and alert when any group falls behind by more than 10,000 messages."

--- a/tools/src/aden_tools/tools/mongodb_tool/README.md
+++ b/tools/src/aden_tools/tools/mongodb_tool/README.md
@@ -1,0 +1,29 @@
+# MongoDB Tool
+
+Document CRUD and aggregation via the MongoDB Atlas Data API (or compatible replacements like Delbridge and RESTHeart).
+
+## Supported Actions
+
+- **mongodb_find** – Query documents with filter, projection, sort, and limit
+- **mongodb_find_one** – Find a single document by filter
+- **mongodb_insert_one** – Insert a document into a collection
+- **mongodb_update_one** – Update a document with filter and update operators
+- **mongodb_delete_one** – Delete a single document by filter
+- **mongodb_aggregate** – Run an aggregation pipeline
+
+## Setup
+
+1. Enable the [Atlas Data API](https://www.mongodb.com/docs/atlas/app-services/data-api/) or deploy a compatible REST interface.
+
+2. Set the required environment variables:
+   ```bash
+   export MONGODB_DATA_API_URL=https://data.mongodb-api.com/app/<app-id>/endpoint/data/v1
+   export MONGODB_API_KEY=your-api-key
+   export MONGODB_DATA_SOURCE=your-cluster-name
+   ```
+
+> **Note:** The Atlas Data API reached EOL in September 2025. Compatible replacements (Delbridge, RESTHeart) use the same interface.
+
+## Use Case
+
+Example: "Query the `transactions` collection for all records over $10,000 in the last 24 hours and aggregate them by merchant category."

--- a/tools/src/aden_tools/tools/redis_tool/README.md
+++ b/tools/src/aden_tools/tools/redis_tool/README.md
@@ -1,0 +1,31 @@
+# Redis Tool
+
+In-memory data store operations for key-value, hash, list, pub/sub, and TTL management.
+
+## Supported Actions
+
+- **redis_get** / **redis_set** / **redis_delete** – Basic key-value operations with optional TTL
+- **redis_keys** – Non-blocking key scan with glob patterns (uses SCAN, not KEYS)
+- **redis_hset** / **redis_hgetall** – Hash field operations
+- **redis_lpush** / **redis_lrange** – List push and range queries
+- **redis_publish** – Pub/sub message publishing
+- **redis_info** – Server stats (version, memory, connections, keyspace)
+- **redis_ttl** – Check remaining TTL on a key
+
+## Setup
+
+Set the connection URL:
+```bash
+export REDIS_URL=redis://localhost:6379
+```
+
+For authenticated instances:
+```bash
+export REDIS_URL=redis://:your-password@host:6379/0
+```
+
+The tool also supports the Hive credential store — store the URL under the `redis` credential key.
+
+## Use Case
+
+Example: "Cache API responses for 5 minutes to avoid rate limits, and publish a notification to the `cache-invalidation` channel when stale entries are cleared."


### PR DESCRIPTION
## Summary

Adds missing README.md documentation for three enterprise-critical tools, addressing part of #6487 (43 tools missing README.md).

Each README follows the established format used by `discord_tool` and `email_tool`:
- Tool description
- Supported actions with brief explanations
- Setup instructions with environment variables
- Practical use case example

### Tools documented

| Tool | Actions | Key credentials |
|------|---------|----------------|
| **kafka_tool** | list/get/create topics, produce messages, consumer group lag | `KAFKA_REST_URL`, `KAFKA_CLUSTER_ID` |
| **redis_tool** | key-value, hash, list, pub/sub, TTL, server info | `REDIS_URL` |
| **mongodb_tool** | find, insert, update, delete, aggregate | `MONGODB_DATA_API_URL`, `MONGODB_API_KEY` |

## Test plan

- [x] Verified action names match actual tool function names in source code
- [x] Verified credential variable names match source code
- [x] Follows existing README format (discord_tool, email_tool)

🤖 Generated with [Claude Code](https://claude.com/claude-code)