### PR TITLE
docs(host): replace print() with logger.info in docstring examples

### DIFF
--- a/core/framework/host/agent_host.py
+++ b/core/framework/host/agent_host.py
@@ -82,8 +82,6 @@ class AgentHost:
     - Handle lifecycle events (start, pause, shutdown)
 
     Example:
-	import logging 
-	logger = logging.getLogger(__name__)
         # Create runtime
         runtime = AgentRuntime(
             graph=support_agent_graph,

--- a/core/framework/host/agent_host.py
+++ b/core/framework/host/agent_host.py
@@ -82,6 +82,8 @@ class AgentHost:
     - Handle lifecycle events (start, pause, shutdown)
 
     Example:
+	import logging 
+	logger = logging.getLogger(__name__)
         # Create runtime
         runtime = AgentRuntime(
             graph=support_agent_graph,
@@ -116,7 +118,7 @@ class AgentHost:
 
         # Check goal progress
         progress = await runtime.get_goal_progress()
-        print(f"Progress: {progress['overall_progress']:.1%}")
+        logger.info("Progress: %.1f%%", progress['overall_progress'] * 100)
 
         # Stop runtime
         await runtime.stop()

--- a/core/framework/host/agent_host.py
+++ b/core/framework/host/agent_host.py
@@ -82,6 +82,8 @@ class AgentHost:
     - Handle lifecycle events (start, pause, shutdown)
 
     Example:
+        import logging
+        logger = logging.getLogger(__name__)
         # Create runtime
         runtime = AgentRuntime(
             graph=support_agent_graph,

--- a/core/framework/host/event_bus.py
+++ b/core/framework/host/event_bus.py
@@ -235,8 +235,7 @@ class EventBus:
     - Event history for debugging
 
     Example:
-	import logging
-	logger = logging.getLogger(__name__)
+
         bus = EventBus()
 
         # Subscribe to execution events

--- a/core/framework/host/event_bus.py
+++ b/core/framework/host/event_bus.py
@@ -235,11 +235,13 @@ class EventBus:
     - Event history for debugging
 
     Example:
+	import logging
+	logger = logging.getLogger(__name__)
         bus = EventBus()
 
         # Subscribe to execution events
         async def on_execution_complete(event: AgentEvent):
-            print(f"Execution {event.execution_id} completed")
+            logger.info("Execution %s completed", event.execution_id)
 
         bus.subscribe(
             event_types=[EventType.EXECUTION_COMPLETED],


### PR DESCRIPTION
## Summary
Replace `print()` statements with `logger.info()` in docstring examples 
for `AgentHost` and `EventBus` classes in `core/framework/host/`.

## Related Issue
Closes #7153

## Changes Made
- `agent_host.py`: Added `import logging` + `logger` setup in class 
  docstring example. Replaced `print()` with `logger.info()`.
- `event_bus.py`: Added `import logging` + `logger` setup in class 
  docstring example. Replaced `print()` in async callback with `logger.info()`.

## Why
Docstring examples are reference implementations for developers.
Using `print()` teaches bad habits and is inconsistent with the 
framework's logging conventions. Examples should be copy-paste ready 
and model correct patterns.

## Consistency
This follows the same fix pattern applied in:
- #7152 (local credential modules)
- PR linked to #4783 (aden client)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated internal example snippets to demonstrate using structured logging (logger.info) instead of print statements for progress and completion messages. This is a documentation-only change to encourage logging best practices; there are no runtime behavior alterations, no public API changes, and no impact on exported interfaces. The updates are purely illustrative and intended to improve example clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->