### PR TITLE
fix(micro-fix): add missing warning logs to broad exception handlers in credentials/setup.py

### DIFF
--- a/core/framework/credentials/setup.py
+++ b/core/framework/credentials/setup.py
@@ -457,7 +457,11 @@ class CredentialSetupSession:
                 self._print("Please connect this integration on https://hive.adenhq.com first.")
                 return False
         except Exception as e:
-            logger.warning("Failed to sync credentials from Aden for %s", cred.credential_name, exc_info=True)
+            logger.warning(
+                "Failed to sync credentials from Aden for %s",
+                cred.credential_name,
+                exc_info=True,
+            )
             self._print(f"{Colors.RED}Failed to sync from Aden: {e}{Colors.NC}")
             return False
 

--- a/core/framework/credentials/setup.py
+++ b/core/framework/credentials/setup.py
@@ -225,6 +225,7 @@ class CredentialSetupSession:
                 skipped.append(cred.credential_name)
                 break
             except Exception as e:
+                logger.warning("Error setting up credential %s", cred.credential_name, exc_info=True)
                 errors.append(f"{cred.credential_name}: {e}")
 
         self._print_summary(configured, skipped, errors)
@@ -273,6 +274,7 @@ class CredentialSetupSession:
             )
             return True
         except Exception as e:
+            logger.warning("Failed to initialize credential store", exc_info=True)
             self._print(f"{Colors.RED}Failed to initialize credential store: {e}{Colors.NC}")
             return False
 
@@ -455,6 +457,7 @@ class CredentialSetupSession:
                 self._print("Please connect this integration on https://hive.adenhq.com first.")
                 return False
         except Exception as e:
+            logger.warning("Failed to sync credentials from Aden for %s", cred.credential_name, exc_info=True)
             self._print(f"{Colors.RED}Failed to sync from Aden: {e}{Colors.NC}")
             return False
 
@@ -495,6 +498,7 @@ class CredentialSetupSession:
             store.save_credential(cred_obj)
             self._print(f"{Colors.GREEN}✓ Stored in ~/.hive/credentials/{Colors.NC}")
         except Exception as e:
+            logger.warning("Failed to store credential %s in credential store", cred.credential_id or cred.credential_name, exc_info=True)
             self._print(f"{Colors.YELLOW}⚠ Could not store in credential store: {e}{Colors.NC}")
 
         # Export to current session

--- a/core/framework/credentials/setup.py
+++ b/core/framework/credentials/setup.py
@@ -225,7 +225,9 @@ class CredentialSetupSession:
                 skipped.append(cred.credential_name)
                 break
             except Exception as e:
-                logger.warning("Error setting up credential %s", cred.credential_name, exc_info=True)
+                logger.warning(
+                    "Error setting up credential %s", cred.credential_name, exc_info=True
+                )
                 errors.append(f"{cred.credential_name}: {e}")
 
         self._print_summary(configured, skipped, errors)

--- a/core/framework/credentials/setup.py
+++ b/core/framework/credentials/setup.py
@@ -498,7 +498,11 @@ class CredentialSetupSession:
             store.save_credential(cred_obj)
             self._print(f"{Colors.GREEN}✓ Stored in ~/.hive/credentials/{Colors.NC}")
         except Exception as e:
-            logger.warning("Failed to store credential %s in credential store", cred.credential_id or cred.credential_name, exc_info=True)
+            logger.warning(
+                "Failed to store credential %s in credential store",
+                cred.credential_id or cred.credential_name,
+                exc_info=True,
+            )
             self._print(f"{Colors.YELLOW}⚠ Could not store in credential store: {e}{Colors.NC}")
 
         # Export to current session


### PR DESCRIPTION
## What

Four `except Exception` blocks in `core/framework/credentials/setup.py` silently swallowed errors with no log entry, making failures invisible in production log aggregators and hard to debug. This adds `logger.warning(exc_info=True)` to each of the four affected handlers.

## How

Added a `logger.warning(...)` call (with `exc_info=True` for full tracebacks) immediately before the existing user-facing print/append in each of the four blocks that were missing log entries:

- `run_interactive` (line 227) — error silently appended to errors list
- `_ensure_credential_key` (line 275) — failure only printed to UI
- `_setup_via_aden` (line 457) — Aden sync failure only printed to UI
- `_store_credential` (line 497) — store failure only printed to UI

The remaining six broad handlers already had `logger.warning(exc_info=True)` and were left unchanged.

## Testing

- [x] Existing tests pass (`uv run pytest core/framework/credentials/tests/ core/tests/test_credential_bootstrap.py` — 65 passed)
- [x] No behaviour changes — additions only, no logic altered

## Related

Closes #6995

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic logging during credential setup: added warning-level logs capturing exception details for multiple failure paths (per-credential setup, credential key initialization, external credential sync, and credential saving), including identifiers when available. User-facing messages, collected error lists, and error-handling behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->