### PR TITLE
feat: add per-node latency tracking and tests for executor

### DIFF
--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -11,6 +11,7 @@ The executor:
 
 import asyncio
 import logging
+import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -70,6 +71,9 @@ class ExecutionResult:
 
     # Visit tracking (for feedback/callback edges)
     node_visit_counts: dict[str, int] = field(default_factory=dict)  # {node_id: visit_count}
+
+    # Per-node latency breakdown
+    node_latencies: dict[str, int] = field(default_factory=dict)  # {node_id: latency_ms}
 
     @property
     def is_clean_success(self) -> bool:
@@ -561,6 +565,7 @@ class GraphExecutor:
         total_latency = 0
         node_retry_counts: dict[str, int] = {}  # Track retries per node
         node_visit_counts: dict[str, int] = {}  # Track visits for feedback loops
+        node_latencies: dict[str, int] = {}  # Per-node latency breakdown
         _is_retry = False  # True when looping back for a retry (not a new visit)
 
         # Restore node_visit_counts from session state if available
@@ -818,6 +823,7 @@ class GraphExecutor:
                         error="Execution paused by user request",
                         session_state=pause_session_state,
                         node_visit_counts=dict(node_visit_counts),
+                        node_latencies=dict(node_latencies),
                     )
 
                 # Get current node
@@ -975,7 +981,14 @@ class GraphExecutor:
 
                 # Execute node
                 self.logger.info("   Executing...")
+                _node_start = time.perf_counter()
                 result = await node_impl.execute(ctx)
+                _node_elapsed_ms = int((time.perf_counter() - _node_start) * 1000)
+                if result.latency_ms == 0:
+                    result.latency_ms = _node_elapsed_ms
+                node_latencies[current_node_id] = (
+                    node_latencies.get(current_node_id, 0) + result.latency_ms
+                )
 
                 # GCU tab cleanup: stop the browser profile after a top-level GCU node
                 # finishes so tabs don't accumulate. Mirrors the subagent cleanup in
@@ -1212,6 +1225,7 @@ class GraphExecutor:
                                 had_partial_failures=len(nodes_failed) > 0,
                                 execution_quality="failed",
                                 node_visit_counts=dict(node_visit_counts),
+                                node_latencies=dict(node_latencies),
                                 session_state=failure_session_state,
                             )
 
@@ -1273,6 +1287,7 @@ class GraphExecutor:
                         had_partial_failures=len(nodes_failed) > 0,
                         execution_quality=exec_quality,
                         node_visit_counts=dict(node_visit_counts),
+                        node_latencies=dict(node_latencies),
                     )
 
                 # Check if this is a terminal node - if so, we're done
@@ -1626,6 +1641,7 @@ class GraphExecutor:
                 had_partial_failures=len(nodes_failed) > 0,
                 execution_quality=exec_quality,
                 node_visit_counts=dict(node_visit_counts),
+                node_latencies=dict(node_latencies),
                 session_state={
                     "memory": output,  # output IS memory.read_all()
                     "execution_path": list(path),
@@ -1703,6 +1719,7 @@ class GraphExecutor:
                 had_partial_failures=len(nodes_failed) > 0,
                 execution_quality=exec_quality,
                 node_visit_counts=dict(node_visit_counts),
+                node_latencies=dict(node_latencies),
             )
 
         except Exception as e:
@@ -1802,6 +1819,7 @@ class GraphExecutor:
                 had_partial_failures=len(nodes_failed) > 0,
                 execution_quality="failed",
                 node_visit_counts=dict(node_visit_counts),
+                node_latencies=dict(node_latencies),
                 session_state=session_state_out,
             )
 
@@ -2224,7 +2242,11 @@ class GraphExecutor:
                     self.logger.info(
                         f"      ▶ Branch {node_spec.name}: executing (attempt {attempt + 1})"
                     )
+                    _branch_start = time.perf_counter()
                     result = await node_impl.execute(ctx)
+                    _branch_elapsed_ms = int((time.perf_counter() - _branch_start) * 1000)
+                    if result.latency_ms == 0:
+                        result.latency_ms = _branch_elapsed_ms
                     last_result = result
 
                     # Ensure L2 entry for this branch node

--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -1360,6 +1360,7 @@ class GraphExecutor:
                             source_node_spec=node_spec,
                             path=path,
                             node_registry=node_registry,
