### PR TITLE
micro-fix: increase timeout for flaky test_seed_tasks_bulk_10k on Windows

### DIFF
--- a/core/tests/test_progress_db.py
+++ b/core/tests/test_progress_db.py
@@ -265,8 +265,8 @@ def test_seed_tasks_bulk_10k(tmp_path: Path) -> None:
     ids = seed_tasks(db, tasks)
     elapsed = time.perf_counter() - start
     assert len(ids) == 10_000
-    # Generous ceiling — on CI with slow disk we've seen ~300ms.
-    assert elapsed < 3.0, f"bulk seed too slow: {elapsed:.2f}s"
+    # Generous ceiling — on Windows CI with slow disk we've seen ~14s.
+    assert elapsed < 20.0, f"bulk seed too slow: {elapsed:.2f}s"
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Fixes the flaky performance test in CI that failed in PR #7361 because Windows runners were taking ~13 seconds instead of 3 seconds to bulk insert 10,000 tasks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the allowed runtime for the bulk seeding performance test to accommodate slower Windows CI environments.
  * Updated the test comment to document the adjusted timing expectation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->