### PR TITLE
fix(test): update queen memory reflection test mocks for litellm format

### DIFF
--- a/core/tests/test_queen_memory.py
+++ b/core/tests/test_queen_memory.py
@@ -18,6 +18,23 @@ from framework.agents.queen.recall_selector import (
 from framework.graph.prompting import build_system_prompt_for_node_context
 from framework.tools.queen_lifecycle_tools import QueenPhaseState
 
+
+def _make_litellm_response(tool_calls: list[dict] | None = None, content: str = ""):
+    """Build a mock that mirrors litellm ModelResponse structure."""
+    if tool_calls:
+        tc_objects = []
+        for tc in tool_calls:
+            fn = SimpleNamespace(
+                name=tc["name"],
+                arguments=json.dumps(tc.get("input", {})),
+            )
+            tc_objects.append(SimpleNamespace(id=tc["id"], function=fn))
+        message = SimpleNamespace(tool_calls=tc_objects)
+    else:
+        message = SimpleNamespace(tool_calls=None)
+    raw = SimpleNamespace(choices=[SimpleNamespace(message=message)])
+    return MagicMock(content=content, raw_response=raw)
+
 # ---------------------------------------------------------------------------
 # parse_frontmatter
 # ---------------------------------------------------------------------------
@@ -244,28 +261,23 @@ async def test_short_reflection(tmp_path: Path):
     llm = AsyncMock()
     llm.acomplete.side_effect = [
         # Turn 1: LLM writes a global memory file
-        MagicMock(
-            content="",
-            raw_response={
-                "tool_calls": [
-                    {
-                        "id": "tc_1",
-                        "name": "write_memory_file",
-                        "input": {
-                            "filename": "user-likes-tests.md",
-                            "content": (
-                                "---\nname: user-likes-tests\n"
-                                "type: preference\n"
-                                "description: User values thorough testing\n"
-                                "---\nObserved emphasis on test coverage."
-                            ),
-                        },
-                    }
-                ]
-            },
-        ),
+        _make_litellm_response(tool_calls=[
+            {
+                "id": "tc_1",
+                "name": "write_memory_file",
+                "input": {
+                    "filename": "user-likes-tests.md",
+                    "content": (
+                        "---\nname: user-likes-tests\n"
+                        "type: preference\n"
+                        "description: User values thorough testing\n"
+                        "---\nObserved emphasis on test coverage."
+                    ),
+                },
+            }
+        ]),
         # Turn 2: done
-        MagicMock(content="Done reflecting.", raw_response={}),
+        _make_litellm_response(content="Done reflecting."),
     ]
 
     session_dir = tmp_path / "session"
@@ -312,39 +324,29 @@ async def test_long_reflection(tmp_path: Path):
 
     llm = AsyncMock()
     llm.acomplete.side_effect = [
-        MagicMock(
-            content="",
-            raw_response={
-                "tool_calls": [
-                    {"id": "tc_1", "name": "list_memory_files", "input": {}},
-                ]
+        _make_litellm_response(tool_calls=[
+            {"id": "tc_1", "name": "list_memory_files", "input": {}},
+        ]),
+        _make_litellm_response(tool_calls=[
+            {
+                "id": "tc_2",
+                "name": "write_memory_file",
+                "input": {
+                    "filename": "dup-a.md",
+                    "content": (
+                        "---\nname: dup-a\ntype: profile\n"
+                        "description: profile A (merged)\n"
+                        "---\nProfile A details. Also same profile A."
+                    ),
+                },
             },
-        ),
-        MagicMock(
-            content="",
-            raw_response={
-                "tool_calls": [
-                    {
-                        "id": "tc_2",
-                        "name": "write_memory_file",
-                        "input": {
-                            "filename": "dup-a.md",
-                            "content": (
-                                "---\nname: dup-a\ntype: profile\n"
-                                "description: profile A (merged)\n"
-                                "---\nProfile A details. Also same profile A."
-                            ),
-                        },
-                    },
-                    {
-                        "id": "tc_3",
-                        "name": "delete_memory_file",
-                        "input": {"filename": "dup-b.md"},
-                    },
-                ]
+            {
+                "id": "tc_3",
+                "name": "delete_memory_file",
+                "input": {"filename": "dup-b.md"},
             },
-        ),
-        MagicMock(content="Housekeeping complete.", raw_response={}),
+        ]),
+        _make_litellm_response(content="Housekeeping complete."),
     ]
 
     await run_long_reflection(llm, memory_dir=mem_dir)

--- a/core/tests/test_queen_memory.py
+++ b/core/tests/test_queen_memory.py
@@ -35,6 +35,7 @@ def _make_litellm_response(tool_calls: list[dict] | None = None, content: str = 
     raw = SimpleNamespace(choices=[SimpleNamespace(message=message)])
     return MagicMock(content=content, raw_response=raw)
 
+
 # ---------------------------------------------------------------------------
 # parse_frontmatter
 # ---------------------------------------------------------------------------
@@ -261,21 +262,23 @@ async def test_short_reflection(tmp_path: Path):
     llm = AsyncMock()
     llm.acomplete.side_effect = [
         # Turn 1: LLM writes a global memory file
-        _make_litellm_response(tool_calls=[
-            {
-                "id": "tc_1",
-                "name": "write_memory_file",
-                "input": {
-                    "filename": "user-likes-tests.md",
-                    "content": (
-                        "---\nname: user-likes-tests\n"
-                        "type: preference\n"
-                        "description: User values thorough testing\n"
-                        "---\nObserved emphasis on test coverage."
-                    ),
-                },
-            }
-        ]),
+        _make_litellm_response(
+            tool_calls=[
+                {
+                    "id": "tc_1",
+                    "name": "write_memory_file",
+                    "input": {
+                        "filename": "user-likes-tests.md",
+                        "content": (
+                            "---\nname: user-likes-tests\n"
+                            "type: preference\n"
+                            "description: User values thorough testing\n"
+                            "---\nObserved emphasis on test coverage."
+                        ),
+                    },
+                }
+            ]
+        ),
         # Turn 2: done
         _make_litellm_response(content="Done reflecting."),
     ]
@@ -324,28 +327,32 @@ async def test_long_reflection(tmp_path: Path):
 
     llm = AsyncMock()
     llm.acomplete.side_effect = [
-        _make_litellm_response(tool_calls=[
-            {"id": "tc_1", "name": "list_memory_files", "input": {}},
-        ]),
-        _make_litellm_response(tool_calls=[
-            {
-                "id": "tc_2",
-                "name": "write_memory_file",
-                "input": {
-                    "filename": "dup-a.md",
-                    "content": (
-                        "---\nname: dup-a\ntype: profile\n"
-                        "description: profile A (merged)\n"
-                        "---\nProfile A details. Also same profile A."
-                    ),
+        _make_litellm_response(
+            tool_calls=[
+                {"id": "tc_1", "name": "list_memory_files", "input": {}},
+            ]
+        ),
+        _make_litellm_response(
+            tool_calls=[
+                {
+                    "id": "tc_2",
+                    "name": "write_memory_file",
+                    "input": {
+                        "filename": "dup-a.md",
+                        "content": (
+                            "---\nname: dup-a\ntype: profile\n"
+                            "description: profile A (merged)\n"
+                            "---\nProfile A details. Also same profile A."
+                        ),
+                    },
                 },
-            },
-            {
-                "id": "tc_3",
-                "name": "delete_memory_file",
-                "input": {"filename": "dup-b.md"},
-            },
-        ]),
+                {
+                    "id": "tc_3",
+                    "name": "delete_memory_file",
+                    "input": {"filename": "dup-b.md"},
+                },
+            ]
+        ),
         _make_litellm_response(content="Housekeeping complete."),
     ]
 


### PR DESCRIPTION
## Description

Fix two broken tests on `main` introduced by #6976. The reflection agent now extracts tool calls from litellm `ModelResponse` objects, but the test mocks still used plain dicts, causing tool calls to silently fail.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #6990

## Changes Made

- Added `_make_litellm_response()` helper to build mocks matching litellm `ModelResponse` structure (`choices[0].message.tool_calls`)
- Updated `test_short_reflection` and `test_long_reflection` to use the new helper

## Testing

- [x] Unit tests pass (`cd core && pytest tests/test_queen_memory.py`, 28/28 passed)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a local test helper to standardize simulated model responses for clearer, consistent test fixtures.
  * Updated existing reflection tests to use the new helper, replacing ad-hoc mock payloads with the standardized response format for improved maintainability and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->