### PR TITLE
fix: retry atomic_write replace on Windows sharing violations

### DIFF
--- a/core/framework/utils/io.py
+++ b/core/framework/utils/io.py
@@ -1,7 +1,12 @@
 import os
+import sys
 import tempfile
+import time
 from contextlib import contextmanager
 from pathlib import Path
+
+_MAX_REPLACE_RETRIES = 5
+_REPLACE_RETRY_DELAY = 0.01
 
 
 @contextmanager
@@ -14,6 +19,11 @@ def atomic_write(path: Path, mode: str = "w", encoding: str = "utf-8"):
     each other's temp file mid-write, and the loser's cleanup could delete
     the winner's temp before its rename — corrupting cursor.json /
     summary.json / reminder_state.json under load.
+
+    On Windows, ``os.replace`` can raise ``PermissionError`` when the
+    destination is momentarily held open by another handle (antivirus
+    scanner, search indexer, concurrent reader). We retry a few times
+    with a short backoff to tolerate this transient sharing violation.
     """
     fd, tmp_name = tempfile.mkstemp(
         prefix=f".{path.name}.",
@@ -30,7 +40,22 @@ def atomic_write(path: Path, mode: str = "w", encoding: str = "utf-8"):
             yield f
             f.flush()
             os.fsync(f.fileno())
-        tmp_path.replace(path)
+        _replace_with_retry(tmp_path, path)
     except BaseException:
         tmp_path.unlink(missing_ok=True)
         raise
+
+
+def _replace_with_retry(src: Path, dst: Path) -> None:
+    """Replace *dst* with *src*, retrying on transient Windows sharing violations."""
+    last_err: OSError | None = None
+    for attempt in range(_MAX_REPLACE_RETRIES):
+        try:
+            src.replace(dst)
+            return
+        except PermissionError as exc:
+            if sys.platform != "win32":
+                raise
+            last_err = exc
+            time.sleep(_REPLACE_RETRY_DELAY * (attempt + 1))
+    raise last_err  # type: ignore[misc]

--- a/core/tests/test_atomic_write.py
+++ b/core/tests/test_atomic_write.py
@@ -1,0 +1,119 @@
+"""Tests for atomic_write retry logic on Windows sharing violations."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from framework.utils.io import _replace_with_retry, atomic_write
+
+
+class TestAtomicWriteBasic:
+    def test_creates_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "test.txt"
+        with atomic_write(target) as f:
+            f.write("hello")
+        assert target.read_text(encoding="utf-8") == "hello"
+
+    def test_creates_binary_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "test.bin"
+        with atomic_write(target, mode="wb") as f:
+            f.write(b"\x00\x01\x02")
+        assert target.read_bytes() == b"\x00\x01\x02"
+
+    def test_temp_removed_on_exception(self, tmp_path: Path) -> None:
+        target = tmp_path / "test.txt"
+        with pytest.raises(RuntimeError):
+            with atomic_write(target) as f:
+                f.write("partial")
+                raise RuntimeError("boom")
+        assert not target.exists()
+        leftovers = list(tmp_path.glob(".test.txt.*.tmp"))
+        assert leftovers == []
+
+    def test_existing_file_replaced(self, tmp_path: Path) -> None:
+        target = tmp_path / "test.txt"
+        target.write_text("old", encoding="utf-8")
+        with atomic_write(target) as f:
+            f.write("new")
+        assert target.read_text(encoding="utf-8") == "new"
+
+
+class TestReplaceWithRetry:
+    def test_succeeds_without_error(self, tmp_path: Path) -> None:
+        src = tmp_path / "a.tmp"
+        dst = tmp_path / "b.txt"
+        src.write_text("data")
+        dst.write_text("old")
+        _replace_with_retry(src, dst)
+        assert dst.read_text() == "data"
+        assert not src.exists()
+
+    def test_retries_on_permission_error(self, tmp_path: Path) -> None:
+        src = tmp_path / "a.tmp"
+        dst = tmp_path / "b.txt"
+        src.write_text("new")
+        dst.write_text("old")
+
+        call_count = 0
+        original_replace = Path.replace
+
+        def mock_replace(self, target):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise PermissionError(13, "Access is denied")
+            return original_replace(self, target)
+
+        with patch("framework.utils.io.sys") as mock_sys:
+            mock_sys.platform = "win32"
+            with patch.object(Path, "replace", mock_replace):
+                _replace_with_retry(src, dst)
+
+        assert call_count == 3
+        assert dst.read_text() == "new"
+
+    def test_raises_after_max_retries(self, tmp_path: Path) -> None:
+        src = tmp_path / "a.tmp"
+        dst = tmp_path / "b.txt"
+        src.write_text("new")
+        dst.write_text("old")
+
+        def always_fails(self, target):
+            raise PermissionError(13, "Access is denied")
+
+        with patch("framework.utils.io.sys") as mock_sys:
+            mock_sys.platform = "win32"
+            with patch.object(Path, "replace", always_fails):
+                with pytest.raises(PermissionError):
+                    _replace_with_retry(src, dst)
+
+    def test_no_retry_on_posix(self, tmp_path: Path) -> None:
+        src = tmp_path / "a.tmp"
+        dst = tmp_path / "b.txt"
+        src.write_text("data")
+
+        with patch("framework.utils.io.sys") as mock_sys:
+            mock_sys.platform = "linux"
+
+            def always_fails(self, target):
+                raise PermissionError(13, "Access is denied")
+
+            with patch.object(Path, "replace", always_fails):
+                with pytest.raises(PermissionError):
+                    _replace_with_retry(src, dst)
+
+
+class TestAtomicWriteIntegration:
+    def test_atomic_write_survives_concurrent_reader(self, tmp_path: Path) -> None:
+        """Simulate the exact Windows scenario from the issue."""
+        target = tmp_path / "checkpoint.json"
+        target.write_text("original", encoding="utf-8")
+
+        reader = open(target, encoding="utf-8")
+        try:
+            with atomic_write(target) as f:
+                f.write("new content")
+            assert target.read_text(encoding="utf-8") == "new content"
+        finally:
+            reader.close()


### PR DESCRIPTION
Closes #7369

On Windows, `os.replace()` can fail with `PermissionError` when the destination file is momentarily held open by another handle — antivirus scanner, search indexer, concurrent reader, or a second Hive process instance. This is a well-documented Win32 behavior: renaming over an open file fails unless the handle was opened with `FILE_SHARE_DELETE`.

This adds a retry loop with short backoff for the `replace()` call in `atomic_write()`, matching the standard mitigation used by pip and git-for-windows internals.

## Changes
- `core/framework/utils/io.py`: Extracted `_replace_with_retry()` with 5-attempt backoff (Windows-only; re-raises immediately on POSIX)
- `core/tests/test_atomic_write.py`: 9 tests covering basic write, retry logic, max-retry exhaustion, POSIX passthrough, and concurrent-reader integration scenario

## Testing
- All 9 new tests pass
- `ruff check` and `ruff format` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file replacement reliability on Windows by retrying temporary sharing violations.
  * Preserved immediate replacement behavior on non-Windows platforms.
  * Ensured failed writes clean up temporary files and report errors appropriately.

* **Tests**
  * Added coverage for text and binary writes, file replacement, retry exhaustion, cleanup, and concurrent file access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->