### PR TITLE
fix(quickstart): enable UTF-8 output on Windows Git Bash

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -11,6 +11,9 @@
 
 set -e
 
+# Ensure Python uses UTF-8 output encoding, especially on Windows Git Bash / cp1252 consoles.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # Detect Bash version for compatibility
 BASH_MAJOR_VERSION="${BASH_VERSINFO[0]}"
 USE_ASSOC_ARRAYS=false


### PR DESCRIPTION
Fixes #7203

Export PYTHONUTF8=1 at the top of quickstart.sh so the script can print Unicode
output (checkmarks and warnings) on Windows Git Bash / cp1252 terminals
without crashing during Step 3.

This is a minimal fix for the reported Windows terminal UnicodeEncodeError
during quickstart output verification.