### PR TITLE
fix(credentials): register slack_user credential to fix KeyError [micro-fix]

### DIFF
--- a/tools/src/aden_tools/credentials/health_check.py
+++ b/tools/src/aden_tools/credentials/health_check.py
@@ -1411,6 +1411,7 @@ HEALTH_CHECKERS: dict[str, CredentialHealthChecker] = {
     "serpapi": SerpApiHealthChecker(),
     "similarweb": SimilarWebHealthChecker(),
     "slack": SlackHealthChecker(),
+    "slack_user": SlackHealthChecker(),
     "stripe": StripeHealthChecker(),
     "telegram": TelegramHealthChecker(),
     "trello_key": TrelloKeyHealthChecker(),

--- a/tools/src/aden_tools/credentials/slack.py
+++ b/tools/src/aden_tools/credentials/slack.py
@@ -25,7 +25,6 @@ SLACK_CREDENTIALS = {
             "slack_remove_reaction",
             "slack_list_users",
             "slack_upload_file",
-            "slack_search_messages",
             "slack_get_thread_replies",
             "slack_pin_message",
             "slack_unpin_message",
@@ -94,5 +93,34 @@ SLACK_CREDENTIALS = {
         # Credential store mapping
         credential_id="slack",
         credential_key="access_token",
+    ),
+    "slack_user": CredentialSpec(
+        env_var="SLACK_USER_TOKEN",
+        tools=[
+            "slack_search_messages",
+        ],
+        required=False,
+        startup_required=False,
+        help_url="https://api.slack.com/apps",
+        description="Slack User Token (starts with xoxp-) for search and user-scoped APIs",
+        # Auth method support
+        aden_supported=True,
+        aden_provider_name="slack",
+        direct_api_key_supported=True,
+        api_key_instructions="""To get a Slack User Token:
+1. Go to https://api.slack.com/apps and select your app
+2. Go to "OAuth & Permissions" in the sidebar
+3. Add the following User Token Scopes:
+   - search:read
+   - users.profile:write (for setting status)
+   - users:read (for user presence)
+4. Click "Reinstall to Workspace" if needed
+5. Copy the "User OAuth Token" (starts with xoxp-)""",
+        # Health check configuration
+        health_check_endpoint="https://slack.com/api/auth.test",
+        health_check_method="POST",
+        # Credential store mapping
+        credential_id="slack",
+        credential_key="user_token",
     ),
 }


### PR DESCRIPTION

## Summary
Fixes #6041 - Slack tool crashes with `KeyError: 'Unknown credential slack_user'` when CredentialStoreAdapter is active.

## Root Cause
Slack tool requires two distinct credentials:
- `slack` (bot token `xoxb-`) - for most operations
- `slack_user` (user token `xoxp-`) - for search API and user-scoped operations

Only `slack` was registered in `CREDENTIAL_SPECS`. When `CredentialStoreAdapter.get('slack_user')` was called, it raised `KeyError` (lines 159-160 in `store_adapter.py`) because the credential name wasn't in specs.

This crashed **every** Slack tool invocation since `_get_client()` calls `_get_user_token()` on every call.

## Solution
Register `slack_user` as a proper `CredentialSpec` following the pattern used by other multi-credential tools (reddit, langfuse, twilio, etc.).

### Files Changed
1. `tools/src/aden_tools/credentials/slack.py` - Added `slack_user` CredentialSpec
2. `tools/src/aden_tools/credentials/health_check.py` - Added `SlackHealthChecker` for `slack_user`

### Why This Is Better Than PR #6042
| Aspect | PR #6042 (try/except) | This Fix (register credential) |
|--------|----------------------|--------------------------------|
| Credential store support | ❌ No | ✅ Yes - encryption, auto-refresh |
| Health checks | ❌ No | ✅ Yes |
| Aden OAuth auto-refresh | ❌ No | ✅ Yes (if enabled) |
| Env var fallback | Manual try/except | ✅ Automatic via CompositeStorage |
| Code cleanliness | ⚠️ Special-case handling | ✅ Standard pattern |
| Consistency | ❌ Unique hack | ✅ Follows reddit/langfuse pattern |

## Testing
- ✅ All 168 Slack tests pass
- ✅ All 345 credential registry tests pass  
- ✅ Lint checks pass (`make check`)
- ✅ No changes needed to `slack_tool.py` - it already correctly calls `credentials.get('slack_user')`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a separate Slack user-token credential for search-related functionality.
  * Slack search actions now use this dedicated credential, while the main Slack credential continues to support other Slack features.

* **Bug Fixes**
  * Expanded credential health checks so the new Slack user-token credential is validated properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->