### PR TITLE
fix(config): null llm.max_tokens in configuration.json crashes queen loop on startup

### DIFF
--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -258,7 +258,7 @@ def get_worker_llm_extra_kwargs() -> dict[str, Any]:
             except ImportError:
                 pass
             return {
-                "extra_headers": headers,
+                "extra_headers": headers, 
                 "store": False,
                 "allowed_openai_params": ["store"],
             }

--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -266,6 +266,7 @@ def get_worker_llm_extra_kwargs() -> dict[str, Any]:
         return {"num_ctx": worker_llm.get("num_ctx", 16384)}
     return {}
 
+
 def get_worker_max_tokens() -> int:
     """Return max_tokens for the worker LLM, falling back to default."""
     worker_llm = get_hive_config().get("worker_llm", {})
@@ -315,8 +316,7 @@ def get_max_context_tokens() -> int:
     elif value is not None:
         # Wrapped to satisfy the 120-character limit (E501)
         logger.warning(
-            f"Invalid llm.max_context_tokens: {value}. "
-            f"Using DEFAULT_MAX_CONTEXT_TOKENS ({DEFAULT_MAX_CONTEXT_TOKENS})."
+            f"Invalid llm.max_context_tokens: {value}. Using DEFAULT_MAX_CONTEXT_TOKENS ({DEFAULT_MAX_CONTEXT_TOKENS})."
         )
 
     return DEFAULT_MAX_CONTEXT_TOKENS

--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -270,22 +270,29 @@ def get_worker_llm_extra_kwargs() -> dict[str, Any]:
 def get_worker_max_tokens() -> int:
     """Return max_tokens for the worker LLM, falling back to default."""
     worker_llm = get_hive_config().get("worker_llm", {})
-    if worker_llm and "max_tokens" in worker_llm:
-        return worker_llm["max_tokens"]
+    if worker_llm:
+        value = worker_llm.get("max_tokens")
+        if isinstance(value, int) and value > 0:
+            return value
     return get_max_tokens()
 
 
 def get_worker_max_context_tokens() -> int:
     """Return max_context_tokens for the worker LLM, falling back to default."""
     worker_llm = get_hive_config().get("worker_llm", {})
-    if worker_llm and "max_context_tokens" in worker_llm:
-        return worker_llm["max_context_tokens"]
+    if worker_llm:
+        value = worker_llm.get("max_context_tokens")
+        if isinstance(value, int) and value > 0:
+            return value
     return get_max_context_tokens()
 
 
 def get_max_tokens() -> int:
     """Return the configured max_tokens, falling back to DEFAULT_MAX_TOKENS."""
-    return get_hive_config().get("llm", {}).get("max_tokens", DEFAULT_MAX_TOKENS)
+    value = get_hive_config().get("llm", {}).get("max_tokens")
+    if isinstance(value, int) and value > 0:
+        return value
+    return DEFAULT_MAX_TOKENS
 
 
 DEFAULT_MAX_CONTEXT_TOKENS = 32_000
@@ -294,7 +301,10 @@ OPENROUTER_API_BASE = "https://openrouter.ai/api/v1"
 
 def get_max_context_tokens() -> int:
     """Return the configured max_context_tokens, falling back to DEFAULT_MAX_CONTEXT_TOKENS."""
-    return get_hive_config().get("llm", {}).get("max_context_tokens", DEFAULT_MAX_CONTEXT_TOKENS)
+    value = get_hive_config().get("llm", {}).get("max_context_tokens")
+    if isinstance(value, int) and value > 0:
+        return value
+    return DEFAULT_MAX_CONTEXT_TOKENS
 
 
 def get_api_keys() -> list[str] | None:

--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -258,7 +258,7 @@ def get_worker_llm_extra_kwargs() -> dict[str, Any]:
             except ImportError:
                 pass
             return {
-                "extra_headers": headers, 
+                "extra_headers": headers,
                 "store": False,
                 "allowed_openai_params": ["store"],
             }
