### PR TITLE
fix(credentials): raise CredentialError when Aden sync init fails with API key set

### DIFF
--- a/core/framework/agent_loop/internals/cursor_persistence.py
+++ b/core/framework/agent_loop/internals/cursor_persistence.py
@@ -162,9 +162,7 @@ async def drain_injection_queue(
     conversation: NodeConversation,
     *,
     ctx: NodeContext,
-    caption_image_fn: (
-        Callable[[str, list[dict[str, Any]]], Awaitable[tuple[str, str] | None]] | None
-    ) = None,
+    caption_image_fn: (Callable[[str, list[dict[str, Any]]], Awaitable[tuple[str, str] | None]] | None) = None,
 ) -> int:
     """Drain all pending injected events as user messages. Returns count.
 
@@ -196,9 +194,7 @@ async def drain_injection_queue(
                     ctx.llm.model,
                 )
                 if caption_image_fn is not None:
-                    intent = content or (
-                        "Describe these user-injected images for a text-only agent."
-                    )
+                    intent = content or ("Describe these user-injected images for a text-only agent.")
                     caption_result = await caption_image_fn(intent, image_content)
                     if caption_result:
                         description, vision_model = caption_result

--- a/core/framework/agent_loop/internals/vision_fallback.py
+++ b/core/framework/agent_loop/internals/vision_fallback.py
@@ -203,9 +203,7 @@ async def caption_tool_image(
     # with "LLM Provider NOT provided."
     from framework.llm.litellm import rewrite_proxy_model
 
-    rewritten_model, rewritten_base, extra_headers = rewrite_proxy_model(
-        model, api_key, api_base
-    )
+    rewritten_model, rewritten_base, extra_headers = rewrite_proxy_model(model, api_key, api_base)
 
     kwargs: dict[str, Any] = {
         "model": rewritten_model,

--- a/core/framework/credentials/store.py
+++ b/core/framework/credentials/store.py
@@ -803,5 +803,14 @@ class CredentialStore:
             return cls(storage=local_storage, **kwargs)
 
         except Exception as e:
-            logger.warning(f"Failed to setup Aden sync: {e}. Using local storage.")
-            return cls(storage=local_storage, **kwargs)
+            from .models import CredentialError
+
+            logger.error(
+                "Aden sync initialization failed with ADEN_API_KEY configured: %s",
+                e,
+            )
+            raise CredentialError(
+                f"Failed to initialize Aden sync: {e}. "
+                "ADEN_API_KEY is set but the sync provider could not start. "
+                "Fix the configuration or unset ADEN_API_KEY to use local storage."
+            ) from e

--- a/core/framework/credentials/store.py
+++ b/core/framework/credentials/store.py
@@ -762,7 +762,7 @@ class CredentialStore:
             logger.info("ADEN_API_KEY not set, using local-only credential storage")
             return cls(storage=local_storage, **kwargs)
 
-        # Try to setup Aden sync
+        # Try to import Aden components
         try:
             from .aden import (
                 AdenCachedStorage,
@@ -770,7 +770,12 @@ class CredentialStore:
                 AdenCredentialClient,
                 AdenSyncProvider,
             )
+        except ImportError:
+            logger.warning("Aden components not available, using local storage")
+            return cls(storage=local_storage, **kwargs)
 
+        # Try to setup Aden sync
+        try:
             # Create Aden client
             client = AdenCredentialClient(AdenClientConfig(base_url=base_url))
 
@@ -797,10 +802,6 @@ class CredentialStore:
                 logger.info(f"Synced {synced} credentials from Aden server")
 
             return store
-
-        except ImportError:
-            logger.warning("Aden components not available, using local storage")
-            return cls(storage=local_storage, **kwargs)
 
         except Exception as e:
             from .models import CredentialError

--- a/core/frontend/.gitignore
+++ b/core/frontend/.gitignore
@@ -1,0 +1,15 @@
+
+# === Security: Secret files (auto-added by Secret Sentinel) ===
+.env
+.env.*
+!.env.example
+!.env.template
+.vercel/.env.*
+*.pem
+*.key
+serviceAccountKey*.json
+firebase-service-account*.json
+*.p12
+*.pfx
+.vercel/
+.railway/

--- a/core/frontend/DEPLOY_CHECKLIST.md
+++ b/core/frontend/DEPLOY_CHECKLIST.md
@@ -1,0 +1,29 @@
+# Deployment Security Checklist
+
+Before deploying to any platform (Vercel, Railway, Cloudflare, etc.):
+
+## Secrets
+- [ ] All secrets are in environment variables, NOT in code
+- [ ] .env files are in .gitignore
+- [ ] .env.example exists with placeholder values (no real secrets)
+- [ ] No API keys hardcoded in config files (use env vars)
+- [ ] Firebase config uses env vars, not hardcoded keys
+- [ ] Database URLs use env vars
+
+## Platform Configuration
+- [ ] Enable "Sensitive Environment Variables" on Vercel
+- [ ] Use scoped/restricted API keys (not unrestricted)
+- [ ] Set spending limits on AI provider keys (Gemini, OpenAI, etc.)
+- [ ] Different secrets for staging vs production
+- [ ] Enable 2FA/MFA on the deployment platform
+
+## Git
+- [ ] Pre-commit hook is installed (blocks secrets)
+- [ ] Secret scanning is enabled on GitHub repo
+- [ ] .gitignore covers .env, .vercel/, keys, certs
+
+## After Deployment
+- [ ] Delete any pulled production env files (.vercel/.env.*.local)
+- [ ] Never store production secrets locally long-term
+- [ ] Set up billing alerts on cloud platforms
+- [ ] Document which secrets go where in .env.example

--- a/core/tests/test_aden_sync_error.py
+++ b/core/tests/test_aden_sync_error.py
@@ -1,0 +1,92 @@
+"""Tests for with_aden_sync error handling (issue #5859).
+
+When ADEN_API_KEY is set but Aden sync initialization fails,
+CredentialStore.with_aden_sync() must raise CredentialError
+instead of silently falling back to local storage.
+"""
+
+import sys
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+
+from framework.credentials.models import CredentialError
+from framework.credentials.store import CredentialStore
+
+
+def _stub_aden_modules(monkeypatch, *, sync_all_side_effect=None, init_side_effect=None):
+    """Install fake aden sub-modules so ImportError is not raised."""
+    aden_mod = ModuleType("framework.credentials.aden")
+
+    class FakeConfig:
+        def __init__(self, **kw):
+            pass
+
+    class FakeClient:
+        def __init__(self, config):
+            if init_side_effect:
+                raise init_side_effect
+
+    class FakeProvider:
+        def __init__(self, **kw):
+            pass
+
+        def sync_all(self, store):
+            if sync_all_side_effect:
+                raise sync_all_side_effect
+            return 0
+
+    class FakeCachedStorage:
+        def __init__(self, **kw):
+            pass
+
+    aden_mod.AdenClientConfig = FakeConfig
+    aden_mod.AdenCredentialClient = FakeClient
+    aden_mod.AdenSyncProvider = FakeProvider
+    aden_mod.AdenCachedStorage = FakeCachedStorage
+
+    monkeypatch.setitem(sys.modules, "framework.credentials.aden", aden_mod)
+
+
+def test_raises_when_api_key_set_and_init_fails(monkeypatch, tmp_path):
+    """ADEN_API_KEY present + client init raises → CredentialError."""
+    monkeypatch.setenv("ADEN_API_KEY", "test-key-123")
+    _stub_aden_modules(
+        monkeypatch,
+        init_side_effect=ConnectionError("connection refused"),
+    )
+
+    with pytest.raises(CredentialError, match="Failed to initialize Aden sync"):
+        CredentialStore.with_aden_sync(local_path=str(tmp_path / "creds"))
+
+
+def test_raises_when_api_key_set_and_sync_fails(monkeypatch, tmp_path):
+    """ADEN_API_KEY present + sync_all raises → CredentialError."""
+    monkeypatch.setenv("ADEN_API_KEY", "test-key-123")
+    _stub_aden_modules(
+        monkeypatch,
+        sync_all_side_effect=RuntimeError("server returned 500"),
+    )
+
+    with pytest.raises(CredentialError, match="Failed to initialize Aden sync"):
+        CredentialStore.with_aden_sync(local_path=str(tmp_path / "creds"))
+
+
+def test_falls_back_when_no_api_key(monkeypatch, tmp_path):
+    """No ADEN_API_KEY → local-only storage, no error."""
+    monkeypatch.delenv("ADEN_API_KEY", raising=False)
+
+    store = CredentialStore.with_aden_sync(local_path=str(tmp_path / "creds"))
+    assert store is not None
+
+
+def test_falls_back_when_aden_not_installed(monkeypatch, tmp_path):
+    """ADEN_API_KEY set but aden package missing → local fallback (ImportError)."""
+    monkeypatch.setenv("ADEN_API_KEY", "test-key-123")
+    # Ensure the aden module cannot be imported
+    monkeypatch.delitem(sys.modules, "framework.credentials.aden", raising=False)
+
+    with patch.dict(sys.modules, {"framework.credentials.aden": None}):
+        store = CredentialStore.with_aden_sync(local_path=str(tmp_path / "creds"))
+        assert store is not None


### PR DESCRIPTION
## Summary

`CredentialStore.with_aden_sync()` silently falls back to local storage when `ADEN_API_KEY` is configured but initialization fails (connection errors, auth failures, etc.). This masks real configuration problems — users think they have Aden sync but are actually running local-only.

## Changes

**`core/framework/credentials/store.py`**  
- The broad `except Exception` handler now raises `CredentialError` with a descriptive message when `ADEN_API_KEY` is present but the sync provider cannot start.
- `except ImportError` fallback preserved (graceful degradation when Aden package is not installed).
- Log level changed from `warning` to `error` for the failure case.

**`core/tests/test_aden_sync_error.py`** (new)  
- `test_raises_when_api_key_set_and_init_fails` — client init raises → CredentialError
- `test_raises_when_api_key_set_and_sync_fails` — sync_all raises → CredentialError
- `test_falls_back_when_no_api_key` — no key → local storage (unchanged behavior)
- `test_falls_back_when_aden_not_installed` — ImportError → local storage (unchanged behavior)

## Validation

- `make check` — ruff lint + format: clean
- Core tests: 1603 passed, 0 failed
- Pre-commit hooks: passed

Fixes #5859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Credential sync now logs and raises a clear credential error when external Aden sync is configured but fails to initialize or run; fallback remains when the Aden API key is not set or Aden is unavailable.

* **Tests**
  * Added tests to verify Aden sync failure handling and fallback scenarios.

* **Style**
  * Minor formatting tidy-ups in internal agent loop code (no behavioral changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->