### PR TITLE
micro-fix: fix Hive LLM PowerShell health check path

### DIFF
--- a/core/tests/test_quickstart_ps1.py
+++ b/core/tests/test_quickstart_ps1.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+QUICKSTART_PS1 = Path(__file__).resolve().parents[2] / "quickstart.ps1"
+CHECK_LLM_KEY_SNIPPET = '(Join-Path $ScriptDir "scripts/check_llm_key.py")'
+
+
+def _quickstart_text() -> str:
+    return QUICKSTART_PS1.read_text(encoding="utf-8").replace("\r\n", "\n")
+
+
+def test_all_check_llm_key_invocations_use_scriptdir_join_path():
+    text = _quickstart_text()
+    invocation_lines = [line.strip() for line in text.splitlines() if "check_llm_key.py" in line]
+
+    assert invocation_lines
+    for line in invocation_lines:
+        assert CHECK_LLM_KEY_SNIPPET in line
+
+
+def test_hive_llm_health_check_uses_uv_run_python():
+    text = _quickstart_text()
+    start = text.index("# For Hive LLM: prompt for API key with verification + retry")
+    end = text.index("# Prompt for model if not already selected (manual provider path)")
+    hive_block = text[start:end]
+
+    assert "$PythonCmd scripts/check_llm_key.py hive" not in hive_block
+    assert (
+        '& $UvCmd run python (Join-Path $ScriptDir "scripts/check_llm_key.py") '
+        'hive $apiKey "$HiveLlmEndpoint"'
+    ) in hive_block

--- a/quickstart.ps1
+++ b/quickstart.ps1
@@ -1838,7 +1838,7 @@ if ($SubscriptionMode -eq "hive_llm") {
             # Health check the new key
             Write-Host "  Verifying Hive API key... " -NoNewline
             try {
-                $hcOutput = & $PythonCmd scripts/check_llm_key.py hive $apiKey "$HiveLlmEndpoint" 2>&1
+                $hcOutput = & $UvCmd run python (Join-Path $ScriptDir "scripts/check_llm_key.py") hive $apiKey "$HiveLlmEndpoint" 2>$null
                 $hcJson = $hcOutput | ConvertFrom-Json
                 if ($hcJson.valid -eq $true) {
                     Write-Color -Text "ok" -Color Green


### PR DESCRIPTION
## Summary

- fix the Hive LLM Windows quickstart health check to run through `uv` and resolve `scripts/check_llm_key.py` relative to `$ScriptDir`
- add a regression test that requires every `check_llm_key.py` invocation in `quickstart.ps1` to use `Join-Path $ScriptDir`
- add a focused Hive-specific regression test so the Hive path cannot silently fall back to the system Python again

## Root Cause

The Hive LLM branch in `quickstart.ps1` was the only key-verification path still calling `$PythonCmd scripts/check_llm_key.py` with a relative path. That bypassed the project environment created by `uv` and broke whenever the script was launched outside the repo root.

## Validation

- `uv run pytest core/tests/test_quickstart_ps1.py core/tests/test_check_llm_key_openrouter.py -q`
- `uv run ruff check core/tests/test_quickstart_ps1.py`

Fixes #7037


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation tests for the PowerShell quickstart script to ensure proper execution patterns and robust error handling throughout the API key verification process.

* **Bug Fixes**
  * Improved the Hive LLM API key verification process in the quickstart script by implementing an enhanced execution method with refined error handling and better overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->