### PR TITLE
fix(graph): reduce false positives in code-indicator detection

### DIFF
--- a/core/framework/graph/code_detection.py
+++ b/core/framework/graph/code_detection.py
@@ -1,0 +1,85 @@
+"""Heuristics for detecting code-like content in text payloads."""
+
+from __future__ import annotations
+
+import re
+
+_FULL_SCAN_MAX_CHARS = 10_000
+_SAMPLE_CHUNK_SIZE = 2_000
+
+_STRONG_SUBSTRINGS = (
+    "```",
+    "<script",
+    "<?php",
+    "<%",
+    "if __name__",
+    "=> {",
+    "require(",
+)
+
+_STRONG_PATTERNS = (
+    re.compile(r"^\s*async\s+def\s+[A-Za-z_][\w]*\s*\(", re.MULTILINE),
+    re.compile(r"^\s*def\s+[A-Za-z_][\w]*\s*\(", re.MULTILINE),
+    re.compile(r"^\s*class\s+[A-Za-z_][\w]*\s*[:(]", re.MULTILINE),
+    re.compile(r"^\s*from\s+[A-Za-z_][\w.]*\s+import\s+[\w.*,\s]+$", re.MULTILINE),
+    re.compile(
+        r"^\s*import\s+[A-Za-z_][\w.]*(\s*,\s*[A-Za-z_][\w.]*)*(\s+as\s+[A-Za-z_][\w]*)?\s*$",
+        re.MULTILINE,
+    ),
+    re.compile(r"^\s*try\s*:\s*$", re.MULTILINE),
+    re.compile(r"^\s*except\b.*:\s*$", re.MULTILINE),
+    re.compile(r"^\s*function\s+[A-Za-z_$][\w$]*\s*\(", re.MULTILINE),
+    re.compile(r"^\s*(const|let|var)\s+[A-Za-z_$][\w$]*\s*=", re.MULTILINE),
+    re.compile(r"^\s*export\s+(default\s+)?(function|class|const|let|var|\{)", re.MULTILINE),
+    re.compile(
+        r"^\s*(SELECT|INSERT|UPDATE|DELETE|DROP)\b.+\b(FROM|INTO|TABLE|SET)\b",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+)
+
+_WEAK_PATTERNS = (
+    re.compile(r"^\s*(import|from|class|const|let|var|function|export)\b", re.MULTILINE),
+    re.compile(r"^\s*(select|insert|update|delete|drop)\b", re.IGNORECASE | re.MULTILINE),
+)
+
+
+def _iter_chunks(value: str) -> list[str]:
+    if len(value) < _FULL_SCAN_MAX_CHARS:
+        return [value]
+
+    positions = [
+        0,  # Start
+        len(value) // 4,  # 25%
+        len(value) // 2,  # 50%
+        (3 * len(value)) // 4,  # 75%
+        max(0, len(value) - _SAMPLE_CHUNK_SIZE),  # Near end
+    ]
+    return [value[pos : pos + _SAMPLE_CHUNK_SIZE] for pos in positions]
+
+
+def contains_code_indicators(value: str) -> bool:
+    """Return True when a text chunk is likely code, not plain prose.
+
+    Two-tier strategy:
+    - Strong indicators (code fences/syntax) trigger immediately.
+    - Weak keyword indicators must appear at least twice on line anchors.
+    """
+    if not value:
+        return False
+
+    for chunk in _iter_chunks(value):
+        chunk_lower = chunk.lower()
+
+        if any(indicator in chunk_lower for indicator in _STRONG_SUBSTRINGS):
+            return True
+
+        if any(pattern.search(chunk) for pattern in _STRONG_PATTERNS):
+            return True
+
+        weak_hits = 0
+        for pattern in _WEAK_PATTERNS:
+            weak_hits += len(pattern.findall(chunk))
+            if weak_hits >= 2:
+                return True
+
+    return False

--- a/core/framework/graph/node.py
+++ b/core/framework/graph/node.py
@@ -24,6 +24,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from framework.graph.code_detection import contains_code_indicators
 from framework.llm.provider import LLMProvider, Tool
 from framework.runtime.core import Runtime
 
@@ -373,52 +374,7 @@ class DataBuffer:
         Returns:
             True if code indicators are found, False otherwise
         """
-        code_indicators = [
-            # Python
-            "```python",
-            "def ",
-            "class ",
-            "import ",
-            "async def ",
-            "from ",
-            # JavaScript/TypeScript
-            "function ",
-            "const ",
-            "let ",
-            "=> {",
-            "require(",
-            "export ",
-            # SQL
-            "SELECT ",
-            "INSERT ",
-            "UPDATE ",
-            "DELETE ",
-            "DROP ",
-            # HTML/Script injection
-            "<script",
-            "<?php",
-            "<%",
-        ]
-
-        # For strings under 10KB, check the entire content
-        if len(value) < 10000:
-            return any(indicator in value for indicator in code_indicators)
-
-        # For longer strings, sample at strategic positions
-        sample_positions = [
-            0,  # Start
-            len(value) // 4,  # 25%
-            len(value) // 2,  # 50%
-            3 * len(value) // 4,  # 75%
-            max(0, len(value) - 2000),  # Near end
-        ]
-
-        for pos in sample_positions:
-            chunk = value[pos : pos + 2000]
-            if any(indicator in chunk for indicator in code_indicators):
-                return True
-
-        return False
+        return contains_code_indicators(value)
 
     def read_all(self) -> dict[str, Any]:
         """Read all accessible data."""

--- a/core/framework/graph/validator.py
+++ b/core/framework/graph/validator.py
@@ -10,6 +10,8 @@ from typing import Any
 
 from pydantic import BaseModel, ValidationError
 
+from framework.graph.code_detection import contains_code_indicators
+
 logger = logging.getLogger(__name__)
 
 
@@ -47,55 +49,7 @@ class OutputValidator:
         Returns:
             True if code indicators are found, False otherwise
         """
-        code_indicators = [
-            # Python
-            "def ",
-            "class ",
-            "import ",
-            "from ",
-            "if __name__",
-            "async def ",
-            "await ",
-            "try:",
-            "except:",
-            # JavaScript/TypeScript
-            "function ",
-            "const ",
-            "let ",
-            "=> {",
-            "require(",
-            "export ",
-            # SQL
-            "SELECT ",
-            "INSERT ",
-            "UPDATE ",
-            "DELETE ",
-            "DROP ",
-            # HTML/Script injection
-            "<script",
-            "<?php",
-            "<%",
-        ]
-
-        # For strings under 10KB, check the entire content
-        if len(value) < 10000:
-            return any(indicator in value for indicator in code_indicators)
-
-        # For longer strings, sample at strategic positions
-        sample_positions = [
-            0,  # Start
-            len(value) // 4,  # 25%
-            len(value) // 2,  # 50%
-            3 * len(value) // 4,  # 75%
-            max(0, len(value) - 2000),  # Near end
-        ]
-
-        for pos in sample_positions:
-            chunk = value[pos : pos + 2000]
-            if any(indicator in chunk for indicator in code_indicators):
-                return True
-
-        return False
+        return contains_code_indicators(value)
 
     def validate_output_keys(
         self,

--- a/core/tests/test_hallucination_detection.py
+++ b/core/tests/test_hallucination_detection.py
@@ -106,6 +106,16 @@ class TestDataBufferHallucinationDetection:
         buffer.write("output", content)
         assert buffer.read("output") == content
 
+    def test_allows_long_natural_language_with_keywords(self):
+        """Natural language with programming words should not be rejected as code."""
+        buffer = DataBuffer()
+        content = (
+            "We need to update the class schedule and import all student records carefully. " * 120
+        )
+
+        buffer.write("output", content)
+        assert buffer.read("output") == content
+
     def test_validate_false_bypasses_check(self):
         """Using validate=False should bypass the check."""
         buffer = DataBuffer()
@@ -121,9 +131,8 @@ class TestDataBufferHallucinationDetection:
         # Create a 50KB string with code at the 75% mark
         size = 50000
         code_position = int(size * 0.75)
-        content = (
-            "A" * code_position + "def hidden_code(): pass" + "B" * (size - code_position - 25)
-        )
+        code = "\ndef hidden_code():\n    pass\n"
+        content = "A" * code_position + code + "B" * (size - code_position - len(code))
 
         with pytest.raises(DataBufferWriteError) as exc_info:
             buffer.write("output", content)
@@ -151,8 +160,8 @@ class TestOutputValidatorHallucinationDetection:
         validator = OutputValidator()
 
         # Code at position 600 (was previously missed with [:500] check)
-        padding = "A" * 600
-        code = "import os"
+        padding = "A" * 600 + "\n"
+        code = "import os\n"
         content = padding + code
 
         assert validator._contains_code_indicators(content) is True
@@ -174,6 +183,16 @@ class TestOutputValidatorHallucinationDetection:
 
         # Long text without any code indicators
         content = "This is a perfectly normal document. " * 300
+
+        assert validator._contains_code_indicators(content) is False
+
+    def test_no_false_positive_for_natural_language_keywords(self):
+        """Natural language with words like class/import should stay unflagged."""
+        validator = OutputValidator()
+        content = (
+            "Let me update the class schedule for next week. "
+            "We need to import all data from the database and send a summary."
+        )
 
         assert validator._contains_code_indicators(content) is False
 


### PR DESCRIPTION
## What\nThis PR reduces false positives in code-indicator detection that were triggering on natural-language phrases containing words like class/import.\n\n## Changes\n- Added shared detector utility: core/framework/graph/code_detection.py\n- Refactored both call sites to use shared logic:\n  - core/framework/graph/validator.py\n  - core/framework/graph/node.py\n- Added regression tests in core/tests/test_hallucination_detection.py for natural-language keyword phrases and long prose content.\n\n## Why\nFixes #6997, where naive substring matching was flagging conversational text as code.\n\n## Validation\n- uv run pytest tests/test_hallucination_detection.py tests/test_pydantic_validation.py -q -p no:cacheprovider\n- uv run ruff check core/framework/graph/code_detection.py core/framework/graph/validator.py core/framework/graph/node.py core/tests/test_hallucination_detection.py\n\nAll checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced code detection to more accurately distinguish actual code from natural language containing programming-related terms, reducing false positives.
  * Optimized content scanning for improved performance on long inputs.

* **Tests**
  * Strengthened test coverage for code detection and hallucination detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->