### PR TITLE
fix(graph): remove deprecated ast.Index visitor in safe_eval.py

### DIFF
--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -228,10 +228,6 @@ class SafeEvalVisitor(ast.NodeVisitor):
 
         return func(*args, **keywords)
 
-    def visit_Index(self, node: ast.Index) -> Any:
-        # Python < 3.9
-        return self.visit(node.value)
-
 
 def safe_eval(expr: str, context: dict[str, Any] | None = None) -> Any:
     """


### PR DESCRIPTION
## Description

Remove the deprecated `visit_Index` method from `safe_eval.py`. Python 3.9+ no longer wraps subscript slices in `ast.Index`, and Python 3.12 removed `ast.Index` entirely. The project requires Python >=3.11, so this is dead code.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #4563
Closes #2132

## Changes Made

- Removed `visit_Index(self, node: ast.Index)` method (4 lines)

## Testing

- [x] Unit tests pass (`cd core && pytest tests/test_safe_eval.py` - 113 passed)
- [x] Lint passes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes