### PR TITLE
fix(docs): replace mixed pip/uv guidance in getting-started.md

### DIFF
--- a/core/framework/agent_loop/internals/cursor_persistence.py
+++ b/core/framework/agent_loop/internals/cursor_persistence.py
@@ -162,9 +162,7 @@ async def drain_injection_queue(
     conversation: NodeConversation,
     *,
     ctx: NodeContext,
-    caption_image_fn: (
-        Callable[[str, list[dict[str, Any]]], Awaitable[tuple[str, str] | None]] | None
-    ) = None,
+    caption_image_fn: (Callable[[str, list[dict[str, Any]]], Awaitable[tuple[str, str] | None]] | None) = None,
 ) -> int:
     """Drain all pending injected events as user messages. Returns count.
 
@@ -196,9 +194,7 @@ async def drain_injection_queue(
                     ctx.llm.model,
                 )
                 if caption_image_fn is not None:
-                    intent = content or (
-                        "Describe these user-injected images for a text-only agent."
-                    )
+                    intent = content or ("Describe these user-injected images for a text-only agent.")
                     caption_result = await caption_image_fn(intent, image_content)
                     if caption_result:
                         description, vision_model = caption_result

--- a/core/framework/agent_loop/internals/vision_fallback.py
+++ b/core/framework/agent_loop/internals/vision_fallback.py
@@ -203,9 +203,7 @@ async def caption_tool_image(
     # with "LLM Provider NOT provided."
     from framework.llm.litellm import rewrite_proxy_model
 
-    rewritten_model, rewritten_base, extra_headers = rewrite_proxy_model(
-        model, api_key, api_base
-    )
+    rewritten_model, rewritten_base, extra_headers = rewrite_proxy_model(model, api_key, api_base)
 
     kwargs: dict[str, Any] = {
         "model": rewritten_model,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@ This guide will help you set up the Aden Agent Framework and build your first ag
 ## Prerequisites
 
 - **Python 3.11+** ([Download](https://www.python.org/downloads/)) - Python 3.12 or 3.13 recommended
-- **pip** - Package installer for Python (comes with Python)
+- **uv** ([Install](https://docs.astral.sh/uv/getting-started/installation/)) - Fast Python package manager (this workspace uses `uv` exclusively; do not mix with `pip`)
 - **git** - Version control
 - **Claude Code** ([Install](https://docs.anthropic.com/claude/docs/claude-code)) - Optional, for using building skills
 
@@ -197,20 +197,12 @@ PYTHONPATH=exports uv run python -m my_agent test --type success
 
 ## Troubleshooting
 
-### ModuleNotFoundError: No module named 'framework'
+### ModuleNotFoundError: No module named 'framework' or 'aden_tools'
+
+Re-sync the workspace from the repo root:
 
 ```bash
-# Reinstall framework package
-cd core
-uv pip install -e .
-```
-
-### ModuleNotFoundError: No module named 'aden_tools'
-
-```bash
-# Reinstall tools package
-cd tools
-uv pip install -e .
+uv sync
 ```
 
 ### LLM API Errors
@@ -225,10 +217,20 @@ echo $HIVE_API_KEY
 
 ### Package Installation Issues
 
+**Linux / macOS:**
+
 ```bash
-# Remove and reinstall
-pip uninstall -y framework tools
+# Remove the virtualenv and re-run setup
+rm -rf .venv
 ./quickstart.sh
+```
+
+**Windows (PowerShell):**
+
+```powershell
+# Remove the virtualenv and re-run setup
+Remove-Item -Recurse -Force .venv
+.\quickstart.ps1
 ```
 
 ## Getting Help

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -202,6 +202,10 @@ PYTHONPATH=exports uv run python -m my_agent test --type success
 Re-sync the workspace from the repo root:
 
 ```bash
+# Navigate to repo root
+cd "$(git rev-parse --show-toplevel)"
+
+# Re-sync workspace
 uv sync
 ```
 
@@ -216,6 +220,8 @@ echo $HIVE_API_KEY
 ```
 
 ### Package Installation Issues
+
+If `uv sync` doesn't resolve import errors, or if you encounter persistent installation or dependency conflicts, remove the virtual environment completely and re-run the setup:
 
 **Linux / macOS:**
 


### PR DESCRIPTION
## Summary

Fixes #6812

`docs/getting-started.md` listed `pip` as a prerequisite and used `pip uninstall` / `uv pip install -e .` in troubleshooting — conflicting with the repo's `uv` workspace model.

## Changes

- **Prerequisites**: Replace `pip` with `uv` and add note warning against mixing the two
- **ModuleNotFoundError**: Merge two separate sections (framework / aden_tools) into a single `uv sync` fix
- **Package Installation Issues**: Replace `pip uninstall -y framework tools` + `./quickstart.sh` with `rm -rf .venv` + quickstart, split by platform (bash / PowerShell)

## Acceptance criteria from the issue

- [x] No contradictory `pip` workflow commands remain
- [x] Troubleshooting commands are correct for both Unix and Windows
- [x] Documentation aligns with README `uv` workspace guidance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized prerequisites to use uv as the required package manager in the getting-started guide.
  * Consolidated ModuleNotFoundError troubleshooting into a single instruction to run uv sync from the repository root.
  * Clarified OS-specific recovery: remove the local virtual environment and re-run the appropriate quickstart script on Linux/macOS or Windows PowerShell.

* **Refactor**
  * Internal code formatting tidied with no behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->