### PR TITLE
feat(shopify): add cancel, refund, and invoice tools

### DIFF
--- a/tools/src/aden_tools/tools/shopify_tool/README.md
+++ b/tools/src/aden_tools/tools/shopify_tool/README.md
@@ -99,6 +99,10 @@ shopify_refund_order(
 )
 ```
 
+> Note: If `amount` is less than the calculated refundable total, the tool performs an "amount-only" refund by
+> omitting `refund_line_items` from the create-refund call (avoids marking items fully refunded while refunding
+> only part of the money).
+
 ### List active products
 
 ```python

--- a/tools/src/aden_tools/tools/shopify_tool/README.md
+++ b/tools/src/aden_tools/tools/shopify_tool/README.md
@@ -81,9 +81,10 @@ shopify_update_order(
 shopify_cancel_order(
     order_id="5678901234",
     reason="customer",
-    restock=True,
+    restock=False,
     email=True,
-    refund=False,
+    amount="10.00",
+    currency="USD",
 )
 ```
 

--- a/tools/src/aden_tools/tools/shopify_tool/README.md
+++ b/tools/src/aden_tools/tools/shopify_tool/README.md
@@ -8,6 +8,9 @@ Order, product, and customer management via the Shopify Admin REST API.
 |------|-------------|
 | `shopify_list_orders` | List orders with optional status and fulfillment filters |
 | `shopify_get_order` | Get full details of a specific order by ID |
+| `shopify_update_order` | Update order tags or internal note |
+| `shopify_cancel_order` | Cancel an order (optional restock/email/refund) |
+| `shopify_refund_order` | Refund an order via the store payment gateway |
 | `shopify_list_products` | List products with optional status, type, and vendor filters |
 | `shopify_get_product` | Get full product details including variants and images |
 | `shopify_update_product` | Update title, body_html, status, tags, or vendor of a product |
@@ -15,6 +18,7 @@ Order, product, and customer management via the Shopify Admin REST API.
 | `shopify_get_customer` | Get full customer details including addresses and order stats |
 | `shopify_search_customers` | Search customers by email, name, or other fields |
 | `shopify_create_draft_order` | Create a draft order with line items |
+| `shopify_send_draft_order_invoice` | Send a draft order invoice email to collect payment |
 
 ## Setup
 
@@ -59,6 +63,39 @@ shopify_list_orders(
 
 ```python
 shopify_get_order(order_id="5678901234")
+```
+
+### Update an order's tags / note
+
+```python
+shopify_update_order(
+    order_id="5678901234",
+    tags="vip,needs_followup",
+    note="Customer requested delivery window 2-4pm",
+)
+```
+
+### Cancel an order
+
+```python
+shopify_cancel_order(
+    order_id="5678901234",
+    reason="customer",
+    restock=True,
+    email=True,
+    refund=False,
+)
+```
+
+### Refund an order
+
+```python
+shopify_refund_order(
+    order_id="5678901234",
+    amount="199.00",
+    note="Customer requested refund",
+    notify=False,
+)
 ```
 
 ### List active products
@@ -110,6 +147,16 @@ shopify_create_draft_order(
     customer_id="987654321",
     note="VIP order",
     tags="manual,vip",
+)
+```
+
+### Send draft order invoice email (collect payment)
+
+```python
+shopify_send_draft_order_invoice(
+    draft_order_id="123456789",
+    subject="Invoice for your order",
+    custom_message="Thanks! Please complete payment using the link in this invoice.",
 )
 ```
 

--- a/tools/src/aden_tools/tools/shopify_tool/shopify_tool.py
+++ b/tools/src/aden_tools/tools/shopify_tool/shopify_tool.py
@@ -427,15 +427,48 @@ def register_tools(
             if restock_type in {"cancel", "return"} and not location_id:
                 return {"error": "location_id is required when restock_type is 'cancel' or 'return'"}
 
+            refunds_resp = httpx.get(
+                f"{_base_url(store)}/orders/{order_id}/refunds.json",
+                headers=_headers(token),
+                timeout=30.0,
+            )
+            refunds_result = _handle_response(refunds_resp)
+            if "error" in refunds_result:
+                return refunds_result
+
+            refunded_quantities: dict[int, int] = {}
+            for r in refunds_result.get("refunds", []) or []:
+                for rli in (r.get("refund_line_items") or [])[:]:
+                    li_id = rli.get("line_item_id")
+                    qty = rli.get("quantity")
+                    if not li_id or not qty:
+                        continue
+                    try:
+                        li_id_int = int(li_id)
+                        qty_int = int(qty)
+                    except (TypeError, ValueError):
+                        continue
+                    refunded_quantities[li_id_int] = refunded_quantities.get(li_id_int, 0) + qty_int
+
             refund_line_items: list[dict[str, Any]] = []
             for li in (order.get("line_items") or [])[:]:
                 line_item_id = li.get("id")
                 quantity = li.get("quantity")
                 if not line_item_id or not quantity:
                     continue
+                try:
+                    line_item_id_int = int(line_item_id)
+                    ordered_qty = int(quantity)
+                except (TypeError, ValueError):
+                    continue
+
+                remaining_qty = ordered_qty - refunded_quantities.get(line_item_id_int, 0)
+                if remaining_qty <= 0:
+                    continue
+
                 entry: dict[str, Any] = {
-                    "line_item_id": int(line_item_id),
-                    "quantity": int(quantity),
+                    "line_item_id": line_item_id_int,
+                    "quantity": remaining_qty,
                     "restock_type": restock_type,
                 }
                 if restock_type in {"cancel", "return"}:
@@ -490,6 +523,9 @@ def register_tools(
                 if desired_amount > total_calc:
                     return {"error": f"amount exceeds refundable total ({_format_money(total_calc)} {currency})"}
 
+                if desired_amount < total_calc and refund_shipping:
+                    return {"error": "amount-only refunds do not support refund_shipping; omit refund_shipping or omit amount"}
+
                 ratio = (desired_amount / total_calc) if total_calc != 0 else Decimal("0")
                 scaled: list[dict[str, Any]] = []
                 running = Decimal("0")
@@ -508,13 +544,19 @@ def register_tools(
             create_refund: dict[str, Any] = {
                 "currency": currency,
                 "notify": bool(notify),
-                "note": note,
-                "refund_line_items": calculated.get("refund_line_items", refund_line_items),
                 "transactions": updated_txs,
             }
-            shipping = calculated.get("shipping")
-            if shipping:
-                create_refund["shipping"] = shipping
+            if note:
+                create_refund["note"] = note
+
+            # If the caller provided an amount less than the calculated total, we treat
+            # this as an "amount-only" refund by omitting refund_line_items/shipping.
+            # This avoids inconsistent payloads (line items fully refunded but money partially refunded).
+            if desired_amount is None or desired_amount >= total_calc:
+                create_refund["refund_line_items"] = calculated.get("refund_line_items", refund_line_items)
+                shipping = calculated.get("shipping")
+                if shipping:
+                    create_refund["shipping"] = shipping
 
             refund_resp = httpx.post(
                 f"{_base_url(store)}/orders/{order_id}/refunds.json",

--- a/tools/src/aden_tools/tools/shopify_tool/shopify_tool.py
+++ b/tools/src/aden_tools/tools/shopify_tool/shopify_tool.py
@@ -11,6 +11,7 @@ API Reference: https://shopify.dev/docs/api/admin-rest
 from __future__ import annotations
 
 import os
+from decimal import Decimal, ROUND_HALF_UP
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -74,6 +75,17 @@ def _handle_response(resp: httpx.Response) -> dict[str, Any]:
             detail = resp.text
         return {"error": f"Shopify API error (HTTP {resp.status_code}): {detail}"}
     return resp.json()
+
+
+def _parse_money(value: str) -> Decimal | None:
+    try:
+        return Decimal(str(value))
+    except Exception:
+        return None
+
+
+def _format_money(value: Decimal) -> str:
+    return str(value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
 
 
 def register_tools(
@@ -287,9 +299,10 @@ def register_tools(
     def shopify_cancel_order(
         order_id: str,
         reason: str = "",
-        restock: bool = True,
-        email: bool = True,
-        refund: bool = False,
+        restock: bool = False,
+        email: bool = False,
+        amount: str = "",
+        currency: str = "",
     ) -> dict:
         """
         Cancel an existing Shopify order.
@@ -297,9 +310,10 @@ def register_tools(
         Args:
             order_id: The numeric Shopify order ID (required).
             reason: Optional reason (Shopify-defined values include: "customer", "inventory", "fraud", "declined", "other").
-            restock: Whether to restock inventory for the cancelled order (default True).
-            email: Whether Shopify should email the customer (default True).
-            refund: Whether Shopify should attempt to refund the order (default False).
+            restock: Whether to restock refunded items back to inventory (deprecated by Shopify; default False).
+            email: Whether to send an email to the customer notifying them of the cancellation (default False).
+            amount: Optional amount to refund (string). When set, `currency` is required for multi-currency orders.
+            currency: Optional currency for the refund when `amount` is set.
 
         Returns:
             Dict with cancellation status.
@@ -316,19 +330,22 @@ def register_tools(
         except ValueError:
             return {"error": "order_id must be a numeric Shopify order ID"}
 
-        params: dict[str, Any] = {
-            "restock": str(restock).lower(),
-            "email": str(email).lower(),
-            "refund": str(refund).lower(),
+        payload: dict[str, Any] = {
+            "email": bool(email),
+            "restock": bool(restock),
         }
         if reason:
-            params["reason"] = reason
+            payload["reason"] = reason
+        if amount:
+            payload["amount"] = amount
+            if currency:
+                payload["currency"] = currency
 
         try:
             resp = httpx.post(
                 f"{_base_url(store)}/orders/{order_id}/cancel.json",
                 headers=_headers(token),
-                params=params,
+                json=payload,
                 timeout=30.0,
             )
             result = _handle_response(resp)
@@ -356,18 +373,23 @@ def register_tools(
         amount: str = "",
         note: str = "",
         notify: bool = False,
+        refund_shipping: bool = False,
+        restock_type: str = "no_restock",
+        location_id: str = "",
     ) -> dict:
         """
         Refund an order via the Shopify Admin REST API.
 
-        This uses the store's configured payment gateway by creating a refund transaction
-        against an existing "capture"/"sale" transaction for the order.
+        Uses Shopify's recommended flow: calculate accurate transactions, then create the refund.
 
         Args:
             order_id: The numeric Shopify order ID (required).
             amount: Refund amount as a string (optional). If empty, refunds the order's total_price.
             note: Optional internal note on the refund.
             notify: Whether to notify the customer (default False).
+            refund_shipping: Whether to refund shipping in full (default False).
+            restock_type: Restock behavior for refunded line items ("no_restock", "cancel", "return"). Default "no_restock".
+            location_id: Required when restock_type is "cancel" or "return" (Shopify location id).
 
         Returns:
             Dict with refund ID and status.
@@ -395,57 +417,109 @@ def register_tools(
                 return order_result
 
             order = order_result.get("order", {})
-            refund_amount = amount or str(order.get("total_price") or "")
             currency = order.get("currency") or ""
-            if not refund_amount:
-                return {"error": "amount is required (could not infer from order total_price)"}
             if not currency:
                 return {"error": "Could not infer currency from order"}
 
-            tx_resp = httpx.get(
-                f"{_base_url(store)}/orders/{order_id}/transactions.json",
-                headers=_headers(token),
-                timeout=30.0,
-            )
-            tx_result = _handle_response(tx_resp)
-            if "error" in tx_result:
-                return tx_result
+            valid_restock_types = {"no_restock", "cancel", "return"}
+            if restock_type not in valid_restock_types:
+                return {"error": f"restock_type must be one of: {', '.join(sorted(valid_restock_types))}"}
+            if restock_type in {"cancel", "return"} and not location_id:
+                return {"error": "location_id is required when restock_type is 'cancel' or 'return'"}
 
-            transactions = tx_result.get("transactions", []) or []
-            parent = None
-            for t in transactions:
-                if t.get("kind") in ("capture", "sale"):
-                    parent = t
-                    break
-            if not parent:
-                return {"error": "No refundable transaction found for this order"}
+            refund_line_items: list[dict[str, Any]] = []
+            for li in (order.get("line_items") or [])[:]:
+                line_item_id = li.get("id")
+                quantity = li.get("quantity")
+                if not line_item_id or not quantity:
+                    continue
+                entry: dict[str, Any] = {
+                    "line_item_id": int(line_item_id),
+                    "quantity": int(quantity),
+                    "restock_type": restock_type,
+                }
+                if restock_type in {"cancel", "return"}:
+                    entry["location_id"] = int(location_id)
+                refund_line_items.append(entry)
 
-            parent_id = parent.get("id")
-            gateway = parent.get("gateway")
-            if not parent_id or not gateway:
-                return {"error": "Refund transaction metadata missing (parent_id/gateway)"}
+            if not refund_line_items:
+                return {"error": "Could not infer refund_line_items from order"}
 
-            payload: dict[str, Any] = {
+            calc_payload: dict[str, Any] = {
                 "refund": {
                     "currency": currency,
-                    "notify": bool(notify),
-                    "transactions": [
-                        {
-                            "parent_id": parent_id,
-                            "amount": refund_amount,
-                            "kind": "refund",
-                            "gateway": gateway,
-                        }
-                    ],
+                    "refund_line_items": refund_line_items,
                 }
             }
-            if note:
-                payload["refund"]["note"] = note
+            if refund_shipping:
+                calc_payload["refund"]["shipping"] = {"full_refund": True}
+
+            calc_resp = httpx.post(
+                f"{_base_url(store)}/orders/{order_id}/refunds/calculate.json",
+                headers=_headers(token),
+                json=calc_payload,
+                timeout=30.0,
+            )
+            calc_result = _handle_response(calc_resp)
+            if "error" in calc_result:
+                return calc_result
+
+            calculated = calc_result.get("refund", {}) or {}
+            calc_txs = calculated.get("transactions") or []
+            if not isinstance(calc_txs, list) or not calc_txs:
+                return {"error": "Refund calculation did not return any transactions"}
+
+            desired_amount = _parse_money(amount) if amount else None
+            if desired_amount is not None and desired_amount <= 0:
+                return {"error": "amount must be a positive number"}
+
+            total_calc = Decimal("0")
+            parsed_amounts: list[Decimal] = []
+            for tx in calc_txs:
+                tx_amount = _parse_money(tx.get("amount"))
+                if tx_amount is None:
+                    return {"error": "Refund calculation returned invalid transaction amounts"}
+                parsed_amounts.append(tx_amount)
+                total_calc += tx_amount
+
+            if total_calc <= 0:
+                return {"error": "Refund calculation returned a non-positive total"}
+
+            updated_txs = calc_txs
+            if desired_amount is not None:
+                if desired_amount > total_calc:
+                    return {"error": f"amount exceeds refundable total ({_format_money(total_calc)} {currency})"}
+
+                ratio = (desired_amount / total_calc) if total_calc != 0 else Decimal("0")
+                scaled: list[dict[str, Any]] = []
+                running = Decimal("0")
+                for i, tx in enumerate(calc_txs):
+                    original = parsed_amounts[i]
+                    if i < len(calc_txs) - 1:
+                        new_amount = (original * ratio).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+                        running += new_amount
+                    else:
+                        new_amount = (desired_amount - running).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+                    tx_copy = dict(tx)
+                    tx_copy["amount"] = _format_money(new_amount)
+                    scaled.append(tx_copy)
+                updated_txs = scaled
+
+            create_refund: dict[str, Any] = {
+                "currency": currency,
+                "notify": bool(notify),
+                "note": note,
+                "refund_line_items": calculated.get("refund_line_items", refund_line_items),
+                "transactions": updated_txs,
+            }
+            shipping = calculated.get("shipping")
+            if shipping:
+                create_refund["shipping"] = shipping
 
             refund_resp = httpx.post(
                 f"{_base_url(store)}/orders/{order_id}/refunds.json",
                 headers=_headers(token),
-                json=payload,
+                json={"refund": create_refund},
                 timeout=30.0,
             )
             refund_result = _handle_response(refund_resp)

--- a/tools/src/aden_tools/tools/shopify_tool/shopify_tool.py
+++ b/tools/src/aden_tools/tools/shopify_tool/shopify_tool.py
@@ -220,6 +220,253 @@ def register_tools(
             return {"error": f"Network error: {e}"}
 
     @mcp.tool()
+    def shopify_update_order(
+        order_id: str,
+        tags: str = "",
+        note: str = "",
+    ) -> dict:
+        """
+        Update an existing Shopify order (tags / note).
+
+        Args:
+            order_id: The numeric Shopify order ID (required).
+            tags: Comma-separated tags to replace existing tags (optional).
+            note: Internal order note (optional).
+
+        Returns:
+            Dict with updated order fields.
+        """
+        creds = _get_creds(credentials)
+        if isinstance(creds, dict):
+            return creds
+        token, store = creds
+
+        if not order_id:
+            return {"error": "order_id is required"}
+
+        try:
+            order_id_int = int(order_id)
+        except ValueError:
+            return {"error": "order_id must be a numeric Shopify order ID"}
+
+        order: dict[str, Any] = {"id": order_id_int}
+        if tags:
+            order["tags"] = tags
+        if note:
+            order["note"] = note
+
+        if set(order.keys()) == {"id"}:
+            return {"error": "At least one field to update is required"}
+
+        try:
+            resp = httpx.put(
+                f"{_base_url(store)}/orders/{order_id}.json",
+                headers=_headers(token),
+                json={"order": order},
+                timeout=30.0,
+            )
+            result = _handle_response(resp)
+            if "error" in result:
+                return result
+
+            o = result.get("order", {})
+            return {
+                "id": o.get("id"),
+                "name": o.get("name"),
+                "updated_at": o.get("updated_at"),
+                "tags": o.get("tags"),
+                "note": o.get("note"),
+                "result": "updated",
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def shopify_cancel_order(
+        order_id: str,
+        reason: str = "",
+        restock: bool = True,
+        email: bool = True,
+        refund: bool = False,
+    ) -> dict:
+        """
+        Cancel an existing Shopify order.
+
+        Args:
+            order_id: The numeric Shopify order ID (required).
+            reason: Optional reason (Shopify-defined values include: "customer", "inventory", "fraud", "declined", "other").
+            restock: Whether to restock inventory for the cancelled order (default True).
+            email: Whether Shopify should email the customer (default True).
+            refund: Whether Shopify should attempt to refund the order (default False).
+
+        Returns:
+            Dict with cancellation status.
+        """
+        creds = _get_creds(credentials)
+        if isinstance(creds, dict):
+            return creds
+        token, store = creds
+
+        if not order_id:
+            return {"error": "order_id is required"}
+        try:
+            int(order_id)
+        except ValueError:
+            return {"error": "order_id must be a numeric Shopify order ID"}
+
+        params: dict[str, Any] = {
+            "restock": str(restock).lower(),
+            "email": str(email).lower(),
+            "refund": str(refund).lower(),
+        }
+        if reason:
+            params["reason"] = reason
+
+        try:
+            resp = httpx.post(
+                f"{_base_url(store)}/orders/{order_id}/cancel.json",
+                headers=_headers(token),
+                params=params,
+                timeout=30.0,
+            )
+            result = _handle_response(resp)
+            if "error" in result:
+                return result
+
+            o = result.get("order", {})
+            return {
+                "id": o.get("id"),
+                "name": o.get("name"),
+                "cancelled_at": o.get("cancelled_at"),
+                "cancel_reason": o.get("cancel_reason"),
+                "financial_status": o.get("financial_status"),
+                "fulfillment_status": o.get("fulfillment_status"),
+                "result": "cancelled",
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def shopify_refund_order(
+        order_id: str,
+        amount: str = "",
+        note: str = "",
+        notify: bool = False,
+    ) -> dict:
+        """
+        Refund an order via the Shopify Admin REST API.
+
+        This uses the store's configured payment gateway by creating a refund transaction
+        against an existing "capture"/"sale" transaction for the order.
+
+        Args:
+            order_id: The numeric Shopify order ID (required).
+            amount: Refund amount as a string (optional). If empty, refunds the order's total_price.
+            note: Optional internal note on the refund.
+            notify: Whether to notify the customer (default False).
+
+        Returns:
+            Dict with refund ID and status.
+        """
+        creds = _get_creds(credentials)
+        if isinstance(creds, dict):
+            return creds
+        token, store = creds
+
+        if not order_id:
+            return {"error": "order_id is required"}
+        try:
+            int(order_id)
+        except ValueError:
+            return {"error": "order_id must be a numeric Shopify order ID"}
+
+        try:
+            order_resp = httpx.get(
+                f"{_base_url(store)}/orders/{order_id}.json",
+                headers=_headers(token),
+                timeout=30.0,
+            )
+            order_result = _handle_response(order_resp)
+            if "error" in order_result:
+                return order_result
+
+            order = order_result.get("order", {})
+            refund_amount = amount or str(order.get("total_price") or "")
+            currency = order.get("currency") or ""
+            if not refund_amount:
+                return {"error": "amount is required (could not infer from order total_price)"}
+            if not currency:
+                return {"error": "Could not infer currency from order"}
+
+            tx_resp = httpx.get(
+                f"{_base_url(store)}/orders/{order_id}/transactions.json",
+                headers=_headers(token),
+                timeout=30.0,
+            )
+            tx_result = _handle_response(tx_resp)
+            if "error" in tx_result:
+                return tx_result
+
+            transactions = tx_result.get("transactions", []) or []
+            parent = None
+            for t in transactions:
+                if t.get("kind") in ("capture", "sale"):
+                    parent = t
+                    break
+            if not parent:
+                return {"error": "No refundable transaction found for this order"}
+
+            parent_id = parent.get("id")
+            gateway = parent.get("gateway")
+            if not parent_id or not gateway:
+                return {"error": "Refund transaction metadata missing (parent_id/gateway)"}
+
+            payload: dict[str, Any] = {
+                "refund": {
+                    "currency": currency,
+                    "notify": bool(notify),
+                    "transactions": [
+                        {
+                            "parent_id": parent_id,
+                            "amount": refund_amount,
+                            "kind": "refund",
+                            "gateway": gateway,
+                        }
+                    ],
+                }
+            }
+            if note:
+                payload["refund"]["note"] = note
+
+            refund_resp = httpx.post(
+                f"{_base_url(store)}/orders/{order_id}/refunds.json",
+                headers=_headers(token),
+                json=payload,
+                timeout=30.0,
+            )
+            refund_result = _handle_response(refund_resp)
+            if "error" in refund_result:
+                return refund_result
+
+            r = refund_result.get("refund", {})
+            return {
+                "id": r.get("id"),
+                "order_id": r.get("order_id"),
+                "created_at": r.get("created_at"),
+                "note": r.get("note"),
+                "transactions": r.get("transactions"),
+                "result": "refunded",
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
     def shopify_list_products(
         status: str = "",
         product_type: str = "",
@@ -675,6 +922,69 @@ def register_tools(
                 "line_item_count": len(d.get("line_items", [])),
                 "result": "created",
             }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def shopify_send_draft_order_invoice(
+        draft_order_id: str,
+        to: str = "",
+        subject: str = "",
+        custom_message: str = "",
+        bcc: str = "",
+        from_email: str = "",
+    ) -> dict:
+        """
+        Send a Shopify draft order invoice email to collect payment.
+
+        Args:
+            draft_order_id: The numeric Shopify draft order ID (required).
+            to: Recipient email override (optional). Defaults to Shopify's customer email on the draft order.
+            subject: Email subject override (optional).
+            custom_message: Custom message to include in the invoice email (optional).
+            bcc: BCC email address (optional).
+            from_email: From email override (optional). Must be configured/allowed in Shopify.
+
+        Returns:
+            Dict with result status.
+        """
+        creds = _get_creds(credentials)
+        if isinstance(creds, dict):
+            return creds
+        token, store = creds
+
+        if not draft_order_id:
+            return {"error": "draft_order_id is required"}
+        try:
+            int(draft_order_id)
+        except ValueError:
+            return {"error": "draft_order_id must be a numeric Shopify draft order ID"}
+
+        invoice: dict[str, Any] = {}
+        if to:
+            invoice["to"] = to
+        if subject:
+            invoice["subject"] = subject
+        if custom_message:
+            invoice["custom_message"] = custom_message
+        if bcc:
+            invoice["bcc"] = bcc
+        if from_email:
+            invoice["from"] = from_email
+
+        try:
+            resp = httpx.post(
+                f"{_base_url(store)}/draft_orders/{draft_order_id}/send_invoice.json",
+                headers=_headers(token),
+                json={"draft_order_invoice": invoice},
+                timeout=30.0,
+            )
+            result = _handle_response(resp)
+            if "error" in result:
+                return result
+            return {"draft_order_id": int(draft_order_id), "result": "invoice_sent"}
         except httpx.TimeoutException:
             return {"error": "Request timed out"}
         except httpx.RequestError as e:

--- a/tools/src/aden_tools/tools/shopify_tool/shopify_tool.py
+++ b/tools/src/aden_tools/tools/shopify_tool/shopify_tool.py
@@ -426,6 +426,12 @@ def register_tools(
                 return {"error": f"restock_type must be one of: {', '.join(sorted(valid_restock_types))}"}
             if restock_type in {"cancel", "return"} and not location_id:
                 return {"error": "location_id is required when restock_type is 'cancel' or 'return'"}
+            location_id_int: int | None = None
+            if restock_type in {"cancel", "return"}:
+                try:
+                    location_id_int = int(location_id)
+                except ValueError:
+                    return {"error": "location_id must be a numeric Shopify location ID"}
 
             refunds_resp = httpx.get(
                 f"{_base_url(store)}/orders/{order_id}/refunds.json",
@@ -472,7 +478,7 @@ def register_tools(
                     "restock_type": restock_type,
                 }
                 if restock_type in {"cancel", "return"}:
-                    entry["location_id"] = int(location_id)
+                    entry["location_id"] = location_id_int
                 refund_line_items.append(entry)
 
             if not refund_line_items:
@@ -503,6 +509,8 @@ def register_tools(
                 return {"error": "Refund calculation did not return any transactions"}
 
             desired_amount = _parse_money(amount) if amount else None
+            if amount and desired_amount is None:
+                return {"error": "amount must be a number (e.g. '10.00')"}
             if desired_amount is not None and desired_amount <= 0:
                 return {"error": "amount must be a positive number"}
 

--- a/tools/tests/tools/test_shopify_tool.py
+++ b/tools/tests/tools/test_shopify_tool.py
@@ -219,6 +219,33 @@ class TestShopifyRefundOrder:
             result = tool_fns["shopify_refund_order"](order_id="bad", amount="1.00")
         assert "error" in result
 
+    def test_rejects_invalid_amount(self, tool_fns):
+        with patch.dict("os.environ", ENV):
+            result = tool_fns["shopify_refund_order"](order_id="450789469", amount="abc")
+        assert "error" in result
+
+    def test_rejects_invalid_location_id(self, tool_fns):
+        order_data = {"order": {"id": 450789469, "currency": "USD", "line_items": [{"id": 518995019, "quantity": 1}]}}
+        refunds_data = {"refunds": []}
+
+        def _mock_get(url, *args, **kwargs):
+            if url.endswith("/orders/450789469.json"):
+                return _mock_resp(order_data)
+            if url.endswith("/orders/450789469/refunds.json"):
+                return _mock_resp(refunds_data)
+            raise AssertionError(f"Unexpected GET URL: {url}")
+
+        with (
+            patch.dict("os.environ", ENV),
+            patch("aden_tools.tools.shopify_tool.shopify_tool.httpx.get", side_effect=_mock_get),
+        ):
+            result = tool_fns["shopify_refund_order"](
+                order_id="450789469",
+                restock_type="cancel",
+                location_id="not-a-number",
+            )
+        assert "error" in result
+
     def test_successful_refund(self, tool_fns):
         order_data = {
             "order": {

--- a/tools/tests/tools/test_shopify_tool.py
+++ b/tools/tests/tools/test_shopify_tool.py
@@ -121,6 +121,171 @@ class TestShopifyGetOrder:
         assert result["customer"]["first_name"] == "Bob"
 
 
+class TestShopifyUpdateOrder:
+    def test_missing_id(self, tool_fns):
+        with patch.dict("os.environ", ENV):
+            result = tool_fns["shopify_update_order"](order_id="")
+        assert "error" in result
+
+    def test_requires_numeric_id(self, tool_fns):
+        with patch.dict("os.environ", ENV):
+            result = tool_fns["shopify_update_order"](order_id="not-a-number", tags="vip")
+        assert "error" in result
+
+    def test_requires_fields(self, tool_fns):
+        with patch.dict("os.environ", ENV):
+            result = tool_fns["shopify_update_order"](order_id="450789469")
+        assert "error" in result
+
+    def test_successful_update(self, tool_fns):
+        data = {
+            "order": {
+                "id": 450789469,
+                "name": "#1001",
+                "updated_at": "2025-01-10T12:30:00-05:00",
+                "tags": "vip,needs_followup",
+                "note": "Call customer before shipping",
+            }
+        }
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.shopify_tool.shopify_tool.httpx.put",
+                return_value=_mock_resp(data),
+            ),
+        ):
+            result = tool_fns["shopify_update_order"](
+                order_id="450789469",
+                tags="vip,needs_followup",
+                note="Call customer before shipping",
+            )
+
+        assert result["id"] == 450789469
+        assert result["tags"] == "vip,needs_followup"
+        assert result["result"] == "updated"
+
+
+class TestShopifyCancelOrder:
+    def test_missing_id(self, tool_fns):
+        with patch.dict("os.environ", ENV):
+            result = tool_fns["shopify_cancel_order"](order_id="")
+        assert "error" in result
+
+    def test_requires_numeric_id(self, tool_fns):
+        with patch.dict("os.environ", ENV):
+            result = tool_fns["shopify_cancel_order"](order_id="bad")
+        assert "error" in result
+
+    def test_successful_cancel(self, tool_fns):
+        data = {
+            "order": {
+                "id": 450789469,
+                "name": "#1001",
+                "cancelled_at": "2025-01-10T12:40:00-05:00",
+                "cancel_reason": "customer",
+                "financial_status": "refunded",
+                "fulfillment_status": None,
+            }
+        }
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.shopify_tool.shopify_tool.httpx.post",
+                return_value=_mock_resp(data),
+            ),
+        ):
+            result = tool_fns["shopify_cancel_order"](
+                order_id="450789469",
+                reason="customer",
+                restock=True,
+                email=True,
+                refund=False,
+            )
+
+        assert result["id"] == 450789469
+        assert result["result"] == "cancelled"
+
+
+class TestShopifyRefundOrder:
+    def test_missing_id(self, tool_fns):
+        with patch.dict("os.environ", ENV):
+            result = tool_fns["shopify_refund_order"](order_id="")
+        assert "error" in result
+
+    def test_requires_numeric_id(self, tool_fns):
+        with patch.dict("os.environ", ENV):
+            result = tool_fns["shopify_refund_order"](order_id="bad", amount="1.00")
+        assert "error" in result
+
+    def test_successful_refund(self, tool_fns):
+        order_data = {"order": {"id": 450789469, "total_price": "199.00", "currency": "USD"}}
+        tx_data = {"transactions": [{"id": 111, "kind": "capture", "gateway": "shopify_payments"}]}
+        refund_data = {
+            "refund": {
+                "id": 222,
+                "order_id": 450789469,
+                "created_at": "2025-01-10T12:50:00-05:00",
+                "note": "Customer requested refund",
+                "transactions": [{"id": 333, "amount": "199.00", "kind": "refund"}],
+            }
+        }
+
+        def _mock_get(url, *args, **kwargs):
+            if url.endswith("/orders/450789469.json"):
+                return _mock_resp(order_data)
+            if url.endswith("/orders/450789469/transactions.json"):
+                return _mock_resp(tx_data)
+            raise AssertionError(f"Unexpected GET URL: {url}")
+
+        with (
+            patch.dict("os.environ", ENV),
+            patch("aden_tools.tools.shopify_tool.shopify_tool.httpx.get", side_effect=_mock_get),
+            patch(
+                "aden_tools.tools.shopify_tool.shopify_tool.httpx.post",
+                return_value=_mock_resp(refund_data),
+            ),
+        ):
+            result = tool_fns["shopify_refund_order"](
+                order_id="450789469",
+                amount="199.00",
+                note="Customer requested refund",
+                notify=False,
+            )
+
+        assert result["id"] == 222
+        assert result["order_id"] == 450789469
+        assert result["result"] == "refunded"
+
+
+class TestShopifySendDraftOrderInvoice:
+    def test_missing_id(self, tool_fns):
+        with patch.dict("os.environ", ENV):
+            result = tool_fns["shopify_send_draft_order_invoice"](draft_order_id="")
+        assert "error" in result
+
+    def test_requires_numeric_id(self, tool_fns):
+        with patch.dict("os.environ", ENV):
+            result = tool_fns["shopify_send_draft_order_invoice"](draft_order_id="bad")
+        assert "error" in result
+
+    def test_successful_send(self, tool_fns):
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.shopify_tool.shopify_tool.httpx.post",
+                return_value=_mock_resp({}),
+            ),
+        ):
+            result = tool_fns["shopify_send_draft_order_invoice"](
+                draft_order_id="123456789",
+                subject="Invoice",
+                custom_message="Please pay",
+            )
+
+        assert result["draft_order_id"] == 123456789
+        assert result["result"] == "invoice_sent"
+
+
 class TestShopifyListProducts:
     def test_successful_list(self, tool_fns):
         data = {

--- a/tools/tests/tools/test_shopify_tool.py
+++ b/tools/tests/tools/test_shopify_tool.py
@@ -187,23 +187,25 @@ class TestShopifyCancelOrder:
                 "fulfillment_status": None,
             }
         }
+        mock_post = _mock_resp(data)
         with (
             patch.dict("os.environ", ENV),
-            patch(
-                "aden_tools.tools.shopify_tool.shopify_tool.httpx.post",
-                return_value=_mock_resp(data),
-            ),
+            patch("aden_tools.tools.shopify_tool.shopify_tool.httpx.post", return_value=mock_post) as post_mock,
         ):
             result = tool_fns["shopify_cancel_order"](
                 order_id="450789469",
                 reason="customer",
                 restock=True,
                 email=True,
-                refund=False,
+                amount="10.00",
+                currency="USD",
             )
 
         assert result["id"] == 450789469
         assert result["result"] == "cancelled"
+        assert "json" in post_mock.call_args.kwargs
+        assert "params" not in post_mock.call_args.kwargs
+        assert post_mock.call_args.kwargs["json"]["reason"] == "customer"
 
 
 class TestShopifyRefundOrder:
@@ -218,8 +220,20 @@ class TestShopifyRefundOrder:
         assert "error" in result
 
     def test_successful_refund(self, tool_fns):
-        order_data = {"order": {"id": 450789469, "total_price": "199.00", "currency": "USD"}}
-        tx_data = {"transactions": [{"id": 111, "kind": "capture", "gateway": "shopify_payments"}]}
+        order_data = {
+            "order": {
+                "id": 450789469,
+                "currency": "USD",
+                "line_items": [{"id": 518995019, "quantity": 1}],
+            }
+        }
+        calc_data = {
+            "refund": {
+                "currency": "USD",
+                "transactions": [{"parent_id": 801038806, "amount": "41.94", "kind": "refund", "gateway": "bogus"}],
+                "refund_line_items": [{"line_item_id": 518995019, "quantity": 1, "restock_type": "no_restock"}],
+            }
+        }
         refund_data = {
             "refund": {
                 "id": 222,
@@ -233,21 +247,23 @@ class TestShopifyRefundOrder:
         def _mock_get(url, *args, **kwargs):
             if url.endswith("/orders/450789469.json"):
                 return _mock_resp(order_data)
-            if url.endswith("/orders/450789469/transactions.json"):
-                return _mock_resp(tx_data)
             raise AssertionError(f"Unexpected GET URL: {url}")
+
+        def _mock_post(url, *args, **kwargs):
+            if url.endswith("/orders/450789469/refunds/calculate.json"):
+                return _mock_resp(calc_data)
+            if url.endswith("/orders/450789469/refunds.json"):
+                return _mock_resp(refund_data)
+            raise AssertionError(f"Unexpected POST URL: {url}")
 
         with (
             patch.dict("os.environ", ENV),
             patch("aden_tools.tools.shopify_tool.shopify_tool.httpx.get", side_effect=_mock_get),
-            patch(
-                "aden_tools.tools.shopify_tool.shopify_tool.httpx.post",
-                return_value=_mock_resp(refund_data),
-            ),
+            patch("aden_tools.tools.shopify_tool.shopify_tool.httpx.post", side_effect=_mock_post) as post_mock,
         ):
             result = tool_fns["shopify_refund_order"](
                 order_id="450789469",
-                amount="199.00",
+                amount="41.94",
                 note="Customer requested refund",
                 notify=False,
             )
@@ -255,6 +271,7 @@ class TestShopifyRefundOrder:
         assert result["id"] == 222
         assert result["order_id"] == 450789469
         assert result["result"] == "refunded"
+        assert post_mock.call_count == 2
 
 
 class TestShopifySendDraftOrderInvoice:

--- a/tools/tests/tools/test_shopify_tool.py
+++ b/tools/tests/tools/test_shopify_tool.py
@@ -227,6 +227,7 @@ class TestShopifyRefundOrder:
                 "line_items": [{"id": 518995019, "quantity": 1}],
             }
         }
+        refunds_data = {"refunds": []}
         calc_data = {
             "refund": {
                 "currency": "USD",
@@ -247,6 +248,8 @@ class TestShopifyRefundOrder:
         def _mock_get(url, *args, **kwargs):
             if url.endswith("/orders/450789469.json"):
                 return _mock_resp(order_data)
+            if url.endswith("/orders/450789469/refunds.json"):
+                return _mock_resp(refunds_data)
             raise AssertionError(f"Unexpected GET URL: {url}")
 
         def _mock_post(url, *args, **kwargs):
@@ -272,6 +275,56 @@ class TestShopifyRefundOrder:
         assert result["order_id"] == 450789469
         assert result["result"] == "refunded"
         assert post_mock.call_count == 2
+
+    def test_refund_subtracts_previous_refunds(self, tool_fns):
+        order_data = {
+            "order": {
+                "id": 450789469,
+                "currency": "USD",
+                "line_items": [{"id": 518995019, "quantity": 2}],
+            }
+        }
+        refunds_data = {"refunds": [{"refund_line_items": [{"line_item_id": 518995019, "quantity": 1}]}]}
+        calc_data = {
+            "refund": {
+                "currency": "USD",
+                "transactions": [{"parent_id": 801038806, "amount": "10.00", "kind": "refund", "gateway": "bogus"}],
+                "refund_line_items": [{"line_item_id": 518995019, "quantity": 1, "restock_type": "no_restock"}],
+            }
+        }
+        refund_data = {
+            "refund": {
+                "id": 223,
+                "order_id": 450789469,
+                "created_at": "2025-01-10T12:51:00-05:00",
+                "transactions": [{"id": 334, "amount": "10.00", "kind": "refund"}],
+            }
+        }
+
+        def _mock_get(url, *args, **kwargs):
+            if url.endswith("/orders/450789469.json"):
+                return _mock_resp(order_data)
+            if url.endswith("/orders/450789469/refunds.json"):
+                return _mock_resp(refunds_data)
+            raise AssertionError(f"Unexpected GET URL: {url}")
+
+        def _mock_post(url, *args, **kwargs):
+            if url.endswith("/orders/450789469/refunds/calculate.json"):
+                # quantity should be remaining (2 - 1)
+                assert kwargs["json"]["refund"]["refund_line_items"][0]["quantity"] == 1
+                return _mock_resp(calc_data)
+            if url.endswith("/orders/450789469/refunds.json"):
+                return _mock_resp(refund_data)
+            raise AssertionError(f"Unexpected POST URL: {url}")
+
+        with (
+            patch.dict("os.environ", ENV),
+            patch("aden_tools.tools.shopify_tool.shopify_tool.httpx.get", side_effect=_mock_get),
+            patch("aden_tools.tools.shopify_tool.shopify_tool.httpx.post", side_effect=_mock_post),
+        ):
+            result = tool_fns["shopify_refund_order"](order_id="450789469", amount="10.00")
+
+        assert result["id"] == 223
 
 
 class TestShopifySendDraftOrderInvoice:


### PR DESCRIPTION
## Description

Adds additional Shopify Admin REST API capabilities to the existing shopify_tool so agents can manage order lifecycle and collect payment via Shopify’s native invoice flow.

## Type of Change

- New feature (non-breaking change that adds functionality)
- Documentation update


## Related Issues

Fixes #2805 (tools/integrations meta issue)

## Changes Made

- Added shopify_cancel_order to cancel orders with optional reason, restock, email, and refund flags.
- Added shopify_refund_order to create a refund using the store’s configured gateway by selecting an existing capture/sale transaction.
- Added shopify_send_draft_order_invoice to send Shopify’s default draft-order invoice email for collecting due payment.
- Updated Shopify tool docs and added/updated unit tests.

## Testing

 - Unit tests pass (uv run -m pytest tools/tests/tools/test_shopify_tool.py -q)
 - Lint passes (cd core && ruff check .)
 - Manual testing performed (requires real Shopify store + API scopes)

## Checklist

-  My code follows the project's style guidelines
 - I have performed a self-review of my code
 - I have commented my code, particularly in hard-to-understand areas (not needed)
 - I have made corresponding changes to the documentation
 - My changes generate no new warnings (tests pass; no new runtime warnings expected)
 - I have added tests that prove my feature works
 - New and existing unit tests pass locally with my changes

## Required Shopify scopes for real usage:

- write_orders (cancel/refund)
- write_draft_orders (send invoice)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Four order-management tools: update order metadata (tags/note), cancel orders with reason/restock/refund options, process gateway refunds by amount (supports partial amount-only refunds), and send draft order invoices with custom subject/message.

* **Documentation**
  * README expanded with usage examples for each new tool, including partial-refund behavior and example payloads.

* **Tests**
  * Added tests covering validation failures and success flows, with mocked API interactions for each new tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->