### PR TITLE
fix(storage): add checkpoint integrity validation and isolation [micro-fix]

### DIFF
--- a/core/framework/orchestrator/orchestrator.py
+++ b/core/framework/orchestrator/orchestrator.py
@@ -31,7 +31,7 @@ from framework.orchestrator.node import (
 )
 from framework.orchestrator.validator import OutputValidator
 from framework.schemas.checkpoint import Checkpoint
-from framework.storage.checkpoint_store import CheckpointStore
+from framework.storage.checkpoint_store import CheckpointStore, CheckpointCorruptionError
 from framework.tracker.decision_tracker import DecisionTracker
 from framework.utils.io import atomic_write
 
@@ -646,6 +646,11 @@ class Orchestrator:
                     self.logger.warning(f"Checkpoint {checkpoint_id} not found, resuming from normal entry point")
                     current_node_id = graph.get_entry_point(session_state)
 
+            except CheckpointCorruptionError as e:
+                self.logger.error(
+                    f"🛑 Critical: Checkpoint corruption detected for {checkpoint_id}: {e}. Aborting execution to prevent silent data loss."
+                )
+                raise
             except Exception as e:
                 self.logger.error(f"Failed to load checkpoint {checkpoint_id}: {e}, resuming from normal entry point")
                 current_node_id = graph.get_entry_point(session_state)

--- a/core/framework/storage/checkpoint_store.py
+++ b/core/framework/storage/checkpoint_store.py
@@ -16,6 +16,18 @@ from framework.utils.io import atomic_write
 logger = logging.getLogger(__name__)
 
 
+class CheckpointError(Exception):
+    """Base exception for checkpoint operations."""
+
+    pass
+
+
+class CheckpointCorruptionError(CheckpointError):
+    """Raised when a checkpoint or index file is corrupted or cannot be parsed."""
+
+    pass
+
+
 class CheckpointStore:
     """
     Manages checkpoint storage with atomic writes.
@@ -40,6 +52,29 @@ class CheckpointStore:
         self.checkpoints_dir = self.base_path / "checkpoints"
         self.index_path = self.checkpoints_dir / "index.json"
         self._index_lock = asyncio.Lock()
+
+    def _isolate_corrupted_file(self, file_path: Path) -> Path:
+        """
+        Isolate a corrupted file by moving it to the .corrupted/ directory.
+        """
+        corrupted_dir = self.checkpoints_dir / ".corrupted"
+        corrupted_dir.mkdir(parents=True, exist_ok=True)
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        isolated_path = corrupted_dir / f"{file_path.stem}_{timestamp}{file_path.suffix}"
+
+        try:
+            file_path.rename(isolated_path)
+            logger.warning(f"Isolated corrupted file {file_path} to {isolated_path}")
+        except Exception as e:
+            logger.error(f"Failed to isolate corrupted file {file_path}: {e}")
+            try:
+                file_path.unlink()
+                logger.warning(f"Deleted corrupted file {file_path} after failed rename")
+            except Exception as delete_err:
+                logger.error(f"Failed to delete corrupted file {file_path}: {delete_err}")
+
+        return isolated_path
 
     async def save_checkpoint(self, checkpoint: Checkpoint) -> None:
         """
@@ -98,7 +133,8 @@ class CheckpointStore:
                 return Checkpoint.model_validate_json(checkpoint_path.read_text(encoding="utf-8"))
             except Exception as e:
                 logger.error(f"Failed to load checkpoint {checkpoint_id}: {e}")
-                return None
+                self._isolate_corrupted_file(checkpoint_path)
+                raise CheckpointCorruptionError(f"Checkpoint file '{checkpoint_id}.json' is corrupted: {e}") from e
 
         # Load index to get checkpoint ID if not provided
         if checkpoint_id is None:
@@ -126,7 +162,8 @@ class CheckpointStore:
                 return CheckpointIndex.model_validate_json(self.index_path.read_text(encoding="utf-8"))
             except Exception as e:
                 logger.error(f"Failed to load checkpoint index: {e}")
-                return None
+                self._isolate_corrupted_file(self.index_path)
+                raise CheckpointCorruptionError(f"Checkpoint index file 'index.json' is corrupted: {e}") from e
 
         return await asyncio.to_thread(_read)
 

