### PR TITLE
fix: log warning instead of silently swallowing exception in _prepare_transition_payload

### DIFF
--- a/core/framework/orchestrator/node_worker.py
+++ b/core/framework/orchestrator/node_worker.py
@@ -791,7 +791,12 @@ class NodeWorker:
                     )
                     continue
                 except Exception:
-                    pass
+                    logger.warning(
+                        "Failed to spill buffer key %r to %s",
+                        key,
+                        file_path,
+                        exc_info=True,
+                    )
 
             buffer_items[key] = val_str[:300] + "..." if len(val_str) > 300 else val_str
 


### PR DESCRIPTION
## Changes

Replaces bare  with  when file spill fails in .

## What this fixes

- Operators can now see spillover failures in logs (key name, file path, exception details)
- Downstream behavior unchanged: fallback to inline truncation still works
- Follows the same pattern already used in  

## Testing

- Existing tests pass
- Verified warning appears in logs when disk is full / permissions denied

Fixes #7262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Buffer spillover failures now generate warnings with the affected key, destination path, and diagnostic details, improving visibility into transition issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->