### PR TITLE
perf(test): enable parallel test execution with pytest-xdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         working-directory: core
         run: |
           uv sync
-          uv run pytest tests/ -v
+          uv run pytest tests/ -v -n auto
 
   test-tools:
     name: Test Tools (${{ matrix.os }})
@@ -88,7 +88,7 @@ jobs:
         working-directory: tools
         run: |
           uv sync --extra dev
-          uv run pytest tests/ -v
+          uv run pytest tests/ -v -n auto
 
   validate:
     name: Validate Agent Exports

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run tests
         run: |
           cd core
-          uv run pytest tests/ -v
+          uv run pytest tests/ -v -n auto
 
       - name: Generate changelog
         id: changelog

--- a/Makefile
+++ b/Makefile
@@ -28,18 +28,18 @@ check: ## Run all checks without modifying files (CI-safe)
 	cd tools && uv run ruff format --check .
 
 test: ## Run all tests (core + tools, excludes live)
-	cd core && uv run python -m pytest tests/ -v
-	cd tools && uv run python -m pytest -v
+	cd core && uv run python -m pytest tests/ -v -n auto
+	cd tools && uv run python -m pytest -v -n auto
 
 test-tools: ## Run tool tests only (mocked, no credentials needed)
-	cd tools && uv run python -m pytest -v
+	cd tools && uv run python -m pytest -v -n auto
 
 test-live: ## Run live integration tests (requires real API credentials)
 	cd tools && uv run python -m pytest -m live -s -o "addopts=" --log-cli-level=INFO
 
 test-all: ## Run everything including live tests
-	cd core && uv run python -m pytest tests/ -v
-	cd tools && uv run python -m pytest -v
+	cd core && uv run python -m pytest tests/ -v -n auto
+	cd tools && uv run python -m pytest -v -n auto
 	cd tools && uv run python -m pytest -m live -s -o "addopts=" --log-cli-level=INFO
 
 install-hooks: ## Install pre-commit hooks

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -63,6 +63,7 @@ lint.isort.section-order = [
   "local-folder",
 ]
 [tool.pytest.ini_options]
+asyncio_mode = "auto"
 filterwarnings = [
     "ignore::DeprecationWarning:litellm.*"
 ]

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
+    "pytest-xdist>=3.0",
 ]
 sandbox = [
     "RestrictedPython>=7.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3530,6 +3530,7 @@ databricks = [
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-xdist" },
 ]
 excel = [
     { name = "openpyxl" },
@@ -3587,6 +3588,7 @@ requires-dist = [
     { name = "pytesseract", marker = "extra == 'ocr'", specifier = ">=0.3.10" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "resend", specifier = ">=2.0.0" },


### PR DESCRIPTION
Fixes #6612

Wires up pytest-xdist for parallel test execution. xdist was already a dependency in core but never used — this adds `-n auto` to the Makefile, CI, and release workflows. Also adds the missing xdist dependency to tools and sets `asyncio_mode = "auto"` in core's pytest config to match tools.

test-live is excluded since `-s` is incompatible with xdist workers.

Tested locally — core and tools both pass with identical results in parallel, roughly 2x faster.