### PR TITLE
fix(ci): unblock main CI, sort imports + install Playwright Chromium

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,23 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Install dependencies and run tests
+      - name: Install dependencies
         working-directory: tools
-        run: |
-          uv sync --extra dev
-          uv run pytest tests/ -v
+        run: uv sync --extra dev
+
+      - name: Install Playwright Chromium (Linux)
+        if: runner.os == 'Linux'
+        working-directory: tools
+        run: uv run playwright install --with-deps chromium
+
+      - name: Install Playwright Chromium (Windows)
+        if: runner.os == 'Windows'
+        working-directory: tools
+        run: uv run playwright install chromium
+
+      - name: Run tests
+        working-directory: tools
+        run: uv run pytest tests/ -v
 
   validate:
     name: Validate Agent Exports

--- a/core/framework/server/queen_orchestrator.py
+++ b/core/framework/server/queen_orchestrator.py
@@ -359,7 +359,6 @@ async def create_queen(
         queen_goal,
         queen_loop_config as _base_loop_config,
     )
-    from framework.config import get_max_tokens as _get_max_tokens
     from framework.agents.queen.nodes import (
         _QUEEN_INCUBATING_TOOLS,
         _QUEEN_INDEPENDENT_TOOLS,
@@ -378,6 +377,7 @@ async def create_queen(
         _queen_tools_working,
         finalize_queen_prompt,
     )
+    from framework.config import get_max_tokens as _get_max_tokens
     from framework.host.event_bus import AgentEvent, EventType
     from framework.llm.capabilities import supports_image_tool_results
     from framework.loader.mcp_registry import MCPRegistry

--- a/tools/tests/test_file_state_cache.py
+++ b/tools/tests/test_file_state_cache.py
@@ -2,8 +2,8 @@
 
 These tests cover the stale-edit guard added for Gap 4:
 - read_file records a per-file hash snapshot
-- edit_file / write_file / hashline_edit refuse to run when the on-disk
-  file has diverged from the last recorded read
+- edit_file / write_file refuse to run when the on-disk file has
+  diverged from the last recorded read
 - write_file is allowed without a prior read when the target doesn't
   exist yet (brand-new file, nothing to clobber)
 - re-recording after a successful write keeps chained edits working
@@ -52,7 +52,6 @@ def tools(sandbox: Path):
         "read_file": _find_tool(mcp, "read_file"),
         "write_file": _find_tool(mcp, "write_file"),
         "edit_file": _find_tool(mcp, "edit_file"),
-        "hashline_edit": _find_tool(mcp, "hashline_edit"),
     }
 
 
@@ -129,7 +128,7 @@ def test_edit_file_refuses_without_prior_read(sandbox: Path, tools):
     # Clear the cache first so there's definitely no recorded read.
     file_state_cache.reset_all()
 
-    result = tools["edit_file"]("e.py", "hello", "world")
+    result = tools["edit_file"]("replace", "e.py", "hello", "world")
     assert "Refusing to edit" in result
     assert "read_file" in result
 
@@ -140,7 +139,7 @@ def test_edit_file_proceeds_after_read(sandbox: Path, tools):
     file_state_cache.reset_all()
 
     tools["read_file"]("f.py")
-    result = tools["edit_file"]("f.py", "hello", "world")
+    result = tools["edit_file"]("replace", "f.py", "hello", "world")
     assert "Replaced" in result
     assert target.read_text() == "print('world')\n"
 
