### PR TITLE
Fix: handle directory input for --input-file to prevent crash

### DIFF
--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -402,6 +402,11 @@ def cmd_run(args: argparse.Namespace) -> int:
             return 1
     elif args.input_file:
         try:
+            from pathlib import 
+            if not Path(args.input_file).is_file():
+                print(f"Error: input file is a directory, not a file: {args.input_file}", file=sys.stderr)
+                return 1
+
             with open(args.input_file, encoding="utf-8") as f:
                 context = json.load(f)
         except (FileNotFoundError, json.JSONDecodeError) as e:


### PR DESCRIPTION
Description

Fixed a bug where passing a directory path to --input-file caused a crash with IsADirectoryError.
Now the program checks if the path is a valid file before opening it and shows a user-friendly error message.

Type of Change
 Bug fix (non-breaking change that fixes an issue)
Related Issues

Fixes #6207

Changes Made
Added validation using Path(args.input_file).is_file()
Displayed clear error message when input is a directory
Prevented crash by exiting safely before file open
Testing
 Unit tests pass (cd core && pytest tests/)
 Lint passes (cd core && ruff check .)
 Manual testing performed
Checklist
 My code follows the project's style guidelines
 I have performed a self-review of my code
 My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input file validation to verify that provided file paths point to actual files rather than directories. Users will now receive clear error messages if an invalid file path is supplied, preventing downstream processing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->