### PR TITLE
Fix aiohttp app state AppKey warnings

### DIFF
--- a/core/framework/loader/cli.py
+++ b/core/framework/loader/cli.py
@@ -95,7 +95,7 @@ def cmd_serve(args: argparse.Namespace) -> int:
     _build_frontend()
 
     from framework.observability import configure_logging
-    from framework.server.app import create_app
+    from framework.server.app import MANAGER_KEY, create_app
 
     if getattr(args, "debug", False):
         configure_logging(level="DEBUG")
@@ -120,7 +120,7 @@ def cmd_serve(args: argparse.Namespace) -> int:
     app = create_app(model=model)
 
     async def run_server() -> None:
-        manager = app["manager"]
+        manager = app[MANAGER_KEY]
         shutdown_event = asyncio.Event()
         signal_count = {"n": 0}
 

--- a/core/framework/server/app.py
+++ b/core/framework/server/app.py
@@ -11,6 +11,10 @@ from framework.server.session_manager import Session, SessionManager
 
 logger = logging.getLogger(__name__)
 
+MANAGER_KEY = web.AppKey("manager", SessionManager)
+CREDENTIAL_STORE_KEY = web.AppKey("credential_store", object)
+QUEEN_TOOL_REGISTRY_KEY = web.AppKey("queen_tool_registry", object)
+
 
 # Anchor to the repository root so allowed roots are independent of CWD.
 # app.py lives at core/framework/server/app.py, so four .parent calls
@@ -88,7 +92,7 @@ def resolve_session(request: web.Request):
 
     Returns (session, None) on success or (None, error_response) on failure.
     """
-    manager: SessionManager = request.app["manager"]
+    manager: SessionManager = request.app[MANAGER_KEY]
     sid = request.match_info["session_id"]
     session = manager.get_session(sid)
     if not session:
@@ -210,13 +214,13 @@ async def error_middleware(request: web.Request, handler):
 
 async def _on_shutdown(app: web.Application) -> None:
     """Gracefully unload all agents on server shutdown."""
-    manager: SessionManager = app["manager"]
+    manager: SessionManager = app[MANAGER_KEY]
     await manager.shutdown_all()
 
 
 async def handle_health(request: web.Request) -> web.Response:
     """GET /api/health — simple health check."""
-    manager: SessionManager = request.app["manager"]
+    manager: SessionManager = request.app[MANAGER_KEY]
     sessions = manager.list_sessions()
     return web.json_response(
         {
@@ -358,12 +362,12 @@ def create_app(model: str | None = None) -> web.Application:
         logger.debug("Encrypted credential store unavailable, using in-memory fallback")
         credential_store = CredentialStore.for_testing({})
 
-    app["credential_store"] = credential_store
+    app[CREDENTIAL_STORE_KEY] = credential_store
 
     # Let queen sessions build their registry lazily on first use instead of
     # paying the MCP discovery cost during `hive open`.
-    app["queen_tool_registry"] = None
-    app["manager"] = SessionManager(
+    app[QUEEN_TOOL_REGISTRY_KEY] = None
+    app[MANAGER_KEY] = SessionManager(
         model=model,
         credential_store=credential_store,
         queen_tool_registry=None,

--- a/core/framework/server/routes_colony_tools.py
+++ b/core/framework/server/routes_colony_tools.py
@@ -35,6 +35,7 @@ from framework.host.colony_tools_config import (
     load_colony_tools_config,
     update_colony_tools_config,
 )
+from framework.server.app import MANAGER_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -201,7 +202,7 @@ async def handle_get_tools(request: web.Request) -> web.Response:
     if not colony_metadata_path(colony_name).exists():
         return web.json_response({"error": f"Colony '{colony_name}' not found"}, status=404)
 
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     # Allowlist now lives in a dedicated tools.json sidecar; helper
     # migrates any legacy metadata.json field on first read.
     enabled = load_colony_tools_config(colony_name)
@@ -245,7 +246,7 @@ async def handle_patch_tools(request: web.Request) -> web.Response:
                 status=400,
             )
 
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
 
     # Validate names against the known MCP catalog — lifts the same
     # typo-catching guarantee we already offer on queen tools.

--- a/core/framework/server/routes_colony_tools.py
+++ b/core/framework/server/routes_colony_tools.py
@@ -202,7 +202,7 @@ async def handle_get_tools(request: web.Request) -> web.Response:
     if not colony_metadata_path(colony_name).exists():
         return web.json_response({"error": f"Colony '{colony_name}' not found"}, status=404)
 
-    manager = request.app.get(MANAGER_KEY)
+    manager = request.app[MANAGER_KEY]
     # Allowlist now lives in a dedicated tools.json sidecar; helper
     # migrates any legacy metadata.json field on first read.
     enabled = load_colony_tools_config(colony_name)
@@ -246,7 +246,7 @@ async def handle_patch_tools(request: web.Request) -> web.Response:
                 status=400,
             )
 
-    manager = request.app.get(MANAGER_KEY)
+    manager = request.app[MANAGER_KEY]
 
     # Validate names against the known MCP catalog — lifts the same
     # typo-catching guarantee we already offer on queen tools.

--- a/core/framework/server/routes_config.py
+++ b/core/framework/server/routes_config.py
@@ -30,6 +30,7 @@ from framework.llm.model_catalog import (
     get_models_catalogue,
     get_preset,
 )
+from framework.server.app import CREDENTIAL_STORE_KEY, MANAGER_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -174,7 +175,7 @@ def _resolve_api_key(provider: str, request: web.Request) -> str | None:
     cred_id = _PROVIDER_CRED_MAP.get(provider.lower())
     if cred_id:
         try:
-            store = request.app["credential_store"]
+            store = request.app[CREDENTIAL_STORE_KEY]
             key = store.get(cred_id)
             if key:
                 return key
@@ -293,7 +294,7 @@ def _hot_swap_sessions(request: web.Request, full_model: str, api_key: str | Non
     """
     from framework.server.session_manager import SessionManager
 
