### PR TITLE
chore(micro-fix): upgrade MiniMax default model to M3

### DIFF
--- a/core/framework/llm/model_catalog.json
+++ b/core/framework/llm/model_catalog.json
@@ -159,12 +159,25 @@
       ]
     },
     "minimax": {
-      "default_model": "MiniMax-M2.7",
+      "default_model": "MiniMax-M3",
       "models": [
         {
-          "id": "MiniMax-M2.7",
-          "label": "MiniMax M2.7 - Best coding quality",
+          "id": "MiniMax-M3",
+          "label": "MiniMax M3 - Best coding quality",
           "recommended": true,
+          "max_tokens": 128000,
+          "max_context_tokens": 512000,
+          "pricing_usd_per_mtok": {
+            "input": 0.60,
+            "output": 2.40,
+            "cache_read": 0.12
+          },
+          "supports_vision": true
+        },
+        {
+          "id": "MiniMax-M2.7",
+          "label": "MiniMax M2.7 - Previous generation",
+          "recommended": false,
           "max_tokens": 40960,
           "max_context_tokens": 180000,
           "pricing_usd_per_mtok": {
@@ -174,8 +187,8 @@
           "supports_vision": false
         },
         {
-          "id": "MiniMax-M2.5",
-          "label": "MiniMax M2.5 - Strong value",
+          "id": "MiniMax-M2.7-highspeed",
+          "label": "MiniMax M2.7 Highspeed - Low latency",
           "recommended": false,
           "max_tokens": 40960,
           "max_context_tokens": 180000,
@@ -462,9 +475,9 @@
     "minimax_code": {
       "provider": "minimax",
       "api_key_env_var": "MINIMAX_API_KEY",
-      "model": "MiniMax-M2.7",
-      "max_tokens": 40960,
-      "max_context_tokens": 180800,
+      "model": "MiniMax-M3",
+      "max_tokens": 128000,
+      "max_context_tokens": 512000,
       "api_base": "https://api.minimax.io/v1"
     },
     "kimi_code": {

--- a/core/frontend/src/context/ModelContext.tsx
+++ b/core/frontend/src/context/ModelContext.tsx
@@ -24,7 +24,7 @@ export const LLM_PROVIDERS: ProviderInfo[] = [
   { id: "gemini", name: "Google Gemini", description: "Gemini 3 family - Fast and best quality", envVar: "GEMINI_API_KEY", initial: "G" },
   { id: "groq", name: "Groq", description: "Ultra-fast inference, GPT-OSS and Llama", envVar: "GROQ_API_KEY", initial: "G" },
   { id: "cerebras", name: "Cerebras", description: "Ultra-fast inference, GPT-OSS and Z.ai GLM", envVar: "CEREBRAS_API_KEY", initial: "C" },
-  { id: "minimax", name: "MiniMax", description: "MiniMax M2.7 and M2.5 - Best coding quality", envVar: "MINIMAX_API_KEY", initial: "M" },
+  { id: "minimax", name: "MiniMax", description: "MiniMax M3 - Best coding quality", envVar: "MINIMAX_API_KEY", initial: "M" },
   { id: "openrouter", name: "OpenRouter", description: "200+ models, any provider", envVar: "OPENROUTER_API_KEY", initial: "O" },
   { id: "mistral", name: "Mistral", description: "Mistral Large, Medium, Small, Codestral", envVar: "MISTRAL_API_KEY", initial: "M" },
   { id: "together", name: "Together AI", description: "DeepSeek, Qwen3, GPT-OSS, Llama", envVar: "TOGETHER_API_KEY", initial: "T" },

--- a/core/tests/test_capabilities.py
+++ b/core/tests/test_capabilities.py
@@ -22,6 +22,7 @@ class TestSupportsImageToolResults:
             "gpt-5.4-mini",
             "gemini-3-flash-preview",
             "kimi-k2.5",
+            "MiniMax-M3",
             # Provider-prefixed catalog entries
             "openrouter/openai/gpt-5.4",
             "openrouter/anthropic/claude-sonnet-4.6",
@@ -43,6 +44,7 @@ class TestSupportsImageToolResults:
             "glm-5.1",
             "queen",
             "MiniMax-M2.7",
+            "MiniMax-M2.7-highspeed",
             "codestral-2508",
             "llama-3.3-70b-versatile",
             # Provider-prefixed forms resolve to the same catalog entry

--- a/core/tests/test_model_catalog.py
+++ b/core/tests/test_model_catalog.py
@@ -78,13 +78,15 @@ def test_minimax_catalog_tracks_current_non_legacy_text_models():
     minimax_default = model_catalog.get_default_models()["minimax"]
     minimax_models = model_catalog.get_models_catalogue()["minimax"]
 
-    assert minimax_default == "MiniMax-M2.7"
+    assert minimax_default == "MiniMax-M3"
     assert [model["id"] for model in minimax_models] == [
+        "MiniMax-M3",
         "MiniMax-M2.7",
-        "MiniMax-M2.5",
+        "MiniMax-M2.7-highspeed",
     ]
-    assert all(model["max_context_tokens"] == 180000 for model in minimax_models)
-    assert all(model["max_tokens"] == 40960 for model in minimax_models)
+    assert minimax_models[0]["max_context_tokens"] == 512000
+    assert minimax_models[0]["max_tokens"] == 128000
+    assert minimax_models[0]["supports_vision"] is True
 
 
 def test_mistral_catalog_tracks_current_curated_models():
@@ -189,9 +191,9 @@ def test_minimax_preset_uses_current_default_model():
     preset = model_catalog.get_preset("minimax_code")
 
     assert preset is not None
-    assert preset["model"] == "MiniMax-M2.7"
-    assert preset["max_tokens"] == 40960
-    assert preset["max_context_tokens"] == 180800
+    assert preset["model"] == "MiniMax-M3"
+    assert preset["max_tokens"] == 128000
+    assert preset["max_context_tokens"] == 512000
 
 
 def test_load_model_catalog_rejects_duplicate_model_ids(tmp_path, monkeypatch):

--- a/quickstart.ps1
+++ b/quickstart.ps1
@@ -1369,7 +1369,7 @@ switch ($num) {
         Apply-Preset "minimax_code"
         Write-Host ""
         Write-Ok "Using MiniMax coding key"
-        Write-Color -Text "  Model: MiniMax-M2.7 | API: api.minimax.io" -Color DarkGray
+        Write-Color -Text "  Model: MiniMax-M3 | API: api.minimax.io" -Color DarkGray
     }
     5 {
         # Kimi Code Subscription

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -1459,7 +1459,7 @@ case $choice in
         SIGNUP_URL="https://platform.minimax.io/user-center/basic-information/interface-key"
         echo ""
         echo -e "${GREEN}⬢${NC} Using MiniMax coding key"
-        echo -e "  ${DIM}Model: MiniMax-M2.7 | API: api.minimax.io${NC}"
+        echo -e "  ${DIM}Model: MiniMax-M3 | API: api.minimax.io${NC}"
         ;;
     5)
         # Kimi Code Subscription

--- a/scripts/check_llm_key.py
+++ b/scripts/check_llm_key.py
@@ -244,7 +244,7 @@ def check_minimax(api_key: str, api_base: str = "https://api.minimax.io/v1", **_
                 "Authorization": f"Bearer {api_key}",
                 "Content-Type": "application/json",
             },
-            json={"model": "MiniMax-M2.5", "messages": []},
+            json={"model": "MiniMax-M3", "messages": []},
         )
     if r.status_code in (200, 400, 422, 429):
         return {"valid": True, "message": "MiniMax API key valid"}


### PR DESCRIPTION
## Description
Upgrade the MiniMax provider's default model to M3, add M2.7 and M2.7-highspeed as alternatives, and remove the legacy M2.5 entry from the curated model catalogue.

## Motivation
MiniMax-M3 is the latest flagship model from MiniMax with 512K context window, up to 128K max output, and image input support. The catalog should reflect the current generation as the default while keeping the previous-generation M2.7 (and its highspeed variant) available for users who prefer them.

## Changes
- Added `MiniMax-M3` as the new default model in the `minimax` provider entry
- Kept `MiniMax-M2.7` (relabeled "Previous generation") and added `MiniMax-M2.7-highspeed`
- Removed legacy `MiniMax-M2.5`
- Updated `minimax_code` preset to default to `MiniMax-M3` with the new 128K/512K token limits
- Updated M3 entry with image input support (`supports_vision: true`) and M3 pricing (Input $0.6/M, Output $2.4/M, Cache read $0.12/M)
- Updated unit tests in `test_model_catalog.py` and `test_capabilities.py` to reflect the new model list and image-support change for M3
- Updated frontend provider description and quickstart scripts (`quickstart.sh`, `quickstart.ps1`) to display M3 as the active model
- Updated `scripts/check_llm_key.py` health-check probe to use `MiniMax-M3`

## Testing
- [x] Unit tests added/updated
- [x] All 43 catalog + capabilities tests pass locally
- [x] All 145 litellm provider tests pass locally

## Checklist
- [x] Code follows style guidelines (ruff)
- [x] Self-review completed
- [x] Documentation updated where applicable
- [x] No breaking changes for the public API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgraded MiniMax provider's default model to M3, introducing vision capabilities and significantly increased token limits (128K tokens, 512K context).
  * Added MiniMax-M2.7-highspeed as an alternative model option.

* **Updates**
  * Updated setup scripts and documentation to reflect the new MiniMax M3 default model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->