### PR TITLE
docs(mattermost): add README and new tool methods

### DIFF
--- a/tools/src/aden_tools/tools/mattermost_tool/README.md
+++ b/tools/src/aden_tools/tools/mattermost_tool/README.md
@@ -1,0 +1,124 @@
+# Musik 🎵
+
+A music streaming app built with React Native (Expo) and TypeScript, powered by the JioSaavn API.
+
+---
+
+## Setup
+
+### Prerequisites
+- Node.js 18+
+- Expo CLI: `npm install -g expo-cli`
+- Android device or emulator (or iOS simulator on Mac)
+
+### Install & Run
+
+```bash
+git clone <repo-url>
+cd Musik
+npm install
+npx expo start
+```
+
+Scan the QR code with the Expo Go app, or press `a` for Android emulator / `i` for iOS simulator.
+
+### Build APK
+
+```bash
+npx expo build:android
+# or with EAS
+eas build --platform android --profile preview
+```
+
+---
+
+## Architecture
+
+```
+src/
+├── components/          # Reusable UI (MiniPlayer, SongItem, option sheets)
+├── context/             # ThemeContext (dark/light mode)
+├── hooks/               # usePlayer, useSetupPlayer, useDownload
+├── navigation/          # AppNavigator (Stack) + BottomTabNavigator
+├── screens/             # Home, Player, Search, Queue, Favorites, Playlists, Downloads, Artist, Album
+├── services/            # api.ts (JioSaavn), trackPlayerService.ts (expo-av), downloadService.ts
+├── store/               # Zustand stores: playerStore, playlistStore, favoriteStore
+└── utils/               # helpers.ts (parseSong, parseArtist, parseAlbum, formatDuration)
+```
+
+### State Management — Zustand
+
+Three stores, each persisted to AsyncStorage:
+
+- **playerStore** — current song, queue, queueIndex, shuffle, repeat, playback state. Persisted as `player_state_v1`.
+- **playlistStore** — user-created playlists with songs. Persisted as `mume_playlists_v1`.
+- **favoriteStore** — liked songs. Persisted as `mume_favorites_v1`.
+
+### Audio — expo-av
+
+`trackPlayerService.ts` manages a single `Audio.Sound` instance with a generation counter to prevent race conditions when songs change quickly. Position and duration are tracked via internal refs and a custom listener system — avoiding Zustand updates on every 500ms tick and keeping the seek bar smooth with zero unnecessary re-renders.
+
+### Navigation — React Navigation v6
+
+Stack navigator wrapping a bottom tab navigator. Player opens as a `fullScreenModal` with a slide-up animation. MiniPlayer sits above the tab bar on every tab screen.
+
+---
+
+## Features
+
+### Core
+- **Home** — Suggested/Songs/Artists/Albums tabs, infinite scroll pagination, sort options
+- **Search** — Live search across songs, artists, albums with recent search history
+- **Full Player** — Artwork, seek bar, play/pause, prev/next, ±10s skip, shuffle, repeat (none/all/one), favorites, options sheet
+- **Mini Player** — Persistent bar across all tabs, perfectly synced with full player
+- **Queue** — Add, reorder (drag), remove songs; queue count badge on tab icon; persisted across sessions
+- **Favorites** — Heart any song from any screen; persisted locally
+- **Playlists** — Create, rename, delete playlists; add/remove songs
+- **Downloads** — Save songs for reference; shuffle play downloaded songs
+- **Artist / Album screens** — Browse songs and albums by artist, full album tracklists
+
+### Bonus
+- Shuffle mode with random queue traversal
+- Repeat modes: off → repeat all → repeat one
+- Download songs (metadata saved to AsyncStorage; plays from CDN URL)
+- Dark / Light theme toggle
+- Session restore — last played song reloads on app launch, ready to play immediately
+
+---
+
+## Trade-offs & Known Limitations
+
+**Download is CDN-backed, not truly offline.** `downloadService.ts` saves song metadata locally so the Downloads screen persists across sessions, but audio still streams from the JioSaavn CDN URL. True offline playback would require `expo-file-system` to download the `.mp4` to device storage. This was skipped to avoid the complexity of managing local file paths across OS versions and the EAS build configuration it requires.
+
+**API host fallback.** Three JioSaavn mirror hosts are tried in sequence if a request fails. This improves reliability but adds latency on failover.
+
+**Lyrics, Speed, Timer, Cast** buttons are present in the UI but not functional — the JioSaavn API doesn't provide lyrics data, and the other controls were scoped out for time.
+
+**Folders tab** shows an empty state — device file system access requires `expo-media-library` permissions which are out of scope for a streaming app.
+
+---
+
+## Extra Features Added Beyond Requirements
+
+- Recent search history with per-item and clear-all controls
+- Song options sheet available from every screen (Home, Search, Queue, Artist, Album, Player)
+- Add to playlist flow with inline create-new-playlist option
+- Queue badge showing live song count on the tab bar
+- Drag-to-reorder queue rows
+- Per-session audio state restore (mini player and audio loaded on cold start)
+- API retry logic across 3 mirror hosts
+- Optimistic play/pause UI (no waiting for audio status callbacks)
+
+---
+
+## Tech Stack
+
+| | |
+|---|---|
+| Framework | React Native (Expo SDK 51) |
+| Language | TypeScript |
+| Navigation | React Navigation v6 — Native Stack + Bottom Tabs |
+| State | Zustand |
+| Storage | AsyncStorage |
+| Audio | expo-av |
+| API | JioSaavn (saavn.sumit.co) |

