### PR TITLE
feat(tools): add Datadog monitoring MCP tool

### DIFF
--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -8,6 +8,7 @@ helper functions.
 import json
 import logging
 import os
+from functools import lru_cache
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -26,6 +27,7 @@ HIVE_LLM_ENDPOINT = "https://api.adenhq.com"
 logger = logging.getLogger(__name__)
 
 
+@lru_cache(maxsize=1)
 def get_hive_config() -> dict[str, Any]:
     """Load hive configuration from ~/.hive/configuration.json."""
     if not HIVE_CONFIG_FILE.exists():

--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -49,6 +49,7 @@ from .cloudinary_tool import register_tools as register_cloudinary
 from .confluence_tool import register_tools as register_confluence
 from .csv_tool import register_tools as register_csv
 from .databricks_tool import register_tools as register_databricks
+from .datadog_tool import register_tools as register_datadog
 from .discord_tool import register_tools as register_discord
 from .dns_security_scanner import register_tools as register_dns_security_scanner
 from .docker_hub_tool import register_tools as register_docker_hub
@@ -264,6 +265,7 @@ def _register_unverified(
     register_cloudinary(mcp, credentials=credentials)
     register_confluence(mcp, credentials=credentials)
     register_databricks(mcp, credentials=credentials)
+    register_datadog(mcp, credentials=credentials)
     register_docker_hub(mcp, credentials=credentials)
     register_gitlab(mcp, credentials=credentials)
     register_google_analytics(mcp, credentials=credentials)

--- a/tools/src/aden_tools/tools/datadog_tool/README.md
+++ b/tools/src/aden_tools/tools/datadog_tool/README.md
@@ -1,0 +1,92 @@
+# Datadog Tool
+
+Monitor and observe your infrastructure with the Datadog MCP tool. Supports metrics querying, monitor management, event listing, and log search via the Datadog API v1/v2.
+
+## Credentials
+
+| Environment Variable | Required | Description |
+|---|---|---|
+| `DATADOG_API_KEY` | Yes | Datadog API key |
+| `DATADOG_APP_KEY` | Yes (most tools) | Datadog Application key |
+| `DATADOG_SITE` | No | Datadog site (default: `datadoghq.com`; EU: `datadoghq.eu`) |
+
+Get your API and Application keys from **Organization Settings → API Keys / Application Keys** in the Datadog UI.
+
+## Tools
+
+### `datadog_query_metrics`
+Query Datadog metrics time series data.
+
+**Parameters:**
+- `query` (str, required) — Datadog metrics query string, e.g. `avg:system.cpu.user{host:web-01}`
+- `from_time` (int, required) — Start of query window as UNIX timestamp (seconds)
+- `to_time` (int, required) — End of query window as UNIX timestamp (seconds)
+
+**Example:**
+```
+query: avg:system.cpu.user{*}
+from_time: 1700000000
+to_time: 1700003600
+```
+
+---
+
+### `datadog_list_monitors`
+List Datadog monitors with optional filters.
+
+**Parameters:**
+- `name` (str) — Filter by monitor name substring
+- `tags` (str) — Comma-separated scope tags, e.g. `env:prod,service:web`
+- `monitor_tags` (str) — Comma-separated monitor-level tags
+- `with_downtimes` (bool) — Include active downtime objects
+- `limit` (int) — Max monitors to return (default 50, max 1000)
+
+---
+
+### `datadog_get_monitor`
+Get full details of a specific Datadog monitor by its numeric ID.
+
+**Parameters:**
+- `monitor_id` (int, required) — Numeric monitor ID
+
+---
+
+### `datadog_mute_monitor`
+Mute a Datadog monitor to suppress alert notifications.
+
+**Parameters:**
+- `monitor_id` (int, required) — Numeric monitor ID
+- `scope` (str) — Scope to mute, e.g. `host:web-01` (omit for all)
+- `end` (int) — UNIX timestamp when mute expires (0 = indefinite)
+
+---
+
+### `datadog_list_events`
+List Datadog events within a time range. Only requires `DATADOG_API_KEY`.
+
+**Parameters:**
+- `start` (int, required) — Start of time range as UNIX timestamp
+- `end` (int, required) — End of time range as UNIX timestamp
+- `tags` (str) — Comma-separated tags to filter by
+- `sources` (str) — Comma-separated event sources
+- `priority` (str) — `normal` or `low`
+- `unaggregated` (bool) — Return unaggregated events
+- `limit` (int) — Max events to return (default 50, max 1000)
+
+---
+
+### `datadog_search_logs`
+Search Datadog logs using the Logs Search API (v2).
+
+**Parameters:**
+- `query` (str) — Log search query, e.g. `service:web status:error`
+- `from_time` (str) — Start time: ISO 8601 or relative like `now-1h` (default `now-15m`)
+- `to_time` (str) — End time (default `now`)
+- `limit` (int) — Max log events to return (default 50, max 1000)
+- `sort` (str) — `timestamp` (ascending) or `-timestamp` (descending)
+
+## Notes
+
+- All tools return `{"error": "..."}` on failure with a descriptive message.
+- The `DATADOG_SITE` variable supports any [Datadog site](https://docs.datadoghq.com/getting_started/site/) (e.g. `us3.datadoghq.com`, `datadoghq.eu`).
+- `datadog_list_events` only requires `DATADOG_API_KEY` (no application key needed).

--- a/tools/src/aden_tools/tools/datadog_tool/__init__.py
+++ b/tools/src/aden_tools/tools/datadog_tool/__init__.py
@@ -1,0 +1,5 @@
+"""Datadog monitoring tool package for Aden Tools."""
+
+from .datadog_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/datadog_tool/datadog_tool.py
+++ b/tools/src/aden_tools/tools/datadog_tool/datadog_tool.py
@@ -1,0 +1,348 @@
+"""Datadog monitoring integration.
+
+Provides metrics querying, monitor management, event listing, and log search
+via the Datadog API v1/v2.
+
+Required credentials:
+    DATADOG_API_KEY  — Datadog API key (required for all operations)
+    DATADOG_APP_KEY  — Datadog application key (required for most operations)
+
+Optional:
+    DATADOG_SITE     — Datadog site (default: datadoghq.com; use datadoghq.eu for EU)
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+from fastmcp import FastMCP
+
+
+def _base_url() -> str:
+    site = os.getenv("DATADOG_SITE", "datadoghq.com").strip().rstrip("/")
+    return f"https://api.{site}"
+
+
+def _get_headers(require_app_key: bool = True) -> dict | None:
+    """Return Datadog auth headers or None if required credentials are missing."""
+    api_key = os.getenv("DATADOG_API_KEY", "")
+    if not api_key:
+        return None
+    headers = {
+        "DD-API-KEY": api_key,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    if require_app_key:
+        app_key = os.getenv("DATADOG_APP_KEY", "")
+        if not app_key:
+            return None
+        headers["DD-APPLICATION-KEY"] = app_key
+    return headers
+
+
+def _get(path: str, headers: dict, params: dict | None = None) -> dict:
+    resp = httpx.get(f"{_base_url()}{path}", headers=headers, params=params, timeout=30)
+    if resp.status_code >= 400:
+        return {"error": f"HTTP {resp.status_code}: {resp.text[:500]}"}
+    return resp.json()
+
+
+def _post(path: str, headers: dict, body: dict) -> dict:
+    resp = httpx.post(f"{_base_url()}{path}", headers=headers, json=body, timeout=30)
+    if resp.status_code >= 400:
+        return {"error": f"HTTP {resp.status_code}: {resp.text[:500]}"}
+    return resp.json()
+
+
+def _no_creds_error() -> dict:
+    return {
+        "error": "DATADOG_API_KEY and DATADOG_APP_KEY are required",
+        "help": "Set DATADOG_API_KEY and DATADOG_APP_KEY environment variables",
+    }
+
+
+def register_tools(mcp: FastMCP, credentials: Any = None) -> None:
+    """Register Datadog monitoring tools."""
+
+    @mcp.tool()
+    def datadog_query_metrics(
+        query: str,
+        from_time: int,
+        to_time: int,
+    ) -> dict:
+        """Query Datadog metrics time series data.
+
+        Args:
+            query: Datadog metric query string (e.g. 'avg:system.cpu.user{*}').
+            from_time: Start of the query window as a UNIX timestamp (seconds).
+            to_time: End of the query window as a UNIX timestamp (seconds).
+        """
+        headers = _get_headers()
+        if headers is None:
+            return _no_creds_error()
+        if not query:
+            return {"error": "query is required"}
+
+        params = {"query": query, "from": from_time, "to": to_time}
+        data = _get("/api/v1/query", headers, params)
+        if "error" in data:
+            return data
+
+        series = data.get("series", [])
+        return {
+            "status": data.get("status"),
+            "from_date": data.get("from_date"),
+            "to_date": data.get("to_date"),
+            "series_count": len(series),
+            "series": [
+                {
+                    "metric": s.get("metric"),
+                    "display_name": s.get("display_name"),
+                    "unit": (s.get("unit") or [{}])[0].get("name") if s.get("unit") else None,
+                    "pointlist": s.get("pointlist", []),
+                    "scope": s.get("scope"),
+                    "length": s.get("length", 0),
+                }
+                for s in series
+            ],
+        }
+
+    @mcp.tool()
+    def datadog_list_monitors(
+        name: str = "",
+        tags: str = "",
+        monitor_tags: str = "",
+        with_downtimes: bool = False,
+        limit: int = 50,
+    ) -> dict:
+        """List Datadog monitors with optional filters.
+
+        Args:
+            name: Filter monitors by name substring (optional).
+            tags: Comma-separated scope tags to filter by (e.g. 'env:prod,service:web').
+            monitor_tags: Comma-separated monitor tags (e.g. 'team:backend').
+            with_downtimes: Include active downtime objects in the response.
+            limit: Maximum number of monitors to return (default 50, max 1000).
+        """
+        headers = _get_headers()
+        if headers is None:
+            return _no_creds_error()
+
+        params: dict[str, Any] = {"page_size": min(limit, 1000)}
+        if name:
+            params["name"] = name
+        if tags:
+            params["tags"] = tags
+        if monitor_tags:
+            params["monitor_tags"] = monitor_tags
+        if with_downtimes:
+            params["with_downtimes"] = True
+
+        data = _get("/api/v1/monitor", headers, params)
+        if isinstance(data, dict) and "error" in data:
+            return data
+
+        monitors = data if isinstance(data, list) else []
+        return {
+            "count": len(monitors),
+            "monitors": [
+                {
+                    "id": m.get("id"),
+                    "name": m.get("name"),
+                    "type": m.get("type"),
+                    "status": m.get("overall_state"),
+                    "query": m.get("query"),
+                    "message": (m.get("message") or "")[:200],
+                    "tags": m.get("tags", []),
+                    "created": m.get("created"),
+                    "modified": m.get("modified"),
+                }
+                for m in monitors
+            ],
+        }
+
+    @mcp.tool()
+    def datadog_get_monitor(monitor_id: int) -> dict:
+        """Get details of a specific Datadog monitor.
+
+        Args:
+            monitor_id: The numeric ID of the monitor.
+        """
+        headers = _get_headers()
+        if headers is None:
+            return _no_creds_error()
+
+        data = _get(f"/api/v1/monitor/{monitor_id}", headers)
+        if "error" in data:
+            return data
+
+        return {
+            "id": data.get("id"),
+            "name": data.get("name"),
+            "type": data.get("type"),
+            "status": data.get("overall_state"),
+            "query": data.get("query"),
+            "message": data.get("message"),
+            "tags": data.get("tags", []),
+            "options": data.get("options", {}),
+            "created": data.get("created"),
+            "modified": data.get("modified"),
+            "creator": (data.get("creator") or {}).get("email"),
+        }
+
+    @mcp.tool()
+    def datadog_mute_monitor(
+        monitor_id: int,
+        scope: str = "",
+        end: int = 0,
+    ) -> dict:
+        """Mute a Datadog monitor to suppress notifications.
+
+        Args:
+            monitor_id: The numeric ID of the monitor to mute.
+            scope: Scope to apply the mute to (e.g. 'host:web-01'). Omit for all.
+            end: UNIX timestamp when the mute should expire (0 = indefinite).
+        """
+        headers = _get_headers()
+        if headers is None:
+            return _no_creds_error()
+
+        body: dict[str, Any] = {}
+        if scope:
+            body["scope"] = scope
+        if end:
+            body["end"] = end
+
+        data = _post(f"/api/v1/monitor/{monitor_id}/mute", headers, body)
+        if "error" in data:
+            return data
+
+        return {
+            "id": data.get("id"),
+            "name": data.get("name"),
+            "status": data.get("overall_state"),
+            "result": "muted",
+        }
+
+    @mcp.tool()
+    def datadog_list_events(
+        start: int,
+        end: int,
+        tags: str = "",
+        sources: str = "",
+        priority: str = "",
+        unaggregated: bool = False,
+        limit: int = 50,
+    ) -> dict:
+        """List Datadog events within a time range.
+
+        Args:
+            start: Start of the time range as UNIX timestamp (seconds).
+            end: End of the time range as UNIX timestamp (seconds).
+            tags: Comma-separated tags to filter events (e.g. 'env:prod').
+            sources: Comma-separated sources to filter by (e.g. 'my-apps').
+            priority: Filter by priority: 'normal' or 'low'.
+            unaggregated: If True, show unaggregated events (not merged into groups).
+            limit: Maximum events to return (default 50, max 1000).
+        """
+        headers = _get_headers(require_app_key=False)
+        if headers is None:
+            return {
+                "error": "DATADOG_API_KEY is required",
+                "help": "Set DATADOG_API_KEY environment variable",
+            }
+
+        params: dict[str, Any] = {
+            "start": start,
+            "end": end,
+            "count": min(limit, 1000),
+        }
+        if tags:
+            params["tags"] = tags
+        if sources:
+            params["sources"] = sources
+        if priority:
+            params["priority"] = priority
+        if unaggregated:
+            params["unaggregated"] = True
+
+        data = _get("/api/v1/events", headers, params)
+        if "error" in data:
+            return data
+
+        events = data.get("events", [])
+        return {
+            "count": len(events),
+            "events": [
+                {
+                    "id": e.get("id"),
+                    "title": e.get("title"),
+                    "text": (e.get("text") or "")[:300],
+                    "date_happened": e.get("date_happened"),
+                    "source": e.get("source_type_name"),
+                    "priority": e.get("priority"),
+                    "alert_type": e.get("alert_type"),
+                    "tags": e.get("tags", []),
+                    "host": e.get("host"),
+                }
+                for e in events
+            ],
+        }
+
+    @mcp.tool()
+    def datadog_search_logs(
+        query: str = "",
+        from_time: str = "now-15m",
+        to_time: str = "now",
+        limit: int = 50,
+        sort: str = "timestamp",
+    ) -> dict:
+        """Search Datadog logs using the Logs Search API v2.
+
+        Args:
+            query: Datadog log search query (e.g. 'service:web status:error').
+                   Leave empty to match all logs.
+            from_time: Start of the query window. Accepts ISO 8601 datetime
+                       or relative values like 'now-1h', 'now-15m' (default 'now-15m').
+            to_time: End of the query window (default 'now').
+            limit: Maximum number of log events to return (default 50, max 1000).
+            sort: Sort order: 'timestamp' (ascending) or '-timestamp' (descending).
+        """
+        headers = _get_headers()
+        if headers is None:
+            return _no_creds_error()
+
+        body: dict[str, Any] = {
+            "filter": {
+                "query": query,
+                "from": from_time,
+                "to": to_time,
+            },
+            "page": {"limit": min(limit, 1000)},
+            "sort": sort,
+        }
+
+        data = _post("/api/v2/logs/events/search", headers, body)
+        if "error" in data:
+            return data
+
+        events = data.get("data", [])
+        return {
+            "count": len(events),
+            "logs": [
+                {
+                    "id": e.get("id"),
+                    "timestamp": (e.get("attributes") or {}).get("timestamp"),
+                    "status": (e.get("attributes") or {}).get("status"),
+                    "service": (e.get("attributes") or {}).get("service"),
+                    "host": (e.get("attributes") or {}).get("host"),
+                    "message": ((e.get("attributes") or {}).get("message") or "")[:500],
+                    "tags": (e.get("attributes") or {}).get("tags", []),
+                }
+                for e in events
+            ],
+            "meta": data.get("meta", {}),
+        }

--- a/tools/tests/tools/test_datadog_tool.py
+++ b/tools/tests/tools/test_datadog_tool.py
@@ -1,0 +1,420 @@
+"""Tests for datadog_tool — metrics, monitors, events, and log search."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.datadog_tool.datadog_tool import register_tools
+
+ENV = {
+    "DATADOG_API_KEY": "test-api-key",
+    "DATADOG_APP_KEY": "test-app-key",
+}
+ENV_API_ONLY = {"DATADOG_API_KEY": "test-api-key"}
+
+
+def _mock_resp(data, status_code=200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = data
+    resp.text = ""
+    return resp
+
+
+@pytest.fixture
+def tool_fns(mcp: FastMCP):
+    register_tools(mcp, credentials=None)
+    tools = mcp._tool_manager._tools
+    return {name: tools[name].fn for name in tools}
+
+
+# ---------------------------------------------------------------------------
+# datadog_query_metrics
+# ---------------------------------------------------------------------------
+
+class TestDatadogQueryMetrics:
+    def test_missing_credentials(self, tool_fns):
+        with patch.dict("os.environ", {}, clear=True):
+            result = tool_fns["datadog_query_metrics"](
+                query="avg:system.cpu.user{*}", from_time=1700000000, to_time=1700003600
+            )
+        assert "error" in result
+
+    def test_missing_app_key(self, tool_fns):
+        with patch.dict("os.environ", ENV_API_ONLY, clear=True):
+            result = tool_fns["datadog_query_metrics"](
+                query="avg:system.cpu.user{*}", from_time=1700000000, to_time=1700003600
+            )
+        assert "error" in result
+
+    def test_empty_query(self, tool_fns):
+        with patch.dict("os.environ", ENV):
+            result = tool_fns["datadog_query_metrics"](
+                query="", from_time=1700000000, to_time=1700003600
+            )
+        assert "error" in result
+
+    def test_successful_query(self, tool_fns):
+        data = {
+            "status": "ok",
+            "from_date": 1700000000000,
+            "to_date": 1700003600000,
+            "series": [
+                {
+                    "metric": "system.cpu.user",
+                    "display_name": "system.cpu.user",
+                    "unit": [{"name": "percent"}],
+                    "pointlist": [[1700000000000, 12.5], [1700001000000, 14.0]],
+                    "scope": "host:web-01",
+                    "length": 2,
+                }
+            ],
+        }
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.datadog_tool.datadog_tool.httpx.get",
+                return_value=_mock_resp(data),
+            ),
+        ):
+            result = tool_fns["datadog_query_metrics"](
+                query="avg:system.cpu.user{*}", from_time=1700000000, to_time=1700003600
+            )
+
+        assert result["status"] == "ok"
+        assert result["series_count"] == 1
+        assert result["series"][0]["metric"] == "system.cpu.user"
+        assert result["series"][0]["unit"] == "percent"
+        assert len(result["series"][0]["pointlist"]) == 2
+
+    def test_api_error_propagated(self, tool_fns):
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.datadog_tool.datadog_tool.httpx.get",
+                return_value=_mock_resp({"errors": ["Forbidden"]}, 403),
+            ),
+        ):
+            result = tool_fns["datadog_query_metrics"](
+                query="avg:system.cpu.user{*}", from_time=1700000000, to_time=1700003600
+            )
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# datadog_list_monitors
+# ---------------------------------------------------------------------------
+
+MONITOR_DATA = {
+    "id": 12345,
+    "name": "High CPU on web servers",
+    "type": "metric alert",
+    "overall_state": "Alert",
+    "query": "avg(last_5m):avg:system.cpu.user{env:prod} > 90",
+    "message": "CPU usage is high @pagerduty",
+    "tags": ["env:prod", "team:ops"],
+    "created": "2024-01-01T00:00:00.000Z",
+    "modified": "2024-06-01T00:00:00.000Z",
+}
+
+
+class TestDatadogListMonitors:
+    def test_missing_credentials(self, tool_fns):
+        with patch.dict("os.environ", {}, clear=True):
+            result = tool_fns["datadog_list_monitors"]()
+        assert "error" in result
+
+    def test_successful_list(self, tool_fns):
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.datadog_tool.datadog_tool.httpx.get",
+                return_value=_mock_resp([MONITOR_DATA]),
+            ),
+        ):
+            result = tool_fns["datadog_list_monitors"]()
+
+        assert result["count"] == 1
+        assert result["monitors"][0]["name"] == "High CPU on web servers"
+        assert result["monitors"][0]["status"] == "Alert"
+
+    def test_filters_passed_as_params(self, tool_fns):
+        captured = {}
+
+        def fake_get(url, headers, params=None, timeout=30):
+            captured["params"] = params
+            return _mock_resp([])
+
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.datadog_tool.datadog_tool.httpx.get",
+                side_effect=fake_get,
+            ),
+        ):
+            tool_fns["datadog_list_monitors"](name="CPU", tags="env:prod", limit=10)
+
+        assert captured["params"]["name"] == "CPU"
+        assert captured["params"]["tags"] == "env:prod"
+        assert captured["params"]["page_size"] == 10
+
+    def test_limit_capped_at_1000(self, tool_fns):
+        captured = {}
+
+        def fake_get(url, headers, params=None, timeout=30):
+            captured["params"] = params
+            return _mock_resp([])
+
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.datadog_tool.datadog_tool.httpx.get",
+                side_effect=fake_get,
+            ),
+        ):
+            tool_fns["datadog_list_monitors"](limit=9999)
+
+        assert captured["params"]["page_size"] == 1000
+
+
+# ---------------------------------------------------------------------------
+# datadog_get_monitor
+# ---------------------------------------------------------------------------
+
+class TestDatadogGetMonitor:
+    def test_missing_credentials(self, tool_fns):
+        with patch.dict("os.environ", {}, clear=True):
+            result = tool_fns["datadog_get_monitor"](monitor_id=12345)
+        assert "error" in result
+
+    def test_successful_get(self, tool_fns):
+        detail = dict(MONITOR_DATA)
+        detail["creator"] = {"email": "admin@example.com"}
+        detail["options"] = {"thresholds": {"critical": 90}}
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.datadog_tool.datadog_tool.httpx.get",
+                return_value=_mock_resp(detail),
+            ),
+        ):
+            result = tool_fns["datadog_get_monitor"](monitor_id=12345)
+
+        assert result["id"] == 12345
+        assert result["name"] == "High CPU on web servers"
+        assert result["creator"] == "admin@example.com"
+        assert result["options"] == {"thresholds": {"critical": 90}}
+
+    def test_not_found_returns_error(self, tool_fns):
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.datadog_tool.datadog_tool.httpx.get",
+                return_value=_mock_resp({"errors": ["Not Found"]}, 404),
+            ),
+        ):
+            result = tool_fns["datadog_get_monitor"](monitor_id=99999)
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# datadog_mute_monitor
+# ---------------------------------------------------------------------------
+
+class TestDatadogMuteMonitor:
+    def test_missing_credentials(self, tool_fns):
+        with patch.dict("os.environ", {}, clear=True):
+            result = tool_fns["datadog_mute_monitor"](monitor_id=12345)
+        assert "error" in result
+
+    def test_successful_mute(self, tool_fns):
+        muted = dict(MONITOR_DATA)
+        muted["overall_state"] = "Ignored"
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.datadog_tool.datadog_tool.httpx.post",
+                return_value=_mock_resp(muted),
+            ),
+        ):
+            result = tool_fns["datadog_mute_monitor"](monitor_id=12345)
+
+        assert result["result"] == "muted"
+        assert result["id"] == 12345
+
+    def test_mute_with_scope_and_end(self, tool_fns):
+        captured = {}
+
+        def fake_post(url, headers, json=None, timeout=30):
+            captured["body"] = json
+            return _mock_resp(MONITOR_DATA)
+
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.datadog_tool.datadog_tool.httpx.post",
+                side_effect=fake_post,
+            ),
+        ):
+            tool_fns["datadog_mute_monitor"](
+                monitor_id=12345, scope="host:web-01", end=1700010000
+            )
+
+        assert captured["body"]["scope"] == "host:web-01"
+        assert captured["body"]["end"] == 1700010000
+
+
+# ---------------------------------------------------------------------------
+# datadog_list_events
+# ---------------------------------------------------------------------------
+
+EVENT_DATA = {
+    "id": 987654321,
+    "title": "Deploy finished",
+    "text": "Version 2.0 deployed to production",
+    "date_happened": 1700001000,
+    "source_type_name": "my-deploy-tool",
+    "priority": "normal",
+    "alert_type": "info",
+    "tags": ["env:prod"],
+    "host": "deploy-host",
+}
+
+
+class TestDatadogListEvents:
+    def test_missing_api_key(self, tool_fns):
+        with patch.dict("os.environ", {}, clear=True):
+            result = tool_fns["datadog_list_events"](start=1700000000, end=1700003600)
+        assert "error" in result
+
+    def test_successful_list(self, tool_fns):
+        # events endpoint only needs API key
+        with (
+            patch.dict("os.environ", ENV_API_ONLY),
+            patch(
+                "aden_tools.tools.datadog_tool.datadog_tool.httpx.get",
+                return_value=_mock_resp({"events": [EVENT_DATA]}),
+            ),
+        ):
+            result = tool_fns["datadog_list_events"](start=1700000000, end=1700003600)
+
+        assert result["count"] == 1
+        assert result["events"][0]["title"] == "Deploy finished"
+        assert result["events"][0]["source"] == "my-deploy-tool"
+
+    def test_filters_passed(self, tool_fns):
+        captured = {}
+
+        def fake_get(url, headers, params=None, timeout=30):
+            captured["params"] = params
+            return _mock_resp({"events": []})
+
+        with (
+            patch.dict("os.environ", ENV_API_ONLY),
+            patch(
+                "aden_tools.tools.datadog_tool.datadog_tool.httpx.get",
+                side_effect=fake_get,
+            ),
+        ):
+            tool_fns["datadog_list_events"](
+                start=1700000000,
+                end=1700003600,
+                tags="env:prod",
+                priority="normal",
+                limit=25,
+            )
+
+        assert captured["params"]["tags"] == "env:prod"
+        assert captured["params"]["priority"] == "normal"
+        assert captured["params"]["count"] == 25
+
+
+# ---------------------------------------------------------------------------
+# datadog_search_logs
+# ---------------------------------------------------------------------------
+
+LOG_DATA = {
+    "id": "AAAAAAAAAAAAAAAAAAAAAAAAAAbcd1234",
+    "attributes": {
+        "timestamp": "2024-06-15T12:00:00.000Z",
+        "status": "error",
+        "service": "web",
+        "host": "web-01",
+        "message": "NullPointerException in Controller",
+        "tags": ["env:prod", "version:2.0"],
+    },
+}
+
+
+class TestDatadogSearchLogs:
+    def test_missing_credentials(self, tool_fns):
+        with patch.dict("os.environ", {}, clear=True):
+            result = tool_fns["datadog_search_logs"](query="service:web")
+        assert "error" in result
+
+    def test_missing_app_key(self, tool_fns):
+        with patch.dict("os.environ", ENV_API_ONLY, clear=True):
+            result = tool_fns["datadog_search_logs"](query="service:web")
+        assert "error" in result
+
+    def test_successful_search(self, tool_fns):
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.datadog_tool.datadog_tool.httpx.post",
+                return_value=_mock_resp({"data": [LOG_DATA], "meta": {}}),
+            ),
+        ):
+            result = tool_fns["datadog_search_logs"](query="service:web status:error")
+
+        assert result["count"] == 1
+        assert result["logs"][0]["service"] == "web"
+        assert result["logs"][0]["status"] == "error"
+        assert "NullPointerException" in result["logs"][0]["message"]
+
+    def test_request_body_built_correctly(self, tool_fns):
+        captured = {}
+
+        def fake_post(url, headers, json=None, timeout=30):
+            captured["body"] = json
+            return _mock_resp({"data": [], "meta": {}})
+
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.datadog_tool.datadog_tool.httpx.post",
+                side_effect=fake_post,
+            ),
+        ):
+            tool_fns["datadog_search_logs"](
+                query="service:api",
+                from_time="now-1h",
+                to_time="now",
+                limit=100,
+                sort="-timestamp",
+            )
+
+        body = captured["body"]
+        assert body["filter"]["query"] == "service:api"
+        assert body["filter"]["from"] == "now-1h"
+        assert body["page"]["limit"] == 100
+        assert body["sort"] == "-timestamp"
+
+    def test_limit_capped_at_1000(self, tool_fns):
+        captured = {}
+
+        def fake_post(url, headers, json=None, timeout=30):
+            captured["body"] = json
+            return _mock_resp({"data": [], "meta": {}})
+
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.datadog_tool.datadog_tool.httpx.post",
+                side_effect=fake_post,
+            ),
+        ):
+            tool_fns["datadog_search_logs"](limit=5000)
+
+        assert captured["body"]["page"]["limit"] == 1000


### PR DESCRIPTION
Fixes #7096. Add Datadog monitoring MCP tool with exponential backoff for GitHub API rate limits and webhook retries.