### PR TITLE
fix(templates): Resolve AgentHost initialization TypeError and mock mode LLM provider [micro-fix]

### DIFF
--- a/core/tests/test_templates_mock.py
+++ b/core/tests/test_templates_mock.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add examples/templates to sys.path to allow template package imports
+repo_root = Path(__file__).parents[2]
+templates_root = repo_root / "examples" / "templates"
+if str(templates_root) not in sys.path:
+    sys.path.append(str(templates_root))
+
+TEMPLATES = [
+    "competitive_intel_agent",
+    "deep_research_agent",
+    "email_inbox_management",
+    "email_reply_agent",
+    "job_hunter",
+    "local_business_extractor",
+    "meeting_scheduler",
+    "sdr_agent",
+    "tech_news_reporter",
+    "twitter_news_agent",
+    "vulnerability_assessment",
+]
+
+
+@pytest.mark.parametrize("template_name", TEMPLATES)
+def test_template_mock_setup(template_name: str) -> None:
+    import importlib
+
+    # Import the default_agent from agent.py of the template
+    module = importlib.import_module(f"{template_name}.agent")
+    agent = module.default_agent
+
+    # Verify _setup with mock_mode=True configures the agent correctly
+    agent._setup(mock_mode=True)
+
+    # Retrieve the configured runtime (some agents use _agent_runtime, others use _executor)
+    runtime = getattr(agent, "_agent_runtime", None) or getattr(agent, "_executor", None)
+    assert runtime is not None
+
+    # Verify the LLM provider is indeed MockLLMProvider
+    llm = getattr(runtime, "_llm", None) or getattr(runtime, "llm", None)
+    assert llm is not None
+    assert llm.__class__.__name__ == "MockLLMProvider"

--- a/examples/templates/competitive_intel_agent/__main__.py
+++ b/examples/templates/competitive_intel_agent/__main__.py
@@ -154,19 +154,17 @@ def tui(verbose: bool, debug: bool) -> None:
             graph=graph,
             goal=agent.goal,
             storage_path=storage_path,
-            entry_points=[
-                EntryPointSpec(
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor
+        )
+        runtime.register_entry_point(EntryPointSpec(
                     id="start",
                     name="Start Competitive Analysis",
                     entry_node="intake",
                     trigger_type="manual",
                     isolation_level="isolated",
-                ),
-            ],
-            llm=llm,
-            tools=tools,
-            tool_executor=tool_executor,
-        )
+                ))
 
         await runtime.start()
 

--- a/examples/templates/competitive_intel_agent/__main__.py
+++ b/examples/templates/competitive_intel_agent/__main__.py
@@ -56,6 +56,7 @@ def cli() -> None:
     default="weekly",
     help="Report frequency (default: weekly)",
 )
+@click.option("--mock", is_flag=True, help="Run in mock mode without making LLM calls")
 @click.option("--quiet", "-q", is_flag=True, help="Only output result JSON")
 @click.option("--verbose", "-v", is_flag=True, help="Show execution details")
 @click.option("--debug", is_flag=True, help="Show debug logging")
@@ -63,6 +64,7 @@ def run(
     competitors: str,
     focus_areas: str,
     frequency: str,
+    mock: bool,
     quiet: bool,
     verbose: bool,
     debug: bool,
@@ -93,7 +95,7 @@ def run(
         )
     }
 
-    result = asyncio.run(default_agent.run(context))
+    result = asyncio.run(default_agent.run(context, mock_mode=mock))
 
     output_data: dict[str, Any] = {
         "success": result.success,
@@ -108,9 +110,10 @@ def run(
 
 
 @cli.command()
+@click.option("--mock", is_flag=True, help="Run in mock mode")
 @click.option("--verbose", "-v", is_flag=True, help="Show execution details")
 @click.option("--debug", is_flag=True, help="Show debug logging")
-def tui(verbose: bool, debug: bool) -> None:
+def tui(mock: bool, verbose: bool, debug: bool) -> None:
     """Launch the TUI dashboard for interactive competitive intelligence."""
     setup_logging(verbose=verbose, debug=debug)
 
@@ -140,31 +143,33 @@ def tui(verbose: bool, debug: bool) -> None:
         if mcp_config_path.exists():
             agent._tool_registry.load_mcp_config(mcp_config_path)
 
-        llm = LiteLLMProvider(
-            model=agent.config.model,
-            api_key=agent.config.api_key,
-            api_base=agent.config.api_base,
-        )
+        if mock:
+            from framework.llm.mock import MockLLMProvider
+
+            llm = MockLLMProvider()
+        else:
+            llm = LiteLLMProvider(
+                model=agent.config.model,
+                api_key=agent.config.api_key,
+                api_base=agent.config.api_base,
+            )
 
         tools = list(agent._tool_registry.get_tools().values())
         tool_executor = agent._tool_registry.get_executor()
         graph = agent._build_graph()
 
         runtime = AgentHost(
-            graph=graph,
-            goal=agent.goal,
-            storage_path=storage_path,
-            llm=llm,
-            tools=tools,
-            tool_executor=tool_executor
+            graph=graph, goal=agent.goal, storage_path=storage_path, llm=llm, tools=tools, tool_executor=tool_executor
         )
-        runtime.register_entry_point(EntryPointSpec(
-                    id="start",
-                    name="Start Competitive Analysis",
-                    entry_node="intake",
-                    trigger_type="manual",
-                    isolation_level="isolated",
-                ))
+        runtime.register_entry_point(
+            EntryPointSpec(
+                id="start",
+                name="Start Competitive Analysis",
+                entry_node="intake",
+                trigger_type="manual",
+                isolation_level="isolated",
+            )
+        )
 
         await runtime.start()
 

--- a/examples/templates/competitive_intel_agent/agent.py
+++ b/examples/templates/competitive_intel_agent/agent.py
@@ -219,7 +219,7 @@ class CompetitiveIntelAgent:
             },
         )
 
-    def _setup(self) -> Orchestrator:
+    def _setup(self, mock_mode: bool = False) -> Orchestrator:
         """
         Set up the executor with all components (runtime, LLM, tools).
 
@@ -238,11 +238,16 @@ class CompetitiveIntelAgent:
         if mcp_config_path.exists():
             self._tool_registry.load_mcp_config(mcp_config_path)
 
-        llm = LiteLLMProvider(
-            model=self.config.model,
-            api_key=self.config.api_key,
-            api_base=self.config.api_base,
-        )
+        if mock_mode:
+            from framework.llm.mock import MockLLMProvider
+
+            llm = MockLLMProvider()
+        else:
+            llm = LiteLLMProvider(
+                model=self.config.model,
+                api_key=self.config.api_key,
+                api_base=self.config.api_base,
+            )
 
         tool_executor = self._tool_registry.get_executor()
         tools = list(self._tool_registry.get_tools().values())
@@ -262,10 +267,10 @@ class CompetitiveIntelAgent:
 
         return self._executor
 
-    async def start(self) -> None:
+    async def start(self, mock_mode: bool = False) -> None:
         """Set up the agent (initialize executor and tools)."""
         if self._executor is None:
-            self._setup()
+            self._setup(mock_mode=mock_mode)
 
     async def stop(self) -> None:
         """Clean up resources."""
@@ -303,7 +308,9 @@ class CompetitiveIntelAgent:
             session_state=session_state,
         )
 
-    async def run(self, context: dict[str, Any], session_state: dict[str, Any] | None = None) -> ExecutionResult:
+    async def run(
+        self, context: dict[str, Any], mock_mode: bool = False, session_state: dict[str, Any] | None = None
+    ) -> ExecutionResult:
         """
         Run the agent (convenience method for single execution).
 
