### PR TITLE
feat(skills): default skill lifecycle hooks (iteration, completion, phase transition)

### DIFF
--- a/core/framework/graph/context.py
+++ b/core/framework/graph/context.py
@@ -53,6 +53,7 @@ class GraphContext:
     skill_dirs: list[str] = field(default_factory=list)
     context_warn_ratio: float | None = None
     batch_init_nudge: str | None = None
+    lifecycle_hooks: dict[str, list] = field(default_factory=dict)
     dynamic_tools_provider: Any = None
     dynamic_prompt_provider: Any = None
     dynamic_memory_provider: Any = None

--- a/core/framework/graph/event_loop/event_publishing.py
+++ b/core/framework/graph/event_loop/event_publishing.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import time
+from typing import Any
 
 from framework.graph.conversation import NodeConversation
 from framework.graph.event_loop.types import HookContext
@@ -329,6 +330,10 @@ async def run_hooks(
     event: str,
     conversation: NodeConversation,
     trigger: str | None = None,
+    *,
+    shared_memory: Any = None,
+    iteration: int | None = None,
+    node_id: str | None = None,
 ) -> None:
     """Run all registered hooks for *event*, applying their results.
 
@@ -346,6 +351,9 @@ async def run_hooks(
             event=event,
             trigger=trigger,
             system_prompt=conversation.system_prompt,
+            shared_memory=shared_memory,
+            iteration=iteration,
+            node_id=node_id,
         )
         try:
             result = await hook(ctx)

--- a/core/framework/graph/event_loop/types.py
+++ b/core/framework/graph/event_loop/types.py
@@ -107,6 +107,10 @@ class HookContext:
     event: str
     trigger: str | None
     system_prompt: str
+    # Lifecycle hook extensions (DS-9, DS-10, DS-11)
+    shared_memory: Any = None  # SharedMemory instance when available
+    iteration: int | None = None  # Current iteration (iteration_boundary only)
+    node_id: str | None = None  # Node ID (iteration_boundary, node_complete)
 
 
 @dataclass

--- a/core/framework/graph/event_loop_node.py
+++ b/core/framework/graph/event_loop_node.py
@@ -1042,6 +1042,7 @@ class EventLoopNode(NodeProtocol):
                         node_id,
                         iteration,
                     )
+                    await self._fire_completion_hooks(conversation, ctx, node_id)
                     await self._publish_loop_completed(
                         stream_id, node_id, iteration + 1, execution_id
                     )
@@ -1173,6 +1174,7 @@ class EventLoopNode(NodeProtocol):
                         escalate_count=_escalate_count,
                         continue_count=_continue_count,
                     )
+                await self._fire_completion_hooks(conversation, ctx, node_id)
                 return NodeResult(
                     success=False,
                     error=(
@@ -1265,6 +1267,15 @@ class EventLoopNode(NodeProtocol):
                 recent_responses=recent_responses,
                 recent_tool_fingerprints=recent_tool_fingerprints,
                 pending_input=None,
+            )
+
+            # 6g2. Fire iteration_boundary hooks (DS-9)
+            await self._run_hooks(
+                "iteration_boundary",
+                conversation,
+                shared_memory=ctx.buffer,
+                iteration=iteration,
+                node_id=node_id,
             )
 
             # 6h. Worker auto-escalation on text-only turns
@@ -1824,6 +1835,7 @@ class EventLoopNode(NodeProtocol):
                 for key, value in accumulator.to_dict().items():
                     ctx.buffer.write(key, value, validate=False)
 
+                await self._fire_completion_hooks(conversation, ctx, node_id)
                 await self._publish_loop_completed(stream_id, node_id, iteration + 1, execution_id)
                 latency_ms = int((time.time() - start_time) * 1000)
                 _accept_count += 1
@@ -1867,6 +1879,7 @@ class EventLoopNode(NodeProtocol):
 
             elif verdict.action == "ESCALATE":
                 # Exit point 6: Judge ESCALATE — log step + log_node_complete
+                await self._fire_completion_hooks(conversation, ctx, node_id)
                 await self._publish_loop_completed(stream_id, node_id, iteration + 1, execution_id)
                 latency_ms = int((time.time() - start_time) * 1000)
                 _escalate_count += 1
@@ -1932,6 +1945,7 @@ class EventLoopNode(NodeProtocol):
                 continue
 
         # 7. Max iterations exhausted
+        await self._fire_completion_hooks(conversation, ctx, node_id)
         await self._publish_loop_completed(
             stream_id, node_id, self._config.max_iterations, execution_id
         )
@@ -3557,6 +3571,10 @@ class EventLoopNode(NodeProtocol):
         event: str,
         conversation: NodeConversation,
         trigger: str | None = None,
+        *,
+        shared_memory: Any = None,
+        iteration: int | None = None,
+        node_id: str | None = None,
     ) -> None:
         """Run all registered hooks for *event*, applying their results.
 
@@ -3571,6 +3589,28 @@ class EventLoopNode(NodeProtocol):
             event=event,
             conversation=conversation,
             trigger=trigger,
