### PR TITLE
fix: URL-encode branch names with slashes in github_get_branch

### DIFF
--- a/tools/src/aden_tools/tools/github_tool/github_tool.py
+++ b/tools/src/aden_tools/tools/github_tool/github_tool.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 import httpx
 from fastmcp import FastMCP
@@ -39,6 +40,28 @@ def _sanitize_path_param(param: str, param_name: str = "parameter") -> str:
     if "/" in param or ".." in param:
         raise ValueError(f"Invalid {param_name}: cannot contain '/' or '..'")
     return param
+
+
+def _sanitize_branch_param(branch: str) -> str:
+    """
+    Sanitize a branch name for use in GitHub API URL paths.
+
+    Branch names may contain forward slashes (e.g. ``feature/login``),
+    which are valid in Git but must be URL-encoded for the REST API.
+    Path-traversal sequences are still rejected.
+
+    Args:
+        branch: The branch name to sanitize
+
+    Returns:
+        The URL-encoded branch name (slashes encoded as %2F)
+
+    Raises:
+        ValueError: If branch contains path-traversal sequences
+    """
+    if ".." in branch:
+        raise ValueError("Invalid branch: cannot contain '..'")
+    return quote(branch, safe="")
 
 
 def _sanitize_error_message(error: Exception) -> str:
@@ -396,7 +419,7 @@ class _GitHubClient:
         """Get a specific branch."""
         owner = _sanitize_path_param(owner, "owner")
         repo = _sanitize_path_param(repo, "repo")
-        branch = _sanitize_path_param(branch, "branch")
+        branch = _sanitize_branch_param(branch)
         response = httpx.get(
             f"{GITHUB_API_BASE}/repos/{owner}/{repo}/branches/{branch}",
             headers=self._headers,

--- a/tools/tests/tools/test_github_tool.py
+++ b/tools/tests/tools/test_github_tool.py
@@ -18,6 +18,8 @@ from fastmcp import FastMCP
 
 from aden_tools.tools.github_tool.github_tool import (
     _GitHubClient,
+    _sanitize_branch_param,
+    _sanitize_path_param,
     register_tools,
 )
 
@@ -620,3 +622,80 @@ class TestGitHubBranches:
             result = get_branch(owner="owner", repo="repo", branch="main")
 
             assert result["success"] is True
+
+    @patch("aden_tools.tools.github_tool.github_tool.httpx.get")
+    def test_get_branch_with_slash(self, mock_get, mcp):
+        """Branch names with slashes (e.g. feature/login) must be accepted."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"name": "feature/login", "protected": False}
+        mock_get.return_value = mock_response
+
+        with patch("os.getenv", return_value="ghp_test"):
+            register_tools(mcp, credentials=None)
+            get_branch = mcp._tool_manager._tools["github_get_branch"].fn
+
+            result = get_branch(owner="owner", repo="repo", branch="feature/login")
+
+            assert result["success"] is True
+            # Verify the URL was encoded correctly
+            call_url = mock_get.call_args.args[0]
+            assert "feature%2Flogin" in call_url
+
+    @patch("aden_tools.tools.github_tool.github_tool.httpx.get")
+    def test_get_branch_with_nested_slashes(self, mock_get, mcp):
+        """Deeply nested branch names like release/v2/hotfix must work."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"name": "release/v2/hotfix"}
+        mock_get.return_value = mock_response
+
+        with patch("os.getenv", return_value="ghp_test"):
+            register_tools(mcp, credentials=None)
+            get_branch = mcp._tool_manager._tools["github_get_branch"].fn
+
+            result = get_branch(owner="owner", repo="repo", branch="release/v2/hotfix")
+
+            assert result["success"] is True
+            call_url = mock_get.call_args.args[0]
+            assert "release%2Fv2%2Fhotfix" in call_url
+
+
+# --- Sanitizer unit tests ---
+
+
+class TestSanitizePathParam:
+    def test_simple_name_passes(self):
+        assert _sanitize_path_param("my-repo", "repo") == "my-repo"
+
+    def test_slash_rejected(self):
+        with pytest.raises(ValueError, match="cannot contain"):
+            _sanitize_path_param("owner/name", "owner")
+
+    def test_dot_dot_rejected(self):
+        with pytest.raises(ValueError, match="cannot contain"):
+            _sanitize_path_param("..secret", "repo")
+
+
+class TestSanitizeBranchParam:
+    def test_simple_branch(self):
+        assert _sanitize_branch_param("main") == "main"
+
+    def test_slash_encoded(self):
+        assert _sanitize_branch_param("feature/login") == "feature%2Flogin"
+
+    def test_multiple_slashes_encoded(self):
+        assert _sanitize_branch_param("release/v2/hotfix") == "release%2Fv2%2Fhotfix"
+
+    def test_traversal_rejected(self):
+        with pytest.raises(ValueError, match="cannot contain"):
+            _sanitize_branch_param("../etc/passwd")
+
+    def test_traversal_in_middle_rejected(self):
+        with pytest.raises(ValueError, match="cannot contain"):
+            _sanitize_branch_param("feature/../admin")
+
+    def test_special_chars_encoded(self):
+        # Spaces and other special characters should also be encoded
+        result = _sanitize_branch_param("my branch")
+        assert " " not in result


### PR DESCRIPTION
## Summary

Fixes #6289

`github_get_branch` rejects valid branch names containing `/` (e.g.
`feature/test-branch`, `release/v2/hotfix`) because `_sanitize_path_param()`
treats any forward slash as invalid. The GitHub REST API accepts these when
URL-encoded as `%2F` in the path segment.

## Changes

**`tools/src/aden_tools/tools/github_tool/github_tool.py`**
- Add `_sanitize_branch_param()` that URL-encodes the branch name via
  `urllib.parse.quote(branch, safe='')` while still rejecting `..` traversal
- Replace `_sanitize_path_param(branch, "branch")` with `_sanitize_branch_param(branch)`
  in `get_branch()`
- `_sanitize_path_param()` is unchanged — `owner`, `repo`, `username` still
  reject slashes as before

**`tools/tests/tools/test_github_tool.py`** (11 new tests)
- `TestGitHubBranches`: 2 integration tests — branch with single slash, branch
  with nested slashes — verifying URL encoding in the actual HTTP call
- `TestSanitizePathParam`: 3 unit tests — simple pass, slash rejected, `..` rejected
- `TestSanitizeBranchParam`: 6 unit tests — simple branch, single/multiple slashes
  encoded, traversal rejected (prefix and mid-path), special chars encoded

## Verification

```
make check          → All 4 stages clean (ruff check + format for core + tools)
pytest tools/tests/ → 6651 passed, 294 skipped, 0 failures
```

## Risk Assessment

**Low risk** — Only the `branch` parameter in `get_branch()` is affected.
All other path parameters (`owner`, `repo`, `username`) continue to use
`_sanitize_path_param()` which still rejects slashes. Path traversal via `..`
is still blocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of branch names containing forward slashes (e.g., `feature/login`) in GitHub API queries.

* **Tests**
  * Extended test coverage for branch names with special characters and nested path structures to ensure safe handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->