### PR TITLE
fix(tools): harden HuggingFace inference 503 handling and send task override

### DIFF
--- a/tools/src/aden_tools/tools/huggingface_tool/huggingface_tool.py
+++ b/tools/src/aden_tools/tools/huggingface_tool/huggingface_tool.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 
 BASE_URL = "https://huggingface.co/api"
 INFERENCE_URL = "https://api-inference.huggingface.co/models"
+INFERENCE_PIPELINE_URL = "https://api-inference.huggingface.co/pipeline"
 
 
 def _get_token(credentials: CredentialStoreAdapter | None) -> str | None:
@@ -83,12 +84,14 @@ def _post(
             return {"error": f"Model not found: {url}"}
         if resp.status_code == 503:
             body = resp.json() if resp.headers.get("content-type", "").startswith("application/json") else {}
-            estimated = body.get("estimated_time", "unknown")
-            return {
-                "error": "Model is loading",
-                "estimated_time": estimated,
-                "help": "The model is being loaded. Retry after the estimated time.",
-            }
+            estimated = body.get("estimated_time")
+            if estimated is not None:
+                return {
+                    "error": "Model is loading",
+                    "estimated_time": estimated,
+                    "help": "The model is being loaded. Retry after the estimated time.",
+                }
+            return {"error": f"HuggingFace Inference API error 503: {resp.text[:500]}"}
         if resp.status_code != 200:
             return {"error": (f"HuggingFace Inference API error {resp.status_code}: {resp.text[:500]}")}
         return resp.json()
@@ -410,7 +413,7 @@ def register_tools(
             except _json.JSONDecodeError:
                 return {"error": "parameters must be a valid JSON string"}
 
-        url = f"{INFERENCE_URL}/{model_id}"
+        url = f"{INFERENCE_PIPELINE_URL}/{task}/{model_id}" if task else f"{INFERENCE_URL}/{model_id}"
         data = _post(url, token, payload)
 
         if isinstance(data, dict) and "error" in data:

--- a/tools/tests/tools/test_huggingface_tool.py
+++ b/tools/tests/tools/test_huggingface_tool.py
@@ -286,6 +286,89 @@ class TestHuggingFaceRunInference:
         assert result["error"] == "Model is loading"
         assert result["estimated_time"] == 30.5
 
+    def test_malformed_503_json_without_estimated_time(self, tool_fns):
+        """503 with JSON body but no estimated_time should return a generic API error, not 'Model is loading'."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 503
+        mock_resp.headers = {"content-type": "application/json"}
+        mock_resp.json.return_value = {"message": "Service temporarily unavailable"}
+        mock_resp.text = '{"message": "Service temporarily unavailable"}'
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.huggingface_tool.huggingface_tool.httpx.post",
+                return_value=mock_resp,
+            ),
+        ):
+            result = tool_fns["huggingface_run_inference"](model_id="bigscience/bloom", inputs="Hello")
+
+        assert "error" in result
+        assert result["error"] != "Model is loading"
+        assert "503" in result["error"]
+
+    def test_malformed_503_non_json_body(self, tool_fns):
+        """503 with non-JSON content-type should return a generic API error, not 'Model is loading'."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 503
+        mock_resp.headers = {"content-type": "text/plain"}
+        mock_resp.text = "upstream connect error or disconnect"
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.huggingface_tool.huggingface_tool.httpx.post",
+                return_value=mock_resp,
+            ),
+        ):
+            result = tool_fns["huggingface_run_inference"](model_id="bigscience/bloom", inputs="Hello")
+
+        assert "error" in result
+        assert result["error"] != "Model is loading"
+        assert "503" in result["error"]
+
+    def test_task_override_uses_pipeline_url(self, tool_fns):
+        """When task is provided, the request URL should use the /pipeline/{task}/ format."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = [{"generated_text": "Paris"}]
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.huggingface_tool.huggingface_tool.httpx.post",
+                return_value=mock_resp,
+            ) as mock_post,
+        ):
+            result = tool_fns["huggingface_run_inference"](
+                model_id="deepset/roberta-base-squad2",
+                inputs="What is the capital of France?",
+                task="question-answering",
+            )
+
+        assert result["task"] == "question-answering"
+        called_url = mock_post.call_args[0][0]
+        assert "/pipeline/question-answering/deepset/roberta-base-squad2" in called_url
+
+    def test_no_task_override_uses_models_url(self, tool_fns):
+        """When task is omitted, the request URL should use the /models/ format."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = [{"generated_text": "Hello world"}]
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.huggingface_tool.huggingface_tool.httpx.post",
+                return_value=mock_resp,
+            ) as mock_post,
+        ):
+            result = tool_fns["huggingface_run_inference"](
+                model_id="facebook/bart-large-cnn",
+                inputs="Some text",
+            )
+
+        assert result["task"] == "auto"
+        called_url = mock_post.call_args[0][0]
+        assert "/models/facebook/bart-large-cnn" in called_url
+        assert "/pipeline/" not in called_url
+
 
 class TestHuggingFaceRunEmbedding:
     def test_missing_token(self, tool_fns):


### PR DESCRIPTION
## Summary

Fixes #7267 — two bugs in `huggingface_run_inference` / `_post`:

- **503 response validation**: the old code blindly returned `"Model is loading"` for any HTTP 503, even malformed ones with no `estimated_time` in the body. Now only classified as a loading response when `estimated_time` is present; other 503s return a clear `"HuggingFace Inference API error 503: ..."` message.
- **`task` parameter ignored**: the `task` argument was accepted but never sent to the API. When provided, the request now routes through `/pipeline/{task}/{model_id}` (the correct HuggingFace Inference API format for task overrides) instead of always using `/models/{model_id}`.

## Changes

- `tools/src/aden_tools/tools/huggingface_tool/huggingface_tool.py`
  - Add `INFERENCE_PIPELINE_URL` constant
  - Fix 503 branch to only return loading response when `estimated_time` is present
  - Use pipeline URL when `task` is specified

- `tools/tests/tools/test_huggingface_tool.py`
  - `test_malformed_503_json_without_estimated_time` — 503 with JSON body but no `estimated_time` → generic error
  - `test_malformed_503_non_json_body` — 503 with non-JSON content-type → generic error
  - `test_task_override_uses_pipeline_url` — pipeline URL used when task is set
  - `test_no_task_override_uses_models_url` — models URL used when task is omitted

## Test plan

- [ ] `cd tools && uv run python -m pytest tests/tools/test_huggingface_tool.py -v` — all existing + new tests pass
- [ ] Confirm malformed 503 no longer says "Model is loading"
- [ ] Confirm task override reaches the API via the correct URL

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inference error handling so “Model is loading” is shown only when the response includes an estimated wait time.
  * Added a clearer fallback message for other service-unavailable responses, including non-JSON errors.
  * Updated request routing so task-based inference uses the correct endpoint format, while standard model requests continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->