### PR TITLE
fix(llm): replace asyncio.run with thread-isolated executor in LiteLLMProvider

### DIFF
--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -9,6 +9,7 @@ See: https://docs.litellm.ai/docs/providers
 
 import ast
 import asyncio
+import concurrent.futures
 import hashlib
 import json
 import logging
@@ -748,6 +749,19 @@ class LiteLLMProvider(LLMProvider):
         # unreachable, but satisfies type checker
         raise RuntimeError("Exhausted rate limit retries")
 
+    @staticmethod
+    def _run_async(coro):  # type: ignore[no-untyped-def]
+        """Run an async coroutine from a sync context safely.
+
+        ``asyncio.run()`` raises ``RuntimeError: This event loop is already
+        running`` when called from inside an existing event loop (e.g. FastAPI,
+        Jupyter).  Running the coroutine in a fresh thread gives it its own
+        event loop and avoids that conflict.
+        """
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(asyncio.run, coro)
+            return future.result()
+
     def complete(
         self,
         messages: list[dict[str, Any]],
@@ -762,7 +776,7 @@ class LiteLLMProvider(LLMProvider):
         # Codex ChatGPT backend requires streaming — delegate to the unified
         # async streaming path which properly handles tool calls.
         if self._codex_backend:
-            return asyncio.run(
+            return self._run_async(
                 self.acomplete(
                     messages=messages,
                     system=system,

--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -16,10 +16,12 @@ import logging
 import os
 import re
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Coroutine
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
+
+_T = TypeVar("_T")
 
 try:
     import litellm
@@ -750,7 +752,7 @@ class LiteLLMProvider(LLMProvider):
         raise RuntimeError("Exhausted rate limit retries")
 
     @staticmethod
-    def _run_async(coro):  # type: ignore[no-untyped-def]
+    def _run_async(coro: Coroutine[Any, Any, _T]) -> _T:
         """Run an async coroutine from a sync context safely.
 
         ``asyncio.run()`` raises ``RuntimeError: This event loop is already


### PR DESCRIPTION
## Summary

Fixes #6929

- `LiteLLMProvider.complete()` called `asyncio.run()` to bridge the sync/async boundary for the Codex backend path.
- `asyncio.run()` raises `RuntimeError: This event loop is already running` when invoked from inside an existing event loop (FastAPI request handlers, Jupyter notebooks, etc.).
- The fix introduces a private `_run_async()` helper that submits the coroutine to a `ThreadPoolExecutor` worker. Each worker thread starts with no event loop, so `asyncio.run()` inside it succeeds without conflict.

## Root cause

```
RuntimeError: This event loop is already running
```

This is a Python limitation: `asyncio.run()` creates and runs a new event loop, but it cannot be called when a loop is already running in the current thread.

## Fix

```python
@staticmethod
def _run_async(coro):
    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
        future = pool.submit(asyncio.run, coro)
        return future.result()
```

The coroutine runs in a fresh thread with its own event loop, making it safe to call from both sync and async contexts.

## Test plan

- [ ] Verify `LiteLLMProvider.complete()` works normally in a plain synchronous context
- [ ] Verify `LiteLLMProvider.complete()` no longer raises `RuntimeError` when called from a FastAPI route handler
- [ ] Verify `LiteLLMProvider.complete()` no longer raises `RuntimeError` when called from a Jupyter notebook cell
- [ ] Run existing LiteLLM unit tests: `uv run pytest tests/ -k litellm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asynchronous operation handling to prevent runtime errors when an event loop is already active, enhancing stability and reliability of the framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->