### PR TITLE
fix(security): add SSRF protection to web_scrape tool

### DIFF
--- a/tools/src/aden_tools/tools/web_scrape_tool/web_scrape_tool.py
+++ b/tools/src/aden_tools/tools/web_scrape_tool/web_scrape_tool.py
@@ -4,10 +4,13 @@ Web Scrape Tool - Extract content from web pages.
 Uses Playwright with stealth for headless browser scraping,
 enabling JavaScript-rendered content and bot detection evasion.
 Uses BeautifulSoup for HTML parsing and content extraction.
+Validates URLs against internal network ranges to prevent SSRF attacks.
 """
 
 from __future__ import annotations
 
+import ipaddress
+import socket
 from typing import Any
 from urllib.parse import urljoin, urlparse
 from urllib.robotparser import RobotFileParser
@@ -27,6 +30,49 @@ BROWSER_USER_AGENT = (
     "AppleWebKit/537.36 (KHTML, like Gecko) "
     "Chrome/131.0.0.0 Safari/537.36"
 )
+
+
+def _is_internal_address(raw_ip: str) -> bool:
+    """Check whether an IP address targets non-public infrastructure."""
+    ip_str = raw_ip.split("%")[0] if "%" in raw_ip else raw_ip
+    try:
+        addr = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return True  # Unparseable — fail closed
+    return not addr.is_global or addr.is_multicast
+
+
+def _check_url_target(url: str) -> str | None:
+    """Resolve a URL's hostname and reject it if any address is non-public.
+
+    Returns an error message if blocked, None if safe.
+    """
+    hostname = urlparse(url).hostname
+    if not hostname:
+        return "Invalid URL: missing hostname"
+
+    # Fast-path for raw IP literals
+    try:
+        ipaddress.ip_address(hostname)
+        if _is_internal_address(hostname):
+            return f"Blocked: direct request to internal address ({hostname})"
+    except ValueError:
+        pass  # Not an IP literal, resolve below
+
+    try:
+        results = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    except socket.gaierror:
+        return f"DNS resolution failed for host: {hostname}"
+
+    if not results:
+        return f"No DNS records found for host: {hostname}"
+
+    for entry in results:
+        resolved_ip = str(entry[4][0])
+        if _is_internal_address(resolved_ip):
+            return f"Blocked: {hostname} resolves to internal address"
+
+    return None
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -65,6 +111,12 @@ def register_tools(mcp: FastMCP) -> None:
             # Validate max_length
             max_length = max(1000, min(max_length, 500000))
 
+            # SSRF check: validate URL before making any request (must run
+            # before robots.txt fetch, which also makes a network request)
+            block_reason = _check_url_target(url)
+            if block_reason is not None:
+                return {"error": block_reason, "blocked_by_ssrf_protection": True, "url": url}
+
             # Check robots.txt before launching browser
             if respect_robots_txt:
                 try:
@@ -102,11 +154,43 @@ def register_tools(mcp: FastMCP) -> None:
                     page = await context.new_page()
                     await Stealth().apply_stealth_async(page)
 
+                    # Intercept navigation requests to block SSRF via redirects.
+                    # Only check "document" requests (navigations), not
+                    # sub-resources (CSS/JS/images) to avoid false positives
+                    # and unnecessary DNS lookups.
+                    ssrf_blocked: dict[str, Any] | None = None
+
+                    async def _ssrf_route_handler(route):
+                        nonlocal ssrf_blocked
+                        req_url = route.request.url
+
+                        # Skip non-network schemes (data:, blob:, etc.)
+                        if urlparse(req_url).scheme not in {"http", "https"}:
+                            await route.continue_()
+                            return
+
+                        block = _check_url_target(req_url)
+                        if block is not None:
+                            ssrf_blocked = {
+                                "error": block,
+                                "blocked_by_ssrf_protection": True,
+                                "url": req_url,
+                            }
+                            await route.abort("blockedbyclient")
+                        else:
+                            await route.continue_()
+
+                    await page.route("**/*", _ssrf_route_handler)
+
                     response = await page.goto(
                         url,
                         wait_until="domcontentloaded",
                         timeout=60000,
                     )
+
+                    # Check if a redirect was blocked by SSRF protection
+                    if ssrf_blocked is not None:
+                        return ssrf_blocked
 
                     # Validate response before waiting for JS render
                     if response is None:

--- a/tools/tests/tools/test_web_scrape_tool.py
+++ b/tools/tests/tools/test_web_scrape_tool.py
@@ -1,11 +1,16 @@
 """Tests for web_scrape tool (FastMCP)."""
 
+import socket
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastmcp import FastMCP
 
 from aden_tools.tools.web_scrape_tool import register_tools
+from aden_tools.tools.web_scrape_tool.web_scrape_tool import (
+    _check_url_target,
+    _is_internal_address,
+)
 
 
 @pytest.fixture
@@ -430,3 +435,100 @@ class TestWebScrapeToolRobotsTxt:
         result = await web_scrape_fn(url="https://example.com", respect_robots_txt=False)
         assert "error" not in result
         mock_rp_cls.assert_not_called()
+
+
+_MOD = "aden_tools.tools.web_scrape_tool.web_scrape_tool"
+
+
+class TestIsInternalAddress:
+    """Tests for _is_internal_address."""
+
+    def test_loopback_ipv4(self):
+        assert _is_internal_address("127.0.0.1") is True
+
+    def test_private_10_range(self):
+        assert _is_internal_address("10.0.0.1") is True
+
+    def test_private_192_168(self):
+        assert _is_internal_address("192.168.1.1") is True
+
+    def test_link_local_aws_metadata(self):
+        assert _is_internal_address("169.254.169.254") is True
+
+    def test_public_ipv4(self):
+        assert _is_internal_address("8.8.8.8") is False
+
+    def test_public_ipv6(self):
+        assert _is_internal_address("2607:f8b0:4004:800::200e") is False
+
+    def test_invalid_string_blocked(self):
+        assert _is_internal_address("not-an-ip") is True
+
+
+def _fake_addrinfo(ip: str, port: int = 443) -> list[tuple]:
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, port))]
+
+
+class TestCheckUrlTarget:
+    """Tests for _check_url_target."""
+
+    @patch(f"{_MOD}.socket.getaddrinfo")
+    def test_public_hostname_allowed(self, mock_dns):
+        mock_dns.return_value = _fake_addrinfo("93.184.216.34")
+        assert _check_url_target("https://example.com/page") is None
+
+    @patch(f"{_MOD}.socket.getaddrinfo")
+    def test_private_hostname_blocked(self, mock_dns):
+        mock_dns.return_value = _fake_addrinfo("10.0.0.1")
+        result = _check_url_target("https://evil.com/steal")
+        assert result is not None
+        assert "internal" in result.lower()
+
+    def test_raw_private_ip_blocked(self):
+        result = _check_url_target("http://127.0.0.1/admin")
+        assert result is not None
+
+    @patch(
+        f"{_MOD}.socket.getaddrinfo",
+        side_effect=socket.gaierror("NXDOMAIN"),
+    )
+    def test_dns_failure_returns_error(self, _mock_dns):
+        result = _check_url_target("https://nonexistent.invalid/")
+        assert result is not None
+        assert "DNS" in result
+
+
+class TestWebScrapeSSRF:
+    """SSRF protection through the web_scrape tool."""
+
+    @pytest.mark.asyncio
+    async def test_blocks_private_ip(self, web_scrape_fn):
+        result = await web_scrape_fn(url="http://192.168.1.1/admin")
+        assert "error" in result
+        assert result.get("blocked_by_ssrf_protection") is True
+
+    @pytest.mark.asyncio
+    async def test_blocks_localhost(self, web_scrape_fn):
+        result = await web_scrape_fn(url="http://127.0.0.1/secret")
+        assert "error" in result
+        assert result.get("blocked_by_ssrf_protection") is True
+
+    @pytest.mark.asyncio
+    async def test_blocks_metadata_endpoint(self, web_scrape_fn):
+        result = await web_scrape_fn(url="http://169.254.169.254/latest/meta-data/")
+        assert "error" in result
+        assert result.get("blocked_by_ssrf_protection") is True
+
+    @pytest.mark.asyncio
+    @patch(_STEALTH_PATH)
+    @patch(_PW_PATH)
+    @patch(f"{_MOD}._check_url_target", return_value=None)
+    async def test_allows_public_url(self, _mock_check, mock_pw, mock_stealth, web_scrape_fn):
+        html = "<html><body><p>Hello world</p></body></html>"
+        mock_cm, _, _ = _make_playwright_mocks(html)
+        mock_pw.return_value = mock_cm
+        mock_stealth.return_value.apply_stealth_async = AsyncMock()
+
+        result = await web_scrape_fn(url="https://example.com/")
+        assert "error" not in result
+        assert "Hello world" in result["content"]


### PR DESCRIPTION
## Description

Add SSRF protection to the Playwright-based web_scrape tool. Validates URLs against internal network ranges before requests, and intercepts Playwright navigation to catch redirect-based SSRF bypasses.

Based on the approach from PR #2296 by @Harshitk-cp, rewritten for the current Playwright-based implementation (the original PR targeted the old httpx-based version).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #1157

## Changes Made

- `_is_internal_address()`: checks if IP is private/loopback/link-local/multicast/reserved
- `_check_url_target()`: DNS resolves hostname and validates all returned IPs
- Pre-navigation SSRF check before `page.goto()`
- Playwright route handler intercepts every request during navigation to catch redirect-based SSRF
- Fail-closed on unparseable IPs

## Testing

- [x] Unit tests pass (33 tests, including 11 new SSRF tests)
- [x] Lint passes (`ruff check && ruff format`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Web scraping now enforces SSRF protections: requests to internal/private IPs, malformed or unresolvable URLs, direct non-public IP literals, and navigations that redirect to blocked targets are denied. Blocked attempts return a standardized error indicating SSRF protection.

* **Tests**
  * Expanded coverage for IP classification, DNS failures, blocked navigations (including browser-driven redirects), and allowed public URL flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->