### PR TITLE
[Feature] Route raw exceptions in GraphExecutor to existing retry logic

### DIFF
--- a/core/framework/orchestrator/node_worker.py
+++ b/core/framework/orchestrator/node_worker.py
@@ -424,6 +424,15 @@ class NodeWorker:
                         max(1, max_retries),
                         delay,
                     )
+                    # Emit retry event for raw exceptions
+                    if gc.event_bus:
+                        await gc.event_bus.emit_node_retry(
+                            stream_id=gc.stream_id,
+                            node_id=self.node_spec.id,
+                            attempt=attempt + 1,
+                            max_retries=max_retries,
+                            execution_id=gc.execution_id,
+                        )
                     await asyncio.sleep(delay)
                     continue
                 return NodeResult(

--- a/core/framework/orchestrator/node_worker.py
+++ b/core/framework/orchestrator/node_worker.py
@@ -380,7 +380,8 @@ class NodeWorker:
                 if attempt + 1 < total_attempts:
                     gc.retry_counts[self.node_spec.id] = gc.retry_counts.get(self.node_spec.id, 0) + 1
                     gc.nodes_with_retries.add(self.node_spec.id)
-                    delay = 1.0 * (2**attempt)
+                    import random
+                    delay = (1.0 * (2**attempt)) + random.uniform(0.1, 0.5)
                     logger.warning(
                         "Worker %s failed (attempt %d/%d), retrying in %.1fs: %s",
                         self.node_spec.id,
@@ -413,7 +414,8 @@ class NodeWorker:
                 if attempt + 1 < total_attempts:
                     gc.retry_counts[self.node_spec.id] = gc.retry_counts.get(self.node_spec.id, 0) + 1
                     gc.nodes_with_retries.add(self.node_spec.id)
-                    delay = 1.0 * (2**attempt)
+                    import random
+                    delay = (1.0 * (2**attempt)) + random.uniform(0.1, 0.5)
                     logger.warning(
                         "Worker %s raised %s (attempt %d/%d), retrying in %.1fs",
                         self.node_spec.id,

--- a/core/framework/orchestrator/node_worker.py
+++ b/core/framework/orchestrator/node_worker.py
@@ -337,6 +337,9 @@ class NodeWorker:
                 self._last_result = result
                 self._last_activations = activations
                 await self._publish_failure(result.error or "Unknown error")
+        except asyncio.CancelledError:
+            # Re-raise to preserve system responsiveness and lifecycle interrupts
+            raise
         except Exception as exc:
             error = str(exc) or type(exc).__name__
             logger.exception("Worker %s crashed during execution", node_spec.id)
@@ -403,6 +406,9 @@ class NodeWorker:
                         error=f"failed after {attempt + 1} attempts: {result.error}",
                     )
 
+            except asyncio.CancelledError:
+                # Re-raise to preserve system responsiveness and lifecycle interrupts
+                raise
             except Exception as exc:
                 if attempt + 1 < total_attempts:
                     gc.retry_counts[self.node_spec.id] = gc.retry_counts.get(self.node_spec.id, 0) + 1

--- a/core/framework/orchestrator/orchestrator.py
+++ b/core/framework/orchestrator/orchestrator.py
@@ -1028,7 +1028,25 @@ class Orchestrator:
                         )
 
                     self.logger.info(f"      ▶ Branch {node_spec.name}: executing (attempt {attempt + 1})")
-                    result = await node_impl.execute(ctx)
+                    
+                    try:
+                        result = await node_impl.execute(ctx)
+                    except asyncio.CancelledError:
+                        # Re-raise to preserve system responsiveness and lifecycle interrupts
+                        raise
+                    except Exception as e:
+                        # Catch raw exceptions and route them to the standard retry loop
+                        import traceback
+                        stack_trace = traceback.format_exc()
+                        self.logger.error(
+                            f"      ✗ Branch {node_spec.name}: unhandled system exception during execution:\n{stack_trace}"
+                        )
+                        result = NodeResult(
+                            success=False,
+                            output={},
+                            error=f"Unhandled system exception: {str(e)}"
+                        )
+
                     last_result = result
 
                     # Ensure L2 entry for this branch node

--- a/core/framework/orchestrator/orchestrator.py
+++ b/core/framework/orchestrator/orchestrator.py
@@ -1032,10 +1032,8 @@ class Orchestrator:
                     try:
                         result = await node_impl.execute(ctx)
                     except asyncio.CancelledError:
-                        # Re-raise to preserve system responsiveness and lifecycle interrupts
                         raise
                     except Exception as e:
-                        # Catch raw exceptions and route them to the standard retry loop
                         import traceback
                         stack_trace = traceback.format_exc()
                         self.logger.error(
@@ -1097,7 +1095,12 @@ class Orchestrator:
                         self.logger.info(f"      ✓ Branch {node_spec.name}: success (tokens: {result.tokens_used}, latency: {result.latency_ms}ms)")
                         return branch, result
 
-                    self.logger.warning(f"      ↻ Branch {node_spec.name}: retry {attempt + 1}/{effective_max_retries}")
+                    if attempt + 1 < effective_max_retries:
+                        import random
+                        # Exponential backoff with up to 500ms of random jitter
+                        delay = (1.0 * (2 ** attempt)) + random.uniform(0.1, 0.5)
+                        self.logger.warning(f"      ↻ Branch {node_spec.name}: retry {attempt + 1}/{effective_max_retries} in {delay:.2f}s")
+                        await asyncio.sleep(delay)
 
                 # All retries exhausted
                 branch.status = "failed"
@@ -1140,6 +1143,9 @@ class Orchestrator:
         failed_branches: list[ParallelBranch] = []
 
         for i, result in enumerate(results):
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+
             branch = branch_list[i]
 
             if isinstance(result, asyncio.TimeoutError):
@@ -1562,12 +1568,7 @@ class Orchestrator:
                         worker = workers[wid]
 
                         if task.cancelled():
-                            error = "Worker task was cancelled unexpectedly"
-                            failed_workers[wid] = error
-                            self.logger.error(f"  ✗ Worker failed: {wid} - {error}")
-                            if wid in terminal_worker_ids:
-                                completed_terminals.add(wid)
-                            continue
+                            raise asyncio.CancelledError(f"Worker task {wid} was cancelled")
 
                         task_error = None
                         try:

--- a/core/framework/orchestrator/orchestrator.py
+++ b/core/framework/orchestrator/orchestrator.py
@@ -964,7 +964,8 @@ class Orchestrator:
             # Get node implementation to check its type
             branch_impl = self._get_node_implementation(node_spec, graph.cleanup_llm_model)
 
-            effective_max_retries = node_spec.max_retries
+            # Normalize to at least 1 attempt, so max_retries=0 still executes once
+            effective_max_retries = max(1, node_spec.max_retries)
             # Only override for actual AgentLoop instances, not custom NodeProtocol impls
             from framework.agent_loop.agent_loop import AgentLoop as _AgentLoop  # noqa: F811
 
@@ -1757,6 +1758,21 @@ class Orchestrator:
             )
 
         finally:
+            # Cancel and await all outstanding worker and timeout tasks
+            tasks_to_cancel = []
+            for w in workers.values():
+                if w._task is not None and not w._task.done():
+                    w._task.cancel()
+                    tasks_to_cancel.append(w._task)
+            
+            for task in _fanout_branch_tasks.values():
+                if task is not None and not task.done():
+                    task.cancel()
+                    tasks_to_cancel.append(task)
+            
+            if tasks_to_cancel:
+                await asyncio.gather(*tasks_to_cancel, return_exceptions=True)
+
             if has_event_subscription and self._event_bus:
                 if sub_completed:
                     self._event_bus.unsubscribe(sub_completed)

--- a/core/framework/runtime/tests/test_system_level_retries.py
+++ b/core/framework/runtime/tests/test_system_level_retries.py
@@ -29,7 +29,6 @@ class CancelledNode(NodeProtocol):
 async def test_worker_catches_raw_exception_and_retries():
     """Verify that a raw exception is caught and triggers the retry loop."""
     
-    # 1. Setup minimal mock context
     node_spec = NodeSpec(
         id="test_flaky_node", 
         name="Flaky Node", 
@@ -37,7 +36,6 @@ async def test_worker_catches_raw_exception_and_retries():
         max_retries=3
     )
     
-    # Added goal_id="test_goal" to satisfy Pydantic
     mock_graph = GraphSpec(id="test_graph", goal_id="test_goal", entry_node="test_flaky_node", nodes=[node_spec], edges=[])
     
     # Mocking GraphContext to bypass deep instantiation
@@ -51,8 +49,8 @@ async def test_worker_catches_raw_exception_and_retries():
     mock_gc.node_visit_counts = {}
     mock_gc.path = []
     mock_gc.buffer = MagicMock(spec=DataBuffer)
+    mock_gc.event_bus = None
     
-    # 2. Initialize worker and inject our custom flaking node
     worker = NodeWorker(node_spec=node_spec, graph_context=mock_gc)
     worker._node_impl = FlakySystemNode()
     
@@ -62,10 +60,8 @@ async def test_worker_catches_raw_exception_and_retries():
     worker._publish_completion = AsyncMock()
     worker._publish_failure = AsyncMock()
     
-    # 3. Execute
     await worker._execute_self()
     
-    # 4. Assertions
     assert worker.lifecycle == WorkerLifecycle.COMPLETED
     assert worker._node_impl.attempts == 3
     assert mock_gc.retry_counts["test_flaky_node"] == 2
@@ -91,6 +87,7 @@ async def test_worker_respects_asyncio_cancelled_error():
     mock_gc.node_visit_counts = {}
     mock_gc.path = []
     mock_gc.buffer = MagicMock(spec=DataBuffer)
+    mock_gc.event_bus = None
     
     worker = NodeWorker(node_spec=node_spec, graph_context=mock_gc)
     worker._node_impl = CancelledNode()

--- a/core/framework/runtime/tests/test_system_level_retries.py
+++ b/core/framework/runtime/tests/test_system_level_retries.py
@@ -1,0 +1,101 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from framework.orchestrator.node import NodeProtocol, NodeContext, NodeResult, NodeSpec, DataBuffer
+from framework.orchestrator.node_worker import NodeWorker, WorkerLifecycle
+from framework.orchestrator.context import GraphContext
+from framework.orchestrator.edge import GraphSpec
+
+class FlakySystemNode(NodeProtocol):
+    """A mock node that simulates a transient infrastructure crash before succeeding."""
+    def __init__(self):
+        self.attempts = 0
+
+    async def execute(self, ctx: NodeContext) -> NodeResult:
+        self.attempts += 1
+        if self.attempts < 3:
+            # Simulate a raw system exception (e.g., DB connection dropped)
+            raise ConnectionError("Simulated transient network drop.")
+        
+        return NodeResult(success=True, output={"status": "recovered"})
+
+class CancelledNode(NodeProtocol):
+    """A mock node that simulates a system interruption."""
+    async def execute(self, ctx: NodeContext) -> NodeResult:
+        raise asyncio.CancelledError("Simulated system interrupt.")
+
+@pytest.mark.asyncio
+async def test_worker_catches_raw_exception_and_retries():
+    """Verify that a raw exception is caught and triggers the retry loop."""
+    
+    # 1. Setup minimal mock context
+    node_spec = NodeSpec(
+        id="test_flaky_node", 
+        name="Flaky Node", 
+        description="Tests retries", 
+        max_retries=3
+    )
+    
+    # Added goal_id="test_goal" to satisfy Pydantic
+    mock_graph = GraphSpec(id="test_graph", goal_id="test_goal", entry_node="test_flaky_node", nodes=[node_spec], edges=[])
+    
+    # Mocking GraphContext to bypass deep instantiation
+    mock_gc = MagicMock(spec=GraphContext)
+    mock_gc.graph = mock_graph
+    mock_gc.retry_counts = {}
+    mock_gc.nodes_with_retries = set()
+    mock_gc.is_continuous = False
+    mock_gc._visits_lock = asyncio.Lock()
+    mock_gc._path_lock = asyncio.Lock()
+    mock_gc.node_visit_counts = {}
+    mock_gc.path = []
+    mock_gc.buffer = MagicMock(spec=DataBuffer)
+    
+    # 2. Initialize worker and inject our custom flaking node
+    worker = NodeWorker(node_spec=node_spec, graph_context=mock_gc)
+    worker._node_impl = FlakySystemNode()
+    
+    # Mock out internal methods that would try to touch the real event bus/edges
+    worker._build_node_context = MagicMock(return_value=MagicMock(spec=NodeContext))
+    worker._evaluate_outgoing_edges = AsyncMock(return_value=[])
+    worker._publish_completion = AsyncMock()
+    worker._publish_failure = AsyncMock()
+    
+    # 3. Execute
+    await worker._execute_self()
+    
+    # 4. Assertions
+    assert worker.lifecycle == WorkerLifecycle.COMPLETED
+    assert worker._node_impl.attempts == 3
+    assert mock_gc.retry_counts["test_flaky_node"] == 2
+    assert worker._last_result is not None
+    assert worker._last_result.success is True
+
+@pytest.mark.asyncio
+async def test_worker_respects_asyncio_cancelled_error():
+    """Verify that asyncio.CancelledError is NOT swallowed by the broad exception handler."""
+    
+    node_spec = NodeSpec(
+        id="test_cancel_node", 
+        name="Cancel Node", 
+        description="Tests cancellation", 
+        max_retries=3
+    )
+    
+    mock_gc = MagicMock(spec=GraphContext)
+    # Added goal_id="test_goal" to satisfy Pydantic
+    mock_gc.graph = GraphSpec(id="test_graph", goal_id="test_goal", entry_node="test_cancel_node", nodes=[node_spec], edges=[])
+    mock_gc._visits_lock = asyncio.Lock()
+    mock_gc._path_lock = asyncio.Lock()
+    mock_gc.node_visit_counts = {}
+    mock_gc.path = []
+    mock_gc.buffer = MagicMock(spec=DataBuffer)
+    
+    worker = NodeWorker(node_spec=node_spec, graph_context=mock_gc)
+    worker._node_impl = CancelledNode()
+    worker._build_node_context = MagicMock(return_value=MagicMock(spec=NodeContext))
+    
+    # The CancelledError should bubble up completely, bypassing the retry loop
+    with pytest.raises(asyncio.CancelledError):
+        await worker._execute_self()

--- a/core/framework/runtime/tests/test_system_level_retries.py
+++ b/core/framework/runtime/tests/test_system_level_retries.py
@@ -49,7 +49,9 @@ async def test_worker_catches_raw_exception_and_retries():
     mock_gc.node_visit_counts = {}
     mock_gc.path = []
     mock_gc.buffer = MagicMock(spec=DataBuffer)
-    mock_gc.event_bus = None
+    mock_gc.event_bus = AsyncMock()
+    mock_gc.stream_id = "test_stream"
+    mock_gc.execution_id = "test_exec"
     
     worker = NodeWorker(node_spec=node_spec, graph_context=mock_gc)
     worker._node_impl = FlakySystemNode()
@@ -68,6 +70,16 @@ async def test_worker_catches_raw_exception_and_retries():
     assert worker._last_result is not None
     assert worker._last_result.success is True
 
+    # Regression assertion verifying the retry event is emitted on exception
+    assert mock_gc.event_bus.emit_node_retry.call_count == 2
+    mock_gc.event_bus.emit_node_retry.assert_called_with(
+        stream_id="test_stream",
+        node_id="test_flaky_node",
+        attempt=2,
+        max_retries=3,
+        execution_id="test_exec",
+    )
+
 @pytest.mark.asyncio
 async def test_worker_respects_asyncio_cancelled_error():
     """Verify that asyncio.CancelledError is NOT swallowed by the broad exception handler."""
@@ -80,7 +92,6 @@ async def test_worker_respects_asyncio_cancelled_error():
     )
     
     mock_gc = MagicMock(spec=GraphContext)
