### PR TITLE
fix(runtime): prevent dual execution on session after forced cancel timeout

### DIFF
--- a/core/framework/runtime/execution_stream.py
+++ b/core/framework/runtime/execution_stream.py
@@ -164,6 +164,8 @@ class ExecutionStream:
         result = await stream.wait_for_completion(exec_id)
     """
 
+    _CANCEL_GRACE_SECONDS: float = 0.25
+
     def __init__(
         self,
         stream_id: str,
@@ -536,6 +538,14 @@ class ExecutionStream:
                         node.cancel_current_turn()
             await self.cancel_execution(eid, reason="Restarted with new execution")
 
+        # Give cancelling tasks a short grace window to finish before failing
+        # fast with ExecutionAlreadyRunningError.
+        running_tasks = [
+            task for task in self._execution_tasks.values() if task is not None and not task.done()
+        ]
+        if running_tasks:
+            await asyncio.wait(running_tasks, timeout=self._CANCEL_GRACE_SECONDS)
+
         # When resuming, reuse the original session ID so the execution
         # continues in the same session directory instead of creating a new one.
         resume_session_id = session_state.get("resume_session_id") if session_state else None
@@ -580,12 +590,20 @@ class ExecutionStream:
         )
 
         async with self._lock:
+            still_running = [
+                eid
+                for eid, task in self._execution_tasks.items()
+                if task is not None and not task.done()
+            ]
+            if still_running:
+                raise ExecutionAlreadyRunningError(self.stream_id, still_running)
+
             self._active_executions[execution_id] = ctx
             self._completion_events[execution_id] = asyncio.Event()
-
-        # Start execution task
-        task = asyncio.create_task(self._run_execution(ctx))
-        self._execution_tasks[execution_id] = task
+            # Start execution task under the same lock as bookkeeping writes
+            # so concurrent execute() calls cannot interleave between check and set.
+            task = asyncio.create_task(self._run_execution(ctx))
+            self._execution_tasks[execution_id] = task
 
         logger.debug(f"Queued execution {execution_id} for stream {self.stream_id}")
         return execution_id
@@ -1231,20 +1249,58 @@ class ExecutionStream:
             # respond to cancellation quickly.
             done, _ = await asyncio.wait({task}, timeout=5.0)
             if not done:
-                # Task didn't finish within timeout — clean up bookkeeping now
-                # so the session doesn't think it still has running executions.
-                # The task will continue winding down in the background and its
-                # finally block will harmlessly pop already-removed keys.
+                # Task didn't finish within timeout — keep bookkeeping in place
+                # so the stream remains locked until the task's own cleanup runs.
+                # This prevents a second execution from starting on the same
+                # session while the original task is still mutating state.
                 logger.warning(
-                    "Execution %s did not finish within cancel timeout; force-cleaning bookkeeping",
+                    "Execution %s did not finish within cancel timeout; keeping stream locked "
+                    "until task terminates",
                     execution_id,
                 )
-                async with self._lock:
-                    self._active_executions.pop(execution_id, None)
-                    self._execution_tasks.pop(execution_id, None)
-                self._active_executors.pop(execution_id, None)
+                ctx = self._active_executions.get(execution_id)
+                if ctx is not None:
+                    ctx.status = "cancelling"
+                # Ensure bookkeeping is eventually cleared when the stuck task
+                # finally terminates, even if cancel() timed out.
+                task.add_done_callback(
+                    lambda _t, _execution_id=execution_id: self._schedule_deferred_cleanup(
+                        _execution_id
+                    )
+                )
             return True
         return False
+
+    def _schedule_deferred_cleanup(self, execution_id: str) -> None:
+        """Schedule deferred cleanup and log any background failures."""
+
+        cleanup_task = asyncio.create_task(self._deferred_cleanup(execution_id))
+
+        def _log_cleanup_failure(done_task: asyncio.Task) -> None:
+            try:
+                done_task.result()
+            except Exception:
+                logger.exception("Deferred cleanup failed for execution %s", execution_id)
+
+        cleanup_task.add_done_callback(_log_cleanup_failure)
+
+    async def _deferred_cleanup(self, execution_id: str) -> None:
+        """Best-effort fallback cleanup after timed-out cancellation.
+
+        Normal cleanup happens in _run_execution()'s finally block.
+        This method is idempotent and acts as a safety net for tasks that
+        finish after cancel timeout.
+        """
+
+        async with self._lock:
+            self._active_executions.pop(execution_id, None)
+            self._execution_tasks.pop(execution_id, None)
+            completion_event = self._completion_events.pop(execution_id, None)
+
+        # Keep these pops outside the lock; they are independent and idempotent.
+        self._active_executors.pop(execution_id, None)
+        if completion_event is not None:
+            completion_event.set()
 
     # === STATS AND MONITORING ===
 

--- a/core/framework/runtime/tests/test_execution_stream_cancel.py
+++ b/core/framework/runtime/tests/test_execution_stream_cancel.py
@@ -1,0 +1,87 @@
+"""Regression tests for forced-cancel behavior in ExecutionStream."""
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from framework.runtime.execution_stream import (
+    EntryPointSpec,
+    ExecutionAlreadyRunningError,
+    ExecutionContext,
+    ExecutionStream,
+)
+from framework.runtime.shared_state import IsolationLevel, SharedBufferManager
+
+
+@pytest.mark.asyncio
+async def test_execute_does_not_start_second_execution_when_cancel_times_out(monkeypatch):
+    """A timed-out cancel must not unlock the stream for a second execution."""
+    stream = ExecutionStream(
+        stream_id="api",
+        entry_spec=EntryPointSpec(
+            id="api",
+            name="API",
+            entry_node="start",
+            trigger_type="api",
+            max_concurrent=1,
+        ),
+        graph=SimpleNamespace(id="g1"),
+        goal=SimpleNamespace(id="goal-1", description="goal"),
+        state_manager=SharedBufferManager(),
+        storage=SimpleNamespace(base_path=Path(".")),
+        outcome_aggregator=SimpleNamespace(),
+    )
+    stream._running = True
+
+    release = asyncio.Event()
+
+    async def ignores_cancel():
+        while True:
+            try:
+                await release.wait()
+                return
+            except asyncio.CancelledError:
+                # Simulate non-cooperative execution that ignores cancellation.
+                continue
+
+    stuck_task = asyncio.create_task(ignores_cancel())
+    execution_id = "exec-stuck"
+    stream._execution_tasks[execution_id] = stuck_task
+    stream._active_executions[execution_id] = ExecutionContext(
+        id=execution_id,
+        correlation_id=execution_id,
+        stream_id=stream.stream_id,
+        entry_point=stream.entry_spec.id,
+        input_data={},
+        isolation_level=IsolationLevel.SHARED,
+    )
+    stream._completion_events[execution_id] = asyncio.Event()
+
+    async def fake_wait(tasks, timeout=None):
+        return set(), set(tasks)
+
+    monkeypatch.setattr(asyncio, "wait", fake_wait)
+
+    try:
+        with pytest.raises(ExecutionAlreadyRunningError):
+            await stream.execute({"input": "new run"})
+
+        assert execution_id in stream._execution_tasks
+        assert not stream._execution_tasks[execution_id].done()
+        assert stream._active_executions[execution_id].status == "cancelling"
+    finally:
+        release.set()
+        try:
+            await asyncio.sleep(0)
+            await asyncio.wait_for(stuck_task, timeout=1.0)
+        except (asyncio.CancelledError, TimeoutError):
+            pass
+
+    # Once the stuck task actually exits, deferred cleanup should unlock the stream.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert execution_id not in stream._execution_tasks
+    assert execution_id not in stream._active_executions
+    assert execution_id not in stream._completion_events


### PR DESCRIPTION
## Description
Fixes a race condition where a force-cancelled execution that exceeded its cancel timeout
would allow a new execution to start on the same session while the previous task was still
running. This caused concurrent writes to shared session state, overlapping events, and
non-deterministic behavior.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
Fixes #6967

## Changes Made
- Keep bookkeeping (`_active_executions`, `_execution_tasks`) in place after cancel timeout
  instead of eagerly removing it; mark execution status as `"cancelling"` so the stream
  remains locked until the task actually terminates
- Add a `still_running` guard inside `self._lock` in `execute()` that raises
  `ExecutionAlreadyRunningError` if any task is still alive, preventing concurrent starts
- Move `create_task` inside the same lock as the guard check and bookkeeping writes so
  concurrent `execute()` calls cannot interleave between check and registration
- Register a `done_callback` on the stuck task via `_schedule_deferred_cleanup` to clear
  all per-execution state (`_active_executions`, `_execution_tasks`, `_completion_events`,
  `_active_executors`) once the task eventually terminates
- Add `_CANCEL_GRACE_SECONDS = 0.25` class constant and a grace window `asyncio.wait`
  before the lock check, giving cooperative tasks a short window to finish cleanly before
  raising
- Add regression test covering the full lifecycle: stream stays locked during timeout,
  `status == "cancelling"` is set, and all registries are cleared after task exits

## Testing
- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

**Regression test added:** `tests/runtime/test_forced_cancel_regression.py`

The test simulates a non-cooperative task that ignores `CancelledError`, monkeypatches
`asyncio.wait` to always time out, and asserts:
1. `ExecutionAlreadyRunningError` is raised when a second execution attempts to start
2. The stuck task and its bookkeeping remain in place during the timeout
3. All three registries are fully cleared once the stuck task terminates

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved execution stream cancellation handling to gracefully manage stuck tasks without forcing premature cleanup.
  * Enhanced concurrent execution protection to prevent race conditions when multiple executions are initiated simultaneously.
  * Refined timeout behavior during task cancellation to maintain stream integrity while awaiting task completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->