### PR TITLE
docs(tools): add README for 10 tools (batch 3)

### DIFF
--- a/tools/src/aden_tools/tools/docker_hub_tool/README.md
+++ b/tools/src/aden_tools/tools/docker_hub_tool/README.md
@@ -1,0 +1,124 @@
+# Docker Hub Tool
+
+Search repositories, list tags, inspect images, manage webhooks, and delete tags via the Docker Hub API v2.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `docker_hub_search` | Search Docker Hub for public repositories |
+| `docker_hub_list_repos` | List repositories for a user or organization |
+| `docker_hub_get_repo` | Get detailed info about a specific repository |
+| `docker_hub_list_tags` | List tags for a repository |
+| `docker_hub_get_tag_detail` | Get details for a specific image tag |
+| `docker_hub_delete_tag` | Delete a tag from a repository |
+| `docker_hub_list_webhooks` | List webhooks configured for a repository |
+
+## Setup
+
+Requires a Docker Hub Personal Access Token (PAT):
+
+1. Go to [hub.docker.com](https://hub.docker.com) → **Account Settings → Security → New Access Token**
+2. Give it a name and select the required permissions (Read, Write, Delete as needed)
+3. Copy the token immediately — it is only shown once
+
+```bash
+DOCKER_HUB_TOKEN=your-personal-access-token
+DOCKER_HUB_USERNAME=your-docker-hub-username
+```
+
+> `DOCKER_HUB_USERNAME` is used as the default namespace when listing repos. If it is unset and no `namespace` is passed to `docker_hub_list_repos`, the tool will return an error: `"namespace is required (or set DOCKER_HUB_USERNAME)"`.
+
+## Usage Examples
+
+### Search for public repositories
+
+```python
+docker_hub_search(query="nginx", max_results=10)
+```
+
+### List your own repositories
+
+```python
+docker_hub_list_repos(namespace="myusername", max_results=25)
+```
+
+### Get repository details
+
+```python
+docker_hub_get_repo(repository="library/nginx")
+```
+
+### List tags for a repository
+
+```python
+docker_hub_list_tags(repository="library/nginx", max_results=20)
+```
+
+### Get details for a specific tag
+
+```python
+docker_hub_get_tag_detail(
+    repository="library/nginx",
+    tag="latest",
+)
+```
+
+### Delete a tag
+
+```python
+docker_hub_delete_tag(
+    repository="myusername/myapp",
+    tag="old-release-1.0",
+)
+```
+
+### List webhooks for a repository
+
+```python
+docker_hub_list_webhooks(repository="myusername/myapp")
+```
+
+## Response Format
+
+`docker_hub_list_tags` returns tags sorted by `last_updated` descending:
+
+```python
+{
+    "repository": "library/nginx",
+    "tags": [
+        {
+            "name": "latest",
+            "full_size": 68000000,
+            "last_updated": "2025-05-01T12:00:00Z",
+            "digest": "sha256:abc123...",
+        },
+        ...
+    ]
+}
+```
+
+`docker_hub_get_tag_detail` includes per-architecture image info:
+
+```python
+{
+    "repository": "library/nginx",
+    "tag": "latest",
+    "full_size": 68000000,
+    "images": [
+        {"architecture": "amd64", "os": "linux", "size": 34000000, "digest": "sha256:..."},
+        {"architecture": "arm64", "os": "linux", "size": 32000000, "digest": "sha256:..."},
+    ]
+}
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+
+```python
+{"error": "DOCKER_HUB_TOKEN not set", "help": "Create a PAT at https://hub.docker.com/settings/security"}
+{"error": "Unauthorized. Check your DOCKER_HUB_TOKEN."}
+{"error": "Not found"}
+{"error": "Request to Docker Hub timed out"}
+```

--- a/tools/src/aden_tools/tools/shopify_tool/README.md
+++ b/tools/src/aden_tools/tools/shopify_tool/README.md
@@ -1,0 +1,135 @@
+# Shopify Tool
+
+Order, product, and customer management via the Shopify Admin REST API.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `shopify_list_orders` | List orders with optional status and fulfillment filters |
+| `shopify_get_order` | Get full details of a specific order by ID |
+| `shopify_list_products` | List products with optional status, type, and vendor filters |
+| `shopify_get_product` | Get full product details including variants and images |
+| `shopify_update_product` | Update title, description, status, tags, or vendor of a product |
+| `shopify_list_customers` | List customers in the store |
+| `shopify_get_customer` | Get full customer details including addresses and order stats |
+| `shopify_search_customers` | Search customers by email, name, or other fields |
+| `shopify_create_draft_order` | Create a draft order with line items |
+
+## Setup
+
+Requires a Shopify Custom App access token and your store name:
+
+1. Go to your Shopify admin → **Settings → Apps and sales channels → Develop apps**
+2. Create a custom app and install it with the required API scopes
+3. Copy the **Admin API access token** from the app credentials
+
+```bash
+SHOPIFY_ACCESS_TOKEN=shpat_xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+SHOPIFY_STORE_NAME=your-store-name
+```
+
+> `SHOPIFY_STORE_NAME` is the subdomain of your store. For `https://my-shop.myshopify.com`, use `my-shop`.
+
+Required API scopes:
+- `read_orders`, `write_orders` — order management
+- `read_products`, `write_products` — product management
+- `read_customers`, `write_customers` — customer management
+- `read_draft_orders`, `write_draft_orders` — draft order creation
+
+## Usage Examples
+
+### List open orders
+
+```python
+shopify_list_orders(status="open", limit=50)
+```
+
+### List paid but unfulfilled orders
+
+```python
+shopify_list_orders(
+    financial_status="paid",
+    fulfillment_status="unfulfilled",
+    limit=25,
+)
+```
+
+### Get a specific order
+
+```python
+shopify_get_order(order_id="5678901234")
+```
+
+### List active products
+
+```python
+shopify_list_products(status="active", limit=50)
+```
+
+### Get a specific product
+
+```python
+shopify_get_product(product_id="1234567890")
+```
+
+### Update a product
+
+```python
+shopify_update_product(
+    product_id="1234567890",
+    title="Updated Product Name",
+    status="active",
+    tags="sale,featured",
+)
+```
+
+### List customers
+
+```python
+shopify_list_customers(limit=100)
+```
+
+### Search customers by email
+
+```python
+shopify_search_customers(query="email:alice@example.com")
+```
+
+### Search customers by name
+
+```python
+shopify_search_customers(query="first_name:Alice")
+```
+
+### Create a draft order
+
+```python
+shopify_create_draft_order(
+    line_items_json='[{"variant_id": 12345678, "quantity": 2}]',
+    customer_id="987654321",
+    note="VIP order",
+    tags="manual,vip",
+)
+```
+
+## Order Status Values
+
+| Filter | Values |
+|--------|--------|
+| `status` | `open`, `closed`, `cancelled`, `any` |
+| `financial_status` | `paid`, `pending`, `refunded`, `voided` |
+| `fulfillment_status` | `fulfilled`, `partial`, `on_hold`, `null` (unfulfilled) |
+
+> **Note:** `fulfillment_status=null` filters for unfulfilled orders. Shopify silently ignores unrecognized filter values rather than returning an error.
+
+## Error Handling
+
+All tools return error dicts on failure:
+
+```python
+{"error": "Shopify credentials not configured", "help": "Set SHOPIFY_ACCESS_TOKEN and SHOPIFY_STORE_NAME environment variables or configure via credential store"}
+{"error": "Invalid Shopify access token"}
+{"error": "Insufficient API scopes for this Shopify resource"}
+{"error": "Shopify rate limit exceeded. Try again later."}
+```

--- a/tools/src/aden_tools/tools/shopify_tool/README.md
+++ b/tools/src/aden_tools/tools/shopify_tool/README.md
@@ -10,7 +10,7 @@ Order, product, and customer management via the Shopify Admin REST API.
 | `shopify_get_order` | Get full details of a specific order by ID |
 | `shopify_list_products` | List products with optional status, type, and vendor filters |
 | `shopify_get_product` | Get full product details including variants and images |
-| `shopify_update_product` | Update title, description, status, tags, or vendor of a product |
+| `shopify_update_product` | Update title, body_html, status, tags, or vendor of a product |
 | `shopify_list_customers` | List customers in the store |
 | `shopify_get_customer` | Get full customer details including addresses and order stats |
 | `shopify_search_customers` | Search customers by email, name, or other fields |
@@ -50,7 +50,7 @@ shopify_list_orders(status="open", limit=50)
 ```python
 shopify_list_orders(
     financial_status="paid",
-    fulfillment_status="unfulfilled",
+    fulfillment_status="unshipped",
     limit=25,
 )
 ```

--- a/tools/src/aden_tools/tools/snowflake_tool/README.md
+++ b/tools/src/aden_tools/tools/snowflake_tool/README.md
@@ -1,0 +1,111 @@
+# Snowflake Tool
+
+SQL statement execution and async query management via the Snowflake REST API v2.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `snowflake_execute_sql` | Execute a SQL statement and return results |
+| `snowflake_get_statement_status` | Poll the status and results of an async query |
+| `snowflake_cancel_statement` | Cancel a running SQL statement |
+
+## Setup
+
+Requires a Snowflake account identifier and an OAuth or JWT access token:
+
+1. Note your **Account Identifier** (e.g. `orgname-accountname` or `xy12345.us-east-1`)
+2. Generate an access token via OAuth, key-pair authentication, or Snowflake programmatic access
+
+```bash
+SNOWFLAKE_ACCOUNT=orgname-accountname
+SNOWFLAKE_TOKEN=your-oauth-or-jwt-token
+```
+
+Optional — set default context to avoid repeating them per query:
+
+```bash
+SNOWFLAKE_WAREHOUSE=COMPUTE_WH
+SNOWFLAKE_DATABASE=MY_DATABASE
+SNOWFLAKE_SCHEMA=PUBLIC
+SNOWFLAKE_TOKEN_TYPE=OAUTH
+```
+
+> `SNOWFLAKE_TOKEN_TYPE` defaults to `OAUTH`. Set to `KEYPAIR_JWT` if using key-pair auth.
+
+## Usage Examples
+
+### Run a simple query
+
+```python
+snowflake_execute_sql(statement="SELECT CURRENT_USER(), CURRENT_DATABASE()")
+```
+
+### Query a specific database and schema
+
+```python
+snowflake_execute_sql(
+    statement="SELECT * FROM orders WHERE status = 'pending' LIMIT 100",
+    database="SALES_DB",
+    schema="PUBLIC",
+    warehouse="COMPUTE_WH",
+)
+```
+
+### Run a long query asynchronously
+
+```python
+# Returns immediately with status="running"
+result = snowflake_execute_sql(
+    statement="SELECT COUNT(*) FROM very_large_table",
+    timeout=120,
+)
+
+# Poll until complete
+snowflake_get_statement_status(
+    statement_handle=result["statement_handle"]
+)
+```
+
+### Cancel a running query
+
+```python
+snowflake_cancel_statement(
+    statement_handle="01abc123-0000-0001-0000-000100020003"
+)
+```
+
+## Response Format
+
+A completed query returns:
+
+```python
+{
+    "statement_handle": "01abc...",
+    "status": "complete",
+    "num_rows": 42,
+    "columns": ["ID", "NAME", "CREATED_AT"],
+    "rows": [["1", "Alice", "2024-01-01"], ...],
+    "truncated": False,  # True if > 100 rows returned
+}
+```
+
+An async query in progress returns:
+
+```python
+{
+    "statement_handle": "01abc...",
+    "status": "running",
+    "message": "Asynchronous execution in progress",
+}
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+
+```python
+{"error": "SNOWFLAKE_ACCOUNT and SNOWFLAKE_TOKEN are required", "help": "Set SNOWFLAKE_ACCOUNT and SNOWFLAKE_TOKEN environment variables"}
+{"error": "HTTP 422: Query failed"}
+{"error": "statement is required"}
+```

--- a/tools/src/aden_tools/tools/supabase_tool/README.md
+++ b/tools/src/aden_tools/tools/supabase_tool/README.md
@@ -1,0 +1,131 @@
+# Supabase Tool
+
+Database queries, auth, and edge function invocation via the Supabase REST API.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `supabase_select` | Query rows from a table using PostgREST filters |
+| `supabase_insert` | Insert one or more rows into a table |
+| `supabase_update` | Update rows matching PostgREST filters |
+| `supabase_delete` | Delete rows matching PostgREST filters |
+| `supabase_auth_signup` | Register a new user via Supabase Auth (GoTrue) |
+| `supabase_auth_signin` | Sign in a user and retrieve an access token |
+| `supabase_edge_invoke` | Invoke a Supabase Edge Function |
+
+## Setup
+
+Requires a Supabase project URL and anon/service key:
+
+1. Go to [supabase.com/dashboard](https://supabase.com/dashboard) → your project → **Project Settings → API**
+2. Copy your **Project URL** and **anon public** key (or service role key for elevated access)
+
+Set the following environment variables:
+
+```bash
+SUPABASE_URL=https://your-project-id.supabase.co
+SUPABASE_ANON_KEY=your-anon-or-service-key
+```
+
+## Usage Examples
+
+### Query rows with filters
+
+```python
+supabase_select(
+    table="users",
+    columns="id,name,email",
+    filters="status=eq.active&role=eq.admin",
+    order="created_at.desc",
+    limit=50,
+)
+```
+
+### Insert a single row
+
+```python
+supabase_insert(
+    table="orders",
+    rows='{"customer_id": 42, "total": 99.99, "status": "pending"}',
+)
+```
+
+### Insert multiple rows
+
+```python
+supabase_insert(
+    table="products",
+    rows='[{"name": "Widget A", "price": 10}, {"name": "Widget B", "price": 20}]',
+)
+```
+
+### Update rows matching a filter
+
+```python
+supabase_update(
+    table="orders",
+    filters="id=eq.123",
+    data='{"status": "shipped"}',
+)
+```
+
+### Delete rows matching a filter
+
+```python
+supabase_delete(
+    table="sessions",
+    filters="expires_at=lt.2024-01-01",
+)
+```
+
+### Sign up a new user
+
+```python
+supabase_auth_signup(
+    email="alice@example.com",
+    password="securepassword",
+)
+```
+
+### Sign in and get an access token
+
+```python
+supabase_auth_signin(
+    email="alice@example.com",
+    password="securepassword",
+)
+```
+
+### Invoke an Edge Function
+
+```python
+supabase_edge_invoke(
+    function_name="send-welcome-email",
+    body='{"user_id": "abc123"}',
+    method="POST",
+)
+```
+
+## PostgREST Filter Syntax
+
+| Operator | Meaning | Example |
+|----------|---------|---------|
+| `eq` | equals | `status=eq.active` |
+| `neq` | not equals | `role=neq.admin` |
+| `gt` | greater than | `age=gt.18` |
+| `lt` | less than | `price=lt.100` |
+| `like` | pattern match | `name=like.*Alice*` |
+| `is` | is null/true/false | `deleted_at=is.null` |
+
+Combine multiple filters with `&`: `"status=eq.active&role=eq.admin"`
+
+## Error Handling
+
+All tools return error dicts on failure:
+
+```python
+{"error": "SUPABASE_ANON_KEY or SUPABASE_URL not set", "help": "Get your keys at https://supabase.com/dashboard → Project Settings → API"}
+{"error": "Supabase error 403: ..."}
+{"error": "Request to Supabase timed out"}
+```

--- a/tools/src/aden_tools/tools/twilio_tool/README.md
+++ b/tools/src/aden_tools/tools/twilio_tool/README.md
@@ -1,0 +1,111 @@
+# Twilio Tool
+
+SMS and WhatsApp messaging, call logs, and phone number management via the Twilio REST API.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `twilio_send_sms` | Send an SMS message |
+| `twilio_send_whatsapp` | Send a WhatsApp message |
+| `twilio_list_messages` | List recent messages with optional filters |
+| `twilio_get_message` | Get details of a specific message by SID |
+| `twilio_delete_message` | Delete a message from your Twilio account |
+| `twilio_list_phone_numbers` | List phone numbers owned by the account |
+| `twilio_list_calls` | List recent calls with optional filters |
+
+## Setup
+
+Requires a Twilio Account SID and Auth Token:
+
+1. Go to [console.twilio.com](https://console.twilio.com)
+2. Copy your **Account SID** and **Auth Token** from the dashboard
+
+```bash
+TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_AUTH_TOKEN=your-auth-token
+```
+
+> Phone numbers must be in **E.164 format**: `+14155552671`
+
+## Usage Examples
+
+### Send an SMS
+
+```python
+twilio_send_sms(
+    to="+14155552671",
+    from_number="+18005550100",
+    body="Your verification code is 123456",
+)
+```
+
+### Send a WhatsApp message
+
+```python
+twilio_send_whatsapp(
+    to="+14155552671",
+    from_number="+14155550000",
+    body="Hello from Twilio WhatsApp!",
+)
+```
+
+### List recent messages
+
+```python
+twilio_list_messages(page_size=20)
+```
+
+### Filter messages by recipient
+
+```python
+twilio_list_messages(to="+14155552671", page_size=10)
+```
+
+### Get a specific message
+
+```python
+twilio_get_message(message_sid="SMxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+```
+
+### Delete a message
+
+```python
+twilio_delete_message(message_sid="SMxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+```
+
+### List phone numbers on the account
+
+```python
+twilio_list_phone_numbers()
+```
+
+### List recent calls
+
+```python
+twilio_list_calls(status="completed", page_size=20)
+```
+
+## Call Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `queued` | Call is queued |
+| `ringing` | Recipient's phone is ringing |
+| `in-progress` | Call is active |
+| `completed` | Call ended successfully |
+| `busy` | Recipient was busy |
+| `failed` | Call failed |
+| `no-answer` | No answer |
+| `canceled` | Call was canceled |
+
+## Error Handling
+
+All tools return error dicts on failure:
+
+```python
+{"error": "TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN not set", "help": "Get credentials from https://console.twilio.com/"}
+{"error": "Unauthorized. Check your Twilio credentials."}
+{"error": "Rate limited. Try again shortly."}
+{"error": "Message not found."}
+```

--- a/tools/src/aden_tools/tools/twitter_tool/README.md
+++ b/tools/src/aden_tools/tools/twitter_tool/README.md
@@ -1,0 +1,108 @@
+# Twitter Tool
+
+Tweet search, user lookup, and timeline access via the X (Twitter) API v2.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `twitter_search_tweets` | Search recent tweets from the last 7 days |
+| `twitter_get_user` | Get a user profile by username |
+| `twitter_get_user_tweets` | Get recent tweets from a user's timeline |
+| `twitter_get_tweet` | Get details of a specific tweet by ID |
+| `twitter_get_user_followers` | Get followers of a user |
+| `twitter_get_tweet_replies` | Get replies to a specific tweet |
+| `twitter_get_list_tweets` | Get recent tweets from a Twitter/X list |
+
+## Setup
+
+Requires an X (Twitter) Bearer Token for read-only API v2 access:
+
+1. Go to [developer.x.com](https://developer.x.com) → **Projects & Apps → Your App → Keys and Tokens**
+2. Copy the **Bearer Token** under **Authentication Tokens**
+
+```bash
+X_BEARER_TOKEN=your-bearer-token
+```
+
+> The Bearer Token provides read-only access. Write operations (post, like, retweet) are not supported by this tool.
+
+## Usage Examples
+
+### Search recent tweets
+
+```python
+twitter_search_tweets(
+    query="python machine learning -is:retweet lang:en",
+    max_results=25,
+    sort_order="recency",
+)
+```
+
+### Search tweets from a specific user
+
+```python
+twitter_search_tweets(query="from:openai has:media", max_results=10)
+```
+
+### Get a user profile
+
+```python
+twitter_get_user(username="elonmusk")
+```
+
+### Get a user's recent tweets
+
+```python
+twitter_get_user_tweets(
+    user_id="44196397",
+    max_results=20,
+    exclude_replies=True,
+    exclude_retweets=True,
+)
+```
+
+### Get a specific tweet
+
+```python
+twitter_get_tweet(tweet_id="1234567890123456789")
+```
+
+### Get followers of a user
+
+```python
+twitter_get_user_followers(user_id="44196397", max_results=50)
+```
+
+### Get replies to a tweet
+
+```python
+twitter_get_tweet_replies(tweet_id="1234567890123456789", max_results=20)
+```
+
+### Get tweets from a list
+
+```python
+twitter_get_list_tweets(list_id="84839422", max_results=10)
+```
+
+## Search Query Operators
+
+| Operator | Example | Meaning |
+|----------|---------|---------|
+| `from:` | `from:nasa` | Tweets by a specific user |
+| `to:` | `to:support` | Replies to a specific user |
+| `-is:retweet` | `-is:retweet` | Exclude retweets |
+| `has:media` | `has:media` | Tweets with media |
+| `lang:` | `lang:en` | Filter by language |
+| `#` | `#python` | Hashtag search |
+
+## Error Handling
+
+All tools return error dicts on failure:
+
+```python
+{"error": "X_BEARER_TOKEN is required", "help": "Set X_BEARER_TOKEN environment variable"}
+{"error": "HTTP 429: ..."}
+{"error": "tweet_id is required"}
+```

--- a/tools/src/aden_tools/tools/yahoo_finance_tool/README.md
+++ b/tools/src/aden_tools/tools/yahoo_finance_tool/README.md
@@ -1,0 +1,118 @@
+# Yahoo Finance Tool
+
+Latest available stock quotes, historical prices, financial statements, and company info via the `yfinance` library.
+
+> **Note:** Data is sourced from Yahoo Finance and may be delayed by 15 minutes or more depending on the exchange.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `yahoo_finance_quote` | Get current stock quote and key statistics |
+| `yahoo_finance_history` | Get historical OHLCV price data |
+| `yahoo_finance_financials` | Get income statement, balance sheet, or cash flow |
+| `yahoo_finance_info` | Get detailed company information |
+| `yahoo_finance_search` | Search for ticker symbols by company name or keyword |
+
+## Setup
+
+No API key or credentials required. The tool uses the `yfinance` Python library which accesses Yahoo Finance data directly.
+
+> Data is provided by Yahoo Finance and is subject to their terms of use.
+
+## Usage Examples
+
+### Get a stock quote
+
+```python
+yahoo_finance_quote(symbol="AAPL")
+```
+
+### Get historical daily prices for the last month
+
+```python
+yahoo_finance_history(
+    symbol="MSFT",
+    period="1mo",
+    interval="1d",
+)
+```
+
+### Get intraday prices (last 5 days, hourly)
+
+```python
+yahoo_finance_history(
+    symbol="GOOGL",
+    period="5d",
+    interval="1h",
+)
+```
+
+### Get the income statement
+
+```python
+yahoo_finance_financials(symbol="AAPL", statement="income")
+```
+
+### Get the balance sheet
+
+```python
+yahoo_finance_financials(symbol="TSLA", statement="balance")
+```
+
+### Get the cash flow statement
+
+```python
+yahoo_finance_financials(symbol="NVDA", statement="cashflow")
+```
+
+### Get company info
+
+```python
+yahoo_finance_info(symbol="AMZN")
+```
+
+### Search for a ticker symbol
+
+```python
+yahoo_finance_search(query="Tesla")
+```
+
+## Period Values
+
+| Period | Meaning |
+|--------|---------|
+| `1d` | 1 day |
+| `5d` | 5 days |
+| `1mo` | 1 month |
+| `3mo` | 3 months |
+| `6mo` | 6 months |
+| `1y` | 1 year |
+| `2y` | 2 years |
+| `5y` | 5 years |
+| `ytd` | Year to date |
+| `max` | All available history |
+
+## Interval Values
+
+| Interval | Meaning |
+|----------|---------|
+| `1m` | 1 minute (last 7 days only) |
+| `5m` | 5 minutes |
+| `1h` | 1 hour |
+| `1d` | Daily |
+| `1wk` | Weekly |
+| `1mo` | Monthly |
+
+> **Interval constraints:** Intraday intervals have range limits enforced by yfinance. `1m` is limited to the last 7 days. `5m`, `15m`, `30m`, and `1h` are limited to the last 60 days. Invalid combinations return an empty result silently rather than raising an error.
+
+## Error Handling
+
+All tools return error dicts on failure:
+
+```python
+{"error": "symbol is required"}
+{"error": "No data found for symbol 'XYZ'"}
+{"error": "Invalid statement type: xyz. Use: income, balance, cashflow"}
+{"error": "Failed to fetch quote for AAPL: ..."}
+```

--- a/tools/src/aden_tools/tools/youtube_transcript_tool/README.md
+++ b/tools/src/aden_tools/tools/youtube_transcript_tool/README.md
@@ -1,0 +1,110 @@
+# YouTube Transcript Tool
+
+Retrieve video transcripts and list available caption tracks via the `youtube-transcript-api` library.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `youtube_get_transcript` | Get the transcript/captions for a YouTube video |
+| `youtube_list_transcripts` | List all available transcript languages for a video |
+
+## Setup
+
+No API key required. The tool uses the `youtube-transcript-api` Python library and works with any public video that has captions enabled — no authentication needed.
+
+Ensure the package is installed:
+
+```bash
+pip install youtube-transcript-api
+```
+
+> Only videos with captions enabled (auto-generated or manual) can be transcribed. Private or age-restricted videos may not be accessible.
+
+## Usage Examples
+
+### Get the English transcript of a video
+
+```python
+youtube_get_transcript(
+    video_id="dQw4w9WgXcQ",
+    language="en",
+)
+```
+
+### Get transcript in another language
+
+```python
+youtube_get_transcript(
+    video_id="dQw4w9WgXcQ",
+    language="de",
+)
+```
+
+### Get transcript preserving HTML formatting tags
+
+```python
+youtube_get_transcript(
+    video_id="dQw4w9WgXcQ",
+    language="en",
+    preserve_formatting=True,
+)
+```
+
+### List all available transcript languages
+
+```python
+youtube_list_transcripts(video_id="dQw4w9WgXcQ")
+```
+
+## Response Format
+
+`youtube_get_transcript` returns:
+
+```python
+{
+    "video_id": "dQw4w9WgXcQ",
+    "language": "English",
+    "language_code": "en",
+    "is_generated": True,
+    "snippet_count": 312,
+    "snippets": [
+        {"text": "Never gonna give you up", "start": 18.44, "duration": 1.72},
+        ...
+    ]
+}
+```
+
+`youtube_list_transcripts` returns:
+
+```python
+{
+    "video_id": "dQw4w9WgXcQ",
+    "count": 3,
+    "transcripts": [
+        {"language": "English", "language_code": "en", "is_generated": True, "is_translatable": True},
+        {"language": "German", "language_code": "de", "is_generated": False, "is_translatable": True},
+    ]
+}
+```
+
+## Finding the Video ID
+
+The video ID is the `v=` parameter in a YouTube URL:
+
+```
+https://www.youtube.com/watch?v=dQw4w9WgXcQ
+                                 ^^^^^^^^^^^
+                                 This is the video ID
+```
+
+## Error Handling
+
+All tools return error dicts on failure:
+
+```python
+{"error": "video_id is required"}
+{"error": "TranscriptsDisabled: ..."}
+{"error": "NoTranscriptFound: ..."}
+{"error": "youtube-transcript-api package not installed. Run: pip install youtube-transcript-api"}
+```

--- a/tools/src/aden_tools/tools/zendesk_tool/README.md
+++ b/tools/src/aden_tools/tools/zendesk_tool/README.md
@@ -1,0 +1,134 @@
+# Zendesk Tool
+
+Ticket management, comments, user listing, and search via the Zendesk Support API.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `zendesk_list_tickets` | List tickets in the account |
+| `zendesk_get_ticket` | Get full details of a specific ticket |
+| `zendesk_create_ticket` | Create a new support ticket |
+| `zendesk_update_ticket` | Update ticket status, priority, or tags |
+| `zendesk_search_tickets` | Search tickets using Zendesk query syntax |
+| `zendesk_get_ticket_comments` | List all comments on a ticket |
+| `zendesk_add_ticket_comment` | Add a public reply or internal note to a ticket |
+| `zendesk_list_users` | List users filtered by role |
+
+## Setup
+
+Requires a Zendesk subdomain, agent email, and API token:
+
+1. Log in to your Zendesk admin panel
+2. Go to **Admin → Apps and integrations → APIs → Zendesk API**
+3. Enable **Token Access** and create a new API token
+
+```bash
+ZENDESK_SUBDOMAIN=your-subdomain
+ZENDESK_EMAIL=agent@yourcompany.com
+ZENDESK_API_TOKEN=your-api-token
+```
+
+> `ZENDESK_SUBDOMAIN` is the part before `.zendesk.com`. For `https://acme.zendesk.com`, use `acme`.
+
+## Usage Examples
+
+### List open tickets
+
+```python
+zendesk_list_tickets(page_size=25)
+```
+
+### Get a specific ticket
+
+```python
+zendesk_get_ticket(ticket_id=12345)
+```
+
+### Create a new ticket
+
+```python
+zendesk_create_ticket(
+    subject="Login button not working",
+    body="Users are reporting that the login button on mobile is unresponsive.",
+    priority="high",
+    ticket_type="incident",
+    tags="mobile,login,bug",
+)
+```
+
+### Update a ticket status
+
+```python
+zendesk_update_ticket(
+    ticket_id=12345,
+    status="pending",
+    priority="urgent",
+)
+```
+
+### Add a public reply to a ticket
+
+```python
+zendesk_add_ticket_comment(
+    ticket_id=12345,
+    body="We have identified the issue and a fix is being deployed.",
+    public=True,
+)
+```
+
+### Add an internal note
+
+```python
+zendesk_add_ticket_comment(
+    ticket_id=12345,
+    body="Escalated to the backend team via Slack #incidents.",
+    public=False,
+)
+```
+
+### Search tickets
+
+```python
+zendesk_search_tickets(
+    query="status:open priority:urgent",
+    sort_by="updated_at",
+    sort_order="desc",
+)
+```
+
+### Search by assignee and tag
+
+```python
+zendesk_search_tickets(query="assignee:agent@company.com tags:billing")
+```
+
+### List all agents
+
+```python
+zendesk_list_users(role="agent", page_size=50)
+```
+
+## Ticket Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `new` | Newly created, unassigned |
+| `open` | Assigned and being worked on |
+| `pending` | Waiting for requester response |
+| `hold` | Waiting on a third party |
+| `solved` | Resolved by agent |
+| `closed` | Permanently closed |
+
+## Error Handling
+
+All tools return error dicts on failure:
+
+```python
+[
+    {"error": "ZENDESK_SUBDOMAIN, ZENDESK_EMAIL, and ZENDESK_API_TOKEN not set", "help": "Create an API token in Zendesk Admin > Apps and integrations > APIs > Zendesk API"},
+    {"error": "Unauthorized. Check your Zendesk credentials."},
+    {"error": "Forbidden. Check your Zendesk permissions."},
+    {"error": "Rate limited. Try again shortly."},
+]
+```

--- a/tools/src/aden_tools/tools/zoom_tool/README.md
+++ b/tools/src/aden_tools/tools/zoom_tool/README.md
@@ -1,0 +1,130 @@
+# Zoom Tool
+
+Meeting management, recordings, and user info via the Zoom API v2.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `zoom_get_user` | Get Zoom user profile information |
+| `zoom_list_meetings` | List scheduled, live, or upcoming meetings for a user |
+| `zoom_get_meeting` | Get full details of a specific meeting |
+| `zoom_create_meeting` | Create a new instant or scheduled meeting |
+| `zoom_update_meeting` | Update topic, time, duration, or agenda of a meeting |
+| `zoom_delete_meeting` | Cancel and delete a meeting |
+| `zoom_list_recordings` | List cloud recordings within a date range |
+| `zoom_list_meeting_participants` | List participants from a past meeting |
+| `zoom_list_meeting_registrants` | List registrants for a registration-enabled meeting |
+
+## Setup
+
+Requires a Zoom Server-to-Server OAuth access token:
+
+1. Go to [marketplace.zoom.us](https://marketplace.zoom.us) → **Develop → Build App → Server-to-Server OAuth**
+2. Create an app and note the **Account ID**, **Client ID**, and **Client Secret**
+3. Generate an access token and set it as an environment variable:
+
+```bash
+ZOOM_ACCESS_TOKEN=your-server-to-server-oauth-token
+```
+
+> **Token expiry:** Server-to-Server OAuth tokens expire after **1 hour**. You will need to regenerate the token and update `ZOOM_ACCESS_TOKEN` when you see an `"Invalid or expired Zoom access token"` error.
+
+Required OAuth scopes:
+- `meeting:read` — list and read meetings
+- `meeting:write` — create, update, delete meetings
+- `recording:read` — list cloud recordings
+- `user:read` — read user profiles
+
+## Usage Examples
+
+### Get authenticated user info
+
+```python
+zoom_get_user(user_id="me")
+```
+
+### List upcoming meetings
+
+```python
+zoom_list_meetings(user_id="me", type="upcoming", page_size=10)
+```
+
+### Create a scheduled meeting
+
+```python
+zoom_create_meeting(
+    topic="Sprint Planning",
+    start_time="2025-06-01T10:00:00Z",
+    duration=60,
+    timezone="America/New_York",
+    agenda="Review sprint backlog and assign tasks",
+)
+```
+
+### Create an instant meeting
+
+```python
+zoom_create_meeting(topic="Quick Sync")
+```
+
+### Update a meeting
+
+```python
+zoom_update_meeting(
+    meeting_id="123456789",
+    topic="Sprint Planning - Updated",
+    duration=90,
+)
+```
+
+### Delete a meeting
+
+```python
+zoom_delete_meeting(meeting_id="123456789")
+```
+
+### List cloud recordings for a date range
+
+```python
+zoom_list_recordings(
+    from_date="2025-05-01",
+    to_date="2025-05-31",
+    user_id="me",
+)
+```
+
+### List participants from a past meeting
+
+```python
+zoom_list_meeting_participants(meeting_id="123456789")
+```
+
+### List approved registrants
+
+```python
+zoom_list_meeting_registrants(
+    meeting_id="123456789",
+    status="approved",
+)
+```
+
+## Meeting Types
+
+| Type value | Meaning |
+|------------|---------|
+| `upcoming` | All upcoming meetings |
+| `scheduled` | Scheduled meetings only |
+| `live` | Currently live meetings |
+| `previous_meetings` | Past meetings |
+
+## Error Handling
+
+All tools return error dicts on failure:
+
+```python
+{"error": "Zoom credentials not configured", "help": "Set ZOOM_ACCESS_TOKEN environment variable or configure via credential store"}
+{"error": "Invalid or expired Zoom access token"}
+{"error": "Insufficient Zoom API scopes for this operation"}
+{"error": "Zoom rate limit exceeded. Try again later."}
+```


### PR DESCRIPTION
Adds README.md documentation for 10 tools that were missing it.

Partial fix for #6486

## Tools Documented
`supabase_tool`, `zoom_tool`, `twitter_tool`, `twilio_tool`, `shopify_tool`,
`snowflake_tool`, `zendesk_tool`, `yahoo_finance_tool`, `youtube_transcript_tool`,
`docker_hub_tool`

## Format
Each README follows the existing pattern (e.g., `gmail_tool/README.md`):
- Tool name and description
- Tools table with all available functions
- Setup instructions with required credentials and env vars
- Usage examples
- Error handling

## Checklist
- [x] Follows existing README format
- [x] Self-reviewed
- [x] No unrelated files included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive README guides for Docker Hub, Shopify, Snowflake, Twilio, Twitter/X, Yahoo Finance, YouTube Transcript, Zendesk, Zoom, and Supabase tools — each describing available tool entry points, setup and required credentials/scopes, usage examples, supported parameters/filters, expected response shapes, async behaviors, and standardized error-handling contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->