### PR TITLE
fix(core): return None instead of expired tokens when refresh fails

### DIFF
--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -244,8 +244,11 @@ def get_claude_code_token() -> str | None:
     # Token is expired or near expiry — attempt refresh
     refresh_token = oauth.get("refreshToken")
     if not refresh_token:
-        logger.warning("Claude Code token expired and no refresh token available")
-        return access_token  # Return expired token; it may still work briefly
+        logger.warning(
+            "Claude Code token expired and no refresh token available. "
+            "Run 'claude' to re-authenticate."
+        )
+        return None
 
     logger.info("Claude Code token expired or near expiry, refreshing...")
     token_data = _refresh_claude_code_token(refresh_token)
@@ -254,9 +257,10 @@ def get_claude_code_token() -> str | None:
         _save_refreshed_credentials(token_data)
         return token_data["access_token"]
 
-    # Refresh failed — return the existing token and warn
+    # Refresh failed — return None so callers see a clear auth failure
+    # instead of wasting retry budget on a token that is known to be expired.
     logger.warning("Claude Code token refresh failed. Run 'claude' to re-authenticate.")
-    return access_token
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -448,8 +452,10 @@ def get_codex_token() -> str | None:
     # Token is expired or near expiry — attempt refresh
     refresh_token = tokens.get("refresh_token")
     if not refresh_token:
-        logger.warning("Codex token expired and no refresh token available")
-        return access_token  # Return expired token; it may still work briefly
+        logger.warning(
+            "Codex token expired and no refresh token available. Run 'codex' to re-authenticate."
+        )
+        return None
 
     logger.info("Codex token expired or near expiry, refreshing...")
     token_data = _refresh_codex_token(refresh_token)
@@ -458,9 +464,10 @@ def get_codex_token() -> str | None:
         _save_refreshed_codex_credentials(auth_data, token_data)
         return token_data["access_token"]
 
-    # Refresh failed — return the existing token and warn
+    # Refresh failed — return None so callers see a clear auth failure
+    # instead of wasting retry budget on a token that is known to be expired.
     logger.warning("Codex token refresh failed. Run 'codex' to re-authenticate.")
-    return access_token
+    return None
 
 
 def _get_account_id_from_jwt(access_token: str) -> str | None:

