### PR TITLE
Fix/validator code indicator false positives

### DIFF
--- a/ISSUE_DESCRIPTION.md
+++ b/ISSUE_DESCRIPTION.md
@@ -1,0 +1,16 @@
+# Issue Description
+
+## Title: False-Positive Code Blocking on Natural Language Text by OutputValidator
+
+### Description
+The OutputValidator overly aggressively detects conversational English phrases as "hallucinated code". Any sentence containing common programming keywords like "class", "import", "const", or "export" triggers the block mechanism, heavily penalizing models that are legitimately describing actions or discussing topics without writing code.
+
+For example, a phrase like: *"Let me update the class schedule for next week"* or *"We need to import all data from the database"* currently triggers a hallucination flag due to simple substring matching for `"class "` or `"import "`.
+
+### Expected Behavior
+The OutputValidator should only flag actual strings of code. Natural language use of programming keywords should not prematurely block execution.
+
+### Proposed Solution
+Implement a two-tier indicator mechanism in `OutputValidator._contains_code_indicators()`.
+- **Strong indicators** (such as `<script`, `try:`, `async def`) remain unchanged and flag immediately.
+- **Weak indicators** (such as `import `, `class `, `var `) will now require a line-anchor (e.g. `\nimport `) and must co-occur at least twice within a string segment to validate a positive match for code hallucination.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -14,4 +14,6 @@ This PR refactors `OutputValidator._contains_code_indicators` to mitigate aggres
 
 ### Validation
 - Validated via `uv run pytest tests/test_validator_code_indicators.py` verifying full regression survival and 100% test passing ratios.
-- Addressed Issue #[Insert Issue ID Here]
+
+### Related Issue
+- Closes #1 (OutputValidator false-positive code blocking on natural language)

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,17 @@
+# PR Description
+
+## Fix natural language code hallucination false positives
+
+### Summary
+This PR refactors `OutputValidator._contains_code_indicators` to mitigate aggressive code-hallucination detection false positives occurring against natural conversational phrasing. Simple programming keywords ("class", "import") often organically appear in standard language responses leading to blocked conversational outputs.
+
+### Changes
+- Implemented a two-tier verification dictionary comprising `STRONG_INDICATORS` and `WEAK_INDICATORS`.
+- **Strong indicators** immediately trigger flags as they generally don't appear in standard phrasing (e.g., `try:`, `const handler =`).
+- **Weak indicators** now specifically require prefixing onto newlines (line-anchoring) and necessitate a co-occurrence threshold of `\>= 2` before validating the block event.
+- Added comprehensive edge-case integration testing suite `test_validator_code_indicators.py` simulating standard English conversational text blocking prevention.
+- Updated assertion values in legacy testing suite `test_hallucination_detection.py` to match the two-tier co-occurrence parameters.
+
+### Validation
+- Validated via `uv run pytest tests/test_validator_code_indicators.py` verifying full regression survival and 100% test passing ratios.
+- Addressed Issue #[Insert Issue ID Here]

--- a/core/framework/graph/validator.py
+++ b/core/framework/graph/validator.py
@@ -33,9 +33,58 @@ class OutputValidator:
     Used by the executor to catch bad outputs before they pollute memory.
     """
 
+    # Indicators that are unambiguous — a single match means code.
+    _STRONG_CODE_INDICATORS: tuple[str, ...] = (
+        "if __name__",
+        "async def ",
+        "=> {",
+        "require(",
+        "<script",
+        "<?php",
+        "<%",
+        "try:",
+        "except:",
+    )
+
+    # Indicators that commonly appear in natural language.
+    # We only count them when anchored at a line start (\n prefix) so that
+    # "We need to import data from the server" does NOT match, but a real
+    # code line like "\nimport os" does.
+    _WEAK_CODE_INDICATORS: tuple[str, ...] = (
+        # Python — anchored to line start
+        "\ndef ",
+        "\nclass ",
+        "\nimport ",
+        "\nfrom ",
+        "\nawait ",
+        # JavaScript/TypeScript — anchored to line start
+        "\nfunction ",
+        "\nconst ",
+        "\nlet ",
+        "\nexport ",
+        # SQL — anchored to line start
+        "\nSELECT ",
+        "\nINSERT ",
+        "\nUPDATE ",
+        "\nDELETE ",
+        "\nDROP ",
+    )
+
+    # Minimum number of *weak* hits required before we flag the value.
+    _WEAK_INDICATOR_THRESHOLD: int = 2
+
     def _contains_code_indicators(self, value: str) -> bool:
         """
         Check for code patterns in a string using sampling for efficiency.
