### PR TITLE
fix(host): make cancel_execution timeout configurable via env var

### DIFF
--- a/core/framework/host/execution_manager.py
+++ b/core/framework/host/execution_manager.py
@@ -50,6 +50,10 @@ logger = logging.getLogger(__name__)
 
 CancelExecutionResult = Literal["cancelled", "cancelling", "not_found"]
 
+# How long cancel_execution waits for a task to exit before returning "cancelling".
+# Override with HIVE_CANCEL_TIMEOUT_SECONDS for environments with slow LLM teardown.
+_CANCEL_TIMEOUT_SECONDS: float = float(os.environ.get("HIVE_CANCEL_TIMEOUT_SECONDS", "5.0"))
+
 
 class GraphScopedEventBus(EventBus):
     """Proxy that stamps ``graph_id`` on every published event.
@@ -436,11 +440,12 @@ class ExecutionManager:
         if tasks_to_wait:
             # Wait briefly — don't block indefinitely if tasks are stuck
             # in long-running operations (LLM calls, tool executions).
-            _, pending = await asyncio.wait(tasks_to_wait, timeout=5.0)
+            _, pending = await asyncio.wait(tasks_to_wait, timeout=_CANCEL_TIMEOUT_SECONDS)
             if pending:
                 logger.warning(
-                    "%d execution task(s) did not finish within 5s after cancellation",
+                    "%d execution task(s) did not finish within %.1fs after cancellation",
                     len(pending),
+                    _CANCEL_TIMEOUT_SECONDS,
                 )
 
         logger.info(f"ExecutionStream '{self.stream_id}' stopped")
@@ -1240,15 +1245,17 @@ class ExecutionManager:
         # Wait briefly for the task to finish. Don't block indefinitely —
         # the task may be stuck in a long LLM API call that doesn't
         # respond to cancellation quickly.
-        done, _ = await asyncio.wait({task}, timeout=5.0)
+        done, _ = await asyncio.wait({task}, timeout=_CANCEL_TIMEOUT_SECONDS)
         if not done:
             # Keep bookkeeping in place until the task's own finally block runs.
             # We intentionally do not add deferred cleanup keyed by execution_id
             # here because resumed executions reuse the same id; a delayed pop
             # could otherwise delete bookkeeping that belongs to the new run.
             logger.warning(
-                "Execution %s did not finish within cancel timeout; leaving bookkeeping in place until task exit",
+                "Execution %s did not finish within %.1fs cancel timeout; "
+                "task will be detached. Set HIVE_CANCEL_TIMEOUT_SECONDS to adjust.",
                 execution_id,
+                _CANCEL_TIMEOUT_SECONDS,
             )
             return "cancelling"
         return "cancelled"


### PR DESCRIPTION
## Description

Both cancellation paths in `ExecutionManager` hard-coded a 5-second grace period before returning `"cancelling"` for tasks stuck in LLM API calls or slow tool executions. There was no way to tune this for slow models, high-latency environments, or fast CI runs, and the log message gave no hint about the knob.

**Fix:**
- Introduce `_CANCEL_TIMEOUT_SECONDS` (default `5.0`) at module level
- Read `HIVE_CANCEL_TIMEOUT_SECONDS` env var at import time to allow override
- Update both `asyncio.wait` call sites (`cancel_execution` and `stop`/shutdown path)
- Log messages now include the actual timeout value and the env var name so operators can diagnose and adjust without reading source

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #7082

## Testing

- [ ] Unit tests pass (`cd core && uv run pytest tests/`)
- [x] Lint passes (`cd core && uv run ruff check .`)
- [x] Manual testing: `HIVE_CANCEL_TIMEOUT_SECONDS=1 ...` — verified log shows correct timeout value and env var hint

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Cancellation grace period for task termination is now configurable via the `HIVE_CANCEL_TIMEOUT_SECONDS` environment variable, providing greater flexibility over execution management behavior (default: 5.0 seconds).
  * Enhanced logging and warning messages to clearly display actual timeout values and reference the configuration option for adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->