### PR TITLE
fix: add missing agent.json to email_reply_agent and meeting_scheduler templates

### DIFF
--- a/examples/templates/email_reply_agent/agent.json
+++ b/examples/templates/email_reply_agent/agent.json
@@ -1,0 +1,198 @@
+{
+  "agent": {
+    "id": "email_reply_agent",
+    "name": "Email Reply Agent",
+    "version": "1.0.0",
+    "description": "Filter unreplied emails by user criteria, confirm recipients, send personalized replies."
+  },
+  "graph": {
+    "id": "email-reply-graph",
+    "goal_id": "email-reply-goal",
+    "version": "1.0.0",
+    "entry_node": "intake",
+    "entry_points": {
+      "start": "intake"
+    },
+    "pause_nodes": [],
+    "terminal_nodes": [],
+    "conversation_mode": "continuous",
+    "identity_prompt": "You are a helpful email reply assistant that filters unreplied emails and sends personalized responses.",
+    "nodes": [
+      {
+        "id": "intake",
+        "name": "Intake",
+        "description": "Gather email filter criteria from user",
+        "node_type": "event_loop",
+        "input_keys": ["batch_complete", "restart"],
+        "output_keys": ["filter_criteria"],
+        "nullable_output_keys": ["batch_complete", "restart"],
+        "input_schema": {},
+        "output_schema": {},
+        "system_prompt": "You are an intake specialist for email replies. Your ONLY job is to gather filter criteria and call set_output.\n\nIf the user has already provided criteria in their message, IMMEDIATELY call:\nset_output(\"filter_criteria\", {\"sender_pattern\": \"...\", \"date_range\": \"...\", \"max_results\": 50, \"tone_guidance\": \"...\"})\n\nDO NOT:\n- Read files\n- Search files\n- List directories\n- Ask for confirmation if criteria are already provided\n\nIf you need more information, ask ONE brief question. Otherwise, call set_output immediately.\n\nAfter batch_complete or restart, acknowledge and ask for next criteria.",
+        "tools": [],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 0,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": true,
+        "success_criteria": "Filter criteria is specific enough to search Gmail (sender, subject, date range, or keywords)."
+      },
+      {
+        "id": "search",
+        "name": "Search Emails",
+        "description": "Search Gmail for unreplied emails matching filter criteria",
+        "node_type": "event_loop",
+        "input_keys": ["filter_criteria"],
+        "output_keys": ["email_list"],
+        "nullable_output_keys": [],
+        "input_schema": {},
+        "output_schema": {},
+        "system_prompt": "You are a Gmail search agent. Find unreplied emails matching the user's filter criteria.\n\n## Workflow:\n1. Build Gmail search query from filter_criteria:\n   - Use \"is:unread\" to find unreplied (standard proxy for unreplied)\n   - Add sender: from:(pattern) if sender_pattern provided\n   - Add subject: subject:(keywords) if subject_keywords provided\n   - Add after: after:YYYY/MM/DD if date_range provided\n   - Limit to max_results (default 50)\n2. Call gmail_list_messages with the query\n3. For each message_id, call gmail_get_message to get full content (sender, subject, body)\n4. Build a structured list of emails\n\n## Output:\nset_output(\"email_list\", JSON list with fields for each email:\n- message_id\n- sender (email address)\n- sender_name (if available)\n- subject\n- snippet (first 200 chars of body)\n- received_date (ISO format)\n)\n\nIf no emails found, set empty array: set_output(\"email_list\", [])",
+        "tools": ["gmail_list_messages", "gmail_get_message", "gmail_batch_get_messages"],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 0,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": false,
+        "success_criteria": "Found unreplied emails matching criteria with sender, subject, snippet, message_id."
+      },
+      {
+        "id": "confirm-draft",
+        "name": "Confirm & Reply",
+        "description": "Present emails for confirmation, send personalized replies",
+        "node_type": "event_loop",
+        "input_keys": ["email_list", "filter_criteria"],
+        "output_keys": ["batch_complete", "restart"],
+        "nullable_output_keys": ["batch_complete", "restart"],
+        "input_schema": {},
+        "output_schema": {},
+        "system_prompt": "You are a Gmail reply assistant. Present emails for confirmation, then send personalized replies.\n\n**STEP 1 — Present for confirmation (text only, NO tool calls):**\n1. Show the email list in readable format:\n   - #. Sender Name <email> - Subject (Date)\n   - Snippet: first 150 chars\n2. Ask: \"These are the emails to reply to. Confirm? Any tone preferences or specific messages?\"\n3. Wait for user response\n\n**STEP 2 — Handle user response:**\n\nIf user CONFIRMS (says yes, go ahead, sounds good, etc.):\nFor EACH email in email_list:\n1. Read the subject and snippet\n2. Use tone_guidance from filter_criteria + any user-specified preferences\n3. Call gmail_reply_email with:\n   - message_id: the email's message_id\n   - html: personalized 2-4 sentence reply based on email context\n   (The tool automatically handles recipient, subject, and threading)\n4. After all replies sent, call: set_output(\"batch_complete\", True)\n\nIf user wants to CHANGE LOGIC/FILTER (says change filter, different criteria, not these emails, wrong emails, etc.):\n1. Acknowledge their request\n2. Call: set_output(\"restart\", True)\n\nPersonalization rules:\n- Reference specific details from their email (questions asked, topics mentioned)\n- Match their formality level (formal→formal, casual→casual)\n- If tone_guidance specifies style, follow it\n- Keep replies concise but warm",
+        "tools": ["gmail_reply_email"],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 0,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": true,
+        "success_criteria": "User confirmed recipients and personalized replies sent for each."
+      }
+    ],
+    "edges": [
+      {
+        "id": "intake-to-search",
+        "source": "intake",
+        "target": "search",
+        "condition": "on_success",
+        "condition_expr": null,
+        "priority": 1,
+        "input_mapping": {}
+      },
+      {
+        "id": "search-to-confirm",
+        "source": "search",
+        "target": "confirm-draft",
+        "condition": "on_success",
+        "condition_expr": null,
+        "priority": 1,
+        "input_mapping": {}
+      },
+      {
+        "id": "confirm-to-intake-on-restart",
+        "source": "confirm-draft",
+        "target": "intake",
+        "condition": "conditional",
+        "condition_expr": "restart == True",
+        "priority": 2,
+        "input_mapping": {}
+      },
+      {
+        "id": "confirm-to-intake-on-complete",
+        "source": "confirm-draft",
+        "target": "intake",
+        "condition": "conditional",
+        "condition_expr": "batch_complete == True",
+        "priority": 1,
+        "input_mapping": {}
+      }
+    ],
+    "max_steps": 500,
+    "max_retries_per_node": 3,
+    "description": "Filter unreplied emails by user criteria, confirm recipients, send personalized replies."
+  },
+  "goal": {
+    "id": "email-reply-goal",
+    "name": "Email Reply Agent",
+    "description": "Filter unreplied emails by user criteria, confirm recipients, send personalized replies.",
+    "status": "draft",
+    "success_criteria": [
+      {
+        "id": "sc-filter",
+        "description": "Accurately finds unreplied emails matching user criteria",
+        "metric": "Precision of email filtering",
+        "target": "90%",
+        "weight": 0.35,
+        "met": false
+      },
+      {
+        "id": "sc-confirm",
+        "description": "User confirms recipient list before sending",
+        "metric": "Confirmation rate",
+        "target": "100%",
+        "weight": 0.25,
+        "met": false
+      },
+      {
+        "id": "sc-personalize",
+        "description": "Replies are personalized based on email content and tone guidance",
+        "metric": "User satisfaction with reply relevance",
+        "target": "85%",
+        "weight": 0.40,
+        "met": false
+      }
+    ],
+    "constraints": [
+      {
+        "id": "c-privacy",
+        "description": "Never send emails without explicit user confirmation; always present recipient list and get approval first",
+        "constraint_type": "hard",
+        "category": "functional",
+        "check": ""
+      },
+      {
+        "id": "c-batch",
+        "description": "Process up to 50 emails per batch",
+        "constraint_type": "hard",
+        "category": "functional",
+        "check": ""
+      }
+    ],
+    "context": {},
+    "required_capabilities": [],
+    "input_schema": {},
+    "output_schema": {},
+    "version": "1.0.0",
+    "parent_version": null,
+    "evolution_reason": null
+  },
+  "required_tools": [
+    "gmail_list_messages",
+    "gmail_get_message",
+    "gmail_batch_get_messages",
+    "gmail_reply_email"
+  ],
+  "metadata": {
+    "node_count": 3,
+    "edge_count": 4
+  }
+}

