### PR TITLE
fix: reset node_retry_counts on fresh node visits to restore retry budget in feedback-loop graphs (Fixes #6605)

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -550,7 +550,8 @@ class GraphExecutor:
         path: list[str] = []
         total_tokens = 0
         total_latency = 0
-        node_retry_counts: dict[str, int] = {}  # Track retries per node
+        node_retry_counts: dict[str, int] = {}  # Per-visit retry budget (reset on fresh visits)
+        node_retry_totals: dict[str, int] = {}  # Cumulative retry counts (never reset)
         node_visit_counts: dict[str, int] = {}  # Track visits for feedback loops
         _is_retry = False  # True when looping back for a retry (not a new visit)
 
@@ -821,6 +822,7 @@ class GraphExecutor:
                 if not _is_retry:
                     cnt = node_visit_counts.get(current_node_id, 0) + 1
                     node_visit_counts[current_node_id] = cnt
+                    node_retry_counts[current_node_id] = 0  # fresh visit = fresh retry budget
                 _is_retry = False
                 max_visits = getattr(node_spec, "max_node_visits", 0)
                 if max_visits > 0 and node_visit_counts[current_node_id] > max_visits:
@@ -946,7 +948,7 @@ class GraphExecutor:
                         current_node=node_spec.id,
                         execution_path=list(path),
                         memory=memory,
-                        is_clean=(sum(node_retry_counts.values()) == 0),
+                        is_clean=(sum(node_retry_totals.values()) == 0),
                     )
 
                     if checkpoint_config.async_checkpoint:
@@ -1080,6 +1082,9 @@ class GraphExecutor:
                     node_retry_counts[current_node_id] = (
                         node_retry_counts.get(current_node_id, 0) + 1
                     )
+                    node_retry_totals[current_node_id] = (
+                        node_retry_totals.get(current_node_id, 0) + 1
+                    )
 
                     # [CORRECTED] Use node_spec.max_retries instead of hardcoded 3
                     max_retries = getattr(node_spec, "max_retries", 3)
@@ -1166,8 +1171,8 @@ class GraphExecutor:
                             )
 
                             # Calculate quality metrics
-                            total_retries_count = sum(node_retry_counts.values())
-                            nodes_failed = list(node_retry_counts.keys())
+                            total_retries_count = sum(node_retry_totals.values())
+                            nodes_failed = list(node_retry_totals.keys())
 
                             if self.runtime_logger:
                                 await self.runtime_logger.end_run(
@@ -1199,7 +1204,7 @@ class GraphExecutor:
                                 path=path,
                                 total_retries=total_retries_count,
                                 nodes_with_failures=nodes_failed,
-                                retry_details=dict(node_retry_counts),
+                                retry_details=dict(node_retry_totals),
                                 had_partial_failures=len(nodes_failed) > 0,
                                 execution_quality="failed",
                                 node_visit_counts=dict(node_visit_counts),
@@ -1237,8 +1242,8 @@ class GraphExecutor:
                     )
 
                     # Calculate quality metrics
-                    total_retries_count = sum(node_retry_counts.values())
-                    nodes_failed = [nid for nid, count in node_retry_counts.items() if count > 0]
+                    total_retries_count = sum(node_retry_totals.values())
+                    nodes_failed = [nid for nid, count in node_retry_totals.items() if count > 0]
                     exec_quality = "degraded" if total_retries_count > 0 else "clean"
 
                     if self.runtime_logger:
@@ -1260,7 +1265,7 @@ class GraphExecutor:
                         session_state=session_state_out,
                         total_retries=total_retries_count,
                         nodes_with_failures=nodes_failed,
-                        retry_details=dict(node_retry_counts),
+                        retry_details=dict(node_retry_totals),
                         had_partial_failures=len(nodes_failed) > 0,
                         execution_quality=exec_quality,
                         node_visit_counts=dict(node_visit_counts),
@@ -1387,7 +1392,7 @@ class GraphExecutor:
                                 execution_path=list(path),
                                 memory=memory,
                                 next_node=next_node,
-                                is_clean=(sum(node_retry_counts.values()) == 0),
+                                is_clean=(sum(node_retry_totals.values()) == 0),
                             )
 
                             if checkpoint_config.async_checkpoint:
@@ -1577,8 +1582,8 @@ class GraphExecutor:
             self.logger.info(f"   Total latency: {total_latency}ms")
 
             # Calculate execution quality metrics
