### PR TITLE
fix(graph): prevent request_input cancellation leak and result race

### DIFF
--- a/core/framework/graph/client_io.py
+++ b/core/framework/graph/client_io.py
@@ -81,27 +81,27 @@ class ActiveNodeClientIO(NodeClientIO):
         self._input_event = asyncio.Event()
         self._input_result = None
 
-        if self._event_bus is not None:
-            await self._event_bus.emit_client_input_requested(
-                stream_id=self.node_id,
-                node_id=self.node_id,
-                prompt=prompt,
-                execution_id=self._execution_id or None,
-            )
-
         try:
+            if self._event_bus is not None:
+                await self._event_bus.emit_client_input_requested(
+                    stream_id=self.node_id,
+                    node_id=self.node_id,
+                    prompt=prompt,
+                    execution_id=self._execution_id or None,
+                )
+
             if timeout is not None:
                 await asyncio.wait_for(self._input_event.wait(), timeout=timeout)
             else:
                 await self._input_event.wait()
+
+            if self._input_result is None:
+                raise RuntimeError("input event was set but no input was provided")
+            result = self._input_result
+            self._input_result = None
+            return result
         finally:
             self._input_event = None
-
-        if self._input_result is None:
-            raise RuntimeError("input event was set but no input was provided")
-        result = self._input_result
-        self._input_result = None
-        return result
 
     async def provide_input(self, content: str) -> None:
         """Called externally to fulfill a pending request_input()."""

--- a/core/tests/test_client_io.py
+++ b/core/tests/test_client_io.py
@@ -99,6 +99,69 @@ async def test_active_request_input_timeout():
         await io.request_input(prompt="waiting", timeout=0.01)
 
 
+@pytest.mark.asyncio
+async def test_active_request_input_cancellation_leak_regression():
+    """
+    Regression test for cancellation during emit_client_input_requested.
+
+    If request_input is cancelled while awaiting the event bus emission, internal state must be
+    reset so that a subsequent request_input can proceed normally.
+    """
+
+    class SlowEventBus(MockEventBus):
+        async def emit_client_input_requested(self, **kwargs) -> None:
+            await asyncio.sleep(1.0)
+            await super().emit_client_input_requested(**kwargs)
+
+    bus = SlowEventBus()
+    io = ActiveNodeClientIO(node_id="n1", event_bus=bus)
+
+    task1 = asyncio.create_task(io.request_input(prompt="Wait"))
+    await asyncio.sleep(0.01)
+    task1.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task1
+
+    task2 = asyncio.create_task(io.request_input(prompt="Second"))
+    await asyncio.sleep(0.01)
+    await io.provide_input("data")
+    assert await task2 == "data"
+
+
+@pytest.mark.asyncio
+async def test_active_request_input_result_read_happens_with_event_active_regression():
+    """
+    Regression test for a critical section gap where _input_event was cleared before _input_result
+    was read, enabling a concurrent request to wipe the result.
+    """
+
+    class ResultTracker:
+        reads_with_event_active: list[bool] = []
+
+        def __get__(self, obj, objtype=None):
+            if obj is None:
+                return self
+            self.reads_with_event_active.append(obj._input_event is not None)
+            return getattr(obj, "_mock_result", None)
+
+        def __set__(self, obj, value):
+            obj._mock_result = value
+
+    class TrackedIO(ActiveNodeClientIO):
+        _input_result = ResultTracker()
+
+    io = TrackedIO(node_id="n1")
+
+    task = asyncio.create_task(io.request_input(prompt="1"))
+    await asyncio.sleep(0.01)
+
+    await io.provide_input("test_data")
+    assert await task == "test_data"
+
+    assert True in TrackedIO._input_result.reads_with_event_active
+
+
 # --- InertNodeClientIO tests ---
 
 


### PR DESCRIPTION
## Summary
Fix two race conditions in `ActiveNodeClientIO.request_input`:
- Move `emit_client_input_requested()` inside the `try/finally` so cancellation can’t leak `_input_event`
- Keep `_input_event` active until `_input_result` is captured, preventing a concurrent request from wiping the result

Adds regression tests for both scenarios.

## Description
Fixes cancellation leak and critical-section ordering in `request_input`, with regression coverage to prevent reintroducing the races.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
Fixes #6885

## Changes Made
- Ensure `request_input` cleanup runs even if cancelled during event bus emission
- Capture `_input_result` before clearing `_input_event` to preserve the critical section
- Add regression tests for cancellation leak + result-read ordering

## Testing
- [x] Unit tests pass (`cd core && uv run python -m pytest tests/test_client_io.py -q`)
- [x] Lint passes (`make check`)
- [ ] Manual testing performed

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in client input request operations to ensure proper resource cleanup during exceptions or timeouts.

* **Tests**
  * Added regression tests for client input request handling, including cancellation and error condition scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->