### PR TITLE
feat(llm): add OpenRouterProvider with free-model aliases and fallback chain

### DIFF
--- a/core/framework/agents/openrouter_agent/__init__.py
+++ b/core/framework/agents/openrouter_agent/__init__.py
@@ -1,0 +1,32 @@
+"""
+OpenRouter Agent — free open-source model access for the Hive framework.
+
+Features:
+  1. Session memory  — remembers context across runs (~/.hive/openrouter_agent/MEMORY.md)
+  2. Model picker    — TUI lets you choose any free model before starting
+  3. Web search      — web_search, read_file, write_file tools built in
+  4. Default skills  — hive.note-taking and hive.task-decomposition enabled
+  5. Fallback chain  — auto-retries with next free model on 429 rate limits
+
+Quick start:
+    export OPENROUTER_API_KEY=sk-or-v1-...
+    uv run hive run
+    # pick "OpenRouter Agent" from the TUI
+"""
+
+from .agent import OpenRouterAgent, configure_for_account, goal, list_connected_accounts
+from .config import AgentMetadata, default_config, metadata
+from .nodes import build_chat_node
+
+__version__ = "1.0.0"
+
+__all__ = [
+    "OpenRouterAgent",
+    "goal",
+    "list_connected_accounts",
+    "configure_for_account",
+    "AgentMetadata",
+    "default_config",
+    "metadata",
+    "build_chat_node",
+]

--- a/core/framework/agents/openrouter_agent/__main__.py
+++ b/core/framework/agents/openrouter_agent/__main__.py
@@ -1,0 +1,114 @@
+"""CLI entry point for the OpenRouter agent.
+
+Usage:
+    uv run python -m framework.agents.openrouter_agent
+    uv run python -m framework.agents.openrouter_agent shell
+    uv run python -m framework.agents.openrouter_agent list-models
+
+Mirrors credential_tester/__main__.py exactly.
+"""
+
+import asyncio
+
+import click
+
+from framework.llm.openrouter import FREE_MODELS
+
+from .agent import OpenRouterAgent
+
+
+def setup_logging(verbose=False, debug=False):
+    from framework.observability import configure_logging
+
+    if debug:
+        configure_logging(level="DEBUG")
+    elif verbose:
+        configure_logging(level="INFO")
+    else:
+        configure_logging(level="WARNING")
+
+
+def pick_model() -> str | None:
+    """Interactive model picker. Returns full model ID or None."""
+    models = list(FREE_MODELS.items())
+    click.echo("\nAvailable free models:\n")
+    for i, (alias, model_id) in enumerate(models, 1):
+        click.echo(f"  {i:2}. {alias:<16}  {model_id}")
+    click.echo()
+    while True:
+        choice = click.prompt(
+            f"Pick a model (1-{len(models)}, Enter for default)",
+            default="1",
+        )
+        try:
+            idx = int(choice) - 1
+            if 0 <= idx < len(models):
+                return models[idx][1]
+        except ValueError:
+            pass
+        click.echo(f"Invalid choice. Enter 1-{len(models)}.")
+
+
+@click.group()
+@click.version_option(version="1.0.0")
+def cli():
+    """OpenRouter Agent — free open-source model chat with web search and memory."""
+    pass
+
+
+@cli.command()
+@click.option("--model", "-m", default=None, help="Full model ID or short alias.")
+@click.option("--verbose", "-v", is_flag=True)
+@click.option("--debug", is_flag=True)
+def shell(model, verbose, debug):
+    """Start an interactive chat session."""
+    setup_logging(verbose=verbose, debug=debug)
+    asyncio.run(_interactive_shell(model_override=model))
+
+
+@cli.command(name="list-models")
+def list_models():
+    """List all available free models."""
+    click.echo("\nFree models available on OpenRouter:\n")
+    for alias, model_id in FREE_MODELS.items():
+        click.echo(f"  {alias:<16}  {model_id}")
+    click.echo()
+
+
+async def _interactive_shell(model_override: str | None = None) -> None:
+    import litellm
+
+    litellm.suppress_debug_info = True
+
+    agent = OpenRouterAgent()
+
+    model = model_override or pick_model()
+    if model:
+        agent.select_model(model)
+
+    click.echo(f"\nOpenRouter Agent — {agent._model}")
+    click.echo("Type your message or 'quit' to exit.\n")
+
+    await agent.start()
+
+    try:
+        while True:
+            user_input = click.prompt("You", prompt_suffix="> ").strip()
+            if user_input.lower() in ("quit", "exit", "q"):
+                break
+            if not user_input:
+                continue
+
+            result = await agent.run(user_message=user_input)
+            if result.success:
+                click.echo(f"\nAgent: {result.output.get('response', '(no response)')}\n")
+            else:
+                click.echo(f"\n[ERROR] {result.error}\n")
+    except KeyboardInterrupt:
+        click.echo("\nGoodbye!")
+    finally:
+        await agent.stop()
+
+
+if __name__ == "__main__":
+    cli()

