### PR TITLE
fix: move antigravity warning before OAuth and add confirmation prompt

### DIFF
--- a/quickstart.ps1
+++ b/quickstart.ps1
@@ -1366,6 +1366,14 @@ switch ($num) {
         # Antigravity Subscription
         if (-not $AntigravityCredDetected) {
             Write-Host ""
+            Write-Warn "Using Antigravity can technically cause your account suspension. Please use at your own risk."
+            Write-Host ""
+
+            if (-not (Prompt-YesNo "Proceed with Antigravity authentication?" "n")) {
+                $SelectedProviderId = ""
+                break
+            }
+            Write-Host ""
             Write-Color -Text "  Setting up Antigravity authentication..." -Color Cyan
             Write-Host ""
             Write-Warn "A browser window will open for Google OAuth."
@@ -1394,8 +1402,6 @@ switch ($num) {
             $SelectedModel           = "gemini-3-flash"
             $SelectedMaxTokens       = 32768
             $SelectedMaxContextTokens = 1000000
-            Write-Host ""
-            Write-Warn "Using Antigravity can technically cause your account suspension. Please use at your own risk."
             Write-Host ""
             Write-Ok "Using Antigravity subscription"
             Write-Color -Text "  Model: gemini-3-flash | Direct OAuth (no proxy required)" -Color DarkGray


### PR DESCRIPTION
## Description

This PR fixes a UX safety issue where the Antigravity account suspension warning was displayed **after OAuth authentication completed**, leaving users no opportunity to opt out before a potentially risky action.

The warning is now shown **before the OAuth flow**, along with a **default-No confirmation prompt**, ensuring proper user consent before proceeding.

---

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)

---

## Related Issues

Fixes #7038

---

## Changes Made

* Moved Antigravity warning message to appear before OAuth authentication
* Added confirmation prompt (`Prompt-YesNo`) with default set to **No**
* Removed redundant warning shown after OAuth completion

---

## Testing

* [ ] Unit tests pass (`cd core && pytest tests/`)
* [ ] Lint passes (`cd core && ruff check .`)
* [x] Manual testing performed

**Manual Test:**

* Selected Antigravity option in quickstart
* Verified warning appears before OAuth
* Verified user can cancel before authentication
* Verified OAuth only triggers after confirmation

---

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] My changes generate no new warnings

---

## Screenshots (if applicable)

N/A (CLI UX change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit consent prompt for Antigravity authentication when credentials are not detected; defaults to declining to prevent unauthorized access.

* **Bug Fixes**
  * Removed redundant warning message from successful Antigravity authentication flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->