### PR TITLE
micro-fix(security): mitigate ast.Pow DoS and enforce safe_eval timeout

### DIFF
--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -23,7 +23,7 @@ def _safe_pow(base: Any, exp: Any) -> Any:
         abs_base = abs(base)
         if abs_base > 1:
             # Estimate bit growth instead of materializing a huge integer.
-            estimated_bits = exp * (abs_base.bit_length() - 1) + 1
+            estimated_bits = exp * abs_base.bit_length()
             if estimated_bits > MAX_POWER_RESULT_BITS:
                 raise ValueError("Power operation exceeds safe size limit")
 

--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -51,10 +51,18 @@ def _execution_timeout(timeout_ms: int | None):
     can_use_alarm = (
         hasattr(signal, "SIGALRM")
         and hasattr(signal, "ITIMER_REAL")
+        and hasattr(signal, "getitimer")
         and hasattr(signal, "setitimer")
         and threading.current_thread() is threading.main_thread()
     )
     if not can_use_alarm:
+        yield
+        return
+
+    current_delay, current_interval = signal.getitimer(signal.ITIMER_REAL)
+    if current_delay > 0 or current_interval > 0:
+        # safe_eval runs inside a shared framework process, so it must not
+        # replace a timer another subsystem already owns.
         yield
         return
 
@@ -63,12 +71,12 @@ def _execution_timeout(timeout_ms: int | None):
 
     old_handler = signal.getsignal(signal.SIGALRM)
     signal.signal(signal.SIGALRM, _handle_timeout)
-    signal.setitimer(signal.ITIMER_REAL, timeout_ms / 1000)
+    old_delay, old_interval = signal.setitimer(signal.ITIMER_REAL, timeout_ms / 1000)
     try:
         yield
     finally:
-        signal.setitimer(signal.ITIMER_REAL, 0)
         signal.signal(signal.SIGALRM, old_handler)
+        signal.setitimer(signal.ITIMER_REAL, old_delay, old_interval)
 
 
 # Safe operators whitelist

--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -1,11 +1,18 @@
 import ast
 import operator
+import signal
+import threading
+import time
+from contextlib import contextmanager
 from typing import Any
 
 # Power operations can allocate extremely large integers. Keep conservative
 # limits here so untrusted edge conditions cannot exhaust CPU or memory.
 MAX_POWER_ABS_EXPONENT = 1_000
 MAX_POWER_RESULT_BITS = 4_096
+# Typical edge-condition evaluations in this repo complete well under 1ms.
+# 100ms leaves ample headroom for legitimate checks while failing fast on abuse.
+DEFAULT_TIMEOUT_MS = 100
 
 
 def _safe_pow(base: Any, exp: Any) -> Any:
@@ -23,6 +30,47 @@ def _safe_pow(base: Any, exp: Any) -> Any:
                 raise ValueError("Power operation exceeds safe size limit")
 
     return operator.pow(base, exp)
+
+
+def _timeout_message(timeout_ms: int) -> str:
+    return f"safe_eval exceeded {timeout_ms}ms execution timeout"
+
+
+def _check_timeout(deadline: float | None, timeout_ms: int | None) -> None:
+    if deadline is not None and timeout_ms is not None and time.perf_counter() >= deadline:
+        raise TimeoutError(_timeout_message(timeout_ms))
+
+
+@contextmanager
+def _execution_timeout(timeout_ms: int | None):
+    if timeout_ms is None:
+        yield
+        return
+
+    if timeout_ms <= 0:
+        raise ValueError("timeout_ms must be greater than 0")
+
+    can_use_alarm = (
+        hasattr(signal, "SIGALRM")
+        and hasattr(signal, "ITIMER_REAL")
+        and hasattr(signal, "setitimer")
+        and threading.current_thread() is threading.main_thread()
+    )
+    if not can_use_alarm:
+        yield
+        return
+
+    def _handle_timeout(signum, frame):
+        raise TimeoutError(_timeout_message(timeout_ms))
+
+    old_handler = signal.getsignal(signal.SIGALRM)
+    signal.signal(signal.SIGALRM, _handle_timeout)
+    signal.setitimer(signal.ITIMER_REAL, timeout_ms / 1000)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, old_handler)
 
 
 # Safe operators whitelist
