### PR TITLE
micro-fix: update stale repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Hive - Aden Agent Framework - Build goal-driven, self-improving AI agents",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adenhq/hive.git"
+    "url": "https://github.com/aden-hive/hive.git"
   },
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Closes #7282

## Description
Fixes the stale repository URL in package.json to correctly point to the aden-hive organization.

## Motivation
Keep metadata accurate.

## Changes
- Updated package.json repository url

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist
- [x] Code follows style guidelines (ruff)
- [x] Self-review completed
- [x] Documentation updated
- [x] No breaking changes (or documented if unavoidable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the repository link to reflect its new location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->