### PR TITLE
fix(tasks): treat archived completed tasks as resolved blockers

### DIFF
--- a/core/framework/tasks/models.py
+++ b/core/framework/tasks/models.py
@@ -57,6 +57,19 @@ def is_task_idle(record: TaskRecord, *, now: float | None = None) -> bool:
     return current - (record.updated_at or 0.0) > IDLE_TASK_THRESHOLD_SECONDS
 
 
+def is_task_completed(record: TaskRecord) -> bool:
+    """True when a task is completed, or archived after having been completed.
+
+    Used by dependency/blocker resolution so that archiving finished work
+    does not cause dependent tasks to become permanently blocked.
+    """
+    if record.status is TaskStatus.COMPLETED:
+        return True
+    if record.status is TaskStatus.ARCHIVED and record.metadata.get("archived_from") == TaskStatus.COMPLETED.value:
+        return True
+    return False
+
+
 class TaskRecord(BaseModel):
     """One unit of work tracked by an agent."""
 

--- a/core/framework/tasks/store.py
+++ b/core/framework/tasks/store.py
@@ -37,6 +37,7 @@ from framework.tasks.models import (
     TaskListMeta,
     TaskRecord,
     TaskStatus,
+    is_task_completed,
     is_task_idle,
 )
 from framework.utils.io import atomic_write
@@ -818,7 +819,7 @@ class TaskStore:
             unresolved_blockers: list[int] = []
             for b in current.blocked_by:
                 blocker = next((r for r in doc.tasks if r.id == b), None)
-                if blocker is not None and blocker.status != TaskStatus.COMPLETED:
+                if blocker is not None and not is_task_completed(blocker):
                     unresolved_blockers.append(b)
             if unresolved_blockers:
                 return ClaimBlocked(kind="blocked", by=unresolved_blockers)

--- a/core/framework/tasks/tests/test_store.py
+++ b/core/framework/tasks/tests/test_store.py
@@ -365,6 +365,23 @@ async def test_claim_blocked(store: TaskStore, session_id: str) -> None:
     assert a.id in result.by
 
 
+@pytest.mark.asyncio
+async def test_claim_after_blocker_archived_completed(store: TaskStore, session_id: str) -> None:
+    await store.ensure_task_list(session_id)
+    a = await store.create_task(session_id, subject="prereq")
+    b = await store.create_task(session_id, subject="dep")
+    await store.update_task(session_id, b.id, add_blocked_by=[a.id])
+
+    # Complete and archive blocker 'a'
+    await store.update_task(session_id, a.id, status=TaskStatus.COMPLETED)
+    await store.archive_completed_tasks(session_id)
+
+    # b should now be claimable since blocker 'a' was completed before archive
+    result = await store.claim_task_with_busy_check(session_id, b.id, "agent_a")
+    assert isinstance(result, ClaimOk)
+    assert result.record.owner == "agent_a"
+
+
 # ---------------------------------------------------------------------------
 # Meta lifecycle: ensure_task_list is idempotent
 # ---------------------------------------------------------------------------

