### PR TITLE
docs: remove stale references to deleted editor and MCP configs

### DIFF
--- a/docs/contributing-lint-setup.md
+++ b/docs/contributing-lint-setup.md
@@ -125,24 +125,22 @@ make check    # Verify locally before pushing
 | `tools/pyproject.toml` `[tool.ruff]` | Ruff rules for `tools/` (mirrors core, first-party = `aden_tools`) |
 | `.editorconfig` | Editor-agnostic formatting defaults |
 | `.pre-commit-config.yaml` | Pre-commit hook definitions |
-| `.vscode/settings.json` | VS Code ruff integration |
-| `.vscode/extensions.json` | Recommended VS Code extensions |
 | `.claude/settings.json` | Claude Code post-edit hooks |
 
-The single source of truth for lint rules is the `[tool.ruff]` section in each package's `pyproject.toml`. All other configs (VS Code, pre-commit, Makefile, CI) reference these.
+The single source of truth for lint rules is the `[tool.ruff]` section in each package's `pyproject.toml`. All other configs (pre-commit, Makefile, CI) reference these.
 
 ---
 
 ## FAQ
 
 **Q: Do I need to install anything beyond `uv pip install -e ".[dev]"`?**
-Only if you want pre-commit hooks: `make install-hooks`. Everything else (VS Code settings, editorconfig) works automatically.
+Only if you want pre-commit hooks: `make install-hooks`. Baseline formatting (`.editorconfig`) works automatically.
 
 **Q: Can I use a different formatter (black, autopep8)?**
 No. The project standardizes on ruff for both linting and formatting. Using a different formatter will cause CI failures.
 
 **Q: What if ruff and my editor disagree?**
-The `.vscode/settings.json` is configured to use ruff as the formatter. If you use a different editor, run `make format` before committing, or rely on the pre-commit hook.
+Configure your editor to use ruff as the formatter (see the [VS Code](#vs-code-recommended) setup above). You can also run `make format` before committing, or rely on the pre-commit hook.
 
 **Q: I'm getting lint errors in code I didn't write. Do I need to fix them?**
 Only fix lint errors in files you modified. Don't send drive-by lint fix PRs for unrelated files without coordinating first.

--- a/docs/contributing-lint-setup.md
+++ b/docs/contributing-lint-setup.md
@@ -74,15 +74,13 @@ git commit --no-verify -m "message"
 
 ### VS Code (Recommended)
 
-The repository includes `.vscode/extensions.json` and `.vscode/settings.json`. On first open, VS Code will prompt you to install the recommended Ruff extension.
+Install the recommended [Ruff extension](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff) (`charliermarsh.ruff`).
 
-Once installed, the editor will:
+Once installed, configure the editor to:
 
 - **Format on save** using ruff
 - **Auto-fix lint issues** on save (import sorting, fixable violations)
 - Show a **ruler at column 100**
-
-No manual configuration needed.
 
 ### Other Editors
 
@@ -97,10 +95,6 @@ For any editor, you can always rely on `make lint` and `make format` from the co
 ### Claude Code
 
 The repository includes a `.claude/settings.json` hook that automatically runs `ruff check --fix` and `ruff format` after every file edit made by Claude Code. No setup needed — it works out of the box.
-
-### Codex CLI
-
-Codex CLI (OpenAI, v0.101.0+) is supported via `.codex/config.toml` (MCP server config). This file is tracked in git. Run `codex` in the repo root to use the configured MCP tools. See the [Codex CLI section in the README](../README.md#codex-cli) for details.
 
 ---
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -78,9 +78,6 @@ hive/                                    # Repository root
 │   ├── PULL_REQUEST_TEMPLATE.md         # PR description template
 │   └── CODEOWNERS                       # Auto-assign reviewers
 │
-├── .codex/                              # Codex CLI project config
-│   └── config.toml                      # Codex MCP server definitions
-│
 ├── core/                                # CORE FRAMEWORK PACKAGE
 │   ├── framework/                       # Main package code
 │   │   ├── agents/                      # Agent definitions and helpers
@@ -135,7 +132,6 @@ hive/                                    # Repository root
 ├── scripts/                             # Utility scripts
 │   └── auto-close-duplicates.ts         # GitHub duplicate issue closer
 │
-├── .agent/                        # Antigravity IDE: mcp_config.json + skills (symlinks)
 ├── quickstart.sh                        # Interactive setup wizard
 ├── README.md                            # Project overview
 ├── CONTRIBUTING.md                      # Contribution guidelines

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -107,6 +107,7 @@ MCP tools are also available in Cursor. To enable:
    {
      "mcpServers": {
        "hive_tools": {
+         "type": "stdio",
          "command": "uv",
          "args": ["run", "python", "mcp_server.py", "--stdio"],
          "cwd": "tools"

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -101,21 +101,15 @@ This sets up the MCP tools and workflows for building agents.
 
 MCP tools are also available in Cursor. To enable:
 
-1. Open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`)
-2. Run `MCP: Enable` to enable MCP servers
-3. Restart Cursor to load the MCP servers from `.cursor/mcp.json`
-4. Open Agent chat and verify MCP tools are available
+1. Open Cursor Settings > Features > MCP
+2. Add your configured MCP servers
+3. Open Agent chat and verify MCP tools are available
 
 ### 2. Build an Agent
 
 **Claude Code:**
 ```
 Use the files-tools initialize_and_build_agent tool to scaffold a new agent
-```
-
-**Codex CLI:**
-```
-Start Codex in the repo root and use the configured MCP tools
 ```
 
 Follow the prompts to:

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -101,9 +101,20 @@ This sets up the MCP tools and workflows for building agents.
 
 MCP tools are also available in Cursor. To enable:
 
-1. Open Cursor Settings > Features > MCP
-2. Add your configured MCP servers
-3. Open Agent chat and verify MCP tools are available
+1. Open Cursor Settings (`Cmd+,` / `Ctrl+,`) and navigate to **Customize > MCPs** (or open the Command Palette and run `Open MCP Settings`).
+2. Add the `hive_tools` server configuration:
+   ```json
+   {
+     "mcpServers": {
+       "hive_tools": {
+         "command": "uv",
+         "args": ["run", "python", "mcp_server.py", "--stdio"],
+         "cwd": "tools"
+       }
+     }
+   }
+   ```
+3. Open Agent chat and verify MCP tools are available.
 
 ### 2. Build an Agent
 


### PR DESCRIPTION
## Description

Commit 13a8e28a cleaned up old skill trees and removed editor/MCP configs (.agent/, .codex/, .cursor/mcp.json, and .vscode/). Several documentation pages continued to reference those removed paths.

This PR cleans up those stale references across the documentation.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #7383

## Changes Made

- docs/contributing-lint-setup.md: Removed stale claim that .vscode/ configs are tracked in git; updated VS Code setup to install Ruff extension directly; removed obsolete Codex CLI section.
- docs/environment-setup.md: Updated Cursor IDE section to configure MCP via Cursor settings instead of deleted .cursor/mcp.json.
- docs/developer-guide.md: Removed deleted .codex/ and .agent/ entries from the repository tree diagram.

## Testing

- [x] Verified markdown formatting and links
- [x] Lint passes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated VS Code guidance to explain manual Ruff extension installation and editor configuration.
  * Clarified formatting behavior and troubleshooting when editor settings conflict with Ruff.
  * Revised Cursor MCP setup with settings paths, shortcuts, configuration details, and verification steps.
  * Removed outdated Codex CLI guidance and references to deprecated project configuration directories from setup and developer documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->