### PR TITLE
micro-fix: fix date formatting issue on windows and mattermost formatting issue 

### DIFF
--- a/core/framework/agents/queen/queen_memory.py
+++ b/core/framework/agents/queen/queen_memory.py
@@ -31,6 +31,11 @@ def _queen_dir() -> Path:
     return Path.home() / ".hive" / "queen"
 
 
+def format_memory_date(d: date) -> str:
+    """Return a cross-platform long date label without a zero-padded day."""
+    return f"{d.strftime('%B')} {d.day}, {d.year}"
+
+
 def semantic_memory_path() -> Path:
     return _queen_dir() / "MEMORY.md"
 
@@ -91,9 +96,9 @@ def format_for_injection() -> str:
             content = content[:_EPISODIC_CHAR_BUDGET] + "\n\n…(truncated)"
         today = date.today()
         if d == today:
-            label = f"## Today — {d.strftime('%B %-d, %Y')}"
+            label = f"## Today — {format_memory_date(d)}"
         else:
-            label = f"## {d.strftime('%B %-d, %Y')}"
+            label = f"## {format_memory_date(d)}"
         parts.append(f"{label}\n\n{content}")
 
     if not parts:
@@ -127,7 +132,7 @@ def append_episodic_entry(content: str) -> None:
     ep_path = episodic_memory_path()
     ep_path.parent.mkdir(parents=True, exist_ok=True)
     today = date.today()
-    today_str = f"{today.strftime('%B')} {today.day}, {today.year}"
+    today_str = format_memory_date(today)
     timestamp = datetime.now().strftime("%H:%M")
     if not ep_path.exists():
         header = f"# {today_str}\n\n"