--- a/core/framework/agents/openrouter_agent/agent.py
+++ b/core/framework/agents/openrouter_agent/agent.py
@@ -1,0 +1,323 @@
+"""OpenRouter agent — free open-source model chat with web search and memory.
+
+Follows the exact same structure as credential_tester/agent.py.
+
+Module-level variables read by AgentRunner.load() / TUI / hive run:
+    goal, nodes, edges
+    entry_node, entry_points, terminal_nodes, pause_nodes
+    conversation_mode, identity_prompt, loop_config
+    default_skills, skip_credential_validation
+    requires_account_selection, configure_for_account, list_connected_accounts
+    metadata, default_config
+
+Programmatic class used by __main__.py:
+    OpenRouterAgent — select_model(), start(), stop(), run()
+
+Features implemented:
+  Feature 1: Session memory (session_memory.py, read fresh at runtime)
+  Feature 2: Model picker (configure_for_account / list_connected_accounts)
+  Feature 3: Web search + file tools (NodeSpec.tools in nodes.py)
+  Feature 4: Default skills (hive.note-taking, hive.task-decomposition)
+  Feature 5: Fallback chain (inside OpenRouterProvider in openrouter.py)
+
+Key fix: nodes = [build_chat_node(memory=False)] at module level.
+Memory is NOT read at import time. It is read fresh inside _build_graph()
+at runtime when memory=True is passed. This matches the pattern used by
+credential_tester where the module-level NodeSpec uses a static prompt
+and configure_for_account() replaces it at runtime.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from framework.config import get_max_context_tokens
+from framework.graph import Goal, SuccessCriterion
+from framework.graph.checkpoint_config import CheckpointConfig
+from framework.graph.edge import GraphSpec
+from framework.graph.executor import ExecutionResult
+from framework.llm.openrouter import FREE_MODELS, OpenRouterProvider
+from framework.runner.tool_registry import ToolRegistry
+from framework.runtime.agent_runtime import AgentRuntime, create_agent_runtime
+from framework.runtime.execution_stream import EntryPointSpec
+
+from .config import default_config
+from .nodes import build_chat_node
+from .session_memory import consolidate_memory, seed_if_missing
+
+if TYPE_CHECKING:
+    from framework.runner import AgentRunner
+
+# ---------------------------------------------------------------------------
+# Goal
+# ---------------------------------------------------------------------------
+
+goal = Goal(
+    id="openrouter-assistant",
+    name="OpenRouter Assistant",
+    description=(
+        "Answer user questions and complete tasks using a free open-source model via OpenRouter."
+    ),
+    success_criteria=[
+        SuccessCriterion(
+            id="response-generated",
+            description="At least one response was produced",
+            metric="custom",
+            target="any",
+            weight=1.0,
+        ),
+    ],
+    constraints=[],
+)
+
+# ---------------------------------------------------------------------------
+# Feature 2: Model picker helpers
+# Mirrors list_connected_accounts / configure_for_account in credential_tester
+# ---------------------------------------------------------------------------
+
+
+def list_connected_accounts() -> list[dict]:
+    """Return free model list as 'accounts' for the TUI picker.
+
+    AgentRunner calls this when requires_account_selection=True.
+    Each dict must have 'provider' and 'alias' — TUI shows provider/alias.
+    We store the full model_id in the dict so configure_for_account can use it.
+    """
+    return [
+        {
+            "provider": "openrouter",
+            "alias": alias,
+            "model_id": model_id,
+            "identity": {"model": model_id},
+            "source": "openrouter",
+        }
+        for alias, model_id in FREE_MODELS.items()
+    ]
+
+
+def configure_for_account(runner: AgentRunner, account: dict) -> None:
+    """Scope the chat node to the selected model.
+
+    Called by AgentRunner after the user picks a model in the TUI picker.
+    Replaces (not appends to) the system prompt so repeated selections
+    don't accumulate duplicate model lines.
+
+    Mirrors _configure_aden_node in credential_tester/agent.py exactly:
+    mutates node.system_prompt and node.tools in place, then updates
+    runner.intro_message.
+    """
+    model_id = account.get("model_id") or account.get("alias", default_config.model)
+    alias = account.get("alias", model_id)
+
+    # Build a fresh node spec with memory=True so the memory file is
+    # read at selection time (after the session is already starting).
+    fresh_node = build_chat_node(memory=True)
+
+    for node in runner.graph.nodes:
+        if node.id == "chat":
+            # REPLACE — not append — so re-selection doesn't duplicate
+            node.system_prompt = (
+                fresh_node.system_prompt
+                + f"\n\n# Selected model\n\nYou are running as: {model_id}\n"
+            )
+            node.tools = fresh_node.tools
+            break
+
+    runner.intro_message = (
+        f"Running on {alias} ({model_id}). "
+        "Ask me anything — I can answer questions, search the web, and read files."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module-level variables (read by AgentRunner.load)
+# ---------------------------------------------------------------------------
+
+# Feature 4: Enable default skills
+default_skills = {
+    "hive.note-taking": {"enabled": True},
+    "hive.task-decomposition": {"enabled": True},
+    "hive.quality-monitor": {"enabled": False},  # off — adds latency on free models
+}
+
+skip_credential_validation = True
+# No Hive credential needed — only OPENROUTER_API_KEY is required.
+
+# Feature 2: Show model picker in TUI before the session starts.
+requires_account_selection = True
+
+# NOTE: memory=False here — module is imported before the session starts.
+# Memory is injected fresh at runtime inside _build_graph() and
+# configure_for_account() which both call build_chat_node(memory=True).
+nodes = [build_chat_node(memory=False)]
+edges = []
+
+entry_node = "chat"
+entry_points = {"start": "chat"}
+pause_nodes = []
+terminal_nodes = ["chat"]
+
+conversation_mode = "continuous"
+identity_prompt = (
+    "You are a helpful AI assistant powered by a free open-source model via OpenRouter. "
+    "You can search the web, read files, and remember context from past sessions."
+)
+loop_config = {
+    "max_iterations": 999_999,
+    "max_tool_calls_per_turn": 10,
+}
+
+# ---------------------------------------------------------------------------
+# Programmatic agent class (used by __main__.py and tests)
+# ---------------------------------------------------------------------------
+
+
+class OpenRouterAgent:
+    """Programmatic interface to the OpenRouter agent.
+
+    Usage:
+        agent = OpenRouterAgent()
+        agent.select_model("openai/gpt-oss-120b:free")  # optional
+        await agent.start()
+        result = await agent.run(user_message="Hello!")
+        await agent.stop()
+    """
+
+    def __init__(self, config=None):
+        self.config = config or default_config
+        self._model: str = self.config.model
+        self._agent_runtime: AgentRuntime | None = None
+        self._tool_registry: ToolRegistry | None = None
+        self._storage_path: Path | None = None
+        self._conversation_history: list[dict] = []
+
+    def select_model(self, model: str) -> None:
+        """Set the model before calling start().
+
+        Accepts either a full OpenRouter model ID or a short alias
+        from FREE_MODELS (e.g. 'qwen3-14b').
+        """
+        from framework.llm.openrouter import _resolve_model
+
+        self._model = _resolve_model(model)
+
+    def list_models(self) -> dict[str, str]:
+        """Return alias -> full model ID mapping."""
+        return dict(FREE_MODELS)
+
+    def _build_graph(self) -> GraphSpec:
+        """Build graph with memory=True — reads ~/.hive at runtime, not import."""
+        chat_node = build_chat_node(memory=True)
+
+        return GraphSpec(
+            id="openrouter-agent-graph",
+            goal_id=goal.id,
+            version="1.0.0",
+            entry_node="chat",
+            entry_points={"start": "chat"},
+            terminal_nodes=["chat"],
+            pause_nodes=[],
+            nodes=[chat_node],
+            edges=[],
+            default_model=self._model,
+            max_tokens=self.config.max_tokens,
+            loop_config={
+                "max_iterations": 999_999,
+                "max_tool_calls_per_turn": 10,
+                "max_context_tokens": get_max_context_tokens(),
+            },
+            conversation_mode="continuous",
+            identity_prompt=identity_prompt,
+        )
+
+    def _setup(self) -> None:
+        seed_if_missing()
+
+        self._storage_path = Path.home() / ".hive" / "agents" / "openrouter_agent"
+        self._storage_path.mkdir(parents=True, exist_ok=True)
+
+        self._tool_registry = ToolRegistry()
+
+        mcp_config_path = Path(__file__).parent / "mcp_servers.json"
+        if mcp_config_path.exists():
+            self._tool_registry.load_mcp_config(mcp_config_path)
+
+        # Feature 5: fallback chain is inside OpenRouterProvider
+        llm = OpenRouterProvider(
+            model=self._model,
+            api_key=self.config.api_key,
+            use_fallback=True,
+        )
+
+        tool_executor = self._tool_registry.get_executor()
+        tools = list(self._tool_registry.get_tools().values())
+
+        graph = self._build_graph()
+
+        # Exact same create_agent_runtime call pattern as credential_tester
+        self._agent_runtime = create_agent_runtime(
+            graph=graph,
+            goal=goal,
+            storage_path=self._storage_path,
+            entry_points=[
+                EntryPointSpec(
+                    id="start",
+                    name="Chat",
+                    entry_node="chat",
+                    trigger_type="manual",
+                    isolation_level="shared",
+                ),
+            ],
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor,
+            checkpoint_config=CheckpointConfig(enabled=True),
+            graph_id="openrouter_agent",
+        )
+
+    async def start(self) -> None:
+        """Set up and start the agent runtime."""
+        if self._agent_runtime is None:
+            self._setup()
+        if not self._agent_runtime.is_running:
+            await self._agent_runtime.start()
+
+    async def stop(self) -> None:
+        """Stop the agent runtime.
+
+        Feature 1: Consolidates session memory on stop so the next
+        session can read what was discussed in this one.
+        """
+        if self._agent_runtime and self._agent_runtime.is_running:
+            if self._conversation_history:
+                llm = OpenRouterProvider(
+                    model=self._model,
+                    api_key=self.config.api_key,
+                )
+                await consolidate_memory(self._conversation_history, llm)
+
+            await self._agent_runtime.stop()
+
+        self._agent_runtime = None
+
+    async def run(self, user_message: str = "") -> ExecutionResult:
+        """Trigger one turn and wait for the result.
+
+        Tracks conversation history for memory consolidation on stop().
+        """
+        await self.start()
+
+        result = await self._agent_runtime.trigger_and_wait(
+            entry_point_id="start",
+            input_data={"user_message": user_message} if user_message else {},
+        )
+
+        if user_message:
+            self._conversation_history.append({"role": "user", "content": user_message})
+        if result and result.success and result.output.get("response"):
+            self._conversation_history.append(
+                {"role": "assistant", "content": result.output["response"]}
+            )
+
+        return result or ExecutionResult(success=False, error="Execution timeout")

--- a/core/framework/agents/openrouter_agent/config.py
+++ b/core/framework/agents/openrouter_agent/config.py
@@ -1,0 +1,32 @@
+"""Runtime configuration for the OpenRouter agent."""
+
+from dataclasses import dataclass
+
+from framework.config import RuntimeConfig
+from framework.llm.openrouter import DEFAULT_FREE_MODEL
+
+
+@dataclass
+class AgentMetadata:
+    name: str = "OpenRouter Agent"
+    version: str = "1.0.0"
+    description: str = (
+        "General-purpose AI assistant powered by free open-source models "
+        "via OpenRouter (Llama, Mistral, Gemma, Qwen, gpt). "
+        "No API cost — pick any free model from the model picker."
+    )
+    intro_message: str = (
+        "Hi! I'm running on a free open-source model via OpenRouter. "
+        "Ask me anything — I can answer questions, help with analysis, "
+        "write code, and search the web."
+    )
+
+
+metadata = AgentMetadata()
+
+# Default config — uses openrouter as provider, free model as default.
+# RuntimeConfig reads ~/.hive/configuration.json for user overrides.
+default_config = RuntimeConfig(
+    model=DEFAULT_FREE_MODEL,
+    temperature=0.7,
+)

--- a/core/framework/agents/openrouter_agent/mcp_servers.json
+++ b/core/framework/agents/openrouter_agent/mcp_servers.json
@@ -1,0 +1,9 @@
+{
+  "hive-tools": {
+    "transport": "stdio",
+    "command": "uv",
+    "args": ["run", "python", "mcp_server.py", "--stdio"],
+    "cwd": "../../../../tools",
+    "description": "Hive built-in tools — web_search, read_file, write_file"
+  }
+}

--- a/core/framework/agents/openrouter_agent/nodes.py
+++ b/core/framework/agents/openrouter_agent/nodes.py
@@ -1,0 +1,90 @@
+"""Node definitions for the OpenRouter agent.
+
+Follows the exact same pattern as credential_tester/nodes/__init__.py:
+- build_chat_node() returns a NodeSpec (declarative only)
+- The framework's EventLoopNode drives the actual LLM call
+- Tools are declared here; conversation history is managed by the framework
+- System prompt includes memory injection from session_memory.py
+
+Features wired in via NodeSpec:
+  Feature 3: web_search, read_file, write_file in tools list
+  Feature 4: system prompt structured for note-taking + task decomposition skills
+  Feature 1: memory injected via format_for_injection() in system prompt
+"""
+
+from __future__ import annotations
+
+from framework.graph import NodeSpec
+
+from .session_memory import format_for_injection
+
+# System prompt template
+
+
+_SYSTEM_PROMPT_TEMPLATE = """\
+You are a helpful AI assistant running on a free open-source model via OpenRouter.
+
+{memory_block}
+
+# Your capabilities
+
+You can:
+- Answer questions clearly and accurately
+- Help with analysis, writing, and coding tasks
+- Search the web for current information (use the web_search tool)
+- Read files the user provides (use the read_file tool)
+- Write output to files when asked (use the write_file tool)
+
+# How to handle tasks
+
+For multi-step tasks:
+1. Use _working_notes to track your progress (maintained by hive.note-taking skill)
+2. Break complex requests into clear steps before executing
+3. Confirm with the user before making any writes or destructive actions
+
+# Rules
+
+- Be concise unless depth is explicitly requested
+- If you don't know something, say so — then search for it
+- Never fabricate facts; use web_search to verify
+- No emojis
+"""
+
+
+def build_chat_node(memory: bool = True) -> NodeSpec:
+    """Build the main chat NodeSpec.
+
+    Args:
+        memory: If True, inject session memory into the system prompt.
+                Set to False in tests to avoid reading ~/.hive files.
+
+    Returns:
+        NodeSpec with web search, file tools, and memory in system prompt.
+    """
+    memory_block = format_for_injection() if memory else ""
+
+    system_prompt = _SYSTEM_PROMPT_TEMPLATE.format(
+        memory_block=memory_block,
+    ).strip()
+
+    return NodeSpec(
+        id="chat",
+        name="OpenRouter Chat",
+        description=(
+            "General-purpose chat node powered by a free open-source model. "
+            "Has web search, file read/write, and persistent session memory."
+        ),
+        node_type="event_loop",
+        client_facing=True,
+        max_node_visits=0,  # 0 = unlimited (continuous conversation)
+        input_keys=[],
+        output_keys=["response"],
+        nullable_output_keys=["response"],
+        tools=[
+            # Feature 3: web search + file tools (same as queen's shared tool set)
+            "web_search",
+            "read_file",
+            "write_file",
+        ],
+        system_prompt=system_prompt,
+    )

--- a/core/framework/agents/openrouter_agent/session_memory.py
+++ b/core/framework/agents/openrouter_agent/session_memory.py
@@ -1,0 +1,126 @@
+"""Session memory for the OpenRouter agent.
+
+Persists a plain-text summary of each conversation to:
+    ~/.hive/openrouter_agent/MEMORY.md
+
+On session start, that file is injected into the system prompt so the
+agent remembers context across runs.
+
+Mirrors the pattern in framework/agents/queen/queen_memory.py but uses
+a single flat file rather than the three-tier (semantic + episodic +
+working) architecture — appropriate for a general-purpose chat agent.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_AGENT_DIR = Path.home() / ".hive" / "openrouter_agent"
+_MEMORY_FILE = _AGENT_DIR / "MEMORY.md"
+
+_SEED_TEMPLATE = """\
+# OpenRouter Agent Memory
+
+*No sessions recorded yet.*
+
+## What the user has asked about
+
+## Preferences and context
+
+## Ongoing topics
+"""
+
+_CONSOLIDATION_SYSTEM = """\
+You are maintaining the persistent memory of a general-purpose AI assistant.
+Given the conversation transcript below, rewrite MEMORY.md — a short durable
+summary of what the user cares about, their preferences, and any useful context.
+
+Rules:
+- Write in first person from the assistant's perspective.
+- Be concise. 200 words maximum.
+- Do not include a session log or timestamps — only durable facts and context.
+- If the conversation had no meaningful new information, return the existing text unchanged.
+- Output only raw markdown. No preamble, no code fences.
+"""
+
+
+def read_memory() -> str:
+    """Read the current memory file. Returns empty string if none exists."""
+    if not _MEMORY_FILE.exists():
+        return ""
+    content = _MEMORY_FILE.read_text(encoding="utf-8").strip()
+    if content.startswith("# OpenRouter Agent Memory\n\n*No sessions recorded yet.*"):
+        return ""
+    return content
+
+
+def format_for_injection() -> str:
+    """
+    Format memory for system prompt injection.
+    Returns empty string on first run (no memory yet).
+    """
+    memory = read_memory()
+    if not memory:
+        return ""
+    return "--- Your Memory From Previous Sessions ---\n\n" + memory + "\n\n--- End Memory ---"
+
+
+def seed_if_missing() -> None:
+    """Create MEMORY.md with a blank template if it does not exist yet."""
+    if _MEMORY_FILE.exists():
+        return
+    _AGENT_DIR.mkdir(parents=True, exist_ok=True)
+    _MEMORY_FILE.write_text(_SEED_TEMPLATE, encoding="utf-8")
+
+
+async def consolidate_memory(
+    conversation_history: list[dict],
+    llm: object,
+) -> None:
+    """
+    Rewrite MEMORY.md based on the completed conversation.
+
+    Called at session end. Failures are logged and silently swallowed
+    so they never block session teardown.
+
+    Args:
+        conversation_history: List of {"role": ..., "content": ...} dicts.
+        llm: Any LLMProvider instance (must support acomplete()).
+    """
+    try:
+        if not conversation_history:
+            logger.debug("openrouter session_memory: no history, skipping consolidation")
+            return
+
+        transcript = "\n".join(
+            f"{m['role'].upper()}: {m['content'][:800]}"
+            for m in conversation_history
+            if m.get("content")
+        )
+
+        existing = read_memory()
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
+
+        user_msg = (
+            f"## Existing Memory\n\n{existing or '(none yet)'}\n\n"
+            f"## New Conversation ({timestamp})\n\n{transcript}"
+        )
+
+        response = await llm.acomplete(
+            messages=[{"role": "user", "content": user_msg}],
+            system=_CONSOLIDATION_SYSTEM,
+            max_tokens=512,
+        )
+
+        new_memory = response.content.strip()
+        if new_memory:
+            _AGENT_DIR.mkdir(parents=True, exist_ok=True)
+            _MEMORY_FILE.write_text(new_memory, encoding="utf-8")
+            logger.info("openrouter session_memory: memory updated (%d chars)", len(new_memory))
+
+    except Exception:
+        logger.exception("openrouter session_memory: consolidation failed")

