### PR TITLE
fix(orchestrator): validate duplicate edge IDs, self-loops, and empty conditional expr

### DIFF
--- a/core/framework/orchestrator/edge.py
+++ b/core/framework/orchestrator/edge.py
@@ -513,6 +513,30 @@ class GraphSpec(BaseModel):
             if not self.get_node(edge.target):
                 errors.append(f"Edge '{edge.id}' references missing target '{edge.target}'")
 
+        # Check for duplicate edge IDs
+        seen_edge_ids: dict[str, str] = {}
+        for edge in self.edges:
+            if edge.id in seen_edge_ids:
+                errors.append(f"Edge '{edge.id}' has duplicate ID (first seen on '{edge.source}' -> '{edge.target}')")
+            else:
+                seen_edge_ids[edge.id] = edge.source
+
+        # Check for unconditional self-loops
+        unconditional_conditions = {
+            EdgeCondition.ALWAYS,
+            EdgeCondition.ON_SUCCESS,
+            EdgeCondition.ON_FAILURE,
+        }
+        for edge in self.edges:
+            if edge.source == edge.target and edge.condition in unconditional_conditions:
+                errors.append(f"Edge '{edge.id}' is an unconditional self-loop ('{edge.source}' -> '{edge.target}')")
+
+        # CONDITIONAL edges must have a condition_expr
+        for edge in self.edges:
+            if edge.condition == EdgeCondition.CONDITIONAL:
+                if not edge.condition_expr or not edge.condition_expr.strip():
+                    errors.append(f"Edge '{edge.id}' has condition CONDITIONAL but no condition_expr is set")
+
         # Check for unreachable nodes
         # Start with main entry node and all entry points (for pause/resume architecture)
         reachable = set()

--- a/core/tests/test_graphspec_validate_gaps.py
+++ b/core/tests/test_graphspec_validate_gaps.py
@@ -1,0 +1,114 @@
+"""Tests for GraphSpec.validate() gap fixes (issue #6090).
+
+Covers:
+- Duplicate edge IDs
+- Unconditional self-loops (source == target with ALWAYS/ON_SUCCESS/ON_FAILURE)
+- CONDITIONAL edge with empty or missing condition_expr
+"""
+
+import pytest
+
+from framework.orchestrator.edge import EdgeCondition, EdgeSpec, GraphSpec
+
+
+def _make_graph(edges, nodes=None):
+    """Build a minimal GraphSpec with the given edges."""
+    if nodes is None:
+        # Provide minimal stubs for all source/target nodes referenced in edges
+        seen = set()
+        for e in edges:
+            seen.add(e.source)
+            seen.add(e.target)
+        nodes = [type("Node", (), {"id": nid, "node_type": "stub"})() for nid in seen]
+    return GraphSpec(
+        id="test-graph",
+        goal_id="g1",
+        entry_node=edges[0].source if edges else nodes[0].id,
+        terminal_nodes=[],
+        nodes=nodes,
+        edges=edges,
+    )
+
+
+class TestDuplicateEdgeIds:
+    def test_duplicate_edge_ids_detected(self):
+        e1 = EdgeSpec(id="e1", source="a", target="b")
+        e2 = EdgeSpec(id="e1", source="b", target="c")
+        graph = _make_graph([e1, e2])
+        result = graph.validate()
+        assert any("duplicate" in err.lower() for err in result["errors"])
+
+    def test_unique_edge_ids_no_error(self):
+        e1 = EdgeSpec(id="e1", source="a", target="b")
+        e2 = EdgeSpec(id="e2", source="b", target="c")
+        graph = _make_graph([e1, e2])
+        result = graph.validate()
+        assert not any("duplicate" in err.lower() for err in result["errors"])
+
+
+class TestUnconditionalSelfLoops:
+    @pytest.mark.parametrize(
+        "condition",
+        [EdgeCondition.ALWAYS, EdgeCondition.ON_SUCCESS, EdgeCondition.ON_FAILURE],
+    )
+    def test_self_loop_unconditional(self, condition):
+        e = EdgeSpec(id="e1", source="a", target="a", condition=condition)
+        graph = _make_graph([e])
+        result = graph.validate()
+        assert any("self-loop" in err.lower() for err in result["errors"])
+
+    def test_conditional_self_loop_not_flagged(self):
+        e = EdgeSpec(
+            id="e1",
+            source="a",
+            target="a",
+            condition=EdgeCondition.CONDITIONAL,
+            condition_expr="true",
+        )
+        graph = _make_graph([e])
+        result = graph.validate()
+        assert not any("self-loop" in err.lower() for err in result["errors"])
+
+
+class TestConditionalMissingExpr:
+    def test_conditional_edge_missing_expr(self):
+        e = EdgeSpec(id="e1", source="a", target="b", condition=EdgeCondition.CONDITIONAL)
+        graph = _make_graph([e])
+        result = graph.validate()
+        assert any("condition_expr" in err.lower() or "expression" in err.lower() for err in result["errors"])
+
+    def test_conditional_edge_empty_expr(self):
+        e = EdgeSpec(
+            id="e1",
+            source="a",
+            target="b",
+            condition=EdgeCondition.CONDITIONAL,
+            condition_expr="",
+        )
+        graph = _make_graph([e])
+        result = graph.validate()
+        assert any("condition_expr" in err.lower() or "expression" in err.lower() for err in result["errors"])
+
+    def test_conditional_edge_whitespace_only_expr(self):
+        e = EdgeSpec(
+            id="e1",
+            source="a",
+            target="b",
+            condition=EdgeCondition.CONDITIONAL,
+            condition_expr="   ",
+        )
+        graph = _make_graph([e])
+        result = graph.validate()
+        assert any("condition_expr" in err.lower() or "expression" in err.lower() for err in result["errors"])
+
+    def test_conditional_edge_with_expr_no_error(self):
+        e = EdgeSpec(
+            id="e1",
+            source="a",
+            target="b",
+            condition=EdgeCondition.CONDITIONAL,
+            condition_expr="output.x > 1",
+        )
+        graph = _make_graph([e])
+        result = graph.validate()
+        assert not any("condition_expr" in err.lower() or "expression" in err.lower() for err in result["errors"])


