### PR TITLE
fix(micro-fix): prevent infinite retry loop in headless mode (Issue #6193)

### DIFF
--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -2046,21 +2046,35 @@ class AgentRunner:
 
         elif has_client_facing and not sys.stdin.isatty():
             from framework.runtime.event_bus import EventType
+
             runtime = self._agent_runtime
+            _headless_input_consumed = False
+            _headless_error: str | None = None
 
             async def _handle_headless_input(event):
+                nonlocal _headless_input_consumed, _headless_error
+                if _headless_input_consumed:
+                    return
+                
                 node_id = event.node_id
                 if input_data:
                     import json
-                    await runtime.inject_input(node_id, json.dumps(input_data))
-                else:
-                    print(
-                        "\n[Error] Agent requires interactive input but was run in headless mode.\n"
-                        "Please provide complete input data via --input-file or use interactive mode.",
-                        file=sys.stderr
+                    delivered = await runtime.inject_input(
+                        node_id, json.dumps(input_data),
                     )
-                    import os
-                    os._exit(1)
+                    if not delivered:
+                        _headless_error = (
+                            f"Headless execution failed: node '{node_id}' not found. "
+                            f"Agent requires interactive input but was run in headless mode. "
+                            f"Provide input via --input-file or use interactive mode."
+                        )
+                        return
+                    _headless_input_consumed = True
+                else:
+                    _headless_error = (
+                        "Agent requires interactive input but was run in headless mode. "
+                        "Provide input via --input-file or use interactive mode."
+                    )
 
             sub_ids.append(runtime.subscribe_to_events(
                 event_types=[EventType.CLIENT_INPUT_REQUESTED], handler=_handle_headless_input))
@@ -2080,6 +2094,10 @@ class AgentRunner:
                 input_data=input_data,
                 session_state=session_state,
             )
+            
+            # Check for headless input errors
+            if _headless_error:
+                return ExecutionResult(success=False, error=_headless_error)
 
             # Return result or create error result
             if result is not None:

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -2044,6 +2044,26 @@ class AgentRunner:
                 )
             )
 
+        elif has_client_facing and not sys.stdin.isatty():
+            from framework.runtime.event_bus import EventType
+            runtime = self._agent_runtime
+
+            async def _handle_headless_input(event):
+                node_id = event.node_id
+                if input_data:
+                    import json
+                    await runtime.inject_input(node_id, json.dumps(input_data))
+                else:
+                    print(
+                        "\n[Error] Agent requires interactive input but was run in headless mode.\n"
+                        "Please provide complete input data via --input-file or use interactive mode.",
+                        file=sys.stderr
+                    )
+                    import os
+                    os._exit(1)
+
+            sub_ids.append(runtime.subscribe_to_events(
+                event_types=[EventType.CLIENT_INPUT_REQUESTED], handler=_handle_headless_input))
         # Determine entry point
         if entry_point_id is None:
             # Use first entry point or "default" if no entry points defined

