### PR TITLE
fix(orchestrator): raise ConditionEvaluationError when EdgeCondition …

### DIFF
--- a/core/framework/orchestrator/__init__.py
+++ b/core/framework/orchestrator/__init__.py
@@ -9,7 +9,7 @@ def __getattr__(name: str):
         from framework.orchestrator.context import GraphContext
 
         return GraphContext
-    if name in ("DEFAULT_MAX_TOKENS", "EdgeCondition", "EdgeSpec", "GraphSpec"):
+    if name in ("DEFAULT_MAX_TOKENS", "EdgeCondition", "EdgeSpec", "GraphSpec", "ConditionEvaluationError"):
         from framework.orchestrator import edge as _e
 
         return getattr(_e, name)

--- a/core/framework/orchestrator/edge.py
+++ b/core/framework/orchestrator/edge.py
@@ -37,6 +37,12 @@ logger = logging.getLogger(__name__)
 DEFAULT_MAX_TOKENS = 8192
 
 
+class ConditionEvaluationError(Exception):
+    """Raised when an edge condition expression fails to evaluate due to a runtime or syntax error."""
+
+    pass
+
+
 class EdgeCondition(StrEnum):
     """When an edge should be traversed."""
 
@@ -196,10 +202,18 @@ class EdgeSpec(BaseModel):
             )
             return result
         except Exception as e:
-            logger.warning(f"      ⚠ Condition evaluation failed: {self.condition_expr}")
-            logger.warning(f"         Error: {e}")
-            logger.warning(f"         Available context keys: {list(context.keys())}")
-            return False
+            logger.error(
+                "      ❌ Edge '%s' condition evaluation failed: %s\n"
+                "         Error: %s\n"
+                "         Available context keys: %s",
+                self.id,
+                self.condition_expr,
+                e,
+                list(context.keys()),
+            )
+            raise ConditionEvaluationError(
+                f"Edge '{self.id}' condition evaluation failed for expression '{self.condition_expr}': {e}"
+            ) from e
 
     async def _llm_decide(
         self,

--- a/core/tests/test_edge_condition_error.py
+++ b/core/tests/test_edge_condition_error.py
@@ -1,0 +1,107 @@
+"""Tests for EdgeCondition evaluation error handling (Issue #7393).
+
+Ensures that evaluation failures in EdgeSpec conditions raise ConditionEvaluationError
+rather than silently returning False and terminating graph execution without an error.
+"""
+
+import pytest
+from framework.orchestrator import (
+    ConditionEvaluationError,
+    EdgeCondition,
+    EdgeSpec,
+)
+
+
+class TestEdgeConditionErrorHandling:
+    """Test suite for EdgeSpec condition evaluation errors."""
+
+    def test_condition_evaluation_raises_error_on_invalid_attribute(self):
+        """Accessing a non-existent property on result should raise ConditionEvaluationError."""
+        edge = EdgeSpec(
+            id="edge-1",
+            source="node-a",
+            target="node-b",
+            condition=EdgeCondition.CONDITIONAL,
+            condition_expr="result.invalid_prop > 5",
+        )
+        output = {"result": "some_string"}
+        buffer_data = {}
+
+        with pytest.raises(ConditionEvaluationError) as exc_info:
+            edge._evaluate_condition(output, buffer_data)
+
+        err_msg = str(exc_info.value)
+        assert "edge-1" in err_msg
+        assert "result.invalid_prop > 5" in err_msg
+        assert "Object has no attribute 'invalid_prop'" in err_msg or "AttributeError" in err_msg
+
+    def test_condition_evaluation_raises_error_on_undefined_variable(self):
+        """Referencing an undefined variable in context should raise ConditionEvaluationError."""
+        edge = EdgeSpec(
+            id="edge-2",
+            source="node-a",
+            target="node-b",
+            condition=EdgeCondition.CONDITIONAL,
+            condition_expr="unknown_var == True",
+        )
+
+        with pytest.raises(ConditionEvaluationError) as exc_info:
+            edge._evaluate_condition({}, {})
+
+        err_msg = str(exc_info.value)
+        assert "edge-2" in err_msg
+        assert "unknown_var" in err_msg
+
+    def test_condition_evaluation_raises_error_on_syntax_error(self):
+        """Syntax errors in condition_expr should raise ConditionEvaluationError."""
+        edge = EdgeSpec(
+            id="edge-3",
+            source="node-a",
+            target="node-b",
+            condition=EdgeCondition.CONDITIONAL,
+            condition_expr="output['key' == ",
+        )
+
+        with pytest.raises(ConditionEvaluationError) as exc_info:
+            edge._evaluate_condition({}, {})
+
+        assert "edge-3" in str(exc_info.value)
+
+    def test_condition_evaluation_succeds_on_valid_expr(self):
+        """Valid condition expressions returning True/False should work normally."""
+        edge_true = EdgeSpec(
+            id="edge-true",
+            source="node-a",
+            target="node-b",
+            condition=EdgeCondition.CONDITIONAL,
+            condition_expr="output.get('status') == 'success'",
+        )
+        edge_false = EdgeSpec(
+            id="edge-false",
+            source="node-a",
+            target="node-b",
+            condition=EdgeCondition.CONDITIONAL,
+            condition_expr="output.get('status') == 'failed'",
+        )
+
+        output = {"status": "success"}
+        assert edge_true._evaluate_condition(output, {}) is True
+        assert edge_false._evaluate_condition(output, {}) is False
+
+    @pytest.mark.asyncio
+    async def test_should_traverse_propagates_condition_evaluation_error(self):
+        """should_traverse should propagate ConditionEvaluationError for CONDITIONAL edges."""
+        edge = EdgeSpec(
+            id="edge-async",
+            source="node-a",
+            target="node-b",
+            condition=EdgeCondition.CONDITIONAL,
+            condition_expr="result.non_existent > 10",
+        )
+
+        with pytest.raises(ConditionEvaluationError):
+            await edge.should_traverse(
+                source_success=True,
+                source_output={"result": 123},
+                buffer_data={},
+            )


### PR DESCRIPTION
## Summary
Fixes #7393.

When an `EdgeCondition` expression evaluation fails (e.g., due to an `AttributeError`, `NameError`, or syntax error), `_evaluate_condition` now logs the error and raises `ConditionEvaluationError` instead of silently returning `False`.

## Verification
- Added unit tests in `core/tests/test_edge_condition_error.py`
- Passed all 122 `test_safe_eval.py` tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Condition evaluation failures now raise a clear error instead of silently preventing edge traversal.
  * Error details include the affected edge, expression, underlying issue, and available context to support troubleshooting.
  * Valid condition expressions continue to evaluate as expected, including during asynchronous traversal.

* **Tests**
  * Added coverage for invalid attributes, undefined variables, syntax errors, valid expressions, and asynchronous error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->