### PR TITLE
fix: atomic_write retry on PermissionError for Windows (micro-fix)

### DIFF
--- a/core/framework/utils/io.py
+++ b/core/framework/utils/io.py
@@ -6,6 +6,11 @@ from pathlib import Path
 
 @contextmanager
 def atomic_write(path: Path, mode: str = "w", encoding: str = "utf-8"):
+    """Write to a file atomically by writing to a temporary file first and replacing it.
+
+    Includes a retry mechanism on Windows to mitigate PermissionErrors caused by
+    concurrent readers (e.g., antivirus scanners) locking the file during replacement.
+    """
     tmp_path = path.with_suffix(path.suffix + ".tmp")
     try:
         with open(tmp_path, mode, encoding=encoding) as f:

--- a/core/framework/utils/io.py
+++ b/core/framework/utils/io.py
@@ -1,4 +1,5 @@
 import os
+import time
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -11,7 +12,17 @@ def atomic_write(path: Path, mode: str = "w", encoding: str = "utf-8"):
             yield f
             f.flush()
             os.fsync(f.fileno())
-        tmp_path.replace(path)
+
+        max_retries = 10 if os.name == "nt" else 1
+        for attempt in range(max_retries):
+            try:
+                tmp_path.replace(path)
+                break
+            except PermissionError:
+                if attempt < max_retries - 1:
+                    time.sleep(0.01)
+                else:
+                    raise
     except BaseException:
         tmp_path.unlink(missing_ok=True)
         raise

--- a/core/tests/test_io.py
+++ b/core/tests/test_io.py
@@ -8,6 +8,11 @@ from framework.utils.io import atomic_write
 
 @pytest.mark.skipif(sys.platform != "win32", reason="PermissionError lock scenario is Windows-specific")
 def test_atomic_write_concurrent_reader(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Test that atomic_write retries file replacement on Windows if a PermissionError is raised.
+
+    This deterministic test mocks pathlib.Path.replace to raise a PermissionError on the
+    first attempt and succeed on the second attempt, mirroring transient Windows file locks.
+    """
     target = tmp_path / "checkpoint.json"
     target.write_text("original", encoding="utf-8")
 

--- a/core/tests/test_io.py
+++ b/core/tests/test_io.py
@@ -20,6 +20,7 @@ def test_atomic_write_concurrent_reader(tmp_path: Path, monkeypatch: pytest.Monk
     original_replace = type(target).replace
 
     def mocked_replace(self, *args, **kwargs):
+        """Mock replacement that throws PermissionError once, then succeeds."""
         call_count[0] += 1
         if call_count[0] == 1:
             raise PermissionError(13, "Access is denied")

--- a/core/tests/test_io.py
+++ b/core/tests/test_io.py
@@ -1,32 +1,28 @@
-import threading
-import time
+import sys
 from pathlib import Path
 
+import pytest
 from framework.utils.io import atomic_write
 
 
-def test_atomic_write_concurrent_reader(tmp_path: Path):
+@pytest.mark.skipif(sys.platform != "win32", reason="PermissionError lock scenario is Windows-specific")
+def test_atomic_write_concurrent_reader(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     target = tmp_path / "checkpoint.json"
     target.write_text("original", encoding="utf-8")
 
-    # To simulate a concurrent reader, we open the file and keep it open.
-    # On Windows, this will cause a PermissionError during replace.
-    # We want to test that atomic_write retries and eventually succeeds
-    # if the reader closes the file within the retry window.
+    call_count = [0]
+    original_replace = type(target).replace
 
-    reader = open(target, encoding="utf-8")
+    def mocked_replace(self, *args, **kwargs):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            raise PermissionError(13, "Access is denied")
+        return original_replace(self, *args, **kwargs)
 
-    # Use a background thread to close the reader after a short delay
-    # The atomic_write should retry and succeed once this thread closes the handle.
-    def close_reader():
-        time.sleep(0.05)
-        reader.close()
-
-    t = threading.Thread(target=close_reader)
-    t.start()
+    monkeypatch.setattr(type(target), "replace", mocked_replace)
 
     with atomic_write(target) as f:
         f.write("new content")
 
-    t.join()
+    assert call_count[0] == 2
     assert target.read_text(encoding="utf-8") == "new content"

--- a/core/tests/test_io.py
+++ b/core/tests/test_io.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 
 import pytest
+
 from framework.utils.io import atomic_write
 
 

--- a/core/tests/test_io.py
+++ b/core/tests/test_io.py
@@ -1,0 +1,32 @@
+import threading
+import time
+from pathlib import Path
+
+from framework.utils.io import atomic_write
+
+
+def test_atomic_write_concurrent_reader(tmp_path: Path):
+    target = tmp_path / "checkpoint.json"
+    target.write_text("original", encoding="utf-8")
+
+    # To simulate a concurrent reader, we open the file and keep it open.
+    # On Windows, this will cause a PermissionError during replace.
+    # We want to test that atomic_write retries and eventually succeeds
+    # if the reader closes the file within the retry window.
+
+    reader = open(target, encoding="utf-8")
+
+    # Use a background thread to close the reader after a short delay
+    # The atomic_write should retry and succeed once this thread closes the handle.
+    def close_reader():
+        time.sleep(0.05)
+        reader.close()
+
+    t = threading.Thread(target=close_reader)
+    t.start()
+
+    with atomic_write(target) as f:
+        f.write("new content")
+
+    t.join()
+    assert target.read_text(encoding="utf-8") == "new content"


### PR DESCRIPTION
Fixes #7369 by adding a short retry loop with backoff to atomic_write on Windows to handle transient PermissionErrors caused by concurrent readers locking the target file during replace. Also adds a new test to reproduce and verify the race condition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file-saving reliability on Windows by retrying when the destination file is temporarily locked.
  - Retries are limited to prevent indefinite delays.
  - Preserves the original failure behavior if the file remains unavailable after multiple attempts.
  - Non-Windows file-saving behavior remains unchanged.

- **Tests**
  - Added Windows-specific coverage confirming that a temporary permission failure is retried and the new file content is saved successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->