### PR TITLE
feat(credentials): add Mattermost health checker (bounty:code)

### DIFF
--- a/tools/src/aden_tools/credentials/health_check.py
+++ b/tools/src/aden_tools/credentials/health_check.py
@@ -1374,6 +1374,91 @@ class CloudflareHealthChecker(BaseHttpHealthChecker):
     SERVICE_NAME = "Cloudflare"
 
 
+class MattermostHealthChecker:
+    """Health checker for Mattermost personal access tokens.
+
+    Mattermost is self-hosted, so the server URL is a separate credential.
+    The checker resolves it from the credential store or MATTERMOST_URL env var,
+    mirroring mattermost_tool.py._get_url().
+    """
+
+    TIMEOUT = 10.0
+
+    def _resolve_url(self) -> str | None:
+        """Resolve Mattermost server URL.
+
+        The health checker is invoked with only the token, so the server URL is
+        read from the MATTERMOST_URL env var (mirroring mattermost_tool.py
+        _get_url(), which falls back to os.getenv("MATTERMOST_URL") when no
+        credential-store handle is in scope).
+        """
+        return os.getenv("MATTERMOST_URL")
+
+    def check(self, token: str) -> HealthCheckResult:
+        """Validate Mattermost token by hitting /api/v4/users/me."""
+        base_url = self._resolve_url()
+        if not base_url:
+            return HealthCheckResult(
+                valid=False,
+                message=("Mattermost server URL not configured (set MATTERMOST_URL or mattermost_url credential)"),
+                details={"missing": "url"},
+            )
+
+        base_url = base_url.rstrip("/")
+        if not base_url.endswith("/api/v4"):
+            base_url += "/api/v4"
+        url = f"{base_url}/users/me"
+
+        try:
+            with httpx.Client(timeout=self.TIMEOUT) as client:
+                response = client.get(
+                    url,
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "Accept": "application/json",
+                    },
+                )
+
+                if response.status_code == 200:
+                    data = response.json()
+                    username = data.get("username", "unknown")
+                    return HealthCheckResult(
+                        valid=True,
+                        message=f"Mattermost credentials valid (user: {username})",
+                        details={"username": username},
+                    )
+                elif response.status_code == 401:
+                    return HealthCheckResult(
+                        valid=False,
+                        message="Mattermost token is invalid or expired",
+                        details={"status_code": 401},
+                    )
+                elif response.status_code == 403:
+                    return HealthCheckResult(
+                        valid=False,
+                        message="Mattermost token lacks required permissions",
+                        details={"status_code": 403},
+                    )
+                else:
+                    return HealthCheckResult(
+                        valid=False,
+                        message=f"Mattermost API returned status {response.status_code}",
+                        details={"status_code": response.status_code},
+                    )
+        except httpx.TimeoutException:
+            return HealthCheckResult(
+                valid=False,
+                message="Mattermost API request timed out",
+                details={"error": "timeout"},
+            )
+        except httpx.RequestError as e:
+            return HealthCheckResult(
+                valid=False,
+                message=f"Failed to connect to Mattermost: {e}",
+                details={"error": str(e)},
+            )
+
+
 # Registry of health checkers
 HEALTH_CHECKERS: dict[str, CredentialHealthChecker] = {
     "apify": ApifyHealthChecker(),
@@ -1401,6 +1486,7 @@ HEALTH_CHECKERS: dict[str, CredentialHealthChecker] = {
     "intercom": IntercomHealthChecker(),
     "linear": LinearHealthChecker(),
     "lusha_api_key": LushaHealthChecker(),
+    "mattermost": MattermostHealthChecker(),
     "microsoft_graph": MicrosoftGraphHealthChecker(),
     "newsdata": NewsdataHealthChecker(),
     "notion": NotionHealthChecker(),

--- a/tools/tests/test_health_checks.py
+++ b/tools/tests/test_health_checks.py
@@ -12,6 +12,7 @@ from aden_tools.credentials.health_check import (
     GoogleMapsHealthChecker,
     GoogleSearchHealthChecker,
     LushaHealthChecker,
+    MattermostHealthChecker,
     ResendHealthChecker,
     check_credential_health,
 )
@@ -83,6 +84,7 @@ class TestHealthCheckerRegistry:
             "intercom",
             "linear",
             "lusha_api_key",
+            "mattermost",
             "microsoft_graph",
             "newsdata",
             "notion",
@@ -597,3 +599,106 @@ class TestGoogleHealthChecker:
 
         assert not result.valid
         assert "Connection refused" in result.message
+
+
+class TestMattermostHealthChecker:
+    """Tests for MattermostHealthChecker."""
+
+    def _mock_response(self, status_code, json_data=None):
+        response = MagicMock(spec=httpx.Response)
+        response.status_code = status_code
+        if json_data:
+            response.json.return_value = json_data
+        return response
+
+    def test_registered_in_health_checkers(self):
+        """MattermostHealthChecker is registered in HEALTH_CHECKERS."""
+        assert "mattermost" in HEALTH_CHECKERS
+        assert isinstance(HEALTH_CHECKERS["mattermost"], MattermostHealthChecker)
+
+    @patch("aden_tools.credentials.health_check.os.getenv")
+    @patch("aden_tools.credentials.health_check.httpx.Client")
+    def test_valid_token_200(self, mock_client_cls, mock_getenv):
+        mock_getenv.return_value = "https://mattermost.example.com"
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = self._mock_response(200, {"username": "admin", "id": "abc123"})
+
+        checker = MattermostHealthChecker()
+        result = checker.check("mm_test-token")
+
+        assert result.valid is True
+        assert "admin" in result.message
+        assert result.details["username"] == "admin"
+
+    @patch("aden_tools.credentials.health_check.os.getenv")
+    @patch("aden_tools.credentials.health_check.httpx.Client")
+    def test_invalid_token_401(self, mock_client_cls, mock_getenv):
+        mock_getenv.return_value = "https://mattermost.example.com"
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = self._mock_response(401)
+
+        checker = MattermostHealthChecker()
+        result = checker.check("invalid-token")
+
+        assert result.valid is False
+        assert result.details["status_code"] == 401
+
+    @patch("aden_tools.credentials.health_check.os.getenv")
+    def test_missing_url_returns_invalid(self, mock_getenv):
+        mock_getenv.return_value = None
+
+        checker = MattermostHealthChecker()
+        result = checker.check("some-token")
+
+        assert result.valid is False
+        assert result.details["missing"] == "url"
+        assert "not configured" in result.message.lower()
+
+    @patch("aden_tools.credentials.health_check.os.getenv")
+    @patch("aden_tools.credentials.health_check.httpx.Client")
+    def test_timeout(self, mock_client_cls, mock_getenv):
+        mock_getenv.return_value = "https://mattermost.example.com"
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_client.get.side_effect = httpx.TimeoutException("timed out")
+
+        checker = MattermostHealthChecker()
+        result = checker.check("mm_test-token")
+
+        assert result.valid is False
+        assert result.details["error"] == "timeout"
+
+    @patch("aden_tools.credentials.health_check.os.getenv")
+    @patch("aden_tools.credentials.health_check.httpx.Client")
+    def test_url_appends_api_v4(self, mock_client_cls, mock_getenv):
+        mock_getenv.return_value = "https://mattermost.example.com"
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = self._mock_response(200, {"username": "user"})
+
+        checker = MattermostHealthChecker()
+        checker.check("mm_test-token")
+
+        call_url = mock_client.get.call_args[0][0]
+        assert call_url == "https://mattermost.example.com/api/v4/users/me"
+
+    @patch("aden_tools.credentials.health_check.os.getenv")
+    @patch("aden_tools.credentials.health_check.httpx.Client")
+    def test_url_not_duplicated_when_already_has_api_v4(self, mock_client_cls, mock_getenv):
+        mock_getenv.return_value = "https://mattermost.example.com/api/v4"
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = self._mock_response(200, {"username": "user"})
+
+        checker = MattermostHealthChecker()
+        checker.check("mm_test-token")
+
+        call_url = mock_client.get.call_args[0][0]
+        assert call_url == "https://mattermost.example.com/api/v4/users/me"


### PR DESCRIPTION
## Description

Mattermost credentials had \`health_check_endpoint=None\` in their \`CredentialSpec\`, so
\`check_credential_health(\"mattermost\", token)\` currently hits the \"No health checker,
assuming valid\" fallback — Mattermost tokens were **never actually validated**.

This adds \`MattermostHealthChecker\`, which:
- Resolves the server URL from \`MATTERMOST_URL\` (Mattermost is self-hosted; the URL is a
  separate credential, and the checker is invoked with only the token).
- GETs \`{MATTERMOST_URL}/api/v4/users/me\` with \`Authorization: Bearer <token>\`.
- Interprets 200 (valid), 401 (invalid/expired), 403 (missing permissions), other statuses,
  timeouts and connection errors.
- Registered in \`HEALTH_CHECKERS\` under \`\"mattermost\"\` to match the spec credential name.

## Type of Change

- [x] New feature (credential health checker)

## Changes Made

- \`tools/src/aden_tools/credentials/health_check.py\` — new \`MattermostHealthChecker\` class +
  registry entry.
- \`tools/tests/test_health_checks.py\` — \`TestMattermostHealthChecker\` (6 tests: registration,
  valid 200, invalid 401, missing URL, timeout, api/v4 path handling).

## Testing

- \`uv run pytest tools/tests/test_health_checks.py\` → **47 passed** (41 + 6 new).
- \`uv run ruff check\` + \`ruff format --check\` clean on both files.

## Bounty

\`bounty:code\` contribution (30 XP). Requesting a maintainer apply the \`bounty:code\` label
before merge so XP is awarded via the bounty pipeline.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Mattermost credential health checks.
  * Validates Mattermost access tokens and reports the authenticated account.
  * Handles missing server configuration, invalid credentials, API errors, and connection timeouts.
  * Supports Mattermost API v4 endpoint configuration without duplicating URL paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->