### PR TITLE
fix: validate output_keys integrity at NodeSpec/AgentSpec construction

### DIFF
--- a/core/framework/agent_loop/types.py
+++ b/core/framework/agent_loop/types.py
@@ -10,11 +10,12 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Self
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from framework.llm.provider import LLMProvider, Tool
+from framework.output_key_validation import validate_output_keys
 from framework.tracker.decision_tracker import DecisionTracker
 
 
@@ -104,6 +105,11 @@ class AgentSpec(BaseModel):
     )
 
     model_config = {"extra": "allow", "arbitrary_types_allowed": True}
+
+    @model_validator(mode="after")
+    def _validate_output_keys(self) -> Self:
+        validate_output_keys(self.output_keys, self.nullable_output_keys)
+        return self
 
     def is_queen(self) -> bool:
         return self.id == "queen"

--- a/core/framework/orchestrator/node.py
+++ b/core/framework/orchestrator/node.py
@@ -20,11 +20,12 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Self
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from framework.llm.provider import LLMProvider, Tool
+from framework.output_key_validation import validate_output_keys
 from framework.tracker.decision_tracker import DecisionTracker
 
 logger = logging.getLogger(__name__)
@@ -216,6 +217,11 @@ class NodeSpec(BaseModel):
     )
 
     model_config = {"extra": "allow", "arbitrary_types_allowed": True}
+
+    @model_validator(mode="after")
+    def _validate_output_keys(self) -> Self:
+        validate_output_keys(self.output_keys, self.nullable_output_keys)
+        return self
 
     def is_queen_node(self) -> bool:
         """Return True when this spec is the queen conversational node."""

--- a/core/framework/output_key_validation.py
+++ b/core/framework/output_key_validation.py
@@ -1,0 +1,37 @@
+"""Shared validation for declarative output key configuration."""
+
+
+def _ordered_duplicates(keys: list[str]) -> list[str]:
+    """Return duplicated keys ordered by their first appearance."""
+    seen: set[str] = set()
+    duplicate_set: set[str] = set()
+    for key in keys:
+        if key in seen:
+            duplicate_set.add(key)
+        seen.add(key)
+    return list(dict.fromkeys(key for key in keys if key in duplicate_set))
+
+
+def validate_output_keys(output_keys: list[str], nullable_output_keys: list[str]) -> None:
+    """Raise when output key declarations are internally inconsistent."""
+    errors: list[str] = []
+
+    for field_name, keys in (
+        ("output_keys", output_keys),
+        ("nullable_output_keys", nullable_output_keys),
+    ):
+        blank_keys = [key for key in keys if not key.strip()]
+        if blank_keys:
+            errors.append(f"{field_name} contains empty or whitespace-only keys: {blank_keys!r}")
+
+        duplicate_keys = _ordered_duplicates(keys)
+        if duplicate_keys:
+            errors.append(f"{field_name} contains duplicate keys: {duplicate_keys!r}")
+
+    output_key_set = set(output_keys)
+    orphan_nullable_keys = list(dict.fromkeys(key for key in nullable_output_keys if key not in output_key_set))
+    if orphan_nullable_keys:
+        errors.append(f"nullable_output_keys contains keys not present in output_keys: {orphan_nullable_keys!r}")
+
+    if errors:
+        raise ValueError("Invalid output key configuration: " + "; ".join(errors))

--- a/core/framework/tests/test_output_key_validation.py
+++ b/core/framework/tests/test_output_key_validation.py
@@ -1,0 +1,69 @@
+import pytest
+from pydantic import ValidationError
+
+from framework.agent_loop.types import AgentSpec
+from framework.orchestrator.node import NodeSpec
+
+
+@pytest.fixture(params=[NodeSpec, AgentSpec], ids=["node", "agent"])
+def spec_type(request):
+    return request.param
+
+
+def make_spec(spec_type, **overrides):
+    values = {
+        "id": "test",
+        "name": "Test",
+        "description": "Test spec",
+    }
+    values.update(overrides)
+    return spec_type(**values)
+
+
+def test_valid_output_keys(spec_type):
+    spec = make_spec(
+        spec_type,
+        output_keys=["a", "b"],
+        nullable_output_keys=["a"],
+    )
+
+    assert spec.output_keys == ["a", "b"]
+    assert spec.nullable_output_keys == ["a"]
+
+
+def test_duplicate_output_keys_raise(spec_type):
+    with pytest.raises(ValidationError, match=r"output_keys contains duplicate keys: \['b', 'a'\]"):
+        make_spec(spec_type, output_keys=["b", "a", "a", "b"])
+
+
+def test_duplicate_nullable_output_keys_raise(spec_type):
+    with pytest.raises(ValidationError, match=r"nullable_output_keys contains duplicate keys: \['a'\]"):
+        make_spec(
+            spec_type,
+            output_keys=["a"],
+            nullable_output_keys=["a", "a"],
+        )
+
+
+@pytest.mark.parametrize("blank_key", ["", "   "])
+def test_empty_or_whitespace_only_output_keys_raise(spec_type, blank_key):
+    with pytest.raises(ValidationError, match="output_keys contains empty or whitespace-only keys"):
+        make_spec(spec_type, output_keys=[blank_key])
+
+
+@pytest.mark.parametrize("blank_key", ["", "   "])
+def test_empty_or_whitespace_only_nullable_output_keys_raise(spec_type, blank_key):
+    with pytest.raises(ValidationError, match="nullable_output_keys contains empty or whitespace-only keys"):
+        make_spec(spec_type, nullable_output_keys=[blank_key])
+
+
+def test_orphan_nullable_output_keys_raise(spec_type):
+    with pytest.raises(
+        ValidationError,
+        match=r"nullable_output_keys contains keys not present in output_keys: \['missing'\]",
+    ):
+        make_spec(
+            spec_type,
+            output_keys=["a"],
+            nullable_output_keys=["missing"],
+        )


### PR DESCRIPTION
Fixes #7317

## Summary

`output_keys` / `nullable_output_keys` integrity is only checked after the agent loop starts missing keys. A typo or orphan nullable key can waste a full LLM turn before failing far from the graph definition.

This PR validates those fields when `NodeSpec` and `AgentSpec` are constructed (graph/agent load time).

## Changes

- Add shared `validate_output_key_configuration()` helper
- Apply it from both `NodeSpec` and `AgentSpec` model validators
- Reject empty/whitespace keys, duplicates, and nullable keys not present in `output_keys`
- Add unit tests covering valid and invalid cases for both spec types

## Verification

- `pytest core/framework/tests/test_output_key_validation.py` (16 tests; run during development in a full workspace checkout)
- Ruff clean on touched files
- Runtime missing-key handling in the agent loop is unchanged

## Backwards compatibility

- Valid graphs/agents load as before
- Invalid `output_keys` / `nullable_output_keys` now fail at construction with a clear `ValidationError` instead of after the first LLM turn