-    manager: SessionManager = request.app["manager"]
+    manager: SessionManager = request.app[MANAGER_KEY]
     manager._model = full_model
     swapped = 0
     for session in manager.list_sessions():

--- a/core/framework/server/routes_credentials.py
+++ b/core/framework/server/routes_credentials.py
@@ -9,7 +9,7 @@ from pydantic import SecretStr
 
 from framework.credentials.models import CredentialDecryptionError, CredentialKey, CredentialObject
 from framework.credentials.store import CredentialStore
-from framework.server.app import validate_agent_path
+from framework.server.app import CREDENTIAL_STORE_KEY, MANAGER_KEY, validate_agent_path
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ def _get_llm_key_providers() -> dict:
 
 
 def _get_store(request: web.Request) -> CredentialStore:
-    return request.app["credential_store"]
+    return request.app[CREDENTIAL_STORE_KEY]
 
 
 def _invalidate_queen_credentials_cache(request: web.Request) -> None:
@@ -50,7 +50,7 @@ def _invalidate_queen_credentials_cache(request: web.Request) -> None:
     appear in the Queen's prompt on her next turn instead of waiting for the
     cache TTL to expire.
     """
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     if manager is None:
         return
     sessions = getattr(manager, "_sessions", None)

--- a/core/framework/server/routes_execution.py
+++ b/core/framework/server/routes_execution.py
@@ -11,7 +11,7 @@ from aiohttp import web
 from framework.agent_loop.conversation import LEGACY_RUN_ID
 from framework.credentials.validation import validate_agent_credentials
 from framework.host.execution_manager import ExecutionAlreadyRunningError
-from framework.server.app import resolve_session, safe_path_segment, sessions_dir
+from framework.server.app import MANAGER_KEY, resolve_session, safe_path_segment, sessions_dir
 from framework.server.routes_sessions import _credential_error_response
 
 logger = logging.getLogger(__name__)
@@ -334,7 +334,7 @@ async def handle_chat(request: web.Request) -> web.Response:
 
     # Queen is dead — try to revive her
     logger.warning("[handle_chat] Queen is dead for session '%s', reviving on /chat request", session.id)
-    manager: Any = request.app["manager"]
+    manager: Any = request.app[MANAGER_KEY]
     try:
         logger.debug("[handle_chat] Calling manager.revive_queen()...")
         await manager.revive_queen(session)
@@ -387,7 +387,7 @@ async def handle_queen_context(request: web.Request) -> web.Response:
         "Queen is dead for session '%s', reviving on /queen-context request",
         session.id,
     )
-    manager: Any = request.app["manager"]
+    manager: Any = request.app[MANAGER_KEY]
     try:
         await manager.revive_queen(session)
         # After revival, deliver the message
@@ -982,7 +982,7 @@ async def handle_compact_and_fork(request: web.Request) -> web.Response:
     except OSError:
         logger.warning("compact_and_fork: failed to write new meta.json", exc_info=True)
 
-    manager: Any = request.app["manager"]
+    manager: Any = request.app[MANAGER_KEY]
     try:
         new_session = await manager.create_session(
             session_id=None,

--- a/core/framework/server/routes_messages.py
+++ b/core/framework/server/routes_messages.py
@@ -9,6 +9,7 @@
 from aiohttp import web
 
 from framework.agents.queen.queen_profiles import ensure_default_queens, select_queen
+from framework.server.app import MANAGER_KEY
 
 
 async def handle_classify_message(request: web.Request) -> web.Response:
@@ -16,7 +17,7 @@ async def handle_classify_message(request: web.Request) -> web.Response:
     import traceback as _tb
 
     try:
-        manager = request.app["manager"]
+        manager = request.app[MANAGER_KEY]
         body = await request.json() if request.can_read_body else {}
         message = body.get("message")
         if not isinstance(message, str) or not message.strip():

--- a/core/framework/server/routes_queen_tools.py
+++ b/core/framework/server/routes_queen_tools.py
@@ -40,6 +40,7 @@ from framework.agents.queen.queen_tools_defaults import (
     queen_role_categories,
     resolve_category_tools,
 )
+from framework.server.app import MANAGER_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -288,7 +289,7 @@ async def handle_get_tools(request: web.Request) -> web.Response:
     except FileNotFoundError:
         return web.json_response({"error": f"Queen '{queen_id}' not found"}, status=404)
 
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     session = _live_queen_session(manager, queen_id) if manager is not None else None
 
     # Prefer a live session's registry for freshness. Otherwise use (or
@@ -398,7 +399,7 @@ async def handle_patch_tools(request: web.Request) -> web.Response:
     # Validate names against the known MCP tool catalog. We prefer a live
     # session's registry for the most up-to-date set, then fall back to
     # the manager-level snapshot (building it on demand if absent).
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     session = _live_queen_session(manager, queen_id) if manager is not None else None
     if session is not None:
         catalog = _catalog_from_live_session(session)
@@ -484,7 +485,7 @@ async def handle_delete_tools(request: web.Request) -> web.Response:
     # Recompute the queen's effective allowlist from the role defaults
     # so we can hot-reload live sessions in one pass (same shape as
     # PATCH).
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     session = _live_queen_session(manager, queen_id) if manager is not None else None
     if session is not None:
         catalog = _catalog_from_live_session(session)

--- a/core/framework/server/routes_queens.py
+++ b/core/framework/server/routes_queens.py
@@ -23,6 +23,7 @@ from framework.agents.queen.queen_profiles import (
     update_queen_profile,
 )
 from framework.config import QUEENS_DIR
+from framework.server.app import MANAGER_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -232,7 +233,7 @@ async def handle_queen_session(request: web.Request) -> web.Response:
     from framework.server.session_manager import SessionManager
 
     queen_id = request.match_info["queen_id"]
-    manager: SessionManager = request.app["manager"]
+    manager: SessionManager = request.app[MANAGER_KEY]
 
     ensure_default_queens()
     try:
@@ -333,7 +334,7 @@ async def handle_queen_session(request: web.Request) -> web.Response:
 async def handle_select_queen_session(request: web.Request) -> web.Response:
     """POST /api/queen/{queen_id}/session/select -- resume a specific queen session."""
     queen_id = request.match_info["queen_id"]
-    manager = request.app["manager"]
+    manager = request.app[MANAGER_KEY]
 
     ensure_default_queens()
     try:
@@ -388,7 +389,7 @@ async def handle_new_queen_session(request: web.Request) -> web.Response:
     from framework.tools.queen_lifecycle_tools import QUEEN_PHASES
 
     queen_id = request.match_info["queen_id"]
-    manager = request.app["manager"]
+    manager = request.app[MANAGER_KEY]
 
     ensure_default_queens()
     try:

--- a/core/framework/server/routes_sessions.py
+++ b/core/framework/server/routes_sessions.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from aiohttp import web
 
 from framework.server.app import (
+    MANAGER_KEY,
     resolve_session,
     validate_agent_path,
 )
@@ -38,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 
 def _get_manager(request: web.Request) -> SessionManager:
-    return request.app["manager"]
+    return request.app[MANAGER_KEY]
 
 
 def _session_to_live_dict(session) -> dict:
@@ -1121,7 +1122,7 @@ async def handle_delete_agent(request: web.Request) -> web.Response:
 
 async def handle_reveal_session_folder(request: web.Request) -> web.Response:
     """POST /api/sessions/{session_id}/reveal — open session data folder in the OS file manager."""
-    manager: SessionManager = request.app["manager"]
+    manager: SessionManager = request.app[MANAGER_KEY]
     session_id = request.match_info["session_id"]
 
     session = manager.get_session(session_id)

--- a/core/framework/server/routes_skills.py
+++ b/core/framework/server/routes_skills.py
@@ -38,6 +38,7 @@ from typing import Any
 from aiohttp import web
 
 from framework.config import COLONIES_DIR, QUEENS_DIR
+from framework.server.app import MANAGER_KEY
 from framework.skills.authoring import (
     build_draft,
     remove_skill as authoring_remove_skill,
@@ -365,7 +366,7 @@ def _serialize_skill(
 
 
 async def handle_list_queen_skills(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     queen_id = request.match_info["queen_id"]
     scope = _queen_scope(manager, queen_id)
     if scope is None:
@@ -386,7 +387,7 @@ async def handle_list_queen_skills(request: web.Request) -> web.Response:
 
 
 async def handle_list_colony_skills(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     colony_name = request.match_info["colony_name"]
     scope = _colony_scope(manager, colony_name)
     if scope is None:
@@ -775,7 +776,7 @@ def _requester_id(request: web.Request) -> str:
 
 
 async def handle_create_queen_skill(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _queen_scope(manager, request.match_info["queen_id"])
     if scope is None:
         return web.json_response({"error": "queen not found"}, status=404)
@@ -787,7 +788,7 @@ async def handle_create_queen_skill(request: web.Request) -> web.Response:
 
 
 async def handle_patch_queen_skill(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _queen_scope(manager, request.match_info["queen_id"])
     if scope is None:
         return web.json_response({"error": "queen not found"}, status=404)
@@ -799,7 +800,7 @@ async def handle_patch_queen_skill(request: web.Request) -> web.Response:
 
 
 async def handle_put_queen_skill_body(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _queen_scope(manager, request.match_info["queen_id"])
     if scope is None:
         return web.json_response({"error": "queen not found"}, status=404)
@@ -811,7 +812,7 @@ async def handle_put_queen_skill_body(request: web.Request) -> web.Response:
 
 
 async def handle_delete_queen_skill(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _queen_scope(manager, request.match_info["queen_id"])
     if scope is None:
         return web.json_response({"error": "queen not found"}, status=404)
@@ -819,7 +820,7 @@ async def handle_delete_queen_skill(request: web.Request) -> web.Response:
 
 
 async def handle_reload_queen_skills(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _queen_scope(manager, request.match_info["queen_id"])
     if scope is None:
         return web.json_response({"error": "queen not found"}, status=404)
@@ -827,7 +828,7 @@ async def handle_reload_queen_skills(request: web.Request) -> web.Response:
 
 
 async def handle_create_colony_skill(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _colony_scope(manager, request.match_info["colony_name"])
     if scope is None:
         return web.json_response({"error": "colony not found"}, status=404)
@@ -839,7 +840,7 @@ async def handle_create_colony_skill(request: web.Request) -> web.Response:
 
 
 async def handle_patch_colony_skill(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _colony_scope(manager, request.match_info["colony_name"])
     if scope is None:
         return web.json_response({"error": "colony not found"}, status=404)
@@ -851,7 +852,7 @@ async def handle_patch_colony_skill(request: web.Request) -> web.Response:
 
 
 async def handle_put_colony_skill_body(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _colony_scope(manager, request.match_info["colony_name"])
     if scope is None:
         return web.json_response({"error": "colony not found"}, status=404)
@@ -863,7 +864,7 @@ async def handle_put_colony_skill_body(request: web.Request) -> web.Response:
 
 
 async def handle_delete_colony_skill(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _colony_scope(manager, request.match_info["colony_name"])
     if scope is None:
         return web.json_response({"error": "colony not found"}, status=404)
@@ -871,7 +872,7 @@ async def handle_delete_colony_skill(request: web.Request) -> web.Response:
 
 
 async def handle_reload_colony_skills(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _colony_scope(manager, request.match_info["colony_name"])
     if scope is None:
         return web.json_response({"error": "colony not found"}, status=404)
@@ -894,7 +895,7 @@ async def handle_upload_skill(request: web.Request) -> web.Response:
       ``replace_existing``          — "true"/"false" (defaults false)
       ``name``                      — optional override for single-.md uploads
     """
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     if not request.content_type.startswith("multipart/"):
         return web.json_response({"error": "expected multipart/form-data"}, status=400)
 

