### PR TITLE
feat(eval): wire criterion evaluation, failure reports, and evolution trigger (#3900)

### DIFF
--- a/core/framework/graph/goal.py
+++ b/core/framework/graph/goal.py
@@ -17,6 +17,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from framework.schemas.failure_report import FailureReport
+
 
 class GoalStatus(StrEnum):
     """Lifecycle status of a goal."""
@@ -150,6 +152,11 @@ class Goal(BaseModel):
     version: str = "1.0.0"
     parent_version: str | None = None
     evolution_reason: str | None = None
+
+    # Failure history (Phase 2): each entry is a versioned FailureReport
+    # appended by OutcomeAggregator.evaluate_output() when the goal is not
+    # achieved. The newest report is failure_history[-1].
+    failure_history: list[FailureReport] = Field(default_factory=list)
 
     # Timestamps
     created_at: datetime = Field(default_factory=datetime.now)

--- a/core/framework/graph/judge.py
+++ b/core/framework/graph/judge.py
@@ -1,0 +1,96 @@
+"""Goal-level criterion judge using LLM evaluation.
+
+Evaluates whether an execution output satisfies a SuccessCriterion
+whose metric is 'llm_judge'. Used by OutcomeAggregator to dispatch
+criterion evaluation.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from framework.graph.goal import SuccessCriterion
+    from framework.llm.provider import LLMProvider
+
+logger = logging.getLogger(__name__)
+
+_JUDGE_SYSTEM = (
+    "You are evaluating whether an execution output satisfies a success criterion. "
+    "Be precise. Evaluate based on the criterion, not on style or verbosity."
+)
+
+_JUDGE_PROMPT = """Evaluate whether this output satisfies the success criterion.
+
+CRITERION: {description}
+TARGET: {target}
+
+OUTPUT:
+{output}
+
+Respond in exactly this JSON format:
+{{"met": true or false, "confidence": 0.0 to 1.0, "reason": "brief explanation"}}"""
+
+
+async def judge_criterion(
+    llm: LLMProvider,
+    criterion: SuccessCriterion,
+    execution_output: Any,
+    max_tokens: int = 512,
+) -> bool:
+    """Evaluate a criterion using an LLM judge.
+
+    Args:
+        llm: LLM provider for evaluation.
+        criterion: The success criterion to evaluate.
+        execution_output: The execution output to judge.
+        max_tokens: Token budget for the judge response.
+
+    Returns:
+        True if the criterion is met according to the LLM.
+    """
+    output_str = _format_output(execution_output)
+
+    prompt = _JUDGE_PROMPT.format(
+        description=criterion.description,
+        target=criterion.target,
+        output=output_str,
+    )
+
+    try:
+        response = await llm.acomplete(
+            messages=[{"role": "user", "content": prompt}],
+            system=_JUDGE_SYSTEM,
+            max_tokens=max_tokens,
+            json_mode=True,
+            max_retries=1,
+        )
+        return _parse_judge_response(response.content)
+    except Exception as e:
+        logger.warning(f"LLM judge failed for criterion {criterion.id}: {e}")
+        return False
+
+
+def _format_output(output: Any) -> str:
+    """Format execution output for the judge prompt."""
+    if isinstance(output, dict):
+        try:
+            return json.dumps(output, indent=2, default=str)[:4000]
+        except (TypeError, ValueError):
+            pass
+    text = str(output)
+    return text[:4000] if len(text) > 4000 else text
+
+
+def _parse_judge_response(text: str) -> bool:
+    """Parse the LLM judge JSON response, returning whether the criterion is met."""
+    try:
+        if "```" in text:
+            text = text.split("```")[1].replace("json", "").strip()
+        result = json.loads(text.strip())
+        return bool(result.get("met", False))
+    except (json.JSONDecodeError, IndexError, AttributeError) as e:
+        logger.warning(f"Failed to parse judge response: {e}")
+        return False

--- a/core/framework/runtime/agent_runtime.py
+++ b/core/framework/runtime/agent_runtime.py
@@ -231,7 +231,9 @@ class AgentRuntime:
         # Initialize shared components
         self._state_manager = SharedBufferManager()
         self._event_bus = event_bus or EventBus(max_history=self._config.max_history)
-        self._outcome_aggregator = OutcomeAggregator(goal, self._event_bus)
+        self._outcome_aggregator = OutcomeAggregator(
+            goal, self._event_bus, llm_provider=llm, storage_path=storage_path_obj,
+        )
 
         # LLM and tools
         self._llm = llm

--- a/core/framework/runtime/evolution_trigger.py
+++ b/core/framework/runtime/evolution_trigger.py
@@ -1,0 +1,401 @@
+"""Evolution Trigger - turn FailureReports into graph-evolution requests.
+
+When OutcomeAggregator emits a FailureReport, this module packages it into a
+structured prompt and dispatches it to a coding agent. Two dispatch modes are
+supported:
+
+1. **Direct LLM mode**: call an `LLMProvider` (via `acomplete(json_mode=True)`)
+   to get a structured evolution plan. Suitable for offline / CLI use where no
+   live queen session exists.
+
+2. **Queen-injection mode**: if a live queen node is supplied, fire a
+   `TriggerEvent` via `queen_node.inject_trigger()` so the running queen picks
+   up the failure as a new task. Mirrors how timer/webhook triggers feed into
+   the queen elsewhere in the codebase.
+
+The structured-prompt format and the `EvolutionPlan` schema are intentionally
+small — the goal is to get a usable starting point for graph evolution, not to
+fully automate code generation.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from framework.graph.goal import Goal
+    from framework.llm.provider import LLMProvider
+    from framework.schemas.failure_report import FailureReport
+
+logger = logging.getLogger(__name__)
+
+
+_EVOLUTION_SYSTEM = (
+    "You are a coding agent that evolves agent graphs to fix goal failures. "
+    "Given a failure report describing unmet success criteria and violated "
+    "constraints, propose concrete, minimal changes to the agent's graph "
+    "(nodes, edges, prompts, or success criteria) that would fix the failure. "
+    "Be specific about which node IDs to modify and what the change is. "
+    "Do not invent context that isn't in the report."
+)
+
+_EVOLUTION_PROMPT = """A goal-driven agent run failed. Propose graph evolution.
+
+GOAL: {goal_name} (id={goal_id})
+
+UNMET SUCCESS CRITERIA ({n_unmet}):
+{unmet_block}
+
+VIOLATED CONSTRAINTS ({n_violated}):
+{violated_block}
+
+RELEVANT NODE IDs FROM EXECUTION TRACE:
+{node_ids}
+
+ERROR CATEGORY: {error_category}
+
+EXECUTION METRICS:
+- decisions: {total_decisions}
+- successful outcomes: {successful_outcomes}
+- failed outcomes: {failed_outcomes}
+
+SUMMARY:
+{summary}
+
+Respond in exactly this JSON format:
+{{
+  "diagnosis": "1-3 sentences: what went wrong and why",
+  "proposed_changes": [
+    {{
+      "target": "node_id | edge | success_criterion | prompt",
+      "target_id": "id of the thing to change, or null",
+      "change_type": "add | modify | remove",
+      "rationale": "why this change addresses the failure",
+      "details": "concrete description of the change"
+    }}
+  ],
+  "confidence": 0.0,
+  "needs_human_review": true
+}}"""
+
+
+@dataclass
+class ProposedChange:
+    """A single graph-evolution change proposed by the coding agent."""
+
+    target: str
+    target_id: str | None
+    change_type: str
+    rationale: str
+    details: str
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ProposedChange:
+        return cls(
+            target=str(d.get("target", "")),
+            target_id=d.get("target_id"),
+            change_type=str(d.get("change_type", "")),
+            rationale=str(d.get("rationale", "")),
+            details=str(d.get("details", "")),
+        )
+
+
+@dataclass
+class EvolutionPlan:
+    """Structured response from the coding agent."""
+
+    diagnosis: str = ""
+    proposed_changes: list[ProposedChange] = field(default_factory=list)
+    confidence: float = 0.0
+    needs_human_review: bool = True
+    raw_response: str = ""
+
+    def is_empty(self) -> bool:
+        return not self.proposed_changes and not self.diagnosis
+
+
+class EvolutionTrigger:
+    """Convert FailureReports into evolution requests for a coding agent.
+
+    Either ``llm_provider`` or ``queen_node`` must be supplied. If both are
+    supplied, ``queen_node`` wins (live queen takes precedence over a one-shot
+    LLM call).
+    """
+
+    def __init__(
+        self,
+        llm_provider: LLMProvider | None = None,
+        queen_node: Any = None,
+        max_tokens: int = 1024,
+    ) -> None:
+        if llm_provider is None and queen_node is None:
+            raise ValueError(
+                "EvolutionTrigger requires either llm_provider or queen_node",
+            )
+        self._llm = llm_provider
+        self._queen = queen_node
+        self._max_tokens = max_tokens
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def build_prompt(self, report: FailureReport) -> str:
+        """Package a FailureReport into the structured prompt."""
+        unmet_lines = [
+            f"- [{c.criterion_id}] {c.description} "
+            f"(metric={c.metric}, target={c.target!r}, weight={c.weight})"
+            for c in report.unmet_criteria
+        ] or ["(none)"]
+
+        violated_lines = [
+            f"- [{c.constraint_id}] ({c.constraint_type}) {c.description} "
+            f"-- {c.violation_details}"
+            for c in report.violated_constraints
+        ] or ["(none)"]
+
+        node_ids = ", ".join(report.node_ids) if report.node_ids else "(none)"
+
+        return _EVOLUTION_PROMPT.format(
+            goal_name=report.goal_name,
+            goal_id=report.goal_id,
+            n_unmet=len(report.unmet_criteria),
+            unmet_block="\n".join(unmet_lines),
+            n_violated=len(report.violated_constraints),
+            violated_block="\n".join(violated_lines),
+            node_ids=node_ids,
+            error_category=report.error_category or "(uncategorized)",
+            total_decisions=report.total_decisions,
+            successful_outcomes=report.successful_outcomes,
+            failed_outcomes=report.failed_outcomes,
+            summary=report.summary or "(no summary)",
+        )
+
+    async def trigger(self, report: FailureReport) -> EvolutionPlan:
+        """Dispatch the failure report to a coding agent.
+
+        Returns an EvolutionPlan. If queen-injection mode is used, the plan is
+        empty (the queen handles the work asynchronously) but ``diagnosis``
+        notes that injection succeeded.
+        """
+        prompt = self.build_prompt(report)
+
+        if self._queen is not None:
+            return await self._dispatch_to_queen(prompt, report)
+
+        assert self._llm is not None  # narrow for type-checkers
+        return await self._dispatch_to_llm(prompt)
+
+    # ------------------------------------------------------------------
+    # Dispatch backends
+    # ------------------------------------------------------------------
+
+    async def _dispatch_to_llm(self, prompt: str) -> EvolutionPlan:
+        try:
+            response = await self._llm.acomplete(  # type: ignore[union-attr]
+                messages=[{"role": "user", "content": prompt}],
+                system=_EVOLUTION_SYSTEM,
+                max_tokens=self._max_tokens,
+                json_mode=True,
+                max_retries=1,
+            )
+        except Exception as e:
+            logger.warning(f"EvolutionTrigger LLM call failed: {e}")
+            return EvolutionPlan(diagnosis=f"LLM call failed: {e}")
+
+        return self._parse_response(response.content)
+
+    async def _dispatch_to_queen(
+        self, prompt: str, report: FailureReport
+    ) -> EvolutionPlan:
+        # Local import — TriggerEvent lives next to the event-loop node and
+        # importing eagerly would pull in heavyweight graph code.
+        from framework.graph.event_loop.types import TriggerEvent
+
+        trigger_event = TriggerEvent(
+            trigger_type="evolution",
+            source_id=f"failure_report:{report.goal_id}",
+            payload={
+                "task": prompt,
+                "goal_id": report.goal_id,
+                "goal_name": report.goal_name,
+                "unmet_criteria": [c.model_dump() for c in report.unmet_criteria],
+                "violated_constraints": [
+                    c.model_dump() for c in report.violated_constraints
+                ],
+                "node_ids": list(report.node_ids),
+                "summary": report.summary,
+            },
+        )
+
+        try:
+            await self._queen.inject_trigger(trigger_event)
+            return EvolutionPlan(
+                diagnosis="Failure report injected into queen as evolution trigger",
+                needs_human_review=False,
+            )
+        except Exception as e:
+            logger.warning(f"EvolutionTrigger queen injection failed: {e}")
+            return EvolutionPlan(diagnosis=f"Queen injection failed: {e}")
+
+    # ------------------------------------------------------------------
+    # Parsing
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_response(text: str) -> EvolutionPlan:
+        raw = text or ""
+        cleaned = raw.strip()
+        if "```" in cleaned:
+            # Strip markdown code fences (```json ... ```).
+            try:
+                cleaned = cleaned.split("```")[1]
+                if cleaned.startswith("json"):
+                    cleaned = cleaned[4:]
+                cleaned = cleaned.strip()
+            except IndexError:
+                pass
+
+        try:
+            data = json.loads(cleaned)
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.warning(f"Failed to parse evolution response: {e}")
+            return EvolutionPlan(
+                diagnosis="Failed to parse coding-agent response",
+                raw_response=raw,
+            )
+
+        changes_raw = data.get("proposed_changes") or []
+        if not isinstance(changes_raw, list):
+            changes_raw = []
+
+        return EvolutionPlan(
+            diagnosis=str(data.get("diagnosis", "")),
+            proposed_changes=[
+                ProposedChange.from_dict(c) for c in changes_raw if isinstance(c, dict)
+            ],
+            confidence=float(data.get("confidence", 0.0) or 0.0),
+            needs_human_review=bool(data.get("needs_human_review", True)),
+            raw_response=raw,
+        )
+
+
+# ----------------------------------------------------------------------
+# Helpers for the CLI / offline use
+# ----------------------------------------------------------------------
+
+
+def _bump_patch(version: str) -> str:
+    """Increment the patch component of a semver string. Falls back to '+.1'."""
+    parts = version.split(".")
+    if len(parts) == 3 and all(p.isdigit() for p in parts):
+        major, minor, patch = (int(p) for p in parts)
+        return f"{major}.{minor}.{patch + 1}"
+    return f"{version}.1"
+
+
+def apply_plan(goal: Goal, plan: EvolutionPlan, report: FailureReport) -> Goal:
+    """Apply an EvolutionPlan to a Goal, recording the version chain.
+
+    This is intentionally minimal: it sets ``parent_version``, bumps
+    ``version``, and writes ``evolution_reason`` so downstream code (and
+    humans) can trace why the goal changed. Concrete graph mutations
+    (nodes/edges/prompts) are appended to ``goal.context['evolution_log']``
+    as a structured audit trail; the actual graph rewrite is the coding
+    agent's responsibility once it picks up the trigger.
+
+    Args:
+        goal: The goal to evolve in-place.
+        plan: The EvolutionPlan returned by ``EvolutionTrigger.trigger``.
+        report: The FailureReport that prompted the evolution.
+
+    Returns:
+        The same goal instance, mutated.
+    """
+    from datetime import datetime
+
+    if plan.is_empty():
+        logger.info("apply_plan: plan is empty, skipping version bump")
+        return goal
+
+    goal.parent_version = goal.version
+    goal.version = _bump_patch(goal.version)
+    goal.evolution_reason = (
+        plan.diagnosis
+        or f"Evolved from failure report v{report.version} ({len(report.unmet_criteria)} unmet)"
+    )
+    goal.updated_at = datetime.now()
+
+    log_entry = {
+        "from_version": goal.parent_version,
+        "to_version": goal.version,
+        "failure_report_version": report.version,
+        "failure_report_goal_id": report.goal_id,
+        "diagnosis": plan.diagnosis,
+        "confidence": plan.confidence,
+        "needs_human_review": plan.needs_human_review,
+        "changes": [
+            {
+                "target": c.target,
+                "target_id": c.target_id,
+                "change_type": c.change_type,
+                "rationale": c.rationale,
+                "details": c.details,
+            }
+            for c in plan.proposed_changes
+        ],
+        "applied_at": datetime.now().isoformat(),
+    }
+    evolution_log = goal.context.setdefault("evolution_log", [])
+    if isinstance(evolution_log, list):
+        evolution_log.append(log_entry)
+    else:
+        # context['evolution_log'] was set to something unexpected — overwrite
+        goal.context["evolution_log"] = [log_entry]
+
+    return goal
+
+
+def compute_failure_rate(reports_dir: Path, window: int) -> tuple[float, int]:
+    """Failure rate over the most recent ``window`` reports on disk.
+
+    Returns ``(rate, count)`` where ``rate = count / window`` (capped at 1.0)
+    and ``count`` is the number of failure reports found in the window.
+    A higher count of recent reports => higher failure pressure => more
+    reason to auto-evolve.
+    """
+    if window <= 0:
+        return 0.0, 0
+    if not reports_dir.exists() or not reports_dir.is_dir():
+        return 0.0, 0
+
+    paths = sorted(
+        reports_dir.glob("*.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    count = min(len(paths), window)
+    return min(count / window, 1.0), count
+
+
+def load_failure_reports(reports_dir: Path) -> list[FailureReport]:
+    """Load every FailureReport JSON file in ``reports_dir``, newest first."""
+    from framework.schemas.failure_report import FailureReport
+
+    if not reports_dir.exists() or not reports_dir.is_dir():
+        return []
+
+    reports: list[tuple[float, FailureReport]] = []
+    for path in reports_dir.glob("*.json"):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            reports.append((path.stat().st_mtime, FailureReport(**data)))
+        except Exception as e:
+            logger.warning(f"Skipping unreadable failure report {path}: {e}")
+
+    reports.sort(key=lambda pair: pair[0], reverse=True)
+    return [r for _, r in reports]

--- a/core/framework/runtime/notifications.py
+++ b/core/framework/runtime/notifications.py
@@ -1,0 +1,108 @@
+"""Developer notifications for OutcomeAggregator events (Phase 4).
+
+A small, dependency-free notifier abstraction. The aggregator calls
+``notifier.notify_failure(report)`` (and optionally ``notify_progress``)
+whenever a goal evaluation completes. Concrete implementations can fan
+the event out to logs, stdout, a webhook, Slack, etc.
+
+Kept intentionally minimal — no async fan-out, no retry logic. The point
+is to give developers an actionable signal in real time without coupling
+the runtime to any specific transport.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any, Protocol
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+if TYPE_CHECKING:
+    from framework.schemas.failure_report import FailureReport
+
+logger = logging.getLogger(__name__)
+
+
+class DeveloperNotifier(Protocol):
+    """Sink for developer-facing evaluation events."""
+
+    def notify_failure(self, report: "FailureReport") -> None: ...
+
+    def notify_progress(self, progress: dict[str, Any]) -> None: ...
+
+
+class ConsoleNotifier:
+    """Default notifier — writes a one-line summary to stdout/logger.
+
+    Useful as a development default and as a base when no webhook is
+    configured. Printing rather than logging makes the signal visible
+    even when the host process suppresses framework logs.
+    """
+
+    def notify_failure(self, report: "FailureReport") -> None:
+        line = (
+            f"[hive] FAILURE goal={report.goal_name} ({report.goal_id}) "
+            f"unmet={len(report.unmet_criteria)} "
+            f"violated={len(report.violated_constraints)} "
+            f"v={report.version}"
+        )
+        print(line)
+        logger.info(line)
+
+    def notify_progress(self, progress: dict[str, Any]) -> None:
+        pct = progress.get("overall_progress", 0.0)
+        logger.info(f"[hive] progress {pct:.1%}")
+
+
+class WebhookNotifier:
+    """POST a JSON payload to a webhook URL on each failure.
+
+    Best-effort: network errors are logged but never raised, so a flaky
+    notification endpoint can never break a runtime evaluation.
+    """
+
+    def __init__(self, url: str, timeout: float = 5.0) -> None:
+        self._url = url
+        self._timeout = timeout
+
+    def notify_failure(self, report: "FailureReport") -> None:
+        payload = {
+            "event": "goal_failure",
+            "goal_id": report.goal_id,
+            "goal_name": report.goal_name,
+            "version": report.version,
+            "unmet_criteria": [c.criterion_id for c in report.unmet_criteria],
+            "violated_constraints": [
+                v.constraint_id for v in report.violated_constraints
+            ],
+            "node_ids": list(report.node_ids),
+            "edge_ids": list(report.edge_ids),
+            "summary": report.summary,
+            "metrics": {
+                "total_decisions": report.total_decisions,
+                "successful_outcomes": report.successful_outcomes,
+                "failed_outcomes": report.failed_outcomes,
+            },
+        }
+        self._post(payload)
+
+    def notify_progress(self, progress: dict[str, Any]) -> None:
+        self._post({"event": "goal_progress", **progress})
+
+    def _post(self, payload: dict[str, Any]) -> None:
+        try:
+            data = json.dumps(payload, default=str).encode("utf-8")
+            req = urlrequest.Request(
+                self._url,
+                data=data,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urlrequest.urlopen(req, timeout=self._timeout) as resp:
+                if resp.status >= 400:
+                    logger.warning(
+                        f"WebhookNotifier non-2xx response: {resp.status}"
+                    )
+        except (urlerror.URLError, TimeoutError, OSError) as e:
+            logger.warning(f"WebhookNotifier post failed: {e}")

--- a/core/framework/runtime/outcome_aggregator.py
+++ b/core/framework/runtime/outcome_aggregator.py
@@ -9,13 +9,21 @@ import asyncio
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from framework.schemas.decision import Decision, Outcome
+from framework.schemas.failure_report import (
+    FailureReport,
+    UnmetCriterion,
+    ViolatedConstraint,
+)
 
 if TYPE_CHECKING:
-    from framework.graph.goal import Goal
+    from framework.graph.goal import Goal, SuccessCriterion
+    from framework.llm.provider import LLMProvider
     from framework.runtime.event_bus import EventBus
+    from framework.runtime.notifications import DeveloperNotifier
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +90,9 @@ class OutcomeAggregator:
         self,
         goal: "Goal",
         event_bus: "EventBus | None" = None,
+        llm_provider: "LLMProvider | None" = None,
+        storage_path: "str | Path | None" = None,
+        notifier: "DeveloperNotifier | None" = None,
     ):
         """
         Initialize outcome aggregator.
@@ -89,9 +100,14 @@ class OutcomeAggregator:
         Args:
             goal: The goal to evaluate progress against
             event_bus: Optional event bus for publishing progress events
+            llm_provider: Optional LLM provider for llm_judge criteria
+            storage_path: Optional path for persisting failure reports
         """
         self.goal = goal
         self._event_bus = event_bus
+        self._llm_provider = llm_provider
+        self._storage_path = Path(storage_path) if storage_path else None
+        self._notifier = notifier
 
         # Decision tracking
         self._decisions: list[DecisionRecord] = []
@@ -109,6 +125,9 @@ class OutcomeAggregator:
         self._total_decisions = 0
         self._successful_outcomes = 0
         self._failed_outcomes = 0
+
+        # Last failure report (populated when goal fails)
+        self._last_failure_report: FailureReport | None = None
 
     def _initialize_criteria(self) -> None:
         """Initialize criterion status from goal."""
@@ -220,6 +239,314 @@ class OutcomeAggregator:
                 )
             )
 
+    # === CRITERION EVALUATION ===
+
+    async def evaluate_criterion(
+        self,
+        criterion: "SuccessCriterion",
+        execution_output: Any,
+    ) -> bool:
+        """Evaluate a single criterion against an execution output.
+
+        Dispatches based on criterion.metric:
+        - 'output_contains': checks target substring in str(output)
+        - 'output_equals': checks str(output) == str(target)
+        - 'llm_judge': uses LLM to evaluate (requires llm_provider)
+        - 'custom': evaluates target as a safe expression with output in scope
+
+        Args:
+            criterion: The success criterion to evaluate.
+            execution_output: The output from an execution run.
+
+        Returns:
+            True if the criterion is met.
+        """
+        metric = criterion.metric
+        target = criterion.target
+
+        try:
+            if metric == "output_contains":
+                return self._eval_output_contains(target, execution_output)
+            elif metric == "output_equals":
+                return self._eval_output_equals(target, execution_output)
+            elif metric == "llm_judge":
+                return await self._eval_llm_judge(criterion, execution_output)
+            elif metric == "custom":
+                return self._eval_custom(target, execution_output)
+            else:
+                # Unknown metric — fall back to success_rate heuristic
+                logger.debug(
+                    f"Unknown metric '{metric}' for criterion {criterion.id}, "
+                    "skipping output-based evaluation"
+                )
+                return False
+        except Exception as e:
+            logger.warning(f"Error evaluating criterion {criterion.id}: {e}")
+            return False
+
+    async def evaluate_output(self, execution_output: Any) -> bool:
+        """Evaluate all goal criteria against an execution output.
+
+        Sets criterion.met on each SuccessCriterion and returns
+        goal.is_success(). When the goal is not achieved, automatically
+        generates a FailureReport and persists it to disk (if storage_path
+        is configured).
+
+        Args:
+            execution_output: The output from an execution run.
+
+        Returns:
+            True if the goal is achieved (via goal.is_success()).
+        """
+        for criterion in self.goal.success_criteria:
+            met = await self.evaluate_criterion(criterion, execution_output)
+            criterion.met = met
+
+            status = self._criterion_status.get(criterion.id)
+            if status:
+                status.met = met
+                status.progress = 1.0 if met else status.progress
+                if met:
+                    status.evidence.append(
+                        f"criterion met via {criterion.metric} evaluation"
+                    )
+
+        success = self.goal.is_success()
+        if not success:
+            report = self.generate_failure_report()
+            # Append to the goal's failure history with a monotonic version
+            # so callers (e.g. evolution) can iterate the full history.
+            report.version = len(self.goal.failure_history) + 1
+            self.goal.failure_history.append(report)
+            self._last_failure_report = report
+            self.save_failure_report(report)
+
+            # Phase 4: developer notification on failure (best-effort)
+            if self._notifier is not None:
+                try:
+                    self._notifier.notify_failure(report)
+                except Exception as e:
+                    logger.warning(f"Notifier.notify_failure failed: {e}")
+
+        return success
+
+    # === FAILURE REPORTING ===
+
+    @property
+    def last_failure_report(self) -> FailureReport | None:
+        """The most recent failure report, or None if the goal succeeded."""
+        return self._last_failure_report
+
+    def generate_failure_report(self) -> FailureReport:
+        """Build a FailureReport from current aggregator state.
+
+        Synthesizes unmet criteria, violated constraints, relevant node IDs
+        from the execution trace, and a human-readable summary.
+        """
+        # Collect unmet criteria
+        unmet = [
+            UnmetCriterion(
+                criterion_id=c.id,
+                description=c.description,
+                metric=c.metric,
+                target=c.target,
+                weight=c.weight,
+            )
+            for c in self.goal.success_criteria
+            if not c.met
+        ]
+
+        # Collect violated constraints
+        violated = [
+            ViolatedConstraint(
+                constraint_id=v.constraint_id,
+                description=v.description,
+                constraint_type=self._constraint_type_for(v.constraint_id),
+                violation_details=v.violation_details or "",
+                stream_id=v.stream_id,
+                execution_id=v.execution_id,
+            )
+            for v in self._constraint_violations
+            if v.violated
+        ]
+
+        # Collect node IDs from decisions whose outcomes failed
+        node_ids: list[str] = []
+        seen: set[str] = set()
+        for rec in self._decisions:
+            nid = rec.decision.node_id
+            if nid in seen:
+                continue
+            # Include nodes with failed outcomes, or nodes related to
+            # unmet criteria (by keyword overlap)
+            if rec.outcome and not rec.outcome.success:
+                node_ids.append(nid)
+                seen.add(nid)
+            elif any(
+                self._is_related_to_criterion(rec.decision, c)
+                for c in self.goal.success_criteria
+                if not c.met
+            ):
+                node_ids.append(nid)
+                seen.add(nid)
+
+        # Derive edge IDs from consecutive decisions in the trace.
+        # An edge "src->dst" is included when either endpoint is a node
+        # already flagged as failure-relevant, so evolution can target the
+        # transitions that led into/out of failing nodes.
+        edge_ids: list[str] = []
+        edge_seen: set[str] = set()
+        flagged = set(node_ids)
+        for prev, curr in zip(self._decisions, self._decisions[1:]):
+            src = prev.decision.node_id
+            dst = curr.decision.node_id
+            if src == dst:
+                continue
+            if src not in flagged and dst not in flagged:
+                continue
+            edge_id = f"{src}->{dst}"
+            if edge_id in edge_seen:
+                continue
+            edge_ids.append(edge_id)
+            edge_seen.add(edge_id)
+
+        summary = self._build_failure_summary(unmet, violated, node_ids)
+
+        # Tag the report with an ErrorCategory derived from the summary +
+        # any constraint violation details. Best-effort: failures here are
+        # non-fatal because the categorizer is only an evolution hint.
+        error_category: str | None = None
+        try:
+            from framework.testing.categorizer import ErrorCategorizer
+
+            cat_text_parts = [summary] + [v.violation_details for v in violated]
+            cat_text = " ".join(p for p in cat_text_parts if p)
+            error_category = str(ErrorCategorizer().categorize_text(cat_text))
+        except Exception as e:
+            logger.debug(f"Skipping error categorization: {e}")
+
+        return FailureReport(
+            goal_id=self.goal.id,
+            goal_name=self.goal.name,
+            unmet_criteria=unmet,
+            violated_constraints=violated,
+            node_ids=node_ids,
+            edge_ids=edge_ids,
+            error_category=error_category,
+            summary=summary,
+            total_decisions=self._total_decisions,
+            successful_outcomes=self._successful_outcomes,
+            failed_outcomes=self._failed_outcomes,
+        )
+
+    def save_failure_report(self, report: FailureReport) -> Path | None:
+        """Persist a failure report to disk.
+
+        Writes to ``{storage_path}/failure_reports/{goal_id}_{timestamp}.json``.
+        Returns the path written, or None if no storage_path is configured.
+        """
+        if self._storage_path is None:
+            return None
+
+        reports_dir = self._storage_path / "failure_reports"
+        reports_dir.mkdir(parents=True, exist_ok=True)
+
+        timestamp = report.timestamp.strftime("%Y%m%d_%H%M%S")
+        filename = f"{report.goal_id}_{timestamp}.json"
+        report_path = reports_dir / filename
+
+        try:
+            from framework.utils.io import atomic_write
+
+            with atomic_write(report_path) as f:
+                f.write(report.model_dump_json(indent=2))
+            logger.info(f"Saved failure report to {report_path}")
+            return report_path
+        except Exception as e:
+            logger.error(f"Failed to save failure report: {e}")
+            return None
+
+    def _constraint_type_for(self, constraint_id: str) -> str:
+        """Look up constraint_type from the goal's constraint list."""
+        for c in self.goal.constraints:
+            if c.id == constraint_id:
+                return c.constraint_type
+        return "unknown"
+
+    @staticmethod
+    def _build_failure_summary(
+        unmet: list[UnmetCriterion],
+        violated: list[ViolatedConstraint],
+        node_ids: list[str],
+    ) -> str:
+        parts: list[str] = []
+
+        if unmet:
+            criteria_desc = "; ".join(c.description for c in unmet)
+            parts.append(f"{len(unmet)} unmet criteria: {criteria_desc}")
+
+        if violated:
+            hard = [v for v in violated if v.constraint_type == "hard"]
+            soft = [v for v in violated if v.constraint_type != "hard"]
+            if hard:
+                parts.append(
+                    f"{len(hard)} hard constraint violation(s): "
+                    + "; ".join(v.violation_details for v in hard)
+                )
+            if soft:
+                parts.append(f"{len(soft)} soft constraint violation(s)")
+
+        if node_ids:
+            parts.append(f"Relevant nodes: {', '.join(node_ids)}")
+
+        if not parts:
+            return "Goal not achieved (no specific failure details available)."
+        return "Goal not achieved. " + ". ".join(parts) + "."
+
+    # --- metric dispatch helpers ---
+
+    @staticmethod
+    def _eval_output_contains(target: Any, output: Any) -> bool:
+        output_str = str(output)
+        target_str = str(target)
+        return target_str in output_str
+
+    @staticmethod
+    def _eval_output_equals(target: Any, output: Any) -> bool:
+        # Try exact match first, then string comparison
+        if output == target:
+            return True
+        return str(output).strip() == str(target).strip()
+
+    async def _eval_llm_judge(
+        self,
+        criterion: "SuccessCriterion",
+        output: Any,
+    ) -> bool:
+        if self._llm_provider is None:
+            logger.warning(
+                f"llm_judge requested for criterion {criterion.id} "
+                "but no LLM provider configured — skipping"
+            )
+            return False
+
+        from framework.graph.judge import judge_criterion
+
+        return await judge_criterion(self._llm_provider, criterion, output)
+
+    @staticmethod
+    def _eval_custom(target: Any, output: Any) -> bool:
+        """Evaluate a custom expression using safe_eval.
+
+        The target is treated as a Python expression string.
+        The variable 'output' is available in the expression scope.
+        """
+        from framework.graph.safe_eval import safe_eval
+
+        expr = str(target)
+        result = safe_eval(expr, {"output": output})
+        return bool(result)
+
     # === GOAL EVALUATION ===
 
     async def evaluate_goal_progress(self) -> dict[str, Any]:
@@ -313,29 +640,39 @@ class OutcomeAggregator:
     async def _evaluate_criterion(self, criterion: Any) -> CriterionStatus:
         """
         Evaluate a single success criterion.
-        This is a heuristic evaluation based on decision outcomes.
-        More sophisticated evaluation can be added per criterion type.
+
+        For metric-based criteria (output_contains/equals/llm_judge/custom),
+        this returns the cached criterion.met set by ``evaluate_output``. The
+        legacy keyword-heuristic path was removed in favor of
+        ``evaluate_criterion`` which dispatches on the actual metric type
+        (issue #3900, Phase 1).
+
+        For success_rate criteria, decision outcomes are still used — but
+        without the brittle description-keyword filter; we instead consider
+        all decisions whose ``active_constraints`` reference this criterion.
         """
         status = CriterionStatus(
             criterion_id=criterion.id,
             description=criterion.description,
-            met=False,
-            progress=0.0,
+            met=bool(getattr(criterion, "met", False)),
+            progress=1.0 if getattr(criterion, "met", False) else 0.0,
             evidence=[],
         )
 
-        # Guard: only apply this heuristic to success-rate criteria
         criterion_type = getattr(criterion, "type", "success_rate")
         if criterion_type != "success_rate":
+            # Metric-based criterion: trust the value set by evaluate_output.
             return status
 
-        # Get relevant decisions (those mentioning this criterion or related intents)
-        relevant_decisions = [
+        # Success-rate criterion: aggregate from decisions whose
+        # active_constraints reference this criterion id. Falls back to all
+        # decisions if no constraint-tagging is in use.
+        tagged_decisions = [
             d
             for d in self._decisions
             if criterion.id in str(d.decision.active_constraints)
-            or self._is_related_to_criterion(d.decision, criterion)
         ]
+        relevant_decisions = tagged_decisions or list(self._decisions)
 
         if not relevant_decisions:
             # No evidence yet
@@ -455,5 +792,6 @@ class OutcomeAggregator:
         self._total_decisions = 0
         self._successful_outcomes = 0
         self._failed_outcomes = 0
+        self._last_failure_report = None
         self._initialize_criteria()
         logger.info("OutcomeAggregator reset")

--- a/core/framework/runtime/stream_runtime.py
+++ b/core/framework/runtime/stream_runtime.py
@@ -172,6 +172,29 @@ class StreamRuntime:
         run.output_data = output_data or {}
         run.complete(status, narrative)
 
+        # Evaluate goal criteria against the execution output.
+        # end_run is sync, so we schedule evaluation as a task — but attach a
+        # done-callback so exceptions surface in logs instead of being silently
+        # swallowed by the event loop.
+        if self._outcome_aggregator and output_data:
+            eval_task = asyncio.create_task(
+                self._outcome_aggregator.evaluate_output(output_data)
+            )
+
+            def _log_eval_exception(task: "asyncio.Task[Any]") -> None:
+                try:
+                    exc = task.exception()
+                except asyncio.CancelledError:
+                    return
+                if exc is not None:
+                    logger.error(
+                        "OutcomeAggregator.evaluate_output failed for "
+                        f"execution {execution_id}: {exc}",
+                        exc_info=exc,
+                    )
+
+            eval_task.add_done_callback(_log_eval_exception)
+
         # Save to storage asynchronously
         asyncio.create_task(self._save_run(execution_id, run))
 

--- a/core/framework/runtime/tests/test_agent_runtime.py
+++ b/core/framework/runtime/tests/test_agent_runtime.py
@@ -388,6 +388,442 @@ class TestOutcomeAggregator:
         assert aggregator._constraint_violations[0].constraint_id == "c-1"
 
 
+class TestEvaluateCriterion:
+    """Tests for OutcomeAggregator.evaluate_criterion dispatch."""
+
+    def _make_goal(self, criteria):
+        return Goal(
+            id="eval-goal",
+            name="Eval Goal",
+            description="Test evaluation",
+            success_criteria=criteria,
+        )
+
+    @pytest.mark.asyncio
+    async def test_output_contains_met(self):
+        criterion = SuccessCriterion(
+            id="c1",
+            description="Output contains greeting",
+            metric="output_contains",
+            target="hello",
+        )
+        goal = self._make_goal([criterion])
+        agg = OutcomeAggregator(goal)
+        assert await agg.evaluate_criterion(criterion, "say hello world") is True
+
+    @pytest.mark.asyncio
+    async def test_output_contains_not_met(self):
+        criterion = SuccessCriterion(
+            id="c1",
+            description="Output contains greeting",
+            metric="output_contains",
+            target="hello",
+        )
+        goal = self._make_goal([criterion])
+        agg = OutcomeAggregator(goal)
+        assert await agg.evaluate_criterion(criterion, "goodbye") is False
+
+    @pytest.mark.asyncio
+    async def test_output_equals_exact(self):
+        criterion = SuccessCriterion(
+            id="c1",
+            description="Output equals 42",
+            metric="output_equals",
+            target=42,
+        )
+        goal = self._make_goal([criterion])
+        agg = OutcomeAggregator(goal)
+        assert await agg.evaluate_criterion(criterion, 42) is True
+
+    @pytest.mark.asyncio
+    async def test_output_equals_string_strip(self):
+        criterion = SuccessCriterion(
+            id="c1",
+            description="Output equals result",
+            metric="output_equals",
+            target="result",
+        )
+        goal = self._make_goal([criterion])
+        agg = OutcomeAggregator(goal)
+        assert await agg.evaluate_criterion(criterion, "  result  ") is True
+
+    @pytest.mark.asyncio
+    async def test_output_equals_not_met(self):
+        criterion = SuccessCriterion(
+            id="c1",
+            description="Output equals result",
+            metric="output_equals",
+            target="expected",
+        )
+        goal = self._make_goal([criterion])
+        agg = OutcomeAggregator(goal)
+        assert await agg.evaluate_criterion(criterion, "actual") is False
+
+    @pytest.mark.asyncio
+    async def test_custom_expression(self):
+        criterion = SuccessCriterion(
+            id="c1",
+            description="Output length > 5",
+            metric="custom",
+            target="len(str(output)) > 5",
+        )
+        goal = self._make_goal([criterion])
+        agg = OutcomeAggregator(goal)
+        assert await agg.evaluate_criterion(criterion, "long enough") is True
+        assert await agg.evaluate_criterion(criterion, "hi") is False
+
+    @pytest.mark.asyncio
+    async def test_custom_dict_access(self):
+        criterion = SuccessCriterion(
+            id="c1",
+            description="Output has status ok",
+            metric="custom",
+            target='output.get("status") == "ok"',
+        )
+        goal = self._make_goal([criterion])
+        agg = OutcomeAggregator(goal)
+        assert await agg.evaluate_criterion(criterion, {"status": "ok"}) is True
+        assert await agg.evaluate_criterion(criterion, {"status": "error"}) is False
+
+    @pytest.mark.asyncio
+    async def test_llm_judge_no_provider_returns_false(self):
+        criterion = SuccessCriterion(
+            id="c1",
+            description="Semantically correct",
+            metric="llm_judge",
+            target="Answer is factually accurate",
+        )
+        goal = self._make_goal([criterion])
+        agg = OutcomeAggregator(goal)  # no llm_provider
+        assert await agg.evaluate_criterion(criterion, "some output") is False
+
+    @pytest.mark.asyncio
+    async def test_unknown_metric_returns_false(self):
+        criterion = SuccessCriterion(
+            id="c1",
+            description="Some criterion",
+            metric="unknown_metric_xyz",
+            target="whatever",
+        )
+        goal = self._make_goal([criterion])
+        agg = OutcomeAggregator(goal)
+        assert await agg.evaluate_criterion(criterion, "output") is False
+
+
+class TestEvaluateOutput:
+    """Tests for OutcomeAggregator.evaluate_output and goal.is_success wiring."""
+
+    @pytest.mark.asyncio
+    async def test_all_criteria_met(self):
+        criteria = [
+            SuccessCriterion(
+                id="c1",
+                description="Contains hello",
+                metric="output_contains",
+                target="hello",
+                weight=1.0,
+            ),
+            SuccessCriterion(
+                id="c2",
+                description="Contains world",
+                metric="output_contains",
+                target="world",
+                weight=1.0,
+            ),
+        ]
+        goal = Goal(
+            id="g1", name="G", description="test", success_criteria=criteria
+        )
+        agg = OutcomeAggregator(goal)
+
+        result = await agg.evaluate_output("hello world")
+
+        assert result is True
+        assert goal.is_success() is True
+        assert criteria[0].met is True
+        assert criteria[1].met is True
+
+    @pytest.mark.asyncio
+    async def test_partial_criteria_met_below_threshold(self):
+        criteria = [
+            SuccessCriterion(
+                id="c1",
+                description="Contains hello",
+                metric="output_contains",
+                target="hello",
+                weight=1.0,
+            ),
+            SuccessCriterion(
+                id="c2",
+                description="Contains xyz",
+                metric="output_contains",
+                target="xyz",
+                weight=1.0,
+            ),
+        ]
+        goal = Goal(
+            id="g1", name="G", description="test", success_criteria=criteria
+        )
+        agg = OutcomeAggregator(goal)
+
+        result = await agg.evaluate_output("hello world")
+
+        # 50% met, below 90% threshold
+        assert result is False
+        assert goal.is_success() is False
+        assert criteria[0].met is True
+        assert criteria[1].met is False
+
+    @pytest.mark.asyncio
+    async def test_criterion_status_updated(self):
+        criteria = [
+            SuccessCriterion(
+                id="c1",
+                description="Equals 42",
+                metric="output_equals",
+                target=42,
+                weight=1.0,
+            ),
+        ]
+        goal = Goal(
+            id="g1", name="G", description="test", success_criteria=criteria
+        )
+        agg = OutcomeAggregator(goal)
+
+        await agg.evaluate_output(42)
+
+        status = agg.get_criterion_status("c1")
+        assert status is not None
+        assert status.met is True
+        assert status.progress == 1.0
+        assert len(status.evidence) > 0
+
+
+class TestFailureReport:
+    """Tests for FailureReport generation and persistence."""
+
+    def _make_goal(self, criteria, constraints=None):
+        return Goal(
+            id="fr-goal",
+            name="Failure Report Goal",
+            description="Test failure reporting",
+            success_criteria=criteria,
+            constraints=constraints or [],
+        )
+
+    @pytest.mark.asyncio
+    async def test_failure_report_generated_on_failure(self):
+        """evaluate_output sets last_failure_report when goal fails."""
+        criteria = [
+            SuccessCriterion(
+                id="c1",
+                description="Contains magic",
+                metric="output_contains",
+                target="magic",
+                weight=1.0,
+            ),
+        ]
+        goal = self._make_goal(criteria)
+        agg = OutcomeAggregator(goal)
+
+        result = await agg.evaluate_output("no match here")
+
+        assert result is False
+        report = agg.last_failure_report
+        assert report is not None
+        assert report.goal_id == "fr-goal"
+        assert len(report.unmet_criteria) == 1
+        assert report.unmet_criteria[0].criterion_id == "c1"
+        assert "1 unmet criteria" in report.summary
+
+    @pytest.mark.asyncio
+    async def test_no_failure_report_on_success(self):
+        """evaluate_output does not set last_failure_report on success."""
+        criteria = [
+            SuccessCriterion(
+                id="c1",
+                description="Contains hello",
+                metric="output_contains",
+                target="hello",
+                weight=1.0,
+            ),
+        ]
+        goal = self._make_goal(criteria)
+        agg = OutcomeAggregator(goal)
+
+        result = await agg.evaluate_output("hello world")
+
+        assert result is True
+        assert agg.last_failure_report is None
+
+    @pytest.mark.asyncio
+    async def test_failure_report_includes_constraint_violations(self):
+        """Constraint violations appear in the failure report."""
+        criteria = [
+            SuccessCriterion(
+                id="c1",
+                description="Always fails",
+                metric="output_equals",
+                target="impossible",
+                weight=1.0,
+            ),
+        ]
+        constraints = [
+            Constraint(
+                id="rate-limit",
+                description="Must not exceed rate limits",
+                constraint_type="hard",
+            ),
+        ]
+        goal = self._make_goal(criteria, constraints)
+        agg = OutcomeAggregator(goal)
+
+        agg.record_constraint_violation(
+            constraint_id="rate-limit",
+            description="Must not exceed rate limits",
+            violation_details="100 requests/min exceeded",
+            stream_id="s1",
+            execution_id="e1",
+        )
+
+        await agg.evaluate_output("nope")
+
+        report = agg.last_failure_report
+        assert report is not None
+        assert len(report.violated_constraints) == 1
+        vc = report.violated_constraints[0]
+        assert vc.constraint_id == "rate-limit"
+        assert vc.constraint_type == "hard"
+        assert "100 requests/min" in vc.violation_details
+        assert "hard constraint violation" in report.summary
+
+    @pytest.mark.asyncio
+    async def test_failure_report_includes_node_ids(self):
+        """Node IDs from failed decisions appear in the report."""
+        from framework.schemas.decision import Decision, DecisionType, Outcome
+
+        criteria = [
+            SuccessCriterion(
+                id="c1",
+                description="Always fails",
+                metric="output_equals",
+                target="impossible",
+                weight=1.0,
+            ),
+        ]
+        goal = self._make_goal(criteria)
+        agg = OutcomeAggregator(goal)
+
+        decision = Decision(
+            id="d1",
+            node_id="process-node",
+            intent="Process data",
+            decision_type=DecisionType.TOOL_SELECTION,
+        )
+        agg.record_decision("s1", "e1", decision)
+        agg.record_outcome(
+            "s1", "e1", "d1",
+            Outcome(success=False, error="Something broke"),
+        )
+
+        await agg.evaluate_output("nope")
+
+        report = agg.last_failure_report
+        assert report is not None
+        assert "process-node" in report.node_ids
+        assert report.failed_outcomes == 1
+
+    @pytest.mark.asyncio
+    async def test_failure_report_saved_to_disk(self, tmp_path):
+        """Failure report is persisted when storage_path is set."""
+        criteria = [
+            SuccessCriterion(
+                id="c1",
+                description="Always fails",
+                metric="output_equals",
+                target="impossible",
+                weight=1.0,
+            ),
+        ]
+        goal = self._make_goal(criteria)
+        agg = OutcomeAggregator(goal, storage_path=tmp_path)
+
+        await agg.evaluate_output("nope")
+
+        reports_dir = tmp_path / "failure_reports"
+        assert reports_dir.exists()
+        report_files = list(reports_dir.glob("fr-goal_*.json"))
+        assert len(report_files) == 1
+
+        # Verify the file is valid JSON and round-trips
+        import json
+
+        content = json.loads(report_files[0].read_text())
+        assert content["goal_id"] == "fr-goal"
+        assert len(content["unmet_criteria"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_failure_report_not_saved_without_storage(self):
+        """No crash when storage_path is None."""
+        criteria = [
+            SuccessCriterion(
+                id="c1",
+                description="Always fails",
+                metric="output_equals",
+                target="impossible",
+                weight=1.0,
+            ),
+        ]
+        goal = self._make_goal(criteria)
+        agg = OutcomeAggregator(goal)  # no storage_path
+
+        await agg.evaluate_output("nope")
+
+        # Should still have the in-memory report
+        assert agg.last_failure_report is not None
+
+    def test_generate_failure_report_directly(self):
+        """generate_failure_report works as a standalone call."""
+        criteria = [
+            SuccessCriterion(
+                id="c1",
+                description="Check A",
+                metric="output_contains",
+                target="A",
+                weight=0.5,
+                met=False,
+            ),
+            SuccessCriterion(
+                id="c2",
+                description="Check B",
+                metric="output_contains",
+                target="B",
+                weight=0.5,
+                met=True,
+            ),
+        ]
+        goal = self._make_goal(criteria)
+        agg = OutcomeAggregator(goal)
+
+        report = agg.generate_failure_report()
+
+        assert len(report.unmet_criteria) == 1
+        assert report.unmet_criteria[0].criterion_id == "c1"
+        assert report.unmet_criteria[0].weight == 0.5
+        assert "Check A" in report.summary
+
+    def test_reset_clears_failure_report(self):
+        """reset() clears last_failure_report."""
+        goal = self._make_goal([])
+        agg = OutcomeAggregator(goal)
+        # Manually set a report
+        from framework.schemas.failure_report import FailureReport
+
+        agg._last_failure_report = FailureReport(goal_id="x", goal_name="x")
+        agg.reset()
+        assert agg.last_failure_report is None
+
+
 # === AgentRuntime Tests ===
 
 

--- a/core/framework/runtime/tests/test_evaluate_criterion.py
+++ b/core/framework/runtime/tests/test_evaluate_criterion.py
@@ -1,0 +1,233 @@
+"""Tests for OutcomeAggregator.evaluate_criterion() — all four metric types.
+
+Covers the dispatch table in OutcomeAggregator.evaluate_criterion:
+  - output_contains
+  - output_equals
+  - custom        (safe_eval expression)
+  - llm_judge     (delegates to framework.graph.judge.judge_criterion)
+
+Plus the unknown-metric fallback.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from framework.graph.goal import Goal, SuccessCriterion
+from framework.runtime.outcome_aggregator import OutcomeAggregator
+
+
+def _goal(criterion: SuccessCriterion) -> Goal:
+    return Goal(
+        id="g1",
+        name="Test Goal",
+        description="test",
+        success_criteria=[criterion],
+        constraints=[],
+    )
+
+
+def _agg(criterion: SuccessCriterion, llm_provider=None) -> OutcomeAggregator:
+    return OutcomeAggregator(_goal(criterion), llm_provider=llm_provider)
+
+
+# ----------------------------------------------------------------------
+# output_contains
+# ----------------------------------------------------------------------
+
+
+class TestOutputContains:
+    @pytest.mark.asyncio
+    async def test_substring_present_returns_true(self) -> None:
+        c = SuccessCriterion(
+            id="c1",
+            description="must mention widgets",
+            metric="output_contains",
+            target="widgets",
+        )
+        assert await _agg(c).evaluate_criterion(c, "we sell widgets here") is True
+
+    @pytest.mark.asyncio
+    async def test_substring_absent_returns_false(self) -> None:
+        c = SuccessCriterion(
+            id="c1",
+            description="must mention widgets",
+            metric="output_contains",
+            target="widgets",
+        )
+        assert await _agg(c).evaluate_criterion(c, "nothing relevant") is False
+
+    @pytest.mark.asyncio
+    async def test_non_string_output_is_stringified(self) -> None:
+        c = SuccessCriterion(
+            id="c1",
+            description="contains 42",
+            metric="output_contains",
+            target="42",
+        )
+        assert await _agg(c).evaluate_criterion(c, {"answer": 42}) is True
+
+
+# ----------------------------------------------------------------------
+# output_equals
+# ----------------------------------------------------------------------
+
+
+class TestOutputEquals:
+    @pytest.mark.asyncio
+    async def test_exact_match(self) -> None:
+        c = SuccessCriterion(
+            id="c1", description="exact", metric="output_equals", target=42
+        )
+        assert await _agg(c).evaluate_criterion(c, 42) is True
+
+    @pytest.mark.asyncio
+    async def test_string_strip_match(self) -> None:
+        c = SuccessCriterion(
+            id="c1", description="exact", metric="output_equals", target="result"
+        )
+        assert await _agg(c).evaluate_criterion(c, "  result  ") is True
+
+    @pytest.mark.asyncio
+    async def test_mismatch_returns_false(self) -> None:
+        c = SuccessCriterion(
+            id="c1", description="exact", metric="output_equals", target="expected"
+        )
+        assert await _agg(c).evaluate_criterion(c, "actual") is False
+
+
+# ----------------------------------------------------------------------
+# custom (safe_eval)
+# ----------------------------------------------------------------------
+
+
+class TestCustomMetric:
+    @pytest.mark.asyncio
+    async def test_length_expression_met(self) -> None:
+        c = SuccessCriterion(
+            id="c1",
+            description="long enough",
+            metric="custom",
+            target="len(output) >= 5",
+        )
+        assert await _agg(c).evaluate_criterion(c, "long enough") is True
+
+    @pytest.mark.asyncio
+    async def test_length_expression_not_met(self) -> None:
+        c = SuccessCriterion(
+            id="c1",
+            description="long enough",
+            metric="custom",
+            target="len(output) >= 5",
+        )
+        assert await _agg(c).evaluate_criterion(c, "hi") is False
+
+    @pytest.mark.asyncio
+    async def test_dict_field_access(self) -> None:
+        c = SuccessCriterion(
+            id="c1",
+            description="status ok",
+            metric="custom",
+            target="output.get('status') == 'ok'",
+        )
+        agg = _agg(c)
+        assert await agg.evaluate_criterion(c, {"status": "ok"}) is True
+        assert await agg.evaluate_criterion(c, {"status": "error"}) is False
+
+    @pytest.mark.asyncio
+    async def test_invalid_expression_returns_false(self) -> None:
+        c = SuccessCriterion(
+            id="c1",
+            description="bad expr",
+            metric="custom",
+            target="this is not valid python",
+        )
+        assert await _agg(c).evaluate_criterion(c, "anything") is False
+
+
+# ----------------------------------------------------------------------
+# llm_judge
+# ----------------------------------------------------------------------
+
+
+def _mock_llm(response_content: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        acomplete=AsyncMock(return_value=SimpleNamespace(content=response_content))
+    )
+
+
+class TestLLMJudge:
+    @pytest.mark.asyncio
+    async def test_no_provider_returns_false(self) -> None:
+        c = SuccessCriterion(
+            id="c1",
+            description="semantically correct",
+            metric="llm_judge",
+            target="answer is accurate",
+        )
+        assert await _agg(c).evaluate_criterion(c, "anything") is False
+
+    @pytest.mark.asyncio
+    async def test_judge_says_met(self) -> None:
+        c = SuccessCriterion(
+            id="c1",
+            description="semantically correct",
+            metric="llm_judge",
+            target="answer is accurate",
+        )
+        llm = _mock_llm('{"met": true, "confidence": 0.9, "reason": "ok"}')
+        assert await _agg(c, llm_provider=llm).evaluate_criterion(c, "blue") is True
+        llm.acomplete.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_judge_says_not_met(self) -> None:
+        c = SuccessCriterion(
+            id="c1",
+            description="semantically correct",
+            metric="llm_judge",
+            target="answer is accurate",
+        )
+        llm = _mock_llm('{"met": false, "confidence": 0.8, "reason": "wrong"}')
+        assert await _agg(c, llm_provider=llm).evaluate_criterion(c, "green") is False
+
+    @pytest.mark.asyncio
+    async def test_judge_handles_fenced_json(self) -> None:
+        c = SuccessCriterion(
+            id="c1",
+            description="semantically correct",
+            metric="llm_judge",
+            target="answer is accurate",
+        )
+        llm = _mock_llm('```json\n{"met": true, "confidence": 1.0}\n```')
+        assert await _agg(c, llm_provider=llm).evaluate_criterion(c, "x") is True
+
+    @pytest.mark.asyncio
+    async def test_judge_llm_failure_returns_false(self) -> None:
+        c = SuccessCriterion(
+            id="c1",
+            description="semantically correct",
+            metric="llm_judge",
+            target="answer is accurate",
+        )
+        llm = SimpleNamespace(acomplete=AsyncMock(side_effect=RuntimeError("boom")))
+        assert await _agg(c, llm_provider=llm).evaluate_criterion(c, "x") is False
+
+
+# ----------------------------------------------------------------------
+# Unknown metric
+# ----------------------------------------------------------------------
+
+
+class TestUnknownMetric:
+    @pytest.mark.asyncio
+    async def test_unknown_metric_returns_false(self) -> None:
+        c = SuccessCriterion(
+            id="c1",
+            description="mystery",
+            metric="not_a_real_metric",
+            target="whatever",
+        )
+        assert await _agg(c).evaluate_criterion(c, "output") is False

--- a/core/framework/runtime/tests/test_evolution_trigger.py
+++ b/core/framework/runtime/tests/test_evolution_trigger.py
@@ -1,0 +1,319 @@
+"""Tests for EvolutionTrigger."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from framework.graph.goal import Goal
+from framework.runtime.evolution_trigger import (
+    EvolutionPlan,
+    EvolutionTrigger,
+    ProposedChange,
+    apply_plan,
+    compute_failure_rate,
+    load_failure_reports,
+)
+from framework.schemas.failure_report import (
+    FailureReport,
+    UnmetCriterion,
+    ViolatedConstraint,
+)
+
+
+def _make_report() -> FailureReport:
+    return FailureReport(
+        goal_id="g1",
+        goal_name="Test Goal",
+        unmet_criteria=[
+            UnmetCriterion(
+                criterion_id="c1",
+                description="Output mentions widgets",
+                metric="output_contains",
+                target="widgets",
+                weight=1.0,
+            )
+        ],
+        violated_constraints=[
+            ViolatedConstraint(
+                constraint_id="x1",
+                description="No PII",
+                constraint_type="hard",
+                violation_details="email leaked",
+            )
+        ],
+        node_ids=["nodeA", "nodeB"],
+        summary="Goal not achieved",
+        total_decisions=3,
+        successful_outcomes=1,
+        failed_outcomes=2,
+    )
+
+
+class TestBuildPrompt:
+    def test_prompt_includes_all_sections(self) -> None:
+        llm = SimpleNamespace(acomplete=AsyncMock())
+        trigger = EvolutionTrigger(llm_provider=llm)
+        prompt = trigger.build_prompt(_make_report())
+
+        assert "Test Goal" in prompt
+        assert "g1" in prompt
+        assert "c1" in prompt
+        assert "widgets" in prompt
+        assert "x1" in prompt
+        assert "email leaked" in prompt
+        assert "nodeA" in prompt
+        assert "decisions: 3" in prompt
+
+    def test_prompt_includes_error_category(self) -> None:
+        llm = SimpleNamespace(acomplete=AsyncMock())
+        trigger = EvolutionTrigger(llm_provider=llm)
+        report = _make_report()
+        report.error_category = "implementation_error"
+        prompt = trigger.build_prompt(report)
+        assert "ERROR CATEGORY: implementation_error" in prompt
+
+    def test_prompt_handles_missing_error_category(self) -> None:
+        llm = SimpleNamespace(acomplete=AsyncMock())
+        trigger = EvolutionTrigger(llm_provider=llm)
+        prompt = trigger.build_prompt(_make_report())
+        assert "ERROR CATEGORY: (uncategorized)" in prompt
+
+
+class TestRequiresBackend:
+    def test_construction_requires_backend(self) -> None:
+        with pytest.raises(ValueError):
+            EvolutionTrigger()
+
+
+class TestParseResponse:
+    def test_parses_valid_json(self) -> None:
+        payload = json.dumps(
+            {
+                "diagnosis": "missing prompt instruction",
+                "proposed_changes": [
+                    {
+                        "target": "node_id",
+                        "target_id": "nodeA",
+                        "change_type": "modify",
+                        "rationale": "add explicit mention",
+                        "details": "append 'widgets' to prompt",
+                    }
+                ],
+                "confidence": 0.7,
+                "needs_human_review": False,
+            }
+        )
+        plan = EvolutionTrigger._parse_response(payload)
+        assert plan.diagnosis == "missing prompt instruction"
+        assert plan.confidence == 0.7
+        assert plan.needs_human_review is False
+        assert len(plan.proposed_changes) == 1
+        assert plan.proposed_changes[0].target_id == "nodeA"
+
+    def test_parses_markdown_fenced_json(self) -> None:
+        payload = (
+            "```json\n"
+            '{"diagnosis":"x","proposed_changes":[],'
+            '"confidence":0.1,"needs_human_review":true}\n```'
+        )
+        plan = EvolutionTrigger._parse_response(payload)
+        assert plan.diagnosis == "x"
+
+    def test_invalid_json_returns_empty_plan_with_raw(self) -> None:
+        plan = EvolutionTrigger._parse_response("not json at all")
+        assert "Failed to parse" in plan.diagnosis
+        assert plan.raw_response == "not json at all"
+
+
+class TestDispatchToLLM:
+    @pytest.mark.asyncio
+    async def test_calls_llm_and_parses(self) -> None:
+        response = SimpleNamespace(
+            content=json.dumps(
+                {
+                    "diagnosis": "ok",
+                    "proposed_changes": [],
+                    "confidence": 0.5,
+                    "needs_human_review": True,
+                }
+            )
+        )
+        llm = SimpleNamespace(acomplete=AsyncMock(return_value=response))
+        trigger = EvolutionTrigger(llm_provider=llm)
+
+        plan = await trigger.trigger(_make_report())
+
+        assert plan.diagnosis == "ok"
+        llm.acomplete.assert_awaited_once()
+        kwargs = llm.acomplete.await_args.kwargs
+        assert kwargs["json_mode"] is True
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_returns_error_plan(self) -> None:
+        llm = SimpleNamespace(acomplete=AsyncMock(side_effect=RuntimeError("boom")))
+        trigger = EvolutionTrigger(llm_provider=llm)
+        plan = await trigger.trigger(_make_report())
+        assert "boom" in plan.diagnosis
+
+
+class TestDispatchToQueen:
+    @pytest.mark.asyncio
+    async def test_injects_trigger_event(self) -> None:
+        queen_node = SimpleNamespace(inject_trigger=AsyncMock())
+        trigger = EvolutionTrigger(queen_node=queen_node)
+
+        plan = await trigger.trigger(_make_report())
+
+        assert queen_node.inject_trigger.await_count == 1
+        event = queen_node.inject_trigger.await_args.args[0]
+        assert event.trigger_type == "evolution"
+        assert event.payload["goal_id"] == "g1"
+        assert event.payload["node_ids"] == ["nodeA", "nodeB"]
+        assert "task" in event.payload
+        assert plan.needs_human_review is False
+
+    @pytest.mark.asyncio
+    async def test_queen_takes_precedence_over_llm(self) -> None:
+        queen_node = SimpleNamespace(inject_trigger=AsyncMock())
+        llm = SimpleNamespace(acomplete=AsyncMock())
+        trigger = EvolutionTrigger(llm_provider=llm, queen_node=queen_node)
+        await trigger.trigger(_make_report())
+        queen_node.inject_trigger.assert_awaited_once()
+        llm.acomplete.assert_not_awaited()
+
+
+class TestLoadFailureReports:
+    def test_loads_and_sorts_newest_first(self, tmp_path: Path) -> None:
+        d = tmp_path / "failure_reports"
+        d.mkdir()
+
+        r1 = _make_report()
+        r1.goal_id = "older"
+        r2 = _make_report()
+        r2.goal_id = "newer"
+
+        p1 = d / "older.json"
+        p2 = d / "newer.json"
+        p1.write_text(r1.model_dump_json())
+        p2.write_text(r2.model_dump_json())
+
+        # Force p2 to be newer
+        import os
+        import time
+
+        old_time = time.time() - 100
+        os.utime(p1, (old_time, old_time))
+
+        loaded = load_failure_reports(d)
+        assert [r.goal_id for r in loaded] == ["newer", "older"]
+
+    def test_missing_dir_returns_empty(self, tmp_path: Path) -> None:
+        assert load_failure_reports(tmp_path / "nope") == []
+
+
+def test_proposed_change_from_dict_handles_missing_fields() -> None:
+    c = ProposedChange.from_dict({})
+    assert c.target == ""
+    assert c.target_id is None
+
+
+def test_evolution_plan_is_empty_default() -> None:
+    plan = EvolutionPlan()
+    assert plan.is_empty()
+
+
+# ----------------------------------------------------------------------
+# apply_plan: Phase 3 version-chain bookkeeping
+# ----------------------------------------------------------------------
+
+
+class TestApplyPlan:
+    def test_version_bump_and_chain(self) -> None:
+        goal = Goal(id="g", name="G", description="d", version="1.2.3")
+        plan = EvolutionPlan(
+            diagnosis="missing widget",
+            proposed_changes=[
+                ProposedChange(
+                    target="node_id",
+                    target_id="nA",
+                    change_type="modify",
+                    rationale="r",
+                    details="dt",
+                )
+            ],
+            confidence=0.6,
+        )
+        report = FailureReport(goal_id="g", goal_name="G", version=3)
+
+        apply_plan(goal, plan, report)
+        assert goal.parent_version == "1.2.3"
+        assert goal.version == "1.2.4"
+        assert goal.evolution_reason == "missing widget"
+
+        log = goal.context["evolution_log"]
+        assert len(log) == 1
+        assert log[0]["from_version"] == "1.2.3"
+        assert log[0]["to_version"] == "1.2.4"
+        assert log[0]["failure_report_version"] == 3
+        assert log[0]["changes"][0]["target_id"] == "nA"
+
+    def test_empty_plan_skips_bump(self) -> None:
+        goal = Goal(id="g", name="G", description="d", version="1.0.0")
+        apply_plan(goal, EvolutionPlan(), FailureReport(goal_id="g", goal_name="G"))
+        assert goal.version == "1.0.0"
+        assert goal.parent_version is None
+        assert "evolution_log" not in goal.context
+
+    def test_non_semver_version_falls_back(self) -> None:
+        goal = Goal(id="g", name="G", description="d", version="alpha")
+        plan = EvolutionPlan(
+            diagnosis="x",
+            proposed_changes=[
+                ProposedChange(
+                    target="prompt",
+                    target_id=None,
+                    change_type="add",
+                    rationale="r",
+                    details="d",
+                )
+            ],
+        )
+        apply_plan(goal, plan, FailureReport(goal_id="g", goal_name="G"))
+        assert goal.version == "alpha.1"
+
+
+# ----------------------------------------------------------------------
+# compute_failure_rate: Phase 3 automatic-trigger gate
+# ----------------------------------------------------------------------
+
+
+class TestComputeFailureRate:
+    def test_empty_dir_returns_zero(self, tmp_path: Path) -> None:
+        rate, count = compute_failure_rate(tmp_path / "missing", 4)
+        assert rate == 0.0
+        assert count == 0
+
+    def test_zero_window(self, tmp_path: Path) -> None:
+        assert compute_failure_rate(tmp_path, 0) == (0.0, 0)
+
+    def test_full_window(self, tmp_path: Path) -> None:
+        d = tmp_path / "failure_reports"
+        d.mkdir()
+        for i in range(4):
+            (d / f"r{i}.json").write_text("{}")
+        rate, count = compute_failure_rate(d, 4)
+        assert rate == 1.0
+        assert count == 4
+
+    def test_partial_window(self, tmp_path: Path) -> None:
+        d = tmp_path / "failure_reports"
+        d.mkdir()
+        (d / "r1.json").write_text("{}")
+        rate, count = compute_failure_rate(d, 4)
+        assert count == 1
+        assert rate == 0.25

--- a/core/framework/runtime/tests/test_notifications.py
+++ b/core/framework/runtime/tests/test_notifications.py
@@ -1,0 +1,99 @@
+"""Tests for the developer-notification sinks (Phase 4).
+
+Covers ConsoleNotifier (stdout one-liner) and WebhookNotifier (POSTs JSON
+payload, swallows network errors so a flaky endpoint can never break a
+runtime evaluation).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from framework.runtime.notifications import ConsoleNotifier, WebhookNotifier
+from framework.schemas.failure_report import (
+    FailureReport,
+    UnmetCriterion,
+    ViolatedConstraint,
+)
+
+
+class TestConsoleNotifier:
+    def test_notify_failure_prints_summary(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        ConsoleNotifier().notify_failure(
+            FailureReport(goal_id="g1", goal_name="G", version=2)
+        )
+        out = capsys.readouterr().out
+        assert "FAILURE goal=G (g1)" in out
+        assert "v=2" in out
+
+
+class TestWebhookNotifier:
+    def test_post_called_with_json_payload(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict = {}
+
+        class _Resp:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def fake_urlopen(req, timeout):  # noqa: ARG001
+            captured["url"] = req.full_url
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            return _Resp()
+
+        monkeypatch.setattr(
+            "framework.runtime.notifications.urlrequest.urlopen", fake_urlopen
+        )
+
+        WebhookNotifier("https://example.test/hook").notify_failure(
+            FailureReport(
+                goal_id="g1",
+                goal_name="G",
+                unmet_criteria=[
+                    UnmetCriterion(
+                        criterion_id="c1",
+                        description="d",
+                        metric="output_contains",
+                        target="x",
+                        weight=1.0,
+                    )
+                ],
+                violated_constraints=[
+                    ViolatedConstraint(
+                        constraint_id="k1",
+                        description="d",
+                        constraint_type="hard",
+                        violation_details="v",
+                    )
+                ],
+                edge_ids=["a->b"],
+            )
+        )
+        assert captured["url"] == "https://example.test/hook"
+        assert captured["body"]["event"] == "goal_failure"
+        assert captured["body"]["unmet_criteria"] == ["c1"]
+        assert captured["body"]["edge_ids"] == ["a->b"]
+
+    def test_network_failure_is_swallowed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def boom(req, timeout):  # noqa: ARG001
+            raise OSError("no route")
+
+        monkeypatch.setattr(
+            "framework.runtime.notifications.urlrequest.urlopen", boom
+        )
+        # Must not raise.
+        WebhookNotifier("https://x").notify_failure(
+            FailureReport(goal_id="g", goal_name="G")
+        )

--- a/core/framework/runtime/tests/test_outcome_aggregator.py
+++ b/core/framework/runtime/tests/test_outcome_aggregator.py
@@ -1,0 +1,142 @@
+"""Tests for OutcomeAggregator failure recording, history, and notifier integration.
+
+Companion to ``test_evaluate_criterion.py`` (which covers metric dispatch).
+This file focuses on the Phase 2/4 surfaces of OutcomeAggregator:
+
+- ``evaluate_output`` populates ``Goal.failure_history`` with monotonic versions
+- successful evaluations don't append to history
+- failure reports are persisted to disk under ``storage_path``
+- ``generate_failure_report`` derives ``edge_ids`` from consecutive decisions
+- Phase 4 developer notifier is invoked on failure and isolated from exceptions
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from framework.graph.goal import Goal, SuccessCriterion
+from framework.runtime.outcome_aggregator import OutcomeAggregator
+from framework.schemas.decision import Decision, Outcome
+from framework.schemas.failure_report import FailureReport
+
+
+def _failing_goal() -> Goal:
+    return Goal(
+        id="g1",
+        name="G",
+        description="d",
+        success_criteria=[
+            SuccessCriterion(
+                id="c1",
+                description="must contain widgets",
+                metric="output_contains",
+                target="widgets",
+            )
+        ],
+    )
+
+
+class TestFailureHistory:
+    @pytest.mark.asyncio
+    async def test_evaluate_output_appends_history_with_versioning(
+        self, tmp_path: Path
+    ) -> None:
+        goal = _failing_goal()
+        agg = OutcomeAggregator(goal, storage_path=tmp_path)
+
+        ok = await agg.evaluate_output("nothing relevant")
+        assert ok is False
+        assert len(goal.failure_history) == 1
+        assert goal.failure_history[0].version == 1
+
+        for c in goal.success_criteria:
+            c.met = False
+        ok = await agg.evaluate_output("still nothing")
+        assert ok is False
+        assert len(goal.failure_history) == 2
+        assert goal.failure_history[1].version == 2
+
+    @pytest.mark.asyncio
+    async def test_successful_evaluation_does_not_append(self) -> None:
+        goal = _failing_goal()
+        agg = OutcomeAggregator(goal)
+        ok = await agg.evaluate_output("we have widgets here")
+        assert ok is True
+        assert goal.failure_history == []
+
+    @pytest.mark.asyncio
+    async def test_failure_report_persisted_to_disk(self, tmp_path: Path) -> None:
+        goal = _failing_goal()
+        agg = OutcomeAggregator(goal, storage_path=tmp_path)
+        await agg.evaluate_output("no match")
+        files = list((tmp_path / "failure_reports").glob("*.json"))
+        assert len(files) == 1
+        data = json.loads(files[0].read_text())
+        assert data["goal_id"] == "g1"
+        assert data["version"] == 1
+
+
+class TestGenerateFailureReportEdges:
+    def test_edge_ids_field_default_empty(self) -> None:
+        r = FailureReport(goal_id="g", goal_name="n")
+        assert r.edge_ids == []
+
+    def test_derives_edges_between_failed_nodes(self) -> None:
+        goal = _failing_goal()
+        agg = OutcomeAggregator(goal)
+
+        d1 = Decision(
+            id="d1", node_id="nodeA", intent="i", action="a", reasoning="r"
+        )
+        d2 = Decision(
+            id="d2", node_id="nodeB", intent="i", action="a", reasoning="r"
+        )
+        agg.record_decision("s", "e", d1)
+        agg.record_outcome("s", "e", "d1", Outcome(decision_id="d1", success=False))
+        agg.record_decision("s", "e", d2)
+        agg.record_outcome("s", "e", "d2", Outcome(decision_id="d2", success=False))
+
+        report = agg.generate_failure_report()
+        assert "nodeA" in report.node_ids
+        assert "nodeB" in report.node_ids
+        assert "nodeA->nodeB" in report.edge_ids
+
+
+class TestErrorCategoryWiring:
+    @pytest.mark.asyncio
+    async def test_failure_report_has_error_category(self) -> None:
+        goal = _failing_goal()
+        agg = OutcomeAggregator(goal)
+        await agg.evaluate_output("no match")
+        assert goal.failure_history[0].error_category is not None
+
+
+class TestNotifierIntegration:
+    @pytest.mark.asyncio
+    async def test_notifier_invoked_on_failure(self) -> None:
+        calls: list = []
+        notifier = SimpleNamespace(
+            notify_failure=lambda r: calls.append(r),
+            notify_progress=lambda p: None,
+        )
+        agg = OutcomeAggregator(_failing_goal(), notifier=notifier)
+        await agg.evaluate_output("none")
+        assert len(calls) == 1
+        assert calls[0].goal_id == "g1"
+
+    @pytest.mark.asyncio
+    async def test_notifier_exception_does_not_break_eval(self) -> None:
+        def boom(_r):
+            raise RuntimeError("notifier down")
+
+        notifier = SimpleNamespace(
+            notify_failure=boom, notify_progress=lambda p: None
+        )
+        agg = OutcomeAggregator(_failing_goal(), notifier=notifier)
+        # Best-effort: notifier failure must not propagate.
+        result = await agg.evaluate_output("none")
+        assert result is False

--- a/core/framework/schemas/__init__.py
+++ b/core/framework/schemas/__init__.py
@@ -1,6 +1,7 @@
 """Schema definitions for runtime data."""
 
 from framework.schemas.decision import Decision, DecisionEvaluation, Option, Outcome
+from framework.schemas.failure_report import FailureReport, UnmetCriterion, ViolatedConstraint
 from framework.schemas.run import Problem, Run, RunSummary
 
 __all__ = [
@@ -11,4 +12,7 @@ __all__ = [
     "Run",
     "RunSummary",
     "Problem",
+    "FailureReport",
+    "UnmetCriterion",
+    "ViolatedConstraint",
 ]

--- a/core/framework/schemas/failure_report.py
+++ b/core/framework/schemas/failure_report.py
@@ -1,0 +1,95 @@
+"""
+Failure Report - Synthesized diagnosis when goal.is_success() returns False.
+
+Generated automatically by OutcomeAggregator after evaluate_output detects
+that the goal was not achieved. Captures unmet criteria, violated constraints,
+relevant node IDs from the execution trace, and a human-readable summary.
+"""
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class UnmetCriterion(BaseModel):
+    """A success criterion that was not met."""
+
+    criterion_id: str
+    description: str
+    metric: str
+    target: Any
+    weight: float
+
+    model_config = {"extra": "allow"}
+
+
+class ViolatedConstraint(BaseModel):
+    """A constraint that was violated during execution."""
+
+    constraint_id: str
+    description: str
+    constraint_type: str  # "hard" or "soft"
+    violation_details: str
+    stream_id: str | None = None
+    execution_id: str | None = None
+
+    model_config = {"extra": "allow"}
+
+
+class FailureReport(BaseModel):
+    """Synthesized report when goal evaluation fails.
+
+    Combines unmet criteria, violated constraints, and execution trace
+    data into a single artifact for debugging and iteration guidance.
+    """
+
+    goal_id: str
+    goal_name: str
+
+    # What failed
+    unmet_criteria: list[UnmetCriterion] = Field(default_factory=list)
+    violated_constraints: list[ViolatedConstraint] = Field(default_factory=list)
+
+    # Execution context
+    node_ids: list[str] = Field(
+        default_factory=list,
+        description="Node IDs from the execution trace relevant to the failure",
+    )
+    edge_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Edge IDs ('src->dst') derived from consecutive decisions in the "
+            "failed execution trace, used for targeted evolution"
+        ),
+    )
+
+    # Versioning: monotonically increasing sequence per goal
+    version: int = Field(
+        default=1,
+        description="Sequence number within the goal's failure history",
+    )
+
+    # Categorization (Phase 3): category derived from the failure summary
+    # via ErrorCategorizer, used by EvolutionTrigger to scope its prompt.
+    # Stored as a plain string to keep this schema decoupled from the
+    # testing module's ErrorCategory enum.
+    error_category: str | None = Field(
+        default=None,
+        description="logic_error | implementation_error | edge_case",
+    )
+
+    # Summary
+    summary: str = Field(
+        default="",
+        description="Human-readable summary of why the goal was not achieved",
+    )
+
+    # Metrics snapshot
+    total_decisions: int = 0
+    successful_outcomes: int = 0
+    failed_outcomes: int = 0
+
+    timestamp: datetime = Field(default_factory=datetime.now)
+
+    model_config = {"extra": "allow"}

--- a/core/framework/testing/categorizer.py
+++ b/core/framework/testing/categorizer.py
@@ -159,6 +159,28 @@ class ErrorCategorizer:
         confidence = edge_matches / total_matches if total_matches > 0 else 0.5
         return ErrorCategory.EDGE_CASE, min(0.9, 0.5 + confidence * 0.4)
 
+    def categorize_text(self, text: str) -> ErrorCategory:
+        """
+        Categorize a raw error / failure-summary string.
+
+        Used by OutcomeAggregator to tag a FailureReport with an
+        ErrorCategory without needing a TestResult. Same priority order as
+        ``categorize``: logic > implementation > edge case.
+        """
+        if not text:
+            return ErrorCategory.IMPLEMENTATION_ERROR
+
+        for pattern in self._logic_patterns:
+            if pattern.search(text):
+                return ErrorCategory.LOGIC_ERROR
+        for pattern in self._impl_patterns:
+            if pattern.search(text):
+                return ErrorCategory.IMPLEMENTATION_ERROR
+        for pattern in self._edge_patterns:
+            if pattern.search(text):
+                return ErrorCategory.EDGE_CASE
+        return ErrorCategory.IMPLEMENTATION_ERROR
+
     def _get_error_text(self, result: TestResult) -> str:
         """Extract all error text from a result for analysis."""
         parts = []

--- a/core/framework/testing/cli.py
+++ b/core/framework/testing/cli.py
@@ -15,6 +15,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 
 def _check_pytest_available() -> bool:
@@ -76,6 +77,49 @@ def register_testing_commands(subparsers: argparse._SubParsersAction) -> None:
         default="all",
         help="Type of tests to run",
     )
+    run_parser.add_argument(
+        "--auto-evolve",
+        action="store_true",
+        help=(
+            "If tests fail, load recent FailureReports from the agent's "
+            "storage and dispatch them through EvolutionTrigger to a "
+            "coding agent for proposed graph changes."
+        ),
+    )
+    run_parser.add_argument(
+        "--storage-path",
+        default=None,
+        help=(
+            "Storage root containing failure_reports/ "
+            "(defaults to <agent_path>/.runtime). Used with --auto-evolve."
+        ),
+    )
+    run_parser.add_argument(
+        "--max-reports",
+        type=int,
+        default=1,
+        help="Max failure reports to evolve (newest first). Default: 1",
+    )
+    run_parser.add_argument(
+        "--evolve-threshold",
+        type=float,
+        default=None,
+        help=(
+            "Failure-rate threshold (0.0-1.0). When set with --auto-evolve, "
+            "evolution only fires if recent failure rate over --evolve-window "
+            "meets or exceeds this value. Without it, --auto-evolve fires on "
+            "any pytest failure."
+        ),
+    )
+    run_parser.add_argument(
+        "--evolve-window",
+        type=int,
+        default=4,
+        help=(
+            "Number of recent failure reports to consider when computing "
+            "the failure rate for --evolve-threshold. Default: 4"
+        ),
+    )
     run_parser.set_defaults(func=cmd_test_run)
 
     # test-debug
@@ -126,6 +170,112 @@ def register_testing_commands(subparsers: argparse._SubParsersAction) -> None:
         help="Path to agent export folder (e.g., exports/my_agent)",
     )
     stats_parser.set_defaults(func=cmd_test_stats)
+
+    # eval-report
+    eval_parser = subparsers.add_parser(
+        "eval-report",
+        help="Print formatted summary of the most recent FailureReport on disk",
+    )
+    eval_parser.add_argument(
+        "agent_path",
+        help="Path to agent export folder",
+    )
+    eval_parser.add_argument(
+        "--storage-path",
+        default=None,
+        help="Storage root containing failure_reports/ (default: <agent_path>/.runtime)",
+    )
+    eval_parser.add_argument(
+        "--goal",
+        "-g",
+        default=None,
+        help="Filter to a specific goal_id (default: latest report regardless of goal)",
+    )
+    eval_parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Print all reports (newest first) instead of only the latest",
+    )
+    eval_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit raw JSON instead of formatted text",
+    )
+    eval_parser.set_defaults(func=cmd_eval_report)
+
+    # evolve (manual trigger)
+    evolve_parser = subparsers.add_parser(
+        "evolve",
+        help=(
+            "Manually dispatch FailureReports to a coding agent and apply "
+            "the resulting EvolutionPlan to the goal (Phase 3 trigger)."
+        ),
+    )
+    evolve_parser.add_argument("agent_path", help="Path to agent export folder")
+    evolve_parser.add_argument(
+        "--storage-path",
+        default=None,
+        help="Storage root containing failure_reports/ (default: <agent_path>/.runtime)",
+    )
+    evolve_parser.add_argument(
+        "--goal",
+        "-g",
+        default=None,
+        help="Restrict to a specific goal_id",
+    )
+    evolve_parser.add_argument(
+        "--max-reports",
+        type=int,
+        default=1,
+        help="Max reports to dispatch (newest first). Default: 1",
+    )
+    evolve_parser.add_argument(
+        "--goal-file",
+        default=None,
+        help=(
+            "Path to a goal JSON file to mutate in-place (parent_version, "
+            "version, evolution_reason). If omitted, the plan is printed only."
+        ),
+    )
+    evolve_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the proposed plan without writing the goal file",
+    )
+    evolve_parser.add_argument(
+        "--rerun-tests",
+        action="store_true",
+        help=(
+            "After applying the evolution plan, re-run the agent's test "
+            "suite to validate the change (Phase 4 feedback loop)."
+        ),
+    )
+    evolve_parser.set_defaults(func=cmd_evolve)
+
+    # eval-trends
+    trends_parser = subparsers.add_parser(
+        "eval-trends",
+        help="Emit per-version evaluation trends from stored failure reports",
+    )
+    trends_parser.add_argument("agent_path", help="Path to agent export folder")
+    trends_parser.add_argument(
+        "--storage-path",
+        default=None,
+        help="Storage root containing failure_reports/ (default: <agent_path>/.runtime)",
+    )
+    trends_parser.add_argument(
+        "--goal",
+        "-g",
+        default=None,
+        help="Restrict to a specific goal_id",
+    )
+    trends_parser.add_argument(
+        "--format",
+        choices=["json", "table"],
+        default="table",
+        help="Output format. JSON is suitable for dashboard ingestion.",
+    )
+    trends_parser.set_defaults(func=cmd_eval_trends)
 
 
 def cmd_test_run(args: argparse.Namespace) -> int:
