### PR TITLE
fix: restore Codex runtime parity and route GPT-5.4 through Responses backend

### DIFF
--- a/core/framework/graph/event_loop_node.py
+++ b/core/framework/graph/event_loop_node.py
@@ -3031,8 +3031,7 @@ class EventLoopNode(NodeProtocol):
             return False
 
         return not any(
-            tc.get("is_error") and tc.get("tool_name") != "set_output"
-            for tc in logged_tool_calls
+            tc.get("is_error") and tc.get("tool_name") != "set_output" for tc in logged_tool_calls
         )
 
     # -------------------------------------------------------------------

--- a/core/framework/graph/event_loop_node.py
+++ b/core/framework/graph/event_loop_node.py
@@ -2359,6 +2359,7 @@ class EventLoopNode(NodeProtocol):
                                     "tool_input": tc.tool_input,
                                     "content": result.content,
                                     "is_error": result.is_error,
+                                    "is_duplicate_set_output": True,
                                     "start_timestamp": _tc_ts,
                                     "duration_s": round(time.time() - _tc_start, 3),
                                 }
@@ -2451,11 +2452,16 @@ class EventLoopNode(NodeProtocol):
                             )
 
                     if display_prompt:
+                        snapshot = (
+                            f"{accumulated_text}{display_prompt}"
+                            if accumulated_text
+                            else display_prompt
+                        )
                         await self._publish_text_delta(
                             stream_id,
                             node_id,
                             content=display_prompt,
-                            snapshot=display_prompt,
+                            snapshot=snapshot,
                             ctx=ctx,
                             execution_id=execution_id,
                             iteration=iteration,
@@ -3076,7 +3082,11 @@ class EventLoopNode(NodeProtocol):
             return False
 
         return not any(
-            tc.get("is_error") and tc.get("tool_name") != "set_output" for tc in logged_tool_calls
+            tc.get("is_error")
+            and (
+                tc.get("tool_name") != "set_output" or not tc.get("is_duplicate_set_output", False)
+            )
+            for tc in logged_tool_calls
         )
 
     # -------------------------------------------------------------------

--- a/core/framework/graph/event_loop_node.py
+++ b/core/framework/graph/event_loop_node.py
@@ -166,7 +166,18 @@ def _is_context_too_large_error(exc: BaseException) -> bool:
 
 _ASSISTANT_INPUT_PATTERNS = (
     re.compile(r"\?\s*$"),
-    re.compile(r"\b(let me know|tell me|share|choose|pick|approve|confirm|which|what)\b", re.I),
+    re.compile(r"(?:^|[\n.!?]\s*)(?:let me know|tell me|share)\b", re.I),
+    re.compile(
+        r"(?:^|[\n.!?]\s*)(?:please\s+|kindly\s+)?(?:confirm|approve|choose|pick)\b",
+        re.I,
+    ),
+    re.compile(
+        r"\b("
+        r"what would you like|what should (?:i|we)|which option|which one|"
+        r"would you like|do you want|can you|could you|are you okay with"
+        r")\b",
+        re.I,
+    ),
     re.compile(r"\bready to proceed\b", re.I),
 )
 _QUESTION_WIDGET_FALLBACK = "Choose an option below."
@@ -1001,6 +1012,12 @@ class EventLoopNode(NodeProtocol):
             if _llm_turn_failed_waiting_input:
                 continue
 
+            # Feed actual API token count back for accurate estimation even
+            # on auto-complete exits that return before the judge path.
+            turn_input = turn_tokens.get("input", 0)
+            if turn_input > 0:
+                conversation.update_token_count(turn_input)
+
             if self._should_auto_complete_after_outputs(
                 ctx=ctx,
                 accumulator=accumulator,
@@ -1015,6 +1032,8 @@ class EventLoopNode(NodeProtocol):
                     node_id,
                     iteration,
                 )
+                for key, value in accumulator.to_dict().items():
+                    ctx.memory.write(key, value, validate=False)
                 await self._write_cursor(
                     ctx,
                     conversation,
@@ -1025,6 +1044,37 @@ class EventLoopNode(NodeProtocol):
                 )
                 await self._publish_loop_completed(stream_id, node_id, iteration + 1, execution_id)
                 latency_ms = int((time.time() - start_time) * 1000)
+                _accept_count += 1
+                if ctx.runtime_logger:
+                    iter_latency_ms = int((time.time() - iter_start) * 1000)
+                    ctx.runtime_logger.log_step(
+                        node_id=node_id,
+                        node_type="event_loop",
+                        step_index=iteration,
+                        verdict="ACCEPT",
+                        verdict_feedback="Required outputs satisfied via set_output.",
+                        tool_calls=logged_tool_calls,
+                        llm_text=assistant_text,
+                        input_tokens=turn_tokens.get("input", 0),
+                        output_tokens=turn_tokens.get("output", 0),
+                        latency_ms=iter_latency_ms,
+                    )
+                    ctx.runtime_logger.log_node_complete(
+                        node_id=node_id,
+                        node_name=ctx.node_spec.name,
+                        node_type="event_loop",
+                        success=True,
+                        total_steps=iteration + 1,
+                        tokens_used=total_input_tokens + total_output_tokens,
+                        input_tokens=total_input_tokens,
+                        output_tokens=total_output_tokens,
+                        latency_ms=latency_ms,
+                        exit_status="success",
+                        accept_count=_accept_count,
+                        retry_count=_retry_count,
+                        escalate_count=_escalate_count,
+                        continue_count=_continue_count,
+                    )
                 return NodeResult(
                     success=True,
                     output=accumulator.to_dict(),
@@ -1032,11 +1082,6 @@ class EventLoopNode(NodeProtocol):
                     latency_ms=latency_ms,
                     conversation=conversation if _is_continuous else None,
                 )
-
-            # 6e'. Feed actual API token count back for accurate estimation
-            turn_input = turn_tokens.get("input", 0)
-            if turn_input > 0:
-                conversation.update_token_count(turn_input)
 
             # 6e''. Post-turn compaction check (catches tool-result bloat).
             # Skip if pre-turn already compacted this iteration — two compactions

--- a/core/framework/graph/event_loop_node.py
+++ b/core/framework/graph/event_loop_node.py
@@ -164,6 +164,67 @@ def _is_context_too_large_error(exc: BaseException) -> bool:
     return bool(_CONTEXT_TOO_LARGE_RE.search(str(exc)))
 
 
+_ASSISTANT_INPUT_PATTERNS = (
+    re.compile(r"\?\s*$"),
+    re.compile(r"\b(let me know|tell me|share|choose|pick|approve|confirm|which|what)\b", re.I),
+    re.compile(r"\bready to proceed\b", re.I),
+)
+_QUESTION_WIDGET_FALLBACK = "Choose an option below."
+
+
+def _assistant_text_requires_input(text: str) -> bool:
+    """Return True when assistant text clearly invites a user reply."""
+    stripped = text.strip()
+    if not stripped:
+        return False
+    return any(pattern.search(stripped) for pattern in _ASSISTANT_INPUT_PATTERNS)
+
+
+def _split_prompt_for_question_widget(
+    prompt: str,
+    *,
+    stream_id: str,
+    has_structured_choices: bool,
+) -> tuple[str | None, str]:
+    """Split a long queen ask_user prompt into display text plus a widget question."""
+    stripped = prompt.strip()
+    if stream_id != "queen" or not has_structured_choices or not stripped:
+        return None, stripped
+
+    if len(stripped) <= 180 and "\n" not in stripped:
+        return None, stripped
+
+    paragraphs = [part.strip() for part in re.split(r"\n\s*\n", stripped) if part.strip()]
+    if len(paragraphs) >= 2:
+        tail = paragraphs[-1]
+        body = "\n\n".join(paragraphs[:-1]).strip()
+        if body and (_assistant_text_requires_input(tail) or tail.endswith("?")):
+            return body, tail
+
+    lines = [line.strip() for line in stripped.splitlines() if line.strip()]
+    if len(lines) >= 2:
+        tail = lines[-1]
+        body = "\n".join(lines[:-1]).strip()
+        if body and (_assistant_text_requires_input(tail) or tail.endswith("?")):
+            return body, tail
+
+    last_q = stripped.rfind("?")
+    if last_q != -1 and last_q >= len(stripped) - 220:
+        split_idx = max(
+            stripped.rfind("\n", 0, last_q),
+            stripped.rfind(". ", 0, last_q),
+            stripped.rfind("! ", 0, last_q),
+        )
+        if split_idx != -1:
+            start = split_idx + (2 if stripped[split_idx : split_idx + 2] in {". ", "! "} else 1)
+            body = stripped[:start].strip()
+            tail = stripped[start:].strip()
+            if body and tail:
+                return body, tail
+
+    return stripped, _QUESTION_WIDGET_FALLBACK
+
+
 # ---------------------------------------------------------------------------
 # Escalation receiver (temporary routing target for subagent → user input)
 # ---------------------------------------------------------------------------
@@ -940,6 +1001,38 @@ class EventLoopNode(NodeProtocol):
             if _llm_turn_failed_waiting_input:
                 continue
 
+            if self._should_auto_complete_after_outputs(
+                ctx=ctx,
+                accumulator=accumulator,
+                outputs_set=outputs_set,
+                logged_tool_calls=logged_tool_calls,
+                user_input_requested=user_input_requested,
+                queen_input_requested=queen_input_requested,
+                reported_to_parent=reported_to_parent,
+            ):
+                logger.info(
+                    "[%s] iter=%d: required outputs satisfied via set_output - auto-completing",
+                    node_id,
+                    iteration,
+                )
+                await self._write_cursor(
+                    ctx,
+                    conversation,
+                    accumulator,
+                    iteration,
+                    recent_responses=recent_responses,
+                    recent_tool_fingerprints=recent_tool_fingerprints,
+                )
+                await self._publish_loop_completed(stream_id, node_id, iteration + 1, execution_id)
+                latency_ms = int((time.time() - start_time) * 1000)
+                return NodeResult(
+                    success=True,
+                    output=accumulator.to_dict(),
+                    tokens_used=total_input_tokens + total_output_tokens,
+                    latency_ms=latency_ms,
+                    conversation=conversation if _is_continuous else None,
+                )
+
             # 6e'. Feed actual API token count back for accurate estimation
             turn_input = turn_tokens.get("input", 0)
             if turn_input > 0:
@@ -1346,6 +1439,10 @@ class EventLoopNode(NodeProtocol):
                     prompt=_cf_prompt,
                     options=ask_user_options,
                     questions=multi_qs,
+                    auto_blocked=_cf_auto,
+                    assistant_text_requires_input=bool(
+                        _cf_auto and _assistant_text_requires_input(assistant_text)
+                    ),
                 )
                 # Emit deferred tool_call_completed for ask_user / ask_user_multiple
                 deferred = getattr(self, "_deferred_tool_complete", None)
