### PR TITLE
docs: fix CLI command in README (hive -> ./hive) [micro-fix]

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ This sets up:
 
 - Finally, it will open the Hive interface in your browser
 
-> **Tip:** To reopen the dashboard later, run `hive open` from the project directory.
+> **Tip:** To reopen the dashboard later, run `./hive open` from the project directory.  
+> Note: Always run commands using `./hive` from the repository root directory.
 
 ### Build Your First Agent
 


### PR DESCRIPTION
Fixed incorrect CLI command in README from "hive open" to "./hive open" to ensure correct usage from repository root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated instructions for reopening the dashboard to use the repository-local executable (`./hive open`) instead of invoking the command globally
  * Added clarification reminding users that all `hive` commands must be executed from the repository root directory for proper functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->