--- a/test_issue6193_redteam.py
+++ b/test_issue6193_redteam.py
@@ -1,0 +1,82 @@
+"""
+Red Team Test: Issue #6193 Fix Verification
+Simulates headless environment to verify:
+1. Agent fails FAST instead of looping when no input_data
+2. Agent properly injects input_data when available
+"""
+
+import asyncio
+import sys
+import os
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Add core to path
+sys.path.insert(0, str(Path(__file__).resolve().parent / "core"))
+
+from framework.graph.client_io import ActiveNodeClientIO
+from framework.runtime.event_bus import EventBus
+
+async def test_fail_fast_when_no_input():
+    """When headless + no input_data -> should call os._exit(1)"""
+    print("[TEST 1] Fail-fast behavior when no input_data...")
+    
+    with patch("os._exit") as mock_exit:
+        input_data = {}
+        if not input_data:
+            print("  -> Detected empty input_data, calling os._exit(1)")
+            os._exit(1)
+        
+        if mock_exit.called:
+            print("  [PASS] os._exit(1) was called -- no infinite loop!")
+            return True
+        else:
+            print("  [FAIL] os._exit was NOT called")
+            return False
+
+async def test_injects_json_when_input_exists():
+    """When headless + input_data -> should JSON-serialize and inject"""
+    print("[TEST 2] JSON injection when input_data exists...")
+    
+    captured = {}
+    
+    def capture_inject(node_id, content):
+        captured["node_id"] = node_id
+        captured["content"] = content
+        print(f"  -> Captured inject_input: node={node_id}, content={content[:50]}...")
+    
+    input_data = {"file": "/tmp/data.csv", "format": "csv"}
+    if input_data:
+        import json
+        user_input = json.dumps(input_data)
+        capture_inject("intake", user_input)
+    
+    if "content" in captured:
+        print("  [PASS] JSON data was prepared for injection!")
+        return True
+    else:
+        print("  [FAIL] No injection data prepared")
+        return False
+
+async def main():
+    print("=" * 60)
+    print("RED TEAM: Issue #6193 Fix Verification")
+    print("=" * 60)
+    
+    results = []
+    
+    result1 = await test_fail_fast_when_no_input()
+    results.append(result1)
+    
+    result2 = await test_injects_json_when_input_exists()
+    results.append(result2)
+    
+    print("=" * 60)
+    if all(results):
+        print("ALL RED TEAM TESTS PASSED -- Infinite loop is DEAD.")
+    else:
+        print("REDFLAG: Some tests failed. Fix needs revision.")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/test_issue6193_redteam.py
+++ b/test_issue6193_redteam.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import asyncio
+import json
 import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock, AsyncMock
@@ -10,8 +13,9 @@ from framework.runner.runner import AgentRunner
 from framework.graph.edge import GraphSpec
 from framework.graph.goal import Goal
 from framework.runtime.event_bus import EventType
+from framework.graph.executor import ExecutionResult
 
-async def test_fail_fast_when_no_input():
+async def test_fail_fast_when_no_input() -> bool:
     """Verify headless execution fails when no input_data provided."""
     print("[TEST 1] Fail-fast behavior when no input_data...")
     
@@ -66,7 +70,7 @@ async def test_fail_fast_when_no_input():
         print(f"  [FAIL] Expected failure result, got: {result}")
         return False
 
-async def test_injects_json_when_input_exists():
+async def test_injects_json_when_input_exists() -> bool:
     """Verify headless execution injects input_data correctly."""
     print("[TEST 2] JSON injection when input_data exists...")
     
@@ -121,13 +125,16 @@ async def test_injects_json_when_input_exists():
             await runner.run(input_data=input_data)
     
     if mock_runtime.inject_input.called:
+        mock_runtime.inject_input.assert_called_once_with(
+            "test-node", json.dumps(input_data),
+        )
         print("  [PASS] Input handler was registered and inject_input called!")
         return True
     else:
         print("  [FAIL] Input handler not registered or inject_input not called")
         return False
 
-async def main():
+async def main() -> None:
     print("=" * 60)
     print("RED TEAM: Issue #6193 Fix Verification")
     print("=" * 60)

--- a/test_issue6193_redteam.py
+++ b/test_issue6193_redteam.py
@@ -1,61 +1,130 @@
-"""
-Red Team Test: Issue #6193 Fix Verification
-Simulates headless environment to verify:
-1. Agent fails FAST instead of looping when no input_data
-2. Agent properly injects input_data when available
-"""
-
 import asyncio
 import sys
-import os
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 
 # Add core to path
 sys.path.insert(0, str(Path(__file__).resolve().parent / "core"))
 
-from framework.graph.client_io import ActiveNodeClientIO
-from framework.runtime.event_bus import EventBus
+from framework.runner.runner import AgentRunner
+from framework.graph.edge import GraphSpec
+from framework.graph.goal import Goal
+from framework.runtime.event_bus import EventType
 
 async def test_fail_fast_when_no_input():
-    """When headless + no input_data -> should call os._exit(1)"""
+    """Verify headless execution fails when no input_data provided."""
     print("[TEST 1] Fail-fast behavior when no input_data...")
     
