### PR TITLE
docs: align getting-started setup and troubleshooting with uv workflow

### DIFF
--- a/core/tests/test_check_llm_key_script.py
+++ b/core/tests/test_check_llm_key_script.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 import importlib.util
 import json
 from pathlib import Path
+from types import ModuleType
+from typing import Any
 
 import pytest
 
 
-def _load_check_llm_key_module():
+@pytest.fixture(scope="session")
+def check_llm_key_module() -> ModuleType:
     module_path = Path(__file__).resolve().parents[2] / "scripts" / "check_llm_key.py"
     spec = importlib.util.spec_from_file_location("check_llm_key_script", module_path)
     module = importlib.util.module_from_spec(spec)
@@ -15,45 +20,65 @@ def _load_check_llm_key_module():
 
 
 class _FakeResponse:
-    def __init__(self, status_code: int, payload=None, text: str = ""):
+    def __init__(
+        self,
+        status_code: int,
+        payload: Any | None = None,
+        text: str = "",
+    ) -> None:
         self.status_code = status_code
         self._payload = payload
         self.text = text
 
-    def json(self):
+    def json(self) -> Any:
         if self._payload is None:
             raise ValueError("no json payload")
         return self._payload
 
 
 def _patch_client(
-    monkeypatch,
-    module,
+    monkeypatch: pytest.MonkeyPatch,
+    module: ModuleType,
     *,
     status_code: int,
-    payload=None,
+    payload: Any | None = None,
     text: str = "",
-):
-    calls = {}
+) -> dict[str, Any]:
+    calls: dict[str, Any] = {}
 
     class FakeClient:
-        def __init__(self, timeout):
+        def __init__(self, timeout: float) -> None:
             calls["timeout"] = timeout
 
-        def __enter__(self):
+        def __enter__(self) -> FakeClient:
             return self
 
-        def __exit__(self, exc_type, exc, tb):
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: Any,
+        ) -> bool:
             return False
 
-        def get(self, endpoint, headers=None, params=None):
+        def get(
+            self,
+            endpoint: str,
+            headers: dict[str, str] | None = None,
+            params: dict[str, str] | None = None,
+        ) -> _FakeResponse:
             calls["method"] = "get"
             calls["endpoint"] = endpoint
             calls["headers"] = headers
             calls["params"] = params
             return _FakeResponse(status_code, payload=payload, text=text)
 
-        def post(self, endpoint, headers=None, json=None):
+        def post(
+            self,
+            endpoint: str,
+            headers: dict[str, str] | None = None,
+            json: dict[str, Any] | None = None,
+        ) -> _FakeResponse:
             calls["method"] = "post"
             calls["endpoint"] = endpoint
             calls["headers"] = headers
@@ -64,7 +89,12 @@ def _patch_client(
     return calls
 
 
-def _run_main(module, monkeypatch, capsys, argv):
+def _run_main(
+    module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    argv: list[str],
+) -> tuple[int | None, dict[str, Any]]:
     monkeypatch.setattr(module.sys, "argv", ["check_llm_key.py", *argv])
     with pytest.raises(SystemExit) as exc:
         module.main()
@@ -82,8 +112,8 @@ def _run_main(module, monkeypatch, capsys, argv):
         (500, {"valid": False, "message": "OpenAI API returned status 500"}),
     ],
 )
-def test_check_openai_compatible_statuses(monkeypatch, status_code, expected):
-    module = _load_check_llm_key_module()
+def test_check_openai_compatible_statuses(check_llm_key_module, monkeypatch, status_code, expected):
+    module = check_llm_key_module
     calls = _patch_client(monkeypatch, module, status_code=status_code)
 
     result = module.check_openai_compatible(
@@ -109,8 +139,8 @@ def test_check_openai_compatible_statuses(monkeypatch, status_code, expected):
         (500, {"valid": False, "message": "Unexpected status 500"}),
     ],
 )
-def test_check_anthropic_statuses(monkeypatch, status_code, expected):
-    module = _load_check_llm_key_module()
+def test_check_anthropic_statuses(check_llm_key_module, monkeypatch, status_code, expected):
+    module = check_llm_key_module
     calls = _patch_client(monkeypatch, module, status_code=status_code)
 
     result = module.check_anthropic("test-key")
@@ -132,8 +162,8 @@ def test_check_anthropic_statuses(monkeypatch, status_code, expected):
         (500, {"valid": False, "message": "Gemini API returned status 500"}),
     ],
 )
-def test_check_gemini_statuses(monkeypatch, status_code, expected):
-    module = _load_check_llm_key_module()
+def test_check_gemini_statuses(check_llm_key_module, monkeypatch, status_code, expected):
+    module = check_llm_key_module
     calls = _patch_client(monkeypatch, module, status_code=status_code)
 
     result = module.check_gemini("test-key")
@@ -156,8 +186,8 @@ def test_check_gemini_statuses(monkeypatch, status_code, expected):
         (500, {"valid": False, "message": "MiniMax API returned status 500"}),
     ],
 )
-def test_check_minimax_statuses(monkeypatch, status_code, expected):
-    module = _load_check_llm_key_module()
+def test_check_minimax_statuses(check_llm_key_module, monkeypatch, status_code, expected):
+    module = check_llm_key_module
     calls = _patch_client(monkeypatch, module, status_code=status_code)
 
     result = module.check_minimax("test-key")
