### PR TITLE
fix(micro-fix): import NodeSpec directly for Pylance

### DIFF
--- a/core/framework/agents/queen/nodes/__init__.py
+++ b/core/framework/agents/queen/nodes/__init__.py
@@ -2,7 +2,7 @@
 
 import re
 
-from framework.orchestrator import NodeSpec
+from framework.orchestrator.node import NodeSpec
 
 # Wraps prompt sections that should only be shown to vision-capable models.
 # Content inside `<!-- vision-only -->...<!-- /vision-only -->` is kept for


### PR DESCRIPTION
Addresses #7231.

## Summary

This is scoped to the import-resolution part of the issue. NodeSpec is now imported directly from framework.orchestrator.node instead of through framework.orchestrator, which avoids relying on the lazy module loader for this static analysis path.

One file changed: core/framework/agents/queen/nodes/__init__.py.

## Verification

- ruff check
- ruff format --check
- pytest core/tests/test_queen_nodes_prompt.py
- pyright core/framework/agents/queen/nodes/__init__.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->