-    with patch("os._exit") as mock_exit:
-        input_data = {}
-        if not input_data:
-            print("  -> Detected empty input_data, calling os._exit(1)")
-            os._exit(1)
+    # Mock Graph and Goal
+    graph = MagicMock(spec=GraphSpec)
+    graph.description = "Test Graph"
+    graph.id = "test-agent"
+    graph.nodes = [MagicMock(client_facing=True)]
+    graph.edges = []
+    graph.entry_node = "test-node"
+    graph.terminal_nodes = []
+    
+    goal = MagicMock(spec=Goal)
+    goal.success_criteria = []
+    goal.constraints = []
+    goal.name = "Test Goal"
+    goal.description = "Test Goal Description"
+    goal.id = "test-goal"
+    
+    with patch("framework.runner.runner.run_preload_validation"):
+        runner = AgentRunner(Path("."), graph, goal, interactive=False, skip_credential_validation=True)
+    
+        # Mock runtime
+        mock_runtime = MagicMock()
+        mock_runtime.start = AsyncMock()
+        mock_runtime.get_entry_points = MagicMock(return_value=[])
         
-        if mock_exit.called:
-            print("  [PASS] os._exit(1) was called -- no infinite loop!")
-            return True
-        else:
-            print("  [FAIL] os._exit was NOT called")
-            return False
-
-async def test_injects_json_when_input_exists():
-    """When headless + input_data -> should JSON-serialize and inject"""
-    print("[TEST 2] JSON injection when input_data exists...")
+        # Manually track subscriptions
+        input_handlers = []
+        def subscribe(event_types, handler):
+            if EventType.CLIENT_INPUT_REQUESTED in event_types:
+                input_handlers.append(handler)
+            return "sub1"
+        mock_runtime.subscribe_to_events = subscribe
+        
+        # Trigger and wait
+        async def trigger_and_wait(*args, **kwargs):
+            for handler in input_handlers:
+                await handler(MagicMock(node_id="test-node"))
+            return MagicMock()
+        mock_runtime.trigger_and_wait = trigger_and_wait
+        runner._agent_runtime = mock_runtime
+        
+        # Simulate run with no input
+        with patch("sys.stdin.isatty", return_value=False):
+            result = await runner.run(input_data={})
     
-    captured = {}
-    
-    def capture_inject(node_id, content):
-        captured["node_id"] = node_id
-        captured["content"] = content
-        print(f"  -> Captured inject_input: node={node_id}, content={content[:50]}...")
-    
-    input_data = {"file": "/tmp/data.csv", "format": "csv"}
-    if input_data:
-        import json
-        user_input = json.dumps(input_data)
-        capture_inject("intake", user_input)
-    
-    if "content" in captured:
-        print("  [PASS] JSON data was prepared for injection!")
+    if not result.success and "headless mode" in result.error:
+        print("  [PASS] Agent correctly returned failure result without infinite loop!")
         return True
     else:
-        print("  [FAIL] No injection data prepared")
+        print(f"  [FAIL] Expected failure result, got: {result}")
+        return False
+
+async def test_injects_json_when_input_exists():
+    """Verify headless execution injects input_data correctly."""
+    print("[TEST 2] JSON injection when input_data exists...")
+    
+    # Mock Graph and Goal
+    graph = MagicMock(spec=GraphSpec)
+    graph.description = "Test Graph"
+    graph.id = "test-agent"
+    graph.nodes = [MagicMock(client_facing=True)]
+    graph.edges = []
+    graph.entry_node = "test-node"
+    graph.terminal_nodes = []
+    
+    goal = MagicMock(spec=Goal)
+    goal.success_criteria = []
+    goal.constraints = []
+    goal.name = "Test Goal"
+    goal.description = "Test Goal Description"
+    goal.id = "test-goal"
+    
+    with patch("framework.runner.runner.run_preload_validation"):
+        runner = AgentRunner(Path("."), graph, goal, interactive=False, skip_credential_validation=True)
+    
+        # Mock runtime
+        mock_runtime = MagicMock()
+        mock_runtime.start = AsyncMock()
+        mock_runtime.get_entry_points = MagicMock(return_value=[])
+        
+        # Track subscriptions
+        input_handlers = []
+        def subscribe(event_types, handler):
+            if EventType.CLIENT_INPUT_REQUESTED in event_types:
+                input_handlers.append(handler)
+            return "sub1"
+        mock_runtime.subscribe_to_events = subscribe
+        
+        # Mock inject_input
+        mock_runtime.inject_input = AsyncMock(return_value=True)
+        
+        # Mock trigger_and_wait
+        async def trigger_and_wait(*args, **kwargs):
+            for handler in input_handlers:
+                await handler(MagicMock(node_id="test-node"))
+            return MagicMock()
+        mock_runtime.trigger_and_wait = trigger_and_wait
+        
+        runner._agent_runtime = mock_runtime
+        
+        input_data = {"file": "/tmp/data.csv", "format": "csv"}
+        
+        # Run with input
+        with patch("sys.stdin.isatty", return_value=False):
+            await runner.run(input_data=input_data)
+    
+    if mock_runtime.inject_input.called:
+        print("  [PASS] Input handler was registered and inject_input called!")
+        return True
+    else:
+        print("  [FAIL] Input handler not registered or inject_input not called")
         return False
 
 async def main():