--- a/core/tests/test_colony_fork_flow.py
+++ b/core/tests/test_colony_fork_flow.py
@@ -22,7 +22,7 @@ import pytest
 from aiohttp.test_utils import TestClient, TestServer
 
 from framework.agent_loop.internals.types import LoopConfig
-from framework.server.app import create_app
+from framework.server.app import MANAGER_KEY, create_app
 from framework.server.session_manager import Session, _queen_session_dir
 
 # Modules that import HIVE_HOME / QUEENS_DIR / COLONIES_DIR / MEMORIES_DIR /
@@ -263,7 +263,7 @@ async def test_colony_spawn_creates_correct_artifacts(tmp_path, monkeypatch):
 
     # Build the in-process aiohttp app and inject our fake session
     app = create_app()
-    manager = app["manager"]
+    manager = app[MANAGER_KEY]
     session = _make_session_with_queen_state(
         session_id=source_session_id,
         queen_name=queen_name,

--- a/core/tests/test_colony_fork_live.py
+++ b/core/tests/test_colony_fork_live.py
@@ -129,7 +129,7 @@ async def test_live_queen_fork_to_colony(isolated_hive_home):
       5. Conversations are copied through to worker storage
     """
     from framework.agents.queen.queen_profiles import ensure_default_queens
-    from framework.server.app import create_app
+    from framework.server.app import MANAGER_KEY, create_app
     from framework.server.session_manager import _queen_session_dir
 
     # Pre-populate queen profiles in the temp ~/.hive so the identity
@@ -137,7 +137,7 @@ async def test_live_queen_fork_to_colony(isolated_hive_home):
     ensure_default_queens()
 
     app = create_app()  # picks up model from copied configuration.json
-    manager = app["manager"]
+    manager = app[MANAGER_KEY]
 
     async with TestClient(TestServer(app)) as client:
         # ── 1. Create a queen-only session ─────────────────────────


### PR DESCRIPTION
Fixes #6161

## Summary
- Migrates aiohttp application state from string keys to typed `web.AppKey` constants.
- Updates server app state read/write call sites for `manager`, `credential_store`, and `queen_tool_registry`.
- Updates tests and CLI access to use the new typed keys.

## Why
This removes `NotAppKeyWarning` from aiohttp and aligns the server app state handling with aiohttp’s recommended typed `web.AppKey` pattern.

## Testing
- `uv run pytest core/tests/test_validate_agent_path.py::TestHTTPEndpointsRejectMaliciousPaths::test_create_session_rejects_outside_path -q -W error::aiohttp.web_app.NotAppKeyWarning`
- `uv run pytest core/tests/test_validate_agent_path.py -q`
- `uv run ruff check <touched files>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced string-based application lookups with typed application keys for runtime services across server routes and startup/shutdown flows.
* **Tests**
  * Updated tests to use the new application keys to access runtime services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->