### PR TITLE
fix(core): add Python 3.13 classifier to pyproject.toml [micro-fix]

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -2,6 +2,9 @@
 name = "framework"
 version = "0.7.1"
 description = "Goal-driven agent runtime with Builder-friendly observability"
+classifiers = [
+    "Programming Language :: Python :: 3.13",
+]
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Description
Adds the missing `Programming Language :: Python :: 3.13` classifier to `core/pyproject.toml`. The framework already supports Python 3.13 but the package metadata did not reflect this.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Related Issues
Fixes #1911

## Changes Made
- Added `Programming Language :: Python :: 3.13` classifier to `core/pyproject.toml`

## Testing
- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for Python 3.13 to project metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->