### PR TITLE
Fix/6391 use multi sse session reconnect

### DIFF
--- a/core/frontend/src/hooks/multi-sse-diff.test.ts
+++ b/core/frontend/src/hooks/multi-sse-diff.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { agentTypesToClose, connectionsToOpen } from "./multi-sse-diff";
+
+describe("multi-sse-diff", () => {
+  it("closes when agent type is removed from sessions", () => {
+    const current = new Map([["queen-dm", { sessionId: "s1" }]]);
+    expect(agentTypesToClose(current, {})).toEqual(["queen-dm"]);
+  });
+
+  it("closes when session ID changes for the same agent type", () => {
+    const current = new Map([["researcher-agent", { sessionId: "session_abc123" }]]);
+    const sessions = { "researcher-agent": "session_xyz789" };
+    expect(agentTypesToClose(current, sessions)).toEqual(["researcher-agent"]);
+  });
+
+  it("does not close when agent type and session ID are unchanged", () => {
+    const current = new Map([["queen-dm", { sessionId: "s1" }]]);
+    expect(agentTypesToClose(current, { "queen-dm": "s1" })).toEqual([]);
+  });
+
+  it("opens a new connection when agent type is new", () => {
+    expect(connectionsToOpen(new Map(), { "queen-dm": "s1" })).toEqual([
+      { agentType: "queen-dm", sessionId: "s1" },
+    ]);
+  });
+
+  it("opens when session ID changes after stale entry would be closed", () => {
+    const current = new Map([["researcher-agent", { sessionId: "session_abc123" }]]);
+    const sessions = { "researcher-agent": "session_xyz789" };
+    expect(connectionsToOpen(current, sessions)).toEqual([
+      { agentType: "researcher-agent", sessionId: "session_xyz789" },
+    ]);
+  });
+
+  it("does not open when session ID is unchanged", () => {
+    const current = new Map([["queen-dm", { sessionId: "s1" }]]);
+    expect(connectionsToOpen(current, { "queen-dm": "s1" })).toEqual([]);
+  });
+
+  it("skips empty session IDs", () => {
+    expect(connectionsToOpen(new Map(), { "queen-dm": "" })).toEqual([]);
+  });
+
+  it("reconnect flow: close then open on session restart", () => {
+    const before = new Map([["colony-worker", { sessionId: "old" }]]);
+    const afterSessions = { "colony-worker": "new" };
+    const toClose = agentTypesToClose(before, afterSessions);
+    expect(toClose).toEqual(["colony-worker"]);
+
+    const mid = new Map(before);
+    for (const agentType of toClose) mid.delete(agentType);
+    expect(connectionsToOpen(mid, afterSessions)).toEqual([
+      { agentType: "colony-worker", sessionId: "new" },
+    ]);
+  });
+});

--- a/core/frontend/src/hooks/multi-sse-diff.ts
+++ b/core/frontend/src/hooks/multi-sse-diff.ts
@@ -1,0 +1,39 @@
+/** Tracked SSE connection metadata (EventSource lives in the hook ref). */
+export interface SSEConnectionMeta {
+  sessionId: string;
+}
+
+/**
+ * Agent types whose EventSource should be closed: removed from `sessions` or
+ * bound to a different session ID.
+ */
+export function agentTypesToClose(
+  current: ReadonlyMap<string, SSEConnectionMeta>,
+  sessions: Record<string, string>,
+): string[] {
+  const desired = new Set(Object.keys(sessions));
+  const toClose: string[] = [];
+  for (const [agentType, entry] of current) {
+    if (!desired.has(agentType) || sessions[agentType] !== entry.sessionId) {
+      toClose.push(agentType);
+    }
+  }
+  return toClose;
+}
+
+/**
+ * Agent types that need a new EventSource: missing entry or session ID changed.
+ */
+export function connectionsToOpen(
+  current: ReadonlyMap<string, SSEConnectionMeta>,
+  sessions: Record<string, string>,
+): Array<{ agentType: string; sessionId: string }> {
+  const toOpen: Array<{ agentType: string; sessionId: string }> = [];
+  for (const [agentType, sessionId] of Object.entries(sessions)) {
+    if (!sessionId) continue;
+    const existing = current.get(agentType);
+    if (existing?.sessionId === sessionId) continue;
+    toOpen.push({ agentType, sessionId });
+  }
+  return toOpen;
+}

