### PR TITLE
fix(ci): unbreak main, ruff format browser and refresh test_model_catalog

### DIFF
--- a/core/tests/test_model_catalog.py
+++ b/core/tests/test_model_catalog.py
@@ -67,14 +67,11 @@ def test_cerebras_catalog_tracks_public_models_endpoint():
     assert cerebras_default == "gpt-oss-120b"
     assert [model["id"] for model in cerebras_models] == [
         "gpt-oss-120b",
-        "llama3.1-8b",
         "zai-glm-4.7",
         "qwen-3-235b-a22b-instruct-2507",
     ]
-    assert cerebras_models[0]["max_tokens"] == 40960
-    assert cerebras_models[0]["max_context_tokens"] == 131072
-    assert cerebras_models[1]["max_tokens"] == 8192
-    assert cerebras_models[1]["max_context_tokens"] == 32768
+    assert all(model["max_tokens"] == 40960 for model in cerebras_models)
+    assert all(model["max_context_tokens"] == 131072 for model in cerebras_models)
 
 
 def test_minimax_catalog_tracks_current_non_legacy_text_models():
@@ -86,8 +83,8 @@ def test_minimax_catalog_tracks_current_non_legacy_text_models():
         "MiniMax-M2.7",
         "MiniMax-M2.5",
     ]
-    assert all(model["max_context_tokens"] == 204800 for model in minimax_models)
-    assert all(model["max_tokens"] == 32768 for model in minimax_models)
+    assert all(model["max_context_tokens"] == 180000 for model in minimax_models)
+    assert all(model["max_tokens"] == 40960 for model in minimax_models)
 
 
 def test_mistral_catalog_tracks_current_curated_models():
@@ -149,26 +146,25 @@ def test_openrouter_catalog_tracks_current_frontier_set():
         "anthropic/claude-sonnet-4.6",
         "anthropic/claude-opus-4.6",
         "google/gemini-3.1-pro-preview-customtools",
-        "deepseek/deepseek-v3.2",
         "qwen/qwen3.6-plus",
         "z-ai/glm-5v-turbo",
-        "x-ai/grok-4.20",
+        "z-ai/glm-5.1",
+        "minimax/minimax-m2.7",
         "xiaomi/mimo-v2-pro",
-        "stepfun/step-3.5-flash",
     ]
     assert openrouter_models[0]["max_tokens"] == 128000
-    assert openrouter_models[0]["max_context_tokens"] == 922000
-    assert openrouter_models[1]["max_context_tokens"] == 936000
+    assert openrouter_models[0]["max_context_tokens"] == 872000
+    assert openrouter_models[1]["max_context_tokens"] == 872000
     assert openrouter_models[2]["max_context_tokens"] == 872000
-    assert openrouter_models[3]["max_context_tokens"] == 1048576
-    assert openrouter_models[4]["max_context_tokens"] == 163840
+    assert openrouter_models[3]["max_context_tokens"] == 872000
+    assert openrouter_models[4]["max_context_tokens"] == 240000
 
 
 def test_find_model_any_provider_returns_provider_and_model():
     provider_id, model = model_catalog.find_model_any_provider("google/gemini-3.1-pro-preview-customtools")
 
     assert provider_id == "openrouter"
-    assert model["max_context_tokens"] == 1048576
+    assert model["max_context_tokens"] == 872000
 
 
 def test_get_preset_returns_subscription_specific_limits():
@@ -187,8 +183,8 @@ def test_minimax_preset_uses_current_default_model():
 
     assert preset is not None
     assert preset["model"] == "MiniMax-M2.7"
-    assert preset["max_tokens"] == 32768
-    assert preset["max_context_tokens"] == 204800
+    assert preset["max_tokens"] == 40960
+    assert preset["max_context_tokens"] == 180800
 
 
 def test_load_model_catalog_rejects_duplicate_model_ids(tmp_path, monkeypatch):

