### PR TITLE
fix(llm): ensure store=False is passed to Codex Responses API

### DIFF
--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -1959,6 +1959,10 @@ class LiteLLMProvider(LLMProvider):
         if self._codex_backend:
             kwargs.pop("max_tokens", None)
             kwargs.pop("stream_options", None)
+            # Pass store directly to OpenAI in case litellm drops it as unknown
+            if "extra_body" not in kwargs:
+                kwargs["extra_body"] = {}
+            kwargs["extra_body"]["store"] = False
 
         request_summary = _summarize_request_for_log(kwargs)
         logger.debug(


### PR DESCRIPTION
## Description
Forces `store: false` into the `extra_body` payload for Codex-style models so that LiteLLM successfully passes it down to the ChatGPT Responses API backend, fixing the `BadRequestError`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #7056

## Changes Made

- Updated `core/framework/llm/litellm.py` to check if `self._codex_backend` is true.
- Injected `kwargs["extra_body"]["store"] = False` into the payload before the request is dispatched.

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
<img width="1906" height="947" alt="image" src="https://github.com/user-attachments/assets/0a2bdba7-41b4-4db0-8d10-5870e5b546fe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling for ChatGPT backend integration to ensure configuration parameters are correctly passed through to the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->