### PR TITLE
micro-fix: warn and skip duplicate tool name registration in ToolRegistry

### DIFF
--- a/core/framework/loader/tool_registry.py
+++ b/core/framework/loader/tool_registry.py
@@ -136,6 +136,14 @@ class ToolRegistry:
             tool: Tool definition
             executor: Function that takes tool input dict and returns result
         """
+        if name in self._tools:
+            logger.warning(
+                "⚠ Tool '%s' already registered, skipping duplicate. "
+                "Existing: %s",
+                name,
+                self._tools[name].tool.description,
+            )
+            return
         self._tools[name] = RegisteredTool(tool=tool, executor=executor)
 
     def register_function(

--- a/core/framework/loader/tool_registry.py
+++ b/core/framework/loader/tool_registry.py
@@ -127,6 +127,8 @@ class ToolRegistry:
         name: str,
         tool: Tool,
         executor: Callable[[dict], Any],
+        *,
+        overwrite: bool = True,
     ) -> None:
         """
         Register a single tool with its executor.
@@ -135,8 +137,13 @@ class ToolRegistry:
             name: Tool name (must match tool.name)
             tool: Tool definition
             executor: Function that takes tool input dict and returns result
+            overwrite: If False, log a warning and keep the existing
+                registration when ``name`` is already present. Defaults to
+                True to preserve the documented idempotent-overwrite
+                contract used by ``register_task_tools`` and
+                ``AgentLoader.register_tool``.
         """
-        if name in self._tools:
+        if name in self._tools and not overwrite:
             logger.warning(
                 "⚠ Tool '%s' already registered, skipping duplicate. "
                 "Existing: %s",


### PR DESCRIPTION
## Fix: ToolRegistry silent overwrite bug (fixes #2540)

### Problem
`ToolRegistry.register()` silently overwrites existing tools when a duplicate name is registered, with no warning or error. This causes silent failures in multi-MCP server environments.

### Solution
Added a check in `register()` that logs a warning and skips the duplicate registration instead of unconditionally overwriting.

### Changes
- **File**: `core/framework/loader/tool_registry.py`
- Added duplicate name check before registration
- Logs warning with existing tool description when duplicate detected
- Skips registration instead of overwriting

### Why this matters
- Prevents silent data loss when multiple MCP servers have overlapping tool names
- Makes registration collisions visible for debugging
- Maintains backward compatibility (no errors thrown)
- Matches the proposed Option 2 from issue #2540

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate tool registrations can now be detected and skipped: when duplicate protection is enabled, the system logs a warning and keeps the existing tool instead of replacing it.
* **New Features**
  * Added an option to control whether registering a tool overwrites an existing registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->