### PR TITLE
feat: add Novita AI as LLM provider

### DIFF
--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -164,6 +164,7 @@ RATE_LIMIT_BACKOFF_BASE = 2  # seconds
 RATE_LIMIT_MAX_DELAY = 120  # seconds - cap to prevent absurd waits
 MINIMAX_API_BASE = "https://api.minimax.io/v1"
 OPENROUTER_API_BASE = "https://openrouter.ai/api/v1"
+NOVITA_API_BASE = "https://api.novita.ai/openai"
 
 # Providers that accept cache_control on message content blocks.
 # Anthropic: native ephemeral caching. MiniMax & Z-AI/GLM: pass-through to their APIs.
@@ -547,6 +548,8 @@ class LiteLLMProvider(LLMProvider):
             return MINIMAX_API_BASE
         if model_lower.startswith("openrouter/"):
             return OPENROUTER_API_BASE
+        if model_lower.startswith("novita/"):
+            return NOVITA_API_BASE
         if model_lower.startswith("kimi/"):
             return KIMI_API_BASE
         if model_lower.startswith("hive/"):

--- a/core/tests/test_litellm_provider.py
+++ b/core/tests/test_litellm_provider.py
@@ -90,6 +90,20 @@ class TestLiteLLMProviderInit:
         )
         assert provider.api_base == "https://proxy.example/v1"
 
+    def test_init_novita_defaults_api_base(self):
+        """Novita should default to the official OpenAI-compatible endpoint."""
+        provider = LiteLLMProvider(model="novita/moonshotai/kimi-k2.5", api_key="my-key")
+        assert provider.api_base == "https://api.novita.ai/openai"
+
+    def test_init_novita_keeps_custom_api_base(self):
+        """Explicit api_base should win over Novita defaults."""
+        provider = LiteLLMProvider(
+            model="novita/moonshotai/kimi-k2.5",
+            api_key="my-key",
+            api_base="https://proxy.example/v1",
+        )
+        assert provider.api_base == "https://proxy.example/v1"
+
     def test_init_ollama_no_key_needed(self):
         """Test that Ollama models don't require API key."""
         with patch.dict(os.environ, {}, clear=True):

--- a/quickstart.ps1
+++ b/quickstart.ps1
@@ -813,6 +813,7 @@ $ProviderMap = [ordered]@{
     MISTRAL_API_KEY   = @{ Name = "Mistral";             Id = "mistral" }
     TOGETHER_API_KEY  = @{ Name = "Together AI";         Id = "together" }
     DEEPSEEK_API_KEY  = @{ Name = "DeepSeek";            Id = "deepseek" }
+    NOVITA_API_KEY    = @{ Name = "Novita AI";           Id = "novita" }
 }
 
 $DefaultModels = @{
@@ -825,6 +826,7 @@ $DefaultModels = @{
     mistral     = "mistral-large-latest"
     together_ai = "meta-llama/Llama-3.3-70B-Instruct-Turbo"
     deepseek    = "deepseek-chat"
+    novita      = "moonshotai/kimi-k2.5"
 }
 
 # Model choices: array of hashtables per provider
@@ -850,6 +852,11 @@ $ModelChoices = @{
     cerebras = @(
         @{ Id = "zai-glm-4.7";                    Label = "ZAI-GLM 4.7 - Best quality (recommended)"; MaxTokens = 8192; MaxContextTokens = 120000 },
         @{ Id = "qwen3-235b-a22b-instruct-2507";  Label = "Qwen3 235B - Frontier reasoning";          MaxTokens = 8192; MaxContextTokens = 120000 }
+    )
+    novita = @(
+        @{ Id = "moonshotai/kimi-k2.5";   Label = "Kimi K2.5 - Best value (recommended)"; MaxTokens = 32768; MaxContextTokens = 240000 },
+        @{ Id = "zai-org/glm-5";          Label = "GLM-5 - Reasoning model";              MaxTokens = 32768; MaxContextTokens = 180000 },
+        @{ Id = "minimax/minimax-m2.5";   Label = "MiniMax M2.5 - Cost-effective";        MaxTokens = 32768; MaxContextTokens = 180000 }
     )
 }
 
@@ -1023,16 +1030,17 @@ if (-not $hiveKey) { $hiveKey = $env:HIVE_API_KEY }
 if ($hiveKey) { $HiveCredDetected = $true }
 
 # Detect API key providers
-$ProviderMenuEnvVars  = @("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GROQ_API_KEY", "CEREBRAS_API_KEY", "OPENROUTER_API_KEY")
-$ProviderMenuNames    = @("Anthropic (Claude) - Recommended", "OpenAI (GPT)", "Google Gemini - Free tier available", "Groq - Fast, free tier", "Cerebras - Fast, free tier", "OpenRouter - Bring any OpenRouter model")
-$ProviderMenuIds      = @("anthropic", "openai", "gemini", "groq", "cerebras", "openrouter")
+$ProviderMenuEnvVars  = @("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GROQ_API_KEY", "CEREBRAS_API_KEY", "OPENROUTER_API_KEY", "NOVITA_API_KEY")
+$ProviderMenuNames    = @("Anthropic (Claude) - Recommended", "OpenAI (GPT)", "Google Gemini - Free tier available", "Groq - Fast, free tier", "Cerebras - Fast, free tier", "OpenRouter - Bring any OpenRouter model", "Novita AI - Best value LLMs")
+$ProviderMenuIds      = @("anthropic", "openai", "gemini", "groq", "cerebras", "openrouter", "novita")
 $ProviderMenuUrls     = @(
     "https://console.anthropic.com/settings/keys",
     "https://platform.openai.com/api-keys",
     "https://aistudio.google.com/apikey",
     "https://console.groq.com/keys",
     "https://cloud.cerebras.ai/",
-    "https://openrouter.ai/keys"
+    "https://openrouter.ai/keys",
+    "https://novita.ai/settings/key-management"
 )
 
 # ── Read previous configuration (if any) ──────────────────────
@@ -1301,7 +1309,7 @@ switch ($num) {
         }
         Write-Color -Text "  Model: $SelectedModel | API: $HiveLlmEndpoint" -Color DarkGray
     }
