### PR TITLE
fix(quickstart): pin uv to detected Python interpreter

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -167,6 +167,9 @@ fi
 echo -e "${GREEN}⬢${NC} Python $PYTHON_VERSION"
 echo ""
 
+# Keep uv on the interpreter we just validated (3.11+).
+export UV_PYTHON="$PYTHON_CMD"
+
 # Check for uv (install automatically if missing)
 if ! command -v uv &> /dev/null; then
     echo -e "${YELLOW}  uv not found. Installing...${NC}"
@@ -264,6 +267,8 @@ if [ -f "pyproject.toml" ]; then
         echo -e "${GREEN}  ✓ workspace packages installed${NC}"
     else
         echo -e "${RED}  ✗ workspace installation failed${NC}"
+        echo -e "${DIM}    quickstart selected: $PYTHON_CMD (Python $PYTHON_VERSION)${NC}"
+        echo -e "${DIM}    If this machine also has a pinned Python version file, ensure that interpreter exists.${NC}"
         exit 1
     fi
 else


### PR DESCRIPTION
## Description

Pins uv to the Python interpreter detected in Step 1 (3.11+), preventing unexpected failures in Step 2 when uv reads local .python-version pins.

## Motivation

Fixes #7167 — quickstart passes Python 3.11+ check but fails at `uv sync` when only Python 3.12 exists because uv defaults to repo-pinned version instead of the validated interpreter.

## Changes

- Export `UV_PYTHON` after Python detection so uv uses the same interpreter confirmed in Step 1
- Improve Step 2 failure message to include which Python interpreter quickstart selected

## Testing

- Syntax check: `bash -n quickstart.sh`
- Dry-run: `uv sync --dry-run`
- Manual: Ran on Python 3.12-only system — Step 2 completes where it previously failed

## Checklist

- [x] Code follows style guidelines (bash)
- [x] Self-review completed
- [x] Documentation updated (n/a — quickstart is self-documenting)

Closes #7167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup script reliability by ensuring the correct Python interpreter is properly configured during initialization.
  * Enhanced error messages during setup failures to provide clearer diagnostic information about the Python environment and version requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->