### PR TITLE
feat(economic-mode): add --node-budget flag for paid tool call budgeting

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -40,6 +40,20 @@ uv run python -m framework shell exports/calculator
 uv run python -m framework info exports/calculator
 ```
 
+### Economic Mode
+
+Limit how many paid external API calls (e.g. web search, data enrichment) an agent can make per node with `--node-budget`:
+
+```bash
+# Allow at most 2 paid tool calls per node
+uv run hive run examples/templates/deep_research_agent --node-budget 2
+
+# Block all paid tool calls (free tools only)
+uv run hive run examples/templates/deep_research_agent --node-budget 0
+```
+
+When the budget is exhausted the agent receives an error result and paid tools are hidden from its tool list, so it adapts gracefully using free alternatives. Budget usage is tracked in the runtime logs (`paid_tool_calls_used`, `budget_blocked_calls`) at both node and run level.
+
 ### Using the Runtime
 
 ```python

--- a/core/framework/graph/event_loop/cursor_persistence.py
+++ b/core/framework/graph/event_loop/cursor_persistence.py
@@ -32,6 +32,7 @@ class RestoredState:
     recent_responses: list[str]
     recent_tool_fingerprints: list[list[tuple[str, str]]]
     pending_input: dict[str, Any] | None
+    paid_calls_used: int = 0
 
 
 async def restore(
@@ -86,12 +87,16 @@ async def restore(
     if not isinstance(pending_input, dict):
         pending_input = None
 
+    # Restore economic mode counter so budget is not reset on crash-resume.
+    paid_calls_used: int = cursor.get("paid_calls_used", 0)
+
     logger.info(
         f"Restored event loop: iteration={start_iteration}, "
         f"messages={conversation.message_count}, "
         f"outputs={list(accumulator.values.keys())}, "
         f"stall_window={len(recent_responses)}, "
-        f"doom_window={len(recent_tool_fingerprints)}"
+        f"doom_window={len(recent_tool_fingerprints)}, "
+        f"paid_calls_used={paid_calls_used}"
     )
     return RestoredState(
         conversation=conversation,
@@ -100,6 +105,7 @@ async def restore(
         recent_responses=recent_responses,
         recent_tool_fingerprints=recent_tool_fingerprints,
         pending_input=pending_input,
+        paid_calls_used=paid_calls_used,
     )
 
 
@@ -113,6 +119,7 @@ async def write_cursor(
     recent_responses: list[str] | None = None,
     recent_tool_fingerprints: list[list[tuple[str, str]]] | None = None,
     pending_input: dict[str, Any] | None = None,
+    paid_calls_used: int | None = None,
 ) -> None:
     """Write checkpoint cursor for crash recovery.
 
@@ -139,6 +146,9 @@ async def write_cursor(
         # Persist blocked-input state so restored runs re-block instead of
         # manufacturing a synthetic continuation turn.
         cursor["pending_input"] = pending_input
+        # Persist economic mode counter so budget survives crash-resume.
+        if paid_calls_used is not None:
+            cursor["paid_calls_used"] = paid_calls_used
         await conversation_store.write_cursor(cursor)
 
 

--- a/core/framework/graph/event_loop/types.py
+++ b/core/framework/graph/event_loop/types.py
@@ -92,6 +92,10 @@ class LoopConfig:
     # Set to 0 to use only the wall-clock timeout.
     subagent_inactivity_timeout_seconds: float = 300.0
 
+    # Economic mode: max paid tool calls (is_paid=True) allowed per node run.
+    # -1 = disabled (default). 0 = all paid calls blocked.
+    max_paid_calls_per_node: int = -1
+
     # Lifecycle hooks.
     hooks: dict[str, list] | None = None
 

--- a/core/framework/graph/event_loop_node.py
+++ b/core/framework/graph/event_loop_node.py
@@ -219,6 +219,32 @@ HookResult = event_loop_types.HookResult
 OutputAccumulator = event_loop_types.OutputAccumulator
 
 
+def _build_economic_block(remaining: int, paid_tool_names: list[str]) -> str:
+    """Build the ## Economic Mode system prompt block."""
+    tool_list = ", ".join(paid_tool_names) if paid_tool_names else "none"
+    if remaining > 0:
+        guidance = (
+            f"You have {remaining} paid call(s) available — use them to get higher-quality results. "
+            f"Prefer paid tools over free alternatives when they are relevant to the task. "
+            f"When multiple paid tools could satisfy a requirement, prefer the one likely to be cheaper. "
+            f"This budget applies only to the current step — use it as needed, there is no benefit to saving calls for later."
+        )
+    else:
+        guidance = (
+            f"Your paid tool budget is exhausted. "
+            f"Do not call paid tools — use only free alternatives. "
+            f"If a task cannot be completed without paid tools, inform the user of what is missing."
+        )
+    return (
+        f"## Economic Mode\n"
+        f"Paid tool call budget remaining: {remaining} call(s).\n"
+        f"Paid tools (each call counts against your budget): {tool_list}.\n"
+        f"{guidance}"
+    )
+
+
+
+
 # ---------------------------------------------------------------------------
 # EventLoopNode
 # ---------------------------------------------------------------------------
@@ -387,6 +413,7 @@ class EventLoopNode(NodeProtocol):
             _restored_recent_responses: list[str] = []
             _restored_tool_fingerprints: list[list[tuple[str, str]]] = []
             _restored_pending_input = None
+            _restored_paid_calls_used: int = 0
         else:
             # Try crash-recovery restore from store, then fall back to fresh.
             restored = await self._restore(ctx)
@@ -397,6 +424,7 @@ class EventLoopNode(NodeProtocol):
                 _restored_recent_responses = restored.recent_responses
                 _restored_tool_fingerprints = restored.recent_tool_fingerprints
                 _restored_pending_input = restored.pending_input
+                _restored_paid_calls_used = restored.paid_calls_used
 
                 # Refresh the system prompt with full composition including
                 # execution preamble and node-type preamble.  The stored
@@ -418,6 +446,7 @@ class EventLoopNode(NodeProtocol):
                 _restored_recent_responses = []
                 _restored_tool_fingerprints = []
                 _restored_pending_input = None
+                _restored_paid_calls_used = 0
 
                 # Clear any stale conversation parts before starting fresh.
                 # This ensures a clean slate even if the store directory is reused.
@@ -542,6 +571,21 @@ class EventLoopNode(NodeProtocol):
             type(self._judge).__name__ if self._judge else "None",
         )
 
+        # 3b. Economic mode: inject budget block into system prompt now that
+        # the tools list is fully built (paid tool names are known).
+        if self._config.max_paid_calls_per_node >= 0:
+            _paid_names = [t.name for t in tools if t.is_paid]
+            _eco_block = _build_economic_block(self._config.max_paid_calls_per_node, _paid_names)
+            conversation.update_system_prompt(
+                f"{conversation.system_prompt}\n\n{_eco_block}"
+            )
+            logger.info(
+                "[%s] Economic mode active: budget=%d paid tool calls, paid tools: %s",
+                node_id,
+                self._config.max_paid_calls_per_node,
+                _paid_names or "none",
+            )
+
         # 4. Publish loop started
         await self._publish_loop_started(stream_id, node_id, execution_id)
 
@@ -562,6 +606,11 @@ class EventLoopNode(NodeProtocol):
         recent_tool_fingerprints: list[list[tuple[str, str]]] = _restored_tool_fingerprints
         pending_input_state: dict[str, Any] | None = _restored_pending_input
         _consecutive_empty_turns: int = 0
+
+        # 5b. Economic mode: paid-tool-call counter. Restored from cursor on
+        # crash-resume so the budget is not accidentally reset mid-execution.
+        paid_calls_used: int = _restored_paid_calls_used
+        budget_blocked_calls: int = 0  # total paid calls blocked by budget this node run
 
         # 6. Main loop
         logger.debug(
@@ -707,6 +756,16 @@ class EventLoopNode(NodeProtocol):
                     conversation.update_system_prompt(_new_prompt)
                     logger.info("[%s] Dynamic prompt updated", node_id)
 
+            # 6b4. Economic mode: refresh remaining budget in system prompt each iteration.
+            if self._config.max_paid_calls_per_node >= 0 and iteration > start_iteration:
+                _remaining = self._config.max_paid_calls_per_node - paid_calls_used
+                _paid_names = [t.name for t in tools if t.is_paid]
+                _eco_block = _build_economic_block(_remaining, _paid_names)
+                _current_sp = conversation.system_prompt
+                _marker = "\n\n## Economic Mode\n"
+                _base_sp = _current_sp.split(_marker)[0] if _marker in _current_sp else _current_sp
+                conversation.update_system_prompt(f"{_base_sp}\n\n{_eco_block}")
+
             # 6c. Publish iteration event (with per-iteration metadata when available)
             _iter_meta = None
             if ctx.iteration_metadata_provider is not None:
@@ -769,9 +828,32 @@ class EventLoopNode(NodeProtocol):
                         request_system_prompt,
                         request_messages,
                         reported_to_parent,
+                        _paid_this_turn,
+                        _budget_blocked_this_turn,
                     ) = await self._run_single_turn(
-                        ctx, conversation, tools, iteration, accumulator
+                        ctx,
+                        conversation,
+                        tools,
+                        iteration,
+                        accumulator,
+                        paid_budget_remaining=(
+                            self._config.max_paid_calls_per_node - paid_calls_used
+                            if self._config.max_paid_calls_per_node >= 0
+                            else -1
+                        ),
                     )
+                    # Economic mode: accumulate paid calls used this turn for logging.
+                    if self._config.max_paid_calls_per_node >= 0 and _paid_this_turn > 0:
+                        paid_calls_used += _paid_this_turn
+                        logger.info(
+                            "[%s] Economic mode: %d paid call(s) this turn, "
+                            "%d/%d total used",
+                            node_id,
+                            _paid_this_turn,
+                            paid_calls_used,
+                            self._config.max_paid_calls_per_node,
+                        )
+                    budget_blocked_calls += _budget_blocked_this_turn
                     logger.debug(
                         "[EventLoopNode.execute] iteration=%d:"
                         " _run_single_turn completed successfully",
@@ -1265,6 +1347,7 @@ class EventLoopNode(NodeProtocol):
                 recent_responses=recent_responses,
                 recent_tool_fingerprints=recent_tool_fingerprints,
                 pending_input=None,
+                paid_calls_used=paid_calls_used,
             )
 
             # 6h. Worker auto-escalation on text-only turns
@@ -1856,6 +1939,8 @@ class EventLoopNode(NodeProtocol):
                         retry_count=_retry_count,
                         escalate_count=_escalate_count,
                         continue_count=_continue_count,
+                        paid_tool_calls_used=paid_calls_used,
+                        budget_blocked_calls=budget_blocked_calls,
                     )
                 return NodeResult(
                     success=True,
@@ -1931,7 +2016,7 @@ class EventLoopNode(NodeProtocol):
                     await conversation.add_user_message(f"[Judge feedback]: {fb}")
                 continue
 
-        # 7. Max iterations exhausted
+        # 7. Max iterations exhausted (falls through from the for loop)
         await self._publish_loop_completed(
             stream_id, node_id, self._config.max_iterations, execution_id
         )
@@ -1953,6 +2038,8 @@ class EventLoopNode(NodeProtocol):
                 retry_count=_retry_count,
                 escalate_count=_escalate_count,
                 continue_count=_continue_count,
+                paid_tool_calls_used=paid_calls_used,
+                budget_blocked_calls=budget_blocked_calls,
             )
         return NodeResult(
             success=False,
@@ -2107,6 +2194,7 @@ class EventLoopNode(NodeProtocol):
         tools: list[Tool],
         iteration: int,
         accumulator: OutputAccumulator,
+        paid_budget_remaining: int = -1,
     ) -> tuple[
         str,
         list[dict],
@@ -2120,12 +2208,15 @@ class EventLoopNode(NodeProtocol):
         str,
         list[dict[str, Any]],
         bool,
+        int,
+        int,
     ]:
         """Run a single LLM turn with streaming and tool execution.
 
         Returns (assistant_text, real_tool_results, outputs_set, token_counts, logged_tool_calls,
         user_input_requested, ask_user_prompt, ask_user_options, queen_input_requested,
-        system_prompt, messages, reported_to_parent).
+        system_prompt, messages, reported_to_parent, paid_calls_this_turn,
+        budget_blocked_this_turn).
 
         ``real_tool_results`` contains only results from actual tools (web_search,
         etc.), NOT from synthetic framework tools such as ``set_output``,
@@ -2158,6 +2249,10 @@ class EventLoopNode(NodeProtocol):
         ask_user_options: list[str] | None = None
         queen_input_requested = False
         reported_to_parent = False
+        # Economic mode: count paid tool calls made this turn.
+        paid_calls_this_turn: int = 0
+        # Economic mode: accumulate budget-blocked calls across all inner iterations.
+        _total_blocked_this_turn: int = 0
         # Accumulate ALL tool calls across inner iterations for L3 logging.
         # Unlike real_tool_results (reset each inner iteration), this persists.
         logged_tool_calls: list[dict] = []
@@ -2206,6 +2301,21 @@ class EventLoopNode(NodeProtocol):
             tool_calls: list[ToolCallEvent] = []
             _stream_error: StreamErrorEvent | None = None
 
+            # Economic mode: hide paid tools from the LLM when budget is exhausted
+            # so it cannot attempt to call them (stronger than error-result fallback).
+            if paid_budget_remaining == 0:
+                _visible_tools = [t for t in tools if not t.is_paid]
+                _hidden = [t.name for t in tools if t.is_paid]
+                if _hidden:
+                    logger.info(
+                        "[%s] Economic mode: paid budget exhausted — hiding %s from LLM; "
+                        "free tools still available: %s",
+                        node_id,
+                        _hidden,
+                        [t.name for t in _visible_tools],
+                    )
+            else:
+                _visible_tools = tools
             logger.debug(
                 "[_run_single_turn] inner_turn=%d: Starting LLM stream with %d messages, %d tools",
                 inner_turn,
@@ -2226,7 +2336,7 @@ class EventLoopNode(NodeProtocol):
                 async for event in ctx.llm.stream(
                     messages=_msgs,
                     system=conversation.system_prompt,
-                    tools=tools if tools else None,
+                    tools=_visible_tools if _visible_tools else None,
                     max_tokens=ctx.max_tokens,
                 ):
                     if isinstance(event, TextDeltaEvent):
@@ -2349,6 +2459,8 @@ class EventLoopNode(NodeProtocol):
                     final_system_prompt,
                     final_messages,
                     reported_to_parent,
+                    paid_calls_this_turn,
+                    _total_blocked_this_turn,
                 )
 
             # Execute tool calls — framework tools (set_output, ask_user)
@@ -2368,6 +2480,7 @@ class EventLoopNode(NodeProtocol):
             ] = {}  # tool_use_id -> {start_timestamp, duration_s}
             pending_real: list[ToolCallEvent] = []
             pending_subagent: list[ToolCallEvent] = []
+            budget_blocked: list[ToolCallEvent] = []  # paid calls blocked by economic mode
 
             for tc in tool_calls:
                 tool_call_count += 1
@@ -2699,6 +2812,21 @@ class EventLoopNode(NodeProtocol):
                         )
                         results_by_id[tc.tool_use_id] = result
                     else:
+                        # Economic mode: block paid calls when budget exhausted.
+                        # paid_budget_remaining == -1 means mode is off.
+                        if paid_budget_remaining >= 0:
+                            _paid_tool_names = {t.name for t in tools if t.is_paid}
+                            if tc.tool_name in _paid_tool_names:
+                                # Count paid calls already queued ahead of this one.
+                                _paid_in_batch = sum(
+                                    1 for _t in pending_real
+                                    if _t.tool_name in _paid_tool_names
+                                )
+                                # paid_calls_this_turn: paid calls executed in prior
+                                # inner iterations of this _run_single_turn call.
+                                if paid_calls_this_turn + _paid_in_batch >= paid_budget_remaining:
+                                    budget_blocked.append(tc)
+                                    continue
                         pending_real.append(tc)
 
             # Phase 2a: execute real tools in parallel.
@@ -2753,6 +2881,39 @@ class EventLoopNode(NodeProtocol):
                     else:
                         result = raw
                     results_by_id[tc.tool_use_id] = self._truncate_tool_result(result, tc.tool_name)
+                    # Economic mode: count executed paid tool calls for logging.
+                    _tool_obj = next((t for t in tools if t.name == tc.tool_name), None)
+                    if _tool_obj and _tool_obj.is_paid:
+                        paid_calls_this_turn += 1
+
+            # Phase 2a-eco: return error results for budget-blocked paid calls.
+            if budget_blocked:
+                _paid_names = {t.name for t in tools if t.is_paid}
+                _free_ran = [tc.tool_name for tc in pending_real if tc.tool_name not in _paid_names]
+                logger.info(
+                    "[%s] Economic mode: budget exhausted mid-turn — "
+                    "LLM requested paid tool(s) %s (blocked); "
+                    "free tool(s) that ran in the same turn: %s",
+                    node_id,
+                    [tc.tool_name for tc in budget_blocked],
+                    _free_ran or ["(none)"],
+                )
+            for tc in budget_blocked:
+                results_by_id[tc.tool_use_id] = ToolResult(
+                    tool_use_id=tc.tool_use_id,
+                    content=(
+                        f"Budget exhausted: '{tc.tool_name}' is a paid tool and the paid-call "
+                        f"budget for this run has been reached. "
+                        f"Use a free alternative or let the user know this step could not be completed."
+                    ),
+                    is_error=False,
+                )
+                timing_by_id[tc.tool_use_id] = {
+                    "start_timestamp": datetime.now(UTC).isoformat(),
+                    "duration_s": 0.0,
+                }
+            # Accumulate across inner iterations so the final return reflects all blocks.
+            _total_blocked_this_turn += len(budget_blocked)
 
             # Phase 2b: execute subagent delegations in parallel.
             if pending_subagent:
@@ -2925,6 +3086,10 @@ class EventLoopNode(NodeProtocol):
 
             # Phase 3: record results into conversation in original order,
             # build logged/real lists, and publish completed events.
+            # Budget-blocked calls are informational only — exclude them from
+            # real_tool_results so the implicit judge does not treat them as
+            # real work and issue a spurious RETRY.
+            _budget_blocked_ids = {tc.tool_use_id for tc in budget_blocked}
             for tc in tool_calls[:executed_in_batch]:
                 result = results_by_id.get(tc.tool_use_id)
                 if result is None:
@@ -2939,15 +3104,20 @@ class EventLoopNode(NodeProtocol):
                     "delegate_to_sub_agent",
                     "report_to_parent",
                 ):
+                    _tool_obj_phase3 = next((t for t in tools if t.name == tc.tool_name), None)
                     tool_entry = {
                         "tool_use_id": tc.tool_use_id,
                         "tool_name": tc.tool_name,
                         "tool_input": tc.tool_input,
                         "content": result.content,
                         "is_error": result.is_error,
+                        "is_paid": _tool_obj_phase3.is_paid if _tool_obj_phase3 else False,
                         **timing_by_id.get(tc.tool_use_id, {}),
                     }
-                    real_tool_results.append(tool_entry)
+                    # Budget-blocked calls go to log only; real_tool_results is
+                    # used by the implicit judge to decide whether to RETRY.
+                    if tc.tool_use_id not in _budget_blocked_ids:
+                        real_tool_results.append(tool_entry)
                     logged_tool_calls.append(tool_entry)
 
                 image_content = result.image_content
@@ -3057,6 +3227,8 @@ class EventLoopNode(NodeProtocol):
                     final_system_prompt,
                     final_messages,
                     reported_to_parent,
+                    paid_calls_this_turn,
+                    _total_blocked_this_turn,
                 )
 
             # --- Mid-turn pruning: prevent context blowup within a single turn ---
@@ -3091,6 +3263,8 @@ class EventLoopNode(NodeProtocol):
                     final_system_prompt,
                     final_messages,
                     reported_to_parent,
+                    paid_calls_this_turn,
+                    _total_blocked_this_turn,
                 )
 
             # Tool calls processed -- loop back to stream with updated conversation
@@ -3463,11 +3637,13 @@ class EventLoopNode(NodeProtocol):
         recent_responses: list[str] | None = None,
         recent_tool_fingerprints: list[list[tuple[str, str]]] | None = None,
         pending_input: dict[str, Any] | None = None,
+        paid_calls_used: int | None = None,
     ) -> None:
         """Write checkpoint cursor for crash recovery.
 
-        Persists iteration counter, accumulator outputs, and stall/doom-loop
-        detection state so that resume picks up exactly where execution stopped.
+        Persists iteration counter, accumulator outputs, stall/doom-loop
+        detection state, and economic-mode paid-call counter so that resume
+        picks up exactly where execution stopped.
         """
         return await write_cursor(
             conversation_store=self._conversation_store,
@@ -3478,6 +3654,7 @@ class EventLoopNode(NodeProtocol):
             recent_responses=recent_responses,
             recent_tool_fingerprints=recent_tool_fingerprints,
             pending_input=pending_input,
+            paid_calls_used=paid_calls_used,
         )
 
     async def _drain_injection_queue(self, conversation: NodeConversation, ctx: NodeContext) -> int:

--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -669,6 +669,70 @@ class GraphExecutor:
 
         steps = 0  # noqa: F841
 
+        # Fresh shared-session execution: clear stale cursor so the entry
+        # node doesn't restore a filled OutputAccumulator from the previous
+        # webhook run (which would cause the judge to accept immediately).
+        # The conversation history is preserved (continuous memory).
+        # Exclude cold restores — those need to continue the conversation
+        # naturally without a "start fresh" marker.
+        _is_fresh_shared = bool(
+            session_state
+            and session_state.get("resume_session_id")
+            and not session_state.get("paused_at")
+            and not session_state.get("resume_from_checkpoint")
+            and not session_state.get("cold_restore")
+            and not session_state.get("resume_from")  # exclude resurrection (failure recovery)
+        )
+        if _is_fresh_shared and is_continuous and self._storage_path:
+            try:
+                from framework.storage.conversation_store import FileConversationStore
+
+                entry_conv_path = self._storage_path / "conversations"
+                if entry_conv_path.exists():
+                    _store = FileConversationStore(base_path=entry_conv_path)
+
+                    # Read cursor to find next seq for the transition marker.
+                    _cursor = await _store.read_cursor() or {}
+                    _next_seq = _cursor.get("next_seq", 0)
+                    if _next_seq == 0:
+                        # Fallback: scan part files for max seq
+                        _parts = await _store.read_parts()
+                        if _parts:
+                            _next_seq = max(p.get("seq", 0) for p in _parts) + 1
+
+                    # Reset cursor — clears stale accumulator outputs and
+                    # iteration counter so the node starts fresh work while
+                    # the conversation thread carries forward.
+                    await _store.write_cursor({})
+
+                    # Append a transition marker so the LLM knows a new
+                    # event arrived and previous results are outdated.
+                    await _store.write_part(
+                        _next_seq,
+                        {
+                            "role": "user",
+                            "content": (
+                                "--- NEW EVENT TRIGGER ---\n"
+                                "A new event has been received. "
+                                "Process this as a fresh request — "
+                                "previous outputs are no longer valid."
+                            ),
+                            "seq": _next_seq,
+                            "is_transition_marker": True,
+                        },
+                    )
+                    self.logger.info(
+                        "🔄 Cleared stale cursor and added transition marker "
+                        "for shared-session entry node '%s'",
+                        current_node_id,
+                    )
+            except Exception:
+                self.logger.debug(
+                    "Could not prepare conversation store for shared-session entry node '%s'",
+                    current_node_id,
+                    exc_info=True,
+                )
+
         if session_state and current_node_id != graph.entry_node:
             self.logger.info(f"🔄 Resuming from: {current_node_id}")
 
@@ -690,6 +754,7 @@ class GraphExecutor:
         if self.runtime_logger:
             session_id = self._get_runtime_log_session_id()
             self.runtime_logger.start_run(goal_id=goal.id, session_id=session_id)
+            self.runtime_logger.set_node_budget(self._loop_config.get("max_paid_calls_per_node", -1))
 
         self.logger.info(f"🚀 Starting execution: {goal.name}")
         self.logger.info(f"   Goal: {goal.description}")
@@ -814,6 +879,7 @@ class GraphExecutor:
                     max_tool_result_chars=lc.get("max_tool_result_chars", 30_000),
                     spillover_dir=spillover,
                     hooks=lc.get("hooks", {}),
+                    max_paid_calls_per_node=lc.get("max_paid_calls_per_node", -1),
                 ),
                 tool_executor=self.tool_executor,
                 conversation_store=conv_store,

--- a/core/framework/llm/provider.py
+++ b/core/framework/llm/provider.py
@@ -27,6 +27,10 @@ class Tool:
     name: str
     description: str
     parameters: dict[str, Any] = field(default_factory=dict)
+    # Economic mode: marks tools that make paid external API calls.
+    # Set by tool authors via MCP annotations or directly on Tool(..., is_paid=True).
+    # Never sent to the LLM API — purely internal to the framework.
+    is_paid: bool = False
 
 
 @dataclass

--- a/core/framework/runner/cli.py
+++ b/core/framework/runner/cli.py
@@ -76,6 +76,14 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         default=None,
         help="Resume from a specific checkpoint (requires --resume-session)",
     )
+    run_parser.add_argument(
+        "--node-budget",
+        type=int,
+        default=None,
+        metavar="N",
+        dest="node_budget",
+        help="Economic mode: maximum number of paid tool calls allowed per node",
+    )
     run_parser.set_defaults(func=cmd_run)
 
     # info command
@@ -393,6 +401,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         runner = AgentRunner.load(
             args.agent_path,
             model=args.model,
+            node_budget=getattr(args, "node_budget", None),
         )
     except CredentialError as e:
         print(f"\n{e}", file=sys.stderr)

--- a/core/framework/runner/mcp_client.py
+++ b/core/framework/runner/mcp_client.py
@@ -49,6 +49,7 @@ class MCPTool:
     description: str
     input_schema: dict[str, Any]
     server_name: str
+    annotations: Any = None  # ToolAnnotations or dict from MCP server
 
 
 class MCPClient:
@@ -373,6 +374,7 @@ class MCPClient:
                     description=tool_data.get("description", ""),
                     input_schema=tool_data.get("inputSchema", {}),
                     server_name=self.config.name,
+                    annotations=tool_data.get("annotations"),
                 )
                 self._tools[tool.name] = tool
 
@@ -400,6 +402,7 @@ class MCPClient:
                     "name": tool.name,
                     "description": tool.description,
                     "inputSchema": tool.inputSchema,
+                    "annotations": getattr(tool, "annotations", None),
                 }
             )
 

--- a/core/framework/runner/runner.py
+++ b/core/framework/runner/runner.py
@@ -1025,6 +1025,7 @@ class AgentRunner:
         configure_for_account: Callable | None = None,
         list_accounts: Callable | None = None,
         credential_store: Any | None = None,
+        node_budget: int | None = None,
     ):
         """
         Initialize the runner (use AgentRunner.load() instead).
@@ -1053,6 +1054,9 @@ class AgentRunner:
         self.model = model or self._resolve_default_model()
         self.intro_message = intro_message
         self.runtime_config = runtime_config
+        # Economic mode: max paid tool calls per node (None = disabled).
+        if node_budget is not None and node_budget >= 0:
+            self.graph.loop_config["max_paid_calls_per_node"] = node_budget
         self._interactive = interactive
         self.skip_credential_validation = skip_credential_validation
         self.requires_account_selection = requires_account_selection
@@ -1158,6 +1162,7 @@ class AgentRunner:
         interactive: bool = True,
         skip_credential_validation: bool | None = None,
         credential_store: Any | None = None,
+        node_budget: int | None = None,
     ) -> "AgentRunner":
         """
         Load an agent from an export folder.
@@ -1293,6 +1298,7 @@ class AgentRunner:
                 configure_for_account=configure_fn,
                 list_accounts=list_accts_fn,
                 credential_store=credential_store,
+                node_budget=node_budget,
             )
             # Stash skill config for use in _setup()
             runner._agent_default_skills = agent_default_skills
@@ -1328,6 +1334,7 @@ class AgentRunner:
             interactive=interactive,
             skip_credential_validation=skip_credential_validation or False,
             credential_store=credential_store,
+            node_budget=node_budget,
         )
         runner._agent_default_skills = None
         runner._agent_skills = None

--- a/core/framework/runner/tool_registry.py
+++ b/core/framework/runner/tool_registry.py
@@ -808,6 +808,19 @@ class ToolRegistry:
         properties = {k: v for k, v in properties.items() if k not in self.CONTEXT_PARAMS}
         required = [r for r in required if r not in self.CONTEXT_PARAMS]
 
+        # Read is_paid from MCP tool annotations (set by tool authors via
+        # @mcp.tool(annotations={"is_paid": True})).
+        # ToolAnnotations is a Pydantic model with extra="allow", so is_paid is
+        # preserved as an attribute but .get() doesn't exist on Pydantic models.
+        _annotations = getattr(mcp_tool, "annotations", None)
+        if _annotations is None:
+            _is_paid = False
+        elif isinstance(_annotations, dict):
+            _is_paid = bool(_annotations.get("is_paid", False))
+        else:
+            # Pydantic model (ToolAnnotations with extra="allow")
+            _is_paid = bool(getattr(_annotations, "is_paid", False))
+
         # Convert to framework Tool format
         tool = Tool(
             name=mcp_tool.name,
@@ -817,6 +830,7 @@ class ToolRegistry:
                 "properties": properties,
                 "required": required,
             },
+            is_paid=_is_paid,
         )
 
         return tool

--- a/core/framework/runtime/runtime_log_schemas.py
+++ b/core/framework/runtime/runtime_log_schemas.py
@@ -26,6 +26,8 @@ class ToolCallLog(BaseModel):
     is_error: bool = False
     start_timestamp: str = ""  # ISO 8601 timestamp when tool execution started
     duration_s: float = 0.0  # Wall-clock execution time in seconds
+    # Economic mode: True when this tool call counts against the paid budget.
+    is_paid: bool = False
 
 
 class NodeStepLog(BaseModel):
@@ -89,6 +91,9 @@ class NodeDetail(BaseModel):
     retry_count: int = 0
     escalate_count: int = 0
     continue_count: int = 0
+    # Economic mode:
+    paid_tool_calls_used: int = 0
+    budget_blocked_calls: int = 0   # paid calls blocked due to exhausted budget
     needs_attention: bool = False
     attention_reasons: list[str] = Field(default_factory=list)
     # OTel / trace context (from observability; empty if not set):
@@ -120,6 +125,11 @@ class RunSummaryLog(BaseModel):
     started_at: str = ""  # ISO timestamp
     duration_ms: int = 0
     execution_quality: str = ""  # "clean"|"degraded"|"failed"
+    # Economic mode:
+    economic_mode: bool = False       # True when --node-budget was set
+    node_budget: int = 0              # max_paid_calls_per_node for this run
+    total_paid_tool_calls: int = 0    # sum across all nodes
+    budget_blocked_calls: int = 0     # paid calls blocked (returned error) due to exhausted budget
     # OTel / trace context (from observability; empty if not set):
     trace_id: str = ""
     execution_id: str = ""

--- a/core/framework/runtime/runtime_logger.py
+++ b/core/framework/runtime/runtime_logger.py
@@ -52,6 +52,7 @@ class RuntimeLogger:
         self._started_at = ""
         self._logged_node_ids: set[str] = set()
         self._lock = threading.Lock()
+        self._node_budget: int = -1  # -1 = economic mode off
 
     def start_run(self, goal_id: str = "", session_id: str = "") -> str:
         """Start a new run. Called by GraphExecutor at graph start. Returns run_id.