-    { $_ -ge 7 -and $_ -le 12 } {
+    { $_ -ge 7 -and $_ -le 13 } {
         # API key providers
         $provIdx = $num - 7
         $SelectedEnvVar     = $ProviderMenuEnvVars[$provIdx]
@@ -1310,6 +1318,8 @@ switch ($num) {
         $signupUrl          = $ProviderMenuUrls[$provIdx]
         if ($SelectedProviderId -eq "openrouter") {
             $SelectedApiBase = "https://openrouter.ai/api/v1"
+        } elseif ($SelectedProviderId -eq "novita") {
+            $SelectedApiBase = "https://api.novita.ai/openai"
         } else {
             $SelectedApiBase = ""
         }
@@ -2006,6 +2016,9 @@ if ($SelectedProviderId) {
     } elseif ($SelectedProviderId -eq "openrouter") {
         Write-Ok "OpenRouter API Key -> $SelectedModel"
         Write-Color -Text "  API: openrouter.ai/api/v1 (OpenAI-compatible)" -Color DarkGray
+    } elseif ($SelectedProviderId -eq "novita") {
+        Write-Ok "Novita AI API Key -> $SelectedModel"
+        Write-Color -Text "  API: api.novita.ai/openai (OpenAI-compatible)" -Color DarkGray
     } else {
         Write-Color -Text "  $SelectedProviderId" -Color Cyan -NoNewline
         Write-Host " -> " -NoNewline

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -377,6 +377,7 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
         ["MISTRAL_API_KEY"]="Mistral"
         ["TOGETHER_API_KEY"]="Together AI"
         ["DEEPSEEK_API_KEY"]="DeepSeek"
+        ["NOVITA_API_KEY"]="Novita AI"
     )
 
     declare -A PROVIDER_IDS=(
@@ -391,6 +392,7 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
         ["MISTRAL_API_KEY"]="mistral"
         ["TOGETHER_API_KEY"]="together"
         ["DEEPSEEK_API_KEY"]="deepseek"
+        ["NOVITA_API_KEY"]="novita"
     )
 
     declare -A DEFAULT_MODELS=(
@@ -403,6 +405,7 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
         ["mistral"]="mistral-large-latest"
         ["together_ai"]="meta-llama/Llama-3.3-70B-Instruct-Turbo"
         ["deepseek"]="deepseek-chat"
+        ["novita"]="moonshotai/kimi-k2.5"
     )
 
     # Model choices per provider: composite-key associative arrays
@@ -420,6 +423,9 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
         ["groq:1"]="openai/gpt-oss-120b"
         ["cerebras:0"]="zai-glm-4.7"
         ["cerebras:1"]="qwen3-235b-a22b-instruct-2507"
+        ["novita:0"]="moonshotai/kimi-k2.5"
+        ["novita:1"]="zai-org/glm-5"
+        ["novita:2"]="minimax/minimax-m2.5"
     )
 
     declare -A MODEL_CHOICES_LABEL=(
@@ -435,6 +441,9 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
         ["groq:1"]="GPT-OSS 120B - Fast reasoning"
         ["cerebras:0"]="ZAI-GLM 4.7 - Best quality (recommended)"
         ["cerebras:1"]="Qwen3 235B - Frontier reasoning"
+        ["novita:0"]="Kimi K2.5 - Best value (recommended)"
+        ["novita:1"]="GLM-5 - Reasoning model"
+        ["novita:2"]="MiniMax M2.5 - Cost-effective"
     )
 
     declare -A MODEL_CHOICES_MAXTOKENS=(
@@ -450,6 +459,9 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
         ["groq:1"]=8192
         ["cerebras:0"]=8192
         ["cerebras:1"]=8192
+        ["novita:0"]=32768
+        ["novita:1"]=32768
+        ["novita:2"]=32768
     )
 
     # Max context tokens (input history budget) per model, based on actual context windows.
@@ -467,6 +479,9 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
         ["groq:1"]=120000        # GPT-OSS 120B — 128k context window
         ["cerebras:0"]=120000    # ZAI-GLM 4.7 — 128k context window
         ["cerebras:1"]=120000    # Qwen3 235B — 128k context window
+        ["novita:0"]=240000      # Kimi K2.5 — 256k context window
+        ["novita:1"]=180000      # GLM-5 — 200k context window
+        ["novita:2"]=180000      # MiniMax M2.5 — 200k context window
     )
 
     declare -A MODEL_CHOICES_COUNT=(
@@ -475,6 +490,7 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
         ["gemini"]=2
         ["groq"]=2
         ["cerebras"]=2
+        ["novita"]=3
     )
 
     # Helper functions for Bash 4+
@@ -511,13 +527,13 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
     }
 else
     # Bash 3.2 - use parallel indexed arrays
