### PR TITLE
fix: validate --input-file is not a directory before execution

### DIFF
--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -401,6 +401,13 @@ def cmd_run(args: argparse.Namespace) -> int:
             print(f"Error parsing --input JSON: {e}", file=sys.stderr)
             return 1
     elif args.input_file:
+        input_path = Path(args.input_file)
+        if input_path.is_dir():
+            print(
+                f"Error: input file is a directory, not a file: {args.input_file}",
+                file=sys.stderr,
+            )
+            return 1
         try:
             with open(args.input_file, encoding="utf-8") as f:
                 context = json.load(f)


### PR DESCRIPTION
## Summary
- Adds early validation in `cmd_run` that checks if `--input-file` points to a directory
- Prints a clear error message and exits with code 1 instead of crashing with a raw `IsADirectoryError` traceback
- Uses `Path.is_dir()` check before attempting to open the file, consistent with the existing `--output` path validation pattern already in the same function

Closes #6207

## Test plan
- [x] Verified the fix matches the error message format suggested in the issue
- [x] Confirmed `Path` is already imported at the top of `cli.py`
- [x] Validated that the existing `--output` directory validation follows the same pattern (lines 410-424)
- [ ] Manual: `hive run exports/my_agent --input-file exports/` should print `Error: input file is a directory, not a file: exports/` and exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)