### PR TITLE
fix(zoho_crm): update outdated tests to match current 6-tool MCP API

### DIFF
--- a/tools/src/aden_tools/tools/zoho_crm_tool/tests/test_zoho_crm_tool.py
+++ b/tools/src/aden_tools/tools/zoho_crm_tool/tests/test_zoho_crm_tool.py
@@ -1,11 +1,11 @@
 """
-Tests for Zoho CRM tool and OAuth2 provider.
+Tests for Zoho CRM MCP tools and OAuth2 provider.
 
 Covers:
-- _ZohoCRMClient methods (search, get, create, update, add_note)
-- Error handling (401, 403, 404, 429, timeout)
-- Credential retrieval (CredentialStoreAdapter vs env vs exchange)
-- All 5 MCP tool functions
+- Tool registration and credential retrieval (CredentialStoreAdapter vs env)
+- All 6 MCP tool functions (list_records, get_record, create_record,
+  search_records, list_modules, add_note)
+- Error handling (timeout, network error, missing params)
 - ZohoOAuth2Provider configuration
 - Credential spec
 """
@@ -15,161 +15,18 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import httpx
-import pytest
 
-from aden_tools.tools.zoho_crm_tool.zoho_crm_tool import (
-    CRM_API_VERSION,
-    _ZohoCRMClient,
-    register_tools,
-)
-
-# --- _ZohoCRMClient tests ---
-
-
-class TestZohoCRMClient:
-    def setup_method(self):
-        self.client = _ZohoCRMClient("test-token")
-
-    def test_headers(self):
-        headers = self.client._headers
-        assert headers["Authorization"] == "Zoho-oauthtoken test-token"
-        assert headers["Content-Type"] == "application/json"
-
-    def test_handle_response_success(self):
-        response = MagicMock()
-        response.status_code = 200
-        response.json.return_value = {"data": []}
-        assert self.client._handle_response(response) == {"data": []}
-
-    @pytest.mark.parametrize(
-        "status_code,expected_substring",
-        [
-            (401, "Invalid or expired"),
-            (403, "Insufficient permissions"),
-            (404, "not found"),
-            (429, "rate limit"),
-        ],
-    )
-    def test_handle_response_errors(self, status_code, expected_substring):
-        response = MagicMock()
-        response.status_code = status_code
-        result = self.client._handle_response(response)
-        assert "error" in result
-        assert expected_substring in result["error"]
-
-    def test_handle_response_429_retriable(self):
-        response = MagicMock()
-        response.status_code = 429
-        result = self.client._handle_response(response)
-        assert result.get("retriable") is True
-
-    def test_handle_response_generic_error(self):
-        response = MagicMock()
-        response.status_code = 500
-        response.json.return_value = {"message": "Internal Server Error"}
-        result = self.client._handle_response(response)
-        assert "error" in result
-        assert "500" in result["error"]
-
-    @patch("aden_tools.tools.zoho_crm_tool.zoho_crm_tool.httpx.get")
-    def test_search_records(self, mock_get):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "data": [{"id": "1", "First_Name": "Zoho"}],
-            "info": {"page": 1, "per_page": 2, "more_records": False},
-        }
-        mock_get.return_value = mock_response
-
-        result = self.client.search_records("Leads", criteria="", word="Zoho", page=1, per_page=2)
-
-        mock_get.assert_called_once()
-        call_url = mock_get.call_args.args[0]
-        assert f"/crm/{CRM_API_VERSION}/Leads/search" in call_url
-        assert result["data"]
-        assert result["info"]["page"] == 1
-
-    @patch("aden_tools.tools.zoho_crm_tool.zoho_crm_tool.httpx.get")
-    def test_get_record(self, mock_get):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"data": [{"id": "1192161000000585006"}]}
-        mock_get.return_value = mock_response
-
-        result = self.client.get_record("Leads", "1192161000000585006")
-
-        mock_get.assert_called_once_with(
-            f"{self.client._api_base}/Leads/1192161000000585006",
-            headers=self.client._headers,
-            timeout=30.0,
-        )
-        assert result["data"][0]["id"] == "1192161000000585006"
-
-    @patch("aden_tools.tools.zoho_crm_tool.zoho_crm_tool.httpx.post")
-    def test_create_record(self, mock_post):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "data": [{"details": {"id": "1192161000000586001"}}],
-        }
-        mock_post.return_value = mock_response
-
-        data = {"First_Name": "Zoho", "Last_Name": "Test", "Company": "Hive"}
-        result = self.client.create_record("Leads", data)
-
-        mock_post.assert_called_once_with(
-            f"{self.client._api_base}/Leads",
-            headers=self.client._headers,
-            json={"data": [data]},
-            timeout=30.0,
-        )
-        assert result["data"][0]["details"]["id"] == "1192161000000586001"
-
-    @patch("aden_tools.tools.zoho_crm_tool.zoho_crm_tool.httpx.put")
-    def test_update_record(self, mock_put):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"data": [{"details": {"id": "1192161000000586001"}}]}
-        mock_put.return_value = mock_response
-
-        result = self.client.update_record("Leads", "1192161000000586001", {"Description": "Updated"})
-
-        mock_put.assert_called_once_with(
-            f"{self.client._api_base}/Leads/1192161000000586001",
-            headers=self.client._headers,
-            json={"data": [{"Description": "Updated"}]},
-            timeout=30.0,
-        )
-        assert result["data"][0]["details"]["id"] == "1192161000000586001"
-
-    @patch("aden_tools.tools.zoho_crm_tool.zoho_crm_tool.httpx.post")
-    def test_add_note_parent_id_structure(self, mock_post):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"data": [{"details": {"id": "note-1"}}]}
-        mock_post.return_value = mock_response
-
-        self.client.add_note("Leads", "1192161000000586001", "Title", "Content")
-
-        call_json = mock_post.call_args.kwargs["json"]
-        note_data = call_json["data"][0]
-        assert note_data["Parent_Id"] == {
-            "module": {"api_name": "Leads"},
-            "id": "1192161000000586001",
-        }
-        assert note_data["Note_Title"] == "Title"
-        assert note_data["Note_Content"] == "Content"
-
+from aden_tools.tools.zoho_crm_tool.zoho_crm_tool import register_tools
 
 # --- Tool registration and credential tests ---
 
 
 class TestToolRegistration:
-    def test_register_tools_registers_all_five_tools(self):
+    def test_register_tools_registers_all_six_tools(self):
         mcp = MagicMock()
         mcp.tool.return_value = lambda fn: fn
         register_tools(mcp)
-        assert mcp.tool.call_count == 5
+        assert mcp.tool.call_count == 6
 
     def test_no_credentials_returns_error(self):
         mcp = MagicMock()
@@ -179,10 +36,10 @@ class TestToolRegistration:
         with patch.dict("os.environ", {}, clear=True):
             register_tools(mcp, credentials=None)
 
-        search_fn = next(fn for fn in registered_fns if fn.__name__ == "zoho_crm_search")
+        search_fn = next(fn for fn in registered_fns if fn.__name__ == "zoho_crm_search_records")
         result = search_fn(module="Leads", word="Zoho")
         assert "error" in result
-        assert "not configured" in result["error"]
+        assert "ZOHO_CRM_ACCESS_TOKEN" in result["error"]
 
     def test_credentials_from_adapter(self):
         mcp = MagicMock()
@@ -190,34 +47,33 @@ class TestToolRegistration:
         mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
 
         cred = MagicMock()
-        cred.get_key.return_value = "test-token"
+        cred.get.return_value = "test-token"
 
         register_tools(mcp, credentials=cred)
 
-        search_fn = next(fn for fn in registered_fns if fn.__name__ == "zoho_crm_search")
+        search_fn = next(fn for fn in registered_fns if fn.__name__ == "zoho_crm_search_records")
 
         with patch("aden_tools.tools.zoho_crm_tool.zoho_crm_tool.httpx.get") as mock_get:
             mock_get.return_value = MagicMock(
                 status_code=200,
-                json=MagicMock(return_value={"data": [], "info": {"page": 1, "per_page": 2}}),
+                json=MagicMock(return_value={"data": [{"id": "1"}], "info": {"page": 1}}),
             )
             result = search_fn(module="Leads", word="Zoho")
 
-        cred.get_key.assert_any_call("zoho_crm", "access_token")
-        assert result["success"] is True
-        assert result["count"] == 0
+        cred.get.assert_any_call("zoho_crm")
+        assert result["count"] == 1
 