@@ -331,7 +336,7 @@ async def consolidate_queen_memory(
         existing_semantic = read_semantic_memory()
         today_journal = read_episodic_memory()
         today = date.today()
-        today_str = f"{today.strftime('%B')} {today.day}, {today.year}"
+        today_str = format_memory_date(today)
         adapt_path = session_dir / "data" / "adapt.md"
 
         user_msg = (

--- a/core/framework/tools/queen_memory_tools.py
+++ b/core/framework/tools/queen_memory_tools.py
@@ -49,7 +49,7 @@ def recall_diary(query: str = "", days_back: int = 7) -> str:
     """
     from datetime import date, timedelta
 
-    from framework.agents.queen.queen_memory import read_episodic_memory
+    from framework.agents.queen.queen_memory import format_memory_date, read_episodic_memory
 
     days_back = max(1, min(days_back, 30))
     today = date.today()
@@ -70,7 +70,7 @@ def recall_diary(query: str = "", days_back: int = 7) -> str:
             if not matched:
                 continue
             content = "### ".join(matched)
-        label = d.strftime("%B %-d, %Y")
+        label = format_memory_date(d)
         if d == today:
             label = f"Today — {label}"
         entry = f"## {label}\n\n{content}"

--- a/core/tests/test_queen_memory.py
+++ b/core/tests/test_queen_memory.py
@@ -1,0 +1,35 @@
+from datetime import date
+
+from framework.agents.queen import queen_memory
+from framework.tools.queen_memory_tools import recall_diary
+
+
+def test_format_memory_date_uses_unpadded_day() -> None:
+    assert queen_memory.format_memory_date(date(2026, 3, 7)) == "March 7, 2026"
+
+
+def test_format_for_injection_formats_recent_memory(monkeypatch) -> None:
+    monkeypatch.setattr(queen_memory, "read_semantic_memory", lambda: "")
+    monkeypatch.setattr(
+        queen_memory,
+        "_find_recent_episodic",
+        lambda lookback=7: (date(2026, 3, 7), "Remembered context."),
+    )
+
+    result = queen_memory.format_for_injection()
+
+    assert "## March 7, 2026" in result
+    assert "Remembered context." in result
+
+
+def test_recall_diary_formats_today_without_platform_specific_strftime(monkeypatch) -> None:
+    monkeypatch.setattr(
+        queen_memory,
+        "read_episodic_memory",
+        lambda d=None: "Today's note." if d == date.today() else "",
+    )
+
+    result = recall_diary(days_back=1)
+
+    assert "## Today" in result
+    assert "Today's note." in result

--- a/tools/src/aden_tools/tools/mattermost_tool/mattermost_tool.py
+++ b/tools/src/aden_tools/tools/mattermost_tool/mattermost_tool.py
@@ -55,9 +55,7 @@ class _MattermostClient:
             response = httpx.request(method, url, **request_kwargs)
             if response.status_code == 429 and attempt < MAX_RETRIES:
                 try:
-                    wait = min(
-                        float(response.headers.get("Retry-After", 1)), MAX_RETRY_WAIT
-                    )
+                    wait = min(float(response.headers.get("Retry-After", 1)), MAX_RETRY_WAIT)
                 except (ValueError, TypeError):
                     wait = min(2**attempt, MAX_RETRY_WAIT)
                 time.sleep(wait)
@@ -96,13 +94,9 @@ class _MattermostClient:
 
     def list_teams(self) -> dict[str, Any]:
         """List teams the authenticated user belongs to."""
-        return self._request_with_retry(
-            "GET", f"{self._base_url}/users/me/teams"
-        )
+        return self._request_with_retry("GET", f"{self._base_url}/users/me/teams")
 
-    def list_channels(
-        self, team_id: str, per_page: int = 100
-    ) -> dict[str, Any]:
+    def list_channels(self, team_id: str, per_page: int = 100) -> dict[str, Any]:
         """List public channels for a team."""
         return self._request_with_retry(
             "GET",
@@ -112,9 +106,7 @@ class _MattermostClient:
 
     def get_channel(self, channel_id: str) -> dict[str, Any]:
         """Get detailed information about a channel."""
-        return self._request_with_retry(
-            "GET", f"{self._base_url}/channels/{channel_id}"
-        )
+        return self._request_with_retry("GET", f"{self._base_url}/channels/{channel_id}")
 
     def send_message(
         self,
@@ -185,9 +177,7 @@ class _MattermostClient:
 
     def delete_post(self, post_id: str) -> dict[str, Any]:
         """Delete a post."""
-        return self._request_with_retry(
-            "DELETE", f"{self._base_url}/posts/{post_id}"
-        )
+        return self._request_with_retry("DELETE", f"{self._base_url}/posts/{post_id}")
 
 
 def register_tools(
@@ -204,7 +194,8 @@ def register_tools(
             token = credentials.get("mattermost")
             if token is not None and not isinstance(token, str):
                 raise TypeError(
-                    f"Expected string from credentials.get('mattermost'), got {type(token).__name__}"
+                    "Expected string from credentials.get('mattermost'), "
+                    f"got {type(token).__name__}"
                 )
             return token
         return os.getenv("MATTERMOST_ACCESS_TOKEN")
@@ -215,7 +206,8 @@ def register_tools(
             url = credentials.get("mattermost_url")
             if url is not None and not isinstance(url, str):
                 raise TypeError(
-                    f"Expected string from credentials.get('mattermost_url'), got {type(url).__name__}"
+                    "Expected string from credentials.get('mattermost_url'), "
+                    f"got {type(url).__name__}"
                 )
             if url:
                 return url
@@ -267,9 +259,7 @@ def register_tools(
             return {"error": f"Network error: {e}"}
 
     @mcp.tool()
-    def mattermost_list_channels(
-        team_id: str, per_page: int = 100, account: str = ""
-    ) -> dict:
+    def mattermost_list_channels(team_id: str, per_page: int = 100, account: str = "") -> dict:
         """
         List public channels for a Mattermost team.
 

--- a/tools/tests/tools/test_mattermost_tool.py
+++ b/tools/tests/tools/test_mattermost_tool.py
@@ -26,9 +26,7 @@ from aden_tools.tools.mattermost_tool.mattermost_tool import (
 
 class TestMattermostClient:
     def setup_method(self):
-        self.client = _MattermostClient(
-            "test-access-token", "https://mattermost.example.com"
-        )
+        self.client = _MattermostClient("test-access-token", "https://mattermost.example.com")
 
     def test_headers(self):
         headers = self.client._headers
@@ -198,8 +196,10 @@ class TestMattermostClient:
 
     @patch("aden_tools.tools.mattermost_tool.mattermost_tool.httpx.request")
     def test_delete_post(self, mock_request):
-        mock_request.return_value = MagicMock(status_code=200, json=MagicMock(return_value={"status": "ok"}))
-        result = self.client.delete_post("p123")
+        mock_request.return_value = MagicMock(
+            status_code=200, json=MagicMock(return_value={"status": "ok"})
+        )
+        self.client.delete_post("p123")
         assert mock_request.call_args[0][0] == "DELETE"
         assert "posts/p123" in mock_request.call_args[0][1]
 
@@ -238,9 +238,7 @@ class TestMattermostClient:
             ),
             MagicMock(
                 status_code=200,
-                json=MagicMock(
-                    return_value=[{"id": "t1", "name": "team"}]
-                ),
+                json=MagicMock(return_value=[{"id": "t1", "name": "team"}]),
             ),
         ]
         result = self.client.list_teams()
@@ -285,9 +283,7 @@ class TestMattermostListTeamsTool:
     def test_list_teams_success(self, mock_request):
         mock_request.return_value = MagicMock(
             status_code=200,
-            json=MagicMock(
-                return_value=[{"id": "t1", "name": "test-team"}]
-            ),
+            json=MagicMock(return_value=[{"id": "t1", "name": "test-team"}]),
         )
         result = self._fn("mattermost_list_teams")()
         assert result["success"] is True
@@ -300,9 +296,7 @@ class TestMattermostListTeamsTool:
         mcp.tool.return_value = lambda fn: fns.append(fn) or fn
         register_tools(mcp, credentials=None)
         with patch.dict("os.environ", {"MATTERMOST_ACCESS_TOKEN": ""}, clear=False):
-            result = next(
-                f for f in fns if f.__name__ == "mattermost_list_teams"
-            )()
+            result = next(f for f in fns if f.__name__ == "mattermost_list_teams")()
         assert "error" in result
         assert "not configured" in result["error"]
 
@@ -395,9 +389,7 @@ class TestMattermostSendMessageTool:
         ) as mock_request:
             mock_request.return_value = MagicMock(
                 status_code=201,
-                json=MagicMock(
-                    return_value={"id": "p1", "channel_id": "c1", "message": content}
-                ),
+                json=MagicMock(return_value={"id": "p1", "channel_id": "c1", "message": content}),
             )
             result = self._fn("mattermost_send_message")("c1", content)
         assert result["success"] is True
