### PR TITLE
fix(typo): correct 'judgement' to 'judgment' in core strings (micro-fix)

### DIFF
--- a/core/framework/agents/queen/nodes/__init__.py
+++ b/core/framework/agents/queen/nodes/__init__.py
@@ -154,7 +154,7 @@ Before you call ``create_colony``, sort out the operational details that \
 conversation tends to skip. The "Approved → operational checklist" block \
 in your tools doc lists the kinds of things to think about (concurrency, \
 schedule, result-tracking, failure handling, credentials). Treat that \
-list as prompts for YOUR judgement — only ask the user about the items \
+list as prompts for YOUR judgment — only ask the user about the items \
 that actually matter for THIS colony and that the conversation hasn't \
 already settled. Use ``ask_user`` (pass a ``questions`` array — batch \
 several entries for multi-question turns) for the gaps; plain prose for \
@@ -273,7 +273,7 @@ you commit (e.g. peek at an existing skill in ~/.hive/skills/, sanity-check \
 an API URL). search_files covers both grep (target='content') and ls/find \
 (target='files', glob like '*.py').
 
-## Approved → operational checklist (use your judgement, ask only what's missing)
+## Approved → operational checklist (use your judgment, ask only what's missing)
 The conversation that got you here probably did NOT cover all of:
 - Concurrency: how many tasks should run in parallel? Single-fire?
 - Schedule: cron expression, interval (every N minutes), webhook, \
@@ -285,7 +285,7 @@ The conversation that got you here probably did NOT cover all of:
   haven't discussed (API keys, OAuth, browser profile)?
 - Skills the worker needs beyond the one you'll write inline.
 
-These are PROMPTS for your judgement, not a required checklist. Cover \
+These are PROMPTS for your judgment, not a required checklist. Cover \
 the items that actually matter for THIS colony, and only the ones the \
 user hasn't already implied. Use ``ask_user`` (batch several questions \
 into one call when you have multiple gaps) for answers you need; skip \

--- a/core/framework/server/routes_execution.py
+++ b/core/framework/server/routes_execution.py
@@ -1330,7 +1330,7 @@ async def fork_session_into_colony(
         "You are a focused worker agent spawned by the queen to carry out "
         "one specific task. Read the goal carefully, use your available "
         "tools to make progress, and call set_output when complete. "
-        "If you get stuck or need human judgement, call escalate to hand "
+        "If you get stuck or need human judgment, call escalate to hand "
         "the question back to the queen.\n\n"
         f"Task: {worker_task}"
     )

--- a/core/framework/tools/queen_lifecycle_tools.py
+++ b/core/framework/tools/queen_lifecycle_tools.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 # tracking, failure handling, credentials) live ongoingly inside
 # ``_queen_tools_incubating`` so the queen sees them every turn — this
 # constant is the single-shot version that lands as the tool result.
-# Phrasing intentionally invites the queen's judgement; do NOT turn this
+# Phrasing intentionally invites the queen's judgment; do NOT turn this
 # into a hard checklist.
 _INCUBATING_APPROVAL_GUIDANCE = (
     "Approved to incubate colony '{colony_name}'.\n\n"


### PR DESCRIPTION
## Description

Repo convention is \`judgment\` (22 existing uses). Five stragglers in queen/agent prompt
strings and a server error message used the misspelling \`judgement\`. Corrected to
\`judgment\`. Pure spelling fix — no logic, behavior, or API change.

## Type of Change

- [x] Documentation update (string/typo fix)

## Changes Made

- \`core/framework/server/routes_execution.py\` — 1 fix (error message)
- \`core/framework/tools/queen_lifecycle_tools.py\` — 1 fix (comment)
- \`core/framework/agents/queen/nodes/__init__.py\` — 3 fixes (prompt strings)

## Testing

Spelling-only change (5 lines). Verified no \`judgement\` (case-insensitive) remains in the
three files; \`ruff check\` clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected spelling in guidance and worker prompt text.
  - Applied minor formatting and whitespace cleanup.
  - No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->