### PR TITLE
feat(neutrosophic): add Phase 1 scoring primitives

### DIFF
--- a/core/framework/neutrosophic/__init__.py
+++ b/core/framework/neutrosophic/__init__.py
@@ -1,0 +1,15 @@
+"""Neutrosophic scoring helpers for swarm decision quality."""
+
+from framework.neutrosophic.scoring import (
+    NeutrosophicDecision,
+    NeutrosophicScore,
+    aggregate_scores,
+    score_worker_report,
+)
+
+__all__ = [
+    "NeutrosophicDecision",
+    "NeutrosophicScore",
+    "aggregate_scores",
+    "score_worker_report",
+]

--- a/core/framework/neutrosophic/__init__.py
+++ b/core/framework/neutrosophic/__init__.py
@@ -1,6 +1,6 @@
 """Neutrosophic scoring helpers for swarm decision quality."""
 
-from framework.neutrosophic.scoring import (
+from .scoring import (
     NeutrosophicDecision,
     NeutrosophicScore,
     aggregate_scores,

--- a/core/framework/neutrosophic/scoring.py
+++ b/core/framework/neutrosophic/scoring.py
@@ -1,0 +1,144 @@
+"""Core neutrosophic score primitives.
+
+The score keeps three independent signals:
+- truth: evidence that a result satisfies the task
+- indeterminacy: missing, ambiguous, or incomplete evidence
+- falsity: contradiction, failure, drift, or risk evidence
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class NeutrosophicDecision(StrEnum):
+    """Default action suggested by a neutrosophic score."""
+
+    ACCEPT = "accept"
+    CLARIFY = "clarify"
+    RETRY = "retry"
+    ESCALATE = "escalate"
+    CAVEAT = "caveat"
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+@dataclass(frozen=True)
+class NeutrosophicScore:
+    """Decision-quality triplet for one result or an aggregate."""
+
+    truth: float
+    indeterminacy: float
+    falsity: float
+    rationale: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "truth", _clamp(self.truth))
+        object.__setattr__(self, "indeterminacy", _clamp(self.indeterminacy))
+        object.__setattr__(self, "falsity", _clamp(self.falsity))
+
+    @property
+    def decision(self) -> NeutrosophicDecision:
+        """Return the default decision policy for the score."""
+        if self.falsity >= 0.65:
+            return NeutrosophicDecision.ESCALATE
+        if self.indeterminacy >= 0.65:
+            return NeutrosophicDecision.CLARIFY
+        if self.truth >= 0.72 and self.indeterminacy <= 0.35 and self.falsity <= 0.35:
+            return NeutrosophicDecision.ACCEPT
+        if self.falsity >= 0.45:
+            return NeutrosophicDecision.RETRY
+        return NeutrosophicDecision.CAVEAT
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "truth": round(self.truth, 3),
+            "indeterminacy": round(self.indeterminacy, 3),
+            "falsity": round(self.falsity, 3),
+            "decision": self.decision.value,
+            "rationale": list(self.rationale),
+        }
+
+
+def score_worker_report(
+    *,
+    status: str,
+    summary: str = "",
+    data: dict[str, Any] | None = None,
+    error: str | None = None,
+    signals: dict[str, Any] | None = None,
+) -> NeutrosophicScore:
+    """Score a Hive worker report without changing runtime behavior."""
+    normalized_status = str(status or "").strip().lower()
+    normalized_summary = str(summary or "").strip()
+    payload = data if isinstance(data, dict) else {}
+    evidence = signals if isinstance(signals, dict) else {}
+    rationale: list[str] = []
+
+    if normalized_status == "success":
+        truth, indeterminacy, falsity = 0.78, 0.12, 0.08
+        rationale.append("status=success")
+    elif normalized_status == "partial":
+        truth, indeterminacy, falsity = 0.38, 0.55, 0.18
+        rationale.append("status=partial")
+    elif normalized_status in {"failed", "timeout", "stopped"}:
+        truth, indeterminacy, falsity = 0.12, 0.35, 0.68
+        rationale.append(f"status={normalized_status}")
+    else:
+        truth, indeterminacy, falsity = 0.25, 0.62, 0.25
+        rationale.append("status=unknown")
+
+    if normalized_summary:
+        truth += 0.07
+        indeterminacy -= 0.05
+        rationale.append("summary_present")
+    else:
+        indeterminacy += 0.18
+        rationale.append("summary_missing")
+
+    if payload:
+        truth += 0.08
+        indeterminacy -= 0.04
+        rationale.append("data_present")
+    else:
+        indeterminacy += 0.05
+        rationale.append("data_missing")
+
+    if error:
+        truth -= 0.12
+        falsity += 0.2
+        rationale.append("error_present")
+
+    if evidence.get("stalled"):
+        indeterminacy += 0.2
+        falsity += 0.12
+        rationale.append("stall_signal")
+
+    if evidence.get("doom_loop"):
+        indeterminacy += 0.15
+        falsity += 0.22
+        rationale.append("doom_loop_signal")
+
+    if evidence.get("contradiction"):
+        falsity += 0.25
+        indeterminacy += 0.1
+        rationale.append("contradiction_signal")
+
+    return NeutrosophicScore(truth, indeterminacy, falsity, tuple(rationale))
+
+
+def aggregate_scores(scores: list[NeutrosophicScore]) -> NeutrosophicScore:
+    """Average a batch of scores into one swarm-level score."""
+    if not scores:
+        return NeutrosophicScore(0.0, 1.0, 0.0, ("no_scores",))
+
+    count = len(scores)
+    truth = sum(score.truth for score in scores) / count
+    indeterminacy = sum(score.indeterminacy for score in scores) / count
+    falsity = sum(score.falsity for score in scores) / count
+    rationale = tuple(f"aggregate_count={count}" for _ in range(1))
+    return NeutrosophicScore(truth, indeterminacy, falsity, rationale)

--- a/core/framework/neutrosophic/scoring.py
+++ b/core/framework/neutrosophic/scoring.py
@@ -8,6 +8,7 @@ The score keeps three independent signals:
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any, Final
@@ -56,7 +57,10 @@ class NeutrosophicDecision(StrEnum):
 
 
 def _clamp(value: float) -> float:
-    return max(0.0, min(1.0, float(value)))
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError("Neutrosophic score components must be finite numbers.")
+    return max(0.0, min(1.0, parsed))
 
 
 @dataclass(frozen=True)

--- a/core/framework/neutrosophic/scoring.py
+++ b/core/framework/neutrosophic/scoring.py
@@ -10,7 +10,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any
+from typing import Any, Final
+
+# Decision thresholds — named here so reviewers can audit them without
+# tracing magic numbers through the decision property.
+_I_CLARIFY_MIN: Final = 0.65  # indeterminacy above this → CLARIFY
+_F_ESCALATE_MIN: Final = 0.65  # falsity above this → ESCALATE
+_T_ACCEPT_MIN: Final = 0.72  # truth must reach this for a clean ACCEPT
+_I_ACCEPT_MAX: Final = 0.35  # indeterminacy must stay below this for ACCEPT
+_F_ACCEPT_MAX: Final = 0.35  # falsity must stay below this for ACCEPT
+_F_RETRY_MIN: Final = 0.45  # moderate falsity (below escalate) → RETRY
 
 
 class NeutrosophicDecision(StrEnum):
@@ -43,14 +52,20 @@ class NeutrosophicScore:
 
     @property
     def decision(self) -> NeutrosophicDecision:
-        """Return the default decision policy for the score."""
-        if self.falsity >= 0.65:
-            return NeutrosophicDecision.ESCALATE
-        if self.indeterminacy >= 0.65:
+        """Return the default decision policy for the score.
+
+        Priority order follows the RFC: high indeterminacy triggers CLARIFY
+        before high falsity triggers ESCALATE.  A score that is simultaneously
+        high-I and high-F is ambiguous enough to clarify first rather than
+        immediately escalate.
+        """
+        if self.indeterminacy >= _I_CLARIFY_MIN:
             return NeutrosophicDecision.CLARIFY
-        if self.truth >= 0.72 and self.indeterminacy <= 0.35 and self.falsity <= 0.35:
+        if self.falsity >= _F_ESCALATE_MIN:
+            return NeutrosophicDecision.ESCALATE
+        if self.truth >= _T_ACCEPT_MIN and self.indeterminacy <= _I_ACCEPT_MAX and self.falsity <= _F_ACCEPT_MAX:
             return NeutrosophicDecision.ACCEPT
-        if self.falsity >= 0.45:
+        if self.falsity >= _F_RETRY_MIN:
             return NeutrosophicDecision.RETRY
         return NeutrosophicDecision.CAVEAT
 
@@ -140,5 +155,5 @@ def aggregate_scores(scores: list[NeutrosophicScore]) -> NeutrosophicScore:
     truth = sum(score.truth for score in scores) / count
     indeterminacy = sum(score.indeterminacy for score in scores) / count
     falsity = sum(score.falsity for score in scores) / count
-    rationale = tuple(f"aggregate_count={count}" for _ in range(1))
+    rationale = (f"aggregate_count={count}",)
     return NeutrosophicScore(truth, indeterminacy, falsity, rationale)

--- a/core/framework/neutrosophic/scoring.py
+++ b/core/framework/neutrosophic/scoring.py
@@ -21,6 +21,29 @@ _I_ACCEPT_MAX: Final = 0.35  # indeterminacy must stay below this for ACCEPT
 _F_ACCEPT_MAX: Final = 0.35  # falsity must stay below this for ACCEPT
 _F_RETRY_MIN: Final = 0.45  # moderate falsity (below escalate) → RETRY
 
+_SUCCESS_BASE: Final = (0.78, 0.12, 0.08)
+_PARTIAL_BASE: Final = (0.38, 0.55, 0.18)
+_TERMINAL_FAILURE_BASE: Final = (0.12, 0.35, 0.68)
+_UNKNOWN_STATUS_BASE: Final = (0.25, 0.62, 0.25)
+
+_SUMMARY_TRUTH_INC: Final = 0.07
+_SUMMARY_INDETERMINACY_DEC: Final = 0.05
+_SUMMARY_MISSING_INDETERMINACY_INC: Final = 0.18
+
+_DATA_TRUTH_INC: Final = 0.08
+_DATA_INDETERMINACY_DEC: Final = 0.04
+_DATA_MISSING_INDETERMINACY_INC: Final = 0.05
+
+_ERROR_TRUTH_DEC: Final = 0.12
+_ERROR_FALSITY_INC: Final = 0.38
+
+_STALL_INDETERMINACY_INC: Final = 0.2
+_STALL_FALSITY_INC: Final = 0.12
+_DOOM_LOOP_INDETERMINACY_INC: Final = 0.15
+_DOOM_LOOP_FALSITY_INC: Final = 0.22
+_CONTRADICTION_FALSITY_INC: Final = 0.25
+_CONTRADICTION_INDETERMINACY_INC: Final = 0.1
+
 
 class NeutrosophicDecision(StrEnum):
     """Default action suggested by a neutrosophic score."""
@@ -95,52 +118,52 @@ def score_worker_report(
     rationale: list[str] = []
 
     if normalized_status == "success":
-        truth, indeterminacy, falsity = 0.78, 0.12, 0.08
+        truth, indeterminacy, falsity = _SUCCESS_BASE
         rationale.append("status=success")
     elif normalized_status == "partial":
-        truth, indeterminacy, falsity = 0.38, 0.55, 0.18
+        truth, indeterminacy, falsity = _PARTIAL_BASE
         rationale.append("status=partial")
     elif normalized_status in {"failed", "timeout", "stopped"}:
-        truth, indeterminacy, falsity = 0.12, 0.35, 0.68
+        truth, indeterminacy, falsity = _TERMINAL_FAILURE_BASE
         rationale.append(f"status={normalized_status}")
     else:
-        truth, indeterminacy, falsity = 0.25, 0.62, 0.25
+        truth, indeterminacy, falsity = _UNKNOWN_STATUS_BASE
         rationale.append("status=unknown")
 
     if normalized_summary:
-        truth += 0.07
-        indeterminacy -= 0.05
+        truth += _SUMMARY_TRUTH_INC
+        indeterminacy -= _SUMMARY_INDETERMINACY_DEC
         rationale.append("summary_present")
     else:
-        indeterminacy += 0.18
+        indeterminacy += _SUMMARY_MISSING_INDETERMINACY_INC
         rationale.append("summary_missing")
 
     if payload:
-        truth += 0.08
-        indeterminacy -= 0.04
+        truth += _DATA_TRUTH_INC
+        indeterminacy -= _DATA_INDETERMINACY_DEC
         rationale.append("data_present")
     else:
-        indeterminacy += 0.05
+        indeterminacy += _DATA_MISSING_INDETERMINACY_INC
         rationale.append("data_missing")
 
     if error:
-        truth -= 0.12
-        falsity += 0.2
+        truth -= _ERROR_TRUTH_DEC
+        falsity += _ERROR_FALSITY_INC
         rationale.append("error_present")
 
     if evidence.get("stalled"):
-        indeterminacy += 0.2
-        falsity += 0.12
+        indeterminacy += _STALL_INDETERMINACY_INC
+        falsity += _STALL_FALSITY_INC
         rationale.append("stall_signal")
 
     if evidence.get("doom_loop"):
-        indeterminacy += 0.15
-        falsity += 0.22
+        indeterminacy += _DOOM_LOOP_INDETERMINACY_INC
+        falsity += _DOOM_LOOP_FALSITY_INC
         rationale.append("doom_loop_signal")
 
     if evidence.get("contradiction"):
-        falsity += 0.25
-        indeterminacy += 0.1
+        falsity += _CONTRADICTION_FALSITY_INC
+        indeterminacy += _CONTRADICTION_INDETERMINACY_INC
         rationale.append("contradiction_signal")
 
     return NeutrosophicScore(truth, indeterminacy, falsity, tuple(rationale))

--- a/core/framework/neutrosophic/scoring.py
+++ b/core/framework/neutrosophic/scoring.py
@@ -117,6 +117,7 @@ def score_worker_report(
     """Score a Hive worker report without changing runtime behavior."""
     normalized_status = str(status or "").strip().lower()
     normalized_summary = str(summary or "").strip()
+    normalized_error = str(error or "").strip()
     payload = data if isinstance(data, dict) else {}
     evidence = signals if isinstance(signals, dict) else {}
     rationale: list[str] = []
@@ -150,22 +151,22 @@ def score_worker_report(
         indeterminacy += _DATA_MISSING_INDETERMINACY_INC
         rationale.append("data_missing")
 
-    if error:
+    if normalized_error:
         truth -= _ERROR_TRUTH_DEC
         falsity += _ERROR_FALSITY_INC
         rationale.append("error_present")
 
-    if evidence.get("stalled"):
+    if evidence.get("stalled") is True:
         indeterminacy += _STALL_INDETERMINACY_INC
         falsity += _STALL_FALSITY_INC
         rationale.append("stall_signal")
 
-    if evidence.get("doom_loop"):
+    if evidence.get("doom_loop") is True:
         indeterminacy += _DOOM_LOOP_INDETERMINACY_INC
         falsity += _DOOM_LOOP_FALSITY_INC
         rationale.append("doom_loop_signal")
 
-    if evidence.get("contradiction"):
+    if evidence.get("contradiction") is True:
         falsity += _CONTRADICTION_FALSITY_INC
         indeterminacy += _CONTRADICTION_INDETERMINACY_INC
         rationale.append("contradiction_signal")

--- a/core/tests/test_neutrosophic_scoring.py
+++ b/core/tests/test_neutrosophic_scoring.py
@@ -93,3 +93,15 @@ def test_unknown_status_scores_conservatively() -> None:
     assert "status=unknown" in score.rationale
     # Unknown status should not yield ACCEPT — too little evidence.
     assert score.decision != NeutrosophicDecision.ACCEPT
+
+
+def test_success_report_with_error_does_not_clean_accept() -> None:
+    score = score_worker_report(
+        status="success",
+        summary="Completed with warning",
+        data={"rows": 3},
+        error="post-processing failed",
+    )
+
+    assert "error_present" in score.rationale
+    assert score.decision != NeutrosophicDecision.ACCEPT

--- a/core/tests/test_neutrosophic_scoring.py
+++ b/core/tests/test_neutrosophic_scoring.py
@@ -56,3 +56,40 @@ def test_aggregate_scores_averages_triplets() -> None:
     assert aggregate.indeterminacy == 0.5
     assert aggregate.falsity == 0.0
     assert aggregate.rationale == ("aggregate_count=2",)
+
+
+def test_aggregate_scores_empty_returns_fully_indeterminate() -> None:
+    # An empty batch has no evidence: indeterminacy=1.0 is the conservative default.
+    aggregate = aggregate_scores([])
+
+    assert aggregate.truth == 0.0
+    assert aggregate.indeterminacy == 1.0
+    assert aggregate.falsity == 0.0
+    assert aggregate.rationale == ("no_scores",)
+    assert aggregate.decision == NeutrosophicDecision.CLARIFY
+
+
+def test_high_indeterminacy_takes_priority_over_high_falsity() -> None:
+    # RFC specifies: I >= 0.65 → CLARIFY before F >= 0.65 → ESCALATE.
+    # A score that crosses both thresholds should yield CLARIFY, not ESCALATE.
+    score = NeutrosophicScore(truth=0.1, indeterminacy=0.8, falsity=0.7)
+
+    assert score.decision == NeutrosophicDecision.CLARIFY
+
+
+def test_to_dict_contract() -> None:
+    score = NeutrosophicScore(0.9, 0.05, 0.05, ("status=success",))
+    result = score.to_dict()
+
+    assert set(result.keys()) == {"truth", "indeterminacy", "falsity", "decision", "rationale"}
+    assert isinstance(result["truth"], float)
+    assert isinstance(result["rationale"], list)
+    assert result["decision"] == "accept"
+
+
+def test_unknown_status_scores_conservatively() -> None:
+    score = score_worker_report(status="pending")
+
+    assert "status=unknown" in score.rationale
+    # Unknown status should not yield ACCEPT — too little evidence.
+    assert score.decision != NeutrosophicDecision.ACCEPT

--- a/core/tests/test_neutrosophic_scoring.py
+++ b/core/tests/test_neutrosophic_scoring.py
@@ -1,0 +1,58 @@
+from framework.neutrosophic import NeutrosophicDecision, NeutrosophicScore, aggregate_scores, score_worker_report
+
+
+def test_score_clamps_values() -> None:
+    score = NeutrosophicScore(2.0, -1.0, 0.5)
+
+    assert score.truth == 1.0
+    assert score.indeterminacy == 0.0
+    assert score.falsity == 0.5
+
+
+def test_success_worker_report_accepts_with_evidence() -> None:
+    score = score_worker_report(status="success", summary="Completed task", data={"rows": 3})
+
+    assert score.decision == NeutrosophicDecision.ACCEPT
+    assert score.truth > score.indeterminacy
+    assert score.truth > score.falsity
+    assert "status=success" in score.rationale
+
+
+def test_partial_worker_report_requests_clarification() -> None:
+    score = score_worker_report(status="partial", summary="Found some data", data={})
+
+    assert score.decision in {NeutrosophicDecision.CLARIFY, NeutrosophicDecision.CAVEAT}
+    assert score.indeterminacy >= score.truth
+
+
+def test_failed_worker_report_escalates() -> None:
+    score = score_worker_report(status="failed", summary="Tool failed", error="missing credentials")
+
+    assert score.decision == NeutrosophicDecision.ESCALATE
+    assert score.falsity > score.truth
+
+
+def test_loop_signals_increase_risk() -> None:
+    baseline = score_worker_report(status="partial", summary="Still trying")
+    risky = score_worker_report(
+        status="partial",
+        summary="Still trying",
+        signals={"stalled": True, "doom_loop": True},
+    )
+
+    assert risky.indeterminacy > baseline.indeterminacy
+    assert risky.falsity > baseline.falsity
+
+
+def test_aggregate_scores_averages_triplets() -> None:
+    aggregate = aggregate_scores(
+        [
+            NeutrosophicScore(1.0, 0.0, 0.0),
+            NeutrosophicScore(0.0, 1.0, 0.0),
+        ]
+    )
+
+    assert aggregate.truth == 0.5
+    assert aggregate.indeterminacy == 0.5
+    assert aggregate.falsity == 0.0
+    assert aggregate.rationale == ("aggregate_count=2",)

--- a/core/tests/test_neutrosophic_scoring.py
+++ b/core/tests/test_neutrosophic_scoring.py
@@ -1,3 +1,7 @@
+import math
+
+import pytest
+
 from framework.neutrosophic import NeutrosophicDecision, NeutrosophicScore, aggregate_scores, score_worker_report
 
 
@@ -7,6 +11,14 @@ def test_score_clamps_values() -> None:
     assert score.truth == 1.0
     assert score.indeterminacy == 0.0
     assert score.falsity == 0.5
+
+
+def test_score_rejects_non_finite_values() -> None:
+    with pytest.raises(ValueError, match="finite numbers"):
+        NeutrosophicScore(math.nan, 0.0, 0.0)
+
+    with pytest.raises(ValueError, match="finite numbers"):
+        NeutrosophicScore(0.0, math.inf, 0.0)
 
 
 def test_success_worker_report_accepts_with_evidence() -> None:
@@ -75,6 +87,12 @@ def test_high_indeterminacy_takes_priority_over_high_falsity() -> None:
     score = NeutrosophicScore(truth=0.1, indeterminacy=0.8, falsity=0.7)
 
     assert score.decision == NeutrosophicDecision.CLARIFY
+
+
+def test_moderate_falsity_retries_without_escalating() -> None:
+    score = NeutrosophicScore(truth=0.5, indeterminacy=0.2, falsity=0.5)
+
+    assert score.decision == NeutrosophicDecision.RETRY
 
 
 def test_to_dict_contract() -> None:

--- a/core/tests/test_neutrosophic_scoring.py
+++ b/core/tests/test_neutrosophic_scoring.py
@@ -123,3 +123,27 @@ def test_success_report_with_error_does_not_clean_accept() -> None:
 
     assert "error_present" in score.rationale
     assert score.decision != NeutrosophicDecision.ACCEPT
+
+
+def test_blank_error_is_ignored() -> None:
+    baseline = score_worker_report(status="success", summary="Completed task", data={"rows": 3})
+    blank_error = score_worker_report(status="success", summary="Completed task", data={"rows": 3}, error="   ")
+
+    assert "error_present" not in blank_error.rationale
+    assert blank_error.truth == baseline.truth
+    assert blank_error.falsity == baseline.falsity
+
+
+def test_non_boolean_signals_do_not_trigger_risk_adjustments() -> None:
+    baseline = score_worker_report(status="partial", summary="Still trying")
+    noisy = score_worker_report(
+        status="partial",
+        summary="Still trying",
+        signals={"stalled": "true", "doom_loop": 1, "contradiction": "yes"},
+    )
+
+    assert "stall_signal" not in noisy.rationale
+    assert "doom_loop_signal" not in noisy.rationale
+    assert "contradiction_signal" not in noisy.rationale
+    assert noisy.indeterminacy == baseline.indeterminacy
+    assert noisy.falsity == baseline.falsity


### PR DESCRIPTION
## Summary

Refs #7179.

This is the staged Phase 1 implementation for the neutrosophic consensus RFC. It intentionally keeps the scope small:

- add core `NeutrosophicScore` and `NeutrosophicDecision` primitives
- add `score_worker_report()` for conservative report scoring
- add `aggregate_scores()` for swarm-level score aggregation
- add focused unit tests for thresholds, serialization, non-finite values, and report scoring

This PR does not change runtime behavior, worker report payloads, Queen prompts, judge behavior, UI, or dependencies. Phase 2 and Phase 3 remain out of upstream review until maintainers decide whether this direction should proceed.

## Coordination

This is opened as a draft because there are already overlapping implementation PRs: aden-hive/hive PR 7187 and aden-hive/hive PR 7195. The goal is to make the original reviewed Phase 1 branch available directly to maintainers while keeping RFC 7179 as the design source of truth.

## Validation

- `.\.venv\Scripts\python.exe -m pytest core/tests/test_neutrosophic_scoring.py` -> 13 passed
- `ruff check core/framework/neutrosophic core/tests/test_neutrosophic_scoring.py` -> passed
- `ruff format --check core/framework/neutrosophic core/tests/test_neutrosophic_scoring.py` -> passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a neutrosophic scoring system using truth/indeterminacy/falsity metrics, worker-report evaluation with multiple decision outcomes (Accept, Clarify, Retry, Escalate, Caveat), and score aggregation for consensus-based decisions. Includes value clamping/validation and conservative defaults for empty inputs.

* **Tests**
  * Added comprehensive tests for scoring validation, worker report handling (including signals and error handling), aggregation behavior, decision precedence, and serialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aden-hive/hive/pull/7197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->