-    PROVIDER_ENV_VARS=(ANTHROPIC_API_KEY OPENAI_API_KEY MINIMAX_API_KEY GEMINI_API_KEY GOOGLE_API_KEY GROQ_API_KEY CEREBRAS_API_KEY OPENROUTER_API_KEY MISTRAL_API_KEY TOGETHER_API_KEY DEEPSEEK_API_KEY)
-    PROVIDER_DISPLAY_NAMES=("Anthropic (Claude)" "OpenAI (GPT)" "MiniMax" "Google Gemini" "Google AI" "Groq" "Cerebras" "OpenRouter" "Mistral" "Together AI" "DeepSeek")
-    PROVIDER_ID_LIST=(anthropic openai minimax gemini google groq cerebras openrouter mistral together deepseek)
+    PROVIDER_ENV_VARS=(ANTHROPIC_API_KEY OPENAI_API_KEY MINIMAX_API_KEY GEMINI_API_KEY GOOGLE_API_KEY GROQ_API_KEY CEREBRAS_API_KEY OPENROUTER_API_KEY MISTRAL_API_KEY TOGETHER_API_KEY DEEPSEEK_API_KEY NOVITA_API_KEY)
+    PROVIDER_DISPLAY_NAMES=("Anthropic (Claude)" "OpenAI (GPT)" "MiniMax" "Google Gemini" "Google AI" "Groq" "Cerebras" "OpenRouter" "Mistral" "Together AI" "DeepSeek" "Novita AI")
+    PROVIDER_ID_LIST=(anthropic openai minimax gemini google groq cerebras openrouter mistral together deepseek novita)
 
     # Default models by provider id (parallel arrays)
-    MODEL_PROVIDER_IDS=(anthropic openai minimax gemini groq cerebras mistral together_ai deepseek)
-    MODEL_DEFAULTS=("claude-haiku-4-5-20251001" "gpt-5-mini" "MiniMax-M2.5" "gemini-3-flash-preview" "moonshotai/kimi-k2-instruct-0905" "zai-glm-4.7" "mistral-large-latest" "meta-llama/Llama-3.3-70B-Instruct-Turbo" "deepseek-chat")
+    MODEL_PROVIDER_IDS=(anthropic openai minimax gemini groq cerebras mistral together_ai deepseek novita)
+    MODEL_DEFAULTS=("claude-haiku-4-5-20251001" "gpt-5-mini" "MiniMax-M2.5" "gemini-3-flash-preview" "moonshotai/kimi-k2-instruct-0905" "zai-glm-4.7" "mistral-large-latest" "meta-llama/Llama-3.3-70B-Instruct-Turbo" "deepseek-chat" "moonshotai/kimi-k2.5")
 
     # Helper: get provider display name for an env var
     get_provider_name() {
@@ -559,14 +575,12 @@ else
     }
 
     # Model choices per provider - flat parallel arrays with provider offsets
-    # Provider order: anthropic(4), openai(2), gemini(2), groq(2), cerebras(2)
-    MC_PROVIDERS=(anthropic anthropic anthropic anthropic openai openai gemini gemini groq groq cerebras cerebras)
-    MC_IDS=("claude-haiku-4-5-20251001" "claude-sonnet-4-20250514" "claude-sonnet-4-5-20250929" "claude-opus-4-6" "gpt-5-mini" "gpt-5.2" "gemini-3-flash-preview" "gemini-3.1-pro-preview" "moonshotai/kimi-k2-instruct-0905" "openai/gpt-oss-120b" "zai-glm-4.7" "qwen3-235b-a22b-instruct-2507")
-    MC_LABELS=("Haiku 4.5 - Fast + cheap (recommended)" "Sonnet 4 - Fast + capable" "Sonnet 4.5 - Best balance" "Opus 4.6 - Most capable" "GPT-5 Mini - Fast + cheap (recommended)" "GPT-5.2 - Most capable" "Gemini 3 Flash - Fast (recommended)" "Gemini 3.1 Pro - Best quality" "Kimi K2 - Best quality (recommended)" "GPT-OSS 120B - Fast reasoning" "ZAI-GLM 4.7 - Best quality (recommended)" "Qwen3 235B - Frontier reasoning")
-    MC_MAXTOKENS=(8192 8192 16384 32768 16384 16384 8192 8192 8192 8192 8192 8192)
-    # Max context tokens per model (same order as MC_PROVIDERS/MC_IDS above)
-    # Based on actual context windows with ~10% headroom for system prompt + output.
-    MC_MAXCONTEXTTOKENS=(180000 180000 180000 180000 120000 120000 900000 900000 120000 120000 120000 120000)
+    # Provider order: anthropic(4), openai(2), gemini(2), groq(2), cerebras(2), novita(3)
+    MC_PROVIDERS=(anthropic anthropic anthropic anthropic openai openai gemini gemini groq groq cerebras cerebras novita novita novita)
+    MC_IDS=("claude-haiku-4-5-20251001" "claude-sonnet-4-20250514" "claude-sonnet-4-5-20250929" "claude-opus-4-6" "gpt-5-mini" "gpt-5.2" "gemini-3-flash-preview" "gemini-3.1-pro-preview" "moonshotai/kimi-k2-instruct-0905" "openai/gpt-oss-120b" "zai-glm-4.7" "qwen3-235b-a22b-instruct-2507" "moonshotai/kimi-k2.5" "zai-org/glm-5" "minimax/minimax-m2.5")
+    MC_LABELS=("Haiku 4.5 - Fast + cheap (recommended)" "Sonnet 4 - Fast + capable" "Sonnet 4.5 - Best balance" "Opus 4.6 - Most capable" "GPT-5 Mini - Fast + cheap (recommended)" "GPT-5.2 - Most capable" "Gemini 3 Flash - Fast (recommended)" "Gemini 3.1 Pro - Best quality" "Kimi K2 - Best quality (recommended)" "GPT-OSS 120B - Fast reasoning" "ZAI-GLM 4.7 - Best quality (recommended)" "Qwen3 235B - Frontier reasoning" "Kimi K2.5 - Best value (recommended)" "GLM-5 - Reasoning model" "MiniMax M2.5 - Cost-effective")
+    MC_MAXTOKENS=(8192 8192 16384 32768 16384 16384 8192 8192 8192 8192 8192 8192 32768 32768 32768)
+    MC_MAXCONTEXTTOKENS=(180000 180000 180000 180000 120000 120000 900000 900000 120000 120000 120000 120000 240000 180000 180000)
 
     # Helper: get number of model choices for a provider
     get_model_choice_count() {
@@ -1118,6 +1132,7 @@ if [ -n "$PREV_SUB_MODE" ] || [ -n "$PREV_PROVIDER" ]; then
                 groq)      DEFAULT_CHOICE=11 ;;
                 cerebras)  DEFAULT_CHOICE=12 ;;
                 openrouter) DEFAULT_CHOICE=13 ;;