--- a/examples/templates/meeting_scheduler/agent.json
+++ b/examples/templates/meeting_scheduler/agent.json
@@ -1,0 +1,215 @@
+{
+  "agent": {
+    "id": "meeting_scheduler",
+    "name": "Meeting Scheduler",
+    "version": "1.0.0",
+    "description": "Schedule meetings by checking Google Calendar availability, booking optimal time slots, recording details in Google Sheets, and sending email confirmations with Google Meet links to attendees."
+  },
+  "graph": {
+    "id": "meeting-scheduler-graph",
+    "goal_id": "meeting-scheduler-goal",
+    "version": "1.0.0",
+    "entry_node": "intake",
+    "entry_points": {
+      "start": "intake"
+    },
+    "pause_nodes": [],
+    "terminal_nodes": [],
+    "conversation_mode": "continuous",
+    "identity_prompt": "You are a helpful meeting scheduler assistant that manages calendar availability and sends confirmations.",
+    "nodes": [
+      {
+        "id": "intake",
+        "name": "Intake",
+        "description": "Gather meeting details from the user",
+        "node_type": "event_loop",
+        "input_keys": ["attendee_email", "meeting_duration_minutes"],
+        "output_keys": ["attendee_email", "meeting_duration_minutes", "meeting_title"],
+        "nullable_output_keys": ["attendee_email", "meeting_duration_minutes", "meeting_title"],
+        "input_schema": {},
+        "output_schema": {},
+        "system_prompt": "You are a meeting scheduler assistant.\n\n**STEP 1 — Use ask_user to collect meeting details:**\n1. Call ask_user to ask for: attendee email, meeting duration (minutes), and meeting title\n2. Wait for the user's response before proceeding\n\n**STEP 2 — After user provides all details, call set_output:**\n- set_output(\"attendee_email\", \"user's email address\")\n- set_output(\"meeting_duration_minutes\", meeting duration as string)\n- set_output(\"meeting_title\", \"title of the meeting\")",
+        "tools": [],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 0,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": true,
+        "success_criteria": "User has provided attendee email, meeting duration, and title."
+      },
+      {
+        "id": "schedule",
+        "name": "Schedule",
+        "description": "Find available time on calendar, book meeting with Google Meet, and log to Google Sheet",
+        "node_type": "event_loop",
+        "input_keys": ["attendee_email", "meeting_duration_minutes", "meeting_title"],
+        "output_keys": ["meeting_time", "booking_confirmed", "spreadsheet_recorded", "email_sent", "meet_link"],
+        "nullable_output_keys": [],
+        "input_schema": {},
+        "output_schema": {},
+        "system_prompt": "You are a meeting booking agent that creates Google Calendar events with Google Meet and logs to Google Sheets.\n\n## STEP 1 — Calendar Operations (tool calls in this turn):\n\n1. **Find availability and verify conflicts:**\n   - Use calendar_check_availability to find potential time slots.\n   - **CRITICAL:** Always search a broad window (at least 8 hours) for the target day to see the full context of the user's schedule.\n   - **SECONDARY CHECK:** Before finalizing a slot, use calendar_list_events for that specific day.\n\n2. **Create the event WITH GOOGLE MEET (AUTOMATIC):**\n   - Use calendar_create_event with summary, start_time, end_time, attendees, and timezone.\n   - The tool automatically generates a Google Meet link when attendees are provided.\n   - Extract the meet_link from conferenceData.entryPoints[0].uri in the response.\n\n3. **Log to Google Sheets:**\n   - Use google_sheets_get_spreadsheet with spreadsheet_id=\"Meeting Scheduler\" to check if it exists.\n   - If it doesn't exist, use google_sheets_create_spreadsheet with title=\"Meeting Scheduler\".\n   - Then use google_sheets_append_values to add a row with: Date, Time, Attendee Email, Meeting Title, Google Meet Link.\n\n4. **Send confirmation email:**\n   - Use send_email to send the attendee a confirmation with meeting title, date/time, and Google Meet link.\n\n## STEP 2 — set_output (SEPARATE turn, no other tool calls):\n\nAfter all tools complete successfully, call set_output:\n- set_output(\"meeting_time\", \"YYYY-MM-DD HH:MM\")\n- set_output(\"meet_link\", \"https://meet.google.com/xxx/yyy\")\n- set_output(\"booking_confirmed\", \"true\")\n- set_output(\"spreadsheet_recorded\", \"true\")\n- set_output(\"email_sent\", \"true\")",
+        "tools": [
+          "calendar_check_availability",
+          "calendar_create_event",
+          "calendar_list_events",
+          "google_sheets_create_spreadsheet",
+          "google_sheets_get_spreadsheet",
+          "google_sheets_append_values",
+          "send_email"
+        ],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 0,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": false,
+        "success_criteria": "Meeting time found, Google Meet created, Google Sheet 'Meeting Scheduler' updated with date/time/attendee/title/meet_link, and confirmation email sent."
+      },
+      {
+        "id": "confirm",
+        "name": "Confirm",
+        "description": "Present booking confirmation to user with Google Meet link",
+        "node_type": "event_loop",
+        "input_keys": ["meeting_time", "booking_confirmed", "meet_link"],
+        "output_keys": ["next_action"],
+        "nullable_output_keys": ["next_action"],
+        "input_schema": {},
+        "output_schema": {},
+        "system_prompt": "You are a confirmation assistant.\n\n**STEP 1 — Present confirmation and ask user:**\n1. Show the meeting details (date, time, attendee, title)\n2. Display the Google Meet link prominently\n3. Confirm the booking is complete and logged to Google Sheets\n4. Call ask_user to ask if they want to schedule another meeting or finish\n\n**STEP 2 — After user responds, call set_output:**\n- set_output(\"next_action\", \"another\") — if booking another meeting\n- set_output(\"next_action\", \"done\") — if finished",
+        "tools": [],
+        "model": null,
+        "function": null,
+        "routes": {},
+        "max_retries": 3,
+        "retry_on": [],
+        "max_node_visits": 0,
+        "output_model": null,
+        "max_validation_retries": 2,
+        "client_facing": true,
+        "success_criteria": "User has acknowledged the booking and received the Google Meet link."
+      }
+    ],
+    "edges": [
+      {
+        "id": "intake-to-schedule",
+        "source": "intake",
+        "target": "schedule",
+        "condition": "on_success",
+        "condition_expr": null,
+        "priority": 1,
+        "input_mapping": {}
+      },
+      {
+        "id": "schedule-to-confirm",
+        "source": "schedule",
+        "target": "confirm",
+        "condition": "on_success",
+        "condition_expr": null,
+        "priority": 1,
+        "input_mapping": {}
+      },
+      {
+        "id": "confirm-to-intake",
+        "source": "confirm",
+        "target": "intake",
+        "condition": "conditional",
+        "condition_expr": "str(next_action).lower() == 'another'",
+        "priority": 1,
+        "input_mapping": {}
+      }
+    ],
+    "max_steps": 500,
+    "max_retries_per_node": 3,
+    "description": "Schedule meetings by checking Google Calendar availability, booking optimal time slots, recording details in Google Sheets, and sending email confirmations with Google Meet links to attendees."
+  },
+  "goal": {
+    "id": "meeting-scheduler-goal",
+    "name": "Schedule Meetings",
+    "description": "Check calendar availability, find optimal meeting times, record meetings, and send reminders.",
+    "status": "draft",
+    "success_criteria": [
+      {
+        "id": "sc-1",
+        "description": "Meeting time found within requested duration",
+        "metric": "calendar_availability",
+        "target": "success",
+        "weight": 0.35,
+        "met": false
+      },
+      {
+        "id": "sc-2",
+        "description": "Meeting recorded in spreadsheet accurately",
+        "metric": "data_persistence",
+        "target": "recorded",
+        "weight": 0.30,
+        "met": false
+      },
+      {
+        "id": "sc-3",
+        "description": "Attendee email reminder sent",
+        "metric": "communication",
+        "target": "sent",
+        "weight": 0.25,
+        "met": false
+      },
+      {
+        "id": "sc-4",
+        "description": "User confirms meeting details",
+        "metric": "user_acknowledgment",
+        "target": "confirmed",
+        "weight": 0.10,
+        "met": false
+      }
+    ],
+    "constraints": [
+      {
+        "id": "c-1",
+        "description": "Must use Google Calendar API for availability check",
+        "constraint_type": "hard",
+        "category": "functional",
+        "check": ""
+      },
+      {
+        "id": "c-2",
+        "description": "Meeting duration must match requested time",
+        "constraint_type": "hard",
+        "category": "accuracy",
+        "check": ""
+      },
+      {
+        "id": "c-3",
+        "description": "Spreadsheet record must include date, time, attendee, title",
+        "constraint_type": "hard",
+        "category": "quality",
+        "check": ""
+      }
+    ],
+    "context": {},
+    "required_capabilities": [],
+    "input_schema": {},
+    "output_schema": {},
+    "version": "1.0.0",
+    "parent_version": null,
+    "evolution_reason": null
+  },
+  "required_tools": [
+    "calendar_check_availability",
+    "calendar_create_event",
+    "calendar_list_events",
+    "google_sheets_create_spreadsheet",
+    "google_sheets_get_spreadsheet",
+    "google_sheets_append_values",
+    "send_email"
+  ],
+  "metadata": {
+    "node_count": 3,
+    "edge_count": 3
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `agent.json` manifest to `examples/templates/email_reply_agent/`
- Adds `agent.json` manifest to `examples/templates/meeting_scheduler/`
- Both templates previously appeared in the UI with `tool_count: 0` and `tags: []` because the discovery system (`discovery.py`) could not extract required tools or metadata without `agent.json`
- Manifests follow the exact same structure as `email_inbox_management/agent.json`, with all data extracted from each template's `agent.py`, `config.py`, and `nodes/__init__.py`

Closes #6272

## Test plan
- [x] Both JSON files are valid (`json.load()` succeeds)
- [x] Structure matches the reference template (`email_inbox_management/agent.json`)
- [x] All required_tools match the tools declared in each node's `tools` list
- [x] Node/edge counts in metadata match the actual definitions
- [ ] Manual: verify both agents now show correct `tool_count` and tags in the UI agent picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)