@@ -201,7 +351,538 @@ def cmd_test_run(args: argparse.Namespace) -> int:
         print(f"Error: Failed to run pytest: {e}")
         return 1
 
+    # Goal-criteria evaluation alongside pytest pass/fail (AC #4 of #3900).
+    # We load the agent's goal and report its current criterion.met status
+    # plus any FailureReports generated during this run, so test-run is no
+    # longer just pytest pass/fail.
+    _print_goal_criteria_status(agent_path, args.storage_path)
+
+    if result.returncode != 0 and getattr(args, "auto_evolve", False):
+        # Optional failure-rate gating: only evolve when recent failure
+        # pressure crosses --evolve-threshold over --evolve-window reports.
+        threshold = getattr(args, "evolve_threshold", None)
+        if threshold is not None:
+            from framework.runtime.evolution_trigger import compute_failure_rate
+
+            storage_root = (
+                Path(args.storage_path)
+                if args.storage_path
+                else agent_path / ".runtime"
+            )
+            reports_dir = storage_root / "failure_reports"
+            rate, count = compute_failure_rate(reports_dir, args.evolve_window)
+            print(
+                f"\n[auto-evolve] failure rate {rate:.2f} "
+                f"({count}/{args.evolve_window} recent reports), "
+                f"threshold={threshold:.2f}"
+            )
+            if rate < threshold:
+                print("[auto-evolve] below threshold - skipping evolution")
+                return result.returncode
+
+        _run_auto_evolve(
+            agent_path=agent_path,
+            storage_path=args.storage_path,
+            max_reports=args.max_reports,
+        )
+
     return result.returncode
