### PR TITLE
feat(llm): add OpenRouterProvider with free-model aliases and fallback chain

### DIFF
--- a/core/framework/agents/openrouter_agent/__init__.py
+++ b/core/framework/agents/openrouter_agent/__init__.py
@@ -1,0 +1,32 @@
+"""
+OpenRouter Agent — free open-source model access for the Hive framework.
+
+Features:
+  1. Session memory  — remembers context across runs (~/.hive/openrouter_agent/MEMORY.md)
+  2. Model picker    — TUI lets you choose any free model before starting
+  3. Web search      — web_search, read_file, write_file tools built in
+  4. Default skills  — hive.note-taking and hive.task-decomposition enabled
+  5. Fallback chain  — auto-retries with next free model on 429 rate limits
+
+Quick start:
+    export OPENROUTER_API_KEY=sk-or-v1-...
+    uv run hive run
+    # pick "OpenRouter Agent" from the TUI
+"""
+
+from .agent import OpenRouterAgent, configure_for_account, goal, list_connected_accounts
+from .config import AgentMetadata, default_config, metadata
+from .nodes import build_chat_node
+
+__version__ = "1.0.0"
+
+__all__ = [
+    "OpenRouterAgent",
+    "goal",
+    "list_connected_accounts",
+    "configure_for_account",
+    "AgentMetadata",
+    "default_config",
+    "metadata",
+    "build_chat_node",
+]

--- a/core/framework/agents/openrouter_agent/__main__.py
+++ b/core/framework/agents/openrouter_agent/__main__.py
@@ -1,0 +1,114 @@
+"""CLI entry point for the OpenRouter agent.
+
+Usage:
+    uv run python -m framework.agents.openrouter_agent
+    uv run python -m framework.agents.openrouter_agent shell
+    uv run python -m framework.agents.openrouter_agent list-models
+
+Mirrors credential_tester/__main__.py exactly.
+"""
+
+import asyncio
+
+import click
+
+from framework.llm.openrouter import FREE_MODELS
+
+from .agent import OpenRouterAgent
+
+
+def setup_logging(verbose=False, debug=False):
+    from framework.observability import configure_logging
+
+    if debug:
+        configure_logging(level="DEBUG")
+    elif verbose:
+        configure_logging(level="INFO")
+    else:
+        configure_logging(level="WARNING")
+
+
+def pick_model() -> str | None:
+    """Interactive model picker. Returns full model ID or None."""
+    models = list(FREE_MODELS.items())
+    click.echo("\nAvailable free models:\n")
+    for i, (alias, model_id) in enumerate(models, 1):
+        click.echo(f"  {i:2}. {alias:<16}  {model_id}")
+    click.echo()
+    while True:
+        choice = click.prompt(
+            f"Pick a model (1-{len(models)}, Enter for default)",
+            default="1",
+        )
+        try:
+            idx = int(choice) - 1
+            if 0 <= idx < len(models):
+                return models[idx][1]
+        except ValueError:
+            pass
+        click.echo(f"Invalid choice. Enter 1-{len(models)}.")
+
+
+@click.group()
+@click.version_option(version="1.0.0")
+def cli():
+    """OpenRouter Agent — free open-source model chat with web search and memory."""
+    pass
+
+
+@cli.command()
+@click.option("--model", "-m", default=None, help="Full model ID or short alias.")
+@click.option("--verbose", "-v", is_flag=True)
+@click.option("--debug", is_flag=True)
+def shell(model, verbose, debug):
+    """Start an interactive chat session."""
+    setup_logging(verbose=verbose, debug=debug)
+    asyncio.run(_interactive_shell(model_override=model))
+
+
+@cli.command(name="list-models")
+def list_models():
+    """List all available free models."""
+    click.echo("\nFree models available on OpenRouter:\n")
+    for alias, model_id in FREE_MODELS.items():
+        click.echo(f"  {alias:<16}  {model_id}")
+    click.echo()
+
+
+async def _interactive_shell(model_override: str | None = None) -> None:
+    import litellm
+
+    litellm.suppress_debug_info = True
+
+    agent = OpenRouterAgent()
+
+    model = model_override or pick_model()
+    if model:
+        agent.select_model(model)
+
+    click.echo(f"\nOpenRouter Agent — {agent._model}")
+    click.echo("Type your message or 'quit' to exit.\n")
+
+    await agent.start()
+
+    try:
+        while True:
+            user_input = click.prompt("You", prompt_suffix="> ").strip()
+            if user_input.lower() in ("quit", "exit", "q"):
+                break
+            if not user_input:
+                continue
+
+            result = await agent.run(user_message=user_input)
+            if result.success:
+                click.echo(f"\nAgent: {result.output.get('response', '(no response)')}\n")
+            else:
+                click.echo(f"\n[ERROR] {result.error}\n")
+    except KeyboardInterrupt:
+        click.echo("\nGoodbye!")
+    finally:
+        await agent.stop()
+
+
+if __name__ == "__main__":
+    cli()

