### PR TITLE
refactor: remove legacy get_sandboxed_path in favor of resolve_safe_path (micro-fix)

### DIFF
--- a/tools/src/aden_tools/tools/excel_tool/excel_tool.py
+++ b/tools/src/aden_tools/tools/excel_tool/excel_tool.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from fastmcp import FastMCP
 
-from ..file_system_toolkits.security import get_sandboxed_path
+from ..file_system_toolkits.security import resolve_safe_path
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -47,7 +47,7 @@ def register_tools(mcp: FastMCP) -> None:
             }
 
         try:
-            secure_path = get_sandboxed_path(path, agent_id)
+            secure_path = resolve_safe_path(path)
 
             if not os.path.exists(secure_path):
                 return {"error": f"File not found: {path}"}
@@ -172,7 +172,7 @@ def register_tools(mcp: FastMCP) -> None:
             }
 
         try:
-            secure_path = get_sandboxed_path(path, agent_id)
+            secure_path = resolve_safe_path(path)
 
             if not path.lower().endswith((".xlsx", ".xlsm")):
                 return {"error": "File must have .xlsx or .xlsm extension"}
@@ -249,7 +249,7 @@ def register_tools(mcp: FastMCP) -> None:
             }
 
         try:
-            secure_path = get_sandboxed_path(path, agent_id)
+            secure_path = resolve_safe_path(path)
 
             if not os.path.exists(secure_path):
                 return {"error": f"File not found: {path}. Use excel_write to create a new file."}
@@ -343,7 +343,7 @@ def register_tools(mcp: FastMCP) -> None:
             }
 
         try:
-            secure_path = get_sandboxed_path(path, agent_id)
+            secure_path = resolve_safe_path(path)
 
             if not os.path.exists(secure_path):
                 return {"error": f"File not found: {path}"}
@@ -426,7 +426,7 @@ def register_tools(mcp: FastMCP) -> None:
             }
 
         try:
-            secure_path = get_sandboxed_path(path, agent_id)
+            secure_path = resolve_safe_path(path)
 
             if not os.path.exists(secure_path):
                 return {"error": f"File not found: {path}"}
@@ -504,7 +504,7 @@ def register_tools(mcp: FastMCP) -> None:
             }
 
         try:
-            secure_path = get_sandboxed_path(path, agent_id)
+            secure_path = resolve_safe_path(path)
 
             if not os.path.exists(secure_path):
                 return {"error": f"File not found: {path}"}
@@ -663,7 +663,7 @@ def register_tools(mcp: FastMCP) -> None:
             }
 
         try:
-            secure_path = get_sandboxed_path(path, agent_id)
+            secure_path = resolve_safe_path(path)
 
             if not os.path.exists(secure_path):
                 return {"error": f"File not found: {path}"}

--- a/tools/src/aden_tools/tools/file_system_toolkits/apply_diff/apply_diff.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/apply_diff/apply_diff.py
@@ -3,7 +3,7 @@ import os
 import diff_match_patch as dmp_module
 from mcp.server.fastmcp import FastMCP
 
-from ..security import get_sandboxed_path
+from ..security import resolve_safe_path
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -34,7 +34,7 @@ def register_tools(mcp: FastMCP) -> None:
             Dict with application status and patch results, or error dict
         """
         try:
-            secure_path = get_sandboxed_path(path, agent_id)
+            secure_path = resolve_safe_path(path)
             if not os.path.exists(secure_path):
                 return {"error": f"File not found at {path}"}
 

--- a/tools/src/aden_tools/tools/file_system_toolkits/apply_patch/apply_patch.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/apply_patch/apply_patch.py
@@ -3,7 +3,7 @@ import os
 import diff_match_patch as dmp_module
 from mcp.server.fastmcp import FastMCP
 
-from ..security import get_sandboxed_path
+from ..security import resolve_safe_path
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -38,7 +38,7 @@ def register_tools(mcp: FastMCP) -> None:
         """
         # Logic duplicated from apply_diff for atomic isolation
         try:
-            secure_path = get_sandboxed_path(path, agent_id)
+            secure_path = resolve_safe_path(path)
             if not os.path.exists(secure_path):
                 return {"error": f"File not found at {path}"}
 

--- a/tools/src/aden_tools/tools/file_system_toolkits/execute_command_tool/execute_command_tool.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/execute_command_tool/execute_command_tool.py
@@ -24,7 +24,7 @@ import time
 from mcp.server.fastmcp import FastMCP
 
 from ..command_sanitizer import CommandBlockedError, validate_command
-from ..security import AGENT_SANDBOXES_DIR, get_sandboxed_path
+from ..security import resolve_safe_path
 from .background_jobs import get as get_job
 from .background_jobs import kill as kill_job
 from .background_jobs import spawn as spawn_job
@@ -39,11 +39,9 @@ _DEFAULT_TIMEOUT = 120
 
 
 def _resolve_cwd(cwd: str | None, agent_id: str) -> str:
-    agent_root = os.path.join(AGENT_SANDBOXES_DIR, agent_id, "current")
-    os.makedirs(agent_root, exist_ok=True)
     if cwd:
-        return get_sandboxed_path(cwd, agent_id)
-    return agent_root
+        return resolve_safe_path(cwd)
+    return os.path.expanduser("~/.hive")
 
 
 def register_tools(mcp: FastMCP) -> None:

--- a/tools/src/aden_tools/tools/file_system_toolkits/execute_command_tool/execute_command_tool.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/execute_command_tool/execute_command_tool.py
@@ -38,7 +38,7 @@ _MAX_TIMEOUT = 600
 _DEFAULT_TIMEOUT = 120
 
 
-def _resolve_cwd(cwd: str | None, agent_id: str) -> str:
+def _resolve_cwd(cwd: str | None) -> str:
     if cwd:
         return resolve_safe_path(cwd)
     return os.path.expanduser("~/.hive")

--- a/tools/src/aden_tools/tools/file_system_toolkits/grep_search/grep_search.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/grep_search/grep_search.py
@@ -5,7 +5,7 @@ from mcp.server.fastmcp import FastMCP
 
 from aden_tools.hashline import HASHLINE_MAX_FILE_BYTES, compute_line_hash
 
-from ..security import AGENT_SANDBOXES_DIR, get_sandboxed_path
+from ..security import resolve_safe_path
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -44,9 +44,9 @@ def register_tools(mcp: FastMCP) -> None:
             return {"error": f"Invalid regex pattern: {e.msg}"}
 
         try:
-            secure_path = get_sandboxed_path(path, agent_id)
-            # Use agent sandbox root for relative path calculations
-            agent_root = os.path.join(AGENT_SANDBOXES_DIR, agent_id, "current")
+            secure_path = resolve_safe_path(path)
+            # Use the directory of the path as root for relative paths
+            agent_root = os.path.dirname(secure_path) if os.path.isfile(secure_path) else secure_path
 
             matches = []
             skipped_large_files = []

