### PR TITLE
fix(frontend): clear stale ?session= URL param on 404 after session deletion

### DIFF
--- a/core/frontend/src/pages/queen-dm.tsx
+++ b/core/frontend/src/pages/queen-dm.tsx
@@ -401,14 +401,16 @@ export default function QueenDM() {
       } catch {
         // Session creation/selection failed. If the URL param came from
         // our own localStorage restore, the stored session is stale (e.g.
-        // deleted on disk) — clear it so the next navigation falls
-        // through to getOrCreate instead of looping on the bad id.
+        // deleted on disk) — clear it and remove the ?session= URL param
+        // so the effect re-runs immediately with getOrCreate instead of
+        // requiring a second click on the same queen.
         if (
           queenId &&
           selectedSessionParam &&
           selectedSessionParam === readLastSession(queenId)
         ) {
           clearLastSession(queenId);
+          setSearchParams({}, { replace: true });
         }
       } finally {
         if (!cancelled) {


### PR DESCRIPTION
## Description

Fixes the double-click bug when selecting a queen after its sessions folder has been deleted.

Closes #7251

## Root Cause

When a queen's sessions folder is deleted on disk while hive is not running, `localStorage` still holds the last session ID (`hive:queen:<id>:lastSession`).

On the next visit the effect reads this stored ID and redirects to `?session=<stale-id>`. The effect then calls `POST /queen/<id>/session/select` → **404**.

The `catch` block already called `clearLastSession(queenId)` to wipe `localStorage`, but **left `?session=<stale-id>` in the URL**. Because the param was still present, the effect re-ran with `selectedSessionParam` still set — it could not fall through to `getOrCreate`. This is exactly why a second click was needed.

## Fix

One line added in the `catch` block:

```ts
clearLastSession(queenId);
setSearchParams({}, { replace: true }); // ← strips ?session= from URL
```

Removing `?session=` causes the effect to re-run without a session param → falls through to `getOrCreate` → fresh session opens in **one click**.

## Changes

- `core/frontend/src/pages/queen-dm.tsx` — +1 line of logic, updated comment

## Checklist

- [x] Root cause identified
- [x] Fix is minimal and surgical (1 new line)
- [x] No new dependencies
- [x] Self-review completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session recovery to properly clear invalid session parameters from the URL, allowing the app to establish a fresh session when a stale session is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->