### PR TITLE
fix(docs): replace print() with logger.info() in docstring examples

### DIFF
--- a/core/framework/credentials/aden/client.py
+++ b/core/framework/credentials/aden/client.py
@@ -21,11 +21,11 @@ Usage:
 
     # List what's connected
     for info in client.list_integrations():
-        print(f"{info.provider}/{info.alias}: {info.status}")
+        logger.info(f"{info.provider}/{info.alias}: {info.status}")
 
     # Get an access token
     cred = client.get_credential(info.integration_id)
-    print(cred.access_token)
+    logger.info(cred.access_token)
 """
 
 from __future__ import annotations
@@ -248,7 +248,7 @@ class AdenCredentialClient:
 
         # List integrations
         for info in client.list_integrations():
-            print(f"{info.provider}/{info.alias}: {info.status}")
+            logger.info(f"{info.provider}/{info.alias}: {info.status}")
 
         # Get access token (uses base64 integration_id, NOT provider name)
         cred = client.get_credential(info.integration_id)

--- a/core/framework/credentials/local/__init__.py
+++ b/core/framework/credentials/local/__init__.py
@@ -14,9 +14,9 @@ Usage:
 
     # List all stored local accounts
     for account in registry.list_accounts():
-        print(f"{account.credential_id}/{account.alias}: {account.status}")
+        logger.info(f"{account.credential_id}/{account.alias}: {account.status}")
         if account.identity.is_known:
-            print(f"  Identity: {account.identity.label}")
+            logger.info(f"  Identity: {account.identity.label}")
 
     # Re-validate a stored account
     result = registry.validate_account("github", "personal")

--- a/core/framework/credentials/local/registry.py
+++ b/core/framework/credentials/local/registry.py
@@ -17,11 +17,11 @@ Usage:
 
     # Add a new account
     info, health = registry.save_account("brave_search", "work", "BSA-xxx")
-    print(info.status, info.identity.label)
+    logger.info(info.status, info.identity.label)
 
     # List all accounts
     for account in registry.list_accounts():
-        print(f"{account.credential_id}/{account.alias}: {account.status}")
+        logger.info(f"{account.credential_id}/{account.alias}: {account.status}")
 
     # Get the raw API key for a specific account
     key = registry.get_key("github", "personal")

--- a/core/framework/host/agent_host.py
+++ b/core/framework/host/agent_host.py
@@ -116,7 +116,7 @@ class AgentHost:
 
         # Check goal progress
         progress = await runtime.get_goal_progress()
-        print(f"Progress: {progress['overall_progress']:.1%}")
+        logger.info(f"Progress: {progress['overall_progress']:.1%}")
 
         # Stop runtime
         await runtime.stop()

--- a/core/framework/host/event_bus.py
+++ b/core/framework/host/event_bus.py
@@ -239,7 +239,7 @@ class EventBus:
 
         # Subscribe to execution events
         async def on_execution_complete(event: AgentEvent):
-            print(f"Execution {event.execution_id} completed")
+            logger.info(f"Execution {event.execution_id} completed")
 
         bus.subscribe(
             event_types=[EventType.EXECUTION_COMPLETED],

--- a/core/framework/skills/manager.py
+++ b/core/framework/skills/manager.py
@@ -12,8 +12,8 @@ Typical usage — **config-driven** (runner passes configuration)::
     )
     mgr = SkillsManager(config)
     mgr.load()
-    print(mgr.protocols_prompt)       # default skill protocols
-    print(mgr.skills_catalog_prompt)  # community skills XML
+    logger.info(mgr.protocols_prompt)       # default skill protocols
+    logger.info(mgr.skills_catalog_prompt)  # community skills XML
 
 Typical usage — **bare** (exported agents, SDK users)::
 

--- a/core/framework/tools/migrate_agent.py
+++ b/core/framework/tools/migrate_agent.py
@@ -15,7 +15,7 @@ After migration, verify with::
     import yaml, pathlib
     data = yaml.safe_load(pathlib.Path('exports/lead_enrichment_agent/agent.yaml').read_text())
     graph, goal = load_agent_config(data)
-    print(f'OK: {len(graph.nodes)} nodes, {len(graph.edges)} edges')
+    logger.info(f'OK: {len(graph.nodes)} nodes, {len(graph.edges)} edges')
     "
 """
 


### PR DESCRIPTION
## Summary
- Replaced all `print()` with `logger.info()` in docstring examples across `core/framework/`
- All affected files already had `logger = logging.getLogger(__name__)` configured
- Consistent with conventions established in #4783 and #7152

## Files Changed (7 total)
- `core/framework/host/agent_host.py` — class docstring
- `core/framework/host/event_bus.py` — class docstring
- `core/framework/credentials/aden/client.py` — module + class docstring
- `core/framework/credentials/local/registry.py` — module docstring
- `core/framework/credentials/local/__init__.py` — module docstring
- `core/framework/skills/manager.py` — module docstring
- `core/framework/tools/migrate_agent.py` — module docstring

## Note
Expanded beyond the 2 files in the issue to cover ALL `print()` in docstrings across `core/framework/` (verified via AST scan).

Closes #7153

## Test plan
- [x] AST-based scan confirms zero `print()` calls remain in any docstring (module or class/function) across `core/framework/`
- [x] Changes are docstring-only — no runtime behavior affected
- [x] Rebased on latest main — no conflicts

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated logging output to use consistent logging approach across credential and host framework modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aden-hive/hive/pull/7200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->