### PR TITLE
fix(windows): use shared uv discovery in setup_worker_model.ps1

### DIFF
--- a/scripts/setup_worker_model.ps1
+++ b/scripts/setup_worker_model.ps1
@@ -236,9 +236,9 @@ function Get-ModelSelection {
 # Main
 # ============================================================
 
-$uvInfo = Find-Uv
+$uvInfo = Get-WorkingUvInfo
 if (-not $uvInfo) {
-    Write-Color -Text "uv not found. Run quickstart.ps1 first." -Color Red
+    Write-Color -Text "uv is not installed or is not runnable. Run .\quickstart.ps1 first." -Color Red
     exit 1
 }
 $UvCmd = $uvInfo.Path


### PR DESCRIPTION
## Description

Fixes the Windows PowerShell startup failure in `scripts/setup_worker_model.ps1` by using the shared `scripts/uv-discovery.ps1` helper instead of calling the undefined `Find-Uv` function. This keeps the change scoped to the PowerShell `uv` bootstrap path and preserves the existing worker model setup flow.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #6744

## Changes Made

- Replaced the undefined `Find-Uv` call with `Get-WorkingUvInfo`
- Reused the existing shared PowerShell helper from `scripts/uv-discovery.ps1`
- Updated the missing-`uv` error text to report the real failure condition

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

Manual testing performed:
- Verified `uv --version` works in PowerShell on Windows
- Reproduced the original `Find-Uv` command-not-found failure before the fix
- Re-ran `scripts/setup_worker_model.ps1` in PowerShell after the fix and confirmed it gets past `uv` discovery and reaches the worker model selection flow

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
<img width="1294" height="859" alt="image" src="https://github.com/user-attachments/assets/e1cb6479-f965-4b64-bd0d-5e65cc65ebd7" />