### PR TITLE
fix(orchestrator): prevent buffer keys from shadowing edge condition builtins (#7380)

### DIFF
--- a/core/framework/orchestrator/edge.py
+++ b/core/framework/orchestrator/edge.py
@@ -169,14 +169,16 @@ class EdgeSpec(BaseModel):
             return True
 
         # Build evaluation context
-        # Include buffer keys directly for easier access in conditions
+        # Unpack buffer keys first so the framework builtins below always take
+        # precedence — a buffer key named "result"/"true"/"false"/"output"/"buffer"
+        # must not shadow the reserved names and mis-route the edge (issue #7380).
         context = {
+            **buffer_data,  # Unpack buffer keys directly into context
             "output": output,
             "buffer": buffer_data,
             "result": output.get("result"),
             "true": True,  # Allow lowercase true/false in conditions
             "false": False,
-            **buffer_data,  # Unpack buffer keys directly into context
         }
 
         try:

--- a/core/tests/test_edge_condition_context.py
+++ b/core/tests/test_edge_condition_context.py
@@ -1,0 +1,41 @@
+"""Regression tests for edge-condition context precedence (issue #7380).
+
+A buffer key that happens to share a reserved name (``result``/``true``/``false``/
+``output``/``buffer``) must not shadow the framework builtins injected into the
+condition-evaluation context, or conditional edges route on stale/incorrect values.
+"""
+
+from framework.orchestrator.edge import EdgeCondition, EdgeSpec
+
+
+def _conditional_edge(expr: str) -> EdgeSpec:
+    return EdgeSpec(
+        id="e1",
+        source="a",
+        target="b",
+        condition=EdgeCondition.CONDITIONAL,
+        condition_expr=expr,
+    )
+
+
+def test_result_builtin_not_shadowed_by_stale_buffer():
+    """`result` resolves to the current output, not a stale buffer value (issue #7380)."""
+    edge = _conditional_edge("result == 'NEW'")
+    # Buffer still holds the previous node's result; the builtin must win.
+    assert edge._evaluate_condition({"result": "NEW"}, {"result": "OLD"}) is True
+
+
+def test_true_false_builtins_not_shadowed_by_buffer():
+    """Buffer keys named true/false cannot override the boolean builtins."""
+    edge_true = _conditional_edge("true")
+    assert edge_true._evaluate_condition({}, {"true": False}) is True
+
+    edge_false = _conditional_edge("false")
+    assert edge_false._evaluate_condition({}, {"false": True}) is False
+
+
+def test_non_reserved_buffer_keys_remain_accessible():
+    """Buffer keys that don't collide with a builtin are still usable in conditions."""
+    edge = _conditional_edge("score > 3")
+    assert edge._evaluate_condition({}, {"score": 5}) is True
+    assert edge._evaluate_condition({}, {"score": 1}) is False


### PR DESCRIPTION
## Description

When building the context for a conditional edge, `EdgeSpec._evaluate_condition()` spreads `**buffer_data` last. That means a buffer key called `result`, `true`, `false`, `output`, or `buffer` silently overrides the builtin of the same name.

So if the buffer still holds an old `result` from an earlier node, a condition like `result == "NEW"` ends up checking the stale value and the edge routes the wrong way.

The fix is just to flip the order — spread `buffer_data` first, then set the five reserved names, so the builtins always win. Buffer keys that don't clash keep working as before.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #7380

## Changes Made

- `core/framework/orchestrator/edge.py` — reorder the context dict so buffer keys can't shadow the reserved builtins.
- `core/tests/test_edge_condition_context.py` — regression tests: a stale buffer `result` no longer shadows the builtin, buffer `true`/`false` can't flip the boolean builtins, and non-reserved buffer keys still resolve. I confirmed these fail on the current code and pass with the change.

## Testing

- `cd core && pytest tests/test_edge_condition_context.py` — passing
- `cd core && ruff check .` — clean

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