--- a/test_stress_user_perspective.py
+++ b/test_stress_user_perspective.py
@@ -1,0 +1,140 @@
+import asyncio
+import sys
+import os
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "core"))
+
+print("=" * 70)
+print("STRESS TESTS + USER PERSPECTIVE TESTS: Issue #6193")
+print("=" * 70)
+
+async def stress_multiple_nodes():
+    print("\n[STRESS 1] Multiple client_facing nodes with partial input_data...")
+    nodes = ["intake", "processor", "output"]
+    input_data = {"processor": "data.csv"}
+    injected = []
+    def mock_inject(node_id, content):
+        injected.append({"node": node_id, "content": content})
+    for node_id in nodes:
+        if node_id in input_data:
+            mock_inject(node_id, json.dumps(input_data[node_id]))
+        else:
+            print(f"  -> Node '{node_id}' has no input, would exit(1)")
+    if len(injected) == 1 and injected[0]["node"] == "processor":
+        print("  [PASS] Only matching node received data")
+        return True
+    return False
+
+async def stress_malformed_data():
+    print("\n[STRESS 2] Malformed input_data (circular reference)...")
+    try:
+        circular = {"a": None}
+        circular["a"] = circular
+        json.dumps(circular)
+        return False
+    except (TypeError, ValueError) as e:
+        print(f"  [PASS] Correctly caught malformed data: {type(e).__name__}")
+        return True
+
+async def stress_empty_node_id():
+    print("\n[STRESS 3] Empty string node_id handling...")
+    input_data = {"": "some_data", "intake": "file.csv"}
+    if "" in input_data and "intake" in input_data:
+        print("  [PASS] Empty string handled as valid key but real nodes preferred")
+        return True
+    return False
+
+async def stress_rapid_injects():
+    print("\n[STRESS 4] Rapid successive inject_input calls...")
+    calls = []
+    async def mock_inject(node_id, content):
+        calls.append({"node": node_id, "content": content})
+    nodes = ["node1", "node2", "node3", "node4", "node5"]
+    input_data = {n: f"data_{i}" for i, n in enumerate(nodes)}
+    tasks = [mock_inject(n, json.dumps(input_data[n])) for n in nodes]
+    for t in tasks:
+        await t
+    if len(calls) == 5:
+        print("  [PASS] All 5 rapid injections succeeded")
+        return True
+    return False
+
+async def user_error_message():
+    print("\n[USER 1] Error message readability...")
+    import io
+    from contextlib import redirect_stderr
+    stderr_capture = io.StringIO()
+    error_msg = "\n[Error] Agent requires interactive input but was run in headless mode.\nPlease provide complete input data via --input-file or use interactive mode."
+    with redirect_stderr(stderr_capture):
+        print(error_msg, file=sys.stderr)
+    output = stderr_capture.getvalue()
+    checks = [
+        ("[Error]" in output, "Has [Error] prefix"),
+        ("interactive input" in output, "Mentions interactive input"),
+        ("headless mode" in output, "Mentions headless mode"),
+        ("--input-file" in output, "Mentions correct flag"),
+        ("interactive mode" in output, "Suggests alternative"),
+    ]
+    all_pass = True
+    for check, desc in checks:
+        print(f"  {'[PASS]' if check else '[FAIL]'} {desc}")
+        if not check: all_pass = False
+    return all_pass
+
+async def stress_cicd_simulation():
+    print("\n[STRESS 5] CI/CD Pipeline simulation (exit code check)...")
+    exit_called = False
+    exit_code = None
+    def mock_exit(code):
+        nonlocal exit_called, exit_code
+        exit_called = True
+        exit_code = code
+    with patch("os._exit", mock_exit):
+        input_data = {}
+        if not input_data:
+            mock_exit(1)
+    if exit_called and exit_code == 1:
+        print("  [PASS] CI pipeline would get exit code 1 (failure)")
+        return True
+    return False
+
+async def stress_partial_data():
+    print("\n[STRESS 6] Partial input_data with some nodes satisfied...")
+    input_data = {"intake": "/tmp/data.csv"}
+    injected = []
+    def mock_inject(node_id, content):
+        injected.append(node_id)
+    for node_id in ["intake", "validator", "output"]:
+        if node_id in input_data:
+            mock_inject(node_id, json.dumps(input_data[node_id]))
+        else:
+            print(f"  -> Node '{node_id}' would trigger exit (no data)")
+    if "intake" in injected and "validator" not in injected:
+        print("  [PASS] Partial data handled correctly")
+        return True
+    return False
+
+async def main():
+    results = [
+        await stress_multiple_nodes(),
+        await stress_malformed_data(),
+        await stress_empty_node_id(),
+        await stress_rapid_injects(),
+        await user_error_message(),
+        await stress_cicd_simulation(),
+        await stress_partial_data()
+    ]
+    print("\n" + "=" * 70)
+    passed = sum(1 for r in results if r)
+    print(f"RESULTS: {passed}/{len(results)} tests passed")
+    if all(results):
+        print("ALL STRESS + USER TESTS PASSED")
+    else:
+        print("REDFLAG: Tests failed.")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/test_stress_user_perspective.py
+++ b/test_stress_user_perspective.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import sys
 from pathlib import Path
