### PR TITLE
docs(duckduckgo_tool): add README with tool descriptions and parameters

### DIFF
--- a/tools/src/aden_tools/tools/duckduckgo_tool/README.md
+++ b/tools/src/aden_tools/tools/duckduckgo_tool/README.md
@@ -1,0 +1,110 @@
+# DuckDuckGo Tool
+
+Search the web, news, and images using DuckDuckGo — no API key or credentials required.
+
+## Tools
+
+### `duckduckgo_search`
+
+Search the web for any query.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | string | required | Search query |
+| `max_results` | int | 10 | Number of results (1–50) |
+| `region` | string | `us-en` | Region code (e.g. `uk-en`, `de-de`) |
+| `safesearch` | string | `moderate` | Safety filter: `on`, `moderate`, `off` |
+| `timelimit` | string | `""` | Time filter: `d` (day), `w` (week), `m` (month), `y` (year), `""` (any) |
+
+**Returns**
+```json
+{
+  "query": "your search query",
+  "count": 10,
+  "results": [
+    {
+      "title": "Result title",
+      "url": "https://example.com",
+      "snippet": "Brief description of the result"
+    }
+  ]
+}
+```
+
+---
+
+### `duckduckgo_news`
+
+Search recent news articles.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | string | required | News search query |
+| `max_results` | int | 10 | Number of results (1–50) |
+| `region` | string | `us-en` | Region code |
+| `timelimit` | string | `""` | Time filter: `d`, `w`, `m`, `""` |
+
+**Returns**
+```json
+{
+  "query": "your search query",
+  "count": 10,
+  "results": [
+    {
+      "title": "Article title",
+      "url": "https://example.com/article",
+      "source": "News Source",
+      "date": "2026-03-22",
+      "snippet": "Article summary"
+    }
+  ]
+}
+```
+
+---
+
+### `duckduckgo_images`
+
+Search for images.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | string | required | Image search query |
+| `max_results` | int | 10 | Number of results (1–50) |
+| `region` | string | `us-en` | Region code |
+| `safesearch` | string | `moderate` | Safety filter: `on`, `moderate`, `off` |
+| `size` | string | `""` | Size filter: `Small`, `Medium`, `Large`, `Wallpaper`, `""` (any) |
+
+**Returns**
+```json
+{
+  "query": "your search query",
+  "count": 10,
+  "results": [
+    {
+      "title": "Image title",
+      "image_url": "https://example.com/image.jpg",
+      "thumbnail_url": "https://example.com/thumb.jpg",
+      "source": "example.com",
+      "width": 1920,
+      "height": 1080
+    }
+  ]
+}
+```
+
+---
+
+## No credentials needed
+
+Unlike most tools in this directory, the DuckDuckGo tool requires no API key or environment variables. It works out of the box.
+
+## Dependencies
+
+Uses the [`duckduckgo-search`](https://pypi.org/project/duckduckgo-search/) Python library, installed automatically with the tools package.


### PR DESCRIPTION
## Description

Adds README.md for the `duckduckgo_tool` documenting all three available tools with parameter tables, return value formats, and usage notes.

## Type of Change

- [x] Documentation update

## What was added

- Description of all three tools: `duckduckgo_search`, `duckduckgo_news`, `duckduckgo_images`
- Parameter tables for each tool (name, type, default, description)
- Example return value (JSON format) for each tool
- Note that no API key or credentials are required
- Link to the `duckduckgo-search` PyPI dependency

## Related Issue

Closes #6304