### PR TITLE
docs: fix non-existent marketing_agent template reference

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -25,8 +25,11 @@ Use templates when you want to:
 ## How to use a template
 
 ```bash
-# 1. Copy the template
-cp -r examples/templates/marketing_agent exports/my_agent
+# 1. Copy an existing template (for example: job_hunter)
+cp -r examples/templates/job_hunter exports/my_agent
+
+# (Optional) See available templates
+ls examples/templates
 
 # 2. Edit the goal, nodes, and edges in agent.py and nodes/__init__.py
 


### PR DESCRIPTION
## Summary
- fix the template example in `examples/README.md` to reference an existing template
- replace `examples/templates/marketing_agent` with `examples/templates/job_hunter`
- add an optional `ls examples/templates` step so users can discover available templates

## Why
Issue #6823 reports that `marketing_agent` does not exist, which breaks the getting-started flow in the examples guide.

Closes #6823


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated template usage instructions with a clearer example source and added an optional command to list available templates for easier reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->