### PR TITLE
fix: validate session_id in all session routes to prevent path traversal

### DIFF
--- a/core/framework/server/app.py
+++ b/core/framework/server/app.py
@@ -78,7 +78,7 @@ def resolve_session(request: web.Request):
     Returns (session, None) on success or (None, error_response) on failure.
     """
     manager: SessionManager = request.app["manager"]
-    sid = request.match_info["session_id"]
+    sid = safe_path_segment(request.match_info["session_id"])
     session = manager.get_session(sid)
     if not session:
         return None, web.json_response({"error": f"Session '{sid}' not found"}, status=404)

--- a/core/framework/server/routes_sessions.py
+++ b/core/framework/server/routes_sessions.py
@@ -29,6 +29,7 @@ from aiohttp import web
 
 from framework.server.app import (
     resolve_session,
+    safe_path_segment,
     validate_agent_path,
 )
 from framework.server.session_manager import SessionManager
@@ -198,7 +199,7 @@ async def handle_get_live_session(request: web.Request) -> web.Response:
     This lets the frontend detect a server restart and restore message history.
     """
     manager = _get_manager(request)
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
     session = manager.get_session(session_id)
 
     if session is None:
@@ -255,7 +256,7 @@ async def handle_get_live_session(request: web.Request) -> web.Response:
 async def handle_stop_session(request: web.Request) -> web.Response:
     """DELETE /api/sessions/{session_id} — stop a session entirely."""
     manager = _get_manager(request)
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
 
     stopped = await manager.stop_session(session_id)
     if not stopped:
@@ -278,7 +279,7 @@ async def handle_load_colony(request: web.Request) -> web.Response:
     Body: {"agent_path": "...", "colony_id": "..." (optional), "model": "..." (optional)}
     """
     manager = _get_manager(request)
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
     body = await request.json()
 
     agent_path = body.get("agent_path")
@@ -317,7 +318,7 @@ async def handle_load_colony(request: web.Request) -> web.Response:
 async def handle_unload_colony(request: web.Request) -> web.Response:
     """DELETE /api/sessions/{session_id}/colony — unload colony, keep queen alive."""
     manager = _get_manager(request)
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
 
     removed = await manager.unload_colony(session_id)
     if not removed:
@@ -343,7 +344,7 @@ async def handle_unload_colony(request: web.Request) -> web.Response:
 async def handle_session_stats(request: web.Request) -> web.Response:
     """GET /api/sessions/{session_id}/stats — runtime statistics."""
     manager = _get_manager(request)
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
     session = manager.get_session(session_id)
 
     if session is None:
@@ -359,7 +360,7 @@ async def handle_session_stats(request: web.Request) -> web.Response:
 async def handle_session_entry_points(request: web.Request) -> web.Response:
     """GET /api/sessions/{session_id}/entry-points — list entry points."""
     manager = _get_manager(request)
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
     session = manager.get_session(session_id)
 
     if session is None:
@@ -508,7 +509,7 @@ async def handle_update_trigger_task(request: web.Request) -> web.Response:
             await _start_trigger_webhook(session, trigger_id, tdef)
 
     if trigger_id in getattr(session, "active_trigger_ids", set()):
-        session_id = request.match_info["session_id"]
+        session_id = safe_path_segment(request.match_info["session_id"])
         await _persist_active_triggers(session, session_id)
 
     _save_trigger_to_agent(session, trigger_id, tdef)
@@ -588,7 +589,7 @@ async def handle_activate_trigger(request: web.Request) -> web.Response:
 
     tdef.active = True
     session.active_trigger_ids.add(trigger_id)
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
     await _persist_active_triggers(session, session_id)
 
     bus = getattr(session, "event_bus", None)
@@ -649,7 +650,7 @@ async def handle_deactivate_trigger(request: web.Request) -> web.Response:
 
     from framework.tools.queen_lifecycle_tools import _persist_active_triggers
 
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
     await _persist_active_triggers(session, session_id)
 
     bus = getattr(session, "event_bus", None)
@@ -673,7 +674,7 @@ async def handle_deactivate_trigger(request: web.Request) -> web.Response:
 async def handle_session_colonies(request: web.Request) -> web.Response:
     """GET /api/sessions/{session_id}/colonies — list loaded colonies."""
     manager = _get_manager(request)
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
     session = manager.get_session(session_id)
 
     if session is None:
@@ -719,7 +720,7 @@ async def handle_session_events_history(request: web.Request) -> web.Response:
     events; before this cap, restoring on page-mount shipped the whole thing
     down the wire and blocked the UI for seconds.
     """
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
 
     try:
         limit = int(request.query.get("limit", str(_EVENTS_HISTORY_DEFAULT_LIMIT)))
