### PR TITLE
fix(credentials): prevent bare except from swallowing KeyboardInterrupt in setup.py

### DIFF
--- a/core/framework/credentials/setup.py
+++ b/core/framework/credentials/setup.py
@@ -272,6 +272,8 @@ class CredentialSetupSession:
                 f"{Colors.GREEN}✓ Encryption key saved to ~/.hive/secrets/credential_key{Colors.NC}"
             )
             return True
+        except (KeyboardInterrupt, SystemExit):
+            raise
         except Exception as e:
             self._print(f"{Colors.RED}Failed to initialize credential store: {e}{Colors.NC}")
             return False
@@ -371,6 +373,8 @@ class CredentialSetupSession:
         except (EOFError, OSError) as exc:
             logger.debug("Password input unavailable, falling back to plain input: %s", exc)
             api_key = self._input(f"Paste your {cred.env_var}: ").strip()
+        except (KeyboardInterrupt, SystemExit):
+            raise
         except Exception:
             logger.warning("Unexpected error reading password input", exc_info=True)
             api_key = self._input(f"Paste your {cred.env_var}: ").strip()
@@ -412,6 +416,8 @@ class CredentialSetupSession:
             except (EOFError, OSError) as exc:
                 logger.debug("Password input unavailable for ADEN_API_KEY: %s", exc)
                 aden_key = self._input("Paste your ADEN_API_KEY: ").strip()
+            except (KeyboardInterrupt, SystemExit):
+                raise
             except Exception:
                 logger.warning("Unexpected error reading ADEN_API_KEY input", exc_info=True)
                 aden_key = self._input("Paste your ADEN_API_KEY: ").strip()
@@ -445,6 +451,8 @@ class CredentialSetupSession:
                         os.environ[cred.env_var] = value
                 except (KeyError, OSError) as exc:
                     logger.debug("Could not export credential to env: %s", exc)
+                except (KeyboardInterrupt, SystemExit):
+                    raise
                 except Exception:
                     logger.warning("Unexpected error exporting credential to env", exc_info=True)
                 return True
@@ -454,6 +462,8 @@ class CredentialSetupSession:
                 )
                 self._print("Please connect this integration on https://hive.adenhq.com first.")
                 return False
+        except (KeyboardInterrupt, SystemExit):
+            raise
         except Exception as e:
             self._print(f"{Colors.RED}Failed to sync from Aden: {e}{Colors.NC}")
             return False
@@ -472,6 +482,8 @@ class CredentialSetupSession:
         except ImportError:
             # No health checker available
             return None
+        except (KeyboardInterrupt, SystemExit):
+            raise
         except Exception:
             logger.warning("Health check failed for %s", cred.credential_name, exc_info=True)
             return None
@@ -494,6 +506,8 @@ class CredentialSetupSession:
             )
             store.save_credential(cred_obj)
             self._print(f"{Colors.GREEN}✓ Stored in ~/.hive/credentials/{Colors.NC}")
+        except (KeyboardInterrupt, SystemExit):
+            raise
         except Exception as e:
             self._print(f"{Colors.YELLOW}⚠ Could not store in credential store: {e}{Colors.NC}")
 
@@ -579,6 +593,8 @@ def _load_nodes_from_python_agent(agent_path: Path) -> list:
     except (ImportError, OSError) as exc:
         logger.debug("Could not load agent module: %s", exc)
         return []
+    except (KeyboardInterrupt, SystemExit):
+        raise
     except Exception:
         logger.warning("Unexpected error loading agent module", exc_info=True)
         return []
@@ -610,6 +626,8 @@ def _load_nodes_from_json_agent(agent_json: Path) -> list:
     except (json.JSONDecodeError, KeyError, OSError) as exc:
         logger.debug("Could not load JSON agent: %s", exc)
         return []
+    except (KeyboardInterrupt, SystemExit):
+        raise
     except Exception:
         logger.warning("Unexpected error loading JSON agent", exc_info=True)
         return []


### PR DESCRIPTION
## Summary

Fixes #6995.

`core/framework/credentials/setup.py` contained ~9 bare `except Exception` blocks that would silently catch `KeyboardInterrupt` and `SystemExit`, preventing Ctrl+C from working during interactive credential setup.

Changes made:
- Added `except (KeyboardInterrupt, SystemExit): raise` immediately before every broad `except Exception` handler in the file
- Affected locations: `_ensure_credential_key`, `_setup_direct_api_key` (password input fallback), `_setup_via_aden` (ADEN_API_KEY input, credential export, and Aden sync), `_run_health_check`, `_store_credential`, `_load_nodes_from_python_agent`, `_load_nodes_from_json_agent`
- No program logic was changed — only exception handling order

## Test plan

- [ ] Verify Ctrl+C during credential setup (e.g., at a password prompt) correctly interrupts the process instead of being swallowed
- [ ] Verify `sys.exit()` propagates correctly from within credential setup flows
- [ ] Run existing credential-related tests to confirm no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced credential setup to properly handle user-initiated termination signals such as Ctrl+C and system exit signals. These signals now propagate correctly through the setup workflow instead of being caught and treated as generic errors, enabling responsive application shutdown when requested by users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->