### PR TITLE
Fix Codex subscription requests missing store=false

### DIFF
--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -161,9 +161,58 @@ def _patch_litellm_metadata_nonetype() -> None:
         )
 
 
+def _patch_litellm_responses_bridge_store_param() -> None:
+    """Patch LiteLLM's chat-to-Responses bridge for the ChatGPT Codex backend.
+
+    The ChatGPT Codex backend rejects Responses API requests unless
+    ``store`` is explicitly false. Hive passes ``store=False`` to LiteLLM,
+    but LiteLLM 1.83.4 drops it while translating chat-completions requests
+    to Responses API requests. This patch restores the flag at the final
+    transformed request layer for that backend only.
+    """
+    try:
+        from litellm.completion_extras.litellm_responses_transformation.transformation import (
+            LiteLLMResponsesTransformationHandler,
+        )
+    except ImportError:
+        logger.warning(
+            "Could not apply litellm Responses bridge store patch — litellm internals "
+            "may have changed. Codex subscription calls may fail with 'Store must be "
+            "set to false'. Current litellm version: %s",
+            getattr(litellm, "__version__", "unknown"),
+        )
+        return
+
+    patch_marker = "_hive_codex_store_patch_applied"
+    if getattr(LiteLLMResponsesTransformationHandler, patch_marker, False):
+        return
+
+    original = LiteLLMResponsesTransformationHandler.transform_request
+
+    def _patched_transform_request(self, *args, **kwargs):
+        request_data = original(self, *args, **kwargs)
+
+        api_base = request_data.get("api_base")
+        if not api_base:
+            litellm_params = kwargs.get("litellm_params")
+            if litellm_params is None and len(args) >= 4:
+                litellm_params = args[3]
+            if isinstance(litellm_params, dict):
+                api_base = litellm_params.get("api_base")
+
+        if api_base and "chatgpt.com/backend-api/codex" in str(api_base).lower():
+            request_data["store"] = False
+
+        return request_data
+
+    LiteLLMResponsesTransformationHandler.transform_request = _patched_transform_request
+    setattr(LiteLLMResponsesTransformationHandler, patch_marker, True)
+
+
 if litellm is not None:
     _patch_litellm_anthropic_oauth()
     _patch_litellm_metadata_nonetype()
+    _patch_litellm_responses_bridge_store_param()
     # Let litellm silently drop params unsupported by the target provider
     # (e.g. stream_options for Anthropic) instead of forwarding them verbatim.
     litellm.drop_params = True


### PR DESCRIPTION
## Description

When using Hive with the Codex subscription model, `gpt-5.3-codex`, LLM calls could fail with:

```text
OpenAIException - {"detail":"Store must be set to false"}
```
Codex backend requires every Responses API request to include: `"store": false`
Hive was already trying to send `store=False`, but LiteLLM drops that field while converting Hive’s chat-completions request into a Responses API request.
So the final request reaching the Codex backend was missing store: false, and the backend rejected it.

Now for the fix, this PR adds a small patch in Hive’s LiteLLM wrapper.
After LiteLLM converts the request, Hive checks whether the request is going to the Codex backend:
`chatgpt.com/backend-api/codex`, if it is, then Hive adds: `"store": false` into the final request.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #7056

## Changes Made

- Adds a LiteLLM compatibility patch in core/framework/llm/litellm.py.
- The patch runs after LiteLLM converts Hive’s chat request into a Responses API request.
- If the request is going to the Codex backend, chatgpt.com/backend-api/codex, it adds:
```
"store": false
```
- This is required because the Codex backend rejects requests unless store is explicitly set to false.
- The change is limited to the Codex backend only, so other providers and normal OpenAI API calls are not affected.

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Before (error): 
<img width="3024" height="1816" alt="image" src="https://github.com/user-attachments/assets/6f6e72d2-17be-4806-bd9e-8682ef43cbd2" />

After (working as expected):
<img width="1512" height="910" alt="Screenshot 2026-04-16 at 20 50 05" src="https://github.com/user-attachments/assets/6a0de1bc-f9b6-4a08-b7d3-b9e28e318dfb" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced request handling for ChatGPT Codex backend compatibility with improved parameter configuration.
  * Improved error handling and diagnostic logging for LiteLLM integration issues with graceful fallback behavior when dependencies are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->