### PR TITLE
fix: windows Codex OAuth browser launch and manual fallback

### DIFF
--- a/core/codex_oauth.py
+++ b/core/codex_oauth.py
@@ -17,6 +17,7 @@ import http.server
 import json
 import os
 import platform
+import queue
 import secrets
 import subprocess
 import sys
@@ -27,6 +28,7 @@ import urllib.parse
 import urllib.request
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TextIO
 
 # OAuth constants (from the Codex CLI binary)
 CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
@@ -165,11 +167,11 @@ def open_browser(url: str) -> bool:
         if system == "Darwin":
             subprocess.Popen(["open", url], stdout=devnull, stderr=devnull)
         elif system == "Windows":
-            subprocess.Popen(["cmd", "/c", "start", url], stdout=devnull, stderr=devnull)
+            os.startfile(url)  # type: ignore[attr-defined]
         else:
             subprocess.Popen(["xdg-open", url], stdout=devnull, stderr=devnull)
         return True
-    except OSError:
+    except (AttributeError, OSError):
         return False
 
 
@@ -266,6 +268,71 @@ def parse_manual_input(value: str, expected_state: str) -> str | None:
     return None
 
 
+def _read_manual_input_lines(
+    manual_inputs: queue.Queue[str],
+    stop_event: threading.Event,
+    stdin: TextIO | None = None,
+) -> None:
+    stream = sys.stdin if stdin is None else stdin
+
+    while not stop_event.is_set():
+        try:
+            manual = stream.readline()
+        except (EOFError, OSError):
+            return
+
+        if not manual:
+            return
+
+        if manual.strip():
+            manual_inputs.put(manual)
+
+
+def wait_for_code_from_callback_or_stdin(
+    expected_state: str,
+    callback_result: list[str | None],
+    callback_done: threading.Event,
+    timeout_secs: float = 120,
+    poll_interval: float = 0.1,
+    stdin: TextIO | None = None,
+) -> str | None:
+    manual_inputs: queue.Queue[str] = queue.Queue()
+    stop_event = threading.Event()
+
+    # Read stdin on a daemon thread so manual paste works on platforms where
+    # select() cannot poll console handles, including Windows terminals.
+    threading.Thread(
+        target=_read_manual_input_lines,
+        args=(manual_inputs, stop_event, stdin),
+        daemon=True,
+    ).start()
+
+    deadline = time.time() + timeout_secs
+    try:
+        while time.time() < deadline:
+            if callback_result[0]:
+                return callback_result[0]
+
+            while True:
+                try:
+                    manual = manual_inputs.get_nowait()
+                except queue.Empty:
+                    break
+
+                code = parse_manual_input(manual, expected_state)
+                if code:
+                    return code
+
+            if callback_done.is_set():
+                return callback_result[0]
+
+            time.sleep(poll_interval)
+
+        return callback_result[0]
+    finally:
+        stop_event.set()
+
+
 def main() -> int:
     # Generate PKCE and state
     verifier, challenge = generate_pkce()
@@ -315,41 +382,28 @@ def main() -> int:
 
         # Start callback server in background
         callback_result: list[str | None] = [None]
+        callback_done = threading.Event()
 
         def run_server() -> None:
-            callback_result[0] = wait_for_callback(state, timeout_secs=120)
+            try:
+                callback_result[0] = wait_for_callback(state, timeout_secs=120)
+            finally:
+                callback_done.set()
 
         server_thread = threading.Thread(target=run_server)
         server_thread.daemon = True
         server_thread.start()
 
-        # Also accept manual input in parallel
-        # We poll for both the server result and stdin
         try:
-            import select
-
-            while server_thread.is_alive():
-                # Check if stdin has data (non-blocking on unix)
-                if hasattr(select, "select"):
-                    ready, _, _ = select.select([sys.stdin], [], [], 0.5)
-                    if ready:
-                        manual = sys.stdin.readline()
-                        if manual.strip():
-                            code = parse_manual_input(manual, state)
-                            if code:
-                                break
-                else:
-                    time.sleep(0.5)
-
-                if callback_result[0]:
-                    code = callback_result[0]
-                    break
-        except (KeyboardInterrupt, EOFError):
+            code = wait_for_code_from_callback_or_stdin(
+                state,
+                callback_result,
+                callback_done,
+                timeout_secs=120,
+            )
+        except KeyboardInterrupt:
             print("\n\033[0;31mCancelled.\033[0m")
             return 1
