### PR TITLE
feat(core): suggest closest tool name on unknown tool errors

### DIFF
--- a/core/framework/agents/queen/reflection_agent.py
+++ b/core/framework/agents/queen/reflection_agent.py
@@ -39,6 +39,7 @@ from framework.agents.queen.queen_memory_v2 import (
 )
 from framework.llm.provider import LLMResponse, Tool
 from framework.tracker.llm_debug_logger import log_llm_turn
+from framework.utils.tool_suggestions import format_unknown_tool_error
 
 logger = logging.getLogger(__name__)
 
@@ -132,6 +133,8 @@ _REFLECTION_TOOLS: list[Tool] = [
         },
     ),
 ]
+
+_REFLECTION_TOOL_NAMES: tuple[str, ...] = tuple(tool.name for tool in _REFLECTION_TOOLS)
 
 
 def _normalize_memory_dirs(
@@ -292,7 +295,7 @@ def _execute_tool(
         logger.debug("reflect: tool delete_memory_file[%s] → %s", scope, filename)
         return f"Deleted {scope}:{filename}."
 
-    return f"ERROR: Unknown tool: {name}"
+    return f"ERROR: {format_unknown_tool_error(name, _REFLECTION_TOOL_NAMES)}"
 
 
 # ---------------------------------------------------------------------------

--- a/core/framework/loader/tool_registry.py
+++ b/core/framework/loader/tool_registry.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from framework.llm.provider import Tool, ToolResult, ToolUse
+from framework.utils.tool_suggestions import format_unknown_tool_error
 
 logger = logging.getLogger(__name__)
 
@@ -340,9 +341,10 @@ class ToolRegistry:
             registry_ref.resync_mcp_servers_if_needed()
 
             if tool_use.name not in registry_ref._tools:
+                error_msg = format_unknown_tool_error(tool_use.name, registry_ref._tools.keys())
                 return ToolResult(
                     tool_use_id=tool_use.id,
-                    content=json.dumps({"error": f"Unknown tool: {tool_use.name}"}),
+                    content=json.dumps({"error": error_msg}),
                     is_error=True,
                 )
 

--- a/core/framework/utils/tool_suggestions.py
+++ b/core/framework/utils/tool_suggestions.py
@@ -1,0 +1,35 @@
+"""Helpers for producing actionable errors when an agent calls an unknown tool.
+
+When an LLM hallucinates or misspells a tool name, returning a bare
+``Unknown tool`` error usually makes the model repeat the same bad call and
+waste a turn.  These helpers suggest the closest registered names so the
+model can self-correct on the next turn.  Both the main tool registry and the
+reflection agent reuse :func:`format_unknown_tool_error`, so suggestion
+behaviour stays consistent across call sites.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from difflib import get_close_matches
+
+_SUGGESTION_COUNT = 2
+_SUGGESTION_CUTOFF = 0.5
+
+
+def format_unknown_tool_error(name: str, known_tool_names: Iterable[str]) -> str:
+    """Build an "Unknown tool" error message, appending close matches when found.
+
+    When no registered tool name is close enough to ``name``, the message has
+    no "Did you mean" suffix, preserving the behaviour of existing callers.
+    """
+    message = f"Unknown tool: {name}"
+    matches = get_close_matches(
+        str(name),
+        list(known_tool_names),
+        n=_SUGGESTION_COUNT,
+        cutoff=_SUGGESTION_CUTOFF,
+    )
+    if matches:
+        message += f" Did you mean: {', '.join(matches)}?"
+    return message

--- a/core/tests/test_queen_memory.py
+++ b/core/tests/test_queen_memory.py
@@ -419,6 +419,17 @@ async def test_queen_short_reflection_writes_only_queen_scope(tmp_path: Path):
     assert list(global_dir.glob("*.md")) == []
 
 
+def test_reflection_unknown_tool_suggests_closest_memory_tool_name(tmp_path: Path):
+    """Reflection unknown-tool error hints at the closest memory tool name."""
+    from framework.agents.queen.reflection_agent import _execute_tool
+
+    result = _execute_tool("read_memry_fil", {}, tmp_path)
+
+    assert result.startswith("ERROR: Unknown tool: read_memry_fil")
+    assert "Did you mean" in result
+    assert "read_memory_file" in result
+
+
 @pytest.mark.asyncio
 async def test_unified_short_reflection_can_write_both_scopes_in_one_loop(tmp_path: Path):
     """Unified short reflection can place memories in both scopes in one pass."""

--- a/core/tests/test_tool_registry.py
+++ b/core/tests/test_tool_registry.py
@@ -365,6 +365,32 @@ def test_unknown_tool_error_returns_proper_result():
     assert "nonexistent_tool" in result.content
 
 
+def test_unknown_tool_error_suggests_closest_registered_tool():
+    """Unknown tool error should hint at the closest registered tool name."""
+    registry = ToolRegistry()
+    for name in ("web_search", "exa_search"):
+        tool = Tool(
+            name=name,
+            description="Search the web",
+            parameters={"type": "object", "properties": {}},
+        )
+        registry.register(name, tool, lambda inputs, _name=name: {"ok": _name})
+
+    tool_use = ToolUse(
+        id="typo_call",
+        name="web_seach",
+        input={},
+    )
+
+    executor = registry.get_executor()
+    result = executor(tool_use)
+
+    assert result.is_error is True
+    assert "Unknown tool: web_seach" in result.content
+    assert "web_search" in result.content
+    assert "Did you mean" in result.content
+
+
 def test_tool_execution_error_truncates_large_inputs(caplog):
     """ToolRegistry should truncate large inputs in error logs."""
     registry = ToolRegistry()

--- a/core/tests/test_tool_suggestions.py
+++ b/core/tests/test_tool_suggestions.py
@@ -1,0 +1,32 @@
+"""Unit tests for framework.utils.tool_suggestions."""
+
+from framework.utils.tool_suggestions import format_unknown_tool_error
+
+
+def test_no_close_match_returns_bare_message():
+    """Names with no close match yield the bare Unknown tool message."""
+    known = ["web_search", "exa_search"]
+    assert format_unknown_tool_error("fetch_news", known) == "Unknown tool: fetch_news"
+
+
+def test_close_typo_suggests_best_matches():
+    """A typo should produce a Did you mean hint with the closest names."""
+    known = ["web_search", "exa_search"]
+    message = format_unknown_tool_error("web_seach", known)
+    assert message.startswith("Unknown tool: web_seach")
+    assert "Did you mean: web_search, exa_search?" in message
+
+
+def test_suggestions_capped_at_two():
+    """Suggestion lists never exceed the cap, even with many candidates."""
+    known = [
+        "list_memory_files",
+        "read_memory_file",
+        "write_memory_file",
+        "delete_memory_file",
+        "format_memory_manifest",
+    ]
+    message = format_unknown_tool_error("read_memry_fil", known)
+    suggestions = message.split("Did you mean: ", 1)[1].rstrip("?")
+    assert len(suggestions.split(", ")) <= 2
+    assert "read_memory_file" in suggestions


### PR DESCRIPTION
## Description
When an LLM calls a hallucinated or misspelled tool name, the tool registry returned `{"error": "Unknown tool: <name>"}` with no hint, so the agent tends to repeat the bad call and waste a turn. This PR makes the error actionable: both unknown-tool paths now suggest the closest registered tool names using `difflib.get_close_matches`.

## Motivation
Closes #7315. The same dead-end existed at `tool_registry.py` (executor) and `reflection_agent.py` (`_execute_tool`); the hint logic now lives once in a shared helper (`framework.utils.tool_suggestions`).

## Changes
- New `core/framework/utils/tool_suggestions.py`: `format_unknown_tool_error()` builds the `Unknown tool` message and appends up to 2 close matches (difflib `get_close_matches`, cutoff 0.5) when available.
- `core/framework/loader/tool_registry.py`: executor's unknown-tool `ToolResult` now carries the hint.
- `core/framework/agents/queen/reflection_agent.py`: unknown reflection-tool errors now hint at the internal memory tool names and use the same helper.
- Tests: new `core/tests/test_tool_suggestions.py` (unit) plus integration coverage in `core/tests/test_tool_registry.py` and `core/tests/test_queen_memory.py`.

## Testing
- [x] Unit tests added/updated
- [x] `pytest` passed on affected modules (82 passed)
- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] Verified behavior unchanged when no close name exists (bare `Unknown tool` message preserved)

## Checklist
- [X] Code follows style guidelines (ruff)
- [X] Self-review completed
- [X] No breaking changes

(I have commented on the issue and would appreciate being assigned to #7315 under the project's contribution policy.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved unknown-tool error messages by suggesting up to two likely matching tool names.
  - Applied helpful suggestions consistently across reflection tools and the tool registry.
  - Preserved clear error reporting when no close match is available.

- **Tests**
  - Added coverage for typo correction, suggestion ranking, suggestion limits, and unchanged error status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->