-    # Added goal_id="test_goal" to satisfy Pydantic
     mock_gc.graph = GraphSpec(id="test_graph", goal_id="test_goal", entry_node="test_cancel_node", nodes=[node_spec], edges=[])
     mock_gc._visits_lock = asyncio.Lock()
     mock_gc._path_lock = asyncio.Lock()


### PR DESCRIPTION
Fixes: #5105

## Summary

Route raw (system-level) exceptions thrown by node implementations into the existing node-level retry mechanism so transient infra failures (network timeouts, DB drops, 500s, etc.) do not crash the entire agent run. Preserve cancellation semantics so `asyncio.CancelledError` continues to propagate immediately.

## Problem

Previously, `node_impl.execute(ctx)` could raise uncaught exceptions that bypassed the node retry loops and terminated the whole graph run. This makes the system fragile to temporary infrastructure "blips".

## Changes

- Wrap node execution in both execution paths to capture raw exceptions and convert them into a failure `NodeResult` so existing retry/backoff logic is used:
  - core/framework/orchestrator/orchestrator.py
    - Wraps `node_impl.execute(ctx)` in the branch execution loop with a try/except.
    - Converts non-Cancelled exceptions into `NodeResult(success=False, error=...)`.
    - Keeps existing logging and node-retry event emission.
    - Adds exponential backoff with jitter to retry sleeps.
  - core/framework/orchestrator/node_worker.py
    - Ensures `_execute_with_retries()` treats non-Cancelled exceptions as retriable failures.
    - Re-raises `asyncio.CancelledError` to preserve cancellation/HITL/TUI responsiveness.
    - Adds jitter to backoff delays to avoid thundering-herd retries.

