### PR TITLE
Docs: clarify allowed-tools field with examples and behavior explanation

### DIFF
--- a/docs/skills-user-guide.md
+++ b/docs/skills-user-guide.md
@@ -116,6 +116,41 @@ Use this skill when the user needs to extract text from PDFs or merge documents.
 | `metadata` | No | Arbitrary key-value pairs (author, version, etc.). |
 | `allowed-tools` | No | Space-delimited list of pre-approved tools. |
 
+### allowed-tools
+
+The `allowed-tools` field defines a list of tools that an agent is explicitly permitted to use during execution.
+<!-- updated -->
+### Example
+
+```yaml
+
+allowed-tools: bash read_file write_file
+```
+#### What counts as a tool?
+
+Tools refer to executable capabilities available to the agent, including:
+- Built-in Hive tools (e.g., `read_file`, `write_file`)
+- System-level tools (e.g., `bash`, if enabled)
+- External integrations exposed via MCP
+
+#### What does "pre-approved" mean?
+
+Tools listed under `allowed-tools` are explicitly permitted without additional approval during execution.
+
+#### What happens to tools not listed?
+
+Tools not included may be:
+- Blocked, or
+- Subject to additional validation depending on configuration
+
+#### Security implications
+
+This field acts as a permission control layer, restricting the agent to a defined set of tools and helping ensure safe execution.
+
+
+
+
+
 ### Writing good descriptions
 
 The description is critical — it's what the agent uses to decide whether to activate a skill. Be specific:

--- a/docs/skills-user-guide.md
+++ b/docs/skills-user-guide.md
@@ -126,7 +126,10 @@ Currently, Hive parses and validates this metadata and may emit warnings
 
 ```yaml
 
-allowed-tools: bash read_file write_file
+allowed-tools:
+  - bash
+  - read_file
+  - write_file
 ```
 #### What counts as a tool?
 

--- a/docs/skills-user-guide.md
+++ b/docs/skills-user-guide.md
@@ -118,7 +118,9 @@ Use this skill when the user needs to extract text from PDFs or merge documents.
 
 ### allowed-tools
 
-The `allowed-tools` field defines a list of tools that an agent is explicitly permitted to use during execution.
+The `allowed-tools` field declares an intended list of tools for the skill.
+Currently, Hive parses and validates this metadata and may emit warnings
+(for example, malformed values or missing tools on PATH).
 <!-- updated -->
 ### Example
 
@@ -135,17 +137,17 @@ Tools refer to executable capabilities available to the agent, including:
 
 #### What does "pre-approved" mean?
 
-Tools listed under `allowed-tools` are explicitly permitted without additional approval during execution.
+Tools listed under `allowed-tools` are declared by the skill author as expected tools.
+This metadata does not currently enforce runtime allow/deny behavior by itself..
 
 #### What happens to tools not listed?
 
-Tools not included may be:
-- Blocked, or
-- Subject to additional validation depending on configuration
+Tools not included are not automatically blocked solely by this field.
+Any enforcement depends on separate runtime policy/configuration layers.
 
 #### Security implications
 
-This field acts as a permission control layer, restricting the agent to a defined set of tools and helping ensure safe execution.
+This field improves transparency and can support policy tooling, but should not be treated as a standalone runtime security boundary., restricting the agent to a defined set of tools and helping ensure safe execution.
 
 
 


### PR DESCRIPTION
## What I did
Added a dedicated section explaining the `allowed-tools` field.

## Why
The field was referenced but not properly documented, causing confusion about:
- What qualifies as a tool
- What "pre-approved" means
- How it affects execution and permissions

## Changes
- Added definition of `allowed-tools`
- Included usage example
- Clarified behavior of tools not listed
- Explained security implications

## Impact
Improves clarity and helps prevent misuse of a potentially security-relevant configuration field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "allowed-tools" section to the skills guide: defines what counts as a tool, includes a YAML example, explains that the platform parses/validates the field and may emit warnings (e.g., malformed values or missing tools), and clarifies the field documents expected/pre-approved tools for transparency and policy support rather than enforcing runtime allow/deny behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->