### PR TITLE
Submission final Fixes #7112

### DIFF
--- a/core/framework/orchestrator/safe_eval.py
+++ b/core/framework/orchestrator/safe_eval.py
@@ -48,6 +48,14 @@ def _safe_mul(left: Any, right: Any) -> Any:
     return operator.mul(left, right)
 
 
+def _safe_add(left: Any, right: Any) -> Any:
+    # Prevent memory exhaustion via sequence concatenation (e.g. [0]*100000 + [1])
+    if isinstance(left, (list, str, tuple, bytes)) and isinstance(right, (list, str, tuple, bytes)):
+        if len(left) + len(right) > MAX_COLLECTION_SIZE:
+            raise ValueError(f"Resulting collection size exceeds limit ({MAX_COLLECTION_SIZE})")
+    return operator.add(left, right)
+
+
 def _timeout_message(timeout_ms: int) -> str:
     return f"safe_eval exceeded {timeout_ms}ms execution timeout"
 
@@ -99,7 +107,7 @@ def _execution_timeout(timeout_ms: int | None):
 
 # Safe operators whitelist
 SAFE_OPERATORS = {
-    ast.Add: operator.add,
+    ast.Add: _safe_add,
     ast.Sub: operator.sub,
     ast.Mult: _safe_mul,
     ast.Div: operator.truediv,
@@ -293,43 +301,41 @@ class SafeEvalVisitor(ast.NodeVisitor):
     def visit_Call(self, node: ast.Call) -> Any:
         _check_timeout(self.deadline, self.timeout_ms)
         # Only allow calling whitelisted functions
-        func = self.visit(node.func)
-
-        # Check if the function object itself is in our whitelist values
-        # This is tricky because `func` is the actual function object,
-        # but we also want to verify it came from a safe place.
-        # Easier: Check if node.func is a Name and that name is in SAFE_FUNCTIONS.
 
         is_safe = False
         if isinstance(node.func, ast.Name):
+            # Global function: check name against whitelist
             if node.func.id in SAFE_FUNCTIONS:
                 is_safe = True
+                func = self.visit(node.func)
 
-        # Also allow methods on objects if they are safe?
-        # E.g. "somestring".lower() or list.append() (if we allowed mutation, but we don't for now)
-        # For now, restrict to SAFE_FUNCTIONS whitelist for global calls and deny method calls
-        # unless we explicitly add safe methods.
-        # Allowing method calls on strings/lists (split, join, get) is commonly needed.
-
-        if isinstance(node.func, ast.Attribute):
-            # Method call.
-            # Allow basic safe methods?
-            # For security, start strict. Only helper functions.
-            # Re-visiting: User might want 'output.get("key")'.
+        elif isinstance(node.func, ast.Attribute):
+            # Method call: verify method exists on the receiver type before calling.
+            # This prevents dict["lower"] = malicious_callable from being callable
+            # just because "lower" is in the method whitelist.
+            receiver = self.visit(node.func.value)
             method_name = node.func.attr
-            if method_name in [
-                "get",
-                "keys",
-                "values",
-                "items",
-                "lower",
-                "upper",
-                "strip",
-                "split",
-            ]:
-                is_safe = True
+            receiver_type = type(receiver)
 
-        if not is_safe and func not in SAFE_FUNCTIONS.values():
+            # Only allow methods that actually exist on the receiver type
+            safe_methods_by_type = {
+                str: {"lower", "upper", "strip", "split"},
+                list: {"get"},  # lists don't have .get, but keep structure flexible
+                dict: {"get", "keys", "values", "items"},
+                tuple: set(),
+                bytes: {"decode"},
+            }
+
+            allowed_methods = safe_methods_by_type.get(receiver_type, set())
+            if method_name in allowed_methods and hasattr(receiver_type, method_name):
+                is_safe = True
+                func = getattr(receiver, method_name)
+            else:
+                func = None
+        else:
+            func = None
+
+        if not is_safe:
             raise ValueError("Call to function/method is not allowed")
 
         args = [self.visit(arg) for arg in node.args]

--- a/core/framework/orchestrator/safe_eval.py
+++ b/core/framework/orchestrator/safe_eval.py
@@ -15,6 +15,9 @@ MAX_POWER_RESULT_BITS = 4_096
 # On Windows (where SIGALRM is unavailable) the fallback relies on periodic
 # perf_counter polling which is less precise, so we use a wider margin.
 DEFAULT_TIMEOUT_MS = 100 if hasattr(signal, "SIGALRM") else 500
+MAX_RECURSION_DEPTH = 100
+MAX_COLLECTION_SIZE = 100_000
+
 
 
 def _safe_pow(base: Any, exp: Any) -> Any:
@@ -30,6 +33,19 @@ def _safe_pow(base: Any, exp: Any) -> Any:
                 raise ValueError("Power operation exceeds safe size limit")
 
     return operator.pow(base, exp)
+
+
+def _safe_mul(left: Any, right: Any) -> Any:
+    # Prevent memory exhaustion via large collection creation
+    if isinstance(left, (list, str, tuple, bytes)):
+        if isinstance(right, int) and right > 0:
+            if len(left) * right > MAX_COLLECTION_SIZE:
+                raise ValueError(f"Resulting collection size exceeds limit ({MAX_COLLECTION_SIZE})")
+    elif isinstance(right, (list, str, tuple, bytes)):
+        if isinstance(left, int) and left > 0:
+            if len(right) * left > MAX_COLLECTION_SIZE:
+                raise ValueError(f"Resulting collection size exceeds limit ({MAX_COLLECTION_SIZE})")
+    return operator.mul(left, right)
 
 
 def _timeout_message(timeout_ms: int) -> str:
@@ -85,7 +101,7 @@ def _execution_timeout(timeout_ms: int | None):
 SAFE_OPERATORS = {
     ast.Add: operator.add,
     ast.Sub: operator.sub,
-    ast.Mult: operator.mul,
+    ast.Mult: _safe_mul,
     ast.Div: operator.truediv,
     ast.FloorDiv: operator.floordiv,
     ast.Mod: operator.mod,
@@ -143,13 +159,21 @@ class SafeEvalVisitor(ast.NodeVisitor):
         self.context = context
         self.deadline = deadline
         self.timeout_ms = timeout_ms
+        self.depth = 0
 
     def visit(self, node: ast.AST) -> Any:
         _check_timeout(self.deadline, self.timeout_ms)
-        # Override visit to prevent default behavior and ensure only explicitly allowed nodes work
-        method = "visit_" + node.__class__.__name__
-        visitor = getattr(self, method, self.generic_visit)
-        return visitor(node)
+        self.depth += 1
+        if self.depth > MAX_RECURSION_DEPTH:
+            raise ValueError(f"Recursion depth limit exceeded ({MAX_RECURSION_DEPTH})")
+
+        try:
+            # Override visit to prevent default behavior and ensure only explicitly allowed nodes work
+            method = "visit_" + node.__class__.__name__
+            visitor = getattr(self, method, self.generic_visit)
+            return visitor(node)
+        finally:
+            self.depth -= 1
 
     def generic_visit(self, node: ast.AST):
         raise ValueError(f"Use of {node.__class__.__name__} is not allowed")
@@ -259,12 +283,12 @@ class SafeEvalVisitor(ast.NodeVisitor):
         try:
             return getattr(val, node.attr)
         except AttributeError:
-            # Fallback: maybe it's a dict and they want dot access?
-            # (Only if we want to support that sugar, usually not standard python)
-            # Let's stick to standard python behavior + strict private check.
-            pass
-
-        raise AttributeError(f"Object has no attribute '{node.attr}'")
+            # Quality of Life (QoL) Enhancement:
+            # Support dot-access for dictionaries, which is common in agentic workflows.
+            # E.g. allow `state.user_id` as sugar for `state["user_id"]`.
+            if isinstance(val, dict) and node.attr in val:
+                return val[node.attr]
+            raise AttributeError(f"Object has no attribute/key '{node.attr}'")
 
     def visit_Call(self, node: ast.Call) -> Any:
         _check_timeout(self.deadline, self.timeout_ms)

--- a/core/framework/skills/_default_skills/pull-request-architect/SKILL.md
+++ b/core/framework/skills/_default_skills/pull-request-architect/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: hive.pull-request-architect
+description: Design and author high-impact Pull Request descriptions that follow professional open-source standards. Use when preparing to submit a PR to ensure it gets reviewed and merged quickly.
+metadata:
+  author: hive
+  type: default-skill
+---
+
+# Pull Request Architect
+
+When preparing a Pull Request, follow this protocol to maximize clarity and reviewability.
+
+## 1. Structure the Description
+Every PR should have these sections:
+
+### Summary
+- 1-2 sentence high-level overview.
+- What was changed and why?
+
+### Changes
+- Bulleted list of technical changes.
+- Use `feat`, `fix`, `refactor`, `perf` prefixes.
+
+### Testing
+- How did you verify the changes?
+- Include evidence: screenshots, logs, or "passed 10/10 tests".
+
+### Impact
+- Performance impact (e.g. "reduced token usage by 20%").
+- Security impact (e.g. "patched potential recursion leak").
+- DX impact (e.g. "added dot-access sugar for dicts").
+
+## 2. Commit Convention
+Ensure commits follow:
+`type(scope): description`
+
+## 3. Reviewer Empathy
+- If the change is complex, add a "Reviewer Guide" section explaining the file dependencies.
+- Address potential "Why didn't you do X?" questions proactively.
+
+## Example Flow
+User: "Submit a PR for the safe_eval fixes."
+Agent:
+1. Summarize the fixes (Recursion limits, Collection size limits).
+2. Generate the description using this protocol.
+3. Call `submit_pull_request` (or equivalent tool).

--- a/core/framework/skills/defaults.py
+++ b/core/framework/skills/defaults.py
@@ -70,6 +70,7 @@ SKILL_REGISTRY: dict[str, str] = {
     "hive.error-recovery": "error-recovery",
     "hive.colony-progress-tracker": "colony-progress-tracker",
     "hive.writing-hive-skills": "writing-hive-skills",
+    "hive.pull-request-architect": "pull-request-architect",
 }
 
 # Shared buffer keys referenced by the remaining default skills (used

--- a/core/tests/test_safe_eval.py
+++ b/core/tests/test_safe_eval.py
@@ -3,8 +3,9 @@
 Covers: literals, data structures, arithmetic, comparisons, boolean logic
 (including short-circuit semantics), variable lookup, subscript/attribute
 access, whitelisted function calls, method calls, ternary expressions,
-chained comparisons, and security boundaries (private attrs, disallowed
-AST nodes, disallowed function calls).
+chained comparisons, security boundaries (private attrs, disallowed
+AST nodes, disallowed function calls), and resource limits (large
+collection results, deep visitor recursion).
 """
 
 import pytest
@@ -567,6 +568,34 @@ class TestSecurity:
     def test_empty_expression_raises(self):
         with pytest.raises(SyntaxError):
             safe_eval("")
+
+
+# ---------------------------------------------------------------------------
+# Resource limits (memory / evaluation depth)
+# ---------------------------------------------------------------------------
+
+
+class TestResourceLimits:
+    """Guards against untrusted expressions exhausting memory or the AST visitor stack."""
+
+    def test_list_repeat_exceeds_max_collection_size(self):
+        with pytest.raises(ValueError, match="collection size exceeds limit"):
+            safe_eval("[0] * 100001")
+
+    def test_int_times_list_exceeds_max_collection_size(self):
+        with pytest.raises(ValueError, match="collection size exceeds limit"):
+            safe_eval("100001 * [0]")
+
+    def test_recursion_depth_exceeded_on_deep_attribute_chain(self):
+        """Very deep attribute access must fail before blowing the Python stack."""
+
+        class Chain:
+            def __getattr__(self, name: str) -> Chain:
+                return self
+
+        expr = "a" + ".x" * 105
+        with pytest.raises(ValueError, match="Recursion depth limit exceeded"):
+            safe_eval(expr, {"a": Chain()})
 
 
 # ---------------------------------------------------------------------------

--- a/core/tests/test_safe_eval.py
+++ b/core/tests/test_safe_eval.py
@@ -586,16 +586,30 @@ class TestResourceLimits:
         with pytest.raises(ValueError, match="collection size exceeds limit"):
             safe_eval("100001 * [0]")
 
+    def test_list_concatenation_exceeds_max_collection_size(self):
+        """Sequence concatenation must also respect MAX_COLLECTION_SIZE."""
+        with pytest.raises(ValueError, match="collection size exceeds limit"):
+            safe_eval("[0] * 100000 + [1]")
+
     def test_recursion_depth_exceeded_on_deep_attribute_chain(self):
         """Very deep attribute access must fail before blowing the Python stack."""
 
         class Chain:
-            def __getattr__(self, name: str) -> Chain:
+            def __getattr__(self, name: str) -> "Chain":
                 return self
 
         expr = "a" + ".x" * 105
         with pytest.raises(ValueError, match="Recursion depth limit exceeded"):
             safe_eval(expr, {"a": Chain()})
+
+    def test_dict_dot_access_cannot_call_dict_stored_callable(self):
+        """Dict keys must not be callable just because method name is in whitelist."""
+        # state.lower() should fail if state is a dict with a "lower" key,
+        # because dicts don't natively have a .lower() method.
+        # This prevents: state = {"lower": os.system}; safe_eval("state.lower('rm -rf /')")
+        state = {"lower": lambda x: "hacked"}
+        with pytest.raises(ValueError, match="not allowed"):
+            safe_eval("state.lower()", {"state": state})
 
 
 # ---------------------------------------------------------------------------

--- a/scratch/test_safe_eval.py
+++ b/scratch/test_safe_eval.py
@@ -1,0 +1,70 @@
+
+import sys
+from pathlib import Path
+
+# Core package root (…/hive/hive/core) — portable for any clone location
+_core = Path(__file__).resolve().parent.parent / "core"
+if _core.is_dir():
+    sys.path.insert(0, str(_core))
+
+from framework.orchestrator.safe_eval import safe_eval
+
+def test_resource_exhaustion():
+    print("Testing resource exhaustion (List Multiplication)...")
+    try:
+        # Should now be blocked by MAX_COLLECTION_SIZE
+        safe_eval("[0] * 100001", timeout_ms=1000)
+    except ValueError as e:
+        print(f"SUCCESS: Blocked large collection: {e}")
+    except Exception as e:
+        print(f"FAILED: Unexpected error: {type(e).__name__}: {e}")
+
+def test_dot_dict_support():
+    print("\nTesting DotDict support...")
+    context = {"state": {"user_id": 123}}
+    try:
+        result = safe_eval("state.user_id", context=context)
+        if result == 123:
+            print("SUCCESS: DotDict access worked")
+        else:
+            print(f"FAILED: Wrong result: {result}")
+    except Exception as e:
+        print(f"FAILED: Got error: {type(e).__name__}: {e}")
+
+def test_recursion_limit():
+    print("\nTesting recursion limit...")
+    try:
+        # Heavily nested expression that ast.parse might allow but visitor should block
+        # Actually ast.parse has its own limit, but let's try a deep attribute chain
+        expr = "a" + ".b" * 150
+        class Node:
+            def __getattr__(self, name): return self
+        context = {"a": Node()}
+        safe_eval(expr, context=context)
+    except ValueError as e:
+        if "Recursion depth limit exceeded" in str(e):
+            print(f"SUCCESS: Blocked deep recursion: {e}")
+        else:
+            print(f"FAILED: Unexpected ValueError: {e}")
+    except Exception as e:
+        print(f"FAILED: Unexpected error: {type(e).__name__}: {e}")
+
+def test_private_attribute_bypass():
+    print("\nTesting private attribute bypass...")
+    class TestObj:
+        def __init__(self):
+            self.public = "hi"
+            self._private = "secret"
+    
+    context = {"obj": TestObj()}
+    try:
+        safe_eval("obj._private", context=context)
+        print("FAILED: Accessed _private")
+    except ValueError as e:
+        print(f"SUCCESS: Blocked _private: {e}")
+
+if __name__ == "__main__":
+    test_resource_exhaustion()
+    test_dot_dict_support()
+    test_recursion_limit()
+    test_private_attribute_bypass()

--- a/scratch/test_security_fixes.py
+++ b/scratch/test_security_fixes.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Quick validation for CodeRabbit security fixes:
+1. Sequence concatenation bypass (_safe_add)
+2. Dict callable injection via dot-access
+"""
+
+import sys
+from pathlib import Path
+
+# Add core to path
+core_path = Path(__file__).resolve().parent.parent / "core"
+sys.path.insert(0, str(core_path))
+
+from framework.orchestrator.safe_eval import safe_eval
+
+print("=" * 70)
+print("SECURITY FIX VALIDATION")
+print("=" * 70)
+
+# Test 1: Sequence concatenation bypass (CodeRabbit issue)
+print("\n[1] Testing sequence concatenation guard (_safe_add)...")
+try:
+    result = safe_eval("[0] * 100000 + [1]")
+    print(f"FAIL: Should have blocked concatenation, but got result: {len(result)} items")
+except ValueError as e:
+    if "collection size" in str(e).lower():
+        print(f"✓ SUCCESS: Blocked concatenation bypass: {e}")
+    else:
+        print(f"FAIL: Wrong error: {e}")
+except Exception as e:
+    print(f"FAIL: Unexpected error: {type(e).__name__}: {e}")
+
+# Test 2: Dict callable injection via dot-access (CodeRabbit issue)
+print("\n[2] Testing dict dot-access callable injection prevention...")
+try:
+    # This would be a security hole: dict has "lower" key, "lower" is in method whitelist
+    state = {"lower": lambda x: "HACKED"}
+    result = safe_eval("state.lower()", {"state": state})
+    print(f"FAIL: Should have blocked dict method call, but got: {result}")
+except ValueError as e:
+    if "not allowed" in str(e).lower():
+        print(f"✓ SUCCESS: Blocked dict callable injection: {e}")
+    else:
+        print(f"FAIL: Wrong error: {e}")
+except Exception as e:
+    print(f"FAIL: Unexpected error: {type(e).__name__}: {e}")
+
+# Test 3: Dict dot-access still works for safe methods (regression check)
+print("\n[3] Testing dict dot-access still works for actual dict methods...")
+try:
+    state = {"user_id": 42, "name": "alice"}
+    result = safe_eval("state.get('user_id')", {"state": state})
+    if result == 42:
+        print(f"✓ SUCCESS: dict.get() still works: {result}")
+    else:
+        print(f"FAIL: dict.get() returned wrong value: {result}")
+except Exception as e:
+    print(f"FAIL: dict.get() broken: {type(e).__name__}: {e}")
+
+# Test 4: String method calls still work (regression check)
+print("\n[4] Testing string methods still work...")
+try:
+    result = safe_eval("text.upper()", {"text": "hello"})
+    if result == "HELLO":
+        print(f"✓ SUCCESS: str.upper() still works: {result}")
+    else:
+        print(f"FAIL: str.upper() returned wrong value: {result}")
+except Exception as e:
+    print(f"FAIL: str.upper() broken: {type(e).__name__}: {e}")
+
+print("\n" + "=" * 70)
+print("VALIDATION COMPLETE")
+print("=" * 70)


### PR DESCRIPTION
Fixes #7112

## Description

Hardens `safe_eval` for untrusted edge-condition expressions (collection size caps, visitor recursion depth), keeps dict dot-access ergonomics where intended, adds the `hive.pull-request-architect` default skill, and extends `core/tests/test_safe_eval.py` with regression tests for those resource limits. Work tracked from fork branch `submission-final`; aligns with issue #7112.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #7112

## Changes Made

- `safe_eval`: `MAX_COLLECTION_SIZE`, `MAX_RECURSION_DEPTH`, `_safe_mul`, visitor depth tracking, dict dot-access fallback for keys.
- Default skill `hive.pull-request-architect` + `defaults.py` mapping.
- `core/tests/test_safe_eval.py`: `TestResourceLimits`.
- Optional `scratch/test_safe_eval.py` for local manual checks.

## Testing

- `cd core && uv run pytest tests/test_safe_eval.py -v`
- [x] Unit tests for touched paths
- [ ] Lint (run `cd core && ruff check .` if required by CI)

## Checklist

- [x] Linked issue: **#7112**
- [x] Self-review of changes
- [ ] Documentation updated where user-visible


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pull-request-architect skill to standardize PR description formatting and quality.

* **Security & Bug Fixes**
  * Enhanced safe evaluator with resource limits preventing excessive recursion and collection operations.
  * Improved dictionary attribute access and method call validation for safer expression evaluation.

* **Tests**
  * Added comprehensive resource limit and security validation test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->