### PR TITLE
docs: document 5 new natively supported LLM providers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,6 +58,25 @@ The framework supports 100+ LLM providers through [LiteLLM](https://docs.litellm
 
 ### Provider Examples
 
+Native Supported Providers (DeepSeek, Mistral, Together AI, xAI, Perplexity):
+
+```json
+{
+  "llm": {
+    "provider": "deepseek",
+    "model": "deepseek-chat",
+    "max_tokens": 8192,
+    "api_key_env_var": "DEEPSEEK_API_KEY"
+  }
+}
+```
+
+Notes:
+
+- Set `provider` to `deepseek` (or `mistral`, `together`, `xai`, `perplexity`)
+- Use the standard model name in `model`, for example `deepseek-chat`
+- **No `api_base` is required** for these natively supported providers
+
 OpenRouter:
 
 ```json


### PR DESCRIPTION
## Summary

Following maintainer feedback on PR #6833, unit tests for `check_llm_key.py` were skipped in favour of this documentation update (tracked in #6860).

PR #6833 added native API key validation support for 5 new LLM providers. This PR updates `docs/configuration.md` to document them for users.

## Changes

- Added a **Native Supported Providers** section to `docs/configuration.md`.
- Documents **DeepSeek, Mistral, Together AI, xAI, and Perplexity** as natively supported providers.
- Includes a JSON configuration example and usage notes (no `api_base` required for these providers).

## Related

Closes #6860

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for Native Supported Providers including DeepSeek, Mistral, Together AI, xAI, and Perplexity with configuration examples and model naming guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->