### PR TITLE
docs: remove deprecated tui references, replace with hive open

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -21,13 +21,13 @@ This guide covers everything you need to know to develop with the Aden Agent Fra
 
 Aden Agent Framework is a Python-based system for building goal-driven, self-improving AI agents.
 
-| Package       | Directory  | Description                               | Tech Stack   |
-| ------------- | ---------- | ----------------------------------------- | ------------ |
-| **framework** | `/core`    | Core runtime, graph executor, protocols   | Python 3.11+ |
-| **tools**     | `/tools`   | MCP tools for agent capabilities          | Python 3.11+ |
-| **exports**   | `/exports` | Agent packages (user-created, gitignored) | Python 3.11+ |
+| Package       | Directory                      | Description                                        | Tech Stack   |
+| ------------- | ------------------------------ | -------------------------------------------------- | ------------ |
+| **framework** | `/core`                        | Core runtime, graph executor, protocols            | Python 3.11+ |
+| **tools**     | `/tools`                       | MCP tools for agent capabilities                   | Python 3.11+ |
+| **exports**   | `/exports`                     | Agent packages (user-created, gitignored)          | Python 3.11+ |
 | **skills**    | `.claude`, `.agents`, `.agent` | Shared skills for Claude/Codex/other coding agents | Markdown     |
-| **codex**     | `.codex`   | Codex CLI project configuration (MCP servers) | TOML         |
+| **codex**     | `.codex`                       | Codex CLI project configuration (MCP servers)      | TOML         |
 
 ### Key Principles
 
@@ -100,7 +100,6 @@ hive/                                    # Repository root
 │   │   ├── storage/                     # File-based persistence
 │   │   ├── testing/                     # Testing utilities
 │   │   ├── tools/                       # Built-in tool implementations
-│   │   ├── tui/                         # Terminal UI dashboard
 │   │   └── utils/                       # Shared utilities
 │   ├── tests/                           # Unit and E2E tests (including dummy agents)
 │   ├── pyproject.toml                   # Package metadata and dependencies