-
-        if not code:
-            code = callback_result[0]
     else:
         # Manual paste mode
         try:

--- a/core/tests/test_codex_oauth.py
+++ b/core/tests/test_codex_oauth.py
@@ -1,0 +1,68 @@
+import io
+import threading
+import time
+
+import codex_oauth
+
+
+def _redirect_url(state: str, code: str) -> str:
+    return f"{codex_oauth.REDIRECT_URI}?code={code}&state={state}"
+
+
+def test_wait_for_code_accepts_valid_manual_input_after_invalid_entry():
+    state = "expected-state"
+    stdin = io.StringIO(f"not a valid code\n{_redirect_url(state, 'manual-code')}\n")
+
+    code = codex_oauth.wait_for_code_from_callback_or_stdin(
+        state,
+        [None],
+        threading.Event(),
+        timeout_secs=0.5,
+        poll_interval=0.01,
+        stdin=stdin,
+    )
+
+    assert code == "manual-code"
+
+
+def test_wait_for_code_returns_callback_when_stdin_reader_fails():
+    class BrokenStdin:
+        def readline(self) -> str:
+            raise OSError("stdin unavailable")
+
+    state = "expected-state"
+    callback_result: list[str | None] = [None]
+    callback_done = threading.Event()
+
+    def resolve_callback() -> None:
+        time.sleep(0.02)
+        callback_result[0] = "callback-code"
+        callback_done.set()
+
+    threading.Thread(target=resolve_callback, daemon=True).start()
+
+    code = codex_oauth.wait_for_code_from_callback_or_stdin(
+        state,
+        callback_result,
+        callback_done,
+        timeout_secs=0.5,
+        poll_interval=0.01,
+        stdin=BrokenStdin(),
+    )
+
+    assert code == "callback-code"
+
+
+def test_open_browser_uses_windows_startfile(monkeypatch):
+    calls: list[str] = []
+
+    monkeypatch.setattr(codex_oauth.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(codex_oauth.os, "startfile", calls.append, raising=False)
+
+    def fail_popen(*args, **kwargs):
+        raise AssertionError("Windows browser launch should not go through cmd /c start")
+
+    monkeypatch.setattr(codex_oauth.subprocess, "Popen", fail_popen)
+
+    assert codex_oauth.open_browser("https://example.com/path?a=1&b=2") is True
+    assert calls == ["https://example.com/path?a=1&b=2"]


### PR DESCRIPTION
## Description

Fix Windows-specific failures in the Codex OAuth flow.

The OAuth helper now avoids `select.select([sys.stdin], ...)` for manual paste fallback and uses a background stdin reader instead, which works on Windows terminals. It also replaces the Windows browser launch path that used `cmd /c start` with a native launch path so OAuth URLs containing `&` are not truncated before reaching OpenAI.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #6731

## Changes Made

- Replace Windows stdin polling in the OAuth wait loop with a platform-neutral background reader thread
- Keep the local callback flow and manual paste fallback running in parallel without relying on `select` for console stdin
- Replace the Windows browser launch implementation so the full OAuth authorize URL is opened intact
- Add focused regression tests for manual input handling, callback completion when stdin reading fails, and Windows browser launching

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

Ran locally:

- `cd core && uv run pytest tests/test_codex_oauth.py`
- `cd core && uv run ruff check codex_oauth.py tests/test_codex_oauth.py`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

before:

<img width="1384" height="495" alt="image" src="https://github.com/user-attachments/assets/86577597-a579-4c56-9e48-7aff6420d030" />


after:
<img width="1404" height="562" alt="image" src="https://github.com/user-attachments/assets/439daba0-fc14-4528-bb68-edbd1f5b52f3" />