+                            node_latencies=node_latencies,
                         )
 
                         total_tokens += branch_tokens
@@ -2145,6 +2146,7 @@ class GraphExecutor:
         source_node_spec: Any,
         path: list[str],
         node_registry: dict[str, NodeSpec] | None = None,
+        node_latencies: dict[str, int] | None = None,
     ) -> tuple[dict[str, NodeResult], int, int]:
         """
         Execute multiple branches in parallel using asyncio.gather.
@@ -2380,6 +2382,11 @@ class GraphExecutor:
                 else:
                     total_tokens += node_result.tokens_used
                     total_latency += node_result.latency_ms
+                    if node_latencies is not None:
+                        node_latencies[returned_branch.node_id] = (
+                            node_latencies.get(returned_branch.node_id, 0)
+                            + node_result.latency_ms
+                        )
                     branch_results[returned_branch.branch_id] = node_result
 
         # Handle failures based on config

--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -982,13 +982,18 @@ class GraphExecutor:
                 # Execute node
                 self.logger.info("   Executing...")
                 _node_start = time.perf_counter()
-                result = await node_impl.execute(ctx)
-                _node_elapsed_ms = int((time.perf_counter() - _node_start) * 1000)
-                if result.latency_ms == 0:
-                    result.latency_ms = _node_elapsed_ms
-                node_latencies[current_node_id] = (
-                    node_latencies.get(current_node_id, 0) + result.latency_ms
-                )
+                _node_result: NodeResult | None = None
+                try:
+                    result = await node_impl.execute(ctx)
+                    _node_result = result
+                finally:
+                    _node_elapsed_ms = int((time.perf_counter() - _node_start) * 1000)
+                    if _node_result is not None and _node_result.latency_ms == 0:
+                        _node_result.latency_ms = _node_elapsed_ms
+                    node_latencies[current_node_id] = (
+                        node_latencies.get(current_node_id, 0)
+                        + (_node_result.latency_ms if _node_result is not None else _node_elapsed_ms)
+                    )
 
                 # GCU tab cleanup: stop the browser profile after a top-level GCU node
                 # finishes so tabs don't accumulate. Mirrors the subagent cleanup in
@@ -2245,10 +2250,16 @@ class GraphExecutor:
                         f"      ▶ Branch {node_spec.name}: executing (attempt {attempt + 1})"
                     )
                     _branch_start = time.perf_counter()
-                    result = await node_impl.execute(ctx)
-                    _branch_elapsed_ms = int((time.perf_counter() - _branch_start) * 1000)
-                    if result.latency_ms == 0:
-                        result.latency_ms = _branch_elapsed_ms
+                    _branch_result: NodeResult | None = None
+                    try:
+                        result = await node_impl.execute(ctx)
+                        _branch_result = result
+                    finally:
+                        _branch_elapsed_ms = int(
+                            (time.perf_counter() - _branch_start) * 1000
+                        )
+                        if _branch_result is not None and _branch_result.latency_ms == 0:
+                            _branch_result.latency_ms = _branch_elapsed_ms
                     last_result = result
 
                     # Ensure L2 entry for this branch node

--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -246,6 +246,7 @@ class GraphExecutor:
         path: list[str],
         memory: Any,
         node_visit_counts: dict[str, int],
+        node_latencies: dict[str, int] | None = None,
     ) -> None:
         """Update state.json with live progress at node transitions.
 
@@ -273,6 +274,8 @@ class GraphExecutor:
             progress["current_node"] = current_node
             progress["path"] = list(path)
             progress["node_visit_counts"] = dict(node_visit_counts)
+            if node_latencies is not None:
+                progress["node_latencies"] = dict(node_latencies)
             progress["steps_executed"] = len(path)
 
             # Update timestamp
@@ -568,6 +571,12 @@ class GraphExecutor:
         node_latencies: dict[str, int] = {}  # Per-node latency breakdown
         _is_retry = False  # True when looping back for a retry (not a new visit)
 
+        # Restore node_latencies from session state if available
+        if session_state and "node_latencies" in session_state:
+            node_latencies = dict(session_state["node_latencies"])
+            if node_latencies:
+                self.logger.info(f"📥 Restored node latencies: {node_latencies}")
+
         # Restore node_visit_counts from session state if available
         if session_state and "node_visit_counts" in session_state:
             node_visit_counts = dict(session_state["node_visit_counts"])
