### PR TITLE
docs: add Windows quickstart.ps1 command in Quick Start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,11 @@ Use Hive when you need:
 git clone https://github.com/aden-hive/hive.git
 cd hive
 
-
-# Run quickstart setup
+# Run quickstart setup (macOS/Linux)
 ./quickstart.sh
-```
+
+# Windows (PowerShell)
+.\quickstart.ps1
 
 This sets up:
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ cd hive
 
 # Windows (PowerShell)
 .\quickstart.ps1
+```
 
 This sets up:
 


### PR DESCRIPTION
Fixes #6780

The Quick Start installation block only showed `./quickstart.sh` with 
no mention of the Windows equivalent. A Windows user following these 
steps would get the script opened in Notepad instead of executed.

Added `.\quickstart.ps1` with a clear Windows label right next to 
the macOS/Linux command so both platforms are covered at a glance.