### PR TITLE
fix(config): handle null max_tokens in configuration.json

### DIFF
--- a/core/framework/agent_loop/internals/event_publishing.py
+++ b/core/framework/agent_loop/internals/event_publishing.py
@@ -184,7 +184,7 @@ async def publish_context_usage(
     from framework.host.event_bus import AgentEvent, EventType
 
     estimated = conversation.estimate_tokens()
-    max_tokens = conversation._max_context_tokens
+    max_tokens = conversation._max_context_tokens or 32000
     ratio = estimated / max_tokens if max_tokens > 0 else 0.0
     await event_bus.publish(
         AgentEvent(

--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -322,7 +322,7 @@ def get_worker_llm_extra_kwargs() -> dict[str, Any]:
 def get_worker_max_tokens() -> int:
     """Return max_tokens for the worker LLM, falling back to default."""
     worker_llm = get_hive_config().get("worker_llm", {})
-    if worker_llm and "max_tokens" in worker_llm:
+    if worker_llm and worker_llm.get("max_tokens") is not None:
         return worker_llm["max_tokens"]
     return get_max_tokens()
 
@@ -330,14 +330,15 @@ def get_worker_max_tokens() -> int:
 def get_worker_max_context_tokens() -> int:
     """Return max_context_tokens for the worker LLM, falling back to default."""
     worker_llm = get_hive_config().get("worker_llm", {})
-    if worker_llm and "max_context_tokens" in worker_llm:
+    if worker_llm and worker_llm.get("max_context_tokens") is not None:
         return worker_llm["max_context_tokens"]
     return get_max_context_tokens()
 
 
 def get_max_tokens() -> int:
     """Return the configured max_tokens, falling back to DEFAULT_MAX_TOKENS."""
-    return get_hive_config().get("llm", {}).get("max_tokens", DEFAULT_MAX_TOKENS)
+    val = get_hive_config().get("llm", {}).get("max_tokens")
+    return val if val is not None else DEFAULT_MAX_TOKENS
 
 
 DEFAULT_MAX_CONTEXT_TOKENS = 32_000
@@ -346,7 +347,8 @@ OPENROUTER_API_BASE = "https://openrouter.ai/api/v1"
 
 def get_max_context_tokens() -> int:
     """Return the configured max_context_tokens, falling back to DEFAULT_MAX_CONTEXT_TOKENS."""
-    return get_hive_config().get("llm", {}).get("max_context_tokens", DEFAULT_MAX_CONTEXT_TOKENS)
+    val = get_hive_config().get("llm", {}).get("max_context_tokens")
+    return val if val is not None else DEFAULT_MAX_CONTEXT_TOKENS
 
 
 def get_api_keys() -> list[str] | None:


### PR DESCRIPTION
## Problem

When `llm.max_tokens` or `llm.max_context_tokens` is explicitly set to `null` in `configuration.json`, Python's `dict.get(key, default)` returns `None` instead of the default value. This is because `.get()` only falls back when the key is **missing**, not when it's `null`.

This causes two crash paths:
1. `get_max_tokens()` and `get_max_context_tokens()` return `None` instead of defaults
2. `publish_context_usage()` crashes with `TypeError: '>' not supported between instances of 'NoneType' and 'int'`

## Fix

**`core/framework/config.py`**:
- `get_max_tokens()`: Extract value, fall back to `DEFAULT_MAX_TOKENS` if `None`
- `get_max_context_tokens()`: Same pattern with `DEFAULT_MAX_CONTEXT_TOKENS`
- `get_worker_max_tokens()` / `get_worker_max_context_tokens()`: Use `is not None` check

**`core/framework/agent_loop/internals/event_publishing.py`**:
- `publish_context_usage()`: Add `or 32000` fallback for null `_max_context_tokens`

Closes #7117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of default token limits when not explicitly configured, ensuring more consistent fallback behavior.
  * Enhanced context usage metrics calculation for more accurate reporting of token consumption and usage ratios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aden-hive/hive/pull/7189)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->