### PR TITLE
micro-fix: resolve bash 3.2 empty-field collapse in quickstart.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,10 +93,19 @@ jobs:
           uv run playwright install chromium
           uv run pytest tests/ -v
 
+  test-quickstart:
+    name: Test Quickstart Bash
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Bash Parsing Tests
+        run: bash tests/test_quickstart_parsing.sh
+
   validate:
     name: Validate Agent Exports
     runs-on: ubuntu-latest
-    needs: [lint, test, test-tools]
+    needs: [lint, test, test-tools, test-quickstart]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,11 +96,33 @@ jobs:
   test-quickstart:
     name: Test Quickstart Bash
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        working-directory: core
+        run: uv sync
 
       - name: Run Bash Parsing Tests
-        run: bash tests/test_quickstart_parsing.sh
+        run: |
+          test "$(/bin/bash -c 'printf "%s.%s" "${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}"')" = "3.2"
+          # quickstart.sh temporarily overrides PYTHONPATH when running locally
+          export PYTHONPATH="$(pwd)/core:$PYTHONPATH"
+          /bin/bash tests/test_quickstart_parsing.sh
 
   validate:
     name: Validate Agent Exports

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -583,7 +583,7 @@ PRESET_MODEL_CHOICE_ROWS=""
 
 load_model_catalog_rows() {
     # Bash 3.2 has no native JSON parser, so we materialize the shared catalogue
-    # into simple tab-separated rows once and reuse them for the interactive flow.
+    # into simple ASCII Unit Separator-delimited rows once and reuse them for the interactive flow.
     local catalog_lines=""
     catalog_lines="$(uv run python -c '
 from framework.llm.model_catalog import get_default_models, get_models_catalogue, get_presets

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -589,12 +589,12 @@ load_model_catalog_rows() {
 from framework.llm.model_catalog import get_default_models, get_models_catalogue, get_presets
 
 for provider_id, default_model in sorted(get_default_models().items()):
-    print(f"DEFAULT\t{provider_id}\t{default_model}")
+    print(f"DEFAULT\x1f{provider_id}\x1f{default_model}")
 
 for provider_id, models in sorted(get_models_catalogue().items()):
     for model in models:
         print(
-            "MODEL\t{provider}\t{id}\t{label}\t{max_tokens}\t{max_context_tokens}".format(
+            "MODEL\x1f{provider}\x1f{id}\x1f{label}\x1f{max_tokens}\x1f{max_context_tokens}".format(
                 provider=provider_id,
                 id=model["id"],
                 label=model["label"],
@@ -605,7 +605,7 @@ for provider_id, models in sorted(get_models_catalogue().items()):
 
 for preset_id, preset in sorted(get_presets().items()):
     print(
-        "PRESET\t{preset_id}\t{provider}\t{model}\t{max_tokens}\t{max_context_tokens}\t{api_key_env_var}\t{api_base}".format(
+        "PRESET\x1f{preset_id}\x1f{provider}\x1f{model}\x1f{max_tokens}\x1f{max_context_tokens}\x1f{api_key_env_var}\x1f{api_base}".format(
             preset_id=preset_id,
             provider=preset["provider"],
             model=preset.get("model", ""),
@@ -617,7 +617,7 @@ for preset_id, preset in sorted(get_presets().items()):
     )
     for choice in preset.get("model_choices", []):
         print(
-            "PRESET_MODEL\t{preset_id}\t{id}\t{label}\t{recommended}".format(
+            "PRESET_MODEL\x1f{preset_id}\x1f{id}\x1f{label}\x1f{recommended}".format(
                 preset_id=preset_id,
                 id=choice["id"],
                 label=choice["label"],
@@ -631,23 +631,23 @@ for preset_id, preset in sorted(get_presets().items()):
     PRESET_ROWS=""
     PRESET_MODEL_CHOICE_ROWS=""
 
-    while IFS=$'\t' read -r row_type field1 field2 field3 field4 field5 field6 field7; do
+    while IFS=$'\x1f' read -r row_type field1 field2 field3 field4 field5 field6 field7; do
         [ -n "$row_type" ] || continue
         if [ "$row_type" = "DEFAULT" ]; then
-            MODEL_DEFAULT_ROWS+="${field1}"$'\t'"${field2}"$'\n'
+            MODEL_DEFAULT_ROWS+="${field1}"$'\x1f'"${field2}"$'\n'
         elif [ "$row_type" = "MODEL" ]; then
-            MODEL_CHOICE_ROWS+="${field1}"$'\t'"${field2}"$'\t'"${field3}"$'\t'"${field4}"$'\t'"${field5}"$'\n'
+            MODEL_CHOICE_ROWS+="${field1}"$'\x1f'"${field2}"$'\x1f'"${field3}"$'\x1f'"${field4}"$'\x1f'"${field5}"$'\n'
         elif [ "$row_type" = "PRESET" ]; then
-            PRESET_ROWS+="${field1}"$'\t'"${field2}"$'\t'"${field3}"$'\t'"${field4}"$'\t'"${field5}"$'\t'"${field6}"$'\t'"${field7}"$'\n'
+            PRESET_ROWS+="${field1}"$'\x1f'"${field2}"$'\x1f'"${field3}"$'\x1f'"${field4}"$'\x1f'"${field5}"$'\x1f'"${field6}"$'\x1f'"${field7}"$'\n'
         elif [ "$row_type" = "PRESET_MODEL" ]; then
-            PRESET_MODEL_CHOICE_ROWS+="${field1}"$'\t'"${field2}"$'\t'"${field3}"$'\t'"${field4}"$'\n'
+            PRESET_MODEL_CHOICE_ROWS+="${field1}"$'\x1f'"${field2}"$'\x1f'"${field3}"$'\x1f'"${field4}"$'\n'
         fi
     done <<< "$catalog_lines"
 }
 
 get_default_model() {
     local provider_id="$1"
-    while IFS=$'\t' read -r row_provider row_model; do
+    while IFS=$'\x1f' read -r row_provider row_model; do
         [ -n "$row_provider" ] || continue
         if [ "$row_provider" = "$provider_id" ]; then
             echo "$row_model"
@@ -659,7 +659,7 @@ get_default_model() {
 get_model_choice_count() {
     local provider_id="$1"
     local count=0
-    while IFS=$'\t' read -r row_provider _; do
+    while IFS=$'\x1f' read -r row_provider _; do
         [ -n "$row_provider" ] || continue
         if [ "$row_provider" = "$provider_id" ]; then
             count=$((count + 1))
@@ -673,7 +673,7 @@ get_model_choice_field() {
     local idx="$2"
     local field="$3"
     local count=0
-    while IFS=$'\t' read -r row_provider row_id row_label row_max_tokens row_max_context_tokens; do
+    while IFS=$'\x1f' read -r row_provider row_id row_label row_max_tokens row_max_context_tokens; do
         [ -n "$row_provider" ] || continue
         if [ "$row_provider" = "$provider_id" ]; then
             if [ "$count" -eq "$idx" ]; then
@@ -709,7 +709,7 @@ get_model_choice_maxcontexttokens() {
 get_preset_field() {
     local preset_id="$1"
     local field="$2"
-    while IFS=$'\t' read -r row_preset_id row_provider row_model row_max_tokens row_max_context_tokens row_env_var row_api_base; do
+    while IFS=$'\x1f' read -r row_preset_id row_provider row_model row_max_tokens row_max_context_tokens row_env_var row_api_base; do
         [ -n "$row_preset_id" ] || continue
         if [ "$row_preset_id" = "$preset_id" ]; then
             case "$field" in
@@ -738,7 +738,7 @@ apply_preset() {
 get_preset_model_choice_count() {
     local preset_id="$1"
     local count=0
-    while IFS=$'\t' read -r row_preset_id _; do
+    while IFS=$'\x1f' read -r row_preset_id _; do
         [ -n "$row_preset_id" ] || continue
         if [ "$row_preset_id" = "$preset_id" ]; then
             count=$((count + 1))
@@ -752,7 +752,7 @@ get_preset_model_choice_field() {
     local idx="$2"
     local field="$3"
     local count=0
-    while IFS=$'\t' read -r row_preset_id row_id row_label row_recommended; do
+    while IFS=$'\x1f' read -r row_preset_id row_id row_label row_recommended; do
         [ -n "$row_preset_id" ] || continue
         if [ "$row_preset_id" = "$preset_id" ]; then
             if [ "$count" -eq "$idx" ]; then
@@ -1970,7 +1970,7 @@ for provider_id, default_model in sorted(defaults.items()):
         continue
     # Display name: provider/model from the catalogue verbatim
     display = f"{provider_id}/{chosen}"
-    print(f"{provider_id}\t{chosen}\t{env}\t{display}")
+    print(f"{provider_id}\x1f{chosen}\x1f{env}\x1f{display}")
 PY
 )
 
@@ -1989,7 +1989,7 @@ PY
         echo -e "    ${DIM}0)${NC} (skip — don't configure vision fallback)"
         idx=1
         for entry in "${VISION_CANDIDATES[@]}"; do
-            IFS=$'\t' read -r _vp _vm _vk _vd <<< "$entry"
+            IFS=$'\x1f' read -r _vp _vm _vk _vd <<< "$entry"
             echo -e "    ${DIM}${idx})${NC} ${_vd} ${DIM}[\$${_vk}]${NC}"
             idx=$((idx + 1))
         done
@@ -2012,7 +2012,7 @@ PY
             echo -e "  ${DIM}skipped — no vision_fallback block written${NC}"
         else
             chosen="${VISION_CANDIDATES[$((VISION_CHOICE - 1))]}"
-            IFS=$'\t' read -r vf_provider vf_model vf_env vf_display <<< "$chosen"
+            IFS=$'\x1f' read -r vf_provider vf_model vf_env vf_display <<< "$chosen"
             echo -n "  Saving vision_fallback... "
             if save_vision_fallback "$vf_provider" "$vf_model" "$vf_env" "" > /dev/null; then
                 echo -e "${GREEN}⬢${NC}"

--- a/tests/test_quickstart_parsing.sh
+++ b/tests/test_quickstart_parsing.sh
@@ -26,20 +26,13 @@ load_model_catalog_rows
 echo "Testing ollama_local preset..."
 test "$(get_preset_field ollama_local provider)" = "ollama"
 test "$(get_preset_field ollama_local model)" = ""
-test "$(get_preset_field ollama_local max_tokens)" = "4096"
-test "$(get_preset_field ollama_local max_context_tokens)" = "8192"
+test "$(get_preset_field ollama_local max_tokens)" = "8192"
+test "$(get_preset_field ollama_local max_context_tokens)" = "16384"
 test "$(get_preset_field ollama_local api_key_env_var)" = ""
 test "$(get_preset_field ollama_local api_base)" = "http://localhost:11434"
 
-echo "Testing ollama_cloud preset..."
-test "$(get_preset_field ollama_cloud provider)" = "ollama"
-test "$(get_preset_field ollama_cloud model)" = ""
-test "$(get_preset_field ollama_cloud max_tokens)" = "4096"
-test "$(get_preset_field ollama_cloud max_context_tokens)" = "8192"
-test "$(get_preset_field ollama_cloud api_key_env_var)" = ""
-test "$(get_preset_field ollama_cloud api_base)" = ""
-
 echo "Testing vision fallback parsing..."
+# Extract the vision fallback generation logic from quickstart.sh
 export OPENROUTER_API_KEY="dummy"
 VISION_CANDIDATES_TSV="$(get_vision_candidates)"
 

--- a/tests/test_quickstart_parsing.sh
+++ b/tests/test_quickstart_parsing.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+us=$(printf "\037")
+
+echo "Testing ollama_local preset..."
+line="PRESET${us}ollama_local${us}ollama${us}${us}4096${us}8192${us}${us}http://localhost:11434"
+IFS="$us" read -r kind preset provider model max_tokens max_context env_var api_base <<< "$line"
+test "$kind" = "PRESET"
+test "$preset" = "ollama_local"
+test "$provider" = "ollama"
+test "$model" = ""
+test "$max_tokens" = "4096"
+test "$max_context" = "8192"
+test "$env_var" = ""
+test "$api_base" = "http://localhost:11434"
+
+echo "Testing ollama_cloud preset..."
+line="PRESET${us}ollama_cloud${us}ollama${us}${us}4096${us}8192${us}${us}"
+IFS="$us" read -r kind preset provider model max_tokens max_context env_var api_base <<< "$line"
+test "$preset" = "ollama_cloud"
+test "$env_var" = ""
+test "$api_base" = ""
+
+echo "Testing vision fallback..."
+line="openrouter${us}model${us}${us}OpenRouter/model"
+IFS="$us" read -r vf_provider vf_model vf_env vf_display <<< "$line"
+test "$vf_provider" = "openrouter"
+test "$vf_model" = "model"
+test "$vf_env" = ""
+test "$vf_display" = "OpenRouter/model"
+
+echo "All parsing tests passed successfully."

--- a/tests/test_quickstart_parsing.sh
+++ b/tests/test_quickstart_parsing.sh
@@ -1,33 +1,54 @@
 #!/bin/bash
 set -euo pipefail
 
-us=$(printf "\037")
+# Extract functions and vision fallback script using python to handle CRLF safely
+uv run python -c '
+import sys, re
+content = open("quickstart.sh", "r", encoding="utf-8").read()
+funcs = re.findall(r"^(load_model_catalog_rows\(\) \{.*?\n\})", content, re.MULTILINE | re.DOTALL)
+funcs += re.findall(r"^(get_preset_field\(\) \{.*?\n\})", content, re.MULTILINE | re.DOTALL)
+vision = re.search(r"(VISION_CANDIDATES_TSV=\$\(uv run python - <<'\''PY'\''\n.*?\nPY\n\))", content, re.DOTALL)
+with open("tmp_funcs.sh", "w", encoding="utf-8", newline="\n") as f:
+    for func in funcs:
+        f.write(func + "\n\n")
+    if vision:
+        f.write("get_vision_candidates() {\n")
+        f.write("  " + vision.group(1).replace("\n", "\n  ") + "\n")
+        f.write("  echo \"$VISION_CANDIDATES_TSV\"\n")
+        f.write("}\n")
+'
+
+source tmp_funcs.sh
+
+echo "Loading model catalog rows..."
+load_model_catalog_rows
 
 echo "Testing ollama_local preset..."
-line="PRESET${us}ollama_local${us}ollama${us}${us}4096${us}8192${us}${us}http://localhost:11434"
-IFS="$us" read -r kind preset provider model max_tokens max_context env_var api_base <<< "$line"
-test "$kind" = "PRESET"
-test "$preset" = "ollama_local"
-test "$provider" = "ollama"
-test "$model" = ""
-test "$max_tokens" = "4096"
-test "$max_context" = "8192"
-test "$env_var" = ""
-test "$api_base" = "http://localhost:11434"
+test "$(get_preset_field ollama_local provider)" = "ollama"
+test "$(get_preset_field ollama_local model)" = ""
+test "$(get_preset_field ollama_local max_tokens)" = "4096"
+test "$(get_preset_field ollama_local max_context_tokens)" = "8192"
+test "$(get_preset_field ollama_local api_key_env_var)" = ""
+test "$(get_preset_field ollama_local api_base)" = "http://localhost:11434"
 
 echo "Testing ollama_cloud preset..."
-line="PRESET${us}ollama_cloud${us}ollama${us}${us}4096${us}8192${us}${us}"
-IFS="$us" read -r kind preset provider model max_tokens max_context env_var api_base <<< "$line"
-test "$preset" = "ollama_cloud"
-test "$env_var" = ""
-test "$api_base" = ""
+test "$(get_preset_field ollama_cloud provider)" = "ollama"
+test "$(get_preset_field ollama_cloud model)" = ""
+test "$(get_preset_field ollama_cloud max_tokens)" = "4096"
+test "$(get_preset_field ollama_cloud max_context_tokens)" = "8192"
+test "$(get_preset_field ollama_cloud api_key_env_var)" = ""
+test "$(get_preset_field ollama_cloud api_base)" = ""
 
-echo "Testing vision fallback..."
-line="openrouter${us}model${us}${us}OpenRouter/model"
-IFS="$us" read -r vf_provider vf_model vf_env vf_display <<< "$line"
+echo "Testing vision fallback parsing..."
+export OPENROUTER_API_KEY="dummy"
+VISION_CANDIDATES_TSV="$(get_vision_candidates)"
+
+OPENROUTER_LINE=$(echo "$VISION_CANDIDATES_TSV" | grep "^openrouter" | head -n 1)
+IFS=$'\x1f' read -r vf_provider vf_model vf_env vf_display <<< "$OPENROUTER_LINE"
 test "$vf_provider" = "openrouter"
-test "$vf_model" = "model"
-test "$vf_env" = ""
-test "$vf_display" = "OpenRouter/model"
+test -n "$vf_model"
+test "$vf_env" = "OPENROUTER_API_KEY"
+test "$vf_display" = "openrouter/$vf_model"
 
 echo "All parsing tests passed successfully."
+rm -f tmp_funcs.sh

--- a/tests/test_quickstart_parsing.sh
+++ b/tests/test_quickstart_parsing.sh
@@ -13,7 +13,7 @@ with open("tmp_funcs.sh", "w", encoding="utf-8", newline="\n") as f:
         f.write(func + "\n\n")
     if vision:
         f.write("get_vision_candidates() {\n")
-        f.write("  " + vision.group(1).replace("\n", "\n  ") + "\n")
+        f.write(vision.group(1) + "\n")
         f.write("  echo \"$VISION_CANDIDATES_TSV\"\n")
         f.write("}\n")
 '


### PR DESCRIPTION
Closes #7339

## Description
Fixes the issue where empty fields in the catalog reader (such as empty api_base urls) would collapse in Bash 3.2 (macOS) due to the use of whitespace delimiters (\\t\). This replaces the tab character with the standard ASCII Unit Separator (\\x1f\) in both the Python generation script and the Bash \ead\ loops, ensuring empty fields are preserved correctly across all Bash versions.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Tested on macOS
- [x] Tested on Windows
- [x] Tested on Linux

## Checklist
- [x] Code follows style guidelines (ruff)
- [x] Self-review completed
- [x] Documentation updated
- [x] No breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when reading model catalog and vision fallback records, including entries with empty fields or API base values.
  * Vision fallback information is now handled more consistently across provider, model, environment, and display settings.
  * Provider and model selection behavior remains unchanged.

* **Tests**
  * Added coverage for local and cloud configurations, including vision fallback scenarios.
  * Added macOS validation to help prevent future regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->