@@ -76,7 +77,12 @@ class RuntimeLogger:
         self._goal_id = goal_id
         self._started_at = datetime.now(UTC).isoformat()
         self._logged_node_ids = set()
+        self._node_budget = -1
         return self._run_id
+
+    def set_node_budget(self, node_budget: int) -> None:
+        """Record the per-node paid tool call budget for this run (-1 = off)."""
+        self._node_budget = node_budget
 
     def log_step(
         self,
@@ -117,6 +123,7 @@ class RuntimeLogger:
                     is_error=tc.get("is_error", False),
                     start_timestamp=tc.get("start_timestamp", ""),
                     duration_s=tc.get("duration_s", 0.0),
+                    is_paid=tc.get("is_paid", False),
                 )
             )
 
@@ -168,6 +175,8 @@ class RuntimeLogger:
         retry_count: int = 0,
         escalate_count: int = 0,
         continue_count: int = 0,
+        paid_tool_calls_used: int = 0,
+        budget_blocked_calls: int = 0,
     ) -> None:
         """Record completion of a node.
 
@@ -224,6 +233,8 @@ class RuntimeLogger:
             retry_count=retry_count,
             escalate_count=escalate_count,
             continue_count=continue_count,
+            paid_tool_calls_used=paid_tool_calls_used,
+            budget_blocked_calls=budget_blocked_calls,
             needs_attention=needs_attention,
             attention_reasons=attention_reasons,
             trace_id=trace_id,
@@ -292,6 +303,11 @@ class RuntimeLogger:
             for nd in node_details:
                 attention_reasons.extend(nd.attention_reasons)
 
+            # Economic mode aggregation
+            total_paid = sum(nd.paid_tool_calls_used for nd in node_details)
+            total_blocked = sum(nd.budget_blocked_calls for nd in node_details)
+            eco_active = self._node_budget >= 0
+
             # OTel / trace context for L1 correlation
             ctx = get_trace_context()
             trace_id = ctx.get("trace_id", "")
@@ -311,6 +327,10 @@ class RuntimeLogger:
                 started_at=self._started_at,
                 duration_ms=duration_ms,
                 execution_quality=execution_quality,
+                economic_mode=eco_active,
+                node_budget=self._node_budget if eco_active else 0,
+                total_paid_tool_calls=total_paid,
+                budget_blocked_calls=total_blocked,
                 trace_id=trace_id,
                 execution_id=execution_id,
             )

--- a/core/tests/test_economic_mode_cli.py
+++ b/core/tests/test_economic_mode_cli.py
@@ -1,0 +1,39 @@
+"""Tests for economic mode --node-budget CLI argument parsing."""
+
+import argparse
+
+from framework.runner import cli as runner_cli
+
+
+def _make_parser() -> argparse.ArgumentParser:
+    """Build a parser that includes the runner subcommands."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    runner_cli.register_commands(subparsers)
+    return parser
+
+
+class TestNodeBudgetArgParsing:
+    """Verify the --node-budget flag is parsed correctly by the CLI."""
+
+    def test_budget_integer_is_parsed(self):
+        parser = _make_parser()
+        args = parser.parse_args(["run", "my-agent", "--node-budget", "5"])
+        assert args.node_budget == 5
+
+    def test_budget_zero_is_parsed(self):
+        """node_budget=0 is a valid value meaning 'block all paid calls'."""
+        parser = _make_parser()
+        args = parser.parse_args(["run", "my-agent", "--node-budget", "0"])
+        assert args.node_budget == 0
+
+    def test_budget_omitted_defaults_to_none(self):
+        """When --node-budget is not passed, budget should be None (mode off)."""
+        parser = _make_parser()
+        args = parser.parse_args(["run", "my-agent"])
+        assert getattr(args, "budget", None) is None
+
+    def test_budget_large_value(self):
+        parser = _make_parser()
+        args = parser.parse_args(["run", "my-agent", "--node-budget", "1000"])
+        assert args.node_budget == 1000

