### PR TITLE
fix(tools): web_scrape truncation no longer exceeds max_length

### DIFF
--- a/tools/src/aden_tools/tools/web_scrape_tool/web_scrape_tool.py
+++ b/tools/src/aden_tools/tools/web_scrape_tool/web_scrape_tool.py
@@ -255,9 +255,10 @@ def register_tools(mcp: FastMCP) -> None:
             # Clean up whitespace
             text = " ".join(text.split())
 
-            # Truncate if needed
+            # Truncate if needed (reserve 3 chars for the ellipsis so the
+            # final string stays within max_length)
             if len(text) > max_length:
-                text = text[:max_length] + "..."
+                text = text[: max_length - 3] + "..."
 
             result: dict[str, Any] = {
                 "url": url,

--- a/tools/tests/tools/test_web_scrape_tool.py
+++ b/tools/tests/tools/test_web_scrape_tool.py
@@ -116,6 +116,24 @@ class TestWebScrapeTool:
     @pytest.mark.asyncio
     @patch(_STEALTH_PATH)
     @patch(_PW_PATH)
+    async def test_truncation_respects_max_length(self, mock_pw, mock_stealth, web_scrape_fn):
+        """Truncated content (including the ellipsis) must not exceed max_length."""
+        # max_length is clamped to >=1000, so build content larger than that
+        long_text = "a" * 5000
+        html = f"<html><body>{long_text}</body></html>"
+        mock_cm, _, _ = _make_playwright_mocks(html, final_url="https://example.com")
+        mock_pw.return_value = mock_cm
+        mock_stealth.return_value.apply_stealth_async = AsyncMock()
+
+        result = await web_scrape_fn(url="https://example.com", max_length=1000)
+        assert "error" not in result
+        assert len(result["content"]) <= 1000
+        assert result["content"].endswith("...")
+        assert result["length"] == len(result["content"])
+
+    @pytest.mark.asyncio
+    @patch(_STEALTH_PATH)
+    @patch(_PW_PATH)
     async def test_include_links_option(self, mock_pw, mock_stealth, web_scrape_fn):
         """include_links parameter is accepted."""
         html = '<html><body><a href="/link">Link</a></body></html>'


### PR DESCRIPTION
## Description

`web_scrape` was returning content that was always 3 characters longer than the requested `max_length` because of how the ellipsis was appended. This PR makes the truncation respect the contract.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #2098

## Changes Made

- `tools/src/aden_tools/tools/web_scrape_tool/web_scrape_tool.py`: reserve 3 chars for the ellipsis inside `max_length` so the final string never exceeds the limit
- `tools/tests/tools/test_web_scrape_tool.py`: add a regression test that calls `web_scrape` with content larger than `max_length` and asserts the truncated result is `<= max_length`

## Testing

- [x] Unit tests pass (`uv run pytest tests/tools/test_web_scrape_tool.py` — 34 passed)
- [x] Lint passes (`uv run ruff check ...` — clean)
- [x] Manual reasoning: with `max_length=1000`, old behavior returned 1003 chars; new behavior returns at most 1000

## Notes

The issue also raised the byte-vs-character question (multi-byte UTF-8 chars exceeding a byte budget). The current `max_length` semantics in the docstring just say "Maximum length of extracted text" without specifying a unit, and the existing validation/clamping treats it as a character count, so this PR keeps it as character count and only fixes the +3 overrun. Happy to follow up with a separate change if maintainers want to switch to byte semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected web scraper text truncation logic to ensure output respects the specified maximum length limit, preventing truncated content from exceeding the configured threshold.

* **Tests**
  * Added test case validating truncation behavior respects maximum length constraints and proper formatting of truncated content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->