--- a/tools/src/aden_tools/tools/file_system_toolkits/hashline_edit/hashline_edit.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/hashline_edit/hashline_edit.py
@@ -20,7 +20,7 @@ from aden_tools.hashline import (
 
 from aden_tools.file_state_cache import Freshness, check_fresh, record_read
 
-from ..security import get_sandboxed_path
+from ..security import resolve_safe_path
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -83,7 +83,7 @@ def register_tools(mcp: FastMCP) -> None:
 
         # 2. Read file
         try:
-            secure_path = get_sandboxed_path(path, agent_id)
+            secure_path = resolve_safe_path(path)
             if not os.path.exists(secure_path):
                 return {"error": f"File not found at {path}"}
             if not os.path.isfile(secure_path):

--- a/tools/src/aden_tools/tools/file_system_toolkits/list_dir/list_dir.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/list_dir/list_dir.py
@@ -2,7 +2,7 @@ import os
 
 from mcp.server.fastmcp import FastMCP
 
-from ..security import get_sandboxed_path
+from ..security import resolve_safe_path
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -32,7 +32,7 @@ def register_tools(mcp: FastMCP) -> None:
             Dict with directory contents and metadata, or error dict
         """
         try:
-            secure_path = get_sandboxed_path(path, agent_id)
+            secure_path = resolve_safe_path(path)
             if not os.path.exists(secure_path):
                 return {"error": f"Path not found: {path}"}
 

--- a/tools/src/aden_tools/tools/file_system_toolkits/replace_file_content/replace_file_content.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/replace_file_content/replace_file_content.py
@@ -2,7 +2,7 @@ import os
 
 from mcp.server.fastmcp import FastMCP
 
-from ..security import get_sandboxed_path
+from ..security import resolve_safe_path
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -34,7 +34,7 @@ def register_tools(mcp: FastMCP) -> None:
             Dict with replacement count and status, or error dict
         """
         try:
-            secure_path = get_sandboxed_path(path, agent_id)
+            secure_path = resolve_safe_path(path)
             if not os.path.exists(secure_path):
                 return {"error": f"File not found at {path}"}
 

--- a/tools/src/aden_tools/tools/file_system_toolkits/security.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/security.py
@@ -33,33 +33,4 @@ def resolve_safe_path(path: str) -> str:
     )
 
 
-# Keep the old API for backward compatibility with non-CSV tools.
-# TODO: migrate remaining callers and remove.
-AGENT_SANDBOXES_DIR = os.path.expanduser("~/.hive/workdir/workspaces/default")
 
-
-def get_sandboxed_path(path: str, agent_id: str) -> str:
-    """Resolve and verify a path within an agent's sandbox directory."""
-    if not agent_id:
-        raise ValueError("agent_id is required")
-
-    agent_dir = os.path.realpath(os.path.join(AGENT_SANDBOXES_DIR, agent_id, "current"))
-    os.makedirs(agent_dir, exist_ok=True)
-
-    path = path.strip()
-
-    if os.path.isabs(path) or path.startswith(("/", "\\")):
-        rel_path = path[1:] if path and path[0] in ("/", "\\") else path
-        final_path = os.path.realpath(os.path.join(agent_dir, rel_path))
-    else:
-        final_path = os.path.realpath(os.path.join(agent_dir, path))
-
-    try:
-        common_prefix = os.path.commonpath([final_path, agent_dir])
-    except ValueError as err:
-        raise ValueError(f"Access denied: Path '{path}' is outside the agent sandbox.") from err
-
-    if common_prefix != agent_dir:
-        raise ValueError(f"Access denied: Path '{path}' is outside the agent sandbox.")
-
-    return final_path

--- a/tools/tests/tools/test_csv_tool.py
+++ b/tools/tests/tools/test_csv_tool.py
@@ -1,6 +1,7 @@
 """Tests for csv_tool - Read and manipulate CSV files."""
 
 import importlib.util
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -16,31 +17,49 @@ TEST_AGENT_ID = "test-agent"
 
 
 @pytest.fixture
+def session_dir(tmp_path: Path) -> Path:
+    """Create and return the session directory within the sandbox."""
+    session_path = tmp_path / TEST_AGENT_ID / "current"
+    session_path.mkdir(parents=True, exist_ok=True)
+    return session_path
+
+
+@pytest.fixture(autouse=True)
+def mock_csv_resolve(session_dir):
+    """Mock resolve_safe_path in csv_tool to resolve paths under session_dir."""
+
+    def _resolve(path):
+        full = os.path.join(session_dir, path)
+        resolved = os.path.realpath(full)
+        real_root = os.path.realpath(str(session_dir))
+        if not (resolved.startswith(real_root + os.sep) or resolved == real_root):
+            raise ValueError(f"Access denied: '{path}' is outside allowed directories.")
+        return resolved
+
+    with patch(
+        "aden_tools.tools.csv_tool.csv_tool.resolve_safe_path",
+        side_effect=_resolve,
+    ):
+        yield
+
+
+@pytest.fixture
 def csv_tools(mcp: FastMCP, tmp_path: Path):
     """Register all CSV tools and return them as a dict."""
-    with patch("aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)):
-        register_tools(mcp)
-        yield {
-            "csv_read": mcp._tool_manager._tools["csv_read"].fn,
-            "csv_write": mcp._tool_manager._tools["csv_write"].fn,
-            "csv_append": mcp._tool_manager._tools["csv_append"].fn,
-            "csv_info": mcp._tool_manager._tools["csv_info"].fn,
-            "csv_sql": mcp._tool_manager._tools["csv_sql"].fn,
-        }
+    register_tools(mcp)
+    yield {
+        "csv_read": mcp._tool_manager._tools["csv_read"].fn,
+        "csv_write": mcp._tool_manager._tools["csv_write"].fn,
+        "csv_append": mcp._tool_manager._tools["csv_append"].fn,
+        "csv_info": mcp._tool_manager._tools["csv_info"].fn,
+        "csv_sql": mcp._tool_manager._tools["csv_sql"].fn,
+    }
 
 
 @pytest.fixture
 def csv_tool_fn(csv_tools):
     """Return csv_read function for backward compatibility."""
     return csv_tools["csv_read"]
-
-
-@pytest.fixture
-def session_dir(tmp_path: Path) -> Path:
-    """Create and return the session directory within the sandbox."""
-    session_path = tmp_path / TEST_AGENT_ID / "current"
-    session_path.mkdir(parents=True, exist_ok=True)
-    return session_path
 
 
 @pytest.fixture
@@ -86,13 +105,9 @@ class TestCsvRead:
 
     def test_read_basic_csv(self, csv_tool_fn, basic_csv, tmp_path):
         """Read a basic CSV file successfully."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tool_fn(
-                path="basic.csv",
-                agent_id=TEST_AGENT_ID,
-            )
+        result = csv_tool_fn(
+            path="basic.csv",
+        )
 
         assert result["success"] is True
         assert result["columns"] == ["name", "age", "city"]
@@ -104,14 +119,10 @@ class TestCsvRead:
 
     def test_read_with_limit(self, csv_tool_fn, basic_csv, tmp_path):
         """Read CSV with row limit."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tool_fn(
-                path="basic.csv",
-                agent_id=TEST_AGENT_ID,
-                limit=2,
-            )
+        result = csv_tool_fn(
+            path="basic.csv",
+            limit=2,
+        )
 
         assert result["success"] is True
         assert result["row_count"] == 2
