### PR TITLE
micro-fix(runner): replace print() with logger.warning() for Antigravity credentials

### DIFF
--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -1547,8 +1547,8 @@ class AgentRunner:
 
                 provider = AntigravityProvider(model=self.model)
                 if not provider.has_credentials():
-                    print(
-                        "Warning: Antigravity credentials not found. "
+                    logger.warning(
+                        "Antigravity credentials not found. "
                         "Run: uv run python core/antigravity_auth.py auth account add"
                     )
                 self._llm = provider


### PR DESCRIPTION
## Description
Replace `print()` with `logger.warning()` for missing Antigravity credentials warning.

## Motivation
Credential warnings should go through the logging system for consistency, filtering, and observability. Same pattern as #6577.

## Changes
- Replace `print()` with `logger.warning()` in `runner.py` for Antigravity credentials check

## Checklist
- [x] Code follows style guidelines (ruff)
- [x] Self-review completed
- [x] No breaking changes