### PR TITLE
docs(tools): add README.md for gitlab, docker-hub, confluence, salesforce, and terraform tools

### DIFF
--- a/tools/src/aden_tools/tools/confluence_tool/README.md
+++ b/tools/src/aden_tools/tools/confluence_tool/README.md
@@ -1,0 +1,26 @@
+# Confluence Tool
+
+Wiki and knowledge management via the Confluence Cloud REST API v2.
+
+## Supported Actions
+
+- **confluence_list_spaces** – List available spaces
+- **confluence_list_pages** / **confluence_get_page** – Browse and read pages
+- **confluence_create_page** / **confluence_update_page** / **confluence_delete_page** – Page CRUD
+- **confluence_search** – Full-text search using CQL (Confluence Query Language)
+- **confluence_get_page_children** – List child pages of a parent
+
+## Setup
+
+1. Generate an API token at [Atlassian API Tokens](https://id.atlassian.com/manage-profile/security/api-tokens).
+
+2. Set the required environment variables:
+   ```bash
+   export CONFLUENCE_URL=https://your-domain.atlassian.net
+   export CONFLUENCE_EMAIL=your-email@example.com
+   export CONFLUENCE_API_TOKEN=your-api-token
+   ```
+
+## Use Case
+
+Example: "Search the Engineering space for all pages mentioning 'database migration', then update the runbook page with the latest procedure."

--- a/tools/src/aden_tools/tools/docker_hub_tool/README.md
+++ b/tools/src/aden_tools/tools/docker_hub_tool/README.md
@@ -1,0 +1,27 @@
+# Docker Hub Tool
+
+Search repositories, list tags, and inspect container images via the Docker Hub API v2.
+
+## Supported Actions
+
+- **docker_hub_search** – Search for public repositories
+- **docker_hub_list_repos** – List repositories for an authenticated user/org
+- **docker_hub_list_tags** – List available tags for a repository
+- **docker_hub_get_repo** – Get detailed repository metadata
+- **docker_hub_get_tag_detail** – Inspect a specific tag (architecture, size, digest)
+- **docker_hub_delete_tag** – Delete a tag from a repository
+- **docker_hub_list_webhooks** – List configured webhooks for a repository
+
+## Setup
+
+1. Create a Personal Access Token at [Docker Hub](https://hub.docker.com/settings/security).
+
+2. Set the required environment variables:
+   ```bash
+   export DOCKER_HUB_USERNAME=your-username
+   export DOCKER_HUB_TOKEN=dckr_pat_xxxxxxxxxxxx
+   ```
+
+## Use Case
+
+Example: "List all tags for the `myorg/api-server` image, find any that are older than 90 days, and delete them to free up storage."

--- a/tools/src/aden_tools/tools/gitlab_tool/README.md
+++ b/tools/src/aden_tools/tools/gitlab_tool/README.md
@@ -1,0 +1,29 @@
+# GitLab Tool
+
+Manage projects, issues, and merge requests via the GitLab REST API v4. Supports both GitLab.com and self-hosted instances.
+
+## Supported Actions
+
+### Projects
+- **gitlab_list_projects** / **gitlab_get_project** – Browse and inspect projects
+
+### Issues
+- **gitlab_list_issues** / **gitlab_get_issue** / **gitlab_create_issue** / **gitlab_update_issue** – Issue CRUD with filtering
+
+### Merge Requests
+- **gitlab_list_merge_requests** / **gitlab_get_merge_request** – Browse MRs
+- **gitlab_create_merge_request_note** – Add comments to merge requests
+
+## Setup
+
+1. Create a Personal Access Token at GitLab (Settings → Access Tokens) with `api` scope.
+
+2. Set the required environment variables:
+   ```bash
+   export GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
+   export GITLAB_URL=https://gitlab.com   # or your self-hosted instance
+   ```
+
+## Use Case
+
+Example: "List all open merge requests in the platform project that have been waiting for review for more than 3 days and add a comment requesting an update."

--- a/tools/src/aden_tools/tools/salesforce_tool/README.md
+++ b/tools/src/aden_tools/tools/salesforce_tool/README.md
@@ -1,0 +1,26 @@
+# Salesforce Tool
+
+Manage Leads, Contacts, Opportunities, and run SOQL queries via the Salesforce REST API.
+
+## Supported Actions
+
+- **salesforce_soql_query** – Execute SOQL queries against any object
+- **salesforce_get_record** / **salesforce_create_record** / **salesforce_update_record** / **salesforce_delete_record** – Record CRUD
+- **salesforce_describe_object** – Get object schema (fields, types, relationships)
+- **salesforce_list_objects** – List all available SObjects
+- **salesforce_search_records** – Full-text SOSL search across objects
+- **salesforce_get_record_count** – Count records matching a filter
+
+## Setup
+
+1. Create a Connected App in Salesforce and obtain an OAuth2 access token.
+
+2. Set the required environment variables:
+   ```bash
+   export SALESFORCE_ACCESS_TOKEN=your-oauth2-access-token
+   export SALESFORCE_INSTANCE_URL=https://your-instance.salesforce.com
+   ```
+
+## Use Case
+
+Example: "Query all Opportunities closing this quarter with amount over $50K, update their stage to 'Negotiation', and create a summary report."

--- a/tools/src/aden_tools/tools/terraform_tool/README.md
+++ b/tools/src/aden_tools/tools/terraform_tool/README.md
@@ -1,0 +1,29 @@
+# Terraform Tool
+
+Manage workspaces and runs via the Terraform Cloud / HCP Terraform REST API v2.
+
+## Supported Actions
+
+- **terraform_list_workspaces** – List workspaces in an organization
+- **terraform_get_workspace** – Get workspace details (VCS settings, execution mode, last run)
+- **terraform_list_runs** – List runs for a workspace with status filtering
+- **terraform_get_run** – Get detailed run information (plan, apply, cost estimate)
+- **terraform_create_run** – Trigger a new plan/apply run
+
+## Setup
+
+1. Create an API token at [Terraform Cloud](https://app.terraform.io/app/settings/tokens) (User, Team, or Organization token).
+
+2. Set the required environment variables:
+   ```bash
+   export TFC_TOKEN=your-terraform-cloud-token
+   ```
+
+3. For Terraform Enterprise (self-hosted):
+   ```bash
+   export TFC_URL=https://your-tfe-instance.example.com
+   ```
+
+## Use Case
+
+Example: "List all workspaces in the production organization, check which ones have pending runs, and trigger a plan for any workspace that hasn't been applied in the last 7 days."


### PR DESCRIPTION
## Summary

Adds missing README.md for five DevOps and enterprise tools, continuing toward #6487 (43 tools missing README.md).

| Tool | Actions | Key credentials |
|------|---------|----------------|
| **gitlab_tool** | Projects, issues, MRs, MR comments | `GITLAB_TOKEN`, `GITLAB_URL` |
| **docker_hub_tool** | Search repos, list/inspect/delete tags, webhooks | `DOCKER_HUB_USERNAME`, `DOCKER_HUB_TOKEN` |
| **confluence_tool** | Spaces, pages CRUD, CQL search, child pages | `CONFLUENCE_URL`, `CONFLUENCE_EMAIL`, `CONFLUENCE_API_TOKEN` |
| **salesforce_tool** | SOQL queries, record CRUD, object schema, SOSL search | `SALESFORCE_ACCESS_TOKEN`, `SALESFORCE_INSTANCE_URL` |
| **terraform_tool** | Workspaces, runs, plan/apply triggers | `TFC_TOKEN` |

**Progress:** 13 of 41 missing tool READMEs now documented (PRs #6708, #6709, and this one).

## Test plan

- [x] Action names verified against source code
- [x] Credential variables verified against source code
- [x] Follows established README format

🤖 Generated with [Claude Code](https://claude.com/claude-code)