### PR TITLE
fix(github): url-encode slashes in branch names for get_branch

### DIFF
--- a/tools/src/aden_tools/tools/github_tool/github_tool.py
+++ b/tools/src/aden_tools/tools/github_tool/github_tool.py
@@ -41,6 +41,36 @@ def _sanitize_path_param(param: str, param_name: str = "parameter") -> str:
     return param
 
 
+def _sanitize_branch_param(branch: str) -> str:
+    """
+    Sanitize a Git branch name for use as a URL path segment.
+
+    Unlike ``_sanitize_path_param``, slashes are **allowed** in branch names
+    (e.g. ``feature/my-branch``) because they are a standard Git convention.
+    Each slash-delimited segment is validated individually so that traversal
+    sequences such as ``../secret`` are still rejected.
+
+    Args:
+        branch: The branch name to sanitize (e.g. ``"main"``, ``"feature/login"``).
+
+    Returns:
+        The branch name with slashes URL-encoded so it can be safely embedded
+        in a URL path (e.g. ``"feature%2Flogin"``).
+
+    Raises:
+        ValueError: If any path segment contains ``..`` or is empty.
+    """
+    from urllib.parse import quote
+
+    segments = branch.split("/")
+    for segment in segments:
+        if not segment:
+            raise ValueError("Invalid branch: branch name must not contain empty segments")
+        if ".." in segment:
+            raise ValueError("Invalid branch: branch name must not contain '..'")
+    return quote(branch, safe="")
+
+
 def _sanitize_error_message(error: Exception) -> str:
     """
     Sanitize error messages to prevent token leaks.
@@ -396,7 +426,7 @@ class _GitHubClient:
         """Get a specific branch."""
         owner = _sanitize_path_param(owner, "owner")
         repo = _sanitize_path_param(repo, "repo")
-        branch = _sanitize_path_param(branch, "branch")
+        branch = _sanitize_branch_param(branch)
         response = httpx.get(
             f"{GITHUB_API_BASE}/repos/{owner}/{repo}/branches/{branch}",
             headers=self._headers,

--- a/tools/tests/tools/test_github_tool.py
+++ b/tools/tests/tools/test_github_tool.py
@@ -290,7 +290,7 @@ class TestGitHubClient:
         assert result["success"] is True
         assert result["data"]["name"] == "main"
 
-    @patch("httpx.get")
+    @patch("aden_tools.tools.github_tool.github_tool.httpx.get")
     def test_get_branch_with_slash(self, mock_get):
         """Slash-separated branch names like feature/my-branch must be accepted."""
         mock_response = MagicMock()
@@ -310,7 +310,7 @@ class TestGitHubClient:
         called_url = mock_get.call_args[0][0]
         assert "feature%2Fmy-branch" in called_url
 
-    @patch("httpx.get")
+    @patch("aden_tools.tools.github_tool.github_tool.httpx.get")
     def test_get_branch_with_multiple_slashes(self, mock_get):
         """Deeply nested branch names like release/v2/hotfix must also be accepted."""
         mock_response = MagicMock()

--- a/tools/tests/tools/test_github_tool.py
+++ b/tools/tests/tools/test_github_tool.py
@@ -290,6 +290,112 @@ class TestGitHubClient:
         assert result["success"] is True
         assert result["data"]["name"] == "main"
 
+    @patch("httpx.get")
+    def test_get_branch_with_slash(self, mock_get):
+        """Slash-separated branch names like feature/my-branch must be accepted."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "name": "feature/my-branch",
+            "protected": False,
+            "commit": {"sha": "def456"},
+        }
+        mock_get.return_value = mock_response
+
+        result = self.client.get_branch("owner", "repo", "feature/my-branch")
+
+        assert result["success"] is True
+        assert result["data"]["name"] == "feature/my-branch"
+        # Confirm the URL had the slash URL-encoded
+        called_url = mock_get.call_args[0][0]
+        assert "feature%2Fmy-branch" in called_url
+
+    @patch("httpx.get")
+    def test_get_branch_with_multiple_slashes(self, mock_get):
+        """Deeply nested branch names like release/v2/hotfix must also be accepted."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"name": "release/v2/hotfix", "protected": True}
+        mock_get.return_value = mock_response
+
+        result = self.client.get_branch("owner", "repo", "release/v2/hotfix")
+
+        assert result["success"] is True
+        called_url = mock_get.call_args[0][0]
+        assert "release%2Fv2%2Fhotfix" in called_url
+
+    def test_get_branch_rejects_path_traversal(self):
+        """Branch names containing '..' must still be rejected."""
+        with pytest.raises(ValueError, match="'\\.\\.'"):
+            self.client.get_branch("owner", "repo", "../etc/passwd")
+
+    def test_get_branch_rejects_traversal_in_slash_name(self):
+        """Traversal sequences inside slash-separated segments must be rejected."""
+        with pytest.raises(ValueError, match="'\\.\\.'"):
+            self.client.get_branch("owner", "repo", "feature/../secret")
+
+    def test_get_branch_rejects_empty_segment(self):
+        """Branch names with empty segments (double slash) must be rejected."""
+        with pytest.raises(ValueError, match="empty segments"):
+            self.client.get_branch("owner", "repo", "feature//broken")
+
+
+# --- _sanitize_branch_param unit tests ---
+
+
+class TestSanitizeBranchParam:
+    """Unit tests for the _sanitize_branch_param helper."""
+
+    def test_simple_branch_name(self):
+        from aden_tools.tools.github_tool.github_tool import _sanitize_branch_param
+
+        assert _sanitize_branch_param("main") == "main"
+
+    def test_slash_branch_is_url_encoded(self):
+        from aden_tools.tools.github_tool.github_tool import _sanitize_branch_param
+
+        assert _sanitize_branch_param("feature/my-branch") == "feature%2Fmy-branch"
+
+    def test_multiple_slashes_are_url_encoded(self):
+        from aden_tools.tools.github_tool.github_tool import _sanitize_branch_param
+
+        assert _sanitize_branch_param("release/v1/patch") == "release%2Fv1%2Fpatch"
+
+    def test_rejects_dotdot_traversal(self):
+        from aden_tools.tools.github_tool.github_tool import _sanitize_branch_param
+
+        with pytest.raises(ValueError, match="'\\.\\.'"):
+            _sanitize_branch_param("../secret")
+
+    def test_rejects_dotdot_inside_slash_segment(self):
+        from aden_tools.tools.github_tool.github_tool import _sanitize_branch_param
+
+        with pytest.raises(ValueError, match="'\\.\\.'"):
+            _sanitize_branch_param("feature/../secret")
+
+    def test_rejects_empty_segment_from_double_slash(self):
+        from aden_tools.tools.github_tool.github_tool import _sanitize_branch_param
+
+        with pytest.raises(ValueError, match="empty segments"):
+            _sanitize_branch_param("feature//broken")
+
+    def test_rejects_leading_slash(self):
+        from aden_tools.tools.github_tool.github_tool import _sanitize_branch_param
+
+        with pytest.raises(ValueError, match="empty segments"):
+            _sanitize_branch_param("/leading-slash")
+
+    def test_rejects_trailing_slash(self):
+        from aden_tools.tools.github_tool.github_tool import _sanitize_branch_param
+
+        with pytest.raises(ValueError, match="empty segments"):
+            _sanitize_branch_param("trailing-slash/")
+
+    def test_hyphenated_branch_name_unchanged(self):
+        from aden_tools.tools.github_tool.github_tool import _sanitize_branch_param
+
+        assert _sanitize_branch_param("fix-issue-123") == "fix-issue-123"
+
 
 # --- Credential retrieval tests ---
 


### PR DESCRIPTION
## Description

Fixes `github_get_branch` rejecting valid branch names that contain `/`, such as `feature/my-branch` or `release/v2/hotfix`.

Closes #6289

## Root Cause

`_sanitize_path_param()` treats any `/` in a parameter as a path-traversal attempt and raises `ValueError`. This is correct for `owner` and `repo`, but branch names legitimately contain slashes (`feature/login`, `release/v2/patch`) and passing them to `github_get_branch` was broken by design.

## Fix

Added `_sanitize_branch_param()` — a branch-aware sanitizer that:
- **URL-encodes** `/` so `feature/my-branch` becomes `feature%2Fmy-branch` in the request URL (GitHub REST API accepts percent-encoded branch names)
- **Still blocks** `..` path traversal in every slash-separated segment
- **Still blocks** empty segments from double-slash (`feature//broken`), leading-slash (`/bad`), or trailing-slash (`trailing/`)

`get_branch()` in `_GitHubClient` now calls `_sanitize_branch_param()` instead of `_sanitize_path_param()` for the branch argument only. `owner` and `repo` are unchanged.

## Changes

- `tools/src/aden_tools/tools/github_tool/github_tool.py` — added `_sanitize_branch_param()`, updated `get_branch()` to use it
- `tools/tests/tools/test_github_tool.py` — 14 new test cases

## Testing

**New tests in `TestGitHubClientBranches`:**
- `test_get_branch_with_slash` — `feature/my-branch` accepted, URL has `feature%2Fmy-branch`
- `test_get_branch_with_multiple_slashes` — `release/v2/hotfix` accepted
- `test_get_branch_rejects_path_traversal` — `../etc/passwd` blocked
- `test_get_branch_rejects_traversal_in_slash_name` — `feature/../secret` blocked
- `test_get_branch_rejects_empty_segment` — `feature//broken` blocked

**New `TestSanitizeBranchParam` class (9 unit tests):**
- Simple name passthrough
- Single slash encoded
- Multiple slashes encoded
- `..` traversal rejected
- `..` inside segment rejected
- Double slash rejected
- Leading slash rejected
- Trailing slash rejected
- Hyphenated name passthrough

## Checklist

- [x] Unit tests added/updated
- [x] Code follows style guidelines (ruff check + format: all passed)
- [x] Self-review completed
- [x] No breaking changes (owner/repo validation unchanged; only branch param affected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Better support for Git branch names that include forward slashes when interacting with GitHub.

* **Bug Fixes**
  * Stronger validation to reject empty segments and path-traversal patterns (e.g., "..") and ensure safe encoding of branch identifiers.

* **Tests**
  * Added tests covering slash-containing branch names, URL-encoding behavior, and validation rejection cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->