### PR TITLE
(doc/docs) Add HVTracker Verified trust badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   <a href="https://x.com/aden_hq"><img src="https://img.shields.io/twitter/follow/teamaden?logo=X&color=%23f5f5f5" alt="Twitter Follow" /></a>
   <a href="https://www.linkedin.com/company/teamaden/"><img src="https://custom-icon-badges.demolab.com/badge/LinkedIn-0A66C2?logo=linkedin-white&logoColor=fff" alt="LinkedIn" /></a>
   <img src="https://img.shields.io/badge/MCP-102_Tools-00ADD8?style=flat-square" alt="MCP" />
+  <a href="https://hvtracker.io/project/aden-hive/hive"><img src="https://img.shields.io/badge/HVTracker-Verified-4caf50?style=flat-square&logo=checkmarx&logoColor=white" alt="HVTracker Verified" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Description

Adds an HVTracker Verified trust badge to the README header alongside the existing shields (MCP, License, Discord, etc.). Surfaces the project's HVTracker verification status directly in the repository, increasing contributor and user trust at a glance.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #2805

## Changes Made

- Added HVTracker Verified badge (green, shields.io) to the README top-level badge row, linking to `https://hvtracker.io/project/aden-hive/hive`

## Testing

- [x] Manual testing performed — badge renders correctly in GitHub Markdown preview; no functional code changed
- [x] Lint passes (documentation-only change, no code modified)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README banner to include an additional “HVTracker Verified” badge linking to hvtracker.io.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->