### PR TITLE
fix: add UTF-8 encoding and improve queen profile error logging

### DIFF
--- a/core/framework/agents/queen/queen_profiles.py
+++ b/core/framework/agents/queen/queen_profiles.py
@@ -1242,7 +1242,7 @@ def ensure_default_queens() -> None:
         if profile_path.exists():
             continue
         queen_dir.mkdir(parents=True, exist_ok=True)
-        profile_path.write_text(yaml.safe_dump(profile, sort_keys=False, allow_unicode=True))
+        profile_path.write_text(yaml.safe_dump(profile, sort_keys=False, allow_unicode=True),encoding="utf-8",)
         created += 1
     if created:
         logger.info("Created %d default queen profile(s) at %s", created, QUEENS_DIR)
@@ -1256,7 +1256,7 @@ def list_queens() -> list[dict[str, str]]:
     for profile_path in sorted(QUEENS_DIR.glob("*/profile.yaml")):
         queen_id = profile_path.parent.name
         try:
-            data = yaml.safe_load(profile_path.read_text())
+            data = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
             results.append(
                 {
                     "id": queen_id,
@@ -1265,7 +1265,7 @@ def list_queens() -> list[dict[str, str]]:
                 }
             )
         except Exception:
-            logger.warning("Failed to read queen profile %s", profile_path)
+            logger.exception("Failed to read queen profile %s", profile_path)
     return results
 
 
@@ -1277,7 +1277,7 @@ def load_queen_profile(queen_id: str) -> dict[str, Any]:
     profile_path = QUEENS_DIR / queen_id / "profile.yaml"
     if not profile_path.exists():
         raise FileNotFoundError(f"Queen profile not found: {queen_id}")
-    data = yaml.safe_load(profile_path.read_text())
+    data = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
     return data
 
 
@@ -1300,7 +1300,7 @@ def update_queen_profile(queen_id: str, updates: dict[str, Any]) -> dict[str, An
             data[key].update(value)
         else:
             data[key] = value
-    profile_path.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True))
+    profile_path.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True),encoding="utf-8",)
     return data
 
 


### PR DESCRIPTION
## Summary

- Added explicit UTF-8 encoding to all read_text() and write_text() calls in queen_profiles.py
- Replaced warning-only exception handling with logger.exception() in list_queens()
- Improves cross-platform compatibility between Windows and Unix systems
- Makes debugging profile loading failures easier by preserving traceback information

Fixes #7226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encoding handling for queen profile files to ensure compatibility with special characters.
  * Enhanced error reporting when profile reading fails, providing more detailed diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->