### PR TITLE
fix(windows): preserve resolved MCP server cwd via env when cwd=None

### DIFF
--- a/core/framework/loader/mcp_client.py
+++ b/core/framework/loader/mcp_client.py
@@ -354,6 +354,12 @@ class MCPClient:
                         candidate = cwd_path / arg
                         if candidate.exists():
                             args[i] = str(candidate.resolve())
+                # Same fix as tool_registry._resolve_mcp_server_config: the
+                # child can no longer see cwd, so hand it over via env.
+                # files_server.py reads HIVE_MCP_SERVER_CWD to anchor its
+                # relative-path fallback instead of inheriting this
+                # process's cwd (a config-supplied env value wins).
+                merged_env.setdefault("HIVE_MCP_SERVER_CWD", str(cwd_path))
                 cwd = None
             server_params = StdioServerParameters(
                 command=self.config.command,

--- a/core/framework/loader/tool_registry.py
+++ b/core/framework/loader/tool_registry.py
@@ -19,6 +19,15 @@ logger = logging.getLogger(__name__)
 
 _INPUT_LOG_MAX_LEN = 500
 
+
+def _is_windows() -> bool:
+    """Indirection so tests can simulate the Windows branch without
+    monkeypatching the real os.name — doing that on a POSIX CI runner makes
+    pathlib construct WindowsPath objects on a real POSIX filesystem, which
+    breaks in ways unrelated to what's actually being tested.
+    """
+    return os.name == "nt"
+
 # Tools whose names match this pattern are assumed to return ImageContent.
 # Matched against the bare tool name (case-insensitive). Used to mark MCP
 # tools with produces_image=True so they can be filtered out for text-only
@@ -635,7 +644,7 @@ class ToolRegistry:
             config["cwd"] = str(resolved_cwd)
             return config
 
-        if os.name == "nt":
+        if _is_windows():
             # Windows: cwd=None avoids WinError 267; use absolute script path.
             # subprocess.Popen never receives resolved_cwd this way, so a
             # server script that falls back to os.getcwd() (e.g. files_server.py

--- a/core/framework/loader/tool_registry.py
+++ b/core/framework/loader/tool_registry.py
@@ -636,12 +636,19 @@ class ToolRegistry:
             return config
 
         if os.name == "nt":
-            # Windows: cwd=None avoids WinError 267; use absolute script path
+            # Windows: cwd=None avoids WinError 267; use absolute script path.
+            # subprocess.Popen never receives resolved_cwd this way, so a
+            # server script that falls back to os.getcwd() (e.g. files_server.py
+            # anchoring relative paths when no explicit home is passed) would
+            # otherwise inherit the *launching* Hive process's cwd instead of
+            # resolved_cwd. Pass it through env so Windows resolves the same
+            # anchor every other platform gets via the real cwd.
             config["cwd"] = None
             abs_script = str((resolved_cwd / script_name).resolve())
             args = list(config["args"])
             args[script_idx] = abs_script
             config["args"] = args
+            config["env"] = {**(config.get("env") or {}), "HIVE_MCP_SERVER_CWD": str(resolved_cwd)}
         else:
             config["cwd"] = str(resolved_cwd)
         return config

--- a/core/tests/test_mcp_client_stdio_teardown.py
+++ b/core/tests/test_mcp_client_stdio_teardown.py
@@ -73,6 +73,56 @@ def _child_pids() -> set[str]:
         return set()
 
 
+def test_windows_stdio_cwd_workaround_passes_dir_via_env(tmp_path) -> None:
+    """On Windows, MCPClient discards cwd (the WinError 267 workaround) but
+    must hand the directory to the child via HIVE_MCP_SERVER_CWD.
+
+    Regression for agent-generated files landing in the project root:
+    without this, any stdio server script that falls back to os.getcwd()
+    for relative paths (e.g. files_server.py) silently inherits the
+    *launching* Hive process's cwd instead of the directory this client was
+    configured with.
+    """
+    if os.name != "nt":
+        pytest.skip("exercises the Windows-only cwd=None workaround")
+
+    srv_dir = tmp_path / "srv"
+    srv_dir.mkdir()
+    script = srv_dir / "env_probe_server.py"
+    script.write_text(
+        textwrap.dedent(
+            """
+            import os
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("env-probe")
+
+            @mcp.tool()
+            def get_cwd_env() -> str:
+                return os.environ.get("HIVE_MCP_SERVER_CWD", "<missing>")
+
+            mcp.run()
+            """
+        )
+    )
+
+    client = MCPClient(
+        MCPServerConfig(
+            name="env-probe",
+            transport="stdio",
+            command=sys.executable,
+            args=["env_probe_server.py"],  # relative — exercises the cwd-resolve branch
+            cwd=str(srv_dir),
+        )
+    )
+    client.connect()
+    try:
+        result = client.call_tool("get_cwd_env", {})
+        assert str(srv_dir) in str(result)
+    finally:
+        client.disconnect()
+
+
 def test_stdio_connect_call_disconnect_is_clean(tmp_path, caplog) -> None:
     script = tmp_path / "echo_server.py"
     script.write_text(_ECHO_SERVER)

--- a/core/tests/test_tool_registry.py
+++ b/core/tests/test_tool_registry.py
@@ -7,7 +7,6 @@ could cause a json.JSONDecodeError and crash execution.
 """
 
 import logging
-import os
 import textwrap
 from pathlib import Path
 from types import SimpleNamespace
@@ -941,7 +940,11 @@ def test_resolve_mcp_server_config_windows_preserves_cwd_via_env(tmp_path, monke
     tools_dir.mkdir()
     (tools_dir / "files_server.py").write_text("# stub")
 
-    monkeypatch.setattr(os, "name", "nt")
+    # Simulate the Windows branch via the module's own indirection, not the
+    # real os.name — monkeypatching os.name globally makes pathlib construct
+    # WindowsPath objects on this (POSIX) CI runner, which breaks unrelated
+    # to what's being tested here.
+    monkeypatch.setattr("framework.loader.tool_registry._is_windows", lambda: True)
 
     registry = ToolRegistry()
     config = registry._resolve_mcp_server_config(
@@ -966,7 +969,11 @@ def test_resolve_mcp_server_config_windows_preserves_existing_env(tmp_path, monk
     tools_dir.mkdir()
     (tools_dir / "files_server.py").write_text("# stub")
 
-    monkeypatch.setattr(os, "name", "nt")
+    # Simulate the Windows branch via the module's own indirection, not the
+    # real os.name — monkeypatching os.name globally makes pathlib construct
+    # WindowsPath objects on this (POSIX) CI runner, which breaks unrelated
+    # to what's being tested here.
+    monkeypatch.setattr("framework.loader.tool_registry._is_windows", lambda: True)
 
     registry = ToolRegistry()
     config = registry._resolve_mcp_server_config(

--- a/core/tests/test_tool_registry.py
+++ b/core/tests/test_tool_registry.py
@@ -7,6 +7,7 @@ could cause a json.JSONDecodeError and crash execution.
 """
 
 import logging
+import os
 import textwrap
 from pathlib import Path
 from types import SimpleNamespace
@@ -923,6 +924,65 @@ def test_load_mcp_config_handles_invalid_json(tmp_path, caplog):
 # ---------------------------------------------------------------------------
 # resync_mcp_servers_if_needed — no-op when nothing changed
 # ---------------------------------------------------------------------------
+
+
+def test_resolve_mcp_server_config_windows_preserves_cwd_via_env(tmp_path, monkeypatch):
+    """On Windows, cwd=None (the WinError 267 workaround) must not silently
+    drop the resolved directory.
+
+    Regression for agent-generated files landing in the project root: a
+    stdio server script that falls back to os.getcwd() for relative paths
+    (e.g. files_server.py) previously inherited the *launching* process's
+    cwd instead of the directory this method resolved. It must now be
+    handed over via HIVE_MCP_SERVER_CWD so Windows matches every other
+    platform, which gets the same directory for free via a real cwd.
+    """
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+    (tools_dir / "files_server.py").write_text("# stub")
+
+    monkeypatch.setattr(os, "name", "nt")
+
+    registry = ToolRegistry()
+    config = registry._resolve_mcp_server_config(
+        {
+            "name": "files-tools",
+            "transport": "stdio",
+            "command": "uv",
+            "args": ["run", "python", "files_server.py", "--stdio"],
+            "cwd": "tools",
+        },
+        tmp_path,
+    )
+
+    assert config["cwd"] is None
+    assert config["env"]["HIVE_MCP_SERVER_CWD"] == str(tools_dir.resolve())
+    assert config["args"][2] == str((tools_dir / "files_server.py").resolve())
+
+
+def test_resolve_mcp_server_config_windows_preserves_existing_env(tmp_path, monkeypatch):
+    """The env injection must merge with, not clobber, a server's own env."""
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+    (tools_dir / "files_server.py").write_text("# stub")
+
+    monkeypatch.setattr(os, "name", "nt")
+
+    registry = ToolRegistry()
+    config = registry._resolve_mcp_server_config(
+        {
+            "name": "files-tools",
+            "transport": "stdio",
+            "command": "uv",
+            "args": ["run", "python", "files_server.py", "--stdio"],
+            "cwd": "tools",
+            "env": {"SOME_OTHER_VAR": "1"},
+        },
+        tmp_path,
+    )
+
+    assert config["env"]["SOME_OTHER_VAR"] == "1"
+    assert config["env"]["HIVE_MCP_SERVER_CWD"] == str(tools_dir.resolve())
 
 
 def test_resync_returns_false_when_no_clients():

--- a/tools/files_server.py
+++ b/tools/files_server.py
@@ -57,7 +57,13 @@ from fastmcp import FastMCP  # noqa: E402
 from aden_tools.file_ops import register_file_tools  # noqa: E402
 
 mcp = FastMCP("files-tools")
-register_file_tools(mcp)
+# HIVE_MCP_SERVER_CWD carries the intended working directory when the
+# launcher couldn't pass it as the real subprocess cwd (Windows: cwd=None
+# is used to avoid WinError 267). Without this, home falls back to
+# os.getcwd(), which on Windows is the *launching* Hive process's cwd
+# (often the project root) instead of the resolved tools/session dir every
+# other platform gets for free via a real cwd.
+register_file_tools(mcp, home=os.environ.get("HIVE_MCP_SERVER_CWD"))
 
 
 # ── Entry point ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #7366.

On Windows, both stdio-launch paths that build an MCP server subprocess null out `cwd` to avoid `WinError 267`:

1. `core/framework/loader/tool_registry.py::_resolve_mcp_server_config` — the primary resolver used by `load_mcp_config`.
2. `core/framework/loader/mcp_client.py::_connect_stdio` — a second, independent workaround for registry-loaded configs from `mcp_registry._manifest_to_config`, which (per its own comment) bypasses path #1 entirely.

Both pass `cwd=None` to `subprocess.Popen`, silently dropping the resolved directory. `files_server.py` calls `register_file_tools(mcp)` with no explicit `home`, so `_FilePolicy` falls back to `os.getcwd()` — which on Windows is now the *launching* Hive process's cwd (often the project root), not the `tools/`-relative directory that was actually resolved (what non-Windows platforms get for free via a real `cwd=`). Agent-written relative paths (e.g. `dataxxx.md`) end up at `<project root>/dataxxx.md` instead of the intended location.

## Changes

- Both places that null `cwd` on Windows now pass the resolved directory through a `HIVE_MCP_SERVER_CWD` env var instead.
- `files_server.py` reads that env var to set `home` explicitly on `register_file_tools`.
- No behavior change wherever the env var isn't set (every non-Windows path).

## Testing

- `core/tests/test_tool_registry.py` — 2 new unit tests on `_resolve_mcp_server_config`'s Windows branch (env is set correctly; merges with rather than clobbers an existing `env`).
- `core/tests/test_mcp_client_stdio_teardown.py` — 1 new **real, non-mocked** subprocess regression test that drives an actual stdio MCP server through `_connect_stdio`'s Windows branch and asserts it sees `HIVE_MCP_SERVER_CWD`. Verified this test fails on the pre-fix code (`os.environ.get(...)` returns `"<missing>"`) and passes with the fix — confirmed on a real Windows machine, not just reasoned about.
- Full existing suites for both touched modules pass: 60 passed, 0 regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows MCP server startup when a working directory is configured.
  * Relative Python script paths now launch reliably while preserving the intended server directory.
  * File tools correctly use the configured working directory in these scenarios.

* **Tests**
  * Added Windows-specific coverage for working-directory propagation, environment preservation, and relative script handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->