@@ -796,6 +805,7 @@ class GraphExecutor:
                         "memory": saved_memory,  # Include memory for resume
                         "execution_path": list(path),
                         "node_visit_counts": dict(node_visit_counts),
+                        "node_latencies": dict(node_latencies),
                     }
 
                     # Create a pause checkpoint
@@ -990,10 +1000,15 @@ class GraphExecutor:
                     _node_elapsed_ms = int((time.perf_counter() - _node_start) * 1000)
                     if _node_result is not None and _node_result.latency_ms == 0:
                         _node_result.latency_ms = _node_elapsed_ms
-                    node_latencies[current_node_id] = (
-                        node_latencies.get(current_node_id, 0)
-                        + (_node_result.latency_ms if _node_result is not None else _node_elapsed_ms)
+                    _lat = (
+                        _node_result.latency_ms
+                        if _node_result is not None
+                        else _node_elapsed_ms
                     )
+                    node_latencies[current_node_id] = (
+                        node_latencies.get(current_node_id, 0) + _lat
+                    )
+                    total_latency += _lat
 
                 # GCU tab cleanup: stop the browser profile after a top-level GCU node
                 # finishes so tabs don't accumulate. Mirrors the subagent cleanup in
@@ -1099,7 +1114,6 @@ class GraphExecutor:
                     self.logger.error(f"   ✗ Failed: {result.error}")
 
                 total_tokens += result.tokens_used
-                total_latency += result.latency_ms
 
                 # Handle failure
                 if not result.success:
@@ -1316,7 +1330,9 @@ class GraphExecutor:
                         )
 
                     current_node_id = result.next_node
-                    self._write_progress(current_node_id, path, memory, node_visit_counts)
+                    self._write_progress(
+                        current_node_id, path, memory, node_visit_counts, node_latencies
+                    )
                 else:
                     # Get all traversable edges for fan-out detection
                     traversable_edges = await self._get_all_traversable_edges(
@@ -1375,7 +1391,10 @@ class GraphExecutor:
                         if fan_in_node:
                             self.logger.info(f"   ⑃ Fan-in: converging at {fan_in_node}")
                             current_node_id = fan_in_node
-                            self._write_progress(current_node_id, path, memory, node_visit_counts)
+                            self._write_progress(
+                                current_node_id, path, memory,
+                                node_visit_counts, node_latencies,
+                            )
                         else:
                             # No convergence point - branches are terminal
                             self.logger.info("   → Parallel branches completed (no convergence)")
@@ -1440,7 +1459,9 @@ class GraphExecutor:
                         current_node_id = next_node
 
                 # Write progress snapshot at node transition
-                self._write_progress(current_node_id, path, memory, node_visit_counts)
+                self._write_progress(
+                    current_node_id, path, memory, node_visit_counts, node_latencies
+                )
 
                 # Continuous mode: thread conversation forward with transition marker
                 if is_continuous and result.conversation is not None:

--- a/core/framework/schemas/session_state.py
+++ b/core/framework/schemas/session_state.py
@@ -55,6 +55,7 @@ class SessionProgress(BaseModel):
     had_partial_failures: bool = False
     execution_quality: str = "clean"  # "clean", "degraded", or "failed"
     node_visit_counts: dict[str, int] = Field(default_factory=dict)
+    node_latencies: dict[str, int] = Field(default_factory=dict)  # {node_id: latency_ms}
 
     model_config = {"extra": "allow"}
 
@@ -237,6 +238,7 @@ class SessionState(BaseModel):
                 had_partial_failures=result.had_partial_failures,
                 execution_quality=result.execution_quality,
                 node_visit_counts=result.node_visit_counts,
+                node_latencies=result.node_latencies,
             ),
             result=SessionResult(
                 success=result.success,
@@ -306,4 +308,5 @@ class SessionState(BaseModel):
             "memory": self.memory,
             "execution_path": self.progress.path,
             "node_visit_counts": self.progress.node_visit_counts,
+            "node_latencies": self.progress.node_latencies,
         }

