### PR TITLE
fix: CompositeStorage.load() tries fallbacks when primary raises CredentialError

### DIFF
--- a/core/framework/credentials/storage.py
+++ b/core/framework/credentials/storage.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from pydantic import SecretStr
 
-from .models import CredentialDecryptionError, CredentialKey, CredentialObject, CredentialType
+from .models import CredentialDecryptionError, CredentialError, CredentialKey, CredentialObject, CredentialType
 
 logger = logging.getLogger(__name__)
 
@@ -609,15 +609,31 @@ class CompositeStorage(CredentialStorage):
     def load(self, credential_id: str) -> CredentialObject | None:
         """Load from primary, then fallbacks."""
         # Try primary first
-        credential = self._primary.load(credential_id)
-        if credential is not None:
-            return credential
+        primary_error: CredentialError | None = None
+        try:
+            credential = self._primary.load(credential_id)
+            if credential is not None:
+                return credential
+        except CredentialError as exc:
+            logger.warning(
+                "Primary storage failed for '%s': %s. Trying fallbacks.",
+                credential_id,
+                exc,
+            )
+            primary_error = exc
 
         # Try fallbacks
         for fallback in self._fallbacks:
-            credential = fallback.load(credential_id)
-            if credential is not None:
-                return credential
+            try:
+                credential = fallback.load(credential_id)
+                if credential is not None:
+                    return credential
+            except CredentialError:
+                continue
+
+        # No backend succeeded — re-raise the primary error if one occurred
+        if primary_error is not None:
+            raise primary_error
 
         return None
 

--- a/core/framework/credentials/tests/test_credential_store.py
+++ b/core/framework/credentials/tests/test_credential_store.py
@@ -19,6 +19,8 @@ from unittest.mock import patch
 import pytest
 from core.framework.credentials import (
     CompositeStorage,
+    CredentialDecryptionError,
+    CredentialError,
     CredentialKey,
     CredentialKeyNotFoundError,
     CredentialNotFoundError,
@@ -358,6 +360,88 @@ class TestCompositeStorage:
 
         assert primary.exists("test")
         assert not fallback.exists("test")
+
+    def test_fallback_on_primary_credential_error(self):
+        """When primary raises CredentialError, fallback should be tried."""
+        primary = InMemoryStorage()
+        fallback = InMemoryStorage()
+        fallback.save(
+            CredentialObject(
+                id="test",
+                keys={"k": CredentialKey(name="k", value=SecretStr("fallback_val"))},
+            )
+        )
+
+        # Make primary raise CredentialDecryptionError
+        def failing_load(cred_id):
+            raise CredentialDecryptionError("corrupted file")
+
+        primary.load = failing_load
+
+        storage = CompositeStorage(primary, [fallback])
+        cred = storage.load("test")
+
+        assert cred is not None
+        assert cred.get_key("k") == "fallback_val"
+
+    def test_primary_error_reraise_when_no_fallback_succeeds(self):
+        """When primary raises and no fallback has the credential, re-raise the original error."""
+        primary = InMemoryStorage()
+        fallback = InMemoryStorage()
+
+        def failing_load(cred_id):
+            raise CredentialDecryptionError("corrupted file")
+
+        primary.load = failing_load
+
+        storage = CompositeStorage(primary, [fallback])
+
+        with pytest.raises(CredentialDecryptionError, match="corrupted file"):
+            storage.load("test")
+
+    def test_fallback_error_skipped_gracefully(self):
+        """When both primary and a fallback raise, skip to the next fallback."""
+        primary = InMemoryStorage()
+        bad_fallback = InMemoryStorage()
+        good_fallback = InMemoryStorage()
+        good_fallback.save(
+            CredentialObject(
+                id="test",
+                keys={"k": CredentialKey(name="k", value=SecretStr("good"))},
+            )
+        )
+
+        def primary_fail(cred_id):
+            raise CredentialDecryptionError("primary corrupted")
+
+        def fallback_fail(cred_id):
+            raise CredentialError("fallback broken")
+
+        primary.load = primary_fail
+        bad_fallback.load = fallback_fail
+
+        storage = CompositeStorage(primary, [bad_fallback, good_fallback])
+        cred = storage.load("test")
+
+        assert cred is not None
+        assert cred.get_key("k") == "good"
+
+    def test_primary_returns_none_still_tries_fallback(self):
+        """Existing behavior: primary returns None → fallback is checked."""
+        primary = InMemoryStorage()
+        fallback = InMemoryStorage()
+        fallback.save(
+            CredentialObject(
+                id="test",
+                keys={"k": CredentialKey(name="k", value=SecretStr("fb"))},
+            )
+        )
+
+        storage = CompositeStorage(primary, [fallback])
+        cred = storage.load("test")
+
+        assert cred is not None
+        assert cred.get_key("k") == "fb"
 
 
 class TestStaticProvider:


### PR DESCRIPTION
## Summary

Fixes #6396

`CompositeStorage.load()` previously called `self._primary.load()` without exception handling. If the primary backend raised a `CredentialError` (e.g. `CredentialDecryptionError` from a corrupted encrypted file), the exception propagated immediately — fallback backends were never consulted.

## Changes

**`core/framework/credentials/storage.py`**
- Wrap primary `.load()` call in `try/except CredentialError`
- Log a warning when primary fails, then proceed to fallbacks
- Wrap each fallback `.load()` in `try/except CredentialError` so one broken fallback doesn't block the rest
- If no backend succeeds, re-raise the original primary error for meaningful diagnostics

**`core/framework/credentials/tests/test_credential_store.py`**
- `test_fallback_on_primary_credential_error` — primary raises → fallback serves credential
- `test_primary_error_reraise_when_no_fallback_succeeds` — primary raises, no fallback has it → original error re-raised
- `test_fallback_error_skipped_gracefully` — primary raises, first fallback raises, second fallback succeeds
- `test_primary_returns_none_still_tries_fallback` — confirms existing None-return behavior is preserved

## Testing

```
pytest core/framework/credentials/tests/test_credential_store.py — 67/67 passed
make check — all 4 stages clean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for credential storage fallback mechanisms to properly manage failures in primary storage and communicate errors more reliably instead of silently failing.

* **Tests**
  * Expanded test coverage for credential storage error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->