--- a/core/tests/dummy_agents/run_all.py
+++ b/core/tests/dummy_agents/run_all.py
@@ -34,6 +34,7 @@ API_KEY_PROVIDERS = [
     ("DEEPSEEK_API_KEY", "DeepSeek", "deepseek-chat"),
     ("MINIMAX_API_KEY", "MiniMax", "MiniMax-M2.5"),
     ("HIVE_API_KEY", "Hive LLM", "hive/queen"),
+    ("OPENROUTER_API_KEY", "OpenRouter (free OSS models)", "openrouter/openai/gpt-oss-120b:free"),
 ]
 
 

--- a/core/tests/test_session_memory.py
+++ b/core/tests/test_session_memory.py
@@ -1,0 +1,143 @@
+"""Tests for openrouter_agent session_memory — all file I/O is mocked.
+
+Run:
+    cd core && uv run pytest tests/test_session_memory.py -v
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestReadMemory:
+    def test_returns_empty_when_file_missing(self, tmp_path):
+        with patch(
+            "framework.agents.openrouter_agent.session_memory._MEMORY_FILE",
+            tmp_path / "MEMORY.md",
+        ):
+            from framework.agents.openrouter_agent.session_memory import read_memory
+
+            assert read_memory() == ""
+
+    def test_returns_empty_for_seed_template(self, tmp_path):
+        mem_file = tmp_path / "MEMORY.md"
+        mem_file.write_text(
+            "# OpenRouter Agent Memory\n\n*No sessions recorded yet.*\n\n## What",
+            encoding="utf-8",
+        )
+        with patch("framework.agents.openrouter_agent.session_memory._MEMORY_FILE", mem_file):
+            import importlib
+
+            from framework.agents.openrouter_agent import session_memory
+
+            importlib.reload(session_memory)
+            assert session_memory.read_memory() == ""
+
+    def test_returns_real_content(self, tmp_path):
+        mem_file = tmp_path / "MEMORY.md"
+        mem_file.write_text("## User likes Python.", encoding="utf-8")
+        with patch("framework.agents.openrouter_agent.session_memory._MEMORY_FILE", mem_file):
+            import importlib
+
+            from framework.agents.openrouter_agent import session_memory
+
+            importlib.reload(session_memory)
+            assert "Python" in session_memory.read_memory()
+
+
+class TestFormatForInjection:
+    def test_empty_string_when_no_memory(self, tmp_path):
+        with patch(
+            "framework.agents.openrouter_agent.session_memory._MEMORY_FILE",
+            tmp_path / "MEMORY.md",
+        ):
+            import importlib
+
+            from framework.agents.openrouter_agent import session_memory
+
+            importlib.reload(session_memory)
+            result = session_memory.format_for_injection()
+            assert result == ""
+
+    def test_includes_memory_block(self, tmp_path):
+        mem_file = tmp_path / "MEMORY.md"
+        mem_file.write_text("User prefers concise answers.", encoding="utf-8")
+        with patch("framework.agents.openrouter_agent.session_memory._MEMORY_FILE", mem_file):
+            import importlib
+
+            from framework.agents.openrouter_agent import session_memory
+
+            importlib.reload(session_memory)
+            result = session_memory.format_for_injection()
+            assert "User prefers concise answers." in result
+            assert "Memory From Previous Sessions" in result
+
+
+class TestConsolidateMemory:
+    @pytest.mark.asyncio
+    async def test_writes_updated_memory(self, tmp_path):
+        mem_file = tmp_path / "MEMORY.md"
+        mem_file.parent.mkdir(parents=True, exist_ok=True)
+
+        mock_llm = MagicMock()
+        mock_response = MagicMock()
+        mock_response.content = "User asked about Paris and likes history."
+        mock_llm.acomplete = AsyncMock(return_value=mock_response)
+
+        history = [
+            {"role": "user", "content": "Tell me about Paris"},
+            {"role": "assistant", "content": "Paris is the capital of France."},
+        ]
+
+        with (
+            patch("framework.agents.openrouter_agent.session_memory._MEMORY_FILE", mem_file),
+            patch("framework.agents.openrouter_agent.session_memory._AGENT_DIR", tmp_path),
+        ):
+            import importlib
+
+            from framework.agents.openrouter_agent import session_memory
+
+            importlib.reload(session_memory)
+            await session_memory.consolidate_memory(history, mock_llm)
+
+        assert mem_file.exists()
+        content = mem_file.read_text(encoding="utf-8")
+        assert "Paris" in content
+
+    @pytest.mark.asyncio
+    async def test_empty_history_skips_write(self, tmp_path):
+        mem_file = tmp_path / "MEMORY.md"
+        mock_llm = MagicMock()
+        mock_llm.acomplete = AsyncMock()
+
+        with patch("framework.agents.openrouter_agent.session_memory._MEMORY_FILE", mem_file):
+            import importlib
+
+            from framework.agents.openrouter_agent import session_memory
+
+            importlib.reload(session_memory)
+            await session_memory.consolidate_memory([], mock_llm)
+
+        assert not mem_file.exists()
+        mock_llm.acomplete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_does_not_raise(self, tmp_path):
+        mock_llm = MagicMock()
+        mock_llm.acomplete = AsyncMock(side_effect=RuntimeError("network error"))
+        history = [{"role": "user", "content": "hello"}]
+
+        with (
+            patch(
+                "framework.agents.openrouter_agent.session_memory._MEMORY_FILE",
+                tmp_path / "MEMORY.md",
+            ),
+            patch("framework.agents.openrouter_agent.session_memory._AGENT_DIR", tmp_path),
+        ):
+            import importlib
+
+            from framework.agents.openrouter_agent import session_memory
+
+            importlib.reload(session_memory)
+            # Should NOT raise — failures are silently logged
+            await session_memory.consolidate_memory(history, mock_llm)


### PR DESCRIPTION
## Description
Fixes #7182
Adds `OpenRouterProvider`, a new LLM backend giving the framework access
to free open-source models via openrouter.ai at zero API cost.

Also registers `openrouter` in the Hive credential store so
`CredentialStoreAdapter.get("openrouter")` works without a KeyError.

## Motivation
The framework currently supports Anthropic, OpenAI, Gemini, and Groq.
OpenRouter provides a single endpoint for 100+ models including Llama,
Mistral, Gemma, Qwen, and DeepSeek — all free. This gives contributors
and users a zero-cost LLM option for development and testing.

## Changes
- `core/framework/llm/openrouter.py` — `OpenRouterProvider` wrapping
  `LiteLLMProvider` with OpenRouter endpoint, free-model alias registry,
  and automatic fallback chain on 429 rate-limit errors
- `core/framework/llm/__init__.py` — exports `OpenRouterProvider`
- `tools/src/aden_tools/credentials/openrouter.py` — `CredentialSpec`
  for `OPENROUTER_API_KEY` with setup instructions
- `tools/src/aden_tools/credentials/__init__.py` — registers the spec
- `core/tests/test_openrouter_provider.py` — 22 unit tests, all mocked

## Testing
- [x] Unit tests added (`test_openrouter_provider.py` — 22 tests, no API key needed)
- [x] Tested on Linux (GitHub Codespaces)
- [ ] Tested on macOS
- [ ] Tested on Windows

## Checklist
- [x] Code follows style guidelines (ruff — `make check` passes)
- [x] Self-review completed
- [x] No breaking changes — all changes are additive, new export wrapped in try/except

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenRouter Agent with interactive CLI for conversational chat sessions.
  * Added model selection and listing capabilities for free OpenRouter models.
  * Added persistent session memory across chat conversations.
  * Integrated web search, file reading, and file writing tools.

* **Tests**
  * Added unit tests for session memory functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->