### PR TITLE
feat(tools): add HackerNews integration with search, caching, and async support

### DIFF
--- a/tools/src/aden_tools/tools/__init__.py
+++ b/tools/src/aden_tools/tools/__init__.py
@@ -70,6 +70,7 @@ from .google_maps_tool import register_tools as register_google_maps
 from .google_search_console_tool import register_tools as register_google_search_console
 from .google_sheets_tool import register_tools as register_google_sheets
 from .greenhouse_tool import register_tools as register_greenhouse
+from .hackernews_tool import register_tools as register_hackernews
 from .http_headers_scanner import register_tools as register_http_headers_scanner
 from .hubspot_tool import register_tools as register_hubspot
 from .huggingface_tool import register_tools as register_huggingface
@@ -247,6 +248,7 @@ def _register_unverified(
     """Register unverified (new/community) tools."""
     # --- No credentials ---
     register_duckduckgo(mcp)
+    register_hackernews(mcp)
     register_yahoo_finance(mcp)
     register_youtube_transcript(mcp)
 

--- a/tools/src/aden_tools/tools/hackernews_tool/README.md
+++ b/tools/src/aden_tools/tools/hackernews_tool/README.md
@@ -1,0 +1,48 @@
+# HackerNews Tool
+
+This tool integrates with [HackerNews](https://news.ycombinator.com/) to provide news retrieval and search capabilities for AI agents. It uses the public Firebase API for fetching stories and the Algolia API for search, requiring **no API keys**.
+
+## Why this matters for agents
+
+HackerNews is a rich source of technical discourse and emerging trends. With this tool, agents can perform:
+- **Trend Discovery:** Monitor top stories to detect emerging frameworks, models, or topics.
+- **Technical Signal Detection:** Analyze high-quality discussions for sentiment on technical choices.
+- **Startup Intelligence:** Track competitor news, product launches (Show HN), or funding events.
+- **Dev Ecosystem Monitoring:** Keep developers informed about critical ecosystem updates or security vulnerabilities.
+
+## Features
+
+- **Top Stories**: Fetch the current top stories on HN, with built-in async concurrency and a TTL cache for fast performance.
+- **Search**: Search for specific keywords or topics using Algolia's HackerNews Search API.
+- **Item Lookup**: Fetch specific items (stories, comments) by their ID.
+- **Filtering**: Apply filters like `min_score` to reduce noise.
+- **Stable Schema**: Returns normalized story metadata (`id`, `title`, `url`, `score`, `by`, `time`, `descendants`, `type`) using Pydantic validation.
+
+## Tools
+
+### `hn_get_top_stories`
+Retrieves the top stories currently on Hacker News.
+- `limit` (int, default 10): Maximum number of stories to return (1-50).
+- `min_score` (int, default 0): Filter out stories with fewer points than this to reduce noise.
+
+### `hn_search_stories`
+Search Hacker News for stories matching a keyword using the Algolia Search API.
+- `query` (str): The search keyword or phrase (e.g., "LLM", "OpenAI").
+- `limit` (int, default 10): Maximum number of results to return (1-50).
+
+### `hn_get_item`
+Fetch details of a specific item from Hacker News by its ID.
+- `item_id` (int): The ID of the Hacker News item.
+
+## Environment Variables
+
+None. This tool does not require any credentials.
+
+## Error Handling
+
+The tool correctly identifies and handles dead or deleted items. It returns an error dict if network requests fail or invalid arguments are provided:
+```json
+{
+  "error": "Failed to fetch top stories: [Error details]"
+}
+```

--- a/tools/src/aden_tools/tools/hackernews_tool/__init__.py
+++ b/tools/src/aden_tools/tools/hackernews_tool/__init__.py
@@ -1,0 +1,3 @@
+from .hackernews_tool import register_tools
+
+__all__ = ["register_tools"]

--- a/tools/src/aden_tools/tools/hackernews_tool/hackernews_tool.py
+++ b/tools/src/aden_tools/tools/hackernews_tool/hackernews_tool.py
@@ -1,0 +1,165 @@
+import asyncio
+import time
+from typing import Any, Dict, List, Optional
+import httpx
+from pydantic import BaseModel, Field
+from fastmcp import FastMCP
+
+class HNItem(BaseModel):
+    id: int
+    title: Optional[str] = None
+    url: Optional[str] = None
+    score: Optional[int] = 0
+    by: Optional[str] = None
+    time: Optional[int] = 0
+    descendants: Optional[int] = 0
+    type: str = "story"
+    dead: Optional[bool] = False
+    deleted: Optional[bool] = False
+
+# Simple TTL cache for top stories
+_CACHE: Dict[str, tuple[float, Any]] = {}
+CACHE_TTL = 120  # seconds
+
+def _get_from_cache(key: str) -> Optional[Any]:
+    if key in _CACHE:
+        timestamp, data = _CACHE[key]
+        if time.time() - timestamp < CACHE_TTL:
+            return data
+    return None
+
+def _set_cache(key: str, data: Any) -> None:
+    _CACHE[key] = (time.time(), data)
+
+def normalize_story(item: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Normalize a HackerNews item using the Pydantic schema."""
+    if not item or item.get("dead") or item.get("deleted"):
+        return None
+        
+    hn_item = HNItem(
+        id=item.get("id", item.get("objectID", 0)),
+        title=item.get("title", ""),
+        url=item.get("url", ""),
+        score=item.get("score", item.get("points", 0)),
+        by=item.get("by", item.get("author", "")),
+        time=item.get("time", item.get("created_at_i", 0)),
+        descendants=item.get("descendants", item.get("num_comments", 0)),
+        type=item.get("type", "story"),
+    )
+    return hn_item.model_dump(exclude_none=True)
+
+async def fetch_item(client: httpx.AsyncClient, item_id: int) -> Optional[Dict[str, Any]]:
+    """Fetch a single item from the HN Firebase API."""
+    try:
+        response = await client.get(f"https://hacker-news.firebaseio.com/v0/item/{item_id}.json")
+        response.raise_for_status()
+        data = response.json()
+        return normalize_story(data) if data else None
+    except httpx.RequestError:
+        return None
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register HackerNews tools with the MCP server."""
+
+    @mcp.tool()
+    async def hn_get_top_stories(limit: int = 10, min_score: int = 0) -> dict:
+        """
+        Get the top stories currently on Hacker News.
+        
+        Args:
+            limit: Maximum number of stories to return (1-50, default 10)
+            min_score: Filter out stories with fewer points than this (default 0)
+            
+        Returns:
+            Dict containing the list of top stories or an error
+        """
+        limit = max(1, min(100, limit))
+        
+        try:
+            top_ids = _get_from_cache('topstories')
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                if not top_ids:
+                    resp = await client.get("https://hacker-news.firebaseio.com/v0/topstories.json")
+                    resp.raise_for_status()
+                    top_ids = resp.json()
+                    _set_cache('topstories', top_ids)
+                
+                # Fetch a larger batch if min_score is used
+                fetch_limit = min(limit * 4, 200) if min_score > 0 else limit
+                ids_to_fetch = top_ids[:fetch_limit]
+                
+                # Concurrently fetch details
+                tasks = [fetch_item(client, item_id) for item_id in ids_to_fetch]
+                items = await asyncio.gather(*tasks)
+                
+                valid_items = [item for item in items if item is not None and item.get("type") == "story"]
+                if min_score > 0:
+                    valid_items = [item for item in valid_items if item.get("score", 0) >= min_score]
+                
+                return {
+                    "results": valid_items[:limit],
+                    "total": len(valid_items[:limit])
+                }
+        except Exception as e:
+            return {"error": f"Failed to fetch top stories: {str(e)}"}
+
+    @mcp.tool()
+    async def hn_search_stories(query: str, limit: int = 10) -> dict:
+        """
+        Search Hacker News for stories matching a keyword using the Algolia Search API.
+        
+        Args:
+            query: The search keyword or phrase
+            limit: Maximum number of results to return (1-50, default 10)
+            
+        Returns:
+            Dict containing the matching stories or an error
+        """
+        if not query:
+            return {"error": "Query cannot be empty"}
+            
+        limit = max(1, min(50, limit))
+        
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                params = {
+                    "query": query,
+                    "tags": "story",
+                    "hitsPerPage": limit
+                }
+                resp = await client.get("https://hn.algolia.com/api/v1/search", params=params)
+                resp.raise_for_status()
+                data = resp.json()
+                
+                raw_hits = data.get("hits", [])
+                results = [normalize_story(hit) for hit in raw_hits]
+                valid_results = [r for r in results if r is not None]
+                
+                return {
+                    "query": query,
+                    "results": valid_results,
+                    "total": len(valid_results)
+                }
+        except Exception as e:
+            return {"error": f"Search failed: {str(e)}"}
+
+    @mcp.tool()
+    async def hn_get_item(item_id: int) -> dict:
+        """
+        Fetch details of a specific item from Hacker News by its ID.
+        
+        Args:
+            item_id: The ID of the Hacker News item
+            
+        Returns:
+            Dict containing the item details or an error if not found/deleted
+        """
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                item = await fetch_item(client, item_id)
+                if not item:
+                    return {"error": f"Item {item_id} not found, dead, or deleted"}
+                
+                return {"result": item}
+        except Exception as e:
+            return {"error": f"Failed to fetch item {item_id}: {str(e)}"}

--- a/tools/tests/tools/test_hackernews_tool.py
+++ b/tools/tests/tools/test_hackernews_tool.py
@@ -1,0 +1,162 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastmcp import FastMCP
+from aden_tools.tools.hackernews_tool import register_tools
+from aden_tools.tools.hackernews_tool.hackernews_tool import _CACHE
+
+@pytest.fixture
+def mcp():
+    """Create a FastMCP instance with HackerNews tools registered."""
+    server = FastMCP("test")
+    register_tools(server)
+    return server
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Clear the cache before each test."""
+    _CACHE.clear()
+    yield
+
+@pytest.mark.asyncio
+@patch('httpx.AsyncClient.get')
+async def test_hn_get_top_stories_basic(mock_get, mcp):
+    """Test basic functionality of hn_get_top_stories with caching."""
+    mock_topstories_resp = MagicMock()
+    mock_topstories_resp.json.return_value = [1, 2]
+    
+    mock_item1_resp = MagicMock()
+    mock_item1_resp.json.return_value = {
+        "id": 1, "title": "Test Story 1", "url": "https://test.com/1", "score": 100, "by": "user1", "time": 12345, "type": "story"
+    }
+    mock_item2_resp = MagicMock()
+    mock_item2_resp.json.return_value = {
+        "id": 2, "title": "Test Story 2", "url": "https://test.com/2", "score": 50, "by": "user2", "time": 12346, "type": "story"
+    }
+    
+    async def side_effect(url, **kwargs):
+        if "topstories.json" in str(url):
+            return mock_topstories_resp
+        elif "item/1.json" in str(url):
+            return mock_item1_resp
+        elif "item/2.json" in str(url):
+            return mock_item2_resp
+        raise ValueError(f"Unexpected URL: {url}")
+        
+    mock_get.side_effect = side_effect
+    
+    tool_fn = mcp._tool_manager._tools["hn_get_top_stories"].fn
+    result = await tool_fn(limit=2)
+    
+    assert "results" in result
+    assert result["total"] == 2
+    assert result["results"][0]["title"] == "Test Story 1"
+    assert result["results"][1]["score"] == 50
+
+@pytest.mark.asyncio
+@patch('httpx.AsyncClient.get')
+async def test_hn_get_top_stories_min_score(mock_get, mcp):
+    """Test min_score filtering."""
+    mock_topstories_resp = MagicMock()
+    mock_topstories_resp.json.return_value = [1, 2]
+    
+    mock_item1_resp = MagicMock()
+    mock_item1_resp.json.return_value = {
+        "id": 1, "title": "Test Story 1", "score": 100, "type": "story"
+    }
+    mock_item2_resp = MagicMock()
+    mock_item2_resp.json.return_value = {
+        "id": 2, "title": "Test Story 2", "score": 20, "type": "story"
+    }
+    
+    async def side_effect(url, **kwargs):
+        if "topstories.json" in str(url):
+            return mock_topstories_resp
+        elif "item/1.json" in str(url):
+            return mock_item1_resp
+        elif "item/2.json" in str(url):
+            return mock_item2_resp
+            
+    mock_get.side_effect = side_effect
+    
+    tool_fn = mcp._tool_manager._tools["hn_get_top_stories"].fn
+    result = await tool_fn(limit=2, min_score=50)
+    
+    assert "results" in result
+    assert result["total"] == 1
+    assert result["results"][0]["id"] == 1
+
+@pytest.mark.asyncio
+@patch('httpx.AsyncClient.get')
+async def test_hn_search_stories(mock_get, mcp):
+    """Test searching by keyword using Algolia API."""
+    mock_search_resp = MagicMock()
+    mock_search_resp.json.return_value = {
+        "hits": [
+            {
+                "objectID": "123",
+                "title": "LLM Agents",
+                "url": "https://example.com/llm",
+                "points": 500,
+                "author": "ai_dev",
+                "created_at_i": 1600000000
+            }
+        ]
+    }
+    mock_get.return_value = mock_search_resp
+    
+    tool_fn = mcp._tool_manager._tools["hn_search_stories"].fn
+    result = await tool_fn(query="LLM", limit=1)
+    
+    assert "results" in result
+    assert result["total"] == 1
+    assert result["results"][0]["id"] == 123
+    assert result["results"][0]["title"] == "LLM Agents"
+    assert result["results"][0]["score"] == 500
+    
+    mock_get.assert_called_once()
+    call_args = mock_get.call_args
+    assert "hn.algolia.com" in call_args[0][0]
+    assert call_args[1]["params"]["query"] == "LLM"
+    assert call_args[1]["params"]["hitsPerPage"] == 1
+
+@pytest.mark.asyncio
+async def test_hn_search_stories_empty(mcp):
+    """Test validation of empty query."""
+    tool_fn = mcp._tool_manager._tools["hn_search_stories"].fn
+    result = await tool_fn(query="")
+    
+    assert "error" in result
+    assert "Query cannot be empty" in result["error"]
+
+@pytest.mark.asyncio
+@patch('httpx.AsyncClient.get')
+async def test_hn_get_item_valid(mock_get, mcp):
+    """Test get_item with a valid item."""
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "id": 999, "title": "Valid Item", "score": 100, "type": "story"
+    }
+    mock_get.return_value = mock_resp
+    
+    tool_fn = mcp._tool_manager._tools["hn_get_item"].fn
+    result = await tool_fn(item_id=999)
+    
+    assert "result" in result
+    assert result["result"]["id"] == 999
+    assert result["result"]["title"] == "Valid Item"
+
+@pytest.mark.asyncio
+@patch('httpx.AsyncClient.get')
+async def test_hn_get_item_deleted(mock_get, mcp):
+    """Test get_item with a deleted item."""
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "id": 999, "deleted": True
+    }
+    mock_get.return_value = mock_resp
+    
+    tool_fn = mcp._tool_manager._tools["hn_get_item"].fn
+    result = await tool_fn(item_id=999)
+    
+    assert "error" in result
+    assert "not found, dead, or deleted" in result["error"]


### PR DESCRIPTION
## Summary
Adds HackerNews integration to Aden Hive as an unverified tool.

Closes #7298

## Features
- Top stories retrieval
- Story lookup by item ID
- Keyword search via Algolia API
- Async concurrent fetching
- TTL caching
- Pydantic normalized schemas
- Score filtering

## Testing
- Unit tests with mocked httpx
- Spec conformance tests
- Ruff linting and formatting

## Why this matters
This enables agents to consume real-time technical discussions, startup news, and trending developer insights.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Hacker News tools for viewing top stories, searching stories, and fetching individual items.
  * Enabled these tools in the no-credentials tool set when unverified/community tools are included.

* **Documentation**
  * Added usage and behavior documentation for the new Hacker News tools, including supported actions and error responses.

* **Tests**
  * Added coverage for story retrieval, search behavior, item lookup, filtering, and validation/error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->