--- a/core/tests/test_economic_mode_executor.py
+++ b/core/tests/test_economic_mode_executor.py
@@ -1,0 +1,257 @@
+"""Tests for economic mode budget propagation through GraphExecutor -> LoopConfig."""
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from framework.graph.event_loop_node import EventLoopNode, LoopConfig
+from framework.graph.executor import GraphExecutor
+from framework.graph.node import DataBuffer, NodeContext, NodeSpec
+from framework.llm.provider import LLMProvider, LLMResponse, Tool
+from framework.llm.stream_events import FinishEvent, TextDeltaEvent, ToolCallEvent
+from framework.runtime.core import Runtime
+
+
+@pytest.fixture
+def runtime():
+    r = MagicMock(spec=Runtime)
+    r.start_run = MagicMock(return_value="test_run_id")
+    r.decide = MagicMock(return_value="test_decision_id")
+    r.record_outcome = MagicMock()
+    r.end_run = MagicMock()
+    r.report_problem = MagicMock()
+    r.set_node = MagicMock()
+    return r
+
+
+def _event_loop_node_spec() -> NodeSpec:
+    return NodeSpec(
+        id="main",
+        name="Main",
+        description="",
+        node_type="event_loop",
+        output_keys=[],
+    )
+
+
+def _capture_loop_config(runtime, loop_config: dict) -> LoopConfig:
+    """
+    Build a GraphExecutor with the given loop_config, call _get_node_implementation
+    for an event_loop node, and return the LoopConfig the EventLoopNode was built with.
+    """
+    captured = {}
+    original_init = EventLoopNode.__init__
+
+    def spy_init(self_node, *args, **kwargs):
+        original_init(self_node, *args, **kwargs)
+        captured["config"] = self_node._config
+
+    executor = GraphExecutor(runtime=runtime, loop_config=loop_config)
+    with patch.object(EventLoopNode, "__init__", spy_init):
+        executor._get_node_implementation(_event_loop_node_spec())
+
+    return captured["config"]
+
+
+class TestExecutorLoopConfigPropagation:
+    """Verify GraphExecutor passes loop_config['max_paid_calls_per_node'] into LoopConfig."""
+
+    def test_budget_propagated_to_loop_config(self, runtime):
+        cfg = _capture_loop_config(runtime, {"max_paid_calls_per_node": 5})
+        assert cfg.max_paid_calls_per_node == 5
+
+    def test_zero_budget_propagated(self, runtime):
+        cfg = _capture_loop_config(runtime, {"max_paid_calls_per_node": 0})
+        assert cfg.max_paid_calls_per_node == 0
+
+    def test_absent_key_defaults_to_minus_one(self, runtime):
+        """When the key is absent, max_paid_calls_per_node must default to -1 (mode off)."""
+        cfg = _capture_loop_config(runtime, {})
+        assert cfg.max_paid_calls_per_node == -1
+
+    def test_other_loop_config_keys_unaffected(self, runtime):
+        """Setting max_paid_calls_per_node should not disturb other LoopConfig fields."""
+        cfg = _capture_loop_config(runtime, {"max_paid_calls_per_node": 3, "max_iterations": 77})
+        assert cfg.max_paid_calls_per_node == 3
+        assert cfg.max_iterations == 77
+
+
+# ===========================================================================
+# Budget blocking: end-to-end EventLoopNode execution tests
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Minimal streaming LLM mock for budget-blocking tests
+# ---------------------------------------------------------------------------
+
+
+class _MockLLM(LLMProvider):
+    """Pre-programmed LLM mock. Each call consumes the next scenario."""
+
+    def __init__(self, scenarios: list[list]) -> None:
+        self.scenarios = scenarios
+        self._call = 0
+        self.calls: list[dict[str, Any]] = []
+
+    async def stream(
+        self,
+        messages: list[dict[str, Any]],
+        system: str = "",
+        tools: list[Tool] | None = None,
+        max_tokens: int = 4096,
+    ) -> AsyncIterator:
+        self.calls.append({"messages": messages, "tools": tools or []})
+        events = self.scenarios[self._call % len(self.scenarios)]
+        self._call += 1
+        for event in events:
+            yield event
+
+    def complete(self, messages: list, system: str = "", **kwargs: Any) -> LLMResponse:
+        return LLMResponse(content="summary", model="mock", stop_reason="stop")
+
+
+def _tc(name: str, inp: dict, uid: str | None = None) -> ToolCallEvent:
+    return ToolCallEvent(tool_use_id=uid or f"id_{name}", tool_name=name, tool_input=inp)
+
+
+def _tool_turn(*events: ToolCallEvent) -> list:
+    return [*events, FinishEvent(stop_reason="tool_calls", input_tokens=10, output_tokens=5, model="mock")]
+
+
+def _text_turn(text: str = "Done.") -> list:
+    return [
+        TextDeltaEvent(content=text, snapshot=text),
+        FinishEvent(stop_reason="stop", input_tokens=10, output_tokens=5, model="mock"),
+    ]
+
+
+def _node_spec(output_keys: list[str] | None = None) -> NodeSpec:
+    return NodeSpec(
+        id="main",
+        name="Main",
+        description="",
+        node_type="event_loop",
+        output_keys=output_keys if output_keys is not None else ["result"],
+    )
+
+
+def _ctx(
+    runtime: MagicMock,
+    spec: NodeSpec,
+    llm: _MockLLM,
+    tools: list[Tool] | None = None,
+    runtime_logger: Any = None,
+) -> NodeContext:
+    return NodeContext(
+        runtime=runtime,
+        node_id=spec.id,
+        node_spec=spec,
+        buffer=DataBuffer(),
+        input_data={},
+        llm=llm,
+        available_tools=tools or [],
+        goal_context="",
+        runtime_logger=runtime_logger,
+    )
+
+
+class TestBudgetBlocking:
+    """Verify that EventLoopNode actually blocks paid calls when the budget is exhausted."""
+
+    @pytest.mark.asyncio
+    async def test_paid_call_blocked_at_zero_budget(self, runtime):
+        """budget=0: paid tool is blocked; node still completes successfully (soft block)."""
+        paid_tool = Tool(name="search", description="Web search", is_paid=True)
+        llm = _MockLLM([
+            # Turn 1 (inner): LLM calls paid tool → gets budget-exhausted error
+            _tool_turn(_tc("search", {"q": "test"}, "ws1")),
+            # Turn 2 (inner): LLM calls set_output after seeing the budget error
+            _tool_turn(_tc("set_output", {"key": "result", "value": "done"}, "so1")),
+            # Turn 3 (inner): text-only → exits _run_single_turn → outer judge accepts
+            _text_turn("All done."),
+        ])
+        spec = _node_spec(["result"])
+        node = EventLoopNode(config=LoopConfig(max_paid_calls_per_node=0, max_iterations=10))
+
+        result = await node.execute(_ctx(runtime, spec, llm, tools=[paid_tool]))
+
+        assert result.success is True
+        assert result.output.get("result") == "done"
+
+    @pytest.mark.asyncio
+    async def test_budget_blocked_calls_reported_to_logger(self, runtime):
+        """budget=0: budget_blocked_calls=1 is passed to runtime_logger.log_node_complete."""
+        paid_tool = Tool(name="search", description="Web search", is_paid=True)
+        llm = _MockLLM([
+            _tool_turn(_tc("search", {"q": "test"}, "ws1")),
+            _tool_turn(_tc("set_output", {"key": "result", "value": "done"}, "so1")),
+            _text_turn("Done."),
+        ])
+        mock_logger = MagicMock()
+        spec = _node_spec(["result"])
+        node = EventLoopNode(config=LoopConfig(max_paid_calls_per_node=0, max_iterations=10))
+
+        result = await node.execute(_ctx(runtime, spec, llm, tools=[paid_tool], runtime_logger=mock_logger))
+
+        assert result.success is True
+        # The success log_node_complete call must carry budget_blocked_calls=1
+        success_calls = [
+            c for c in mock_logger.log_node_complete.call_args_list
+            if c.kwargs.get("success") is True
+        ]
+        assert success_calls, "log_node_complete(success=True) was never called"
+        assert success_calls[-1].kwargs.get("budget_blocked_calls") == 1
+
+    @pytest.mark.asyncio
+    async def test_first_paid_call_allowed_second_blocked_in_batch(self, runtime):
+        """budget=1: when two paid calls arrive in the same LLM turn, the first is
+        allowed (executes with no-executor error) and the second is blocked."""
+        paid_tool = Tool(name="search", description="Web search", is_paid=True)
+        llm = _MockLLM([
+            # Turn 1: two paid calls in the same batch; second should be blocked
+            _tool_turn(
+                _tc("search", {"q": "a"}, "ws1"),
+                _tc("search", {"q": "b"}, "ws2"),
+            ),
+            # Turn 2: set_output (after one search executed, one blocked)
+            _tool_turn(_tc("set_output", {"key": "result", "value": "done"}, "so1")),
+            _text_turn("Done."),
+        ])
+        mock_logger = MagicMock()
+        spec = _node_spec(["result"])
+        node = EventLoopNode(config=LoopConfig(max_paid_calls_per_node=1, max_iterations=10))
+
+        result = await node.execute(
+            _ctx(runtime, spec, llm, tools=[paid_tool], runtime_logger=mock_logger)
+        )
+
+        assert result.success is True
+        success_calls = [
+            c for c in mock_logger.log_node_complete.call_args_list
+            if c.kwargs.get("success") is True
+        ]
+        assert success_calls, "log_node_complete(success=True) was never called"
+        last = success_calls[-1].kwargs
+        assert last.get("paid_tool_calls_used") == 1   # first search executed
+        assert last.get("budget_blocked_calls") == 1   # second search blocked
+
+    @pytest.mark.asyncio
+    async def test_paid_tool_hidden_from_llm_stream_when_budget_zero(self, runtime):
+        """budget=0: the paid tool must NOT appear in the tools list sent to the LLM."""
+        paid_tool = Tool(name="search", description="Web search", is_paid=True)
+        free_tool = Tool(name="calculator", description="Free tool", is_paid=False)
+        # Node with no output_keys so it accepts on first text response
+        spec = _node_spec([])
+        llm = _MockLLM([_text_turn("No search needed.")])
+        node = EventLoopNode(config=LoopConfig(max_paid_calls_per_node=0, max_iterations=5))
+
+        result = await node.execute(_ctx(runtime, spec, llm, tools=[paid_tool, free_tool]))
+
+        assert result.success is True
+        # The framework-visible tools in the first LLM stream call must not include the paid tool.
+        first_call_tool_names = {t.name for t in llm.calls[0]["tools"]}
+        assert "search" not in first_call_tool_names, "Paid tool must be hidden when budget=0"
+        assert "calculator" in first_call_tool_names, "Free tool must remain visible"