+                novita)    DEFAULT_CHOICE=14 ;;
                 minimax)   DEFAULT_CHOICE=4 ;;
                 kimi)      DEFAULT_CHOICE=5 ;;
                 hive)      DEFAULT_CHOICE=6 ;;
@@ -1183,9 +1198,9 @@ fi
 echo ""
 echo -e "  ${CYAN}${BOLD}API key providers:${NC}"
 
-# 8-13) API key providers — show (credential detected) if key already set
-PROVIDER_MENU_ENVS=(ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY GROQ_API_KEY CEREBRAS_API_KEY OPENROUTER_API_KEY)
-PROVIDER_MENU_NAMES=("Anthropic (Claude) - Recommended" "OpenAI (GPT)" "Google Gemini - Free tier available" "Groq - Fast, free tier" "Cerebras - Fast, free tier" "OpenRouter - Bring any OpenRouter model")
+# 8-14) API key providers — show (credential detected) if key already set
+PROVIDER_MENU_ENVS=(ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY GROQ_API_KEY CEREBRAS_API_KEY OPENROUTER_API_KEY NOVITA_API_KEY)
+PROVIDER_MENU_NAMES=("Anthropic (Claude) - Recommended" "OpenAI (GPT)" "Google Gemini - Free tier available" "Groq - Fast, free tier" "Cerebras - Fast, free tier" "OpenRouter - Bring any OpenRouter model" "Novita AI - Best value LLMs")
 for idx in "${!PROVIDER_MENU_ENVS[@]}"; do
     num=$((idx + 8))
     env_var="${PROVIDER_MENU_ENVS[$idx]}"
@@ -1414,6 +1429,13 @@ case $choice in
         PROVIDER_NAME="OpenRouter"
         SIGNUP_URL="https://openrouter.ai/keys"
         ;;
+    14)
+        SELECTED_ENV_VAR="NOVITA_API_KEY"
+        SELECTED_PROVIDER_ID="novita"
+        SELECTED_API_BASE="https://api.novita.ai/openai"
+        PROVIDER_NAME="Novita AI"
+        SIGNUP_URL="https://novita.ai/settings/key-management"
+        ;;
     "$SKIP_CHOICE")
         echo ""
         echo -e "${YELLOW}Skipped.${NC} An LLM API key is required to test and use worker agents."
@@ -1583,6 +1605,8 @@ if [ -n "$SELECTED_PROVIDER_ID" ]; then
     elif [ "$SUBSCRIPTION_MODE" = "hive_llm" ]; then
         save_configuration "$SELECTED_PROVIDER_ID" "$SELECTED_ENV_VAR" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "" "$SELECTED_API_BASE" > /dev/null || SAVE_OK=false
     elif [ "$SELECTED_PROVIDER_ID" = "openrouter" ]; then
+        save_configuration "$SELECTED_PROVIDER_ID" "$SELECTED_ENV_VAR" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "" "$SELECTED_API_BASE" > /dev/null || SAVE_OK=false
+    elif [ "$SELECTED_PROVIDER_ID" = "novita" ]; then
         save_configuration "$SELECTED_PROVIDER_ID" "$SELECTED_ENV_VAR" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "" "$SELECTED_API_BASE" > /dev/null || SAVE_OK=false
     else
         save_configuration "$SELECTED_PROVIDER_ID" "$SELECTED_ENV_VAR" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" > /dev/null || SAVE_OK=false
@@ -1859,6 +1883,9 @@ if [ -n "$SELECTED_PROVIDER_ID" ]; then
     elif [ "$SELECTED_PROVIDER_ID" = "openrouter" ]; then
         echo -e "  ${GREEN}⬢${NC} OpenRouter API Key → ${DIM}$SELECTED_MODEL${NC}"
         echo -e "  ${DIM}API: openrouter.ai/api/v1 (OpenAI-compatible)${NC}"
