### PR TITLE
feat: server app: migrate aiohttp app state keys to web.AppKey

### DIFF
--- a/core/framework/loader/cli.py
+++ b/core/framework/loader/cli.py
@@ -95,7 +95,7 @@ def cmd_serve(args: argparse.Namespace) -> int:
     _build_frontend()
 
     from framework.observability import configure_logging
-    from framework.server.app import create_app
+    from framework.server.app import MANAGER_KEY, create_app
 
     if getattr(args, "debug", False):
         configure_logging(level="DEBUG")
@@ -120,7 +120,7 @@ def cmd_serve(args: argparse.Namespace) -> int:
     app = create_app(model=model)
 
     async def run_server() -> None:
-        manager = app["manager"]
+        manager = app[MANAGER_KEY]
         shutdown_event = asyncio.Event()
         signal_count = {"n": 0}
 

--- a/core/framework/server/app.py
+++ b/core/framework/server/app.py
@@ -7,9 +7,14 @@ from pathlib import Path
 
 from aiohttp import web
 
+from framework.credentials.store import CredentialStore
 from framework.server.session_manager import Session, SessionManager
 
 logger = logging.getLogger(__name__)
+
+CREDENTIAL_STORE_KEY: web.AppKey[CredentialStore] = web.AppKey("credential_store", CredentialStore)
+QUEEN_TOOL_REGISTRY_KEY: web.AppKey[object | None] = web.AppKey("queen_tool_registry", object)
+MANAGER_KEY: web.AppKey[SessionManager] = web.AppKey("manager", SessionManager)
 
 
 # Anchor to the repository root so allowed roots are independent of CWD.
@@ -88,7 +93,7 @@ def resolve_session(request: web.Request):
 
     Returns (session, None) on success or (None, error_response) on failure.
     """
-    manager: SessionManager = request.app["manager"]
+    manager: SessionManager = request.app[MANAGER_KEY]
     sid = request.match_info["session_id"]
     session = manager.get_session(sid)
     if not session:
@@ -210,13 +215,13 @@ async def error_middleware(request: web.Request, handler):
 
 async def _on_shutdown(app: web.Application) -> None:
     """Gracefully unload all agents on server shutdown."""
-    manager: SessionManager = app["manager"]
+    manager: SessionManager = app[MANAGER_KEY]
     await manager.shutdown_all()
 
 
 async def handle_health(request: web.Request) -> web.Response:
     """GET /api/health — simple health check."""
-    manager: SessionManager = request.app["manager"]
+    manager: SessionManager = request.app[MANAGER_KEY]
     sessions = manager.list_sessions()
     return web.json_response(
         {
@@ -324,8 +329,6 @@ def create_app(model: str | None = None) -> web.Application:
     app = web.Application(middlewares=[desktop_auth_middleware, no_cache_api_middleware, error_middleware])
 
     # Initialize credential store (before SessionManager so it can be shared)
-    from framework.credentials.store import CredentialStore
-
     try:
         from framework.credentials.validation import ensure_credential_key_env
 
@@ -358,12 +361,12 @@ def create_app(model: str | None = None) -> web.Application:
         logger.debug("Encrypted credential store unavailable, using in-memory fallback")
         credential_store = CredentialStore.for_testing({})
 
-    app["credential_store"] = credential_store
+    app[CREDENTIAL_STORE_KEY] = credential_store
 
     # Let queen sessions build their registry lazily on first use instead of
     # paying the MCP discovery cost during `hive open`.
-    app["queen_tool_registry"] = None
-    app["manager"] = SessionManager(
+    app[QUEEN_TOOL_REGISTRY_KEY] = None
+    app[MANAGER_KEY] = SessionManager(
         model=model,
         credential_store=credential_store,
         queen_tool_registry=None,

--- a/core/framework/server/routes_colonies.py
+++ b/core/framework/server/routes_colonies.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from aiohttp import web
 
 from framework.config import COLONIES_DIR
+from framework.server.app import MANAGER_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -510,7 +511,7 @@ def _find_workers_bound_to_profile(request: web.Request, colony_name: str, profi
     spawn time and a profile mutation underneath a running worker would
     leave its tool calls pointing at a removed alias on the next turn.
     """
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     if manager is None:
         return []
     bound: list[str] = []