--- a/tools/src/aden_tools/tools/mattermost_tool/README.md
+++ b/tools/src/aden_tools/tools/mattermost_tool/README.md
@@ -46,7 +46,7 @@ hive credentials set mattermost
 | `mattermost_create_reaction` | Add an emoji reaction to a post |
 | `mattermost_delete_post` | Delete a post |
 | `mattermost_update_post` | Edit an existing post |
-| `mattermost_search_posts` | Search for posts across the server |
+| `mattermost_search_posts` | Search for posts across a team |
 | `mattermost_get_user` | Get information about a user |
 | `mattermost_create_direct_channel` | Open a direct message channel with a user |
 | `mattermost_upload_file` | Upload a file to a channel |

--- a/tools/src/aden_tools/tools/mattermost_tool/README.md
+++ b/tools/src/aden_tools/tools/mattermost_tool/README.md
@@ -1,124 +1,130 @@
-# Musik 🎵
+# Mattermost Tool
 
-A music streaming app built with React Native (Expo) and TypeScript, powered by the JioSaavn API.
+Interact with Mattermost servers — send messages, manage channels, react to posts, and more — within the Aden agent framework.
 
----
+## Installation
+
+The Mattermost tool uses `httpx` which is already included in the base dependencies. No additional installation required.
 
 ## Setup
 
-### Prerequisites
-- Node.js 18+
-- Expo CLI: `npm install -g expo-cli`
-- Android device or emulator (or iOS simulator on Mac)
+You need a Mattermost **Personal Access Token** and the **URL** of your Mattermost server.
 
-### Install & Run
+### Getting a Personal Access Token
 
-```bash
-git clone <repo-url>
-cd Musik
-npm install
-npx expo start
-```
+1. Log into your Mattermost instance
+2. Go to **Profile → Security → Personal Access Tokens**
+3. Click **Create Token**, give it a description (e.g., "Hive Agent")
+4. Copy the token (shown only once)
 
-Scan the QR code with the Expo Go app, or press `a` for Android emulator / `i` for iOS simulator.
+> **Note:** Personal Access Tokens must be enabled by your Mattermost admin under **System Console → Integrations → Integration Management**.
 
-### Build APK
+### Configuration
+
+Set the following environment variables:
 
 ```bash
-npx expo build:android
-# or with EAS
-eas build --platform android --profile preview
+export MATTERMOST_ACCESS_TOKEN="your-token-here"
+export MATTERMOST_URL="https://your-mattermost.example.com"
 ```
 
----
+Or configure via the Hive credential store:
 
