### PR TITLE
fix(antigravity): unblock Gemini chats — schema sanitizer + UA bump

### DIFF
--- a/core/framework/llm/antigravity.py
+++ b/core/framework/llm/antigravity.py
@@ -282,10 +282,16 @@ def _sanitize_schema_for_gemini(schema: Any) -> Any:
             out["type"] = "string"
             out["nullable"] = True
         else:
-            # Multi-type union without a clean null reduction — pick first and warn.
-            out["type"] = non_null[0] if non_null else t[0]
-            if has_null:
-                out["nullable"] = True
+            # Multi-type non-null unions (e.g. ["string", "integer", "null"])
+            # have no faithful Gemini equivalent. Silently picking one type
+            # changes the contract for callers who rely on the others, so
+            # fail loud and let the schema author rewrite it as anyOf or
+            # narrow to a single type.
+            raise ValueError(
+                f"Unsupported Gemini schema union: {t!r}. "
+                "Gemini accepts a single primitive type plus optional 'nullable: true'. "
+                "Rewrite as anyOf or pick a single type."
+            )
 
     if "properties" in out and isinstance(out["properties"], dict):
         out["properties"] = {k: _sanitize_schema_for_gemini(v) for k, v in out["properties"].items()}

--- a/core/framework/llm/antigravity.py
+++ b/core/framework/llm/antigravity.py
@@ -254,6 +254,50 @@ def _clean_tool_name(name: str) -> str:
     return name[:64]
 
 
+def _sanitize_schema_for_gemini(schema: Any) -> Any:
+    """Convert JSON Schema 2020-12 features to the OpenAPI 3.0 dialect Gemini accepts.
+
+    Gemini's function_declarations parser rejects union ``"type": ["string", "null"]``.
+    Translate any such union to a single type plus ``"nullable": true``. Recurse into
+    ``properties``, ``items``, and the ``anyOf``/``oneOf``/``allOf`` combinators.
+    """
+    if isinstance(schema, list):
+        return [_sanitize_schema_for_gemini(s) for s in schema]
+    if not isinstance(schema, dict):
+        return schema
+
+    out = dict(schema)
+    t = out.get("type")
+    if isinstance(t, list):
+        non_null = [x for x in t if x != "null"]
+        has_null = "null" in t
+        if len(non_null) == 1:
+            out["type"] = non_null[0]
+            if has_null:
+                out["nullable"] = True
+        elif not non_null and has_null:
+            # Pure null type: fall back to string-nullable.
+            out["type"] = "string"
+            out["nullable"] = True
+        else:
+            # Multi-type union without a clean null reduction — pick first and warn.
+            out["type"] = non_null[0] if non_null else t[0]
+            if has_null:
+                out["nullable"] = True
+
+    if "properties" in out and isinstance(out["properties"], dict):
+        out["properties"] = {k: _sanitize_schema_for_gemini(v) for k, v in out["properties"].items()}
+    if "items" in out:
+        out["items"] = _sanitize_schema_for_gemini(out["items"])
+    if "additionalProperties" in out and isinstance(out["additionalProperties"], dict):
+        out["additionalProperties"] = _sanitize_schema_for_gemini(out["additionalProperties"])
+    for combinator in ("anyOf", "oneOf", "allOf"):
+        if combinator in out:
+            out[combinator] = _sanitize_schema_for_gemini(out[combinator])
+
+    return out
+
+
 def _to_gemini_contents(
     messages: list[dict[str, Any]],
     thought_sigs: dict[str, str] | None = None,
@@ -555,11 +599,13 @@ class AntigravityProvider(LLMProvider):
                         {
                             "name": _clean_tool_name(t.name),
                             "description": t.description,
-                            "parameters": t.parameters
-                            or {
-                                "type": "object",
-                                "properties": {},
-                            },
+                            "parameters": _sanitize_schema_for_gemini(
+                                t.parameters
+                                or {
+                                    "type": "object",
+                                    "properties": {},
+                                }
+                            ),
                         }
                         for t in tools
                     ]

