### PR TITLE
docs(micro-fix): use canonical Discord invite across quickstart and docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -170,7 +170,7 @@ Get your API keys:
 - **Anthropic**: [console.anthropic.com](https://console.anthropic.com/)
 - **OpenAI**: [platform.openai.com](https://platform.openai.com/)
 - **OpenRouter**: [openrouter.ai/keys](https://openrouter.ai/keys)
-- **Hive LLM**: [Hive Discord](https://discord.com/invite/hQdU7QDkgR)
+- **Hive LLM**: [Hive Discord](https://discord.com/invite/MXE49hrKDk)
 - **Brave Search**: [brave.com/search/api](https://brave.com/search/api/)
 
 Quickstart can configure OpenRouter and Hive LLM for you interactively. See [configuration.md](./configuration.md) for the full configuration examples.

--- a/quickstart.ps1
+++ b/quickstart.ps1
@@ -1824,7 +1824,7 @@ if ($SubscriptionMode -eq "hive_llm") {
         } else {
             Write-Host ""
             Write-Host "  Get your API key from: " -NoNewline
-            Write-Color -Text "https://discord.com/invite/hQdU7QDkgR" -Color Cyan
+            Write-Color -Text "https://discord.com/invite/MXE49hrKDk" -Color Cyan
             Write-Host ""
             $apiKey = Read-Host "Paste your Hive API key (or press Enter to skip)"
         }

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -1476,7 +1476,7 @@ case $choice in
         SUBSCRIPTION_MODE="hive_llm"
         apply_preset "hive_llm"
         PROVIDER_NAME="Hive"
-        SIGNUP_URL="https://discord.com/invite/hQdU7QDkgR"
+        SIGNUP_URL="https://discord.com/invite/MXE49hrKDk"
         echo ""
         echo -e "${GREEN}⬢${NC} Using Hive LLM"
         echo ""


### PR DESCRIPTION
## Summary

Three files point to the expired Discord invite `hQdU7QDkgR`, while every other Discord reference in the repo (README badge, CONTRIBUTING.md, developer-guide.md, `docs/getting-started.md` lines 196 and 238, and `tools/.../redshift_tool/README.md`) uses the canonical `MXE49hrKDk` invite.

Result: new users running `./quickstart.sh` or `./quickstart.ps1` to set up the **Hive LLM** subscription, and readers of the API-key section of `docs/getting-started.md`, are sent to an invalid invite link and can't reach the community to grab a Hive API key. I hit this myself onboarding from the YC outreach — `hQdU7QDkgR` returns "Invite Invalid" in Discord, `MXE49hrKDk` works.

## Changes

Replaced `discord.com/invite/hQdU7QDkgR` → `discord.com/invite/MXE49hrKDk` in:

- `quickstart.sh` (Hive LLM signup URL)
- `quickstart.ps1` (Hive LLM signup URL)
- `docs/getting-started.md` ("Hive Discord" link in the API-keys section)

3 files, +3 / -3.

## Verification

After the change, `grep -rn "hQdU7QDkgR" .` returns no matches. All remaining Discord references resolve to the working invite.

## Note

Qualifies as `micro-fix` per CONTRIBUTING.md — < 20 lines, doc-only, no logic changes. `micro-fix` is in the PR title to bypass the linked-issue requirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Discord community invite links across documentation and setup scripts to reflect the current community channel URL for Hive LLM users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aden-hive/hive/pull/7198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->