### PR TITLE
refac(mcp_client): simplify tool discovery and enforce return contract

### DIFF
--- a/core/framework/runner/mcp_client.py
+++ b/core/framework/runner/mcp_client.py
@@ -357,30 +357,22 @@ class MCPClient:
             raise RuntimeError(f"Failed to connect to MCP server: {e}") from e
 
     def _discover_tools(self) -> None:
-        """Discover available tools from the MCP server."""
-        try:
-            if self.config.transport in {"stdio", "sse"}:
-                tools_list = self._run_async(self._list_tools_stdio_async())
-            else:
-                tools_list = self._list_tools_http()
+          """Discover available tools from the MCP server."""
 
-            self._tools = {}
-            for tool_data in tools_list:
-                tool = MCPTool(
-                    name=tool_data["name"],
-                    description=tool_data.get("description", ""),
-                    input_schema=tool_data.get("inputSchema", {}),
-                    server_name=self.config.name,
-                )
-                self._tools[tool.name] = tool
+          if self.config.transport in {"stdio", "sse"}:
+              tools_list = self._run_async(self._list_tools_stdio_async())
 
-            tool_names = list(self._tools.keys())
-            logger.info(
-                f"Discovered {len(self._tools)} tools from '{self.config.name}': {tool_names}"
-            )
-        except Exception as e:
-            logger.error(f"Failed to discover tools from '{self.config.name}': {e}")
-            raise
+          elif self.config.transport in {"http", "unix"}:
+              tools_list = self._list_tools_http()
+
+          # _run_async is not strictly typed and may propagate unexpected values
+          if not isinstance(tools_list, list): raise TypeError(f"Expected tools_list to be a list, got {type(tools_list)}")
+
+          self._tools = {} # reset to avoid mixing tools from previous connections
+
+          for tool_data in tools_list:
+              tool = MCPTool(name = tool_data["name"], description = tool_data.get("description", ""), input_schema = tool_data.get("inputSchema", {}), server_name = self.config.name)
+              self._tools[tool.name] = tool
 
     async def _list_tools_stdio_async(self) -> list[dict]:
         """List tools via STDIO protocol using persistent session."""

--- a/core/tests/test_mcp_client.py
+++ b/core/tests/test_mcp_client.py
@@ -34,6 +34,32 @@ class _FakeHttpClient:
         self.closed = True
 
 
+class TestDiscoverTools:
+
+      def test_http(self, monkeypatch):
+
+            client = MCPClient(MCPServerConfig(name="test", transport="http"))
+            monkeypatch.setattr(client, "_list_tools_http", lambda: [{"name": "tool1", "description": "example", "inputSchema": {}}])
+
+            client._discover_tools()
+            assert "tool1" in client._tools
+
+      def test_stdio(self, monkeypatch):
+
+            client = MCPClient(MCPServerConfig(name="test", transport="stdio"))
+            monkeypatch.setattr(client, "_list_tools_stdio_async", lambda: [{"name": "tool2"}])
+            monkeypatch.setattr(client, "_run_async", lambda coro: coro)
+
+            client._discover_tools()
+            assert "tool2" in client._tools
+
+      def test_invalid_return(self, monkeypatch):
+            client = MCPClient(MCPServerConfig(name="test", transport="http"))
+            monkeypatch.setattr(client, "_list_tools_http", lambda: None)
+
+            with pytest.raises(TypeError): client._discover_tools()
+
+
 def test_connect_unix_transport_uses_socket_path(monkeypatch):
     created = {}
 


### PR DESCRIPTION
Fixes - #6790 

## Description
- _discover_tools mixed responsibilities: transport handling, logging, error wrapping
- generic try/except masked underlying errors and made debugging harder
- _run_async has no type guarantees, causing static analysis warnings: tools_list could be None
- redundant logging added noise without clear value

## Type of Change
- [X] Refactoring (no functional changes)

## Related Issues
- no issue or PRs opened

## Changes Made
- removed generic try/except to allow errors to propagate to the caller
- simplified transport branching logic: stdio/sse vs http/unix
- removed non-essential logging
- added explicit runtime validation to enforce that tools_list is a list
- Added unit tests covering: HTTP path, STDIO path and Invalid return

## Results
- cleaner and more predictable control flow
- fail-fast behavior with clearer error visibility
- improved type safety at runtime
- reduced noise in logs
- better test coverage for tool discovery behavior

## Testing
- [X] Unit tests pass (`cd core && pytest tests/`)

## Checklist
- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes