### PR TITLE
fix(frontend): handle clipboard API rejection in PromptLibrary (#6306)

### DIFF
--- a/core/frontend/src/pages/prompt-library.tsx
+++ b/core/frontend/src/pages/prompt-library.tsx
@@ -1,20 +1,24 @@
 import { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
-import { Search, Copy, Check, Sparkles, MessageSquarePlus } from "lucide-react";
+import { Search, Copy, Check, Sparkles, MessageSquarePlus, AlertCircle } from "lucide-react";
 import { prompts, promptCategories, categoryToQueen, queenNames } from "@/data/prompts";
 
 function PromptCard({ prompt, onUse }: { prompt: typeof prompts[0]; onUse: (content: string, category: string) => void }) {
   const [copied, setCopied] = useState(false);
+  const [error, setError] = useState(false);
   const queenId = categoryToQueen[prompt.category];
   const queenName = queenNames[queenId] || "Queen";
 
   const handleCopy = async () => {
     try {
+      setError(false);
       await navigator.clipboard.writeText(prompt.content);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
       console.error("Clipboard copy failed:", err);
+      setError(true);
+      setTimeout(() => setError(false), 3000);
     }
   };
 
@@ -28,9 +32,15 @@ function PromptCard({ prompt, onUse }: { prompt: typeof prompts[0]; onUse: (cont
           <button
             onClick={handleCopy}
             className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors"
-            title="Copy prompt"
+            title={error ? "Copy failed" : "Copy prompt"}
           >
-            {copied ? <Check className="w-3.5 h-3.5 text-emerald-500" /> : <Copy className="w-3.5 h-3.5" />}
+            {error ? (
+              <AlertCircle className="w-3.5 h-3.5 text-destructive" />
+            ) : copied ? (
+              <Check className="w-3.5 h-3.5 text-emerald-500" />
+            ) : (
+              <Copy className="w-3.5 h-3.5" />
+            )}
           </button>
         </div>
       </div>

--- a/core/frontend/src/pages/prompt-library.tsx
+++ b/core/frontend/src/pages/prompt-library.tsx
@@ -9,9 +9,13 @@ function PromptCard({ prompt, onUse }: { prompt: typeof prompts[0]; onUse: (cont
   const queenName = queenNames[queenId] || "Queen";
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(prompt.content);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    try {
+      await navigator.clipboard.writeText(prompt.content);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Clipboard copy failed:", err);
+    }
   };
 
   return (


### PR DESCRIPTION
This PR resolves a "False Success" UI bug in the Prompt Library. Previously, clicking the copy icon would immediately show a green checkmark even if the browser blocked the clipboard operation (e.g., due to permission issues or insecure contexts). This was misleading as it gave the user positive feedback while their clipboard remained empty.

File: core/frontend/src/pages/prompt-library.tsx
Wrapped the asynchronous navigator.clipboard.writeText call in a try/catch block.
Moved the setCopied(true) state update inside the success path so it only triggers upon a successful copy.
Added console error logging for failed clipboard operations to assist with debugging permission issues.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved copy-to-clipboard reliability in the prompt library with enhanced error handling. The interface now displays clear visual feedback, showing a success indicator when content is copied, and an error message if the copy operation fails. Status messages automatically clear after a brief delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->