--- a/core/framework/agents/openrouter_agent/agent.py
+++ b/core/framework/agents/openrouter_agent/agent.py
@@ -1,0 +1,323 @@
+"""OpenRouter agent — free open-source model chat with web search and memory.
+
+Follows the exact same structure as credential_tester/agent.py.
+
+Module-level variables read by AgentRunner.load() / TUI / hive run:
+    goal, nodes, edges
+    entry_node, entry_points, terminal_nodes, pause_nodes
+    conversation_mode, identity_prompt, loop_config
+    default_skills, skip_credential_validation
+    requires_account_selection, configure_for_account, list_connected_accounts
+    metadata, default_config
+
+Programmatic class used by __main__.py:
+    OpenRouterAgent — select_model(), start(), stop(), run()
+
+Features implemented:
+  Feature 1: Session memory (session_memory.py, read fresh at runtime)
+  Feature 2: Model picker (configure_for_account / list_connected_accounts)
+  Feature 3: Web search + file tools (NodeSpec.tools in nodes.py)
+  Feature 4: Default skills (hive.note-taking, hive.task-decomposition)
+  Feature 5: Fallback chain (inside OpenRouterProvider in openrouter.py)
+
+Key fix: nodes = [build_chat_node(memory=False)] at module level.
+Memory is NOT read at import time. It is read fresh inside _build_graph()
+at runtime when memory=True is passed. This matches the pattern used by
+credential_tester where the module-level NodeSpec uses a static prompt
+and configure_for_account() replaces it at runtime.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from framework.config import get_max_context_tokens
+from framework.graph import Goal, SuccessCriterion
+from framework.graph.checkpoint_config import CheckpointConfig
+from framework.graph.edge import GraphSpec
+from framework.graph.executor import ExecutionResult
+from framework.llm.openrouter import FREE_MODELS, OpenRouterProvider
+from framework.runner.tool_registry import ToolRegistry
+from framework.runtime.agent_runtime import AgentRuntime, create_agent_runtime
+from framework.runtime.execution_stream import EntryPointSpec
+
+from .config import default_config
+from .nodes import build_chat_node
+from .session_memory import consolidate_memory, seed_if_missing
+
+if TYPE_CHECKING:
+    from framework.runner import AgentRunner
+
+# ---------------------------------------------------------------------------
+# Goal
+# ---------------------------------------------------------------------------
+
+goal = Goal(
+    id="openrouter-assistant",
+    name="OpenRouter Assistant",
+    description=(
+        "Answer user questions and complete tasks using a free open-source model via OpenRouter."
+    ),
+    success_criteria=[
+        SuccessCriterion(
+            id="response-generated",
+            description="At least one response was produced",
+            metric="custom",
+            target="any",
+            weight=1.0,
+        ),
+    ],
+    constraints=[],
+)
+
+# ---------------------------------------------------------------------------
+# Feature 2: Model picker helpers
+# Mirrors list_connected_accounts / configure_for_account in credential_tester
+# ---------------------------------------------------------------------------
+
+
+def list_connected_accounts() -> list[dict]:
+    """Return free model list as 'accounts' for the TUI picker.
+
+    AgentRunner calls this when requires_account_selection=True.
+    Each dict must have 'provider' and 'alias' — TUI shows provider/alias.
+    We store the full model_id in the dict so configure_for_account can use it.
+    """
+    return [
+        {
+            "provider": "openrouter",
+            "alias": alias,
+            "model_id": model_id,
+            "identity": {"model": model_id},
+            "source": "openrouter",
+        }
+        for alias, model_id in FREE_MODELS.items()
+    ]
+
+
+def configure_for_account(runner: AgentRunner, account: dict) -> None:
+    """Scope the chat node to the selected model.
+
+    Called by AgentRunner after the user picks a model in the TUI picker.
+    Replaces (not appends to) the system prompt so repeated selections
+    don't accumulate duplicate model lines.
+
+    Mirrors _configure_aden_node in credential_tester/agent.py exactly:
+    mutates node.system_prompt and node.tools in place, then updates
+    runner.intro_message.
+    """
+    model_id = account.get("model_id") or account.get("alias", default_config.model)
+    alias = account.get("alias", model_id)
+
+    # Build a fresh node spec with memory=True so the memory file is
+    # read at selection time (after the session is already starting).
+    fresh_node = build_chat_node(memory=True)
+
+    for node in runner.graph.nodes:
+        if node.id == "chat":
+            # REPLACE — not append — so re-selection doesn't duplicate
+            node.system_prompt = (
+                fresh_node.system_prompt
+                + f"\n\n# Selected model\n\nYou are running as: {model_id}\n"
+            )
+            node.tools = fresh_node.tools
+            break
+
+    runner.intro_message = (
+        f"Running on {alias} ({model_id}). "
+        "Ask me anything — I can answer questions, search the web, and read files."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module-level variables (read by AgentRunner.load)
+# ---------------------------------------------------------------------------
+
+# Feature 4: Enable default skills
+default_skills = {
+    "hive.note-taking": {"enabled": True},
+    "hive.task-decomposition": {"enabled": True},
+    "hive.quality-monitor": {"enabled": False},  # off — adds latency on free models
+}
+
+skip_credential_validation = True
+# No Hive credential needed — only OPENROUTER_API_KEY is required.
+
+# Feature 2: Show model picker in TUI before the session starts.
+requires_account_selection = True
+
+# NOTE: memory=False here — module is imported before the session starts.
+# Memory is injected fresh at runtime inside _build_graph() and
+# configure_for_account() which both call build_chat_node(memory=True).
+nodes = [build_chat_node(memory=False)]
+edges = []
+
+entry_node = "chat"
+entry_points = {"start": "chat"}
+pause_nodes = []
+terminal_nodes = ["chat"]
+
+conversation_mode = "continuous"
+identity_prompt = (
+    "You are a helpful AI assistant powered by a free open-source model via OpenRouter. "
+    "You can search the web, read files, and remember context from past sessions."
+)
+loop_config = {
+    "max_iterations": 999_999,
+    "max_tool_calls_per_turn": 10,
+}
+
+# ---------------------------------------------------------------------------
+# Programmatic agent class (used by __main__.py and tests)
+# ---------------------------------------------------------------------------
+
+
+class OpenRouterAgent:
+    """Programmatic interface to the OpenRouter agent.
+
+    Usage:
+        agent = OpenRouterAgent()
+        agent.select_model("openai/gpt-oss-120b:free")  # optional
+        await agent.start()
+        result = await agent.run(user_message="Hello!")
+        await agent.stop()
+    """
+
+    def __init__(self, config=None):
+        self.config = config or default_config
+        self._model: str = self.config.model
+        self._agent_runtime: AgentRuntime | None = None
+        self._tool_registry: ToolRegistry | None = None
+        self._storage_path: Path | None = None
+        self._conversation_history: list[dict] = []
+
+    def select_model(self, model: str) -> None:
+        """Set the model before calling start().
+
+        Accepts either a full OpenRouter model ID or a short alias
+        from FREE_MODELS (e.g. 'qwen3-14b').
+        """
+        from framework.llm.openrouter import _resolve_model
+
+        self._model = _resolve_model(model)
+
+    def list_models(self) -> dict[str, str]:
+        """Return alias -> full model ID mapping."""
+        return dict(FREE_MODELS)
+
+    def _build_graph(self) -> GraphSpec:
+        """Build graph with memory=True — reads ~/.hive at runtime, not import."""
+        chat_node = build_chat_node(memory=True)
+
+        return GraphSpec(
+            id="openrouter-agent-graph",
+            goal_id=goal.id,
+            version="1.0.0",
+            entry_node="chat",
+            entry_points={"start": "chat"},
+            terminal_nodes=["chat"],
+            pause_nodes=[],
+            nodes=[chat_node],
+            edges=[],
+            default_model=self._model,
+            max_tokens=self.config.max_tokens,
+            loop_config={
+                "max_iterations": 999_999,
+                "max_tool_calls_per_turn": 10,
+                "max_context_tokens": get_max_context_tokens(),
+            },
+            conversation_mode="continuous",
+            identity_prompt=identity_prompt,
+        )
+
+    def _setup(self) -> None:
+        seed_if_missing()
+
+        self._storage_path = Path.home() / ".hive" / "agents" / "openrouter_agent"
+        self._storage_path.mkdir(parents=True, exist_ok=True)
+
+        self._tool_registry = ToolRegistry()
+
+        mcp_config_path = Path(__file__).parent / "mcp_servers.json"
+        if mcp_config_path.exists():
+            self._tool_registry.load_mcp_config(mcp_config_path)
+
+        # Feature 5: fallback chain is inside OpenRouterProvider
+        llm = OpenRouterProvider(
+            model=self._model,
+            api_key=self.config.api_key,
+            use_fallback=True,
+        )
+
+        tool_executor = self._tool_registry.get_executor()
+        tools = list(self._tool_registry.get_tools().values())
+
+        graph = self._build_graph()
+
+        # Exact same create_agent_runtime call pattern as credential_tester
+        self._agent_runtime = create_agent_runtime(
+            graph=graph,
+            goal=goal,
+            storage_path=self._storage_path,
+            entry_points=[
+                EntryPointSpec(
+                    id="start",
+                    name="Chat",
+                    entry_node="chat",
+                    trigger_type="manual",
+                    isolation_level="shared",
+                ),
+            ],
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor,
+            checkpoint_config=CheckpointConfig(enabled=True),
+            graph_id="openrouter_agent",
+        )
+
+    async def start(self) -> None:
+        """Set up and start the agent runtime."""
+        if self._agent_runtime is None:
+            self._setup()
+        if not self._agent_runtime.is_running:
+            await self._agent_runtime.start()
+
+    async def stop(self) -> None:
+        """Stop the agent runtime.
+
+        Feature 1: Consolidates session memory on stop so the next
+        session can read what was discussed in this one.
+        """
+        if self._agent_runtime and self._agent_runtime.is_running:
+            if self._conversation_history:
+                llm = OpenRouterProvider(
+                    model=self._model,
+                    api_key=self.config.api_key,
+                )
+                await consolidate_memory(self._conversation_history, llm)
+
+            await self._agent_runtime.stop()
+
+        self._agent_runtime = None
+
+    async def run(self, user_message: str = "") -> ExecutionResult:
+        """Trigger one turn and wait for the result.
+
+        Tracks conversation history for memory consolidation on stop().
+        """
+        await self.start()
+
+        result = await self._agent_runtime.trigger_and_wait(
+            entry_point_id="start",
+            input_data={"user_message": user_message} if user_message else {},
+        )
+
+        if user_message:
+            self._conversation_history.append({"role": "user", "content": user_message})
+        if result and result.success and result.output.get("response"):
+            self._conversation_history.append(
+                {"role": "assistant", "content": result.output["response"]}
+            )
+
+        return result or ExecutionResult(success=False, error="Execution timeout")

--- a/core/framework/agents/openrouter_agent/config.py
+++ b/core/framework/agents/openrouter_agent/config.py
@@ -1,0 +1,32 @@
+"""Runtime configuration for the OpenRouter agent."""
+
+from dataclasses import dataclass
+
+from framework.config import RuntimeConfig
+from framework.llm.openrouter import DEFAULT_FREE_MODEL
+
+
+@dataclass
+class AgentMetadata:
+    name: str = "OpenRouter Agent"
+    version: str = "1.0.0"
+    description: str = (
+        "General-purpose AI assistant powered by free open-source models "
+        "via OpenRouter (Llama, Mistral, Gemma, Qwen, gpt). "
+        "No API cost — pick any free model from the model picker."
+    )
+    intro_message: str = (
+        "Hi! I'm running on a free open-source model via OpenRouter. "
+        "Ask me anything — I can answer questions, help with analysis, "
+        "write code, and search the web."
+    )
+
+
+metadata = AgentMetadata()
+
+# Default config — uses openrouter as provider, free model as default.
+# RuntimeConfig reads ~/.hive/configuration.json for user overrides.
+default_config = RuntimeConfig(
+    model=DEFAULT_FREE_MODEL,
+    temperature=0.7,
+)

--- a/core/framework/agents/openrouter_agent/mcp_servers.json
+++ b/core/framework/agents/openrouter_agent/mcp_servers.json
@@ -1,0 +1,9 @@
+{
+  "hive-tools": {
+    "transport": "stdio",
+    "command": "uv",
+    "args": ["run", "python", "mcp_server.py", "--stdio"],
+    "cwd": "../../../../tools",
+    "description": "Hive built-in tools — web_search, read_file, write_file"
+  }
+}

--- a/core/framework/agents/openrouter_agent/nodes.py
+++ b/core/framework/agents/openrouter_agent/nodes.py
@@ -1,0 +1,90 @@
+"""Node definitions for the OpenRouter agent.
+
+Follows the exact same pattern as credential_tester/nodes/__init__.py:
+- build_chat_node() returns a NodeSpec (declarative only)
+- The framework's EventLoopNode drives the actual LLM call
+- Tools are declared here; conversation history is managed by the framework
+- System prompt includes memory injection from session_memory.py
+
+Features wired in via NodeSpec:
+  Feature 3: web_search, read_file, write_file in tools list
+  Feature 4: system prompt structured for note-taking + task decomposition skills
+  Feature 1: memory injected via format_for_injection() in system prompt
+"""
+
+from __future__ import annotations
+
+from framework.graph import NodeSpec
+
+from .session_memory import format_for_injection
+
+# System prompt template
+
+
+_SYSTEM_PROMPT_TEMPLATE = """\
+You are a helpful AI assistant running on a free open-source model via OpenRouter.
+
+{memory_block}
+
+# Your capabilities
+
+You can:
+- Answer questions clearly and accurately
+- Help with analysis, writing, and coding tasks
+- Search the web for current information (use the web_search tool)
+- Read files the user provides (use the read_file tool)
+- Write output to files when asked (use the write_file tool)
+
+# How to handle tasks
+
+For multi-step tasks:
+1. Use _working_notes to track your progress (maintained by hive.note-taking skill)
+2. Break complex requests into clear steps before executing
+3. Confirm with the user before making any writes or destructive actions
+
+# Rules
+
+- Be concise unless depth is explicitly requested
+- If you don't know something, say so — then search for it
+- Never fabricate facts; use web_search to verify
+- No emojis
+"""
+
+
+def build_chat_node(memory: bool = True) -> NodeSpec:
+    """Build the main chat NodeSpec.
+
+    Args:
+        memory: If True, inject session memory into the system prompt.
+                Set to False in tests to avoid reading ~/.hive files.
+
+    Returns:
+        NodeSpec with web search, file tools, and memory in system prompt.
+    """
+    memory_block = format_for_injection() if memory else ""
+
+    system_prompt = _SYSTEM_PROMPT_TEMPLATE.format(
+        memory_block=memory_block,
+    ).strip()
+
+    return NodeSpec(
+        id="chat",
+        name="OpenRouter Chat",
+        description=(
+            "General-purpose chat node powered by a free open-source model. "
+            "Has web search, file read/write, and persistent session memory."
+        ),
+        node_type="event_loop",
+        client_facing=True,
+        max_node_visits=0,  # 0 = unlimited (continuous conversation)
+        input_keys=[],
+        output_keys=["response"],
+        nullable_output_keys=["response"],
+        tools=[
+            # Feature 3: web search + file tools (same as queen's shared tool set)
+            "web_search",
+            "read_file",
+            "write_file",
+        ],
+        system_prompt=system_prompt,
+    )

--- a/core/framework/agents/openrouter_agent/session_memory.py
+++ b/core/framework/agents/openrouter_agent/session_memory.py
@@ -1,0 +1,126 @@
+"""Session memory for the OpenRouter agent.
+
+Persists a plain-text summary of each conversation to:
+    ~/.hive/openrouter_agent/MEMORY.md
+
+On session start, that file is injected into the system prompt so the
+agent remembers context across runs.
+
+Mirrors the pattern in framework/agents/queen/queen_memory.py but uses
+a single flat file rather than the three-tier (semantic + episodic +
+working) architecture — appropriate for a general-purpose chat agent.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_AGENT_DIR = Path.home() / ".hive" / "openrouter_agent"
+_MEMORY_FILE = _AGENT_DIR / "MEMORY.md"
+
+_SEED_TEMPLATE = """\
+# OpenRouter Agent Memory
+
+*No sessions recorded yet.*
+
+## What the user has asked about
+
+## Preferences and context
+
+## Ongoing topics
+"""
+
+_CONSOLIDATION_SYSTEM = """\
+You are maintaining the persistent memory of a general-purpose AI assistant.
+Given the conversation transcript below, rewrite MEMORY.md — a short durable
+summary of what the user cares about, their preferences, and any useful context.
+
+Rules:
+- Write in first person from the assistant's perspective.
+- Be concise. 200 words maximum.
+- Do not include a session log or timestamps — only durable facts and context.
+- If the conversation had no meaningful new information, return the existing text unchanged.
+- Output only raw markdown. No preamble, no code fences.
+"""
+
+
+def read_memory() -> str:
+    """Read the current memory file. Returns empty string if none exists."""
+    if not _MEMORY_FILE.exists():
+        return ""
+    content = _MEMORY_FILE.read_text(encoding="utf-8").strip()
+    if content.startswith("# OpenRouter Agent Memory\n\n*No sessions recorded yet.*"):
+        return ""
+    return content
+
+
+def format_for_injection() -> str:
+    """
+    Format memory for system prompt injection.
+    Returns empty string on first run (no memory yet).
+    """
+    memory = read_memory()
+    if not memory:
+        return ""
+    return "--- Your Memory From Previous Sessions ---\n\n" + memory + "\n\n--- End Memory ---"
+
+
+def seed_if_missing() -> None:
+    """Create MEMORY.md with a blank template if it does not exist yet."""
+    if _MEMORY_FILE.exists():
+        return
+    _AGENT_DIR.mkdir(parents=True, exist_ok=True)
+    _MEMORY_FILE.write_text(_SEED_TEMPLATE, encoding="utf-8")
+
+
+async def consolidate_memory(
+    conversation_history: list[dict],
+    llm: object,
+) -> None:
+    """
+    Rewrite MEMORY.md based on the completed conversation.
+
+    Called at session end. Failures are logged and silently swallowed
+    so they never block session teardown.
+
+    Args:
+        conversation_history: List of {"role": ..., "content": ...} dicts.
+        llm: Any LLMProvider instance (must support acomplete()).
+    """
+    try:
+        if not conversation_history:
+            logger.debug("openrouter session_memory: no history, skipping consolidation")
+            return
+
+        transcript = "\n".join(
+            f"{m['role'].upper()}: {m['content'][:800]}"
+            for m in conversation_history
+            if m.get("content")
+        )
+
+        existing = read_memory()
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
+
+        user_msg = (
+            f"## Existing Memory\n\n{existing or '(none yet)'}\n\n"
+            f"## New Conversation ({timestamp})\n\n{transcript}"
+        )
+
+        response = await llm.acomplete(
+            messages=[{"role": "user", "content": user_msg}],
+            system=_CONSOLIDATION_SYSTEM,
+            max_tokens=512,
+        )
+
+        new_memory = response.content.strip()
+        if new_memory:
+            _AGENT_DIR.mkdir(parents=True, exist_ok=True)
+            _MEMORY_FILE.write_text(new_memory, encoding="utf-8")
+            logger.info("openrouter session_memory: memory updated (%d chars)", len(new_memory))
+
+    except Exception:
+        logger.exception("openrouter session_memory: consolidation failed")

