### PR TITLE
fix: reduce OutputValidator false positives for natural language [micro-fix]

### DIFF
--- a/core/framework/graph/validator.py
+++ b/core/framework/graph/validator.py
@@ -84,7 +84,17 @@ class OutputValidator:
             "DROP ",
         ]
 
-        def _check_segment(segment: str) -> bool:
+        def _check_segment(segment: str, before_char: str = "") -> bool:
+            """Check a segment for code indicators.
+
+            Args:
+                segment: The text segment to check.
+                before_char: The character immediately preceding this segment in
+                    the original string (empty string if this segment starts at
+                    position 0 of the original).  Used so that idx==0 inside a
+                    sampled chunk is not incorrectly treated as a true line-start
+                    when the chunk was taken from the middle of a larger string.
+            """
             # Strong indicators: immediate match
             if any(indicator in segment for indicator in strong_indicators):
                 return True
@@ -98,7 +108,15 @@ class OutputValidator:
             for indicator in weak_indicators:
                 idx = segment.find(indicator)
                 while idx != -1:
-                    at_line_start = idx == 0 or segment[idx - 1] == "\n"
+                    # True line-start: either we're at position 0 of the
+                    # original string (before_char is empty) or the preceding
+                    # character — either inside the segment or the carried-in
+                    # before_char — is a newline.
+                    if idx == 0:
+                        prev_char = before_char
+                    else:
+                        prev_char = segment[idx - 1]
+                    at_line_start = prev_char == "" or prev_char == "\n"
                     if at_line_start:
                         return True
                     # Mid-line: check if code context follows the indicator
@@ -109,17 +127,19 @@ class OutputValidator:
                     # non-whitespace character (true punctuation / syntax context).
                     # Whitespace alone (e.g. "update the class schedule") is NOT
                     # treated as code context to avoid false positives.
-                    before_char = segment[idx - 1] if idx > 0 else ""
-                    if before_char and not before_char.isalpha() and not before_char.isspace():
+                    if prev_char and not prev_char.isalpha() and not prev_char.isspace():
                         return True
                     idx = segment.find(indicator, idx + 1)
             return False
 
-        # For strings under 10KB, check the entire content
+        # For strings under 10KB, check the entire content (before_char="" since
+        # we're checking from position 0 of the original string).
         if len(value) < 10000:
             return _check_segment(value)
 