@@ -123,14 +134,10 @@ class TestCsvRead:
 
     def test_read_with_offset(self, csv_tool_fn, basic_csv, tmp_path):
         """Read CSV with row offset."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tool_fn(
-                path="basic.csv",
-                agent_id=TEST_AGENT_ID,
-                offset=1,
-            )
+        result = csv_tool_fn(
+            path="basic.csv",
+            offset=1,
+        )
 
         assert result["success"] is True
         assert result["row_count"] == 2
@@ -140,15 +147,11 @@ class TestCsvRead:
 
     def test_read_with_limit_and_offset(self, csv_tool_fn, large_csv, tmp_path):
         """Read CSV with both limit and offset (pagination)."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tool_fn(
-                path="large.csv",
-                agent_id=TEST_AGENT_ID,
-                limit=10,
-                offset=50,
-            )
+        result = csv_tool_fn(
+            path="large.csv",
+            limit=10,
+            offset=50,
+        )
 
         assert result["success"] is True
         assert result["row_count"] == 10
@@ -160,56 +163,40 @@ class TestCsvRead:
 
     def test_negative_limit(self, csv_tool_fn, basic_csv, tmp_path):
         """Return error for negative limit."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tool_fn(
-                path="basic.csv",
-                agent_id=TEST_AGENT_ID,
-                limit=-1,
-            )
+        result = csv_tool_fn(
+            path="basic.csv",
+            limit=-1,
+        )
 
         assert "error" in result
         assert "non-negative" in result["error"].lower()
 
     def test_negative_offset(self, csv_tool_fn, basic_csv, tmp_path):
         """Return error for negative offset."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tool_fn(
-                path="basic.csv",
-                agent_id=TEST_AGENT_ID,
-                offset=-1,
-            )
+        result = csv_tool_fn(
+            path="basic.csv",
+            offset=-1,
+        )
 
         assert "error" in result
         assert "non-negative" in result["error"].lower()
 
     def test_negative_limit_and_offset(self, csv_tool_fn, basic_csv, tmp_path):
         """Return error for both negative limit and offset."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tool_fn(
-                path="basic.csv",
-                agent_id=TEST_AGENT_ID,
-                limit=-5,
-                offset=-10,
-            )
+        result = csv_tool_fn(
+            path="basic.csv",
+            limit=-5,
+            offset=-10,
+        )
 
         assert "error" in result
         assert "non-negative" in result["error"].lower()
 
     def test_file_not_found(self, csv_tool_fn, session_dir, tmp_path):
         """Return error for non-existent file."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tool_fn(
-                path="nonexistent.csv",
-                agent_id=TEST_AGENT_ID,
-            )
+        result = csv_tool_fn(
+            path="nonexistent.csv",
+        )
 
         assert "error" in result
         assert "not found" in result["error"].lower()
@@ -220,39 +207,27 @@ class TestCsvRead:
         txt_file = session_dir / "data.txt"
         txt_file.write_text("name,age\nAlice,30\n", encoding="utf-8")
 
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tool_fn(
-                path="data.txt",
-                agent_id=TEST_AGENT_ID,
-            )
+        result = csv_tool_fn(
+            path="data.txt",
+        )
 
         assert "error" in result
         assert ".csv" in result["error"].lower()
 
     def test_empty_csv_file(self, csv_tool_fn, empty_csv, tmp_path):
         """Return error for empty CSV file."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tool_fn(
-                path="empty.csv",
-                agent_id=TEST_AGENT_ID,
-            )
+        result = csv_tool_fn(
+            path="empty.csv",
+        )
 
         assert "error" in result
         assert "empty" in result["error"].lower() or "no headers" in result["error"].lower()
 
     def test_headers_only_csv(self, csv_tool_fn, headers_only_csv, tmp_path):
         """Read CSV with only headers (no data rows)."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tool_fn(
-                path="headers_only.csv",
-                agent_id=TEST_AGENT_ID,
-            )
+        result = csv_tool_fn(
+            path="headers_only.csv",
+        )
 
         assert result["success"] is True
         assert result["columns"] == ["name", "age", "city"]
@@ -265,13 +240,9 @@ class TestCsvRead:
         csv_file = session_dir / "unicode.csv"
         csv_file.write_text("名前,年齢,都市\n太郎,30,東京\nAlice,25,北京\n", encoding="utf-8")
 
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tool_fn(
-                path="unicode.csv",
-                agent_id=TEST_AGENT_ID,
-            )
+        result = csv_tool_fn(
+            path="unicode.csv",
+        )
 
         assert result["success"] is True
         assert result["columns"] == ["名前", "年齢", "都市"]
@@ -286,13 +257,9 @@ class TestCsvRead:
             encoding="utf-8",
         )
 
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tool_fn(
-                path="quoted.csv",
-                agent_id=TEST_AGENT_ID,
-            )
+        result = csv_tool_fn(
+            path="quoted.csv",
+        )
 
         assert result["success"] is True
         assert result["rows"][0]["name"] == "Smith, John"
@@ -300,26 +267,18 @@ class TestCsvRead:
 
     def test_path_traversal_blocked(self, csv_tool_fn, session_dir, tmp_path):
         """Prevent path traversal attacks."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tool_fn(
-                path="../../../etc/passwd",
-                agent_id=TEST_AGENT_ID,
-            )
+        result = csv_tool_fn(
+            path="../../../etc/passwd",
+        )
 
         assert "error" in result
 
     def test_offset_beyond_rows(self, csv_tool_fn, basic_csv, tmp_path):
         """Offset beyond available rows returns empty result."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tool_fn(
-                path="basic.csv",
-                agent_id=TEST_AGENT_ID,
-                offset=100,
-            )
+        result = csv_tool_fn(
+            path="basic.csv",
+            offset=100,
+        )
 
         assert result["success"] is True
         assert result["row_count"] == 0
