### PR TITLE
docs(gitlab): add GitLab tool README

### DIFF
--- a/tools/src/aden_tools/tools/gitlab_tool/README.md
+++ b/tools/src/aden_tools/tools/gitlab_tool/README.md
@@ -29,24 +29,31 @@ Get a token at: [GitLab Access Tokens](https://gitlab.com/-/user_settings/person
 
 Required scopes: `api` (full API access) or `read_api` + `read_repository` for read-only.
 
+Alternatively, configure credentials in the Aden credential store:
+- `gitlab_token`
+
 ## Usage Examples
 
 ### List your projects
+
 ```python
 gitlab_list_projects(membership=True, per_page=10)
 ```
 
 ### Search for issues
+
 ```python
 gitlab_list_issues(project_id="12345", state="opened", labels="bug")
 ```
 
 ### Create an issue
+
 ```python
 gitlab_create_issue(project_id="12345", title="Fix login bug", description="Steps to reproduce...")
 ```
 
 ### Add a comment to a merge request
+
 ```python
 gitlab_create_merge_request_note(project_id="12345", merge_request_iid=42, body="LGTM!")
 ```
@@ -54,6 +61,7 @@ gitlab_create_merge_request_note(project_id="12345", merge_request_iid=42, body=
 ## Error Handling
 
 All tools return error dicts on failure:
+
 ```python
 {"error": "GITLAB_TOKEN not set", "help": "Create a personal access token at https://gitlab.com/-/user_settings/personal_access_tokens"}
 {"error": "Unauthorized. Check your GitLab token."}


### PR DESCRIPTION
## Description
Adds a README for the GitLab tool with setup, tool list, and examples.

## Type of Change
- [x] Documentation update

## Related Issues
N/A (docs-only)

## Changes Made
- Added `tools/src/aden_tools/tools/gitlab_tool/README.md`
- Documented GITLAB_* env vars and credential store keys
- Listed tools and added usage examples

## Testing
- [x] Manual testing performed (docs review only)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New documentation for the GitLab Tool: explains authentication (token and optional instance URL), configuration, supported operations (project discovery, issue create/read/update, merge request listing/retrieval, and adding notes), lists available commands, provides practical Python examples for listing projects, creating issues, and listing merge requests, and links to the upstream GitLab REST API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->