@@ -10,9 +12,9 @@ from framework.runner.runner import AgentRunner
 from framework.graph.edge import GraphSpec
 from framework.graph.goal import Goal
 from framework.runtime.event_bus import EventType
+from framework.graph.executor import ExecutionResult
 
-# Mock Agent for testing
-async def run_agent(input_data):
+def make_test_agent() -> tuple[MagicMock, MagicMock, MagicMock]:
     graph = MagicMock(spec=GraphSpec)
     graph.description = "Test Graph"
     graph.id = "test-agent"
@@ -28,13 +30,17 @@ async def run_agent(input_data):
     goal.description = "Test Goal Description"
     goal.id = "test-goal"
     
+    mock_runtime = MagicMock()
+    mock_runtime.start = AsyncMock()
+    mock_runtime.get_entry_points = MagicMock(return_value=[])
+    
+    return graph, goal, mock_runtime
+
+async def run_agent(input_data: dict) -> "ExecutionResult":
+    graph, goal, mock_runtime = make_test_agent()
+    
     with patch("framework.runner.runner.run_preload_validation"):
         runner = AgentRunner(Path("."), graph, goal, interactive=False, skip_credential_validation=True)
-    
-        # Mock runtime
-        mock_runtime = MagicMock()
-        mock_runtime.start = AsyncMock()
-        mock_runtime.get_entry_points = MagicMock(return_value=[])
         
         # Track subscriptions
         input_handlers = []
@@ -56,7 +62,7 @@ async def run_agent(input_data):
         with patch("sys.stdin.isatty", return_value=False):
             return await runner.run(input_data=input_data)
 
-async def test_cicd_simulation():
+async def test_cicd_simulation() -> bool:
     print("\n[STRESS 5] CI/CD Pipeline simulation (result check)...")
     result = await run_agent(input_data={})
     
@@ -65,7 +71,7 @@ async def test_cicd_simulation():
         return True
     return False
 
-async def test_user_error_message():
+async def test_user_error_message() -> bool:
     print("\n[USER 1] Error message readability...")
     result = await run_agent(input_data={})
     
@@ -82,10 +88,11 @@ async def test_user_error_message():
     all_pass = True
     for check, desc in checks:
         print(f"  {'[PASS]' if check else '[FAIL]'} {desc}")
-        if not check: all_pass = False
+        if not check:
+            all_pass = False
     return all_pass
 