@@ -179,8 +209,13 @@ def test_check_minimax_statuses(monkeypatch, status_code, expected):
         (500, {"valid": False, "message": "Kimi API returned status 500"}),
     ],
 )
-def test_check_anthropic_compatible_statuses(monkeypatch, status_code, expected):
-    module = _load_check_llm_key_module()
+def test_check_anthropic_compatible_statuses(
+    check_llm_key_module,
+    monkeypatch,
+    status_code,
+    expected,
+):
+    module = check_llm_key_module
     calls = _patch_client(monkeypatch, module, status_code=status_code)
 
     result = module.check_anthropic_compatible(
@@ -195,8 +230,8 @@ def test_check_anthropic_compatible_statuses(monkeypatch, status_code, expected)
     assert calls["headers"]["x-api-key"] == "test-key"
 
 
-def test_check_openrouter_unexpected_status(monkeypatch):
-    module = _load_check_llm_key_module()
+def test_check_openrouter_unexpected_status(check_llm_key_module, monkeypatch):
+    module = check_llm_key_module
     calls = _patch_client(monkeypatch, module, status_code=500)
 
     result = module.check_openrouter("test-key", api_base="https://router.example/v1/")
@@ -208,8 +243,8 @@ def test_check_openrouter_unexpected_status(monkeypatch):
     assert calls["endpoint"] == "https://router.example/v1/models"
 
 
-def test_main_usage_when_args_missing(monkeypatch, capsys):
-    module = _load_check_llm_key_module()
+def test_main_usage_when_args_missing(check_llm_key_module, monkeypatch, capsys):
+    module = check_llm_key_module
     code, payload = _run_main(module, monkeypatch, capsys, [])
 
     assert code == 2
@@ -217,8 +252,8 @@ def test_main_usage_when_args_missing(monkeypatch, capsys):
     assert "Usage: check_llm_key.py" in payload["message"]
 
 
-def test_main_routes_openrouter_model_branch(monkeypatch, capsys):
-    module = _load_check_llm_key_module()
+def test_main_routes_openrouter_model_branch(check_llm_key_module, monkeypatch, capsys):
+    module = check_llm_key_module
     calls = {}
 
     def fake_openrouter_model(api_key, model, api_base):
@@ -244,8 +279,8 @@ def test_main_routes_openrouter_model_branch(monkeypatch, capsys):
     }
 
 
-def test_main_routes_kimi_custom_api_base(monkeypatch, capsys):
-    module = _load_check_llm_key_module()
+def test_main_routes_kimi_custom_api_base(check_llm_key_module, monkeypatch, capsys):
+    module = check_llm_key_module
     calls = {}
 
     def fake_anthropic_compatible(api_key, endpoint, name):
@@ -271,8 +306,8 @@ def test_main_routes_kimi_custom_api_base(monkeypatch, capsys):
     }
 
 
-def test_main_routes_custom_api_base_for_zai(monkeypatch, capsys):
-    module = _load_check_llm_key_module()
+def test_main_routes_custom_api_base_for_zai(check_llm_key_module, monkeypatch, capsys):
+    module = check_llm_key_module
     calls = {}
 
     def fake_openai_compatible(api_key, endpoint, name):
@@ -298,8 +333,8 @@ def test_main_routes_custom_api_base_for_zai(monkeypatch, capsys):
     }
 
 
-def test_main_unknown_provider_exits_zero(monkeypatch, capsys):
-    module = _load_check_llm_key_module()
+def test_main_unknown_provider_exits_zero(check_llm_key_module, monkeypatch, capsys):
+    module = check_llm_key_module
     code, payload = _run_main(module, monkeypatch, capsys, ["unknown-provider", "test-key"])
 
     assert code == 0
@@ -309,8 +344,12 @@ def test_main_unknown_provider_exits_zero(monkeypatch, capsys):
     }
 
 
