### PR TITLE
fix(dnssec): Implement custom resolver for reliable AD flag validation (micro-fix)

### DIFF
--- a/tools/src/aden_tools/tools/dns_security_scanner/dns_security_scanner.py
+++ b/tools/src/aden_tools/tools/dns_security_scanner/dns_security_scanner.py
@@ -11,6 +11,7 @@ from fastmcp import FastMCP
 
 try:
     import dns.exception
+    import dns.flags
     import dns.name
     import dns.query
     import dns.rdatatype
@@ -198,11 +199,24 @@ def _check_dkim(resolver: dns.resolver.Resolver, domain: str) -> dict:
 
 
 def _check_dnssec(resolver: dns.resolver.Resolver, domain: str) -> dict:
-    """Check if DNSSEC is enabled."""
+    """Check if DNSSEC is enabled and validated."""
     try:
-        answers = resolver.resolve(domain, "DNSKEY")
-        if answers:
+        # Create an isolated resolver to avoid polluting the default one
+        sec_resolver = dns.resolver.Resolver()
+        
+        # Use known validating nameservers (Google, Cloudflare)
+        sec_resolver.nameservers = ['8.8.8.8', '1.1.1.1']
+        
+        # Use EDNS to request DNSSEC validation (DO flag) and increase packet size
+        sec_resolver.use_edns(0, dns.flags.DO, 4096)
+        
+        # Query for SOA records (mandatory for all domains)
+        answers = sec_resolver.resolve(domain, "SOA")
+        
+        # Verify the Authenticated Data (AD) flag is present
+        if answers.response.flags & dns.flags.AD:
             return {"enabled": True, "issues": []}
+            
     except dns.resolver.NoAnswer:
         pass
     except (dns.resolver.NXDOMAIN, dns.exception.DNSException):
@@ -211,7 +225,7 @@ def _check_dnssec(resolver: dns.resolver.Resolver, domain: str) -> dict:
     return {
         "enabled": False,
         "issues": [
-            "DNSSEC not enabled. The domain is vulnerable to DNS spoofing and cache poisoning."
+            "DNSSEC is not enabled or could not be validated. The domain is vulnerable to DNS spoofing and cache poisoning."
         ],
     }
 

--- a/tools/src/aden_tools/tools/dns_security_scanner/dns_security_scanner.py
+++ b/tools/src/aden_tools/tools/dns_security_scanner/dns_security_scanner.py
@@ -64,7 +64,7 @@ def register_tools(mcp: FastMCP) -> None:
         spf = _check_spf(resolver, domain)
         dmarc = _check_dmarc(resolver, domain)
         dkim = _check_dkim(resolver, domain)
-        dnssec = _check_dnssec(resolver, domain)
+        dnssec = _check_dnssec(domain)
         mx = _check_mx(resolver, domain)
         caa = _check_caa(resolver, domain)
         zone_transfer = _check_zone_transfer(resolver, domain)
@@ -198,7 +198,7 @@ def _check_dkim(resolver: dns.resolver.Resolver, domain: str) -> dict:
     }
 
 
-def _check_dnssec(resolver: dns.resolver.Resolver, domain: str) -> dict:
+def _check_dnssec(domain: str) -> dict:
     """Check if DNSSEC is enabled and validated."""
     try:
         # Create an isolated resolver to avoid polluting the default one
@@ -217,9 +217,7 @@ def _check_dnssec(resolver: dns.resolver.Resolver, domain: str) -> dict:
         if answers.response.flags & dns.flags.AD:
             return {"enabled": True, "issues": []}
             
-    except dns.resolver.NoAnswer:
-        pass
-    except (dns.resolver.NXDOMAIN, dns.exception.DNSException):
+    except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN, dns.exception.DNSException):
         pass
 
     return {


### PR DESCRIPTION
Fixes #5112.

The \_check_dnssec\ tool was returning false positives because the system resolver doesn't always validate DNSSEC, or strips the AD flag. This PR ensures we:
1. Initialize an isolated \dns.resolver.Resolver()\
2. Target public resolvers known to perform validation (8.8.8.8, 1.1.1.1)
3. Request validation using EDNS DO bit
4. Check the AD flag on the returned SOA records

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced DNSSEC validation in the DNS security scanner. The scanner now confirms DNSSEC enablement only when cryptographic validation succeeds, provides clearer "enabled"/"disabled" reporting, and gives more informative issue messages when DNSSEC is absent or cannot be validated. Improvements reduce false positives and improve the accuracy of validation status shown to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->