-## Architecture
-
-```
-src/
-├── components/          # Reusable UI (MiniPlayer, SongItem, option sheets)
-├── context/             # ThemeContext (dark/light mode)
-├── hooks/               # usePlayer, useSetupPlayer, useDownload
-├── navigation/          # AppNavigator (Stack) + BottomTabNavigator
-├── screens/             # Home, Player, Search, Queue, Favorites, Playlists, Downloads, Artist, Album
-├── services/            # api.ts (JioSaavn), trackPlayerService.ts (expo-av), downloadService.ts
-├── store/               # Zustand stores: playerStore, playlistStore, favoriteStore
-└── utils/               # helpers.ts (parseSong, parseArtist, parseAlbum, formatDuration)
+```bash
+hive credentials set mattermost
 ```
 
-### State Management — Zustand
+## Available Tools
 
-Three stores, each persisted to AsyncStorage:
-
-- **playerStore** — current song, queue, queueIndex, shuffle, repeat, playback state. Persisted as `player_state_v1`.
-- **playlistStore** — user-created playlists with songs. Persisted as `mume_playlists_v1`.
-- **favoriteStore** — liked songs. Persisted as `mume_favorites_v1`.
-
-### Audio — expo-av
-
-`trackPlayerService.ts` manages a single `Audio.Sound` instance with a generation counter to prevent race conditions when songs change quickly. Position and duration are tracked via internal refs and a custom listener system — avoiding Zustand updates on every 500ms tick and keeping the seek bar smooth with zero unnecessary re-renders.
-
-### Navigation — React Navigation v6
-
-Stack navigator wrapping a bottom tab navigator. Player opens as a `fullScreenModal` with a slide-up animation. MiniPlayer sits above the tab bar on every tab screen.
-
----
-
-## Features
-
-### Core
-- **Home** — Suggested/Songs/Artists/Albums tabs, infinite scroll pagination, sort options
-- **Search** — Live search across songs, artists, albums with recent search history
-- **Full Player** — Artwork, seek bar, play/pause, prev/next, ±10s skip, shuffle, repeat (none/all/one), favorites, options sheet
-- **Mini Player** — Persistent bar across all tabs, perfectly synced with full player
-- **Queue** — Add, reorder (drag), remove songs; queue count badge on tab icon; persisted across sessions
-- **Favorites** — Heart any song from any screen; persisted locally
-- **Playlists** — Create, rename, delete playlists; add/remove songs
-- **Downloads** — Save songs for reference; shuffle play downloaded songs
-- **Artist / Album screens** — Browse songs and albums by artist, full album tracklists
-
-### Bonus
-- Shuffle mode with random queue traversal
-- Repeat modes: off → repeat all → repeat one
-- Download songs (metadata saved to AsyncStorage; plays from CDN URL)
-- Dark / Light theme toggle
-- Session restore — last played song reloads on app launch, ready to play immediately
-
----
-
-## Trade-offs & Known Limitations
-
-**Download is CDN-backed, not truly offline.** `downloadService.ts` saves song metadata locally so the Downloads screen persists across sessions, but audio still streams from the JioSaavn CDN URL. True offline playback would require `expo-file-system` to download the `.mp4` to device storage. This was skipped to avoid the complexity of managing local file paths across OS versions and the EAS build configuration it requires.
-
-**API host fallback.** Three JioSaavn mirror hosts are tried in sequence if a request fails. This improves reliability but adds latency on failover.
-
-**Lyrics, Speed, Timer, Cast** buttons are present in the UI but not functional — the JioSaavn API doesn't provide lyrics data, and the other controls were scoped out for time.
-
-**Folders tab** shows an empty state — device file system access requires `expo-media-library` permissions which are out of scope for a streaming app.
-
----
-
-## Extra Features Added Beyond Requirements
-
-- Recent search history with per-item and clear-all controls
-- Song options sheet available from every screen (Home, Search, Queue, Artist, Album, Player)
-- Add to playlist flow with inline create-new-playlist option
-- Queue badge showing live song count on the tab bar
-- Drag-to-reorder queue rows
-- Per-session audio state restore (mini player and audio loaded on cold start)
-- API retry logic across 3 mirror hosts
-- Optimistic play/pause UI (no waiting for audio status callbacks)
-
----
-
-## Tech Stack
-
-| | |
+| Tool | Description |
 |---|---|
-| Framework | React Native (Expo SDK 51) |
-| Language | TypeScript |
-| Navigation | React Navigation v6 — Native Stack + Bottom Tabs |
-| State | Zustand |
-| Storage | AsyncStorage |
-| Audio | expo-av |
-| API | JioSaavn (saavn.sumit.co) |
+| `mattermost_list_teams` | List all teams the bot belongs to |
+| `mattermost_list_channels` | List public channels for a team |
+| `mattermost_get_channel` | Get info about a specific channel |
+| `mattermost_send_message` | Send a message to a channel |
+| `mattermost_get_posts` | Fetch posts (messages) from a channel |
+| `mattermost_create_reaction` | Add an emoji reaction to a post |
+| `mattermost_delete_post` | Delete a post |
+| `mattermost_update_post` | Edit an existing post |
+| `mattermost_search_posts` | Search for posts across the server |
+| `mattermost_get_user` | Get information about a user |
+| `mattermost_create_direct_channel` | Open a direct message channel with a user |
+| `mattermost_upload_file` | Upload a file to a channel |
+
+## Example Usage
+
+### Send a message
+
+```python
+result = mattermost_send_message(
+    channel_id="abc123",
+    message="Hello from Hive! :wave:"
+)
+```
+
+### Reply in a thread
+
+```python
+result = mattermost_send_message(
+    channel_id="abc123",
+    message="This is a thread reply",
+    root_id="parent_post_id_here"
+)
+```
+
+### Search for posts
+
+```python
+result = mattermost_search_posts(
+    team_id="team123",
+    terms="deployment failed",
+    is_or_search=False
+)
+```
+
+### Send a direct message
+
+```python
+# First open a DM channel
+dm = mattermost_create_direct_channel(user_id="user123")
+channel_id = dm["channel"]["id"]
+
+# Then send
+mattermost_send_message(channel_id=channel_id, message="Hey, quick question...")
+```
+
+## Required Permissions
+
+The token needs the following Mattermost permissions:
+
+- `read_channel` — to list and read channels
+- `post_all` — to send messages in any channel
+- `create_post` — to create posts
+- `delete_post` — to delete posts (own posts, or admin for others)
+- `edit_post` — to edit posts
+- `create_direct_channel` — to open DMs
+- `upload_file` — to attach files
+
+For most use cases, a standard user token with default permissions is sufficient.
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `MATTERMOST_ACCESS_TOKEN` | Yes | Personal Access Token |
+| `MATTERMOST_URL` | Yes | Full URL of your Mattermost server (e.g., `https://chat.example.com`) |
+
+## Notes
+
+- The Mattermost API base path (`/api/v4`) is appended automatically — do not include it in `MATTERMOST_URL`
+- Message length is capped at **16,383 characters** (Mattermost API limit)
+- Rate-limited requests (HTTP 429) are automatically retried up to 2 times with backoff
+- Self-hosted and Mattermost Cloud instances are both supported
+
+## API Reference
+
+[https://api.mattermost.com/](https://api.mattermost.com/)
+
+## Contributed by
+
+

--- a/tools/src/aden_tools/tools/mattermost_tool/mattermost_tool.py
+++ b/tools/src/aden_tools/tools/mattermost_tool/mattermost_tool.py
@@ -55,7 +55,9 @@ class _MattermostClient:
             response = httpx.request(method, url, **request_kwargs)
             if response.status_code == 429 and attempt < MAX_RETRIES:
                 try:
-                    wait = min(float(response.headers.get("Retry-After", 1)), MAX_RETRY_WAIT)
+                    wait = min(
+                        float(response.headers.get("Retry-After", 1)), MAX_RETRY_WAIT
+                    )
                 except (ValueError, TypeError):
                     wait = min(2**attempt, MAX_RETRY_WAIT)
                 time.sleep(wait)
@@ -106,7 +108,9 @@ class _MattermostClient:
 
     def get_channel(self, channel_id: str) -> dict[str, Any]:
         """Get detailed information about a channel."""
-        return self._request_with_retry("GET", f"{self._base_url}/channels/{channel_id}")
+        return self._request_with_retry(
+            "GET", f"{self._base_url}/channels/{channel_id}"
+        )
 
     def send_message(
         self,
@@ -114,6 +118,7 @@ class _MattermostClient:
         message: str,
         *,
         root_id: str = "",
+        file_ids: list[str] | None = None,
     ) -> dict[str, Any]:
         """Create a post in a channel."""
         body: dict[str, Any] = {
@@ -122,6 +127,8 @@ class _MattermostClient:
         }
         if root_id:
             body["root_id"] = root_id
+        if file_ids:
+            body["file_ids"] = file_ids
         return self._request_with_retry(
             "POST",
             f"{self._base_url}/posts",
@@ -156,11 +163,7 @@ class _MattermostClient:
         post_id: str,
         emoji_name: str,
     ) -> dict[str, Any]:
-        """Add a reaction to a post.
-
-        API ref: POST /reactions
-        """
-        # Need user_id for the reaction; fetch from /users/me
+        """Add a reaction to a post."""
         me = self.get_me()
         if isinstance(me, dict) and "error" in me:
             return me
@@ -179,11 +182,7 @@ class _MattermostClient:
         """Delete a post."""
         return self._request_with_retry("DELETE", f"{self._base_url}/posts/{post_id}")
 
-    def update_post(
-        self,
-        post_id: str,
-        message: str,
-    ) -> dict[str, Any]:
+    def update_post(self, post_id: str, message: str) -> dict[str, Any]:
         """Update (edit) an existing post."""
         return self._request_with_retry(
             "PUT",
@@ -197,10 +196,7 @@ class _MattermostClient:
         terms: str,
         is_or_search: bool = False,
     ) -> dict[str, Any]:
-        """Search for posts across a team.
-
-        API ref: POST /teams/{team_id}/posts/search
-        """
+        """Search for posts across a team."""
         return self._request_with_retry(
             "POST",
             f"{self._base_url}/teams/{team_id}/posts/search",
@@ -208,17 +204,11 @@ class _MattermostClient:
         )
 
     def get_user(self, user_id: str) -> dict[str, Any]:
-        """Get information about a user by ID or username.
-
-        Pass a user ID (e.g. 'abc123') or use 'me' for the authenticated user.
-        """
+        """Get information about a user by ID or username."""
         return self._request_with_retry("GET", f"{self._base_url}/users/{user_id}")
 
     def create_direct_channel(self, other_user_id: str) -> dict[str, Any]:
-        """Open (or retrieve) a direct message channel with another user.
-
-        Returns the channel object; use channel['id'] to send messages.
-        """
+        """Open (or retrieve) a direct message channel with another user."""
         me = self.get_me()
         if isinstance(me, dict) and "error" in me:
             return me
@@ -236,21 +226,14 @@ class _MattermostClient:
         content: bytes,
         mime_type: str = "application/octet-stream",
     ) -> dict[str, Any]:
