### PR TITLE
fix: add 404 Not Found page for undefined routes

### DIFF
--- a/core/frontend/src/App.tsx
+++ b/core/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from "react-router-dom";
 import Home from "./pages/home";
 import MyAgents from "./pages/my-agents";
 import Workspace from "./pages/workspace";
+import NotFound from "./pages/not-found";
 
 function App() {
   return (
@@ -9,6 +10,7 @@ function App() {
       <Route path="/" element={<Home />} />
       <Route path="/my-agents" element={<MyAgents />} />
       <Route path="/workspace" element={<Workspace />} />
+      <Route path="*" element={<NotFound />} />
     </Routes>
   );
 }

--- a/core/frontend/src/pages/not-found.tsx
+++ b/core/frontend/src/pages/not-found.tsx
@@ -1,0 +1,41 @@
+import { useNavigate } from "react-router-dom";
+import { Hexagon, ArrowLeft } from "lucide-react";
+import TopBar from "@/components/TopBar";
+
+export default function NotFound() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col">
+      <TopBar />
+
+      <div className="flex-1 flex flex-col items-center justify-center p-6">
+        <div className="text-center max-w-md">
+          <div
+            className="inline-flex w-14 h-14 rounded-2xl items-center justify-center mb-6"
+            style={{
+              backgroundColor: "hsl(45,95%,58%,0.1)",
+              border: "1.5px solid hsl(45,95%,58%,0.25)",
+              boxShadow: "0 0 24px hsl(45,95%,58%,0.08)",
+            }}
+          >
+            <Hexagon className="w-7 h-7 text-primary" />
+          </div>
+
+          <h1 className="text-5xl font-bold text-foreground mb-2">404</h1>
+          <p className="text-lg text-muted-foreground mb-6">
+            This page doesn't exist in the hive.
+          </p>
+
+          <button
+            onClick={() => navigate("/")}
+            className="inline-flex items-center gap-2 text-sm font-medium px-5 py-2.5 rounded-lg border border-border/60 text-muted-foreground hover:text-foreground hover:border-primary/30 hover:bg-primary/[0.03] transition-all"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            <span>Back to Home</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a catch-all `*` route in `App.tsx` that renders a `NotFound` component
- Creates `not-found.tsx` page with the project's existing design system (TopBar, Tailwind theme tokens, Lucide icons)
- Users navigating to invalid URLs now see a friendly 404 page with a "Back to Home" button instead of a blank dark screen

Closes #6336

## Test plan
- [x] TypeScript compiles without errors (`tsc --noEmit`)
- [x] All existing tests pass (`vitest run` — 55 tests)
- [x] Verified the component uses the same patterns as `home.tsx` (TopBar, theme colors, Lucide icons)
- [ ] Manual: navigate to `/nonexistent-page` → should show 404 page with navigation back to home

🤖 Generated with [Claude Code](https://claude.com/claude-code)