@@ -77,10 +125,19 @@ SAFE_FUNCTIONS = {
 
 
 class SafeEvalVisitor(ast.NodeVisitor):
-    def __init__(self, context: dict[str, Any]):
+    def __init__(
+        self,
+        context: dict[str, Any],
+        *,
+        deadline: float | None = None,
+        timeout_ms: int | None = None,
+    ):
         self.context = context
+        self.deadline = deadline
+        self.timeout_ms = timeout_ms
 
     def visit(self, node: ast.AST) -> Any:
+        _check_timeout(self.deadline, self.timeout_ms)
         # Override visit to prevent default behavior and ensure only explicitly allowed nodes work
         method = "visit_" + node.__class__.__name__
         visitor = getattr(self, method, self.generic_visit)
@@ -206,6 +263,7 @@ class SafeEvalVisitor(ast.NodeVisitor):
         raise AttributeError(f"Object has no attribute '{node.attr}'")
 
     def visit_Call(self, node: ast.Call) -> Any:
+        _check_timeout(self.deadline, self.timeout_ms)
         # Only allow calling whitelisted functions
         func = self.visit(node.func)
 
@@ -249,16 +307,24 @@ class SafeEvalVisitor(ast.NodeVisitor):
         args = [self.visit(arg) for arg in node.args]
         keywords = {kw.arg: self.visit(kw.value) for kw in node.keywords}
 
+        _check_timeout(self.deadline, self.timeout_ms)
         return func(*args, **keywords)
 
 
-def safe_eval(expr: str, context: dict[str, Any] | None = None) -> Any:
+def safe_eval(
+    expr: str,
+    context: dict[str, Any] | None = None,
+    *,
+    timeout_ms: int | None = DEFAULT_TIMEOUT_MS,
+) -> Any:
     """
     Safely evaluate a python expression string.
 
     Args:
         expr: The expression string to evaluate.
         context: Dictionary of variables available in the expression.
+        timeout_ms: Maximum evaluation time in milliseconds. Use ``None`` to
+            disable the timeout.
 
     Returns:
         The result of the evaluation.
@@ -274,10 +340,18 @@ def safe_eval(expr: str, context: dict[str, Any] | None = None) -> Any:
     full_context = context.copy()
     full_context.update(SAFE_FUNCTIONS)
 
-    try:
-        tree = ast.parse(expr, mode="eval")
-    except SyntaxError as e:
-        raise SyntaxError(f"Invalid syntax in expression: {e}") from e
+    deadline = None if timeout_ms is None else time.perf_counter() + (timeout_ms / 1000)
 
-    visitor = SafeEvalVisitor(full_context)
-    return visitor.visit(tree)
+    with _execution_timeout(timeout_ms):
+        try:
+            tree = ast.parse(expr, mode="eval")
+        except SyntaxError as e:
+            raise SyntaxError(f"Invalid syntax in expression: {e}") from e
+
+        _check_timeout(deadline, timeout_ms)
+        visitor = SafeEvalVisitor(
+            full_context,
+            deadline=deadline,
+            timeout_ms=timeout_ms,
+        )
+        return visitor.visit(tree)

--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -17,9 +17,7 @@ DEFAULT_TIMEOUT_MS = 100
 
 def _safe_pow(base: Any, exp: Any) -> Any:
     if isinstance(exp, (int, float)) and abs(exp) > MAX_POWER_ABS_EXPONENT:
-        raise ValueError(
-            f"Power exponent exceeds safe limit ({MAX_POWER_ABS_EXPONENT})"
-        )
+        raise ValueError(f"Power exponent exceeds safe limit ({MAX_POWER_ABS_EXPONENT})")
 
     if isinstance(base, int) and isinstance(exp, int) and exp > 0:
         abs_base = abs(base)

--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -2,6 +2,29 @@ import ast
 import operator
 from typing import Any
 
+# Power operations can allocate extremely large integers. Keep conservative
+# limits here so untrusted edge conditions cannot exhaust CPU or memory.
+MAX_POWER_ABS_EXPONENT = 1_000
+MAX_POWER_RESULT_BITS = 4_096
+
+
+def _safe_pow(base: Any, exp: Any) -> Any:
+    if isinstance(exp, (int, float)) and abs(exp) > MAX_POWER_ABS_EXPONENT:
+        raise ValueError(
+            f"Power exponent exceeds safe limit ({MAX_POWER_ABS_EXPONENT})"
+        )
+
+    if isinstance(base, int) and isinstance(exp, int) and exp > 0:
+        abs_base = abs(base)
+        if abs_base > 1:
+            # Estimate bit growth instead of materializing a huge integer.
+            estimated_bits = exp * (abs_base.bit_length() - 1) + 1
+            if estimated_bits > MAX_POWER_RESULT_BITS:
+                raise ValueError("Power operation exceeds safe size limit")
+
+    return operator.pow(base, exp)
+
+
 # Safe operators whitelist
 SAFE_OPERATORS = {
     ast.Add: operator.add,
@@ -10,7 +33,7 @@ SAFE_OPERATORS = {
     ast.Div: operator.truediv,
     ast.FloorDiv: operator.floordiv,
     ast.Mod: operator.mod,
-    ast.Pow: operator.pow,
+    ast.Pow: _safe_pow,
     ast.LShift: operator.lshift,
     ast.RShift: operator.rshift,
     ast.BitOr: operator.or_,

--- a/core/tests/test_safe_eval.py
+++ b/core/tests/test_safe_eval.py
@@ -94,6 +94,18 @@ class TestArithmetic:
     def test_power(self):
         assert safe_eval("2 ** 10") == 1024
 
+    def test_power_large_exponent_blocked(self):
+        with pytest.raises(ValueError, match="Power exponent"):
+            safe_eval("2 ** 1001")
+
+    def test_power_large_result_blocked(self):
+        with pytest.raises(ValueError, match="Power operation"):
+            safe_eval("99 ** 1000")
+
+    def test_nested_power_blocked(self):
+        with pytest.raises(ValueError, match="Power exponent"):
+            safe_eval("2 ** 2 ** 20")
+
     def test_complex_expression(self):
         assert safe_eval("(2 + 3) * 4 - 1") == 19
 

--- a/core/tests/test_safe_eval.py
+++ b/core/tests/test_safe_eval.py
@@ -9,6 +9,7 @@ AST nodes, disallowed function calls).
 
 import pytest
 
+import framework.graph.safe_eval as safe_eval_module
 from framework.graph.safe_eval import safe_eval
 
 # ---------------------------------------------------------------------------
@@ -108,6 +109,25 @@ class TestArithmetic:
 
     def test_complex_expression(self):
         assert safe_eval("(2 + 3) * 4 - 1") == 19
+
+
+class TestExecutionTimeout:
+    def test_default_timeout(self):
+        assert safe_eval_module.DEFAULT_TIMEOUT_MS == 100
+
+    def test_timeout_must_be_positive(self):
+        with pytest.raises(ValueError, match="timeout_ms"):
+            safe_eval("1 + 1", timeout_ms=0)
+
+    def test_timeout_can_be_disabled(self):
+        assert safe_eval("1 + 1", timeout_ms=None) == 2
+
+    def test_timeout_exceeded_raises(self, monkeypatch):
+        ticks = iter([0.0, 1.0])
+        monkeypatch.setattr(safe_eval_module.time, "perf_counter", lambda: next(ticks))
+
+        with pytest.raises(TimeoutError, match="1ms"):
+            safe_eval("1 + 1", timeout_ms=1)
 
 
 # ---------------------------------------------------------------------------

--- a/core/tests/test_safe_eval.py
+++ b/core/tests/test_safe_eval.py
@@ -129,6 +129,89 @@ class TestExecutionTimeout:
         with pytest.raises(TimeoutError, match="1ms"):
             safe_eval("1 + 1", timeout_ms=1)
 
+    def test_existing_process_timer_is_preserved(self, monkeypatch):
+        calls: list[tuple[str, object]] = []
+        main_thread = object()
+
+        monkeypatch.setattr(safe_eval_module.signal, "SIGALRM", object(), raising=False)
+        monkeypatch.setattr(safe_eval_module.signal, "ITIMER_REAL", object(), raising=False)
+        monkeypatch.setattr(
+            safe_eval_module.signal,
+            "getitimer",
+            lambda which: (5.0, 0.0),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            safe_eval_module.signal,
+            "setitimer",
+            lambda *args: calls.append(("setitimer", args)),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            safe_eval_module.signal,
+            "signal",
+            lambda *args: calls.append(("signal", args)),
+        )
+        monkeypatch.setattr(safe_eval_module.threading, "main_thread", lambda: main_thread)
+        monkeypatch.setattr(
+            safe_eval_module.threading,
+            "current_thread",
+            lambda: main_thread,
+        )
+
+        with safe_eval_module._execution_timeout(100):
+            pass
+
+        assert calls == []
+
+    def test_timeout_restores_alarm_state(self, monkeypatch):
+        calls: list[tuple[str, object]] = []
+        main_thread = object()
+        old_handler = object()
+
+        monkeypatch.setattr(safe_eval_module.signal, "SIGALRM", object(), raising=False)
+        monkeypatch.setattr(safe_eval_module.signal, "ITIMER_REAL", object(), raising=False)
+        monkeypatch.setattr(
+            safe_eval_module.signal,
+            "getitimer",
+            lambda which: (0.0, 0.0),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            safe_eval_module.signal,
+            "getsignal",
+            lambda which: old_handler,
+        )
+
+        def fake_signal(which, handler):
+            calls.append(("signal", handler))
+
+        def fake_setitimer(which, delay, interval=0.0):
+            calls.append(("setitimer", (delay, interval)))
+            return (0.0, 0.0)
+
+        monkeypatch.setattr(safe_eval_module.signal, "signal", fake_signal)
+        monkeypatch.setattr(
+            safe_eval_module.signal,
+            "setitimer",
+            fake_setitimer,
+            raising=False,
+        )
+        monkeypatch.setattr(safe_eval_module.threading, "main_thread", lambda: main_thread)
+        monkeypatch.setattr(
+            safe_eval_module.threading,
+            "current_thread",
+            lambda: main_thread,
+        )
+
+        with safe_eval_module._execution_timeout(100):
+            pass
+
+        assert calls[0][0] == "signal"
+        assert calls[1] == ("setitimer", (0.1, 0.0))
+        assert calls[2] == ("signal", old_handler)
+        assert calls[3] == ("setitimer", (0.0, 0.0))
+
 
 # ---------------------------------------------------------------------------
 # Unary operators


### PR DESCRIPTION
## Description

Mitigates denial-of-service vectors in `framework.graph.safe_eval` by hardening power evaluation and enforcing a bounded execution timeout for edge-condition expressions.

The change is intentionally scoped to `safe_eval` so existing graph execution behavior stays intact outside of rejecting pathological or abusive expressions. Existing callers do not need to change: `safe_eval(expr, context)` remains valid.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)


## Changes Made

- Replace direct `ast.Pow` evaluation with a bounded helper that rejects oversized exponents
- Reject integer power expressions whose estimated result size would exceed safe limits
- Add a default `safe_eval` execution timeout of `100ms` for edge-condition evaluation
- Keep timeout configurable via `timeout_ms`, including `timeout_ms=None` to disable it explicitly
- Preserve backward compatibility for existing `safe_eval(expr, context)` call sites
- Add regression coverage for power-operator DoS cases and timeout behavior

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

Manual testing:
- Ran `cd core && uv run pytest tests/ -v`
- Result: `1562 passed, 43 skipped`
- Ran `cd core && uv run ruff check .`
- Ran `cd core && uv run ruff format --check .`
- Ran focused `safe_eval` and conditional-edge tests during development
- Benchmarked representative edge-condition expressions locally; typical evaluations were ~`0.01ms` to `0.05ms`, which supports a `100ms` default timeout with ample headroom for legitimate use

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable execution timeout for evaluations (default 100 ms) to prevent long-running runs; pass timeout_ms=None to disable.

* **Improvements**
  * Clearer validation and errors for timeout values (rejects non-positive timeouts).
  * Strengthened exponentiation safety: rejects excessively large exponents/results with explicit errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->