+    elif [ "$SELECTED_PROVIDER_ID" = "novita" ]; then
+        echo -e "  ${GREEN}⬢${NC} Novita AI API Key → ${DIM}$SELECTED_MODEL${NC}"
+        echo -e "  ${DIM}API: api.novita.ai/openai (OpenAI-compatible)${NC}"
     else
         echo -e "  ${CYAN}$SELECTED_PROVIDER_ID${NC} → ${DIM}$SELECTED_MODEL${NC}"
     fi

--- a/scripts/check_llm_key.py
+++ b/scripts/check_llm_key.py
@@ -305,6 +305,28 @@ def check_gemini(api_key: str, **_: str) -> dict:
     return {"valid": False, "message": f"Gemini API returned status {r.status_code}"}
 
 
+NOVITA_API_BASE = "https://api.novita.ai/openai"
+
+
+def check_novita(
+    api_key: str, api_base: str = "https://api.novita.ai/openai", **_: str
+) -> dict:
+    """Validate Novita AI key against GET /models."""
+    endpoint = f"{api_base.rstrip('/')}/models"
+    with httpx.Client(timeout=TIMEOUT) as client:
+        r = client.get(endpoint, headers={"Authorization": f"Bearer {api_key}"})
+    if r.status_code in (200, 429):
+        return {"valid": True, "message": "Novita API key valid"}
+    if r.status_code == 401:
+        return {"valid": False, "message": "Invalid Novita API key"}
+    if r.status_code == 403:
+        return {"valid": False, "message": "Novita API key lacks permissions"}
+    return {
+        "valid": False,
+        "message": f"Novita API returned status {r.status_code}",
+    }
+
+
 PROVIDERS = {
     "anthropic": lambda key, **kw: check_anthropic(key),
     "openai": lambda key, **kw: check_openai_compatible(
@@ -319,6 +341,7 @@ PROVIDERS = {
     ),
     "openrouter": lambda key, **kw: check_openrouter(key, **kw),
     "minimax": lambda key, **kw: check_minimax(key),
+    "novita": lambda key, **kw: check_novita(key, **kw),
     # Kimi For Coding uses an Anthropic-compatible endpoint; check via /v1/messages
     # with empty messages (same as check_anthropic, triggers 400 not 401).
     "kimi": lambda key, **kw: check_anthropic_compatible(
@@ -359,6 +382,8 @@ def main() -> None:
             result = check_minimax(api_key, api_base)
         elif api_base and provider_id == "openrouter":
             result = check_openrouter(api_key, api_base)
+        elif api_base and provider_id == "novita":
+            result = check_novita(api_key, api_base)
         elif api_base and provider_id == "kimi":
             # Kimi uses an Anthropic-compatible endpoint; check via /v1/messages
             result = check_anthropic_compatible(

--- a/scripts/setup_worker_model.ps1
+++ b/scripts/setup_worker_model.ps1
@@ -70,6 +70,7 @@ $ProviderMap = [ordered]@{
     MISTRAL_API_KEY   = @{ Name = "Mistral";             Id = "mistral" }
     TOGETHER_API_KEY  = @{ Name = "Together AI";         Id = "together" }
     DEEPSEEK_API_KEY  = @{ Name = "DeepSeek";            Id = "deepseek" }
+    NOVITA_API_KEY    = @{ Name = "Novita AI";           Id = "novita" }
 }
 
 $DefaultModels = @{
@@ -81,6 +82,7 @@ $DefaultModels = @{
     mistral     = "mistral-large-latest"
     together_ai = "meta-llama/Llama-3.3-70B-Instruct-Turbo"
     deepseek    = "deepseek-chat"
+    novita      = "moonshotai/kimi-k2.5"
 }
 
 # Model choices: array of hashtables per provider
@@ -106,6 +108,11 @@ $ModelChoices = @{
     cerebras = @(
         @{ Id = "zai-glm-4.7";                    Label = "ZAI-GLM 4.7 - Best quality (recommended)"; MaxTokens = 8192; MaxContextTokens = 120000 },
         @{ Id = "qwen3-235b-a22b-instruct-2507";  Label = "Qwen3 235B - Frontier reasoning";          MaxTokens = 8192; MaxContextTokens = 120000 }
+    )
+    novita = @(
+        @{ Id = "moonshotai/kimi-k2.5";   Label = "Kimi K2.5 - Best value (recommended)"; MaxTokens = 32768; MaxContextTokens = 240000 },
+        @{ Id = "zai-org/glm-5";          Label = "GLM-5 - Reasoning model";              MaxTokens = 32768; MaxContextTokens = 180000 },
+        @{ Id = "minimax/minimax-m2.5";   Label = "MiniMax M2.5 - Cost-effective";        MaxTokens = 32768; MaxContextTokens = 180000 }
     )
 }
 
@@ -312,16 +319,17 @@ if (-not $hiveKey) { $hiveKey = $env:HIVE_API_KEY }
 if ($hiveKey) { $HiveCredDetected = $true }
 
 # Detect API key providers
-$ProviderMenuEnvVars  = @("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GROQ_API_KEY", "CEREBRAS_API_KEY", "OPENROUTER_API_KEY")
-$ProviderMenuNames    = @("Anthropic (Claude) - Recommended", "OpenAI (GPT)", "Google Gemini - Free tier available", "Groq - Fast, free tier", "Cerebras - Fast, free tier", "OpenRouter - Bring any OpenRouter model")
-$ProviderMenuIds      = @("anthropic", "openai", "gemini", "groq", "cerebras", "openrouter")
+$ProviderMenuEnvVars  = @("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GROQ_API_KEY", "CEREBRAS_API_KEY", "OPENROUTER_API_KEY", "NOVITA_API_KEY")
+$ProviderMenuNames    = @("Anthropic (Claude) - Recommended", "OpenAI (GPT)", "Google Gemini - Free tier available", "Groq - Fast, free tier", "Cerebras - Fast, free tier", "OpenRouter - Bring any OpenRouter model", "Novita AI - Best value LLMs")
+$ProviderMenuIds      = @("anthropic", "openai", "gemini", "groq", "cerebras", "openrouter", "novita")
 $ProviderMenuUrls     = @(
     "https://console.anthropic.com/settings/keys",
     "https://platform.openai.com/api-keys",
     "https://aistudio.google.com/apikey",
     "https://console.groq.com/keys",
     "https://cloud.cerebras.ai/",
-    "https://openrouter.ai/keys"
+    "https://openrouter.ai/keys",
+    "https://novita.ai/settings/key-management"
 )
 
 # -- Read previous worker_llm configuration (if any) ---------

--- a/scripts/setup_worker_model.sh
+++ b/scripts/setup_worker_model.sh
@@ -73,6 +73,7 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
         ["MISTRAL_API_KEY"]="Mistral"
         ["TOGETHER_API_KEY"]="Together AI"
         ["DEEPSEEK_API_KEY"]="DeepSeek"
+        ["NOVITA_API_KEY"]="Novita AI"
     )
 
     declare -A PROVIDER_IDS=(
@@ -87,6 +88,7 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
         ["MISTRAL_API_KEY"]="mistral"
         ["TOGETHER_API_KEY"]="together"
         ["DEEPSEEK_API_KEY"]="deepseek"
+        ["NOVITA_API_KEY"]="novita"
     )
 
     declare -A DEFAULT_MODELS=(
@@ -99,6 +101,7 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
         ["mistral"]="mistral-large-latest"
         ["together_ai"]="meta-llama/Llama-3.3-70B-Instruct-Turbo"
         ["deepseek"]="deepseek-chat"
+        ["novita"]="moonshotai/kimi-k2.5"
     )
 
     declare -A MODEL_CHOICES_ID=(
@@ -114,6 +117,9 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
         ["groq:1"]="openai/gpt-oss-120b"
         ["cerebras:0"]="zai-glm-4.7"
         ["cerebras:1"]="qwen3-235b-a22b-instruct-2507"
+        ["novita:0"]="moonshotai/kimi-k2.5"
+        ["novita:1"]="zai-org/glm-5"
+        ["novita:2"]="minimax/minimax-m2.5"
     )
 
     declare -A MODEL_CHOICES_LABEL=(
@@ -129,6 +135,9 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
         ["groq:1"]="GPT-OSS 120B - Fast reasoning"
         ["cerebras:0"]="ZAI-GLM 4.7 - Best quality (recommended)"
         ["cerebras:1"]="Qwen3 235B - Frontier reasoning"
+        ["novita:0"]="Kimi K2.5 - Best value (recommended)"
+        ["novita:1"]="GLM-5 - Reasoning model"
+        ["novita:2"]="MiniMax M2.5 - Cost-effective"
     )
 
     declare -A MODEL_CHOICES_MAXTOKENS=(
@@ -144,6 +153,9 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
         ["groq:1"]=8192
         ["cerebras:0"]=8192
         ["cerebras:1"]=8192
+        ["novita:0"]=32768
+        ["novita:1"]=32768
+        ["novita:2"]=32768
     )
 
     declare -A MODEL_CHOICES_MAXCONTEXTTOKENS=(
@@ -159,6 +171,9 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
         ["groq:1"]=120000
         ["cerebras:0"]=120000
         ["cerebras:1"]=120000
+        ["novita:0"]=240000
+        ["novita:1"]=180000
+        ["novita:2"]=180000
     )
 
     declare -A MODEL_CHOICES_COUNT=(
@@ -167,6 +182,7 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
         ["gemini"]=2
         ["groq"]=2
         ["cerebras"]=2
+        ["novita"]=3
     )
 
     get_provider_name()  { echo "${PROVIDER_NAMES[$1]}"; }
@@ -179,12 +195,12 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
     get_model_choice_maxcontexttokens() { echo "${MODEL_CHOICES_MAXCONTEXTTOKENS[$1:$2]}"; }
 else
     # Bash 3.2 fallback
-    PROVIDER_ENV_VARS=(ANTHROPIC_API_KEY OPENAI_API_KEY MINIMAX_API_KEY GEMINI_API_KEY GOOGLE_API_KEY GROQ_API_KEY CEREBRAS_API_KEY OPENROUTER_API_KEY MISTRAL_API_KEY TOGETHER_API_KEY DEEPSEEK_API_KEY)
-    PROVIDER_DISPLAY_NAMES=("Anthropic (Claude)" "OpenAI (GPT)" "MiniMax" "Google Gemini" "Google AI" "Groq" "Cerebras" "OpenRouter" "Mistral" "Together AI" "DeepSeek")
-    PROVIDER_ID_LIST=(anthropic openai minimax gemini google groq cerebras openrouter mistral together deepseek)
+    PROVIDER_ENV_VARS=(ANTHROPIC_API_KEY OPENAI_API_KEY MINIMAX_API_KEY GEMINI_API_KEY GOOGLE_API_KEY GROQ_API_KEY CEREBRAS_API_KEY OPENROUTER_API_KEY MISTRAL_API_KEY TOGETHER_API_KEY DEEPSEEK_API_KEY NOVITA_API_KEY)
+    PROVIDER_DISPLAY_NAMES=("Anthropic (Claude)" "OpenAI (GPT)" "MiniMax" "Google Gemini" "Google AI" "Groq" "Cerebras" "OpenRouter" "Mistral" "Together AI" "DeepSeek" "Novita AI")
+    PROVIDER_ID_LIST=(anthropic openai minimax gemini google groq cerebras openrouter mistral together deepseek novita)
 
-    MODEL_PROVIDER_IDS=(anthropic openai minimax gemini groq cerebras mistral together_ai deepseek)
-    MODEL_DEFAULTS=("claude-haiku-4-5-20251001" "gpt-5-mini" "MiniMax-M2.5" "gemini-3-flash-preview" "moonshotai/kimi-k2-instruct-0905" "zai-glm-4.7" "mistral-large-latest" "meta-llama/Llama-3.3-70B-Instruct-Turbo" "deepseek-chat")
+    MODEL_PROVIDER_IDS=(anthropic openai minimax gemini groq cerebras mistral together_ai deepseek novita)
+    MODEL_DEFAULTS=("claude-haiku-4-5-20251001" "gpt-5-mini" "MiniMax-M2.5" "gemini-3-flash-preview" "moonshotai/kimi-k2-instruct-0905" "zai-glm-4.7" "mistral-large-latest" "meta-llama/Llama-3.3-70B-Instruct-Turbo" "deepseek-chat" "moonshotai/kimi-k2.5")
 
     get_provider_name() {
         local env_var="$1"; local i=0
@@ -208,11 +224,11 @@ else
         done
     }
 
-    MC_PROVIDERS=(anthropic anthropic anthropic anthropic openai openai gemini gemini groq groq cerebras cerebras)
-    MC_IDS=("claude-haiku-4-5-20251001" "claude-sonnet-4-20250514" "claude-sonnet-4-5-20250929" "claude-opus-4-6" "gpt-5-mini" "gpt-5.2" "gemini-3-flash-preview" "gemini-3.1-pro-preview" "moonshotai/kimi-k2-instruct-0905" "openai/gpt-oss-120b" "zai-glm-4.7" "qwen3-235b-a22b-instruct-2507")
-    MC_LABELS=("Haiku 4.5 - Fast + cheap (recommended for workers)" "Sonnet 4 - Fast + capable" "Sonnet 4.5 - Best balance" "Opus 4.6 - Most capable" "GPT-5 Mini - Fast + cheap (recommended for workers)" "GPT-5.2 - Most capable" "Gemini 3 Flash - Fast (recommended for workers)" "Gemini 3.1 Pro - Best quality" "Kimi K2 - Best quality (recommended)" "GPT-OSS 120B - Fast reasoning" "ZAI-GLM 4.7 - Best quality (recommended)" "Qwen3 235B - Frontier reasoning")
-    MC_MAXTOKENS=(8192 8192 16384 32768 16384 16384 8192 8192 8192 8192 8192 8192)
-    MC_MAXCONTEXTTOKENS=(180000 180000 180000 180000 120000 120000 900000 900000 120000 120000 120000 120000)
+    MC_PROVIDERS=(anthropic anthropic anthropic anthropic openai openai gemini gemini groq groq cerebras cerebras novita novita novita)
+    MC_IDS=("claude-haiku-4-5-20251001" "claude-sonnet-4-20250514" "claude-sonnet-4-5-20250929" "claude-opus-4-6" "gpt-5-mini" "gpt-5.2" "gemini-3-flash-preview" "gemini-3.1-pro-preview" "moonshotai/kimi-k2-instruct-0905" "openai/gpt-oss-120b" "zai-glm-4.7" "qwen3-235b-a22b-instruct-2507" "moonshotai/kimi-k2.5" "zai-org/glm-5" "minimax/minimax-m2.5")
+    MC_LABELS=("Haiku 4.5 - Fast + cheap (recommended for workers)" "Sonnet 4 - Fast + capable" "Sonnet 4.5 - Best balance" "Opus 4.6 - Most capable" "GPT-5 Mini - Fast + cheap (recommended for workers)" "GPT-5.2 - Most capable" "Gemini 3 Flash - Fast (recommended for workers)" "Gemini 3.1 Pro - Best quality" "Kimi K2 - Best quality (recommended)" "GPT-OSS 120B - Fast reasoning" "ZAI-GLM 4.7 - Best quality (recommended)" "Qwen3 235B - Frontier reasoning" "Kimi K2.5 - Best value (recommended)" "GLM-5 - Reasoning model" "MiniMax M2.5 - Cost-effective")
+    MC_MAXTOKENS=(8192 8192 16384 32768 16384 16384 8192 8192 8192 8192 8192 8192 32768 32768 32768)
+    MC_MAXCONTEXTTOKENS=(180000 180000 180000 180000 120000 120000 900000 900000 120000 120000 120000 120000 240000 180000 180000)
 
     get_model_choice_count() {
         local p="$1"; local cnt=0; local i=0
@@ -714,6 +730,7 @@ if [ -n "$PREV_SUB_MODE" ] || [ -n "$PREV_PROVIDER" ]; then
                 groq)      DEFAULT_CHOICE=11 ;;
                 cerebras)  DEFAULT_CHOICE=12 ;;
                 openrouter) DEFAULT_CHOICE=13 ;;
+                novita)    DEFAULT_CHOICE=14 ;;
                 minimax)   DEFAULT_CHOICE=4 ;;
                 kimi)      DEFAULT_CHOICE=5 ;;
                 hive)      DEFAULT_CHOICE=6 ;;