--- a/core/tests/test_runner_token_expiry.py
+++ b/core/tests/test_runner_token_expiry.py
@@ -1,0 +1,134 @@
+"""Tests for expired token handling in get_claude_code_token / get_codex_token.
+
+Verifies that expired tokens are NOT silently returned when refresh fails.
+Instead, None is returned so callers see a clear auth failure rather than
+wasting LLM retry budget on 401/403 errors.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+from framework.runner.runner import get_claude_code_token, get_codex_token
+
+
+def _make_claude_creds(*, expired: bool = False, refresh_token: str | None = "refresh-tok") -> dict:
+    """Build a mock Claude credentials dict."""
+    now_ms = int(time.time() * 1000)
+    expires_at = now_ms - 60_000 if expired else now_ms + 600_000
+    oauth: dict = {"accessToken": "old-access-tok", "expiresAt": expires_at}
+    if refresh_token is not None:
+        oauth["refreshToken"] = refresh_token
+    return {"claudeAiOauth": oauth}
+
+
+def _make_codex_auth(*, expired: bool = False, refresh_token: str | None = "refresh-tok") -> dict:
+    """Build a mock Codex auth dict."""
+    now_s = time.time()
+    expires_at = now_s - 60 if expired else now_s + 600
+    tokens: dict = {"access_token": "old-codex-tok"}
+    if refresh_token is not None:
+        tokens["refresh_token"] = refresh_token
+    return {"tokens": tokens, "expires_at": expires_at}
+
+
+# ---------------------------------------------------------------------------
+# Claude Code token tests
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeCodeTokenExpiry:
+    def test_valid_token_returned(self):
+        """Non-expired token should be returned as-is."""
+        creds = _make_claude_creds(expired=False)
+        with patch("framework.runner.runner._read_claude_credentials", return_value=creds):
+            assert get_claude_code_token() == "old-access-tok"
+
+    def test_expired_no_refresh_returns_none(self):
+        """Expired token with no refresh token should return None."""
+        creds = _make_claude_creds(expired=True, refresh_token=None)
+        with patch("framework.runner.runner._read_claude_credentials", return_value=creds):
+            result = get_claude_code_token()
+            assert result is None
+
+    def test_expired_refresh_fails_returns_none(self):
+        """Expired token where refresh fails should return None."""
+        creds = _make_claude_creds(expired=True)
+        with (
+            patch("framework.runner.runner._read_claude_credentials", return_value=creds),
+            patch("framework.runner.runner._refresh_claude_code_token", return_value=None),
+        ):
+            result = get_claude_code_token()
+            assert result is None
+
+    def test_expired_refresh_succeeds(self):
+        """Expired token where refresh succeeds should return new token."""
+        creds = _make_claude_creds(expired=True)
+        new_tokens = {"access_token": "new-access-tok", "expires_in": 3600}
+        with (
+            patch("framework.runner.runner._read_claude_credentials", return_value=creds),
+            patch("framework.runner.runner._refresh_claude_code_token", return_value=new_tokens),
+            patch("framework.runner.runner._save_refreshed_credentials"),
+        ):
+            result = get_claude_code_token()
+            assert result == "new-access-tok"
+
+    def test_no_credentials_returns_none(self):
+        """No credentials at all should return None."""
+        with patch("framework.runner.runner._read_claude_credentials", return_value=None):
+            assert get_claude_code_token() is None
+
+
+# ---------------------------------------------------------------------------
+# Codex token tests
+# ---------------------------------------------------------------------------
+
+
+class TestCodexTokenExpiry:
+    def test_valid_token_returned(self):
+        """Non-expired token should be returned as-is."""
+        auth = _make_codex_auth(expired=False)
+        with (
+            patch("framework.runner.runner._read_codex_keychain", return_value=None),
+            patch("framework.runner.runner._read_codex_auth_file", return_value=auth),
+            patch("framework.runner.runner._is_codex_token_expired", return_value=False),
+        ):
+            assert get_codex_token() == "old-codex-tok"
+
+    def test_expired_no_refresh_returns_none(self):
+        """Expired token with no refresh token should return None."""
+        auth = _make_codex_auth(expired=True, refresh_token=None)
+        with (
+            patch("framework.runner.runner._read_codex_keychain", return_value=None),
+            patch("framework.runner.runner._read_codex_auth_file", return_value=auth),
+            patch("framework.runner.runner._is_codex_token_expired", return_value=True),
+        ):
+            result = get_codex_token()
+            assert result is None
+
+    def test_expired_refresh_fails_returns_none(self):
+        """Expired token where refresh fails should return None."""
+        auth = _make_codex_auth(expired=True)
+        with (
+            patch("framework.runner.runner._read_codex_keychain", return_value=None),
+            patch("framework.runner.runner._read_codex_auth_file", return_value=auth),
+            patch("framework.runner.runner._is_codex_token_expired", return_value=True),
+            patch("framework.runner.runner._refresh_codex_token", return_value=None),
+        ):
+            result = get_codex_token()
+            assert result is None
+
+    def test_expired_refresh_succeeds(self):
+        """Expired token where refresh succeeds should return new token."""
+        auth = _make_codex_auth(expired=True)
+        new_tokens = {"access_token": "new-codex-tok", "expires_in": 3600}
+        with (
+            patch("framework.runner.runner._read_codex_keychain", return_value=None),
+            patch("framework.runner.runner._read_codex_auth_file", return_value=auth),
+            patch("framework.runner.runner._is_codex_token_expired", return_value=True),
+            patch("framework.runner.runner._refresh_codex_token", return_value=new_tokens),
+            patch("framework.runner.runner._save_refreshed_codex_credentials"),
+        ):
+            result = get_codex_token()
+            assert result == "new-codex-tok"


### PR DESCRIPTION
## Summary

`get_claude_code_token()` and `get_codex_token()` previously returned **known-expired** access tokens when token refresh failed or no refresh token was available. This caused downstream LLM API calls to fail with cryptic 401/403 errors, wasting all retry attempts on requests that could never succeed.

### Changes

Both functions now return `None` instead of the expired token in two failure paths:
1. **No refresh token available** — token is expired but there is nothing to refresh with
2. **Refresh attempt failed** — the refresh endpoint returned an error

All callers already check `if not api_key:` or `if token:` before using the return value, so returning `None` is fully backward-compatible — it just triggers the existing "please re-authenticate" error path instead of silently passing a dead token to the LLM provider.

### 9 new tests covering:

| Test | What it verifies |
|------|-----------------|
| `test_valid_token_returned` | Non-expired token returned as-is (both Claude + Codex) |
| `test_expired_no_refresh_returns_none` | Expired + no refresh token → None |
| `test_expired_refresh_fails_returns_none` | Expired + refresh fails → None |
| `test_expired_refresh_succeeds` | Expired + refresh succeeds → new token |
| `test_no_credentials_returns_none` | No credentials at all → None |

Closes #6702

## Test plan

- [x] All 9 new tests pass
- [x] `ruff check` and `ruff format --check` pass
- [ ] Verify callers handle None correctly (confirmed via grep — all use `if not api_key:` guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)