--- a/core/tests/test_economic_mode_runner.py
+++ b/core/tests/test_economic_mode_runner.py
@@ -1,0 +1,70 @@
+"""Tests for economic mode budget propagation through AgentRunner.__init__."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from framework.graph.edge import GraphSpec
+from framework.graph.goal import Goal
+from framework.graph.node import NodeSpec
+from framework.runner.runner import AgentRunner
+
+
+def _make_graph(loop_config: dict | None = None) -> GraphSpec:
+    node_spec = NodeSpec(
+        id="main",
+        name="Main",
+        description="",
+        node_type="event_loop",
+        output_keys=[],
+    )
+    return GraphSpec(
+        id="test-graph",
+        goal_id="test-goal",
+        entry_node="main",
+        terminal_nodes=["main"],
+        nodes=[node_spec],
+        edges=[],
+        loop_config=loop_config or {},
+    )
+
+
+def _make_runner(node_budget: int | None, graph: GraphSpec | None = None) -> AgentRunner:
+    """Build a minimal AgentRunner, bypassing preload validation."""
+    if graph is None:
+        graph = _make_graph()
+    goal = Goal(id="test-goal", name="Test Goal", description="")
+    with patch("framework.runner.runner.run_preload_validation"):
+        return AgentRunner(
+            agent_path=Path("/tmp/fake-agent"),
+            graph=graph,
+            goal=goal,
+            skip_credential_validation=True,
+            node_budget=node_budget,
+        )
+
+
+class TestAgentRunnerBudgetPropagation:
+    """Verify that AgentRunner propagates node_budget into graph.loop_config."""
+
+    def test_budget_is_set_in_loop_config(self):
+        runner = _make_runner(node_budget=7)
+        assert runner.graph.loop_config["max_paid_calls_per_node"] == 7
+
+    def test_zero_budget_is_set_in_loop_config(self):
+        """node_budget=0 is valid (block all paid calls) and must not be silently ignored."""
+        runner = _make_runner(node_budget=0)
+        assert runner.graph.loop_config["max_paid_calls_per_node"] == 0
+
+    def test_none_budget_does_not_set_loop_config(self):
+        """When node_budget is None, loop_config should not contain the key."""
+        runner = _make_runner(node_budget=None)
+        assert "max_paid_calls_per_node" not in runner.graph.loop_config
+
+    def test_existing_loop_config_is_preserved(self):
+        """Setting node_budget should not wipe other loop_config entries."""
+        graph = _make_graph(loop_config={"max_iterations": 42})
+        runner = _make_runner(node_budget=3, graph=graph)
+        assert runner.graph.loop_config["max_paid_calls_per_node"] == 3
+        assert runner.graph.loop_config["max_iterations"] == 42

--- a/core/tests/test_event_loop_node.py
+++ b/core/tests/test_event_loop_node.py
@@ -2502,3 +2502,454 @@ class TestSubagentAccumulatorMemory:
         # Should return None (not raise PermissionError)
         assert scoped.read("tweet_content") is None
         assert scoped.read("user_request") == "hi"
+
+
+# ===========================================================================
+# Economic mode
+# ===========================================================================
+
+
+class TestEconomicMode:
+    """Tests for max_paid_calls_per_node budget enforcement."""
+
+    def _make_tool_executor(self, results: dict[str, str] | None = None):
+        """Return a tool executor that maps tool_name -> content."""
+        results = results or {}
+
+        def executor(tool_use: ToolUse) -> ToolResult:
+            content = results.get(tool_use.name, f"result from {tool_use.name}")
+            return ToolResult(tool_use_id=tool_use.id, content=content)
+
+        return executor
+
+    @pytest.mark.asyncio
+    async def test_budget_not_exhausted_when_within_limit(self, runtime, node_spec, memory):
+        """A single paid call within budget should succeed normally."""
+        node_spec.output_keys = []
+        paid_tool = Tool(name="web_search", description="Search the web", parameters={}, is_paid=True)
+
+        llm = MockStreamingLLM(
+            scenarios=[
+                tool_call_scenario("web_search", {"query": "hello"}, tool_use_id="c1"),
+                text_scenario("Done"),
+            ]
+        )
+        ctx = build_ctx(runtime, node_spec, memory, llm, tools=[paid_tool])
+        node = EventLoopNode(
+            tool_executor=self._make_tool_executor(),
+            config=LoopConfig(max_iterations=10, max_paid_calls_per_node=3),
+        )
+        result = await node.execute(ctx)
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_budget_exhausted_returns_error_to_llm(self, runtime, node_spec, memory):
+        """When budget is hit, over-budget paid calls return an error result to the LLM
+        so it can adapt gracefully — the run does not abort."""
+        node_spec.output_keys = []
+        paid_tool = Tool(name="exa_search", description="Paid search", parameters={}, is_paid=True)
+
+        # LLM calls paid tool 3 times; budget is 2, so the 3rd gets an error result.
+        # The LLM then receives that error and produces a final text response.
+        llm = MockStreamingLLM(
+            scenarios=[
+                tool_call_scenario("exa_search", {"query": "q1"}, tool_use_id="c1"),
+                tool_call_scenario("exa_search", {"query": "q2"}, tool_use_id="c2"),
+                tool_call_scenario("exa_search", {"query": "q3"}, tool_use_id="c3"),
+                text_scenario("Done with available results"),
+            ]
+        )
+        call_count = {"n": 0}
+        original_executor = self._make_tool_executor()
+
+        def counting_executor(tool_use: ToolUse) -> ToolResult:
+            call_count["n"] += 1
+            return original_executor(tool_use)
+
+        ctx = build_ctx(runtime, node_spec, memory, llm, tools=[paid_tool])
+        node = EventLoopNode(
+            tool_executor=counting_executor,
+            config=LoopConfig(max_iterations=10, max_paid_calls_per_node=2),
+        )
+        result = await node.execute(ctx)
+        # Run continues — not a hard failure
+        assert result.success is True
+        # Only 2 paid calls were actually dispatched; the 3rd was blocked
+        assert call_count["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_free_tools_do_not_count_against_budget(self, runtime, node_spec, memory):
+        """Calls to free tools (is_paid=False) should not consume budget."""
+        node_spec.output_keys = []
+        free_tool = Tool(name="list_files", description="List local files", parameters={}, is_paid=False)
+        paid_tool = Tool(name="exa_search", description="Paid search", parameters={}, is_paid=True)
+
+        # Many free calls, then one paid call — should succeed with budget=1
+        llm = MockStreamingLLM(
+            scenarios=[
+                tool_call_scenario("list_files", {}, tool_use_id="c1"),
+                tool_call_scenario("list_files", {}, tool_use_id="c2"),
+                tool_call_scenario("list_files", {}, tool_use_id="c3"),
+                tool_call_scenario("exa_search", {"query": "q"}, tool_use_id="c4"),
+                text_scenario("Done"),
+            ]
+        )
+        ctx = build_ctx(runtime, node_spec, memory, llm, tools=[free_tool, paid_tool])
+        node = EventLoopNode(
+            tool_executor=self._make_tool_executor(),
+            config=LoopConfig(max_iterations=10, max_paid_calls_per_node=1),
+        )
+        result = await node.execute(ctx)
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_economic_mode_off_by_default(self, runtime, node_spec, memory):
+        """max_paid_calls_per_node=-1 (default) means no budget limit."""
+        node_spec.output_keys = []
+        paid_tool = Tool(name="stripe_charge", description="Charge a card", parameters={}, is_paid=True)
+
+        # Many paid calls — should all succeed when mode is off
+        llm = MockStreamingLLM(
+            scenarios=[
+                tool_call_scenario("stripe_charge", {"amount": 100}, tool_use_id="c1"),
+                tool_call_scenario("stripe_charge", {"amount": 200}, tool_use_id="c2"),
+                tool_call_scenario("stripe_charge", {"amount": 300}, tool_use_id="c3"),
+                text_scenario("Done"),
+            ]
+        )
+        ctx = build_ctx(runtime, node_spec, memory, llm, tools=[paid_tool])
+        node = EventLoopNode(
+            tool_executor=self._make_tool_executor(),
+            config=LoopConfig(max_iterations=10, max_paid_calls_per_node=-1),
+        )
+        result = await node.execute(ctx)
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_zero_budget_blocks_all_paid_calls(self, runtime, node_spec, memory):
+        """max_paid_calls_per_node=0 blocks every paid call — none are dispatched,
+        each returns an error result so the LLM can adapt and continue."""
+        node_spec.output_keys = []
+        paid_tool = Tool(name="exa_search", description="Paid search", parameters={}, is_paid=True)
+
+        # LLM tries a paid call, receives an error result, then produces a final text.
+        llm = MockStreamingLLM(
+            scenarios=[
+                tool_call_scenario("exa_search", {"query": "q1"}, tool_use_id="c1"),
+                text_scenario("Done without paid tools"),
+            ]
+        )
+        call_count = {"n": 0}
+        original_executor = self._make_tool_executor()
+
+        def counting_executor(tool_use: ToolUse) -> ToolResult:
+            call_count["n"] += 1
+            return original_executor(tool_use)
+
+        ctx = build_ctx(runtime, node_spec, memory, llm, tools=[paid_tool])
+        node = EventLoopNode(
+            tool_executor=counting_executor,
+            config=LoopConfig(max_iterations=10, max_paid_calls_per_node=0),
+        )
+        result = await node.execute(ctx)
+        # No paid calls were dispatched to the real executor
+        assert call_count["n"] == 0
+        # Run continues — LLM received the error result and produced a response
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_economic_block_injected_in_system_prompt(self, runtime, node_spec, memory):
+        """System prompt should contain the ## Economic Mode block when mode is active."""
+        node_spec.output_keys = []
+        paid_tool = Tool(name="web_search", description="Search", parameters={}, is_paid=True)
+
+        llm = MockStreamingLLM(scenarios=[text_scenario("Done")])
+        ctx = build_ctx(runtime, node_spec, memory, llm, tools=[paid_tool])
+        node = EventLoopNode(
+            tool_executor=self._make_tool_executor(),
+            config=LoopConfig(max_iterations=5, max_paid_calls_per_node=3),
+        )
+        await node.execute(ctx)
+
+        # The system prompt sent to the LLM should contain the economic block
+        assert llm.stream_calls, "LLM should have been called"
+        first_system = llm.stream_calls[0]["system"]
+        assert "## Economic Mode" in first_system
+        assert "web_search" in first_system
+        assert "3" in first_system
+
+    @pytest.mark.asyncio
+    async def test_no_economic_block_when_mode_off(self, runtime, node_spec, memory):
+        """System prompt should NOT contain the economic block when mode is off."""
+        node_spec.output_keys = []
+        paid_tool = Tool(name="web_search", description="Search", parameters={}, is_paid=True)
+
+        llm = MockStreamingLLM(scenarios=[text_scenario("Done")])
+        ctx = build_ctx(runtime, node_spec, memory, llm, tools=[paid_tool])
+        node = EventLoopNode(
+            tool_executor=self._make_tool_executor(),
+            config=LoopConfig(max_iterations=5, max_paid_calls_per_node=-1),
+        )
+        await node.execute(ctx)
+
+        first_system = llm.stream_calls[0]["system"]
+        assert "## Economic Mode" not in first_system
+
+    @pytest.mark.asyncio
+    async def test_blocked_call_error_content(self, runtime, node_spec, memory):
+        """The error result returned to the LLM for a blocked call must mention 'budget'
+        and 'paid', so the LLM understands why the tool call failed."""
+        node_spec.output_keys = []
+        paid_tool = Tool(name="search", description="Search", parameters={}, is_paid=True)
+
+        # budget=0 so every paid call is blocked; LLM sees the error and finishes.
+        llm = MockStreamingLLM(
+            scenarios=[
+                tool_call_scenario("search", {"q": "1"}, tool_use_id="c1"),
+                text_scenario("Done"),
+            ]
+        )
+        # Capture what the LLM receives as tool results via stream_calls inspection.
+        ctx = build_ctx(runtime, node_spec, memory, llm, tools=[paid_tool])
+        node = EventLoopNode(
+            tool_executor=self._make_tool_executor(),
+            config=LoopConfig(max_iterations=10, max_paid_calls_per_node=0),
+        )
+        await node.execute(ctx)
+
+        # The second stream call should include the error tool result in messages.
+        assert len(llm.stream_calls) >= 2
+        second_messages = llm.stream_calls[1]["messages"]
+        # Collect content from tool-role messages (OpenAI format).
+        tool_result_contents = [
+            msg.get("content", "")
+            for msg in second_messages
+            if msg.get("role") == "tool"
+        ]
+        assert any("budget" in c.lower() for c in tool_result_contents), (
+            f"Expected 'budget' in tool result content, got: {tool_result_contents}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_paid_tools_hidden_from_llm_when_budget_exhausted(
+        self, runtime, node_spec, memory
+    ):
+        """When budget is 0, paid tools must not appear in the tool list sent to the LLM,
+        preventing hallucinated retries entirely."""
+        node_spec.output_keys = []
+        free_tool = Tool(name="web_scrape", description="Scrape a URL", parameters={}, is_paid=False)
+        paid_tool = Tool(name="web_search", description="Paid search", parameters={}, is_paid=True)
+
+        llm = MockStreamingLLM(scenarios=[text_scenario("Done")])
+        ctx = build_ctx(runtime, node_spec, memory, llm, tools=[free_tool, paid_tool])
+        node = EventLoopNode(
+            tool_executor=self._make_tool_executor(),
+            config=LoopConfig(max_iterations=5, max_paid_calls_per_node=0),
+        )
+        await node.execute(ctx)
+
+        # The LLM should only have seen the free tool
+        assert llm.stream_calls, "LLM should have been called"
+        visible_tool_names = [t.name for t in (llm.stream_calls[0]["tools"] or [])]
+        assert "web_scrape" in visible_tool_names
+        assert "web_search" not in visible_tool_names
+
+    @pytest.mark.asyncio
+    async def test_paid_tools_visible_when_budget_remaining(
+        self, runtime, node_spec, memory
+    ):
+        """When budget > 0, paid tools must still appear in the tool list."""
+        node_spec.output_keys = []
+        free_tool = Tool(name="web_scrape", description="Scrape a URL", parameters={}, is_paid=False)
+        paid_tool = Tool(name="web_search", description="Paid search", parameters={}, is_paid=True)
+
+        llm = MockStreamingLLM(scenarios=[text_scenario("Done")])
+        ctx = build_ctx(runtime, node_spec, memory, llm, tools=[free_tool, paid_tool])
+        node = EventLoopNode(
+            tool_executor=self._make_tool_executor(),
+            config=LoopConfig(max_iterations=5, max_paid_calls_per_node=3),
+        )
+        await node.execute(ctx)
+
+        visible_tool_names = [t.name for t in (llm.stream_calls[0]["tools"] or [])]
+        assert "web_scrape" in visible_tool_names
+        assert "web_search" in visible_tool_names
+
+    @pytest.mark.asyncio
+    async def test_tool_hiding_logged_when_budget_zero(
+        self, runtime, node_spec, memory, caplog
+    ):
+        """When budget=0, a log line must name which paid tools are hidden and
+        which free tools remain available as substitutes."""
+        import logging
+
+        node_spec.output_keys = []
+        free_tool = Tool(name="web_scrape", description="Scrape", parameters={}, is_paid=False)
+        paid_tool = Tool(name="web_search", description="Search", parameters={}, is_paid=True)
+
+        llm = MockStreamingLLM(scenarios=[text_scenario("Done")])
+        ctx = build_ctx(runtime, node_spec, memory, llm, tools=[free_tool, paid_tool])
+        node = EventLoopNode(
+            tool_executor=self._make_tool_executor(),
+            config=LoopConfig(max_iterations=5, max_paid_calls_per_node=0),
+        )
+        with caplog.at_level(logging.INFO):
+            await node.execute(ctx)
+
+        hiding_records = [r for r in caplog.records if "paid budget exhausted" in r.message]
+        assert hiding_records, "Expected a 'paid budget exhausted' log line when budget=0"
+        msg = hiding_records[0].message
+        assert "web_search" in msg, "Hidden paid tool should be named in the log"
+        assert "web_scrape" in msg, "Available free tool should be named in the log"
+
+    @pytest.mark.asyncio
+    async def test_mid_turn_blocking_logged_with_free_substitutes(
+        self, runtime, node_spec, memory, caplog
+    ):
+        """When the LLM batches more paid calls than the remaining budget in a single
+        turn, the log must show which paid calls were blocked and which free tools
+        ran in the same batch (the natural substitutes)."""
+        import logging
+
+        node_spec.output_keys = []
+        free_tool = Tool(name="web_scrape", description="Scrape", parameters={}, is_paid=False)
+        paid_tool = Tool(name="web_search", description="Search", parameters={}, is_paid=True)
+
+        # Budget = 1. LLM batches [web_search, web_search, web_scrape] in one turn.
+        # Triage: first web_search runs (uses budget), second is blocked, web_scrape runs.
+        batch_scenario = [
+            ToolCallEvent(tool_use_id="c1", tool_name="web_search", tool_input={"q": "a"}),
+            ToolCallEvent(tool_use_id="c2", tool_name="web_search", tool_input={"q": "b"}),
+            ToolCallEvent(tool_use_id="c3", tool_name="web_scrape", tool_input={"url": "x"}),
+            FinishEvent(stop_reason="tool_calls", input_tokens=10, output_tokens=5, model="mock"),
+        ]
+        llm = MockStreamingLLM(scenarios=[batch_scenario, text_scenario("Done")])
+        ctx = build_ctx(runtime, node_spec, memory, llm, tools=[free_tool, paid_tool])
+        node = EventLoopNode(
+            tool_executor=self._make_tool_executor(),
+            config=LoopConfig(max_iterations=10, max_paid_calls_per_node=1),
+        )
+        with caplog.at_level(logging.INFO):
+            await node.execute(ctx)
+
+        blocking_records = [r for r in caplog.records if "budget exhausted mid-turn" in r.message]
+        assert blocking_records, "Expected a mid-turn blocking log when batch exceeds budget"
+        msg = blocking_records[0].message
+        assert "web_search" in msg, "Blocked paid tool should be named"
+        assert "web_scrape" in msg, "Free tool that ran should be named as substitute"
+
+    @pytest.mark.asyncio
+    async def test_paid_calls_used_persisted_in_cursor(self, tmp_path, runtime, node_spec, memory):
+        """paid_calls_used must survive crash-resume via cursor.
+
+        Seed the conversation store with a cursor that records paid_calls_used=1
+        and a budget of 2.  A fresh EventLoopNode should restore the counter and
+        only allow 1 more paid call — not start over at 0 and allow 2.
+        """
+        node_spec.output_keys = []
+        paid_tool = Tool(name="web_search", description="Search", parameters={}, is_paid=True)
+
+        # Pre-seed store: partial run already used 1 paid call
+        store = FileConversationStore(tmp_path / "conv")
+        conv = NodeConversation(
+            system_prompt="You are a test assistant.",
+            output_keys=[],
+            store=store,
+        )
+        await conv.add_user_message("Research request")
+        await conv.add_assistant_message("Working...")
+        await store.write_cursor(
+            {
+                "iteration": 0,
+                "next_seq": conv.next_seq,
+                "outputs": {},
+                "paid_calls_used": 1,  # already spent 1 of 2
+            }
+        )
+
+        # LLM tries 2 paid calls; with budget=2 and paid_calls_used already=1,
+        # only 1 more should be dispatched.
+        call_count = {"n": 0}
+        original_executor = self._make_tool_executor()
+
+        def counting_executor(tool_use: ToolUse) -> ToolResult:
+            call_count["n"] += 1
+            return original_executor(tool_use)
+
+        llm = MockStreamingLLM(
+            scenarios=[
+                tool_call_scenario("web_search", {"query": "q1"}, tool_use_id="c1"),
+                tool_call_scenario("web_search", {"query": "q2"}, tool_use_id="c2"),
+                text_scenario("Done"),
+            ]
+        )
+        ctx = build_ctx(runtime, node_spec, memory, llm, tools=[paid_tool])
+        node = EventLoopNode(
+            conversation_store=store,
+            tool_executor=counting_executor,
+            config=LoopConfig(max_iterations=10, max_paid_calls_per_node=2),
+        )
+        result = await node.execute(ctx)
+
+        assert result.success is True
+        # Only 1 paid call dispatched (restored paid_calls_used=1, budget=2 → 1 left)
+        assert call_count["n"] == 1, (
+            f"Expected 1 paid call (budget=2, 1 already used), got {call_count['n']}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_budget_blocked_calls_excluded_from_judge_tool_results(
+        self, runtime, node_spec, memory
+    ):
+        """Budget-blocked calls must not appear in real_tool_results.
+
+        When the LLM batches more paid calls than the remaining budget, the
+        over-budget calls are blocked (informational).  A subsequent turn where
+        only blocked calls were attempted must NOT appear in the judge's
+        tool_results as real work — otherwise the implicit judge triggers a
+        spurious RETRY.
+
+        Scenario: budget=1, LLM turn 1 exhausts it with c1, LLM turn 2 tries c2
+        (budget_remaining=0, paid tools hidden, so LLM is forced to text only).
+        We then inject a turn where we can verify the blocked-call path directly
+        by using budget=1, a batch of [c1 (runs), c2 (blocked)], then a text turn.
+        The judge context for the BATCH turn must include c1 but not c2.
+        """
+        node_spec.output_keys = []
+        paid_tool = Tool(name="web_search", description="Search", parameters={}, is_paid=True)
+
+        # Budget=1. LLM batches [c1, c2] in one turn. c1 runs, c2 is blocked.
+        # The inner while loop calls the LLM again after the tool results →
+        # that second inner call produces text 'Done' with no tool calls, and
+        # that empty real_tool_results is what the outer loop sees for the judge.
+        # To verify the blocked-call exclusion directly, we capture what went
+        # into the conversation as tool_result messages: the blocked call must
+        # appear in the conversation (LLM informed about budget exhaustion) but
+        # its entry must carry is_error=False (not a real failure).
+        # We also verify that only 1 executor call is made (c1 runs, c2 does not).
+        call_count = {"n": 0}
+        original = self._make_tool_executor()
+
+        def counting_executor(tool_use: ToolUse) -> ToolResult:
+            call_count["n"] += 1
+            return original(tool_use)
+
+        batch = [
+            ToolCallEvent(tool_use_id="c1", tool_name="web_search", tool_input={"q": "a"}),
+            ToolCallEvent(tool_use_id="c2", tool_name="web_search", tool_input={"q": "b"}),
+            FinishEvent(stop_reason="tool_calls", input_tokens=10, output_tokens=5, model="mock"),
+        ]
+        llm = MockStreamingLLM(scenarios=[batch, text_scenario("Done")])
+
+        ctx = build_ctx(runtime, node_spec, memory, llm, tools=[paid_tool])
+        node = EventLoopNode(
+            tool_executor=counting_executor,
+            config=LoopConfig(max_iterations=5, max_paid_calls_per_node=1),
+        )
+        result = await node.execute(ctx)
+
+        assert result.success is True
+        # c1 ran, c2 was blocked — only 1 real dispatch
+        assert call_count["n"] == 1, (
+            f"Executor called {call_count['n']} time(s); expected 1 (c2 must be budget-blocked)"
+        )