--- a/core/framework/llm/antigravity.py
+++ b/core/framework/llm/antigravity.py
@@ -61,10 +61,12 @@ _IDE_STATE_DB_KEY = "antigravityUnifiedStateSync.oauthToken"
 
 _BASE_HEADERS: dict[str, str] = {
     # Mimic the Antigravity Electron app so the API accepts the request.
+    # Google deprecates older client versions over time, so this needs periodic
+    # bumping to match whatever the current Antigravity desktop release advertises.
     "User-Agent": (
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Antigravity/1.18.3 Chrome/138.0.7204.235 "
-        "Electron/37.3.1 Safari/537.36"
+        "(KHTML, like Gecko) Antigravity/1.23.2 Chrome/138.0.7204.235 "
+        "Electron/39.2.3 Safari/537.36"
     ),
     "X-Goog-Api-Client": "google-cloud-sdk vscode_cloudshelleditor/0.1",
     "Client-Metadata": '{"ideType":"ANTIGRAVITY","platform":"MACOS","pluginType":"GEMINI"}',

--- a/core/tests/test_antigravity_schema.py
+++ b/core/tests/test_antigravity_schema.py
@@ -65,7 +65,7 @@ def test_pure_null_type_falls_back_to_string():
 
 
 def test_multi_type_non_null_union_raises():
-    """Silently picking one type would change the contract — fail loud instead."""
+    """Silently picking one type would change the contract; fail loud instead."""
     with pytest.raises(ValueError, match="Unsupported Gemini schema union"):
         _sanitize_schema_for_gemini({"type": ["string", "integer", "null"]})
 

--- a/core/tests/test_antigravity_schema.py
+++ b/core/tests/test_antigravity_schema.py
@@ -1,0 +1,62 @@
+"""Tests for the Antigravity Gemini schema sanitizer.
+
+Run with:
+    cd core
+    pytest tests/test_antigravity_schema.py -v
+"""
+
+from framework.llm.antigravity import _sanitize_schema_for_gemini
+
+
+def test_union_with_null_becomes_nullable():
+    assert _sanitize_schema_for_gemini({"type": ["string", "null"]}) == {
+        "type": "string",
+        "nullable": True,
+    }
+
+
+def test_plain_schema_passthrough():
+    assert _sanitize_schema_for_gemini({"type": "string"}) == {"type": "string"}
+
+
+def test_recurses_into_properties():
+    out = _sanitize_schema_for_gemini(
+        {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "owner": {"type": ["string", "null"]},
+            },
+            "required": ["id"],
+        }
+    )
+    assert out["properties"]["id"] == {"type": "integer"}
+    assert out["properties"]["owner"] == {"type": "string", "nullable": True}
+    assert out["required"] == ["id"]
+
+
+def test_recurses_into_items():
+    assert _sanitize_schema_for_gemini({"type": "array", "items": {"type": ["integer", "null"]}}) == {
+        "type": "array",
+        "items": {"type": "integer", "nullable": True},
+    }
+
+
+def test_recurses_into_combinators():
+    assert _sanitize_schema_for_gemini({"anyOf": [{"type": ["string", "null"]}, {"type": "integer"}]}) == {
+        "anyOf": [{"type": "string", "nullable": True}, {"type": "integer"}]
+    }
+
+
+def test_does_not_mutate_input():
+    schema = {"type": "object", "properties": {"x": {"type": ["string", "null"]}}}
+    snapshot = {"type": "object", "properties": {"x": {"type": ["string", "null"]}}}
+    _sanitize_schema_for_gemini(schema)
+    assert schema == snapshot
+
+
+def test_pure_null_type_falls_back_to_string():
+    assert _sanitize_schema_for_gemini({"type": ["null"]}) == {
+        "type": "string",
+        "nullable": True,
+    }

--- a/core/tests/test_antigravity_schema.py
+++ b/core/tests/test_antigravity_schema.py
@@ -5,6 +5,8 @@ Run with:
     pytest tests/test_antigravity_schema.py -v
 """
 
+import pytest
+
 from framework.llm.antigravity import _sanitize_schema_for_gemini
 
 
@@ -60,3 +62,12 @@ def test_pure_null_type_falls_back_to_string():
         "type": "string",
         "nullable": True,
     }
+
+
+def test_multi_type_non_null_union_raises():
+    """Silently picking one type would change the contract — fail loud instead."""
+    with pytest.raises(ValueError, match="Unsupported Gemini schema union"):
+        _sanitize_schema_for_gemini({"type": ["string", "integer", "null"]})
+
+    with pytest.raises(ValueError, match="Unsupported Gemini schema union"):
+        _sanitize_schema_for_gemini({"type": ["string", "integer"]})


### PR DESCRIPTION
## Description

Fixes two Gemini compatibility issues in the Antigravity provider that currently prevent any chat from succeeding.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #7169

## Changes Made

- Add `_sanitize_schema_for_gemini()` in `core/framework/llm/antigravity.py` and apply it in `_build_body` so JSON Schema 2020-12 union types like `"type": ["string", "null"]` are translated to OpenAPI 3.0 `"nullable": true` before going on the wire. Recurses through `properties`, `items`, `additionalProperties`, and `anyOf`/`oneOf`/`allOf`.
- Bump spoofed `User-Agent` from `Antigravity/1.18.3` → `1.23.2` and `Electron/37.3.1` → `39.2.3` so Google stops returning the deprecation message. Added a comment that this needs periodic re-bumping until we auto-detect.
- New unit tests in `core/tests/test_antigravity_schema.py` covering union → nullable, nested recursion, combinators, and idempotence on plain schemas.

Source tool schemas (`colony_tools.py`, `session_tools.py`) keep their JSON-Schema-2020-12 form, so OpenAI/Anthropic backends are unaffected.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/test_antigravity_schema.py`)
- [x] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed — verified `gemini-3-flash` chat against a local Antigravity OAuth setup; previously-failing turns now succeed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A — backend bug fix; no UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the desktop client User-Agent and improved JSON Schema normalization so tool parameter schemas (including empty defaults) are converted to nullable-compatible forms for better compatibility; ambiguous multi-type unions are now rejected to avoid incorrect type assumptions.

* **Tests**
  * Added tests covering union-to-nullable conversion, recursive sanitization, input immutability, pure-null fallback, and unsupported-union error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->