### PR TITLE
Make web scrape tests hermetic and document Playwright setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,11 @@ cd hive
 uv venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 uv sync
+
+# Browser-backed tools (and their tests) need a Chromium build matching the
+# pinned Playwright version. ./quickstart.sh installs this for you; the manual
+# path does not.
+uv run playwright install chromium
 ```
 
 ### Fork and Branch Workflow
@@ -139,7 +144,7 @@ uv sync
 # Run core tests
 uv run pytest core/tests/
 
-# Run tool tests (mocked, no real API calls)
+# Run tool tests (no real API calls; a few browser-backed tests launch Chromium)
 uv run pytest tools/tests/
 
 # Run linter
@@ -148,6 +153,14 @@ uv run ruff check .
 # Run formatter
 uv run ruff format .
 ```
+
+> **`Executable doesn't exist at .../chrome-headless-shell`?** The chart
+> rendering tests (`tools/tests/test_chart_tools_smoke.py`) launch a real
+> browser, so Playwright needs a Chromium build matching its pinned version.
+> Run `uv run playwright install chromium` from `tools/`. This also bites when a
+> preinstalled Chromium is present but built for a different Playwright release
+> — the version must match, not merely exist. Other browser-backed tools, such
+> as `web_scrape`, mock Playwright and run fine without a browser.
 
 ---
 

--- a/tools/tests/tools/test_web_scrape_tool.py
+++ b/tools/tests/tools/test_web_scrape_tool.py
@@ -20,6 +20,23 @@ def web_scrape_fn(mcp: FastMCP):
     return mcp._tool_manager._tools["web_scrape"].fn
 
 
+@pytest.fixture(autouse=True)
+def allow_robots_txt():
+    """Neutralize the robots.txt network fetch for all tests by default.
+
+    The scrape path fetches robots.txt before launching the browser, which
+    would make a real network request and make these (otherwise mocked) tests
+    non-hermetic. Default to allow-all; tests that specifically exercise
+    robots.txt behavior patch RobotFileParser themselves, which takes
+    precedence over this fixture.
+    """
+    with patch("aden_tools.tools.web_scrape_tool.web_scrape_tool.RobotFileParser") as mock_rp_cls:
+        mock_rp = MagicMock()
+        mock_rp.can_fetch.return_value = True
+        mock_rp_cls.return_value = mock_rp
+        yield mock_rp_cls
+
+
 def _make_playwright_mocks(html, status=200, final_url="https://example.com/page"):
     """Build a full playwright mock chain and return (context_manager, response, page)."""
     mock_response = MagicMock(


### PR DESCRIPTION
## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified browser-backed tool setup requirements, including installing the matching Chromium version.
  * Updated testing guidance to explain that browser-backed tests launch Chromium.
  * Added troubleshooting steps for missing or mismatched browser components.

* **Tests**
  * Improved web scraping test reliability by consistently allowing test requests despite `robots.txt` rules, while preserving support for explicit test overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->