### PR TITLE
fix(orchestrator): add execution timeouts for sequential nodes (#7401)

### DIFF
--- a/core/framework/orchestrator/__init__.py
+++ b/core/framework/orchestrator/__init__.py
@@ -13,7 +13,7 @@ def __getattr__(name: str):
         from framework.orchestrator import edge as _e
 
         return getattr(_e, name)
-    if name in ("Orchestrator", "ExecutionResult"):
+    if name in ("Orchestrator", "ExecutionResult", "ParallelExecutionConfig"):
         from framework.orchestrator import orchestrator as _o
 
         return getattr(_o, name)

--- a/core/framework/orchestrator/node.py
+++ b/core/framework/orchestrator/node.py
@@ -145,6 +145,12 @@ class NodeSpec(BaseModel):
     max_retries: int = Field(default=3)
     retry_on: list[str] = Field(default_factory=list, description="Error types to retry on")
 
+    # Execution timeout
+    timeout_seconds: float | None = Field(
+        default=None,
+        description="Timeout in seconds for this node. If None, uses orchestrator default.",
+    )
+
     # Visit limits (for feedback/callback edges)
     max_node_visits: int = Field(
         default=0,

--- a/core/framework/orchestrator/orchestrator.py
+++ b/core/framework/orchestrator/orchestrator.py
@@ -1396,7 +1396,7 @@ class Orchestrator:
                     async def _watch_timeout(task: asyncio.Task, target_wid: str, t_val: float, fanout: bool):
                         try:
                             await task
-                        except asyncio.TimeoutError:
+                        except TimeoutError:
                             err_msg = f"Branch failed (timed out after {t_val}s)" if fanout else f"Node failed (timed out after {t_val}s)"
                             w = workers.get(target_wid)
                             if w:
@@ -1638,7 +1638,11 @@ class Orchestrator:
                         # Check for node or fan-out branch timeout
                         if isinstance(task_error, asyncio.TimeoutError) and wid in _timed_node_tasks:
                             _, timeout_sec, is_fanout = _timed_node_tasks.pop(wid)
-                            error = f"Branch failed (timed out after {timeout_sec}s)" if is_fanout else f"Node failed (timed out after {timeout_sec}s)"
+                            error = (
+                                f"Branch failed (timed out after {timeout_sec}s)"
+                                if is_fanout
+                                else f"Node failed (timed out after {timeout_sec}s)"
+                            )
                             failed_workers[wid] = error
                             worker.lifecycle = WorkerLifecycle.FAILED
                             worker._last_result = NodeResult(success=False, error=error)

--- a/core/framework/orchestrator/orchestrator.py
+++ b/core/framework/orchestrator/orchestrator.py
@@ -111,6 +111,9 @@ class ParallelExecutionConfig:
     # Timeout per branch in seconds
     branch_timeout_seconds: float = 300.0
 
+    # Timeout per sequential node in seconds
+    node_timeout_seconds: float = 300.0
+
 
 class Orchestrator:
     """
@@ -158,6 +161,7 @@ class Orchestrator:
         skills_catalog_prompt: str = "",
         protocols_prompt: str = "",
         skill_dirs: list[str] | None = None,
+        node_timeout_seconds: float | None = None,
     ):
         """
         Initialize the executor.
@@ -188,6 +192,7 @@ class Orchestrator:
             skills_catalog_prompt: Available skills catalog for system prompt
             protocols_prompt: Default skill operational protocols for system prompt
             skill_dirs: Skill base directories for Tier 3 resource access
+            node_timeout_seconds: Timeout for sequential (non-fanout) nodes in seconds
         """
         self.runtime = runtime
         self.llm = llm
@@ -235,6 +240,11 @@ class Orchestrator:
         # Parallel execution settings
         self.enable_parallel_execution = enable_parallel_execution
         self._parallel_config = parallel_config or ParallelExecutionConfig()
+        self.node_timeout_seconds = (
+            node_timeout_seconds
+            if node_timeout_seconds is not None
+            else getattr(self._parallel_config, "node_timeout_seconds", 300.0)
+        )
 
         # Pause/resume control
         self._pause_requested = asyncio.Event()
@@ -1358,9 +1368,64 @@ class Orchestrator:
             self.logger.error(execution_error)
             return True
 
-        # Track fan-out branch workers for per-branch timeout enforcement
-        _fanout_branch_tasks: dict[str, asyncio.Task] = {}  # worker_id → timeout-wrapper task
+        # Check event bus availability early
+        has_event_subscription = self._event_bus is not None and hasattr(self._event_bus, "subscribe")
+
+        # Track node/branch workers for timeout enforcement: worker_id → (timed_task, timeout, is_fanout)
+        _timed_node_tasks: dict[str, tuple[asyncio.Task, float, bool]] = {}
         branch_timeout = self._parallel_config.branch_timeout_seconds if self._parallel_config else 300.0
+        node_timeout = self.node_timeout_seconds
+
+        def _wrap_worker_task(worker: NodeWorker, is_fanout: bool) -> asyncio.Task | None:
+            """Wrap a worker task in an asyncio.wait_for timeout."""
+            if worker._task is None:
+                return None
+            spec_timeout = getattr(worker.node_spec, "timeout_seconds", None)
+            if spec_timeout is not None and spec_timeout > 0:
+                timeout = spec_timeout
+            else:
+                timeout = branch_timeout if is_fanout else node_timeout
+
+            if timeout > 0:
+                timed_task = asyncio.ensure_future(asyncio.wait_for(worker._task, timeout=timeout))
+                _timed_node_tasks[worker.node_spec.id] = (timed_task, timeout, is_fanout)
+
+                if has_event_subscription:
+                    wid = worker.node_spec.id
+
+                    async def _watch_timeout(task: asyncio.Task, target_wid: str, t_val: float, fanout: bool):
+                        try:
+                            await task
+                        except asyncio.TimeoutError:
+                            err_msg = f"Branch failed (timed out after {t_val}s)" if fanout else f"Node failed (timed out after {t_val}s)"
+                            w = workers.get(target_wid)
+                            if w:
+                                w.lifecycle = WorkerLifecycle.FAILED
+                                w._last_result = NodeResult(success=False, error=err_msg)
+                            self.logger.warning(f"  ⏱ {'Branch' if fanout else 'Node'} {target_wid}: {err_msg}")
+                            if self._event_bus and hasattr(self._event_bus, "emit_worker_failed"):
+                                await self._event_bus.emit_worker_failed(
+                                    stream_id=self._stream_id,
+                                    node_id=target_wid,
+                                    worker_id=target_wid,
+                                    error=err_msg,
+                                    execution_id=self._execution_id,
+                                )
+                            else:
+                                failed_workers[target_wid] = err_msg
+                                if target_wid in terminal_worker_ids:
+                                    completed_terminals.add(target_wid)
+                                if _check_graph_done() or _mark_quiescent_terminal_failure():
+                                    completion_event.set()
+                        except asyncio.CancelledError:
+                            pass
+                        except Exception:
+                            pass
+
+                    asyncio.create_task(_watch_timeout(timed_task, wid, timeout, is_fanout))
+
+                return timed_task
+            return worker._task
 
         def _route_activation(
             activation: Activation,
@@ -1394,14 +1459,11 @@ class Orchestrator:
             if target_worker.check_readiness():
                 target_worker.activate(inherited_tags=activation.fan_out_tags)
                 if target_worker._task is not None:
-                    # Fan-out branch: wrap with timeout
+                    # Wrap with branch or sequential node timeout
                     is_fanout_branch = any(tag.via_branch == activation.target_id for tag in activation.fan_out_tags)
-                    if is_fanout_branch and branch_timeout > 0:
-                        timed_task = asyncio.ensure_future(asyncio.wait_for(target_worker._task, timeout=branch_timeout))
-                        _fanout_branch_tasks[activation.target_id] = timed_task
+                    timed_task = _wrap_worker_task(target_worker, is_fanout_branch)
+                    if timed_task is not None:
                         pending_tasks_map[activation.target_id] = timed_task
-                    else:
-                        pending_tasks_map[activation.target_id] = target_worker._task
 
         # Subscribe to worker events
         sub_completed = None
@@ -1489,7 +1551,6 @@ class Orchestrator:
                 completion_event.set()
 
         # Subscribe to events (only if event bus has subscribe capability)
-        has_event_subscription = self._event_bus is not None and hasattr(self._event_bus, "subscribe")
         if has_event_subscription:
             sub_completed = self._event_bus.subscribe(
                 event_types=[EventType.WORKER_COMPLETED],
@@ -1512,11 +1573,27 @@ class Orchestrator:
 
             # Wait for completion — two strategies depending on event bus availability
             if has_event_subscription and sub_completed is not None:
-                # Event-driven: wait for completion events
+                # Event-driven: wrap entry workers with timeout watcher and wait for completion events
+                for wid in entry_worker_ids:
+                    w = workers[wid]
+                    if w._task is not None:
+                        _wrap_worker_task(w, is_fanout=False)
                 await completion_event.wait()
             else:
                 # No event bus: wait on worker tasks directly and route completions inline.
-                pending_tasks: dict[str, asyncio.Task] = {wid: w._task for wid, w in workers.items() if w._task is not None}
+                pending_tasks: dict[str, asyncio.Task] = {}
+                for wid in entry_worker_ids:
+                    w = workers[wid]
+                    if w._task is not None:
+                        t = _wrap_worker_task(w, is_fanout=False)
+                        if t is not None:
+                            pending_tasks[wid] = t
+                for wid, w in workers.items():
+                    if wid not in pending_tasks and w._task is not None:
+                        t = _wrap_worker_task(w, is_fanout=False)
+                        if t is not None:
+                            pending_tasks[wid] = t
+
                 while True:
                     if _check_graph_done():
                         break
@@ -1558,16 +1635,30 @@ class Orchestrator:
                         except Exception as exc:
                             task_error = exc
 
-                        # Check for fan-out branch timeout
-                        if isinstance(task_error, asyncio.TimeoutError) and wid in _fanout_branch_tasks:
-                            error = f"Branch failed (timed out after {branch_timeout}s)"
+                        # Check for node or fan-out branch timeout
+                        if isinstance(task_error, asyncio.TimeoutError) and wid in _timed_node_tasks:
+                            _, timeout_sec, is_fanout = _timed_node_tasks.pop(wid)
+                            error = f"Branch failed (timed out after {timeout_sec}s)" if is_fanout else f"Node failed (timed out after {timeout_sec}s)"
                             failed_workers[wid] = error
                             worker.lifecycle = WorkerLifecycle.FAILED
-                            self.logger.warning(f"  ⏱ Branch {wid}: {error}")
+                            worker._last_result = NodeResult(success=False, error=error)
+                            self.logger.warning(f"  ⏱ {'Branch' if is_fanout else 'Node'} {wid}: {error}")
                             if wid in terminal_worker_ids:
                                 completed_terminals.add(wid)
-                            _fanout_branch_tasks.pop(wid, None)
+
+                            # Route ON_FAILURE activations
+                            outgoing = await worker._evaluate_outgoing_edges(worker._last_result)
+                            worker._last_activations = outgoing
+                            for activation in outgoing:
+                                _route_activation(
+                                    activation,
+                                    workers,
+                                    pending_tasks,
+                                    has_event_subscription=False,
+                                )
                             continue
+
+                        _timed_node_tasks.pop(wid, None)
 
                         if worker.lifecycle == WorkerLifecycle.COMPLETED and task_error is None:
                             # Read result directly from the worker

--- a/core/tests/test_orchestrator_timeout.py
+++ b/core/tests/test_orchestrator_timeout.py
@@ -1,0 +1,424 @@
+"""Tests for GraphExecutor / Orchestrator sequential node execution timeouts."""
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from framework.host.event_bus import EventBus, EventType
+from framework.llm.provider import LLMProvider, LLMResponse
+from framework.orchestrator import (
+    EdgeCondition,
+    EdgeSpec,
+    ExecutionResult,
+    Goal,
+    GraphSpec,
+    NodeContext,
+    NodeProtocol,
+    NodeResult,
+    NodeSpec,
+    Orchestrator,
+    ParallelExecutionConfig,
+)
+from framework.tracker.decision_tracker import DecisionTracker as Runtime
+
+
+class DummyLLM(LLMProvider):
+    model: str = "dummy"
+
+    def complete(self, messages, system="", **kwargs) -> LLMResponse:
+        return LLMResponse(content="OK", model="dummy", stop_reason="stop")
+
+
+class FastNode(NodeProtocol):
+    """A node that completes quickly."""
+
+    async def execute(self, ctx: NodeContext) -> NodeResult:
+        return NodeResult(success=True, output={"status": "fast_done"})
+
+
+class SlowHangingNode(NodeProtocol):
+    """A node that hangs longer than timeout."""
+
+    def __init__(self, delay: float = 10.0):
+        self.delay = delay
+
+    async def execute(self, ctx: NodeContext) -> NodeResult:
+        await asyncio.sleep(self.delay)
+        return NodeResult(success=True, output={"status": "slow_done"})
+
+
+class FallbackNode(NodeProtocol):
+    """A fallback node executed on failure."""
+
+    async def execute(self, ctx: NodeContext) -> NodeResult:
+        return NodeResult(success=True, output={"status": "fallback_done"})
+
+
+@pytest.fixture
+def runtime(tmp_path):
+    return Runtime(storage_path=tmp_path / "tracker")
+
+
+@pytest.fixture
+def dummy_llm():
+    return DummyLLM()
+
+
+@pytest.mark.asyncio
+async def test_sequential_entry_node_timeout(runtime, dummy_llm):
+    """Test that a sequential entry node times out when exceeding node_timeout_seconds."""
+    graph = GraphSpec(
+        id="test_seq_timeout",
+        name="Sequential Timeout Graph",
+        goal_id="goal-1",
+        entry_node="slow_node",
+        terminal_nodes=["slow_node"],
+        nodes=[
+            NodeSpec(
+                id="slow_node",
+                name="Slow Hanging Node",
+                description="Hangs indefinitely",
+                node_type="custom",
+            )
+        ],
+        edges=[],
+    )
+
+    node_registry = {
+        "slow_node": SlowHangingNode(delay=5.0),
+    }
+
+    orchestrator = Orchestrator(
+        runtime=runtime,
+        llm=dummy_llm,
+        node_registry=node_registry,
+        node_timeout_seconds=0.1,  # 100ms timeout
+    )
+
+    goal = Goal(id="goal-1", name="Test Sequential Timeout", description="Test sequential timeout")
+    result = await orchestrator.execute(graph=graph, goal=goal, validate_graph=False)
+
+    assert not result.success
+    assert result.execution_quality == "failed"
+    assert "slow_node" in result.nodes_with_failures
+    assert result.error is not None
+    assert "timed out after 0.1s" in result.error
+
+
+@pytest.mark.asyncio
+async def test_sequential_downstream_node_timeout(runtime, dummy_llm):
+    """Test that a sequential downstream node times out when exceeding node_timeout_seconds."""
+    graph = GraphSpec(
+        id="test_seq_downstream_timeout",
+        name="Downstream Timeout Graph",
+        goal_id="goal-2",
+        entry_node="start_node",
+        terminal_nodes=["slow_node"],
+        nodes=[
+            NodeSpec(
+                id="start_node",
+                name="Start Node",
+                description="Fast start node",
+                node_type="custom",
+            ),
+            NodeSpec(
+                id="slow_node",
+                name="Slow Hanging Node",
+                description="Hangs indefinitely",
+                node_type="custom",
+            ),
+        ],
+        edges=[
+            EdgeSpec(
+                id="e1",
+                source="start_node",
+                target="slow_node",
+                condition=EdgeCondition.ON_SUCCESS,
+            )
+        ],
+    )
+
+    node_registry = {
+        "start_node": FastNode(),
+        "slow_node": SlowHangingNode(delay=5.0),
+    }
+
+    orchestrator = Orchestrator(
+        runtime=runtime,
+        llm=dummy_llm,
+        node_registry=node_registry,
+        node_timeout_seconds=0.15,
+    )
+
+    goal = Goal(id="goal-2", name="Test Downstream Timeout", description="Test downstream timeout")
+    result = await orchestrator.execute(graph=graph, goal=goal, validate_graph=False)
+
+    assert not result.success
+    assert "slow_node" in result.nodes_with_failures
+    assert "timed out after 0.15s" in result.error
+    assert "start_node" in result.path
+
+
+@pytest.mark.asyncio
+async def test_sequential_node_success_within_timeout(runtime, dummy_llm):
+    """Test that sequential nodes complete successfully when within timeout."""
+    graph = GraphSpec(
+        id="test_seq_success",
+        name="Sequential Success Graph",
+        goal_id="goal-3",
+        entry_node="start_node",
+        terminal_nodes=["start_node"],
+        nodes=[
+            NodeSpec(
+                id="start_node",
+                name="Fast Start Node",
+                description="Fast node",
+                node_type="custom",
+            ),
+        ],
+        edges=[],
+    )
+
+    node_registry = {
+        "start_node": FastNode(),
+    }
+
+    orchestrator = Orchestrator(
+        runtime=runtime,
+        llm=dummy_llm,
+        node_registry=node_registry,
+        node_timeout_seconds=2.0,
+    )
+
+    goal = Goal(id="goal-3", name="Test Fast Node", description="Test fast node")
+    result = await orchestrator.execute(graph=graph, goal=goal, validate_graph=False)
+
+    assert result.success
+    assert result.output.get("status") == "fast_done"
+
+
+@pytest.mark.asyncio
+async def test_node_spec_custom_timeout_override(runtime, dummy_llm):
+    """Test that NodeSpec.timeout_seconds overrides the orchestrator's default node_timeout_seconds."""
+    graph = GraphSpec(
+        id="test_node_override",
+        name="Node Override Graph",
+        goal_id="goal-4",
+        entry_node="slow_node",
+        terminal_nodes=["slow_node"],
+        nodes=[
+            NodeSpec(
+                id="slow_node",
+                name="Custom Timeout Node",
+                description="Node with custom 0.1s timeout override",
+                node_type="custom",
+                timeout_seconds=0.1,  # Custom override
+            )
+        ],
+        edges=[],
+    )
+
+    node_registry = {
+        "slow_node": SlowHangingNode(delay=5.0),
+    }
+
+    # Global timeout is 300s, but node has 0.1s override
+    orchestrator = Orchestrator(
+        runtime=runtime,
+        llm=dummy_llm,
+        node_registry=node_registry,
+        node_timeout_seconds=300.0,
+    )
+
+    goal = Goal(id="goal-4", name="Test Node Override", description="Test node timeout override")
+    result = await orchestrator.execute(graph=graph, goal=goal, validate_graph=False)
+
+    assert not result.success
+    assert "timed out after 0.1s" in result.error
+
+
+@pytest.mark.asyncio
+async def test_on_failure_edge_after_timeout(runtime, dummy_llm):
+    """Test that ON_FAILURE edges are followed when a sequential node times out."""
+    graph = GraphSpec(
+        id="test_on_failure_timeout",
+        name="ON_FAILURE Timeout Graph",
+        goal_id="goal-5",
+        entry_node="slow_node",
+        terminal_nodes=["fallback_node"],
+        nodes=[
+            NodeSpec(
+                id="slow_node",
+                name="Slow Node",
+                description="Hangs and times out",
+                node_type="custom",
+                timeout_seconds=0.1,
+            ),
+            NodeSpec(
+                id="fallback_node",
+                name="Fallback Node",
+                description="Recovers after slow node failure",
+                node_type="custom",
+            ),
+        ],
+        edges=[
+            EdgeSpec(
+                id="e_fallback",
+                source="slow_node",
+                target="fallback_node",
+                condition=EdgeCondition.ON_FAILURE,
+            )
+        ],
+    )
+
+    node_registry = {
+        "slow_node": SlowHangingNode(delay=5.0),
+        "fallback_node": FallbackNode(),
+    }
+
+    orchestrator = Orchestrator(
+        runtime=runtime,
+        llm=dummy_llm,
+        node_registry=node_registry,
+        node_timeout_seconds=10.0,
+    )
+
+    goal = Goal(id="goal-5", name="Test ON_FAILURE", description="Test ON_FAILURE recovery")
+    result = await orchestrator.execute(graph=graph, goal=goal, validate_graph=False)
+
+    # The fallback node succeeded, and terminal node fallback_node completed
+    assert result.success
+    assert result.output.get("status") == "fallback_done"
+    assert "fallback_node" in result.path
+
+
+@pytest.mark.asyncio
+async def test_fanout_branch_timeout_preservation(runtime, dummy_llm):
+    """Test that fan-out branches continue to use branch_timeout_seconds."""
+    graph = GraphSpec(
+        id="test_fanout_timeout",
+        name="Fanout Timeout Graph",
+        goal_id="goal-6",
+        entry_node="split_node",
+        terminal_nodes=["branch1", "branch2"],
+        nodes=[
+            NodeSpec(
+                id="split_node",
+                name="Split Node",
+                description="Entry node for fanout",
+                node_type="custom",
+            ),
+            NodeSpec(
+                id="branch1",
+                name="Branch 1 (Fast)",
+                description="Fast branch",
+                node_type="custom",
+            ),
+            NodeSpec(
+                id="branch2",
+                name="Branch 2 (Slow)",
+                description="Slow branch that times out",
+                node_type="custom",
+            ),
+        ],
+        edges=[
+            EdgeSpec(
+                id="e_b1",
+                source="split_node",
+                target="branch1",
+                condition=EdgeCondition.ON_SUCCESS,
+            ),
+            EdgeSpec(
+                id="e_b2",
+                source="split_node",
+                target="branch2",
+                condition=EdgeCondition.ON_SUCCESS,
+            ),
+        ],
+    )
+
+    node_registry = {
+        "split_node": FastNode(),
+        "branch1": FastNode(),
+        "branch2": SlowHangingNode(delay=5.0),
+    }
+
+    parallel_config = ParallelExecutionConfig(
+        branch_timeout_seconds=0.1,
+        node_timeout_seconds=10.0,
+    )
+
+    orchestrator = Orchestrator(
+        runtime=runtime,
+        llm=dummy_llm,
+        node_registry=node_registry,
+        parallel_config=parallel_config,
+    )
+
+    goal = Goal(id="goal-6", name="Test Fanout Timeout", description="Test fanout timeout")
+    result = await orchestrator.execute(graph=graph, goal=goal, validate_graph=False)
+
+    assert not result.success
+    assert "branch2" in result.nodes_with_failures
+    assert "Branch failed (timed out after 0.1s)" in result.error
+
+
+@pytest.mark.asyncio
+async def test_event_driven_mode_timeout(runtime, dummy_llm):
+    """Test timeout handling in event-driven mode with EventBus."""
+    event_bus = EventBus()
+    stream_id = "test-stream-timeout"
+    execution_id = "test-exec-timeout"
+
+    graph = GraphSpec(
+        id="test_event_timeout",
+        name="Event-Driven Timeout Graph",
+        goal_id="goal-7",
+        entry_node="slow_node",
+        terminal_nodes=["slow_node"],
+        nodes=[
+            NodeSpec(
+                id="slow_node",
+                name="Slow Hanging Node",
+                description="Hangs indefinitely",
+                node_type="custom",
+                timeout_seconds=0.1,
+            )
+        ],
+        edges=[],
+    )
+
+    node_registry = {
+        "slow_node": SlowHangingNode(delay=5.0),
+    }
+
+    failed_events = []
+
+    async def on_failed(event):
+        failed_events.append(event)
+
+    event_bus.subscribe(
+        event_types=[EventType.WORKER_FAILED],
+        handler=on_failed,
+        filter_stream=stream_id,
+        filter_execution=execution_id,
+    )
+
+    orchestrator = Orchestrator(
+        runtime=runtime,
+        llm=dummy_llm,
+        node_registry=node_registry,
+        event_bus=event_bus,
+        stream_id=stream_id,
+        execution_id=execution_id,
+        node_timeout_seconds=10.0,
+    )
+
+    goal = Goal(id="goal-7", name="Test Event Timeout", description="Test event timeout")
+    result = await orchestrator.execute(graph=graph, goal=goal, validate_graph=False)
+
+    assert not result.success
+    assert "slow_node" in result.nodes_with_failures
+    assert len(failed_events) >= 1
+    assert failed_events[0].data["worker_id"] == "slow_node"

--- a/core/tests/test_orchestrator_timeout.py
+++ b/core/tests/test_orchestrator_timeout.py
@@ -1,7 +1,6 @@
 """Tests for GraphExecutor / Orchestrator sequential node execution timeouts."""
 
 import asyncio
-from typing import Any
 
 import pytest
 
@@ -10,7 +9,6 @@ from framework.llm.provider import LLMProvider, LLMResponse
 from framework.orchestrator import (
     EdgeCondition,
     EdgeSpec,
-    ExecutionResult,
     Goal,
     GraphSpec,
     NodeContext,


### PR DESCRIPTION
## Description

Enforces execution timeouts for sequential (non-fanout) nodes and entry nodes in `GraphExecutor` / `Orchestrator` using `asyncio.wait_for`. Previously, only fan-out branches were wrapped with `branch_timeout_seconds`, allowing stalled sequential nodes to block agent graph execution indefinitely.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #7401

## Changes Made

- **Added `node_timeout_seconds` configuration**:
  - Added `node_timeout_seconds: float = 300.0` to `ParallelExecutionConfig`.
  - Added `node_timeout_seconds` parameter to `Orchestrator.__init__` (defaulting to 300.0s).
  - Added optional `timeout_seconds` to `NodeSpec` for node-level custom timeout overrides.
  - Exported `ParallelExecutionConfig` from `framework.orchestrator`.
- **Wrapped sequential & entry nodes in `asyncio.wait_for`**:
  - Implemented `_wrap_worker_task` in `Orchestrator._execute_with_workers` to wrap entry nodes, downstream sequential nodes, and fan-out branches with timeouts.
  - Handled timeouts in inline task polling to mark `WorkerLifecycle.FAILED`, set `failed_workers`, log warnings, and route any downstream `ON_FAILURE` edges.
  - Added background watchers in event-driven mode (`has_event_subscription`) to emit `WORKER_FAILED` events on timeout and unblock graph execution.
- **Added unit test suite**:
  - Added `core/tests/test_orchestrator_timeout.py` covering entry node timeout, downstream sequential timeout, normal completion within timeout, node-level `NodeSpec.timeout_seconds` override, `ON_FAILURE` recovery edge traversal, fan-out timeout preservation, and event-driven mode.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`) — `core/tests/test_orchestrator_timeout.py` (7/7 passed), `core/tests/test_event_loop_node.py` (all passed).
- [x] Lint passes (`cd core && ruff check .`) — `ruff check` on modified files passed with 0 errors.
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable execution timeouts for individual workflow nodes.
  * Supports a default timeout with optional per-node overrides.
  * Timed-out nodes now report failures and can trigger configured recovery paths.
  * Preserved separate timeout handling for parallel branches.
  * Made the parallel execution configuration available through the public orchestrator interface.

* **Bug Fixes**
  * Improved timeout handling across sequential, event-driven, and polling execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->