### PR TITLE
fix: include tool_calls in token counting fallback estimate

### DIFF
--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -271,7 +271,15 @@ def _estimate_tokens(model: str, messages: list[dict]) -> tuple[int, str]:
             pass
 
     # Fallback: rough estimate based on character count (~4 chars per token)
-    total_chars = sum(len(str(m.get("content", ""))) for m in messages)
+    total_chars = 0
+    for m in messages:
+        total_chars += len(str(m.get("content", "")))
+        for tc in m.get("tool_calls", []):
+            func = tc.get("function", {})
+            total_chars += len(func.get("name", ""))
+            total_chars += len(func.get("arguments", ""))
+        if m.get("tool_call_id"):
+            total_chars += len(str(m.get("tool_call_id", "")))
     return total_chars // 4, "estimate"
 
 


### PR DESCRIPTION
## Summary
- Fixes the fallback token estimator in `_estimate_tokens()` (`core/framework/llm/litellm.py`) to count all message fields, not just `content`
- Now includes `tool_calls[].function.name`, `tool_calls[].function.arguments`, and `tool_call_id` in the character count
- Previously underestimated by up to 50%+ in tool-heavy conversations, causing inaccurate compaction decisions and silent context window overflows

Closes #6715

## Test plan
- [x] Verified content-only messages produce same estimate as before
- [x] Verified tool_call messages now include function name + arguments (e.g., 21 tokens vs old 3)
- [x] Verified tool result messages include `tool_call_id`
- [x] Verified messages with `None` content and tool_calls are handled correctly
- [x] No existing tests broken — the fix is additive to the character sum

🤖 Generated with [Claude Code](https://claude.com/claude-code)