### PR TITLE
fix(conversation): needs_compaction returns False when max_context_tokens=0

### DIFF
--- a/core/framework/graph/conversation.py
+++ b/core/framework/graph/conversation.py
@@ -562,6 +562,8 @@ class NodeConversation:
         return self.estimate_tokens() / self._max_context_tokens
 
     def needs_compaction(self) -> bool:
+        if self._max_context_tokens <= 0:
+            return False
         return self.estimate_tokens() >= self._max_context_tokens * self._compaction_threshold
 
     # --- Output-key extraction ---------------------------------------------

--- a/core/tests/test_node_conversation.py
+++ b/core/tests/test_node_conversation.py
@@ -238,6 +238,21 @@ class TestNodeConversation:
         assert conv.needs_compaction() is True
 
     @pytest.mark.asyncio
+    async def test_needs_compaction_unlimited_context(self):
+        """needs_compaction returns False when max_context_tokens=0 (unlimited)."""
+        conv = NodeConversation(max_context_tokens=0)
+        await conv.add_user_message("x" * 10000)
+        assert conv.needs_compaction() is False
+
+    @pytest.mark.asyncio
+    async def test_needs_compaction_unlimited_context_with_actual_tokens(self):
+        """needs_compaction returns False even after update_token_count when unlimited."""
+        conv = NodeConversation(max_context_tokens=0)
+        await conv.add_user_message("hello")
+        conv.update_token_count(999999)
+        assert conv.needs_compaction() is False
+
+    @pytest.mark.asyncio
     async def test_compact_replaces_with_summary(self):
         """keep_recent=0 replaces all messages; empty conversation is a no-op."""
         conv = NodeConversation()


### PR DESCRIPTION
Closes #6711

## Description
Fix `needs_compaction()` always returning `True` when `max_context_tokens=0`.

## Motivation
When agents are configured with unlimited context (`max_context_tokens=0`), compaction was triggered on every single turn, causing unnecessary context loss. `usage_ratio()` already had the correct guard but `needs_compaction()` duplicated the logic without it.

## Changes
- Added `if self._max_context_tokens <= 0: return False` guard to `needs_compaction()`
- Added tests for unlimited context with and without actual token counts

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist
- [x] Code follows style guidelines (ruff)
- [x] Self-review completed
- [ ] Documentation updated
- [x] No breaking changes