+            shared_memory=shared_memory,
+            iteration=iteration,
+            node_id=node_id,
+        )
+
+    async def _fire_completion_hooks(
+        self,
+        conversation: NodeConversation,
+        ctx: NodeContext,
+        node_id: str,
+    ) -> None:
+        """Fire node_complete hooks (DS-10).
+
+        Called at all semantic exit points: ACCEPT, ESCALATE, max-iterations,
+        empty-response fast-accept, and stall-detection failure.
+        Not called on mechanical aborts (pause, LLM crash, shutdown).
+        """
+        await self._run_hooks(
+            "node_complete",
+            conversation,
+            shared_memory=ctx.buffer,
+            node_id=node_id,
         )
 
     async def _publish_context_usage(

--- a/core/framework/graph/executor.py
+++ b/core/framework/graph/executor.py
@@ -112,6 +112,42 @@ class ParallelExecutionConfig:
     branch_timeout_seconds: float = 300.0
 
 
+async def _run_phase_transition_hooks(
+    hooks: dict[str, list],
+    shared_memory: DataBuffer,
+    from_node: str,
+    to_node: str,
+) -> None:
+    """Fire phase_transition hooks after edge traversal (DS-11).
+
+    Unlike EventLoopNode's run_hooks(), this runs without a conversation
+    object — hooks can only read/write shared memory and log.  HookResult
+    inject/system_prompt fields are ignored.
+    """
+    from framework.graph.event_loop.types import HookContext
+
+    hook_list = hooks.get("phase_transition", [])
+    if not hook_list:
+        return
+    for hook in hook_list:
+        ctx = HookContext(
+            event="phase_transition",
+            trigger=None,
+            system_prompt="",
+            shared_memory=shared_memory,
+            node_id=from_node,
+        )
+        try:
+            await hook(ctx)
+        except Exception:
+            logger.warning(
+                "Phase transition hook raised an exception (from=%s to=%s)",
+                from_node,
+                to_node,
+                exc_info=True,
+            )
+
+
 class GraphExecutor:
     """
     Executes agent graphs.
@@ -164,6 +200,7 @@ class GraphExecutor:
         colony_worker_sessions_dir: Any = None,
         colony_recall_cache: dict[str, str] | None = None,
         colony_reflect_llm: Any = None,
+        lifecycle_hooks: dict[str, list] | None = None,
     ):
         """
         Initialize the executor.
@@ -196,6 +233,7 @@ class GraphExecutor:
             skill_dirs: Skill base directories for Tier 3 resource access
             context_warn_ratio: Token usage ratio to trigger DS-13 preservation warning
             batch_init_nudge: System prompt nudge for DS-12 batch auto-detection
+            lifecycle_hooks: Precomputed default skill lifecycle hooks (DS-9/10/11)
         """
         self.runtime = runtime
         self.llm = llm
@@ -236,6 +274,7 @@ class GraphExecutor:
         self.colony_worker_sessions_dir = colony_worker_sessions_dir
         self.colony_recall_cache = colony_recall_cache or {}
         self.colony_reflect_llm = colony_reflect_llm
+        self._lifecycle_hooks: dict[str, list] = lifecycle_hooks or {}
 
         if protocols_prompt:
             self.logger.info(
@@ -738,6 +777,20 @@ class GraphExecutor:
         "human_input": "event_loop",  # Use queen interaction / escalation instead
     }
 
+    def _merged_hooks(self, user_hooks: dict[str, list]) -> dict[str, list]:
+        """Merge user-provided hooks with default skill lifecycle hooks.
+
+        Per-event lists are concatenated — user hooks run first, then
+        lifecycle hooks.  Returns a new dict (neither input is mutated).
+        """
+        if not self._lifecycle_hooks:
+            return user_hooks
+        merged: dict[str, list] = {}
+        all_keys = set(user_hooks) | set(self._lifecycle_hooks)
+        for key in all_keys:
+            merged[key] = user_hooks.get(key, []) + self._lifecycle_hooks.get(key, [])
+        return merged
+
     def _get_node_implementation(
         self, node_spec: NodeSpec, cleanup_llm_model: str | None = None
     ) -> NodeProtocol:
@@ -813,7 +866,7 @@ class GraphExecutor:
                     max_context_tokens=lc.get("max_context_tokens", _default_max_context_tokens()),
                     max_tool_result_chars=lc.get("max_tool_result_chars", 30_000),
                     spillover_dir=spillover,
-                    hooks=lc.get("hooks", {}),
+                    hooks=self._merged_hooks(lc.get("hooks", {})),
                 ),
                 tool_executor=self.tool_executor,
                 conversation_store=conv_store,
@@ -1339,6 +1392,7 @@ class GraphExecutor:
             skill_dirs=self.skill_dirs,
             context_warn_ratio=self.context_warn_ratio,
             batch_init_nudge=self.batch_init_nudge,
+            lifecycle_hooks=self._merged_hooks(self._loop_config.get("hooks", {})),
             dynamic_tools_provider=self.dynamic_tools_provider,
             dynamic_prompt_provider=self.dynamic_prompt_provider,
             dynamic_memory_provider=self.dynamic_memory_provider,

--- a/core/framework/graph/worker_agent.py
+++ b/core/framework/graph/worker_agent.py
@@ -521,6 +521,18 @@ class WorkerAgent:
                 f" (fan-out: {[a.target_id for a in activations]})" if is_fan_out else "",
             )
 
+        # Fire phase transition hooks (DS-11) for each edge traversal
+        if activations and gc.lifecycle_hooks:
+            from framework.graph.executor import _run_phase_transition_hooks
+
+            for activation in activations:
+                await _run_phase_transition_hooks(
+                    gc.lifecycle_hooks,
+                    gc.buffer,
+                    self.node_spec.id,
+                    activation.target_id,
+                )
+
         return activations
 
     # ------------------------------------------------------------------

--- a/core/framework/runtime/agent_runtime.py
+++ b/core/framework/runtime/agent_runtime.py
@@ -206,6 +206,7 @@ class AgentRuntime:
         self.skill_dirs: list[str] = self._skills_manager.allowlisted_dirs
         self.context_warn_ratio: float | None = self._skills_manager.context_warn_ratio
         self.batch_init_nudge: str | None = self._skills_manager.batch_init_nudge
+        self.lifecycle_hooks: dict[str, list] = self._skills_manager.lifecycle_hooks
 
         # Primary graph identity
         self._graph_id: str = graph_id or "primary"
@@ -373,6 +374,7 @@ class AgentRuntime:
                     colony_worker_sessions_dir=self._colony_worker_sessions_dir,
                     colony_recall_cache=self._colony_recall_cache,
                     colony_reflect_llm=self._colony_reflect_llm,
+                    lifecycle_hooks=self.lifecycle_hooks,
                 )
                 await stream.start()
                 self._streams[ep_id] = stream

--- a/core/framework/runtime/execution_stream.py
+++ b/core/framework/runtime/execution_stream.py
@@ -196,6 +196,7 @@ class ExecutionStream:
         colony_worker_sessions_dir: Any = None,
         colony_recall_cache: dict[str, str] | None = None,
         colony_reflect_llm: Any = None,
+        lifecycle_hooks: dict[str, list] | None = None,
     ):
         """
         Initialize execution stream.
@@ -255,6 +256,7 @@ class ExecutionStream:
         self._colony_worker_sessions_dir = colony_worker_sessions_dir
         self._colony_recall_cache = colony_recall_cache
         self._colony_reflect_llm = colony_reflect_llm
+        self._lifecycle_hooks: dict[str, list] = lifecycle_hooks or {}
 
         _es_logger = logging.getLogger(__name__)
         if protocols_prompt:
@@ -739,6 +741,7 @@ class ExecutionStream:
                         colony_worker_sessions_dir=self._colony_worker_sessions_dir,
                         colony_recall_cache=self._colony_recall_cache,
                         colony_reflect_llm=self._colony_reflect_llm,
+                        lifecycle_hooks=self._lifecycle_hooks,
                     )
                     # Track executor so inject_input() can reach EventLoopNode instances
                     self._active_executors[execution_id] = executor

