### PR TITLE
fix: prevent cancellation leak and result race in ActiveNodeClientIO.request_input

### DIFF
--- a/core/framework/graph/client_io.py
+++ b/core/framework/graph/client_io.py
@@ -87,27 +87,33 @@ class ActiveNodeClientIO(NodeClientIO):
 
         self._input_event = asyncio.Event()
         self._input_result = None
-
-        if self._event_bus is not None:
-            await self._event_bus.emit_client_input_requested(
-                stream_id=self.node_id,
-                node_id=self.node_id,
-                prompt=prompt,
-                execution_id=self._execution_id or None,
-            )
+        result: str | None = None
 
         try:
+            # Include emit inside try/finally so cancellation during this await
+            # still triggers cleanup and resets _input_event to None.
+            if self._event_bus is not None:
+                await self._event_bus.emit_client_input_requested(
+                    stream_id=self.node_id,
+                    node_id=self.node_id,
+                    prompt=prompt,
+                    execution_id=self._execution_id or None,
+                )
+
             if timeout is not None:
                 await asyncio.wait_for(self._input_event.wait(), timeout=timeout)
             else:
                 await self._input_event.wait()
+
+            # Capture result before finally releases _input_event, preventing a
+            # concurrent request_input from wiping _input_result before we read it.
+            result = self._input_result
+            self._input_result = None
         finally:
             self._input_event = None
 
-        if self._input_result is None:
+        if result is None:
             raise RuntimeError("input event was set but no input was provided")
-        result = self._input_result
-        self._input_result = None
         return result
 
     async def provide_input(self, content: str) -> None:

--- a/core/tests/test_client_io.py
+++ b/core/tests/test_client_io.py
@@ -17,14 +17,15 @@ from framework.graph.client_io import ActiveNodeClientIO
 class _MockEventBus:
     """Minimal event bus stub — no-ops all emit calls."""
 
-    async def emit_client_input_requested(self, **kwargs) -> None:
-        pass
+    async def emit_client_input_requested(self, **kwargs: object) -> None:
+        """No-op implementation for testing."""
 
 
 class _SlowEventBus(_MockEventBus):
     """Event bus that blocks in emit_client_input_requested for cancellation tests."""
 
-    async def emit_client_input_requested(self, **kwargs) -> None:
+    async def emit_client_input_requested(self, **kwargs: object) -> None:
+        """Block for 1 second to allow cancellation during emit."""
         await asyncio.sleep(1.0)
 
 
@@ -64,17 +65,25 @@ async def test_request_input_result_captured_before_lock_release():
     reads_with_event_active: list[bool] = []
 
     class _TrackerDescriptor:
-        def __get__(self, obj, objtype=None):
+        """Data descriptor that records whether _input_event is active on each read."""
+
+        def __get__(self, obj: object, objtype: object = None) -> object:
+            """Return mock result and record whether _input_event was active."""
             if obj is None:
                 return self
-            reads_with_event_active.append(obj._input_event is not None)
+            reads_with_event_active.append(
+                getattr(obj, "_input_event", None) is not None
+            )
             return getattr(obj, "_mock_result", None)
 
-        def __set__(self, obj, value):
-            obj._mock_result = value
+        def __set__(self, obj: object, value: object) -> None:
+            """Store value in _mock_result to avoid descriptor recursion."""
+            obj._mock_result = value  # type: ignore[attr-defined]
 
     class _TrackedIO(ActiveNodeClientIO):
-        _input_result = _TrackerDescriptor()
+        """ActiveNodeClientIO subclass that tracks _input_result reads."""
+
+        _input_result = _TrackerDescriptor()  # type: ignore[assignment]
 
     io = _TrackedIO(node_id="n1")
 

--- a/core/tests/test_client_io.py
+++ b/core/tests/test_client_io.py
@@ -71,9 +71,7 @@ async def test_request_input_result_captured_before_lock_release():
             """Return mock result and record whether _input_event was active."""
             if obj is None:
                 return self
-            reads_with_event_active.append(
-                getattr(obj, "_input_event", None) is not None
-            )
+            reads_with_event_active.append(getattr(obj, "_input_event", None) is not None)
             return getattr(obj, "_mock_result", None)
 
         def __set__(self, obj: object, value: object) -> None:
@@ -94,6 +92,6 @@ async def test_request_input_result_captured_before_lock_release():
 
     # The result must have been read while _input_event was still active (True)
     assert any(reads_with_event_active), (
-        "Expected at least one _input_result read while _input_event was set; "
-        "got reads_with_event_active=%r" % reads_with_event_active
+        f"Expected at least one _input_result read while _input_event was set; "
+        f"got reads_with_event_active={reads_with_event_active!r}"
     )