@@ -780,8 +797,8 @@ echo ""
 echo -e "  ${CYAN}${BOLD}API key providers:${NC}"
 
 # 8-13) API key providers — show (credential detected) if key already set
-PROVIDER_MENU_ENVS=(ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY GROQ_API_KEY CEREBRAS_API_KEY OPENROUTER_API_KEY)
-PROVIDER_MENU_NAMES=("Anthropic (Claude) - Recommended" "OpenAI (GPT)" "Google Gemini - Free tier available" "Groq - Fast, free tier" "Cerebras - Fast, free tier" "OpenRouter - Bring any OpenRouter model")
+PROVIDER_MENU_ENVS=(ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY GROQ_API_KEY CEREBRAS_API_KEY OPENROUTER_API_KEY NOVITA_API_KEY)
+PROVIDER_MENU_NAMES=("Anthropic (Claude) - Recommended" "OpenAI (GPT)" "Google Gemini - Free tier available" "Groq - Fast, free tier" "Cerebras - Fast, free tier" "OpenRouter - Bring any OpenRouter model" "Novita AI - Best value LLMs")
 for idx in "${!PROVIDER_MENU_ENVS[@]}"; do
     num=$((idx + 8))
     env_var="${PROVIDER_MENU_ENVS[$idx]}"
