### PR TITLE
docs(tools): add README for 11 tools (batch 2 of 2)

### DIFF
--- a/tools/src/aden_tools/tools/n8n_tool/README.md
+++ b/tools/src/aden_tools/tools/n8n_tool/README.md
@@ -1,0 +1,56 @@
+# n8n Tool
+
+Manage n8n workflows and executions via the n8n REST API.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `n8n_list_workflows` | List workflows with optional status and tag filters |
+| `n8n_get_workflow` | Get details of a specific workflow |
+| `n8n_activate_workflow` | Activate a workflow |
+| `n8n_deactivate_workflow` | Deactivate a workflow |
+| `n8n_list_executions` | List workflow executions with optional status filter |
+| `n8n_get_execution` | Get details of a specific execution |
+
+## Setup
+
+Set the following environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `N8N_API_KEY` | n8n API key |
+| `N8N_BASE_URL` | n8n instance URL (e.g., `https://your-n8n.example.com`) |
+
+Get an API key at: Settings → API → Create API Key in your n8n instance.
+
+## Usage Examples
+
+### List active workflows
+```python
+n8n_list_workflows(active="true")
+```
+
+### Get workflow details
+```python
+n8n_get_workflow(workflow_id="123")
+```
+
+### Activate a workflow
+```python
+n8n_activate_workflow(workflow_id="123")
+```
+
+### List recent executions
+```python
+n8n_list_executions(status="success", limit=10)
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "n8n credentials not configured", "help": "Set N8N_API_KEY and N8N_BASE_URL environment variables or configure via credential store"}
+{"error": "n8n API error (HTTP 404): Workflow not found"}
+{"error": "Request timed out"}
+```

--- a/tools/src/aden_tools/tools/obsidian_tool/README.md
+++ b/tools/src/aden_tools/tools/obsidian_tool/README.md
@@ -1,0 +1,54 @@
+# Obsidian Tool
+
+Read, write, search, and manage notes in an Obsidian vault via the Obsidian Local REST API.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `obsidian_read_note` | Read the content of a note by path |
+| `obsidian_write_note` | Create or overwrite a note |
+| `obsidian_append_note` | Append content to an existing note |
+| `obsidian_search` | Search notes by text or regex |
+| `obsidian_list_files` | List files and folders in a vault path |
+| `obsidian_get_active` | Get the currently active note |
+
+## Setup
+
+Requires the [Obsidian Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api) plugin.
+
+| Variable | Description |
+|----------|-------------|
+| `OBSIDIAN_REST_API_KEY` | API key from the Local REST API plugin |
+| `OBSIDIAN_REST_BASE_URL` | REST API URL (default: `https://127.0.0.1:27124`) |
+
+## Usage Examples
+
+### Read a note
+```python
+obsidian_read_note(path="Projects/hive-contributions.md")
+```
+
+### Write a note
+```python
+obsidian_write_note(path="Daily/2026-03-30.md", content="# Today\n\n- Submitted PR")
+```
+
+### Search the vault
+```python
+obsidian_search(query="event bus tests", context_length=100)
+```
+
+### List files in a folder
+```python
+obsidian_list_files(path="Projects/")
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "OBSIDIAN_REST_API_KEY not set", "help": "Set OBSIDIAN_REST_API_KEY environment variable or configure via credential store"}
+{"error": "Obsidian API error (HTTP 404): Note not found"}
+{"error": "Request timed out"}
+```