--- a/core/tests/test_client_io.py
+++ b/core/tests/test_client_io.py
@@ -1,0 +1,90 @@
+"""Regression tests for ActiveNodeClientIO race conditions.
+
+Covers:
+- Coroutine cancellation leak: _input_event not cleaned up when cancelled
+  during emit_client_input_requested (before the try/finally block).
+- Premature lock release: _input_result wiped by a concurrent request_input
+  because _input_event was cleared before the result was captured.
+"""
+
+import asyncio
+
+import pytest
+
+from framework.graph.client_io import ActiveNodeClientIO
+
+
+class _MockEventBus:
+    """Minimal event bus stub — no-ops all emit calls."""
+
+    async def emit_client_input_requested(self, **kwargs) -> None:
+        pass
+
+
+class _SlowEventBus(_MockEventBus):
+    """Event bus that blocks in emit_client_input_requested for cancellation tests."""
+
+    async def emit_client_input_requested(self, **kwargs) -> None:
+        await asyncio.sleep(1.0)
+
+
+@pytest.mark.asyncio
+async def test_request_input_cancellation_leak():
+    """Cancelling during emit must not leave _input_event set.
+
+    If _input_event leaks, the second request_input raises
+    'request_input already pending for this node'.
+    """
+    bus = _SlowEventBus()
+    io = ActiveNodeClientIO(node_id="n1", event_bus=bus)
+
+    # Cancel during the slow emit
+    task1 = asyncio.create_task(io.request_input(prompt="Wait"))
+    await asyncio.sleep(0.01)
+    task1.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task1
+
+    # A second request must succeed — no leaked state
+    task2 = asyncio.create_task(io.request_input(prompt="Second"))
+    await asyncio.sleep(0.01)
+    await io.provide_input("data")
+    assert await task2 == "data"
+
+
+@pytest.mark.asyncio
+async def test_request_input_result_captured_before_lock_release():
+    """_input_result must be read while _input_event is still set.
+
+    In the old code, _input_event = None ran in finally *before* the result
+    was captured, opening a race window where a concurrent request could
+    overwrite _input_result with None.
+    """
+
+    reads_with_event_active: list[bool] = []
+
+    class _TrackerDescriptor:
+        def __get__(self, obj, objtype=None):
+            if obj is None:
+                return self
+            reads_with_event_active.append(obj._input_event is not None)
+            return getattr(obj, "_mock_result", None)
+
+        def __set__(self, obj, value):
+            obj._mock_result = value
+
+    class _TrackedIO(ActiveNodeClientIO):
+        _input_result = _TrackerDescriptor()
+
+    io = _TrackedIO(node_id="n1")
+
+    task = asyncio.create_task(io.request_input(prompt="1"))
+    await asyncio.sleep(0.01)
+    await io.provide_input("test_data")
+    assert await task == "test_data"
+
+    # The result must have been read while _input_event was still active (True)
+    assert any(reads_with_event_active), (
+        "Expected at least one _input_result read while _input_event was set; "
+        "got reads_with_event_active=%r" % reads_with_event_active
+    )


### PR DESCRIPTION
## What

Two race conditions in `ActiveNodeClientIO.request_input` that cause unrecoverable node state under cancellation or concurrent access.

## Bugs Fixed

**1. Coroutine Cancellation Leak**

`emit_client_input_requested` was awaited *before* the `try/finally` block. If a cancellation arrived during that await, the function exited without running `finally`, leaving `_input_event` permanently set. Every subsequent `request_input` call would then raise:
```
RuntimeError: request_input already pending for this node
```
Fix: move the emit call inside the `try` block so `finally` always resets `_input_event`.

**2. Premature Lock Release (Critical Section Violation)**

In the original `finally`, `_input_event = None` ran *before* `_input_result` was read. This opened a race window where a concurrent `request_input` could reset `_input_result = None`, causing the waking task to raise:
```
RuntimeError: input event was set but no input was provided
```
Fix: capture `result = self._input_result` inside the `try` block, before `finally` releases the lock.

## Changes

- `core/framework/graph/client_io.py` — two-line structural change to `request_input`
- `core/tests/test_client_io.py` — new file with two regression tests (one per race condition)

## Testing

- [x] `test_request_input_cancellation_leak` — PASSED
- [x] `test_request_input_result_captured_before_lock_release` — PASSED
- [x] Full credential test suite — 67 passed, 0 failed

## Related

Closes #6885

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition in input-request handling so cancellations and concurrent requests no longer cause lost or stale input results.

* **Tests**
  * Added async regression tests that validate input-request synchronization and correct behavior across cancellation and concurrent scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->