### PR TITLE
fix(micro-fix): update stale repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Hive - Aden Agent Framework - Build goal-driven, self-improving AI agents",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adenhq/hive.git"
+    "url": "https://github.com/aden-hive/hive.git"
   },
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Fixes #7282

## Summary

The  field in  points to the old repo name . The repository was renamed to . This PR updates the URL to match.

## Change

- :  updated from  to 

## Verification

- The new URL resolves correctly (GitHub confirms  is the canonical name)
- No logic, API, or DB changes -- metadata-only fix
- Qualifies as micro-fix per CONTRIBUTING.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository URL metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->