-async def main():
+async def main() -> None:
     print("=" * 70)
     print("STRESS TESTS + USER PERSPECTIVE TESTS: Issue #6193")
     print("=" * 70)

--- a/test_stress_user_perspective.py
+++ b/test_stress_user_perspective.py
@@ -1,81 +1,82 @@
 import asyncio
 import sys
-import os
-import json
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 
+# Add core to path
 sys.path.insert(0, str(Path(__file__).resolve().parent / "core"))
 
-print("=" * 70)
-print("STRESS TESTS + USER PERSPECTIVE TESTS: Issue #6193")
-print("=" * 70)
+from framework.runner.runner import AgentRunner
+from framework.graph.edge import GraphSpec
+from framework.graph.goal import Goal
+from framework.runtime.event_bus import EventType
 
-async def stress_multiple_nodes():
-    print("\n[STRESS 1] Multiple client_facing nodes with partial input_data...")
-    nodes = ["intake", "processor", "output"]
-    input_data = {"processor": "data.csv"}
-    injected = []
-    def mock_inject(node_id, content):
-        injected.append({"node": node_id, "content": content})
-    for node_id in nodes:
-        if node_id in input_data:
-            mock_inject(node_id, json.dumps(input_data[node_id]))
-        else:
-            print(f"  -> Node '{node_id}' has no input, would exit(1)")
-    if len(injected) == 1 and injected[0]["node"] == "processor":
-        print("  [PASS] Only matching node received data")
+# Mock Agent for testing
+async def run_agent(input_data):
+    graph = MagicMock(spec=GraphSpec)
+    graph.description = "Test Graph"
+    graph.id = "test-agent"
+    graph.nodes = [MagicMock(client_facing=True)]
+    graph.edges = []
+    graph.entry_node = "test-node"
+    graph.terminal_nodes = []
+    
+    goal = MagicMock(spec=Goal)
+    goal.success_criteria = []
+    goal.constraints = []
+    goal.name = "Test Goal"
+    goal.description = "Test Goal Description"
+    goal.id = "test-goal"
+    
+    with patch("framework.runner.runner.run_preload_validation"):
+        runner = AgentRunner(Path("."), graph, goal, interactive=False, skip_credential_validation=True)
+    
+        # Mock runtime
+        mock_runtime = MagicMock()
+        mock_runtime.start = AsyncMock()
+        mock_runtime.get_entry_points = MagicMock(return_value=[])
+        
+        # Track subscriptions
+        input_handlers = []
+        def subscribe(event_types, handler):
+            if EventType.CLIENT_INPUT_REQUESTED in event_types:
+                input_handlers.append(handler)
+            return "sub1"
+        mock_runtime.subscribe_to_events = subscribe
+        
+        # Mock trigger_and_wait to simulate input request
+        async def trigger_and_wait(*args, **kwargs):
+            for handler in input_handlers:
+                await handler(MagicMock(node_id="test-node"))
+            return MagicMock()
+        mock_runtime.trigger_and_wait = trigger_and_wait
+        
+        runner._agent_runtime = mock_runtime
+        
+        with patch("sys.stdin.isatty", return_value=False):
+            return await runner.run(input_data=input_data)
+
+async def test_cicd_simulation():
+    print("\n[STRESS 5] CI/CD Pipeline simulation (result check)...")
+    result = await run_agent(input_data={})
+    
+    if not result.success and "headless mode" in result.error:
+        print("  [PASS] CI pipeline would get failure result")
         return True
     return False
 
-async def stress_malformed_data():
-    print("\n[STRESS 2] Malformed input_data (circular reference)...")
-    try:
-        circular = {"a": None}
-        circular["a"] = circular
-        json.dumps(circular)
-        return False
-    except (TypeError, ValueError) as e:
-        print(f"  [PASS] Correctly caught malformed data: {type(e).__name__}")
-        return True
-
-async def stress_empty_node_id():
-    print("\n[STRESS 3] Empty string node_id handling...")
-    input_data = {"": "some_data", "intake": "file.csv"}
-    if "" in input_data and "intake" in input_data:
-        print("  [PASS] Empty string handled as valid key but real nodes preferred")
-        return True
-    return False
-
-async def stress_rapid_injects():
-    print("\n[STRESS 4] Rapid successive inject_input calls...")
-    calls = []
-    async def mock_inject(node_id, content):
-        calls.append({"node": node_id, "content": content})
-    nodes = ["node1", "node2", "node3", "node4", "node5"]
-    input_data = {n: f"data_{i}" for i, n in enumerate(nodes)}
-    tasks = [mock_inject(n, json.dumps(input_data[n])) for n in nodes]
-    for t in tasks:
-        await t
-    if len(calls) == 5:
-        print("  [PASS] All 5 rapid injections succeeded")
-        return True
-    return False
-
-async def user_error_message():
+async def test_user_error_message():
     print("\n[USER 1] Error message readability...")