@@ -172,13 +171,11 @@ Use the coder-tools MCP tools from your IDE agent chat (e.g., initialize_and_bui
    ```
 
 2. **Design the Workflow**
-
    - The workflow guides you through defining nodes
    - Each node is a unit of work (LLM call with event_loop)
    - Edges define how execution flows
 
 3. **Generate the Agent**
-
    - The workflow generates a complete Python package in `exports/`
    - Includes: `agent.json`, `tools.py`, `README.md`
 
@@ -235,27 +232,24 @@ If you prefer to build agents manually:
 ### Using the `hive` CLI
 
 ```bash
-# Browse and run agents interactively (Recommended)
-hive tui
+# Launch the web dashboard in your browser
+hive open
 
 # Run a specific agent
 hive run exports/my_agent --input '{"ticket_content": "My login is broken", "customer_id": "CUST-123"}'
-
-# Run with TUI dashboard
-hive run exports/my_agent --tui
 ```
 
 ### CLI Command Reference
 
-| Command                | Description                                                             |
-| ---------------------- | ----------------------------------------------------------------------- |
-| `hive tui`             | Browse agents and launch TUI dashboard                                  |
-| `hive run <path>`      | Execute an agent (`--tui`, `--model`, `--mock`, `--quiet`, `--verbose`) |
-| `hive shell [path]`    | Interactive REPL (`--multi`, `--no-approve`)                            |
-| `hive info <path>`     | Show agent details                                                      |
-| `hive validate <path>` | Validate agent structure                                                |
-| `hive list [dir]`      | List available agents                                                   |
-| `hive dispatch [dir]`  | Multi-agent orchestration                                               |
+| Command                | Description                                                    |
+| ---------------------- | -------------------------------------------------------------- |
+| `hive open`            | Launch the web dashboard in your browser                       |
+| `hive run <path>`      | Execute an agent (`--model`, `--mock`, `--quiet`, `--verbose`) |
+| `hive shell [path]`    | Interactive REPL (`--multi`, `--no-approve`)                   |
+| `hive info <path>`     | Show agent details                                             |
+| `hive validate <path>` | Validate agent structure                                       |
+| `hive list [dir]`      | List available agents                                          |
+| `hive dispatch [dir]`  | Multi-agent orchestration                                      |
 
 ### Using Python Directly
 

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -109,11 +109,13 @@ MCP tools are also available in Cursor. To enable:
 ### 2. Build an Agent
 
 **Claude Code:**
+
 ```
 Use the coder-tools initialize_and_build_agent tool to scaffold a new agent
 ```
 
 **Codex CLI:**
+
 ```
 Start Codex in the repo root and use the configured MCP tools
 ```
@@ -372,8 +374,8 @@ claude> test workflow
 ### 5. Run Agent
 
 ```bash
-# Interactive dashboard
-hive tui
+# Launch the web dashboard
+hive open
 
 # Or run directly
 hive run exports/your_agent_name --input '{"task": "..."}'
@@ -405,14 +407,14 @@ cd core && uv run python tests/dummy_agents/run_all.py --verbose
 
 ### What's Covered
 
-| Agent          | Tests | Coverage                                          |
-| -------------- | ----- | ------------------------------------------------- |
-| echo           | 2     | Single-node lifecycle, basic `set_output`          |
-| pipeline       | 4     | Multi-node traversal, `input_mapping`, conversation modes |
-| branch         | 3     | Conditional edges, LLM-driven routing              |
-| parallel_merge | 4     | Fan-out/fan-in, failure strategies                  |
-| retry          | 4     | Retry mechanics, exhaustion, `ON_FAILURE` edges     |
-| feedback_loop  | 3     | Feedback cycles, `max_node_visits`                  |
+| Agent          | Tests | Coverage                                                                     |
+| -------------- | ----- | ---------------------------------------------------------------------------- |
+| echo           | 2     | Single-node lifecycle, basic `set_output`                                    |
+| pipeline       | 4     | Multi-node traversal, `input_mapping`, conversation modes                    |
+| branch         | 3     | Conditional edges, LLM-driven routing                                        |
+| parallel_merge | 4     | Fan-out/fan-in, failure strategies                                           |
+| retry          | 4     | Retry mechanics, exhaustion, `ON_FAILURE` edges                              |
+| feedback_loop  | 3     | Feedback cycles, `max_node_visits`                                           |
 | worker         | 4     | Real MCP tools (`example_tool`, `get_current_time`, `save_data`/`load_data`) |
 
 Typical runtime is 1–3 minutes depending on provider latency.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -121,7 +121,6 @@ hive/
 │   │   ├── schemas/        # Data schemas
 │   │   ├── storage/        # File-based persistence
 │   │   ├── testing/        # Testing utilities
-│   │   └── tui/            # Terminal UI dashboard
 │   └── pyproject.toml      # Package metadata
 │
 ├── tools/                  # MCP Tools Package
@@ -147,14 +146,8 @@ hive/
 # Launch the web dashboard in your browser
 hive open
 
-# Browse and run agents in terminal
-hive tui
-
 # Run a specific agent
 hive run exports/my_agent --input '{"task": "Your input here"}'
-
-# Run with TUI dashboard
-hive run exports/my_agent --tui
 
 ```
 
@@ -194,7 +187,7 @@ PYTHONPATH=exports uv run python -m my_agent test --type success
 
 ## Next Steps
 
-1. **Dashboard**: Run `hive open` to launch the web dashboard, or `hive tui` for the terminal UI
+1. **Dashboard**: Run `hive open` to launch the web dashboard
 2. **Detailed Setup**: See [environment-setup.md](./environment-setup.md)
 3. **Developer Guide**: See [developer-guide.md](./developer-guide.md)
 4. **Build Agents**: Use the coder-tools `initialize_and_build_agent` tool in Claude Code


### PR DESCRIPTION
## Description

Remove deprecated `hive tui` command references from user-facing docs and replace with the current `hive open` command. The TUI was removed and replaced by the browser-based dashboard, but two docs still referenced it as active functionality.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

N/A — documentation PRs do not require a linked issue.

## Changes Made

- `docs/getting-started.md`: removed `tui/` from project structure diagram, replaced `hive tui` with `hive open`, removed redundant `# Run with TUI dashboard` block
- `docs/developer-guide.md`: removed `tui/` from project structure diagram, replaced `hive tui` with `hive open`, removed redundant `# Run with TUI dashboard` block

## Testing

- [x] Lint passes (`uv run ruff check .`)
- [x] Unit tests pass (`uv run pytest core/tests/`)
- [x] Manual testing performed — verified `hive open` launches the dashboard correctly

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A — documentation-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI examples and guidance in developer guide, getting started, and environment setup
  * Replaced terminal TUI examples with the web dashboard command across docs
  * Removed deprecated TUI flags and command rows from command reference tables
  * Reformatted several documentation tables and spacing for improved readability and consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->