### PR TITLE
docs: add input/output schema examples for tech_news_reporter

### DIFF
--- a/examples/templates/tech_news_reporter/README.md
+++ b/examples/templates/tech_news_reporter/README.md
@@ -87,19 +87,19 @@ intake → research → compile-report
 ### Basic Usage
 
 ```python
-from framework.runner import AgentRunner
+from examples.templates.tech_news_reporter.agent import TechNewsReporterAgent
 
 # Load the agent
-runner = AgentRunner.load("examples/templates/tech_news_reporter")
+agent = TechNewsReporterAgent()
 
 # Run with an initial topic
-result = await runner.run({
+result = await agent.run({
     "user_message": "Find me the latest news about AI startups"
 })
 
 # Access results
 print(result.output)
-print(result.status)
+print(result.success)
 ```
 
 ### Input Schema

--- a/examples/templates/tech_news_reporter/README.md
+++ b/examples/templates/tech_news_reporter/README.md
@@ -87,19 +87,24 @@ intake → research → compile-report
 ### Basic Usage
 
 ```python
+import asyncio
 from examples.templates.tech_news_reporter.agent import TechNewsReporterAgent
 
-# Load the agent
-agent = TechNewsReporterAgent()
+async def main():
+    # Load the agent
+    agent = TechNewsReporterAgent()
+    
+    # Run with an initial topic
+    result = await agent.run({
+        "user_message": "Find me the latest news about AI startups"
+    })
+    
+    # Access results
+    print(result.output)
+    print(result.success)
 
-# Run with an initial topic
-result = await agent.run({
-    "user_message": "Find me the latest news about AI startups"
-})
-
-# Access results
-print(result.output)
-print(result.success)
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 ### Input Schema

--- a/examples/templates/tech_news_reporter/README.md
+++ b/examples/templates/tech_news_reporter/README.md
@@ -92,8 +92,10 @@ from framework.runner import AgentRunner
 # Load the agent
 runner = AgentRunner.load("examples/templates/tech_news_reporter")
 
-# Run with input
-result = await runner.run({"input_key": "value"})
+# Run with an initial topic
+result = await runner.run({
+    "user_message": "Find me the latest news about AI startups"
+})
 
 # Access results
 print(result.output)
@@ -102,12 +104,25 @@ print(result.status)
 
 ### Input Schema
 
-The agent's entry node `intake` requires:
+The agent's entry node `intake` can accept an initial user message. If provided, it uses this to guide the research. If omitted, the agent will prompt the user for topics.
 
+```json
+{
+  "user_message": "Find me the latest news about AI startups"
+}
+```
 
 ### Output Schema
 
 Terminal nodes: `compile-report`
+
+The agent outputs the path to the generated HTML report:
+
+```json
+{
+  "report_file": "tech_news_report.html"
+}
+```
 
 ## Version History
 


### PR DESCRIPTION
## Related Issues

Fixes #4477

## Changes Made

- Replaced the placeholder `{"input_key": "value"}` in the `tech_news_reporter` README with a realistic `user_message` input example.
- Documented the exact JSON `Input Schema` expected by the agent's intake node.
- Documented the exact JSON `Output Schema` returned by the agent's compile-report node.

## Testing

Describe the tests you ran to verify your changes:

- [ ] Unit tests pass (`cd core && pytest tests/`)
- [ ] Lint passes (`cd core && ruff check .`)
- [x] Manual testing performed (Verified the schema matches the agent's internal `nodes/__init__.py` definitions)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Tech & AI News Reporter usage example to reflect the current direct invocation workflow.
  * Clarified how to provide an optional user message in the input.
  * Documented the generated HTML report output and its file path.
  * Updated result handling examples to show the generated output and success status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->