-            total_retries_count = sum(node_retry_counts.values())
-            nodes_failed = [nid for nid, count in node_retry_counts.items() if count > 0]
+            total_retries_count = sum(node_retry_totals.values())
+            nodes_failed = [nid for nid, count in node_retry_totals.items() if count > 0]
             exec_quality = "degraded" if total_retries_count > 0 else "clean"
 
             # Update narrative to reflect execution quality
@@ -1613,7 +1618,7 @@ class GraphExecutor:
                 path=path,
                 total_retries=total_retries_count,
                 nodes_with_failures=nodes_failed,
-                retry_details=dict(node_retry_counts),
+                retry_details=dict(node_retry_totals),
                 had_partial_failures=len(nodes_failed) > 0,
                 execution_quality=exec_quality,
                 node_visit_counts=dict(node_visit_counts),
@@ -1665,8 +1670,8 @@ class GraphExecutor:
             }
 
             # Calculate quality metrics
-            total_retries_count = sum(node_retry_counts.values())
-            nodes_failed = [nid for nid, count in node_retry_counts.items() if count > 0]
+            total_retries_count = sum(node_retry_totals.values())
+            nodes_failed = [nid for nid, count in node_retry_totals.items() if count > 0]
             exec_quality = "degraded" if total_retries_count > 0 else "clean"
 
             if self.runtime_logger:
@@ -1690,7 +1695,7 @@ class GraphExecutor:
                 session_state=session_state_out,
                 total_retries=total_retries_count,
                 nodes_with_failures=nodes_failed,
-                retry_details=dict(node_retry_counts),
+                retry_details=dict(node_retry_totals),
                 had_partial_failures=len(nodes_failed) > 0,
                 execution_quality=exec_quality,
                 node_visit_counts=dict(node_visit_counts),
@@ -1722,8 +1727,8 @@ class GraphExecutor:
                 )
 
             # Calculate quality metrics even for exceptions
