### PR TITLE
docs(bounty-program): fix broken BUILDING_TOOLS.md links (micro-fix)

### DIFF
--- a/docs/bounty-program/README.md
+++ b/docs/bounty-program/README.md
@@ -194,7 +194,7 @@ Without this link, bounties are still tracked but Lurkr can't push XP to your Di
 - [Promotion Checklist](promotion-checklist.md) — Criteria for unverified → verified
 - [Tool README Template](templates/tool-readme-template.md)
 - [Agent Test Report Template](templates/agent-test-report-template.md)
-- [Building Tools Guide](../tools/BUILDING_TOOLS.md)
+- [Building Tools Guide](../../tools/BUILDING_TOOLS.md)
 - [Lurkr API Docs](https://lurkr.gg/docs/api)
 
 ### Automation Files

--- a/docs/bounty-program/contributor-guide.md
+++ b/docs/bounty-program/contributor-guide.md
@@ -74,7 +74,7 @@ Add a health checker, fix a bug, or improve an integration.
 
 Build a complete integration from scratch.
 
-1. Follow the [BUILDING_TOOLS.md](../tools/BUILDING_TOOLS.md) guide
+1. Follow the [BUILDING_TOOLS.md](../../tools/BUILDING_TOOLS.md) guide
 2. Create: tool + credential spec + health checker + tests + README
 3. Register in `_register_unverified()` in `tools/__init__.py`
 4. Run `make check && make test`
@@ -162,6 +162,6 @@ A: You'll still get credit in GitHub, but no Lurkr XP or Discord roles. Run `/li
 | README template | [templates/tool-readme-template.md](templates/tool-readme-template.md) |
 | Test report template | [templates/agent-test-report-template.md](templates/agent-test-report-template.md) |
 | Promotion checklist | [promotion-checklist.md](promotion-checklist.md) |
-| Building tools | [BUILDING_TOOLS.md](../tools/BUILDING_TOOLS.md) |
+| Building tools | [BUILDING_TOOLS.md](../../tools/BUILDING_TOOLS.md) |
 | Discord | [Join](https://discord.com/invite/MXE49hrKDk) |
 | Your rank | `/rank` in Discord |

--- a/docs/bounty-program/promotion-checklist.md
+++ b/docs/bounty-program/promotion-checklist.md
@@ -6,7 +6,7 @@ Formal criteria for promoting a tool from **unverified** to **verified**. A tool
 
 ### Code Quality (Required)
 
-- [ ] **`register_tools` function** follows the standard signature pattern from [BUILDING_TOOLS.md](../tools/BUILDING_TOOLS.md)
+- [ ] **`register_tools` function** follows the standard signature pattern from [BUILDING_TOOLS.md](../../tools/BUILDING_TOOLS.md)
 - [ ] **Error handling** — all tools return `{"error": ...}` dicts instead of raising exceptions
 - [ ] **Credential handling** — graceful fallback when credentials are missing, with actionable `"help"` message
 - [ ] **Input validation** — parameters are validated before making API calls


### PR DESCRIPTION
## Description

The bounty-program docs linked to \`../tools/BUILDING_TOOLS.md\`, but the guide lives at
repo-root \`tools/BUILDING_TOOLS.md\`. From \`docs/bounty-program/\`, the correct relative path is
\`../../tools/BUILDING_TOOLS.md\`. Fixed 4 broken links across 3 files.

## Type of Change

- [x] Documentation update

## Changes Made

- \`docs/bounty-program/promotion-checklist.md\` — 1 link fixed
- \`docs/bounty-program/contributor-guide.md\` — 2 links fixed
- \`docs/bounty-program/README.md\` — 1 link fixed

## Testing

Documentation-only change (4 lines changed, no logic/code). Verified each link now resolves to
the existing \`tools/BUILDING_TOOLS.md\` and \`ruff check core/ tools/\` remains clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected links to the Building Tools Guide across bounty program documentation.
  * Updated contributor guidance and promotion checklist references to point to the correct location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->