### PR TITLE
docs: remove directories that no longer exist from the structure diagrams

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -601,7 +601,7 @@ and produce a weekly intelligence report.
 
 **Runtime Performance**
 ```python
-# core/framework/runtime/runtime_logger.py
+# core/framework/tracker/runtime_logger.py
 class RuntimeLogger:
     def log_node_execution(self, node_id: str, duration: float, tokens: int):
         # Tracks per-node performance

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -84,14 +84,10 @@ hive/                                    # Repository root
 ├── core/                                # CORE FRAMEWORK PACKAGE
 │   ├── framework/                       # Main package code
 │   │   ├── agents/                      # Agent definitions and helpers
-│   │   ├── builder/                     # Agent builder utilities
 │   │   ├── credentials/                 # Credential management
 │   │   ├── debugger/                    # Debugging tools
-│   │   ├── graph/                       # GraphExecutor - executes node graphs
 │   │   ├── llm/                         # LLM provider integrations (Anthropic, OpenAI, OpenRouter, Hive, etc.)
-│   │   ├── mcp/                         # MCP server integration
 │   │   ├── observability/               # Structured logging - human-readable and machine-parseable tracing
-│   │   ├── runner/                      # AgentRunner - loads and runs agents
 │   │   ├── runtime/                     # Runtime environment
 │   │   ├── schemas/                     # Data schemas
 │   │   ├── server/                      # HTTP API server
@@ -129,7 +125,6 @@ hive/                                    # Repository root
 │   ├── configuration.md                 # Configuration reference
 │   ├── architecture/                    # System architecture
 │   ├── articles/                        # Technical articles
-│   ├── quizzes/                         # Developer quizzes
 │   └── i18n/                            # Translations
 │
 ├── scripts/                             # Utility scripts

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -111,17 +111,12 @@ This demonstrates the core runtime loop using pure Python functions, skipping th
 hive/
 ├── core/                   # Core Framework
 │   ├── framework/          # Agent runtime, graph executor
-│   │   ├── builder/        # Agent builder utilities
 │   │   ├── credentials/    # Credential management
-│   │   ├── graph/          # GraphExecutor - executes node graphs
 │   │   ├── llm/            # LLM provider integrations
-│   │   ├── mcp/            # MCP server integration
-│   │   ├── runner/         # AgentRunner - loads and runs agents
 │   │   ├── runtime/        # Runtime environment
 │   │   ├── schemas/        # Data schemas
 │   │   ├── storage/        # File-based persistence
-│   │   ├── testing/        # Testing utilities
-│   │   └── tui/            # Terminal UI dashboard
+│   │   └── testing/        # Testing utilities
 │   └── pyproject.toml      # Package metadata
 │
 ├── tools/                  # MCP Tools Package


### PR DESCRIPTION
Both project-structure diagrams list directories under `core/framework/` that are not in the
tree. Every other entry in both diagrams still exists, which is what makes the five stand out:

| entry | removed in |
|---|---|
| `builder/` | `2aefdf5b` "refactor: remove deprecated codes" |
| `graph/` | `3c9911c2` "refactor: grand clean-up" |
| `mcp/` | `2aefdf5b` |
| `runner/` | `3c9911c2` |
| `tui/` | `2aefdf5b` |

`docs/developer-guide.md` also lists `docs/quizzes/`, removed in `645792fb` ("docs: remove
outdated documents"), while `docs/architecture/`, `docs/articles/` and `docs/i18n/` beside it
are all still there.

`CONTRIBUTING.md:604` names `core/framework/runtime/runtime_logger.py` in its "Current
Monitoring Tools" section. That file moved to `core/framework/tracker/runtime_logger.py` in
`3c9911c2` and is at the new path now, so this is a one-word change.

`getting-started.md` needed one extra edit: `tui/` was the last child, so `testing/` above it
takes the closing connector.

**Removed rather than replaced, deliberately.** Ten directories exist under `core/framework/`
that neither diagram lists: `agent_loop`, `global_db`, `host`, `loader`, `maintenance`,
`orchestrator`, `pipeline`, `sentinel`, `tasks`, `tracker`. Writing one-line descriptions for
those would be inventing documentation rather than fixing it, so they are named here for
whoever knows what they do.

**Two things I found and left alone**, both because the right fix is a judgement rather than a
lookup:

- `docs/draft-flowchart-schema.md:32,33,35` : the "Key files" list points at
  `core/framework/server/routes_graphs.py`, `core/frontend/src/components/DraftGraph.tsx` and
  `core/frontend/src/pages/workspace.tsx`. All three are gone and I could not identify
  successors. `routes_workers.py` carries no draft or flowchart endpoints, and there is no
  `DraftGraph` or `workspace` page left under `core/frontend/src/`.
- The MCP and editor configs, which are issue #7383.

Found with [docproof](https://github.com/melbinjp/docproof), which checks what documentation
claims against what the repository actually contains.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented runtime logger location.
  * Refreshed repository and project structure guides to reflect the current directory layout.
  * Removed outdated framework and quiz directory references from developer documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->