### PR TITLE
fix: handle null max_context_tokens in config

### DIFF
--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -346,8 +346,10 @@ OPENROUTER_API_BASE = "https://openrouter.ai/api/v1"
 
 def get_max_context_tokens() -> int:
     """Return the configured max_context_tokens, falling back to DEFAULT_MAX_CONTEXT_TOKENS."""
-    return get_hive_config().get("llm", {}).get("max_context_tokens") or DEFAULT_MAX_CONTEXT_TOKENS
-
+    llm = get_hive_config().get("llm", {})
+    if "max_context_tokens" in llm and llm["max_context_tokens"] is not None:
+        return llm["max_context_tokens"]
+    return DEFAULT_MAX_CONTEXT_TOKENS
 
 def get_api_keys() -> list[str] | None:
     """Return a list of API keys if ``api_keys`` is configured, else ``None``.

--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -322,7 +322,7 @@ def get_worker_llm_extra_kwargs() -> dict[str, Any]:
 def get_worker_max_tokens() -> int:
     """Return max_tokens for the worker LLM, falling back to default."""
     worker_llm = get_hive_config().get("worker_llm", {})
-    if "max_tokens" in worker_llm and worker_llm["max_tokens"] is not None:
+    if worker_llm and "max_tokens" in worker_llm and worker_llm["max_tokens"] is not None:
         return worker_llm["max_tokens"]
     return get_max_tokens()
 
@@ -330,7 +330,7 @@ def get_worker_max_tokens() -> int:
 def get_worker_max_context_tokens() -> int:
     """Return max_context_tokens for the worker LLM, falling back to default."""
     worker_llm = get_hive_config().get("worker_llm", {})
-    if "max_context_tokens" in worker_llm and worker_llm["max_context_tokens"] is not None:
+    if worker_llm and "max_context_tokens" in worker_llm and worker_llm["max_context_tokens"] is not None:
         return worker_llm["max_context_tokens"]
     return get_max_context_tokens()
 

--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -346,7 +346,7 @@ OPENROUTER_API_BASE = "https://openrouter.ai/api/v1"
 
 def get_max_context_tokens() -> int:
     """Return the configured max_context_tokens, falling back to DEFAULT_MAX_CONTEXT_TOKENS."""
-    return get_hive_config().get("llm", {}).get("max_context_tokens", DEFAULT_MAX_CONTEXT_TOKENS)
+    return get_hive_config().get("llm", {}).get("max_context_tokens") or DEFAULT_MAX_CONTEXT_TOKENS
 
 
 def get_api_keys() -> list[str] | None:

--- a/core/framework/config.py
+++ b/core/framework/config.py
@@ -322,7 +322,7 @@ def get_worker_llm_extra_kwargs() -> dict[str, Any]:
 def get_worker_max_tokens() -> int:
     """Return max_tokens for the worker LLM, falling back to default."""
     worker_llm = get_hive_config().get("worker_llm", {})
-    if worker_llm and "max_tokens" in worker_llm:
+    if "max_tokens" in worker_llm and worker_llm["max_tokens"] is not None:
         return worker_llm["max_tokens"]
     return get_max_tokens()
 
@@ -330,15 +330,17 @@ def get_worker_max_tokens() -> int:
 def get_worker_max_context_tokens() -> int:
     """Return max_context_tokens for the worker LLM, falling back to default."""
     worker_llm = get_hive_config().get("worker_llm", {})
-    if worker_llm and "max_context_tokens" in worker_llm:
+    if "max_context_tokens" in worker_llm and worker_llm["max_context_tokens"] is not None:
         return worker_llm["max_context_tokens"]
     return get_max_context_tokens()
 
 
 def get_max_tokens() -> int:
     """Return the configured max_tokens, falling back to DEFAULT_MAX_TOKENS."""
-    return get_hive_config().get("llm", {}).get("max_tokens", DEFAULT_MAX_TOKENS)
-
+    llm = get_hive_config().get("llm", {})
+    if "max_tokens" in llm and llm["max_tokens"] is not None:
+        return llm["max_tokens"]
+    return DEFAULT_MAX_TOKENS
 
 DEFAULT_MAX_CONTEXT_TOKENS = 32_000
 OPENROUTER_API_BASE = "https://openrouter.ai/api/v1"

--- a/core/tests/test_config.py
+++ b/core/tests/test_config.py
@@ -2,6 +2,8 @@
 
 import logging
 
+from playwright.sync_api import expect
+
 from framework.config import get_api_base, get_hive_config, get_preferred_model, get_max_context_tokens, get_max_tokens, get_worker_max_tokens, get_worker_max_context_tokens
 
 
@@ -24,39 +26,59 @@ class TestGetHiveConfig:
 
     def test_get_max_context_tokens_handles_explicit_null(self, tmp_path, monkeypatch):
         """Test that explicit null max_context_tokens falls back to default."""
+        # baseline: absent key behaviour
+        baseline_path = tmp_path / "baseline_configuration.json"
+        baseline_path.write_text('{"llm": {}}')
+        monkeypatch.setattr("framework.config.HIVE_CONFIG_FILE", baseline_path)
+        expected = get_max_context_tokens()
+
         config_file = tmp_path / "configuration.json"
         config_file.write_text('{"llm": {"max_context_tokens": null}}')
         monkeypatch.setattr("framework.config.HIVE_CONFIG_FILE", config_file)
         result = get_max_context_tokens()
-        assert result is not None
-        assert isinstance(result, int)
+        assert expected == result
 
     def test_get_max_tokens_handles_explicit_null(self, tmp_path, monkeypatch):
         """Test that explicit null max_tokens falls back to default."""
+        # baseline: absent key behaviour
+        baseline_path = tmp_path / "baseline_configuration.json"
+        baseline_path.write_text('{"llm": {}}')
+        monkeypatch.setattr("framework.config.HIVE_CONFIG_FILE", baseline_path)
+        expected = get_max_tokens()
+
         config_file = tmp_path / "configuration.json"
         config_file.write_text('{"llm": {"max_tokens": null}}')
         monkeypatch.setattr("framework.config.HIVE_CONFIG_FILE", config_file)
         result = get_max_tokens()
-        assert result is not None
-        assert isinstance(result, int)
+        assert expected == result
 
     def test_get_worker_max_tokens_handles_explicit_null(self, tmp_path, monkeypatch):
         """Test that explicit null max_tokens for worker_llm falls back to default."""
+        # baseline: absent key behaviour
+        baseline_path = tmp_path / "baseline_configuration.json"
+        baseline_path.write_text('{"llm": {}}')
+        monkeypatch.setattr("framework.config.HIVE_CONFIG_FILE", baseline_path)
+        expected = get_worker_max_tokens()
+
         config_file = tmp_path / "configuration.json"
         config_file.write_text('{"worker_llm": {"max_tokens": null}}')
         monkeypatch.setattr("framework.config.HIVE_CONFIG_FILE", config_file)
         result = get_worker_max_tokens()
-        assert result is not None
-        assert isinstance(result, int)
+        assert expected == result
 
     def test_get_worker_max_context_tokens_handles_explicit_null(self, tmp_path, monkeypatch):
         """Test that explicit null max_context_tokens for worker_llm falls back to default."""
+        # baseline: absent key behaviour
+        baseline_path = tmp_path / "baseline_configuration.json"
+        baseline_path.write_text('{"llm": {}}')
+        monkeypatch.setattr("framework.config.HIVE_CONFIG_FILE", baseline_path)
+        expected = get_worker_max_context_tokens()
+
         config_file = tmp_path / "configuration.json"
         config_file.write_text('{"worker_llm": {"max_context_tokens": null}}')
         monkeypatch.setattr("framework.config.HIVE_CONFIG_FILE", config_file)
         result = get_worker_max_context_tokens()
-        assert result is not None
-        assert isinstance(result, int)
+        assert expected == result
 
 
 class TestOpenRouterConfig:

--- a/core/tests/test_config.py
+++ b/core/tests/test_config.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from framework.config import get_api_base, get_hive_config, get_preferred_model
+from framework.config import get_api_base, get_hive_config, get_preferred_model, get_max_context_tokens, get_max_tokens, get_worker_max_tokens, get_worker_max_context_tokens
 
 
 class TestGetHiveConfig:
@@ -21,6 +21,42 @@ class TestGetHiveConfig:
         assert result == {}
         assert "Failed to load Hive config" in caplog.text
         assert str(config_file) in caplog.text
+
+    def test_get_max_context_tokens_handles_explicit_null(self, tmp_path, monkeypatch):
+        """Test that explicit null max_context_tokens falls back to default."""
+        config_file = tmp_path / "configuration.json"
+        config_file.write_text('{"llm": {"max_context_tokens": null}}')
+        monkeypatch.setattr("framework.config.HIVE_CONFIG_FILE", config_file)
+        result = get_max_context_tokens()
+        assert result is not None
+        assert isinstance(result, int)
+
+    def test_get_max_tokens_handles_explicit_null(self, tmp_path, monkeypatch):
+        """Test that explicit null max_tokens falls back to default."""
+        config_file = tmp_path / "configuration.json"
+        config_file.write_text('{"llm": {"max_tokens": null}}')
+        monkeypatch.setattr("framework.config.HIVE_CONFIG_FILE", config_file)
+        result = get_max_tokens()
+        assert result is not None
+        assert isinstance(result, int)
+
+    def test_get_worker_max_tokens_handles_explicit_null(self, tmp_path, monkeypatch):
+        """Test that explicit null max_tokens for worker_llm falls back to default."""
+        config_file = tmp_path / "configuration.json"
+        config_file.write_text('{"worker_llm": {"max_tokens": null}}')
+        monkeypatch.setattr("framework.config.HIVE_CONFIG_FILE", config_file)
+        result = get_worker_max_tokens()
+        assert result is not None
+        assert isinstance(result, int)
+
+    def test_get_worker_max_context_tokens_handles_explicit_null(self, tmp_path, monkeypatch):
+        """Test that explicit null max_context_tokens for worker_llm falls back to default."""
+        config_file = tmp_path / "configuration.json"
+        config_file.write_text('{"worker_llm": {"max_context_tokens": null}}')
+        monkeypatch.setattr("framework.config.HIVE_CONFIG_FILE", config_file)
+        result = get_worker_max_context_tokens()
+        assert result is not None
+        assert isinstance(result, int)
 
 
 class TestOpenRouterConfig:

--- a/quickstart.ps1
+++ b/quickstart.ps1
@@ -166,49 +166,49 @@ function Test-DefenderExclusions {
         Hashtable with DefenderEnabled, MissingPaths, and optional Error
     #>
     param([string[]]$Paths)
-    
+
     # Security: Define safe path prefixes (project + user directories only)
     $safePrefixes = @(
         $ScriptDir,         # Project directory
         $env:LOCALAPPDATA,  # User local appdata
         $env:APPDATA        # User roaming appdata
     )
-    
+
     # Normalize and filter null/empty values
     $safePrefixes = $safePrefixes | Where-Object { $_ } | ForEach-Object {
         try { [System.IO.Path]::GetFullPath($_) } catch { $null }
     } | Where-Object { $_ }
-    
+
     try {
         # Check if Defender cmdlets are available (may not exist on older Windows)
         $mpModule = Get-Module -ListAvailable -Name Defender -ErrorAction SilentlyContinue
         if (-not $mpModule) {
-            return @{ 
+            return @{
                 DefenderEnabled = $false
                 Error = "Windows Defender module not available"
             }
         }
-        
+
         # Check if Defender is running
         $status = Get-MpComputerStatus -ErrorAction Stop
         if (-not $status.RealTimeProtectionEnabled) {
-            return @{ 
+            return @{
                 DefenderEnabled = $false
                 Reason = "Real-time protection is disabled"
             }
         }
-        
+
         # Get current exclusions
         $prefs = Get-MpPreference -ErrorAction Stop
         $existing = $prefs.ExclusionPath
         if (-not $existing) { $existing = @() }
-        
+
         # Normalize existing paths for comparison (some may contain wildcards
         # or env vars that GetFullPath rejects — skip those gracefully)
         $existing = $existing | Where-Object { $_ } | ForEach-Object {
             try { [System.IO.Path]::GetFullPath($_) } catch { $_ }
         }
-        
+
         # Normalize paths and find missing exclusions
         $missing = @()
         foreach ($path in $Paths) {
@@ -217,7 +217,7 @@ function Test-DefenderExclusions {
             } catch {
                 continue  # Skip paths with unsupported format
             }
-            
+
             # Security: Ensure path is within safe boundaries
             $isSafe = $false
             foreach ($prefix in $safePrefixes) {
@@ -226,17 +226,17 @@ function Test-DefenderExclusions {
                     break
                 }
             }
-            
+
             if (-not $isSafe) {
                 Write-Warn "Security: Refusing to exclude path outside safe boundaries: $normalized"
                 continue
             }
-            
+
             # Info: Warn if path doesn't exist yet (but still process it)
             if (-not (Test-Path $path -ErrorAction SilentlyContinue)) {
                 Write-Verbose "Path does not exist yet: $path (will be excluded when created)"
             }
-            
+
             # Check if path is already excluded (or is a child of an excluded path)
             $alreadyExcluded = $false
             foreach ($excluded in $existing) {
@@ -245,19 +245,19 @@ function Test-DefenderExclusions {
                     break
                 }
             }
-            
+
             if (-not $alreadyExcluded) {
                 $missing += $normalized
             }
         }
-        
+
         return @{
             DefenderEnabled = $true
             MissingPaths = $missing
             ExistingPaths = $existing
         }
     } catch {
-        return @{ 
+        return @{
             DefenderEnabled = $false
             Error = $_.Exception.Message
         }
@@ -276,7 +276,7 @@ function Test-IsDefenderEnabled {
         if (-not $mpModule) {
             return $false
         }
-        
+
         $status = Get-MpComputerStatus -ErrorAction Stop
         return $status.RealTimeProtectionEnabled
     } catch {
@@ -295,10 +295,10 @@ function Add-DefenderExclusions {
         Hashtable with Added and Failed arrays
     #>
     param([string[]]$Paths)
-    
+
     $added = @()
     $failed = @()
-    
+
     foreach ($path in $Paths) {
         try {
             try {
@@ -309,14 +309,14 @@ function Add-DefenderExclusions {
             Add-MpPreference -ExclusionPath $normalized -ErrorAction Stop
             $added += $normalized
         } catch {
-            $failed += @{ 
+            $failed += @{
                 Path = $path
                 Error = $_.Exception.Message
             }
         }
     }
-    
-    return @{ 
+
+    return @{
         Added = $added
         Failed = $failed
     }
@@ -657,37 +657,37 @@ if (-not $checkResult.DefenderEnabled) {
         Write-Color -Text "  - $path" -Color Cyan
     }
     Write-Host ""
-    
+
     # Security notice
     Write-Color -Text "⚠️  Security Trade-off:" -Color Yellow
     Write-Host "Adding exclusions improves performance but reduces real-time protection."
     Write-Host "Only proceed if you trust this project and its dependencies."
     Write-Host ""
-    
+
     # Prompt for consent (default = No for security)
     if (Prompt-YesNo "Add these Defender exclusions?" "n") {
         Write-Host ""
-        
+
         # Check admin privileges
         if (-not (Test-IsAdmin)) {
             Write-Warn "Administrator privileges required to modify Defender settings."
             Write-Host ""
             Write-Color -Text "To add exclusions manually, run PowerShell as Administrator and paste:" -Color White
             Write-Host ""
-            
+
             foreach ($path in $checkResult.MissingPaths) {
                 $cmd = "Add-MpPreference -ExclusionPath '$path'"
                 Write-Color -Text "  $cmd" -Color Cyan
             }
-            
+
             Write-Host ""
             Write-Color -Text "Or copy all commands to clipboard? [y/N]" -Color White
             $copyChoice = Read-Host
             if ($copyChoice -match "^[Yy]") {
-                $commands = ($checkResult.MissingPaths | ForEach-Object { 
-                    "Add-MpPreference -ExclusionPath '$_'" 
+                $commands = ($checkResult.MissingPaths | ForEach-Object {
+                    "Add-MpPreference -ExclusionPath '$_'"
                 }) -join "`r`n"
-                
+
                 try {
                     Set-Clipboard -Value $commands
                     Write-Ok "Commands copied to clipboard"
@@ -704,7 +704,7 @@ if (-not $checkResult.DefenderEnabled) {
             } else {
                 # Add exclusions
                 Write-Host "  Adding exclusions... " -NoNewline
-                
+
                 # Re-check paths in case something changed
                 $freshCheck = Test-DefenderExclusions -Paths $pathsToExclude
                 if ($freshCheck.MissingPaths.Count -eq 0) {
@@ -712,17 +712,17 @@ if (-not $checkResult.DefenderEnabled) {
                     Write-Host "  (Exclusions were added by another process)"
                 } else {
                     $result = Add-DefenderExclusions -Paths $freshCheck.MissingPaths
-                    
+
                     if ($result.Added.Count -gt 0) {
                         Write-Ok "done"
                         foreach ($path in $result.Added) {
                             Write-Ok "Excluded: $path"
                         }
                     }
-                    
+
                     if ($result.Failed.Count -gt 0) {
                         Write-Host ""
-                        
+
                         # Calculate and show success rate
                         $totalPaths = $result.Added.Count + $result.Failed.Count
                         if ($totalPaths -gt 0) {
@@ -731,7 +731,7 @@ if (-not $checkResult.DefenderEnabled) {
                             Write-Host "Performance benefit may be reduced."
                             Write-Host ""
                         }
-                        
+
                         Write-Warn "Failed exclusions:"
                         foreach ($failure in $result.Failed) {
                             Write-Warn "  $($failure.Path): $($failure.Error)"
@@ -769,7 +769,7 @@ $modulesToCheck = @("framework", "aden_tools", "litellm")
 try {
     $checkOutput = & $UvCmd run python scripts/check_requirements.py @modulesToCheck 2>&1 | Out-String
     $resultJson = $null
-    
+
     # Try to parse JSON result
     try {
         $resultJson = $checkOutput | ConvertFrom-Json
@@ -778,12 +778,12 @@ try {
         Write-Host $checkOutput
         exit 1
     }
-    
+
     # Display results for each module
     foreach ($imp in $imports) {
         Write-Host "  $($imp.Label)... " -NoNewline
         $status = $resultJson.$($imp.Module)
-        
+
         if ($status -eq "ok") {
             Write-Ok "ok"
         } elseif ($imp.Required) {
@@ -1000,7 +1000,11 @@ function Get-ModelSelection {
         return @{ Model = (Get-DefaultModel $ProviderId); MaxTokens = 8192; MaxContextTokens = 120000 }
     }
     if ($choices.Count -eq 1) {
-        return @{ Model = $choices[0].Id; MaxTokens = $choices[0].MaxTokens; MaxContextTokens = $choices[0].MaxContextTokens }
+        return @{
+            Model = $choices[0].Id
+            MaxTokens = if ($choices[0].MaxTokens) { $choices[0].MaxTokens } else { 8192 }
+            MaxContextTokens = if ($choices[0].MaxContextTokens) { $choices[0].MaxContextTokens } else { 120000 }
+        }
     }
 
     # Find default index from previous model (if same provider)
@@ -1033,7 +1037,11 @@ function Get-ModelSelection {
                 $sel = $choices[$num - 1]
                 Write-Host ""
                 Write-Ok "Model: $($sel.Id)"
-                return @{ Model = $sel.Id; MaxTokens = $sel.MaxTokens; MaxContextTokens = $sel.MaxContextTokens }
+                return @{
+                    Model = $sel.Id
+                    MaxTokens = if ($sel.MaxTokens) { $sel.MaxTokens } else { 8192 }
+                    MaxContextTokens = if ($sel.MaxContextTokens) { $sel.MaxContextTokens } else { 120000 }
+                }
             }
         }
         Write-Color -Text "Invalid choice. Please enter 1-$($choices.Count)" -Color Red
@@ -1584,7 +1592,7 @@ switch ($num) {
             }
         }
         Write-Host ""
-        
+
         while ($true) {
             $raw = Read-Host "Enter choice (1-$($ollamaModels.Count)) [$defaultIdx]"
             if ([string]::IsNullOrWhiteSpace($raw)) { $raw = $defaultIdx }
@@ -2078,7 +2086,7 @@ $verifyModules = @("framework", "aden_tools")
 try {
     $verifyOutput = & $UvCmd run python scripts/check_requirements.py @verifyModules 2>&1 | Out-String
     $verifyJson = $null
-    
+
     try {
         $verifyJson = $verifyOutput | ConvertFrom-Json
     } catch {
@@ -2091,12 +2099,12 @@ try {
             else { Write-Fail "failed"; $verifyErrors++ }
         }
     }
-    
+
     if ($verifyJson) {
         Write-Host "  $([char]0x2B21) framework... " -NoNewline
         if ($verifyJson.framework -eq "ok") { Write-Ok "ok" }
         else { Write-Fail "failed"; $verifyErrors++ }
-        
+
         Write-Host "  $([char]0x2B21) aden_tools... " -NoNewline
         if ($verifyJson.aden_tools -eq "ok") { Write-Ok "ok" }
         else { Write-Fail "failed"; $verifyErrors++ }


### PR DESCRIPTION
## Description

Fixes a crash in the queen loop when max_context_tokens is explicitly set to null in configuration.json.

The previous implementation relied on dict.get(key, default), which only returns the default when the key is missing. If the key exists with a value of null, None is returned instead, which later causes a TypeError when publish_context_usage() evaluates max_context_tokens > 0.

Also fixes the root cause in quickstart.ps1 where Get-ModelSelection could 
return null for MaxTokens and MaxContextTokens when a provider's model 
entry doesn't define them.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #7227

## Changes Made

- `config.py`: Fixed null handling in `get_max_context_tokens()`, `get_max_tokens()`, 
  `get_worker_max_context_tokens()`, and `get_worker_max_tokens()` to treat explicit 
  `null` as missing
- `quickstart.ps1`: Fixed `Get-ModelSelection` to fall back to `8192`/`120000` 
  when `MaxTokens`/`MaxContextTokens` are null in model entries

## Testing
- [x] Unit tests added for all four fixed config functions
- [x] Manual testing performed — confirmed queen loop no longer crashes with 
  `null` values in `configuration.json`
- [x] Existing tests pass: `cd core && uv run pytest tests/ -v`


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Reproduction & Verification

**Before fix: checking configuration.json after running quickstart.ps1 with Gemini:**
```bash
cat ~/.hive/configuration.json | grep -E "max_tokens|max_context_tokens"
```
**Output:**
"max_context_tokens": null,
"max_tokens": null

**Crash log before fix:**
[_queen_loop] Queen conversation crashed: '>' not supported between
instances of 'NoneType' and 'int'
[_queen_loop] Queen loop exiting - clearing queen_executor for session...

**After fix: same command shows:**
```bash
cat ~/.hive/configuration.json | grep -E "max_tokens|max_context_tokens"
```
"max_context_tokens": 120000,
"max_tokens": 8192
Queen loop starts successfully with no crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration now treats explicitly null token/context values as "not configured", reliably falling back to defaults so token limits are applied correctly.
* **Improvements**
  * Quickstart on Windows: clearer security notice and consent flow for exclusions, better reporting of added/failed exclusions, and fallback/manual commands when admin rights are unavailable.
  * Model-selection in the quickstart defaults token/context limits only when values are omitted.
* **Tests**
  * Added tests verifying null-config fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aden-hive/hive/pull/7229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->