--- a/core/framework/storage/checkpoint_store.py
+++ b/core/framework/storage/checkpoint_store.py
@@ -53,12 +53,21 @@ class CheckpointStore:
         self.index_path = self.checkpoints_dir / "index.json"
         self._index_lock = asyncio.Lock()
 
-    def _isolate_corrupted_file(self, file_path: Path) -> Path:
+    def _isolate_corrupted_file(self, file_path: Path) -> Path | None:
         """
         Isolate a corrupted file by moving it to the .corrupted/ directory.
         """
         corrupted_dir = self.checkpoints_dir / ".corrupted"
-        corrupted_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            corrupted_dir.mkdir(parents=True, exist_ok=True)
+        except Exception as e:
+            logger.error(f"Failed to create corruption quarantine directory: {e}")
+            try:
+                file_path.unlink()
+                logger.warning(f"Deleted corrupted file {file_path} after failed directory creation")
+            except Exception as delete_err:
+                logger.error(f"Failed to delete corrupted file {file_path}: {delete_err}")
+            return None
 
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         isolated_path = corrupted_dir / f"{file_path.stem}_{timestamp}{file_path.suffix}"

--- a/core/tests/test_checkpoint_integrity.py
+++ b/core/tests/test_checkpoint_integrity.py
@@ -103,3 +103,57 @@ async def test_load_corrupted_index_raises_and_isolates(tmp_path):
     corrupted_files = list(corrupted_dir.glob("index_*.json"))
     assert len(corrupted_files) == 1
     assert "checkpoints" in corrupted_files[0].read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_load_invalid_schema_checkpoint_raises_and_isolates(tmp_path):
+    # Setup CheckpointStore
+    store = CheckpointStore(base_path=tmp_path)
+    store.checkpoints_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write a valid JSON but invalid schema checkpoint (missing required fields like created_at, checkpoint_type)
+    checkpoint_id = "cp_node_start_node_1_12345"
+    checkpoint_path = store.checkpoints_dir / f"{checkpoint_id}.json"
+    checkpoint_path.write_text(
+        '{"checkpoint_id": "cp_node_start_node_1_12345", "session_id": "test"}', encoding="utf-8"
+    )
+
+    # Attempt to load and verify it raises exception
+    with pytest.raises(CheckpointCorruptionError) as exc_info:
+        await store.load_checkpoint(checkpoint_id)
+
+    assert "is corrupted" in str(exc_info.value)
+
+    # Verify original file is moved to .corrupted
+    assert not checkpoint_path.exists()
+
+    corrupted_dir = store.checkpoints_dir / ".corrupted"
+    assert corrupted_dir.exists()
+    corrupted_files = list(corrupted_dir.glob(f"{checkpoint_id}_*.json"))
+    assert len(corrupted_files) == 1
+    assert "checkpoint_id" in corrupted_files[0].read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_load_invalid_schema_index_raises_and_isolates(tmp_path):
+    # Setup CheckpointStore
+    store = CheckpointStore(base_path=tmp_path)
+    store.checkpoints_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write a valid JSON but invalid schema index (missing required session_id)
+    store.index_path.write_text('{"checkpoints": []}', encoding="utf-8")
+
+    # Attempt to load index and verify it raises exception
+    with pytest.raises(CheckpointCorruptionError) as exc_info:
+        await store.load_index()
+
+    assert "is corrupted" in str(exc_info.value)
+
+    # Verify original index file is moved to .corrupted
+    assert not store.index_path.exists()
+
+    corrupted_dir = store.checkpoints_dir / ".corrupted"
+    assert corrupted_dir.exists()
+    corrupted_files = list(corrupted_dir.glob("index_*.json"))
+    assert len(corrupted_files) == 1
+    assert "checkpoints" in corrupted_files[0].read_text(encoding="utf-8")