@@ -266,14 +266,16 @@ def get_worker_llm_extra_kwargs() -> dict[str, Any]:
         return {"num_ctx": worker_llm.get("num_ctx", 16384)}
     return {}
 
-
 def get_worker_max_tokens() -> int:
     """Return max_tokens for the worker LLM, falling back to default."""
     worker_llm = get_hive_config().get("worker_llm", {})
     if worker_llm:
         value = worker_llm.get("max_tokens")
-        if isinstance(value, int) and value > 0:
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
             return value
+        elif value is not None:
+            logger.warning(f"Invalid worker_llm.max_tokens: {value}. Falling back to global default.")
+
     return get_max_tokens()
 
 
@@ -282,16 +284,22 @@ def get_worker_max_context_tokens() -> int:
     worker_llm = get_hive_config().get("worker_llm", {})
     if worker_llm:
         value = worker_llm.get("max_context_tokens")
-        if isinstance(value, int) and value > 0:
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
             return value
+        elif value is not None:
+            logger.warning(f"Invalid worker_llm.max_context_tokens: {value}. Falling back to global default.")
+
     return get_max_context_tokens()
 
 
 def get_max_tokens() -> int:
     """Return the configured max_tokens, falling back to DEFAULT_MAX_TOKENS."""
     value = get_hive_config().get("llm", {}).get("max_tokens")
-    if isinstance(value, int) and value > 0:
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
         return value
+    elif value is not None:
+        logger.warning(f"Invalid llm.max_tokens: {value}. Using DEFAULT_MAX_TOKENS ({DEFAULT_MAX_TOKENS}).")
+
     return DEFAULT_MAX_TOKENS
 
 
@@ -302,8 +310,15 @@ OPENROUTER_API_BASE = "https://openrouter.ai/api/v1"
 def get_max_context_tokens() -> int:
     """Return the configured max_context_tokens, falling back to DEFAULT_MAX_CONTEXT_TOKENS."""
     value = get_hive_config().get("llm", {}).get("max_context_tokens")
-    if isinstance(value, int) and value > 0:
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
         return value
+    elif value is not None:
+        # Wrapped to satisfy the 120-character limit (E501)
+        logger.warning(
+            f"Invalid llm.max_context_tokens: {value}. "
+            f"Using DEFAULT_MAX_CONTEXT_TOKENS ({DEFAULT_MAX_CONTEXT_TOKENS})."
+        )
+
     return DEFAULT_MAX_CONTEXT_TOKENS
 
 


### PR DESCRIPTION

## Description
Fix startup crash caused by null token values in configuration.json. 
When llm.max_tokens or llm.max_context_tokens are set to null, the config 
getters returned None instead of falling back to defaults, causing a 
TypeError crash in the queen loop before any LLM call is made.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
Fixes #7117

## Changes Made
- Updated `get_max_tokens()` to validate value is a positive int before using it
- Updated `get_max_context_tokens()` with same validation
- Updated `get_worker_max_tokens()` with same validation
- Updated `get_worker_max_context_tokens()` with same validation

## Testing
- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

**Before fix:**
```
[ERROR] [_queen_loop] Queen conversation crashed: 
'>' not supported between instances of 'NoneType' and 'int'
```

**After fix:**
```
[INFO] Queen starting in independent phase with 129 tools...
[INFO] [queen] Dynamic prompt updated
[INFO] [queen] iter=0: running LLM turn
```

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Notes
Reproduced and tested on Windows 11 with both Groq and Gemini providers.
The fix is non-invasive — only affects config validation logic in 4 getter 
functions. No breaking changes for correctly configured setups.
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced stricter validation for token configuration (both per-worker and global): only positive integers are accepted; invalid, non-positive, or non-integer values now fall back to defaults.
  * Invalid but non-empty configuration values now produce warning logs to surface misconfiguration instead of being silently accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->