@@ -819,7 +820,7 @@ async def handle_delete_history_session(request: web.Request) -> web.Response:
     This is the frontend 'delete from history' action.
     """
     manager = _get_manager(request)
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
 
     # Stop the live session if it exists (best-effort)
     if manager.get_session(session_id):
@@ -919,7 +920,7 @@ async def handle_delete_agent(request: web.Request) -> web.Response:
 async def handle_reveal_session_folder(request: web.Request) -> web.Response:
     """POST /api/sessions/{session_id}/reveal — open session data folder in the OS file manager."""
     manager: SessionManager = request.app["manager"]
-    session_id = request.match_info["session_id"]
+    session_id = safe_path_segment(request.match_info["session_id"])
 
     session = manager.get_session(session_id)
     storage_session_id = (session.queen_resume_from or session.id) if session else session_id

--- a/core/tests/test_session_path_traversal.py
+++ b/core/tests/test_session_path_traversal.py
@@ -1,0 +1,81 @@
+"""Tests for path traversal protection in session route handlers.
+
+Verifies that safe_path_segment() — now used by all 13 session_id extraction
+points in routes_sessions.py — correctly rejects malicious path traversal
+payloads.
+"""
+
+import pytest
+from aiohttp import web
+
+from framework.server.app import safe_path_segment
+
+
+class TestSafePathSegment:
+    """Verify safe_path_segment rejects traversal payloads."""
+
+    def test_valid_session_id(self):
+        assert safe_path_segment("abc123") == "abc123"
+
+    def test_valid_uuid(self):
+        assert safe_path_segment("550e8400-e29b-41d4-a716-446655440000") == "550e8400-e29b-41d4-a716-446655440000"
+
+    def test_rejects_empty(self):
+        with pytest.raises(web.HTTPBadRequest):
+            safe_path_segment("")
+
+    def test_rejects_dot(self):
+        with pytest.raises(web.HTTPBadRequest):
+            safe_path_segment(".")
+
+    def test_rejects_double_dot(self):
+        with pytest.raises(web.HTTPBadRequest):
+            safe_path_segment("..")
+
+    def test_rejects_slash(self):
+        with pytest.raises(web.HTTPBadRequest):
+            safe_path_segment("abc/def")
+
+    def test_rejects_backslash(self):
+        with pytest.raises(web.HTTPBadRequest):
+            safe_path_segment("abc\\def")
+
+    def test_rejects_traversal_sequence(self):
+        with pytest.raises(web.HTTPBadRequest):
+            safe_path_segment("../../etc/passwd")
+
+    def test_rejects_encoded_traversal(self):
+        # aiohttp decodes %2F before route matching, so / appears literally
+        with pytest.raises(web.HTTPBadRequest):
+            safe_path_segment("../../../tmp")
+
+    def test_rejects_dot_dot_in_middle(self):
+        with pytest.raises(web.HTTPBadRequest):
+            safe_path_segment("foo/../bar")
+
+
+class TestSessionRoutesUseSafePathSegment:
+    """Verify routes_sessions.py actually calls safe_path_segment.
+
+    This is a code-level assertion — if someone removes the validation,
+    this test will catch it.
+    """
+
+    def test_all_session_id_extractions_are_validated(self):
+        """Every match_info['session_id'] in routes_sessions.py must go through safe_path_segment."""
+        import inspect
+
+        from framework.server import routes_sessions
+
+        source = inspect.getsource(routes_sessions)
+
+        # Count raw extractions (unsafe pattern)
+        raw_count = source.count('request.match_info["session_id"]')
+        # Count validated extractions (safe pattern)
+        safe_count = source.count('safe_path_segment(request.match_info["session_id"])')
+
+        assert raw_count > 0, "Expected session_id extractions in routes_sessions"
+        assert raw_count == safe_count, (
+            f"Found {raw_count} session_id extractions but only {safe_count} "
+            f"go through safe_path_segment — {raw_count - safe_count} are unprotected"
+        )


### PR DESCRIPTION
## Summary

Fixes #6553 — path traversal vulnerability in session route handlers.

## Problem

All **13** `session_id` extractions in `routes_sessions.py` passed the raw URL parameter directly to filesystem operations without validation. The most critical was `handle_delete_history_session` which fed unsanitized `session_id` through `_find_queen_session_dir()` → `shutil.rmtree()`, enabling **arbitrary directory deletion** via crafted `session_id` values like `../../etc`.

`safe_path_segment()` already existed in `app.py` and was used by `routes_execution.py` and `routes_workers.py` — the session routes were the only module that missed it.

## Changes

- **`routes_sessions.py`**: All 13 `request.match_info["session_id"]` extractions now go through `safe_path_segment()` which rejects `/`, `\\`, `..`, and empty values with HTTP 400.
- **`app.py`**: `resolve_session()` also validates `session_id` for defense in depth.
- **`test_session_path_traversal.py`**: 11 tests — 9 unit tests for traversal payloads + 1 code-level assertion that every `match_info["session_id"]` in `routes_sessions.py` goes through `safe_path_segment` (regression guard).

## Testing

- All 11 new tests pass
- Full core suite: 1610 passed, 15 skipped
- Lint: clean (`ruff format --check`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of session identifiers across all session route handlers to ensure malformed inputs are properly rejected.

* **Tests**
  * Added comprehensive test coverage for session identifier validation, including edge cases and malicious input patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->