### PR TITLE
fix(llm): prevent mid-stream retry from duplicating published tokens

### DIFF
--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -2693,6 +2693,17 @@ class LiteLLMProvider(LLMProvider):
 
             except RateLimitError as e:
                 if attempt < RATE_LIMIT_MAX_RETRIES:
+                    if accumulated_text:
+                        # Text deltas were already yielded to the caller (and
+                        # published to the event bus) in real time — they cannot
+                        # be recalled.  Retrying restarts the stream from token 1
+                        # (accumulated_text is reset per attempt above),
+                        # duplicating content the client already received.
+                        # Signal a recoverable error instead: the consumer
+                        # (AgentLoop) commits the partial text and skips the
+                        # outer retry when accumulated_text is non-empty.
+                        yield StreamErrorEvent(error=str(e), recoverable=True)
+                        return
                     wait = _compute_retry_delay(attempt, exception=e)
                     logger.warning(
                         f"[stream-retry] {self.model} rate limited (429): {e!s}. "
@@ -2746,6 +2757,14 @@ class LiteLLMProvider(LLMProvider):
                         yield event
                     return
                 if _is_stream_transient_error(e) and attempt < STREAM_TRANSIENT_MAX_RETRIES:
+                    if accumulated_text:
+                        # Same guard as RateLimitError: text already streamed to
+                        # the caller in real time cannot be recalled.  Stop
+                        # retrying to avoid client-visible duplication; signal a
+                        # recoverable error so the consumer commits the partial
+                        # text instead of re-streaming from token 1.
+                        yield StreamErrorEvent(error=str(e), recoverable=True)
+                        return
                     wait = _compute_retry_delay(attempt, exception=e)
                     logger.warning(
                         f"[stream-retry] {self.model} transient error "

--- a/core/tests/test_event_loop_node.py
+++ b/core/tests/test_event_loop_node.py
@@ -2257,3 +2257,90 @@ class TestReplayDetector:
         await node.execute(ctx)
 
         assert captured == []
+
+
+# ===========================================================================
+# Mid-stream retry must not duplicate already-published tokens (#5923)
+# ===========================================================================
+
+
+def _partial_then_recoverable_error(tokens: list[str], error: str = "429 mid-stream") -> list:
+    """A stream that yields text deltas then fails mid-stream with a recoverable
+    error and no FinishEvent — what LiteLLMProvider.stream now emits instead of
+    silently re-streaming after a mid-stream RateLimitError/transient error.
+    """
+    events: list = []
+    snapshot = ""
+    for tok in tokens:
+        snapshot += tok
+        events.append(TextDeltaEvent(content=tok, snapshot=snapshot))
+    events.append(StreamErrorEvent(error=error, recoverable=True))
+    return events
+
+
+class TestMidStreamRetryNoDuplication:
+    """End-to-end (AgentLoop + provider contract): a recoverable error that
+    arrives AFTER text was published commits the partial turn and does NOT re-run
+    the LLM; one that arrives BEFORE any text triggers the outer retry."""
+
+    @pytest.mark.asyncio
+    async def test_partial_stream_recoverable_error_no_outer_retry(self, runtime, node_spec, buffer):
+        node_spec.output_keys = []
+        llm = MockStreamingLLM(scenarios=[_partial_then_recoverable_error(["Hel", "lo ", "world"])])
+        bus = EventBus()
+        deltas: list = []
+        bus.subscribe(
+            event_types=[EventType.LLM_TEXT_DELTA],
+            handler=lambda e: deltas.append(e),
+        )
+
+        ctx = build_ctx(runtime, node_spec, buffer, llm, is_subagent_mode=True)
+        node = EventLoopNode(event_bus=bus, config=LoopConfig(max_iterations=5))
+        result = await node.execute(ctx)
+
+        # The stream ran exactly once — the partial turn was committed, not
+        # re-run (a re-run would re-publish every token).
+        assert llm._call_index == 1
+        # Each of the three tokens was published exactly once (no duplication).
+        assert len(deltas) == 3
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_partial_stream_many_chunks_no_duplicate_deltas(self, runtime, node_spec, buffer):
+        node_spec.output_keys = []
+        tokens = [f"t{i} " for i in range(20)]
+        llm = MockStreamingLLM(scenarios=[_partial_then_recoverable_error(tokens)])
+        bus = EventBus()
+        deltas: list = []
+        bus.subscribe(
+            event_types=[EventType.LLM_TEXT_DELTA],
+            handler=lambda e: deltas.append(e),
+        )
+
+        ctx = build_ctx(runtime, node_spec, buffer, llm, is_subagent_mode=True)
+        node = EventLoopNode(event_bus=bus, config=LoopConfig(max_iterations=5))
+        result = await node.execute(ctx)
+
+        assert llm._call_index == 1
+        assert len(deltas) == 20  # exactly the 20 published tokens, none re-sent
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_recoverable_error_before_text_triggers_outer_retry(self, runtime, node_spec, buffer):
+        node_spec.output_keys = []
+        llm = MockStreamingLLM(
+            scenarios=[
+                # attempt 1: recoverable error before any text was published
+                [StreamErrorEvent(error="429 at chunk 0", recoverable=True)],
+                # attempt 2: succeeds
+                text_scenario("recovered"),
+            ]
+        )
+
+        ctx = build_ctx(runtime, node_spec, buffer, llm, is_subagent_mode=True)
+        node = EventLoopNode(event_bus=None, config=LoopConfig(max_iterations=5))
+        result = await node.execute(ctx)
+
+        # Nothing was published, so the outer retry correctly re-ran the stream.
+        assert llm._call_index == 2
+        assert result.success is True

--- a/core/tests/test_event_loop_node.py
+++ b/core/tests/test_event_loop_node.py
@@ -2285,6 +2285,7 @@ class TestMidStreamRetryNoDuplication:
 
     @pytest.mark.asyncio
     async def test_partial_stream_recoverable_error_no_outer_retry(self, runtime, node_spec, buffer):
+        """Text + recoverable error commits the partial turn: one stream call, each delta once."""
         node_spec.output_keys = []
         llm = MockStreamingLLM(scenarios=[_partial_then_recoverable_error(["Hel", "lo ", "world"])])
         bus = EventBus()
@@ -2307,6 +2308,7 @@ class TestMidStreamRetryNoDuplication:
 
     @pytest.mark.asyncio
     async def test_partial_stream_many_chunks_no_duplicate_deltas(self, runtime, node_spec, buffer):
+        """A 20-token partial stream publishes exactly 20 deltas with no outer retry."""
         node_spec.output_keys = []
         tokens = [f"t{i} " for i in range(20)]
         llm = MockStreamingLLM(scenarios=[_partial_then_recoverable_error(tokens)])
@@ -2327,6 +2329,7 @@ class TestMidStreamRetryNoDuplication:
 
     @pytest.mark.asyncio
     async def test_recoverable_error_before_text_triggers_outer_retry(self, runtime, node_spec, buffer):
+        """A recoverable error before any text was published still triggers the outer retry."""
         node_spec.output_keys = []
         llm = MockStreamingLLM(
             scenarios=[

--- a/core/tests/test_stream_retry_duplication.py
+++ b/core/tests/test_stream_retry_duplication.py
@@ -1,0 +1,174 @@
+"""
+Regression test for GitHub issue #5923:
+mid-stream retry must not duplicate already-published tokens.
+
+``LiteLLMProvider.stream`` yields ``TextDeltaEvent``s to the caller in real
+time (they are published to the event bus as they arrive). If the underlying
+streaming call fails *after* some text has been yielded, the provider's retry
+loop resets ``accumulated_text`` and re-streams from token 1 — duplicating
+content the client already received.
+
+Fix: once any text has been streamed, stop retrying and emit a recoverable
+``StreamErrorEvent`` instead. The consumer (AgentLoop) then commits the partial
+text and skips the outer retry. The legitimate retry path (failure *before* any
+text was published) must remain intact.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from litellm.exceptions import RateLimitError
+
+from framework.llm.litellm import LiteLLMProvider
+from framework.llm.stream_events import StreamErrorEvent, TextDeltaEvent
+
+# ---------------------------------------------------------------------------
+# Minimal chunk stubs mirroring the litellm streaming chunk shape the loop
+# actually touches: chunk.choices[0].delta.content / .tool_calls and
+# choice.finish_reason.
+# ---------------------------------------------------------------------------
+
+
+class _Delta:
+    def __init__(self, content=None):
+        self.content = content
+        self.tool_calls = None
+
+
+class _Choice:
+    def __init__(self, content=None, finish_reason=None):
+        self.delta = _Delta(content)
+        self.finish_reason = finish_reason
+
+
+class _Chunk:
+    def __init__(self, content=None, finish_reason=None):
+        self.choices = [_Choice(content, finish_reason)]
+        self.usage = None
+
+
+def _text(content):
+    return _Chunk(content=content)
+
+
+def _finish():
+    return _Chunk(finish_reason="stop")
+
+
+def _scripted_acompletion(scripts):
+    """Build an ``acompletion`` side-effect that plays one script per call.
+
+    Each script is ``(chunks, exc_or_none)``: yield each chunk, then raise
+    ``exc`` (mid-stream) if provided.
+    """
+    state = {"calls": 0}
+
+    async def _side_effect(*args, **kwargs):
+        idx = min(state["calls"], len(scripts) - 1)
+        state["calls"] += 1
+        chunks, exc = scripts[idx]
+
+        async def _gen():
+            for chunk in chunks:
+                yield chunk
+            if exc is not None:
+                raise exc
+
+        return _gen()
+
+    return _side_effect
+
+
+async def _collect(provider):
+    events = []
+    async for event in provider.stream(
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=64,
+    ):
+        events.append(event)
+    return events
+
+
+@pytest.mark.asyncio
+@patch("framework.llm.litellm._compute_retry_delay", return_value=0.0)
+@patch("litellm.acompletion")
+async def test_rate_limit_after_streamed_text_does_not_duplicate(mock_acompletion, _delay):
+    provider = LiteLLMProvider(model="gpt-4o-mini", api_key="test-key")
+
+    rate_limited = RateLimitError(
+        message="429 rate limited", llm_provider="openai", model="gpt-4o-mini"
+    )
+    mock_acompletion.side_effect = _scripted_acompletion(
+        [
+            # attempt 1: stream two tokens, then hit a 429 mid-stream
+            ([_text("Hello "), _text("world")], rate_limited),
+            # attempt 2: only the buggy code reaches this — it re-streams the text
+            ([_text("Hello "), _text("world"), _finish()], None),
+        ]
+    )
+
+    events = await _collect(provider)
+
+    text = "".join(e.content for e in events if isinstance(e, TextDeltaEvent))
+    errors = [e for e in events if isinstance(e, StreamErrorEvent)]
+
+    # Once text has been published, the provider must not retry...
+    assert mock_acompletion.call_count == 1
+    # ...so every token appears exactly once (no duplication)...
+    assert text == "Hello world"
+    # ...and the caller is told the failure is recoverable.
+    assert len(errors) == 1
+    assert errors[0].recoverable is True
+
+
+@pytest.mark.asyncio
+@patch("framework.llm.litellm._compute_retry_delay", return_value=0.0)
+@patch("litellm.acompletion")
+async def test_transient_error_after_streamed_text_does_not_duplicate(mock_acompletion, _delay):
+    provider = LiteLLMProvider(model="gpt-4o-mini", api_key="test-key")
+
+    transient = ConnectionError("connection reset by peer")
+    mock_acompletion.side_effect = _scripted_acompletion(
+        [
+            ([_text("Hello "), _text("world")], transient),
+            ([_text("Hello "), _text("world"), _finish()], None),
+        ]
+    )
+
+    events = await _collect(provider)
+
+    text = "".join(e.content for e in events if isinstance(e, TextDeltaEvent))
+    errors = [e for e in events if isinstance(e, StreamErrorEvent)]
+
+    assert mock_acompletion.call_count == 1
+    assert text == "Hello world"
+    assert len(errors) == 1
+    assert errors[0].recoverable is True
+
+
+@pytest.mark.asyncio
+@patch("framework.llm.litellm._compute_retry_delay", return_value=0.0)
+@patch("litellm.acompletion")
+async def test_transient_error_before_any_text_still_retries(mock_acompletion, _delay):
+    """Non-regression guard: a failure *before* any text was published is safe
+    to retry, and the provider should still do so."""
+    provider = LiteLLMProvider(model="gpt-4o-mini", api_key="test-key")
+
+    mock_acompletion.side_effect = _scripted_acompletion(
+        [
+            # attempt 1: fail before yielding any text
+            ([], ConnectionError("reset before first token")),
+            # attempt 2: succeeds
+            ([_text("Hello world"), _finish()], None),
+        ]
+    )
+
+    events = await _collect(provider)
+
+    text = "".join(e.content for e in events if isinstance(e, TextDeltaEvent))
+
+    # Nothing was published yet, so retrying is correct.
+    assert mock_acompletion.call_count == 2
+    assert text == "Hello world"

--- a/core/tests/test_stream_retry_duplication.py
+++ b/core/tests/test_stream_retry_duplication.py
@@ -16,6 +16,7 @@ text was published) must remain intact.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -25,53 +26,36 @@ from framework.llm.litellm import LiteLLMProvider
 from framework.llm.stream_events import StreamErrorEvent, TextDeltaEvent
 
 # ---------------------------------------------------------------------------
-# Minimal chunk stubs mirroring the litellm streaming chunk shape the loop
-# actually touches: chunk.choices[0].delta.content / .tool_calls and
-# choice.finish_reason.
+# Minimal stubs mirroring the litellm streaming chunk shape the loop actually
+# touches: chunk.choices[0].delta.content / .tool_calls and choice.finish_reason.
 # ---------------------------------------------------------------------------
 
 
-class _Fn:
-    def __init__(self, name=None, arguments=None):
-        self.name = name
-        self.arguments = arguments
+def _tool_call(name, arguments, tc_id="call_1"):
+    """Build a stub tool-call delta entry (id + index + function name/args)."""
+    return SimpleNamespace(id=tc_id, index=0, function=SimpleNamespace(name=name, arguments=arguments))
 
 
-class _ToolCall:
-    def __init__(self, tc_id=None, name=None, arguments=None, index=0):
-        self.id = tc_id
-        self.index = index
-        self.function = _Fn(name, arguments)
-
-
-class _Delta:
-    def __init__(self, content=None, tool_calls=None):
-        self.content = content
-        self.tool_calls = tool_calls
-
-
-class _Choice:
-    def __init__(self, content=None, finish_reason=None, tool_calls=None):
-        self.delta = _Delta(content, tool_calls)
-        self.finish_reason = finish_reason
-
-
-class _Chunk:
-    def __init__(self, content=None, finish_reason=None, tool_calls=None):
-        self.choices = [_Choice(content, finish_reason, tool_calls)]
-        self.usage = None
+def _chunk(content=None, finish_reason=None, tool_calls=None):
+    """Build a stub streaming chunk wrapping a single choice/delta."""
+    delta = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], usage=None)
 
 
 def _text(content):
-    return _Chunk(content=content)
+    """A chunk carrying a single text delta."""
+    return _chunk(content=content)
 
 
 def _tool(name, arguments, tc_id="call_1"):
-    return _Chunk(tool_calls=[_ToolCall(tc_id=tc_id, name=name, arguments=arguments)])
+    """A chunk carrying a single tool-call delta (no text)."""
+    return _chunk(tool_calls=[_tool_call(name, arguments, tc_id)])
 
 
 def _finish(reason="stop"):
-    return _Chunk(finish_reason=reason)
+    """A terminal chunk carrying a finish_reason and no delta content."""
+    return _chunk(finish_reason=reason)
 
 
 def _scripted_acompletion(scripts):
@@ -99,6 +83,7 @@ def _scripted_acompletion(scripts):
 
 
 async def _collect(provider):
+    """Drive ``provider.stream(...)`` to exhaustion and return all emitted events."""
     events = []
     async for event in provider.stream(
         messages=[{"role": "user", "content": "hi"}],
@@ -112,6 +97,7 @@ async def _collect(provider):
 @patch("framework.llm.litellm._compute_retry_delay", return_value=0.0)
 @patch("litellm.acompletion")
 async def test_rate_limit_after_streamed_text_does_not_duplicate(mock_acompletion, _delay):
+    """A 429 after text was streamed yields one recoverable error, no retry, no duplication."""
     provider = LiteLLMProvider(model="gpt-4o-mini", api_key="test-key")
 
     rate_limited = RateLimitError(message="429 rate limited", llm_provider="openai", model="gpt-4o-mini")
@@ -142,6 +128,7 @@ async def test_rate_limit_after_streamed_text_does_not_duplicate(mock_acompletio
 @patch("framework.llm.litellm._compute_retry_delay", return_value=0.0)
 @patch("litellm.acompletion")
 async def test_transient_error_after_streamed_text_does_not_duplicate(mock_acompletion, _delay):
+    """A transient error after text was streamed behaves like the 429 case: no retry, no duplication."""
     provider = LiteLLMProvider(model="gpt-4o-mini", api_key="test-key")
 
     transient = ConnectionError("connection reset by peer")

--- a/core/tests/test_stream_retry_duplication.py
+++ b/core/tests/test_stream_retry_duplication.py
@@ -31,21 +31,34 @@ from framework.llm.stream_events import StreamErrorEvent, TextDeltaEvent
 # ---------------------------------------------------------------------------
 
 
+class _Fn:
+    def __init__(self, name=None, arguments=None):
+        self.name = name
+        self.arguments = arguments
+
+
+class _ToolCall:
+    def __init__(self, tc_id=None, name=None, arguments=None, index=0):
+        self.id = tc_id
+        self.index = index
+        self.function = _Fn(name, arguments)
+
+
 class _Delta:
-    def __init__(self, content=None):
+    def __init__(self, content=None, tool_calls=None):
         self.content = content
-        self.tool_calls = None
+        self.tool_calls = tool_calls
 
 
 class _Choice:
-    def __init__(self, content=None, finish_reason=None):
-        self.delta = _Delta(content)
+    def __init__(self, content=None, finish_reason=None, tool_calls=None):
+        self.delta = _Delta(content, tool_calls)
         self.finish_reason = finish_reason
 
 
 class _Chunk:
-    def __init__(self, content=None, finish_reason=None):
-        self.choices = [_Choice(content, finish_reason)]
+    def __init__(self, content=None, finish_reason=None, tool_calls=None):
+        self.choices = [_Choice(content, finish_reason, tool_calls)]
         self.usage = None
 
 
@@ -53,8 +66,12 @@ def _text(content):
     return _Chunk(content=content)
 
 
-def _finish():
-    return _Chunk(finish_reason="stop")
+def _tool(name, arguments, tc_id="call_1"):
+    return _Chunk(tool_calls=[_ToolCall(tc_id=tc_id, name=name, arguments=arguments)])
+
+
+def _finish(reason="stop"):
+    return _Chunk(finish_reason=reason)
 
 
 def _scripted_acompletion(scripts):
@@ -97,9 +114,7 @@ async def _collect(provider):
 async def test_rate_limit_after_streamed_text_does_not_duplicate(mock_acompletion, _delay):
     provider = LiteLLMProvider(model="gpt-4o-mini", api_key="test-key")
 
-    rate_limited = RateLimitError(
-        message="429 rate limited", llm_provider="openai", model="gpt-4o-mini"
-    )
+    rate_limited = RateLimitError(message="429 rate limited", llm_provider="openai", model="gpt-4o-mini")
     mock_acompletion.side_effect = _scripted_acompletion(
         [
             # attempt 1: stream two tokens, then hit a 429 mid-stream
@@ -172,3 +187,61 @@ async def test_transient_error_before_any_text_still_retries(mock_acompletion, _
     # Nothing was published yet, so retrying is correct.
     assert mock_acompletion.call_count == 2
     assert text == "Hello world"
+
+
+@pytest.mark.asyncio
+@patch("framework.llm.litellm._compute_retry_delay", return_value=0.0)
+@patch("litellm.acompletion")
+async def test_no_duplicate_deltas_across_many_chunks(mock_acompletion, _delay):
+    """A long partial stream then a 429: every token appears exactly once and in
+    order — no chunk is re-emitted by a restart."""
+    provider = LiteLLMProvider(model="gpt-4o-mini", api_key="test-key")
+
+    tokens = [f"t{i} " for i in range(50)]
+    rate_limited = RateLimitError(message="429 rate limited", llm_provider="openai", model="gpt-4o-mini")
+    mock_acompletion.side_effect = _scripted_acompletion(
+        [
+            ([_text(t) for t in tokens], rate_limited),
+            # only the buggy code reaches attempt 2 and re-streams the 50 tokens
+            ([_text(t) for t in tokens] + [_finish()], None),
+        ]
+    )
+
+    events = await _collect(provider)
+
+    deltas = [e.content for e in events if isinstance(e, TextDeltaEvent)]
+    errors = [e for e in events if isinstance(e, StreamErrorEvent)]
+
+    assert mock_acompletion.call_count == 1
+    assert deltas == tokens  # exactly 50, in order, no duplicates
+    assert len(errors) == 1
+    assert errors[0].recoverable is True
+
+
+@pytest.mark.asyncio
+@patch("framework.llm.litellm._compute_retry_delay", return_value=0.0)
+@patch("litellm.acompletion")
+async def test_tool_only_stream_error_still_retries_internally(mock_acompletion, _delay):
+    """The guard keys on accumulated_text, not buffered tool-call deltas. Tool
+    deltas are never published before the stream completes, so a transient error
+    during a tool-only stream is still safe to retry internally."""
+    provider = LiteLLMProvider(model="gpt-4o-mini", api_key="test-key")
+
+    mock_acompletion.side_effect = _scripted_acompletion(
+        [
+            # attempt 1: only tool-call deltas (no text), then a transient error
+            ([_tool("search", '{"q": "x"}')], ConnectionError("reset mid-tool")),
+            # attempt 2: succeeds
+            ([_tool("search", '{"q": "x"}'), _finish("tool_calls")], None),
+        ]
+    )
+
+    events = await _collect(provider)
+
+    text = "".join(e.content for e in events if isinstance(e, TextDeltaEvent))
+    errors = [e for e in events if isinstance(e, StreamErrorEvent)]
+
+    # No text was published, so the guard must NOT fire — the stream is retried.
+    assert mock_acompletion.call_count == 2
+    assert text == ""
+    assert errors == []


### PR DESCRIPTION
## Description

Fixes #5923. When the LiteLLM streaming layer retried after a mid-stream `RateLimitError` or transient error, it re-streamed from token 1, duplicating content that had already been yielded to callers and published to the event bus. Because published `TextDeltaEvent`s cannot be recalled, the retry must be abandoned once a partial stream has already been emitted.

**Root cause.** `LiteLLMProvider.stream()` (`core/framework/llm/litellm.py`) runs an internal retry loop that resets `accumulated_text` at the top of each attempt and yields `TextDeltaEvent`s in real time. Both the `RateLimitError` handler (`L2694`) and the transient `except Exception` handler (`L2759`) called `continue` unconditionally — restarting the stream from the beginning even when text had already been published.

```python
# Before — restarts the stream, re-publishing every prior token:
except RateLimitError as e:
    if attempt < RATE_LIMIT_MAX_RETRIES:
        wait = _compute_retry_delay(attempt, exception=e)
        await asyncio.sleep(wait)
        continue
```

**Fix.** In both handlers, check `accumulated_text` before retrying. If any text was already yielded, emit a `recoverable=True` `StreamErrorEvent` and return instead of retrying.

```python
except RateLimitError as e:
    if attempt < RATE_LIMIT_MAX_RETRIES:
        if accumulated_text:               # L2705
            yield StreamErrorEvent(error=str(e), recoverable=True)
            return
        wait = _compute_retry_delay(attempt, exception=e)
        ...
        continue
```

The cooperating consumer already exists in `AgentLoop`: a `recoverable=True` error is not raised (`agent_loop.py:2634`), and `ConnectionError` is raised only when the partial response is empty (`agent_loop.py:2857`). So a non-empty `accumulated_text` commits the partial turn and skips the outer retry, while an empty one falls through to the outer transient retry (`agent_loop.py:1089`). The guard keys on `accumulated_text` only — tool-call deltas are buffered and never published before stream completion, so tool-only streams remain safe to retry internally.

> Supersedes #6541, whose branch predated the graph→orchestrator revamp; this is the same fix reworked on current `main` (the consumer is now `AgentLoop`, not `EventLoopNode`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #5923

## Changes Made

- `core/framework/llm/litellm.py`: add an `accumulated_text` guard to the `RateLimitError` handler (L2694 → yields a recoverable error at L2705) and the transient `Exception` handler (L2759 → L2766) so a mid-stream failure after text was published stops retrying instead of re-streaming.
- `core/tests/test_stream_retry_duplication.py` (new): 5 provider unit tests covering rate-limit/transient after text (no duplication, recoverable error, single stream call), a 50-chunk no-duplication case, a tool-only stream that still retries internally, and the before-any-text path that still retries.
- `core/tests/test_event_loop_node.py` (new `TestMidStreamRetryNoDuplication`): 3 AgentLoop integration tests proving the end-to-end contract — a recoverable error after text commits the partial turn with no outer retry (`llm._call_index == 1`, each delta published once), while a recoverable error before any text triggers the outer retry (`llm._call_index == 2`).

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/test_stream_retry_duplication.py tests/test_event_loop_node.py::TestMidStreamRetryNoDuplication`) — 8 new tests pass; 145 existing `test_litellm_provider.py` tests pass.
- [x] Lint passes (`cd core && ruff check .` and `ruff format --check`) — clean on changed files.
- [x] Manual testing performed — verified via TDD: with the guards removed, the duplication tests fail (`call_count` becomes 2, deltas double); with the guards in place they pass.

Pure-Python change with no OS-specific code; developed/run on Windows (Python 3.11 via `uv`). macOS/Linux covered by CI.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — N/A (internal bug fix, no public API or user-facing behavior change)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevented duplicated streaming output when rate-limit or transient connection errors occur mid-stream. The stream now stops retrying after partial content has already been delivered, emits a recoverable error, and avoids restarting already-published text.

* **Tests**
  * Added regression coverage to ensure mid-stream retry behavior never duplicates published text, and that retries still occur when failures happen before any content is emitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->