### PR TITLE
microfix(quickstart): avoid UnicodeEncodeError on Windows Git Bash in Step 3

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -29,6 +29,21 @@ BOLD='\033[1m'
 DIM='\033[2m'
 NC='\033[0m' # No Color
 
+# Windows / Git Bash / MSYS: cp1252 consoles cannot encode Unicode status glyphs (#7203).
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*) export PYTHONUTF8=1
+                              QUICKSTART_ASCII_STATUS=1 ;;
+esac
+if [ "${QUICKSTART_ASCII_STATUS:-0}" = 1 ]; then
+    QS_OK='[OK]'
+    QS_FAIL='[X]'
+    QS_WARN='[!]'
+else
+    QS_OK='✓'
+    QS_FAIL='✗'
+    QS_WARN='⚠'
+fi
+
 # Get the directory where this script is located
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -420,9 +435,13 @@ CHECK_EXIT=$?
 if [ $CHECK_EXIT -eq 0 ] || echo "$CHECK_RESULT" | grep -q "^{"; then
     # Try to parse JSON and display formatted results
     echo "$CHECK_RESULT" | uv run python -c "
-import json, sys
+import json, sys, platform
 
 GREEN, RED, YELLOW, NC = '\033[0;32m', '\033[0;31m', '\033[1;33m', '\033[0m'
+if platform.system() == 'Windows':
+    OK, FAIL, WARN = '[OK]', '[X]', '[!]'
+else:
+    OK, FAIL, WARN = '\u2713', '\u2717', '\u26a0'
 
 try:
     data = json.loads(sys.stdin.read())
@@ -435,14 +454,14 @@ try:
     for mod, label, required in modules:
         status = data.get(mod, 'error: not checked')
         if status == 'ok':
-            print(f'{GREEN}  ✓ {label}{NC}')
+            print(f'{GREEN}  {OK} {label}{NC}')
         elif required:
-            print(f'{RED}  ✗ {label} failed{NC}')
+            print(f'{RED}  {FAIL} {label} failed{NC}')
             if status != 'error: not checked':
                 print(f'    {status}')
             import_errors += 1
         else:
-            print(f'{YELLOW}  ⚠ {label} (may be OK){NC}')
+            print(f'{YELLOW}  {WARN} {label} (may be OK){NC}')
     sys.exit(import_errors)
 except json.JSONDecodeError:
     print(f'{RED}Error: Could not parse import check results{NC}', file=sys.stderr)
@@ -450,7 +469,7 @@ except json.JSONDecodeError:
 " 2>&1
     IMPORT_ERRORS=$?
 else
-    echo -e "${RED}  ✗ Import check failed${NC}"
+    echo -e "${RED}  ${QS_FAIL} Import check failed${NC}"
     echo "$CHECK_RESULT"
     IMPORT_ERRORS=1
 fi


### PR DESCRIPTION
Use ASCII status markers and PYTHONUTF8 on MSYS/MINGW so import verification does not crash on cp1252 consoles.
Fixes #7203

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)
#7203


## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cross-platform compatibility by automatically detecting Windows, Git Bash, MSYS, and Cygwin environments and displaying ASCII status symbols instead of Unicode characters on incompatible consoles. The quickstart script now reliably provides consistent status output across all platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aden-hive/hive/pull/7207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->