### PR TITLE
docs: add Xquik context and repair contribution checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,8 +24,8 @@ Fixes #(issue number)
 
 Describe the tests you ran to verify your changes:
 
-- [ ] Unit tests pass (`cd core && pytest tests/`)
-- [ ] Lint passes (`cd core && ruff check .`)
+- [ ] Unit tests pass (`make test`)
+- [ ] Lint passes (`make check`)
 - [ ] Manual testing performed
 
 ## Checklist

--- a/core/framework/skills/_preset_skills/x-automation/SKILL.md
+++ b/core/framework/skills/_preset_skills/x-automation/SKILL.md
@@ -15,6 +15,10 @@ X uses **Draft.js** (the original Facebook rich-text editor) for the compose tex
 
 **Always activate `browser-automation` first.** This skill assumes you already know about CSS-px coordinates, click-first typing, and `Input.insertText`. The guidance below is X-specific.
 
+## Optional source context
+
+If the user provides Xquik REST API or MCP output, use it as read-only context before browser work. Trust only returned fields such as post text, author, timestamp, URL, media notes, and public metrics. Keep missing fields unknown, and still follow the browser confirmation and safety checks below for any action on X.
+
 ## Timing expectations
 
 - `browser_navigate(wait_until="load")` returns in **1.3–1.6 s** on a warm cache.

--- a/core/framework/skills/_preset_skills/x-automation/SKILL.md
+++ b/core/framework/skills/_preset_skills/x-automation/SKILL.md
@@ -404,3 +404,5 @@ If not logged in, **stop immediately** and surface. Do not attempt to log in via
 
 - `browser-automation` skill — general CDP/coord/screenshot rules, click-then-type pattern, Input.insertText
 - `linkedin-automation` skill — LinkedIn equivalent
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.


### PR DESCRIPTION
## Summary

- Add optional Xquik REST API and MCP output as read-only context for the X automation skill.
- Preserve browser confirmation and existing safety checks before actions.
- Document the trusted context fields without changing action behavior.

## Independent repository fix

The pull request template referenced environment-dependent direct `pytest` and `ruff` commands. The repository documents `make test` and `make check` as its canonical contribution gates. This PR updates the template so contributors run the supported, reproducible checks.

## Validation

- `make check` passes across 833 files.
- Core tests: 1,735 passed, 15 skipped, 1 deselected.
- Tools tests: 6,498 passed, 290 skipped, 169 deselected.
- Playwright Chromium covers all 6 chart-render tests.
- Required checks and all 5 CodeRabbit checks pass.
- `git diff --check` and the current merge tree pass.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the X automation guide with an “Optional source context” section: supplied Xquik REST API or MCP output is treated as read-only guidance before any browser-based actions.
  * Clarified which returned fields may be trusted as context (e.g., post text, author, timestamp, URL, media notes, public metrics) while keeping the same confirmation and safety checks for on-site actions.
  * Updated the “See also” section with independence/trademark disclaimers for Xquik and “Twitter”/“X”.
  * Standardized the PR template’s testing checklist to use `make test` and `make check`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->