### PR TITLE
docs: fix CLI command in README (hive -> ./hive) [micro-fix]

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ This sets up:
 
 - Finally, it will open the Hive interface in your browser
 
-> **Tip:** To reopen the dashboard later, run `hive open` from the project directory.
+> **Tip:** To reopen the dashboard later, run `./hive open` from the project directory.  
+> Note: Always run commands using `./hive` from the repository root directory.
 
 ### Build Your First Agent
 


### PR DESCRIPTION
## Description
Fixed CLI command in README from "hive open" to "./hive open".

## Type of Change
Documentation update

## Related Issue
Fixes #6901

## Changes Made
- Updated CLI command usage in README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions with correct command syntax for reopening the dashboard.
  * Added clarification to run commands from the repository root directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->