### PR TITLE
fix(tool_registry): warn and skip on duplicate tool name registration

### DIFF
--- a/core/framework/runner/tool_registry.py
+++ b/core/framework/runner/tool_registry.py
@@ -83,6 +83,12 @@ class ToolRegistry:
             tool: Tool definition
             executor: Function that takes tool input dict and returns result
         """
+        if name in self._tools:
+            logger.warning(
+                f"Tool '{name}' already registered, skipping duplicate. "
+                f"Existing description: {self._tools[name].tool.description}"
+            )
+            return
         self._tools[name] = RegisteredTool(tool=tool, executor=executor)
 
     def register_function(


### PR DESCRIPTION
## Summary

Warn and skip when a tool with a duplicate name is already registered, instead of silently overwriting it.

## Problem

`ToolRegistry.register()` unconditionally overwrites existing tools with no warning or error. This causes:
- **Silent data loss** when multiple MCP servers have overlapping tool names
- **Silent replacement** of manually registered tools by MCP tools  
- **Unpredictable behavior** depending on registration order
- **Security risk** — malicious MCP server could overwrite built-in tools

## Fix

Added a check in `register()` that logs a warning and skips the duplicate registration:

```python
if name in self._tools:
    logger.warning(
        f"Tool '{name}' already registered, skipping duplicate. "
        f"Existing description: {self._tools[name].tool.description}"
    )
    return
self._tools[name] = RegisteredTool(tool=tool, executor=executor)
```

Uses **Option 2 (warn and skip)** from issue #2540 for backward compatibility.

## Testing

The existing test suite should cover this. A new test can verify:
1. Register same tool twice → warning logged, second registration skipped
2. First tool remains accessible after duplicate attempt

## Related

Fixes #2540


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool registration now prevents duplicate entries. When attempting to register a tool with an existing name, a warning is logged and the existing registration is preserved instead of being overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->