--- a/tools/BUILDING_TOOLS.md
+++ b/tools/BUILDING_TOOLS.md
@@ -277,6 +277,19 @@ The following tools require credentials that are not set:
 Set these environment variables and re-run the agent.
 ```
 
+## Economic Mode — Marking Paid Tools
+
+If your tool makes external API calls that incur a cost (e.g. web search, data enrichment, SMS), mark it with `is_paid: True` in the MCP annotations. This lets the framework enforce `--node-budget` limits at runtime.
+
+```python
+@mcp.tool(annotations={"is_paid": True})
+def web_search(query: str, num_results: int = 10) -> dict:
+    """Search the web. Counts against the node's paid tool budget."""
+    ...
+```
+
+Tools **without** this annotation are treated as free and are never blocked by the budget. Only annotate tools that genuinely cost money per call — the framework uses this to decide what to hide from the LLM when the budget is exhausted.
+
 ## Best Practices
 
 ### Error Handling

--- a/tools/src/aden_tools/tools/apify_tool/apify_tool.py
+++ b/tools/src/aden_tools/tools/apify_tool/apify_tool.py
@@ -80,7 +80,7 @@ def register_tools(
 ) -> None:
     """Register Apify tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def apify_run_actor(
         actor_id: str,
         input_data: dict[str, Any] | None = None,
@@ -143,7 +143,7 @@ def register_tools(
             "started_at": data.get("startedAt", ""),
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def apify_get_run(
         actor_id: str,
         run_id: str,
@@ -180,7 +180,7 @@ def register_tools(
             "usage_usd": usage.get("ACTOR_COMPUTE_UNITS", 0),
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def apify_get_dataset_items(
         dataset_id: str,
         limit: int = 100,
@@ -229,7 +229,7 @@ def register_tools(
             return {"items": items, "count": len(items)}
         return {"items": [items], "count": 1}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def apify_list_actors(
         limit: int = 50,
         offset: int = 0,
@@ -267,7 +267,7 @@ def register_tools(
             )
         return {"actors": actors, "count": len(actors)}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def apify_list_runs(
         actor_id: str = "",
         limit: int = 50,
@@ -308,7 +308,7 @@ def register_tools(
             )
         return {"runs": runs, "count": len(runs)}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def apify_get_kv_store_record(
         store_id: str,
         key: str,

--- a/tools/src/aden_tools/tools/apollo_tool/apollo_tool.py
+++ b/tools/src/aden_tools/tools/apollo_tool/apollo_tool.py
@@ -458,7 +458,7 @@ def register_tools(
 
     # --- Person Enrichment ---
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def apollo_enrich_person(
         email: str | None = None,
         linkedin_url: str | None = None,
@@ -529,7 +529,7 @@ def register_tools(
 
     # --- Company Enrichment ---
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def apollo_enrich_company(domain: str) -> dict:
         """
         Enrich a company by domain.
@@ -562,7 +562,7 @@ def register_tools(
 
     # --- People Search ---
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def apollo_search_people(
         titles: list[str] | None = None,
         seniorities: list[str] | None = None,
@@ -624,7 +624,7 @@ def register_tools(
 
     # --- Person Activities ---
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def apollo_get_person_activities(person_id: str) -> dict:
         """
         Get activity history for a person in Apollo (emails, calls, tasks).
@@ -649,7 +649,7 @@ def register_tools(
 
     # --- Email Accounts ---
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def apollo_list_email_accounts() -> dict:
         """
         List email accounts connected to Apollo for sending sequences.
@@ -669,7 +669,7 @@ def register_tools(
 
     # --- Bulk Enrichment ---
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def apollo_bulk_enrich_people(details_json: str) -> dict:
         """
         Bulk enrich up to 10 people at once by email or domain+name.
@@ -707,7 +707,7 @@ def register_tools(
 
     # --- Company Search ---
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def apollo_search_companies(
         industries: list[str] | None = None,
         employee_counts: list[str] | None = None,

--- a/tools/src/aden_tools/tools/brevo_tool/brevo_tool.py
+++ b/tools/src/aden_tools/tools/brevo_tool/brevo_tool.py
@@ -250,7 +250,7 @@ def register_tools(
             }
         return _BrevoClient(api_key)
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def brevo_send_email(
         to_email: str,
         to_name: str,
@@ -299,7 +299,7 @@ def register_tools(
         except httpx.RequestError as e:
             return {"error": f"Network error: {e}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def brevo_send_sms(
         to: str,
         content: str,
@@ -339,7 +339,7 @@ def register_tools(
         except httpx.RequestError as e:
             return {"error": f"Network error: {e}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def brevo_create_contact(
         email: str,
         first_name: str | None = None,
@@ -385,7 +385,7 @@ def register_tools(
         except httpx.RequestError as e:
             return {"error": f"Network error: {e}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def brevo_get_contact(email: str) -> dict:
         """
         Retrieve a contact from Brevo by email address.
@@ -424,7 +424,7 @@ def register_tools(
         except httpx.RequestError as e:
             return {"error": f"Network error: {e}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def brevo_update_contact(
         email: str,
         first_name: str | None = None,
@@ -466,7 +466,7 @@ def register_tools(
         except httpx.RequestError as e:
             return {"error": f"Network error: {e}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def brevo_list_contacts(
         limit: int = 50,
         offset: int = 0,
@@ -516,7 +516,7 @@ def register_tools(
         except httpx.RequestError as e:
             return {"error": f"Network error: {e}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def brevo_delete_contact(email: str) -> dict:
         """
         Delete a contact from Brevo by email address.
@@ -542,7 +542,7 @@ def register_tools(
         except httpx.RequestError as e:
             return {"error": f"Network error: {e}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def brevo_list_email_campaigns(
         status: str = "",
         limit: int = 50,
@@ -594,7 +594,7 @@ def register_tools(
         except httpx.RequestError as e:
             return {"error": f"Network error: {e}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def brevo_get_email_stats(message_id: str) -> dict:
         """
         Get delivery statistics for a sent transactional email.

--- a/tools/src/aden_tools/tools/cloudinary_tool/cloudinary_tool.py
+++ b/tools/src/aden_tools/tools/cloudinary_tool/cloudinary_tool.py
@@ -82,7 +82,7 @@ def register_tools(
 ) -> None:
     """Register Cloudinary tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def cloudinary_upload(
         file_url: str,
         public_id: str = "",
@@ -133,7 +133,7 @@ def register_tools(
             "created_at": result.get("created_at", ""),
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def cloudinary_list_resources(
         resource_type: str = "image",
         max_results: int = 30,
@@ -178,7 +178,7 @@ def register_tools(
             )
         return {"resources": resources, "count": len(resources)}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def cloudinary_get_resource(
         public_id: str,
         resource_type: str = "image",
@@ -217,7 +217,7 @@ def register_tools(
             "status": data.get("status", ""),
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def cloudinary_delete_resource(
         public_id: str,
         resource_type: str = "image",
@@ -245,7 +245,7 @@ def register_tools(
 
         return {"public_id": public_id, "result": data.get("result", "unknown")}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def cloudinary_search(
         expression: str,
         max_results: int = 30,
@@ -294,7 +294,7 @@ def register_tools(
             "total_count": data.get("total_count", 0),
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def cloudinary_get_usage() -> dict[str, Any]:
         """
         Get current Cloudinary account usage and limits.
@@ -333,7 +333,7 @@ def register_tools(
             "last_updated": data.get("last_updated", ""),
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def cloudinary_rename_resource(
         from_public_id: str,
         to_public_id: str,
@@ -377,7 +377,7 @@ def register_tools(
             "status": "renamed",
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def cloudinary_add_tag(
         tag: str,
         public_ids: str,

--- a/tools/src/aden_tools/tools/exa_search_tool/exa_search_tool.py
+++ b/tools/src/aden_tools/tools/exa_search_tool/exa_search_tool.py
@@ -81,7 +81,7 @@ def register_tools(
 
         return response.json()
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def exa_search(
         query: str,
         num_results: int = 10,
@@ -185,7 +185,7 @@ def register_tools(
         except Exception as e:
             return {"error": f"Exa search failed: {str(e)}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def exa_find_similar(
         url: str,
         num_results: int = 10,
@@ -265,7 +265,7 @@ def register_tools(
         except Exception as e:
             return {"error": f"Exa find similar failed: {str(e)}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def exa_get_contents(
         urls: list[str],
         include_text: bool = True,
@@ -337,7 +337,7 @@ def register_tools(
         except Exception as e:
             return {"error": f"Exa content extraction failed: {str(e)}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def exa_answer(
         query: str,
         include_citations: bool = True,
@@ -401,7 +401,7 @@ def register_tools(
         except Exception as e:
             return {"error": f"Exa answer failed: {str(e)}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def exa_search_news(
         query: str,
         num_results: int = 10,
@@ -484,7 +484,7 @@ def register_tools(
         except Exception as e:
             return {"error": f"Exa news search failed: {str(e)}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def exa_search_papers(
         query: str,
         num_results: int = 10,
@@ -560,7 +560,7 @@ def register_tools(
         except Exception as e:
             return {"error": f"Exa paper search failed: {str(e)}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def exa_search_companies(
         query: str,
         num_results: int = 10,

--- a/tools/src/aden_tools/tools/google_maps_tool/google_maps_tool.py
+++ b/tools/src/aden_tools/tools/google_maps_tool/google_maps_tool.py
@@ -102,7 +102,7 @@ def register_tools(
 
     # ── Tool 1: Geocoding ──────────────────────────────────────────────
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def maps_geocode(
         address: str,
         components: str = "",
@@ -191,7 +191,7 @@ def register_tools(
 
     # ── Tool 2: Reverse Geocoding ──────────────────────────────────────
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def maps_reverse_geocode(
         latitude: float,
         longitude: float,
@@ -277,7 +277,7 @@ def register_tools(
 
     # ── Tool 3: Directions ─────────────────────────────────────────────
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def maps_directions(
         origin: str,
         destination: str,
@@ -407,7 +407,7 @@ def register_tools(
 
     # ── Tool 4: Distance Matrix ────────────────────────────────────────
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def maps_distance_matrix(
         origins: str,
         destinations: str,
@@ -504,7 +504,7 @@ def register_tools(
 
     # ── Tool 5: Place Details ──────────────────────────────────────────
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def maps_place_details(
         place_id: str,
         fields: str = (
@@ -580,7 +580,7 @@ def register_tools(
 
     # ── Tool 6: Place Search ───────────────────────────────────────────
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def maps_place_search(
         query: str,
         location: str = "",

--- a/tools/src/aden_tools/tools/lusha_tool/lusha_tool.py
+++ b/tools/src/aden_tools/tools/lusha_tool/lusha_tool.py
@@ -72,7 +72,7 @@ def _extract_company(c: dict) -> dict:
 def register_tools(mcp: FastMCP, credentials: Any = None) -> None:
     """Register Lusha tools."""
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def lusha_enrich_person(
         first_name: str = "",
         last_name: str = "",
@@ -115,7 +115,7 @@ def register_tools(mcp: FastMCP, credentials: Any = None) -> None:
 
         return _extract_person(data)
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def lusha_enrich_company(
         domain: str = "",
         company_name: str = "",
@@ -147,7 +147,7 @@ def register_tools(mcp: FastMCP, credentials: Any = None) -> None:
 
         return _extract_company(data)
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def lusha_search_contacts(
         seniorities: str = "",
         departments: str = "",
@@ -226,7 +226,7 @@ def register_tools(mcp: FastMCP, credentials: Any = None) -> None:
             ],
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def lusha_search_companies(
         company_names: str = "",
         domains: str = "",
@@ -288,7 +288,7 @@ def register_tools(mcp: FastMCP, credentials: Any = None) -> None:
             "companies": [_extract_company(c) for c in companies],
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def lusha_get_usage() -> dict:
         """Get Lusha API credit usage statistics."""
         headers = _get_headers()
@@ -304,7 +304,7 @@ def register_tools(mcp: FastMCP, credentials: Any = None) -> None:
 
         return data
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def lusha_bulk_enrich_persons(
         details_json: str,
     ) -> dict:
@@ -345,7 +345,7 @@ def register_tools(mcp: FastMCP, credentials: Any = None) -> None:
             results.append(_extract_person(p))
         return {"results": results, "count": len(results)}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def lusha_get_technologies(
         domain: str,
     ) -> dict:
@@ -374,7 +374,7 @@ def register_tools(mcp: FastMCP, credentials: Any = None) -> None:
             "industry": data.get("industry", ""),
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def lusha_search_decision_makers(
         company_domains: str,
         country: str = "",

--- a/tools/src/aden_tools/tools/news_tool/news_tool.py
+++ b/tools/src/aden_tools/tools/news_tool/news_tool.py
@@ -301,7 +301,7 @@ def register_tools(
             "providers": {"primary": primary, "fallback": fallback},
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def news_search(
         query: str,
         from_date: str | None = None,
@@ -359,7 +359,7 @@ def register_tools(
         result["query"] = query
         return result
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def news_headlines(
         category: str,
         country: str,
@@ -410,7 +410,7 @@ def register_tools(
         result["country"] = country
         return result
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def news_by_company(
         company_name: str,
         days_back: int = 7,
@@ -466,7 +466,7 @@ def register_tools(
         result["days_back"] = days_back
         return result
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def news_sentiment(
         query: str,
         from_date: str | None = None,
@@ -521,7 +521,7 @@ def register_tools(
         except Exception as e:
             return {"error": f"News sentiment failed: {e}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def news_latest(
         language: str = "en",
         country: str | None = None,
@@ -595,7 +595,7 @@ def register_tools(
         )
         return result
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def news_by_source(
         sources: str,
         query: str | None = None,
@@ -651,7 +651,7 @@ def register_tools(
             result["query"] = query
         return result
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def news_by_topic(
         topic: str,
         days_back: int = 3,

--- a/tools/src/aden_tools/tools/plaid_tool/plaid_tool.py
+++ b/tools/src/aden_tools/tools/plaid_tool/plaid_tool.py
@@ -79,7 +79,7 @@ def register_tools(
 ) -> None:
     """Register Plaid tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def plaid_get_accounts(access_token: str) -> dict[str, Any]:
         """
         Get all accounts linked to a Plaid Item.
@@ -118,7 +118,7 @@ def register_tools(
             )
         return {"accounts": accounts, "count": len(accounts)}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def plaid_get_balance(access_token: str) -> dict[str, Any]:
         """
         Get real-time balance for all accounts linked to a Plaid Item.
@@ -155,7 +155,7 @@ def register_tools(
             )
         return {"accounts": accounts}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def plaid_sync_transactions(
         access_token: str,
         cursor: str = "",
@@ -214,7 +214,7 @@ def register_tools(
             "has_more": data.get("has_more", False),
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def plaid_get_transactions(
         access_token: str,
         start_date: str,
@@ -275,7 +275,7 @@ def register_tools(
             "total_transactions": data.get("total_transactions", 0),
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def plaid_get_institution(
         institution_id: str,
         country_codes: list[str] | None = None,
@@ -316,7 +316,7 @@ def register_tools(
             "oauth": inst.get("oauth", False),
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def plaid_search_institutions(
         query: str,
         country_codes: list[str] | None = None,

--- a/tools/src/aden_tools/tools/serpapi_tool/serpapi_tool.py
+++ b/tools/src/aden_tools/tools/serpapi_tool/serpapi_tool.py
@@ -193,7 +193,7 @@ def register_tools(
             }
         return _SerpAPIClient(api_key)
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def scholar_search(
         query: str,
         num_results: int = 10,
@@ -282,7 +282,7 @@ def register_tools(
         except Exception as e:
             return {"error": f"Scholar search failed: {e}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def scholar_get_citations(result_id: str) -> dict:
         """
         Get formatted citations for a Google Scholar paper.
@@ -321,7 +321,7 @@ def register_tools(
         except Exception as e:
             return {"error": f"Citation lookup failed: {e}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def scholar_get_author(
         author_id: str,
         num_articles: int = 20,
@@ -400,7 +400,7 @@ def register_tools(
         except Exception as e:
             return {"error": f"Author lookup failed: {e}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def patents_search(
         query: str,
         page: int = 1,
@@ -485,7 +485,7 @@ def register_tools(
         except Exception as e:
             return {"error": f"Patent search failed: {e}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def patents_get_details(patent_id: str) -> dict:
         """
         Get detailed information for a specific patent.
@@ -540,7 +540,7 @@ def register_tools(
         except Exception as e:
             return {"error": f"Patent detail lookup failed: {e}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def scholar_cited_by(
         cites_id: str,
         num_results: int = 10,
@@ -605,7 +605,7 @@ def register_tools(
         except Exception as e:
             return {"error": f"Cited-by lookup failed: {e}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def scholar_search_profiles(
         query: str,
         num_results: int = 10,
@@ -662,7 +662,7 @@ def register_tools(
         except Exception as e:
             return {"error": f"Profile search failed: {e}"}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def serpapi_google_search(
         query: str,
         num_results: int = 10,

--- a/tools/src/aden_tools/tools/twilio_tool/twilio_tool.py
+++ b/tools/src/aden_tools/tools/twilio_tool/twilio_tool.py
@@ -95,7 +95,7 @@ def register_tools(
 ) -> None:
     """Register Twilio tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def twilio_send_sms(
         to: str,
         from_number: str,
@@ -131,7 +131,7 @@ def register_tools(
 
         return _extract_message(data)
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def twilio_send_whatsapp(
         to: str,
         from_number: str,
@@ -173,7 +173,7 @@ def register_tools(
 
         return _extract_message(data)
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def twilio_list_messages(
         to: str = "",
         from_number: str = "",
@@ -208,7 +208,7 @@ def register_tools(
         messages = [_extract_message(m) for m in data.get("messages", [])]
         return {"messages": messages, "count": len(messages)}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def twilio_get_message(message_sid: str) -> dict[str, Any]:
         """
         Get details about a specific Twilio message.
@@ -232,7 +232,7 @@ def register_tools(
 
         return _extract_message(data)
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def twilio_list_phone_numbers() -> dict[str, Any]:
         """
         List phone numbers owned by the Twilio account.
@@ -265,7 +265,7 @@ def register_tools(
             )
         return {"phone_numbers": numbers, "count": len(numbers)}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def twilio_list_calls(
         to: str = "",
         from_number: str = "",
@@ -319,7 +319,7 @@ def register_tools(
             )
         return {"calls": calls, "count": len(calls)}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def twilio_delete_message(message_sid: str) -> dict[str, Any]:
         """
         Delete a message from Twilio.

--- a/tools/src/aden_tools/tools/vision_tool/vision_tool.py
+++ b/tools/src/aden_tools/tools/vision_tool/vision_tool.py
@@ -368,7 +368,7 @@ def register_tools(
             }
         return _VisionClient(api_key)
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def vision_detect_labels(
         image_source: str,
         max_labels: int = 10,
@@ -388,7 +388,7 @@ def register_tools(
             return client
         return client.detect_labels(image_source, min(max(1, max_labels), 100))
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def vision_detect_text(image_source: str) -> dict:
         """
         Extract text from an image (OCR).
@@ -404,7 +404,7 @@ def register_tools(
             return client
         return client.detect_text(image_source)
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def vision_detect_faces(
         image_source: str,
         max_faces: int = 10,
@@ -424,7 +424,7 @@ def register_tools(
             return client
         return client.detect_faces(image_source, min(max(1, max_faces), 100))
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def vision_localize_objects(
         image_source: str,
         max_objects: int = 10,
@@ -444,7 +444,7 @@ def register_tools(
             return client
         return client.localize_objects(image_source, min(max(1, max_objects), 100))
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def vision_detect_logos(
         image_source: str,
         max_logos: int = 5,
@@ -464,7 +464,7 @@ def register_tools(
             return client
         return client.detect_logos(image_source, min(max(1, max_logos), 20))
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def vision_detect_landmarks(
         image_source: str,
         max_landmarks: int = 5,
@@ -484,7 +484,7 @@ def register_tools(
             return client
         return client.detect_landmarks(image_source, min(max(1, max_landmarks), 20))
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def vision_image_properties(image_source: str) -> dict:
         """
         Get image properties including dominant colors and crop hints.
@@ -500,7 +500,7 @@ def register_tools(
             return client
         return client.get_image_properties(image_source)
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def vision_web_detection(image_source: str) -> dict:
         """
         Find similar images and web references for an image.
@@ -516,7 +516,7 @@ def register_tools(
             return client
         return client.web_detection(image_source)
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def vision_safe_search(image_source: str) -> dict:
         """
         Detect inappropriate content in an image.

--- a/tools/src/aden_tools/tools/web_search_tool/web_search_tool.py
+++ b/tools/src/aden_tools/tools/web_search_tool/web_search_tool.py
@@ -152,7 +152,7 @@ def register_tools(
             "brave_api_key": os.getenv("BRAVE_SEARCH_API_KEY"),
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def web_search(
         query: str,
         num_results: int = 10,

--- a/tools/src/aden_tools/tools/youtube_tool/youtube_tool.py
+++ b/tools/src/aden_tools/tools/youtube_tool/youtube_tool.py
@@ -93,7 +93,7 @@ def register_tools(
 ) -> None:
     """Register YouTube Data API tools with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def youtube_search_videos(
         query: str,
         max_results: int = 10,
@@ -170,7 +170,7 @@ def register_tools(
             "total_results": data.get("pageInfo", {}).get("totalResults", 0),
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def youtube_get_video_details(
         video_ids: str,
     ) -> dict[str, Any]:
@@ -229,7 +229,7 @@ def register_tools(
             )
         return {"videos": videos}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def youtube_get_channel(
         channel_id: str = "",
         username: str = "",
@@ -290,7 +290,7 @@ def register_tools(
             .get("uploads", ""),
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def youtube_list_channel_videos(
         channel_id: str,
         max_results: int = 20,
@@ -346,7 +346,7 @@ def register_tools(
             )
         return {"channel_id": channel_id, "videos": videos}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def youtube_get_playlist(
         playlist_id: str,
         max_results: int = 20,
@@ -423,7 +423,7 @@ def register_tools(
             "items": items,
         }
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def youtube_search_channels(
         query: str,
         max_results: int = 10,
@@ -477,7 +477,7 @@ def register_tools(
             )
         return {"query": query, "results": results}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def youtube_get_video_comments(
         video_id: str,
         max_results: int = 20,
@@ -532,7 +532,7 @@ def register_tools(
             )
         return {"video_id": video_id, "comments": comments}
 
-    @mcp.tool()
+    @mcp.tool(annotations={"is_paid": True})
     def youtube_get_video_categories(
         region_code: str = "US",
     ) -> dict[str, Any]:


### PR DESCRIPTION
## Description

Introduces economic mode: a per-node budget cap on paid external API calls.

- CLI: `--node-budget N` flag on `hive run`
- Runner/Executor: propagates `node_budget` through `loop_config` into `LoopConfig`
- EventLoopNode: enforces budget per node — blocks paid tool calls once exhausted, hides paid tools from LLM when budget is zero, accumulates `budget_blocked_calls` across all inner iterations with `_total_blocked_this_turn` fix
- Tool contract: `is_paid` field on `Tool`; MCP annotation wiring in `mcp_client` + `tool_registry` reads `annotations.is_paid` from MCP servers
- Tool authors: 13 aden_tools marked with `@mcp.tool(annotations={"is_paid": True})`
- Observability: `budget_blocked_calls` tracked at node level (`NodeDetail`) and aggregated into run summary (`RunSummaryLog`) via `runtime_logger`
- Tests: 16 new unit tests covering CLI parsing, runner propagation, executor config wiring, and end-to-end budget blocking behaviour

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

#6789 

## Changes Made

- `runner/cli.py` — `--node-budget N` argument
- `runner/runner.py` — propagates `node_budget` into `graph.loop_config`
- `graph/executor.py` — passes `max_paid_calls_per_node` into `LoopConfig`; calls `set_node_budget()` on logger
- `graph/event_loop_node.py` — budget enforcement, tool hiding, `_total_blocked_this_turn` accumulator
- `graph/event_loop/types.py` — `max_paid_calls_per_node: int = -1` on `LoopConfig`
- `graph/event_loop/cursor_persistence.py` — `paid_calls_used` in `RestoredState` and `write_cursor` for crash-resume safety
- `llm/provider.py` — `is_paid: bool = False` on `Tool`
- `runner/mcp_client.py` + `runner/tool_registry.py` — reads `annotations.is_paid` from MCP servers
- 13 aden_tools — `@mcp.tool(annotations={"is_paid": True})` on paid tools
- `runtime/runtime_log_schemas.py` + `runtime/runtime_logger.py` — `budget_blocked_calls` at node and run level

## Testing

- [x] Unit tests pass (`cd core && pytest tests/`) — 16 new tests, 1401 total passing
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed — live run with `--node-budget 1` on `deep_research_agent`: research node used 1 paid call, blocked 2, completed successfully (`paid=1, blocked=2, success=True`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Economic Mode: per-node paid-call budget with enforcement and persisted crash-resume of budget usage
  * Added --node-budget CLI option to configure per-node limits
  * Paid tools can be hidden/blocked when budget is exhausted; blocked calls return budget-aware error results

* **Logging**
  * Runtime logs now record paid-call usage and budget-blocked counts at node and run levels

* **Documentation**
  * Docs updated to describe Economic Mode and paid-tool annotation

* **Tests**
  * New test coverage for CLI, executor, runner, and node budget behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->