--- a/tools/src/gcu/browser/bridge.py
+++ b/tools/src/gcu/browser/bridge.py
@@ -469,11 +469,13 @@ class BeelineBridge:
                     parsed = json.loads(payload)
                 except Exception:
                     parsed = {"_raw": payload}
-                write_log({
-                    "type": "viewport_event",
-                    "tab_id": tab_id,
-                    **parsed,
-                })
+                write_log(
+                    {
+                        "type": "viewport_event",
+                        "tab_id": tab_id,
+                        **parsed,
+                    }
+                )
                 return
 
             # Attach-time canary → attach_canary (proves extension
@@ -483,11 +485,13 @@ class BeelineBridge:
                     parsed = json.loads(payload)
                 except Exception:
                     parsed = {"_raw": payload}
-                write_log({
-                    "type": "attach_canary",
-                    "tab_id": tab_id,
-                    **parsed,
-                })
+                write_log(
+                    {
+                        "type": "attach_canary",
+                        "tab_id": tab_id,
+                        **parsed,
+                    }
+                )
                 return
 
             # Everything else — keep a compact row so we can tell
@@ -503,24 +507,28 @@ class BeelineBridge:
                     compact.append(v[:120])
                 elif v is not None:
                     compact.append(str(v)[:120])
-            write_log({
-                "type": "cdp_event",
-                "tab_id": tab_id,
-                "method": method,
-                "level": params.get("type"),
-                "args": compact,
-            })
+            write_log(
+                {
+                    "type": "cdp_event",
+                    "tab_id": tab_id,
+                    "method": method,
+                    "level": params.get("type"),
+                    "args": compact,
+                }
+            )
             return
 
         # Other forwarded events (Page.lifecycleEvent, frameResized,
         # frameNavigated, Target.targetInfoChanged) are rare and high
         # signal — keep the full param dict but truncate strings.
-        write_log({
-            "type": "cdp_event",
-            "tab_id": tab_id,
-            "method": method,
-            "params": params,
-        })
+        write_log(
+            {
+                "type": "cdp_event",
+                "tab_id": tab_id,
+                "method": method,
+                "params": params,
+            }
+        )
 
         # Main-frame navigation wipes the previous document's scripts.
         # Our [hive_vp] probe's event listeners die with it. Reinstall
@@ -541,6 +549,7 @@ class BeelineBridge:
         if method == "Page.frameResized" and tab_id is not None:
             try:
                 from .tools.inspection import _viewport_sizes
+
                 _viewport_sizes.pop(tab_id, None)
             except Exception:
                 pass
