### PR TITLE
fix: ensure MCP server cwd is set to absolute path on Windows (micro-fix)

### DIFF
--- a/core/framework/loader/tool_registry.py
+++ b/core/framework/loader/tool_registry.py
@@ -588,12 +588,13 @@ class ToolRegistry:
             return config
 
         # Resolve cwd relative to base_dir
-        resolved_cwd: Path | None = None
         if cwd:
             if Path(cwd).is_absolute():
-                resolved_cwd = Path(cwd)
+                resolved_cwd = Path(cwd).resolve()
             else:
                 resolved_cwd = (base_dir / cwd).resolve()
+        else:
+            resolved_cwd = base_dir.resolve()
 
         # Find .py script in args (e.g. files_server.py)
         script_name = None
@@ -603,8 +604,7 @@ class ToolRegistry:
                 script_idx = i
                 break
 
-        if resolved_cwd is None:
-            return config
+
 
         # If resolved cwd doesn't exist or (when we have a script) doesn't contain it,
         # try fallback

--- a/core/framework/loader/tool_registry.py
+++ b/core/framework/loader/tool_registry.py
@@ -602,8 +602,6 @@ class ToolRegistry:
                 script_idx = i
                 break
 
-
-
         # If resolved cwd doesn't exist or (when we have a script) doesn't contain it,
         # try fallback
         tools_fallback = Path.cwd() / "tools"

--- a/core/framework/loader/tool_registry.py
+++ b/core/framework/loader/tool_registry.py
@@ -630,20 +630,14 @@ class ToolRegistry:
                 config["cwd"] = str(resolved_cwd)
                 return config
 
-        if not script_name:
-            # No .py script (e.g. GCU uses -m gcu.server); just set cwd
-            config["cwd"] = str(resolved_cwd)
-            return config
+        config["cwd"] = str(resolved_cwd.resolve())
 
-        if os.name == "nt":
-            # Windows: cwd=None avoids WinError 267; use absolute script path
-            config["cwd"] = None
+        if script_name:
             abs_script = str((resolved_cwd / script_name).resolve())
             args = list(config["args"])
             args[script_idx] = abs_script
             config["args"] = args
-        else:
-            config["cwd"] = str(resolved_cwd)
+
         return config
 
     def load_mcp_config(self, config_path: Path) -> None:

--- a/core/framework/loader/tool_registry.py
+++ b/core/framework/loader/tool_registry.py
@@ -584,8 +584,6 @@ class ToolRegistry:
 
         cwd = config.get("cwd")
         args = list(config.get("args", []))
-        if not cwd and not args:
-            return config
 
         # Resolve cwd relative to base_dir
         if cwd:

--- a/core/tests/test_tool_registry.py
+++ b/core/tests/test_tool_registry.py
@@ -920,6 +920,36 @@ def test_load_mcp_config_handles_invalid_json(tmp_path, caplog):
     assert any("Failed to load MCP config" in r.message for r in caplog.records)
 
 
+def test_resolve_mcp_server_config_without_cwd(tmp_path):
+    """Ensure missing cwd defaults to base_dir and script paths are absolutized."""
+    registry = ToolRegistry()
+    config = {"transport": "stdio", "command": "python", "args": ["server.py"]}
+
+    # Create the script in tmp_path so it doesn't fallback
+    (tmp_path / "server.py").touch()
+
+    resolved = registry._resolve_mcp_server_config(config, tmp_path)
+    assert resolved["cwd"] == str(tmp_path.resolve())
+    assert resolved["args"][0] == str((tmp_path / "server.py").resolve())
+
+
+def test_resolve_mcp_server_config_fallback(tmp_path, monkeypatch):
+    """Ensure fallback tools dir is used when script is not in base_dir."""
+    registry = ToolRegistry()
+    config = {"transport": "stdio", "command": "python", "args": ["server.py"]}
+
+    # Mock Path.cwd to return tmp_path, so tools_fallback = tmp_path / "tools"
+    monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+    (tools_dir / "server.py").touch()
+
+    resolved = registry._resolve_mcp_server_config(config, tmp_path / "nonexistent")
+    assert resolved["cwd"] == str(tools_dir.resolve())
+    assert resolved["args"][0] == str((tools_dir / "server.py").resolve())
+
+
 # ---------------------------------------------------------------------------
 # resync_mcp_servers_if_needed — no-op when nothing changed
 # ---------------------------------------------------------------------------

--- a/core/tests/test_tool_registry.py
+++ b/core/tests/test_tool_registry.py
@@ -933,6 +933,16 @@ def test_resolve_mcp_server_config_without_cwd(tmp_path):
     assert resolved["args"][0] == str((tmp_path / "server.py").resolve())
 
 
+def test_resolve_mcp_server_config_without_cwd_or_args(tmp_path):
+    """Ensure missing cwd and args defaults cwd to base_dir."""
+    registry = ToolRegistry()
+    config = {"transport": "stdio", "command": "node"}
+
+    resolved = registry._resolve_mcp_server_config(config, tmp_path)
+    assert resolved["cwd"] == str(tmp_path.resolve())
+    assert "args" not in resolved
+
+
 def test_resolve_mcp_server_config_fallback(tmp_path, monkeypatch):
     """Ensure fallback tools dir is used when script is not in base_dir."""
     registry = ToolRegistry()


### PR DESCRIPTION
Fixes #7366. Removes legacy \os.name == 'nt'\ branch that set \cwd=None\ for MCP servers, forcing them to inherit the Hive process root directory and causing agent documents to spill into the root project folder. Instead, this uses an absolute resolved path for the \cwd\ universally across all platforms, which properly avoids WinError 267.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP stdio configuration handling by consistently resolving working directories to absolute paths.
  * Python script arguments are now converted to absolute paths for more reliable execution across platforms.
  * Standardized behavior across Windows and non-script servers.
  * Added fallback handling when configured scripts are missing.
  * Preserved configurations that do not specify arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->