### PR TITLE
docs(readme): clarify hive CLI repo-root requirement (Fixes #6176)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,12 @@ This sets up:
 
 - Finally, it will open the Hive interface in your browser
 
-> **Tip:** To reopen the dashboard later, run `hive open` from the project directory.
+> **Note:** The `hive` CLI must be run from the repository root. The wrapper demands that
+> your current directory exactly equals the repo root (it refuses to run from subdirectories).
+> Since quickstart installs `hive` into `~/.local/bin` (added to your PATH), you can run
+> `hive open` from the repo root, or `./hive open` when using the in-repo wrapper directly.
+
+> **Tip:** To reopen the dashboard later, run `hive open` from the repository root.
 
 ### Build Your First Agent
 


### PR DESCRIPTION
Docs-only fix for #6176.

README said run `hive open` from `the project directory`, but the in-repo `hive` wrapper (quickstart.sh symlinks it to ~/.local/bin/hive, on PATH) hard-fails unless `pwd` exactly equals the repo root. Clarifies: root requirement, `hive` (PATH) vs `./hive` (in-repo) invocation. No code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Quick Start guide with clearer instructions for running the `hive` CLI.
  * Clarified that commands must be run from the repository root.
  * Documented installation to `~/.local/bin`, PATH setup, and supported command formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->