### PR TITLE
micro-fix(queen_profiles): fix encoding crash and improve logger

### DIFF
--- a/core/framework/agents/queen/queen_profiles.py
+++ b/core/framework/agents/queen/queen_profiles.py
@@ -1109,7 +1109,7 @@ def ensure_default_queens() -> None:
         if profile_path.exists():
             continue
         queen_dir.mkdir(parents=True, exist_ok=True)
-        profile_path.write_text(yaml.safe_dump(profile, sort_keys=False, allow_unicode=True))
+        profile_path.write_text(yaml.safe_dump(profile, sort_keys=False, allow_unicode=True), encoding="UTF-8")
         created += 1
     if created:
         logger.info("Created %d default queen profile(s) at %s", created, QUEENS_DIR)
@@ -1123,7 +1123,7 @@ def list_queens() -> list[dict[str, str]]:
     for profile_path in sorted(QUEENS_DIR.glob("*/profile.yaml")):
         queen_id = profile_path.parent.name
         try:
-            data = yaml.safe_load(profile_path.read_text())
+            data = yaml.safe_load(profile_path.read_text(encoding="UTF-8"))
             results.append(
                 {
                     "id": queen_id,
@@ -1131,8 +1131,8 @@ def list_queens() -> list[dict[str, str]]:
                     "title": data.get("title", ""),
                 }
             )
-        except Exception:
-            logger.warning("Failed to read queen profile %s", profile_path)
+        except Exception as error:
+            logger.error("Failed to read queen profile %s. Reason: %s", profile_path, str(error))
     return results
 
 
@@ -1144,7 +1144,7 @@ def load_queen_profile(queen_id: str) -> dict[str, Any]:
     profile_path = QUEENS_DIR / queen_id / "profile.yaml"
     if not profile_path.exists():
         raise FileNotFoundError(f"Queen profile not found: {queen_id}")
-    data = yaml.safe_load(profile_path.read_text())
+    data = yaml.safe_load(profile_path.read_text(encoding="UTF-8"))
     return data
 
 
@@ -1161,13 +1161,13 @@ def update_queen_profile(queen_id: str, updates: dict[str, Any]) -> dict[str, An
     profile_path = QUEENS_DIR / queen_id / "profile.yaml"
     if not profile_path.exists():
         raise FileNotFoundError(f"Queen profile not found: {queen_id}")
-    data = yaml.safe_load(profile_path.read_text())
+    data = yaml.safe_load(profile_path.read_text(encoding="UTF-8"))
     for key, value in updates.items():
         if isinstance(value, dict) and isinstance(data.get(key), dict):
             data[key].update(value)
         else:
             data[key] = value
-    profile_path.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True))
+    profile_path.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True), encoding="UTF-8")
     return data
 
 


### PR DESCRIPTION
## Problem:
- System failed to load queen profiles due to `UnicodeDecodeError 0x97`
- The existing logger was swallowing exceptions, making it difficult to diagnose why profiles were failing to load

## Decision:
- Explicitly set `encoding="UTF-8"` to handle legacy Windows encodings and special characters
- Updated the catch block to include the exception message in the logs for better traceability

## Result:
- Improved system resilience across different operating systems and file encodings
- Faster debugging process for future contributors due to transparent error reporting

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
- No Issues or PRs related

## Testing
- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Warning:
<img width="1919" height="332" alt="1" src="https://github.com/user-attachments/assets/bfd25742-bcad-4c4b-91f0-89136c2c346e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Profile files are now read with explicit UTF‑8 decoding to avoid encoding inconsistencies.
  * Newly created and updated profiles are persisted using explicit UTF‑8 encoding.
  * Improved error handling: failures reading profiles now log as errors and include exception details for clearer troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->