### PR TITLE
Make web scrape tests hermetic against robots.txt fetch

### DIFF
--- a/tools/tests/tools/test_web_scrape_tool.py
+++ b/tools/tests/tools/test_web_scrape_tool.py
@@ -20,6 +20,23 @@ def web_scrape_fn(mcp: FastMCP):
     return mcp._tool_manager._tools["web_scrape"].fn
 
 
+@pytest.fixture(autouse=True)
+def allow_robots_txt():
+    """Neutralize the robots.txt network fetch for all tests by default.
+
+    The scrape path fetches robots.txt before launching the browser, which
+    would make a real network request and make these (otherwise mocked) tests
+    non-hermetic. Default to allow-all; tests that specifically exercise
+    robots.txt behavior patch RobotFileParser themselves, which takes
+    precedence over this fixture.
+    """
+    with patch("aden_tools.tools.web_scrape_tool.web_scrape_tool.RobotFileParser") as mock_rp_cls:
+        mock_rp = MagicMock()
+        mock_rp.can_fetch.return_value = True
+        mock_rp_cls.return_value = mock_rp
+        yield mock_rp_cls
+
+
 def _make_playwright_mocks(html, status=200, final_url="https://example.com/page"):
     """Build a full playwright mock chain and return (context_manager, response, page)."""
     mock_response = MagicMock(


### PR DESCRIPTION
## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test setup to prevent external robots.txt requests during automated checks.
  * Ensured tests can still explicitly verify robots.txt behavior when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->