### PR TITLE
fix: only show Copied feedback when clipboard write succeeds

### DIFF
--- a/core/frontend/src/pages/prompt-library.tsx
+++ b/core/frontend/src/pages/prompt-library.tsx
@@ -21,9 +21,13 @@ function PromptCard({
   const isCustom = "custom" in prompt && prompt.custom;
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(prompt.content);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    try {
+      await navigator.clipboard.writeText(prompt.content);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API unavailable (insecure context); silently no-op.
+    }
   };
 
   return (


### PR DESCRIPTION
* Fixes #6306
* Added try-catch around `navigator.clipboard.writeText()` in `prompt-library.tsx`
* Updated copy flow to call `setCopied(true)` only on successful clipboard writes
* Prevented false "Copied" feedback when Clipboard API fails (e.g. insecure context or permission denied)
* Aligned clipboard error handling behavior with existing implementation in `ChartToolDetail.tsx`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the copy prompt feature to handle clipboard access restrictions gracefully. Users will no longer encounter errors in certain browser contexts, while the existing copy confirmation behavior is preserved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aden-hive/hive/pull/7219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->