### PR TITLE
fix: validate queen route path segments

### DIFF
--- a/core/framework/server/routes_queens.py
+++ b/core/framework/server/routes_queens.py
@@ -23,6 +23,7 @@ from framework.agents.queen.queen_profiles import (
     update_queen_profile,
 )
 from framework.config import QUEENS_DIR
+from framework.server.app import safe_path_segment
 
 logger = logging.getLogger(__name__)
 
@@ -157,7 +158,7 @@ def _transform_profile_for_api(profile: dict) -> dict:
 
 async def handle_get_profile(request: web.Request) -> web.Response:
     """GET /api/queen/{queen_id}/profile — get full queen profile."""
-    queen_id = request.match_info["queen_id"]
+    queen_id = safe_path_segment(request.match_info["queen_id"])
     ensure_default_queens()
     try:
         profile = load_queen_profile(queen_id)
@@ -198,7 +199,7 @@ def _reverse_transform_for_yaml(body: dict) -> dict:
 
 async def handle_update_profile(request: web.Request) -> web.Response:
     """PATCH /api/queen/{queen_id}/profile — update queen profile fields."""
-    queen_id = request.match_info["queen_id"]
+    queen_id = safe_path_segment(request.match_info["queen_id"])
     try:
         body = await request.json()
     except Exception:
@@ -231,7 +232,7 @@ async def handle_queen_session(request: web.Request) -> web.Response:
     """
     from framework.server.session_manager import SessionManager
 
-    queen_id = request.match_info["queen_id"]
+    queen_id = safe_path_segment(request.match_info["queen_id"])
     manager: SessionManager = request.app["manager"]
 
     ensure_default_queens()
@@ -332,7 +333,7 @@ async def handle_queen_session(request: web.Request) -> web.Response:
 
 async def handle_select_queen_session(request: web.Request) -> web.Response:
     """POST /api/queen/{queen_id}/session/select -- resume a specific queen session."""
-    queen_id = request.match_info["queen_id"]
+    queen_id = safe_path_segment(request.match_info["queen_id"])
     manager = request.app["manager"]
 
     ensure_default_queens()
@@ -345,7 +346,7 @@ async def handle_select_queen_session(request: web.Request) -> web.Response:
     target_session_id = body.get("session_id")
     if not isinstance(target_session_id, str) or not target_session_id.strip():
         return web.json_response({"error": "session_id is required"}, status=400)
-    target_session_id = target_session_id.strip()
+    target_session_id = safe_path_segment(target_session_id.strip())
 
     if not _session_belongs_to_queen(manager, target_session_id, queen_id):
         return web.json_response(
@@ -387,7 +388,7 @@ async def handle_new_queen_session(request: web.Request) -> web.Response:
     """POST /api/queen/{queen_id}/session/new -- create a fresh queen session."""
     from framework.tools.queen_lifecycle_tools import QUEEN_PHASES
 
-    queen_id = request.match_info["queen_id"]
+    queen_id = safe_path_segment(request.match_info["queen_id"])
     manager = request.app["manager"]
 
     ensure_default_queens()
@@ -446,7 +447,7 @@ async def handle_upload_avatar(request: web.Request) -> web.Response:
     """
     from framework.config import QUEENS_DIR
 
-    queen_id = request.match_info["queen_id"]
+    queen_id = safe_path_segment(request.match_info["queen_id"])
     queen_dir = QUEENS_DIR / queen_id
     if not (queen_dir / "profile.yaml").exists():
         return web.json_response({"error": f"Queen '{queen_id}' not found"}, status=404)
@@ -500,7 +501,7 @@ async def handle_get_avatar(request: web.Request) -> web.Response:
     """GET /api/queen/{queen_id}/avatar — serve queen avatar image."""
     from framework.config import QUEENS_DIR
 
-    queen_id = request.match_info["queen_id"]
+    queen_id = safe_path_segment(request.match_info["queen_id"])
     queen_dir = QUEENS_DIR / queen_id
 
     # Find avatar file with any supported extension

--- a/core/framework/server/tests/test_api.py
+++ b/core/framework/server/tests/test_api.py
@@ -608,6 +608,35 @@ class TestMessageBootstrap:
 
 class TestQueenSessionSelection:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method", "path", "kwargs"),
+        [
+            ("get", "/api/queen/..%2Ftmp/profile", {}),
+            ("patch", "/api/queen/..%2Ftmp/profile", {"json": {"title": "x"}}),
+            ("post", "/api/queen/..%2Ftmp/session", {"json": {}}),
+            ("post", "/api/queen/..%2Ftmp/session/new", {"json": {}}),
+            ("post", "/api/queen/..%2Ftmp/session/select", {"json": {"session_id": "session_ok"}}),
+            ("get", "/api/queen/..%2Ftmp/avatar", {}),
+            ("post", "/api/queen/..%2Ftmp/avatar", {"data": {}}),
+        ],
+    )
+    async def test_queen_routes_reject_unsafe_queen_id(self, method, path, kwargs):
+        app = create_app()
+        async with TestClient(TestServer(app)) as client:
+            resp = await getattr(client, method)(path, **kwargs)
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_select_queen_session_rejects_unsafe_session_id(self):
+        app = create_app()
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/queen/queen_technology/session/select",
+                json={"session_id": "../other_session"},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
     async def test_select_queen_session_rejects_foreign_session(self, monkeypatch, tmp_path):
         _patch_queen_storage(monkeypatch, tmp_path)
         _write_queen_session(tmp_path, "queen_growth", "other_session", {"queen_id": "queen_growth"})


### PR DESCRIPTION
## Summary
- validate queen_id route params on queen profile, session, and avatar endpoints
- validate the body-sourced session_id used by queen session selection
- add regression coverage for encoded slash traversal attempts across the queen routes

Closes #7099

## Tests
- cd core && uv run python -m pytest framework/server/tests/test_api.py::TestQueenSessionSelection::test_queen_routes_reject_unsafe_queen_id framework/server/tests/test_api.py::TestQueenSessionSelection::test_select_queen_session_rejects_unsafe_session_id framework/server/tests/test_api.py::TestQueenSessionSelection::test_select_queen_session_rejects_foreign_session framework/server/tests/test_api.py::TestQueenSessionSelection::test_select_queen_session_returns_live_session_without_duplication framework/server/tests/test_api.py::TestQueenSessionSelection::test_new_queen_session_creates_fresh_thread -q
- cd core && uv run ruff check framework/server/routes_queens.py framework/server/tests/test_api.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of queen identifiers and session tokens to ensure secure and reliable access to profiles and sessions.

* **Tests**
  * Added new security and validation test coverage for queen routing endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->