@@ -314,7 +321,7 @@ class CompetitiveIntelAgent:
         Returns:
             The final execution result.
         """
-        await self.start()
+        await self.start(mock_mode=mock_mode)
         try:
             result = await self.trigger_and_wait("start", context, session_state=session_state)
             return result or ExecutionResult(success=False, error="Execution timeout")

--- a/examples/templates/deep_research_agent/__main__.py
+++ b/examples/templates/deep_research_agent/__main__.py
@@ -34,17 +34,18 @@ def cli():
 
 @cli.command()
 @click.option("--topic", "-t", type=str, required=True, help="Research topic")
+@click.option("--mock", is_flag=True, help="Run in mock mode without making LLM calls")
 @click.option("--quiet", "-q", is_flag=True, help="Only output result JSON")
 @click.option("--verbose", "-v", is_flag=True, help="Show execution details")
 @click.option("--debug", is_flag=True, help="Show debug logging")
-def run(topic, quiet, verbose, debug):
+def run(topic, mock, quiet, verbose, debug):
     """Execute research on a topic."""
     if not quiet:
         setup_logging(verbose=verbose, debug=debug)
 
     context = {"topic": topic}
 
-    result = asyncio.run(default_agent.run(context))
+    result = asyncio.run(default_agent.run(context, mock_mode=mock))
 
     output_data = {
         "success": result.success,
@@ -107,19 +108,17 @@ def tui(verbose, debug):
             graph=graph,
             goal=agent.goal,
             storage_path=storage_path,
-            entry_points=[
-                EntryPointSpec(
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor
+        )
+        runtime.register_entry_point(EntryPointSpec(
                     id="start",
                     name="Start Research",
                     entry_node="intake",
                     trigger_type="manual",
                     isolation_level="isolated",
-                ),
-            ],
-            llm=llm,
-            tools=tools,
-            tool_executor=tool_executor,
-        )
+                ))
 
         await runtime.start()
 

--- a/examples/templates/deep_research_agent/__main__.py
+++ b/examples/templates/deep_research_agent/__main__.py
@@ -105,20 +105,17 @@ def tui(verbose, debug):
         graph = agent._build_graph()
 
         runtime = AgentHost(
-            graph=graph,
-            goal=agent.goal,
-            storage_path=storage_path,
-            llm=llm,
-            tools=tools,
-            tool_executor=tool_executor
+            graph=graph, goal=agent.goal, storage_path=storage_path, llm=llm, tools=tools, tool_executor=tool_executor
         )
-        runtime.register_entry_point(EntryPointSpec(
-                    id="start",
-                    name="Start Research",
-                    entry_node="intake",
-                    trigger_type="manual",
-                    isolation_level="isolated",
-                ))
+        runtime.register_entry_point(
+            EntryPointSpec(
+                id="start",
+                name="Start Research",
+                entry_node="intake",
+                trigger_type="manual",
+                isolation_level="isolated",
+            )
+        )
 
         await runtime.start()
 

--- a/examples/templates/deep_research_agent/agent.py
+++ b/examples/templates/deep_research_agent/agent.py
@@ -215,6 +215,7 @@ class DeepResearchAgent:
 
         if mock_mode:
             from framework.llm.mock import MockLLMProvider
+
             llm = MockLLMProvider()
         else:
             llm = LiteLLMProvider(
@@ -253,7 +254,7 @@ class DeepResearchAgent:
             llm=llm,
             tools=tools,
             tool_executor=tool_executor,
-            checkpoint_config=checkpoint_config
+            checkpoint_config=checkpoint_config,
         )
         for spec in entry_point_specs:
             self._agent_runtime.register_entry_point(spec)

--- a/examples/templates/deep_research_agent/agent.py
+++ b/examples/templates/deep_research_agent/agent.py
@@ -213,8 +213,10 @@ class DeepResearchAgent:
         if mcp_config_path.exists():
             self._tool_registry.load_mcp_config(mcp_config_path)
 
-        llm = None
-        if not mock_mode:
+        if mock_mode:
+            from framework.llm.mock import MockLLMProvider
+            llm = MockLLMProvider()
+        else:
             llm = LiteLLMProvider(
                 model=self.config.model,
                 api_key=self.config.api_key,
@@ -248,12 +250,13 @@ class DeepResearchAgent:
             graph=self._graph,
             goal=self.goal,
             storage_path=self._storage_path,
-            entry_points=entry_point_specs,
             llm=llm,
             tools=tools,
             tool_executor=tool_executor,
-            checkpoint_config=checkpoint_config,
+            checkpoint_config=checkpoint_config
         )
+        for spec in entry_point_specs:
+            self._agent_runtime.register_entry_point(spec)
 
     async def start(self, mock_mode=False) -> None:
         """Set up and start the agent runtime."""

--- a/examples/templates/email_inbox_management/__main__.py
+++ b/examples/templates/email_inbox_management/__main__.py
@@ -122,19 +122,17 @@ def tui(mock, verbose, debug):
             graph=graph,
             goal=agent.goal,
             storage_path=storage_path,
-            entry_points=[
-                EntryPointSpec(
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor
+        )
+        runtime.register_entry_point(EntryPointSpec(
                     id="start",
                     name="Start Inbox Triage",
                     entry_node="intake",
                     trigger_type="manual",
                     isolation_level="isolated",
-                ),
-            ],
-            llm=llm,
-            tools=tools,
-            tool_executor=tool_executor,
-        )
+                ))
 
         await runtime.start()
 

--- a/examples/templates/email_inbox_management/__main__.py
+++ b/examples/templates/email_inbox_management/__main__.py
@@ -106,8 +106,10 @@ def tui(mock, verbose, debug):
         if tools_path.exists():
             agent._tool_registry.discover_from_module(tools_path)
 
-        llm = None
-        if not mock:
+        if mock:
+            from framework.llm.mock import MockLLMProvider
+            llm = MockLLMProvider()
+        else:
             llm = LiteLLMProvider(
                 model=agent.config.model,
                 api_key=agent.config.api_key,

--- a/examples/templates/email_inbox_management/__main__.py
+++ b/examples/templates/email_inbox_management/__main__.py
@@ -108,6 +108,7 @@ def tui(mock, verbose, debug):
 
         if mock:
             from framework.llm.mock import MockLLMProvider
+
             llm = MockLLMProvider()
         else:
             llm = LiteLLMProvider(
@@ -121,20 +122,17 @@ def tui(mock, verbose, debug):
         graph = agent._build_graph()
 
         runtime = AgentHost(
-            graph=graph,
-            goal=agent.goal,
-            storage_path=storage_path,
-            llm=llm,
-            tools=tools,
-            tool_executor=tool_executor
+            graph=graph, goal=agent.goal, storage_path=storage_path, llm=llm, tools=tools, tool_executor=tool_executor
         )
-        runtime.register_entry_point(EntryPointSpec(
-                    id="start",
-                    name="Start Inbox Triage",
-                    entry_node="intake",
-                    trigger_type="manual",
-                    isolation_level="isolated",
-                ))
+        runtime.register_entry_point(
+            EntryPointSpec(
+                id="start",
+                name="Start Inbox Triage",
+                entry_node="intake",
+                trigger_type="manual",
+                isolation_level="isolated",
+            )
+        )
 
         await runtime.start()
 

--- a/examples/templates/email_inbox_management/agent.py
+++ b/examples/templates/email_inbox_management/agent.py
@@ -229,6 +229,7 @@ class EmailInboxManagementAgent:
 
         if mock_mode:
             from framework.llm.mock import MockLLMProvider
+
             llm = MockLLMProvider()
         else:
             llm = LiteLLMProvider(
@@ -269,7 +270,7 @@ class EmailInboxManagementAgent:
             llm=llm,
             tools=tools,
             tool_executor=tool_executor,
-            checkpoint_config=checkpoint_config
+            checkpoint_config=checkpoint_config,
         )
         for spec in entry_point_specs:
             self._agent_runtime.register_entry_point(spec)

--- a/examples/templates/email_inbox_management/agent.py
+++ b/examples/templates/email_inbox_management/agent.py
@@ -227,8 +227,10 @@ class EmailInboxManagementAgent:
         if tools_path.exists():
             self._tool_registry.discover_from_module(tools_path)
 
-        llm = None
-        if not mock_mode:
+        if mock_mode:
+            from framework.llm.mock import MockLLMProvider
+            llm = MockLLMProvider()
+        else:
             llm = LiteLLMProvider(
                 model=self.config.model,
                 api_key=self.config.api_key,
@@ -264,12 +266,13 @@ class EmailInboxManagementAgent:
             graph=self._graph,
             goal=self.goal,
             storage_path=self._storage_path,
-            entry_points=entry_point_specs,
             llm=llm,
             tools=tools,
             tool_executor=tool_executor,
-            checkpoint_config=checkpoint_config,
+            checkpoint_config=checkpoint_config
         )
+        for spec in entry_point_specs:
+            self._agent_runtime.register_entry_point(spec)
 
         return self._executor
 

--- a/examples/templates/email_reply_agent/__main__.py
+++ b/examples/templates/email_reply_agent/__main__.py
@@ -29,11 +29,12 @@ def cli():
 
 @cli.command()
 @click.option("--filter", "-f", "filter_text", help="Email filter description")
+@click.option("--mock", is_flag=True, help="Run in mock mode")
 @click.option("--verbose", "-v", is_flag=True)
-def run(filter_text, verbose):
+def run(filter_text, mock, verbose):
     """Execute the agent."""
     setup_logging(verbose=verbose)
-    result = asyncio.run(default_agent.run({"filter": filter_text or ""}))
+    result = asyncio.run(default_agent.run({"filter": filter_text or ""}, mock_mode=mock))
     click.echo(
         json.dumps(
             {"success": result.success, "output": result.output},
@@ -45,7 +46,8 @@ def run(filter_text, verbose):
 
 
 @cli.command()
-def tui():
+@click.option("--mock", is_flag=True, help="Run in mock mode")
+def tui(mock=False):
     """Launch TUI dashboard."""
     from pathlib import Path
 
@@ -63,26 +65,33 @@ def tui():
         mcp_cfg = Path(__file__).parent / "mcp_servers.json"
         if mcp_cfg.exists():
             agent._tool_registry.load_mcp_config(mcp_cfg)
-        llm = LiteLLMProvider(
-            model=agent.config.model,
-            api_key=agent.config.api_key,
-            api_base=agent.config.api_base,
-        )
+        if mock:
+            from framework.llm.mock import MockLLMProvider
+
+            llm = MockLLMProvider()
+        else:
+            llm = LiteLLMProvider(
+                model=agent.config.model,
+                api_key=agent.config.api_key,
+                api_base=agent.config.api_base,
+            )
         runtime = AgentHost(
             graph=agent._build_graph(),
             goal=agent.goal,
             storage_path=storage,
             llm=llm,
             tools=list(agent._tool_registry.get_tools().values()),
-            tool_executor=agent._tool_registry.get_executor()
+            tool_executor=agent._tool_registry.get_executor(),
         )
-        runtime.register_entry_point(EntryPointSpec(
-                    id="start",
-                    name="Start",
-                    entry_node="intake",
-                    trigger_type="manual",
-                    isolation_level="isolated",
-                ))
+        runtime.register_entry_point(
+            EntryPointSpec(
+                id="start",
+                name="Start",
+                entry_node="intake",
+                trigger_type="manual",
+                isolation_level="isolated",
+            )
+        )
         await runtime.start()
         try:
             app = AdenTUI(runtime)

--- a/examples/templates/email_reply_agent/__main__.py
+++ b/examples/templates/email_reply_agent/__main__.py
@@ -72,19 +72,17 @@ def tui():
             graph=agent._build_graph(),
             goal=agent.goal,
             storage_path=storage,
-            entry_points=[
-                EntryPointSpec(
+            llm=llm,
+            tools=list(agent._tool_registry.get_tools().values()),
+            tool_executor=agent._tool_registry.get_executor()
+        )
+        runtime.register_entry_point(EntryPointSpec(
                     id="start",
                     name="Start",
                     entry_node="intake",
                     trigger_type="manual",
                     isolation_level="isolated",
-                )
-            ],
-            llm=llm,
-            tools=list(agent._tool_registry.get_tools().values()),
-            tool_executor=agent._tool_registry.get_executor(),
-        )
+                ))
         await runtime.start()
         try:
             app = AdenTUI(runtime)

--- a/examples/templates/email_reply_agent/agent.py
+++ b/examples/templates/email_reply_agent/agent.py
@@ -165,15 +165,6 @@ class EmailReplyAgent:
             graph=self._graph,
             goal=self.goal,
             storage_path=self._storage_path,
-            entry_points=[
-                EntryPointSpec(
-                    id="default",
-                    name="Default",
-                    entry_node=self.entry_node,
-                    trigger_type="manual",
-                    isolation_level="shared",
-                ),
-            ],
             llm=llm,
             tools=tools,
             tool_executor=tool_executor,
@@ -182,8 +173,15 @@ class EmailReplyAgent:
                 checkpoint_on_node_complete=True,
                 checkpoint_max_age_days=7,
                 async_checkpoint=True,
-            ),
+            )
         )
+        self._agent_runtime.register_entry_point(EntryPointSpec(
+                    id="default",
+                    name="Default",
+                    entry_node=self.entry_node,
+                    trigger_type="manual",
+                    isolation_level="shared",
+                ))
 
     async def start(self):
         if self._agent_runtime is None:

--- a/examples/templates/email_reply_agent/agent.py
+++ b/examples/templates/email_reply_agent/agent.py
@@ -146,18 +146,23 @@ class EmailReplyAgent:
             identity_prompt=identity_prompt,
         )
 
-    def _setup(self):
+    def _setup(self, mock_mode: bool = False):
         self._storage_path = Path.home() / ".hive" / "agents" / "email_reply_agent"
         self._storage_path.mkdir(parents=True, exist_ok=True)
         self._tool_registry = ToolRegistry()
         mcp_config = Path(__file__).parent / "mcp_servers.json"
         if mcp_config.exists():
             self._tool_registry.load_mcp_config(mcp_config)
-        llm = LiteLLMProvider(
-            model=self.config.model,
-            api_key=self.config.api_key,
-            api_base=self.config.api_base,
-        )
+        if mock_mode:
+            from framework.llm.mock import MockLLMProvider
+
+            llm = MockLLMProvider()
+        else:
+            llm = LiteLLMProvider(
+                model=self.config.model,
+                api_key=self.config.api_key,
+                api_base=self.config.api_base,
+            )
         tools = list(self._tool_registry.get_tools().values())
         tool_executor = self._tool_registry.get_executor()
         self._graph = self._build_graph()
@@ -173,19 +178,21 @@ class EmailReplyAgent:
                 checkpoint_on_node_complete=True,
                 checkpoint_max_age_days=7,
                 async_checkpoint=True,
+            ),
+        )
+        self._agent_runtime.register_entry_point(
+            EntryPointSpec(
+                id="default",
+                name="Default",
+                entry_node=self.entry_node,
+                trigger_type="manual",
+                isolation_level="shared",
             )
         )
-        self._agent_runtime.register_entry_point(EntryPointSpec(
-                    id="default",
-                    name="Default",
-                    entry_node=self.entry_node,
-                    trigger_type="manual",
-                    isolation_level="shared",
-                ))
 
-    async def start(self):
+    async def start(self, mock_mode: bool = False):
         if self._agent_runtime is None:
-            self._setup()
+            self._setup(mock_mode=mock_mode)
         if not self._agent_runtime.is_running:
             await self._agent_runtime.start()
 
@@ -209,8 +216,8 @@ class EmailReplyAgent:
             session_state=session_state,
         )
 
-    async def run(self, context, session_state=None):
-        await self.start()
+    async def run(self, context, mock_mode: bool = False, session_state=None):
+        await self.start(mock_mode=mock_mode)
         try:
             result = await self.trigger_and_wait("default", context, session_state=session_state)
             return result or ExecutionResult(success=False, error="Execution timeout")

--- a/examples/templates/job_hunter/__main__.py
+++ b/examples/templates/job_hunter/__main__.py
@@ -94,8 +94,10 @@ def tui(mock, verbose, debug):
         if mcp_config_path.exists():
             agent._tool_registry.load_mcp_config(mcp_config_path)
 
-        llm = None
-        if not mock:
+        if mock:
+            from framework.llm.mock import MockLLMProvider
+            llm = MockLLMProvider()
+        else:
             llm = LiteLLMProvider(
                 model=agent.config.model,
                 api_key=agent.config.api_key,

--- a/examples/templates/job_hunter/__main__.py
+++ b/examples/templates/job_hunter/__main__.py
@@ -110,19 +110,17 @@ def tui(mock, verbose, debug):
             graph=graph,
             goal=agent.goal,
             storage_path=storage_path,
-            entry_points=[
-                EntryPointSpec(
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor
+        )
+        runtime.register_entry_point(EntryPointSpec(
                     id="start",
                     name="Start Job Hunt",
                     entry_node="intake",
                     trigger_type="manual",
                     isolation_level="isolated",
-                ),
-            ],
-            llm=llm,
-            tools=tools,
-            tool_executor=tool_executor,
-        )
+                ))
 
         await runtime.start()
 

--- a/examples/templates/job_hunter/__main__.py
+++ b/examples/templates/job_hunter/__main__.py
@@ -96,6 +96,7 @@ def tui(mock, verbose, debug):
 
         if mock:
             from framework.llm.mock import MockLLMProvider
+
             llm = MockLLMProvider()
         else:
             llm = LiteLLMProvider(
@@ -109,20 +110,17 @@ def tui(mock, verbose, debug):
         graph = agent._build_graph()
 
         runtime = AgentHost(
-            graph=graph,
-            goal=agent.goal,
-            storage_path=storage_path,
-            llm=llm,
-            tools=tools,
-            tool_executor=tool_executor
+            graph=graph, goal=agent.goal, storage_path=storage_path, llm=llm, tools=tools, tool_executor=tool_executor
         )
-        runtime.register_entry_point(EntryPointSpec(
-                    id="start",
-                    name="Start Job Hunt",
-                    entry_node="intake",
-                    trigger_type="manual",
-                    isolation_level="isolated",
-                ))
+        runtime.register_entry_point(
+            EntryPointSpec(
+                id="start",
+                name="Start Job Hunt",
+                entry_node="intake",
+                trigger_type="manual",
+                isolation_level="isolated",
+            )
+        )
 
         await runtime.start()
 

--- a/examples/templates/job_hunter/agent.py
+++ b/examples/templates/job_hunter/agent.py
@@ -193,8 +193,10 @@ class JobHunterAgent:
         if mcp_config_path.exists():
             self._tool_registry.load_mcp_config(mcp_config_path)
 
-        llm = None
-        if not mock_mode:
+        if mock_mode:
+            from framework.llm.mock import MockLLMProvider
+            llm = MockLLMProvider()
+        else:
             llm = LiteLLMProvider(
                 model=self.config.model,
                 api_key=self.config.api_key,
@@ -228,12 +230,13 @@ class JobHunterAgent:
             graph=self._graph,
             goal=self.goal,
             storage_path=self._storage_path,
-            entry_points=entry_point_specs,
             llm=llm,
             tools=tools,
             tool_executor=tool_executor,
-            checkpoint_config=checkpoint_config,
+            checkpoint_config=checkpoint_config
         )
+        for spec in entry_point_specs:
+            self._agent_runtime.register_entry_point(spec)
 
     async def start(self, mock_mode=False) -> None:
         """Set up and start the agent runtime."""

--- a/examples/templates/job_hunter/agent.py
+++ b/examples/templates/job_hunter/agent.py
@@ -195,6 +195,7 @@ class JobHunterAgent:
 
         if mock_mode:
             from framework.llm.mock import MockLLMProvider
+
             llm = MockLLMProvider()
         else:
             llm = LiteLLMProvider(
@@ -233,7 +234,7 @@ class JobHunterAgent:
             llm=llm,
             tools=tools,
             tool_executor=tool_executor,
-            checkpoint_config=checkpoint_config
+            checkpoint_config=checkpoint_config,
         )
         for spec in entry_point_specs:
             self._agent_runtime.register_entry_point(spec)

--- a/examples/templates/local_business_extractor/__main__.py
+++ b/examples/templates/local_business_extractor/__main__.py
@@ -38,17 +38,18 @@ def cli():
     required=True,
     help="Search query (e.g. 'bakeries in San Francisco')",
 )
+@click.option("--mock", is_flag=True, help="Run in mock mode without making LLM calls")
 @click.option("--quiet", is_flag=True, help="Only output result JSON")
 @click.option("--verbose", "-v", is_flag=True, help="Show execution details")
 @click.option("--debug", is_flag=True, help="Show debug logging")
-def run(query, quiet, verbose, debug):
+def run(query, mock, quiet, verbose, debug):
     """Extract businesses matching a search query."""
     if not quiet:
         setup_logging(verbose=verbose, debug=debug)
 
     context = {"user_request": query}
 
-    result = asyncio.run(default_agent.run(context))
+    result = asyncio.run(default_agent.run(context, mock_mode=mock))
 
     output_data = {
         "success": result.success,

--- a/examples/templates/local_business_extractor/agent.py
+++ b/examples/templates/local_business_extractor/agent.py
@@ -110,18 +110,23 @@ class LocalBusinessExtractor:
             identity_prompt=identity_prompt,
         )
 
-    def _setup(self):
+    def _setup(self, mock_mode: bool = False):
         self._storage_path = Path.home() / ".hive" / "agents" / "local_business_extractor"
         self._storage_path.mkdir(parents=True, exist_ok=True)
         self._tool_registry = ToolRegistry()
         mcp_config = Path(__file__).parent / "mcp_servers.json"
         if mcp_config.exists():
             self._tool_registry.load_mcp_config(mcp_config)
-        llm = LiteLLMProvider(
-            model=self.config.model,
-            api_key=self.config.api_key,
-            api_base=self.config.api_base,
-        )
+        if mock_mode:
+            from framework.llm.mock import MockLLMProvider
+
+            llm = MockLLMProvider()
+        else:
+            llm = LiteLLMProvider(
+                model=self.config.model,
+                api_key=self.config.api_key,
+                api_base=self.config.api_base,
+            )
         tools = list(self._tool_registry.get_tools().values())
         tool_executor = self._tool_registry.get_executor()
         self._graph = self._build_graph()
@@ -132,19 +137,21 @@ class LocalBusinessExtractor:
             llm=llm,
             tools=tools,
             tool_executor=tool_executor,
-            checkpoint_config=CheckpointConfig(enabled=True, checkpoint_on_node_complete=True)
+            checkpoint_config=CheckpointConfig(enabled=True, checkpoint_on_node_complete=True),
         )
-        self._agent_runtime.register_entry_point(EntryPointSpec(
-                    id="default",
-                    name="Default",
-                    entry_node=self.entry_node,
-                    trigger_type="manual",
-                    isolation_level="shared",
-                ))
+        self._agent_runtime.register_entry_point(
+            EntryPointSpec(
+                id="default",
+                name="Default",
+                entry_node=self.entry_node,
+                trigger_type="manual",
+                isolation_level="shared",
+            )
+        )
 
-    async def start(self):
+    async def start(self, mock_mode: bool = False):
         if self._agent_runtime is None:
-            self._setup()
+            self._setup(mock_mode=mock_mode)
         if not self._agent_runtime.is_running:
             await self._agent_runtime.start()
 
@@ -153,8 +160,8 @@ class LocalBusinessExtractor:
             await self._agent_runtime.stop()
         self._agent_runtime = None
 
-    async def run(self, context, session_state=None):
-        await self.start()
+    async def run(self, context, mock_mode: bool = False, session_state=None):
+        await self.start(mock_mode=mock_mode)
         try:
             result = await self._agent_runtime.trigger_and_wait("default", context, session_state=session_state)
             return result or ExecutionResult(success=False, error="Execution timeout")

--- a/examples/templates/local_business_extractor/agent.py
+++ b/examples/templates/local_business_extractor/agent.py
@@ -129,20 +129,18 @@ class LocalBusinessExtractor:
             graph=self._graph,
             goal=self.goal,
             storage_path=self._storage_path,
-            entry_points=[
-                EntryPointSpec(
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor,
+            checkpoint_config=CheckpointConfig(enabled=True, checkpoint_on_node_complete=True)
+        )
+        self._agent_runtime.register_entry_point(EntryPointSpec(
                     id="default",
                     name="Default",
                     entry_node=self.entry_node,
                     trigger_type="manual",
                     isolation_level="shared",
-                )
-            ],
-            llm=llm,
-            tools=tools,
-            tool_executor=tool_executor,
-            checkpoint_config=CheckpointConfig(enabled=True, checkpoint_on_node_complete=True),
-        )
+                ))
 
     async def start(self):
         if self._agent_runtime is None:

--- a/examples/templates/meeting_scheduler/__main__.py
+++ b/examples/templates/meeting_scheduler/__main__.py
@@ -73,19 +73,17 @@ def tui():
             graph=agent._build_graph(),
             goal=agent.goal,
             storage_path=storage,
-            entry_points=[
-                EntryPointSpec(
+            llm=llm,
+            tools=list(agent._tool_registry.get_tools().values()),
+            tool_executor=agent._tool_registry.get_executor()
+        )
+        runtime.register_entry_point(EntryPointSpec(
                     id="start",
                     name="Start",
                     entry_node="intake",
                     trigger_type="manual",
                     isolation_level="isolated",
-                )
-            ],
-            llm=llm,
-            tools=list(agent._tool_registry.get_tools().values()),
-            tool_executor=agent._tool_registry.get_executor(),
-        )
+                ))
         await runtime.start()
         try:
             app = AdenTUI(runtime)

--- a/examples/templates/meeting_scheduler/__main__.py
+++ b/examples/templates/meeting_scheduler/__main__.py
@@ -29,8 +29,9 @@ def cli():
 @click.option("--attendee", "-a", required=True, help="Attendee email address")
 @click.option("--duration", "-d", type=int, required=True, help="Meeting duration in minutes")
 @click.option("--title", "-t", required=True, help="Meeting title")
+@click.option("--mock", is_flag=True, help="Run in mock mode")
 @click.option("--verbose", "-v", is_flag=True)
-def run(attendee, duration, title, verbose):
+def run(attendee, duration, title, mock, verbose):
     """Execute the scheduler."""
     setup_logging(verbose=verbose)
     result = asyncio.run(
@@ -39,7 +40,8 @@ def run(attendee, duration, title, verbose):
                 "attendee_email": attendee,
                 "meeting_duration_minutes": str(duration),
                 "meeting_title": title,
-            }
+            },
+            mock_mode=mock,
         )
     )
     click.echo(json.dumps({"success": result.success, "output": result.output}, indent=2, default=str))
@@ -47,7 +49,8 @@ def run(attendee, duration, title, verbose):
 
 
 @cli.command()
-def tui():
+@click.option("--mock", is_flag=True, help="Run in mock mode")
+def tui(mock=False):
     """Launch TUI dashboard."""
     from pathlib import Path
     from framework.tui.app import AdenTUI
@@ -64,26 +67,33 @@ def tui():
         mcp_cfg = Path(__file__).parent / "mcp_servers.json"
         if mcp_cfg.exists():
             agent._tool_registry.load_mcp_config(mcp_cfg)
-        llm = LiteLLMProvider(
-            model=agent.config.model,
-            api_key=agent.config.api_key,
-            api_base=agent.config.api_base,
-        )
+        if mock:
+            from framework.llm.mock import MockLLMProvider
+
+            llm = MockLLMProvider()
+        else:
+            llm = LiteLLMProvider(
+                model=agent.config.model,
+                api_key=agent.config.api_key,
+                api_base=agent.config.api_base,
+            )
         runtime = AgentHost(
             graph=agent._build_graph(),
             goal=agent.goal,
             storage_path=storage,
             llm=llm,
             tools=list(agent._tool_registry.get_tools().values()),
-            tool_executor=agent._tool_registry.get_executor()
+            tool_executor=agent._tool_registry.get_executor(),
         )
-        runtime.register_entry_point(EntryPointSpec(
-                    id="start",
-                    name="Start",
-                    entry_node="intake",
-                    trigger_type="manual",
-                    isolation_level="isolated",
-                ))
+        runtime.register_entry_point(
+            EntryPointSpec(
+                id="start",
+                name="Start",
+                entry_node="intake",
+                trigger_type="manual",
+                isolation_level="isolated",
+            )
+        )
         await runtime.start()
         try:
             app = AdenTUI(runtime)

--- a/examples/templates/meeting_scheduler/agent.py
+++ b/examples/templates/meeting_scheduler/agent.py
@@ -152,18 +152,23 @@ class MeetingScheduler:
             identity_prompt=identity_prompt,
         )
 
-    def _setup(self):
+    def _setup(self, mock_mode: bool = False):
         self._storage_path = Path.home() / ".hive" / "agents" / "meeting_scheduler"
         self._storage_path.mkdir(parents=True, exist_ok=True)
         self._tool_registry = ToolRegistry()
         mcp_config = Path(__file__).parent / "mcp_servers.json"
         if mcp_config.exists():
             self._tool_registry.load_mcp_config(mcp_config)
-        llm = LiteLLMProvider(
-            model=self.config.model,
-            api_key=self.config.api_key,
-            api_base=self.config.api_base,
-        )
+        if mock_mode:
+            from framework.llm.mock import MockLLMProvider
+
+            llm = MockLLMProvider()
+        else:
+            llm = LiteLLMProvider(
+                model=self.config.model,
+                api_key=self.config.api_key,
+                api_base=self.config.api_base,
+            )
         tools = list(self._tool_registry.get_tools().values())
         tool_executor = self._tool_registry.get_executor()
         self._graph = self._build_graph()
@@ -179,19 +184,21 @@ class MeetingScheduler:
                 checkpoint_on_node_complete=True,
                 checkpoint_max_age_days=7,
                 async_checkpoint=True,
+            ),
+        )
+        self._agent_runtime.register_entry_point(
+            EntryPointSpec(
+                id="default",
+                name="Default",
+                entry_node=self.entry_node,
+                trigger_type="manual",
+                isolation_level="shared",
             )
         )
-        self._agent_runtime.register_entry_point(EntryPointSpec(
-                    id="default",
-                    name="Default",
-                    entry_node=self.entry_node,
-                    trigger_type="manual",
-                    isolation_level="shared",
-                ))
 
-    async def start(self):
+    async def start(self, mock_mode: bool = False):
         if self._agent_runtime is None:
-            self._setup()
+            self._setup(mock_mode=mock_mode)
         if not self._agent_runtime.is_running:
             await self._agent_runtime.start()
 
@@ -209,8 +216,8 @@ class MeetingScheduler:
             session_state=session_state,
         )
 
-    async def run(self, context, session_state=None):
-        await self.start()
+    async def run(self, context, mock_mode: bool = False, session_state=None):
+        await self.start(mock_mode=mock_mode)
         try:
             result = await self.trigger_and_wait("default", context, session_state=session_state)
             return result or ExecutionResult(success=False, error="Execution timeout")

--- a/examples/templates/meeting_scheduler/agent.py
+++ b/examples/templates/meeting_scheduler/agent.py
@@ -171,15 +171,6 @@ class MeetingScheduler:
             graph=self._graph,
             goal=self.goal,
             storage_path=self._storage_path,
-            entry_points=[
-                EntryPointSpec(
-                    id="default",
-                    name="Default",
-                    entry_node=self.entry_node,
-                    trigger_type="manual",
-                    isolation_level="shared",
-                )
-            ],
             llm=llm,
             tools=tools,
             tool_executor=tool_executor,
@@ -188,8 +179,15 @@ class MeetingScheduler:
                 checkpoint_on_node_complete=True,
                 checkpoint_max_age_days=7,
                 async_checkpoint=True,
-            ),
+            )
         )
+        self._agent_runtime.register_entry_point(EntryPointSpec(
+                    id="default",
+                    name="Default",
+                    entry_node=self.entry_node,
+                    trigger_type="manual",
+                    isolation_level="shared",
+                ))
 
     async def start(self):
         if self._agent_runtime is None:

--- a/examples/templates/sdr_agent/agent.py
+++ b/examples/templates/sdr_agent/agent.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from framework.orchestrator import EdgeSpec, EdgeCondition, Goal, SuccessCriterion, Constraint
 from framework.orchestrator.checkpoint_config import CheckpointConfig
-from framework.orchestrator.edge import AsyncEntryPointSpec, GraphSpec
+from framework.orchestrator.edge import GraphSpec
 from framework.orchestrator.orchestrator import ExecutionResult
 from framework.llm import LiteLLMProvider
 from framework.loader.tool_registry import ToolRegistry
@@ -147,7 +147,7 @@ edges = [
 # Graph configuration
 entry_node = "intake"
 entry_points = {"start": "intake"}
-async_entry_points: list[AsyncEntryPointSpec] = []  # SDR Agent is manually triggered
+async_entry_points: list = []  # SDR Agent is manually triggered
 pause_nodes = []
 terminal_nodes = []
 loop_config = {
@@ -269,7 +269,7 @@ class SDRAgent:
             llm=llm,
             tools=tools,
             tool_executor=tool_executor,
-            checkpoint_config=checkpoint_config
+            checkpoint_config=checkpoint_config,
         )
         for spec in entry_point_specs:
             self._agent_runtime.register_entry_point(spec)

--- a/examples/templates/sdr_agent/agent.py
+++ b/examples/templates/sdr_agent/agent.py
@@ -266,12 +266,13 @@ class SDRAgent:
             graph=self._graph,
             goal=self.goal,
             storage_path=self._storage_path,
-            entry_points=entry_point_specs,
             llm=llm,
             tools=tools,
             tool_executor=tool_executor,
-            checkpoint_config=checkpoint_config,
+            checkpoint_config=checkpoint_config
         )
+        for spec in entry_point_specs:
+            self._agent_runtime.register_entry_point(spec)
 
     async def start(self, mock_mode=False) -> None:
         """Set up and start the agent runtime."""

--- a/examples/templates/tech_news_reporter/__main__.py
+++ b/examples/templates/tech_news_reporter/__main__.py
@@ -105,19 +105,17 @@ def tui(verbose, debug):
             graph=graph,
             goal=agent.goal,
             storage_path=storage_path,
-            entry_points=[
-                EntryPointSpec(
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor
+        )
+        runtime.register_entry_point(EntryPointSpec(
                     id="start",
                     name="Start News Report",
                     entry_node="intake",
                     trigger_type="manual",
                     isolation_level="isolated",
-                ),
-            ],
-            llm=llm,
-            tools=tools,
-            tool_executor=tool_executor,
-        )
+                ))
 
         await runtime.start()
 

--- a/examples/templates/tech_news_reporter/__main__.py
+++ b/examples/templates/tech_news_reporter/__main__.py
@@ -33,17 +33,18 @@ def cli():
 
 
 @cli.command()
+@click.option("--mock", is_flag=True, help="Run in mock mode without making LLM calls")
 @click.option("--quiet", "-q", is_flag=True, help="Only output result JSON")
 @click.option("--verbose", "-v", is_flag=True, help="Show execution details")
 @click.option("--debug", is_flag=True, help="Show debug logging")
-def run(quiet, verbose, debug):
+def run(mock, quiet, verbose, debug):
     """Execute the news reporter agent."""
     if not quiet:
         setup_logging(verbose=verbose, debug=debug)
 
     context = {}
 
-    result = asyncio.run(default_agent.run(context))
+    result = asyncio.run(default_agent.run(context, mock_mode=mock))
 
     output_data = {
         "success": result.success,
@@ -58,9 +59,10 @@ def run(quiet, verbose, debug):
 
 
 @cli.command()
+@click.option("--mock", is_flag=True, help="Run in mock mode")
 @click.option("--verbose", "-v", is_flag=True, help="Show execution details")
 @click.option("--debug", is_flag=True, help="Show debug logging")
-def tui(verbose, debug):
+def tui(mock, verbose, debug):
     """Launch the TUI dashboard for interactive news reporting."""
     setup_logging(verbose=verbose, debug=debug)
 
@@ -91,31 +93,33 @@ def tui(verbose, debug):
         if mcp_config_path.exists():
             agent._tool_registry.load_mcp_config(mcp_config_path)
 
-        llm = LiteLLMProvider(
-            model=agent.config.model,
-            api_key=agent.config.api_key,
-            api_base=agent.config.api_base,
-        )
+        if mock:
+            from framework.llm.mock import MockLLMProvider
+
+            llm = MockLLMProvider()
+        else:
+            llm = LiteLLMProvider(
+                model=agent.config.model,
+                api_key=agent.config.api_key,
+                api_base=agent.config.api_base,
+            )
 
         tools = list(agent._tool_registry.get_tools().values())
         tool_executor = agent._tool_registry.get_executor()
         graph = agent._build_graph()
 
         runtime = AgentHost(
-            graph=graph,
-            goal=agent.goal,
-            storage_path=storage_path,
-            llm=llm,
-            tools=tools,
-            tool_executor=tool_executor
+            graph=graph, goal=agent.goal, storage_path=storage_path, llm=llm, tools=tools, tool_executor=tool_executor
         )
-        runtime.register_entry_point(EntryPointSpec(
-                    id="start",
-                    name="Start News Report",
-                    entry_node="intake",
-                    trigger_type="manual",
-                    isolation_level="isolated",
-                ))
+        runtime.register_entry_point(
+            EntryPointSpec(
+                id="start",
+                name="Start News Report",
+                entry_node="intake",
+                trigger_type="manual",
+                isolation_level="isolated",
+            )
+        )
 
         await runtime.start()
 

--- a/examples/templates/tech_news_reporter/agent.py
+++ b/examples/templates/tech_news_reporter/agent.py
@@ -157,7 +157,7 @@ class TechNewsReporterAgent:
             },
         )
 
-    def _setup(self) -> Orchestrator:
+    def _setup(self, mock_mode: bool = False) -> Orchestrator:
         """Set up the executor with all components."""
         from pathlib import Path
 
@@ -171,11 +171,16 @@ class TechNewsReporterAgent:
         if mcp_config_path.exists():
             self._tool_registry.load_mcp_config(mcp_config_path)
 
-        llm = LiteLLMProvider(
-            model=self.config.model,
-            api_key=self.config.api_key,
-            api_base=self.config.api_base,
-        )
+        if mock_mode:
+            from framework.llm.mock import MockLLMProvider
+
+            llm = MockLLMProvider()
+        else:
+            llm = LiteLLMProvider(
+                model=self.config.model,
+                api_key=self.config.api_key,
+                api_base=self.config.api_base,
+            )
 
         tool_executor = self._tool_registry.get_executor()
         tools = list(self._tool_registry.get_tools().values())
@@ -195,10 +200,10 @@ class TechNewsReporterAgent:
 
         return self._executor
 
-    async def start(self) -> None:
+    async def start(self, mock_mode: bool = False) -> None:
         """Set up the agent (initialize executor and tools)."""
         if self._executor is None:
-            self._setup()
+            self._setup(mock_mode=mock_mode)
 
     async def stop(self) -> None:
         """Clean up resources."""
@@ -225,9 +230,9 @@ class TechNewsReporterAgent:
             session_state=session_state,
         )
 
-    async def run(self, context: dict, session_state=None) -> ExecutionResult:
+    async def run(self, context: dict, mock_mode: bool = False, session_state=None) -> ExecutionResult:
         """Run the agent (convenience method for single execution)."""
-        await self.start()
+        await self.start(mock_mode=mock_mode)
         try:
             result = await self.trigger_and_wait("start", context, session_state=session_state)
             return result or ExecutionResult(success=False, error="Execution timeout")

--- a/examples/templates/twitter_news_agent/__main__.py
+++ b/examples/templates/twitter_news_agent/__main__.py
@@ -38,10 +38,11 @@ def cli():
     default=None,
     help="Comma-separated Twitter handles to monitor",
 )
+@click.option("--mock", is_flag=True, help="Run in mock mode without making LLM calls")
 @click.option("--quiet", is_flag=True, help="Only output result JSON")
 @click.option("--verbose", "-v", is_flag=True, help="Show execution details")
 @click.option("--debug", is_flag=True, help="Show debug logging")
-def run(handles, quiet, verbose, debug):
+def run(handles, mock, quiet, verbose, debug):
     """Fetch and summarize tech news from Twitter."""
     if not quiet:
         setup_logging(verbose=verbose, debug=debug)
@@ -50,7 +51,7 @@ def run(handles, quiet, verbose, debug):
     if handles:
         context["twitter_handles"] = [h.strip() for h in handles.split(",")]
 
-    result = asyncio.run(default_agent.run(context))
+    result = asyncio.run(default_agent.run(context, mock_mode=mock))
 
     output_data = {
         "success": result.success,

--- a/examples/templates/twitter_news_agent/agent.py
+++ b/examples/templates/twitter_news_agent/agent.py
@@ -134,18 +134,23 @@ class TwitterNewsAgent:
             identity_prompt=identity_prompt,
         )
 
-    def _setup(self):
+    def _setup(self, mock_mode: bool = False):
         self._storage_path = Path.home() / ".hive" / "agents" / "twitter_news_agent"
         self._storage_path.mkdir(parents=True, exist_ok=True)
         self._tool_registry = ToolRegistry()
         mcp_config = Path(__file__).parent / "mcp_servers.json"
         if mcp_config.exists():
             self._tool_registry.load_mcp_config(mcp_config)
-        llm = LiteLLMProvider(
-            model=self.config.model,
-            api_key=self.config.api_key,
-            api_base=self.config.api_base,
-        )
+        if mock_mode:
+            from framework.llm.mock import MockLLMProvider
+
+            llm = MockLLMProvider()
+        else:
+            llm = LiteLLMProvider(
+                model=self.config.model,
+                api_key=self.config.api_key,
+                api_base=self.config.api_base,
+            )
         tools = list(self._tool_registry.get_tools().values())
         tool_executor = self._tool_registry.get_executor()
         self._graph = self._build_graph()
@@ -161,19 +166,21 @@ class TwitterNewsAgent:
                 checkpoint_on_node_complete=True,
                 checkpoint_max_age_days=7,
                 async_checkpoint=True,
+            ),
+        )
+        self._agent_runtime.register_entry_point(
+            EntryPointSpec(
+                id="default",
+                name="Default",
+                entry_node=self.entry_node,
+                trigger_type="manual",
+                isolation_level="shared",
             )
         )
-        self._agent_runtime.register_entry_point(EntryPointSpec(
-                    id="default",
-                    name="Default",
-                    entry_node=self.entry_node,
-                    trigger_type="manual",
-                    isolation_level="shared",
-                ))
 
-    async def start(self):
+    async def start(self, mock_mode: bool = False):
         if self._agent_runtime is None:
-            self._setup()
+            self._setup(mock_mode=mock_mode)
         if not self._agent_runtime.is_running:
             await self._agent_runtime.start()
 
@@ -191,8 +198,8 @@ class TwitterNewsAgent:
             session_state=session_state,
         )
 
-    async def run(self, context, session_state=None):
-        await self.start()
+    async def run(self, context, mock_mode: bool = False, session_state=None):
+        await self.start(mock_mode=mock_mode)
         try:
             result = await self.trigger_and_wait("default", context, session_state=session_state)
             return result or ExecutionResult(success=False, error="Execution timeout")

--- a/examples/templates/twitter_news_agent/agent.py
+++ b/examples/templates/twitter_news_agent/agent.py
@@ -153,15 +153,6 @@ class TwitterNewsAgent:
             graph=self._graph,
             goal=self.goal,
             storage_path=self._storage_path,
-            entry_points=[
-                EntryPointSpec(
-                    id="default",
-                    name="Default",
-                    entry_node=self.entry_node,
-                    trigger_type="manual",
-                    isolation_level="shared",
-                )
-            ],
             llm=llm,
             tools=tools,
             tool_executor=tool_executor,
@@ -170,8 +161,15 @@ class TwitterNewsAgent:
                 checkpoint_on_node_complete=True,
                 checkpoint_max_age_days=7,
                 async_checkpoint=True,
-            ),
+            )
         )
+        self._agent_runtime.register_entry_point(EntryPointSpec(
+                    id="default",
+                    name="Default",
+                    entry_node=self.entry_node,
+                    trigger_type="manual",
+                    isolation_level="shared",
+                ))
 
     async def start(self):
         if self._agent_runtime is None:

--- a/examples/templates/vulnerability_assessment/__main__.py
+++ b/examples/templates/vulnerability_assessment/__main__.py
@@ -111,19 +111,17 @@ def tui(mock, verbose, debug):
             graph=graph,
             goal=agent.goal,
             storage_path=storage_path,
-            entry_points=[
-                EntryPointSpec(
+            llm=llm,
+            tools=tools,
+            tool_executor=tool_executor
+        )
+        runtime.register_entry_point(EntryPointSpec(
                     id="start",
                     name="Start Vulnerability Assessment",
                     entry_node="intake",
                     trigger_type="manual",
                     isolation_level="isolated",
-                ),
-            ],
-            llm=llm,
-            tools=tools,
-            tool_executor=tool_executor,
-        )
+                ))
 
         await runtime.start()
 

--- a/examples/templates/vulnerability_assessment/__main__.py
+++ b/examples/templates/vulnerability_assessment/__main__.py
@@ -95,8 +95,10 @@ def tui(mock, verbose, debug):
         if mcp_config_path.exists():
             agent._tool_registry.load_mcp_config(mcp_config_path)
 
-        llm = None
-        if not mock:
+        if mock:
+            from framework.llm.mock import MockLLMProvider
+            llm = MockLLMProvider()
+        else:
             llm = LiteLLMProvider(
                 model=agent.config.model,
                 api_key=agent.config.api_key,

--- a/examples/templates/vulnerability_assessment/__main__.py
+++ b/examples/templates/vulnerability_assessment/__main__.py
@@ -97,6 +97,7 @@ def tui(mock, verbose, debug):
 
         if mock:
             from framework.llm.mock import MockLLMProvider
+
             llm = MockLLMProvider()
         else:
             llm = LiteLLMProvider(
@@ -110,20 +111,17 @@ def tui(mock, verbose, debug):
         graph = agent._build_graph()
 
         runtime = AgentHost(
-            graph=graph,
-            goal=agent.goal,
-            storage_path=storage_path,
-            llm=llm,
-            tools=tools,
-            tool_executor=tool_executor
+            graph=graph, goal=agent.goal, storage_path=storage_path, llm=llm, tools=tools, tool_executor=tool_executor
         )
-        runtime.register_entry_point(EntryPointSpec(
-                    id="start",
-                    name="Start Vulnerability Assessment",
-                    entry_node="intake",
-                    trigger_type="manual",
-                    isolation_level="isolated",
-                ))
+        runtime.register_entry_point(
+            EntryPointSpec(
+                id="start",
+                name="Start Vulnerability Assessment",
+                entry_node="intake",
+                trigger_type="manual",
+                isolation_level="isolated",
+            )
+        )
 
         await runtime.start()
 

--- a/examples/templates/vulnerability_assessment/agent.py
+++ b/examples/templates/vulnerability_assessment/agent.py
@@ -231,8 +231,10 @@ class VulnerabilityResearcherAgent:
         if mcp_config_path.exists():
             self._tool_registry.load_mcp_config(mcp_config_path)
 
-        llm = None
-        if not mock_mode:
+        if mock_mode:
+            from framework.llm.mock import MockLLMProvider
+            llm = MockLLMProvider()
+        else:
             llm = LiteLLMProvider(
                 model=self.config.model,
                 api_key=self.config.api_key,

--- a/examples/templates/vulnerability_assessment/agent.py
+++ b/examples/templates/vulnerability_assessment/agent.py
@@ -233,6 +233,7 @@ class VulnerabilityResearcherAgent:
 
         if mock_mode:
             from framework.llm.mock import MockLLMProvider
+
             llm = MockLLMProvider()
         else:
             llm = LiteLLMProvider(


### PR DESCRIPTION
Resolves #7199 by: 1. Removing the deprecated 'entry_points' parameter from the 'AgentHost' constructor across all templates and instead calling '.register_entry_point(spec)' on the instantiated runtime. 2. Instantiating a 'MockLLMProvider()' inside 'agent.py' for mock mode runs instead of passing 'None' to 'AgentHost', preventing 'LLM provider not available' errors. 3. Adding the '--mock' flag option back to the 'deep_research_agent' CLI run subcommand as documented in its README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --mock CLI option to templates to enable mock LLM mode for testing.

* **Chores**
  * Standardized mock-mode LLM initialization across templates for consistent test behavior.
  * Refactored how agent entry points are registered across templates for more consistent runtime setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aden-hive/hive/pull/7210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->