@@ -1010,6 +1027,13 @@ case $choice in
         PROVIDER_NAME="OpenRouter"
         SIGNUP_URL="https://openrouter.ai/keys"
         ;;
+    14)
+        SELECTED_ENV_VAR="NOVITA_API_KEY"
+        SELECTED_PROVIDER_ID="novita"
+        SELECTED_API_BASE="https://api.novita.ai/openai"
+        PROVIDER_NAME="Novita AI"
+        SIGNUP_URL="https://novita.ai/settings/key-management"
+        ;;
     "$SKIP_CHOICE")
         echo ""
         echo -e "${YELLOW}Skipped.${NC} Worker model not configured."
@@ -1176,6 +1200,8 @@ if [ -n "$SELECTED_PROVIDER_ID" ]; then
     elif [ "$SUBSCRIPTION_MODE" = "hive_llm" ]; then
         save_worker_configuration "$SELECTED_PROVIDER_ID" "$SELECTED_ENV_VAR" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "" "$SELECTED_API_BASE" > /dev/null || SAVE_OK=false
     elif [ "$SELECTED_PROVIDER_ID" = "openrouter" ]; then
+        save_worker_configuration "$SELECTED_PROVIDER_ID" "$SELECTED_ENV_VAR" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "" "$SELECTED_API_BASE" > /dev/null || SAVE_OK=false
+    elif [ "$SELECTED_PROVIDER_ID" = "novita" ]; then
         save_worker_configuration "$SELECTED_PROVIDER_ID" "$SELECTED_ENV_VAR" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" "" "$SELECTED_API_BASE" > /dev/null || SAVE_OK=false
     else
         save_worker_configuration "$SELECTED_PROVIDER_ID" "$SELECTED_ENV_VAR" "$SELECTED_MODEL" "$SELECTED_MAX_TOKENS" "$SELECTED_MAX_CONTEXT_TOKENS" > /dev/null || SAVE_OK=false


