### PR TITLE
fix(orchestrator): log warning on transition payload spillover failure [micro-fix]

### DIFF
--- a/core/framework/orchestrator/node_worker.py
+++ b/core/framework/orchestrator/node_worker.py
@@ -790,8 +790,15 @@ class NodeWorker:
                         f"[Saved to '{filename}' ({file_size:,} bytes). Use read_file(path='{filename}') to access.]"
                     )
                     continue
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.warning(
+                        "Worker %s: failed to spill buffer key '%s' to '%s': %s",
+                        self.node_spec.id,
+                        key,
+                        file_path,
+                        exc,
+                        exc_info=True,
+                    )
 
             buffer_items[key] = val_str[:300] + "..." if len(val_str) > 300 else val_str
 

--- a/core/tests/test_node_worker_spillover.py
+++ b/core/tests/test_node_worker_spillover.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+import logging
+from framework.orchestrator.node_worker import NodeWorker
+from framework.orchestrator.node import NodeSpec
+
+def test_node_worker_spillover_exception_logging(caplog):
+    # Setup NodeSpec and mock GraphContext
+    node_spec = NodeSpec(id="test_node", name="Test Node", description="Test description", node_type="task", output_keys=["large_key"])
+    gc = MagicMock()
+    
+    # Configure GraphContext mocks
+    gc.storage_path = Path("/some/path")
+    gc.buffer.read_all.return_value = {
+        "large_key": "x" * 500  # Longer than 300 characters
+    }
+    
+    # Instantiate worker
+    worker = NodeWorker(node_spec=node_spec, graph_context=gc)
+    
+    # Mock Path methods to raise an error during write_text
+    with patch.object(Path, "mkdir"), \
+         patch.object(Path, "write_text", side_effect=PermissionError("Permission denied")), \
+         caplog.at_level(logging.WARNING):
+         
+        buffer_items, data_files = worker._prepare_transition_payload()
+        
+        # Verify fallback logic works (truncating to 300 chars + "...")
+        assert "large_key" in buffer_items
+        assert buffer_items["large_key"] == "x" * 300 + "..."
+        
+        # Verify warning is logged with correct details
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.levelname == "WARNING"
+        assert "failed to spill buffer key 'large_key'" in record.message
+        assert record.exc_info is not None

--- a/core/tests/test_node_worker_spillover.py
+++ b/core/tests/test_node_worker_spillover.py
@@ -11,6 +11,8 @@ def test_node_worker_spillover_exception_logging(caplog):
     
     # Configure GraphContext mocks
     gc.storage_path = Path("/some/path")
+    gc.graph.get_incoming_edges.return_value = []
+    gc.graph.get_outgoing_edges.return_value = []
     gc.buffer.read_all.return_value = {
         "large_key": "x" * 500  # Longer than 300 characters
     }


### PR DESCRIPTION
Resolves #7262. Added structured warning logging with exc_info=True when spilling transition payload buffer key values fails, while maintaining the inline truncation fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved system visibility by logging warning details when large buffer spill operations fail. Failures now emit an informative warning (including worker and buffer context and exception details) instead of being silently ignored, while preserving the existing truncated-value fallback behavior.

* **Tests**
  * Added a unit test to verify that spill failures during buffer handling are logged correctly (single warning at WARNING level with exception info) and that returned values are properly truncated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->