### PR TITLE
fix(tools): validate port scanner ranges

### DIFF
--- a/tools/src/aden_tools/tools/port_scanner/port_scanner.py
+++ b/tools/src/aden_tools/tools/port_scanner/port_scanner.py
@@ -190,6 +190,8 @@ def register_tools(mcp: FastMCP) -> None:
                 port_list = sorted({int(p.strip()) for p in ports.split(",") if p.strip()})
             except ValueError:
                 return {"error": f"Invalid port list: {ports}. Use 'top20', 'top100', or '80,443'"}
+            if any(port < 1 or port > 65535 for port in port_list):
+                return {"error": f"Invalid port list: {ports}. Ports must be between 1 and 65535"}
 
         # Resolve hostname
         try:

--- a/tools/tests/tools/test_port_scanner.py
+++ b/tools/tests/tools/test_port_scanner.py
@@ -62,6 +62,23 @@ class TestInputValidation:
             assert "Invalid port list" in result["error"]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("ports", ["0", "65536", "-1", "80,70000"])
+    async def test_rejects_out_of_range_ports(self, scan_fn, ports):
+        with (
+            patch("socket.gethostbyname", return_value="93.184.216.34") as mock_resolve,
+            patch(
+                "aden_tools.tools.port_scanner.port_scanner._check_port",
+                new_callable=AsyncMock,
+                return_value={"open": False},
+            ) as mock_check,
+        ):
+            result = await scan_fn("example.com", ports=ports)
+
+        assert result == {"error": f"Invalid port list: {ports}. Ports must be between 1 and 65535"}
+        mock_resolve.assert_not_called()
+        mock_check.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_custom_port_list(self, scan_fn):
         with patch("socket.gethostbyname", return_value="93.184.216.34"):
             with patch(


### PR DESCRIPTION
## Description

Validate custom `port_scan` values against the TCP destination-port range before
hostname resolution or connection attempts. This prevents invalid values such as
0, negative numbers, and values above 65535 from being counted as scanned and
reported as closed ports.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #7409

## Changes Made

- Enforce the `1..65535` range for every custom port.
- Return a structured error before DNS resolution when any port is invalid.
- Add regression coverage for zero, negative, over-limit, and mixed port lists.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`uv run --active --no-sync pytest tools/tests/tools/test_port_scanner.py -q` — 21 passed)
- [x] Lint passes (`uv run --active --no-sync ruff check tools/src/aden_tools/tools/port_scanner/port_scanner.py tools/tests/tools/test_port_scanner.py`)
- [x] Formatting passes (`uv run --active --no-sync ruff format --check tools/src/aden_tools/tools/port_scanner/port_scanner.py tools/tests/tools/test_port_scanner.py`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (no tricky logic added)
- [x] I have made corresponding changes to the documentation (no documentation change is required)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A — no UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Port scanning now rejects port values outside the valid range of 1–65535.
  - Invalid port lists return a clear validation error before any network checks are performed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->