@@ -332,18 +291,14 @@ class TestCsvWrite:
 
     def test_write_new_csv(self, csv_tools, session_dir, tmp_path):
         """Write a new CSV file successfully."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_write"](
-                path="output.csv",
-                agent_id=TEST_AGENT_ID,
-                columns=["name", "age", "city"],
-                rows=[
-                    {"name": "Alice", "age": "30", "city": "NYC"},
-                    {"name": "Bob", "age": "25", "city": "LA"},
-                ],
-            )
+        result = csv_tools["csv_write"](
+            path="output.csv",
+            columns=["name", "age", "city"],
+            rows=[
+                {"name": "Alice", "age": "30", "city": "NYC"},
+                {"name": "Bob", "age": "25", "city": "LA"},
+            ],
+        )
 
         assert result["success"] is True
         assert result["columns"] == ["name", "age", "city"]
@@ -358,60 +313,44 @@ class TestCsvWrite:
 
     def test_write_creates_parent_directories(self, csv_tools, session_dir, tmp_path):
         """Write creates parent directories if needed."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_write"](
-                path="subdir/nested/output.csv",
-                agent_id=TEST_AGENT_ID,
-                columns=["id"],
-                rows=[{"id": "1"}],
-            )
+        result = csv_tools["csv_write"](
+            path="subdir/nested/output.csv",
+            columns=["id"],
+            rows=[{"id": "1"}],
+        )
 
         assert result["success"] is True
         assert (session_dir / "subdir" / "nested" / "output.csv").exists()
 
     def test_write_empty_columns_error(self, csv_tools, session_dir, tmp_path):
         """Return error when columns is empty."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_write"](
-                path="output.csv",
-                agent_id=TEST_AGENT_ID,
-                columns=[],
-                rows=[],
-            )
+        result = csv_tools["csv_write"](
+            path="output.csv",
+            columns=[],
+            rows=[],
+        )
 
         assert "error" in result
         assert "empty" in result["error"].lower()
 
     def test_write_non_csv_extension_error(self, csv_tools, session_dir, tmp_path):
         """Return error for non-CSV file extension."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_write"](
-                path="output.txt",
-                agent_id=TEST_AGENT_ID,
-                columns=["id"],
-                rows=[],
-            )
+        result = csv_tools["csv_write"](
+            path="output.txt",
+            columns=["id"],
+            rows=[],
+        )
 
         assert "error" in result
         assert ".csv" in result["error"].lower()
 
     def test_write_filters_extra_columns(self, csv_tools, session_dir, tmp_path):
         """Extra columns in rows are filtered out."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_write"](
-                path="output.csv",
-                agent_id=TEST_AGENT_ID,
-                columns=["name"],
-                rows=[{"name": "Alice", "extra": "ignored"}],
-            )
+        result = csv_tools["csv_write"](
+            path="output.csv",
+            columns=["name"],
+            rows=[{"name": "Alice", "extra": "ignored"}],
+        )
 
         assert result["success"] is True
 
@@ -421,15 +360,11 @@ class TestCsvWrite:
 
     def test_write_empty_rows(self, csv_tools, session_dir, tmp_path):
         """Write CSV with headers but no rows."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_write"](
-                path="output.csv",
-                agent_id=TEST_AGENT_ID,
-                columns=["name", "age"],
-                rows=[],
-            )
+        result = csv_tools["csv_write"](
+            path="output.csv",
+            columns=["name", "age"],
+            rows=[],
+        )
 
         assert result["success"] is True
         assert result["rows_written"] == 0
@@ -439,15 +374,11 @@ class TestCsvWrite:
 
     def test_write_unicode_content(self, csv_tools, session_dir, tmp_path):
         """Write CSV with Unicode content."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_write"](
-                path="unicode.csv",
-                agent_id=TEST_AGENT_ID,
-                columns=["名前", "都市"],
-                rows=[{"名前": "太郎", "都市": "東京"}],
-            )
+        result = csv_tools["csv_write"](
+            path="unicode.csv",
+            columns=["名前", "都市"],
+            rows=[{"名前": "太郎", "都市": "東京"}],
+        )
 
         assert result["success"] is True
 
@@ -457,18 +388,14 @@ class TestCsvWrite:
 
     def test_write_no_parent_directory(self, csv_tools, session_dir, tmp_path):
         """Write CSV to root without parent directory (fixes #1843)."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_write"](
-                path="data.csv",
-                agent_id=TEST_AGENT_ID,
-                columns=["id", "value"],
-                rows=[
-                    {"id": "1", "value": "test1"},
-                    {"id": "2", "value": "test2"},
-                ],
-            )
+        result = csv_tools["csv_write"](
+            path="data.csv",
+            columns=["id", "value"],
+            rows=[
+                {"id": "1", "value": "test1"},
+                {"id": "2", "value": "test2"},
+            ],
+        )
 
         assert result["success"] is True
         assert result["rows_written"] == 2
@@ -488,17 +415,13 @@ class TestCsvAppend:
 
     def test_append_to_existing_csv(self, csv_tools, basic_csv, tmp_path):
         """Append rows to an existing CSV file."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_append"](
-                path="basic.csv",
-                agent_id=TEST_AGENT_ID,
-                rows=[
-                    {"name": "David", "age": "28", "city": "Seattle"},
-                    {"name": "Eve", "age": "32", "city": "Boston"},
-                ],
-            )
+        result = csv_tools["csv_append"](
+            path="basic.csv",
+            rows=[
+                {"name": "David", "age": "28", "city": "Seattle"},
+                {"name": "Eve", "age": "32", "city": "Boston"},
+            ],
+        )
 
         assert result["success"] is True
         assert result["rows_appended"] == 2
@@ -506,42 +429,30 @@ class TestCsvAppend:
 
     def test_append_file_not_found(self, csv_tools, session_dir, tmp_path):
         """Return error when file doesn't exist."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_append"](
-                path="nonexistent.csv",
-                agent_id=TEST_AGENT_ID,
-                rows=[{"name": "Alice"}],
-            )
+        result = csv_tools["csv_append"](
+            path="nonexistent.csv",
+            rows=[{"name": "Alice"}],
+        )
 
         assert "error" in result
         assert "not found" in result["error"].lower()
 
     def test_append_empty_rows_error(self, csv_tools, basic_csv, tmp_path):
         """Return error when rows is empty."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_append"](
-                path="basic.csv",
-                agent_id=TEST_AGENT_ID,
-                rows=[],
-            )
+        result = csv_tools["csv_append"](
+            path="basic.csv",
+            rows=[],
+        )
 
         assert "error" in result
         assert "empty" in result["error"].lower()
 
     def test_append_filters_extra_columns(self, csv_tools, basic_csv, session_dir, tmp_path):
         """Extra columns in rows are filtered out based on existing headers."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_append"](
-                path="basic.csv",
-                agent_id=TEST_AGENT_ID,
-                rows=[{"name": "David", "age": "28", "city": "Seattle", "extra": "ignored"}],
-            )
+        result = csv_tools["csv_append"](
+            path="basic.csv",
+            rows=[{"name": "David", "age": "28", "city": "Seattle", "extra": "ignored"}],
+        )
 
         assert result["success"] is True
 
@@ -555,14 +466,10 @@ class TestCsvAppend:
         txt_file = session_dir / "data.txt"
         txt_file.write_text("name\nAlice\n", encoding="utf-8")
 
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_append"](
-                path="data.txt",
-                agent_id=TEST_AGENT_ID,
-                rows=[{"name": "Bob"}],
-            )
+        result = csv_tools["csv_append"](
+            path="data.txt",
+            rows=[{"name": "Bob"}],
+        )
 
         assert "error" in result
         assert ".csv" in result["error"].lower()
