### PR TITLE
docs: fix agent.json examples to match current schema

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -198,33 +198,44 @@ Use the coder-tools MCP tools from your IDE agent chat (e.g., initialize_and_bui
 
 If you prefer to build agents manually:
 
-```python
-# exports/my_agent/agent.json
+```jsonc
+// exports/my_agent/agent.json
 {
-  "goal": {
+  "agent": {
+    "id": "my_agent",
+    "name": "Support Ticket Handler",
+    "version": "1.0.0",
+    "description": "Process customer support tickets"
+  },
+  "graph": {
+    "id": "my_agent-graph",
     "goal_id": "support_ticket",
+    "entry_node": "analyze",
+    "terminal_nodes": ["analyze"],
+    "nodes": [
+      {
+        "id": "analyze",
+        "name": "Analyze Ticket",
+        "description": "Categorize and prioritize the support ticket",
+        "node_type": "event_loop",
+        "system_prompt": "Analyze this support ticket...",
+        "input_keys": ["ticket_content"],
+        "output_keys": ["category", "priority"]
+      }
+    ],
+    "edges": []
+  },
+  "goal": {
+    "id": "support_ticket",
     "name": "Support Ticket Handler",
     "description": "Process customer support tickets",
-    "success_criteria": "Ticket is categorized, prioritized, and routed correctly"
-  },
-  "nodes": [
-    {
-      "node_id": "analyze",
-      "name": "Analyze Ticket",
-      "node_type": "event_loop",
-      "system_prompt": "Analyze this support ticket...",
-      "input_keys": ["ticket_content"],
-      "output_keys": ["category", "priority"]
-    }
-  ],
-  "edges": [
-    {
-      "edge_id": "start_to_analyze",
-      "source": "START",
-      "target": "analyze",
-      "condition": "on_success"
-    }
-  ]
+    "success_criteria": [
+      {
+        "id": "sc-categorized",
+        "description": "Ticket is categorized and prioritized correctly"
+      }
+    ]
+  }
 }
 ```
 
@@ -532,16 +543,17 @@ def my_custom_tool(param1: str, param2: int) -> Dict[str, Any]:
     # Implementation
     return {"result": "success", "data": ...}
 
-# Register tool in agent.json
+# Register tool in agent.json (inside "graph" → "nodes")
 {
-  "nodes": [
-    {
-      "node_id": "use_tool",
-      "node_type": "event_loop",
-      "tools": ["my_custom_tool"],
-      ...
-    }
-  ]
+  "graph": {
+    "nodes": [
+      {
+        "id": "use_tool",
+        "node_type": "event_loop",
+        "tools": ["my_custom_tool"]
+      }
+    ]
+  }
 }
 ```
 
@@ -560,15 +572,16 @@ def my_custom_tool(param1: str, param2: int) -> Dict[str, Any]:
   }
 }
 
-# 2. Reference tools in agent.json
+# 2. Reference tools in agent.json (inside "graph" → "nodes")
 {
-  "nodes": [
-    {
-      "node_id": "search",
-      "tools": ["web_search", "web_scrape"],
-      ...
-    }
-  ]
+  "graph": {
+    "nodes": [
+      {
+        "id": "search",
+        "tools": ["web_search", "web_scrape"]
+      }
+    ]
+  }
 }
 ```
 


### PR DESCRIPTION
## Description

Fix outdated agent.json examples in the developer guide that use `node_id`/`edge_id` and a flat structure. Updated to match the current `load_agent_export()` schema with proper `graph` wrapper, `id` fields, and `goal` section.

Based on the approach from PR #6452 by @Jose37456.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #897

## Changes Made

- Replaced `node_id` / `edge_id` with `id` in all agent.json examples
- Wrapped `nodes` and `edges` under `graph` key
- Added `goal` section with `success_criteria`
- Added `agent` metadata section
- Verified the example JSON loads correctly via `load_agent_export()`

## Testing

- [x] Verified example JSON loads correctly with `load_agent_export()`
- [x] Compared against real agent.json files in `examples/templates/`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer guide examples to reflect the new agent configuration schema with an improved nested structure. Agent metadata, graph definitions, nodes, and edges are now organized more clearly. The success criteria format evolved from a single string to a structured array of criteria objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->