-    def test_credentials_from_env_ZOHO_ACCESS_TOKEN(self):
+    def test_credentials_from_env_ZOHO_CRM_ACCESS_TOKEN(self):
         mcp = MagicMock()
         registered_fns = []
         mcp.tool.return_value = lambda fn: registered_fns.append(fn) or fn
 
         register_tools(mcp, credentials=None)
 
-        search_fn = next(fn for fn in registered_fns if fn.__name__ == "zoho_crm_search")
+        search_fn = next(fn for fn in registered_fns if fn.__name__ == "zoho_crm_search_records")
 
         with (
-            patch.dict("os.environ", {"ZOHO_ACCESS_TOKEN": "env-token"}),
+            patch.dict("os.environ", {"ZOHO_CRM_ACCESS_TOKEN": "env-token"}),
             patch("aden_tools.tools.zoho_crm_tool.zoho_crm_tool.httpx.get") as mock_get,
         ):
             mock_get.return_value = MagicMock(
@@ -226,8 +82,8 @@ class TestToolRegistration:
             )
             result = search_fn(module="Leads", word="Zoho")
 
-        assert result["success"] is True
-        call_headers = mock_get.call_args.kwargs["headers"]
+        assert result["count"] == 0
+        call_headers = mock_get.call_args.kwargs.get("headers") or mock_get.call_args[1].get("headers", {})
         assert call_headers["Authorization"] == "Zoho-oauthtoken env-token"
 
 
@@ -240,54 +96,49 @@ class TestZohoCRMTools:
         self.fns = []
         self.mcp.tool.return_value = lambda fn: self.fns.append(fn) or fn
         cred = MagicMock()
-        cred.get_key.return_value = "tok"
+        cred.get.return_value = "tok"
         register_tools(self.mcp, credentials=cred)
 
     def _fn(self, name):
         return next(f for f in self.fns if f.__name__ == name)
 
     @patch("aden_tools.tools.zoho_crm_tool.zoho_crm_tool.httpx.get")
-    def test_zoho_crm_search_success(self, mock_get):
+    def test_zoho_crm_search_records_success(self, mock_get):
         mock_get.return_value = MagicMock(
             status_code=200,
             json=MagicMock(
                 return_value={
                     "data": [{"id": "1", "First_Name": "Zoho"}],
-                    "info": {"page": 1, "per_page": 2, "more_records": False},
                 }
             ),
         )
-        result = self._fn("zoho_crm_search")(module="Leads", word="Zoho")
-        assert result["success"] is True
+        result = self._fn("zoho_crm_search_records")(module="Leads", word="Zoho")
         assert result["count"] == 1
         assert result["module"] == "Leads"
-        assert result["next_page"] is None
-        assert "data" in result
-        assert "raw" in result
+        assert "results" in result
 
     @patch("aden_tools.tools.zoho_crm_tool.zoho_crm_tool.httpx.get")
-    def test_zoho_crm_search_next_page(self, mock_get):
+    def test_zoho_crm_list_records_success(self, mock_get):
         mock_get.return_value = MagicMock(
             status_code=200,
             json=MagicMock(
                 return_value={
                     "data": [{"id": "1"}],
-                    "info": {"page": 2, "per_page": 200, "more_records": True},
+                    "info": {"page": 1, "count": 1, "more_records": False},
                 }
             ),
         )
-        result = self._fn("zoho_crm_search")(module="Leads", criteria="(Email:equals:a@b.com)")
-        assert result["next_page"] == 3
+        result = self._fn("zoho_crm_list_records")(module="Leads")
+        assert result["module"] == "Leads"
+        assert "records" in result
 
-    def test_zoho_crm_search_invalid_module(self):
-        result = self._fn("zoho_crm_search")(module="Invalid", word="x")
+    def test_zoho_crm_search_records_no_params(self):
+        result = self._fn("zoho_crm_search_records")(module="Leads")
         assert "error" in result
-        assert "Invalid module" in result["error"]
 
-    def test_zoho_crm_search_no_word_or_criteria(self):
-        result = self._fn("zoho_crm_search")(module="Leads")
+    def test_zoho_crm_search_records_no_module(self):
+        result = self._fn("zoho_crm_search_records")(module="", word="x")
         assert "error" in result
