### PR TITLE
fix(tools): validate QuickBooks invoice line items

### DIFF
--- a/tools/src/aden_tools/tools/quickbooks_tool/quickbooks_tool.py
+++ b/tools/src/aden_tools/tools/quickbooks_tool/quickbooks_tool.py
@@ -195,6 +195,8 @@ def register_tools(mcp: FastMCP, credentials: Any = None) -> None:
             return {"error": "line_items must be valid JSON"}
         if not isinstance(items, list) or len(items) == 0:
             return {"error": "line_items must be a non-empty JSON array"}
+        if not all(isinstance(item, dict) for item in items):
+            return {"error": "each line item must be a JSON object"}
 
         lines = []
         for item in items:

--- a/tools/tests/tools/test_quickbooks_tool.py
+++ b/tools/tests/tools/test_quickbooks_tool.py
@@ -128,6 +128,17 @@ class TestQuickbooksCreateInvoice:
             result = tool_fns["quickbooks_create_invoice"](customer_id="1", line_items="not json")
         assert "error" in result
 
+    @pytest.mark.parametrize("line_items", ["[1]", '["item"]', "[null]", "[[]]"])
+    def test_rejects_non_object_line_items(self, tool_fns, line_items):
+        with (
+            patch.dict("os.environ", ENV),
+            patch("aden_tools.tools.quickbooks_tool.quickbooks_tool.httpx.post") as mock_post,
+        ):
+            result = tool_fns["quickbooks_create_invoice"](customer_id="1", line_items=line_items)
+
+        assert result == {"error": "each line item must be a JSON object"}
+        mock_post.assert_not_called()
+
     def test_successful_create(self, tool_fns):
         data = {
             "Invoice": {


### PR DESCRIPTION
## Description

Validate every parsed QuickBooks invoice line item as a JSON object before
constructing the API request. This keeps valid JSON arrays containing integers,
strings, `null`, or nested arrays on the tool's structured-error path instead of
raising `AttributeError`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #7408

## Changes Made

- Reject invoice arrays containing a non-object member with a clear validation error.
- Ensure malformed line items are rejected before any QuickBooks HTTP request.
- Add regression coverage for number, string, `null`, and array members.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`uv run --active --no-sync pytest tools/tests/tools/test_quickbooks_tool.py -q` — 16 passed)
- [x] Lint passes (`uv run --active --no-sync ruff check tools/src/aden_tools/tools/quickbooks_tool/quickbooks_tool.py tools/tests/tools/test_quickbooks_tool.py`)
- [x] Formatting passes (`uv run --active --no-sync ruff format --check tools/src/aden_tools/tools/quickbooks_tool/quickbooks_tool.py tools/tests/tools/test_quickbooks_tool.py`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (no tricky logic added)
- [x] I have made corresponding changes to the documentation (no documentation change is required)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A — this is a backend input-validation change with no UI impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invoice creation now rejects line-item lists containing values that are not JSON objects.
  - Clear validation errors are returned before any invoice request is submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->