--- a/core/framework/tasks/tests/test_tools.py
+++ b/core/framework/tasks/tests/test_tools.py
@@ -452,6 +452,38 @@ async def test_completion_suffix_skips_blocked_pending(
 
 
 @pytest.mark.asyncio
+async def test_task_list_and_update_after_blocker_archived(
+    registry_with_session_tools: ToolRegistry,
+) -> None:
+    reg = registry_with_session_tools
+    session_id = "sess_1"
+    token = _set_ctx(agent_id="agent_a", session_id=session_id)
+    try:
+        await _create_one(reg, subject="prereq")
+        await _create_one(reg, subject="dep")
+        await _invoke(reg, "task_update", id=2, add_blocked_by=[1])
+
+        # Complete and archive task 1
+        await _invoke(reg, "task_update", id=1, status="completed")
+        await _invoke(reg, "task_update", id=1, status="archived")
+
+        # 1. task_list without include_archived should not show [blocked by #1]
+        list_res = await _invoke(reg, "task_list")
+        list_body = json.loads(list_res.content)
+        assert list_body["count"] == 1
+        assert "[blocked by" not in list_body["lines"][0]
+
+        # 2. task_update on another task should suggest #2 as next pending
+        await _create_one(reg, subject="unrelated")
+        await _invoke(reg, "task_update", id=3, status="completed")
+        upd_res = await _invoke(reg, "task_update", id=3, status="completed")
+        upd_body = json.loads(upd_res.content)
+        assert 'Next pending: #2 — "dep"' in upd_body["message"]
+    finally:
+        ToolRegistry.reset_execution_context(token)
+
+
+@pytest.mark.asyncio
 async def test_hook_blocks_task_created(
     registry_with_session_tools: ToolRegistry,
 ) -> None:

--- a/core/framework/tasks/tools/session_tools.py
+++ b/core/framework/tasks/tools/session_tools.py
@@ -32,7 +32,7 @@ from framework.tasks.hooks import (
     BlockingHookError,
     run_task_hooks,
 )
-from framework.tasks.models import TaskRecord, TaskStatus
+from framework.tasks.models import TaskRecord, TaskStatus, is_task_completed
 from framework.tasks.store import (
     _UNSET_SENTINEL as _UNSET,  # re-export for clarity
     TaskStore,
@@ -592,7 +592,7 @@ def _make_update_executor(store: TaskStore):
         message = f"Task #{task_id} updated. Fields changed: {', '.join(fields) or '(none)'}."
         if status_enum == TaskStatus.COMPLETED and "status" in fields:
             others = await store.list_tasks(session_id)
-            completed_ids = {r.id for r in others if r.status == TaskStatus.COMPLETED}
+            completed_ids = {r.id for r in others if is_task_completed(r)}
             next_pending = next(
                 (r for r in others if r.status == TaskStatus.PENDING and not [b for b in r.blocked_by if b not in completed_ids]),
                 None,
@@ -642,14 +642,16 @@ def _make_list_executor(store: TaskStore):
         # Filtering here (not in store.list_tasks) keeps the REST snapshot
         # serving archived tasks to the panel's History view.
         include_archived = bool(inputs.get("include_archived"))
-        records = await store.list_tasks(session_id)
-        if not include_archived:
-            records = [r for r in records if r.status is not TaskStatus.ARCHIVED]
+        all_records = await store.list_tasks(session_id)
+        # Filter resolved blockers from the rendering so a completed
+        # (or completed-then-archived) blocker disappears from blocked_by.
+        completed_ids = {r.id for r in all_records if is_task_completed(r)}
+        if include_archived:
+            records = all_records
+        else:
+            records = [r for r in all_records if r.status is not TaskStatus.ARCHIVED]
         meta = await store.get_meta(session_id)
         goal = meta.goal if meta is not None else None
-        # Filter resolved blockers from the rendering so a completed
-        # blocker disappears from blocked_by.
-        completed_ids = {r.id for r in records if r.status == TaskStatus.COMPLETED}
         rendered: list[str] = []
         # Lead with the stored goal so a queen scanning task_list before
         # deciding whether a new batch is a pivot has the anchor in view.


### PR DESCRIPTION
## Description

When a completed task is archived, its status transitions from `TaskStatus.COMPLETED` to `TaskStatus.ARCHIVED`, while preserving the origin status in `record.metadata["archived_from"] = "completed"`. Previously, blocker resolution checks across `TaskStore._claim_sync`, `task_list`, and `task_update` next-step steering strictly checked `record.status == TaskStatus.COMPLETED`. This caused dependent tasks whose blockers were completed and then archived to remain permanently blocked (workers could never claim them, next-step steering would skip them, and `task_list` would display false `[blocked by #X]` tags).

This PR introduces `is_task_completed(record)` to recognize completed tasks even when archived, and updates blocker checks and `task_list` completed resolution accordingly.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #7396

## Changes Made

- Added `is_task_completed(record: TaskRecord) -> bool` helper in task store/records to check if a task is currently completed or was completed prior to being archived (`record.metadata.get("archived_from") == "completed"`).
- Updated `TaskStore._claim_sync` to consider archived completed blocker tasks as resolved.
- Updated `task_update` next-step steering in `session_tools.py` to identify completed tasks across all records before filtering.
- Updated `task_list` in `session_tools.py` so `completed_ids` resolves completed blockers even when `include_archived=False`.
- Added regression unit tests for claiming, next-step steering, and list rendering with archived completed blockers.

## Testing

- [x] Unit tests pass
- [x] Lint passes
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Archived tasks that were completed now correctly count as resolved blockers.
  - Tasks can be claimed once their completed prerequisite has been archived.
  - Archived tasks are excluded from active task listings and no longer appear as unresolved blockers.
  - Task updates now recommend remaining unblocked pending tasks correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->