-        # For longer strings, sample at strategic positions
+        # For longer strings, sample at strategic positions.  Pass the character
+        # immediately before each chunk so _check_segment can correctly determine
+        # whether the very first character of the chunk is a true line-start.
         sample_positions = [
             0,  # Start
             len(value) // 4,  # 25%
@@ -130,7 +150,10 @@ class OutputValidator:
 
         for pos in sample_positions:
             chunk = value[pos : pos + 2000]
-            if _check_segment(chunk):
+            # The character just before the chunk in the original string.
+            # Empty string when the chunk starts at the very beginning.
+            chunk_before_char = value[pos - 1] if pos > 0 else ""
+            if _check_segment(chunk, before_char=chunk_before_char):
                 return True
 
         return False

--- a/core/framework/graph/validator.py
+++ b/core/framework/graph/validator.py
@@ -35,11 +35,13 @@ class OutputValidator:
 
     def _contains_code_indicators(self, value: str) -> bool:
         """
-        Check for code patterns in a string using sampling for efficiency.
+        Check for code patterns in a string using a two-tier system.
 
-        For strings under 10KB, checks the entire content.
-        For longer strings, samples at strategic positions to balance
-        performance with detection accuracy.
+        Strong indicators (e.g. "<script", "try:") flag immediately.
+        Weak indicators (e.g. "class ", "import ") only flag when they appear
+        at the start of a line (\n prefix) AND occur at least twice in the
+        string segment. This prevents false positives from natural language
+        like "Let me update the class schedule".
 
         Args:
             value: The string to check for code indicators
@@ -47,17 +49,25 @@ class OutputValidator:
         Returns:
             True if code indicators are found, False otherwise
         """
-        code_indicators = [
-            # Python
+        strong_indicators = [
+            # Python — structural syntax that rarely appears in prose
+            "if __name__",
+            "async def ",
+            "try:",
+            "except:",
+            # HTML/Script injection — always suspicious
+            "<script",
+            "<?php",
+            "<%",
+        ]
+
+        weak_indicators = [
+            # Python — common in natural language ("import goods", "class schedule")
             "def ",
             "class ",
             "import ",
             "from ",
-            "if __name__",
-            "async def ",
             "await ",
-            "try:",
-            "except:",
             # JavaScript/TypeScript
             "function ",
             "const ",
@@ -65,21 +75,45 @@ class OutputValidator:
             "=> {",
             "require(",
             "export ",
-            # SQL
+            # SQL — can appear in business prose
             "SELECT ",
             "INSERT ",
             "UPDATE ",
             "DELETE ",
             "DROP ",
-            # HTML/Script injection
-            "<script",
-            "<?php",
-            "<%",
         ]
+
+        def _check_segment(segment: str) -> bool:
+            # Strong indicators: immediate match
+            if any(indicator in segment for indicator in strong_indicators):
+                return True
+
+            # Weak indicators: require line-anchor OR code-context confirmation.
+            # A weak indicator at the start of a line is always treated as code.
+            # A weak indicator mid-line requires additional code context (e.g.
+            # parentheses, braces, colons, equals) to disambiguate from
+            # natural language usage like "class schedule" or "import goods".
+            code_context_chars = set("(){}[]:;=<>+-*/\\@#")
+            for indicator in weak_indicators:
+                idx = segment.find(indicator)
+                while idx != -1:
+                    at_line_start = idx == 0 or segment[idx - 1] == "\n"
+                    if at_line_start:
+                        return True
+                    # Mid-line: check if code context follows the indicator
+                    after = segment[idx + len(indicator):]
+                    if after and after[0] in code_context_chars:
+                        return True
+                    # Also check if the indicator is preceded by non-alpha (not a word part)
+                    before_char = segment[idx - 1] if idx > 0 else ""
+                    if before_char and not before_char.isalpha():
+                        return True
+                    idx = segment.find(indicator, idx + 1)
+            return False
 
         # For strings under 10KB, check the entire content
         if len(value) < 10000:
-            return any(indicator in value for indicator in code_indicators)
+            return _check_segment(value)
 
         # For longer strings, sample at strategic positions
         sample_positions = [
@@ -92,7 +126,7 @@ class OutputValidator:
 
         for pos in sample_positions:
             chunk = value[pos : pos + 2000]
-            if any(indicator in chunk for indicator in code_indicators):
+            if _check_segment(chunk):
                 return True
 
         return False

--- a/core/framework/graph/validator.py
+++ b/core/framework/graph/validator.py
@@ -39,9 +39,10 @@ class OutputValidator:
 
         Strong indicators (e.g. "<script", "try:") flag immediately.
         Weak indicators (e.g. "class ", "import ") only flag when they appear
-        at the start of a line (\n prefix) AND occur at least twice in the
-        string segment. This prevents false positives from natural language
-        like "Let me update the class schedule".
+        at the start of a line, or are preceded by non-whitespace punctuation /
+        syntax characters, or are immediately followed by code-context characters
+        (parentheses, braces, colons, etc.). This prevents false positives from
+        natural language like "Let me update the class schedule".
 
         Args:
             value: The string to check for code indicators
@@ -104,9 +105,12 @@ class OutputValidator:
                     after = segment[idx + len(indicator):]
                     if after and after[0] in code_context_chars:
                         return True
-                    # Also check if the indicator is preceded by non-alpha (not a word part)
+                    # Also check if the indicator is preceded by a non-alpha,
+                    # non-whitespace character (true punctuation / syntax context).
+                    # Whitespace alone (e.g. "update the class schedule") is NOT
+                    # treated as code context to avoid false positives.
                     before_char = segment[idx - 1] if idx > 0 else ""
-                    if before_char and not before_char.isalpha():
+                    if before_char and not before_char.isalpha() and not before_char.isspace():
                         return True
                     idx = segment.find(indicator, idx + 1)
             return False

--- a/core/tests/test_hallucination_detection.py
+++ b/core/tests/test_hallucination_detection.py
@@ -152,7 +152,7 @@ class TestOutputValidatorHallucinationDetection:
 
         # Code at position 600 (was previously missed with [:500] check)
         padding = "A" * 600
-        code = "import os"
+        code = "\nimport os"
         content = padding + code
 
         assert validator._contains_code_indicators(content) is True
@@ -176,6 +176,34 @@ class TestOutputValidatorHallucinationDetection:
         content = "This is a perfectly normal document. " * 300
 
         assert validator._contains_code_indicators(content) is False
+
+    def test_no_false_positive_for_natural_language_keywords(self):
+        """Natural language use of programming keywords should not trigger."""
+        validator = OutputValidator()
+
+        # These are natural language sentences, not code
+        sentences = [
+            "Let me update the class schedule for next week",
+            "We need to import all data from the database",
+            "The function of this device is to measure temperature",
+            "Please select your preferred option",
+            "We export goods to many countries",
+        ]
+        for sentence in sentences:
+            assert validator._contains_code_indicators(sentence) is False, (
+                f"False positive: {sentence}"
+            )
+
+        # But actual code lines should still be detected
+        code_lines = [
+            "\nimport os\n",
+            "\ndef hello():\n",
+            "\nclass MyClass:\n",
+        ]
+        for code in code_lines:
+            assert validator._contains_code_indicators(code) is True, (
+                f"False negative: {code}"
+            )
 
     def test_detects_multiple_languages(self):
         """Should detect code patterns from multiple programming languages."""

--- a/core/tests/test_hallucination_detection.py
+++ b/core/tests/test_hallucination_detection.py
@@ -177,7 +177,7 @@ class TestOutputValidatorHallucinationDetection:
 
         assert validator._contains_code_indicators(content) is False
 
-    def test_no_false_positive_for_natural_language_keywords(self):
+    def test_no_false_positive_for_natural_language_keywords(self) -> None:
         """Natural language use of programming keywords should not trigger."""
         validator = OutputValidator()
 


### PR DESCRIPTION
Fixes #7000

## Problem

The `OutputValidator._contains_code_indicators()` method uses simple substring matching for keywords like `"class "`, `"import "`, `"const "`, etc. This causes false positives when conversational English contains these words:

- "Let me update the **class** schedule for next week" → flagged
- "We need to **import** all data from the database" → flagged
- "Please **select** your preferred option" → flagged

## Fix

Implement a two-tier indicator system:

- **Strong indicators** (`<script`, `try:`, `async def`, `<?php`, `<%`) flag immediately — these rarely appear in prose
- **Weak indicators** (`class `, `import `, `function `, SQL keywords, etc.) only flag when:
  - At the start of a line (`\n` prefix or position 0), OR
  - Preceded by a non-alpha character (not part of a word), OR
  - Followed by a code-context character (parentheses, braces, colons, etc.)

Added new test `test_no_false_positive_for_natural_language_keywords` to verify the fix.

Fixes #6997

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false positives by refining code-like indicator detection with a clearer distinction between strong and weak markers and improved handling around line starts and contextual delimiters.
  * Improved accuracy for code patterns appearing after line breaks and in sampled/long inputs.

* **Tests**
  * Added/updated tests to ensure natural-language sentences no longer trigger code detection while real code snippets still do.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->