### PR TITLE
feat(tools): added optional auth credentials in credential store for prometheus tool

### DIFF
--- a/tools/src/aden_tools/credentials/prometheus.py
+++ b/tools/src/aden_tools/credentials/prometheus.py
@@ -55,8 +55,8 @@ Notes:
 export PROMETHEUS_TOKEN=your-token
 """,
         health_check_endpoint="",
-        credential_id="prometheus",
-        credential_key="token",
+        credential_id="prometheus_token",
+        credential_key="api_key",
     ),
     "prometheus_username": CredentialSpec(
         env_var="PROMETHEUS_USERNAME",
@@ -75,7 +75,7 @@ export PROMETHEUS_TOKEN=your-token
 export PROMETHEUS_USERNAME=admin
 """,
         health_check_endpoint="",
-        credential_id="prometheus",
+        credential_id="prometheus_username",
         credential_key="username",
     ),
     "prometheus_password": CredentialSpec(
@@ -95,7 +95,7 @@ export PROMETHEUS_USERNAME=admin
 export PROMETHEUS_PASSWORD=secret
 """,
         health_check_endpoint="",
-        credential_id="prometheus",
+        credential_id="prometheus_password",
         credential_key="password",
     ),
 }

--- a/tools/src/aden_tools/credentials/prometheus.py
+++ b/tools/src/aden_tools/credentials/prometheus.py
@@ -38,4 +38,64 @@ Notes:
         credential_id="prometheus",
         credential_key="base_url",
     ),
+    "prometheus_token": CredentialSpec(
+        env_var="PROMETHEUS_TOKEN",
+        tools=[
+            "prometheus_query",
+            "prometheus_query_range",
+        ],
+        required=False,
+        startup_required=False,
+        help_url="https://prometheus.io/docs/prometheus/latest/querying/api/",
+        description="Optional Bearer token for Prometheus authentication",
+        aden_supported=False,
+        direct_api_key_supported=False,
+        api_key_instructions="""Optional: set a bearer token for authenticated Prometheus instances:
+
+export PROMETHEUS_TOKEN=your-token
+""",
+        health_check_endpoint="",
+        credential_id="prometheus",
+        credential_key="token",
+    ),
+    "prometheus_username": CredentialSpec(
+        env_var="PROMETHEUS_USERNAME",
+        tools=[
+            "prometheus_query",
+            "prometheus_query_range",
+        ],
+        required=False,
+        startup_required=False,
+        help_url="https://prometheus.io/docs/prometheus/latest/querying/api/",
+        description="Optional username for basic auth",
+        aden_supported=False,
+        direct_api_key_supported=False,
+        api_key_instructions="""Optional: set username for basic authentication:
+
+export PROMETHEUS_USERNAME=admin
+""",
+        health_check_endpoint="",
+        credential_id="prometheus",
+        credential_key="username",
+    ),
+    "prometheus_password": CredentialSpec(
+        env_var="PROMETHEUS_PASSWORD",
+        tools=[
+            "prometheus_query",
+            "prometheus_query_range",
+        ],
+        required=False,
+        startup_required=False,
+        help_url="https://prometheus.io/docs/prometheus/latest/querying/api/",
+        description="Optional password for basic auth",
+        aden_supported=False,
+        direct_api_key_supported=False,
+        api_key_instructions="""Optional: set password for basic authentication:
+
+export PROMETHEUS_PASSWORD=secret
+""",
+        health_check_endpoint="",
+        credential_id="prometheus",
+        credential_key="password",
+    ),
 }

--- a/tools/src/aden_tools/credentials/prometheus.py
+++ b/tools/src/aden_tools/credentials/prometheus.py
@@ -14,7 +14,7 @@ PROMETHEUS_CREDENTIALS = {
         help_url="https://prometheus.io/docs/prometheus/latest/querying/api/",
         description="Base URL of Prometheus server",
         aden_supported=False,
-        direct_api_key_supported=False,
+        direct_api_key_supported=True,
         api_key_instructions="""To configure Prometheus access:
 
 1. Set your Prometheus base URL:
@@ -49,7 +49,7 @@ Notes:
         help_url="https://prometheus.io/docs/prometheus/latest/querying/api/",
         description="Optional Bearer token for Prometheus authentication",
         aden_supported=False,
-        direct_api_key_supported=False,
+        direct_api_key_supported=True,
         api_key_instructions="""Optional: set a bearer token for authenticated Prometheus instances:
 
 export PROMETHEUS_TOKEN=your-token
@@ -69,7 +69,7 @@ export PROMETHEUS_TOKEN=your-token
         help_url="https://prometheus.io/docs/prometheus/latest/querying/api/",
         description="Optional username for basic auth",
         aden_supported=False,
-        direct_api_key_supported=False,
+        direct_api_key_supported=True,
         api_key_instructions="""Optional: set username for basic authentication:
 
 export PROMETHEUS_USERNAME=admin
@@ -89,7 +89,7 @@ export PROMETHEUS_USERNAME=admin
         help_url="https://prometheus.io/docs/prometheus/latest/querying/api/",
         description="Optional password for basic auth",
         aden_supported=False,
-        direct_api_key_supported=False,
+        direct_api_key_supported=True,
         api_key_instructions="""Optional: set password for basic authentication:
 
 export PROMETHEUS_PASSWORD=secret

--- a/tools/src/aden_tools/tools/prometheus_tool/prometheus_tool.py
+++ b/tools/src/aden_tools/tools/prometheus_tool/prometheus_tool.py
@@ -67,20 +67,30 @@ def _missing_prometheus_credential_response() -> dict:
 def _get_auth(
     credentials: CredentialStoreAdapter | None,
 ) -> tuple[dict[str, str], httpx.BasicAuth | None]:
-    headers: dict[str, str] = {}
-    auth = None
+    """
+    Resolve authentication for Prometheus requests.
 
-    creds = credentials.get("prometheus") if credentials else {}
+    Uses credential store first, then environment variables.
+    Supports Bearer token, Basic Auth or no auth.
+
+    Returns:
+        (headers, auth) tuple for httpx requests
+    """
+
+    headers: dict[str, str] = {}
+    auth: httpx.BasicAuth | None = None
 
     # Bearer token
-    token = (creds or {}).get("prometheus_token") or os.getenv("PROMETHEUS_TOKEN")
+    token = (credentials.get("prometheus_token") if credentials else None) or os.getenv("PROMETHEUS_TOKEN")
+
     if token:
         headers["Authorization"] = f"Bearer {token}"
         return headers, None
 
     # Basic auth
-    username = (creds or {}).get("prometheus_username") or os.getenv("PROMETHEUS_USERNAME")
-    password = (creds or {}).get("prometheus_password") or os.getenv("PROMETHEUS_PASSWORD")
+    username = (credentials.get("prometheus_username") if credentials else None) or os.getenv("PROMETHEUS_USERNAME")
+
+    password = (credentials.get("prometheus_password") if credentials else None) or os.getenv("PROMETHEUS_PASSWORD")
 
     if username and password:
         auth = httpx.BasicAuth(username, password)
@@ -126,7 +136,7 @@ def register_tools(
 
         url = f"{base_url.rstrip('/')}/api/v1/query"
 
-        headers, auth = _get_auth()
+        headers, auth = _get_auth(credentials)
 
         try:
             response = httpx.get(
@@ -212,7 +222,7 @@ def register_tools(
 
         url = f"{base_url.rstrip('/')}/api/v1/query_range"
 
-        headers, auth = _get_auth()
+        headers, auth = _get_auth(credentials)
 
         try:
             response = httpx.get(

--- a/tools/src/aden_tools/tools/prometheus_tool/prometheus_tool.py
+++ b/tools/src/aden_tools/tools/prometheus_tool/prometheus_tool.py
@@ -64,19 +64,24 @@ def _missing_prometheus_credential_response() -> dict:
     }
 
 
-def _get_auth() -> tuple[dict[str, str], httpx.BasicAuth | None]:
+def _get_auth(
+    credentials: CredentialStoreAdapter | None,
+) -> tuple[dict[str, str], httpx.BasicAuth | None]:
     headers: dict[str, str] = {}
     auth = None
 
+    creds = credentials.get("prometheus") if credentials else {}
+
     # Bearer token
-    token = os.getenv("PROMETHEUS_TOKEN")
+    token = (creds or {}).get("prometheus_token") or os.getenv("PROMETHEUS_TOKEN")
     if token:
         headers["Authorization"] = f"Bearer {token}"
         return headers, None
 
     # Basic auth
-    username = os.getenv("PROMETHEUS_USERNAME")
-    password = os.getenv("PROMETHEUS_PASSWORD")
+    username = (creds or {}).get("prometheus_username") or os.getenv("PROMETHEUS_USERNAME")
+    password = (creds or {}).get("prometheus_password") or os.getenv("PROMETHEUS_PASSWORD")
+
     if username and password:
         auth = httpx.BasicAuth(username, password)
 


### PR DESCRIPTION

## Description

Added optional auth credentials in the credential store for prometheus tool

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Fixes #7101 

## Changes Made

- added optional PROMETHEUS_TOKEN, PROMETHEUS_USERNAME, PROMETHEUS_PASSWORD in the credential spec of prometheus tool
- updated the get auth method for prometheus tool accordingly 

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`uv run ruff check .\tools\src\aden_tools\tools\prometheus_tool`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prometheus tools now support direct API key usage for simpler access.
  * Token (Bearer) authentication supported for Prometheus Query and Query Range via PROMETHEUS_TOKEN.
  * Basic authentication (username/password) supported for Prometheus Query and Query Range via PROMETHEUS_USERNAME and PROMETHEUS_PASSWORD.
  * Credential resolution prefers stored credentials and falls back to environment variables for flexible authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->