@@ -573,13 +480,9 @@ class TestCsvInfo:
 
     def test_get_info_basic_csv(self, csv_tools, basic_csv, tmp_path):
         """Get info about a basic CSV file."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_info"](
-                path="basic.csv",
-                agent_id=TEST_AGENT_ID,
-            )
+        result = csv_tools["csv_info"](
+            path="basic.csv",
+        )
 
         assert result["success"] is True
         assert result["columns"] == ["name", "age", "city"]
@@ -590,13 +493,9 @@ class TestCsvInfo:
 
     def test_get_info_large_csv(self, csv_tools, large_csv, tmp_path):
         """Get info about a large CSV file."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_info"](
-                path="large.csv",
-                agent_id=TEST_AGENT_ID,
-            )
+        result = csv_tools["csv_info"](
+            path="large.csv",
+        )
 
         assert result["success"] is True
         assert result["total_rows"] == 100
@@ -604,39 +503,27 @@ class TestCsvInfo:
 
     def test_get_info_file_not_found(self, csv_tools, session_dir, tmp_path):
         """Return error when file doesn't exist."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_info"](
-                path="nonexistent.csv",
-                agent_id=TEST_AGENT_ID,
-            )
+        result = csv_tools["csv_info"](
+            path="nonexistent.csv",
+        )
 
         assert "error" in result
         assert "not found" in result["error"].lower()
 
     def test_get_info_empty_csv(self, csv_tools, empty_csv, tmp_path):
         """Return error for empty CSV file."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_info"](
-                path="empty.csv",
-                agent_id=TEST_AGENT_ID,
-            )
+        result = csv_tools["csv_info"](
+            path="empty.csv",
+        )
 
         assert "error" in result
         assert "empty" in result["error"].lower() or "no headers" in result["error"].lower()
 
     def test_get_info_headers_only(self, csv_tools, headers_only_csv, tmp_path):
         """Get info about CSV with only headers."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_info"](
-                path="headers_only.csv",
-                agent_id=TEST_AGENT_ID,
-            )
+        result = csv_tools["csv_info"](
+            path="headers_only.csv",
+        )
 
         assert result["success"] is True
         assert result["columns"] == ["name", "age", "city"]
@@ -647,13 +534,9 @@ class TestCsvInfo:
         txt_file = session_dir / "data.txt"
         txt_file.write_text("name\nAlice\n", encoding="utf-8")
 
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_info"](
-                path="data.txt",
-                agent_id=TEST_AGENT_ID,
-            )
+        result = csv_tools["csv_info"](
+            path="data.txt",
+        )
 
         assert "error" in result
         assert ".csv" in result["error"].lower()
@@ -680,14 +563,10 @@ class TestCsvSql:
 
     def test_basic_select(self, csv_tools, products_csv, tmp_path):
         """Execute basic SELECT query."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_sql"](
-                path="products.csv",
-                agent_id=TEST_AGENT_ID,
-                query="SELECT * FROM data",
-            )
+        result = csv_tools["csv_sql"](
+            path="products.csv",
+            query="SELECT * FROM data",
+        )
 
         assert result["success"] is True
         assert result["row_count"] == 5
@@ -699,14 +578,10 @@ class TestCsvSql:
         csv_file = session_dir / "O'Reilly.csv"
         csv_file.write_text("name,age\nAlice,21\nBob,22\n", encoding="utf-8")
 
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_sql"](
-                path="O'Reilly.csv",
-                agent_id=TEST_AGENT_ID,
-                query="SELECT * FROM data",
-            )
+        result = csv_tools["csv_sql"](
+            path="O'Reilly.csv",
+            query="SELECT * FROM data",
+        )
 
         assert "error" not in result, result
         assert result["success"] is True
@@ -719,54 +594,38 @@ class TestCsvSql:
 
     def test_reject_non_select(self, csv_tools, products_csv, tmp_path):
         """Reject any non-SELECT / non-WITH query."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_sql"](
-                path=products_csv.name,
-                agent_id=TEST_AGENT_ID,
-                query="DROP TABLE data",
-            )
+        result = csv_tools["csv_sql"](
+            path=products_csv.name,
+            query="DROP TABLE data",
+        )
         assert "error" in result
 
     def test_reject_multi_statement(self, csv_tools, products_csv, tmp_path):
         """Reject multi-statement queries with semicolons."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_sql"](
-                path=products_csv.name,
-                agent_id=TEST_AGENT_ID,
-                query="SELECT * FROM data; DROP TABLE data",
-            )
+        result = csv_tools["csv_sql"](
+            path=products_csv.name,
+            query="SELECT * FROM data; DROP TABLE data",
+        )
         assert "error" in result
 
     def test_reject_sql_comment_dash(self, csv_tools, products_csv, tmp_path):
         """Reject queries with SQL line comments."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_sql"](
-                path=products_csv.name,
-                agent_id=TEST_AGENT_ID,
-                query="SELECT * FROM data -- WHERE id = 1",
-            )
+        result = csv_tools["csv_sql"](
+            path=products_csv.name,
+            query="SELECT * FROM data -- WHERE id = 1",
+        )
         assert "error" in result
 
     def test_with_cte_allowed(self, csv_tools, products_csv, tmp_path):
         """Allow valid WITH (CTE) queries."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_sql"](
-                path=products_csv.name,
-                agent_id=TEST_AGENT_ID,
-                query=(
-                    "WITH electronics AS (SELECT * FROM data"
-                    " WHERE category = 'Electronics')"
-                    " SELECT * FROM electronics"
-                ),
-            )
+        result = csv_tools["csv_sql"](
+            path=products_csv.name,
+            query=(
+                "WITH electronics AS (SELECT * FROM data"
+                " WHERE category = 'Electronics')"
+                " SELECT * FROM electronics"
+            ),
+        )
         assert result["success"] is True
 
     def test_keyword_in_column_name_allowed(self, csv_tools, session_dir, tmp_path):
@@ -777,27 +636,19 @@ class TestCsvSql:
             encoding="utf-8",
         )
 
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_sql"](
-                path="timestamps.csv",
-                agent_id=TEST_AGENT_ID,
-                query="SELECT created_at, updated_at FROM data",
-            )
+        result = csv_tools["csv_sql"](
+            path="timestamps.csv",
+            query="SELECT created_at, updated_at FROM data",
+        )
         assert "error" not in result, result
         assert result["success"] is True
 
     def test_where_clause(self, csv_tools, products_csv, tmp_path):
         """Filter with WHERE clause."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_sql"](
-                path="products.csv",
-                agent_id=TEST_AGENT_ID,
-                query="SELECT name, price FROM data WHERE price > 500",
-            )
+        result = csv_tools["csv_sql"](
+            path="products.csv",
+            query="SELECT name, price FROM data WHERE price > 500",
+        )
 
         assert result["success"] is True
         assert result["row_count"] == 2
@@ -807,31 +658,23 @@ class TestCsvSql:
 
     def test_aggregate_functions(self, csv_tools, products_csv, tmp_path):
         """Use aggregate functions."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_sql"](
-                path="products.csv",
-                agent_id=TEST_AGENT_ID,
-                query=(
-                    "SELECT category, COUNT(*) as count, "
-                    "AVG(price) as avg_price FROM data GROUP BY category"
-                ),
-            )
+        result = csv_tools["csv_sql"](
+            path="products.csv",
+            query=(
+                "SELECT category, COUNT(*) as count, "
+                "AVG(price) as avg_price FROM data GROUP BY category"
+            ),
+        )
 
         assert result["success"] is True
         assert result["row_count"] == 2  # Electronics and Kitchen
 
     def test_order_by_and_limit(self, csv_tools, products_csv, tmp_path):
         """Sort and limit results."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_sql"](
-                path="products.csv",
-                agent_id=TEST_AGENT_ID,
-                query="SELECT name, price FROM data ORDER BY price DESC LIMIT 2",
-            )
+        result = csv_tools["csv_sql"](
+            path="products.csv",
+            query="SELECT name, price FROM data ORDER BY price DESC LIMIT 2",
+        )
 
         assert result["success"] is True
         assert result["row_count"] == 2
@@ -840,14 +683,10 @@ class TestCsvSql:
 
     def test_like_search(self, csv_tools, products_csv, tmp_path):
         """Search with LIKE operator."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_sql"](
-                path="products.csv",
-                agent_id=TEST_AGENT_ID,
-                query="SELECT * FROM data WHERE LOWER(name) LIKE '%book%'",
-            )
+        result = csv_tools["csv_sql"](
+            path="products.csv",
+            query="SELECT * FROM data WHERE LOWER(name) LIKE '%book%'",
+        )
 
         assert result["success"] is True
         assert result["row_count"] == 1
