### PR TITLE
feat: add Exa integration tracking header (micro-fix)

### DIFF
--- a/tools/src/aden_tools/tools/exa_search_tool/exa_search_tool.py
+++ b/tools/src/aden_tools/tools/exa_search_tool/exa_search_tool.py
@@ -62,6 +62,7 @@ def register_tools(
                 headers={
                     "x-api-key": api_key,
                     "Content-Type": "application/json",
+                    "x-exa-integration": "hive",
                 },
                 timeout=30.0,
             )


### PR DESCRIPTION
Fixes #7033

## Summary
- Adds the `x-exa-integration: hive` header to all Exa API requests in the existing Exa search tool
- This allows Exa to attribute API usage to the hive integration

## Code example
The header is set in the shared `_make_request` helper, so all Exa tools (`exa_search`, `exa_find_similar`, `exa_get_contents`, `exa_answer`, `exa_search_news`, `exa_search_papers`, `exa_search_companies`) automatically include it.

```python
headers={
    "x-api-key": api_key,
    "Content-Type": "application/json",
    "x-exa-integration": "hive",
},
```

## Files changed
- `tools/src/aden_tools/tools/exa_search_tool/exa_search_tool.py` — added one header line to `_make_request`

## Test plan
- [ ] Existing Exa tool tests continue to pass
- [ ] Verify header appears in outgoing requests (e.g. via request logging or proxy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)