@@ -424,9 +416,7 @@ class TestMattermostSendMessageTool:
             ),
             MagicMock(
                 status_code=201,
-                json=MagicMock(
-                    return_value={"id": "p1", "channel_id": "c1", "message": "Hi"}
-                ),
+                json=MagicMock(return_value={"id": "p1", "channel_id": "c1", "message": "Hi"}),
             ),
         ]
         result = self._fn("mattermost_send_message")("c1", "Hi")


### PR DESCRIPTION
## Description

Fixes the Windows session startup failure caused by platform-specific queen memory date formatting, and cleans up Mattermost formatting/lint issues so CI passes without changing Mattermost behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Related Issues

No linked issue provided.

## Changes Made

- Replace Windows-incompatible `strftime('%B %-d, %Y')` usage in queen memory paths with a cross-platform date formatting helper.
- Add regression tests covering queen memory injection and diary recall formatting on Windows.
- Fix Mattermost tool and test formatting/lint issues so `make check` passes cleanly without changing implementation behavior.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`uv run pytest core/tests/test_queen_memory.py -q` and `cd tools && uv run pytest tests/tools/test_mattermost_tool.py -q`)
- [x] Lint passes (`make check`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
before: 
<img width="1860" height="286" alt="image" src="https://github.com/user-attachments/assets/389ead9a-7c3f-45d7-91c9-297cd8e9fc25" />
after:
<img width="1918" height="873" alt="image" src="https://github.com/user-attachments/assets/2f83a2e7-51d7-45f3-b8c3-01cdc77f51fa" />