-def test_main_returns_exit_one_for_invalid_provider_result(monkeypatch, capsys):
-    module = _load_check_llm_key_module()
+def test_main_returns_exit_one_for_invalid_provider_result(
+    check_llm_key_module,
+    monkeypatch,
+    capsys,
+):
+    module = check_llm_key_module
     monkeypatch.setitem(
         module.PROVIDERS,
         "openai",
@@ -323,8 +362,8 @@ def test_main_returns_exit_one_for_invalid_provider_result(monkeypatch, capsys):
     assert payload == {"valid": False, "message": "bad key"}
 
 
-def test_main_timeout_exception_exits_two(monkeypatch, capsys):
-    module = _load_check_llm_key_module()
+def test_main_timeout_exception_exits_two(check_llm_key_module, monkeypatch, capsys):
+    module = check_llm_key_module
 
     def raise_timeout(_key):
         raise module.httpx.TimeoutException("timed out")
@@ -336,8 +375,8 @@ def test_main_timeout_exception_exits_two(monkeypatch, capsys):
     assert payload == {"valid": None, "message": "Request timed out"}
 
 
-def test_main_request_error_redacts_api_key(monkeypatch, capsys):
-    module = _load_check_llm_key_module()
+def test_main_request_error_redacts_api_key(check_llm_key_module, monkeypatch, capsys):
+    module = check_llm_key_module
 
     def raise_request_error(api_key):
         request = module.httpx.Request("GET", "https://example.test/models")
@@ -351,3 +390,4 @@ def test_main_request_error_redacts_api_key(monkeypatch, capsys):
     assert payload["message"].startswith("Connection failed: ")
     assert "***" in payload["message"]
     assert "super-secret-key" not in payload["message"]
+

--- a/core/tests/test_check_llm_key_script.py
+++ b/core/tests/test_check_llm_key_script.py
@@ -390,4 +390,3 @@ def test_main_request_error_redacts_api_key(check_llm_key_module, monkeypatch, c
     assert payload["message"].startswith("Connection failed: ")
     assert "***" in payload["message"]
     assert "super-secret-key" not in payload["message"]
-

--- a/core/tests/test_check_llm_key_script.py
+++ b/core/tests/test_check_llm_key_script.py
@@ -1,0 +1,353 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _load_check_llm_key_module():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "check_llm_key.py"
+    spec = importlib.util.spec_from_file_location("check_llm_key_script", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload=None, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json payload")
+        return self._payload
+
+
+def _patch_client(
+    monkeypatch,
+    module,
+    *,
+    status_code: int,
+    payload=None,
+    text: str = "",
+):
+    calls = {}
+
+    class FakeClient:
+        def __init__(self, timeout):
+            calls["timeout"] = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, endpoint, headers=None, params=None):
+            calls["method"] = "get"
+            calls["endpoint"] = endpoint
+            calls["headers"] = headers
+            calls["params"] = params
+            return _FakeResponse(status_code, payload=payload, text=text)
+
+        def post(self, endpoint, headers=None, json=None):
+            calls["method"] = "post"
+            calls["endpoint"] = endpoint
+            calls["headers"] = headers
+            calls["json"] = json
+            return _FakeResponse(status_code, payload=payload, text=text)
+
+    monkeypatch.setattr(module.httpx, "Client", FakeClient)
+    return calls
+
+
+def _run_main(module, monkeypatch, capsys, argv):
+    monkeypatch.setattr(module.sys, "argv", ["check_llm_key.py", *argv])
+    with pytest.raises(SystemExit) as exc:
+        module.main()
+    payload = json.loads(capsys.readouterr().out.strip())
+    return exc.value.code, payload
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected"),
+    [
+        (200, {"valid": True, "message": "OpenAI API key valid"}),
+        (401, {"valid": False, "message": "Invalid OpenAI API key"}),
+        (403, {"valid": False, "message": "OpenAI API key lacks permissions"}),
+        (429, {"valid": True, "message": "OpenAI API key valid"}),
+        (500, {"valid": False, "message": "OpenAI API returned status 500"}),
+    ],
+)
+def test_check_openai_compatible_statuses(monkeypatch, status_code, expected):
+    module = _load_check_llm_key_module()
+    calls = _patch_client(monkeypatch, module, status_code=status_code)
+
+    result = module.check_openai_compatible(
+        "test-key",
+        "https://api.openai.com/v1/models",
+        "OpenAI",
+    )
+
+    assert result == expected
+    assert calls["method"] == "get"
+    assert calls["endpoint"] == "https://api.openai.com/v1/models"
+    assert calls["headers"] == {"Authorization": "Bearer test-key"}
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected"),
+    [
+        (200, {"valid": True, "message": "API key valid"}),
+        (400, {"valid": True, "message": "API key valid"}),
+        (401, {"valid": False, "message": "Invalid API key"}),
+        (403, {"valid": False, "message": "API key lacks permissions"}),
+        (429, {"valid": True, "message": "API key valid"}),
+        (500, {"valid": False, "message": "Unexpected status 500"}),
+    ],
+)
+def test_check_anthropic_statuses(monkeypatch, status_code, expected):
+    module = _load_check_llm_key_module()
+    calls = _patch_client(monkeypatch, module, status_code=status_code)
+
+    result = module.check_anthropic("test-key")
+
+    assert result == expected
+    assert calls["method"] == "post"
+    assert calls["endpoint"] == "https://api.anthropic.com/v1/messages"
+    assert calls["headers"]["x-api-key"] == "test-key"
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected"),
+    [
+        (200, {"valid": True, "message": "Gemini API key valid"}),
+        (400, {"valid": False, "message": "Invalid Gemini API key"}),
+        (401, {"valid": False, "message": "Invalid Gemini API key"}),
+        (403, {"valid": False, "message": "Invalid Gemini API key"}),
+        (429, {"valid": True, "message": "Gemini API key valid"}),
+        (500, {"valid": False, "message": "Gemini API returned status 500"}),
+    ],
+)
+def test_check_gemini_statuses(monkeypatch, status_code, expected):
+    module = _load_check_llm_key_module()
+    calls = _patch_client(monkeypatch, module, status_code=status_code)
+
+    result = module.check_gemini("test-key")
+
+    assert result == expected
+    assert calls["method"] == "get"
+    assert calls["endpoint"] == "https://generativelanguage.googleapis.com/v1beta/models"
+    assert calls["params"] == {"key": "test-key"}
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected"),
+    [
+        (200, {"valid": True, "message": "MiniMax API key valid"}),
+        (400, {"valid": True, "message": "MiniMax API key valid"}),
+        (401, {"valid": False, "message": "Invalid MiniMax API key"}),
+        (403, {"valid": False, "message": "MiniMax API key lacks permissions"}),
+        (422, {"valid": True, "message": "MiniMax API key valid"}),
+        (429, {"valid": True, "message": "MiniMax API key valid"}),
+        (500, {"valid": False, "message": "MiniMax API returned status 500"}),
+    ],
+)
+def test_check_minimax_statuses(monkeypatch, status_code, expected):
+    module = _load_check_llm_key_module()
+    calls = _patch_client(monkeypatch, module, status_code=status_code)
+
+    result = module.check_minimax("test-key")
+
+    assert result == expected
+    assert calls["method"] == "post"
+    assert calls["endpoint"] == "https://api.minimax.io/v1/text/chatcompletion_v2"
+    assert calls["headers"]["Authorization"] == "Bearer test-key"
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected"),
+    [
+        (200, {"valid": True, "message": "Kimi API key valid"}),
+        (400, {"valid": True, "message": "Kimi API key valid"}),
+        (401, {"valid": False, "message": "Invalid Kimi API key"}),
+        (403, {"valid": False, "message": "Kimi API key lacks permissions"}),
+        (429, {"valid": True, "message": "Kimi API key valid"}),
+        (500, {"valid": False, "message": "Kimi API returned status 500"}),
+    ],
+)
+def test_check_anthropic_compatible_statuses(monkeypatch, status_code, expected):
+    module = _load_check_llm_key_module()
+    calls = _patch_client(monkeypatch, module, status_code=status_code)
+
+    result = module.check_anthropic_compatible(
+        "test-key",
+        "https://api.kimi.com/coding/v1/messages",
+        "Kimi",
+    )
+
+    assert result == expected
+    assert calls["method"] == "post"
+    assert calls["endpoint"] == "https://api.kimi.com/coding/v1/messages"
+    assert calls["headers"]["x-api-key"] == "test-key"
+
+
+def test_check_openrouter_unexpected_status(monkeypatch):
+    module = _load_check_llm_key_module()
+    calls = _patch_client(monkeypatch, module, status_code=500)
+
+    result = module.check_openrouter("test-key", api_base="https://router.example/v1/")
+
+    assert result == {
+        "valid": False,
+        "message": "OpenRouter API returned status 500",
+    }
+    assert calls["endpoint"] == "https://router.example/v1/models"
+
+
+def test_main_usage_when_args_missing(monkeypatch, capsys):
+    module = _load_check_llm_key_module()
+    code, payload = _run_main(module, monkeypatch, capsys, [])
+
+    assert code == 2
+    assert payload["valid"] is False
+    assert "Usage: check_llm_key.py" in payload["message"]
+
+
+def test_main_routes_openrouter_model_branch(monkeypatch, capsys):
+    module = _load_check_llm_key_module()
+    calls = {}
+
+    def fake_openrouter_model(api_key, model, api_base):
+        calls["api_key"] = api_key
+        calls["model"] = model
+        calls["api_base"] = api_base
+        return {"valid": True, "message": "model ok"}
+
+    monkeypatch.setattr(module, "check_openrouter_model", fake_openrouter_model)
+    code, payload = _run_main(
+        module,
+        monkeypatch,
+        capsys,
+        ["openrouter", "test-key", "https://openrouter.ai/api/v1", "openai/gpt-4o-mini"],
+    )
+
+    assert code == 0
+    assert payload == {"valid": True, "message": "model ok"}
+    assert calls == {
+        "api_key": "test-key",
+        "model": "openai/gpt-4o-mini",
+        "api_base": "https://openrouter.ai/api/v1",
+    }
+
+
+def test_main_routes_kimi_custom_api_base(monkeypatch, capsys):
+    module = _load_check_llm_key_module()
+    calls = {}
+
+    def fake_anthropic_compatible(api_key, endpoint, name):
+        calls["api_key"] = api_key
+        calls["endpoint"] = endpoint
+        calls["name"] = name
+        return {"valid": True, "message": "kimi ok"}
+
+    monkeypatch.setattr(module, "check_anthropic_compatible", fake_anthropic_compatible)
+    code, payload = _run_main(
+        module,
+        monkeypatch,
+        capsys,
+        ["kimi", "test-key", "https://api.kimi.com/coding/"],
+    )
+
+    assert code == 0
+    assert payload == {"valid": True, "message": "kimi ok"}
+    assert calls == {
+        "api_key": "test-key",
+        "endpoint": "https://api.kimi.com/coding/v1/messages",
+        "name": "Kimi",
+    }
+
+
+def test_main_routes_custom_api_base_for_zai(monkeypatch, capsys):
+    module = _load_check_llm_key_module()
+    calls = {}
+
+    def fake_openai_compatible(api_key, endpoint, name):
+        calls["api_key"] = api_key
+        calls["endpoint"] = endpoint
+        calls["name"] = name
+        return {"valid": True, "message": "zai ok"}
+
+    monkeypatch.setattr(module, "check_openai_compatible", fake_openai_compatible)
+    code, payload = _run_main(
+        module,
+        monkeypatch,
+        capsys,
+        ["zai", "test-key", "https://api.z.ai/api/coding/paas/v4/"],
+    )
+
+    assert code == 0
+    assert payload == {"valid": True, "message": "zai ok"}
+    assert calls == {
+        "api_key": "test-key",
+        "endpoint": "https://api.z.ai/api/coding/paas/v4/models",
+        "name": "ZAI",
+    }
+
+
+def test_main_unknown_provider_exits_zero(monkeypatch, capsys):
+    module = _load_check_llm_key_module()
+    code, payload = _run_main(module, monkeypatch, capsys, ["unknown-provider", "test-key"])
+
+    assert code == 0
+    assert payload == {
+        "valid": True,
+        "message": "No health check for unknown-provider",
+    }
+
+
+def test_main_returns_exit_one_for_invalid_provider_result(monkeypatch, capsys):
+    module = _load_check_llm_key_module()
+    monkeypatch.setitem(
+        module.PROVIDERS,
+        "openai",
+        lambda _key: {"valid": False, "message": "bad key"},
+    )
+
+    code, payload = _run_main(module, monkeypatch, capsys, ["openai", "test-key"])
+
+    assert code == 1
+    assert payload == {"valid": False, "message": "bad key"}
+
+
+def test_main_timeout_exception_exits_two(monkeypatch, capsys):
+    module = _load_check_llm_key_module()
+
+    def raise_timeout(_key):
+        raise module.httpx.TimeoutException("timed out")
+
+    monkeypatch.setitem(module.PROVIDERS, "openai", raise_timeout)
+    code, payload = _run_main(module, monkeypatch, capsys, ["openai", "test-key"])
+
+    assert code == 2
+    assert payload == {"valid": None, "message": "Request timed out"}
+
+
+def test_main_request_error_redacts_api_key(monkeypatch, capsys):
+    module = _load_check_llm_key_module()
+
+    def raise_request_error(api_key):
+        request = module.httpx.Request("GET", "https://example.test/models")
+        raise module.httpx.RequestError(f"auth failed for {api_key}", request=request)
+
+    monkeypatch.setitem(module.PROVIDERS, "openai", raise_request_error)
+    code, payload = _run_main(module, monkeypatch, capsys, ["openai", "super-secret-key"])
+
+    assert code == 2
+    assert payload["valid"] is None
+    assert payload["message"].startswith("Connection failed: ")
+    assert "***" in payload["message"]
+    assert "super-secret-key" not in payload["message"]

