### PR TITLE
Fix inconsistent cancellation behavior for long-running executions

### DIFF
--- a/core/framework/host/execution_manager.py
+++ b/core/framework/host/execution_manager.py
@@ -131,6 +131,7 @@ class ExecutionContext:
     started_at: datetime = field(default_factory=datetime.now)
     completed_at: datetime | None = None
     status: str = "pending"  # pending, running, completed, failed, paused
+    cancellation_state: str | None = None  # "graceful", "detached"
 
 
 class ExecutionManager:
@@ -948,6 +949,13 @@ class ExecutionManager:
                 self._write_run_event(execution_id, ctx.run_id, "run_failed", {"error": str(e)})
 
             finally:
+                # If cancellation timed out earlier, the execution may have continued
+                # running in a non-cancellable context (e.g., LLM call, thread executor).
+                # At this point, the task has finally completed — log it for observability
+                # since the system may have already marked it as cancelled/detached.
+                ctx = self._active_executions.get(execution_id)
+                if ctx and getattr(ctx, "cancellation_state", None) == "detached":
+                    logger.warning(f"Detached execution {execution_id} finished after cancellation")
                 # Clean up state
                 self._state_manager.cleanup_execution(execution_id)
 
@@ -1212,13 +1220,13 @@ class ExecutionManager:
                 # The task will continue winding down in the background and its
                 # finally block will harmlessly pop already-removed keys.
                 logger.warning(
-                    "Execution %s did not finish within cancel timeout; force-cleaning bookkeeping",
-                    execution_id,
+                     "Execution %s did not finish within cancel timeout; marking as detached",
+                     execution_id
                 )
-                async with self._lock:
-                    self._active_executions.pop(execution_id, None)
-                    self._execution_tasks.pop(execution_id, None)
-                self._active_executors.pop(execution_id, None)
+                ctx = self._active_executions.get(execution_id)
+                if ctx:
+                    ctx.cancellation_state = "detached"
+                    ctx.status = "cancelling"
             return True
         return False
 


### PR DESCRIPTION
## Description

Improves execution cancellation behavior by addressing cases where tasks may continue running after cancellation is reported as successful.

In certain scenarios (e.g., LLM API calls, thread executors, or long-running tools), Python async cancellation is best-effort and does not guarantee termination. This change ensures such cases are handled more accurately and transparently.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #7082

## Changes Made

* Introduced `cancellation_state` to explicitly track detached executions
* Avoided premature removal of execution bookkeeping when cancellation times out
* Marked executions as `"cancelling"` when termination cannot be guaranteed
* Added logging to surface executions that complete after being marked as detached

## Testing

* [ ] Unit tests pass (`cd core && pytest tests/`)
* [x] Lint passes (`cd core && ruff check .`)
* [x] Manual testing performed

Notes:

* Lint checks passed locally (`ruff`)
* Full test suite shows unrelated collection errors — happy to adjust based on CI feedback

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes

## Additional Notes

Opening PR after initial implementation while awaiting assignment — happy to refine based on feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved execution cancellation behavior to gracefully mark executions as detached when cancellation timeout is exceeded, instead of forcefully terminating them.
  * Added warning logs for executions that complete after cancellation timeout, improving visibility into delayed execution completions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->