### PR DESCRIPTION
## Description

\`GraphSpec.validate()\` performed structural validation (entry/terminal/edge node refs,
reachability, fan-out key overlap) but silently passed three graph defects that produce
runtime failures or silent no-ops. This PR closes those gaps.

Fixes #6090

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #6090

## Changes Made

- **Duplicate edge IDs** — two \`EdgeSpec\`s sharing the same \`id\` now raise an error.
  Duplicate IDs make edge lookup/removal ambiguous at execution time.
- **Unconditional self-loops** — an edge where \`source == target\` with an unconditional
  condition (\`ALWAYS\` / \`ON_SUCCESS\` / \`ON_FAILURE\`) now raises an error. These re-fire
  forever and can wedge graph execution. Conditional self-loops are intentionally *not* flagged.
- **CONDITIONAL without \`condition_expr\`** — a \`CONDITIONAL\` edge whose \`condition_expr\`
  is missing or whitespace-only now raises an error. Without an expr, \`_evaluate_condition\`
  returns \`True\` (always traverses), silently defeating the routing intent.

All checks append to the existing \`errors\` list, so the return shape
(\`{\"errors\": [...], \"warnings\": [...]}\`) is unchanged and no existing behavior is altered.

## Testing

- Added \`core/tests/test_graphspec_validate_gaps.py\` (10 tests across 3 classes):
  duplicate-edge detection + negative, unconditional self-loop (parametrized over the 3
  unconditional conditions) + conditional self-loop negative, and missing/empty/whitespace/
  valid \`condition_expr\` cases.
- Full core suite: **1745 passed, 15 skipped, 0 failed** (15 skipped are pre-existing
  network/platform-specific; no new skips, no regressions).
- Lint: \`ruff check core/ tools/\` clean; \`ruff format --check core/ tools/\` clean
  (834 files formatted).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Graph validation now flags duplicate edge IDs.
  * Unconditional self-loops are reported as validation errors.
  * Conditional edges must include a non-empty condition expression.
* **Tests**
  * Added coverage for invalid and valid edge configurations, including conditional self-loops and whitespace-only conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->