--- a/tools/src/aden_tools/tools/pagerduty_tool/README.md
+++ b/tools/src/aden_tools/tools/pagerduty_tool/README.md
@@ -1,0 +1,62 @@
+# PagerDuty Tool
+
+Manage incidents, services, on-calls, and escalation policies via the PagerDuty REST API v2.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `pagerduty_list_incidents` | List incidents with status, urgency, and date filters |
+| `pagerduty_get_incident` | Get details of a specific incident |
+| `pagerduty_create_incident` | Create a new incident |
+| `pagerduty_update_incident` | Update an incident's status or assignment |
+| `pagerduty_list_services` | List services with optional name filter |
+| `pagerduty_list_oncalls` | List current on-call schedules |
+| `pagerduty_add_incident_note` | Add a note to an incident |
+| `pagerduty_list_escalation_policies` | List escalation policies |
+
+## Setup
+
+Set the following environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `PAGERDUTY_API_KEY` | PagerDuty REST API token |
+| `PAGERDUTY_FROM_EMAIL` | Email address for write operations (used in `From` header) |
+
+Get a token at: [PagerDuty API Access Keys](https://support.pagerduty.com/docs/api-access-keys)
+
+## Usage Examples
+
+### List triggered incidents
+```python
+pagerduty_list_incidents(statuses=["triggered", "acknowledged"], limit=10)
+```
+
+### Create an incident
+```python
+pagerduty_create_incident(
+    title="Database connection pool exhausted",
+    service_id="P1234AB",
+    urgency="high",
+)
+```
+
+### Acknowledge an incident
+```python
+pagerduty_update_incident(incident_id="P5678CD", status="acknowledged")
+```
+
+### Check who's on call
+```python
+pagerduty_list_oncalls()
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "PAGERDUTY_API_KEY is required", "help": "Set PAGERDUTY_API_KEY environment variable"}
+{"error": "PagerDuty API error (HTTP 404): Incident not found"}
+{"error": "Request timed out"}
+```

--- a/tools/src/aden_tools/tools/pipedrive_tool/README.md
+++ b/tools/src/aden_tools/tools/pipedrive_tool/README.md
@@ -1,0 +1,72 @@
+# Pipedrive Tool
+
+Manage deals, contacts, organizations, activities, and pipelines using the Pipedrive CRM API.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `pipedrive_list_deals` | List deals with status, stage, and sort filters |
+| `pipedrive_get_deal` | Get details of a specific deal |
+| `pipedrive_create_deal` | Create a new deal |
+| `pipedrive_update_deal` | Update a deal's properties |
+| `pipedrive_list_persons` | List contacts with optional search |
+| `pipedrive_search_persons` | Search contacts by name or email |
+| `pipedrive_create_person` | Create a new contact |
+| `pipedrive_list_organizations` | List organizations |
+| `pipedrive_list_activities` | List activities with type and date filters |
+| `pipedrive_create_activity` | Create a new activity |
+| `pipedrive_list_pipelines` | List all sales pipelines |
+| `pipedrive_list_stages` | List stages in a pipeline |
+| `pipedrive_add_note` | Add a note to a deal, person, or organization |
+
+## Setup
+
+Set the following environment variable:
+
+| Variable | Description |
+|----------|-------------|
+| `PIPEDRIVE_API_TOKEN` | Pipedrive API token |
+
+Get a token at: Settings > Personal preferences > API in your Pipedrive account.
+
+## Usage Examples
+
+### List open deals
+```python
+pipedrive_list_deals(status="open", sort="update_time DESC", limit=20)
+```
+
+### Search for a contact
+```python
+pipedrive_search_persons(term="jane@example.com")
+```
+
+### Create a deal
+```python
+pipedrive_create_deal(title="Enterprise License", value=50000, currency="USD")
+```
+
+### Create a contact
+```python
+pipedrive_create_person(name="Jane Doe", email="jane@example.com")
+```
+
+### Create an activity
+```python
+pipedrive_create_activity(subject="Follow-up call", activity_type="call", due_date="2026-04-15")
+```
+
+### Add a note to a deal
+```python
+pipedrive_add_note(content="Follow up scheduled for next week.", deal_id=12345)
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "PIPEDRIVE_API_TOKEN not set", "help": "Get your API token from Pipedrive Settings > Personal preferences > API"}
+{"error": "Pipedrive API error (HTTP 404): Deal not found"}
+{"error": "Request timed out"}
+```

--- a/tools/src/aden_tools/tools/plaid_tool/README.md
+++ b/tools/src/aden_tools/tools/plaid_tool/README.md
@@ -1,0 +1,57 @@
+# Plaid Tool
+
+Access bank accounts, balances, and transactions using the Plaid API.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `plaid_get_accounts` | List linked bank accounts |
+| `plaid_get_balance` | Get real-time account balances |
+| `plaid_sync_transactions` | Sync new transactions incrementally |
+| `plaid_get_transactions` | Get transactions with date range and filters |
+| `plaid_get_institution` | Get details about a financial institution |
+| `plaid_search_institutions` | Search for institutions by name |
+
+## Setup
+
+Set the following environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `PLAID_CLIENT_ID` | Plaid client ID |
+| `PLAID_SECRET` | Plaid secret key |
+| `PLAID_ENV` | Environment: `sandbox`, `development`, or `production` (default: `sandbox`) |
+
+Get credentials at: [Plaid Dashboard](https://dashboard.plaid.com/developers/keys)
+
+## Usage Examples
+
+### Get account balances
+```python
+plaid_get_balance(access_token="access-sandbox-abc123")
+```
+
+### Get recent transactions
+```python
+plaid_get_transactions(
+    access_token="access-sandbox-abc123",
+    start_date="2026-01-01",
+    end_date="2026-01-31",
+    count=50,
+)
+```
+
+### Search for a bank
+```python
+plaid_search_institutions(query="Chase", count=5)
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "PLAID_CLIENT_ID and PLAID_SECRET not set", "help": "Get credentials at https://dashboard.plaid.com/developers/keys"}
+{"error": "Plaid API error: INVALID_ACCESS_TOKEN"}
+{"error": "Request timed out"}
+```

--- a/tools/src/aden_tools/tools/powerbi_tool/README.md
+++ b/tools/src/aden_tools/tools/powerbi_tool/README.md
@@ -1,0 +1,56 @@
+# Power BI Tool
+
+Manage Power BI workspaces, datasets, and reports via the Power BI REST API.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `powerbi_list_workspaces` | List workspaces with optional name filter |
+| `powerbi_list_datasets` | List datasets in a workspace |
+| `powerbi_list_reports` | List reports in a workspace |
+| `powerbi_refresh_dataset` | Trigger a dataset refresh |
+| `powerbi_get_refresh_history` | Get refresh history for a dataset |
+
+## Setup
+
+Set the following environment variable:
+
+| Variable | Description |
+|----------|-------------|
+| `POWERBI_ACCESS_TOKEN` | Power BI REST API bearer token |
+
+Get a token via Azure AD: [Power BI REST API](https://learn.microsoft.com/en-us/power-bi/developer/embedded/register-app)
+
+Required permissions: `Dataset.ReadWrite.All`, `Workspace.Read.All`
+
+## Usage Examples
+
+### List workspaces
+```python
+powerbi_list_workspaces()
+```
+
+### List datasets in a workspace
+```python
+powerbi_list_datasets(workspace_id="abc-123")
+```
+
+### Trigger a dataset refresh
+```python
+powerbi_refresh_dataset(workspace_id="abc-123", dataset_id="def-456")
+```
+
+### Check refresh history
+```python
+powerbi_get_refresh_history(workspace_id="abc-123", dataset_id="def-456")
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "POWERBI_ACCESS_TOKEN is required", "help": "Set POWERBI_ACCESS_TOKEN environment variable"}
+{"error": "Power BI API error (HTTP 403): Insufficient permissions"}
+{"error": "Request timed out"}
+```

--- a/tools/src/aden_tools/tools/quickbooks_tool/README.md
+++ b/tools/src/aden_tools/tools/quickbooks_tool/README.md
@@ -1,0 +1,61 @@
+# QuickBooks Tool
+
+Manage customers, invoices, payments, and company info using the QuickBooks Online API.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `quickbooks_query` | Run a QuickBooks SQL-like query |
+| `quickbooks_get_entity` | Get any entity by type and ID |
+| `quickbooks_create_customer` | Create a new customer |
+| `quickbooks_create_invoice` | Create a new invoice |
+| `quickbooks_get_company_info` | Get company information |
+| `quickbooks_list_invoices` | List invoices with date and status filters |
+| `quickbooks_get_customer` | Get a customer by ID |
+| `quickbooks_create_payment` | Record a payment against an invoice |
+
+## Setup
+
+Set the following environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `QUICKBOOKS_ACCESS_TOKEN` | OAuth2 access token |
+| `QUICKBOOKS_REALM_ID` | QuickBooks company/realm ID |
+
+Get credentials at: [Intuit Developer Portal](https://developer.intuit.com/)
+
+## Usage Examples
+
+### Query customers
+```python
+quickbooks_query(query="SELECT * FROM Customer WHERE DisplayName LIKE '%Acme%'")
+```
+
+### Create a customer
+```python
+quickbooks_create_customer(display_name="Acme Corp", email="billing@acme.com")
+```
+
+### Create an invoice
+```python
+quickbooks_create_invoice(
+    customer_id="123",
+    line_items=[{"description": "Consulting", "amount": 5000, "quantity": 1}],
+)
+```
+
+### List recent invoices
+```python
+quickbooks_list_invoices(start_date="2026-01-01", status="Overdue")
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "QUICKBOOKS_ACCESS_TOKEN and QUICKBOOKS_REALM_ID are required", "help": "Set QUICKBOOKS_ACCESS_TOKEN and QUICKBOOKS_REALM_ID environment variables"}
+{"error": "QuickBooks API error (HTTP 401): AuthenticationFailed"}
+{"error": "Request timed out"}
+```

--- a/tools/src/aden_tools/tools/salesforce_tool/README.md
+++ b/tools/src/aden_tools/tools/salesforce_tool/README.md
@@ -1,0 +1,66 @@
+# Salesforce Tool
+
+Query, create, update, and manage Salesforce CRM records via the Salesforce REST API.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `salesforce_soql_query` | Execute a SOQL query |
+| `salesforce_get_record` | Get a record by object type and ID |
+| `salesforce_create_record` | Create a new record |
+| `salesforce_update_record` | Update an existing record |
+| `salesforce_delete_record` | Delete a record |
+| `salesforce_describe_object` | Get metadata and fields for an object type |
+| `salesforce_list_objects` | List all available Salesforce objects |
+| `salesforce_search_records` | Search records using SOSL |
+| `salesforce_get_record_count` | Get the total count of records for an object |
+
+## Setup
+
+Set the following environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `SALESFORCE_ACCESS_TOKEN` | OAuth2 access token |
+| `SALESFORCE_INSTANCE_URL` | Salesforce instance URL (e.g., `https://yourorg.salesforce.com`) |
+
+Get credentials at: [Salesforce Connected Apps](https://help.salesforce.com/s/articleView?id=sf.connected_app_overview.htm)
+
+## Usage Examples
+
+### Query contacts
+```python
+salesforce_soql_query(query="SELECT Id, Name, Email FROM Contact WHERE Email != null LIMIT 10")
+```
+
+### Create a lead
+```python
+salesforce_create_record(
+    object_type="Lead",
+    fields={"FirstName": "Jane", "LastName": "Doe", "Company": "Acme"},
+)
+```
+
+### Update an opportunity
+```python
+salesforce_update_record(
+    object_type="Opportunity",
+    record_id="006xx000001234",
+    fields={"StageName": "Closed Won", "Amount": 50000},
+)
+```
+
+### Search across objects
+```python
+salesforce_search_records(search_query="FIND {Acme} IN ALL FIELDS RETURNING Account, Contact")
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "Salesforce credentials not configured", "help": "Set SALESFORCE_ACCESS_TOKEN and SALESFORCE_INSTANCE_URL environment variables or configure via credential store"}
+{"error": "Salesforce API error (HTTP 400): MALFORMED_QUERY"}
+{"error": "Request timed out"}
+```

--- a/tools/src/aden_tools/tools/sap_tool/README.md
+++ b/tools/src/aden_tools/tools/sap_tool/README.md
@@ -1,0 +1,56 @@
+# SAP Tool
+
+Access SAP S/4HANA data via OData APIs — purchase orders, business partners, products, and sales orders.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `sap_list_purchase_orders` | List purchase orders with optional filters |
+| `sap_get_purchase_order` | Get details of a specific purchase order |
+| `sap_list_business_partners` | List business partners with search and category filters |
+| `sap_list_products` | List products with optional search |
+| `sap_list_sales_orders` | List sales orders with customer and date filters |
+
+## Setup
+
+Set the following environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `SAP_BASE_URL` | SAP S/4HANA OData base URL |
+| `SAP_USERNAME` | SAP username for Basic Auth |
+| `SAP_PASSWORD` | SAP password for Basic Auth |
+
+Get credentials from your SAP system administrator.
+
+## Usage Examples
+
+### List purchase orders
+```python
+sap_list_purchase_orders(top=20)
+```
+
+### Get a specific purchase order
+```python
+sap_get_purchase_order(purchase_order="4500000001")
+```
+
+### Search business partners
+```python
+sap_list_business_partners(search="Acme", category="supplier", top=10)
+```
+
+### List recent sales orders
+```python
+sap_list_sales_orders(top=20)
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "SAP_BASE_URL, SAP_USERNAME, and SAP_PASSWORD are required", "help": "Set SAP_BASE_URL, SAP_USERNAME, and SAP_PASSWORD environment variables"}
+{"error": "SAP API error (HTTP 404): Resource not found"}
+{"error": "Request timed out"}
+```

--- a/tools/src/aden_tools/tools/terraform_tool/README.md
+++ b/tools/src/aden_tools/tools/terraform_tool/README.md
@@ -1,0 +1,57 @@
+# Terraform Tool
+
+Manage Terraform Cloud/Enterprise workspaces and runs via the Terraform API.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `terraform_list_workspaces` | List workspaces in an organization |
+| `terraform_get_workspace` | Get details of a specific workspace |
+| `terraform_list_runs` | List runs for a workspace |
+| `terraform_get_run` | Get details of a specific run |
+| `terraform_create_run` | Trigger a new plan/apply run |
+
+## Setup
+
+Set the following environment variable:
+
+| Variable | Description |
+|----------|-------------|
+| `TFC_TOKEN` | Terraform Cloud/Enterprise API token |
+| `TFC_URL` | Terraform Enterprise URL (optional, defaults to Terraform Cloud) |
+
+Get a token at: [Terraform Cloud Tokens](https://app.terraform.io/app/settings/tokens)
+
+Note: The `organization` name is passed as a parameter to tools, not as an environment variable.
+
+## Usage Examples
+
+### List workspaces
+```python
+terraform_list_workspaces(organization="my-org")
+```
+
+### Get workspace details
+```python
+terraform_get_workspace(workspace_id="ws-abc123")
+```
+
+### List runs for a workspace
+```python
+terraform_list_runs(workspace_id="ws-abc123")
+```
+
+### Trigger a new run
+```python
+terraform_create_run(workspace_id="ws-abc123", message="Deploy v2.1.0")
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "TFC_TOKEN is required", "help": "Set TFC_TOKEN environment variable"}
+{"error": "organization is required"}
+{"error": "Request timed out"}
+```

--- a/tools/src/aden_tools/tools/tines_tool/README.md
+++ b/tools/src/aden_tools/tools/tines_tool/README.md
@@ -1,0 +1,55 @@
+# Tines Tool
+
+Manage Tines automation stories and actions via the Tines API.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `tines_list_stories` | List stories with optional status filter |
+| `tines_get_story` | Get details of a specific story |
+| `tines_list_actions` | List actions in a story |
+| `tines_get_action` | Get details of a specific action |
+| `tines_get_action_logs` | Get execution logs for an action |
+
+## Setup
+
+Set the following environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `TINES_API_KEY` | Tines API key |
+| `TINES_DOMAIN` | Tines tenant URL (e.g., `https://your-tenant.tines.com`) |
+
+Get an API key at: Settings → API Keys in your Tines account.
+
+## Usage Examples
+
+### List all stories
+```python
+tines_list_stories()
+```
+
+### Get story details
+```python
+tines_get_story(story_id=12345)
+```
+
+### List actions in a story
+```python
+tines_list_actions(story_id=12345)
+```
+
+### Get action logs
+```python
+tines_get_action_logs(action_id=67890)
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+```python
+{"error": "TINES_DOMAIN and TINES_API_KEY are required", "help": "Set TINES_DOMAIN and TINES_API_KEY environment variables"}
+{"error": "Tines API error (HTTP 404): Story not found"}
+{"error": "Request timed out"}
+```


### PR DESCRIPTION
## Description

Adds README.md documentation for 11 more tools.

Partial fix for #6486

## Tools Documented

n8n_tool, obsidian_tool, pagerduty_tool, pipedrive_tool, plaid_tool, powerbi_tool, quickbooks_tool, salesforce_tool, sap_tool, terraform_tool, tines_tool

## Format

Each README follows the existing pattern (e.g., `gmail_tool/README.md`):
- Tool name and description
- Tools table with all available functions
- Setup instructions with required credentials
- Usage examples
- Error handling

## Checklist

- [x] Follows existing README format
- [x] Self-reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for 11 new integrations: n8n, Obsidian, PagerDuty, Pipedrive, Plaid, Power BI, QuickBooks, Salesforce, SAP, Terraform, and Tines. Each guide covers setup and required credentials, supported operations, example Python usage, input/parameter options, and standardized error/response formats to aid configuration, common tasks, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->