@@ -855,82 +694,58 @@ class TestCsvSql:
 
     def test_file_not_found(self, csv_tools, session_dir, tmp_path):
         """Return error for non-existent file."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_sql"](
-                path="nonexistent.csv",
-                agent_id=TEST_AGENT_ID,
-                query="SELECT * FROM data",
-            )
+        result = csv_tools["csv_sql"](
+            path="nonexistent.csv",
+            query="SELECT * FROM data",
+        )
 
         assert "error" in result
         assert "not found" in result["error"].lower()
 
     def test_empty_query_error(self, csv_tools, products_csv, tmp_path):
         """Return error for empty query."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_sql"](
-                path="products.csv",
-                agent_id=TEST_AGENT_ID,
-                query="",
-            )
+        result = csv_tools["csv_sql"](
+            path="products.csv",
+            query="",
+        )
 
         assert "error" in result
         assert "empty" in result["error"].lower()
 
     def test_non_select_blocked(self, csv_tools, products_csv, tmp_path):
         """Block non-SELECT queries for security."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_sql"](
-                path="products.csv",
-                agent_id=TEST_AGENT_ID,
-                query="DELETE FROM data WHERE id = 1",
-            )
+        result = csv_tools["csv_sql"](
+            path="products.csv",
+            query="DELETE FROM data WHERE id = 1",
+        )
 
         assert "error" in result
         assert "select" in result["error"].lower()
 
     def test_drop_blocked(self, csv_tools, products_csv, tmp_path):
         """Block DROP statements."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_sql"](
-                path="products.csv",
-                agent_id=TEST_AGENT_ID,
-                query="DROP TABLE data",
-            )
+        result = csv_tools["csv_sql"](
+            path="products.csv",
+            query="DROP TABLE data",
+        )
 
         assert "error" in result
 
     def test_insert_blocked(self, csv_tools, products_csv, tmp_path):
         """Block INSERT statements."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_sql"](
-                path="products.csv",
-                agent_id=TEST_AGENT_ID,
-                query="INSERT INTO data VALUES (6, 'Test', 'Test', 10, 10)",
-            )
+        result = csv_tools["csv_sql"](
+            path="products.csv",
+            query="INSERT INTO data VALUES (6, 'Test', 'Test', 10, 10)",
+        )
 
         assert "error" in result
 
     def test_invalid_sql_syntax(self, csv_tools, products_csv, tmp_path):
         """Return error for invalid SQL syntax."""
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_sql"](
-                path="products.csv",
-                agent_id=TEST_AGENT_ID,
-                query="SELEKT * FORM data",
-            )
+        result = csv_tools["csv_sql"](
+            path="products.csv",
+            query="SELEKT * FORM data",
+        )
 
         assert "error" in result
 
@@ -939,14 +754,10 @@ class TestCsvSql:
         csv_file = session_dir / "unicode.csv"
         csv_file.write_text("名前,価格\n商品A,100\n商品B,200\n", encoding="utf-8")
 
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR", str(tmp_path)
-        ):
-            result = csv_tools["csv_sql"](
-                path="unicode.csv",
-                agent_id=TEST_AGENT_ID,
-                query="SELECT * FROM data WHERE 価格 > 150",
-            )
+        result = csv_tools["csv_sql"](
+            path="unicode.csv",
+            query="SELECT * FROM data WHERE 価格 > 150",
+        )
 
         assert result["success"] is True
         assert result["row_count"] == 1

--- a/tools/tests/tools/test_file_system_toolkits.py
+++ b/tools/tests/tools/test_file_system_toolkits.py
@@ -41,48 +41,40 @@ def mock_workspace():
 
 @pytest.fixture
 def mock_secure_path(tmp_path):
-    """Mock get_sandboxed_path to return temp directory paths."""
+    """Mock resolve_safe_path to return temp directory paths."""
 
-    def _get_sandboxed_path(path, agent_id):
+    def _resolve_safe_path(path, *args, **kwargs):
         return os.path.join(tmp_path, path)
 
     with patch(
-        "aden_tools.tools.file_system_toolkits.list_dir.list_dir.get_sandboxed_path",
-        side_effect=_get_sandboxed_path,
+        "aden_tools.tools.file_system_toolkits.list_dir.list_dir.resolve_safe_path",
+        side_effect=_resolve_safe_path,
     ):
         with patch(
-            "aden_tools.tools.file_system_toolkits.replace_file_content.replace_file_content.get_sandboxed_path",
-            side_effect=_get_sandboxed_path,
+            "aden_tools.tools.file_system_toolkits.replace_file_content.replace_file_content.resolve_safe_path",
+            side_effect=_resolve_safe_path,
         ):
             with patch(
-                "aden_tools.tools.file_system_toolkits.apply_diff.apply_diff.get_sandboxed_path",
-                side_effect=_get_sandboxed_path,
+                "aden_tools.tools.file_system_toolkits.apply_diff.apply_diff.resolve_safe_path",
+                side_effect=_resolve_safe_path,
             ):
                 with patch(
-                    "aden_tools.tools.file_system_toolkits.apply_patch.apply_patch.get_sandboxed_path",
-                    side_effect=_get_sandboxed_path,
+                    "aden_tools.tools.file_system_toolkits.apply_patch.apply_patch.resolve_safe_path",
+                    side_effect=_resolve_safe_path,
                 ):
                     with patch(
-                        "aden_tools.tools.file_system_toolkits.grep_search.grep_search.get_sandboxed_path",
-                        side_effect=_get_sandboxed_path,
+                        "aden_tools.tools.file_system_toolkits.grep_search.grep_search.resolve_safe_path",
+                        side_effect=_resolve_safe_path,
                     ):
                         with patch(
-                            "aden_tools.tools.file_system_toolkits.grep_search.grep_search.AGENT_SANDBOXES_DIR",
-                            str(tmp_path),
+                            "aden_tools.tools.file_system_toolkits.execute_command_tool.execute_command_tool._resolve_cwd",
+                            return_value=str(tmp_path),
                         ):
                             with patch(
-                                "aden_tools.tools.file_system_toolkits.execute_command_tool.execute_command_tool.get_sandboxed_path",
-                                side_effect=_get_sandboxed_path,
+                                "aden_tools.tools.file_system_toolkits.hashline_edit.hashline_edit.resolve_safe_path",
+                                side_effect=_resolve_safe_path,
                             ):
-                                with patch(
-                                    "aden_tools.tools.file_system_toolkits.execute_command_tool.execute_command_tool.AGENT_SANDBOXES_DIR",
-                                    str(tmp_path),
-                                ):
-                                    with patch(
-                                        "aden_tools.tools.file_system_toolkits.hashline_edit.hashline_edit.get_sandboxed_path",
-                                        side_effect=_get_sandboxed_path,
-                                    ):
-                                        yield
+                                yield
 
 
 class TestListDirTool:

--- a/tools/tests/tools/test_hashline_edit.py
+++ b/tools/tests/tools/test_hashline_edit.py
@@ -43,14 +43,14 @@ def mock_workspace():
 
 @pytest.fixture
 def mock_secure_path(tmp_path):
-    """Mock get_sandboxed_path to return temp directory paths."""
+    """Mock resolve_safe_path to return temp directory paths."""
 
-    def _get_sandboxed_path(path, agent_id):
+    def _resolve_safe_path(path, *args, **kwargs):
         return os.path.join(tmp_path, path)
 
     with patch(
-        "aden_tools.tools.file_system_toolkits.hashline_edit.hashline_edit.get_sandboxed_path",
-        side_effect=_get_sandboxed_path,
+        "aden_tools.tools.file_system_toolkits.hashline_edit.hashline_edit.resolve_safe_path",
+        side_effect=_resolve_safe_path,
     ):
         yield
 

--- a/tools/tests/tools/test_security.py
+++ b/tools/tests/tools/test_security.py
@@ -17,8 +17,11 @@ class TestResolveSafePath:
         result = resolve_safe_path(valid_path)
         assert result == valid_path
 
-    def test_relative_path_rejected(self):
+    def test_relative_path_rejected(self, tmp_path_factory, monkeypatch):
         # We assume CWD is not tmp_dir
+        # Ensure CWD is outside the allowed roots
+        outside = tmp_path_factory.mktemp("outside")
+        monkeypatch.chdir(outside)
         with pytest.raises(ValueError, match="Access denied"):
             resolve_safe_path("test.txt")
 

--- a/tools/tests/tools/test_security.py
+++ b/tools/tests/tools/test_security.py
@@ -1,207 +1,31 @@
-"""Tests for security.py - get_sandboxed_path() function."""
+"""Tests for security.py path resolution functions."""
 
-from unittest.mock import patch
-
+import os
 import pytest
+from unittest.mock import patch
+from aden_tools.tools.file_system_toolkits.security import resolve_safe_path
 
-
-class TestGetSandboxedPath:
-    """Tests for get_sandboxed_path() function."""
-
+class TestResolveSafePath:
     @pytest.fixture(autouse=True)
-    def setup_sandboxes_dir(self, tmp_path):
-        """Patch AGENT_SANDBOXES_DIR to use temp directory."""
-        self.sandboxes_dir = tmp_path / "sandboxes" / "default"
-        self.sandboxes_dir.mkdir(parents=True)
-        with patch(
-            "aden_tools.tools.file_system_toolkits.security.AGENT_SANDBOXES_DIR",
-            str(self.sandboxes_dir),
-        ):
+    def setup_allowed_roots(self, tmp_path):
+        self.tmp_dir = str(tmp_path.resolve())
+        with patch("aden_tools.tools.file_system_toolkits.security._ALLOWED_ROOTS", (self.tmp_dir,)):
             yield
 
-    @pytest.fixture
-    def agent_id(self):
-        """Standard agent ID."""
-        return {"agent_id": "test-agent"}
+    def test_valid_path(self):
+        valid_path = os.path.join(self.tmp_dir, "test.txt")
+        result = resolve_safe_path(valid_path)
+        assert result == valid_path
 
-    def test_creates_agent_directory(self, agent_id):
-        """Agent directory is created if it doesn't exist."""
-        from aden_tools.tools.file_system_toolkits.security import get_sandboxed_path
+    def test_relative_path_rejected(self):
+        # We assume CWD is not tmp_dir
+        with pytest.raises(ValueError, match="Access denied"):
+            resolve_safe_path("test.txt")
 
