### PR TITLE
chore(micro-fix): upgrade MiniMax default model from M2.5 to M2.7

### DIFF
--- a/core/tests/dummy_agents/run_all.py
+++ b/core/tests/dummy_agents/run_all.py
@@ -32,7 +32,7 @@ API_KEY_PROVIDERS = [
     ("CEREBRAS_API_KEY", "Cerebras", "cerebras/zai-glm-4.7"),
     ("TOGETHER_API_KEY", "Together AI", "together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo"),
     ("DEEPSEEK_API_KEY", "DeepSeek", "deepseek-chat"),
-    ("MINIMAX_API_KEY", "MiniMax", "MiniMax-M2.5"),
+    ("MINIMAX_API_KEY", "MiniMax", "MiniMax-M2.7"),
     ("HIVE_API_KEY", "Hive LLM", "hive/queen"),
 ]
 

--- a/quickstart.ps1
+++ b/quickstart.ps1
@@ -818,7 +818,7 @@ $ProviderMap = [ordered]@{
 $DefaultModels = @{
     anthropic   = "claude-haiku-4-5-20251001"
     openai      = "gpt-5-mini"
-    minimax     = "MiniMax-M2.5"
+    minimax     = "MiniMax-M2.7"
     gemini      = "gemini-3-flash-preview"
     groq        = "moonshotai/kimi-k2-instruct-0905"
     cerebras    = "zai-glm-4.7"
@@ -1257,13 +1257,13 @@ switch ($num) {
         $SubscriptionMode        = "minimax_code"
         $SelectedProviderId      = "minimax"
         $SelectedEnvVar          = "MINIMAX_API_KEY"
-        $SelectedModel           = "MiniMax-M2.5"
+        $SelectedModel           = "MiniMax-M2.7"
         $SelectedMaxTokens       = 32768
         $SelectedMaxContextTokens = 900000
         $SelectedApiBase         = "https://api.minimax.io/v1"
         Write-Host ""
         Write-Ok "Using MiniMax coding key"
-        Write-Color -Text "  Model: MiniMax-M2.5 | API: api.minimax.io" -Color DarkGray
+        Write-Color -Text "  Model: MiniMax-M2.7 | API: api.minimax.io" -Color DarkGray
     }
     5 {
         # Kimi Code Subscription

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -396,7 +396,7 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
     declare -A DEFAULT_MODELS=(
         ["anthropic"]="claude-haiku-4-5-20251001"
         ["openai"]="gpt-5-mini"
-        ["minimax"]="MiniMax-M2.5"
+        ["minimax"]="MiniMax-M2.7"
         ["gemini"]="gemini-3-flash-preview"
         ["groq"]="moonshotai/kimi-k2-instruct-0905"
         ["cerebras"]="zai-glm-4.7"
@@ -517,7 +517,7 @@ else
 
     # Default models by provider id (parallel arrays)
     MODEL_PROVIDER_IDS=(anthropic openai minimax gemini groq cerebras mistral together_ai deepseek)
-    MODEL_DEFAULTS=("claude-haiku-4-5-20251001" "gpt-5-mini" "MiniMax-M2.5" "gemini-3-flash-preview" "moonshotai/kimi-k2-instruct-0905" "zai-glm-4.7" "mistral-large-latest" "meta-llama/Llama-3.3-70B-Instruct-Turbo" "deepseek-chat")
+    MODEL_DEFAULTS=("claude-haiku-4-5-20251001" "gpt-5-mini" "MiniMax-M2.7" "gemini-3-flash-preview" "moonshotai/kimi-k2-instruct-0905" "zai-glm-4.7" "mistral-large-latest" "meta-llama/Llama-3.3-70B-Instruct-Turbo" "deepseek-chat")
 
     # Helper: get provider display name for an env var
     get_provider_name() {
@@ -1286,15 +1286,15 @@ case $choice in
         SUBSCRIPTION_MODE="minimax_code"
         SELECTED_ENV_VAR="MINIMAX_API_KEY"
         SELECTED_PROVIDER_ID="minimax"
-        SELECTED_MODEL="MiniMax-M2.5"
+        SELECTED_MODEL="MiniMax-M2.7"
         SELECTED_MAX_TOKENS=32768
-        SELECTED_MAX_CONTEXT_TOKENS=900000  # MiniMax M2.5 — 1M context window
+        SELECTED_MAX_CONTEXT_TOKENS=900000  # MiniMax M2.7 — 1M context window
         SELECTED_API_BASE="https://api.minimax.io/v1"
         PROVIDER_NAME="MiniMax"
         SIGNUP_URL="https://platform.minimax.io/user-center/basic-information/interface-key"
         echo ""
         echo -e "${GREEN}⬢${NC} Using MiniMax coding key"
-        echo -e "  ${DIM}Model: MiniMax-M2.5 | API: api.minimax.io${NC}"
+        echo -e "  ${DIM}Model: MiniMax-M2.7 | API: api.minimax.io${NC}"
         ;;
     5)
         # Kimi Code Subscription

--- a/scripts/check_llm_key.py
+++ b/scripts/check_llm_key.py
@@ -259,7 +259,7 @@ def check_minimax(
                 "Authorization": f"Bearer {api_key}",
                 "Content-Type": "application/json",
             },
-            json={"model": "MiniMax-M2.5", "messages": []},
+            json={"model": "MiniMax-M2.7", "messages": []},
         )
     if r.status_code in (200, 400, 422, 429):
         return {"valid": True, "message": "MiniMax API key valid"}

--- a/scripts/setup_worker_model.ps1
+++ b/scripts/setup_worker_model.ps1
@@ -573,13 +573,13 @@ switch ($num) {
         $SubscriptionMode        = "minimax_code"
         $SelectedEnvVar          = "MINIMAX_API_KEY"
         $SelectedProviderId      = "minimax"
-        $SelectedModel           = "MiniMax-M2.5"
+        $SelectedModel           = "MiniMax-M2.7"
         $SelectedMaxTokens       = 32768
-        $SelectedMaxContextTokens = 900000  # MiniMax M2.5 — 1M context window
+        $SelectedMaxContextTokens = 900000  # MiniMax M2.7 — 1M context window
         $SelectedApiBase         = "https://api.minimax.io/v1"
         Write-Host ""
         Write-Ok "Using MiniMax coding key"
-        Write-Color -Text "  Model: MiniMax-M2.5 | API: api.minimax.io" -Color DarkGray
+        Write-Color -Text "  Model: MiniMax-M2.7 | API: api.minimax.io" -Color DarkGray
     }
     5 {
         # Kimi Code Subscription

--- a/scripts/setup_worker_model.sh
+++ b/scripts/setup_worker_model.sh
@@ -92,7 +92,7 @@ if [ "$USE_ASSOC_ARRAYS" = true ]; then
     declare -A DEFAULT_MODELS=(
         ["anthropic"]="claude-haiku-4-5-20251001"
         ["openai"]="gpt-5-mini"
-        ["minimax"]="MiniMax-M2.5"
+        ["minimax"]="MiniMax-M2.7"
         ["gemini"]="gemini-3-flash-preview"
         ["groq"]="moonshotai/kimi-k2-instruct-0905"
         ["cerebras"]="zai-glm-4.7"
@@ -184,7 +184,7 @@ else
     PROVIDER_ID_LIST=(anthropic openai minimax gemini google groq cerebras openrouter mistral together deepseek)
 
     MODEL_PROVIDER_IDS=(anthropic openai minimax gemini groq cerebras mistral together_ai deepseek)
-    MODEL_DEFAULTS=("claude-haiku-4-5-20251001" "gpt-5-mini" "MiniMax-M2.5" "gemini-3-flash-preview" "moonshotai/kimi-k2-instruct-0905" "zai-glm-4.7" "mistral-large-latest" "meta-llama/Llama-3.3-70B-Instruct-Turbo" "deepseek-chat")
+    MODEL_DEFAULTS=("claude-haiku-4-5-20251001" "gpt-5-mini" "MiniMax-M2.7" "gemini-3-flash-preview" "moonshotai/kimi-k2-instruct-0905" "zai-glm-4.7" "mistral-large-latest" "meta-llama/Llama-3.3-70B-Instruct-Turbo" "deepseek-chat")
 
     get_provider_name() {
         local env_var="$1"; local i=0
@@ -882,15 +882,15 @@ case $choice in
         SUBSCRIPTION_MODE="minimax_code"
         SELECTED_ENV_VAR="MINIMAX_API_KEY"
         SELECTED_PROVIDER_ID="minimax"
-        SELECTED_MODEL="MiniMax-M2.5"
+        SELECTED_MODEL="MiniMax-M2.7"
         SELECTED_MAX_TOKENS=32768
-        SELECTED_MAX_CONTEXT_TOKENS=900000  # MiniMax M2.5 — 1M context window
+        SELECTED_MAX_CONTEXT_TOKENS=900000  # MiniMax M2.7 — 1M context window
         SELECTED_API_BASE="https://api.minimax.io/v1"
         PROVIDER_NAME="MiniMax"
         SIGNUP_URL="https://platform.minimax.io/user-center/basic-information/interface-key"
         echo ""
         echo -e "${GREEN}⬢${NC} Using MiniMax coding key"
-        echo -e "  ${DIM}Model: MiniMax-M2.5 | API: api.minimax.io${NC}"
+        echo -e "  ${DIM}Model: MiniMax-M2.7 | API: api.minimax.io${NC}"
         ;;
     5)
         # Kimi Code Subscription


### PR DESCRIPTION
## Summary

Upgrade the default MiniMax model from **M2.5** to **M2.7** across all quickstart scripts, worker model setup, API key validation, and test fixtures.

### Changes

- **quickstart.sh / quickstart.ps1**: Update default model in provider arrays, subscription mode selection, and UI display text
- **scripts/setup_worker_model.sh / setup_worker_model.ps1**: Same updates for worker-level model setup scripts
- **scripts/check_llm_key.py**: Update validation request to use M2.7
- **core/tests/dummy_agents/run_all.py**: Update test fixture default model

MiniMax-M2.7 is the latest production model with improved capabilities while maintaining the same 1M context window and OpenAI-compatible API.

### Test plan

- [x] All M2.5 references replaced with M2.7 (verified via grep)
- [x] No other code logic changed — purely string replacements
- [ ] Existing unit tests pass (prefix routing tests are unaffected)