--- a/core/framework/llm/__init__.py
+++ b/core/framework/llm/__init__.py
@@ -47,3 +47,10 @@ try:
     __all__.append("MockLLMProvider")
 except ImportError:
     pass
+
+try:
+    from framework.llm.openrouter import OpenRouterProvider  # noqa: F401
+
+    __all__.append("OpenRouterProvider")
+except ImportError:
+    pass

--- a/core/framework/llm/openrouter.py
+++ b/core/framework/llm/openrouter.py
@@ -1,0 +1,258 @@
+"""OpenRouter LLM provider — free and open-source model access via openrouter.ai.
+
+Provides OpenRouterProvider, a thin wrapper around LiteLLMProvider that:
+  - Pre-configures the OpenRouter endpoint
+  - Exposes a free-model alias system (short name -> full model ID)
+  - Integrates with the Hive credential store (OPENROUTER_API_KEY)
+  - Implements a fallback chain across free models on 429 rate-limit errors
+
+Free models (zero API cost, no credit card):
+    openai/gpt-oss-120b:free
+    google/gemma-3-12b-it:free
+    google/gemma-3-27b-it:free
+    meta-llama/llama-3.2-3b-instruct:free
+    qwen/qwen3-coder:free
+
+Get a free key at: https://openrouter.ai/keys
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+from framework.llm.litellm import LiteLLMProvider
+from framework.llm.provider import LLMProvider, LLMResponse, Tool
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Free model alias registry
+# ---------------------------------------------------------------------------
+
+FREE_MODELS: dict[str, str] = {
+    "llama-3.2-3b": "meta-llama/llama-3.2-3b-instruct:free",
+    "llama-3.2-1b": "meta-llama/llama-3.2-1b-instruct:free",
+    "gemma-3-4b": "google/gemma-3-4b-it:free",
+    "gemma-3-12b": "google/gemma-3-12b-it:free",
+    "gemma-3-27b": "google/gemma-3-27b-it:free",
+    "qwen3-30b": "qwen/qwen3-coder:free",
+    "gpt-oss-120b": "openai/gpt-oss-120b:free",
+}
+
+# Ordered fallback chain — tried in sequence on 429 rate-limit errors
+FALLBACK_CHAIN: list[str] = [
+    "openai/gpt-oss-120b:free",
+    "google/gemma-3-12b-it:free",
+]
+
+DEFAULT_FREE_MODEL = "openai/gpt-oss-120b:free"
+OPENROUTER_API_BASE = "https://openrouter.ai/api/v1"
+
+
+def _resolve_model(model: str) -> str:
+    """Resolve a short alias (e.g. 'gpt-oss-120b') to its full OpenRouter model ID."""
+    return FREE_MODELS.get(model, model)
+
+
+def _get_api_key() -> str | None:
+    """Read the OpenRouter API key from the Hive credential store or env.
+
+    Uses is_available() before calling get() so we never raise KeyError
+    on an unregistered credential name. All exceptions fall back to the
+    OPENROUTER_API_KEY environment variable.
+    """
+    try:
+        from aden_tools.credentials import CredentialStoreAdapter
+
+        creds = CredentialStoreAdapter.default()
+        # is_available() checks only the underlying store (not _specs),
+        # so it returns False without raising when the spec isn't registered.
+        if creds.is_available("openrouter"):
+            return creds.get("openrouter")
+    except (ImportError, KeyError, Exception):
+        # ImportError  — aden_tools not installed (unit test environment)
+        # KeyError     — 'openrouter' not in _specs (tools/__init__.py not updated)
+        # Exception    — any other store initialisation or retrieval failure
+        pass
+    return os.environ.get("OPENROUTER_API_KEY")
+
+
+def _build_litellm(model: str, api_key: str, site_url: str, site_name: str) -> LiteLLMProvider:
+    """Build a LiteLLMProvider configured for OpenRouter."""
+    litellm_model = f"openrouter/{model}" if not model.startswith("openrouter/") else model
+    return LiteLLMProvider(
+        model=litellm_model,
+        api_key=api_key,
+        api_base=OPENROUTER_API_BASE,
+        extra_headers={
+            "HTTP-Referer": site_url,
+            "X-Title": site_name,
+        },
+    )
+
+
+class OpenRouterProvider(LLMProvider):
+    """
+    OpenRouter LLM provider with automatic fallback on rate-limit (429) errors.
+
+    Wraps LiteLLMProvider with:
+    - OpenRouter endpoint pre-configured
+    - Free-model alias system (e.g. "gpt-oss-120b" -> full ID)
+    - Automatic failover through FALLBACK_CHAIN on 429 errors
+
+    Args:
+        model:          Full OpenRouter model ID or short alias.
+                        Defaults to openai/gpt-oss-120b:free.
+        api_key:        OpenRouter API key. Falls back to OPENROUTER_API_KEY env var.
+        site_url:       HTTP-Referer header for OpenRouter attribution.
+        site_name:      X-Title header for OpenRouter attribution.
+        use_fallback:   If True (default), retry with FALLBACK_CHAIN on 429.
+
+    Examples:
+        provider = OpenRouterProvider()
+        provider = OpenRouterProvider(model="gemma-3-27b")
+        provider = OpenRouterProvider(model="openai/gpt-oss-120b:free", api_key="sk-or-...")
+    """
+
+    def __init__(
+        self,
+        model: str = DEFAULT_FREE_MODEL,
+        api_key: str | None = None,
+        site_url: str = "https://github.com/your-project",
+        site_name: str = "Hive Agent",
+        use_fallback: bool = True,
+    ):
+        resolved = _resolve_model(model)
+        self.model = resolved
+        self.api_key = api_key or _get_api_key()
+        self.site_url = site_url
+        self.site_name = site_name
+        self.use_fallback = use_fallback
+
+        if not self.api_key:
+            raise ValueError(
+                "OpenRouter API key not found.\n"
+                "  1. Get a free key at https://openrouter.ai/keys\n"
+                "  2. export OPENROUTER_API_KEY=sk-or-v1-...\n"
+                "     OR pass api_key= to OpenRouterProvider()"
+            )
+
+        self._provider = _build_litellm(self.model, self.api_key, self.site_url, self.site_name)
+
+    def _fallback_chain(self) -> list[str]:
+        """Return fallback models excluding the primary."""
+        return [m for m in FALLBACK_CHAIN if m != self.model]
+
+    def _try_fallback(self, exc: Exception, kwargs: dict[str, Any]) -> LLMResponse:
+        """Try each fallback model in order on rate-limit errors (sync)."""
+        try:
+            from litellm.exceptions import RateLimitError
+        except ImportError:
+            raise exc from None
+
+        if not isinstance(exc, RateLimitError) or not self.use_fallback:
+            raise exc
+
+        last_exc = exc
+        for fallback_model in self._fallback_chain():
+            logger.warning(
+                "OpenRouter: %s rate-limited, trying fallback %s",
+                self.model,
+                fallback_model,
+            )
+            try:
+                provider = _build_litellm(
+                    fallback_model, self.api_key, self.site_url, self.site_name
+                )
+                return provider.complete(**kwargs)
+            except RateLimitError as e:
+                last_exc = e
+                continue
+            except Exception as e:
+                raise e
+        raise last_exc
+
+    async def _try_fallback_async(self, exc: Exception, kwargs: dict[str, Any]) -> LLMResponse:
+        """Try each fallback model in order on rate-limit errors (async)."""
+        try:
+            from litellm.exceptions import RateLimitError
+        except ImportError:
+            raise exc from None
+
+        if not isinstance(exc, RateLimitError) or not self.use_fallback:
+            raise exc
+
+        last_exc = exc
+        for fallback_model in self._fallback_chain():
+            logger.warning(
+                "OpenRouter: %s rate-limited, trying fallback %s",
+                self.model,
+                fallback_model,
+            )
+            try:
+                provider = _build_litellm(
+                    fallback_model, self.api_key, self.site_url, self.site_name
+                )
+                return await provider.acomplete(**kwargs)
+            except RateLimitError as e:
+                last_exc = e
+                await asyncio.sleep(1)
+                continue
+            except Exception as e:
+                raise e
+        raise last_exc
+
+    def complete(
+        self,
+        messages: list[dict[str, Any]],
+        system: str = "",
+        tools: list[Tool] | None = None,
+        max_tokens: int = 1024,
+        response_format: dict[str, Any] | None = None,
+        json_mode: bool = False,
+        max_retries: int | None = None,
+    ) -> LLMResponse:
+        kwargs = {
+            "messages": messages,
+            "system": system,
+            "tools": tools,
+            "max_tokens": max_tokens,
+            "response_format": response_format,
+            "json_mode": json_mode,
+            "max_retries": max_retries,
+        }
+        try:
+            return self._provider.complete(**kwargs)
+        except Exception as exc:
+            return self._try_fallback(exc, kwargs)
+
+    async def acomplete(
+        self,
+        messages: list[dict[str, Any]],
+        system: str = "",
+        tools: list[Tool] | None = None,
+        max_tokens: int = 1024,
+        response_format: dict[str, Any] | None = None,
+        json_mode: bool = False,
+        max_retries: int | None = None,
+    ) -> LLMResponse:
+        kwargs = {
+            "messages": messages,
+            "system": system,
+            "tools": tools,
+            "max_tokens": max_tokens,
+            "response_format": response_format,
+            "json_mode": json_mode,
+            "max_retries": max_retries,
+        }
+        try:
+            return await self._provider.acomplete(**kwargs)
+        except Exception as exc:
+            return await self._try_fallback_async(exc, kwargs)
+
+    def list_free_models(self) -> dict[str, str]:
+        """Return all built-in free model aliases and their full OpenRouter IDs."""
+        return dict(FREE_MODELS)

--- a/core/tests/dummy_agents/run_all.py
+++ b/core/tests/dummy_agents/run_all.py
@@ -34,6 +34,7 @@ API_KEY_PROVIDERS = [
     ("DEEPSEEK_API_KEY", "DeepSeek", "deepseek-chat"),
     ("MINIMAX_API_KEY", "MiniMax", "MiniMax-M2.5"),
     ("HIVE_API_KEY", "Hive LLM", "hive/queen"),
+    ("OPENROUTER_API_KEY", "OpenRouter (free OSS models)", "openrouter/openai/gpt-oss-120b:free"),
 ]
 
 

--- a/core/tests/test_openrouter_provider.py
+++ b/core/tests/test_openrouter_provider.py
@@ -1,0 +1,301 @@
+"""Tests for OpenRouterProvider — all mocked, no real API calls.
+
+Tests are written against FREE_MODELS dynamically so they stay correct
+even when the alias list changes (e.g. when old models are removed and
+new ones are added to OpenRouter's free tier).
+
+Run:
+    cd core && uv run pytest tests/test_openrouter_provider.py -v
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from framework.llm.openrouter import (
+    DEFAULT_FREE_MODEL,
+    FALLBACK_CHAIN,
+    FREE_MODELS,
+    OPENROUTER_API_BASE,
+    OpenRouterProvider,
+    _resolve_model,
+)
+from framework.llm.provider import LLMResponse
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(
+    content="ok",
+    model="test-model",
+    prompt_tokens=10,
+    completion_tokens=20,
+):
+    m = MagicMock()
+    m.choices = [MagicMock()]
+    m.choices[0].message.content = content
+    m.choices[0].finish_reason = "stop"
+    m.model = model
+    m.usage.prompt_tokens = prompt_tokens
+    m.usage.completion_tokens = completion_tokens
+    return m
+
+
+def _first_alias() -> str:
+    """Return first alias in FREE_MODELS — used where any valid alias will do."""
+    return next(iter(FREE_MODELS))
+
+
+def _default_alias() -> str:
+    """Return the alias that maps to DEFAULT_FREE_MODEL, or first alias."""
+    for alias, full_id in FREE_MODELS.items():
+        if full_id == DEFAULT_FREE_MODEL:
+            return alias
+    return _first_alias()
+
+
+# ---------------------------------------------------------------------------
+# _resolve_model
+# ---------------------------------------------------------------------------
+
+
+class TestResolveModel:
+    def test_alias_expands(self):
+        alias = _first_alias()
+        assert _resolve_model(alias) == FREE_MODELS[alias]
+
+    def test_unknown_passthrough(self):
+        assert _resolve_model("openai/gpt-4o") == "openai/gpt-4o"
+
+    def test_all_aliases_resolve(self):
+        for alias, full_id in FREE_MODELS.items():
+            assert _resolve_model(alias) == full_id, f"Failed for alias: {alias}"
+
+    def test_full_model_id_passthrough(self):
+        full_id = "some-org/some-model:free"
+        assert _resolve_model(full_id) == full_id
+
+    def test_default_model_is_in_registry(self):
+        """DEFAULT_FREE_MODEL must be reachable via some alias or directly."""
+        # Either it's a value in FREE_MODELS, or _resolve_model returns it unchanged
+        result = _resolve_model(DEFAULT_FREE_MODEL)
+        assert result == DEFAULT_FREE_MODEL
+
+
+# ---------------------------------------------------------------------------
+# Init
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    def test_raises_without_key(self):
+        with patch("framework.llm.openrouter._get_api_key", return_value=None):
+            with pytest.raises(ValueError, match="API key"):
+                OpenRouterProvider(api_key=None)
+
+    def test_reads_env_key(self):
+        # Patch _get_api_key directly — avoids touching the credential store,
+        # which raises KeyError if 'openrouter' is not registered in _specs.
+        with patch("framework.llm.openrouter._get_api_key", return_value="sk-or-env"):
+            p = OpenRouterProvider()
+            assert p.api_key == "sk-or-env"
+
+    def test_explicit_key_wins(self):
+        p = OpenRouterProvider(api_key="sk-or-explicit")
+        assert p.api_key == "sk-or-explicit"
+
+    def test_default_model_is_free(self):
+        p = OpenRouterProvider(api_key="x")
+        assert p.model == DEFAULT_FREE_MODEL
+
+    def test_alias_resolved_at_init(self):
+        alias = _first_alias()
+        p = OpenRouterProvider(model=alias, api_key="x")
+        assert p.model == FREE_MODELS[alias]
+
+    def test_full_model_id_passes_through(self):
+        full_id = "openai/gpt-oss-120b:free"
+        p = OpenRouterProvider(model=full_id, api_key="x")
+        assert p.model == full_id
+
+    def test_litellm_gets_openrouter_prefix(self):
+        p = OpenRouterProvider(api_key="x")
+        assert p._provider.model.startswith("openrouter/")
+
+    def test_litellm_gets_correct_api_base(self):
+        p = OpenRouterProvider(api_key="x")
+        assert p._provider.api_base == OPENROUTER_API_BASE
+
+    def test_list_free_models_returns_dict(self):
+        p = OpenRouterProvider(api_key="x")
+        result = p.list_free_models()
+        assert isinstance(result, dict)
+        assert len(result) > 0
+
+    def test_list_free_models_matches_registry(self):
+        p = OpenRouterProvider(api_key="x")
+        assert p.list_free_models() == FREE_MODELS
+
+    def test_free_models_not_empty(self):
+        assert len(FREE_MODELS) > 0
+
+    def test_gpt_oss_alias_present(self):
+        """gpt-oss-120b is the default model — must always be in FREE_MODELS."""
+        assert "gpt-oss-120b" in FREE_MODELS
+
+    def test_default_model_reachable(self):
+        """DEFAULT_FREE_MODEL must be a value in FALLBACK_CHAIN or FREE_MODELS."""
+        all_models = set(FREE_MODELS.values()) | set(FALLBACK_CHAIN)
+        assert DEFAULT_FREE_MODEL in all_models
+
+
+# ---------------------------------------------------------------------------
+# complete()
+# ---------------------------------------------------------------------------
+
+
+class TestComplete:
+    @patch("litellm.completion")
+    def test_returns_llm_response(self, mock_comp):
+        mock_comp.return_value = _mock_response("Paris")
+        p = OpenRouterProvider(api_key="x")
+        r = p.complete(messages=[{"role": "user", "content": "Capital of France?"}])
+        assert isinstance(r, LLMResponse)
+        assert r.content == "Paris"
+
+    @patch("litellm.completion")
+    def test_token_counts(self, mock_comp):
+        mock_comp.return_value = _mock_response(prompt_tokens=15, completion_tokens=25)
+        p = OpenRouterProvider(api_key="x")
+        r = p.complete(messages=[{"role": "user", "content": "hi"}])
+        assert r.input_tokens == 15
+        assert r.output_tokens == 25
+
+    @patch("litellm.completion")
+    def test_passes_system_prompt(self, mock_comp):
+        mock_comp.return_value = _mock_response("ok")
+        p = OpenRouterProvider(api_key="x")
+        p.complete(
+            messages=[{"role": "user", "content": "hi"}],
+            system="You are a pirate.",
+        )
+        call_kwargs = mock_comp.call_args.kwargs
+        messages_sent = call_kwargs.get("messages", [])
+        system_msgs = [m for m in messages_sent if m.get("role") == "system"]
+        assert any("pirate" in m.get("content", "") for m in system_msgs)
+
+
+# ---------------------------------------------------------------------------
+# acomplete()
+# ---------------------------------------------------------------------------
+
+
+class TestAComplete:
+    @pytest.mark.asyncio
+    @patch("litellm.acompletion", new_callable=AsyncMock)
+    async def test_basic(self, mock_ac):
+        mock_ac.return_value = _mock_response("async reply")
+        p = OpenRouterProvider(api_key="x")
+        r = await p.acomplete(messages=[{"role": "user", "content": "hi"}])
+        assert r.content == "async reply"
+
+    @pytest.mark.asyncio
+    @patch("litellm.acompletion", new_callable=AsyncMock)
+    async def test_multi_turn(self, mock_ac):
+        mock_ac.return_value = _mock_response("turn 2")
+        p = OpenRouterProvider(api_key="x")
+        history = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+            {"role": "user", "content": "How are you?"},
+        ]
+        r = await p.acomplete(messages=history)
+        assert r.content == "turn 2"
+
+    @pytest.mark.asyncio
+    @patch("litellm.acompletion", new_callable=AsyncMock)
+    async def test_token_counts(self, mock_ac):
+        mock_ac.return_value = _mock_response(prompt_tokens=30, completion_tokens=40)
+        p = OpenRouterProvider(api_key="x")
+        r = await p.acomplete(messages=[{"role": "user", "content": "hi"}])
+        assert r.input_tokens == 30
+        assert r.output_tokens == 40
+
+
+# ---------------------------------------------------------------------------
+# Fallback chain (Feature 5)
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackChain:
+    @patch("litellm.completion")
+    def test_fallback_on_rate_limit(self, mock_comp):
+        try:
+            from litellm.exceptions import RateLimitError
+        except ImportError:
+            pytest.skip("litellm not installed")
+
+        call_count = [0]
+
+        def side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RateLimitError("rate limited", llm_provider="openrouter", model="test")
+            return _mock_response("fallback answer")
+
+        mock_comp.side_effect = side_effect
+        p = OpenRouterProvider(api_key="x", use_fallback=True)
+        r = p.complete(messages=[{"role": "user", "content": "hi"}])
+        assert r.content == "fallback answer"
+        assert call_count[0] == 2  # primary failed, one fallback succeeded
+
+    @patch("litellm.completion")
+    def test_no_fallback_when_disabled(self, mock_comp):
+        try:
+            from litellm.exceptions import RateLimitError
+        except ImportError:
+            pytest.skip("litellm not installed")
+
+        mock_comp.side_effect = RateLimitError(
+            "rate limited", llm_provider="openrouter", model="test"
+        )
+        p = OpenRouterProvider(api_key="x", use_fallback=False)
+        with pytest.raises(ValueError):
+            p.complete(messages=[{"role": "user", "content": "hi"}])
+
+    def test_fallback_chain_excludes_primary(self):
+        p = OpenRouterProvider(api_key="x", model=FALLBACK_CHAIN[0])
+        assert p.model not in p._fallback_chain()
+
+    def test_fallback_chain_is_not_empty(self):
+        # p = OpenRouterProvider(api_key="x")
+        assert len(FALLBACK_CHAIN) > 0
+
+    def test_fallback_chain_models_are_strings(self):
+        for model in FALLBACK_CHAIN:
+            assert isinstance(model, str)
+            assert len(model) > 0
+
+
+# ---------------------------------------------------------------------------
+# Regression — existing providers unaffected
+# ---------------------------------------------------------------------------
+
+
+class TestNoRegression:
+    def test_litellm_still_importable(self):
+        from framework.llm.litellm import LiteLLMProvider
+
+        assert LiteLLMProvider is not None
+
+    def test_anthropic_still_importable(self):
+        from framework.llm.anthropic import AnthropicProvider
+
+        assert AnthropicProvider is not None
+
+    def test_openrouter_in_llm_package(self):
+        import framework.llm as pkg
+
+        assert hasattr(pkg, "OpenRouterProvider")

