### PR TITLE
fix(security): prevent path traversal in session_store

### DIFF
--- a/core/framework/runtime/execution_stream.py
+++ b/core/framework/runtime/execution_stream.py
@@ -961,7 +961,10 @@ class ExecutionStream:
             return
         import json as _json
 
-        session_dir = self._session_store.get_session_path(execution_id)
+        try:
+            session_dir = self._session_store.get_session_path(execution_id)
+        except ValueError:
+            return
         runs_file = session_dir / "runs.jsonl"
         now = datetime.now()
         record = {

--- a/core/framework/storage/session_store.py
+++ b/core/framework/storage/session_store.py
@@ -62,8 +62,14 @@ class SessionStore:
 
         Returns:
             Path to session directory
+
+        Raises:
+            ValueError: If session_id resolves outside the sessions directory
         """
-        return self.sessions_dir / session_id
+        resolved = (self.sessions_dir / session_id).resolve()
+        if not resolved.is_relative_to(self.sessions_dir.resolve()):
+            raise ValueError(f"Invalid session ID: {session_id}")
+        return resolved
 
     def get_state_path(self, session_id: str) -> Path:
         """

--- a/core/tests/test_path_traversal_fix.py
+++ b/core/tests/test_path_traversal_fix.py
@@ -225,5 +225,28 @@ class TestPathTraversalWithActualFiles:
         assert run_file.exists()
 
 
+class TestSessionStorePathTraversal:
+    """Path traversal protection in SessionStore.get_session_path()."""
+
+    @pytest.fixture
+    def store(self, tmp_path):
+        from framework.storage.session_store import SessionStore
+
+        return SessionStore(tmp_path)
+
+    def test_valid_session_id(self, store):
+        path = store.get_session_path("session_20260206_143022_abc12345")
+        assert path.name == "session_20260206_143022_abc12345"
+
+    def test_blocks_parent_traversal(self, store):
+        with pytest.raises(ValueError, match="Invalid session ID"):
+            store.get_session_path("../../etc/passwd")
+
+    @pytest.mark.asyncio
+    async def test_delete_session_blocks_traversal(self, store):
+        with pytest.raises(ValueError, match="Invalid session ID"):
+            await store.delete_session("../../package")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

Prevent path traversal in `SessionStore.get_session_path()` by validating that the resolved session path stays within the sessions directory.

Based on the approach from PR #2127 by @Alearner12, adapted for the current codebase where session management has moved from `agent_builder_server.py` to `session_store.py`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #1000

## Changes Made

- Added `Path.resolve()` + `is_relative_to()` check in `get_session_path()` to prevent directory traversal
- All methods that accept `session_id` (`delete_session`, `write_state`, `read_state`, `session_exists`) go through `get_session_path()`, so the fix covers all entry points

## Testing

- [x] Unit tests pass (`cd core && pytest tests/ -k session`)
- [x] Lint passes (`ruff check`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened session path validation to block invalid or traversal-style session identifiers; operations now detect and reject such IDs instead of using unsafe paths. The runtime now silently skips processing when an invalid session path is encountered to avoid failures.
* **Tests**
  * Added tests verifying path-traversal protection and correct error behavior for invalid session IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->