--- a/core/tests/test_checkpoint_integrity.py
+++ b/core/tests/test_checkpoint_integrity.py
@@ -1,0 +1,105 @@
+import pytest
+import json
+from pathlib import Path
+from framework.storage.checkpoint_store import CheckpointStore, CheckpointCorruptionError
+from framework.schemas.checkpoint import Checkpoint, CheckpointIndex
+
+
+@pytest.mark.asyncio
+async def test_load_valid_checkpoint(tmp_path):
+    # Setup CheckpointStore
+    store = CheckpointStore(base_path=tmp_path)
+    store.checkpoints_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create and save a valid checkpoint
+    cp = Checkpoint.create(
+        checkpoint_type="node_start",
+        session_id="test_session",
+        run_id="test_run",
+        current_node="node_1",
+        execution_path=[],
+        data_buffer={"a": 1},
+    )
+    await store.save_checkpoint(cp)
+
+    # Load and verify
+    loaded_cp = await store.load_checkpoint(cp.checkpoint_id)
+    assert loaded_cp is not None
+    assert loaded_cp.checkpoint_id == cp.checkpoint_id
+    assert loaded_cp.data_buffer == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_load_corrupted_checkpoint_raises_and_isolates(tmp_path):
+    # Setup CheckpointStore
+    store = CheckpointStore(base_path=tmp_path)
+    store.checkpoints_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write a corrupted checkpoint file (invalid JSON)
+    checkpoint_id = "cp_node_start_node_1_12345"
+    checkpoint_path = store.checkpoints_dir / f"{checkpoint_id}.json"
+    checkpoint_path.write_text('{"checkpoint_id": "cp_1", "state":', encoding="utf-8")
+
+    # Attempt to load and verify it raises exception
+    with pytest.raises(CheckpointCorruptionError) as exc_info:
+        await store.load_checkpoint(checkpoint_id)
+
+    assert "is corrupted" in str(exc_info.value)
+
+    # Verify original file is moved to .corrupted
+    assert not checkpoint_path.exists()
+
+    corrupted_dir = store.checkpoints_dir / ".corrupted"
+    assert corrupted_dir.exists()
+    corrupted_files = list(corrupted_dir.glob(f"{checkpoint_id}_*.json"))
+    assert len(corrupted_files) == 1
+    assert "state" in corrupted_files[0].read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_load_valid_index(tmp_path):
+    # Setup CheckpointStore
+    store = CheckpointStore(base_path=tmp_path)
+    store.checkpoints_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create and save a valid checkpoint (which updates index)
+    cp = Checkpoint.create(
+        checkpoint_type="node_start",
+        session_id="test_session",
+        run_id="test_run",
+        current_node="node_1",
+        execution_path=[],
+        data_buffer={"a": 1},
+    )
+    await store.save_checkpoint(cp)
+
+    # Load and verify index
+    index = await store.load_index()
+    assert index is not None
+    assert index.session_id == "test_session"
+    assert index.latest_checkpoint_id == cp.checkpoint_id
+
+
+@pytest.mark.asyncio
+async def test_load_corrupted_index_raises_and_isolates(tmp_path):
+    # Setup CheckpointStore
+    store = CheckpointStore(base_path=tmp_path)
+    store.checkpoints_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write a corrupted index file
+    store.index_path.write_text('{"session_id": "test_session", "checkpoints":', encoding="utf-8")
+
+    # Attempt to load index and verify it raises exception
+    with pytest.raises(CheckpointCorruptionError) as exc_info:
+        await store.load_index()
+
+    assert "is corrupted" in str(exc_info.value)
+
+    # Verify original index file is moved to .corrupted
+    assert not store.index_path.exists()
+
+    corrupted_dir = store.checkpoints_dir / ".corrupted"
+    assert corrupted_dir.exists()
+    corrupted_files = list(corrupted_dir.glob("index_*.json"))
+    assert len(corrupted_files) == 1
+    assert "checkpoints" in corrupted_files[0].read_text(encoding="utf-8")


### PR DESCRIPTION
Resolves #7263. Adds JSON validation and integrity checks to CheckpointStore.load_checkpoint and load_index. On deserialization failure/corruption, isolates corrupted files by relocating them to a '.corrupted/' directory and raises CheckpointCorruptionError to prevent silent data loss in the orchestrator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkpoint integrity handling: corrupted checkpoint or index files are now detected reliably, quarantined under a `.corrupted/` folder with preserved contents, and surfaced via a dedicated corruption error.
  * During checkpoint resume, corruption is logged and execution is stopped rather than falling back silently.

* **Tests**
  * Added async test coverage for successful loads and for corruption cases (invalid JSON and schema violations), including verification of quarantine behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->