### PR TITLE
fix: propagate contextvars to tool executor threads

### DIFF
--- a/core/framework/graph/event_loop/tool_result_handler.py
+++ b/core/framework/graph/event_loop/tool_result_handler.py
@@ -8,6 +8,7 @@ the context-window-exceeded error detector.
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import json
 import logging
 import re
@@ -446,8 +447,11 @@ async def execute_tool(
         # Offload the executor call to a thread.  Sync MCP executors
         # block on future.result() — running in a thread keeps the
         # event loop free so asyncio.wait_for can fire the timeout.
+        # Copy the current context so contextvars (e.g. data_dir from
+        # execution context) propagate into the worker thread.
         loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(None, tool_executor, tool_use)
+        ctx = contextvars.copy_context()
+        result = await loop.run_in_executor(None, ctx.run, tool_executor, tool_use)
         # Async executors return a coroutine — await it on the loop
         if asyncio.iscoroutine(result) or asyncio.isfuture(result):
             result = await result

--- a/core/tests/test_tool_context_propagation.py
+++ b/core/tests/test_tool_context_propagation.py
@@ -1,0 +1,89 @@
+"""Regression test for contextvars propagation through tool executor threads.
+
+When execute_tool offloads a sync tool executor to a thread pool via
+run_in_executor, Python does not automatically propagate contextvars.
+This caused auto-injected params like data_dir to be lost, making MCP
+tools (save_data, serve_file_to_user, etc.) fail with
+"Missing required argument: data_dir".
+
+Fix: wrap the executor call in contextvars.copy_context().run().
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework.graph.event_loop.tool_result_handler import execute_tool
+from framework.llm.provider import ToolResult, ToolUse
+from framework.runner.tool_registry import _execution_context
+
+
+class _ToolCallEvent:
+    """Minimal stand-in for ToolCallEvent used by execute_tool."""
+
+    def __init__(self, tool_name: str, tool_input: dict) -> None:
+        self.tool_use_id = "test_id"
+        self.tool_name = tool_name
+        self.tool_input = tool_input
+
+
+@pytest.mark.asyncio
+async def test_execution_context_propagates_to_tool_executor() -> None:
+    """data_dir set via set_execution_context must be visible inside
+    the tool executor even though it runs in a thread pool."""
+
+    captured: dict = {}
+
+    def capturing_executor(tool_use: ToolUse) -> ToolResult:
+        # This runs inside run_in_executor (a worker thread).
+        # Before the fix, _execution_context.get() returned None here.
+        ctx = _execution_context.get()
+        captured["exec_ctx"] = ctx
+        return ToolResult(
+            tool_use_id=tool_use.id,
+            content="ok",
+        )
+
+    token = _execution_context.set({"data_dir": "/tmp/test_data"})
+    try:
+        tc = _ToolCallEvent("test_tool", {"arg": "value"})
+        result = await execute_tool(
+            tool_executor=capturing_executor,
+            tc=tc,
+            timeout=10,
+        )
+    finally:
+        _execution_context.reset(token)
+
+    assert result.content == "ok"
+    assert captured["exec_ctx"] is not None, (
+        "execution context was None inside worker thread, "
+        "contextvars did not propagate through run_in_executor"
+    )
+    assert captured["exec_ctx"]["data_dir"] == "/tmp/test_data"
+
+
+@pytest.mark.asyncio
+async def test_execution_context_none_when_not_set() -> None:
+    """When no execution context is set, executor should still work
+    (context is None, not an error)."""
+
+    captured: dict = {}
+
+    def capturing_executor(tool_use: ToolUse) -> ToolResult:
+        captured["exec_ctx"] = _execution_context.get()
+        return ToolResult(
+            tool_use_id=tool_use.id,
+            content="ok",
+        )
+
+    # Don't set any execution context
+    tc = _ToolCallEvent("test_tool", {})
+    result = await execute_tool(
+        tool_executor=capturing_executor,
+        tc=tc,
+        timeout=10,
+    )
+
+    assert result.content == "ok"
+    assert captured["exec_ctx"] is None


### PR DESCRIPTION
## Description

Fix MCP tool context params (data_dir, etc.) being silently lost when tool executors run in thread pool workers, causing save_data, serve_file_to_user, and other data tools to fail with "Missing required argument: data_dir".

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #6853

## Changes Made

- **`core/framework/graph/event_loop/tool_result_handler.py`**: Wrap `tool_executor` call in `contextvars.copy_context().run()` so execution context (data_dir, etc.) propagates into worker threads spawned by `run_in_executor`
- **`core/tests/test_tool_context_propagation.py`**: Regression test verifying contextvars are visible inside tool executors running in thread pool

## Testing

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed
- [x] E2E: ran vulnerability_assessment agent, confirmed save_data writes to session data dir instead of falling back to /tmp
- [x] Regression test: verifies _execution_context is readable inside run_in_executor worker thread

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Context variables are now correctly preserved and available when tools run in background threads, ensuring execution-context data (e.g., runtime settings) is accessible during tool execution.

* **Tests**
  * Added regression tests that validate context propagation for tool execution in thread-pool scenarios, covering both populated and empty context cases to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->