+
+
+def _print_goal_criteria_status(
+    agent_path: Path,
+    storage_path: str | None,
+) -> None:
+    """Print goal success-criteria status after a pytest run.
+
+    Loads the agent module to get its Goal, then reports each criterion's
+    pass/fail. Criterion state is sourced from the most recent FailureReport
+    on disk for the goal (which is generated by OutcomeAggregator during
+    real agent execution). If no FailureReport exists, all criteria are
+    assumed met.
+
+    This makes ``hive test-run`` integrate with goal-criteria evaluation
+    rather than reporting only pytest pass/fail (issue #3900 AC #4).
+    """
+    try:
+        from framework.runner.runner import AgentRunner  # noqa: F401
+    except Exception:
+        pass
+
+    # Load the goal directly from the agent module without bringing up the
+    # full runner. We import agent.py / __init__.py and grab `goal`.
+    goal = _load_agent_goal(agent_path)
+    if goal is None:
+        return
+
+    storage_root = (
+        Path(storage_path) if storage_path else agent_path / ".runtime"
+    )
+    reports_dir = storage_root / "failure_reports"
+
+    latest_unmet_ids: set[str] = set()
+    latest_report = None
+    try:
+        from framework.runtime.evolution_trigger import load_failure_reports
+
+        reports = [r for r in load_failure_reports(reports_dir) if r.goal_id == goal.id]
+        if reports:
+            latest_report = reports[0]
+            latest_unmet_ids = {c.criterion_id for c in latest_report.unmet_criteria}
+    except Exception as e:
+        print(f"\n[criteria] could not load failure reports: {e}")
+
+    print("\n=== Goal Criteria Status ===")
+    print(f"goal: {goal.name} ({goal.id})")
+    if not goal.success_criteria:
+        print("  (no success_criteria defined)")
+        return
+
+    met_count = 0
+    for c in goal.success_criteria:
+        met = c.id not in latest_unmet_ids
+        if met:
+            met_count += 1
+        marker = "PASS" if met else "FAIL"
+        print(f"  [{marker}] {c.id}: {c.description} (metric={c.metric})")
+
+    total = len(goal.success_criteria)
+    print(f"  -> {met_count}/{total} criteria met")
+    if latest_report and latest_report.violated_constraints:
+        print(
+            f"  -> {len(latest_report.violated_constraints)} "
+            "constraint violation(s)"
+        )
+    if latest_report and latest_report.error_category:
+        print(f"  -> error_category: {latest_report.error_category}")
+
+
+def _load_agent_goal(agent_path: Path) -> Any:
+    """Best-effort import of an agent's Goal from agent.py / __init__.py.
+
+    Real-world templates use relative imports (``from .config import ...``)
+    so we must import the agent as a *package*, not as a standalone file.
+    Strategy: add the agent's parent directory to sys.path and do a normal
+    package import (e.g. ``import competitive_intel_agent``), then read
+    ``agent.goal`` or ``package.goal``.
+    """
+    import importlib
+    import sys
+
+    if not agent_path.exists():
+        return None
+
+    # Project root must be importable for ``framework.*`` references inside
+    # the agent module.
+    project_root = Path(__file__).parent.parent.parent.parent.resolve()
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+
+    parent = str(agent_path.parent.resolve())
+    if parent not in sys.path:
+        sys.path.insert(0, parent)
+
+    package_name = agent_path.name
+    try:
+        # Import the package itself first — this evaluates __init__.py and
+        # establishes the package context required by relative imports.
+        pkg = importlib.import_module(package_name)
+        goal = getattr(pkg, "goal", None)
+        if goal is not None:
+            return goal
+
+        # If __init__.py doesn't re-export goal, try the agent submodule.
+        try:
+            agent_mod = importlib.import_module(f"{package_name}.agent")
+            return getattr(agent_mod, "goal", None)
+        except ModuleNotFoundError:
+            return None
+    except Exception as e:
+        print(f"\n[criteria] could not load agent goal for {agent_path.name}: {e}")
+        return None
+
+
+def _run_auto_evolve(
+    agent_path: Path,
+    storage_path: str | None,
+    max_reports: int,
+) -> None:
+    """Load recent FailureReports and dispatch them via EvolutionTrigger.
+
+    Best-effort: failures here never change the test exit code, they only
+    print diagnostics.
+    """
+    import asyncio
+
+    try:
+        from framework.llm.litellm import LiteLLMProvider
+        from framework.runtime.evolution_trigger import (
+            EvolutionTrigger,
+            load_failure_reports,
+        )
+    except Exception as e:
+        print(f"\n[auto-evolve] import failed: {e}")
+        return
+
+    storage_root = Path(storage_path) if storage_path else agent_path / ".runtime"
+    reports_dir = storage_root / "failure_reports"
+
+    print(f"\n[auto-evolve] scanning {reports_dir}")
+    reports = load_failure_reports(reports_dir)
+    if not reports:
+        print("[auto-evolve] no failure reports found - nothing to evolve")
+        return
+
+    reports = reports[: max(1, max_reports)]
+    print(f"[auto-evolve] dispatching {len(reports)} failure report(s)")
+
+    model = os.environ.get("HIVE_EVOLVE_MODEL") or os.environ.get(
+        "HIVE_DEFAULT_MODEL", "gpt-4o-mini"
+    )
+    try:
+        llm = LiteLLMProvider(model=model)
+    except Exception as e:
+        print(f"[auto-evolve] could not initialize LLM provider ({model}): {e}")
+        return
+    print(f"[auto-evolve] using model: {model}")
+
+    trigger = EvolutionTrigger(llm_provider=llm)
+
+    async def _run() -> None:
+        for report in reports:
+            print(f"\n[auto-evolve] goal={report.goal_name} ({report.goal_id})")
+            plan = await trigger.trigger(report)
+            print(f"  diagnosis: {plan.diagnosis}")
+            print(f"  confidence: {plan.confidence}")
+            print(f"  needs_human_review: {plan.needs_human_review}")
+            if plan.proposed_changes:
+                print(f"  proposed changes ({len(plan.proposed_changes)}):")
+                for i, change in enumerate(plan.proposed_changes, 1):
+                    print(
+                        f"    {i}. [{change.change_type}] "
+                        f"{change.target}={change.target_id}"
+                    )
+                    print(f"       rationale: {change.rationale}")
+                    print(f"       details: {change.details}")
+            else:
+                print("  (no concrete changes proposed)")
+
+    try:
+        asyncio.run(_run())
+    except Exception as e:
+        print(f"[auto-evolve] dispatch failed: {e}")
+
+
+def cmd_evolve(args: argparse.Namespace) -> int:
+    """Manually dispatch failure reports through EvolutionTrigger and apply
+    the resulting plan to a goal file (Phase 3 manual trigger).
+    """
+    import asyncio
+    import json as _json
+
+    try:
+        from framework.graph.goal import Goal
+        from framework.llm.litellm import LiteLLMProvider
+        from framework.runtime.evolution_trigger import (
+            EvolutionTrigger,
+            apply_plan,
+            load_failure_reports,
+        )
+    except Exception as e:
+        print(f"[evolve] import failed: {e}")
+        return 1
+
+    agent_path = Path(args.agent_path)
+    storage_root = (
+        Path(args.storage_path) if args.storage_path else agent_path / ".runtime"
+    )
+    reports_dir = storage_root / "failure_reports"
+
+    reports = load_failure_reports(reports_dir)
+    if args.goal:
+        reports = [r for r in reports if r.goal_id == args.goal]
+    if not reports:
+        print(f"[evolve] no failure reports found in {reports_dir}")
+        return 1
+    reports = reports[: max(1, args.max_reports)]
+
+    model = os.environ.get("HIVE_EVOLVE_MODEL") or os.environ.get(
+        "HIVE_DEFAULT_MODEL", "gpt-4o-mini"
+    )
+    try:
+        llm = LiteLLMProvider(model=model)
+    except Exception as e:
+        print(f"[evolve] could not initialize LLM provider ({model}): {e}")
+        return 1
+    print(f"[evolve] using model: {model}")
+
+    # Optionally load the goal to mutate
+    goal: Goal | None = None
+    goal_path: Path | None = None
+    if args.goal_file:
+        goal_path = Path(args.goal_file)
+        try:
+            goal = Goal(**_json.loads(goal_path.read_text(encoding="utf-8")))
+        except Exception as e:
+            print(f"[evolve] failed to load goal file {goal_path}: {e}")
+            return 1
+
+    trigger = EvolutionTrigger(llm_provider=llm)
+
+    async def _run() -> int:
+        nonlocal goal
+        for report in reports:
+            print(f"\n[evolve] dispatching goal={report.goal_name} ({report.goal_id})")
+            plan = await trigger.trigger(report)
+            print(f"  diagnosis: {plan.diagnosis}")
+            print(f"  confidence: {plan.confidence}")
+            if plan.proposed_changes:
+                print(f"  proposed changes ({len(plan.proposed_changes)}):")
+                for i, c in enumerate(plan.proposed_changes, 1):
+                    print(f"    {i}. [{c.change_type}] {c.target}={c.target_id}")
+                    print(f"       rationale: {c.rationale}")
+                    print(f"       details: {c.details}")
+            else:
+                print("  (no concrete changes proposed)")
+
+            if goal is not None and not args.dry_run:
+                old_version = goal.version
+                apply_plan(goal, plan, report)
+                print(
+                    f"  applied: {old_version} -> {goal.version} "
+                    f"(parent={goal.parent_version})"
+                )
+        return 0
+
+    try:
+        rc = asyncio.run(_run())
+    except Exception as e:
+        print(f"[evolve] dispatch failed: {e}")
+        return 1
+
+    if goal is not None and goal_path is not None and not args.dry_run:
+        try:
+            goal_path.write_text(
+                goal.model_dump_json(indent=2), encoding="utf-8"
+            )
+            print(f"\n[evolve] wrote updated goal to {goal_path}")
+        except Exception as e:
+            print(f"[evolve] failed to write goal file: {e}")
+            return 1
+
+    # Phase 4 feedback loop: re-run tests after the evolution applies, so
+    # the developer immediately sees whether the change improved the suite.
+    if getattr(args, "rerun_tests", False):
+        print("\n[evolve] re-running tests to validate evolution...")
+        rerun_args = argparse.Namespace(
+            agent_path=str(agent_path),
+            type="all",
+            fail_fast=False,
+            parallel=0,
+            auto_evolve=False,
+            storage_path=None,
+            max_reports=1,
+            evolve_threshold=None,
+            evolve_window=4,
+        )
+        rerun_rc = cmd_test_run(rerun_args)
+        print(
+            f"[evolve] post-evolution test exit code: {rerun_rc} "
+            f"({'PASS' if rerun_rc == 0 else 'FAIL'})"
+        )
+        # Surface the post-evolution status but don't override the dispatch rc
+        if rc == 0 and rerun_rc != 0:
+            return rerun_rc
+
+    return rc
+
+
+def cmd_eval_trends(args: argparse.Namespace) -> int:
+    """Emit per-goal-version eval trends from stored failure reports.
+
+    Bins reports by ``goal_id`` and report ``version`` and reports
+    aggregate metrics suitable for dashboard time-series ingestion.
+    """
+    import json as _json
+
+    from framework.runtime.evolution_trigger import load_failure_reports
+
+    agent_path = Path(args.agent_path)
+    storage_root = (
+        Path(args.storage_path) if args.storage_path else agent_path / ".runtime"
+    )
+    reports_dir = storage_root / "failure_reports"
+
+    reports = load_failure_reports(reports_dir)
+    if args.goal:
+        reports = [r for r in reports if r.goal_id == args.goal]
+
+    if not reports:
+        print(f"No failure reports found in {reports_dir}")
+        return 0
+
+    # Sort oldest -> newest so trend lines read left-to-right
+    reports = list(reversed(reports))
+
+    rows: list[dict[str, Any]] = []
+    for r in reports:
+        total_outcomes = r.successful_outcomes + r.failed_outcomes
+        success_rate = (
+            r.successful_outcomes / total_outcomes if total_outcomes else 0.0
+        )
+        rows.append(
+            {
+                "goal_id": r.goal_id,
+                "goal_name": r.goal_name,
+                "version": r.version,
+                "timestamp": r.timestamp.isoformat(),
+                "unmet_criteria": len(r.unmet_criteria),
+                "violated_constraints": len(r.violated_constraints),
+                "total_decisions": r.total_decisions,
+                "successful_outcomes": r.successful_outcomes,
+                "failed_outcomes": r.failed_outcomes,
+                "success_rate": round(success_rate, 4),
+                "node_ids": list(r.node_ids),
+                "edge_ids": list(r.edge_ids),
+            }
+        )
+
+    if args.format == "json":
+        print(_json.dumps(rows, indent=2, default=str))
+        return 0
+
+    # Compact table view
+    header = (
+        f"{'goal_id':<20} {'v':<4} {'unmet':<6} {'viol':<5} "
+        f"{'success':<8} {'timestamp':<25}"
+    )
+    print(header)
+    print("-" * len(header))
+    for row in rows:
+        print(
+            f"{row['goal_id'][:20]:<20} "
+            f"{row['version']:<4} "
+            f"{row['unmet_criteria']:<6} "
+            f"{row['violated_constraints']:<5} "
+            f"{row['success_rate']:<8.2f} "
+            f"{row['timestamp']:<25}"
+        )
+    return 0
+
+
+def cmd_eval_report(args: argparse.Namespace) -> int:
+    """Print a formatted summary of the most recent FailureReport(s) on disk."""
+    from framework.runtime.evolution_trigger import load_failure_reports
+
+    agent_path = Path(args.agent_path)
+    storage_root = (
+        Path(args.storage_path) if args.storage_path else agent_path / ".runtime"
+    )
+    reports_dir = storage_root / "failure_reports"
+
+    reports = load_failure_reports(reports_dir)
+    if args.goal:
+        reports = [r for r in reports if r.goal_id == args.goal]
+
+    if not reports:
+        where = f" for goal '{args.goal}'" if args.goal else ""
+        print(f"No failure reports found in {reports_dir}{where}")
+        return 0
+
+    if not args.all:
+        reports = reports[:1]
+
+    if args.json:
+        import json as _json
+
+        out = [r.model_dump(mode="json") for r in reports]
+        print(_json.dumps(out, indent=2, default=str))
+        return 0
+
+    for i, report in enumerate(reports):
+        if i > 0:
+            print()
+        _print_failure_report(report)
+
+    return 0
+
+
+def _print_failure_report(report: Any) -> None:  # type: ignore[valid-type]
+    """Pretty-print a single FailureReport to stdout."""
+    bar = "=" * 70
+    print(bar)
+    print(f"FAILURE REPORT  goal={report.goal_name} ({report.goal_id})")
+    print(f"  timestamp:  {report.timestamp}")
+    print(
+        f"  decisions:  total={report.total_decisions} "
+        f"successful={report.successful_outcomes} failed={report.failed_outcomes}"
+    )
+    print(bar)
+
+    # Criteria status
+    print("\nUNMET SUCCESS CRITERIA:")
+    if not report.unmet_criteria:
+        print("  (none)")
+    else:
+        for c in report.unmet_criteria:
+            print(f"  [X] {c.criterion_id}  weight={c.weight}")
+            print(f"      desc:   {c.description}")
+            print(f"      metric: {c.metric}")
+            print(f"      target: {c.target!r}")
+
+    # Constraint violations
+    print("\nVIOLATED CONSTRAINTS:")
+    if not report.violated_constraints:
+        print("  (none)")
+    else:
+        for v in report.violated_constraints:
+            tag = v.constraint_type.upper()
+            print(f"  [{tag}] {v.constraint_id}")
+            print(f"      desc:    {v.description}")
+            print(f"      details: {v.violation_details}")
+            if getattr(v, "stream_id", None):
+                print(f"      stream:  {v.stream_id}")
+            if getattr(v, "execution_id", None):
+                print(f"      exec:    {v.execution_id}")
+
+    # Responsible nodes
+    print("\nRESPONSIBLE NODES (from execution trace):")
+    if not report.node_ids:
+        print("  (none)")
+    else:
+        for node_id in report.node_ids:
+            print(f"  - {node_id}")
+
+    # Summary
+    print("\nSUMMARY:")
+    print(f"  {report.summary or '(no summary)'}")
+
+    # Phase 4: lightweight, deterministic evolution recommendations derived
+    # straight from the report so developers see actionable next steps
+    # without needing to run an LLM. cmd_evolve still does the real work.
+    print("\nEVOLUTION RECOMMENDATIONS:")
+    recs: list[str] = []
+    for c in report.unmet_criteria:
+        recs.append(
+            f"- Strengthen criterion '{c.criterion_id}' "
+            f"(metric={c.metric}, target={c.target!r}): "
+            f"adjust prompts or graph nodes that produce its output."
+        )
+    for v in report.violated_constraints:
+        recs.append(
+            f"- Add a guard for constraint '{v.constraint_id}' "
+            f"({v.constraint_type}): {v.description}"
+        )
+    if getattr(report, "edge_ids", None):
+        recs.append(
+            f"- Inspect failing edges: {', '.join(report.edge_ids)}"
+        )
+    if not recs:
+        print("  (no specific recommendations)")
+    else:
+        for line in recs:
+            print(f"  {line}")
+    print(bar)
 
 
 def cmd_test_debug(args: argparse.Namespace) -> int:

