### PR TITLE
fix(frontend): recover from stale session id on queen select

### DIFF
--- a/core/frontend/src/pages/queen-dm.tsx
+++ b/core/frontend/src/pages/queen-dm.tsx
@@ -9,6 +9,7 @@ import QueenSessionSwitcher from "@/components/QueenSessionSwitcher";
 import { executionApi } from "@/api/execution";
 import { sessionsApi } from "@/api/sessions";
 import { queensApi } from "@/api/queens";
+import { ApiError } from "@/api/client";
 import { useMultiSSE } from "@/hooks/use-sse";
 import { usePendingQueue } from "@/hooks/use-pending-queue";
 import type { AgentEvent, HistorySession } from "@/api/types";
@@ -311,7 +312,22 @@ export default function QueenDM() {
           );
           bootstrapSessionId = bootstrapResult.session_id;
         } else if (selectedSessionParam) {
-          await queensApi.selectSession(queenId, selectedSessionParam);
+          // Validate the stored/URL session before trusting it downstream.
+          // If the sessions folder was deleted while hive was closed, this
+          // id is stale and selectSession 404s. Recover by clearing the
+          // stale pointer and stripping the param; clearing the param
+          // re-runs this effect into the get-or-create path, so a single
+          // queen selection works instead of erroring on the first click.
+          try {
+            await queensApi.selectSession(queenId, selectedSessionParam);
+          } catch (err) {
+            if (err instanceof ApiError && err.status === 404) {
+              clearLastSession(queenId);
+              setSearchParams({}, { replace: true });
+              return;
+            }
+            throw err;
+          }
         }
         if (cancelled) return;
         let sid: string;


### PR DESCRIPTION
Fixes #7251

## Problem

After deleting a queen's sessions folder while hive is closed, selecting
that queen calls `POST /api/queen/{queen_id}/session/select` with a stale
session id and gets a 404. The user has to click the queen a second time
before it falls through to `POST /api/queen/{queen_id}/session`.

## Root cause

`queen-dm.tsx` persists the last-open session per queen in localStorage
(`hive:queen:{queen_id}:lastSession`). On selecting a queen with no
explicit `?session=` param, the effect redirects to `?session=<stored>`.
When the underlying session no longer exists on disk, the pre-select call
404s. The existing `clearLastSession()` helper was never invoked on that
failure, so the stale pointer persisted and the first click always errored.

## Fix

Guard the pre-select call: on an `ApiError` 404, clear the stale
localStorage pointer and strip the `session` param. Clearing the param
re-runs the effect into the get-or-create path, so a single selection
recovers cleanly. Non-404 errors are re-thrown unchanged.

## Testing

- `tsc -b` clean, `vitest run` all 52 tests pass.
- Manually verified against the repro steps in the issue: after deleting
  the sessions folder and relaunching, selecting the queen now goes
  straight to `POST /session` instead of 404'ing on `/session/select`.