@@ -157,7 +156,7 @@ def test_edit_file_refuses_when_file_changed_between_read_and_edit(sandbox: Path
     target.write_text("print('bye')\n")
     os.utime(str(target), None)
 
-    result = tools["edit_file"]("g.py", "hello", "world")
+    result = tools["edit_file"]("replace", "g.py", "hello", "world")
     assert "Refusing to edit" in result
     assert "Re-read" in result
 
@@ -185,10 +184,10 @@ def test_chained_edits_in_same_turn_do_not_self_invalidate(sandbox: Path, tools)
     file_state_cache.reset_all()
 
     tools["read_file"]("chained.py")
-    r1 = tools["edit_file"]("chained.py", "a", "A")
+    r1 = tools["edit_file"]("replace", "chained.py", "a", "A")
     assert "Replaced" in r1
     # Immediate second edit must NOT trip the stale guard because
     # edit_file re-records the post-write state.
-    r2 = tools["edit_file"]("chained.py", "b", "B")
+    r2 = tools["edit_file"]("replace", "chained.py", "b", "B")
     assert "Replaced" in r2
     assert target.read_text() == "print('A')\nprint('B')\n"

--- a/tools/tests/test_terminal_tools_exec.py
+++ b/tools/tests/test_terminal_tools_exec.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import sys
 import time
 
 import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="terminal_tools is POSIX-only (uses resource module)")
 
 
 @pytest.fixture

--- a/tools/tests/test_terminal_tools_jobs.py
+++ b/tools/tests/test_terminal_tools_jobs.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import sys
 import time
 
 import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="terminal_tools is POSIX-only (uses resource module)")
 
 
 @pytest.fixture

--- a/tools/tests/test_terminal_tools_search.py
+++ b/tools/tests/test_terminal_tools_search.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import shutil
+import sys
 
 import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="terminal_tools is POSIX-only (uses resource module)")
 
 
 @pytest.fixture

--- a/tools/tests/test_terminal_tools_security.py
+++ b/tools/tests/test_terminal_tools_security.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import sys
+
 import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="terminal_tools is POSIX-only (uses resource module)")
 
 
 def test_resolve_shell_rejects_zsh():

--- a/tools/tests/test_terminal_tools_smoke.py
+++ b/tools/tests/test_terminal_tools_smoke.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="terminal_tools is POSIX-only (uses resource module)")
+
 EXPECTED_TOOLS = {
     "terminal_exec",
     "terminal_job_start",


### PR DESCRIPTION
## Description

Fixes the pre-existing CI failures on `main` so PRs can go green again. Four failures in total, all unrelated to each other but all blocking PRs. Verified locally that each fix step makes its corresponding check pass, and the full `tools` suite (6498 tests) is green.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #7171

## Changes Made

- `core/framework/server/queen_orchestrator.py`: reorder deferred imports inside `create_queen` so Ruff `I001` stops failing. One-line move, applied via `ruff check --fix`. No behavior change.
- `.github/workflows/ci.yml`: split the `test-tools` job into install/run steps and add `playwright install chromium` between them. Linux runners use `--with-deps` to pull system libraries; Windows runners only need the browser binary. Required by `tools/tests/test_chart_tools_smoke.py`, which launches a headless Chromium for ECharts and Mermaid rendering.
- `tools/tests/test_file_state_cache.py`: adapt to the file_ops rewrite shipped in `feabf327`. Drop the now-removed `hashline_edit` tool from the fixture and pass `mode="replace"` to every `edit_file` call to match the new mode-first signature.
- `tools/tests/test_terminal_tools_*.py`: add module-level `pytestmark = pytest.mark.skipif(sys.platform == "win32", ...)` to five files so they skip cleanly on Windows. The new `terminal_tools` package imports the POSIX-only `resource` module, so its test suite cannot run on `windows-latest`. `test_terminal_tools_pty.py` already had this skip; the fix matches the existing pattern.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd tools && uv run playwright install chromium && uv run pytest tests/ -v`, 6498 passed locally on macOS)
- [x] Lint passes (`uv run --project core ruff check core/`, `uv run --project core ruff check tools/`)
- [x] Manual testing performed by reproducing each failing CI step against `upstream/main` and confirming the fixes resolve them.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A, CI workflow fix and test/import adjustments, no UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI test workflow sequencing for clearer, more reliable test runs.
* **Tests**
  * Updated test coverage to reflect a refined file-edit behavior and adjusted test inputs.
  * Marked several terminal tool tests as POSIX-only to skip on Windows.
* **Refactor**
  * Minor internal reorganization to improve maintainability without changing public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->