--- a/core/framework/server/routes_colony_tools.py
+++ b/core/framework/server/routes_colony_tools.py
@@ -35,6 +35,7 @@ from framework.host.colony_tools_config import (
     load_colony_tools_config,
     update_colony_tools_config,
 )
+from framework.server.app import MANAGER_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -216,7 +217,7 @@ async def handle_get_tools(request: web.Request) -> web.Response:
     if not colony_metadata_path(colony_name).exists():
         return web.json_response({"error": f"Colony '{colony_name}' not found"}, status=404)
 
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     # Allowlist now lives in a dedicated tools.json sidecar; helper
     # migrates any legacy metadata.json field on first read.
     enabled = load_colony_tools_config(colony_name)
@@ -267,7 +268,7 @@ async def handle_patch_tools(request: web.Request) -> web.Response:
                 status=400,
             )
 
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
 
     # Validate names against the known MCP catalog — lifts the same
     # typo-catching guarantee we already offer on queen tools.

--- a/core/framework/server/routes_config.py
+++ b/core/framework/server/routes_config.py
@@ -30,6 +30,7 @@ from framework.llm.model_catalog import (
     get_models_catalogue,
     get_preset,
 )
+from framework.server.app import CREDENTIAL_STORE_KEY, MANAGER_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -174,7 +175,7 @@ def _resolve_api_key(provider: str, request: web.Request) -> str | None:
     cred_id = _PROVIDER_CRED_MAP.get(provider.lower())
     if cred_id:
         try:
-            store = request.app["credential_store"]
+            store = request.app[CREDENTIAL_STORE_KEY]
             key = store.get(cred_id)
             if key:
                 return key
@@ -293,7 +294,7 @@ def _hot_swap_sessions(request: web.Request, full_model: str, api_key: str | Non
     """
     from framework.server.session_manager import SessionManager
 
-    manager: SessionManager = request.app["manager"]
+    manager: SessionManager = request.app[MANAGER_KEY]
     manager._model = full_model
     swapped = 0
     for session in manager.list_sessions():

--- a/core/framework/server/routes_credentials.py
+++ b/core/framework/server/routes_credentials.py
@@ -9,7 +9,7 @@ from pydantic import SecretStr
 
 from framework.credentials.models import CredentialDecryptionError, CredentialKey, CredentialObject
 from framework.credentials.store import CredentialStore
-from framework.server.app import validate_agent_path
+from framework.server.app import CREDENTIAL_STORE_KEY, MANAGER_KEY, validate_agent_path
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ def _get_llm_key_providers() -> dict:
 
 
 def _get_store(request: web.Request) -> CredentialStore:
-    return request.app["credential_store"]
+    return request.app[CREDENTIAL_STORE_KEY]
 
 
 def _reset_credential_adapter_cache() -> None:
@@ -65,7 +65,7 @@ def _invalidate_queen_credentials_cache(request: web.Request) -> None:
     appear in the Queen's prompt on her next turn instead of waiting for the
     cache TTL to expire.
     """
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     if manager is None:
         return
     sessions = getattr(manager, "_sessions", None)

--- a/core/framework/server/routes_execution.py
+++ b/core/framework/server/routes_execution.py
@@ -11,7 +11,7 @@ from aiohttp import web
 from framework.agent_loop.conversation import LEGACY_RUN_ID
 from framework.credentials.validation import validate_agent_credentials
 from framework.host.execution_manager import ExecutionAlreadyRunningError
-from framework.server.app import resolve_session, safe_path_segment, sessions_dir
+from framework.server.app import MANAGER_KEY, resolve_session, safe_path_segment, sessions_dir
 from framework.server.routes_sessions import _credential_error_response
 
 logger = logging.getLogger(__name__)
@@ -334,7 +334,7 @@ async def handle_chat(request: web.Request) -> web.Response:
 
     # Queen is dead — try to revive her
     logger.warning("[handle_chat] Queen is dead for session '%s', reviving on /chat request", session.id)
-    manager: Any = request.app["manager"]
+    manager: Any = request.app[MANAGER_KEY]
     try:
         logger.debug("[handle_chat] Calling manager.revive_queen()...")
         await manager.revive_queen(session)
@@ -387,7 +387,7 @@ async def handle_queen_context(request: web.Request) -> web.Response:
         "Queen is dead for session '%s', reviving on /queen-context request",
         session.id,
     )