-        """Upload a file to a channel.
-
-        Returns the file info including file_id which can be passed to
-        send_message's file_ids field to attach the file to a post.
-        """
-        import httpx as _httpx
-
+        """Upload a file to a channel."""
         files = {"files": (filename, content, mime_type)}
         params = {"channel_id": channel_id}
         return self._request_with_retry(
+            "POST",
             f"{self._base_url}/files",
-            headers={"Authorization": f"Bearer {self._token}"},
             files=files,
             params=params,
-            timeout=60.0,
         )
 
 
@@ -267,7 +250,9 @@ def register_tools(
                 return credentials.get_by_alias("mattermost", account)
             token = credentials.get("mattermost")
             if token is not None and not isinstance(token, str):
-                raise TypeError(f"Expected string from credentials.get('mattermost'), got {type(token).__name__}")
+                raise TypeError(
+                    f"Expected string from credentials.get('mattermost'), got {type(token).__name__}"
+                )
             return token
         return os.getenv("MATTERMOST_ACCESS_TOKEN")
 
@@ -276,7 +261,9 @@ def register_tools(
         if credentials is not None:
             url = credentials.get("mattermost_url")
             if url is not None and not isinstance(url, str):
-                raise TypeError(f"Expected string from credentials.get('mattermost_url'), got {type(url).__name__}")
+                raise TypeError(
+                    f"Expected string from credentials.get('mattermost_url'), got {type(url).__name__}"
+                )
             if url:
                 return url
         return os.getenv("MATTERMOST_URL")
@@ -327,7 +314,9 @@ def register_tools(
             return {"error": f"Network error: {e}"}
 
     @mcp.tool()
-    def mattermost_list_channels(team_id: str, per_page: int = 100, account: str = "") -> dict:
+    def mattermost_list_channels(
+        team_id: str, per_page: int = 100, account: str = ""
+    ) -> dict:
         """
         List public channels for a Mattermost team.
 
@@ -356,9 +345,6 @@ def register_tools(
         """
         Get detailed information about a Mattermost channel.
 
-        Returns channel metadata including name, display name, header, purpose,
-        and type.
-
         Args:
             channel_id: Channel ID
 
@@ -383,6 +369,7 @@ def register_tools(
         channel_id: str,
         message: str,
         root_id: str = "",
+        file_ids: str = "",
         account: str = "",
     ) -> dict:
         """
@@ -392,6 +379,7 @@ def register_tools(
             channel_id: Channel ID to post in
             message: Message text (max 16383 characters). Supports Markdown.
             root_id: Optional post ID to reply to (creates a thread)
+            file_ids: Optional comma-separated file IDs to attach (from mattermost_upload_file)
 
         Returns:
             Dict with post details or error
@@ -406,7 +394,8 @@ def register_tools(
         if isinstance(client, dict):
             return client
         try:
-            result = client.send_message(channel_id, message, root_id=root_id)
+            ids = [f.strip() for f in file_ids.split(",") if f.strip()] if file_ids else None
+            result = client.send_message(channel_id, message, root_id=root_id, file_ids=ids)
             if isinstance(result, dict) and "error" in result:
                 return result
             return {"success": True, "post": result}
@@ -486,14 +475,9 @@ def register_tools(
             return {"error": f"Network error: {e}"}
 
     @mcp.tool()
-    def mattermost_delete_post(
-        post_id: str,
-        account: str = "",
-    ) -> dict:
+    def mattermost_delete_post(post_id: str, account: str = "") -> dict:
         """
         Delete a post from Mattermost.
-
-        Requires appropriate permissions (post author or admin).
 
         Args:
             post_id: ID of the post to delete
@@ -515,11 +499,7 @@ def register_tools(
             return {"error": f"Network error: {e}"}
 
     @mcp.tool()
-    def mattermost_update_post(
-        post_id: str,
-        message: str,
-        account: str = "",
-    ) -> dict:
+    def mattermost_update_post(post_id: str, message: str, account: str = "") -> dict:
         """
         Edit an existing Mattermost post.
 
@@ -661,8 +641,8 @@ def register_tools(
         """
         Upload a text file to a Mattermost channel.
 
-        After uploading, pass the returned file_id(s) to a subsequent
-        mattermost_send_message call to attach the file to a post.
+        After uploading, pass the returned file_ids to mattermost_send_message
+        to attach the file to a post.
 
         Args:
             channel_id: Channel ID to upload into

--- a/tools/src/aden_tools/tools/mattermost_tool/mattermost_tool.py
+++ b/tools/src/aden_tools/tools/mattermost_tool/mattermost_tool.py
@@ -179,6 +179,81 @@ class _MattermostClient:
         """Delete a post."""
         return self._request_with_retry("DELETE", f"{self._base_url}/posts/{post_id}")
 
+    def update_post(
+        self,
+        post_id: str,
+        message: str,
+    ) -> dict[str, Any]:
+        """Update (edit) an existing post."""
+        return self._request_with_retry(
+            "PUT",
+            f"{self._base_url}/posts/{post_id}",
+            json={"id": post_id, "message": message},
+        )
+
+    def search_posts(
+        self,
+        team_id: str,
+        terms: str,
+        is_or_search: bool = False,
+    ) -> dict[str, Any]:
+        """Search for posts across a team.
+
+        API ref: POST /teams/{team_id}/posts/search
+        """
+        return self._request_with_retry(
+            "POST",
+            f"{self._base_url}/teams/{team_id}/posts/search",
+            json={"terms": terms, "is_or_search": is_or_search},
+        )
+
+    def get_user(self, user_id: str) -> dict[str, Any]:
+        """Get information about a user by ID or username.
+
+        Pass a user ID (e.g. 'abc123') or use 'me' for the authenticated user.
+        """
+        return self._request_with_retry("GET", f"{self._base_url}/users/{user_id}")
+
+    def create_direct_channel(self, other_user_id: str) -> dict[str, Any]:
+        """Open (or retrieve) a direct message channel with another user.
+
+        Returns the channel object; use channel['id'] to send messages.
+        """
+        me = self.get_me()
+        if isinstance(me, dict) and "error" in me:
+            return me
+        my_id = me.get("id", "")
+        return self._request_with_retry(
+            "POST",
+            f"{self._base_url}/channels/direct",
+            json=[my_id, other_user_id],
+        )
+
+    def upload_file(
+        self,
+        channel_id: str,
+        filename: str,
+        content: bytes,
+        mime_type: str = "application/octet-stream",
+    ) -> dict[str, Any]:
+        """Upload a file to a channel.
+
+        Returns the file info including file_id which can be passed to
+        send_message's file_ids field to attach the file to a post.
+        """
+        import httpx as _httpx
+
+        files = {"files": (filename, content, mime_type)}
+        params = {"channel_id": channel_id}
+        response = _httpx.post(
+            f"{self._base_url}/files",
+            headers={"Authorization": f"Bearer {self._token}"},
+            files=files,
+            params=params,
+            timeout=60.0,
+        )
+        return self._handle_response(response)
+
 
 def register_tools(
     mcp: FastMCP,
@@ -435,6 +510,195 @@ def register_tools(
             if isinstance(result, dict) and "error" in result:
                 return result
             return {"success": True, "deleted_post_id": post_id}
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def mattermost_update_post(
+        post_id: str,
+        message: str,
+        account: str = "",
+    ) -> dict:
+        """
+        Edit an existing Mattermost post.
+
+        Args:
+            post_id: ID of the post to update
+            message: New message text (supports Markdown, max 16383 chars)
+
+        Returns:
+            Dict with updated post details or error
+        """
+        if len(message) > MAX_MESSAGE_LENGTH:
+            return {
+                "error": f"Message exceeds {MAX_MESSAGE_LENGTH} character limit",
+                "max_length": MAX_MESSAGE_LENGTH,
+                "provided": len(message),
+            }
+        client = _get_client(account)
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.update_post(post_id, message)
+            if isinstance(result, dict) and "error" in result:
+                return result
+            return {"success": True, "post": result}
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def mattermost_search_posts(
+        team_id: str,
+        terms: str,
+        is_or_search: bool = False,
+        account: str = "",
+    ) -> dict:
+        """
+        Search for posts across a Mattermost team.
+
+        Args:
+            team_id: Team ID. Use mattermost_list_teams to find IDs.
+            terms: Search terms (supports Mattermost syntax e.g. 'from:user in:channel')
+            is_or_search: If True, treats space-separated terms as OR (default: AND)
+
+        Returns:
+            Dict with matching posts or error
+        """
+        client = _get_client(account)
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.search_posts(team_id, terms, is_or_search)
+            if isinstance(result, dict) and "error" in result:
+                return result
+            posts = result.get("posts", result) if isinstance(result, dict) else result
+            return {"success": True, "posts": posts}
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def mattermost_get_user(user_id: str, account: str = "") -> dict:
+        """
+        Get information about a Mattermost user.
+
+        Args:
+            user_id: User ID (e.g. 'abc123') or 'me' for the authenticated user
+
+        Returns:
+            Dict with user profile (id, username, email, roles) or error
+        """
+        client = _get_client(account)
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.get_user(user_id)
+            if isinstance(result, dict) and "error" in result:
+                return result
+            return {
+                "success": True,
+                "user": {
+                    "id": result.get("id"),
+                    "username": result.get("username"),
+                    "email": result.get("email"),
+                    "first_name": result.get("first_name"),
+                    "last_name": result.get("last_name"),
+                    "nickname": result.get("nickname"),
+                    "roles": result.get("roles"),
+                    "locale": result.get("locale"),
+                },
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def mattermost_create_direct_channel(user_id: str, account: str = "") -> dict:
+        """
+        Open (or retrieve) a direct message channel with another user.
+
+        Use the returned channel ID with mattermost_send_message to DM the user.
+
+        Args:
+            user_id: ID of the user to open a DM with
+
+        Returns:
+            Dict with channel details including channel ID, or error
+        """
+        client = _get_client(account)
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.create_direct_channel(user_id)
+            if isinstance(result, dict) and "error" in result:
+                return result
+            return {
+                "success": True,
+                "channel": {
+                    "id": result.get("id"),
+                    "name": result.get("name"),
+                    "type": result.get("type"),
+                    "display_name": result.get("display_name"),
+                },
+            }
+        except httpx.TimeoutException:
+            return {"error": "Request timed out"}
+        except httpx.RequestError as e:
+            return {"error": f"Network error: {e}"}
+
+    @mcp.tool()
+    def mattermost_upload_file(
+        channel_id: str,
+        filename: str,
+        content: str,
+        account: str = "",
+    ) -> dict:
+        """
+        Upload a text file to a Mattermost channel.
+
+        After uploading, pass the returned file_id(s) to a subsequent
+        mattermost_send_message call to attach the file to a post.
+
+        Args:
+            channel_id: Channel ID to upload into
+            filename: Name for the file (e.g. 'report.txt', 'data.csv')
+            content: Text content of the file
+
+        Returns:
+            Dict with file_ids and file info, or error
+        """
+        client = _get_client(account)
+        if isinstance(client, dict):
+            return client
+        try:
+            result = client.upload_file(
+                channel_id,
+                filename,
+                content.encode("utf-8"),
+                mime_type="text/plain",
+            )
+            if isinstance(result, dict) and "error" in result:
+                return result
+            file_infos = result.get("file_infos", [])
+            return {
+                "success": True,
+                "file_ids": [f.get("id") for f in file_infos if f.get("id")],
+                "files": [
+                    {
+                        "id": f.get("id"),
+                        "name": f.get("name"),
+                        "size": f.get("size"),
+                        "mime_type": f.get("mime_type"),
+                    }
+                    for f in file_infos
+                ],
+            }
         except httpx.TimeoutException:
             return {"error": "Request timed out"}
         except httpx.RequestError as e:

--- a/tools/src/aden_tools/tools/mattermost_tool/mattermost_tool.py
+++ b/tools/src/aden_tools/tools/mattermost_tool/mattermost_tool.py
@@ -245,14 +245,13 @@ class _MattermostClient:
 
         files = {"files": (filename, content, mime_type)}
         params = {"channel_id": channel_id}
-        response = _httpx.post(
+        return self._request_with_retry(
             f"{self._base_url}/files",
             headers={"Authorization": f"Bearer {self._token}"},
             files=files,
             params=params,
             timeout=60.0,
         )
-        return self._handle_response(response)
 
 
 def register_tools(


### PR DESCRIPTION
## What this PR does
- Adds missing README.md to mattermost_tool (the only tool out of 102 without one)
- Adds 5 new tool methods for feature parity with the Slack tool:
  - mattermost_update_post - edit existing posts
  - mattermost_search_posts - full-text search across a team
  - mattermost_get_user - fetch user profile by ID
  - mattermost_create_direct_channel - open DM channels
  - mattermost_upload_file - upload text files to channels

## Testing
- Reviewed against Mattermost API docs (https://api.mattermost.com/)
- Follows same patterns as existing slack_tool implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mattermost integration: edit posts, attach existing files to messages, search team posts, fetch user profiles, create direct-message channels, and upload text files. Message length is enforced; rate-limited requests are retried.

* **Documentation**
  * Added a comprehensive Mattermost README with setup via Personal Access Token and server URL, admin requirements, usage examples, permissions needed, operational limits, and links to the API reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->