--- a/core/framework/testing/tests/test_categorizer.py
+++ b/core/framework/testing/tests/test_categorizer.py
@@ -1,0 +1,34 @@
+"""Tests for ErrorCategorizer.categorize_text (added for issue #3900).
+
+The original ``categorize`` API takes a TestResult, but the FailureReport
+flow needs to classify a raw summary string. ``categorize_text`` exposes
+the same patterns without requiring a TestResult.
+"""
+
+from __future__ import annotations
+
+from framework.testing.categorizer import ErrorCategorizer
+from framework.testing.test_result import ErrorCategory
+
+
+def test_categorize_text_logic_error() -> None:
+    cat = ErrorCategorizer()
+    assert cat.categorize_text("criteria not met for goal") == ErrorCategory.LOGIC_ERROR
+
+
+def test_categorize_text_implementation_error() -> None:
+    cat = ErrorCategorizer()
+    assert (
+        cat.categorize_text("AssertionError: expected 1 but got 2")
+        == ErrorCategory.IMPLEMENTATION_ERROR
+    )
+
+
+def test_categorize_text_edge_case() -> None:
+    cat = ErrorCategorizer()
+    assert cat.categorize_text("connection timeout after 30s") == ErrorCategory.EDGE_CASE
+
+
+def test_categorize_text_empty_defaults_to_implementation() -> None:
+    cat = ErrorCategorizer()
+    assert cat.categorize_text("") == ErrorCategory.IMPLEMENTATION_ERROR

