### PR TITLE
fix(server): use aiohttp AppKey for app state

### DIFF
--- a/core/framework/loader/cli.py
+++ b/core/framework/loader/cli.py
@@ -95,7 +95,7 @@ def cmd_serve(args: argparse.Namespace) -> int:
     _build_frontend()
 
     from framework.observability import configure_logging
-    from framework.server.app import create_app
+    from framework.server.app import SESSION_MANAGER_KEY, create_app
 
     if getattr(args, "debug", False):
         configure_logging(level="DEBUG")
@@ -120,7 +120,7 @@ def cmd_serve(args: argparse.Namespace) -> int:
     app = create_app(model=model)
 
     async def run_server() -> None:
-        manager = app["manager"]
+        manager = app[SESSION_MANAGER_KEY]
         shutdown_event = asyncio.Event()
         signal_count = {"n": 0}
 

--- a/core/framework/server/README.md
+++ b/core/framework/server/README.md
@@ -304,7 +304,7 @@ When `verify: true`, runs health checks (lightweight HTTP calls) against each av
 ## Key Patterns
 
 - **Session-primary** — sessions are the lookup key for all routes, workers are optional children
-- **Per-request manager access** — routes get `SessionManager` via `request.app["manager"]`
+- **Per-request manager access** — routes get `SessionManager` via the typed `SESSION_MANAGER_KEY` app key
 - **Path validation** — user-provided path segments validated with `safe_path_segment()` to prevent directory traversal
 - **Event-driven streaming** — per-client buffer queues (max 1000 events) with 15s keepalive pings
 - **Shared EventBus** — session owns the bus, queen and worker both publish to it, SSE always connects to `session.event_bus`

--- a/core/framework/server/app.py
+++ b/core/framework/server/app.py
@@ -6,9 +6,14 @@ from pathlib import Path
 
 from aiohttp import web
 
+from framework.credentials.store import CredentialStore
 from framework.server.session_manager import Session, SessionManager
 
 logger = logging.getLogger(__name__)
+
+CREDENTIAL_STORE_KEY = web.AppKey("credential_store", CredentialStore)
+SESSION_MANAGER_KEY = web.AppKey("manager", SessionManager)
+QUEEN_TOOL_REGISTRY_KEY = web.AppKey("queen_tool_registry", object)
 
 
 # Anchor to the repository root so allowed roots are independent of CWD.
@@ -83,7 +88,7 @@ def resolve_session(request: web.Request):
 
     Returns (session, None) on success or (None, error_response) on failure.
     """
-    manager: SessionManager = request.app["manager"]
+    manager: SessionManager = request.app[SESSION_MANAGER_KEY]
     sid = request.match_info["session_id"]
     session = manager.get_session(sid)
     if not session:
@@ -162,13 +167,13 @@ async def error_middleware(request: web.Request, handler):
 
 async def _on_shutdown(app: web.Application) -> None:
     """Gracefully unload all agents on server shutdown."""
-    manager: SessionManager = app["manager"]
+    manager: SessionManager = app[SESSION_MANAGER_KEY]
     await manager.shutdown_all()
 
 
 async def handle_health(request: web.Request) -> web.Response:
     """GET /api/health — simple health check."""
-    manager: SessionManager = request.app["manager"]
+    manager: SessionManager = request.app[SESSION_MANAGER_KEY]
     sessions = manager.list_sessions()
     return web.json_response(
         {
@@ -271,8 +276,6 @@ def create_app(model: str | None = None) -> web.Application:
     app = web.Application(middlewares=[cors_middleware, error_middleware])
 
     # Initialize credential store (before SessionManager so it can be shared)
-    from framework.credentials.store import CredentialStore
-
     try:
         from framework.credentials.validation import ensure_credential_key_env
 
@@ -305,12 +308,12 @@ def create_app(model: str | None = None) -> web.Application:
         logger.debug("Encrypted credential store unavailable, using in-memory fallback")
         credential_store = CredentialStore.for_testing({})
 
-    app["credential_store"] = credential_store
+    app[CREDENTIAL_STORE_KEY] = credential_store
 
     # Let queen sessions build their registry lazily on first use instead of
     # paying the MCP discovery cost during `hive open`.
-    app["queen_tool_registry"] = None
-    app["manager"] = SessionManager(
+    app[QUEEN_TOOL_REGISTRY_KEY] = None
+    app[SESSION_MANAGER_KEY] = SessionManager(
         model=model,
         credential_store=credential_store,
         queen_tool_registry=None,

--- a/core/framework/server/routes_config.py
+++ b/core/framework/server/routes_config.py
@@ -30,6 +30,7 @@ from framework.llm.model_catalog import (
     get_models_catalogue,
     get_preset,
 )
+from framework.server.app import CREDENTIAL_STORE_KEY, SESSION_MANAGER_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -172,7 +173,7 @@ def _resolve_api_key(provider: str, request: web.Request) -> str | None:
     cred_id = _PROVIDER_CRED_MAP.get(provider.lower())
     if cred_id:
         try:
-            store = request.app["credential_store"]
+            store = request.app[CREDENTIAL_STORE_KEY]
             key = store.get(cred_id)
             if key:
                 return key
@@ -291,7 +292,7 @@ def _hot_swap_sessions(request: web.Request, full_model: str, api_key: str | Non
     """
     from framework.server.session_manager import SessionManager
 