-        get_sandboxed_path("file.txt", agent_id=agent_id["agent_id"])
+    def test_path_traversal_blocked(self):
+        with pytest.raises(ValueError, match="Access denied"):
+            resolve_safe_path(os.path.join(self.tmp_dir, "..", "outside.txt"))
 
-        agent_dir = self.sandboxes_dir / "test-agent" / "current"
-        assert agent_dir.exists()
-        assert agent_dir.is_dir()
-
-    def test_relative_path_resolved(self, agent_id):
-        """Relative paths are resolved within agent directory."""
-        from aden_tools.tools.file_system_toolkits.security import get_sandboxed_path
-
-        result = get_sandboxed_path("subdir/file.txt", agent_id=agent_id["agent_id"])
-
-        expected = self.sandboxes_dir / "test-agent" / "current" / "subdir" / "file.txt"
-        assert result == str(expected)
-
-    def test_absolute_path_treated_as_relative(self, agent_id):
-        """Absolute paths are treated as relative to agent root."""
-        from aden_tools.tools.file_system_toolkits.security import get_sandboxed_path
-
-        result = get_sandboxed_path("/etc/passwd", agent_id=agent_id["agent_id"])
-
-        expected = self.sandboxes_dir / "test-agent" / "current" / "etc" / "passwd"
-        assert result == str(expected)
-
-    def test_path_traversal_blocked(self, agent_id):
-        """Path traversal attempts are blocked."""
-        from aden_tools.tools.file_system_toolkits.security import get_sandboxed_path
-
-        with pytest.raises(ValueError, match="outside the agent sandbox"):
-            get_sandboxed_path("../../../etc/passwd", agent_id=agent_id["agent_id"])
-
-    def test_path_traversal_with_nested_dotdot(self, agent_id):
-        """Nested path traversal with valid prefix is blocked."""
-        from aden_tools.tools.file_system_toolkits.security import get_sandboxed_path
-
-        with pytest.raises(ValueError, match="outside the agent sandbox"):
-            get_sandboxed_path("valid/../../..", agent_id=agent_id["agent_id"])
-
-    def test_path_traversal_absolute_with_dotdot(self, agent_id):
-        """Absolute path with traversal is blocked."""
-        from aden_tools.tools.file_system_toolkits.security import get_sandboxed_path
-
-        with pytest.raises(ValueError, match="outside the agent sandbox"):
-            get_sandboxed_path("/foo/../../../etc/passwd", agent_id=agent_id["agent_id"])
-
-    def test_missing_agent_id_raises(self, agent_id):
-        """Missing agent_id raises ValueError."""
-        from aden_tools.tools.file_system_toolkits.security import get_sandboxed_path
-
-        with pytest.raises(ValueError, match="agent_id.*required"):
-            get_sandboxed_path("file.txt", agent_id="")
-
-    def test_none_agent_id_raises(self, agent_id):
-        """None value for agent_id raises ValueError."""
-        from aden_tools.tools.file_system_toolkits.security import get_sandboxed_path
-
-        with pytest.raises(ValueError):
-            get_sandboxed_path("file.txt", agent_id=None)
-
-    def test_simple_filename(self, agent_id):
-        """Simple filename resolves correctly."""
-        from aden_tools.tools.file_system_toolkits.security import get_sandboxed_path
-
-        result = get_sandboxed_path("file.txt", agent_id=agent_id["agent_id"])
-
-        expected = self.sandboxes_dir / "test-agent" / "current" / "file.txt"
-        assert result == str(expected)
-
-    def test_current_dir_path(self, agent_id):
-        """Current directory path (.) resolves to agent dir."""
-        from aden_tools.tools.file_system_toolkits.security import get_sandboxed_path
-
-        result = get_sandboxed_path(".", agent_id=agent_id["agent_id"])
-
-        expected = self.sandboxes_dir / "test-agent" / "current"
-        assert result == str(expected)
-
-    def test_dot_slash_path(self, agent_id):
-        """Dot-slash paths resolve correctly."""
-        from aden_tools.tools.file_system_toolkits.security import get_sandboxed_path
-
-        result = get_sandboxed_path("./subdir/file.txt", agent_id=agent_id["agent_id"])
-
-        expected = self.sandboxes_dir / "test-agent" / "current" / "subdir" / "file.txt"
-        assert result == str(expected)
-
-    def test_deeply_nested_path(self, agent_id):
-        """Deeply nested paths work correctly."""
-        from aden_tools.tools.file_system_toolkits.security import get_sandboxed_path
-
-        result = get_sandboxed_path("a/b/c/d/e/file.txt", agent_id=agent_id["agent_id"])
-
-        expected = (
-            self.sandboxes_dir / "test-agent" / "current" / "a" / "b" / "c" / "d" / "e" / "file.txt"
-        )
-        assert result == str(expected)
-
-    def test_path_with_spaces(self, agent_id):
-        """Paths with spaces work correctly."""
-        from aden_tools.tools.file_system_toolkits.security import get_sandboxed_path
-
-        result = get_sandboxed_path("my folder/my file.txt", agent_id=agent_id["agent_id"])
-
-        expected = self.sandboxes_dir / "test-agent" / "current" / "my folder" / "my file.txt"
-        assert result == str(expected)
-
-    def test_path_with_special_characters(self, agent_id):
-        """Paths with special characters work correctly."""
-        from aden_tools.tools.file_system_toolkits.security import get_sandboxed_path
-
-        result = get_sandboxed_path("file-name_v2.0.txt", agent_id=agent_id["agent_id"])
-
-        expected = self.sandboxes_dir / "test-agent" / "current" / "file-name_v2.0.txt"
-        assert result == str(expected)
-
-    def test_empty_path(self, agent_id):
-        """Empty string path resolves to agent directory."""
-        from aden_tools.tools.file_system_toolkits.security import get_sandboxed_path
-
-        result = get_sandboxed_path("", agent_id=agent_id["agent_id"])
-
-        expected = self.sandboxes_dir / "test-agent" / "current"
-        assert result == str(expected)
-
-    def test_symlink_within_sandbox_works(self, agent_id):
-        """Symlinks that stay within sandbox are allowed."""
-        from aden_tools.tools.file_system_toolkits.security import get_sandboxed_path
-
-        # Create agent directory structure
-        agent_dir = self.sandboxes_dir / "test-agent" / "current"
-        agent_dir.mkdir(parents=True, exist_ok=True)
-
-        # Create a target file and a symlink to it
-        target_file = agent_dir / "target.txt"
-        target_file.write_text("content", encoding="utf-8")
-        symlink_path = agent_dir / "link_to_target"
-        symlink_path.symlink_to(target_file)
-
-        # Path through symlink should resolve to real target path
-        result = get_sandboxed_path("link_to_target", agent_id=agent_id["agent_id"])
-
-        # realpath resolves to symlink, so result points to real file
-        assert result == str(target_file.resolve())
-
-    def test_symlink_escape_blocked(self, agent_id):
-        """Symlinks pointing outside sandbox are blocked by get_sandboxed_path."""
-        from aden_tools.tools.file_system_toolkits.security import get_sandboxed_path
-
-        # Create agent directory
-        agent_dir = self.sandboxes_dir / "test-agent" / "current"
-        agent_dir.mkdir(parents=True, exist_ok=True)
-
-        # Create a symlink inside agent pointing outside
-        outside_target = self.sandboxes_dir / "outside_file.txt"
-        outside_target.write_text("sensitive data", encoding="utf-8")
-        symlink_path = agent_dir / "escape_link"
-        symlink_path.symlink_to(outside_target)
-
-        # get_sandboxed_path resolves symlinks and blocks escape
-        with pytest.raises(ValueError, match="outside the agent sandbox"):
-            get_sandboxed_path("escape_link", agent_id=agent_id["agent_id"])
-
-    def test_symlink_to_root_escape_blocked(self, agent_id):
-        """Symlink to / inside sandbox then traversing through it is blocked."""
-        from aden_tools.tools.file_system_toolkits.security import get_sandboxed_path
-
-        # Create agent directory
-        agent_dir = self.sandboxes_dir / "test-agent" / "current"
-        agent_dir.mkdir(parents=True, exist_ok=True)
-
-        # Create a symlink to root filesystem inside sandbox
-        symlink_path = agent_dir / "root"
-        symlink_path.symlink_to("/")
-
-        # Attempting to access files through symlink should be blocked
-        with pytest.raises(ValueError, match="outside the agent sandbox"):
-            get_sandboxed_path("root/etc/passwd", agent_id=agent_id["agent_id"])
+    def test_empty_path(self):
+        with pytest.raises(ValueError, match="cannot be empty"):
+            resolve_safe_path("   ")


### PR DESCRIPTION
Remove the deprecated get_sandboxed_path() function and AGENT_SANDBOXES_DIR constant from security.py. Migrate all file-system toolkits (grep_search, execute_command, list_dir, replace_file_content, apply_patch, apply_diff, hashline_edit) and excel_tool to use resolve_safe_path().

Update test suites to mock resolve_safe_path directly instead of patching the removed AGENT_SANDBOXES_DIR constant.

13 files changed, 167 tests pass.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #7076 

## Changes Made

- Change 1
- Change 2
- Change 3
3
## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated how tools validate and resolve file paths; file- and command-related tools now use the unified safe-path resolver and no longer rely on per-agent sandbox roots. The command tool’s default working directory fallback was adjusted.

* **Tests**
  * Test fixtures and suites were updated to align with the new path-resolution behavior and to simplify sandboxing in test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->