@@ -1859,6 +1956,8 @@ class EventLoopNode(NodeProtocol):
         options: list[str] | None = None,
         questions: list[dict] | None = None,
         emit_client_request: bool = True,
+        auto_blocked: bool = False,
+        assistant_text_requires_input: bool = False,
     ) -> bool:
         """Block until user input arrives or shutdown is signaled.
 
@@ -1899,6 +1998,8 @@ class EventLoopNode(NodeProtocol):
                 execution_id=ctx.execution_id or "",
                 options=options,
                 questions=questions,
+                auto_blocked=auto_blocked,
+                assistant_text_requires_input=assistant_text_requires_input,
             )
 
         self._awaiting_input = True
@@ -2197,6 +2298,28 @@ class EventLoopNode(NodeProtocol):
                             except (json.JSONDecodeError, TypeError):
                                 pass
                         key = tc.tool_input.get("key", "")
+                        if accumulator.get(key) == value:
+                            result = ToolResult(
+                                tool_use_id=tc.tool_use_id,
+                                content=(
+                                    f"Output '{key}' is already set to the same value. "
+                                    "Do not repeat identical set_output calls."
+                                ),
+                                is_error=True,
+                            )
+                            logged_tool_calls.append(
+                                {
+                                    "tool_use_id": tc.tool_use_id,
+                                    "tool_name": "set_output",
+                                    "tool_input": tc.tool_input,
+                                    "content": result.content,
+                                    "is_error": result.is_error,
+                                    "start_timestamp": _tc_ts,
+                                    "duration_s": round(time.time() - _tc_start, 3),
+                                }
+                            )
+                            results_by_id[tc.tool_use_id] = result
+                            continue
 
                         # Auto-spill happens inside accumulator.set()
                         # — it fires on every code path (fresh, resume,
@@ -2271,16 +2394,23 @@ class EventLoopNode(NodeProtocol):
 
                     user_input_requested = True
 
-                    # Free-form ask_user (no options): stream the question
-                    # text as a chat message so the user can see it.  When
-                    # options are present the QuestionWidget shows the
-                    # question, but without options nothing renders it.
-                    if ask_user_options is None and ask_user_prompt and ctx.node_spec.client_facing:
+                    display_prompt: str | None = None
+                    if ask_user_prompt and ctx.node_spec.client_facing:
+                        if ask_user_options is None:
+                            display_prompt = ask_user_prompt
+                        else:
+                            display_prompt, ask_user_prompt = _split_prompt_for_question_widget(
+                                ask_user_prompt,
+                                stream_id=stream_id,
+                                has_structured_choices=True,
+                            )
+
+                    if display_prompt:
                         await self._publish_text_delta(
                             stream_id,
                             node_id,
-                            content=ask_user_prompt,
-                            snapshot=ask_user_prompt,
+                            content=display_prompt,
+                            snapshot=display_prompt,
                             ctx=ctx,
                             execution_id=execution_id,
                             iteration=iteration,
@@ -2804,6 +2934,30 @@ class EventLoopNode(NodeProtocol):
                     reported_to_parent,
                 )
 
+            if self._should_auto_complete_after_outputs(
+                ctx=ctx,
+                accumulator=accumulator,
+                outputs_set=outputs_set_this_turn,
+                logged_tool_calls=logged_tool_calls,
+                user_input_requested=user_input_requested,
+                queen_input_requested=queen_input_requested,
+                reported_to_parent=reported_to_parent,
+            ):
+                return (
+                    final_text,
+                    real_tool_results,
+                    outputs_set_this_turn,
+                    token_counts,
+                    logged_tool_calls,
+                    user_input_requested,
+                    ask_user_prompt,
+                    ask_user_options,
+                    queen_input_requested,
+                    final_system_prompt,
+                    final_messages,
+                    reported_to_parent,
+                )
+
             # Tool calls processed -- loop back to stream with updated conversation
             inner_turn += 1
 
@@ -2846,6 +3000,40 @@ class EventLoopNode(NodeProtocol):
     ) -> ToolResult:
         """Handle set_output tool call. Delegates to synthetic_tools module."""
         return handle_set_output(tool_input, output_keys)
+
+    def _should_auto_complete_after_outputs(
+        self,
+        *,
+        ctx: NodeContext,
+        accumulator: OutputAccumulator,
+        outputs_set: list[str],
+        logged_tool_calls: list[dict[str, Any]],
+        user_input_requested: bool,
+        queen_input_requested: bool,
+        reported_to_parent: bool,
+    ) -> bool:
+        """Return True when a simple worker turn can finish immediately after set_output."""
+        if not outputs_set:
+            return False
+        if ctx.node_spec.client_facing or ctx.is_subagent_mode:
+            return False
+        if self._judge is not None or ctx.node_spec.success_criteria:
+            return False
+        if user_input_requested or queen_input_requested or reported_to_parent:
+            return False
+        if not ctx.node_spec.output_keys:
+            return False
+
+        missing = self._get_missing_output_keys(
+            accumulator, ctx.node_spec.output_keys, ctx.node_spec.nullable_output_keys
+        )
+        if missing:
+            return False
+
+        return not any(
+            tc.get("is_error") and tc.get("tool_name") != "set_output"
+            for tc in logged_tool_calls
+        )
 
     # -------------------------------------------------------------------
     # Judge evaluation

--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -179,6 +179,44 @@ def _ensure_ollama_chat_prefix(model: str) -> str:
     return model
 
 
+def _normalize_codex_backend_model(model: str) -> str:
+    """Force Codex backend models onto LiteLLM's Responses API bridge when needed.
+
+    The ChatGPT Codex subscription backend is a Responses API endpoint. Some newer
+    OpenAI model ids can still be tagged as chat-mode in LiteLLM's model registry,
+    which causes LiteLLM to route them through chat completions unless we add the
+    explicit ``openai/responses/`` prefix. Preserve already-responses models and
+    leave non-OpenAI provider prefixes untouched.
+    """
+    model_lower = model.lower()
+    if model_lower.startswith("openai/responses/"):
+        return model
+
+    if "/" in model and not (
+        model_lower.startswith("openai/") or model_lower.startswith("responses/")
+    ):
+        return model
+
+    bare_model = model
+    if model_lower.startswith("openai/"):
+        bare_model = model[len("openai/") :]
+    bare_lower = bare_model.lower()
+    if bare_lower.startswith("responses/"):
+        bare_model = bare_model[len("responses/") :]
+        bare_lower = bare_model.lower()
+
+    registry_entry = litellm.model_cost.get(bare_model) if litellm is not None else None
+    if registry_entry and registry_entry.get("litellm_provider") not in (None, "openai"):
+        return model
+
+    if registry_entry and registry_entry.get("mode") == "responses":
+        if model_lower.startswith("responses/"):
+            return f"openai/{model}"
+        return model
+
+    return f"openai/responses/{bare_model}"
+
+
 RATE_LIMIT_MAX_RETRIES = 10
 RATE_LIMIT_BACKOFF_BASE = 2  # seconds
 RATE_LIMIT_MAX_DELAY = 120  # seconds - cap to prevent absurd waits
@@ -547,6 +585,8 @@ class LiteLLMProvider(LLMProvider):
         self._codex_backend = bool(
             self.api_base and "chatgpt.com/backend-api/codex" in self.api_base
         )
+        if self._codex_backend:
+            self.model = _normalize_codex_backend_model(self.model)
         # Antigravity routes through a local OpenAI-compatible proxy — no patches needed.
         self._antigravity = bool(self.api_base and "localhost:8069" in self.api_base)
 
@@ -556,10 +596,10 @@ class LiteLLMProvider(LLMProvider):
             )
 
         # Note: The Codex ChatGPT backend is a Responses API endpoint at
-        # chatgpt.com/backend-api/codex/responses.  LiteLLM's model registry
-        # correctly marks codex models with mode="responses", so we do NOT
-        # override the mode.  The responses_api_bridge in litellm handles
-        # converting Chat Completions requests to Responses API format.
+        # chatgpt.com/backend-api/codex/responses. Older Codex model ids are
+        # already marked mode="responses" in LiteLLM, but newer OpenAI ids
+        # like gpt-5.4 may still be tagged as chat-mode. Normalize Codex calls
+        # to openai/responses/... so LiteLLM uses the Responses API bridge.
 
     @staticmethod
     def _default_api_base_for_model(model: str) -> str | None:

--- a/core/framework/runtime/event_bus.py
+++ b/core/framework/runtime/event_bus.py
@@ -901,6 +901,8 @@ class EventBus:
         execution_id: str | None = None,
         options: list[str] | None = None,
         questions: list[dict] | None = None,
+        auto_blocked: bool = False,
+        assistant_text_requires_input: bool = False,
     ) -> None:
         """Emit client input requested event (client_facing=True nodes).
 