### PR DESCRIPTION
## Summary

- Add Novita AI as a new LLM provider with OpenAI-compatible API endpoint
- Wire Novita into all provider selection entry points (quickstart scripts, setup scripts)
- Add model choices: `moonshotai/kimi-k2.5` (default), `zai-org/glm-5`, `minimax/minimax-m2.5`
- Add Novita key validation in `scripts/check_llm_key.py`

## Changes

### Core LLM Integration
- `core/framework/llm/litellm.py`: Add `NOVITA_API_BASE` constant and default API base for `novita/` model prefix

### Setup Scripts
- `quickstart.sh`: Add Novita to provider lists, model choices, and menu selection
- `quickstart.ps1`: Add Novita to provider maps, model choices, and menu selection  
- `scripts/setup_worker_model.sh`: Add Novita to worker model configuration
- `scripts/setup_worker_model.ps1`: Add Novita to worker model configuration

### Validation
- `scripts/check_llm_key.py`: Add `check_novita()` function for API key validation

### Tests
- `core/tests/test_litellm_provider.py`: Add tests for Novita provider initialization

## API Details

- **Endpoint**: `https://api.novita.ai/openai` (OpenAI-compatible)
- **API Key**: `NOVITA_API_KEY` environment variable
- **Default Model**: `moonshotai/kimi-k2.5` (256K context, supports function calling, vision, reasoning)

## Test Plan

- [x] Unit tests for Novita provider initialization pass
- [x] `check_llm_key.py novita` validates API keys correctly
- [x] Quickstart scripts syntax validated