### PR TITLE
docs(readme): document required LLM API key env var in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Use Hive when the bottleneck is no longer the model but the harness around it:
 ### Prerequisites
 
 - Python 3.11+ for agent development
-- An LLM provider that powers the agents
+- An LLM provider API key to power the agents, set as an environment variable (e.g. `ANTHROPIC_API_KEY`). Hive works with 100+ providers through LiteLLM — see [Environment Variables](docs/configuration.md#environment-variables) for the full list of supported keys and runtime flags.
 - **ripgrep (optional, recommended on Windows):** The `search_files` tool uses ripgrep for faster file search. If not installed, a Python fallback is used. On Windows: `winget install BurntSushi.ripgrep` or `scoop install ripgrep`
 
 > **Windows Users:** Native Windows is supported via `quickstart.ps1` and `hive.ps1`. Run these in PowerShell 5.1+. WSL is also an option but not required.
@@ -119,6 +119,13 @@ cd hive
 # Windows (PowerShell)
 .\quickstart.ps1
 ```
+
+> **Set your LLM API key** before running an agent. Export the environment
+> variable for your provider, for example `export ANTHROPIC_API_KEY="sk-ant-..."`.
+> The quickstart helps you choose a default model; see
+> [Environment Variables](docs/configuration.md#environment-variables) for the
+> complete list of provider keys (OpenAI, Gemini, OpenRouter, Groq, Hive LLM, …)
+> and optional runtime flags such as `MOCK_MODE`.
 
 This sets up:
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,12 @@ cd hive
 .\quickstart.ps1
 ```
 
-> **Set your LLM API key** before running an agent. Export the environment
-> variable for your provider, for example `export ANTHROPIC_API_KEY="sk-ant-..."`.
+> **Set your LLM API key** before running an agent. Set the environment
+> variable for your provider, for example `ANTHROPIC_API_KEY`:
+>
+> - macOS/Linux: `export ANTHROPIC_API_KEY="sk-ant-..."`
+> - Windows (PowerShell): `setx ANTHROPIC_API_KEY "sk-ant-..."`
+>
 > The quickstart helps you choose a default model; see
 > [Environment Variables](docs/configuration.md#environment-variables) for the
 > complete list of provider keys (OpenAI, Gemini, OpenRouter, Groq, Hive LLM, …)


### PR DESCRIPTION
## What

Documents the required LLM provider API key environment variable directly in the README setup flow, where new users will see it.

## Why

The **Prerequisites** section only said "An LLM provider that powers the agents" and the **Installation** steps never mention setting an API key, so new users run `quickstart.sh` and then hit runtime errors with no centralized reference for which environment variable is required (per #3649).

## Changes (README.md only)

- **Prerequisites:** name the required env var (e.g. `ANTHROPIC_API_KEY`) and link to the existing **Environment Variables** section of `docs/configuration.md` for the full list of supported provider keys and runtime flags.
- **Installation:** add a short note after the quickstart command reminding users to export their provider API key before running an agent, with the same canonical link.

This keeps a single source of truth (`docs/configuration.md`) and does **not** reintroduce a `.env.example`, in line with the direction given when #3658 was closed ("we are no longer using the .env.example").

Docs-only change. `make check` passes.

Closes #3649

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start to require setting an LLM provider API key via environment variables and linked to environment variable docs for supported providers.
  * Added a "Set your LLM API key" note with example OS-specific commands and clarified optional runtime flags (e.g., mock mode) and default model usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->