### PR TITLE
docs(confluence): add Confluence tool README

### DIFF
--- a/tools/src/aden_tools/tools/confluence_tool/README.md
+++ b/tools/src/aden_tools/tools/confluence_tool/README.md
@@ -69,6 +69,11 @@ export CONFLUENCE_EMAIL="you@company.com"
 export CONFLUENCE_API_TOKEN="your_api_token_here"
 ```
 
+Alternatively, configure credentials in the Aden credential store:
+- `confluence_domain`
+- `confluence_email`
+- `confluence_token`
+
 > 💡 **Tip**: Make sure the user has permissions to access the spaces and pages you want to interact with.
 
 ## Example Usage


### PR DESCRIPTION
## Description
Adds a README for the Confluence tool with setup, tool list, and examples.

## Type of Change
- [x] Documentation update

## Related Issues
N/A (docs-only)

## Changes Made
- Added `tools/src/aden_tools/tools/confluence_tool/README.md`
- Documented CONFLUENCE_* env vars and credential store keys
- Listed tools and added usage examples

## Testing
- [x] Manual testing performed (docs review only)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Confluence tool configuration documentation to include an alternative credentials setup method through the credential store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->