@@ -917,6 +919,10 @@ class EventBus:
             data["options"] = options
         if questions:
             data["questions"] = questions
+        if auto_blocked:
+            data["auto_blocked"] = True
+        if assistant_text_requires_input:
+            data["assistant_text_requires_input"] = True
         await self.publish(
             AgentEvent(
                 type=EventType.CLIENT_INPUT_REQUESTED,

--- a/core/framework/server/queen_orchestrator.py
+++ b/core/framework/server/queen_orchestrator.py
@@ -17,6 +17,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _client_input_counts_as_planning_ask(event: Any) -> bool:
+    """Return True when a queen input request should satisfy planning ask rounds."""
+    data = getattr(event, "data", None) or {}
+    if data.get("prompt") or data.get("questions") or data.get("options"):
+        return True
+    if not data.get("auto_blocked"):
+        return False
+    return bool(data.get("assistant_text_requires_input"))
+
+
 async def create_queen(
     session: Session,
     session_manager: Any,
@@ -115,14 +125,7 @@ async def create_queen(
     async def _track_planning_asks(event: AgentEvent) -> None:
         if phase_state.phase != "planning":
             return
-        # Only count explicit ask_user / ask_user_multiple calls, not
-        # auto-block (text-only turns emit CLIENT_INPUT_REQUESTED with
-        # an empty prompt and no options/questions).
-        data = event.data or {}
-        has_prompt = bool(data.get("prompt"))
-        has_questions = bool(data.get("questions"))
-        has_options = bool(data.get("options"))
-        if has_prompt or has_questions or has_options:
+        if _client_input_counts_as_planning_ask(event):
             phase_state.planning_ask_rounds += 1
 
     session.event_bus.subscribe(

--- a/core/tests/debug_codex_stream.py
+++ b/core/tests/debug_codex_stream.py
@@ -33,7 +33,7 @@ async def test_codex_stream():
     print(f"extra_kwargs keys: {list(extra_kwargs.keys())}")
     print(f"extra_headers: {list(extra_kwargs.get('extra_headers', {}).keys())}")
 
-    model = "openai/gpt-5.3-codex"
+    model = "openai/gpt-5.4"
 
     # Create the provider
     provider = LiteLLMProvider(

--- a/core/tests/debug_codex_verbose.py
+++ b/core/tests/debug_codex_verbose.py
@@ -33,7 +33,7 @@ async def main():
         return
 
     provider = LiteLLMProvider(
-        model="openai/gpt-5.3-codex",
+        model="openai/gpt-5.4",
         api_key=api_key,
         api_base=api_base,
         **extra_kwargs,

--- a/core/tests/test_codex_runtime_parity.py
+++ b/core/tests/test_codex_runtime_parity.py
@@ -1,19 +1,26 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import AsyncIterator
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
+from framework.graph.edge import EdgeCondition, EdgeSpec, GraphSpec
+from framework.graph.executor import GraphExecutor
 from framework.graph.event_loop_node import EventLoopNode, LoopConfig
+from framework.graph.goal import Goal
 from framework.graph.node import NodeContext, NodeSpec, SharedMemory
-from framework.llm.provider import LLMProvider, LLMResponse
+from framework.llm.provider import LLMProvider, LLMResponse, Tool, ToolResult, ToolUse
+from framework.runner.tool_registry import ToolRegistry
 from framework.llm.stream_events import FinishEvent, TextDeltaEvent, ToolCallEvent
 from framework.runtime.core import Runtime
-from framework.runtime.event_bus import EventBus, EventType
+from framework.runtime.event_bus import AgentEvent, EventBus, EventType
 from framework.server.queen_orchestrator import _client_input_counts_as_planning_ask
+from framework.tools.queen_lifecycle_tools import QueenPhaseState, register_queen_lifecycle_tools
 
 
 class MockStreamingLLM(LLMProvider):
@@ -64,6 +71,16 @@ def tool_call_scenario(
     ]
 
 
+def multi_tool_call_scenario(*calls: tuple[str, dict[str, Any], str]) -> list:
+    """Build a streamed turn with multiple tool calls before finish."""
+    events = [
+        ToolCallEvent(tool_use_id=tool_use_id, tool_name=tool_name, tool_input=tool_input)
+        for tool_name, tool_input, tool_use_id in calls
+    ]
+    events.append(FinishEvent(stop_reason="tool_calls", input_tokens=10, output_tokens=5, model="mock"))
+    return events
+
+
 @pytest.fixture
 def runtime():
     rt = MagicMock(spec=Runtime)
@@ -100,6 +117,26 @@ def build_ctx(
         goal_context="",
         stream_id=stream_id,
     )
+
+
+def build_goal() -> Goal:
+    return Goal(id="codex_goal", name="Codex parity", description="Codex parity repro")
+
+
+def build_tool(name: str) -> Tool:
+    return Tool(
+        name=name,
+        description=f"Tool {name}",
+        parameters={"type": "object", "properties": {}},
+    )
+
+
+async def execute_registered_tool(executor, name: str, tool_input: dict[str, Any]) -> ToolResult:
+    """Run a registered tool and await it when the executor is async."""
+    result = executor(ToolUse(id=f"use_{name}", name=name, input=tool_input))
+    if asyncio.iscoroutine(result) or asyncio.isfuture(result):
+        result = await result
+    return result
 
 
 @pytest.mark.asyncio
@@ -240,3 +277,233 @@ async def test_worker_auto_completes_after_duplicate_set_output(runtime, memory)
     assert result.success is True
     assert result.output["result"] == "done"
     assert llm._call_index == 1
+
+
+@pytest.mark.asyncio
+async def test_queen_auto_blocked_planning_progresses_to_building(tmp_path, monkeypatch):
+    """Codex-style text-only planning asks should still allow draft -> build progression."""
+    monkeypatch.chdir(tmp_path)
+
+    bus = EventBus()
+    phase_state = QueenPhaseState(phase="planning", event_bus=bus)
+    phase_events = []
+
+    async def track_planning_asks(event: AgentEvent) -> None:
+        if phase_state.phase != "planning":
+            return
+        if _client_input_counts_as_planning_ask(event):
+            phase_state.planning_ask_rounds += 1
+
+    async def capture_phase(event: AgentEvent) -> None:
+        phase_events.append(event)
+
+    bus.subscribe([EventType.CLIENT_INPUT_REQUESTED], track_planning_asks, filter_stream="queen")
+    bus.subscribe([EventType.QUEEN_PHASE_CHANGED], capture_phase, filter_stream="queen")
+
+    registry = ToolRegistry()
+    recorded_init_inputs: dict[str, Any] = {}
+
+    async def fake_initialize(inputs: dict[str, Any]) -> str:
+        recorded_init_inputs.clear()
+        recorded_init_inputs.update(inputs)
+        return json.dumps({"success": True, "agent_name": inputs.get("agent_name", "")})
+
+    registry.register(
+        "initialize_and_build_agent",
+        Tool(
+            name="initialize_and_build_agent",
+            description="Fake scaffolder for tests",
+            parameters={"type": "object", "properties": {"agent_name": {"type": "string"}}},
+        ),
+        fake_initialize,
+    )
+
+    session = SimpleNamespace(
+        id="session_codex",
+        event_bus=bus,
+        worker_runtime=None,
+        worker_path=None,
+        queen_executor=None,
+        active_timer_tasks={},
+        active_webhook_handlers={},
+    )
+
+    register_queen_lifecycle_tools(
+        registry,
+        session=session,
+        session_id=session.id,
+        phase_state=phase_state,
+    )
+    executor = registry.get_executor()
+
+    auto_blocked = AgentEvent(
+        type=EventType.CLIENT_INPUT_REQUESTED,
+        stream_id="queen",
+        data={"auto_blocked": True, "assistant_text_requires_input": True},
+    )
+    await bus.publish(auto_blocked)
+    await bus.publish(auto_blocked)
+
+    assert phase_state.planning_ask_rounds == 2
+
+    draft_result = await execute_registered_tool(
+        executor,
+        "save_agent_draft",
+        {
+            "agent_name": "codex_runtime_agent",
+            "goal": "Produce a runnable research graph",
+            "nodes": [
+                {"id": "intake", "name": "Intake", "description": "Clarify the user goal"},
+                {
+                    "id": "research",
+                    "name": "Research",
+                    "description": "Search for evidence and collect facts",
+                },
+                {
+                    "id": "deep_fetch",
+                    "name": "Deep Fetch",
+                    "description": "Use a delegated sub-agent for deeper collection",
+                    "node_type": "gcu",
+                },
+                {"id": "compile", "name": "Compile", "description": "Assemble the report"},
+                {"id": "deliver", "name": "Deliver", "description": "Present the final answer"},
+            ],
+            "edges": [
+                {"id": "e1", "source": "intake", "target": "research", "condition": "on_success"},
+                {
+                    "id": "e2",
+                    "source": "research",
+                    "target": "deep_fetch",
+                    "condition": "on_success",
+                },
+                {"id": "e3", "source": "research", "target": "compile", "condition": "on_success"},
+                {"id": "e4", "source": "compile", "target": "deliver", "condition": "on_success"},
+            ],
+        },
+    )
+    draft_payload = json.loads(draft_result.content)
+
+    assert draft_payload["status"] == "draft_saved"
+    assert draft_payload["node_count"] == 5
+    assert phase_state.draft_graph is not None
+    assert phase_state.draft_graph["entry_node"] == "intake"
+
+    confirm_result = await execute_registered_tool(executor, "confirm_and_build", {})
+    confirm_payload = json.loads(confirm_result.content)
+
+    assert confirm_payload["status"] == "confirmed"
+    assert confirm_payload["subagent_nodes_dissolved"] == 1
+    assert phase_state.build_confirmed is True
+    assert phase_state.draft_graph is not None
+    assert all(node["id"] != "deep_fetch" for node in phase_state.draft_graph["nodes"])
+
+    init_result = await execute_registered_tool(
+        executor,
+        "initialize_and_build_agent",
+        {"agent_name": "codex_runtime_agent"},
+    )
+    init_payload = json.loads(init_result.content)
+
+    assert init_payload["success"] is True
+    assert phase_state.phase == "building"
+    assert phase_state.agent_path is not None
+    assert phase_state.agent_path.endswith("exports/codex_runtime_agent")
+    assert recorded_init_inputs["agent_name"] == "codex_runtime_agent"
+    assert "_draft" in recorded_init_inputs
+    assert recorded_init_inputs["_draft"]["entry_node"] == "intake"
+    assert all(node["id"] != "deep_fetch" for node in recorded_init_inputs["_draft"]["nodes"])
+    assert phase_events[-1].data["phase"] == "building"
+
+
+@pytest.mark.asyncio
+async def test_codex_style_worker_graph_uses_tool_once_and_hands_off(runtime):
+    """Repro class: real tool use + duplicate set_output should still reach the next node."""
+    llm = MockStreamingLLM(
+        scenarios=[
+            multi_tool_call_scenario(
+                ("set_output", {"key": "brief", "value": "past-week AI roundup"}, "brief_1"),
+            ),
+            multi_tool_call_scenario(
+                ("exa_search", {"query": "AI news past week", "num_results": 3}, "search_1"),
+                (
+                    "set_output",
+                    {"key": "articles_data", "value": json.dumps({"items": ["story-1", "story-2"]})},
+                    "articles_1",
+                ),
+                (
+                    "set_output",
+                    {"key": "articles_data", "value": json.dumps({"items": ["story-1", "story-2"]})},
+                    "articles_2",
+                ),
+            ),
+            multi_tool_call_scenario(
+                ("set_output", {"key": "report", "value": "final report"}, "report_1"),
+            ),
+        ]
+    )
+
+    graph = GraphSpec(
+        id="codex_worker_graph",
+        goal_id="codex_goal",
+        entry_node="intake",
+        nodes=[
+            NodeSpec(
+                id="intake",
+                name="Intake",
+                description="Capture the user's request",
+                node_type="event_loop",
+                output_keys=["brief"],
+            ),
+            NodeSpec(
+                id="research",
+                name="Research",
+                description="Search and structure recent articles",
+                node_type="event_loop",
+                input_keys=["brief"],
+                output_keys=["articles_data"],
+                tools=["exa_search"],
+            ),
+            NodeSpec(
+                id="compile",
+                name="Compile",
+                description="Produce the final report",
+                node_type="event_loop",
+                input_keys=["articles_data"],
+                output_keys=["report"],
+            ),
+        ],
+        edges=[
+            EdgeSpec(id="e1", source="intake", target="research", condition=EdgeCondition.ON_SUCCESS),
+            EdgeSpec(id="e2", source="research", target="compile", condition=EdgeCondition.ON_SUCCESS),
+        ],
+        terminal_nodes=["compile"],
+        conversation_mode="continuous",
+    )
+
+    def tool_executor(tool_use: ToolUse) -> ToolResult:
+        if tool_use.name == "exa_search":
+            return ToolResult(
+                tool_use_id=tool_use.id,
+                content=json.dumps({"results": [{"title": "story-1"}, {"title": "story-2"}]}),
+            )
+        return ToolResult(
+            tool_use_id=tool_use.id,
+            content=json.dumps({"error": f"unexpected tool: {tool_use.name}"}),
+            is_error=True,
+        )
+
+    executor = GraphExecutor(
+        runtime=runtime,
+        llm=llm,
+        tools=[build_tool("exa_search")],
+        tool_executor=tool_executor,
+    )
+
+    result = await executor.execute(graph=graph, goal=build_goal())
+
+    assert result.success is True
+    assert result.path == ["intake", "research", "compile"]
+    assert result.output["brief"] == "past-week AI roundup"
+    assert result.output["articles_data"] == {"items": ["story-1", "story-2"]}
+    assert result.output["report"] == "final report"
+    assert llm._call_index == 3

--- a/core/tests/test_codex_runtime_parity.py
+++ b/core/tests/test_codex_runtime_parity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 from collections.abc import AsyncIterator
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
@@ -412,7 +413,7 @@ async def test_queen_auto_blocked_planning_progresses_to_building(tmp_path, monk
     assert init_payload["success"] is True
     assert phase_state.phase == "building"
     assert phase_state.agent_path is not None
-    assert phase_state.agent_path.endswith("exports/codex_runtime_agent")
+    assert Path(phase_state.agent_path).parts[-2:] == ("exports", "codex_runtime_agent")
     assert recorded_init_inputs["agent_name"] == "codex_runtime_agent"
     assert "_draft" in recorded_init_inputs
     assert recorded_init_inputs["_draft"]["entry_node"] == "intake"

--- a/core/tests/test_codex_runtime_parity.py
+++ b/core/tests/test_codex_runtime_parity.py
@@ -10,17 +10,20 @@ from unittest.mock import MagicMock
 import pytest
 
 from framework.graph.edge import EdgeCondition, EdgeSpec, GraphSpec
-from framework.graph.executor import GraphExecutor
 from framework.graph.event_loop_node import EventLoopNode, LoopConfig
+from framework.graph.executor import GraphExecutor
 from framework.graph.goal import Goal
 from framework.graph.node import NodeContext, NodeSpec, SharedMemory
 from framework.llm.provider import LLMProvider, LLMResponse, Tool, ToolResult, ToolUse
-from framework.runner.tool_registry import ToolRegistry
 from framework.llm.stream_events import FinishEvent, TextDeltaEvent, ToolCallEvent
+from framework.runner.tool_registry import ToolRegistry
 from framework.runtime.core import Runtime
 from framework.runtime.event_bus import AgentEvent, EventBus, EventType
 from framework.server.queen_orchestrator import _client_input_counts_as_planning_ask
-from framework.tools.queen_lifecycle_tools import QueenPhaseState, register_queen_lifecycle_tools
+from framework.tools.queen_lifecycle_tools import (
+    QueenPhaseState,
+    register_queen_lifecycle_tools,
+)
 
 
 class MockStreamingLLM(LLMProvider):
@@ -77,7 +80,9 @@ def multi_tool_call_scenario(*calls: tuple[str, dict[str, Any], str]) -> list:
         ToolCallEvent(tool_use_id=tool_use_id, tool_name=tool_name, tool_input=tool_input)
         for tool_name, tool_input, tool_use_id in calls
     ]
-    events.append(FinishEvent(stop_reason="tool_calls", input_tokens=10, output_tokens=5, model="mock"))
+    events.append(
+        FinishEvent(stop_reason="tool_calls", input_tokens=10, output_tokens=5, model="mock")
+    )
     return events
 
 
@@ -427,12 +432,18 @@ async def test_codex_style_worker_graph_uses_tool_once_and_hands_off(runtime):
                 ("exa_search", {"query": "AI news past week", "num_results": 3}, "search_1"),
                 (
                     "set_output",
-                    {"key": "articles_data", "value": json.dumps({"items": ["story-1", "story-2"]})},
+                    {
+                        "key": "articles_data",
+                        "value": json.dumps({"items": ["story-1", "story-2"]}),
+                    },
                     "articles_1",
                 ),
                 (
                     "set_output",
-                    {"key": "articles_data", "value": json.dumps({"items": ["story-1", "story-2"]})},
+                    {
+                        "key": "articles_data",
+                        "value": json.dumps({"items": ["story-1", "story-2"]}),
+                    },
                     "articles_2",
                 ),
             ),
@@ -473,8 +484,18 @@ async def test_codex_style_worker_graph_uses_tool_once_and_hands_off(runtime):
             ),
         ],
         edges=[
-            EdgeSpec(id="e1", source="intake", target="research", condition=EdgeCondition.ON_SUCCESS),
-            EdgeSpec(id="e2", source="research", target="compile", condition=EdgeCondition.ON_SUCCESS),
+            EdgeSpec(
+                id="e1",
+                source="intake",
+                target="research",
+                condition=EdgeCondition.ON_SUCCESS,
+            ),
+            EdgeSpec(
+                id="e2",
+                source="research",
+                target="compile",
+                condition=EdgeCondition.ON_SUCCESS,
+            ),
         ],
         terminal_nodes=["compile"],
         conversation_mode="continuous",

--- a/core/tests/test_codex_runtime_parity.py
+++ b/core/tests/test_codex_runtime_parity.py
@@ -76,11 +76,18 @@ def tool_call_scenario(
     tool_name: str,
     tool_input: dict[str, Any],
     tool_use_id: str = "call_1",
+    text: str = "",
 ) -> list:
-    return [
-        ToolCallEvent(tool_use_id=tool_use_id, tool_name=tool_name, tool_input=tool_input),
-        FinishEvent(stop_reason="tool_calls", input_tokens=10, output_tokens=5, model="mock"),
-    ]
+    events = []
+    if text:
+        events.append(TextDeltaEvent(content=text, snapshot=text))
+    events.append(
+        ToolCallEvent(tool_use_id=tool_use_id, tool_name=tool_name, tool_input=tool_input)
+    )
+    events.append(
+        FinishEvent(stop_reason="tool_calls", input_tokens=10, output_tokens=5, model="mock")
+    )
+    return events
 
 
 def multi_tool_call_scenario(*calls: tuple[str, dict[str, Any], str]) -> list:
@@ -305,6 +312,58 @@ async def test_queen_ask_user_emits_result_text_before_question_widget(runtime, 
 
 
 @pytest.mark.asyncio
+async def test_queen_ask_user_preserves_prior_streamed_text_in_snapshot(runtime, memory):
+    spec = NodeSpec(
+        id="queen",
+        name="Queen",
+        description="Planning node",
+        node_type="event_loop",
+        output_keys=[],
+        client_facing=True,
+    )
+    llm = MockStreamingLLM(
+        scenarios=[
+            tool_call_scenario(
+                "ask_user",
+                {
+                    "question": (
+                        "Root cause: the database pool is exhausted.\n\n"
+                        "What would you like to do next?"
+                    ),
+                    "options": ["Rerun", "Stop"],
+                },
+                tool_use_id="ask_1",
+                text="I checked the failing run.\n\n",
+            )
+        ]
+    )
+    bus = EventBus()
+    output_events = []
+
+    async def capture_output(event):
+        output_events.append(event)
+
+    bus.subscribe([EventType.CLIENT_OUTPUT_DELTA], capture_output, filter_stream="queen")
+
+    node = EventLoopNode(event_bus=bus, config=LoopConfig(max_iterations=5))
+    ctx = build_ctx(runtime, spec, memory, llm, stream_id="queen")
+
+    async def shutdown():
+        await asyncio.sleep(0.05)
+        node.signal_shutdown()
+
+    task = asyncio.create_task(shutdown())
+    result = await node.execute(ctx)
+    await task
+
+    assert result.success is True
+    assert [event.data["snapshot"] for event in output_events] == [
+        "I checked the failing run.\n\n",
+        "I checked the failing run.\n\nRoot cause: the database pool is exhausted.",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_worker_auto_completes_after_duplicate_set_output(runtime, memory):
     spec = NodeSpec(
         id="worker",
@@ -344,6 +403,35 @@ async def test_worker_auto_completes_after_duplicate_set_output(runtime, memory)
     assert result.success is True
     assert result.output["result"] == "done"
     assert llm._call_index == 1
+
+
+@pytest.mark.asyncio
+async def test_worker_invalid_set_output_error_blocks_auto_complete(runtime, memory):
+    spec = NodeSpec(
+        id="worker",
+        name="Worker",
+        description="Internal worker node",
+        node_type="event_loop",
+        output_keys=["result"],
+    )
+    llm = MockStreamingLLM(
+        scenarios=[
+            multi_tool_call_scenario(
+                ("set_output", {"key": "result", "value": "done"}, "set_valid"),
+                ("set_output", {"key": "wrong_key", "value": "oops"}, "set_invalid"),
+            ),
+            text_scenario("Done"),
+        ]
+    )
+
+    node = EventLoopNode(config=LoopConfig(max_iterations=3, max_tool_calls_per_turn=3))
+    ctx = build_ctx(runtime, spec, memory, llm, stream_id="worker")
+
+    result = await node.execute(ctx)
+
+    assert result.success is True
+    assert result.output["result"] == "done"
+    assert llm._call_index == 2
 
 
 @pytest.mark.asyncio

--- a/core/tests/test_codex_runtime_parity.py
+++ b/core/tests/test_codex_runtime_parity.py
@@ -11,7 +11,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from framework.graph.edge import EdgeCondition, EdgeSpec, GraphSpec
-from framework.graph.event_loop_node import EventLoopNode, LoopConfig
+from framework.graph.event_loop_node import (
+    EventLoopNode,
+    LoopConfig,
+    _assistant_text_requires_input,
+)
 from framework.graph.executor import GraphExecutor
 from framework.graph.goal import Goal
 from framework.graph.node import NodeContext, NodeSpec, SharedMemory
@@ -30,7 +34,7 @@ from framework.tools.queen_lifecycle_tools import (
 class MockStreamingLLM(LLMProvider):
     """Mock LLM that replays deterministic stream scenarios."""
 
-    def __init__(self, scenarios: list[list] | None = None):
+    def __init__(self, scenarios: list[list[Any]] | None = None):
         self.scenarios = scenarios or []
         self._call_index = 0
 
@@ -43,7 +47,11 @@ class MockStreamingLLM(LLMProvider):
     ) -> AsyncIterator:
         if not self.scenarios:
             return
-        events = self.scenarios[self._call_index % len(self.scenarios)]
+        if self._call_index >= len(self.scenarios):
+            raise RuntimeError(
+                "MockStreamingLLM received more stream() calls than configured scenarios"
+            )
+        events = self.scenarios[self._call_index]
         self._call_index += 1
         for event in events:
             yield event
@@ -143,6 +151,59 @@ async def execute_registered_tool(executor, name: str, tool_input: dict[str, Any
     if asyncio.iscoroutine(result) or asyncio.isfuture(result):
         result = await result
     return result
+
+
+def test_auto_blocked_planning_only_counts_real_reply_requests() -> None:
+    status_event = AgentEvent(
+        type=EventType.CLIENT_INPUT_REQUESTED,
+        stream_id="queen",
+        data={
+            "auto_blocked": True,
+            "assistant_text_requires_input": _assistant_text_requires_input(
+                "We still need to confirm the schema before building."
+            ),
+        },
+    )
+    assert status_event.data["assistant_text_requires_input"] is False
+    assert _client_input_counts_as_planning_ask(status_event) is False
+
+    summary_event = AgentEvent(
+        type=EventType.CLIENT_INPUT_REQUESTED,
+        stream_id="queen",
+        data={
+            "auto_blocked": True,
+            "assistant_text_requires_input": _assistant_text_requires_input(
+                "Here is what I found so far."
+            ),
+        },
+    )
+    assert summary_event.data["assistant_text_requires_input"] is False
+    assert _client_input_counts_as_planning_ask(summary_event) is False
+
+    request_event = AgentEvent(
+        type=EventType.CLIENT_INPUT_REQUESTED,
+        stream_id="queen",
+        data={
+            "auto_blocked": True,
+            "assistant_text_requires_input": _assistant_text_requires_input(
+                "Please confirm the schema before I build the agent."
+            ),
+        },
+    )
+    assert request_event.data["assistant_text_requires_input"] is True
+    assert _client_input_counts_as_planning_ask(request_event) is True
+
+
+@pytest.mark.asyncio
+async def test_mock_streaming_llm_raises_on_unexpected_extra_stream_call() -> None:
+    llm = MockStreamingLLM(scenarios=[text_scenario("hello")])
+
+    events = [event async for event in llm.stream(messages=[])]
+    assert len(events) == 2
+
+    with pytest.raises(RuntimeError, match="more stream\\(\\) calls than configured scenarios"):
+        async for _ in llm.stream(messages=[]):
+            pass
 
 
 @pytest.mark.asyncio
@@ -283,6 +344,45 @@ async def test_worker_auto_completes_after_duplicate_set_output(runtime, memory)
     assert result.success is True
     assert result.output["result"] == "done"
     assert llm._call_index == 1
+
+
+@pytest.mark.asyncio
+async def test_worker_auto_complete_uses_normal_success_epilogue(runtime, memory):
+    spec = NodeSpec(
+        id="worker",
+        name="Worker",
+        description="Internal worker node",
+        node_type="event_loop",
+        output_keys=["result"],
+    )
+    llm = MockStreamingLLM(
+        scenarios=[
+            tool_call_scenario(
+                "set_output",
+                {"key": "result", "value": "done"},
+                tool_use_id="set_1",
+            )
+        ]
+    )
+
+    node = EventLoopNode(config=LoopConfig(max_iterations=2))
+    ctx = build_ctx(runtime, spec, memory, llm, stream_id="worker")
+    ctx.continuous_mode = True
+    ctx.runtime_logger = MagicMock()
+
+    result = await node.execute(ctx)
+
+    assert result.success is True
+    assert result.output["result"] == "done"
+    assert memory.read("result") == "done"
+    assert result.conversation is not None
+    assert result.conversation.estimate_tokens() == 10
+    assert ctx.runtime_logger.log_step.call_count == 1
+    assert ctx.runtime_logger.log_step.call_args.kwargs["verdict"] == "ACCEPT"
+    assert ctx.runtime_logger.log_node_complete.call_count == 1
+    assert ctx.runtime_logger.log_node_complete.call_args.kwargs["success"] is True
+    assert ctx.runtime_logger.log_node_complete.call_args.kwargs["exit_status"] == "success"
+    assert ctx.runtime_logger.log_node_complete.call_args.kwargs["accept_count"] == 1
 
 
 @pytest.mark.asyncio

--- a/core/tests/test_codex_runtime_parity.py
+++ b/core/tests/test_codex_runtime_parity.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from framework.graph.event_loop_node import EventLoopNode, LoopConfig
+from framework.graph.node import NodeContext, NodeSpec, SharedMemory
+from framework.llm.provider import LLMProvider, LLMResponse
+from framework.llm.stream_events import FinishEvent, TextDeltaEvent, ToolCallEvent
+from framework.runtime.core import Runtime
+from framework.runtime.event_bus import EventBus, EventType
+from framework.server.queen_orchestrator import _client_input_counts_as_planning_ask
+
+
+class MockStreamingLLM(LLMProvider):
+    """Mock LLM that replays deterministic stream scenarios."""
+
+    def __init__(self, scenarios: list[list] | None = None):
+        self.scenarios = scenarios or []
+        self._call_index = 0
+
+    async def stream(
+        self,
+        messages: list[dict[str, Any]],
+        system: str = "",
+        tools=None,
+        max_tokens: int = 4096,
+    ) -> AsyncIterator:
+        if not self.scenarios:
+            return
+        events = self.scenarios[self._call_index % len(self.scenarios)]
+        self._call_index += 1
+        for event in events:
+            yield event
+
+    def complete(self, messages, system="", **kwargs) -> LLMResponse:
+        return LLMResponse(content="Summary.", model="mock", stop_reason="stop")
+
+
+def text_scenario(text: str, input_tokens: int = 10, output_tokens: int = 5) -> list:
+    return [
+        TextDeltaEvent(content=text, snapshot=text),
+        FinishEvent(
+            stop_reason="stop",
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            model="mock",
+        ),
+    ]
+
+
+def tool_call_scenario(
+    tool_name: str,
+    tool_input: dict[str, Any],
+    tool_use_id: str = "call_1",
+) -> list:
+    return [
+        ToolCallEvent(tool_use_id=tool_use_id, tool_name=tool_name, tool_input=tool_input),
+        FinishEvent(stop_reason="tool_calls", input_tokens=10, output_tokens=5, model="mock"),
+    ]
+
+
+@pytest.fixture
+def runtime():
+    rt = MagicMock(spec=Runtime)
+    rt.start_run = MagicMock(return_value="session_20250101_000000_codex01")
+    rt.decide = MagicMock(return_value="dec_1")
+    rt.record_outcome = MagicMock()
+    rt.end_run = MagicMock()
+    rt.report_problem = MagicMock()
+    rt.set_node = MagicMock()
+    return rt
+
+
+@pytest.fixture
+def memory():
+    return SharedMemory()
+
+
+def build_ctx(
+    runtime,
+    node_spec: NodeSpec,
+    memory: SharedMemory,
+    llm: LLMProvider,
+    *,
+    stream_id: str | None = None,
+) -> NodeContext:
+    return NodeContext(
+        runtime=runtime,
+        node_id=node_spec.id,
+        node_spec=node_spec,
+        memory=memory,
+        input_data={},
+        llm=llm,
+        available_tools=[],
+        goal_context="",
+        stream_id=stream_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_queen_auto_blocked_input_counts_as_planning_ask(runtime, memory):
+    spec = NodeSpec(
+        id="queen",
+        name="Queen",
+        description="Planning node",
+        node_type="event_loop",
+        output_keys=[],
+        client_facing=True,
+    )
+    llm = MockStreamingLLM(
+        scenarios=[text_scenario("I've isolated the root cause. What would you like to do next?")]
+    )
+    bus = EventBus()
+    received = []
+
+    async def capture(event):
+        received.append(event)
+
+    bus.subscribe([EventType.CLIENT_INPUT_REQUESTED], capture, filter_stream="queen")
+
+    node = EventLoopNode(event_bus=bus, config=LoopConfig(max_iterations=5))
+    ctx = build_ctx(runtime, spec, memory, llm, stream_id="queen")
+
+    async def shutdown():
+        await asyncio.sleep(0.05)
+        node.signal_shutdown()
+
+    task = asyncio.create_task(shutdown())
+    result = await node.execute(ctx)
+    await task
+
+    assert result.success is True
+    assert len(received) == 1
+    event = received[0]
+    assert event.data["auto_blocked"] is True
+    assert event.data["assistant_text_requires_input"] is True
+    assert _client_input_counts_as_planning_ask(event) is True
+
+
+@pytest.mark.asyncio
+async def test_queen_ask_user_emits_result_text_before_question_widget(runtime, memory):
+    spec = NodeSpec(
+        id="queen",
+        name="Queen",
+        description="Planning node",
+        node_type="event_loop",
+        output_keys=[],
+        client_facing=True,
+    )
+    llm = MockStreamingLLM(
+        scenarios=[
+            tool_call_scenario(
+                "ask_user",
+                {
+                    "question": (
+                        "Root cause: the database pool is exhausted.\n\n"
+                        "What would you like to do next?"
+                    ),
+                    "options": ["Rerun", "Stop"],
+                },
+                tool_use_id="ask_1",
+            )
+        ]
+    )
+    bus = EventBus()
+    output_events = []
+    input_events = []
+
+    async def capture_output(event):
+        output_events.append(event)
+
+    async def capture_input(event):
+        input_events.append(event)
+
+    bus.subscribe([EventType.CLIENT_OUTPUT_DELTA], capture_output, filter_stream="queen")
+    bus.subscribe([EventType.CLIENT_INPUT_REQUESTED], capture_input, filter_stream="queen")
+
+    node = EventLoopNode(event_bus=bus, config=LoopConfig(max_iterations=5))
+    ctx = build_ctx(runtime, spec, memory, llm, stream_id="queen")
+
+    async def shutdown():
+        await asyncio.sleep(0.05)
+        node.signal_shutdown()
+
+    task = asyncio.create_task(shutdown())
+    result = await node.execute(ctx)
+    await task
+
+    assert result.success is True
+    assert [event.data["snapshot"] for event in output_events] == [
+        "Root cause: the database pool is exhausted."
+    ]
+    assert len(input_events) == 1
+    assert input_events[0].data["prompt"] == "What would you like to do next?"
+    assert input_events[0].data["options"] == ["Rerun", "Stop"]
+
+
+@pytest.mark.asyncio
+async def test_worker_auto_completes_after_duplicate_set_output(runtime, memory):
+    spec = NodeSpec(
+        id="worker",
+        name="Worker",
+        description="Internal worker node",
+        node_type="event_loop",
+        output_keys=["result"],
+    )
+    llm = MockStreamingLLM(
+        scenarios=[
+            [
+                ToolCallEvent(
+                    tool_use_id="set_1",
+                    tool_name="set_output",
+                    tool_input={"key": "result", "value": "done"},
+                ),
+                ToolCallEvent(
+                    tool_use_id="set_2",
+                    tool_name="set_output",
+                    tool_input={"key": "result", "value": "done"},
+                ),
+                FinishEvent(
+                    stop_reason="tool_calls",
+                    input_tokens=10,
+                    output_tokens=5,
+                    model="mock",
+                ),
+            ]
+        ]
+    )
+
+    node = EventLoopNode(config=LoopConfig(max_iterations=2, max_tool_calls_per_turn=3))
+    ctx = build_ctx(runtime, spec, memory, llm, stream_id="worker")
+
+    result = await node.execute(ctx)
+
+    assert result.success is True
+    assert result.output["result"] == "done"
+    assert llm._call_index == 1

--- a/core/tests/test_event_loop_integration.py
+++ b/core/tests/test_event_loop_integration.py
@@ -361,6 +361,77 @@ async def test_event_loop_node_in_graph(runtime):
 
 
 @pytest.mark.asyncio
+async def test_set_output_completion_advances_to_next_node(runtime):
+    """A worker node that only calls set_output should hand off immediately."""
+    llm = ScriptableMockLLMProvider(
+        [
+            StreamScript(
+                tool_calls=[
+                    {
+                        "name": "set_output",
+                        "id": "tc_brief",
+                        "input": {"key": "brief", "value": "the brief"},
+                    }
+                ],
+            ),
+            StreamScript(
+                tool_calls=[
+                    {
+                        "name": "set_output",
+                        "id": "tc_report",
+                        "input": {"key": "report", "value": "the report"},
+                    }
+                ],
+            ),
+        ]
+    )
+
+    brief_spec = NodeSpec(
+        id="briefer",
+        name="Briefer",
+        description="Collect the brief",
+        node_type="event_loop",
+        output_keys=["brief"],
+    )
+    report_spec = NodeSpec(
+        id="reporter",
+        name="Reporter",
+        description="Write the report",
+        node_type="event_loop",
+        output_keys=["report"],
+    )
+
+    graph = GraphSpec(
+        id="handoff_graph",
+        goal_id="test_goal",
+        name="Handoff Graph",
+        entry_node="briefer",
+        nodes=[brief_spec, report_spec],
+        edges=[
+            EdgeSpec(
+                id="e_brief_to_report",
+                source="briefer",
+                target="reporter",
+                condition=EdgeCondition.ON_SUCCESS,
+            )
+        ],
+        terminal_nodes=["reporter"],
+    )
+    goal = Goal(id="test_goal", name="Handoff Test", description="test set_output handoff")
+
+    executor = GraphExecutor(runtime=runtime, llm=llm)
+    executor.register_node("briefer", EventLoopNode(config=LoopConfig(max_iterations=2)))
+    executor.register_node("reporter", EventLoopNode(config=LoopConfig(max_iterations=2)))
+
+    result = await executor.execute(graph, goal, {})
+
+    assert result.success
+    assert result.output["brief"] == "the brief"
+    assert result.output["report"] == "the report"
+    assert llm._call_index == 2
+
+
+@pytest.mark.asyncio
 async def test_event_loop_with_event_bus():
     """Lifecycle events are published correctly to EventBus."""
     recorded: list[AgentEvent] = []

--- a/core/tests/test_event_loop_node.py
+++ b/core/tests/test_event_loop_node.py
@@ -1710,8 +1710,8 @@ class TestTransientErrorRetry:
         assert result.output.get("result") == "done"
         # call 0: recoverable error → ConnectionError raised → outer retry
         # call 1: set_output tool call succeeds
-        # call 2: inner tool loop re-invokes LLM after tool result → text "done"
-        assert call_index == 3
+        # The node now auto-completes immediately after required outputs are set.
+        assert call_index == 2
 
 
 class TestIsTransientError:

--- a/core/tests/test_litellm_provider.py
+++ b/core/tests/test_litellm_provider.py
@@ -100,6 +100,33 @@ class TestLiteLLMProviderInit:
             provider = LiteLLMProvider(model="ollama/llama3")
             assert provider.model == "ollama_chat/llama3"
 
+    def test_init_codex_backend_normalizes_chat_mode_models_to_responses(self):
+        """Codex backend should force newer OpenAI models onto the Responses bridge."""
+        provider = LiteLLMProvider(
+            model="openai/gpt-5.4",
+            api_key="test-key",
+            api_base="https://chatgpt.com/backend-api/codex",
+        )
+        assert provider.model == "openai/responses/gpt-5.4"
+
+    def test_init_codex_backend_keeps_existing_responses_models(self):
+        """Codex backend should preserve models LiteLLM already knows are responses-mode."""
+        provider = LiteLLMProvider(
+            model="openai/gpt-5.3-codex",
+            api_key="test-key",
+            api_base="https://chatgpt.com/backend-api/codex",
+        )
+        assert provider.model == "openai/gpt-5.3-codex"
+
+    def test_init_codex_backend_does_not_rewrite_non_openai_models(self):
+        """Codex normalization should stay scoped to OpenAI-style model ids."""
+        provider = LiteLLMProvider(
+            model="anthropic/claude-3-haiku-20240307",
+            api_key="test-key",
+            api_base="https://chatgpt.com/backend-api/codex",
+        )
+        assert provider.model == "anthropic/claude-3-haiku-20240307"
+
 
 class TestLiteLLMProviderComplete:
     """Test LiteLLMProvider.complete() method."""
@@ -749,7 +776,7 @@ class TestOpenRouterToolCompatFallback:
         )
         tools = [
             Tool(
-                name="web_search",
+                name="exa_search",
                 description="Search the web",
                 parameters={
                     "properties": {
@@ -765,7 +792,7 @@ class TestOpenRouterToolCompatFallback:
         compat_response.choices = [MagicMock()]
         compat_response.choices[0].message.content = (
             '{"assistant_response":"","tool_calls":['
-            '{"name":"web_search","arguments":'
+            '{"name":"exa_search","arguments":'
             '{"query":"Python 3.13 release notes","num_results":3}}'
             "]}"
         )
@@ -797,7 +824,7 @@ class TestOpenRouterToolCompatFallback:
 
         tool_calls = [event for event in events if isinstance(event, ToolCallEvent)]
         assert len(tool_calls) == 1
-        assert tool_calls[0].tool_name == "web_search"
+        assert tool_calls[0].tool_name == "exa_search"
         assert tool_calls[0].tool_input == {
             "query": "Python 3.13 release notes",
             "num_results": 3,
@@ -997,7 +1024,7 @@ class TestOpenRouterToolCompatFallback:
         )
         tools = [
             Tool(
-                name="web_search",
+                name="exa_search",
                 description="Search the web",
                 parameters={"properties": {"query": {"type": "string"}}, "required": ["query"]},
             )

--- a/core/tests/test_subagent_escalation_e2e.py
+++ b/core/tests/test_subagent_escalation_e2e.py
@@ -578,7 +578,7 @@ async def test_mark_complete_e2e_through_execution_stream(tmp_path):
     # Call 1 (subagent turn 1): report_to_parent(mark_complete=True) → sets flag
     # Call 2 (subagent turn 2): text finish (inner loop exit) → _evaluate sees flag → ACCEPT
     # Call 3 (parent turn 2): set_output("result", "...")
-    # Call 4 (parent turn 3): text finish
+    # Parent now auto-completes immediately after required outputs are satisfied.
     scenarios: list[list[StreamEvent]] = [
         # Call 0: Parent delegates
         [
@@ -615,11 +615,6 @@ async def test_mark_complete_e2e_through_execution_stream(tmp_path):
                 tool_use_id="set_1",
             ),
             FinishEvent(stop_reason="tool_use", input_tokens=10, output_tokens=5, model="mock"),
-        ],
-        # Call 4: Parent finishes
-        [
-            TextDeltaEvent(content="Task complete.", snapshot="Task complete."),
-            FinishEvent(stop_reason="end_turn", input_tokens=5, output_tokens=5, model="mock"),
         ],
     ]
 
@@ -682,8 +677,9 @@ async def test_mark_complete_e2e_through_execution_stream(tmp_path):
 
     # 4. The subagent did NOT need to call set_output — it used mark_complete
     # Verify by checking LLM call count: subagent only needed 2 calls
-    # (report_to_parent + text finish), not 3+ (report + set_output + text finish)
-    assert llm._call_index == 5, (
-        f"Expected 5 LLM calls total (delegate + report + finish + set_output + finish), "
+    # (report_to_parent + text finish), and the parent now auto-completes
+    # immediately after its required set_output.
+    assert llm._call_index == 4, (
+        f"Expected 4 LLM calls total (delegate + report + finish + set_output), "
         f"got {llm._call_index}"
     )

--- a/core/tests/test_two_llm_calls.py
+++ b/core/tests/test_two_llm_calls.py
@@ -331,7 +331,7 @@ def _make_codex_provider():
     if not api_key or not api_base:
         return None
     return LiteLLMProvider(
-        model="openai/gpt-5.3-codex",
+        model="openai/gpt-5.4",
         api_key=api_key,
         api_base=api_base,
         **extra_kwargs,

--- a/quickstart.ps1
+++ b/quickstart.ps1
@@ -1279,7 +1279,7 @@ switch ($num) {
         if ($CodexCredDetected) {
             $SubscriptionMode        = "codex"
             $SelectedProviderId      = "openai"
-            $SelectedModel           = "gpt-5.3-codex"
+            $SelectedModel           = "gpt-5.4"
             $SelectedMaxTokens       = 16384
             $SelectedMaxContextTokens = 120000
             Write-Host ""

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -1306,9 +1306,9 @@ case $choice in
         if [ "$CODEX_CRED_DETECTED" = true ]; then
             SUBSCRIPTION_MODE="codex"
             SELECTED_PROVIDER_ID="openai"
-            SELECTED_MODEL="gpt-5.3-codex"
+            SELECTED_MODEL="gpt-5.4"
             SELECTED_MAX_TOKENS=16384
-            SELECTED_MAX_CONTEXT_TOKENS=120000  # GPT Codex — 128k context window
+            SELECTED_MAX_CONTEXT_TOKENS=120000  # Conservative Codex context default
             echo ""
             echo -e "${GREEN}⬢${NC} Using OpenAI Codex subscription"
         fi

--- a/scripts/setup_worker_model.ps1
+++ b/scripts/setup_worker_model.ps1
@@ -561,7 +561,7 @@ switch ($num) {
         if ($CodexCredDetected) {
             $SubscriptionMode        = "codex"
             $SelectedProviderId      = "openai"
-            $SelectedModel           = "gpt-5.3-codex"
+            $SelectedModel           = "gpt-5.4"
             $SelectedMaxTokens       = 16384
             $SelectedMaxContextTokens = 120000
             Write-Host ""

--- a/scripts/setup_worker_model.sh
+++ b/scripts/setup_worker_model.sh
@@ -870,9 +870,9 @@ case $choice in
         if [ "$CODEX_CRED_DETECTED" = true ]; then
             SUBSCRIPTION_MODE="codex"
             SELECTED_PROVIDER_ID="openai"
-            SELECTED_MODEL="gpt-5.3-codex"
+            SELECTED_MODEL="gpt-5.4"
             SELECTED_MAX_TOKENS=16384
-            SELECTED_MAX_CONTEXT_TOKENS=120000  # GPT Codex — 128k context window
+            SELECTED_MAX_CONTEXT_TOKENS=120000  # Conservative Codex context default
             echo ""
             echo -e "${GREEN}⬢${NC} Using OpenAI Codex subscription"
         fi


### PR DESCRIPTION
## Description

Fix remaining Codex-specific parity issues on top of `upstream/main` by routing ChatGPT Codex GPT-5.4 calls through the Responses backend, fixing Codex-exposed runtime handoff/planning issues, and adding focused regressions for the failing graph behaviors maintainers reported.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #6741

## Changes Made

- Route Codex `gpt-5.4` requests through LiteLLM's Responses bridge when using the ChatGPT Codex backend, and update Codex subscription defaults/scripts to `gpt-5.4`.
- Fix Codex-exposed runtime issues around queen planning ask accounting, visible queen result text before follow-up prompts, and worker auto-completion after required `set_output` values are satisfied.
- Add focused regressions for planning-to-build progression, transition-marker tool context, duplicate `set_output`, and next-node handoff on the reproduced worker graph class.

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

Targeted verification run:
- `cd core && uv run pytest tests/test_event_loop_node.py tests/test_event_loop_integration.py tests/test_codex_runtime_parity.py tests/test_litellm_provider.py tests/test_client_io.py tests/test_session_manager_worker_handoff.py tests/test_continuous_conversation.py`
- `cd core && uv run ruff check framework/llm/litellm.py tests/test_codex_runtime_parity.py tests/test_litellm_provider.py tests/test_event_loop_node.py tests/test_event_loop_integration.py tests/test_continuous_conversation.py`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Auto-complete flows: workflows may finish immediately once required outputs are satisfied.
  - Smarter prompts: long assistant prompts are split into streamed display text and a separate interactive question widget.

* **Improvements**
  - Duplicate output attempts are detected and surfaced as errors.
  - Client input events carry richer flags so blocked/text-only prompts and planning-ask counts behave more accurately.
  - Codex/OpenAI model IDs normalized; default Codex model updated to gpt-5.4.

* **Tests**
  - Added/expanded tests for event-loop, Codex parity, set_output, and planning-ask flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->