--- a/core/framework/testing/tests/test_cli.py
+++ b/core/framework/testing/tests/test_cli.py
@@ -1,0 +1,251 @@
+"""Tests for framework.testing.cli — Phase 4 reporting/trends surfaces.
+
+Covers:
+- ``_print_failure_report`` includes the EVOLUTION RECOMMENDATIONS section
+- ``cmd_eval_trends`` table + JSON output and the no-reports path
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+from framework.schemas.failure_report import (
+    FailureReport,
+    UnmetCriterion,
+    ViolatedConstraint,
+)
+from framework.testing.cli import (
+    _load_agent_goal,
+    _print_failure_report,
+    _print_goal_criteria_status,
+    cmd_eval_trends,
+)
+
+
+class TestPrintFailureReport:
+    def test_includes_recommendations_section(self) -> None:
+        report = FailureReport(
+            goal_id="g1",
+            goal_name="G",
+            unmet_criteria=[
+                UnmetCriterion(
+                    criterion_id="c1",
+                    description="must mention widgets",
+                    metric="output_contains",
+                    target="widgets",
+                    weight=1.0,
+                )
+            ],
+            violated_constraints=[
+                ViolatedConstraint(
+                    constraint_id="k1",
+                    description="no PII",
+                    constraint_type="hard",
+                    violation_details="leaked",
+                )
+            ],
+            edge_ids=["a->b"],
+        )
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            _print_failure_report(report)
+        out = buf.getvalue()
+        assert "EVOLUTION RECOMMENDATIONS" in out
+        assert "Strengthen criterion 'c1'" in out
+        assert "guard for constraint 'k1'" in out
+        assert "Inspect failing edges: a->b" in out
+
+
+class TestEvalTrends:
+    def test_outputs_table_for_stored_reports(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        rd = tmp_path / ".runtime" / "failure_reports"
+        rd.mkdir(parents=True)
+        r = FailureReport(
+            goal_id="g1",
+            goal_name="G",
+            version=1,
+            unmet_criteria=[
+                UnmetCriterion(
+                    criterion_id="c1",
+                    description="d",
+                    metric="output_contains",
+                    target="x",
+                    weight=1.0,
+                )
+            ],
+            total_decisions=4,
+            successful_outcomes=1,
+            failed_outcomes=3,
+        )
+        (rd / "g1.json").write_text(r.model_dump_json())
+
+        rc = cmd_eval_trends(
+            argparse.Namespace(
+                agent_path=str(tmp_path),
+                storage_path=None,
+                goal=None,
+                format="table",
+            )
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "g1" in out
+        assert "0.25" in out  # 1 / (1+3) success rate
+
+    def test_json_output_shape(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        rd = tmp_path / ".runtime" / "failure_reports"
+        rd.mkdir(parents=True)
+        (rd / "x.json").write_text(
+            FailureReport(goal_id="g", goal_name="G", version=2).model_dump_json()
+        )
+        rc = cmd_eval_trends(
+            argparse.Namespace(
+                agent_path=str(tmp_path),
+                storage_path=None,
+                goal=None,
+                format="json",
+            )
+        )
+        assert rc == 0
+        rows = json.loads(capsys.readouterr().out)
+        assert isinstance(rows, list)
+        assert rows[0]["goal_id"] == "g"
+        assert rows[0]["version"] == 2
+
+    def _make_agent_dir(self, tmp_path: Path) -> Path:
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        (agent_dir / "agent.py").write_text(
+            """
+from framework.graph.goal import Goal, SuccessCriterion
+
+goal = Goal(
+    id="g1",
+    name="Test Goal",
+    description="d",
+    success_criteria=[
+        SuccessCriterion(
+            id="c1",
+            description="must contain widgets",
+            metric="output_contains",
+            target="widgets",
+            weight=1.0,
+        ),
+        SuccessCriterion(
+            id="c2",
+            description="must equal answer",
+            metric="output_equals",
+            target="42",
+            weight=1.0,
+        ),
+    ],
+)
+nodes = []
+edges = []
+"""
+        )
+        return agent_dir
+
+    def test_missing_reports_returns_zero(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        rc = cmd_eval_trends(
+            argparse.Namespace(
+                agent_path=str(tmp_path),
+                storage_path=None,
+                goal=None,
+                format="table",
+            )
+        )
+        assert rc == 0
+        assert "No failure reports" in capsys.readouterr().out
+
+
+class TestGoalCriteriaStatus:
+    """Tests for the AC #4 integration: hive test-run reports criteria status."""
+
+    def _make_agent_dir(self, tmp_path: Path) -> Path:
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        (agent_dir / "agent.py").write_text(
+            "from framework.graph.goal import Goal, SuccessCriterion\n"
+            "goal = Goal(\n"
+            "    id='g1', name='Test Goal', description='d',\n"
+            "    success_criteria=[\n"
+            "        SuccessCriterion(id='c1', description='must contain widgets',\n"
+            "            metric='output_contains', target='widgets', weight=1.0),\n"
+            "        SuccessCriterion(id='c2', description='answer is 42',\n"
+            "            metric='output_equals', target='42', weight=1.0),\n"
+            "    ],\n"
+            ")\n"
+            "nodes = []\n"
+            "edges = []\n"
+        )
+        return agent_dir
+
+    def test_load_agent_goal(self, tmp_path: Path) -> None:
+        agent_dir = self._make_agent_dir(tmp_path)
+        goal = _load_agent_goal(agent_dir)
+        assert goal is not None
+        assert goal.id == "g1"
+        assert len(goal.success_criteria) == 2
+
+    def test_no_failure_report_means_all_criteria_pass(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        agent_dir = self._make_agent_dir(tmp_path)
+        _print_goal_criteria_status(agent_dir, storage_path=None)
+        out = capsys.readouterr().out
+        assert "Goal Criteria Status" in out
+        assert "[PASS] c1" in out
+        assert "[PASS] c2" in out
+        assert "2/2 criteria met" in out
+
+    def test_failure_report_marks_unmet_criteria_failing(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        agent_dir = self._make_agent_dir(tmp_path)
+        reports_dir = agent_dir / ".runtime" / "failure_reports"
+        reports_dir.mkdir(parents=True)
+        report = FailureReport(
+            goal_id="g1",
+            goal_name="Test Goal",
+            unmet_criteria=[
+                UnmetCriterion(
+                    criterion_id="c1",
+                    description="must contain widgets",
+                    metric="output_contains",
+                    target="widgets",
+                    weight=1.0,
+                )
+            ],
+            error_category="implementation_error",
+        )
+        (reports_dir / "g1_20260101_000000.json").write_text(
+            report.model_dump_json()
+        )
+
+        _print_goal_criteria_status(agent_dir, storage_path=None)
+        out = capsys.readouterr().out
+        assert "[FAIL] c1" in out
+        assert "[PASS] c2" in out
+        assert "1/2 criteria met" in out
+        assert "error_category: implementation_error" in out
+
+    def test_missing_agent_module_is_silent(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        # No agent.py / __init__.py — helper should no-op without raising.
+        _print_goal_criteria_status(tmp_path, storage_path=None)
+        out = capsys.readouterr().out
+        assert "Goal Criteria Status" not in out


### PR DESCRIPTION
## Summary

Implements the missing integration layer for the self-improvement loop described in #3900. The schemas (`SuccessCriterion`, `FailureReport`, `OutcomeAggregator`, `ErrorCategorizer`, `HybridJudge`) were already in place — this PR connects them so:

- `SuccessCriterion.met` is actually populated after each execution
- `goal.is_success()` returns meaningful results
- Failed runs generate persisted, versioned `FailureReport`s
- A coding agent can be invoked with structured failure context to evolve the graph
- `hive test-run` reports goal-criteria status, not just pytest pass/fail

All four phases from the RFC are implemented end-to-end.

### Phase 1 — Criterion Evaluation Engine
- `OutcomeAggregator.evaluate_criterion` dispatches on metric type: `output_contains`, `output_equals`, `llm_judge`, `custom` (via `safe_eval`)
- `evaluate_output` sets `criterion.met` so `goal.is_success()` is meaningful
- Legacy keyword heuristic in `_evaluate_criterion` removed: metric-based criteria read `criterion.met`; success_rate criteria filter by `active_constraints`
- New `framework.graph.judge.judge_criterion` for `llm_judge` dispatch

### Phase 2 — Failure Recording & Diagnosis
- New `FailureReport` / `UnmetCriterion` / `ViolatedConstraint` schemas
- `Goal.failure_history` stores monotonic-versioned reports
- Reports persisted to `{storage_path}/failure_reports/*.json`
- `node_ids` derived from failed-outcome decisions; `edge_ids` derived from consecutive decisions involving failure-relevant nodes
- `error_category` populated via new `ErrorCategorizer.categorize_text()`

### Phase 3 — Evolution Trigger
- `EvolutionTrigger` packages a `FailureReport` into a structured prompt and dispatches to either an `LLMProvider` or a live queen via `inject_trigger`
- `apply_plan` bumps `goal.version`, sets `parent_version` + `evolution_reason`, appends to `goal.context['evolution_log']`
- `compute_failure_rate` / `load_failure_reports` helpers
- Prompt includes `ERROR CATEGORY:` so the coding agent can scope its diagnosis (wires `ErrorCategorizer` into the evolution path)

### Phase 4 — Feedback Loop & Notifications
- `DeveloperNotifier` protocol + `ConsoleNotifier`; `OutcomeAggregator` calls `notify_failure` on every failed evaluation
- `hive eval-report` — prints latest `FailureReport` with evolution recommendations
- `hive eval-trends` — failure-rate trends across stored reports
- `hive evolve` — manual + threshold-based auto-trigger; `--rerun-tests` closes the feedback loop
- `hive test-run --auto-evolve` with `--evolve-threshold` / `--evolve-window` gating
- `hive test-run` prints **Goal Criteria Status** (PASS/FAIL per criterion, met count, error_category) by loading the agent package and reading the most recent `FailureReport` — addresses **AC #4**: test CLI integrates with goal-criteria evaluation, not just pytest pass/fail

### Robustness
- `StreamRuntime.end_run` schedules `evaluate_output` as a task and attaches a done-callback that logs exceptions instead of swallowing them
- `_load_agent_goal` imports the agent as a *package* (sys.path injection + `importlib.import_module`) so templates using relative imports (`from .config import ...`) work correctly — caught by E2E testing against `examples/templates/email_reply_agent`

## Acceptance criteria mapping (#3900)

- [x] `SuccessCriterion.met` populated after every execution
- [x] `goal.is_success()` returns accurate results
- [x] Failed executions produce `FailureReport` with linked criteria, constraints, and node references
- [x] Test CLI (`hive test-run`) integrates with goal criteria evaluation
- [x] Working evolution trigger path: test failure → failure report → coding agent → modified graph

## Test plan

- [x] 61 unit tests pass: metric dispatch, failure history versioning, edge derivation, notifier isolation, EvolutionTrigger prompt/parse/apply, CLI eval-report / eval-trends / criteria-status, ErrorCategorizer categorize_text, full failure-report round-trip
- [x] E2E option A: `hive test-run examples/templates/email_reply_agent --goal email-reply-goal` prints the Goal Criteria Status block with all 3 criteria PASS (no failure reports on disk)
- [x] E2E option B: seeded a `FailureReport` via `OutcomeAggregator.evaluate_output` against the email_reply_agent goal → `hive eval-report` displays full report with evolution recommendations → re-running `test-run` shows all 3 criteria FAIL with `error_category: logic_error`
- [ ] Reviewer: optional full agent run to exercise the `StreamRuntime.end_run` → `evaluate_output` callback path with a real LLM

Closes #3900

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Goals now track failure history for analysis and improvement
* LLM-based success criterion evaluation with multiple metric types
* Automatic goal evolution triggered by detected failures
* Developer notifications via console and webhook endpoints
* Enhanced success criteria evaluation supporting custom expressions and output matching
* CLI tools for analyzing failure trends and applying evolution recommendations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->