### PR TITLE
docs(tools): add README for 11 tools (batch 1 of 2)

### DIFF
--- a/tools/src/aden_tools/tools/aws_s3_tool/README.md
+++ b/tools/src/aden_tools/tools/aws_s3_tool/README.md
@@ -1,0 +1,59 @@
+# AWS S3 Tool
+
+Manage Amazon S3 buckets and objects using AWS Signature V4 authentication.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `s3_list_buckets` | List all S3 buckets in the account |
+| `s3_list_objects` | List objects in a bucket with optional prefix filter |
+| `s3_get_object` | Download an object's content (text or base64) |
+| `s3_put_object` | Upload content to an S3 object |
+| `s3_delete_object` | Delete an object from a bucket |
+| `s3_copy_object` | Copy an object between buckets or keys |
+| `s3_get_object_metadata` | Get object metadata (size, content type, ETag) |
+| `s3_generate_presigned_url` | Generate a pre-signed URL for temporary access |
+
+## Setup
+
+Set the following environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `AWS_ACCESS_KEY_ID` | AWS access key |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret key |
+| `AWS_REGION` | AWS region (default: `us-east-1`) |
+
+Get credentials at: [AWS Console](https://console.aws.amazon.com/iam/)
+
+## Usage Examples
+
+### List buckets
+```python
+s3_list_buckets()
+```
+
+### List objects with prefix
+```python
+s3_list_objects(bucket="my-bucket", prefix="data/", max_keys=20)
+```
+
+### Upload a file
+```python
+s3_put_object(bucket="my-bucket", key="reports/q1.csv", content="col1,col2\n1,2")
+```
+
+### Generate a pre-signed URL
+```python
+s3_generate_presigned_url(bucket="my-bucket", key="file.pdf", expires_in=3600)
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required", "help": "Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables"}
+{"error": "HTTP 404: <NoSuchKey>...</NoSuchKey>"}
+{"error": "Request timed out"}
+```

--- a/tools/src/aden_tools/tools/azure_sql_tool/README.md
+++ b/tools/src/aden_tools/tools/azure_sql_tool/README.md
@@ -1,0 +1,62 @@
+# Azure SQL Tool
+
+Manage Azure SQL servers, databases, and firewall rules via the Azure Management REST API.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `azure_sql_list_servers` | List SQL servers in a subscription or resource group |
+| `azure_sql_get_server` | Get details of a specific SQL server |
+| `azure_sql_list_databases` | List databases on a SQL server |
+| `azure_sql_get_database` | Get details of a specific database |
+| `azure_sql_list_firewall_rules` | List firewall rules for a SQL server |
+
+## Setup
+
+Set the following environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `AZURE_SUBSCRIPTION_ID` | Azure subscription ID |
+| `AZURE_SQL_ACCESS_TOKEN` | Azure Management API bearer token |
+
+To obtain a token:
+1. Register an app in Azure AD (Entra ID)
+2. Assign SQL DB Contributor or Reader role
+3. Obtain a token via client credentials flow with scope `https://management.azure.com/.default`
+
+See: [Azure SQL REST API](https://learn.microsoft.com/en-us/rest/api/sql/)
+
+Note: Access tokens typically expire within 1 hour and require refresh.
+
+## Usage Examples
+
+### List all SQL servers
+```python
+azure_sql_list_servers()
+```
+
+### List servers in a resource group
+```python
+azure_sql_list_servers(resource_group="my-rg")
+```
+
+### Get databases on a server
+```python
+azure_sql_list_databases(resource_group="my-rg", server_name="my-server")
+```
+
+### Check firewall rules
+```python
+azure_sql_list_firewall_rules(resource_group="my-rg", server_name="my-server")
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "AZURE_SQL_ACCESS_TOKEN and AZURE_SUBSCRIPTION_ID are required"}
+{"error": "Azure API error (HTTP 404): Resource not found"}
+{"error": "Request timed out"}
+```

--- a/tools/src/aden_tools/tools/cloudinary_tool/README.md
+++ b/tools/src/aden_tools/tools/cloudinary_tool/README.md
@@ -1,0 +1,59 @@
+# Cloudinary Tool
+
+Upload, manage, search, and transform media assets using the Cloudinary API.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `cloudinary_upload` | Upload an image or file to Cloudinary |
+| `cloudinary_list_resources` | List resources with optional type and prefix filters |
+| `cloudinary_get_resource` | Get detailed info about a specific resource |
+| `cloudinary_delete_resource` | Delete a resource by public ID |
+| `cloudinary_search` | Search resources using Cloudinary's search API |
+| `cloudinary_get_usage` | Get account usage statistics |
+| `cloudinary_rename_resource` | Rename a resource's public ID |
+| `cloudinary_add_tag` | Add a tag to one or more resources |
+
+## Setup
+
+Set the following environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `CLOUDINARY_CLOUD_NAME` | Your Cloudinary cloud name |
+| `CLOUDINARY_API_KEY` | API key |
+| `CLOUDINARY_API_SECRET` | API secret |
+
+Get credentials at: [Cloudinary Console](https://console.cloudinary.com/)
+
+## Usage Examples
+
+### Upload an image
+```python
+cloudinary_upload(file_url="https://example.com/photo.jpg", public_id="my-photo")
+```
+
+### Search for resources
+```python
+cloudinary_search(expression="cat AND format:jpg", max_results=10)
+```
+
+### Get account usage
+```python
+cloudinary_get_usage()
+```
+
+### Delete a resource
+```python
+cloudinary_delete_resource(public_id="my-photo")
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, and CLOUDINARY_API_SECRET not set", "help": "Get credentials from your Cloudinary dashboard at https://console.cloudinary.com/"}
+{"error": "Cloudinary API error (HTTP 404): Resource not found"}
+{"error": "Request timed out"}
+```

--- a/tools/src/aden_tools/tools/duckduckgo_tool/README.md
+++ b/tools/src/aden_tools/tools/duckduckgo_tool/README.md
@@ -1,0 +1,64 @@
+# DuckDuckGo Tool
+
+Search the web, news, and images using DuckDuckGo. No API key required.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `duckduckgo_search` | Search the web for pages and results |
+| `duckduckgo_news` | Search for recent news articles |
+| `duckduckgo_images` | Search for images |
+
+## Setup
+
+No credentials required. DuckDuckGo searches are free and unauthenticated.
+
+## Usage Examples
+
+### Web search
+```python
+duckduckgo_search(query="python async best practices", max_results=5)
+```
+
+### Search with optional parameters
+```python
+duckduckgo_search(
+    query="AI frameworks",
+    max_results=10,
+    region="us-en",
+    safesearch="moderate",
+    timelimit="m",  # past month
+)
+```
+
+### News search
+```python
+duckduckgo_news(query="AI agents 2026", max_results=10, region="us-en")
+```
+
+### Image search
+```python
+duckduckgo_images(query="neural network diagram", max_results=5, size="Large")
+```
+
+## Optional Parameters
+
+| Parameter | Tools | Description |
+|-----------|-------|-------------|
+| `region` | All | Region code (default: `us-en`) |
+| `safesearch` | search, images | `off`, `moderate`, `strict` (default: `moderate`) |
+| `timelimit` | search, news | `d` (day), `w` (week), `m` (month), `y` (year) |
+| `size` | images | `Small`, `Medium`, `Large`, `Wallpaper` |
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "Search failed: connection timeout"}
+```
+
+When no results are found, tools return a successful response with an empty list:
+```python
+{"query": "obscure search", "results": [], "count": 0}
+```

--- a/tools/src/aden_tools/tools/file_system_toolkits/README.md
+++ b/tools/src/aden_tools/tools/file_system_toolkits/README.md
@@ -1,0 +1,65 @@
+# File System Toolkits
+
+A collection of file system tools for reading, writing, searching, and executing commands within the agent workspace.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `apply_diff` | Apply a unified diff to a file |
+| `apply_patch` | Apply a patch file to modify source files |
+| `hashline_edit` | Edit a file using hashline-addressed replacements |
+| `replace_file_content` | Find and replace content in a file |
+| `grep_search` | Search file contents using regex patterns |
+| `list_dir` | List directory contents with metadata |
+| `execute_command_tool` | Execute a shell command in the workspace |
+| `save_data` | Save data to a file in the agent's data directory |
+| `load_data` | Load data from a file in the data directory |
+| `serve_file_to_user` | Serve a file to the user for download |
+| `list_data_files` | List files in the agent's data directory |
+| `append_data` | Append data to an existing file |
+
+## Sub-modules
+
+| Module | Description |
+|--------|-------------|
+| `apply_diff/` | Unified diff application |
+| `apply_patch/` | Patch file application |
+| `data_tools/` | Data persistence (save, load, append, list, serve) |
+| `execute_command_tool/` | Shell command execution with sanitization |
+| `grep_search/` | File content search (uses ripgrep if available) |
+| `hashline_edit/` | Hashline-based file editing |
+| `list_dir/` | Directory listing |
+| `replace_file_content/` | Find-and-replace in files |
+
+## Setup
+
+No external credentials required. File operations are scoped to the agent's workspace directory.
+
+## Security
+
+- `command_sanitizer.py` validates and sanitizes shell commands before execution
+- `security.py` provides path traversal protection
+- All file operations are workspace-scoped
+
+## Usage Examples
+
+### Search for a pattern in files
+```python
+grep_search(pattern="def register_tools", path="tools/src/", include="*.py")
+```
+
+### List directory contents
+```python
+list_dir(path="core/framework/", workspace_id="ws1", agent_id="agent1", session_id="s1")
+```
+
+### Save data to a file
+```python
+save_data(filename="results.json", data='{"status": "complete"}', data_dir="/path/to/data")
+```
+
+### Execute a command
+```python
+execute_command_tool(command="python -m pytest tests/ -v")
+```

--- a/tools/src/aden_tools/tools/gitlab_tool/README.md
+++ b/tools/src/aden_tools/tools/gitlab_tool/README.md
@@ -1,0 +1,62 @@
+# GitLab Tool
+
+Manage GitLab projects, issues, and merge requests via the GitLab REST API v4.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `gitlab_list_projects` | List projects with optional search and visibility filters |
+| `gitlab_get_project` | Get details of a specific project |
+| `gitlab_list_issues` | List issues with state, label, and assignee filters |
+| `gitlab_get_issue` | Get details of a specific issue |
+| `gitlab_create_issue` | Create a new issue in a project |
+| `gitlab_update_issue` | Update an existing issue (title, description, state, labels, assignee) |
+| `gitlab_list_merge_requests` | List merge requests with state and label filters |
+| `gitlab_get_merge_request` | Get details of a specific merge request |
+| `gitlab_create_merge_request_note` | Add a comment to a merge request |
+
+## Setup
+
+Set the following environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `GITLAB_TOKEN` | GitLab personal access token |
+| `GITLAB_URL` | GitLab instance URL (optional, defaults to `https://gitlab.com`) |
+
+Get a token at: [GitLab Access Tokens](https://gitlab.com/-/user_settings/personal_access_tokens)
+
+Required scopes: `api` (full API access) or `read_api` + `read_repository` for read-only.
+
+## Usage Examples
+
+### List your projects
+```python
+gitlab_list_projects(membership=True, per_page=10)
+```
+
+### Search for issues
+```python
+gitlab_list_issues(project_id="12345", state="opened", labels="bug")
+```
+
+### Create an issue
+```python
+gitlab_create_issue(project_id="12345", title="Fix login bug", description="Steps to reproduce...")
+```
+
+### Add a comment to a merge request
+```python
+gitlab_create_merge_request_note(project_id="12345", merge_request_iid=42, body="LGTM!")
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "GITLAB_TOKEN not set", "help": "Create a personal access token at https://gitlab.com/-/user_settings/personal_access_tokens"}
+{"error": "Unauthorized. Check your GitLab token."}
+{"error": "Forbidden. Insufficient permissions."}
+{"error": "Request to GitLab timed out"}
+```

--- a/tools/src/aden_tools/tools/google_search_console_tool/README.md
+++ b/tools/src/aden_tools/tools/google_search_console_tool/README.md
@@ -1,0 +1,68 @@
+# Google Search Console Tool
+
+Analyze search performance, manage sitemaps, and inspect URLs using the Google Search Console API.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `gsc_search_analytics` | Query search analytics data with dimension and date filters |
+| `gsc_list_sites` | List all verified sites in the account |
+| `gsc_list_sitemaps` | List sitemaps for a site |
+| `gsc_inspect_url` | Inspect a URL's indexing status |
+| `gsc_submit_sitemap` | Submit a sitemap URL for a site |
+| `gsc_delete_sitemap` | Delete a submitted sitemap |
+| `gsc_top_queries` | Get top search queries for a site |
+| `gsc_top_pages` | Get top pages by clicks for a site |
+
+## Setup
+
+Requires Google OAuth2 via Aden:
+
+1. Connect your Google account at [hive.adenhq.com](https://hive.adenhq.com)
+2. The `GOOGLE_SEARCH_CONSOLE_TOKEN` is managed automatically by the Aden credential system
+
+Or set manually:
+
+| Variable | Description |
+|----------|-------------|
+| `GOOGLE_SEARCH_CONSOLE_TOKEN` | Google OAuth2 access token |
+
+Required OAuth scopes: `https://www.googleapis.com/auth/webmasters.readonly` (read) or `https://www.googleapis.com/auth/webmasters` (read/write).
+
+## Usage Examples
+
+### Get top queries for the last 7 days
+```python
+gsc_top_queries(site_url="https://example.com", days=7, limit=20)
+```
+
+### Check a URL's index status
+```python
+gsc_inspect_url(site_url="https://example.com", inspection_url="https://example.com/page")
+```
+
+### Submit a sitemap
+```python
+gsc_submit_sitemap(site_url="https://example.com", sitemap_url="https://example.com/sitemap.xml")
+```
+
+### Query search analytics with filters
+```python
+gsc_search_analytics(
+    site_url="https://example.com",
+    start_date="2026-01-01",
+    end_date="2026-01-31",
+    dimensions=["query", "page"],
+    row_limit=50,
+)
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "GOOGLE_SEARCH_CONSOLE_TOKEN not set", "help": "Set GOOGLE_SEARCH_CONSOLE_TOKEN or connect via hive.adenhq.com"}
+{"error": "Unauthorized. Check your GOOGLE_SEARCH_CONSOLE_TOKEN."}
+{"error": "Request timed out"}
+```

--- a/tools/src/aden_tools/tools/greenhouse_tool/README.md
+++ b/tools/src/aden_tools/tools/greenhouse_tool/README.md
@@ -1,0 +1,60 @@
+# Greenhouse Tool
+
+Manage jobs, candidates, applications, and offers using the Greenhouse Harvest API.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `greenhouse_list_jobs` | List jobs with optional status and department filters |
+| `greenhouse_get_job` | Get details of a specific job |
+| `greenhouse_list_candidates` | List candidates with optional search and date filters |
+| `greenhouse_get_candidate` | Get details of a specific candidate |
+| `greenhouse_list_applications` | List applications with optional job and status filters |
+| `greenhouse_get_application` | Get details of a specific application |
+| `greenhouse_list_offers` | List offers with optional status filter |
+| `greenhouse_add_candidate_note` | Add a note to a candidate's profile |
+| `greenhouse_list_scorecards` | List scorecards for an application |
+
+## Setup
+
+Set the following environment variable:
+
+| Variable | Description |
+|----------|-------------|
+| `GREENHOUSE_API_TOKEN` | Greenhouse Harvest API token |
+
+Get a token at: Configure > Dev Center > API Credential Management in your Greenhouse account.
+
+The token uses HTTP Basic Auth (token as username, empty password).
+
+## Usage Examples
+
+### List open jobs
+```python
+greenhouse_list_jobs(status="open", per_page=20)
+```
+
+### Search candidates
+```python
+greenhouse_list_candidates(search="jane@example.com", per_page=10)
+```
+
+### Get application details
+```python
+greenhouse_get_application(application_id=12345)
+```
+
+### Add a note to a candidate
+```python
+greenhouse_add_candidate_note(candidate_id=12345, body="Strong technical interview performance.")
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "GREENHOUSE_API_TOKEN not set", "help": "Get your API key from Greenhouse: Configure > Dev Center > API Credential Management"}
+{"error": "Greenhouse API error (HTTP 404): Resource not found"}
+{"error": "Request timed out"}
+```

--- a/tools/src/aden_tools/tools/hubspot_tool/README.md
+++ b/tools/src/aden_tools/tools/hubspot_tool/README.md
@@ -1,0 +1,73 @@
+# HubSpot Tool
+
+Manage contacts, companies, deals, and associations using the HubSpot CRM API v3/v4.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `hubspot_search_contacts` | Search contacts by name, email, phone |
+| `hubspot_get_contact` | Get a contact by ID |
+| `hubspot_create_contact` | Create a new contact |
+| `hubspot_update_contact` | Update a contact's properties |
+| `hubspot_search_companies` | Search companies by name, domain |
+| `hubspot_get_company` | Get a company by ID |
+| `hubspot_create_company` | Create a new company |
+| `hubspot_update_company` | Update a company's properties |
+| `hubspot_search_deals` | Search deals by name |
+| `hubspot_get_deal` | Get a deal by ID |
+| `hubspot_create_deal` | Create a new deal |
+| `hubspot_update_deal` | Update a deal's properties |
+| `hubspot_delete_object` | Delete (archive) a contact, company, or deal |
+| `hubspot_list_associations` | List associations between CRM objects |
+| `hubspot_create_association` | Create an association between two objects |
+
+## Setup
+
+Set the following environment variable or use Aden OAuth:
+
+| Variable | Description |
+|----------|-------------|
+| `HUBSPOT_ACCESS_TOKEN` | HubSpot private app access token |
+
+Get a token at: [HubSpot Developer Portal](https://developers.hubspot.com/docs/api/creating-an-app)
+
+Supports multi-account via `account` parameter for Aden OAuth users.
+
+## Usage Examples
+
+### Search contacts
+```python
+hubspot_search_contacts(query="jane@example.com", properties=["email", "firstname", "lastname"])
+```
+
+### Create a deal
+```python
+hubspot_create_deal(properties={"dealname": "New Partnership", "amount": "50000"})
+```
+
+### Link a contact to a company
+```python
+hubspot_create_association(
+    from_object_type="contacts",
+    from_object_id="101",
+    to_object_type="companies",
+    to_object_id="202",
+    association_type_id=1,
+)
+```
+
+### Delete a contact
+```python
+hubspot_delete_object(object_type="contacts", object_id="101")
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "HubSpot credentials not configured", "help": "Set HUBSPOT_ACCESS_TOKEN or configure via credential store"}
+{"error": "Invalid or expired HubSpot access token"}
+{"error": "HubSpot rate limit exceeded. Try again later."}
+{"error": "Request timed out"}
+```

--- a/tools/src/aden_tools/tools/kafka_tool/README.md
+++ b/tools/src/aden_tools/tools/kafka_tool/README.md
@@ -1,0 +1,58 @@
+# Kafka Tool
+
+Manage Apache Kafka topics, produce messages, and monitor consumer groups via the Confluent Kafka REST API.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `kafka_list_topics` | List all topics in the Kafka cluster |
+| `kafka_get_topic` | Get details and configuration of a topic |
+| `kafka_create_topic` | Create a new topic with partition and replication settings |
+| `kafka_produce_message` | Produce a message to a topic |
+| `kafka_list_consumer_groups` | List all consumer groups |
+| `kafka_get_consumer_group_lag` | Get consumer lag for a group |
+
+## Setup
+
+Set the following environment variables:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `KAFKA_REST_URL` | Yes | Confluent Kafka REST Proxy URL |
+| `KAFKA_CLUSTER_ID` | Yes | Kafka cluster ID |
+| `KAFKA_API_KEY` | No | API key (for authenticated clusters) |
+| `KAFKA_API_SECRET` | No | API secret (for authenticated clusters) |
+
+Get credentials at: [Confluent Cloud](https://confluent.cloud/)
+
+## Usage Examples
+
+### List topics
+```python
+kafka_list_topics()
+```
+
+### Create a topic
+```python
+kafka_create_topic(topic_name="events", partitions_count=3, replication_factor=3)
+```
+
+### Produce a message
+```python
+kafka_produce_message(topic_name="events", key="user-123", value='{"action": "login"}')
+```
+
+### Check consumer lag
+```python
+kafka_get_consumer_group_lag(consumer_group_id="my-consumer-group")
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "KAFKA_REST_URL is required", "help": "Set KAFKA_REST_URL environment variable"}
+{"error": "KAFKA_CLUSTER_ID is required", "help": "Set KAFKA_CLUSTER_ID environment variable"}
+{"error": "Request timed out"}
+```

--- a/tools/src/aden_tools/tools/microsoft_graph_tool/README.md
+++ b/tools/src/aden_tools/tools/microsoft_graph_tool/README.md
@@ -1,0 +1,83 @@
+# Microsoft Graph Tool
+
+Access Outlook mail, Microsoft Teams, and OneDrive files via the Microsoft Graph API v1.0.
+
+## Tools
+
+### Outlook Mail
+
+| Tool | Description |
+|------|-------------|
+| `outlook_list_messages` | List emails with optional folder and search filters |
+| `outlook_get_message` | Get details of a specific email |
+| `outlook_send_mail` | Send an email |
+
+### Microsoft Teams
+
+| Tool | Description |
+|------|-------------|
+| `teams_list_teams` | List teams the user belongs to |
+| `teams_list_channels` | List channels in a team |
+| `teams_send_channel_message` | Send a message to a team channel |
+| `teams_get_channel_messages` | Get recent messages from a channel |
+
+### OneDrive
+
+| Tool | Description |
+|------|-------------|
+| `onedrive_search_files` | Search for files across OneDrive |
+| `onedrive_list_files` | List files in a folder |
+| `onedrive_download_file` | Download a file's content |
+| `onedrive_upload_file` | Upload a small file to OneDrive (up to 4MB) |
+
+## Setup
+
+Set the following environment variable or use Aden OAuth:
+
+| Variable | Description |
+|----------|-------------|
+| `MICROSOFT_GRAPH_ACCESS_TOKEN` | Microsoft Graph API access token |
+
+Get credentials at: [Azure App Registrations](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps)
+
+Required permissions: `Mail.Read`, `Mail.Send`, `Team.ReadBasic.All`, `Channel.ReadBasic.All`, `ChannelMessage.Send`, `ChannelMessage.Read.All`, `Files.ReadWrite`
+
+## Usage Examples
+
+### List unread emails
+```python
+outlook_list_messages(folder="inbox", search="is:unread", top=10)
+```
+
+### Send an email
+```python
+outlook_send_mail(
+    to=["jane@example.com"],
+    subject="Meeting Notes",
+    body="Here are the notes from today's meeting.",
+)
+```
+
+### List Teams channels
+```python
+teams_list_channels(team_id="team-abc-123")
+```
+
+### Search OneDrive files
+```python
+onedrive_search_files(query="quarterly report", top=5)
+```
+
+### Upload a file to OneDrive
+```python
+onedrive_upload_file(file_path="Documents/notes.txt", content="Meeting notes here")
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "MICROSOFT_GRAPH_ACCESS_TOKEN not set", "help": "Set MICROSOFT_GRAPH_ACCESS_TOKEN or connect via hive.adenhq.com"}
+{"error": "Microsoft Graph API error (HTTP 403): Insufficient privileges"}
+{"error": "Request timed out"}
+```


### PR DESCRIPTION
## Description

Adds README.md documentation for 11 tools that were missing it.

Partial fix for #6486

## Tools Documented

aws_s3_tool, azure_sql_tool, cloudinary_tool, duckduckgo_tool, file_system_toolkits, gitlab_tool, google_search_console_tool, greenhouse_tool, hubspot_tool, kafka_tool, microsoft_graph_tool

## Format

Each README follows the existing pattern (e.g., `gmail_tool/README.md`):
- Tool name and description
- Tools table with all available functions
- Setup instructions with required credentials
- Usage examples
- Error handling

## Checklist

- [x] Follows existing README format
- [x] Self-reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added README documentation for 11 new tools (AWS S3, Azure SQL, Cloudinary, DuckDuckGo, File System Toolkits, GitLab, Google Search Console, Greenhouse, HubSpot, Kafka, Microsoft Graph), each including setup/authentication guidance, example usage for core operations, supported commands overview, and standardized error-handling descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->