-    manager: Any = request.app["manager"]
+    manager: Any = request.app[MANAGER_KEY]
     try:
         await manager.revive_queen(session)
         # After revival, deliver the message
@@ -982,7 +982,7 @@ async def handle_compact_and_fork(request: web.Request) -> web.Response:
     except OSError:
         logger.warning("compact_and_fork: failed to write new meta.json", exc_info=True)
 
-    manager: Any = request.app["manager"]
+    manager: Any = request.app[MANAGER_KEY]
     try:
         new_session = await manager.create_session(
             session_id=None,

--- a/core/framework/server/routes_messages.py
+++ b/core/framework/server/routes_messages.py
@@ -9,6 +9,7 @@
 from aiohttp import web
 
 from framework.agents.queen.queen_profiles import ensure_default_queens, select_queen
+from framework.server.app import MANAGER_KEY
 
 
 async def handle_classify_message(request: web.Request) -> web.Response:
@@ -16,7 +17,7 @@ async def handle_classify_message(request: web.Request) -> web.Response:
     import traceback as _tb
 
     try:
-        manager = request.app["manager"]
+        manager = request.app[MANAGER_KEY]
         body = await request.json() if request.can_read_body else {}
         message = body.get("message")
         if not isinstance(message, str) or not message.strip():

--- a/core/framework/server/routes_queen_tools.py
+++ b/core/framework/server/routes_queen_tools.py
@@ -40,6 +40,7 @@ from framework.agents.queen.queen_tools_defaults import (
     queen_role_categories,
     resolve_category_tools,
 )
+from framework.server.app import MANAGER_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -317,7 +318,7 @@ async def handle_get_tools(request: web.Request) -> web.Response:
     except FileNotFoundError:
         return web.json_response({"error": f"Queen '{queen_id}' not found"}, status=404)
 
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     session = _live_queen_session(manager, queen_id) if manager is not None else None
 
     # Prefer a live session's registry for freshness. Otherwise use (or
@@ -450,7 +451,7 @@ async def handle_patch_tools(request: web.Request) -> web.Response:
     # Validate names against the known MCP tool catalog. We prefer a live
     # session's registry for the most up-to-date set, then fall back to
     # the manager-level snapshot (building it on demand if absent).
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     session = _live_queen_session(manager, queen_id) if manager is not None else None
     if session is not None:
         catalog = _catalog_from_live_session(session)
@@ -536,7 +537,7 @@ async def handle_delete_tools(request: web.Request) -> web.Response:
     # Recompute the queen's effective allowlist from the role defaults
     # so we can hot-reload live sessions in one pass (same shape as
     # PATCH).
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     session = _live_queen_session(manager, queen_id) if manager is not None else None
     if session is not None:
         catalog = _catalog_from_live_session(session)

--- a/core/framework/server/routes_queens.py
+++ b/core/framework/server/routes_queens.py
@@ -23,6 +23,7 @@ from framework.agents.queen.queen_profiles import (
     update_queen_profile,
 )
 from framework.config import QUEENS_DIR
+from framework.server.app import MANAGER_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -232,7 +233,7 @@ async def handle_queen_session(request: web.Request) -> web.Response:
     from framework.server.session_manager import SessionManager
 
     queen_id = request.match_info["queen_id"]
-    manager: SessionManager = request.app["manager"]
+    manager: SessionManager = request.app[MANAGER_KEY]
 
     ensure_default_queens()
     try:
@@ -333,7 +334,7 @@ async def handle_queen_session(request: web.Request) -> web.Response:
 async def handle_select_queen_session(request: web.Request) -> web.Response:
     """POST /api/queen/{queen_id}/session/select -- resume a specific queen session."""
     queen_id = request.match_info["queen_id"]
-    manager = request.app["manager"]
+    manager = request.app[MANAGER_KEY]
 
     ensure_default_queens()
     try:
@@ -388,7 +389,7 @@ async def handle_new_queen_session(request: web.Request) -> web.Response:
     from framework.tools.queen_lifecycle_tools import QUEEN_PHASES
 
     queen_id = request.match_info["queen_id"]
-    manager = request.app["manager"]
+    manager = request.app[MANAGER_KEY]
 
     ensure_default_queens()
     try:

--- a/core/framework/server/routes_sessions.py
+++ b/core/framework/server/routes_sessions.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from aiohttp import web
 
 from framework.server.app import (
+    MANAGER_KEY,
     resolve_session,
     validate_agent_path,
 )
@@ -38,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 
 def _get_manager(request: web.Request) -> SessionManager:
-    return request.app["manager"]
+    return request.app[MANAGER_KEY]
 
 
 def _session_to_live_dict(session) -> dict:
@@ -1121,7 +1122,7 @@ async def handle_delete_agent(request: web.Request) -> web.Response:
 
 async def handle_reveal_session_folder(request: web.Request) -> web.Response:
     """POST /api/sessions/{session_id}/reveal — open session data folder in the OS file manager."""
-    manager: SessionManager = request.app["manager"]
+    manager: SessionManager = request.app[MANAGER_KEY]
     session_id = request.match_info["session_id"]
 
     session = manager.get_session(session_id)

--- a/core/framework/server/routes_skills.py
+++ b/core/framework/server/routes_skills.py
@@ -38,6 +38,7 @@ from typing import Any
 from aiohttp import web
 
 from framework.config import COLONIES_DIR, QUEENS_DIR
+from framework.server.app import MANAGER_KEY
 from framework.skills.authoring import (
     build_draft,
     remove_skill as authoring_remove_skill,
@@ -365,7 +366,7 @@ def _serialize_skill(
 
 
 async def handle_list_queen_skills(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     queen_id = request.match_info["queen_id"]
     scope = _queen_scope(manager, queen_id)
     if scope is None:
@@ -386,7 +387,7 @@ async def handle_list_queen_skills(request: web.Request) -> web.Response:
 
 
 async def handle_list_colony_skills(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     colony_name = request.match_info["colony_name"]
     scope = _colony_scope(manager, colony_name)
     if scope is None:
@@ -775,7 +776,7 @@ def _requester_id(request: web.Request) -> str:
 
 
 async def handle_create_queen_skill(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _queen_scope(manager, request.match_info["queen_id"])
     if scope is None:
         return web.json_response({"error": "queen not found"}, status=404)
@@ -787,7 +788,7 @@ async def handle_create_queen_skill(request: web.Request) -> web.Response:
 
 
 async def handle_patch_queen_skill(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _queen_scope(manager, request.match_info["queen_id"])
     if scope is None:
         return web.json_response({"error": "queen not found"}, status=404)
@@ -799,7 +800,7 @@ async def handle_patch_queen_skill(request: web.Request) -> web.Response:
 
 
 async def handle_put_queen_skill_body(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _queen_scope(manager, request.match_info["queen_id"])
     if scope is None:
         return web.json_response({"error": "queen not found"}, status=404)
@@ -811,7 +812,7 @@ async def handle_put_queen_skill_body(request: web.Request) -> web.Response:
 
 
 async def handle_delete_queen_skill(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _queen_scope(manager, request.match_info["queen_id"])
     if scope is None:
         return web.json_response({"error": "queen not found"}, status=404)
@@ -819,7 +820,7 @@ async def handle_delete_queen_skill(request: web.Request) -> web.Response:
 
 
 async def handle_reload_queen_skills(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _queen_scope(manager, request.match_info["queen_id"])
     if scope is None:
         return web.json_response({"error": "queen not found"}, status=404)
@@ -827,7 +828,7 @@ async def handle_reload_queen_skills(request: web.Request) -> web.Response:
 
 
 async def handle_create_colony_skill(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _colony_scope(manager, request.match_info["colony_name"])
     if scope is None:
         return web.json_response({"error": "colony not found"}, status=404)
@@ -839,7 +840,7 @@ async def handle_create_colony_skill(request: web.Request) -> web.Response:
 
 
 async def handle_patch_colony_skill(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _colony_scope(manager, request.match_info["colony_name"])
     if scope is None:
         return web.json_response({"error": "colony not found"}, status=404)
@@ -851,7 +852,7 @@ async def handle_patch_colony_skill(request: web.Request) -> web.Response:
 
 
 async def handle_put_colony_skill_body(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _colony_scope(manager, request.match_info["colony_name"])
     if scope is None:
         return web.json_response({"error": "colony not found"}, status=404)
@@ -863,7 +864,7 @@ async def handle_put_colony_skill_body(request: web.Request) -> web.Response:
 
 
 async def handle_delete_colony_skill(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _colony_scope(manager, request.match_info["colony_name"])
     if scope is None:
         return web.json_response({"error": "colony not found"}, status=404)
@@ -871,7 +872,7 @@ async def handle_delete_colony_skill(request: web.Request) -> web.Response:
 
 
 async def handle_reload_colony_skills(request: web.Request) -> web.Response:
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     scope = _colony_scope(manager, request.match_info["colony_name"])
     if scope is None:
         return web.json_response({"error": "colony not found"}, status=404)
@@ -894,7 +895,7 @@ async def handle_upload_skill(request: web.Request) -> web.Response:
       ``replace_existing``          — "true"/"false" (defaults false)
       ``name``                      — optional override for single-.md uploads
     """
-    manager = request.app.get("manager")
+    manager = request.app.get(MANAGER_KEY)
     if not request.content_type.startswith("multipart/"):
         return web.json_response({"error": "expected multipart/form-data"}, status=400)
 

--- a/core/framework/server/tests/test_api.py
+++ b/core/framework/server/tests/test_api.py
@@ -22,7 +22,7 @@ from framework.server import (
     routes_queens,
     session_manager as session_manager_module,
 )
-from framework.server.app import create_app
+from framework.server.app import CREDENTIAL_STORE_KEY, MANAGER_KEY, create_app
 from framework.server.session_manager import Session
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -331,7 +331,7 @@ def custom_id_session(tmp_agent_dir):
 def _make_app_with_session(session):
     """Create an aiohttp app with a pre-loaded session."""
     app = create_app()
-    mgr = app["manager"]
+    mgr = app[MANAGER_KEY]
     mgr._sessions[session.id] = session
     return app
 
@@ -386,7 +386,7 @@ class TestSessionCRUD:
     @pytest.mark.asyncio
     async def test_create_session_with_worker_forwards_session_id(self):
         app = create_app()
-        manager = app["manager"]
+        manager = app[MANAGER_KEY]
         manager.create_session_with_worker_colony = AsyncMock(return_value=_make_session(agent_id="my-custom-session"))
 
         async with TestClient(TestServer(app)) as client:
@@ -583,7 +583,7 @@ class TestMessageBootstrap:
     @pytest.mark.asyncio
     async def test_classify_returns_queen_id_without_touching_sessions(self, monkeypatch):
         app = create_app()
-        manager = app["manager"]
+        manager = app[MANAGER_KEY]
         # Pre-existing live session must NOT be stopped by classify.
         existing = _make_session(agent_id="live_session")
         existing.queen_name = "queen_growth"
@@ -623,7 +623,7 @@ class TestQueenSessionSelection:
     @pytest.mark.asyncio
     async def test_select_queen_session_returns_live_session_without_duplication(self):
         app = create_app()
-        manager = app["manager"]
+        manager = app[MANAGER_KEY]
         target = _make_session(agent_id="queen_live")
         target.queen_name = "queen_technology"
         other = _make_session(agent_id="other_live")
@@ -662,7 +662,7 @@ class TestQueenSessionSelection:
         )
 
         app = create_app()
-        manager = app["manager"]
+        manager = app[MANAGER_KEY]
         manager.stop_session = AsyncMock()
         restored = _make_session(agent_id="queen_history", with_queen=False)
         restored.queen_name = "queen_technology"
@@ -702,7 +702,7 @@ class TestQueenSessionSelection:
         )
 
         app = create_app()
-        manager = app["manager"]
+        manager = app[MANAGER_KEY]
         manager.stop_session = AsyncMock()
         restored = _make_session(agent_id="worker_history", with_queen=False)
         restored.queen_name = "queen_technology"
@@ -734,7 +734,7 @@ class TestQueenSessionSelection:
     @pytest.mark.asyncio
     async def test_new_queen_session_creates_fresh_thread(self):
         app = create_app()
-        manager = app["manager"]
+        manager = app[MANAGER_KEY]
         existing = _make_session(agent_id="old_live")
         existing.queen_name = "queen_growth"
         manager._sessions[existing.id] = existing
@@ -1504,7 +1504,7 @@ class TestCredentials:
         from framework.credentials.store import CredentialStore
 
         app = create_app()
-        app["credential_store"] = CredentialStore.for_testing(initial_creds or {})
+        app[CREDENTIAL_STORE_KEY] = CredentialStore.for_testing(initial_creds or {})
         return app
 
     @pytest.mark.asyncio
@@ -1535,7 +1535,7 @@ class TestCredentials:
                 )
 
         app = create_app()
-        app["credential_store"] = BrokenStore()
+        app[CREDENTIAL_STORE_KEY] = BrokenStore()
 
         async with TestClient(TestServer(app)) as client:
             resp = await client.get("/api/credentials")
@@ -1555,7 +1555,7 @@ class TestCredentials:
                 raise CredentialDecryptionError("bad encrypted file")
 
         app = create_app()
-        app["credential_store"] = BrokenStore()
+        app[CREDENTIAL_STORE_KEY] = BrokenStore()
 
         async with TestClient(TestServer(app)) as client:
             resp = await client.get("/api/credentials/bad_cred")
@@ -1654,7 +1654,7 @@ class TestCredentials:
             )
             assert resp.status == 201
 
-            store = app["credential_store"]
+            store = app[CREDENTIAL_STORE_KEY]
             assert store.get_key("test_cred", "api_key") == "new-value"
 
 
@@ -1675,8 +1675,8 @@ class TestConfigRoutes:
     @pytest.mark.asyncio
     async def test_get_llm_config_exposes_subscription_defaults_from_presets(self):
         app = create_app()
-        app["credential_store"] = MagicMock()
-        app["credential_store"].get.return_value = None
+        app[CREDENTIAL_STORE_KEY] = MagicMock()
+        app[CREDENTIAL_STORE_KEY].get.return_value = None
 
         async with TestClient(TestServer(app)) as client:
             resp = await client.get("/api/config/llm")

--- a/core/framework/server/tests/test_colony_tools.py
+++ b/core/framework/server/tests/test_colony_tools.py
@@ -23,6 +23,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from framework.host.colony_runtime import ColonyRuntime
 from framework.llm.provider import Tool
 from framework.server import routes_colony_tools
+from framework.server.app import MANAGER_KEY
 
 
 def _tool(name: str) -> Tool:
@@ -121,7 +122,7 @@ def colony_dir(tmp_path, monkeypatch):
 
 async def _app(manager: _FakeManager) -> web.Application:
     app = web.Application()
-    app["manager"] = manager
+    app[MANAGER_KEY] = manager
     routes_colony_tools.register_routes(app)
     return app
 

--- a/core/framework/server/tests/test_queen_tools.py
+++ b/core/framework/server/tests/test_queen_tools.py
@@ -24,6 +24,7 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from framework.llm.provider import Tool
 from framework.server import routes_queen_tools
+from framework.server.app import MANAGER_KEY
 from framework.tools.queen_lifecycle_tools import QueenPhaseState
 
 # ---------------------------------------------------------------------------
@@ -140,7 +141,7 @@ def queen_dir(tmp_path, monkeypatch):
 
 async def _make_app(*, manager: _FakeManager) -> web.Application:
     app = web.Application()
-    app["manager"] = manager
+    app[MANAGER_KEY] = manager
     routes_queen_tools.register_routes(app)
     return app
 

--- a/core/tests/test_colony_fork_flow.py
+++ b/core/tests/test_colony_fork_flow.py
@@ -22,7 +22,7 @@ import pytest
 from aiohttp.test_utils import TestClient, TestServer
 
 from framework.agent_loop.internals.types import LoopConfig
-from framework.server.app import create_app
+from framework.server.app import MANAGER_KEY, create_app
 from framework.server.session_manager import Session, _queen_session_dir
 
 # Modules that import HIVE_HOME / QUEENS_DIR / COLONIES_DIR / MEMORIES_DIR /
@@ -263,7 +263,7 @@ async def test_colony_spawn_creates_correct_artifacts(tmp_path, monkeypatch):
 
     # Build the in-process aiohttp app and inject our fake session
     app = create_app()
-    manager = app["manager"]
+    manager = app[MANAGER_KEY]
     session = _make_session_with_queen_state(
         session_id=source_session_id,
         queen_name=queen_name,

--- a/core/tests/test_colony_fork_live.py
+++ b/core/tests/test_colony_fork_live.py
@@ -129,7 +129,7 @@ async def test_live_queen_fork_to_colony(isolated_hive_home):
       5. Conversations are copied through to worker storage
     """
     from framework.agents.queen.queen_profiles import ensure_default_queens
-    from framework.server.app import create_app
+    from framework.server.app import MANAGER_KEY, create_app
     from framework.server.session_manager import _queen_session_dir
 
     # Pre-populate queen profiles in the temp ~/.hive so the identity
@@ -137,7 +137,7 @@ async def test_live_queen_fork_to_colony(isolated_hive_home):
     ensure_default_queens()
 
     app = create_app()  # picks up model from copied configuration.json
-    manager = app["manager"]
+    manager = app[MANAGER_KEY]
 
     async with TestClient(TestServer(app)) as client:
         # ── 1. Create a queen-only session ─────────────────────────

--- a/core/tests/test_routes_skills.py
+++ b/core/tests/test_routes_skills.py
@@ -17,6 +17,7 @@ import pytest_asyncio
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
+from framework.server.app import MANAGER_KEY
 from framework.server.routes_skills import register_routes
 from framework.skills.overrides import (
     OverrideEntry,
@@ -45,7 +46,7 @@ class _StubSessionManager:
 
 def _build_app() -> web.Application:
     application = web.Application()
-    application["manager"] = _StubSessionManager()
+    application[MANAGER_KEY] = _StubSessionManager()
     register_routes(application)
     return application
 


### PR DESCRIPTION
Resolves #6161.

`core/framework/server/app.py` stores request/app state with string keys:

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal infrastructure improvements to application state management for enhanced code maintainability and type safety.

*Note: This release contains no user-facing changes or new features.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->