-        assert "word" in result["error"] or "criteria" in result["error"]
 
     @patch("aden_tools.tools.zoho_crm_tool.zoho_crm_tool.httpx.get")
     def test_zoho_crm_get_record_success(self, mock_get):
@@ -295,64 +146,49 @@ class TestZohoCRMTools:
             status_code=200,
             json=MagicMock(return_value={"data": [{"id": "123", "First_Name": "Jane"}]}),
         )
-        result = self._fn("zoho_crm_get_record")(module="Leads", id="123")
-        assert result["success"] is True
-        assert result["data"]["id"] == "123"
+        result = self._fn("zoho_crm_get_record")(module="Leads", record_id="123")
+        assert result["record"]["id"] == "123"
 
     @patch("aden_tools.tools.zoho_crm_tool.zoho_crm_tool.httpx.post")
     def test_zoho_crm_create_record_success(self, mock_post):
         mock_post.return_value = MagicMock(
             status_code=200,
             json=MagicMock(
-                return_value={"data": [{"details": {"id": "456"}}]},
+                return_value={"data": [{"details": {"id": "456"}, "status": "success", "message": "created"}]},
             ),
         )
         result = self._fn("zoho_crm_create_record")(
             module="Leads",
-            data={"First_Name": "A", "Last_Name": "B", "Company": "C"},
+            record_data={"First_Name": "A", "Last_Name": "B", "Company": "C"},
         )
-        assert result["success"] is True
         assert result["id"] == "456"
-
-    @patch("aden_tools.tools.zoho_crm_tool.zoho_crm_tool.httpx.put")
-    def test_zoho_crm_update_record_success(self, mock_put):
-        mock_put.return_value = MagicMock(
-            status_code=200,
-            json=MagicMock(return_value={"data": [{"details": {"id": "123"}}]}),
-        )
-        result = self._fn("zoho_crm_update_record")(module="Leads", id="123", data={"Description": "Updated"})
-        assert result["success"] is True
-        assert result["id"] == "123"
 
     @patch("aden_tools.tools.zoho_crm_tool.zoho_crm_tool.httpx.post")
     def test_zoho_crm_add_note_success(self, mock_post):
         mock_post.return_value = MagicMock(
             status_code=200,
-            json=MagicMock(return_value={"data": [{"details": {"id": "note-1"}}]}),
+            json=MagicMock(return_value={"data": [{"details": {"id": "note-1"}, "status": "success"}]}),
         )
         result = self._fn("zoho_crm_add_note")(
             module="Leads",
-            id="123",
-            note_title="Test",
-            note_content="Body",
+            record_id="123",
+            title="Test",
+            content="Body",
         )
-        assert result["success"] is True
         assert result["id"] == "note-1"
-        assert result["data"]["parent_id"] == "123"
 
     @patch("aden_tools.tools.zoho_crm_tool.zoho_crm_tool.httpx.get")
-    def test_zoho_crm_search_timeout(self, mock_get):
+    def test_zoho_crm_search_records_timeout(self, mock_get):
         mock_get.side_effect = httpx.TimeoutException("timed out")
-        result = self._fn("zoho_crm_search")(module="Leads", word="test")
+        result = self._fn("zoho_crm_search_records")(module="Leads", word="test")
         assert "error" in result
         assert "timed out" in result["error"]
 
     @patch("aden_tools.tools.zoho_crm_tool.zoho_crm_tool.httpx.get")
     def test_zoho_crm_get_record_network_error(self, mock_get):
-        mock_get.side_effect = httpx.RequestError("connection failed")
-        result = self._fn("zoho_crm_get_record")(module="Leads", id="1")
+        mock_get.side_effect = Exception("connection failed")
+        result = self._fn("zoho_crm_get_record")(module="Leads", record_id="1")
         assert "error" in result
-        assert "Network error" in result["error"]
 
 
 # --- ZohoOAuth2Provider tests ---
@@ -488,23 +324,22 @@ class TestZohoOAuth2Provider:
         fns = []
         mcp.tool.return_value = lambda fn: fns.append(fn) or fn
         cred = MagicMock()