--- a/core/tests/test_check_requirements_script.py
+++ b/core/tests/test_check_requirements_script.py
@@ -55,7 +55,7 @@ def test_main_accepts_comma_separated_modules(monkeypatch, capsys):
 
     def fake_check_imports(modules):
         captured["modules"] = modules
-        return {name: "ok" for name in modules}
+        return dict.fromkeys(modules, "ok")
 
     monkeypatch.setattr(module, "check_imports", fake_check_imports)
     code, stdout, stderr = _run_main(

--- a/core/tests/test_check_requirements_script.py
+++ b/core/tests/test_check_requirements_script.py
@@ -1,0 +1,104 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _load_check_requirements_module():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "check_requirements.py"
+    spec = importlib.util.spec_from_file_location("check_requirements_script", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_main(module, monkeypatch, capsys, argv):
+    monkeypatch.setattr(module.sys, "argv", ["check_requirements.py", *argv])
+    with pytest.raises(SystemExit) as exc:
+        module.main()
+    captured = capsys.readouterr()
+    stdout = captured.out.strip()
+    stderr = captured.err.strip()
+    return exc.value.code, stdout, stderr
+
+
+def test_normalize_module_inputs_splits_trims_and_deduplicates():
+    module = _load_check_requirements_module()
+
+    result = module.normalize_module_inputs(
+        [
+            "json, sys",
+            "os",
+            "sys, json",
+            " , ",
+            "",
+            "pathlib",
+        ]
+    )
+
+    assert result == ["json", "sys", "os", "pathlib"]
+
+
+def test_normalize_module_inputs_keeps_space_separated_usage():
+    module = _load_check_requirements_module()
+
+    result = module.normalize_module_inputs(["json", "sys", "os"])
+
+    assert result == ["json", "sys", "os"]
+
+
+def test_main_accepts_comma_separated_modules(monkeypatch, capsys):
+    module = _load_check_requirements_module()
+    captured = {}
+
+    def fake_check_imports(modules):
+        captured["modules"] = modules
+        return {name: "ok" for name in modules}
+
+    monkeypatch.setattr(module, "check_imports", fake_check_imports)
+    code, stdout, stderr = _run_main(
+        module,
+        monkeypatch,
+        capsys,
+        ["json,sys", " os ", "sys, pathlib"],
+    )
+
+    assert code == 0
+    assert stderr == ""
+    assert captured["modules"] == ["json", "sys", "os", "pathlib"]
+    assert json.loads(stdout) == {
+        "json": "ok",
+        "sys": "ok",
+        "os": "ok",
+        "pathlib": "ok",
+    }
+
+
+def test_main_rejects_empty_modules_after_normalization(monkeypatch, capsys):
+    module = _load_check_requirements_module()
+
+    code, stdout, stderr = _run_main(module, monkeypatch, capsys, [" , ", ","])
+
+    assert code == 1
+    assert stdout == ""
+    assert json.loads(stderr) == {"error": "No modules specified"}
+
+
+def test_main_exits_one_when_any_import_fails(monkeypatch, capsys):
+    module = _load_check_requirements_module()
+
+    monkeypatch.setattr(
+        module,
+        "check_imports",
+        lambda _modules: {"json": "ok", "definitely_missing": "error: missing"},
+    )
+    code, stdout, stderr = _run_main(module, monkeypatch, capsys, ["json", "definitely_missing"])
+
+    assert code == 1
+    assert stderr == ""
+    assert json.loads(stdout) == {
+        "json": "ok",
+        "definitely_missing": "error: missing",
+    }

--- a/core/tests/test_checkpoint_store.py
+++ b/core/tests/test_checkpoint_store.py
@@ -1,0 +1,267 @@
+"""Tests for checkpoint storage behavior."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from framework.schemas.checkpoint import Checkpoint
+from framework.storage.checkpoint_store import CheckpointStore
+
+
+def _make_checkpoint(
+    checkpoint_id: str,
+    *,
+    checkpoint_type: str = "node_start",
+    session_id: str = "session-1",
+    created_at: str | None = None,
+    current_node: str = "node-a",
+    is_clean: bool = True,
+) -> Checkpoint:
+    return Checkpoint(
+        checkpoint_id=checkpoint_id,
+        checkpoint_type=checkpoint_type,
+        session_id=session_id,
+        created_at=created_at or datetime.now().isoformat(),
+        current_node=current_node,
+        next_node=None,
+        execution_path=[current_node],
+        shared_memory={"k": "v"},
+        accumulated_outputs={},
+        metrics_snapshot={},
+        is_clean=is_clean,
+        description=f"{checkpoint_type} for {current_node}",
+    )
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> CheckpointStore:
+    return CheckpointStore(tmp_path)
+
+
+class TestCheckpointStoreSaveLoad:
+    @pytest.mark.asyncio
+    async def test_save_checkpoint_writes_file_and_index(self, store: CheckpointStore):
+        checkpoint = _make_checkpoint("cp_node_start_node_a_1")
+
+        await store.save_checkpoint(checkpoint)
+
+        checkpoint_path = store.checkpoints_dir / f"{checkpoint.checkpoint_id}.json"
+        assert checkpoint_path.exists()
+        index = await store.load_index()
+        assert index is not None
+        assert index.total_checkpoints == 1
+        assert index.latest_checkpoint_id == checkpoint.checkpoint_id
+
+    @pytest.mark.asyncio
+    async def test_save_checkpoint_updates_latest_checkpoint_when_saving_multiple(
+        self,
+        store: CheckpointStore,
+    ):
+        first = _make_checkpoint("cp_node_start_node_a_1")
+        second = _make_checkpoint("cp_node_complete_node_a_2", checkpoint_type="node_complete")
+
+        await store.save_checkpoint(first)
+        await store.save_checkpoint(second)
+
+        index = await store.load_index()
+        assert index is not None
+        assert index.total_checkpoints == 2
+        assert index.latest_checkpoint_id == second.checkpoint_id
+
+    @pytest.mark.asyncio
+    async def test_load_checkpoint_by_id_returns_checkpoint(self, store: CheckpointStore):
+        checkpoint = _make_checkpoint("cp_node_start_node_b_1", current_node="node-b")
+        await store.save_checkpoint(checkpoint)
+
+        loaded = await store.load_checkpoint(checkpoint.checkpoint_id)
+
+        assert loaded is not None
+        assert loaded.checkpoint_id == checkpoint.checkpoint_id
+        assert loaded.current_node == "node-b"
+
+    @pytest.mark.asyncio
+    async def test_load_checkpoint_without_id_returns_latest(self, store: CheckpointStore):
+        first = _make_checkpoint("cp_node_start_node_a_1")
+        second = _make_checkpoint("cp_node_start_node_c_2", current_node="node-c")
+        await store.save_checkpoint(first)
+        await store.save_checkpoint(second)
+
+        loaded = await store.load_checkpoint()
+
+        assert loaded is not None
+        assert loaded.checkpoint_id == second.checkpoint_id
+
+    @pytest.mark.asyncio
+    async def test_load_checkpoint_without_index_returns_none(self, store: CheckpointStore):
+        loaded = await store.load_checkpoint()
+
+        assert loaded is None
+
+    @pytest.mark.asyncio
+    async def test_load_checkpoint_missing_file_returns_none(self, store: CheckpointStore):
+        loaded = await store.load_checkpoint("does_not_exist")
+
+        assert loaded is None
+
+    @pytest.mark.asyncio
+    async def test_load_checkpoint_with_corrupt_json_returns_none(self, store: CheckpointStore):
+        checkpoint = _make_checkpoint("cp_node_start_node_a_1")
+        await store.save_checkpoint(checkpoint)
+        checkpoint_path = store.checkpoints_dir / f"{checkpoint.checkpoint_id}.json"
+        checkpoint_path.write_text("{bad json", encoding="utf-8")
+
+        loaded = await store.load_checkpoint(checkpoint.checkpoint_id)
+
+        assert loaded is None
+
+
+class TestCheckpointStoreListAndExists:
+    @pytest.mark.asyncio
+    async def test_list_checkpoints_returns_empty_when_index_missing(self, store: CheckpointStore):
+        checkpoints = await store.list_checkpoints()
+
+        assert checkpoints == []
+
+    @pytest.mark.asyncio
+    async def test_list_checkpoints_returns_all_checkpoints(self, store: CheckpointStore):
+        a = _make_checkpoint("cp_node_start_node_a_1")
+        b = _make_checkpoint("cp_node_complete_node_a_2", checkpoint_type="node_complete")
+        await store.save_checkpoint(a)
+        await store.save_checkpoint(b)
+
+        checkpoints = await store.list_checkpoints()
+
+        assert len(checkpoints) == 2
+        assert [cp.checkpoint_id for cp in checkpoints] == [a.checkpoint_id, b.checkpoint_id]
+
+    @pytest.mark.asyncio
+    async def test_list_checkpoints_filters_by_type(self, store: CheckpointStore):
+        a = _make_checkpoint("cp_node_start_node_a_1", checkpoint_type="node_start")
+        b = _make_checkpoint("cp_node_complete_node_a_2", checkpoint_type="node_complete")
+        await store.save_checkpoint(a)
+        await store.save_checkpoint(b)
+
+        checkpoints = await store.list_checkpoints(checkpoint_type="node_complete")
+
+        assert len(checkpoints) == 1
+        assert checkpoints[0].checkpoint_id == b.checkpoint_id
+
+    @pytest.mark.asyncio
+    async def test_list_checkpoints_filters_by_clean_status(self, store: CheckpointStore):
+        clean = _make_checkpoint("cp_clean_1", is_clean=True)
+        dirty = _make_checkpoint("cp_dirty_1", is_clean=False)
+        await store.save_checkpoint(clean)
+        await store.save_checkpoint(dirty)
+
+        clean_checkpoints = await store.list_checkpoints(is_clean=True)
+        dirty_checkpoints = await store.list_checkpoints(is_clean=False)
+
+        assert [cp.checkpoint_id for cp in clean_checkpoints] == [clean.checkpoint_id]
+        assert [cp.checkpoint_id for cp in dirty_checkpoints] == [dirty.checkpoint_id]
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_exists_true_when_file_present(self, store: CheckpointStore):
+        checkpoint = _make_checkpoint("cp_exists_1")
+        await store.save_checkpoint(checkpoint)
+
+        exists = await store.checkpoint_exists(checkpoint.checkpoint_id)
+
+        assert exists is True
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_exists_false_for_missing_file(self, store: CheckpointStore):
+        exists = await store.checkpoint_exists("missing_checkpoint")
+
+        assert exists is False
+
+
+class TestCheckpointStoreDelete:
+    @pytest.mark.asyncio
+    async def test_delete_checkpoint_removes_file_and_index_entry(self, store: CheckpointStore):
+        checkpoint = _make_checkpoint("cp_delete_1")
+        await store.save_checkpoint(checkpoint)
+
+        deleted = await store.delete_checkpoint(checkpoint.checkpoint_id)
+
+        assert deleted is True
+        assert not (store.checkpoints_dir / f"{checkpoint.checkpoint_id}.json").exists()
+        index = await store.load_index()
+        assert index is not None
+        assert index.total_checkpoints == 0
+
+    @pytest.mark.asyncio
+    async def test_delete_checkpoint_updates_latest_when_deleting_latest(
+        self,
+        store: CheckpointStore,
+    ):
+        first = _make_checkpoint("cp_keep_1")
+        latest = _make_checkpoint("cp_latest_2")
+        await store.save_checkpoint(first)
+        await store.save_checkpoint(latest)
+
+        deleted = await store.delete_checkpoint(latest.checkpoint_id)
+
+        assert deleted is True
+        index = await store.load_index()
+        assert index is not None
+        assert index.latest_checkpoint_id == first.checkpoint_id
+        assert index.total_checkpoints == 1
+
+    @pytest.mark.asyncio
+    async def test_delete_checkpoint_clears_latest_when_last_removed(self, store: CheckpointStore):
+        checkpoint = _make_checkpoint("cp_last_1")
+        await store.save_checkpoint(checkpoint)
+
+        deleted = await store.delete_checkpoint(checkpoint.checkpoint_id)
+
+        assert deleted is True
+        index = await store.load_index()
+        assert index is not None
+        assert index.latest_checkpoint_id is None
+        assert index.total_checkpoints == 0
+
+    @pytest.mark.asyncio
+    async def test_delete_checkpoint_returns_false_when_file_missing(self, store: CheckpointStore):
+        deleted = await store.delete_checkpoint("missing_checkpoint")
+
+        assert deleted is False
+
+
+class TestCheckpointStorePrune:
+    @pytest.mark.asyncio
+    async def test_prune_checkpoints_returns_zero_without_index(self, store: CheckpointStore):
+        deleted_count = await store.prune_checkpoints(max_age_days=7)
+
+        assert deleted_count == 0
+
+    @pytest.mark.asyncio
+    async def test_prune_checkpoints_deletes_only_old_checkpoints(self, store: CheckpointStore):
+        old_created = (datetime.now() - timedelta(days=10)).isoformat()
+        new_created = (datetime.now() - timedelta(days=1)).isoformat()
+        old_checkpoint = _make_checkpoint("cp_old_1", created_at=old_created)
+        new_checkpoint = _make_checkpoint("cp_new_1", created_at=new_created)
+        await store.save_checkpoint(old_checkpoint)
+        await store.save_checkpoint(new_checkpoint)
+
+        deleted_count = await store.prune_checkpoints(max_age_days=7)
+
+        assert deleted_count == 1
+        assert await store.checkpoint_exists(old_checkpoint.checkpoint_id) is False
+        assert await store.checkpoint_exists(new_checkpoint.checkpoint_id) is True
+
+    @pytest.mark.asyncio
+    async def test_prune_checkpoints_skips_invalid_timestamp_entries(self, store: CheckpointStore):
+        invalid_checkpoint = _make_checkpoint("cp_invalid_1", created_at="not-a-date")
+        old_created = (datetime.now() - timedelta(days=30)).isoformat()
+        old_checkpoint = _make_checkpoint("cp_old_2", created_at=old_created)
+        await store.save_checkpoint(invalid_checkpoint)
+        await store.save_checkpoint(old_checkpoint)
+
+        deleted_count = await store.prune_checkpoints(max_age_days=7)
+
+        assert deleted_count == 1
+        assert await store.checkpoint_exists(old_checkpoint.checkpoint_id) is False
+        assert await store.checkpoint_exists(invalid_checkpoint.checkpoint_id) is True

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -234,12 +234,12 @@ echo $HIVE_API_KEY
 ### Package Installation Issues
 
 ```bash
-# Re-run setup on macOS/Linux
+# From the repository root, re-run setup on macOS/Linux
 ./quickstart.sh
 ```
 
 ```powershell
-# Re-run setup on Windows (PowerShell)
+# From the repository root, re-run setup on Windows (PowerShell)
 .\quickstart.ps1
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@ This guide will help you set up the Aden Agent Framework and build your first ag
 ## Prerequisites
 
 - **Python 3.11+** ([Download](https://www.python.org/downloads/)) - Python 3.12 or 3.13 recommended
-- **pip** - Package installer for Python (comes with Python)
+- **uv** ([Install](https://docs.astral.sh/uv/getting-started/installation/)) - Required workspace/package manager for this repository
 - **git** - Version control
 - **Claude Code** ([Install](https://docs.anthropic.com/claude/docs/claude-code)) - Optional, for using building skills
 
@@ -43,6 +43,8 @@ uv run python -c "import framework; import aden_tools; print('Setup complete')"
 
 > **Note:** On Windows, running `.\quickstart.ps1` requires PowerShell 5.1+. If you see a "running scripts is disabled" error, run `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass` first. Alternatively, use WSL — see [environment-setup.md](./environment-setup.md) for details.
 
+> **Workspace note:** Hive uses a `uv` workspace setup. Do not run `pip install -e .` from the repository root, and avoid mixing `pip` and `uv` commands for workspace package management.
+
 ## Building Your First Agent
 
 Agents are not included by default in a fresh clone.
@@ -62,7 +64,7 @@ This is the recommended way to create your first agent.
 - Unix-based shell (macOS, Linux, or Windows via WSL)
 
 ```bash
-# Setup already done via quickstart.sh above
+# Setup is already done via the quickstart command shown above
 
 # Start Claude Code and build an agent
 Use the coder-tools initialize_and_build_agent tool
@@ -232,14 +234,18 @@ echo $HIVE_API_KEY
 ### Package Installation Issues
 
 ```bash
-# Remove and reinstall
-pip uninstall -y framework tools
+# Re-run setup on macOS/Linux
 ./quickstart.sh
+```
+
+```powershell
+# Re-run setup on Windows (PowerShell)
+.\quickstart.ps1
 ```
 
 ## Getting Help
 
 - **Documentation**: Check the `/docs` folder
-- **Issues**: [github.com/adenhq/hive/issues](https://github.com/aden-hive/hive/issues)
+- **Issues**: [github.com/aden-hive/hive/issues](https://github.com/aden-hive/hive/issues)
 - **Discord**: [discord.com/invite/MXE49hrKDk](https://discord.com/invite/MXE49hrKDk)
 - **Build Agents**: Use the coder-tools workflow to create agents

--- a/scripts/check_requirements.py
+++ b/scripts/check_requirements.py
@@ -7,6 +7,7 @@ reducing subprocess spawning overhead significantly on Windows.
 
 Usage:
     python scripts/check_requirements.py <module1> <module2> ...
+    python scripts/check_requirements.py "module1,module2,module3"
 
 Returns:
     JSON object with import status for each module
@@ -16,6 +17,22 @@ Returns:
 import json
 import sys
 from typing import Dict
+
+
+def normalize_module_inputs(raw_modules: list[str]) -> list[str]:
+    """Split comma-separated inputs, trim values, and remove duplicates."""
+    normalized: list[str] = []
+    seen: set[str] = set()
+
+    for raw_value in raw_modules:
+        for module_name in raw_value.split(","):
+            candidate = module_name.strip()
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            normalized.append(candidate)
+
+    return normalized
 
 
 def check_imports(modules: list[str]) -> Dict[str, str]:
@@ -54,7 +71,10 @@ def main():
         print(json.dumps({"error": "No modules specified"}), file=sys.stderr)
         sys.exit(1)
 
-    modules_to_check = sys.argv[1:]
+    modules_to_check = normalize_module_inputs(sys.argv[1:])
+    if not modules_to_check:
+        print(json.dumps({"error": "No modules specified"}), file=sys.stderr)
+        sys.exit(1)
     results = check_imports(modules_to_check)
 
     # Print results as JSON


### PR DESCRIPTION
## Summary
- update prerequisites in `docs/getting-started.md` to document `uv` as the required workspace/package manager
- add a clear workspace note warning against mixing root-level `pip` workflow with `uv` workspace setup
- replace `pip uninstall -y framework tools` recovery step with platform-correct quickstart commands:
  - `./quickstart.sh` for macOS/Linux
  - `./quickstart.ps1` for Windows PowerShell
- fix the issues link text typo (`adenhq` -> `aden-hive`)

## Why
This resolves conflicting setup guidance in the getting-started docs and aligns troubleshooting with the repository's uv-first workflow and platform-specific quickstart commands.

Closes #6812


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated getting-started to use "uv" instead of "pip", added a workspace note against mixing managers or installing from the repo root, clarified quickstart wording, and revised troubleshooting to recommend re-running the quickstart scripts.
* **Tests**
  * Added end-to-end tests covering LLM key checks (provider behaviors, CLI flows, and error handling) and requirements-checking scenarios.
* **Chores**
  * CLI now accepts comma-separated module lists, normalizes inputs (trim/split/dedupe), and reports clear error or result exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->