### PR TITLE
Track reasoning and cache token details in LLM responses (#5348)

### DIFF
--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -515,6 +515,21 @@ def _extract_text_tool_calls(
     return events, cleaned
 
 
+def _extract_token_details(usage: Any) -> tuple[int, int, int]:
+    """Return (reasoning_tokens, cache_read_tokens, cache_creation_tokens)."""
+    if usage is None:
+        return 0, 0, 0
+
+    completion_details = getattr(usage, "completion_tokens_details", None)
+    reasoning_tokens = getattr(completion_details, "reasoning_tokens", None) or 0
+
+    prompt_details = getattr(usage, "prompt_tokens_details", None)
+    cache_read_tokens = getattr(prompt_details, "cached_tokens", None) or 0
+    cache_creation_tokens = getattr(prompt_details, "cache_creation_tokens", None) or 0
+
+    return reasoning_tokens, cache_read_tokens, cache_creation_tokens
+
+
 class LiteLLMProvider(LLMProvider):
     """
     LiteLLM-based LLM provider for multi-provider support.
@@ -826,12 +841,16 @@ class LiteLLMProvider(LLMProvider):
         usage = response.usage
         input_tokens = usage.prompt_tokens if usage else 0
         output_tokens = usage.completion_tokens if usage else 0
+        reasoning_tokens, cache_read_tokens, cache_creation_tokens = _extract_token_details(usage)
 
         return LLMResponse(
             content=content,
             model=response.model or self.model,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
+            reasoning_tokens=reasoning_tokens,
+            cache_read_tokens=cache_read_tokens,
+            cache_creation_tokens=cache_creation_tokens,
             stop_reason=response.choices[0].finish_reason or "",
             raw_response=response,
         )
@@ -1015,12 +1034,16 @@ class LiteLLMProvider(LLMProvider):
         usage = response.usage
         input_tokens = usage.prompt_tokens if usage else 0
         output_tokens = usage.completion_tokens if usage else 0
+        reasoning_tokens, cache_read_tokens, cache_creation_tokens = _extract_token_details(usage)
 
         return LLMResponse(
             content=content,
             model=response.model or self.model,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
+            reasoning_tokens=reasoning_tokens,
+            cache_read_tokens=cache_read_tokens,
+            cache_creation_tokens=cache_creation_tokens,
             stop_reason=response.choices[0].finish_reason or "",
             raw_response=response,
         )
@@ -1471,6 +1494,7 @@ class LiteLLMProvider(LLMProvider):
         usage = response.usage
         input_tokens = usage.prompt_tokens if usage else 0
         output_tokens = usage.completion_tokens if usage else 0
+        reasoning_tokens, cache_read_tokens, cache_creation_tokens = _extract_token_details(usage)
         stop_reason = "tool_calls" if tool_calls else (response.choices[0].finish_reason or "stop")
 
         return LLMResponse(
@@ -1478,6 +1502,9 @@ class LiteLLMProvider(LLMProvider):
             model=response.model or self.model,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
+            reasoning_tokens=reasoning_tokens,
+            cache_read_tokens=cache_read_tokens,
+            cache_creation_tokens=cache_creation_tokens,
             stop_reason=stop_reason,
             raw_response={
                 "compat_mode": "openrouter_tool_emulation",
@@ -1535,6 +1562,9 @@ class LiteLLMProvider(LLMProvider):
             stop_reason=response.stop_reason,
             input_tokens=response.input_tokens,
             output_tokens=response.output_tokens,
+            reasoning_tokens=response.reasoning_tokens,
+            cache_read_tokens=response.cache_read_tokens,
+            cache_creation_tokens=response.cache_creation_tokens,
             model=response.model,
         )
 
@@ -1600,6 +1630,9 @@ class LiteLLMProvider(LLMProvider):
             stop_reason=response.stop_reason or "stop",
             input_tokens=response.input_tokens,
             output_tokens=response.output_tokens,
+            reasoning_tokens=response.reasoning_tokens,
+            cache_read_tokens=response.cache_read_tokens,
+            cache_creation_tokens=response.cache_creation_tokens,
             model=response.model,
         )
 
@@ -1836,29 +1869,37 @@ class LiteLLMProvider(LLMProvider):
                             type(usage).__name__,
                         )
                         cached_tokens = 0
+                        reasoning_tokens = 0
+                        cache_read_tokens = 0
+                        cache_creation_tokens = 0
                         if usage:
                             input_tokens = getattr(usage, "prompt_tokens", 0) or 0
                             output_tokens = getattr(usage, "completion_tokens", 0) or 0
-                            _details = getattr(usage, "prompt_tokens_details", None)
-                            cached_tokens = (
-                                getattr(_details, "cached_tokens", 0) or 0
-                                if _details is not None
-                                else getattr(usage, "cache_read_input_tokens", 0) or 0
-                            )
+                            (
+                                reasoning_tokens,
+                                cache_read_tokens,
+                                cache_creation_tokens,
+                            ) = _extract_token_details(usage)
+                            cached_tokens = cache_read_tokens
                             logger.debug(
                                 "[tokens] finish-chunk usage: "
-                                "input=%d output=%d cached=%d model=%s",
+                                "input=%d output=%d reasoning=%d cached=%d cache_write=%d model=%s",
                                 input_tokens,
                                 output_tokens,
+                                reasoning_tokens,
                                 cached_tokens,
+                                cache_creation_tokens,
                                 self.model,
                             )
 
                         logger.debug(
-                            "[tokens] finish event: input=%d output=%d cached=%d stop=%s model=%s",
+                            "[tokens] finish event: input=%d output=%d reasoning=%d cached=%d "
+                            "cache_write=%d stop=%s model=%s",
                             input_tokens,
                             output_tokens,
+                            reasoning_tokens,
                             cached_tokens,
+                            cache_creation_tokens,
                             choice.finish_reason,
                             self.model,
                         )
@@ -1868,6 +1909,9 @@ class LiteLLMProvider(LLMProvider):
                                 input_tokens=input_tokens,
                                 output_tokens=output_tokens,
                                 cached_tokens=cached_tokens,
+                                reasoning_tokens=reasoning_tokens,
+                                cache_read_tokens=cache_read_tokens,
+                                cache_creation_tokens=cache_creation_tokens,
                                 model=self.model,
                             )
                         )
@@ -1887,18 +1931,20 @@ class LiteLLMProvider(LLMProvider):
                             _usage = calculate_total_usage(chunks=_chunks)
                             input_tokens = _usage.prompt_tokens or 0
                             output_tokens = _usage.completion_tokens or 0
-                            _details = getattr(_usage, "prompt_tokens_details", None)
-                            cached_tokens = (
-                                getattr(_details, "cached_tokens", 0) or 0
-                                if _details is not None
-                                else getattr(_usage, "cache_read_input_tokens", 0) or 0
-                            )
+                            (
+                                reasoning_tokens,
+                                cache_read_tokens,
+                                cache_creation_tokens,
+                            ) = _extract_token_details(_usage)
+                            cached_tokens = cache_read_tokens
                             logger.debug(
                                 "[tokens] post-loop chunks fallback:"
-                                " input=%d output=%d cached=%d model=%s",
+                                " input=%d output=%d reasoning=%d cached=%d cache_write=%d model=%s",
                                 input_tokens,
                                 output_tokens,
+                                reasoning_tokens,
                                 cached_tokens,
+                                cache_creation_tokens,
                                 self.model,
                             )
                             # Patch the FinishEvent already queued with 0 tokens
@@ -1909,6 +1955,9 @@ class LiteLLMProvider(LLMProvider):
                                         input_tokens=input_tokens,
                                         output_tokens=output_tokens,
                                         cached_tokens=cached_tokens,
+                                        reasoning_tokens=reasoning_tokens,
+                                        cache_read_tokens=cache_read_tokens,
+                                        cache_creation_tokens=cache_creation_tokens,
                                         model=_ev.model,
                                     )
                                     break
@@ -2105,6 +2154,9 @@ class LiteLLMProvider(LLMProvider):
         tool_calls: list[dict[str, Any]] = []
         input_tokens = 0
         output_tokens = 0
+        reasoning_tokens = 0
+        cache_read_tokens = 0
+        cache_creation_tokens = 0
         stop_reason = ""
         model = self.model
 
@@ -2122,6 +2174,9 @@ class LiteLLMProvider(LLMProvider):
             elif isinstance(event, FinishEvent):
                 input_tokens = event.input_tokens
                 output_tokens = event.output_tokens
+                reasoning_tokens = event.reasoning_tokens
+                cache_read_tokens = event.cache_read_tokens
+                cache_creation_tokens = event.cache_creation_tokens
                 stop_reason = event.stop_reason
                 if event.model:
                     model = event.model
@@ -2134,6 +2189,9 @@ class LiteLLMProvider(LLMProvider):
             model=model,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
+            reasoning_tokens=reasoning_tokens,
+            cache_read_tokens=cache_read_tokens,
+            cache_creation_tokens=cache_creation_tokens,
             stop_reason=stop_reason,
             raw_response={"tool_calls": tool_calls} if tool_calls else None,
         )

--- a/core/framework/llm/provider.py
+++ b/core/framework/llm/provider.py
@@ -16,6 +16,9 @@ class LLMResponse:
     model: str
     input_tokens: int = 0
     output_tokens: int = 0
+    reasoning_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
     stop_reason: str = ""
     raw_response: Any = None
 
@@ -157,6 +160,9 @@ class LLMProvider(ABC):
             stop_reason=response.stop_reason,
             input_tokens=response.input_tokens,
             output_tokens=response.output_tokens,
+            reasoning_tokens=response.reasoning_tokens,
+            cache_read_tokens=response.cache_read_tokens,
+            cache_creation_tokens=response.cache_creation_tokens,
             model=response.model,
         )
 

--- a/core/framework/llm/stream_events.py
+++ b/core/framework/llm/stream_events.py
@@ -72,6 +72,9 @@ class FinishEvent:
     input_tokens: int = 0
     output_tokens: int = 0
     cached_tokens: int = 0
+    reasoning_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
     model: str = ""
 
 

--- a/core/tests/test_litellm_provider.py
+++ b/core/tests/test_litellm_provider.py
@@ -24,6 +24,7 @@ from framework.llm.litellm import (
     OPENROUTER_TOOL_COMPAT_MODEL_CACHE,
     LiteLLMProvider,
     _compute_retry_delay,
+    _extract_token_details,
     _ensure_ollama_chat_prefix,
     _is_ollama_model,
 )
@@ -115,6 +116,9 @@ class TestLiteLLMProviderComplete:
         mock_response.model = "gpt-4o-mini"
         mock_response.usage.prompt_tokens = 10
         mock_response.usage.completion_tokens = 20
+        mock_response.usage.completion_tokens_details.reasoning_tokens = 7
+        mock_response.usage.prompt_tokens_details.cached_tokens = 11
+        mock_response.usage.prompt_tokens_details.cache_creation_tokens = 13
         mock_completion.return_value = mock_response
 
         provider = LiteLLMProvider(model="gpt-4o-mini", api_key="test-key")
@@ -124,6 +128,9 @@ class TestLiteLLMProviderComplete:
         assert result.model == "gpt-4o-mini"
         assert result.input_tokens == 10
         assert result.output_tokens == 20
+        assert result.reasoning_tokens == 7
+        assert result.cache_read_tokens == 11
+        assert result.cache_creation_tokens == 13
         assert result.stop_reason == "stop"
 
         # Verify litellm.completion was called correctly
@@ -242,6 +249,21 @@ class TestToolConversion:
             provider._parse_tool_call_arguments('{"question": foo', "ask_user")
 
 
+class TestTokenDetails:
+    """Token detail extraction should be resilient across provider shapes."""
+
+    def test_extract_token_details_returns_zeroes_when_usage_missing(self):
+        assert _extract_token_details(None) == (0, 0, 0)
+
+    def test_extract_token_details_reads_public_litellm_fields(self):
+        usage = MagicMock()
+        usage.completion_tokens_details.reasoning_tokens = 17
+        usage.prompt_tokens_details.cached_tokens = 23
+        usage.prompt_tokens_details.cache_creation_tokens = 5
+
+        assert _extract_token_details(usage) == (17, 23, 5)
+
+
 class TestAnthropicProviderBackwardCompatibility:
     """Test AnthropicProvider backward compatibility with LiteLLM backend."""
 
@@ -333,6 +355,9 @@ class TestJsonMode:
         mock_response.model = "gpt-4o-mini"
         mock_response.usage.prompt_tokens = 10
         mock_response.usage.completion_tokens = 5
+        mock_response.usage.completion_tokens_details.reasoning_tokens = 2
+        mock_response.usage.prompt_tokens_details.cached_tokens = 3
+        mock_response.usage.prompt_tokens_details.cache_creation_tokens = 4
         mock_completion.return_value = mock_response
 
         provider = LiteLLMProvider(model="gpt-4o-mini", api_key="test-key")
@@ -583,6 +608,9 @@ class TestAsyncComplete:
         mock_response.model = "gpt-4o-mini"
         mock_response.usage.prompt_tokens = 10
         mock_response.usage.completion_tokens = 5
+        mock_response.usage.completion_tokens_details.reasoning_tokens = 2
+        mock_response.usage.prompt_tokens_details.cached_tokens = 3
+        mock_response.usage.prompt_tokens_details.cache_creation_tokens = 4
 
         # acompletion is async, so mock must return a coroutine
         async def async_return(*args, **kwargs):
@@ -600,6 +628,9 @@ class TestAsyncComplete:
         assert result.model == "gpt-4o-mini"
         assert result.input_tokens == 10
         assert result.output_tokens == 5
+        assert result.reasoning_tokens == 2
+        assert result.cache_read_tokens == 3
+        assert result.cache_creation_tokens == 4
         mock_acompletion.assert_called_once()
 
     @pytest.mark.asyncio
@@ -724,6 +755,32 @@ class TestMiniMaxStreamFallback:
         assert len(finish) == 1
         assert finish[0].model == "minimax-text-01"
 
+    @pytest.mark.asyncio
+    async def test_collect_stream_to_response_preserves_token_details(self):
+        """Collected stream responses should keep reasoning and cache token metadata."""
+        from framework.llm.stream_events import FinishEvent, TextDeltaEvent
+
+        provider = LiteLLMProvider(model="minimax-text-01", api_key="test-key")
+
+        async def stream():
+            yield TextDeltaEvent(content="hello", snapshot="hello")
+            yield FinishEvent(
+                stop_reason="stop",
+                input_tokens=10,
+                output_tokens=4,
+                reasoning_tokens=6,
+                cache_read_tokens=8,
+                cache_creation_tokens=2,
+                model="minimax-text-01",
+            )
+
+        result = await provider._collect_stream_to_response(stream())
+
+        assert result.content == "hello"
+        assert result.reasoning_tokens == 6
+        assert result.cache_read_tokens == 8
+        assert result.cache_creation_tokens == 2
+
     def test_is_minimax_model_variants(self):
         """Recognize both prefixed and plain MiniMax model names."""
         assert LiteLLMProvider(model="minimax-text-01", api_key="x")._is_minimax_model()
@@ -773,6 +830,9 @@ class TestOpenRouterToolCompatFallback:
         compat_response.model = provider.model
         compat_response.usage.prompt_tokens = 18
         compat_response.usage.completion_tokens = 9
+        compat_response.usage.completion_tokens_details.reasoning_tokens = 12
+        compat_response.usage.prompt_tokens_details.cached_tokens = 14
+        compat_response.usage.prompt_tokens_details.cache_creation_tokens = 6
 
         async def side_effect(*args, **kwargs):
             if kwargs.get("stream"):
@@ -809,6 +869,9 @@ class TestOpenRouterToolCompatFallback:
         assert finish_events[0].stop_reason == "tool_calls"
         assert finish_events[0].input_tokens == 18
         assert finish_events[0].output_tokens == 9
+        assert finish_events[0].reasoning_tokens == 12
+        assert finish_events[0].cache_read_tokens == 14
+        assert finish_events[0].cache_creation_tokens == 6
 
         assert mock_acompletion.call_count == 2
         first_call = mock_acompletion.call_args_list[0].kwargs

--- a/core/tests/test_stream_events.py
+++ b/core/tests/test_stream_events.py
@@ -84,6 +84,9 @@ class TestEventDefaults:
         assert e.stop_reason == ""
         assert e.input_tokens == 0
         assert e.output_tokens == 0
+        assert e.reasoning_tokens == 0
+        assert e.cache_read_tokens == 0
+        assert e.cache_creation_tokens == 0
         assert e.model == ""
 
     def test_stream_error_defaults(self):
@@ -150,6 +153,9 @@ class TestEventConstruction:
         assert e.stop_reason == "end_turn"
         assert e.input_tokens == 150
         assert e.output_tokens == 300
+        assert e.reasoning_tokens == 0
+        assert e.cache_read_tokens == 0
+        assert e.cache_creation_tokens == 0
         assert e.model == "claude-haiku-4-5"
 
     def test_stream_error_with_values(self):
@@ -241,6 +247,9 @@ class TestEventSerialization:
             "input_tokens": 10,
             "output_tokens": 20,
             "cached_tokens": 0,
+            "reasoning_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_creation_tokens": 0,
             "model": "gpt-4",
         }
 


### PR DESCRIPTION
## Description

This PR extends `LLMResponse` and the LiteLLM provider so Hive preserves token breakdown metadata that was previously dropped for modern reasoning and cached models.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #5348

## Changes Made

- Added `reasoning_tokens`, `cache_read_tokens`, and `cache_creation_tokens` to `LLMResponse` with `0` defaults for backward compatibility
- Added a shared token-detail extractor for LiteLLM usage objects
- Populated the new fields in sync and async completion paths
- Propagated the new fields through streaming finish events and stream collection
- Updated the OpenRouter tool-compat completion path to preserve the same token metadata
- Added focused tests for token extraction, response propagation, and stream-event serialization

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`python -m pytest core/tests/test_litellm_provider.py core/tests/test_stream_events.py`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added/updated tests that prove the fix works
- [x] This change is backward compatible


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reasoning token tracking for AI models that perform multi-step reasoning operations
  * Added cache token metrics: tracks both cache read tokens and cache creation tokens separately
  * New token statistics are now propagated through both standard and streaming API responses
  * Enhanced token-level visibility provides better insights into API consumption patterns and costs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->