-            total_retries_count = sum(node_retry_counts.values())
-            nodes_failed = list(node_retry_counts.keys())
+            total_retries_count = sum(node_retry_totals.values())
+            nodes_failed = list(node_retry_totals.keys())
 
             if self.runtime_logger:
                 await self.runtime_logger.end_run(
@@ -1789,7 +1794,7 @@ class GraphExecutor:
                 path=path,
                 total_retries=total_retries_count,
                 nodes_with_failures=nodes_failed,
-                retry_details=dict(node_retry_counts),
+                retry_details=dict(node_retry_totals),
                 had_partial_failures=len(nodes_failed) > 0,
                 execution_quality="failed",
                 node_visit_counts=dict(node_visit_counts),

--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -1172,7 +1172,11 @@ class GraphExecutor:
 
                             # Calculate quality metrics
                             total_retries_count = sum(node_retry_totals.values())
-                            nodes_failed = list(node_retry_totals.keys())
+                            nodes_failed = [
+                                nid
+                                for nid, count in node_retry_totals.items()
+                                if count > 0
+                            ]
 
                             if self.runtime_logger:
                                 await self.runtime_logger.end_run(
@@ -1728,7 +1732,9 @@ class GraphExecutor:
 
             # Calculate quality metrics even for exceptions
             total_retries_count = sum(node_retry_totals.values())
-            nodes_failed = list(node_retry_totals.keys())
+            nodes_failed = [
+                nid for nid, count in node_retry_totals.items() if count > 0
+            ]
 
             if self.runtime_logger:
                 await self.runtime_logger.end_run(

--- a/core/tests/test_retry_count_reset_on_revisit.py
+++ b/core/tests/test_retry_count_reset_on_revisit.py
@@ -1,0 +1,328 @@
+"""
+Regression tests for GitHub issue #6605:
+node_retry_counts never reset on node re-visits — nodes silently lose their
+entire retry budget after the first failure cycle in feedback-loop graphs.
+
+Fix: split retry tracking into two counters:
+  - node_retry_counts: per-visit budget counter (reset on fresh visits)
+  - node_retry_totals: cumulative retry metrics (never reset)
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from framework.graph.edge import EdgeCondition, EdgeSpec, GraphSpec
+from framework.graph.executor import GraphExecutor
+from framework.graph.goal import Goal
+from framework.graph.node import NodeContext, NodeProtocol, NodeResult, NodeSpec
+from framework.runtime.core import Runtime
+
+
+# ---------------------------------------------------------------------------
+# Shared node implementations
+# ---------------------------------------------------------------------------
+
+
+class CallCountingFlakyNode(NodeProtocol):
+    """Fails on the first `fail_times` calls, then succeeds.
+
+    `attempt_count` is a shared counter across all visits so the test can
+    assert exactly how many times the executor invoked the node.
+    """
+
+    def __init__(self, fail_times: int):
+        self.fail_times = fail_times
+        self.attempt_count = 0
+
+    async def execute(self, ctx: NodeContext) -> NodeResult:
+        """Fail for the first ``fail_times`` calls, then succeed."""
+        self.attempt_count += 1
+        if self.attempt_count <= self.fail_times:
+            return NodeResult(
+                success=False,
+                error=f"transient error (attempt {self.attempt_count})",
+            )
+        return NodeResult(
+            success=True,
+            output={"result": f"ok after {self.attempt_count} attempts"},
+        )
+
+
+class AlwaysSucceedsNode(NodeProtocol):
+    """Stub node that always succeeds, used as the recovery target in feedback-loop graphs."""
+
+    def __init__(self):
+        self.execute_count = 0
+
+    async def execute(self, ctx: NodeContext) -> NodeResult:
+        """Return a successful result and increment the call counter."""
+        self.execute_count += 1
+        return NodeResult(success=True, output={"recovered": True})
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def fast_sleep(monkeypatch):
+    """Suppress exponential backoff delays."""
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+
+@pytest.fixture
+def runtime():
+    """Provide a mock Runtime with all required methods stubbed."""
+    rt = MagicMock(spec=Runtime)
+    rt.start_run = MagicMock(return_value="run_id")
+    rt.decide = MagicMock(return_value="decision_id")
+    rt.record_outcome = MagicMock()
+    rt.end_run = MagicMock()
+    rt.report_problem = MagicMock()
+    rt.set_node = MagicMock()
+    return rt
+
+
+@pytest.fixture
+def goal():
+    """Provide a minimal Goal for executor tests."""
+    return Goal(id="g1", name="Retry Reset Test", description="Verifies retry budget resets")
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — single failure cycle: visit 1 exhausts retries, visit 2 succeeds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_budget_reset_on_revisit_via_on_failure(runtime, goal):
+    """
+    Graph: FlakyNode (max_retries=3) --ON_FAILURE--> RecoveryNode --> FlakyNode
+
+    FlakyNode fails on calls 1-3, succeeds on call 4.
+
+    Expected with fix:
+        Visit 1 — calls 1, 2, 3 fail  → retry budget exhausted → ON_FAILURE → RecoveryNode
+        Visit 2 — call 4 succeeds     → result.success = True
+
+    Bug behaviour (without fix):
+        Visit 2 — node_retry_counts["flaky"] is still 3, so 3 < 3 is False
+        → immediately routes to ON_FAILURE again with 0 retries granted
+        → infinite loop or hard termination, never succeeds
+    """
+    nodes = [
+        NodeSpec(
+            id="flaky",
+            name="Flaky Node",
+            node_type="event_loop",
+            description="Fails then recovers",
+            output_keys=["result"],
+            max_retries=3,
+        ),
+        NodeSpec(
+            id="recovery",
+            name="Recovery Node",
+            node_type="event_loop",
+            description="Handles failure, loops back",
+            output_keys=["recovered"],
+        ),
+    ]
+
+    edges = [
+        EdgeSpec(
+            id="flaky_on_failure",
+            source="flaky",
+            target="recovery",
+            condition=EdgeCondition.ON_FAILURE,
+        ),
+        EdgeSpec(
+            id="recovery_to_flaky",
+            source="recovery",
+            target="flaky",
+            condition=EdgeCondition.ON_SUCCESS,
+        ),
+    ]
+
+    graph = GraphSpec(
+        id="retry_reset_graph",
+        goal_id="g1",
+        name="Retry Reset Graph",
+        entry_node="flaky",
+        nodes=nodes,
+        edges=edges,
+        terminal_nodes=["flaky"],
+        max_steps=20,
+    )
+
+    flaky = CallCountingFlakyNode(fail_times=3)
+    recovery = AlwaysSucceedsNode()
+
+    executor = GraphExecutor(runtime=runtime)
+    executor.register_node("flaky", flaky)
+    executor.register_node("recovery", recovery)
+
+    result = await executor.execute(graph, goal, {}, validate_graph=False)
+
+    # Visit 1: 3 failures (retried) + ON_FAILURE → recovery
+    # Visit 2: 1 success
+    assert flaky.attempt_count == 4, (
+        f"Expected 4 total calls (3 failed + 1 success), got {flaky.attempt_count}. "
+        "node_retry_counts may not be reset on re-visit."
+    )
+    assert recovery.execute_count == 1
+    assert result.success is True
+
+    # Cumulative metrics must reflect ALL retries, not just the last visit's
+    assert result.total_retries == 3, (
+        f"Expected 3 cumulative retries, got {result.total_retries}. "
+        "node_retry_totals should never be reset."
+    )
+    assert result.retry_details == {"flaky": 3}
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — two failure cycles: each visit independently gets full retry budget
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_budget_independent_per_visit(runtime, goal):
+    """
+    Graph: FlakyNode (max_retries=3) --ON_FAILURE--> RecoveryNode --> FlakyNode
+
+    FlakyNode fails on calls 1-3 AND 4-6, succeeds on call 7.
+
+    Expected with fix:
+        Visit 1 — calls 1, 2, 3 fail → ON_FAILURE → RecoveryNode
+        Visit 2 — calls 4, 5, 6 fail → ON_FAILURE → RecoveryNode
+        Visit 3 — call 7 succeeds
+
+    Verifies that each successive re-visit receives its own independent
+    retry budget, not a permanently depleted one.
+    """
+    nodes = [
+        NodeSpec(
+            id="flaky",
+            name="Flaky Node",
+            node_type="event_loop",
+            description="Fails twice across two visits then recovers",
+            output_keys=["result"],
+            max_retries=3,
+        ),
+        NodeSpec(
+            id="recovery",
+            name="Recovery Node",
+            node_type="event_loop",
+            description="Handles failure, loops back",
+            output_keys=["recovered"],
+        ),
+    ]
+
+    edges = [
+        EdgeSpec(
+            id="flaky_on_failure",
+            source="flaky",
+            target="recovery",
+            condition=EdgeCondition.ON_FAILURE,
+        ),
+        EdgeSpec(
+            id="recovery_to_flaky",
+            source="recovery",
+            target="flaky",
+            condition=EdgeCondition.ON_SUCCESS,
+        ),
+    ]
+
+    graph = GraphSpec(
+        id="retry_reset_graph_2",
+        goal_id="g1",
+        name="Retry Reset Graph 2",
+        entry_node="flaky",
+        nodes=nodes,
+        edges=edges,
+        terminal_nodes=["flaky"],
+        max_steps=30,
+    )
+
+    flaky = CallCountingFlakyNode(fail_times=6)
+    recovery = AlwaysSucceedsNode()
+
+    executor = GraphExecutor(runtime=runtime)
+    executor.register_node("flaky", flaky)
+    executor.register_node("recovery", recovery)
+
+    result = await executor.execute(graph, goal, {}, validate_graph=False)
+
+    assert flaky.attempt_count == 7, (
+        f"Expected 7 total calls (6 failed across 2 visits + 1 success), "
+        f"got {flaky.attempt_count}."
+    )
+    assert recovery.execute_count == 2
+    assert result.success is True
+
+    # Cumulative metrics must reflect retries from ALL visits (3 + 3 = 6)
+    assert result.total_retries == 6, (
+        f"Expected 6 cumulative retries, got {result.total_retries}. "
+        "node_retry_totals should accumulate across visits."
+    )
+    assert result.retry_details == {"flaky": 6}
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — linear graph: existing single-visit retry behavior unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_linear_graph_retry_unaffected(runtime, goal):
+    """Verify that single-visit retry semantics are unchanged by the two-counter split.
+
+    A node fails twice then succeeds in a linear graph (no feedback loop).
+
+    Expected behavior:
+        The node retries within its budget and succeeds — identical to pre-fix
+        behaviour since no re-visit occurs.
+
+    Bug behaviour (without fix):
+        Not applicable — this test guards against regressions in the common
+        single-visit path that the feedback-loop fix must leave untouched.
+    """
+    nodes = [
+        NodeSpec(
+            id="flaky",
+            name="Flaky Node",
+            node_type="event_loop",
+            description="Fails twice then succeeds",
+            output_keys=["result"],
+            max_retries=3,
+        ),
+    ]
+
+    graph = GraphSpec(
+        id="linear_retry_graph",
+        goal_id="g1",
+        name="Linear Retry Graph",
+        entry_node="flaky",
+        nodes=nodes,
+        edges=[],
+        terminal_nodes=["flaky"],
+        max_steps=10,
+    )
+
+    flaky = CallCountingFlakyNode(fail_times=2)
+
+    executor = GraphExecutor(runtime=runtime)
+    executor.register_node("flaky", flaky)
+
+    result = await executor.execute(graph, goal, {}, validate_graph=False)
+
+    assert result.success is True
+    assert flaky.attempt_count == 3, (
+        f"Expected 3 calls (2 failed + 1 success), got {flaky.attempt_count}."
+    )
+
+    # Cumulative metrics for single-visit: 2 retries
+    assert result.total_retries == 2
+    assert result.retry_details == {"flaky": 2}

--- a/core/tests/test_retry_count_reset_on_revisit.py
+++ b/core/tests/test_retry_count_reset_on_revisit.py
@@ -181,6 +181,13 @@ async def test_retry_budget_reset_on_revisit_via_on_failure(runtime, goal):
     )
     assert result.retry_details == {"flaky": 3}
 
+    # Retry telemetry: a successful run that needed retries is a degraded success,
+    # and the failed-but-recovered node must surface in the failure list.
+    assert result.execution_quality == "degraded"
+    assert result.is_degraded_success is True
+    assert result.had_partial_failures is True
+    assert result.nodes_with_failures == ["flaky"]
+
 
 # ---------------------------------------------------------------------------
 # Test 2 — two failure cycles: each visit independently gets full retry budget
@@ -269,6 +276,12 @@ async def test_retry_budget_independent_per_visit(runtime, goal):
     )
     assert result.retry_details == {"flaky": 6}
 
+    # Retry telemetry: degraded success, failed-but-recovered node reported once.
+    assert result.execution_quality == "degraded"
+    assert result.is_degraded_success is True
+    assert result.had_partial_failures is True
+    assert result.nodes_with_failures == ["flaky"]
+
 
 # ---------------------------------------------------------------------------
 # Test 3 — linear graph: existing single-visit retry behavior unchanged
@@ -326,3 +339,9 @@ async def test_linear_graph_retry_unaffected(runtime, goal):
     # Cumulative metrics for single-visit: 2 retries
     assert result.total_retries == 2
     assert result.retry_details == {"flaky": 2}
+
+    # Retry telemetry must be identical in the linear (single-visit) path.
+    assert result.execution_quality == "degraded"
+    assert result.is_degraded_success is True
+    assert result.had_partial_failures is True
+    assert result.nodes_with_failures == ["flaky"]


### PR DESCRIPTION
  ## Problem

  In graphs where an `ON_FAILURE` edge routes back to a previously-failed node,
  that node permanently loses its retry budget after the first failure cycle.
  From visit 2 onward it gets **zero retries** — every transient failure routes
  immediately to failure handling again, making self-healing graphs non-functional.

  ## Root cause

  `node_retry_counts` is initialised once per `execute()` call and only ever
  incremented. It is never reset when the main loop starts a fresh visit to a node.

  The per-visit bookkeeping block at lines 820–824 correctly scopes
  `node_visit_counts` per visit, but has no corresponding reset for
  `node_retry_counts`:

  ```python
  # executor.py  lines 820–824  (before fix)
  if not _is_retry:
      cnt = node_visit_counts.get(current_node_id, 0) + 1
      node_visit_counts[current_node_id] = cnt
      # ← node_retry_counts[current_node_id] never reset here
  _is_retry = False
  ```

  The retry gate at line 1100 uses the cumulative total across all visits:

  ```python
  if node_retry_counts[current_node_id] < max_retries:   # stale total
      _is_retry = True
      continue
  else:
      # routes to ON_FAILURE — fires immediately on visit 2
  ```

  By the time a node reaches its second visit via a feedback edge,
  `node_retry_counts[node_id]` is already `>= max_retries`. The check fires
  on the very first failure of the new visit, granting zero retries.

  ## Failure trace

  Graph: `DataFetcher (max_retries=3) --ON_FAILURE--> ErrorRecovery --> DataFetcher`

  | Visit | Attempt | `node_retry_counts["DataFetcher"]` | Outcome |
  |---|---|---|---|
  | 1 | 1 | 1 | retry |
  | 1 | 2 | 2 | retry |
  | 1 | 3 | 3 | `3 < 3` → False → route to ErrorRecovery |
  | 2 | 1 | 4 | `4 < 3` → False → **route to ErrorRecovery, 0 retries granted** |
  | 3 | 1 | 5 | `5 < 3` → False → **route to ErrorRecovery, 0 retries granted** |

  Each subsequent visit depletes the counter further. The run either hits
  `max_steps` in an infinite failure loop, or the graph terminates if no
  further `ON_FAILURE` edge exists from `ErrorRecovery`.

  ## Why it's hard to spot in production

  **The log looks like legitimate overshoot, not a missing reset.**
  The line `✗ Max retries (3) exceeded for node DataFetcher` appears on every visit.
  With a counter of 4 against a max of 3 it reads as continued retrying, not as a
  budget that was never replenished for the new visit.

  **Only manifests in graphs with ON_FAILURE feedback edges.**
  Linear graphs and graphs with terminal failure paths are completely unaffected.
  The bug surfaces exclusively in graphs designed for self-healing — the exact graphs
  where retry reliability matters most.

  **`EventLoopNode` is immune**, masking the pattern in most integration tests.
  The executor unconditionally overrides `max_retries` to `0` for `EventLoopNode`
  instances (lines 1092–1097). Most high-level agent nodes are `EventLoopNode`, so
  standard tests rarely exercise the broken path.

  ## Fix

  One line added to the fresh-visit bookkeeping block at line 823:

  ```python
  # executor.py  lines 820–825  (after fix)
  if not _is_retry:
      cnt = node_visit_counts.get(current_node_id, 0) + 1
      node_visit_counts[current_node_id] = cnt
      node_retry_counts[current_node_id] = 0  # fresh visit = fresh retry budget
  _is_retry = False
  ```

  **Why this is correct:**

  `_is_retry = True` causes the loop to `continue` before reaching this block,
  so intra-visit retry iterations still accumulate the counter correctly — the
  exponential backoff formula at lines 1105–1107 (`1.0 * (2 ** (retry_count - 1))`)
  continues to work exactly as designed within a single visit.

  `_is_retry = False` (fresh visit from a new edge traversal) resets the counter
  to `0`, giving the node its full `max_retries` allocation regardless of prior
  visit history. This is symmetric with `node_visit_counts` handling, which was
  always the intended design.

  ## Tests added

  `core/tests/test_retry_count_reset_on_revisit.py` — 3 new tests, all passing.

  **`test_retry_budget_reset_on_revisit_via_on_failure`**
  - `FlakyNode (max_retries=3) --ON_FAILURE--> RecoveryNode --> FlakyNode`
  - Node fails on calls 1–3 (visit 1 exhausts budget) → `RecoveryNode` →
    node succeeds on call 4 (visit 2, attempt 1)
  - Asserts `attempt_count == 4` and `result.success is True`
  - Without the fix: `node_retry_counts["flaky"]` is `3` at visit 2 start;
    `3 < 3` is `False`; node is immediately re-routed with 0 retries, never
    reaches call 4

  **`test_retry_budget_independent_per_visit`**
  - Same topology; node fails on calls 1–3 AND 4–6, succeeds on call 7
  - Asserts `attempt_count == 7` and `RecoveryNode.execute_count == 2`
  - Verifies each successive re-visit receives its own independent full budget

  **`test_linear_graph_retry_unaffected`**
  - Single node, no feedback loop; fails twice then succeeds
  - Asserts `attempt_count == 3` and `result.success is True`
  - Confirms the fix introduces no regression in the common single-visit case

  ## Existing test coverage (unchanged, all still passing)

  | File | What it covers |
  |---|---|
  | `test_executor_max_retries.py` | Single-node retry with configurable `max_retries` |
  | `test_on_failure_edges.py` | ON_FAILURE routing to a terminal handler |
  | `dummy_agents/test_retry.py` | Retry exhaustion + ON_FAILURE to terminal error handler |
  | `test_executor_feedback_edges.py` | Feedback loops, `max_node_visits`, visit counts |

  None of these covered the retry + feedback-loop re-visit combination. The gap
  is now closed by the three tests above.
  
## Not covered by existing issues

| Issue | Topic | Overlap |
|---|---|---|
| #3532 | Duplicate counter increments + undefined variable | Different failure mode |
| #2410 | Retry counts not persisted across pause/resume boundaries | Different scope, cross-lifecycle, not within-run feedback loops |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry tracking: retry budgets are refreshed on node re-entry, while cumulative retry totals are now used for execution metrics, failure reporting, checkpoint cleanliness, and final execution outcomes.
* **Tests**
  * Added regression coverage to verify retry-budget reset on revisits, independent behavior across multiple revisit cycles, and unchanged retry behavior for single-pass linear graphs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->