### PR TITLE
Fix/tool registry silent overwrite

### DIFF
--- a/core/framework/loader/tool_registry.py
+++ b/core/framework/loader/tool_registry.py
@@ -155,6 +155,13 @@ class ToolRegistry:
             tool: Tool definition
             executor: Function that takes tool input dict and returns result
         """
+        if name in self._tools:
+            logger.warning(
+                f"Tool '{name}' is already registered. "
+                f"Skipping duplicate. "
+                f"Existing: '{self._tools[name].tool.description}'"
+            )
+            return
         self._tools[name] = RegisteredTool(tool=tool, executor=executor)
 
     def register_function(

--- a/core/tests/test_tool_registry.py
+++ b/core/tests/test_tool_registry.py
@@ -918,4 +918,4 @@ def test_register_duplicate_tool_warns_and_skips(caplog):
 
     # Original tool should still be there, not overwritten
     assert registry._tools["search"].tool.description == "Provider A"  # noqa: SLF001
-    assert "already registered" in caplog.text 
+    assert "already registered" in caplog.text

--- a/core/tests/test_tool_registry.py
+++ b/core/tests/test_tool_registry.py
@@ -903,3 +903,19 @@ def test_concurrency_safe_allowlist_is_conservative():
         "browser_navigate",
     ):
         assert forbidden not in allowlist, f"{forbidden} must not be concurrency-safe"
+
+
+def test_register_duplicate_tool_warns_and_skips(caplog):
+    """Registering a tool with an already-taken name should warn and keep the original."""
+    registry = ToolRegistry()
+    tool1 = Tool(name="search", description="Provider A", parameters={"type": "object", "properties": {}})
+    tool2 = Tool(name="search", description="Provider B", parameters={"type": "object", "properties": {}})
+
+    registry.register("search", tool1, lambda x: {"result": "from_A"})
+
+    with caplog.at_level(logging.WARNING):
+        registry.register("search", tool2, lambda x: {"result": "from_B"})
+
+    # Original tool should still be there, not overwritten
+    assert registry._tools["search"].tool.description == "Provider A"  # noqa: SLF001
+    assert "already registered" in caplog.text 


### PR DESCRIPTION
## Description

This PR fixes issue #2540 by preventing silent overwrites when multiple tools are registered with the same name in `ToolRegistry`.

The change introduces a duplicate registration check in `ToolRegistry.register()`. When a collision is detected, a warning is logged containing details of the existing tool, and the registration is skipped to preserve the first-registered tool, maintaining backward compatibility.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Refactoring (no functional changes)

## Related Issues

Fixes #2540

## Changes Made

* Added duplicate registration detection in `ToolRegistry.register()`
* Added warning logs when a tool name collision occurs
* Preserved first-registered tool by returning early on duplicate registration
* Added unit tests to verify duplicate registration behavior

## Testing

* [x] Unit tests pass
* [ ] Lint passes
* [x] Manual testing performed

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective
* [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool registry now prevents duplicate tool registrations from overwriting existing tools and issues a warning when duplicates are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->