-        cred.get_key.side_effect = lambda cid, key: {
-            "access_token": "tok",
-            "api_domain": "https://www.zohoapis.in",
-        }.get(key)
+        cred.get.return_value = "tok"
         register_tools(mcp, credentials=cred)
 
-        search_fn = next(fn for fn in fns if fn.__name__ == "zoho_crm_search")
-        with patch("aden_tools.tools.zoho_crm_tool.zoho_crm_tool.httpx.get") as mock_get:
+        search_fn = next(fn for fn in fns if fn.__name__ == "zoho_crm_search_records")
+        with (
+            patch.dict("os.environ", {"ZOHO_CRM_DOMAIN": "www.zohoapis.in"}),
+            patch("aden_tools.tools.zoho_crm_tool.zoho_crm_tool.httpx.get") as mock_get,
+        ):
             mock_get.return_value = MagicMock(
                 status_code=200,
                 json=MagicMock(return_value={"data": [], "info": {"page": 1, "per_page": 2}}),
             )
-            result = search_fn(module="Leads", word="Zoho")
+            search_fn(module="Leads", word="Zoho")
 
-        assert result["success"] is True
         called_url = mock_get.call_args.args[0]
-        assert called_url.startswith("https://www.zohoapis.in/crm/v8/")
+        assert called_url.startswith("https://www.zohoapis.in/crm/v7/")
 
 
 # --- Credential spec tests ---
@@ -520,15 +355,16 @@ class TestCredentialSpec:
         from aden_tools.credentials import CREDENTIAL_SPECS
 
         spec = CREDENTIAL_SPECS["zoho_crm"]
-        assert spec.env_var == "ZOHO_REFRESH_TOKEN"
+        assert spec.env_var == "ZOHO_CRM_ACCESS_TOKEN"
 
     def test_zoho_crm_spec_tools(self):
         from aden_tools.credentials import CREDENTIAL_SPECS
 
         spec = CREDENTIAL_SPECS["zoho_crm"]
-        assert "zoho_crm_search" in spec.tools
+        assert "zoho_crm_list_records" in spec.tools
         assert "zoho_crm_get_record" in spec.tools
         assert "zoho_crm_create_record" in spec.tools
-        assert "zoho_crm_update_record" in spec.tools
+        assert "zoho_crm_search_records" in spec.tools
+        assert "zoho_crm_list_modules" in spec.tools
         assert "zoho_crm_add_note" in spec.tools
-        assert len(spec.tools) == 5
+        assert len(spec.tools) == 6


### PR DESCRIPTION
## Summary

Fixes #6819

The Zoho CRM tool was rewritten to use an MCP-based architecture with 6 tools (`list_records`, `get_record`, `create_record`, `search_records`, `list_modules`, `add_note`), but the test suite still referenced the old class-based API that no longer exists.

## Changes

- **Remove obsolete `TestZohoCRMClient` class** — tested the deleted `_ZohoCRMClient` class and `CRM_API_VERSION` constant
- **Remove stale imports** — `CRM_API_VERSION`, `_ZohoCRMClient`, unused `pytest`
- **Rewrite `TestToolRegistration`** — assert 6 tools (not 5), use current function names (`zoho_crm_search_records` not `zoho_crm_search`), use `credentials.get("zoho_crm")` instead of `cred.get_key()`
- **Rewrite `TestZohoCRMTools`** — current function names, current param names (`record_id` not `id`, `record_data` not `data`), current return shapes, removed `zoho_crm_update_record` (no longer exists), added `zoho_crm_list_records` test
- **Fix `TestZohoOAuth2Provider::test_tool_uses_stored_api_domain`** — uses `ZOHO_CRM_DOMAIN` env var (current API), `v7` not `v8`, correct function name
- **Fix `TestCredentialSpec`** — `ZOHO_CRM_ACCESS_TOKEN` (not `ZOHO_REFRESH_TOKEN`), all 6 current tool names

## Testing

All 28 tests pass:
```
28 passed in 2.24s
```

No production code changed. `make check` passes (ruff check + ruff format, core + tools).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored Zoho CRM tool tests to validate MCP tool registration and end-to-end behavior instead of internal implementation details.
  * Expanded tool coverage and updated tool interface validation for search, record retrieval, and note management operations.
  * Updated environment variable expectations and error-handling test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->