### PR TITLE
fix(ci): unbreak main — ruff format, test_refs, test_model_catalog

### DIFF
--- a/core/tests/test_colony_runtime_overseer.py
+++ b/core/tests/test_colony_runtime_overseer.py
@@ -274,9 +274,12 @@ class TestReportToParent:
             worker = colony.get_worker(worker_ids[0])
             assert worker is not None
 
-            # Wait for the worker's background task to finish
+            # Wait for the worker to finish AND for the SUBAGENT_REPORT event
+            # to propagate. On Windows the event loop scheduling differs from
+            # POSIX, so a worker can be marked inactive a few ticks before the
+            # subscriber callback runs. Waiting on both avoids that race.
             deadline = asyncio.get_event_loop().time() + 5.0
-            while worker.is_active and asyncio.get_event_loop().time() < deadline:
+            while (worker.is_active or len(reports) == 0) and asyncio.get_event_loop().time() < deadline:
                 await asyncio.sleep(0.05)
             assert not worker.is_active, "Worker did not finish within timeout"
 

--- a/core/tests/test_model_catalog.py
+++ b/core/tests/test_model_catalog.py
@@ -150,6 +150,11 @@ def test_openrouter_catalog_tracks_current_frontier_set():
         "anthropic/claude-opus-4.6",
         "google/gemini-3.1-pro-preview-customtools",
         "deepseek/deepseek-v3.2",
+        "qwen/qwen3.6-plus",
+        "z-ai/glm-5v-turbo",
+        "x-ai/grok-4.20",
+        "xiaomi/mimo-v2-pro",
+        "stepfun/step-3.5-flash",
     ]
     assert openrouter_models[0]["max_tokens"] == 128000
     assert openrouter_models[0]["max_context_tokens"] == 922000

--- a/tools/src/gcu/browser/refs.py
+++ b/tools/src/gcu/browser/refs.py
@@ -50,6 +50,7 @@ CONTENT_ROLES: frozenset[str] = frozenset(
         "columnheader",
         "gridcell",
         "heading",
+        "img",
         "listitem",
         "main",
         "navigation",

--- a/tools/src/gcu/browser/tools/inspection.py
+++ b/tools/src/gcu/browser/tools/inspection.py
@@ -187,8 +187,7 @@ def _resize_and_annotate(
         )
     except Exception:
         logger.warning(
-            "Screenshot resize/annotate FAILED — returning original image. "
-            "css_width=%s, dpr=%s.",
+            "Screenshot resize/annotate FAILED — returning original image. css_width=%s, dpr=%s.",
             css_width,
             dpr,
             exc_info=True,

--- a/tools/src/gcu/browser/tools/interactions.py
+++ b/tools/src/gcu/browser/tools/interactions.py
@@ -546,10 +546,7 @@ def register_interaction_tools(mcp: FastMCP) -> None:
         if x > 1.5 or y > 1.5 or x < -0.1 or y < -0.1:
             result = {
                 "ok": False,
-                "error": (
-                    f"Coords ({x}, {y}) look like pixels. This tool expects "
-                    "fractions 0..1 of the viewport."
-                ),
+                "error": (f"Coords ({x}, {y}) look like pixels. This tool expects fractions 0..1 of the viewport."),
             }
             log_tool_call("browser_hover_coordinate", params, result=result)
             return result
@@ -627,10 +624,7 @@ def register_interaction_tools(mcp: FastMCP) -> None:
         if x > 1.5 or y > 1.5 or x < -0.1 or y < -0.1:
             result = {
                 "ok": False,
-                "error": (
-                    f"Coords ({x}, {y}) look like pixels. This tool expects "
-                    "fractions 0..1 of the viewport."
-                ),
+                "error": (f"Coords ({x}, {y}) look like pixels. This tool expects fractions 0..1 of the viewport."),
             }
             log_tool_call("browser_press_at", params, result=result)
             return result

--- a/tools/tests/test_refs.py
+++ b/tools/tests/test_refs.py
@@ -45,8 +45,9 @@ class TestAnnotateSnapshot:
     def test_skips_structural_roles(self):
         annotated, ref_map = annotate_snapshot(SAMPLE_SNAPSHOT)
         roles_in_map = {entry.role for entry in ref_map.values()}
-        # navigation, main, list, listitem, paragraph are structural — no refs
-        assert "navigation" not in roles_in_map
+        # main (unnamed), list, listitem (unnamed), paragraph are structural — no refs.
+        # Note: navigation is a landmark role and now gets a ref when named, so it
+        # is not asserted absent here.
         assert "main" not in roles_in_map
         assert "list" not in roles_in_map
         assert "listitem" not in roles_in_map


### PR DESCRIPTION
## Description

Unblock CI on `main` by fixing all three failing checks. Last 8 CI runs on `main` have been failing.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #7083

## Changes Made

**1. Lint Python (ruff format)**
- Reformat `tools/src/gcu/browser/tools/inspection.py`
- Reformat `tools/src/gcu/browser/tools/interactions.py`

**2. Test Tools (`test_refs.py`)**
- Add `img` back to `CONTENT_ROLES` in `refs.py`. The recent `cc6ec97a feat: multiple modes browser snapshot tool` refactor renamed `NAMED_CONTENT_ROLES` → `CONTENT_ROLES` and accidentally dropped `img`, breaking `test_named_content_roles_get_refs`.
- Drop the `navigation` assertion from `test_skips_structural_roles`. The same refactor intentionally added landmark roles (navigation, main, listitem) to `CONTENT_ROLES` so AI agents can ref them by name, and the test was not updated to match.

**3. Test Python Framework (`test_model_catalog.py`)**
- Add 5 openrouter models (qwen3.6-plus, glm-5v-turbo, grok-4.20, mimo-v2-pro, step-3.5-flash) that were added to `model_catalog.json` by #7081 (UI/UX improvements) but not reflected in the test.

## Testing

- [x] Lint passes (`uv run --project core ruff check core/ tools/`)
- [x] Lint passes (`uv run --project core ruff format --check core/ tools/`)
- [x] `tools/tests/test_refs.py` — 19/19 pass
- [x] `core/tests/test_model_catalog.py` — 14/14 pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded model catalog test to include five additional curated models.
  * Refined annotation logic test expectations.
  * Improved a runtime test to reduce intermittent timing/race failures.

* **Refactor**
  * Cleaned up error/log message formatting.
  * Annotation logic now treats named image elements as eligible for reference markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->