### PR TITLE
fix(test): skip symlink escape test when Windows lacks symlink privileges

### DIFF
--- a/core/tests/test_validate_agent_path.py
+++ b/core/tests/test_validate_agent_path.py
@@ -4,6 +4,7 @@ Verifies the allowlist-based path validation that prevents arbitrary code
 execution via importlib.import_module() (Issue #5471).
 """
 
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -195,7 +196,14 @@ class TestValidateAgentPathNegative:
         outside = tmp_path / "outside"
         outside.mkdir()
         link = allowed / "sneaky"
-        link.symlink_to(outside)
+        try:
+            link.symlink_to(outside)
+        except OSError as exc:
+            if sys.platform == "win32" and getattr(exc, "winerror", None) == 1314:
+                pytest.skip(
+                    "Symlink creation requires Administrator privileges or Developer Mode on Windows"
+                )
+            raise
         app_module._ALLOWED_AGENT_ROOTS = (allowed,)
         # The symlink resolves to outside the allowed root
         with pytest.raises(ValueError, match="allowed directory"):


### PR DESCRIPTION
## Summary
- Skip `test_symlink_escape` on Windows when symlink creation raises `WinError 1314` (no Administrator privileges or Developer Mode)
- Keeps the test running on platforms where symlinks can be created, so `validate_agent_path` symlink rejection is still verified

## Test plan
- [x] `cd core && uv run pytest tests/test_validate_agent_path.py::TestValidateAgentPathNegative::test_symlink_escape -v`
- [x] On Windows without symlink privileges, the test reports `SKIPPED` instead of `FAILED`

Fixes #7223