### PR TITLE
fix(command_sanitizer): handle rm -- separator and add rd /s Windows coverage

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/command_sanitizer.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/command_sanitizer.py
@@ -93,11 +93,14 @@ _BLOCKED_EXECUTABLES: list[str] = [
 # These catch dangerous flags and argument combos even when the
 # executable itself isn't blocked (e.g. python -c '...').
 _BLOCKED_PATTERNS: list[re.Pattern[str]] = [
-    # rm with force/recursive flags targeting root or broad paths
-    re.compile(r"\brm\s+(-[rRf]+\s+)*(/|~|\.\.|C:\\)", re.IGNORECASE),
+    # rm with force/recursive flags targeting root or broad paths;
+    # optional -- end-of-options separator before the path
+    re.compile(r"\brm\s+(-[rRf]+\s+)*(--\s+)?(/|~|\.\.|C:\\)", re.IGNORECASE),
     # del /s /q (Windows recursive delete)
     re.compile(r"\bdel\s+.*/[sS]", re.IGNORECASE),
     re.compile(r"\brmdir\s+/[sS]", re.IGNORECASE),
+    # rd (alias for rmdir on Windows) with /s recursive flag
+    re.compile(r"\brd\s+/[sS]", re.IGNORECASE),
     # dd writing to disks/partitions
     re.compile(r"\bdd\s+.*\bof=\s*/dev/", re.IGNORECASE),
     # chmod 777 / chmod -R 777

--- a/tools/tests/test_command_sanitizer.py
+++ b/tools/tests/test_command_sanitizer.py
@@ -146,6 +146,15 @@ class TestBlockedPatterns:
             "rm -rf ..",
             "rm -rf C:\\",
             "rm -f -r /",
+            # rm with -- end-of-options separator
+            "rm -rf -- /",
+            "rm -f -- ~",
+            "rm -r -- ..",
+            # Windows delete variants
+            "del /F /S /Q C:\\Users",
+            "rmdir /S /Q C:\\Temp",
+            "rd /s /q C:\\Temp",
+            "rd /S /Q D:\\",
             # sudo
             "sudo apt install something",
             "sudo rm -rf /var/log",
@@ -229,6 +238,25 @@ class TestEdgeCases:
         """rm of a specific file (not root/home) should pass."""
         validate_command("rm temp.txt")
         validate_command("rm -f output.log")
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # rd/rmdir without /s flag — removing a specific empty dir is fine
+            "rd output",
+            "rd build/artifacts",
+            "rmdir empty_dir",
+            # del without /s flag — removing a single file is fine
+            "del temp.txt",
+            "del /F locked_file.txt",
+            # rm with -- but targeting a plain file, not root/home
+            "rm -- odd-named-file.txt",
+            "rm -f -- temp.log",
+        ],
+    )
+    def test_benign_delete_commands_pass(self, cmd):
+        """Delete commands that target specific files/dirs (not root) should pass."""
+        validate_command(cmd)
 
     def test_python_without_c_flag_is_safe(self):
         """python script.py is safe; only python -c is blocked."""


### PR DESCRIPTION
## Summary

Closes #6734

- Updated the `rm` blocked pattern to handle an optional `--` end-of-options separator before destructive targets (e.g. `rm -rf -- /`, `rm -f -- ~`)
- Added a new `rd /s` pattern to block the Windows `rd` command (an alias for `rmdir`) when used with the recursive `/s` flag
- Added blocked tests for all new variants (`rm -rf -- /`, `rd /s /q`, `del /F /S /Q`, `rmdir /S /Q`)
- Added false-positive tests (`test_benign_delete_commands_pass`) to confirm that safe delete commands (`rd output`, `rmdir empty_dir`, `del /F locked_file.txt`, `rm -- file.txt`) still pass

## Test plan

- [x] All 127 tests pass (`uv run pytest tools/tests/test_command_sanitizer.py -v`)
- [x] New blocked variants are caught by the updated/new patterns
- [x] Benign delete commands are not accidentally blocked