### PR TITLE
docs(micro-fix): correct line-length from 100 to 120 in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,7 +271,7 @@ uv run ruff check . --fix
 Configuration in `pyproject.toml`:
 ```toml
 [tool.ruff]
-line-length = 100
+line-length = 120
 target-version = "py311"
 ```
 
@@ -799,7 +799,7 @@ Closes #123
 - Write docstrings for classes and public functions
 - Use meaningful variable and function names
 - Keep functions focused and small
-- **Line length**: 100 characters
+- **Line length**: 120 characters
 - **Formatting**: Use `ruff format` (no manual formatting)
 - **Linting**: Use `ruff check` (no warnings tolerated)
 

--- a/docs/contributing-lint-setup.md
+++ b/docs/contributing-lint-setup.md
@@ -30,7 +30,7 @@ make install-hooks
 | quotes | `Q` | Consistent double-quote usage |
 | pyupgrade | `UP` | Modernize syntax for Python 3.11+ |
 
-**Line length:** 100 characters.
+**Line length:** 120 characters.
 
 **Import order:** stdlib, third-party, first-party (`framework` / `aden_tools`), local.
 


### PR DESCRIPTION
## Description

The actual ruff config in `core/pyproject.toml` and `tools/pyproject.toml` sets
`line-length = 120`, but three documentation locations incorrectly stated 100.

## Type of Change

- [x] Documentation update

## Related Issues

N/A (micro-fix: docs-only, < 20 lines, no logic changes)

## Changes Made

- `CONTRIBUTING.md` line 274: code example `line-length = 100` → `120`
- `CONTRIBUTING.md` line 802: "Line length: 100 characters" → `120`
- `docs/contributing-lint-setup.md` line 33: "Line length: 100 characters" → `120`

## Testing

- [x] Verified via `rg` that all three locations now read `120`
- [x] Verified `core/pyproject.toml` and `tools/pyproject.toml` both set `line-length = 120`
- [x] No code changes — lint/tests unaffected

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance to reflect a 120-character maximum line length.
  * Aligned Ruff configuration examples and Python style guidelines across the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->