--- a/core/frontend/src/hooks/use-sse.ts
+++ b/core/frontend/src/hooks/use-sse.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback, useState } from "react";
 import type { AgentEvent, EventTypeName } from "@/api/types";
+import { agentTypesToClose, connectionsToOpen } from "./multi-sse-diff";
 
 interface UseSSEOptions {
   sessionId: string;
@@ -73,50 +74,31 @@ interface UseMultiSSEOptions {
 }
 
 /**
- * Manages one EventSource per loaded session. Diffs `sessions` on each render:
- * opens new connections, closes removed ones, leaves existing ones alone.
+ * Manages one EventSource per loaded session. Diffs `sessions` on each change:
+ * opens new connections, closes removed agents, and reconnects when the session
+ * ID changes for an existing agent type.
  */
 export function useMultiSSE({ sessions, onEvent }: UseMultiSSEOptions) {
   const onEventRef = useRef(onEvent);
   onEventRef.current = onEvent;
 
-  // Track both the EventSource and its session ID so we can detect session changes
   const sourcesRef = useRef(new Map<string, { es: EventSource; sessionId: string }>());
 
-  // Diff-based open/close — runs on every `sessions` change
   useEffect(() => {
     const current = sourcesRef.current;
-    const desired = new Set(Object.keys(sessions));
 
-    // Close connections for removed agents OR changed session IDs
-    for (const [agentType, entry] of current) {
-      if (!desired.has(agentType) || sessions[agentType] !== entry.sessionId) {
-        console.log('[SSE] closing:', agentType, entry.sessionId, desired.has(agentType) ? '(session changed)' : '(removed)');
-        entry.es.close();
-        current.delete(agentType);
-      }
+    for (const agentType of agentTypesToClose(current, sessions)) {
+      current.get(agentType)?.es.close();
+      current.delete(agentType);
     }
 
-    // Open connections for new/changed sessions
-    for (const [agentType, sessionId] of Object.entries(sessions)) {
-      if (!sessionId || current.has(agentType)) continue;
-
+    for (const { agentType, sessionId } of connectionsToOpen(current, sessions)) {
       const url = `/api/sessions/${sessionId}/events`;
-      console.log('[SSE] opening:', agentType, sessionId);
       const es = new EventSource(url);
-
-      es.onopen = () => {
-        console.log('[SSE] connected:', agentType, sessionId);
-      };
-
-      es.onerror = () => {
-        console.error('[SSE] error:', agentType, sessionId, 'readyState:', es.readyState);
-      };
 
       es.onmessage = (e: MessageEvent) => {
         try {
           const event: AgentEvent = JSON.parse(e.data);
-          console.log('[SSE] received:', agentType, event.type, event.stream_id, event.node_id);
           onEventRef.current(agentType, event);
         } catch {
           // Ignore parse errors (keepalive comments)
@@ -127,7 +109,6 @@ export function useMultiSSE({ sessions, onEvent }: UseMultiSSEOptions) {
     }
   }, [sessions]);
 
-  // Close all on unmount only
   useEffect(() => {
     return () => {
       for (const entry of sourcesRef.current.values()) entry.es.close();


### PR DESCRIPTION
Fixes #6391

## Summary
Reconnect `useMultiSSE` when the session ID changes for the same agent type so SSE events continue after session restart without a page refresh.

## Changes
- Add `multi-sse-diff.ts` with explicit close/open rules
- Refactor `useMultiSSE` to use those helpers (removes debug console logging)
- Add Vitest tests in `multi-sse-diff.test.ts`

## Testing
- [x] `cd core/frontend && npm test`
- [x] `cd core/frontend && npm run build`
- [ ] Manual: restart session in queen DM / colony chat, confirm streaming works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved SSE connection management for more reliable open/close and reconnect behavior; reduced noisy logging and simplified per-connection event handling.

* **Tests**
  * Added comprehensive tests covering SSE connection lifecycle, session changes, reconnect flows, and edge cases to ensure stable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->