### PR TITLE
fix(tools): reject non-positive subdomain result limits

### DIFF
--- a/tools/src/aden_tools/tools/subdomain_enumerator/subdomain_enumerator.py
+++ b/tools/src/aden_tools/tools/subdomain_enumerator/subdomain_enumerator.py
@@ -98,6 +98,8 @@ def register_tools(mcp: FastMCP) -> None:
         if ":" in domain:
             domain = domain.split(":")[0]
 
+        if max_results < 1:
+            return {"error": "max_results must be at least 1"}
         max_results = min(max_results, 200)
 
         try:

--- a/tools/tests/tools/test_subdomain_enumerator.py
+++ b/tools/tests/tools/test_subdomain_enumerator.py
@@ -41,6 +41,16 @@ class TestInputValidation:
     """Test domain input cleaning."""
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("max_results", [0, -1])
+    async def test_rejects_non_positive_max_results(self, enumerate_fn, max_results):
+        """Non-positive limits must fail before making a network request."""
+        with patch("httpx.AsyncClient") as mock_client:
+            result = await enumerate_fn("example.com", max_results=max_results)
+
+        assert result == {"error": "max_results must be at least 1"}
+        mock_client.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_strips_https_prefix(self, enumerate_fn):
         with patch("httpx.AsyncClient") as MockClient:
             mock_client = AsyncMock()


### PR DESCRIPTION
## Description

Reject non-positive `max_results` values in `subdomain_enumerate` before the tool
makes a crt.sh request. This prevents negative Python slicing from returning
nearly the full result set for an invalid limit.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #7406

## Changes Made

- Validate that `max_results` is at least 1 before performing network I/O.
- Preserve the existing upper cap of 200 for positive limits.
- Add regression coverage for both zero and negative values, including an assertion that no HTTP client is created.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`uv run pytest tools/tests/tools/test_subdomain_enumerator.py -q`) — 17 passed
- [x] Lint passes (`uv run ruff check tools/src/aden_tools/tools/subdomain_enumerator/subdomain_enumerator.py tools/tests/tools/test_subdomain_enumerator.py`)
- [x] Manual testing performed — confirmed the new test fails twice before the fix and passes after it

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas — no tricky logic was added; the validation is self-explanatory
- [ ] I have made corresponding changes to the documentation — not required; the documented positive input contract is unchanged
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A — backend input validation only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved subdomain enumeration input validation by rejecting zero or negative result limits with a clear error message.
  - Prevented network requests when an invalid result limit is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->