### PR TITLE
docs(tools): add README.md for twilio, zendesk, zoom, pagerduty, and supabase tools

### DIFF
--- a/tools/src/aden_tools/tools/pagerduty_tool/README.md
+++ b/tools/src/aden_tools/tools/pagerduty_tool/README.md
@@ -1,0 +1,25 @@
+# PagerDuty Tool
+
+Incident management and on-call operations via the PagerDuty REST API v2.
+
+## Supported Actions
+
+- **pagerduty_list_incidents** / **pagerduty_get_incident** / **pagerduty_create_incident** / **pagerduty_update_incident** – Incident lifecycle management
+- **pagerduty_list_services** – List monitored services
+- **pagerduty_list_oncalls** – List current on-call schedules
+- **pagerduty_add_incident_note** – Add a note to an incident timeline
+- **pagerduty_list_escalation_policies** – List escalation policies
+
+## Setup
+
+1. Create an API key in PagerDuty (Integrations → API Access Keys).
+
+2. Set the required environment variables:
+   ```bash
+   export PAGERDUTY_API_KEY=your-api-key
+   export PAGERDUTY_FROM_EMAIL=your-email@example.com   # required for write operations
+   ```
+
+## Use Case
+
+Example: "List all triggered incidents on the 'Production API' service, acknowledge them, add a note with initial triage findings, and page the current on-call if any are P1."

--- a/tools/src/aden_tools/tools/supabase_tool/README.md
+++ b/tools/src/aden_tools/tools/supabase_tool/README.md
@@ -1,0 +1,34 @@
+# Supabase Tool
+
+Database queries, authentication, and edge function invocation via the Supabase REST API.
+
+## Supported Actions
+
+### Database (PostgREST)
+- **supabase_select** – Query rows with filters, ordering, and pagination
+- **supabase_insert** – Insert one or more rows
+- **supabase_update** – Update rows matching a filter
+- **supabase_delete** – Delete rows matching a filter
+
+### Authentication (GoTrue)
+- **supabase_auth_signup** – Create a new user account
+- **supabase_auth_signin** – Sign in with email and password
+
+### Edge Functions
+- **supabase_edge_invoke** – Invoke a deployed edge function with custom payload
+
+## Setup
+
+1. Get your project URL and API keys from the [Supabase Dashboard](https://supabase.com/dashboard) (Settings → API).
+
+2. Set the required environment variables:
+   ```bash
+   export SUPABASE_URL=https://your-project-id.supabase.co
+   export SUPABASE_KEY=your-anon-or-service-role-key
+   ```
+
+   Use the **anon key** for client-side operations or the **service role key** for admin operations (bypasses Row Level Security).
+
+## Use Case
+
+Example: "Query the `orders` table for all pending orders from the last 24 hours, invoke the `process-payment` edge function for each, and update their status to 'completed'."

--- a/tools/src/aden_tools/tools/twilio_tool/README.md
+++ b/tools/src/aden_tools/tools/twilio_tool/README.md
@@ -1,0 +1,26 @@
+# Twilio Tool
+
+SMS and WhatsApp messaging via the Twilio REST API.
+
+## Supported Actions
+
+- **twilio_send_sms** – Send an SMS message
+- **twilio_send_whatsapp** – Send a WhatsApp message
+- **twilio_list_messages** / **twilio_get_message** / **twilio_delete_message** – Message management
+- **twilio_list_phone_numbers** – List phone numbers on the account
+- **twilio_list_calls** – List recent voice calls
+
+## Setup
+
+1. Get your Account SID and Auth Token from the [Twilio Console](https://console.twilio.com/).
+
+2. Set the required environment variables:
+   ```bash
+   export TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+   export TWILIO_AUTH_TOKEN=your-auth-token
+   export TWILIO_PHONE_NUMBER=+15551234567   # your Twilio phone number
+   ```
+
+## Use Case
+
+Example: "Send an SMS alert to the on-call engineer when a production incident is detected, then log the message SID for tracking."

--- a/tools/src/aden_tools/tools/zendesk_tool/README.md
+++ b/tools/src/aden_tools/tools/zendesk_tool/README.md
@@ -1,0 +1,25 @@
+# Zendesk Tool
+
+Ticket management and search via the Zendesk Support API.
+
+## Supported Actions
+
+- **zendesk_list_tickets** / **zendesk_get_ticket** / **zendesk_create_ticket** / **zendesk_update_ticket** – Ticket CRUD
+- **zendesk_search_tickets** – Search tickets with Zendesk query syntax
+- **zendesk_get_ticket_comments** / **zendesk_add_ticket_comment** – Ticket conversation management
+- **zendesk_list_users** – List users in the account
+
+## Setup
+
+1. Generate an API token in Zendesk (Admin → Channels → API).
+
+2. Set the required environment variables:
+   ```bash
+   export ZENDESK_SUBDOMAIN=your-subdomain          # from your-subdomain.zendesk.com
+   export ZENDESK_EMAIL=your-email@example.com
+   export ZENDESK_API_TOKEN=your-api-token
+   ```
+
+## Use Case
+
+Example: "Search for all open tickets tagged 'billing' that have been unassigned for more than 48 hours, assign them to the billing team, and add an internal comment noting the SLA breach."

--- a/tools/src/aden_tools/tools/zoom_tool/README.md
+++ b/tools/src/aden_tools/tools/zoom_tool/README.md
@@ -1,0 +1,24 @@
+# Zoom Tool
+
+Meeting management, recordings, and user info via the Zoom REST API.
+
+## Supported Actions
+
+- **zoom_get_user** – Get user profile (defaults to authenticated user)
+- **zoom_list_meetings** / **zoom_get_meeting** / **zoom_create_meeting** / **zoom_update_meeting** / **zoom_delete_meeting** – Meeting CRUD
+- **zoom_list_recordings** – List cloud recordings for a user
+- **zoom_list_meeting_participants** – List participants of a past meeting
+- **zoom_list_meeting_registrants** – List registrants for a scheduled meeting
+
+## Setup
+
+1. Create a Server-to-Server OAuth app in the [Zoom Marketplace](https://marketplace.zoom.us/).
+
+2. Set the required environment variable:
+   ```bash
+   export ZOOM_ACCESS_TOKEN=your-server-to-server-oauth-token
+   ```
+
+## Use Case
+
+Example: "List all meetings scheduled for this week, check which ones have no registrants, and send a reminder to the organizer."


### PR DESCRIPTION
## Summary

Adds missing README.md for five communication, support, and BaaS tools, continuing toward #6487 (43 tools missing README.md).

| Tool | Actions | Key credentials |
|------|---------|----------------|
| **twilio_tool** | Send SMS/WhatsApp, list messages/calls, phone numbers | `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN` |
| **zendesk_tool** | Ticket CRUD, search, comments, users | `ZENDESK_SUBDOMAIN`, `ZENDESK_EMAIL`, `ZENDESK_API_TOKEN` |
| **zoom_tool** | Meeting CRUD, recordings, participants, registrants | `ZOOM_ACCESS_TOKEN` |
| **pagerduty_tool** | Incident management, services, on-calls, escalation | `PAGERDUTY_API_KEY`, `PAGERDUTY_FROM_EMAIL` |
| **supabase_tool** | PostgREST CRUD, GoTrue auth, edge functions | `SUPABASE_URL`, `SUPABASE_KEY` |

**Progress:** 18 of 41 missing tool READMEs now documented (PRs #6708, #6709, #6716, and this one).

## Test plan

- [x] Action names verified against source code
- [x] Credential variables verified against source code
- [x] Follows established README format

🤖 Generated with [Claude Code](https://claude.com/claude-code)