### PR TITLE
fix(llm): surface user-friendly message when rate limit retries exhausted

### DIFF
--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -2294,7 +2294,21 @@ class LiteLLMProvider(LLMProvider):
                     )
                     await asyncio.sleep(wait)
                     continue
-                yield StreamErrorEvent(error=str(e), recoverable=False)
+                logger.error(
+                    "[stream] %s: rate limit exhausted after %d attempts: %s",
+                    self.model,
+                    RATE_LIMIT_MAX_RETRIES,
+                    e,
+                )
+                yield StreamErrorEvent(
+                    error=(
+                        f"Rate limit exceeded for model '{self.model}'. "
+                        f"All {RATE_LIMIT_MAX_RETRIES} retry attempts exhausted. "
+                        "Please wait before retrying, reduce request frequency, "
+                        "or check your quota."
+                    ),
+                    recoverable=False,
+                )
                 return
 
             except Exception as e:


### PR DESCRIPTION
## Description

When all `RATE_LIMIT_MAX_RETRIES` streaming attempts fail with a 429 `RateLimitError`, the raw provider exception string was passed directly into `StreamErrorEvent.error`. This verbose API dump (provider-specific quota IDs, request details, etc.) propagated to the UI unchanged, making it impossible for users to understand or recover from the error.

**Fix:** At the single `RateLimitError` exhaustion site in `_stream_completion_with_retry`:
- Log the raw exception at `ERROR` level for debugging/tracing
- Yield a clean, actionable `StreamErrorEvent` message that names the model, the retry count, and concrete recovery options

The raw error is preserved in logs; users see a clean message.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #7067

## Testing

- [ ] Unit tests pass (`cd core && uv run pytest tests/`)
- [x] Lint passes (`cd core && uv run ruff check .`)
- [x] Manual testing: triggered rate limit with low-quota key; verified UI shows friendly message instead of raw API error

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when API rate limits are exhausted. Users now receive clearer, actionable guidance explaining quota exhaustion and retry recommendations instead of generic error text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->