### PR TITLE
docs: clarify uv vs pip usage and add setup verification step

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,9 +5,11 @@ This guide will help you set up the Aden Agent Framework and build your first ag
 ## Prerequisites
 
 - **Python 3.11+** ([Download](https://www.python.org/downloads/)) - Python 3.12 or 3.13 recommended
-- **pip** - Package installer for Python (comes with Python)
+- **uv** - Fast Python package manager used by this project ([Install](https://docs.astral.sh/uv/getting-started/installation/))
 - **git** - Version control
 - **Claude Code** ([Install](https://docs.anthropic.com/claude/docs/claude-code)) - Optional, for using building skills
+
+> **Package manager note:** This project uses `uv` for all package management and script execution. `uv` manages its own isolated virtual environment — do **not** use bare `pip` commands, as they will install packages outside the project's environment and lead to import errors.
 
 ## Quick Start
 
@@ -42,6 +44,16 @@ uv run python -c "import framework; import aden_tools; print('Setup complete')"
 ```
 
 > **Note:** On Windows, running `.\quickstart.ps1` requires PowerShell 5.1+. If you see a "running scripts is disabled" error, run `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass` first. Alternatively, use WSL — see [environment-setup.md](./environment-setup.md) for details.
+
+## Verify Your Setup
+
+After running `quickstart.sh` (or `quickstart.ps1` on Windows), confirm the core framework is importable:
+
+```bash
+uv run python -c "from framework.agents.queen import QueenAgent; print('Setup OK')"
+```
+
+You should see `Setup OK` printed. If you see an import error instead, re-run `./quickstart.sh` or check the [Troubleshooting](#troubleshooting) section below.
 
 ## Building Your First Agent
 
@@ -227,7 +239,7 @@ echo $HIVE_API_KEY
 
 ```bash
 # Remove and reinstall
-pip uninstall -y framework tools
+uv pip uninstall -y framework tools
 ./quickstart.sh
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,10 +50,10 @@ uv run python -c "import framework; import aden_tools; print('Setup complete')"
 After running `quickstart.sh` (or `quickstart.ps1` on Windows), confirm the core framework is importable:
 
 ```bash
-uv run python -c "from framework.agents.queen import QueenAgent; print('Setup OK')"
+uv run python -c "from framework.agents.queen import queen_goal; print('Setup OK')"
 ```
 
-You should see `Setup OK` printed. If you see an import error instead, re-run `./quickstart.sh` or check the [Troubleshooting](#troubleshooting) section below.
+You should see `Setup OK` printed. If you see an import error instead, re-run `./quickstart.sh` (macOS/Linux) or `.\quickstart.ps1` (Windows) or check the [Troubleshooting](#troubleshooting) section below.
 
 ## Building Your First Agent
 


### PR DESCRIPTION
## Summary

Fixes #6946

- Replaced the `pip` prerequisite with `uv` (linking to the uv install docs), since the project requires uv and pip is not used directly
- Added a package manager note immediately after the prerequisites block, explaining that `uv` manages its own isolated venv and bare `pip` commands must not be used
- Added a **Verify Your Setup** section (between Quick Start and Building Your First Agent) with a minimal runnable one-liner: `uv run python -c "from framework.agents.queen import QueenAgent; print('Setup OK')"`
- Fixed the one remaining bare `pip uninstall` in the Troubleshooting section to use `uv pip uninstall`

## Test plan

- [ ] Clone a fresh copy of the repo and follow the updated getting-started guide
- [ ] Confirm the verify step prints `Setup OK` after running quickstart
- [ ] Confirm no bare `pip` commands remain in `docs/getting-started.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated package management prerequisites to require `uv` instead of `pip` and clarified that all operations must use `uv`'s isolated virtual environment
* Added a new "Verify Your Setup" section with instructions for verifying your installation and guidance for troubleshooting import errors
* Updated troubleshooting commands to use `uv pip` instead of `pip`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->