@@ -550,6 +559,7 @@ class BeelineBridge:
         current document of ``tab_id``. Called from sync context
         inside ``_handle_cdp_event``, so we create a task on the
         running loop. Failures are silent."""
+
         async def _do() -> None:
             try:
                 # The new document's global scope doesn't have
@@ -566,6 +576,7 @@ class BeelineBridge:
                 )
             except Exception:
                 pass
+
         try:
             asyncio.get_event_loop().create_task(_do())
         except RuntimeError:
@@ -868,8 +879,7 @@ class BeelineBridge:
                 {
                     "expression": (
                         "console.info('[hive_attach_canary]', "
-                        "JSON.stringify({tabId: "
-                        + str(tab_id) + ", ts: Date.now()}))"
+                        "JSON.stringify({tabId: " + str(tab_id) + ", ts: Date.now()}))"
                     ),
                     "returnByValue": True,
                     "awaitPromise": False,
@@ -1379,9 +1389,7 @@ class BeelineBridge:
             # `(function(){ return (...)(x,y) })()` and the value
             # actually comes back — without it the wrapper drops
             # the result on the floor (returns undefined).
-            probe_result = await self.evaluate(
-                tab_id, f"return ({_HIT_ELEMENT_JS})({x}, {y})"
-            )
+            probe_result = await self.evaluate(tab_id, f"return ({_HIT_ELEMENT_JS})({x}, {y})")
             hit_probe = (probe_result or {}).get("result")
         except Exception:
             hit_probe = None
@@ -1410,16 +1418,19 @@ class BeelineBridge:
         if hit_probe is not None:
             try:
                 from .telemetry import write_log
-                write_log({
-                    "type": "click_hit_probe",
-                    "tab_id": tab_id,
-                    "intended": {"x": x, "y": y},
-                    "viewport": hit_probe.get("viewport"),
-                    "hit": hit_probe.get("hit"),
-                    "stack": hit_probe.get("stack"),
-                    "sweep": hit_probe.get("sweep"),
-                    "offsetInRect": hit_probe.get("offsetInRect"),
-                })
+
+                write_log(
+                    {
+                        "type": "click_hit_probe",
+                        "tab_id": tab_id,
+                        "intended": {"x": x, "y": y},
+                        "viewport": hit_probe.get("viewport"),
+                        "hit": hit_probe.get("hit"),
+                        "stack": hit_probe.get("stack"),
+                        "sweep": hit_probe.get("sweep"),
+                        "offsetInRect": hit_probe.get("offsetInRect"),
+                    }
+                )
             except Exception:
                 pass
         return resp

--- a/tools/src/gcu/browser/tools/inspection.py
+++ b/tools/src/gcu/browser/tools/inspection.py
@@ -240,23 +240,22 @@ async def _ensure_viewport_size(tab_id: int, _caller: str = "unknown") -> tuple[
 
     try:
         from ..telemetry import write_log
-        write_log({
-            "type": "viewport_sample",
-            "tab_id": tab_id,
-            "caller": _caller,
-            "live_w": cw,
-            "live_h": ch,
-            "cached_w": cached_before[0] if cached_before else None,
-            "cached_h": cached_before[1] if cached_before else None,
-            "deltaH_vs_cache": (
-                (ch - cached_before[1])
-                if (cached_before and ch > 0)
-                else None
-            ),
-            "returned_w": result_cw,
-            "returned_h": result_ch,
-            "evaluate_error": evaluate_error,
-        })
+
+        write_log(
+            {
+                "type": "viewport_sample",
+                "tab_id": tab_id,
+                "caller": _caller,
+                "live_w": cw,
+                "live_h": ch,
+                "cached_w": cached_before[0] if cached_before else None,
+                "cached_h": cached_before[1] if cached_before else None,
+                "deltaH_vs_cache": ((ch - cached_before[1]) if (cached_before and ch > 0) else None),
+                "returned_w": result_cw,
+                "returned_h": result_ch,
+                "evaluate_error": evaluate_error,
+            }
+        )
     except Exception:
         pass
 
@@ -362,31 +361,32 @@ def register_inspection_tools(mcp: FastMCP) -> None:
             # physical_scale is derived from pngWidth.
             try:
                 from ..telemetry import write_log
+
                 expected_w = css_width * dpr
                 expected_h = css_height_raw * dpr
-                write_log({
-                    "type": "screenshot_geometry",
-                    "tab_id": target_tab,
-                    "url": screenshot_result.get("url", ""),
-                    "pngWidth": png_w,
-                    "pngHeight": png_h,
-                    "cssWidth": css_width,
-                    "cssHeight": css_height_raw,
-                    "dpr": dpr,
-                    "expectedPngWidth": expected_w,
-                    "expectedPngHeight": expected_h,
-                    "deltaPngWidthPx": png_w - expected_w,
-                    "deltaPngHeightPx": png_h - expected_h,
-                    # If the PNG is taller than cssHeight×dpr (e.g. a
-                    # devtools-attached banner adds rows above the page
-                    # in the capture), clicks land BELOW intended at
-                    # the top of the page and converge to 0 error at
-                    # the bottom. Reverse signs if PNG is shorter.
-                    # Worst-case error in CSS px at fy=0:
-                    "yErrorAtTopCssPx": (
-                        (png_h - expected_h) / dpr if dpr else 0
-                    ),
-                })
+                write_log(
+                    {
+                        "type": "screenshot_geometry",
+                        "tab_id": target_tab,
+                        "url": screenshot_result.get("url", ""),
+                        "pngWidth": png_w,
+                        "pngHeight": png_h,
+                        "cssWidth": css_width,
+                        "cssHeight": css_height_raw,
+                        "dpr": dpr,
+                        "expectedPngWidth": expected_w,
+                        "expectedPngHeight": expected_h,
+                        "deltaPngWidthPx": png_w - expected_w,
+                        "deltaPngHeightPx": png_h - expected_h,
+                        # If the PNG is taller than cssHeight×dpr (e.g. a
+                        # devtools-attached banner adds rows above the page
+                        # in the capture), clicks land BELOW intended at
+                        # the top of the page and converge to 0 error at
+                        # the bottom. Reverse signs if PNG is shorter.
+                        # Worst-case error in CSS px at fy=0:
+                        "yErrorAtTopCssPx": ((png_h - expected_h) / dpr if dpr else 0),
+                    }
+                )
             except Exception:
                 pass
 

--- a/tools/src/gcu/browser/tools/interactions.py
+++ b/tools/src/gcu/browser/tools/interactions.py
@@ -64,11 +64,7 @@ async def _build_visual_response(result: dict, bridge, target_tab: int | None) -
         shot = await bridge.screenshot(target_tab, full_page=False)
         if not shot.get("ok"):
             return [text_block]
-        highlights = (
-            [_interaction_highlights[target_tab]]
-            if target_tab in _interaction_highlights
-            else None
-        )
+        highlights = [_interaction_highlights[target_tab]] if target_tab in _interaction_highlights else None
         data, _ = await asyncio.to_thread(
             _resize_and_annotate,
             shot["data"],


### PR DESCRIPTION
Fixes #7094.

Main CI has been red since `bb39424e` (~10h ago). Two independent issues, split into two commits.

## Commit 1: `chore: ruff format browser bridge and tools`

Three files pushed to main without running `ruff format`:
- `tools/src/gcu/browser/bridge.py`
- `tools/src/gcu/browser/tools/inspection.py`
- `tools/src/gcu/browser/tools/interactions.py`

Pure formatting. Introduced by direct-to-main commits `e55cea97 fix: diagnostics` and `e2bfb9d3 fix: frame resize`.

## Commit 2: `fix(tests): refresh test_model_catalog expectations after catalog drift` (incoming)

Five assertions in `core/tests/test_model_catalog.py` drifted from the JSON catalog after `b27c7a02 chore: update openrouter model selections` and `bb39424e chore: update model context config`:
- cerebras list: dropped `llama3.1-8b`; collapsed per-index token asserts to `all(...)` since the 3 remaining models share limits
- minimax: `max_context_tokens` 204800 to 180000, `max_tokens` 32768 to 40960
- openrouter list now 9 models (dropped `deepseek-v3.2`, `grok-4.20`, `stepfun/step-3.5-flash`; added `z-ai/glm-5.1`, `minimax/minimax-m2.7`); frontier tier context 872000
- `find_model_any_provider` gemini-3.1 context 1048576 to 872000
- minimax preset: max_tokens 40960, max_context_tokens 180800

## Test plan

- [x] `uv run --project tools ruff format --check tools/src/gcu/browser/` passes
- [x] `uv run --project tools ruff check tools/src/gcu/browser/` passes
- [x] `uv run --project core pytest tests/test_model_catalog.py` passes (14/14)
- [ ] CI green

## Note

This is the second time in 3 days the same shape of breakage hit main (#7084 fixed the same thing). Worth making CI a required status check on main so chore commits can't skip it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized telemetry/log formatting and minor code formatting for consistency and maintainability.
* **Tests**
  * Updated provider catalog expectations: adjusted model listings and revised token/context limits to reflect current curated values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->