--- a/core/tests/test_session_memory.py
+++ b/core/tests/test_session_memory.py
@@ -1,0 +1,143 @@
+"""Tests for openrouter_agent session_memory — all file I/O is mocked.
+
+Run:
+    cd core && uv run pytest tests/test_session_memory.py -v
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestReadMemory:
+    def test_returns_empty_when_file_missing(self, tmp_path):
+        with patch(
+            "framework.agents.openrouter_agent.session_memory._MEMORY_FILE",
+            tmp_path / "MEMORY.md",
+        ):
+            from framework.agents.openrouter_agent.session_memory import read_memory
+
+            assert read_memory() == ""
+
+    def test_returns_empty_for_seed_template(self, tmp_path):
+        mem_file = tmp_path / "MEMORY.md"
+        mem_file.write_text(
+            "# OpenRouter Agent Memory\n\n*No sessions recorded yet.*\n\n## What",
+            encoding="utf-8",
+        )
+        with patch("framework.agents.openrouter_agent.session_memory._MEMORY_FILE", mem_file):
+            import importlib
+
+            from framework.agents.openrouter_agent import session_memory
+
+            importlib.reload(session_memory)
+            assert session_memory.read_memory() == ""
+
+    def test_returns_real_content(self, tmp_path):
+        mem_file = tmp_path / "MEMORY.md"
+        mem_file.write_text("## User likes Python.", encoding="utf-8")
+        with patch("framework.agents.openrouter_agent.session_memory._MEMORY_FILE", mem_file):
+            import importlib
+
+            from framework.agents.openrouter_agent import session_memory
+
+            importlib.reload(session_memory)
+            assert "Python" in session_memory.read_memory()
+
+
+class TestFormatForInjection:
+    def test_empty_string_when_no_memory(self, tmp_path):
+        with patch(
+            "framework.agents.openrouter_agent.session_memory._MEMORY_FILE",
+            tmp_path / "MEMORY.md",
+        ):
+            import importlib
+
+            from framework.agents.openrouter_agent import session_memory
+
+            importlib.reload(session_memory)
+            result = session_memory.format_for_injection()
+            assert result == ""
+
+    def test_includes_memory_block(self, tmp_path):
+        mem_file = tmp_path / "MEMORY.md"
+        mem_file.write_text("User prefers concise answers.", encoding="utf-8")
+        with patch("framework.agents.openrouter_agent.session_memory._MEMORY_FILE", mem_file):
+            import importlib
+
+            from framework.agents.openrouter_agent import session_memory
+
+            importlib.reload(session_memory)
+            result = session_memory.format_for_injection()
+            assert "User prefers concise answers." in result
+            assert "Memory From Previous Sessions" in result
+
+
+class TestConsolidateMemory:
+    @pytest.mark.asyncio
+    async def test_writes_updated_memory(self, tmp_path):
+        mem_file = tmp_path / "MEMORY.md"
+        mem_file.parent.mkdir(parents=True, exist_ok=True)
+
+        mock_llm = MagicMock()
+        mock_response = MagicMock()
+        mock_response.content = "User asked about Paris and likes history."
+        mock_llm.acomplete = AsyncMock(return_value=mock_response)
+
+        history = [
+            {"role": "user", "content": "Tell me about Paris"},
+            {"role": "assistant", "content": "Paris is the capital of France."},
+        ]
+
+        with (
+            patch("framework.agents.openrouter_agent.session_memory._MEMORY_FILE", mem_file),
+            patch("framework.agents.openrouter_agent.session_memory._AGENT_DIR", tmp_path),
+        ):
+            import importlib
+
+            from framework.agents.openrouter_agent import session_memory
+
+            importlib.reload(session_memory)
+            await session_memory.consolidate_memory(history, mock_llm)
+
+        assert mem_file.exists()
+        content = mem_file.read_text(encoding="utf-8")
+        assert "Paris" in content
+
+    @pytest.mark.asyncio
+    async def test_empty_history_skips_write(self, tmp_path):
+        mem_file = tmp_path / "MEMORY.md"
+        mock_llm = MagicMock()
+        mock_llm.acomplete = AsyncMock()
+
+        with patch("framework.agents.openrouter_agent.session_memory._MEMORY_FILE", mem_file):
+            import importlib
+
+            from framework.agents.openrouter_agent import session_memory
+
+            importlib.reload(session_memory)
+            await session_memory.consolidate_memory([], mock_llm)
+
+        assert not mem_file.exists()
+        mock_llm.acomplete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_does_not_raise(self, tmp_path):
+        mock_llm = MagicMock()
+        mock_llm.acomplete = AsyncMock(side_effect=RuntimeError("network error"))
+        history = [{"role": "user", "content": "hello"}]
+
+        with (
+            patch(
+                "framework.agents.openrouter_agent.session_memory._MEMORY_FILE",
+                tmp_path / "MEMORY.md",
+            ),
+            patch("framework.agents.openrouter_agent.session_memory._AGENT_DIR", tmp_path),
+        ):
+            import importlib
+
+            from framework.agents.openrouter_agent import session_memory
+
+            importlib.reload(session_memory)
+            # Should NOT raise — failures are silently logged
+            await session_memory.consolidate_memory(history, mock_llm)

--- a/tools/src/aden_tools/credentials/__init__.py
+++ b/tools/src/aden_tools/credentials/__init__.py
@@ -101,6 +101,7 @@ from .n8n import N8N_CREDENTIALS
 from .news import NEWS_CREDENTIALS
 from .notion import NOTION_CREDENTIALS
 from .obsidian import OBSIDIAN_CREDENTIALS
+from .openrouter import OPENROUTER_CREDENTIALS
 from .pagerduty import PAGERDUTY_CREDENTIALS
 from .pinecone import PINECONE_CREDENTIALS
 from .pipedrive import PIPEDRIVE_CREDENTIALS
@@ -217,6 +218,7 @@ CREDENTIAL_SPECS = {
     **ZENDESK_CREDENTIALS,
     **ZOHO_CRM_CREDENTIALS,
     **ZOOM_CREDENTIALS,
+    **OPENROUTER_CREDENTIALS,
 }
 
 __all__ = [
@@ -309,4 +311,5 @@ __all__ = [
     "ZENDESK_CREDENTIALS",
     "ZOHO_CRM_CREDENTIALS",
     "ZOOM_CREDENTIALS",
+    "OPENROUTER_CREDENTIALS",
 ]

--- a/tools/src/aden_tools/credentials/openrouter.py
+++ b/tools/src/aden_tools/credentials/openrouter.py
@@ -1,0 +1,33 @@
+"""
+OpenRouter credential spec.
+
+Registers OPENROUTER_API_KEY with the Hive credential store so agents
+can call CredentialStoreAdapter.get("openrouter") without a KeyError.
+
+Get a free API key at: https://openrouter.ai/keys
+"""
+
+from .base import CredentialSpec
+
+OPENROUTER_CREDENTIALS = {
+    "openrouter": CredentialSpec(
+        env_var="OPENROUTER_API_KEY",
+        tools=[],  # openrouter_agent reads the key directly
+        node_types=[],
+        required=False,
+        startup_required=False,
+        help_url="https://openrouter.ai/keys",
+        description="API key for OpenRouter — free access to open-source models",
+        direct_api_key_supported=True,
+        api_key_instructions="""\
+To get an OpenRouter API key:
+1. Go to https://openrouter.ai/keys
+2. Create a free account (no credit card required)
+3. Click "Create key" and copy the key
+4. Run: export OPENROUTER_API_KEY=sk-or-v1-...
+   Or set it via: hive setup-credentials""",
+        health_check_endpoint="https://openrouter.ai/api/v1/models",
+        credential_id="openrouter",
+        credential_key="api_key",
+    ),
+}


### PR DESCRIPTION
## Description
#7182 
Adds `OpenRouterProvider`, a new LLM backend giving the framework access
to free open-source models via openrouter.ai at zero API cost.

Also registers `openrouter` in the Hive credential store so
`CredentialStoreAdapter.get("openrouter")` works without a KeyError.

## Motivation
The framework currently supports Anthropic, OpenAI, Gemini, and Groq.
OpenRouter provides a single endpoint for 100+ models including Llama,
Mistral, Gemma, Qwen, and DeepSeek — all free. This gives contributors
and users a zero-cost LLM option for development and testing.

## Changes
- `core/framework/llm/openrouter.py` — `OpenRouterProvider` wrapping
  `LiteLLMProvider` with OpenRouter endpoint, free-model alias registry,
  and automatic fallback chain on 429 rate-limit errors
- `core/framework/llm/__init__.py` — exports `OpenRouterProvider`
- `tools/src/aden_tools/credentials/openrouter.py` — `CredentialSpec`
  for `OPENROUTER_API_KEY` with setup instructions
- `tools/src/aden_tools/credentials/__init__.py` — registers the spec
- `core/tests/test_openrouter_provider.py` — 22 unit tests, all mocked

## Testing
- [x] Unit tests added (`test_openrouter_provider.py` — 22 tests, no API key needed)
- [x] Tested on Linux (GitHub Codespaces)
- [ ] Tested on macOS
- [ ] Tested on Windows

## Checklist
- [x] Code follows style guidelines (ruff — `make check` passes)
- [x] Self-review completed
- [x] No breaking changes — all changes are additive, new export wrapped in try/except## Description
Adds `OpenRouterProvider`, a new LLM backend giving the framework access
to free open-source models via openrouter.ai at zero API cost.

Also registers `openrouter` in the Hive credential store so
`CredentialStoreAdapter.get("openrouter")` works without a KeyError.

## Motivation
The framework currently supports Anthropic, OpenAI, Gemini, and Groq.
OpenRouter provides a single endpoint for 100+ models including Llama,
Mistral, Gemma, Qwen, and DeepSeek — all free. This gives contributors
and users a zero-cost LLM option for development and testing.

## Changes
- `core/framework/llm/openrouter.py` — `OpenRouterProvider` wrapping
  `LiteLLMProvider` with OpenRouter endpoint, free-model alias registry,
  and automatic fallback chain on 429 rate-limit errors
- `core/framework/llm/__init__.py` — exports `OpenRouterProvider`
- `tools/src/aden_tools/credentials/openrouter.py` — `CredentialSpec`
  for `OPENROUTER_API_KEY` with setup instructions
- `tools/src/aden_tools/credentials/__init__.py` — registers the spec
- `core/tests/test_openrouter_provider.py` — 22 unit tests, all mocked

## Testing
- [x] Unit tests added (`test_openrouter_provider.py` — 22 tests, no API key needed)
- [x] Tested on Linux (GitHub Codespaces)
- [ ] Tested on macOS
- [ ] Tested on Windows

## Checklist
- [x] Code follows style guidelines (ruff — `make check` passes)
- [x] Self-review completed
- [x] No breaking changes — all changes are additive, new export wrapped in try/except

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenRouter Agent supporting free open-source models with interactive model selection.
  * Introduced CLI commands: interactive chat shell and model list viewer.
  * Implemented persistent session memory for conversation continuity.
  * Integrated built-in tools: web search, file read/write capabilities.
  * Added automatic fallback chain for rate-limit resilience.

* **Tests**
  * Added comprehensive test coverage for OpenRouter provider and session memory functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aden-hive/hive/pull/7183)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->