### PR TITLE
docs(tools): add README.md for jira, hubspot, linear, snowflake, and aws-s3 tools

### DIFF
--- a/tools/src/aden_tools/tools/aws_s3_tool/README.md
+++ b/tools/src/aden_tools/tools/aws_s3_tool/README.md
@@ -1,0 +1,29 @@
+# AWS S3 Tool
+
+Object storage operations via the S3 REST API with SigV4 request signing.
+
+## Supported Actions
+
+- **s3_list_buckets** – List all buckets in the account
+- **s3_list_objects** – List objects in a bucket with optional prefix filter
+- **s3_get_object** – Download an object (returns text content or base64 for binary)
+- **s3_put_object** – Upload content to a key
+- **s3_delete_object** – Delete an object
+- **s3_copy_object** – Copy an object between keys or buckets
+- **s3_get_object_metadata** – Retrieve object metadata (size, content type, last modified)
+- **s3_generate_presigned_url** – Generate a time-limited presigned URL for sharing
+
+## Setup
+
+1. Create an IAM user or role with S3 permissions.
+
+2. Set the required environment variables:
+   ```bash
+   export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+   export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+   export AWS_REGION=us-east-1
+   ```
+
+## Use Case
+
+Example: "List all CSV files uploaded to the `data-ingestion/raw/` prefix today, download each one, and generate presigned URLs for the analytics team to review."

--- a/tools/src/aden_tools/tools/hubspot_tool/README.md
+++ b/tools/src/aden_tools/tools/hubspot_tool/README.md
@@ -1,0 +1,31 @@
+# HubSpot Tool
+
+Manage contacts, companies, and deals via the HubSpot CRM API v3.
+
+## Supported Actions
+
+### Contacts
+- **hubspot_search_contacts** / **hubspot_get_contact** / **hubspot_create_contact** / **hubspot_update_contact**
+
+### Companies
+- **hubspot_search_companies** / **hubspot_get_company** / **hubspot_create_company** / **hubspot_update_company**
+
+### Deals
+- **hubspot_search_deals** / **hubspot_get_deal** / **hubspot_create_deal** / **hubspot_update_deal**
+
+### Associations & Cleanup
+- **hubspot_list_associations** / **hubspot_create_association** – Link objects together
+- **hubspot_delete_object** – Delete any CRM object by type and ID
+
+## Setup
+
+1. Create a Private App in HubSpot (Settings → Integrations → Private Apps).
+
+2. Set the environment variable:
+   ```bash
+   export HUBSPOT_ACCESS_TOKEN=your-private-app-token
+   ```
+
+## Use Case
+
+Example: "Find all contacts who signed up in the last 7 days, create a deal for each, and associate them with the 'Onboarding' pipeline."

