### PR TITLE
fix(cli): validate --colony input path is not a directory before exec…

### DIFF
--- a/core/framework/cli.py
+++ b/core/framework/cli.py
@@ -81,8 +81,14 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    if hasattr(args, "func"):
-        sys.exit(args.func(args))
+    # Preflight path validation check to prevent directory crashes
+    if hasattr(args, "colony") and args.colony:
+        for colony_arg in args.colony:
+            if colony_arg:
+                import os
+                if os.path.isdir(os.path.abspath(colony_arg)):
+                    print(f"Error: input file is a directory, not a file: {colony_arg}")
+                    sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #6207

Added a preflight path validation check in `core/framework/cli.py` using `os.path.isdir()`. 
This ensures that if a user accidentally passes a directory path to the `--colony` argument, the application will catch it early and display a clean error message instead of crashing with a raw Python traceback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a validation check in the command-line interface to catch directory paths passed where files are expected.
  * When an invalid directory path is provided, the CLI now shows a clear error message and exits with a non-zero status instead of continuing unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->