-    import io
-    from contextlib import redirect_stderr
-    stderr_capture = io.StringIO()
-    error_msg = "\n[Error] Agent requires interactive input but was run in headless mode.\nPlease provide complete input data via --input-file or use interactive mode."
-    with redirect_stderr(stderr_capture):
-        print(error_msg, file=sys.stderr)
-    output = stderr_capture.getvalue()
+    result = await run_agent(input_data={})
+    
+    output = result.error
+    # We expect the error to be set by _handle_headless_input
+    # The error message should be: "Agent requires interactive input but was run in headless mode. Provide input via --input-file or use interactive mode."
+    
     checks = [
-        ("[Error]" in output, "Has [Error] prefix"),
         ("interactive input" in output, "Mentions interactive input"),
         ("headless mode" in output, "Mentions headless mode"),
-        ("--input-file" in output, "Mentions correct flag"),
+        ("Provide input" in output, "Suggests providing input"),
         ("interactive mode" in output, "Suggests alternative"),
     ]
     all_pass = True
@@ -84,49 +85,16 @@ async def user_error_message():
         if not check: all_pass = False
     return all_pass
 
-async def stress_cicd_simulation():
-    print("\n[STRESS 5] CI/CD Pipeline simulation (exit code check)...")
-    exit_called = False
-    exit_code = None
-    def mock_exit(code):
-        nonlocal exit_called, exit_code
-        exit_called = True
-        exit_code = code
-    with patch("os._exit", mock_exit):
-        input_data = {}
-        if not input_data:
-            mock_exit(1)
-    if exit_called and exit_code == 1:
-        print("  [PASS] CI pipeline would get exit code 1 (failure)")
-        return True
-    return False
-
-async def stress_partial_data():
-    print("\n[STRESS 6] Partial input_data with some nodes satisfied...")
-    input_data = {"intake": "/tmp/data.csv"}
-    injected = []
-    def mock_inject(node_id, content):
-        injected.append(node_id)
-    for node_id in ["intake", "validator", "output"]:
-        if node_id in input_data:
-            mock_inject(node_id, json.dumps(input_data[node_id]))
-        else:
-            print(f"  -> Node '{node_id}' would trigger exit (no data)")
-    if "intake" in injected and "validator" not in injected:
-        print("  [PASS] Partial data handled correctly")
-        return True
-    return False
-
 async def main():
+    print("=" * 70)
+    print("STRESS TESTS + USER PERSPECTIVE TESTS: Issue #6193")
+    print("=" * 70)
+    
     results = [
-        await stress_multiple_nodes(),
-        await stress_malformed_data(),
-        await stress_empty_node_id(),
-        await stress_rapid_injects(),
-        await user_error_message(),
-        await stress_cicd_simulation(),
-        await stress_partial_data()
+        await test_cicd_simulation(),
+        await test_user_error_message()
     ]
+    
     print("\n" + "=" * 70)
     passed = sum(1 for r in results if r)
     print(f"RESULTS: {passed}/{len(results)} tests passed")


### PR DESCRIPTION
Fixes #6193. sys.stdin.isatty() prevents attaching interactive handles but headless scripts loop infinitely. Circuit breaker auto-injects provided input_data to client_facing nodes or fails fast.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Headless agent execution can accept pre-provided JSON input in non-TTY environments.

* **Bug Fixes**
  * Runner fails fast with a clear headless-specific error when required input is empty or cannot be injected.

* **Tests**
  * Added executable verification and stress tests validating headless input injection, fail-fast behavior, and user-facing error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->