--- a/tools/src/aden_tools/tools/jira_tool/README.md
+++ b/tools/src/aden_tools/tools/jira_tool/README.md
@@ -1,0 +1,26 @@
+# Jira Tool
+
+Issue tracking and project management via the Jira Cloud REST API v3.
+
+## Supported Actions
+
+- **jira_search_issues** – Search issues using JQL queries
+- **jira_get_issue** / **jira_create_issue** / **jira_update_issue** – Issue CRUD
+- **jira_list_projects** / **jira_get_project** – Browse projects
+- **jira_add_comment** – Add comments to issues
+- **jira_list_transitions** / **jira_transition_issue** – Move issues through workflow states
+
+## Setup
+
+1. Generate an API token at [Atlassian API Tokens](https://id.atlassian.com/manage-profile/security/api-tokens).
+
+2. Set the required environment variables:
+   ```bash
+   export JIRA_URL=https://your-domain.atlassian.net
+   export JIRA_EMAIL=your-email@example.com
+   export JIRA_API_TOKEN=your-api-token
+   ```
+
+## Use Case
+
+Example: "Search for all P1 bugs assigned to me in the PLATFORM project and transition any that have a linked PR to 'In Review'."

--- a/tools/src/aden_tools/tools/linear_tool/README.md
+++ b/tools/src/aden_tools/tools/linear_tool/README.md
@@ -1,0 +1,34 @@
+# Linear Tool
+
+Manage issues, projects, teams, and workflows via the Linear GraphQL API.
+
+## Supported Actions
+
+### Issues
+- **linear_issue_create** / **linear_issue_get** / **linear_issue_update** / **linear_issue_delete**
+- **linear_issue_search** – Full-text search across issues
+- **linear_issue_add_comment** / **linear_issue_comments_list**
+- **linear_issue_relation_create** – Link related issues
+
+### Projects & Teams
+- **linear_project_create** / **linear_project_get** / **linear_project_update** / **linear_project_list**
+- **linear_teams_list** / **linear_team_get**
+
+### Workflow & Organization
+- **linear_workflow_states_get** – List workflow states for a team
+- **linear_label_create** / **linear_labels_list**
+- **linear_cycles_list** – List sprint cycles
+- **linear_users_list** / **linear_user_get** / **linear_viewer** – User management
+
+## Setup
+
+1. Create a Personal API Key at [Linear Settings → API](https://linear.app/settings/api).
+
+2. Set the environment variable:
+   ```bash
+   export LINEAR_API_KEY=lin_api_xxxxxxxxxxxx
+   ```
+
+## Use Case
+
+Example: "Find all issues in the 'Backend' team that are blocked, add a comment asking for an update, and move any older than 7 days to the 'Needs Triage' state."

--- a/tools/src/aden_tools/tools/snowflake_tool/README.md
+++ b/tools/src/aden_tools/tools/snowflake_tool/README.md
@@ -1,0 +1,30 @@
+# Snowflake Tool
+
+Execute SQL statements against Snowflake via the REST API v2.
+
+## Supported Actions
+
+- **snowflake_execute_sql** – Submit a SQL statement for execution (returns statement handle for async queries)
+- **snowflake_get_statement_status** – Check the status and retrieve results of a submitted statement
+- **snowflake_cancel_statement** – Cancel a running statement
+
+## Setup
+
+1. Generate a Snowflake OAuth token or use key-pair authentication.
+
+2. Set the required environment variables:
+   ```bash
+   export SNOWFLAKE_ACCOUNT=your-account-identifier    # e.g., xy12345.us-east-1
+   export SNOWFLAKE_TOKEN=your-oauth-or-jwt-token
+   ```
+
+3. Optionally set defaults:
+   ```bash
+   export SNOWFLAKE_WAREHOUSE=COMPUTE_WH
+   export SNOWFLAKE_DATABASE=MY_DB
+   export SNOWFLAKE_SCHEMA=PUBLIC
+   ```
+
+## Use Case
+
+Example: "Run a daily query to aggregate transaction volumes by merchant category and check if any category exceeds the 30-day rolling average by more than 2 standard deviations."


### PR DESCRIPTION
## Summary

Adds missing README.md documentation for five more enterprise tools, continuing the work from #6708 toward addressing #6487 (43 tools missing README.md).

Each README follows the established format (discord_tool, email_tool):
- Tool description and supported actions
- Setup instructions with environment variables
- Practical use case example

### Tools documented

| Tool | Actions | Key credentials |
|------|---------|----------------|
| **jira_tool** | JQL search, issue CRUD, comments, transitions | `JIRA_URL`, `JIRA_EMAIL`, `JIRA_API_TOKEN` |
| **hubspot_tool** | Contact/company/deal CRUD, search, associations | `HUBSPOT_ACCESS_TOKEN` |
| **linear_tool** | Issue/project/team management, workflows, labels, cycles | `LINEAR_API_KEY` |
| **snowflake_tool** | SQL execution, status polling, statement cancellation | `SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_TOKEN` |
| **aws_s3_tool** | Bucket/object CRUD, copy, metadata, presigned URLs | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` |

**Progress:** 8 of 41 missing tool READMEs now documented (this PR + #6708).

## Test plan

- [x] Action names verified against source code function definitions
- [x] Credential variable names verified against source code
- [x] Follows established README format

🤖 Generated with [Claude Code](https://claude.com/claude-code)