### PR TITLE
fix: raise ValueError on undefined variable in edge condition_expr

### DIFF
--- a/core/framework/orchestrator/edge.py
+++ b/core/framework/orchestrator/edge.py
@@ -196,6 +196,15 @@ class EdgeSpec(BaseModel):
                 expr_vars or "none matched",
             )
             return result
+        except NameError as e:
+            # Variable not found — likely a typo in condition_expr.
+            # Raise loudly so developers can fix the expression.
+            available = [k for k in context if k not in ("true", "false")]
+            raise ValueError(
+                f"Edge '{self.id}' condition references undefined variable: {e}. "
+                f"Expression: {self.condition_expr!r}. "
+                f"Available context keys: {available}"
+            ) from e
         except Exception as e:
             logger.warning(f"      ⚠ Condition evaluation failed: {self.condition_expr}")
             logger.warning(f"         Error: {e}")

--- a/core/tests/test_edge_condition_eval.py
+++ b/core/tests/test_edge_condition_eval.py
@@ -1,0 +1,183 @@
+"""Tests for EdgeSpec._evaluate_condition — validates that NameError
+from undefined variables in condition expressions is raised as ValueError
+instead of being silently swallowed.
+
+Covers: successful evaluation, undefined variable detection, general
+exception fallback, empty expression, buffer key access, and helpful
+error context in the raised ValueError.
+"""
+
+import pytest
+
+from framework.orchestrator.edge import EdgeCondition, EdgeSpec
+
+
+def _make_edge(condition_expr: str, edge_id: str = "test-edge") -> EdgeSpec:
+    """Helper to build a CONDITIONAL edge."""
+    return EdgeSpec(
+        id=edge_id,
+        source="src",
+        target="tgt",
+        condition=EdgeCondition.CONDITIONAL,
+        condition_expr=condition_expr,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Successful evaluation (baseline — no regressions)
+# ---------------------------------------------------------------------------
+
+
+class TestConditionEvalSuccess:
+    @pytest.mark.asyncio
+    async def test_simple_true_expression(self):
+        edge = _make_edge("result == 'ok'")
+        assert await edge.should_traverse(
+            source_success=True,
+            source_output={"result": "ok"},
+            buffer_data={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_simple_false_expression(self):
+        edge = _make_edge("result == 'ok'")
+        assert not await edge.should_traverse(
+            source_success=True,
+            source_output={"result": "fail"},
+            buffer_data={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_buffer_key_access(self):
+        """Buffer keys are unpacked into the context and accessible directly."""
+        edge = _make_edge("dispatch_plan == 'reassign'")
+        assert await edge.should_traverse(
+            source_success=True,
+            source_output={},
+            buffer_data={"dispatch_plan": "reassign"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_output_dict_access(self):
+        edge = _make_edge("output.get('confidence', 0) > 0.5")
+        assert await edge.should_traverse(
+            source_success=True,
+            source_output={"confidence": 0.9},
+            buffer_data={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_expression_returns_true(self):
+        """An edge with no condition_expr always evaluates to True."""
+        edge = _make_edge("")
+        assert await edge.should_traverse(
+            source_success=True,
+            source_output={},
+            buffer_data={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_none_expression_returns_true(self):
+        edge = EdgeSpec(
+            id="e",
+            source="s",
+            target="t",
+            condition=EdgeCondition.CONDITIONAL,
+            condition_expr=None,
+        )
+        assert await edge.should_traverse(
+            source_success=True,
+            source_output={},
+            buffer_data={},
+        )
+
+
+# ---------------------------------------------------------------------------
+# NameError → ValueError (the core fix for #6324)
+# ---------------------------------------------------------------------------
+
+
+class TestConditionNameError:
+    @pytest.mark.asyncio
+    async def test_typo_in_variable_raises_value_error(self):
+        """A typo like 'dispach_plan' (missing 't') must raise, not silently return False."""
+        edge = _make_edge("'reassignment' in str(dispach_plan)", edge_id="check-dispatch")
+        with pytest.raises(ValueError, match="undefined variable"):
+            await edge.should_traverse(
+                source_success=True,
+                source_output={},
+                buffer_data={"dispatch_plan": "reassignment"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_error_message_includes_edge_id(self):
+        edge = _make_edge("nonexistent_var > 0", edge_id="my-edge-42")
+        with pytest.raises(ValueError, match="my-edge-42"):
+            await edge.should_traverse(
+                source_success=True,
+                source_output={},
+                buffer_data={},
+            )
+
+    @pytest.mark.asyncio
+    async def test_error_message_includes_expression(self):
+        edge = _make_edge("nonexistent_var > 0")
+        with pytest.raises(ValueError, match="nonexistent_var > 0"):
+            await edge.should_traverse(
+                source_success=True,
+                source_output={},
+                buffer_data={},
+            )
+
+    @pytest.mark.asyncio
+    async def test_error_message_includes_available_keys(self):
+        edge = _make_edge("wrong_key == 1")
+        with pytest.raises(ValueError, match="dispatch_plan") as exc_info:
+            await edge.should_traverse(
+                source_success=True,
+                source_output={"result": "ok"},
+                buffer_data={"dispatch_plan": "go"},
+            )
+        # Verify the original NameError is chained
+        assert exc_info.value.__cause__ is not None
+        assert isinstance(exc_info.value.__cause__, NameError)
+
+    @pytest.mark.asyncio
+    async def test_completely_undefined_variable(self):
+        """Even with empty buffer + output, NameError must still raise."""
+        edge = _make_edge("ghost_variable")
+        with pytest.raises(ValueError, match="undefined variable"):
+            await edge.should_traverse(
+                source_success=True,
+                source_output={},
+                buffer_data={},
+            )
+
+
+# ---------------------------------------------------------------------------
+# General exceptions still fall back to False (non-NameError)
+# ---------------------------------------------------------------------------
+
+
+class TestConditionGeneralException:
+    @pytest.mark.asyncio
+    async def test_type_error_returns_false(self):
+        """A type error in the expression still returns False (not raised)."""
+        # Trying to add string and int → TypeError
+        edge = _make_edge("result + 42")
+        result = await edge.should_traverse(
+            source_success=True,
+            source_output={"result": "text"},
+            buffer_data={},
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_zero_division_returns_false(self):
+        edge = _make_edge("result / 0")
+        result = await edge.should_traverse(
+            source_success=True,
+            source_output={"result": 10},
+            buffer_data={},
+        )
+        assert result is False


### PR DESCRIPTION
## Summary

Fixes #6324

`EdgeSpec._evaluate_condition()` catches **all** exceptions with a blanket
`except Exception` and returns `False`. When a `CONDITIONAL` edge expression
contains a typo (e.g. `dispach_plan` instead of `dispatch_plan`), the resulting
`NameError` is silently swallowed — the edge simply does not fire, and the agent
takes the wrong path with no actionable error visible to the developer.

## Changes

**`core/framework/orchestrator/edge.py`**
- Catch `NameError` separately from the generic `except Exception` handler
- Re-raise as `ValueError` with actionable context:
  - The edge id
  - The offending expression
  - The list of available context keys
- General evaluation errors (`TypeError`, `ZeroDivisionError`, etc.) still
  fall back to `False` with a `logger.warning` — no behavioral change for
  non-name-resolution failures

**`core/tests/test_edge_condition_eval.py`** (new — 13 tests)
- `TestConditionEvalSuccess`: 6 baseline tests — simple true/false, buffer key
  access, output dict access, empty/None expression
- `TestConditionNameError`: 5 tests — typo raises `ValueError`, message includes
  edge id / expression / available keys, chained `NameError` cause
- `TestConditionGeneralException`: 2 tests — `TypeError` and `ZeroDivisionError`
  still return `False` (existing behavior preserved)

## Verification

```
make check         → All 4 stages clean (ruff check + format for core + tools)
pytest core/tests/ → 1612 passed, 15 skipped, 0 failures
```

## Risk Assessment

**Low risk** — The change is additive: only `NameError` (undefined variable names)
is now raised instead of silently returning `False`. All other exception types
continue to be handled identically. Any existing graph that works correctly today
will not be affected, because correct expressions do not produce `NameError`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for conditional expressions with undefined variables. Users now receive detailed context about available variables and the problematic expression when condition evaluation fails due to missing variable definitions.

* **Tests**
  * Added comprehensive test coverage for condition evaluation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->