### PR TITLE
docs(readme): fix hive open CLI mismatch in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ This sets up:
 
 - Finally, it will open the Hive interface in your browser
 
-> **Tip:** To reopen the dashboard later, run `hive open` from the project directory.
+> **Tip:** To reopen the dashboard later, run `./hive open` (macOS/Linux) or `.\hive.ps1 open` (Windows) — using the wrapper script in the repository, not a bare `hive` command. The wrapper must be run from the project root: your current directory has to be the cloned repository itself, not a subdirectory.
 
 ### Build Your First Agent
 


### PR DESCRIPTION
## Description
Fixes the Quick Start tip in README.md that told readers to run `hive open`, a command that doesn't exist.

## Motivation
Hive ships `./hive` (bash) and `hive.ps1` (PowerShell) wrapper scripts, not a bare `hive` command, and both refuse to run unless invoked with the current directory set to the exact repository root. The README's quickstart tip only said `hive open`, which fails as written.

## Changes
- Clarified `./hive open` (macOS/Linux) vs `.\hive.ps1 open` (Windows) in the quickstart tip
- Documented that the wrapper must be run from the project root directory

## Testing
- [ ] Unit tests added/updated - N/A, docs only
- [ ] Integration tests added/updated - N/A, docs only
- [x] Verified against wrapper script behavior (`hive`, `hive.ps1`)

## Checklist
- [x] Documentation updated
- [x] Self-review completed
- [x] No breaking changes

Closes #6176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated dashboard reopening instructions for macOS/Linux and Windows.
  * Clarified that the commands must be run from the project root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->