### PR TITLE
docs: add Unix socket and SSE transport to MCP Integration Guide (#6739)

### DIFF
--- a/core/MCP_INTEGRATION_GUIDE.md
+++ b/core/MCP_INTEGRATION_GUIDE.md
@@ -6,7 +6,7 @@ This guide explains how to integrate Model Context Protocol (MCP) servers with t
 
 The framework provides built-in support for MCP servers, allowing you to:
 
-- **Register MCP servers** via STDIO or HTTP transport
+- **Register MCP servers** via STDIO, HTTP, Unix socket, or SSE transport
 - **Auto-discover tools** from registered servers
 - **Use MCP tools** seamlessly in your agents
 - **Manage multiple MCP servers** simultaneously
@@ -103,6 +103,48 @@ runner.register_mcp_server(
 
 - `url`: Base URL of the MCP server
 - `headers`: HTTP headers to include (optional)
+
+### Unix Socket Transport
+
+Best for same-host inter-process communication with lower overhead than TCP:
+
+```python
+runner.register_mcp_server(
+    name="local-ipc-tools",
+    transport="unix",
+    url="http://localhost",
+    socket_path="/tmp/mcp_server.sock",
+    headers={
+        "Authorization": "Bearer token"
+    }
+)
+```
+
+**Configuration:**
+
+- `url`: Base URL for HTTP requests over the socket (e.g., `"http://localhost"`)
+- `socket_path`: Absolute path to the Unix socket file (e.g., `"/tmp/mcp_server.sock"`)
+- `headers`: HTTP headers to include (optional)
+
+### SSE Transport
+
+Best for real-time, event-driven connections using the MCP SDK's SSE client:
+
+```python
+runner.register_mcp_server(
+    name="streaming-tools",
+    transport="sse",
+    url="http://localhost:8000/sse",
+    headers={
+        "Authorization": "Bearer token"
+    }
+)
+```
+
+**Configuration:**
+
+- `url`: SSE endpoint URL (e.g., `"http://localhost:8000/sse"`)
+- `headers`: HTTP headers for the SSE connection (optional)
 
 ## Using MCP Tools in Agents
 
@@ -258,7 +300,32 @@ runner.register_mcp_server(
 )
 ```
 
-### 3. Handle Cleanup
+### 3. Use Unix Socket for Same-Host IPC
+
+When both the agent and MCP server run on the same machine, Unix sockets avoid TCP overhead:
+
+```python
+runner.register_mcp_server(
+    name="fast-local-tools",
+    transport="unix",
+    url="http://localhost",
+    socket_path="/tmp/mcp_server.sock"
+)
+```
+
+### 4. Use SSE for Streaming and Real-Time Tools
+
+SSE transport maintains a persistent connection, ideal for event-driven servers:
+
+```python
+runner.register_mcp_server(
+    name="realtime-tools",
+    transport="sse",
+    url="http://realtime-server:8000/sse"
+)
+```
+
+### 5. Handle Cleanup
 
 Always clean up MCP connections when done:
 
@@ -280,7 +347,7 @@ async with AgentRunner.load("exports/my-agent") as runner:
     # Automatic cleanup
 ```
 
-### 4. Tool Name Conflicts
+### 6. Tool Name Conflicts
 
 If multiple MCP servers provide tools with the same name, the last registered server wins. To avoid conflicts:
 
@@ -314,6 +381,24 @@ If HTTP transport fails:
 1. Verify the server is running: `curl http://localhost:4001/health`
 2. Check firewall settings
 3. Verify the URL and port are correct
+
+### Unix Socket Not Connecting
+
+If Unix socket transport fails:
+
+1. Verify the socket file exists: `ls -la /tmp/mcp_server.sock`
+2. Check file permissions on the socket
+3. Ensure no other process has locked the socket
+4. Verify the `url` field is set (e.g., `"http://localhost"`)
+
+### SSE Connection Issues
+
+If SSE transport fails:
+
+1. Verify the server supports SSE at the given URL
+2. Check that the `mcp` Python package is installed (`pip install mcp`)
+3. Ensure the SSE endpoint is accessible: `curl http://localhost:8000/sse`
+4. Check for firewall or proxy issues blocking long-lived connections
 
 ## Example: Full Agent with MCP Tools
 

--- a/core/MCP_INTEGRATION_GUIDE.md
+++ b/core/MCP_INTEGRATION_GUIDE.md
@@ -122,8 +122,8 @@ runner.register_mcp_server(
 
 **Configuration:**
 
-- `url`: Base URL for HTTP requests over the socket (e.g., `"http://localhost"`)
-- `socket_path`: Absolute path to the Unix socket file (e.g., `"/tmp/mcp_server.sock"`)
+- `url`: Base URL for HTTP requests over the socket (required, e.g., `"http://localhost"`)
+- `socket_path`: Absolute path to the Unix socket file (required, e.g., `"/tmp/mcp_server.sock"`)
 - `headers`: HTTP headers to include (optional)
 
 ### SSE Transport
@@ -143,7 +143,7 @@ runner.register_mcp_server(
 
 **Configuration:**
 
-- `url`: SSE endpoint URL (e.g., `"http://localhost:8000/sse"`)
+- `url`: SSE endpoint URL (required, e.g., `"http://localhost:8000/sse"`)
 - `headers`: HTTP headers for the SSE connection (optional)
 
 ## Using MCP Tools in Agents


### PR DESCRIPTION
## Description

The MCP client supports four transport types (`stdio`, `http`, `unix`, `sse`),
but the MCP Integration Guide only documents STDIO and HTTP. Unix and SSE were
added in PR #6531 but docs weren't updated.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #6739

## Changes Made

- **Transport Types section** — add `Unix Socket Transport` and `SSE Transport`
  subsections with configuration fields, required/optional status, and examples
- **Overview line** — update "via STDIO or HTTP transport" to include all four
- **Best Practices section** — add guidance on when to choose Unix socket
  (same-host IPC) and SSE (streaming/real-time) over HTTP/STDIO
- **Troubleshooting section** — add debugging steps for Unix socket and SSE
  connection issues

## Testing

- [x] MCP client tests pass (`uv run pytest core/tests/test_mcp_client.py -v`)
- [x] Config fields verified against `MCPServerConfig` dataclass in
  `core/framework/runner/mcp_client.py`
- [x] Documentation style matches existing STDIO/HTTP sections

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Integration guide updated to include Unix socket and SSE transport options (configuration fields and examples), alongside STDIO/HTTP.
  * Best-practices reordered to highlight Unix socket for same-host IPC and SSE for streaming/real-time tools; other items renumbered.
  * Added troubleshooting for Unix socket connection issues and for SSE connection problems and long-lived connection filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->