### PR TITLE
feat: HIVE_DESKTOP_MODE env to skip frontend build in hive serve

### DIFF
--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -15,6 +15,16 @@ from typing import Any
 DEFAULT_MAX_TOKENS = 8192
 
 # ---------------------------------------------------------------------------
+# Desktop mode
+# ---------------------------------------------------------------------------
+# Set by the Electron shell when it spawns `hive serve` so the runtime knows
+# it's hosted inside a desktop client rather than served standalone. Today
+# this only gates the frontend-build step in `hive serve` (the desktop ships
+# its own renderer), but it's also a useful hook for future single-user /
+# telemetry-off branching.
+DESKTOP_MODE: bool = bool(os.environ.get("HIVE_DESKTOP_MODE"))
+
+# ---------------------------------------------------------------------------
 # Hive home directory structure
 # ---------------------------------------------------------------------------
 

--- a/core/framework/loader/cli.py
+++ b/core/framework/loader/cli.py
@@ -92,7 +92,13 @@ def cmd_serve(args: argparse.Namespace) -> int:
 
     from aiohttp import web
 
-    _build_frontend()
+    from framework.config import DESKTOP_MODE
+
+    # Skip frontend build when running inside the desktop shell — Electron
+    # ships its own renderer, and running `npm` from a packaged install
+    # often fails (no toolchain on the user's machine).
+    if not DESKTOP_MODE:
+        _build_frontend()
 
     from framework.observability import configure_logging
     from framework.server.app import create_app


### PR DESCRIPTION
## Summary

- Adds a `DESKTOP_MODE` flag in `framework/config.py` driven by the `HIVE_DESKTOP_MODE` env var.
- `hive serve` now short-circuits `_build_frontend()` when `HIVE_DESKTOP_MODE=1`, avoiding `npm install` / `npm run build` on machines that don't have the toolchain (i.e. inside a packaged desktop client).
- Server deployments are unaffected — default (unset) preserves today's behavior.

## Why

The OpenHive desktop (Electron) bundles upstream `hive` and spawns it with `uv run hive serve`. Electron ships its own renderer, so the React frontend at `core/frontend/` doesn't need to be built — and on a packaged install, `npm` usually isn't on PATH at all, so `_build_frontend()` blows up. Today the desktop has to either ship a fork that strips the build step, or omit `core/frontend/` from the bundle entirely so `_build_frontend()` returns False on the no-`package.json` short-circuit. Both are fragile.

This PR makes the desktop's intent explicit and forward-compatible: set the env var, get the right behavior. The flag also gives future desktop-vs-server branching (single-user mode, telemetry-off, etc.) a stable hook.

## Test plan

- [ ] `HIVE_DESKTOP_MODE=1 uv run hive serve --port 18787` starts the API without invoking npm
- [ ] `uv run hive serve --port 18787` (env unset) still calls `_build_frontend()` exactly as before
- [ ] `curl http://127.0.0.1:18787/api/health` returns `{"status":"ok",…}` in both modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Server startup is now faster when running in desktop mode by skipping unnecessary frontend build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->