-    manager: SessionManager = request.app["manager"]
+    manager: SessionManager = request.app[SESSION_MANAGER_KEY]
     manager._model = full_model
     swapped = 0
     for session in manager.list_sessions():

--- a/core/framework/server/routes_credentials.py
+++ b/core/framework/server/routes_credentials.py
@@ -9,7 +9,7 @@ from pydantic import SecretStr
 
 from framework.credentials.models import CredentialDecryptionError, CredentialKey, CredentialObject
 from framework.credentials.store import CredentialStore
-from framework.server.app import validate_agent_path
+from framework.server.app import CREDENTIAL_STORE_KEY, SESSION_MANAGER_KEY, validate_agent_path
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ def _get_llm_key_providers() -> dict:
 
 
 def _get_store(request: web.Request) -> CredentialStore:
-    return request.app["credential_store"]
+    return request.app[CREDENTIAL_STORE_KEY]
 
 
 def _invalidate_queen_credentials_cache(request: web.Request) -> None:
@@ -50,7 +50,7 @@ def _invalidate_queen_credentials_cache(request: web.Request) -> None:
     appear in the Queen's prompt on her next turn instead of waiting for the
     cache TTL to expire.
     """
-    manager = request.app.get("manager")
+    manager = request.app.get(SESSION_MANAGER_KEY)
     if manager is None:
         return
     sessions = getattr(manager, "_sessions", None)

--- a/core/framework/server/routes_execution.py
+++ b/core/framework/server/routes_execution.py
@@ -11,7 +11,7 @@ from aiohttp import web
 from framework.agent_loop.conversation import LEGACY_RUN_ID
 from framework.credentials.validation import validate_agent_credentials
 from framework.host.execution_manager import ExecutionAlreadyRunningError
-from framework.server.app import resolve_session, safe_path_segment, sessions_dir
+from framework.server.app import SESSION_MANAGER_KEY, resolve_session, safe_path_segment, sessions_dir
 from framework.server.routes_sessions import _credential_error_response
 
 logger = logging.getLogger(__name__)
@@ -335,7 +335,7 @@ async def handle_chat(request: web.Request) -> web.Response:
 
     # Queen is dead — try to revive her
     logger.warning("[handle_chat] Queen is dead for session '%s', reviving on /chat request", session.id)
-    manager: Any = request.app["manager"]
+    manager: Any = request.app[SESSION_MANAGER_KEY]
     try:
         logger.debug("[handle_chat] Calling manager.revive_queen()...")
         await manager.revive_queen(session)
@@ -388,7 +388,7 @@ async def handle_queen_context(request: web.Request) -> web.Response:
         "Queen is dead for session '%s', reviving on /queen-context request",
         session.id,
     )
-    manager: Any = request.app["manager"]
+    manager: Any = request.app[SESSION_MANAGER_KEY]
     try:
         await manager.revive_queen(session)
         # After revival, deliver the message
@@ -983,7 +983,7 @@ async def handle_compact_and_fork(request: web.Request) -> web.Response:
     except OSError:
         logger.warning("compact_and_fork: failed to write new meta.json", exc_info=True)
 
-    manager: Any = request.app["manager"]
+    manager: Any = request.app[SESSION_MANAGER_KEY]
     try:
         new_session = await manager.create_session(
             session_id=None,

--- a/core/framework/server/routes_messages.py
+++ b/core/framework/server/routes_messages.py
@@ -9,6 +9,7 @@
 from aiohttp import web
 
 from framework.agents.queen.queen_profiles import ensure_default_queens, select_queen
+from framework.server.app import SESSION_MANAGER_KEY
 
 
 async def handle_classify_message(request: web.Request) -> web.Response:
@@ -16,7 +17,7 @@ async def handle_classify_message(request: web.Request) -> web.Response:
     import traceback as _tb
 
     try:
-        manager = request.app["manager"]
+        manager = request.app[SESSION_MANAGER_KEY]
         body = await request.json() if request.can_read_body else {}
         message = body.get("message")
         if not isinstance(message, str) or not message.strip():

--- a/core/framework/server/routes_queens.py
+++ b/core/framework/server/routes_queens.py
@@ -23,6 +23,7 @@ from framework.agents.queen.queen_profiles import (
     update_queen_profile,
 )
 from framework.config import QUEENS_DIR
+from framework.server.app import SESSION_MANAGER_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -232,7 +233,7 @@ async def handle_queen_session(request: web.Request) -> web.Response:
     from framework.server.session_manager import SessionManager
 
     queen_id = request.match_info["queen_id"]
-    manager: SessionManager = request.app["manager"]
+    manager: SessionManager = request.app[SESSION_MANAGER_KEY]
 
     ensure_default_queens()
     try:
@@ -326,7 +327,7 @@ async def handle_queen_session(request: web.Request) -> web.Response:
 async def handle_select_queen_session(request: web.Request) -> web.Response:
     """POST /api/queen/{queen_id}/session/select -- resume a specific queen session."""
     queen_id = request.match_info["queen_id"]
-    manager = request.app["manager"]
+    manager = request.app[SESSION_MANAGER_KEY]
 
     ensure_default_queens()
     try:
@@ -379,7 +380,7 @@ async def handle_select_queen_session(request: web.Request) -> web.Response:
 async def handle_new_queen_session(request: web.Request) -> web.Response:
     """POST /api/queen/{queen_id}/session/new -- create a fresh queen session."""
     queen_id = request.match_info["queen_id"]
-    manager = request.app["manager"]
+    manager = request.app[SESSION_MANAGER_KEY]
 
     ensure_default_queens()
     try:

--- a/core/framework/server/routes_sessions.py
+++ b/core/framework/server/routes_sessions.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from aiohttp import web
 
 from framework.server.app import (
+    SESSION_MANAGER_KEY,
     resolve_session,
     validate_agent_path,
 )
@@ -38,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 
 def _get_manager(request: web.Request) -> SessionManager:
-    return request.app["manager"]
+    return request.app[SESSION_MANAGER_KEY]
 
 
 def _session_to_live_dict(session) -> dict:
@@ -1002,7 +1003,7 @@ async def handle_delete_agent(request: web.Request) -> web.Response:
 
 async def handle_reveal_session_folder(request: web.Request) -> web.Response:
     """POST /api/sessions/{session_id}/reveal — open session data folder in the OS file manager."""
-    manager: SessionManager = request.app["manager"]
+    manager: SessionManager = request.app[SESSION_MANAGER_KEY]
     session_id = request.match_info["session_id"]
 
     session = manager.get_session(session_id)

--- a/core/framework/server/tests/test_api.py
+++ b/core/framework/server/tests/test_api.py
@@ -22,7 +22,7 @@ from framework.server import (
     routes_queens,
     session_manager as session_manager_module,
 )
-from framework.server.app import create_app
+from framework.server.app import CREDENTIAL_STORE_KEY, SESSION_MANAGER_KEY, create_app
 from framework.server.session_manager import Session
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -331,7 +331,7 @@ def custom_id_session(tmp_agent_dir):
 def _make_app_with_session(session):
     """Create an aiohttp app with a pre-loaded session."""
     app = create_app()
-    mgr = app["manager"]
+    mgr = app[SESSION_MANAGER_KEY]
     mgr._sessions[session.id] = session
     return app
 
@@ -386,7 +386,7 @@ class TestSessionCRUD:
     @pytest.mark.asyncio
     async def test_create_session_with_worker_forwards_session_id(self):
         app = create_app()
-        manager = app["manager"]
+        manager = app[SESSION_MANAGER_KEY]
         manager.create_session_with_worker_colony = AsyncMock(return_value=_make_session(agent_id="my-custom-session"))
 
         async with TestClient(TestServer(app)) as client:
@@ -583,7 +583,7 @@ class TestMessageBootstrap:
     @pytest.mark.asyncio
     async def test_classify_returns_queen_id_without_touching_sessions(self, monkeypatch):
         app = create_app()
-        manager = app["manager"]
+        manager = app[SESSION_MANAGER_KEY]
         # Pre-existing live session must NOT be stopped by classify.
         existing = _make_session(agent_id="live_session")
         existing.queen_name = "queen_growth"
@@ -623,7 +623,7 @@ class TestQueenSessionSelection:
     @pytest.mark.asyncio
     async def test_select_queen_session_returns_live_session_without_duplication(self):
         app = create_app()
-        manager = app["manager"]
+        manager = app[SESSION_MANAGER_KEY]
         target = _make_session(agent_id="queen_live")
         target.queen_name = "queen_technology"
         other = _make_session(agent_id="other_live")
@@ -662,7 +662,7 @@ class TestQueenSessionSelection:
         )
 
         app = create_app()
-        manager = app["manager"]
+        manager = app[SESSION_MANAGER_KEY]
         manager.stop_session = AsyncMock()
         restored = _make_session(agent_id="queen_history", with_queen=False)
         restored.queen_name = "queen_technology"
@@ -702,7 +702,7 @@ class TestQueenSessionSelection:
         )
 
         app = create_app()
-        manager = app["manager"]
+        manager = app[SESSION_MANAGER_KEY]
         manager.stop_session = AsyncMock()
         restored = _make_session(agent_id="worker_history", with_queen=False)
         restored.queen_name = "queen_technology"
@@ -734,7 +734,7 @@ class TestQueenSessionSelection:
     @pytest.mark.asyncio
     async def test_new_queen_session_creates_fresh_thread(self):
         app = create_app()
-        manager = app["manager"]
+        manager = app[SESSION_MANAGER_KEY]
         existing = _make_session(agent_id="old_live")
         existing.queen_name = "queen_growth"
         manager._sessions[existing.id] = existing
@@ -1504,7 +1504,7 @@ class TestCredentials:
         from framework.credentials.store import CredentialStore
 
         app = create_app()
-        app["credential_store"] = CredentialStore.for_testing(initial_creds or {})
+        app[CREDENTIAL_STORE_KEY] = CredentialStore.for_testing(initial_creds or {})
         return app
 
     @pytest.mark.asyncio
@@ -1535,7 +1535,7 @@ class TestCredentials:
                 )
 
         app = create_app()
-        app["credential_store"] = BrokenStore()
+        app[CREDENTIAL_STORE_KEY] = BrokenStore()
 
         async with TestClient(TestServer(app)) as client:
             resp = await client.get("/api/credentials")
@@ -1555,7 +1555,7 @@ class TestCredentials:
                 raise CredentialDecryptionError("bad encrypted file")
 
         app = create_app()
-        app["credential_store"] = BrokenStore()
+        app[CREDENTIAL_STORE_KEY] = BrokenStore()
 
         async with TestClient(TestServer(app)) as client:
             resp = await client.get("/api/credentials/bad_cred")
@@ -1654,7 +1654,7 @@ class TestCredentials:
             )
             assert resp.status == 201
 
-            store = app["credential_store"]
+            store = app[CREDENTIAL_STORE_KEY]
             assert store.get_key("test_cred", "api_key") == "new-value"
 
 
@@ -1675,8 +1675,8 @@ class TestConfigRoutes:
     @pytest.mark.asyncio
     async def test_get_llm_config_exposes_subscription_defaults_from_presets(self):
         app = create_app()
-        app["credential_store"] = MagicMock()
-        app["credential_store"].get.return_value = None
+        app[CREDENTIAL_STORE_KEY] = MagicMock()
+        app[CREDENTIAL_STORE_KEY].get.return_value = None
 
         async with TestClient(TestServer(app)) as client:
             resp = await client.get("/api/config/llm")

--- a/core/tests/test_colony_fork_flow.py
+++ b/core/tests/test_colony_fork_flow.py
@@ -21,7 +21,7 @@ import pytest
 from aiohttp.test_utils import TestClient, TestServer
 
 from framework.agent_loop.internals.types import LoopConfig
-from framework.server.app import create_app
+from framework.server.app import SESSION_MANAGER_KEY, create_app
 from framework.server.session_manager import Session, _queen_session_dir
 
 # Modules that import HIVE_HOME / QUEENS_DIR / COLONIES_DIR / MEMORIES_DIR /
@@ -262,7 +262,7 @@ async def test_colony_spawn_creates_correct_artifacts(tmp_path, monkeypatch):
 
     # Build the in-process aiohttp app and inject our fake session
     app = create_app()
-    manager = app["manager"]
+    manager = app[SESSION_MANAGER_KEY]
     session = _make_session_with_queen_state(
         session_id=source_session_id,
         queen_name=queen_name,

--- a/core/tests/test_colony_fork_live.py
+++ b/core/tests/test_colony_fork_live.py
@@ -129,7 +129,7 @@ async def test_live_queen_fork_to_colony(isolated_hive_home):
       5. Conversations are copied through to worker storage
     """
     from framework.agents.queen.queen_profiles import ensure_default_queens
