### PR TITLE
fix: don't crash quickstart.sh on unset $TERM, surface real uv sync errors

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -265,7 +265,7 @@ if [ -f "pyproject.toml" ]; then
     else
         echo -e "${RED}  ✗ workspace installation failed${NC}"
         echo ""
-        echo -e "${DIM}${UV_SYNC_OUTPUT}${NC}"
+        printf '%b%s%b\n' "$DIM" "$UV_SYNC_OUTPUT" "$NC"
         exit 1
     fi
 else

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -93,7 +93,7 @@ prompt_choice() {
     done
 }
 
-clear
+clear 2>/dev/null || true
 echo ""
 echo -e "${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}"
 echo ""
@@ -260,10 +260,12 @@ echo -n "  Installing workspace packages... "
 cd "$SCRIPT_DIR"
 
 if [ -f "pyproject.toml" ]; then
-    if uv sync > /dev/null 2>&1; then
+    if UV_SYNC_OUTPUT=$(uv sync 2>&1); then
         echo -e "${GREEN}  ✓ workspace packages installed${NC}"
     else
         echo -e "${RED}  ✗ workspace installation failed${NC}"
+        echo ""
+        echo -e "${DIM}${UV_SYNC_OUTPUT}${NC}"
         exit 1
     fi
 else
@@ -2314,7 +2316,7 @@ fi
 # Success!
 # ============================================================
 
-clear
+clear 2>/dev/null || true
 echo ""
 echo -e "${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}"
 echo ""


### PR DESCRIPTION
## Description
Fixes two robustness bugs in `quickstart.sh` that make failures undiagnosable. `clear` was called unconditionally under `set -e`, so an unset `$TERM` silently kills the whole script. Separately, `uv sync`'s output was redirected to `/dev/null`, so any install failure just printed a generic message with no way to tell what went wrong.

## Motivation
Ran into this firsthand: `./quickstart.sh` died immediately with just `TERM environment variable not set.` and no further explanation. After bypassing that, the workspace-install step failed with only `✗ workspace installation failed` printed — the real error (a `uv sync` timeout fetching the pinned Python 3.11 build) was being swallowed by `> /dev/null 2>&1`.

## Changes
- Guard both `clear` calls: `clear 2>/dev/null || true`
- Capture `uv sync` output via `UV_SYNC_OUTPUT=$(uv sync 2>&1)` and print it when the sync fails

## Testing
- [x] `bash -n quickstart.sh` passes
- [x] Verified the `if VAR=$(failing_cmd)` capture pattern doesn't trigger early exit under `set -e`
- [x] Ran the package-install step of `quickstart.sh` successfully end to end after the fix

## Checklist
- [x] Code follows style guidelines (matches existing script conventions)
- [x] Self-review completed
- [x] No breaking changes

Closes #7368

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quickstart reliability when terminal clearing is unavailable.
  * Installation failures now display helpful command output for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->