- Tests added / updated:
  - core/framework/runtime/tests/test_system_level_retries.py
    - test_worker_catches_raw_exception_and_retries
    - test_worker_respects_asyncio_cancelled_error

## Files changed (high level)

- core/framework/orchestrator/orchestrator.py
- core/framework/orchestrator/node_worker.py
- core/framework/runtime/tests/test_system_level_retries.py

## Test results (local)

- Ran: pytest core/framework/runtime/tests/test_system_level_retries.py
- Result: 2 passed, 4 warnings

## How this addresses the issue

When a node implementation raises a non-Cancelled exception, it is now converted into a `NodeResult(success=False, ...)` and handled by the existing retry loop which respects the node `max_retries` and uses exponential backoff + jitter. `asyncio.CancelledError` is re-raised so cancellations and interactive flows are not degraded.

## Verification / QA

- Unit tests included above validate both retry-on-exception and the correct propagation of CancelledError.
- Recommended additional check: run an integration scenario where a node intermittently raises a transient exception and confirm:
  - The node is retried with exponential backoff and jitter.
  - The graph recovers if the node succeeds within the configured retries or fails cleanly after max retries.

## Notes / Follow-ups

- Ensure CI runs the full test matrix.
- Optionally add an orchestrator-level integration test if one does not already exist to cover the non-worker branch loop end-to-end.
- Consider a short changelog/release note mentioning improved reliability for transient infra failures.

Requesting review and merge. Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when parallel tasks encounter unexpected errors by routing failures through the existing retry process.
  * Added exponential retry delays with randomized timing to improve recovery from transient failures.
  * Ensured retry processing performs at least one attempt when configured with no retries.
  * Transient node failures can now recover successfully after retrying, with retry counts tracked accurately.
  * Task cancellation is preserved correctly and no longer treated as a retryable failure.
  * Improved cleanup of interrupted background tasks.

* **Tests**
  * Added coverage for successful recovery after repeated failures and proper cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->