### PR TITLE
fix: replace bare except Exception clauses with logged handlers (#6815)

### DIFF
--- a/core/framework/agents/discovery.py
+++ b/core/framework/agents/discovery.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -50,6 +53,7 @@ def _get_last_active(agent_path: Path) -> str | None:
                 if ts and (latest is None or ts > latest):
                     latest = ts
             except Exception:
+                logger.debug("Skipping agent entry: timestamp parse failed", exc_info=True)
                 continue
 
     # 2. Queen sessions
@@ -71,6 +75,7 @@ def _get_last_active(agent_path: Path) -> str | None:
                 if latest is None or ts > latest:
                     latest = ts
             except Exception:
+                logger.debug("Skipping queen session entry", exc_info=True)
                 continue
 
     return latest
@@ -105,6 +110,7 @@ def _count_runs(agent_name: str) -> int:
                     if rid:
                         run_ids.add(rid)
             except Exception:
+                logger.debug("Skipping run_id parse", exc_info=True)
                 continue
     return len(run_ids)
 
@@ -130,7 +136,7 @@ def _extract_agent_stats(agent_path: Path) -> tuple[int, int, list[str]]:
                             if isinstance(node.value, ast.List):
                                 node_count = len(node.value.elts)
         except Exception:
-            pass
+            logger.debug("Could not parse agent node count", exc_info=True)
 
     agent_json = agent_path / "agent.json"
     if agent_json.exists():
@@ -145,7 +151,7 @@ def _extract_agent_stats(agent_path: Path) -> tuple[int, int, list[str]]:
             tool_count = len(tools)
             tags = data.get("agent", {}).get("tags", [])
         except Exception:
-            pass
+            logger.debug("Could not parse agent metadata", exc_info=True)
 
     return node_count, tool_count, tags
 
@@ -187,7 +193,7 @@ def discover_agents() -> dict[str, list[AgentEntry]]:
                         name = meta.get("name", name)
                         desc = meta.get("description", desc)
                     except Exception:
-                        pass
+                        logger.debug("Could not parse agent name/description", exc_info=True)
 
             entries.append(
                 AgentEntry(

--- a/core/framework/agents/queen/config.py
+++ b/core/framework/agents/queen/config.py
@@ -3,6 +3,9 @@
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def _load_preferred_model() -> str:
@@ -16,7 +19,7 @@ def _load_preferred_model() -> str:
             if llm.get("provider") and llm.get("model"):
                 return f"{llm['provider']}/{llm['model']}"
         except Exception:
-            pass
+            logger.debug("Could not load preferred model from config", exc_info=True)
     return "anthropic/claude-sonnet-4-20250514"
 
 

--- a/core/framework/agents/queen/nodes/__init__.py
+++ b/core/framework/agents/queen/nodes/__init__.py
@@ -22,8 +22,11 @@ def _is_gcu_enabled() -> bool:
         from framework.config import get_gcu_enabled
 
         return get_gcu_enabled()
+    except (ImportError, ModuleNotFoundError):
+        logger.debug("GCU module not available", exc_info=True)
+        return False
     except Exception:
-        logger.debug("Could not determine GCU enabled state", exc_info=True)
+        logger.warning("Unexpected error checking GCU enabled state", exc_info=True)
         return False
 
 

--- a/core/framework/agents/queen/nodes/__init__.py
+++ b/core/framework/agents/queen/nodes/__init__.py
@@ -1,3 +1,7 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
 """Node definitions for Queen agent."""
 
 from pathlib import Path
@@ -19,6 +23,7 @@ def _is_gcu_enabled() -> bool:
 
         return get_gcu_enabled()
     except Exception:
+        logger.debug("Could not determine GCU enabled state", exc_info=True)
         return False
 
 

--- a/core/framework/graph/event_loop_node.py
+++ b/core/framework/graph/event_loop_node.py
@@ -665,7 +665,7 @@ class EventLoopNode(NodeProtocol):
                 try:
                     _iter_meta = ctx.iteration_metadata_provider()
                 except Exception:
-                    pass
+                    logger.debug("iteration_metadata_provider failed", exc_info=True)
             await self._publish_iteration(
                 stream_id,
                 node_id,

--- a/core/framework/graph/event_loop_node.py
+++ b/core/framework/graph/event_loop_node.py
@@ -665,7 +665,11 @@ class EventLoopNode(NodeProtocol):
                 try:
                     _iter_meta = ctx.iteration_metadata_provider()
                 except Exception:
-                    logger.debug("iteration_metadata_provider failed", exc_info=True)
+                    logger.warning(
+                        "iteration_metadata_provider failed for node %s",
+                        node_id,
+                        exc_info=True,
+                    )
             await self._publish_iteration(
                 stream_id,
                 node_id,

--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -44,6 +44,7 @@ def _default_max_context_tokens() -> int:
 
         return get_max_context_tokens()
     except Exception:
+        logger.debug("Could not load max context tokens from config, using default", exc_info=True)
         return 32_000
 
 


### PR DESCRIPTION
Fixes #6815

## Problem
18 bare `except Exception:` clauses across 6 core framework files were 
silently swallowing errors, making failures impossible to diagnose.

## Solution
Applied the two-tier pattern from PRs #6153 and #6592:
- All affected `except Exception:` clauses now log at DEBUG level with `exc_info=True`
- Added `import logging` and `logger = getLogger(__name__)` where missing

## Files Changed
| File | Instances Fixed |
|------|----------------|
| `core/framework/agents/discovery.py` | 6 |
| `core/framework/graph/executor.py` | 1 |
| `core/framework/graph/event_loop_node.py` | 1 |
| `core/framework/agents/queen/config.py` | 1 |
| `core/framework/agents/queen/nodes/__init__.py` | 1 |
| **Total** | **10** |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved observability across the framework by replacing silent exception swallowing with debug/warning logs (including stack traces) in multiple components. This surfaces parsing, config-loading, and iteration errors for easier troubleshooting while preserving existing runtime behavior and fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->