--- a/core/framework/skills/defaults.py
+++ b/core/framework/skills/defaults.py
@@ -89,6 +89,7 @@ DATA_BUFFER_KEYS: list[str] = [
     "_batch_total",
     "_batch_completed",
     "_batch_failed",
+    "_batch_skipped",
     # context-preservation
     "_handoff_context",
     "_preserved_data",
@@ -276,3 +277,170 @@ class DefaultSkillManager:
             return None
         overrides = self._config.get_default_overrides("hive.context-preservation")
         return float(overrides.get("warn_at_usage_ratio", 0.45))
+
+    def register_hooks(self, hooks: dict[str, list]) -> None:
+        """Register lifecycle hook callbacks for all active default skills.
+
+        Each enabled skill appends its callbacks to the appropriate event
+        lists in *hooks*.  Callbacks read shared state from
+        ``ctx.shared_memory`` at invocation time — no SharedMemory reference
+        is captured here.
+
+        Args:
+            hooks: Mutable dict mapping event names to lists of async callables.
+                   The caller owns this dict; we only append.
+        """
+        from framework.graph.event_loop.types import HookContext, HookResult
+
+        if not self._skills:
+            return
+
+        def _append(event: str, fn: Any) -> None:
+            hooks.setdefault(event, []).append(fn)
+
+        # -- hive.quality-monitor (DS-9) --
+        if "hive.quality-monitor" in self._skills:
+            overrides = self._config.get_default_overrides("hive.quality-monitor")
+            assessment_interval = int(overrides.get("assessment_interval", 5))
+
+            async def _quality_iteration(ctx: HookContext) -> HookResult | None:
+                if ctx.iteration is None or (ctx.iteration + 1) % assessment_interval != 0:
+                    return None
+                return HookResult(
+                    inject=(
+                        f"[QUALITY CHECK — iteration {ctx.iteration + 1}] Self-assess: "
+                        "Are you on-task, thorough, non-repetitive, and consistent? "
+                        "Write assessment to `_quality_log`."
+                    ),
+                )
+
+            _append("iteration_boundary", _quality_iteration)
+
+        # -- hive.note-taking (DS-9, DS-10) --
+        if "hive.note-taking" in self._skills:
+            overrides = self._config.get_default_overrides("hive.note-taking")
+            staleness_threshold = int(overrides.get("staleness_threshold", 5))
+
+            async def _notes_iteration(ctx: HookContext) -> HookResult | None:
+                if ctx.iteration is None or ctx.shared_memory is None:
+                    return None
+                updated_at = ctx.shared_memory.read("_notes_updated_at")
+                if updated_at is None:
+                    return None
+                try:
+                    stale_iterations = ctx.iteration - int(updated_at)
+                except (TypeError, ValueError):
+                    return None
+                if stale_iterations < staleness_threshold:
+                    return None
+                return HookResult(
+                    inject=(
+                        f"[NOTES STALE — last updated {stale_iterations} iterations ago] "
+                        "Update `_working_notes` with current progress."
+                    ),
+                )
+
+            async def _notes_complete(ctx: HookContext) -> HookResult | None:
+                if ctx.shared_memory is None:
+                    return None
+                notes = ctx.shared_memory.read("_working_notes")
+                if notes:
+                    logger.info(
+                        "skill_hook event=node_complete skill=hive.note-taking "
+                        "node=%s notes_length=%d",
+                        ctx.node_id or "unknown",
+                        len(str(notes)),
+                    )
+                return None
+
+            _append("iteration_boundary", _notes_iteration)
+            _append("node_complete", _notes_complete)
+
+        # -- hive.batch-ledger (DS-9, DS-10) --
+        if "hive.batch-ledger" in self._skills:
+            overrides = self._config.get_default_overrides("hive.batch-ledger")
+            checkpoint_every_n = int(overrides.get("checkpoint_every_n", 10))
+
+            async def _batch_iteration(ctx: HookContext) -> HookResult | None:
+                if ctx.iteration is None or (ctx.iteration + 1) % checkpoint_every_n != 0:
+                    return None
+                if ctx.shared_memory is None:
+                    return None
+                total = ctx.shared_memory.read("_batch_total")
+                if total is None:
+                    return None
+                completed = ctx.shared_memory.read("_batch_completed") or 0
+                failed = ctx.shared_memory.read("_batch_failed") or 0
+                skipped = ctx.shared_memory.read("_batch_skipped") or 0
+                remaining = total - completed - failed - skipped
+                logger.info(
+                    "skill_hook event=iteration_boundary skill=hive.batch-ledger "
+                    "checkpoint total=%s completed=%s failed=%s skipped=%s remaining=%s",
+                    total,
+                    completed,
+                    failed,
+                    skipped,
+                    remaining,
+                )
+                return None
+
+            async def _batch_complete(ctx: HookContext) -> HookResult | None:
+                if ctx.shared_memory is None:
+                    return None
+                total = ctx.shared_memory.read("_batch_total")
+                if total is None:
+                    return None
+                completed = ctx.shared_memory.read("_batch_completed") or 0
+                failed = ctx.shared_memory.read("_batch_failed") or 0
+                skipped = ctx.shared_memory.read("_batch_skipped") or 0
+                processed = completed + failed + skipped
+                if processed < total:
+                    logger.warning(
+                        "skill_hook event=node_complete skill=hive.batch-ledger "
+                        "INCOMPLETE node=%s processed=%d/%d "
+                        "(completed=%d failed=%d skipped=%d)",
+                        ctx.node_id or "unknown",
+                        processed,
+                        total,
+                        completed,
+                        failed,
+                        skipped,
+                    )
+                return None
+
+            _append("iteration_boundary", _batch_iteration)
+            _append("node_complete", _batch_complete)
+
+        # -- hive.context-preservation (DS-10, DS-11) --
+        if "hive.context-preservation" in self._skills:
+            overrides = self._config.get_default_overrides("hive.context-preservation")
+            require_handoff = bool(overrides.get("require_handoff", True))
+
+            async def _context_complete(ctx: HookContext) -> HookResult | None:
+                if not require_handoff or ctx.shared_memory is None:
+                    return None
+                handoff = ctx.shared_memory.read("_handoff_context")
+                if not handoff:
+                    logger.warning(
+                        "skill_hook event=node_complete skill=hive.context-preservation "
+                        "MISSING_HANDOFF node=%s require_handoff=True",
+                        ctx.node_id or "unknown",
+                    )
+                return None
+
+            async def _context_transition(ctx: HookContext) -> HookResult | None:
+                if ctx.shared_memory is None:
+                    return None
+                handoff = ctx.shared_memory.read("_handoff_context")
+                if handoff:
+                    logger.info(
+                        "skill_hook event=phase_transition "
+                        "skill=hive.context-preservation "
+                        "handoff_available node=%s handoff_length=%d",
+                        ctx.node_id or "unknown",
+                        len(str(handoff)),
+                    )
+                return None
+
+            _append("node_complete", _context_complete)
+            _append("phase_transition", _context_transition)

--- a/core/framework/skills/manager.py
+++ b/core/framework/skills/manager.py
@@ -207,5 +207,18 @@ class SkillsManager:
         return self._default_mgr.context_warn_ratio  # type: ignore[union-attr]
 
     @property
+    def lifecycle_hooks(self) -> dict[str, list]:
+        """Precomputed lifecycle hook callbacks for default skills (DS-9/10/11).
+
+        Returns a dict suitable for merging into LoopConfig.hooks.
+        Empty dict if skills are not loaded or all defaults disabled.
+        """
+        if self._default_mgr is None:
+            return {}
+        hooks: dict[str, list] = {}
+        self._default_mgr.register_hooks(hooks)  # type: ignore[union-attr]
+        return hooks
+
+    @property
     def is_loaded(self) -> bool:
         return self._loaded

--- a/core/tests/test_default_skill_hooks.py
+++ b/core/tests/test_default_skill_hooks.py
@@ -1,0 +1,662 @@
+"""Tests for default skill lifecycle hooks (DS-9, DS-10, DS-11)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from framework.graph.event_loop.event_publishing import run_hooks
+from framework.graph.event_loop.types import HookContext, HookResult
+from framework.graph.executor import _run_phase_transition_hooks
+from framework.graph.node import DataBuffer
+from framework.skills.config import DefaultSkillConfig, SkillsConfig
+from framework.skills.defaults import DATA_BUFFER_KEYS, SKILL_REGISTRY, DefaultSkillManager
+from framework.skills.manager import SkillsManager
+
+
+class TestHookContextExtension:
+    """HookContext supports new optional fields for lifecycle hooks."""
+
+    def test_new_fields_default_to_none(self):
+        ctx = HookContext(event="session_start", trigger=None, system_prompt="test")
+        assert ctx.shared_memory is None
+        assert ctx.iteration is None
+        assert ctx.node_id is None
+
+    def test_new_fields_populated(self):
+        memory = MagicMock()
+        ctx = HookContext(
+            event="iteration_boundary",
+            trigger=None,
+            system_prompt="test",
+            shared_memory=memory,
+            iteration=5,
+            node_id="worker-1",
+        )
+        assert ctx.shared_memory is memory
+        assert ctx.iteration == 5
+        assert ctx.node_id == "worker-1"
+
+
+class TestRunHooksExtended:
+    """run_hooks() passes new HookContext fields to callbacks."""
+
+    def _make_conversation(self):
+        conv = MagicMock()
+        conv.system_prompt = "test prompt"
+        conv.update_system_prompt = MagicMock()
+        conv.add_user_message = AsyncMock()
+        return conv
+
+    def test_hooks_receive_shared_memory_and_iteration(self):
+        received = {}
+
+        async def capture_hook(ctx: HookContext) -> HookResult | None:
+            received["shared_memory"] = ctx.shared_memory
+            received["iteration"] = ctx.iteration
+            received["node_id"] = ctx.node_id
+            return None
+
+        memory = MagicMock()
+        hooks = {"iteration_boundary": [capture_hook]}
+        asyncio.get_event_loop().run_until_complete(
+            run_hooks(
+                hooks,
+                "iteration_boundary",
+                self._make_conversation(),
+                shared_memory=memory,
+                iteration=3,
+                node_id="worker-1",
+            )
+        )
+        assert received["shared_memory"] is memory
+        assert received["iteration"] == 3
+        assert received["node_id"] == "worker-1"
+
+    def test_hooks_without_new_fields_still_work(self):
+        """Existing callers passing no new fields still work (backward compat)."""
+        called = []
+
+        async def simple_hook(ctx: HookContext) -> HookResult | None:
+            called.append(ctx.event)
+            assert ctx.shared_memory is None
+            assert ctx.iteration is None
+            assert ctx.node_id is None
+            return None
+
+        hooks = {"session_start": [simple_hook]}
+        asyncio.get_event_loop().run_until_complete(
+            run_hooks(hooks, "session_start", self._make_conversation())
+        )
+        assert called == ["session_start"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_manager(**skill_overrides: dict) -> DefaultSkillManager:
+    """Create a loaded manager with optional per-skill config overrides."""
+    configs: dict[str, DefaultSkillConfig] = {}
+    for name, overrides in skill_overrides.items():
+        configs[name] = DefaultSkillConfig.from_dict(overrides)
+    config = SkillsConfig(default_skills=configs)
+    mgr = DefaultSkillManager(config=config)
+    mgr.load()
+    return mgr
+
+
+def _solo_manager(skill_name: str, overrides: dict | None = None) -> DefaultSkillManager:
+    """Manager with only *skill_name* enabled; all others disabled."""
+    all_configs: dict[str, dict] = {}
+
+    for name in SKILL_REGISTRY:
+        if name == skill_name:
+            all_configs[name] = overrides or {}
+        else:
+            all_configs[name] = {"enabled": False}
+    return _make_manager(**all_configs)
+
+
+# ---------------------------------------------------------------------------
+# register_hooks structure tests
+# ---------------------------------------------------------------------------
+
+
+class TestBatchSkippedKey:
+    def test_batch_skipped_in_shared_memory_keys(self):
+        assert "_batch_skipped" in DATA_BUFFER_KEYS
+
+
+class TestRegisterHooks:
+    """DefaultSkillManager.register_hooks() registers per-skill callbacks."""
+
+    def test_registers_iteration_boundary_hooks(self):
+        mgr = _make_manager()
+        hooks: dict[str, list] = {}
+        mgr.register_hooks(hooks)
+        # quality-monitor, note-taking, batch-ledger → 3 iteration hooks
+        assert len(hooks.get("iteration_boundary", [])) == 3
+
+    def test_registers_node_complete_hooks(self):
+        mgr = _make_manager()
+        hooks: dict[str, list] = {}
+        mgr.register_hooks(hooks)
+        # note-taking, batch-ledger, context-preservation → 3 complete hooks
+        assert len(hooks.get("node_complete", [])) == 3
+
+    def test_registers_phase_transition_hooks(self):
+        mgr = _make_manager()
+        hooks: dict[str, list] = {}
+        mgr.register_hooks(hooks)
+        # context-preservation → 1 transition hook
+        assert len(hooks.get("phase_transition", [])) == 1
+
+    def test_disabled_skill_no_hooks(self):
+        mgr = _make_manager(**{"hive.quality-monitor": {"enabled": False}})
+        hooks: dict[str, list] = {}
+        mgr.register_hooks(hooks)
+        # Only note-taking + batch-ledger → 2 iteration hooks
+        assert len(hooks.get("iteration_boundary", [])) == 2
+
+    def test_all_disabled_no_hooks(self):
+        config = SkillsConfig(all_defaults_disabled=True)
+        mgr = DefaultSkillManager(config=config)
+        mgr.load()
+        hooks: dict[str, list] = {}
+        mgr.register_hooks(hooks)
+        assert hooks == {}
+
+
+# ---------------------------------------------------------------------------
+# Per-skill callback tests
+# ---------------------------------------------------------------------------
+
+
+class TestQualityMonitorHook:
+    """hive.quality-monitor iteration_boundary fires every N iterations."""
+
+    def _get_hooks(self, assessment_interval: int = 5) -> list:
+        mgr = _solo_manager("hive.quality-monitor", {"assessment_interval": assessment_interval})
+        hooks: dict[str, list] = {}
+        mgr.register_hooks(hooks)
+        return hooks.get("iteration_boundary", [])
+
+    def test_fires_at_interval(self):
+        hooks = self._get_hooks(assessment_interval=3)
+        hook = hooks[0]
+        results = []
+        for i in range(9):
+            ctx = HookContext(
+                event="iteration_boundary",
+                trigger=None,
+                system_prompt="test",
+                iteration=i,
+            )
+            result = asyncio.get_event_loop().run_until_complete(hook(ctx))
+            results.append(result)
+        # Fires at iterations 2, 5, 8 (0-indexed: (i+1) % 3 == 0)
+        assert results[2] is not None
+        assert results[5] is not None
+        assert results[8] is not None
+        assert results[0] is None
+        assert results[1] is None
+        assert results[3] is None
+
+    def test_uses_default_assessment_interval_from_skill_defaults(self):
+        """When no override is set, _SKILL_DEFAULTS assessment_interval=5 is used."""
+        mgr = _solo_manager("hive.quality-monitor")  # no overrides
+        hooks: dict[str, list] = {}
+        mgr.register_hooks(hooks)
+        hook = hooks["iteration_boundary"][0]
+        # iteration 3 → (3+1)%5 != 0 → no fire
+        ctx = HookContext(event="iteration_boundary", trigger=None, system_prompt="t", iteration=3)
+        assert asyncio.get_event_loop().run_until_complete(hook(ctx)) is None
+        # iteration 4 → (4+1)%5 == 0 → fires
+        ctx = HookContext(event="iteration_boundary", trigger=None, system_prompt="t", iteration=4)
+        result = asyncio.get_event_loop().run_until_complete(hook(ctx))
+        assert result is not None
+        assert "QUALITY CHECK" in result.inject
+
+    def test_inject_contains_quality_check(self):
+        hooks = self._get_hooks(assessment_interval=1)
+        hook = hooks[0]
+        ctx = HookContext(
+            event="iteration_boundary",
+            trigger=None,
+            system_prompt="test",
+            iteration=0,
+        )
+        result = asyncio.get_event_loop().run_until_complete(hook(ctx))
+        assert result is not None
+        assert "QUALITY CHECK" in result.inject
+        assert "_quality_log" in result.inject
+
+
+class TestNoteTakingHook:
+    """hive.note-taking hooks: staleness detection + final snapshot."""
+
+    def _get_hooks(self, staleness_threshold: int = 5) -> tuple[list, list]:
+        mgr = _solo_manager("hive.note-taking", {"staleness_threshold": staleness_threshold})
+        hooks: dict[str, list] = {}
+        mgr.register_hooks(hooks)
+        return hooks.get("iteration_boundary", []), hooks.get("node_complete", [])
+
+    def test_no_warning_when_notes_not_initialized(self):
+        iter_hooks, _ = self._get_hooks(staleness_threshold=3)
+        hook = iter_hooks[0]
+        memory = DataBuffer()
+        ctx = HookContext(
+            event="iteration_boundary",
+            trigger=None,
+            system_prompt="test",
+            shared_memory=memory,
+            iteration=10,
+        )
+        result = asyncio.get_event_loop().run_until_complete(hook(ctx))
+        assert result is None
+
+    def test_warning_when_stale(self):
+        iter_hooks, _ = self._get_hooks(staleness_threshold=3)
+        hook = iter_hooks[0]
+        memory = DataBuffer()
+        memory.write("_notes_updated_at", 2, validate=False)
+        ctx = HookContext(
+            event="iteration_boundary",
+            trigger=None,
+            system_prompt="test",
+            shared_memory=memory,
+            iteration=6,
+        )
+        result = asyncio.get_event_loop().run_until_complete(hook(ctx))
+        assert result is not None
+        assert "NOTES STALE" in result.inject
+
+    def test_no_warning_when_fresh(self):
+        iter_hooks, _ = self._get_hooks(staleness_threshold=5)
+        hook = iter_hooks[0]
+        memory = DataBuffer()
+        memory.write("_notes_updated_at", 8, validate=False)
+        ctx = HookContext(
+            event="iteration_boundary",
+            trigger=None,
+            system_prompt="test",
+            shared_memory=memory,
+            iteration=10,
+        )
+        result = asyncio.get_event_loop().run_until_complete(hook(ctx))
+        assert result is None  # Only 2 iterations stale, threshold is 5
+
+    def test_node_complete_logs_notes(self, caplog):
+        _, complete_hooks = self._get_hooks()
+        hook = complete_hooks[0]
+        memory = DataBuffer()
+        memory.write("_working_notes", "## Objective\nDo stuff", validate=False)
+        ctx = HookContext(
+            event="node_complete",
+            trigger=None,
+            system_prompt="test",
+            shared_memory=memory,
+            node_id="worker-1",
+        )
+        with caplog.at_level(logging.INFO):
+            result = asyncio.get_event_loop().run_until_complete(hook(ctx))
+        assert result is None
+        assert "hive.note-taking" in caplog.text
+        assert "notes_length=" in caplog.text
+
+
+class TestBatchLedgerHook:
+    """hive.batch-ledger hooks: checkpoint + completeness check."""
+
+    def _get_hooks(self, checkpoint_every_n: int = 10) -> tuple[list, list]:
+        mgr = _solo_manager("hive.batch-ledger", {"checkpoint_every_n": checkpoint_every_n})
+        hooks: dict[str, list] = {}
+        mgr.register_hooks(hooks)
+        return hooks.get("iteration_boundary", []), hooks.get("node_complete", [])
+
+    def test_checkpoint_skips_when_no_batch(self):
+        iter_hooks, _ = self._get_hooks(checkpoint_every_n=1)
+        hook = iter_hooks[0]
+        memory = DataBuffer()
+        ctx = HookContext(
+            event="iteration_boundary",
+            trigger=None,
+            system_prompt="test",
+            shared_memory=memory,
+            iteration=0,
+        )
+        result = asyncio.get_event_loop().run_until_complete(hook(ctx))
+        assert result is None
+
+    def test_checkpoint_fires_at_interval(self, caplog):
+        iter_hooks, _ = self._get_hooks(checkpoint_every_n=3)
+        hook = iter_hooks[0]
+        memory = DataBuffer()
+        memory.write("_batch_total", 10, validate=False)
+        memory.write("_batch_completed", 3, validate=False)
+        # iteration 2 → (2+1)%3==0 → fires
+        ctx = HookContext(
+            event="iteration_boundary",
+            trigger=None,
+            system_prompt="test",
+            shared_memory=memory,
+            iteration=2,
+        )
+        with caplog.at_level(logging.INFO):
+            result = asyncio.get_event_loop().run_until_complete(hook(ctx))
+        assert result is None  # checkpoint only logs, no inject
+        assert "checkpoint" in caplog.text
+
+    def test_complete_warns_on_incomplete_batch(self, caplog):
+        _, complete_hooks = self._get_hooks()
+        hook = complete_hooks[0]
+        memory = DataBuffer()
+        memory.write("_batch_total", 10, validate=False)
+        memory.write("_batch_completed", 5, validate=False)
+        memory.write("_batch_failed", 1, validate=False)
+        memory.write("_batch_skipped", 0, validate=False)
+        ctx = HookContext(
+            event="node_complete",
+            trigger=None,
+            system_prompt="test",
+            shared_memory=memory,
+            node_id="worker-1",
+        )
+        with caplog.at_level(logging.WARNING):
+            asyncio.get_event_loop().run_until_complete(hook(ctx))
+        assert "INCOMPLETE" in caplog.text
+        assert "6/10" in caplog.text
+
+    def test_complete_silent_when_all_processed(self, caplog):
+        _, complete_hooks = self._get_hooks()
+        hook = complete_hooks[0]
+        memory = DataBuffer()
+        memory.write("_batch_total", 10, validate=False)
+        memory.write("_batch_completed", 8, validate=False)
+        memory.write("_batch_failed", 1, validate=False)
+        memory.write("_batch_skipped", 1, validate=False)
+        ctx = HookContext(
+            event="node_complete",
+            trigger=None,
+            system_prompt="test",
+            shared_memory=memory,
+            node_id="worker-1",
+        )
+        with caplog.at_level(logging.WARNING):
+            asyncio.get_event_loop().run_until_complete(hook(ctx))
+        assert "INCOMPLETE" not in caplog.text
+
+
+class TestContextPreservationHook:
+    """hive.context-preservation: handoff verification + phase transition logging."""
+
+    def _get_hooks(self, require_handoff: bool = True) -> tuple[list, list]:
+        mgr = _solo_manager("hive.context-preservation", {"require_handoff": require_handoff})
+        hooks: dict[str, list] = {}
+        mgr.register_hooks(hooks)
+        return hooks.get("node_complete", []), hooks.get("phase_transition", [])
+
+    def test_default_require_handoff_is_true(self, caplog):
+        """With no override, require_handoff defaults to True per PRD."""
+        mgr = _solo_manager("hive.context-preservation")  # no overrides
+        hooks: dict[str, list] = {}
+        mgr.register_hooks(hooks)
+        hook = hooks["node_complete"][0]
+        memory = DataBuffer()
+        ctx = HookContext(
+            event="node_complete",
+            trigger=None,
+            system_prompt="test",
+            shared_memory=memory,
+            node_id="worker-1",
+        )
+        with caplog.at_level(logging.WARNING):
+            asyncio.get_event_loop().run_until_complete(hook(ctx))
+        assert "MISSING_HANDOFF" in caplog.text
+
+    def test_warns_on_missing_handoff(self, caplog):
+        complete_hooks, _ = self._get_hooks(require_handoff=True)
+        hook = complete_hooks[0]
+        memory = DataBuffer()
+        ctx = HookContext(
+            event="node_complete",
+            trigger=None,
+            system_prompt="test",
+            shared_memory=memory,
+            node_id="worker-1",
+        )
+        with caplog.at_level(logging.WARNING):
+            asyncio.get_event_loop().run_until_complete(hook(ctx))
+        assert "MISSING_HANDOFF" in caplog.text
+
+    def test_no_warning_when_handoff_present(self, caplog):
+        complete_hooks, _ = self._get_hooks(require_handoff=True)
+        hook = complete_hooks[0]
+        memory = DataBuffer()
+        memory.write("_handoff_context", "Summary of work done", validate=False)
+        ctx = HookContext(
+            event="node_complete",
+            trigger=None,
+            system_prompt="test",
+            shared_memory=memory,
+            node_id="worker-1",
+        )
+        with caplog.at_level(logging.WARNING):
+            asyncio.get_event_loop().run_until_complete(hook(ctx))
+        assert "MISSING_HANDOFF" not in caplog.text
+
+    def test_no_warning_when_require_handoff_disabled(self, caplog):
+        complete_hooks, _ = self._get_hooks(require_handoff=False)
+        hook = complete_hooks[0]
+        memory = DataBuffer()
+        ctx = HookContext(
+            event="node_complete",
+            trigger=None,
+            system_prompt="test",
+            shared_memory=memory,
+            node_id="worker-1",
+        )
+        with caplog.at_level(logging.WARNING):
+            asyncio.get_event_loop().run_until_complete(hook(ctx))
+        assert "MISSING_HANDOFF" not in caplog.text
+
+    def test_phase_transition_logs_handoff(self, caplog):
+        _, transition_hooks = self._get_hooks()
+        hook = transition_hooks[0]
+        memory = DataBuffer()
+        memory.write("_handoff_context", "Next node needs this data", validate=False)
+        ctx = HookContext(
+            event="phase_transition",
+            trigger=None,
+            system_prompt="",
+            shared_memory=memory,
+            node_id="worker-1",
+        )
+        with caplog.at_level(logging.INFO):
+            asyncio.get_event_loop().run_until_complete(hook(ctx))
+        assert "handoff_available" in caplog.text
+
+
+class TestHookErrorResilience:
+    """Hook errors are logged but never block execution."""
+
+    def test_broken_hook_does_not_block_others(self):
+        called = []
+
+        async def broken_hook(ctx: HookContext) -> HookResult | None:
+            raise RuntimeError("intentional test error")
+
+        async def good_hook(ctx: HookContext) -> HookResult | None:
+            called.append(True)
+            return None
+
+        hooks = {"iteration_boundary": [broken_hook, good_hook]}
+        conv = MagicMock()
+        conv.system_prompt = "test"
+        asyncio.get_event_loop().run_until_complete(run_hooks(hooks, "iteration_boundary", conv))
+        assert called == [True]
+
+
+# ---------------------------------------------------------------------------
+# SkillsManager facade tests
+# ---------------------------------------------------------------------------
+
+
+class TestSkillsManagerLifecycleHooks:
+    """SkillsManager.lifecycle_hooks property delegates to DefaultSkillManager."""
+
+    def test_lifecycle_hooks_populated(self):
+
+        mgr = SkillsManager()
+        mgr.load()
+        hooks = mgr.lifecycle_hooks
+        assert "iteration_boundary" in hooks
+        assert "node_complete" in hooks
+        assert "phase_transition" in hooks
+
+    def test_lifecycle_hooks_empty_when_not_loaded(self):
+
+        mgr = SkillsManager()
+        # Don't call load()
+        hooks = mgr.lifecycle_hooks
+        assert hooks == {}
+
+
+# ---------------------------------------------------------------------------
+# Phase transition hook runner tests
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseTransitionFanOut:
+    """Phase transition hooks fire on fan-out edge traversals (executor integration)."""
+
+    @pytest.mark.asyncio
+    async def test_phase_transition_fires_for_each_fanout_edge(self):
+        from unittest.mock import MagicMock as _Mock
+
+        from framework.graph.edge import EdgeCondition, EdgeSpec, GraphSpec
+        from framework.graph.executor import GraphExecutor
+        from framework.graph.goal import Goal
+        from framework.graph.node import NodeContext, NodeProtocol, NodeResult, NodeSpec
+        from framework.runtime.core import Runtime
+
+        class _SuccessNode(NodeProtocol):
+            async def execute(self, ctx: NodeContext) -> NodeResult:
+                return NodeResult(success=True, output={"done": True}, tokens_used=1, latency_ms=1)
+
+        source = NodeSpec(
+            id="src",
+            name="Source",
+            description="entry",
+            node_type="event_loop",
+            output_keys=["data"],
+        )
+        b1 = NodeSpec(
+            id="b1",
+            name="B1",
+            description="branch 1",
+            node_type="event_loop",
+            output_keys=["b1_out"],
+        )
+        b2 = NodeSpec(
+            id="b2",
+            name="B2",
+            description="branch 2",
+            node_type="event_loop",
+            output_keys=["b2_out"],
+        )
+        graph = GraphSpec(
+            id="g",
+            goal_id="g1",
+            name="Fanout",
+            entry_node="src",
+            nodes=[source, b1, b2],
+            edges=[
+                EdgeSpec(id="e1", source="src", target="b1", condition=EdgeCondition.ON_SUCCESS),
+                EdgeSpec(id="e2", source="src", target="b2", condition=EdgeCondition.ON_SUCCESS),
+            ],
+            terminal_nodes=["b1", "b2"],
+        )
+
+        # Track phase_transition hook calls
+        transition_calls: list[str] = []
+
+        async def _track(ctx: HookContext) -> HookResult | None:
+            transition_calls.append(ctx.node_id or "?")
+            return None
+
+        rt = _Mock(spec=Runtime)
+        rt.start_run = _Mock(return_value="run_id")
+        rt.decide = _Mock(return_value="d")
+        rt.record_outcome = _Mock()
+        rt.end_run = _Mock()
+        rt.report_problem = _Mock()
+        rt.set_node = _Mock()
+
+        executor = GraphExecutor(
+            runtime=rt,
+            enable_parallel_execution=True,
+            lifecycle_hooks={"phase_transition": [_track]},
+        )
+        executor.register_node("src", _SuccessNode())
+        executor.register_node("b1", _SuccessNode())
+        executor.register_node("b2", _SuccessNode())
+
+        result = await executor.execute(graph, Goal(id="g1", name="T", description="t"), {})
+
+        assert result.success
+        # Phase transition hooks should fire for both fan-out edges (src → b1, src → b2)
+        assert len(transition_calls) == 2
+        assert all(n == "src" for n in transition_calls)
+
+
+class TestPhaseTransitionHookRunner:
+    """Standalone phase transition hook runner for GraphExecutor."""
+
+    def test_fires_phase_transition_hooks(self):
+
+        called = []
+
+        async def track_hook(ctx: HookContext) -> HookResult | None:
+            called.append(
+                {
+                    "event": ctx.event,
+                    "node_id": ctx.node_id,
+                    "shared_memory": ctx.shared_memory,
+                }
+            )
+            return None
+
+        memory = DataBuffer()
+        hooks = {"phase_transition": [track_hook]}
+        asyncio.get_event_loop().run_until_complete(
+            _run_phase_transition_hooks(hooks, memory, "node-a", "node-b")
+        )
+        assert len(called) == 1
+        assert called[0]["event"] == "phase_transition"
+        assert called[0]["node_id"] == "node-a"
+        assert called[0]["shared_memory"] is memory
+
+    def test_error_in_hook_does_not_propagate(self):
+
+        async def broken_hook(ctx: HookContext) -> HookResult | None:
+            raise RuntimeError("boom")
+
+        hooks = {"phase_transition": [broken_hook]}
+        memory = DataBuffer()
+        # Should not raise
+        asyncio.get_event_loop().run_until_complete(
+            _run_phase_transition_hooks(hooks, memory, "a", "b")
+        )
+
+    def test_no_hooks_is_noop(self):
+
+        memory = DataBuffer()
+        asyncio.get_event_loop().run_until_complete(
+            _run_phase_transition_hooks({}, memory, "a", "b")
+        )


### PR DESCRIPTION
## Summary

Implements DS-9, DS-10, DS-11 from the skill registry PRD — closes #6359.

Default skill protocols were previously prompt-only. This PR adds the runtime lifecycle hook infrastructure that lets default skills verify agent behavior at three points: between iterations, at node completion, and on phase transitions.

## What's in this PR

- **Extended `HookContext`** with `shared_memory`, `iteration`, `node_id` (backward-compatible — existing `session_start` hooks unchanged)
- **`iteration_boundary` hook site** in `EventLoopNode.execute()` after all guards, before judge
- **`node_complete` hook site** via centralized `_fire_completion_hooks()` helper, called at all semantic exit paths:
  - Judge ACCEPT
  - Judge ESCALATE
  - Max-iterations exhausted
  - Empty-response fast-accept (all outputs set despite empty LLM turn)
  - Stall-detection failure
- **`phase_transition` hook site** via `_run_phase_transition_hooks()` fired after every `_follow_edges` traversal:
  - Normal sequential edges
  - Visit-limit skip routing
  - ON_FAILURE handler routing
  - Fan-out branches (one fire per branch)
- **`DefaultSkillManager.register_hooks()`** implementing per-skill callbacks:
  - `hive.quality-monitor`: self-assessment nudge every `assessment_interval` iterations
  - `hive.note-taking`: staleness detection (`staleness_threshold`) + final notes log
  - `hive.batch-ledger`: checkpoint logging (`checkpoint_every_n`) + incomplete batch warning
  - `hive.context-preservation`: missing handoff warning (`require_handoff`, default true) + transition log
- **Runtime plumbing**: `lifecycle_hooks` flows through `SkillsManager` → `AgentRuntime` → `ExecutionStream` → `GraphExecutor` as a precomputed dict, merged into `LoopConfig.hooks` for `EventLoopNode` and passed directly to `_run_phase_transition_hooks` for edge traversals
- **`_batch_skipped`** added to `SHARED_MEMORY_KEYS`

Hooks read `ctx.shared_memory` at call time (not via closure capture), which means the hooks dict is created once at startup and reused — no SkillsManager dependency in GraphExecutor.

## Design notes

- **DS-11 is observe/verify, not data-copy.** `SharedMemory` is already a single global instance passed through the executor, so there's no data to carry forward between nodes. The `context-preservation` phase transition hook only logs whether `_handoff_context` is available.
- **Completion hooks skip mechanical aborts** (pause, LLM crash, shutdown) because no semantic agent work completed. They do fire on stall detection because the agent did produce work before stalling.
- **Hook errors are non-fatal** — existing `run_hooks()` try/except handling applies to all new events.

## Test plan

- [x] `core/tests/test_default_skill_hooks.py` — 33 tests covering:
  - HookContext extension (backward compat + new fields)
  - `run_hooks()` forwarding new fields
  - `register_hooks()` structure (per-skill, disabled, all-disabled)
  - Per-skill callback behavior (quality-monitor interval, note-taking staleness, batch-ledger checkpoint + completeness, context-preservation handoff verification + transition logging)
  - Default config values match PRD (`assessment_interval=5`, `require_handoff=true`)
  - Hook error resilience
  - `SkillsManager.lifecycle_hooks` property
  - `_run_phase_transition_hooks` standalone runner
  - **Fan-out integration test**: end-to-end `GraphExecutor` with diamond graph verifies `phase_transition` fires once per branch
- [x] Full skills suite passes: `test_default_skills.py`, `test_default_skill_hooks.py`, `test_skill_parser.py`, `test_skill_discovery.py`, `test_skill_catalog.py`, `test_skill_integration.py` — 122 passed
- [x] `ruff check` + `ruff format` clean on all modified files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added lifecycle hooks system enabling custom behaviors at key execution phases: iteration boundaries, node completion, and graph phase transitions.
  * Enabled default skills to emit runtime insights including quality assessments, note freshness warnings, batch processing metrics, and context handoff notifications.

* **Tests**
  * Added comprehensive test coverage for lifecycle hooks and default skill behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->