### PR TITLE
fix: catch duplicate edge IDs, unconditional self-loops, and CONDITIO…

### DIFF
--- a/core/framework/orchestrator/edge.py
+++ b/core/framework/orchestrator/edge.py
@@ -506,12 +506,28 @@ class GraphSpec(BaseModel):
                 "Consider adding a termination point where execution ends."
             )
 
-        # Check edge references
+        # Check for duplicate edge IDs
+        seen_edge_ids: set[str] = set()
+        for edge in self.edges:
+            if edge.id in seen_edge_ids:
+                errors.append(f"Duplicate edge ID '{edge.id}'")
+            seen_edge_ids.add(edge.id)
+
+        # Check edge references, self-loops, and missing condition_expr
         for edge in self.edges:
             if not self.get_node(edge.source):
                 errors.append(f"Edge '{edge.id}' references missing source '{edge.source}'")
             if not self.get_node(edge.target):
                 errors.append(f"Edge '{edge.id}' references missing target '{edge.target}'")
+            if edge.source == edge.target and edge.condition == EdgeCondition.ALWAYS:
+                errors.append(
+                    f"Edge '{edge.id}' is an unconditional self-loop "
+                    f"(source == target == '{edge.source}')"
+                )
+            if edge.condition == EdgeCondition.CONDITIONAL and not edge.condition_expr:
+                errors.append(
+                    f"Edge '{edge.id}' has condition=CONDITIONAL but no condition_expr defined"
+                )
 
         # Check for unreachable nodes
         # Start with main entry node and all entry points (for pause/resume architecture)

--- a/core/tests/test_graph_spec_validation.py
+++ b/core/tests/test_graph_spec_validation.py
@@ -1,0 +1,182 @@
+"""Tests for GraphSpec.validate() — duplicate edge IDs, unconditional self-loops,
+and CONDITIONAL edges missing condition_expr.
+
+Run with:
+    cd core
+    pytest tests/test_graph_spec_validation.py -v
+"""
+
+import pytest
+
+from framework.orchestrator.edge import EdgeCondition, EdgeSpec, GraphSpec
+from framework.orchestrator.node import NodeSpec
+
+
+def _node(node_id: str) -> NodeSpec:
+    return NodeSpec(id=node_id, name=node_id, description="")
+
+
+def _base_graph(**kwargs) -> GraphSpec:
+    """Minimal valid graph with two nodes and one edge."""
+    a = _node("a")
+    b = _node("b")
+    edge = EdgeSpec(id="a-b", source="a", target="b", condition=EdgeCondition.ON_SUCCESS)
+    return GraphSpec(
+        id="test-graph",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["b"],
+        nodes=[a, b],
+        edges=[edge],
+        **kwargs,
+    )
+
+
+def test_valid_graph_has_no_errors():
+    result = _base_graph().validate()
+    assert result["errors"] == []
+
+
+def test_duplicate_edge_ids_raises_error():
+    a = _node("a")
+    b = _node("b")
+    c = _node("c")
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["b", "c"],
+        nodes=[a, b, c],
+        edges=[
+            EdgeSpec(id="dup", source="a", target="b"),
+            EdgeSpec(id="dup", source="a", target="c"),
+        ],
+    )
+    errors = graph.validate()["errors"]
+    assert any("Duplicate edge ID 'dup'" in e for e in errors)
+
+
+def test_unique_edge_ids_no_duplicate_error():
+    a = _node("a")
+    b = _node("b")
+    c = _node("c")
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["b", "c"],
+        nodes=[a, b, c],
+        edges=[
+            EdgeSpec(id="a-b", source="a", target="b"),
+            EdgeSpec(id="a-c", source="a", target="c"),
+        ],
+    )
+    errors = graph.validate()["errors"]
+    assert not any("Duplicate edge ID" in e for e in errors)
+
+
+def test_unconditional_self_loop_raises_error():
+    a = _node("a")
+    b = _node("b")
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["b"],
+        nodes=[a, b],
+        edges=[
+            EdgeSpec(id="self-loop", source="a", target="a", condition=EdgeCondition.ALWAYS),
+            EdgeSpec(id="a-b", source="a", target="b"),
+        ],
+    )
+    errors = graph.validate()["errors"]
+    assert any("unconditional self-loop" in e for e in errors)
+    assert any("self-loop" in e for e in errors)
+
+
+def test_conditional_self_loop_is_allowed():
+    """A self-loop with CONDITIONAL is valid — it only fires when the expression is true."""
+    a = _node("a")
+    b = _node("b")
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["b"],
+        nodes=[a, b],
+        edges=[
+            EdgeSpec(
+                id="retry",
+                source="a",
+                target="a",
+                condition=EdgeCondition.CONDITIONAL,
+                condition_expr="output.retry == true",
+            ),
+            EdgeSpec(id="a-b", source="a", target="b"),
+        ],
+    )
+    errors = graph.validate()["errors"]
+    assert not any("self-loop" in e for e in errors)
+
+
+def test_conditional_edge_without_expr_raises_error():
+    a = _node("a")
+    b = _node("b")
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["b"],
+        nodes=[a, b],
+        edges=[
+            EdgeSpec(id="a-b", source="a", target="b", condition=EdgeCondition.CONDITIONAL),
+        ],
+    )
+    errors = graph.validate()["errors"]
+    assert any("condition=CONDITIONAL" in e and "condition_expr" in e for e in errors)
+
+
+def test_conditional_edge_with_expr_is_valid():
+    a = _node("a")
+    b = _node("b")
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["b"],
+        nodes=[a, b],
+        edges=[
+            EdgeSpec(
+                id="a-b",
+                source="a",
+                target="b",
+                condition=EdgeCondition.CONDITIONAL,
+                condition_expr="output.score > 0.8",
+            ),
+        ],
+    )
+    errors = graph.validate()["errors"]
+    assert not any("condition_expr" in e for e in errors)
+
+
+def test_multiple_validation_errors_reported_together():
+    """All three bug classes can be reported in a single validate() call."""
+    a = _node("a")
+    b = _node("b")
+    graph = GraphSpec(
+        id="g",
+        goal_id="g1",
+        entry_node="a",
+        terminal_nodes=["b"],
+        nodes=[a, b],
+        edges=[
+            EdgeSpec(id="dup", source="a", target="b"),
+            EdgeSpec(id="dup", source="a", target="b"),
+            EdgeSpec(id="loop", source="a", target="a", condition=EdgeCondition.ALWAYS),
+            EdgeSpec(id="no-expr", source="a", target="b", condition=EdgeCondition.CONDITIONAL),
+        ],
+    )
+    errors = graph.validate()["errors"]
+    assert any("Duplicate edge ID" in e for e in errors)
+    assert any("unconditional self-loop" in e for e in errors)
+    assert any("condition_expr" in e for e in errors)


### PR DESCRIPTION
* Fixes #6090
* Added validation for duplicate edge IDs in `GraphSpec.validate()`
* Added validation to reject unconditional self-loops (`source == target` with `condition=ALWAYS`)
* Added validation for `CONDITIONAL` edges missing `condition_expr`
* Prevented silent graph execution failures and infinite-loop edge cases
* Added `tests/test_graph_spec_validation.py` with 8 test cases covering invalid and valid scenarios
* No behavior changes for valid graphs



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced graph validation now detects duplicate edge IDs, rejects unconditional self-loops, and identifies missing condition expressions in conditional edges.

* **Tests**
  * Added comprehensive test coverage for graph validation scenarios, including edge case handling and error aggregation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aden-hive/hive/pull/7220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->