-    from framework.server.app import create_app
+    from framework.server.app import SESSION_MANAGER_KEY, create_app
     from framework.server.session_manager import _queen_session_dir
 
     # Pre-populate queen profiles in the temp ~/.hive so the identity
@@ -137,7 +137,7 @@ async def test_live_queen_fork_to_colony(isolated_hive_home):
     ensure_default_queens()
 
     app = create_app()  # picks up model from copied configuration.json
-    manager = app["manager"]
+    manager = app[SESSION_MANAGER_KEY]
 
     async with TestClient(TestServer(app)) as client:
         # ── 1. Create a queen-only session ─────────────────────────


### PR DESCRIPTION
## Summary
- Add typed aiohttp AppKey constants for server app state
- Replace string-key manager and credential store access across server runtime paths
- Update related tests and server README references

Fixes #6161.

## Validation
- ruff check core/framework/server/app.py core/framework/server/routes_config.py core/framework/server/routes_credentials.py core/framework/server/routes_execution.py core/framework/server/routes_messages.py core/framework/server/routes_queens.py core/framework/server/routes_sessions.py core/framework/loader/cli.py core/framework/server/tests/test_api.py core/tests/test_colony_fork_flow.py core/tests/test_colony_fork_live.py
- git diff --check
- python -m py_compile on touched Python files

Note: I attempted the issue repro pytest command, but uv fails dependency resolution from this local Windows workspace path because the parent directory contains # and the editable tools URL is resolved inconsistently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Internal improvements to code organization and dependency management throughout the server framework for enhanced maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->