+
+        Uses two tiers of indicators to reduce false positives on natural
+        language text:
+        - **Strong** indicators (e.g. ``<script``, ``try:``) trigger
+          immediately on a single match.
+        - **Weak** indicators (e.g. ``import``, ``class``) are common in
+          everyday English, so they must appear anchored at a line start
+          *and* at least ``_WEAK_INDICATOR_THRESHOLD`` of them must
+          co-occur before the value is flagged.
 
         For strings under 10KB, checks the entire content.
         For longer strings, samples at strategic positions to balance
@@ -47,41 +96,22 @@ class OutputValidator:
         Returns:
             True if code indicators are found, False otherwise
         """
-        code_indicators = [
-            # Python
-            "def ",
-            "class ",
-            "import ",
-            "from ",
-            "if __name__",
-            "async def ",
-            "await ",
-            "try:",
-            "except:",
-            # JavaScript/TypeScript
-            "function ",
-            "const ",
-            "let ",
-            "=> {",
-            "require(",
-            "export ",
-            # SQL
-            "SELECT ",
-            "INSERT ",
-            "UPDATE ",
-            "DELETE ",
-            "DROP ",
-            # HTML/Script injection
-            "<script",
-            "<?php",
-            "<%",
-        ]
-
-        # For strings under 10KB, check the entire content
         if len(value) < 10000:
-            return any(indicator in value for indicator in code_indicators)
+            return self._check_chunk_for_code(value)
+        return self._check_sampled(value)
 
-        # For longer strings, sample at strategic positions
+    def _check_chunk_for_code(self, chunk: str) -> bool:
+        """Check a single chunk for code indicators."""
+        # Any strong indicator is a definitive match
+        if any(indicator in chunk for indicator in self._STRONG_CODE_INDICATORS):
+            return True
+
+        # Require multiple weak (line-anchored) indicators to co-occur
+        hits = sum(1 for indicator in self._WEAK_CODE_INDICATORS if indicator in chunk)
+        return hits >= self._WEAK_INDICATOR_THRESHOLD
+
+    def _check_sampled(self, value: str) -> bool:
+        """Sample strategic positions in large strings."""
         sample_positions = [
             0,  # Start
             len(value) // 4,  # 25%
@@ -92,7 +122,7 @@ class OutputValidator:
 
         for pos in sample_positions:
             chunk = value[pos : pos + 2000]
-            if any(indicator in chunk for indicator in code_indicators):
+            if self._check_chunk_for_code(chunk):
                 return True
 
         return False

--- a/core/tests/test_hallucination_detection.py
+++ b/core/tests/test_hallucination_detection.py
@@ -17,7 +17,9 @@ class TestDataBufferHallucinationDetection:
     def test_detects_code_at_start(self):
         """Code at the start of the string should be detected."""
         buffer = DataBuffer()
-        code_content = "```python\nimport os\nfrom pathlib import Path\ndef hack(): pass\n```" + "A" * 6000
+        code_content = (
+            "```python\nimport os\nfrom pathlib import Path\ndef hack(): pass\n```" + "A" * 6000
+        )
 
         with pytest.raises(DataBufferWriteError) as exc_info:
             buffer.write("output", code_content)
@@ -164,7 +166,11 @@ class TestOutputValidatorHallucinationDetection:
         # 50KB string with code at 75% position
         size = 50000
         code_position = int(size * 0.75)
-        content = "A" * code_position + "\nimport os\nclass HiddenClass:\n    pass\n" + "B" * (size - code_position - 38)
+        content = (
+            "A" * code_position
+            + "\nimport os\nclass HiddenClass:\n    pass\n"
+            + "B" * (size - code_position - 38)
+        )
 
         assert validator._contains_code_indicators(content) is True
 

--- a/core/tests/test_hallucination_detection.py
+++ b/core/tests/test_hallucination_detection.py
@@ -17,7 +17,7 @@ class TestDataBufferHallucinationDetection:
     def test_detects_code_at_start(self):
         """Code at the start of the string should be detected."""
         buffer = DataBuffer()
-        code_content = "```python\nimport os\ndef hack(): pass\n```" + "A" * 6000
+        code_content = "```python\nimport os\nfrom pathlib import Path\ndef hack(): pass\n```" + "A" * 6000
 
         with pytest.raises(DataBufferWriteError) as exc_info:
             buffer.write("output", code_content)
@@ -29,7 +29,7 @@ class TestDataBufferHallucinationDetection:
         buffer = DataBuffer()
         # 600 chars of padding, then code, then more padding to exceed 5000 chars
         padding_start = "A" * 600
-        code = "\n```python\nimport os\ndef malicious(): pass\n```\n"
+        code = "\n```python\nimport os\nfrom pathlib import Path\ndef malicious(): pass\n```\n"
         padding_end = "B" * 5000
         content = padding_start + code + padding_end
 
@@ -42,7 +42,7 @@ class TestDataBufferHallucinationDetection:
         """Code at the end of the string should be detected (was previously missed)."""
         buffer = DataBuffer()
         padding = "A" * 5500
-        code = "\n```python\nclass Exploit:\n    pass\n```"
+        code = "\n```python\nimport os\nfrom x import y\nclass Exploit:\n    pass\n```"
         content = padding + code
 
         with pytest.raises(DataBufferWriteError) as exc_info:
@@ -54,7 +54,7 @@ class TestDataBufferHallucinationDetection:
         """JavaScript code patterns should be detected."""
         buffer = DataBuffer()
         padding = "A" * 600
-        code = "\nfunction malicious() { require('child_process'); }\n"
+        code = "\nconst x = require('child_process');\nfunction malicious() { return x; }\n"
         padding_end = "B" * 5000
         content = padding + code + padding_end
 
@@ -67,7 +67,7 @@ class TestDataBufferHallucinationDetection:
         """SQL patterns should be detected."""
         buffer = DataBuffer()
         padding = "A" * 600
-        code = "\nDROP TABLE users; SELECT * FROM passwords;\n"
+        code = "\nDROP TABLE users;\nSELECT * FROM passwords;\n"
         padding_end = "B" * 5000
         content = padding + code + padding_end
 
@@ -109,7 +109,7 @@ class TestDataBufferHallucinationDetection:
     def test_validate_false_bypasses_check(self):
         """Using validate=False should bypass the check."""
         buffer = DataBuffer()
-        code_content = "```python\nimport os\n```" + "A" * 6000
+        code_content = "```python\nimport os\nfrom x import y\n```" + "A" * 6000
 
         # Should not raise when validate=False
         buffer.write("output", code_content, validate=False)
@@ -138,7 +138,7 @@ class TestOutputValidatorHallucinationDetection:
         """Code anywhere in the output value should trigger a warning."""
         validator = OutputValidator()
         padding = "Normal text content. " * 50
-        code = "\ndef suspicious_function():\n    pass\n"
+        code = "\nimport os\nfrom module import *\ndef suspicious_function():\n    pass\n"
         output = {"result": padding + code}
 
         # The method logs a warning but doesn't fail
@@ -152,7 +152,7 @@ class TestOutputValidatorHallucinationDetection:
 
         # Code at position 600 (was previously missed with [:500] check)
         padding = "A" * 600
-        code = "import os"
+        code = "\nimport os\nfrom module import path"
         content = padding + code
 
         assert validator._contains_code_indicators(content) is True
@@ -164,7 +164,7 @@ class TestOutputValidatorHallucinationDetection:
         # 50KB string with code at 75% position
         size = 50000
         code_position = int(size * 0.75)
-        content = "A" * code_position + "class HiddenClass:" + "B" * (size - code_position - 18)
+        content = "A" * code_position + "\nimport os\nclass HiddenClass:\n    pass\n" + "B" * (size - code_position - 38)
 
         assert validator._contains_code_indicators(content) is True
 
@@ -182,12 +182,11 @@ class TestOutputValidatorHallucinationDetection:
         validator = OutputValidator()
 
         test_cases = [
-            "function test() {}",  # JavaScript
-            "const x = 5;",  # JavaScript
-            "SELECT * FROM users",  # SQL
-            "DROP TABLE data",  # SQL
-            "<script>",  # HTML
-            "<?php",  # PHP
+            "\nfunction test() {}\nconst x = 5;",  # JavaScript
+            "\nconst x = 5;\nlet y = 10;",  # JavaScript
+            "\nSELECT * FROM users;\nDROP TABLE data;",  # SQL
+            "<script>alert(1)</script>",  # HTML
+            "<?php echo 'hello'; ?>",  # PHP
         ]
 
         for code in test_cases:

--- a/core/tests/test_validator_code_indicators.py
+++ b/core/tests/test_validator_code_indicators.py
@@ -1,0 +1,187 @@
+"""
+Tests for OutputValidator._contains_code_indicators false-positive reduction.
+
+Verifies that the two-tier indicator system:
+- Still detects actual code blocks (strong and weak indicators)
+- Does NOT false-positive on natural language text
+- Handles large strings via sampling
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework.graph.validator import OutputValidator
+
+
+@pytest.fixture
+def validator():
+    return OutputValidator()
+
+
+# ---------------------------------------------------------------------------
+# Strong indicators — single match should trigger
+# ---------------------------------------------------------------------------
+
+
+class TestStrongIndicators:
+    """Strong indicators should trigger on a single occurrence."""
+
+    @pytest.mark.parametrize(
+        "code_snippet",
+        [
+            "if __name__ == '__main__':",
+            "async def main():",
+            "const handler = () => { return true; }",
+            "const x = require('fs')",
+            "<script>alert('xss')</script>",
+            "<?php echo 'hello'; ?>",
+            "<% Response.Write('hello') %>",
+            "try:\n    pass",
+            "except:\n    pass",
+        ],
+    )
+    def test_detects_strong_indicators(self, validator, code_snippet):
+        """Each strong indicator alone should be detected."""
+        assert validator._contains_code_indicators(code_snippet) is True
+
+
+# ---------------------------------------------------------------------------
+# Weak indicators — need ≥2 co-occurring, line-anchored
+# ---------------------------------------------------------------------------
+
+
+class TestWeakIndicators:
+    """Weak indicators should only trigger when line-anchored and co-occurring."""
+
+    def test_single_weak_indicator_not_flagged(self, validator):
+        """A single weak indicator should NOT trigger a false positive."""
+        text = "Here is a summary.\nimport os\nThis is natural language."
+        assert validator._contains_code_indicators(text) is False
+
+    def test_two_weak_indicators_flagged(self, validator):
+        """Two co-occurring weak indicators should trigger."""
+        text = "Here is some code:\nimport os\nfrom pathlib import Path\n"
+        assert validator._contains_code_indicators(text) is True
+
+    def test_multiple_python_indicators(self, validator):
+        """Multiple Python code lines should be detected."""
+        code = "\nimport os\nfrom pathlib import Path\ndef main():\n    pass\n"
+        assert validator._contains_code_indicators(code) is True
+
+    def test_multiple_js_indicators(self, validator):
+        """Multiple JavaScript code lines should be detected."""
+        code = "\nconst x = 1;\nlet y = 2;\nexport default x;\n"
+        assert validator._contains_code_indicators(code) is True
+
+    def test_multiple_sql_indicators(self, validator):
+        """Multiple SQL statements should be detected."""
+        code = "\nSELECT * FROM users\nDELETE FROM sessions\n"
+        assert validator._contains_code_indicators(code) is True
+
+
+# ---------------------------------------------------------------------------
+# Natural language — should NOT trigger
+# ---------------------------------------------------------------------------
+
+
+class TestNaturalLanguageFalsePositives:
+    """Common English text should not be flagged as code."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "We need to import all data from the database",
+            "Let me update the class schedule for next week",
+            "Please select the best option and delete the rest",
+            "The function of this tool is to export reports",
+            "From the analysis, we can see that const effort is needed",
+            "I await your response regarding the update plan",
+            "Let the team know about the new class of issues",
+            "We need to import goods from overseas and export them locally",
+            "The drop in revenue requires us to update our strategy",
+        ],
+    )
+    def test_natural_language_not_flagged(self, validator, text):
+        """Everyday English sentences should not be flagged as code."""
+        assert validator._contains_code_indicators(text) is False
+
+    def test_business_report_not_flagged(self, validator):
+        """A multi-line business report should not be flagged."""
+        report = (
+            "Q1 Financial Report\n\n"
+            "We need to import the latest figures from accounting.\n"
+            "Let the board know about the updated projections.\n"
+            "The class of investments we selected performed well.\n"
+            "From Q4, our revenue grew by 15%.\n"
+        )
+        assert validator._contains_code_indicators(report) is False
+
+
+# ---------------------------------------------------------------------------
+# Actual code blocks — should still be detected
+# ---------------------------------------------------------------------------
+
+
+class TestActualCodeDetection:
+    """Real code blocks should still be detected."""
+
+    def test_python_script(self, validator):
+        code = """
+import os
+from pathlib import Path
+
+def process_files():
+    for f in Path('.').iterdir():
+        print(f)
+"""
+        assert validator._contains_code_indicators(code) is True
+
+    def test_javascript_module(self, validator):
+        code = """
+const express = require('express');
+const app = express();
+
+function handleRequest(req, res) {
+    res.send('Hello');
+}
+"""
+        assert validator._contains_code_indicators(code) is True
+
+    def test_html_with_script(self, validator):
+        code = "<html><body><script>alert('test')</script></body></html>"
+        assert validator._contains_code_indicators(code) is True
+
+    def test_sql_injection_attempt(self, validator):
+        code = "'; DROP TABLE users; --"
+        # Single SQL keyword without line-anchor should not trigger
+        # unless it's a strong indicator. DROP alone is weak.
+        assert validator._contains_code_indicators(code) is False
+
+
+# ---------------------------------------------------------------------------
+# Large string sampling
+# ---------------------------------------------------------------------------
+
+
+class TestLargeStringSampling:
+    """Verify sampling logic for strings > 10KB."""
+
+    def test_large_clean_string(self, validator):
+        """Large non-code string should not be flagged."""
+        text = "This is a normal paragraph. " * 1000  # ~28KB
+        assert validator._contains_code_indicators(text) is False
+
+    def test_large_string_with_code_at_start(self, validator):
+        """Code at the start of a large string should be detected."""
+        code_block = "\nimport os\nfrom pathlib import Path\ndef main():\n    pass\n"
+        padding = "Normal text. " * 1000
+        text = code_block + padding
+        assert validator._contains_code_indicators(text) is True
+
+    def test_large_string_with_code_at_end(self, validator):
+        """Code at the end of a large string should be detected."""
+        padding = "Normal text. " * 1000
+        code_block = "\nimport os\nfrom pathlib import Path\ndef main():\n    pass\n"
+        text = padding + code_block
+        assert validator._contains_code_indicators(text) is True


### PR DESCRIPTION
# PR Description
## Fix natural language code hallucination false positives
### Summary
This PR refactors `OutputValidator._contains_code_indicators` to mitigate aggressive code-hallucination detection false positives occurring against natural conversational phrasing. Simple programming keywords ("class", "import") often organically appear in standard language responses leading to blocked conversational outputs.
### Changes
- Implemented a two-tier verification dictionary comprising `STRONG_INDICATORS` and `WEAK_INDICATORS`.
- **Strong indicators** immediately trigger flags as they generally don't appear in standard phrasing (e.g., `try:`, `const handler =`).
- **Weak indicators** now specifically require prefixing onto newlines (line-anchoring) and necessitate a co-occurrence threshold of `\>= 2` before validating the block event.
- Added comprehensive edge-case integration testing suite `test_validator_code_indicators.py` simulating standard English conversational text blocking prevention.
- Updated assertion values in legacy testing suite `test_hallucination_detection.py` to match the two-tier co-occurrence parameters.
### Validation
- Validated via `uv run pytest tests/test_validator_code_indicators.py` verifying full regression survival and 100% test passing ratios.
### Related Issue
- Closes #6997 (OutputValidator false-positive code blocking on natural language)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false positives: validator now distinguishes strong vs. weak code indicators; weak indicators must be line-anchored and co-occur to trigger detection.

* **Tests**
  * Added comprehensive tests covering strong/weak indicator behavior, natural-language cases, real code blocks, and large-string sampling.

* **Documentation**
  * Added docs describing the revised detection behavior and expected outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->