### PR TITLE
micro-fix: suggest nearest tool name on unknown tool call

### DIFF
--- a/core/framework/loader/tool_registry.py
+++ b/core/framework/loader/tool_registry.py
@@ -437,18 +437,13 @@ class ToolRegistry:
 
             if tool_use.name not in registry_ref._tools:
                 import difflib
-                
+
                 error_msg = f"Unknown tool: {tool_use.name}"
                 if registry_ref._tools:
-                    matches = difflib.get_close_matches(
-                        tool_use.name, 
-                        registry_ref._tools.keys(), 
-                        n=1, 
-                        cutoff=0.6
-                    )
+                    matches = difflib.get_close_matches(tool_use.name, registry_ref._tools.keys(), n=1, cutoff=0.6)
                     if matches:
                         error_msg += f". Did you mean '{matches[0]}'?"
-                        
+
                 return ToolResult(
                     tool_use_id=tool_use.id,
                     content=json.dumps({"error": error_msg}),

--- a/core/framework/loader/tool_registry.py
+++ b/core/framework/loader/tool_registry.py
@@ -436,9 +436,22 @@ class ToolRegistry:
             registry_ref.resync_mcp_servers_if_needed()
 
             if tool_use.name not in registry_ref._tools:
+                import difflib
+                
+                error_msg = f"Unknown tool: {tool_use.name}"
+                if registry_ref._tools:
+                    matches = difflib.get_close_matches(
+                        tool_use.name, 
+                        registry_ref._tools.keys(), 
+                        n=1, 
+                        cutoff=0.6
+                    )
+                    if matches:
+                        error_msg += f". Did you mean '{matches[0]}'?"
+                        
                 return ToolResult(
                     tool_use_id=tool_use.id,
-                    content=json.dumps({"error": f"Unknown tool: {tool_use.name}"}),
+                    content=json.dumps({"error": error_msg}),
                     is_error=True,
                 )
 

--- a/core/tests/test_tool_registry.py
+++ b/core/tests/test_tool_registry.py
@@ -440,16 +440,22 @@ def test_tool_execution_error_logs_inputs(caplog):
 def test_unknown_tool_error_returns_proper_result():
     """ToolRegistry should return proper error for unknown tools and suggest closest match."""
     registry = ToolRegistry()
-    
+
     # Register a tool so it can be suggested
-    def existent_tool() -> str:
+    tool_meta = Tool(
+        name="existent_tool",
+        description="A tool that exists",
+        parameters={"type": "object", "properties": {}},
+    )
+
+    def existent_executor(input_data):
         return "ok"
-    
-    registry.register(existent_tool)
-    
+
+    registry.register(tool=tool_meta, executor=existent_executor)
+
     tool_use = ToolUse(
         id="unknown_call",
-        name="existant_tool", # typo
+        name="existant_tool",  # typo
         input={},
     )
 

--- a/core/tests/test_tool_registry.py
+++ b/core/tests/test_tool_registry.py
@@ -438,11 +438,18 @@ def test_tool_execution_error_logs_inputs(caplog):
 
 
 def test_unknown_tool_error_returns_proper_result():
-    """ToolRegistry should return proper error for unknown tools."""
+    """ToolRegistry should return proper error for unknown tools and suggest closest match."""
     registry = ToolRegistry()
+    
+    # Register a tool so it can be suggested
+    def existent_tool() -> str:
+        return "ok"
+    
+    registry.register(existent_tool)
+    
     tool_use = ToolUse(
         id="unknown_call",
-        name="nonexistent_tool",
+        name="existant_tool", # typo
         input={},
     )
 
@@ -451,7 +458,8 @@ def test_unknown_tool_error_returns_proper_result():
 
     assert result.is_error is True
     assert "Unknown tool" in result.content
-    assert "nonexistent_tool" in result.content
+    assert "existant_tool" in result.content
+    assert "Did you mean 'existent_tool'?" in result.content
 
 
 def test_tool_execution_error_truncates_large_inputs(caplog):

--- a/core/tests/test_tool_registry.py
+++ b/core/tests/test_tool_registry.py
@@ -451,7 +451,7 @@ def test_unknown_tool_error_returns_proper_result():
     def existent_executor(input_data):
         return "ok"
 
-    registry.register(tool=tool_meta, executor=existent_executor)
+    registry.register(name="existent_tool", tool=tool_meta, executor=existent_executor)
 
     tool_use = ToolUse(
         id="unknown_call",


### PR DESCRIPTION
Closes #7315

## Description
Improves agent resilience by suggesting the closest valid tool name using difflib when an unknown tool call is received.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Checklist
- [x] Code follows style guidelines (ruff)
- [x] Self-review completed
- [x] Documentation updated
- [x] No breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unknown-tool error messages by suggesting the closest matching registered tool name when available.
  * Preserved the existing error format when no suitable match is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->