### PR TITLE
feat(core): Implement Phase 1 of Neutrosophic Scoring Module (RFC #7179) [micro-fix]

### DIFF
--- a/core/framework/neutrosophic.py
+++ b/core/framework/neutrosophic.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class NeutrosophicDecision(str, Enum):
+    """Possible decisions derived from a neutrosophic score."""
+    ACCEPT = "accept"
+    CLARIFY = "clarify"
+    RETRY = "retry"
+    ESCALATE = "escalate"
+    CAVEAT = "caveat"
+
+
+@dataclass(frozen=True)
+class NeutrosophicScore:
+    """Immutable T/I/F triplet with clamping between 0.0 and 1.0.
+    
+    T: Truth / support / success
+    I: Indeterminacy / uncertainty / missing data
+    F: Falsity / contradiction / error
+    """
+    t: float
+    i: float
+    f: float
+
+    def __post_init__(self):
+        # Clamp values to [0.0, 1.0]
+        object.__setattr__(self, "t", max(0.0, min(1.0, self.t)))
+        object.__setattr__(self, "i", max(0.0, min(1.0, self.i)))
+        object.__setattr__(self, "f", max(0.0, min(1.0, self.f)))
+
+    def get_decision(
+        self,
+        t_thresh: float = 0.7,
+        i_thresh: float = 0.5,
+        f_thresh: float = 0.5
+    ) -> NeutrosophicDecision:
+        """Derive a decision from the score based on thresholds."""
+        if self.f >= f_thresh:
+            if self.i >= i_thresh:
+                return NeutrosophicDecision.ESCALATE
+            return NeutrosophicDecision.RETRY
+            
+        if self.i >= i_thresh:
+            return NeutrosophicDecision.CLARIFY
+            
+        if self.t >= t_thresh:
+            return NeutrosophicDecision.ACCEPT
+            
+        return NeutrosophicDecision.CAVEAT
+
+
+def score_worker_report(
+    status: str,
+    summary: str,
+    data: dict[str, Any] | None,
+    error: str | None = None
+) -> NeutrosophicScore:
+    """Derive T/I/F from worker report signals.
+    
+    This is a heuristic implementation for Phase 1 to demonstrate
+    deriving multidimensional confidence from flat worker results.
+    """
+    t, i, f = 0.0, 0.0, 0.0
+
+    # Status baseline
+    if status == "success":
+        t += 0.8
+    elif status == "partial":
+        t += 0.4
+        i += 0.4
+    elif status == "failed":
+        f += 0.8
+
+    # Error signal
+    if error:
+        f += 0.5
+
+    # Data completeness signal
+    if data is None or len(data) == 0:
+        i += 0.4
+
+    # Summary analysis (basic heuristic)
+    lower_summary = (summary or "").lower()
+    if "missing" in lower_summary or "unclear" in lower_summary or "unknown" in lower_summary:
+        i += 0.3
+    if "conflict" in lower_summary or "contradict" in lower_summary or "error" in lower_summary:
+        f += 0.3
+    if "confirm" in lower_summary or "verified" in lower_summary or "found" in lower_summary:
+        t += 0.2
+
+    return NeutrosophicScore(t=t, i=i, f=f)
+
+
+def aggregate_scores(scores: list[NeutrosophicScore]) -> NeutrosophicScore:
+    """Combine multiple worker scores into a single swarm consensus score."""
+    if not scores:
+        return NeutrosophicScore(t=0.0, i=1.0, f=0.0)
+
+    avg_t = sum(s.t for s in scores) / len(scores)
+    avg_i = sum(s.i for s in scores) / len(scores)
+    avg_f = sum(s.f for s in scores) / len(scores)
+    
+    return NeutrosophicScore(t=avg_t, i=avg_i, f=avg_f)

--- a/core/tests/test_neutrosophic.py
+++ b/core/tests/test_neutrosophic.py
@@ -1,0 +1,79 @@
+import pytest
+
+from framework.neutrosophic import (
+    NeutrosophicDecision,
+    NeutrosophicScore,
+    aggregate_scores,
+    score_worker_report,
+)
+
+
+def test_neutrosophic_score_clamping():
+    """Test that T/I/F values are correctly clamped between 0.0 and 1.0."""
+    score1 = NeutrosophicScore(t=1.5, i=-0.5, f=0.5)
+    assert score1.t == 1.0
+    assert score1.i == 0.0
+    assert score1.f == 0.5
+
+    score2 = NeutrosophicScore(t=-1.0, i=2.0, f=3.0)
+    assert score2.t == 0.0
+    assert score2.i == 1.0
+    assert score2.f == 1.0
+
+
+def test_neutrosophic_decision_logic():
+    """Test the derivation of decisions based on T/I/F thresholds."""
+    # High truth -> ACCEPT
+    assert NeutrosophicScore(t=0.8, i=0.2, f=0.1).get_decision() == NeutrosophicDecision.ACCEPT
+    
+    # High indeterminacy -> CLARIFY
+    assert NeutrosophicScore(t=0.4, i=0.8, f=0.2).get_decision() == NeutrosophicDecision.CLARIFY
+    
+    # High falsity -> RETRY
+    assert NeutrosophicScore(t=0.1, i=0.1, f=0.8).get_decision() == NeutrosophicDecision.RETRY
+    
+    # High falsity + High indeterminacy -> ESCALATE
+    assert NeutrosophicScore(t=0.1, i=0.8, f=0.9).get_decision() == NeutrosophicDecision.ESCALATE
+    
+    # Below all thresholds -> CAVEAT
+    assert NeutrosophicScore(t=0.4, i=0.4, f=0.4).get_decision() == NeutrosophicDecision.CAVEAT
+
+
+def test_score_worker_report_heuristics():
+    """Test the heuristic scoring of worker reports."""
+    # Perfect success
+    score = score_worker_report(status="success", summary="Found the exact answer.", data={"key": "value"})
+    assert score.t >= 0.8
+    assert score.i == 0.0
+    assert score.f == 0.0
+
+    # Partial success with missing data
+    score = score_worker_report(status="partial", summary="Missing some details.", data=None)
+    assert score.t == 0.4
+    assert score.i >= 0.7  # 0.4 from status + 0.4 from no data + 0.3 from 'missing' = 1.0 (clamped)
+    assert score.f == 0.0
+
+    # Failed with error and conflict
+    score = score_worker_report(status="failed", summary="Conflict in records.", data=None, error="Connection timeout")
+    assert score.t == 0.0
+    assert score.i >= 0.4  # from no data
+    assert score.f >= 1.0  # 0.8 status + 0.5 error + 0.3 conflict (clamped to 1.0)
+
+
+def test_aggregate_scores():
+    """Test the aggregation of multiple neutrosophic scores."""
+    scores = [
+        NeutrosophicScore(t=0.8, i=0.1, f=0.0),
+        NeutrosophicScore(t=0.6, i=0.3, f=0.2),
+        NeutrosophicScore(t=0.4, i=0.5, f=0.4),
+    ]
+    agg = aggregate_scores(scores)
+    assert agg.t == pytest.approx(0.6)
+    assert agg.i == pytest.approx(0.3)
+    assert agg.f == pytest.approx(0.2)
+
+    # Test empty list gives complete indeterminacy
+    empty_agg = aggregate_scores([])
+    assert empty_agg.t == 0.0
+    assert empty_agg.i == 1.0
+    assert empty_agg.f == 0.0


### PR DESCRIPTION
Draft PR for Phase 1 of RFC #7179. Introduces the core \NeutrosophicScore\ and \NeutrosophicDecision\ primitives along with basic heuristic scoring and aggregation functions. Includes full unit tests. No runtime changes to the main framework yet.