--- a/core/tests/test_graph_executor.py
+++ b/core/tests/test_graph_executor.py
@@ -315,3 +315,105 @@ def test_write_progress_logs_warning_on_atomic_write_failure(tmp_path, monkeypat
 
     assert "Failed to persist progress state to" in caplog.text
     assert str(state_path) in caplog.text
+
+
+# ---- Slow node for latency measurement ----
+class SlowNode:
+    """Node that sleeps briefly to produce measurable latency."""
+
+    def validate_input(self, ctx):
+        return []
+
+    async def execute(self, ctx):
+        import asyncio
+
+        await asyncio.sleep(0.05)  # 50 ms
+        return NodeResult(
+            success=True,
+            output={"result": "slow"},
+            tokens_used=2,
+            latency_ms=0,  # left as 0 so executor fills it in
+        )
+
+
+@pytest.mark.asyncio
+async def test_executor_per_node_latency_tracking():
+    """Executor should populate per-node latency via perf_counter when node returns 0."""
+    runtime = DummyRuntime()
+
+    graph = GraphSpec(
+        id="graph-latency",
+        goal_id="g-lat",
+        nodes=[
+            NodeSpec(
+                id="n1",
+                name="slow-node",
+                description="a slow node",
+                node_type="event_loop",
+                input_keys=[],
+                output_keys=["result"],
+                max_retries=0,
+            )
+        ],
+        edges=[],
+        entry_node="n1",
+        terminal_nodes=["n1"],
+    )
+
+    executor = GraphExecutor(
+        runtime=runtime,
+        node_registry={"n1": SlowNode()},
+    )
+
+    goal = Goal(id="g-lat", name="latency-test", description="test latency tracking")
+    result = await executor.execute(graph=graph, goal=goal)
+
+    assert result.success is True
+
+    # Per-node latency should be populated and >= 50 ms
+    assert "n1" in result.node_latencies
+    assert result.node_latencies["n1"] >= 50
+
+    # Total latency should match the per-node sum
+    assert result.total_latency_ms >= 50
+    assert result.total_latency_ms == result.node_latencies["n1"]
+
+
+@pytest.mark.asyncio
+async def test_executor_preserves_node_set_latency():
+    """Executor should keep latency_ms already set by the node implementation."""
+    runtime = DummyRuntime()
+
+    graph = GraphSpec(
+        id="graph-preset",
+        goal_id="g-pre",
+        nodes=[
+            NodeSpec(
+                id="n1",
+                name="preset-node",
+                description="node with preset latency",
+                node_type="event_loop",
+                input_keys=[],
+                output_keys=["result"],
+                max_retries=0,
+            )
+        ],
+        edges=[],
+        entry_node="n1",
+        terminal_nodes=["n1"],
+    )
+
+    executor = GraphExecutor(
+        runtime=runtime,
+        node_registry={"n1": SuccessNode()},  # SuccessNode sets latency_ms=1
+    )
+
+    goal = Goal(id="g-pre", name="preset-test", description="test preset latency")
+    result = await executor.execute(graph=graph, goal=goal)
+
+    assert result.success is True
+
+    # Node already set latency_ms=1, executor should preserve it
+    assert "n1" in result.node_latencies
+    assert result.node_latencies["n1"] == 1
+    assert result.total_latency_ms == 1


### PR DESCRIPTION


```
## Description
Implements per-node performance metrics (latency tracking) in the core `GraphExecutor`. Hooks up the existing `NodeResult.latency_ms` field with high-resolution `time.perf_counter()` timers around every `node_impl.execute()` call. Per-node latencies are aggregated into a new `ExecutionResult.node_latencies` dict, giving developers node-by-node visibility into execution time.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #6926

## Changes Made

- Added `import time` and wrapped both sequential and parallel `node_impl.execute()` calls with `time.perf_counter()` timers
- Added `node_latencies: dict[str, int]` field to `ExecutionResult` dataclass (default empty dict — non-breaking)
- If a node leaves `latency_ms` at 0, the executor fills it from the measured duration; if the node already set it, the value is preserved
- Passed `node_latencies` to all 6 in-loop `ExecutionResult` construction sites (2 early-return validation sites correctly omitted — no nodes executed)
- Added `SlowNode` test helper and 2 new tests: `test_executor_per_node_latency_tracking` (verifies executor-measured latency) and `test_executor_preserves_node_set_latency` (verifies node-preset latency is not overridden)

## Testing

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A — no UI changes.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-node execution latency tracking is recorded, summed into a total, preserved when nodes report their own latency, and persisted into session progress/state and progress writes.

* **Tests**
  * Added tests validating executor-measured per-node latencies, preservation of node-reported latencies, and correct aggregation across sequential and parallel branch executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->