### PR TITLE
fix(frontend): keep a dismissed ask_user question hidden across SSE rehydration

### DIFF
--- a/core/frontend/src/components/MultiQuestionWidget.tsx
+++ b/core/frontend/src/components/MultiQuestionWidget.tsx
@@ -96,6 +96,7 @@ export default function MultiQuestionWidget({ questions, onSubmit, onDismiss, in
           {onDismiss && (
             <button
               onClick={onDismiss}
+              aria-label="Dismiss question"
               className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors flex-shrink-0"
             >
               <X className="w-4 h-4" />

--- a/core/frontend/src/components/QuestionWidget.tsx
+++ b/core/frontend/src/components/QuestionWidget.tsx
@@ -103,6 +103,7 @@ export default function QuestionWidget({ question, options, onSubmit, onDismiss,
           {onDismiss && (
             <button
               onClick={onDismiss}
+              aria-label="Dismiss question"
               className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors flex-shrink-0"
             >
               <X className="w-4 h-4" />

--- a/core/frontend/src/lib/pending-question-dismissal.test.ts
+++ b/core/frontend/src/lib/pending-question-dismissal.test.ts
@@ -55,6 +55,19 @@ describe("pending question dismissal", () => {
     expect(isQuestionSetDismissed("session-a", [{ id: "", prompt: "Which size?" }])).toBe(false);
   });
 
+  it("keeps prompt sets apart when only the position of a newline differs", () => {
+    rememberDismissedQuestions("session-a", [
+      { id: "", prompt: "A\nB" },
+      { id: "", prompt: "C" },
+    ]);
+    expect(
+      isQuestionSetDismissed("session-a", [
+        { id: "", prompt: "A" },
+        { id: "", prompt: "B\nC" },
+      ]),
+    ).toBe(false);
+  });
+
   it("never treats an empty set or a missing session as dismissed", () => {
     rememberDismissedQuestions("session-a", [colorQuestion]);
     expect(isQuestionSetDismissed("session-a", [])).toBe(false);

--- a/core/frontend/src/lib/pending-question-dismissal.test.ts
+++ b/core/frontend/src/lib/pending-question-dismissal.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearDismissedQuestions,
+  isQuestionSetDismissed,
+  rememberDismissedQuestions,
+} from "./pending-question-dismissal";
+
+const colorQuestion = {
+  id: "q-color",
+  prompt: "Which color do you prefer?",
+  options: ["Red", "Blue"],
+};
+const sizeQuestion = { id: "q-size", prompt: "Which size?", options: ["S", "M"] };
+
+describe("pending question dismissal", () => {
+  beforeEach(() => {
+    clearDismissedQuestions("session-a");
+    clearDismissedQuestions("session-b");
+  });
+
+  it("keeps the same question ids hidden after dismissal", () => {
+    rememberDismissedQuestions("session-a", [colorQuestion]);
+    expect(isQuestionSetDismissed("session-a", [colorQuestion])).toBe(true);
+  });
+
+  it("shows a different question set and replaces the old record", () => {
+    rememberDismissedQuestions("session-a", [colorQuestion]);
+    expect(isQuestionSetDismissed("session-a", [sizeQuestion])).toBe(false);
+    rememberDismissedQuestions("session-a", [sizeQuestion]);
+    expect(isQuestionSetDismissed("session-a", [colorQuestion])).toBe(false);
+    expect(isQuestionSetDismissed("session-a", [sizeQuestion])).toBe(true);
+  });
+
+  it("forgets the record after clear", () => {
+    rememberDismissedQuestions("session-a", [colorQuestion]);
+    clearDismissedQuestions("session-a");
+    expect(isQuestionSetDismissed("session-a", [colorQuestion])).toBe(false);
+  });
+
+  it("keeps sessions independent", () => {
+    rememberDismissedQuestions("session-a", [colorQuestion]);
+    expect(isQuestionSetDismissed("session-b", [colorQuestion])).toBe(false);
+  });
+
+  it("matches a multi-question set regardless of order", () => {
+    rememberDismissedQuestions("session-a", [colorQuestion, sizeQuestion]);
+    expect(isQuestionSetDismissed("session-a", [sizeQuestion, colorQuestion])).toBe(true);
+    expect(isQuestionSetDismissed("session-a", [colorQuestion])).toBe(false);
+  });
+
+  it("falls back to prompts when a question has no id", () => {
+    const withoutId = { id: "", prompt: "Which color do you prefer?" };
+    rememberDismissedQuestions("session-a", [withoutId]);
+    expect(isQuestionSetDismissed("session-a", [{ ...withoutId }])).toBe(true);
+    expect(isQuestionSetDismissed("session-a", [{ id: "", prompt: "Which size?" }])).toBe(false);
+  });
+
+  it("never treats an empty set or a missing session as dismissed", () => {
+    rememberDismissedQuestions("session-a", [colorQuestion]);
+    expect(isQuestionSetDismissed("session-a", [])).toBe(false);
+    expect(isQuestionSetDismissed("session-a", null)).toBe(false);
+    expect(isQuestionSetDismissed(null, [colorQuestion])).toBe(false);
+  });
+});

--- a/core/frontend/src/lib/pending-question-dismissal.ts
+++ b/core/frontend/src/lib/pending-question-dismissal.ts
@@ -1,0 +1,35 @@
+export interface PendingQuestion {
+  id: string;
+  prompt: string;
+  options?: string[];
+}
+
+const dismissedQuestionSetBySession = new Map<string, string>();
+
+function questionSetKey(questions: PendingQuestion[]): string {
+  return questions
+    .map((question) => question.id || question.prompt)
+    .sort()
+    .join("\n");
+}
+
+export function rememberDismissedQuestions(
+  sessionId: string | null,
+  questions: PendingQuestion[] | null,
+): void {
+  if (!sessionId || !questions || questions.length === 0) return;
+  dismissedQuestionSetBySession.set(sessionId, questionSetKey(questions));
+}
+
+export function isQuestionSetDismissed(
+  sessionId: string | null,
+  questions: PendingQuestion[] | null,
+): boolean {
+  if (!sessionId || !questions || questions.length === 0) return false;
+  return dismissedQuestionSetBySession.get(sessionId) === questionSetKey(questions);
+}
+
+export function clearDismissedQuestions(sessionId: string | null): void {
+  if (!sessionId) return;
+  dismissedQuestionSetBySession.delete(sessionId);
+}

--- a/core/frontend/src/lib/pending-question-dismissal.ts
+++ b/core/frontend/src/lib/pending-question-dismissal.ts
@@ -7,10 +7,9 @@ export interface PendingQuestion {
 const dismissedQuestionSetBySession = new Map<string, string>();
 
 function questionSetKey(questions: PendingQuestion[]): string {
-  return questions
-    .map((question) => question.id || question.prompt)
-    .sort()
-    .join("\n");
+  return JSON.stringify(
+    questions.map((question) => question.id || question.prompt).sort(),
+  );
 }
 
 export function rememberDismissedQuestions(

--- a/core/frontend/src/pages/queen-dm.tsx
+++ b/core/frontend/src/pages/queen-dm.tsx
@@ -29,6 +29,11 @@ import {
   type OlderCursor,
 } from "@/lib/chat-helpers";
 import {
+  clearDismissedQuestions,
+  isQuestionSetDismissed,
+  rememberDismissedQuestions,
+} from "@/lib/pending-question-dismissal";
+import {
   beginLoad,
   TRACE_ENABLED,
   msgSummary,
@@ -136,6 +141,10 @@ export default function QueenDM() {
 
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [sessionId, setSessionId] = useState<string | null>(null);
+  const sessionIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    sessionIdRef.current = sessionId;
+  }, [sessionId]);
   const [loading, setLoading] = useState(true);
   // Latest runtime bootstrap stage ("Starting tool servers", …), polled
   // from /api/startup-status while the loading overlay is up so a slow
@@ -1673,7 +1682,11 @@ export default function QueenDM() {
           // the switch case that populates pendingQuestions, so the
           // modal can't render and the user has no way to answer the
           // queen.
-          if (Array.isArray(d.pending_questions) && d.pending_questions.length > 0) {
+          if (
+            Array.isArray(d.pending_questions) &&
+            d.pending_questions.length > 0 &&
+            !isQuestionSetDismissed(sessionIdRef.current, d.pending_questions)
+          ) {
             setPendingQuestions(d.pending_questions);
           }
           return;
@@ -1889,7 +1902,9 @@ export default function QueenDM() {
           setAwaitingInput(true);
           setParkReason((event.data?.park_reason as string | undefined) ?? null);
           setIsStreaming(false);
-          setPendingQuestions(questions);
+          if (!isQuestionSetDismissed(sessionIdRef.current, questions)) {
+            setPendingQuestions(questions);
+          }
           break;
         }
 
@@ -1913,6 +1928,7 @@ export default function QueenDM() {
           // resolved requests out of the SSE replay (see
           // collect_resolved_request_seqs in event_bus.py); this is
           // the renderer-side belt to that suspenders.
+          clearDismissedQuestions(sessionIdRef.current);
           setPendingQuestions(null);
           setAwaitingInput(false);
           setParkReason(null);
@@ -2715,7 +2731,7 @@ export default function QueenDM() {
           pendingQuestions={awaitingInput ? pendingQuestions : null}
           onQuestionSubmit={handleQuestionAnswer}
           onQuestionDismiss={() => {
-            setAwaitingInput(false);
+            rememberDismissedQuestions(sessionId, pendingQuestions);
             setPendingQuestions(null);
           }}
           supportsImages={true}


### PR DESCRIPTION
## Description

Dismissing the `ask_user` question widget on the queen DM page only cleared local React state (`setAwaitingInput(false)` and `setPendingQuestions(null)` in `queen-dm.tsx`). The backend was never told, so the session stayed parked in `awaiting_user` with its `pending_questions` intact. Every fresh SSE subscription starts with a `session_snapshot` (`routes_events.py`, built by `compute_session_snapshot` in `event_bus.py`) that returns those same questions whenever the queen is awaiting input, and the snapshot handler re-seeded `pendingQuestions`, so `ChatPanel` rendered the widget again after an SSE reconnect or after leaving and returning to the queen page. A replayed `client_input_requested` re-seeded it the same way.

This change remembers the dismissed question set per session in a small module-level store keyed by the question ids (falling back to prompts) and skips re-seeding from the snapshot or a replayed `client_input_requested` while that set is unchanged. A different question set is always shown and replaces the old record, and the record is cleared on `client_input_received`. `awaitingInput` stays true after a dismissal because the queen really is still parked, which is what makes a free-text reply typed into the composer go straight to the queen as the answer.

The record lives for the lifetime of the loaded app, which covers SSE reconnects and client-side navigation. A hard page reload starts a fresh client with no memory of the dismissal while the queen is still waiting, so the pending question is shown once more there and can be dismissed or answered again.

Only the queen DM page is affected; `colony-chat.tsx` never passes `onQuestionDismiss`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #6808

## Changes Made

- Add `core/frontend/src/lib/pending-question-dismissal.ts` with `rememberDismissedQuestions`, `isQuestionSetDismissed` and `clearDismissedQuestions`, keyed by session id and by the question ids (prompt fallback).
- Add `core/frontend/src/lib/pending-question-dismissal.test.ts` (vitest): same ids stay hidden, a different set is visible and replaces the record, the record is gone after clear, sessions are independent, order-insensitive multi-question sets, prompt fallback, prompt sets that only differ in where a newline falls (the key is the JSON serialization of the sorted ids/prompts), and empty or missing input is never treated as dismissed.
- `core/frontend/src/pages/queen-dm.tsx`: `onQuestionDismiss` records the current questions before clearing them and no longer flips `awaitingInput` off; the `session_snapshot` seed and the `client_input_requested` case only set `pendingQuestions` when the set is not dismissed; `client_input_received` clears the record. A `sessionIdRef` mirrors `sessionId` so the memoized SSE handler can read the current session without new dependencies.
- `core/frontend/src/components/QuestionWidget.tsx` and `MultiQuestionWidget.tsx`: add `aria-label="Dismiss question"` to the X buttons so the dismiss control is addressable by assistive tech and by the Playwright reproduction below.

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core/frontend && npm test`)
- [ ] Lint passes (`cd core && ruff check .`) — fails on pre-existing findings in Python files this PR does not touch, see below
- [x] Manual testing performed (Playwright reproduction before and after, see Evidence)

Commands and results:

```
cd core/frontend && npx vitest run src/lib/pending-question-dismissal.test.ts
  before the implementation: 1 failed (module not found); after: 8 passed
cd core/frontend && npx tsc --noEmit -p .
  no errors
cd core/frontend && npm test
  20 files, 179 passed, 7 skipped
  (run with LC_ALL=en_US.UTF-8; under this machine's default pt-BR locale the pre-existing
   ChatPanel.revealOptions.test.tsx expects "86,425" and fails on number formatting, unrelated to this change)
cd core/frontend && npm run build
  built
make check
  tools: all checks passed
  core: 21 ruff errors and 12 files needing `ruff format` in Python files not touched here
  (framework/server/routes_execution.py and seven others), pre-existing on main at fad7219a
```

## Evidence

Reproduction with the real backend and this branch's frontend (`vite --port 5174`), Chromium headless via Playwright. Result lines printed by `repro.js`:

```
before: {"prefix":"before","questionShown":true,"hiddenAfterDismiss":true,"visibleAfterNavigation":true,"visibleAfterReload":true}
after:  {"prefix":"after","questionShown":true,"hiddenAfterDismiss":true,"visibleAfterNavigation":false,"visibleAfterReload":true}
```

Steps the script performs:

1. Open `/`, skip the first-run tour, take the first queen from the sidebar and open `/#/queen/<id>?new=1` to start a fresh DM session.
2. Send: `Use the ask_user tool right now to ask me exactly one question: "Which color do you prefer?" with the options "Red" and "Blue". Do nothing else and do not answer on my behalf.`
3. Wait for the question widget, then click its X. The widget disappears.
4. Click "New Chat" so the router goes to `/`, wait 1 s, click the same queen in the sidebar, wait 4 s and record whether the widget is visible again (`visibleAfterNavigation`).
5. Reload the page, wait 4 s and record whether the widget is visible (`visibleAfterReload`).

After the fix run, "Blue" was typed into the composer of the same session and the queen resumed and replied, so dismissing and then answering by free text keeps working.

`repro.js` (run with `EVIDENCE_PREFIX=before|after node run.js repro.js` from a directory where `playwright` resolves):

```js
const { chromium } = require('playwright');
const path = require('path');
const os = require('os');

const BASE_URL = process.env.BASE_URL || 'http://localhost:5174';
const prefix = process.env.EVIDENCE_PREFIX || 'before';
const evidenceDir = path.join(os.homedir(), 'hive-evidence', '6808');
const ASK =
  'Use the ask_user tool right now to ask me exactly one question: "Which color do you prefer?" with the options "Red" and "Blue". Do nothing else and do not answer on my behalf.';
const WIDGET_TIMEOUT_MS = 120_000;

const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
const log = (...args) => console.log(new Date().toISOString(), ...args);

function widget(page) {
  return page
    .locator('div:has(> div > p:has-text("Which color")):has(button:has-text("Red")):has(button:has-text("Blue"))')
    .first();
}

function dismissButton(page) {
  return widget(page).locator('button[aria-label="Dismiss question"], p + button').first();
}

function composer(page) {
  return page.locator('[data-tour="tour-queen-chat"] [contenteditable="true"]').first();
}

async function screenshot(page, name) {
  const file = path.join(evidenceDir, `${prefix}-${name}.png`);
  await page.screenshot({ path: file });
  log('screenshot', file);
}

async function sendMessage(page, text) {
  const box = composer(page);
  await box.waitFor({ state: 'visible', timeout: 30_000 });
  await box.click();
  await page.keyboard.type(text);
  await page.keyboard.press('Enter');
  log('sent message');
}

async function waitForWidget(page, timeoutMs) {
  try {
    await widget(page).waitFor({ state: 'visible', timeout: timeoutMs });
    return true;
  } catch {
    return false;
  }
}

(async () => {
  const browser = await chromium.launch({ headless: true });
  const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
  page.on('pageerror', (err) => log('pageerror', err.message));
  const result = {
    prefix,
    questionShown: false,
    hiddenAfterDismiss: false,
    visibleAfterNavigation: null,
    visibleAfterReload: null,
  };
  try {
    await page.goto(`${BASE_URL}/`, { waitUntil: 'domcontentloaded' });
    await page.locator('button[aria-label="Skip tour"]').click({ timeout: 5000 }).catch(() => {});
    const queenLink = page.locator('a[href^="#/queen/"], a[href^="/queen/"]').first();
    await queenLink.waitFor({ state: 'visible', timeout: 30_000 });
    const href = await queenLink.getAttribute('href');
    const queenId = href.replace(/^#?\/queen\//, '').split(/[?#]/)[0];
    log('queen id', queenId);

    await page.goto(`${BASE_URL}/#/queen/${queenId}?new=1`, { waitUntil: 'domcontentloaded' });
    await sendMessage(page, ASK);

    result.questionShown = await waitForWidget(page, WIDGET_TIMEOUT_MS);
    if (!result.questionShown) {
      log('widget not shown after first ask, sending the same message once more');
      await sendMessage(page, ASK);
      result.questionShown = await waitForWidget(page, WIDGET_TIMEOUT_MS);
    }
    log('questionShown', result.questionShown);
    await screenshot(page, '01-question-shown');
    if (!result.questionShown) {
      console.log(JSON.stringify(result));
      return;
    }

    await dismissButton(page).click();
    await sleep(500);
    result.hiddenAfterDismiss = !(await widget(page).isVisible());
    log('hiddenAfterDismiss', result.hiddenAfterDismiss);
    await screenshot(page, '02-after-dismiss');

    await page.locator('button[title="New Chat"], button:has-text("New Chat")').first().click();
    await sleep(1000);
    log('url after home click', page.url());
    await page.locator(`a[href="#/queen/${queenId}"], a[href="/queen/${queenId}"]`).first().click();
    await sleep(4000);
    log('url after queen click', page.url());
    result.visibleAfterNavigation = await widget(page).isVisible();
    log('visibleAfterNavigation', result.visibleAfterNavigation);
    await screenshot(page, '03-after-navigation');

    await page.reload({ waitUntil: 'domcontentloaded' });
    await sleep(4000);
    result.visibleAfterReload = await widget(page).isVisible();
    log('visibleAfterReload', result.visibleAfterReload);
    await screenshot(page, '04-after-reload');

    console.log(JSON.stringify(result));
  } catch (err) {
    log('FAILED', err.stack || err.message);
    await screenshot(page, '99-failure').catch(() => {});
    console.log(JSON.stringify(result));
    process.exitCode = 1;
  } finally {
    await browser.close();
  }
})();
```

Screenshots from the two Playwright runs (headless Chromium, 1280x900). The decisive pair is step 03: before the fix the dismissed question is back, after the fix the composer stays in place.

**Before the fix**

01. the queen parks on `ask_user` and the widget renders
<img width="1280" height="900" alt="before-01-question-shown" src="https://github.com/user-attachments/assets/e2ed28e5-9d62-4755-a66a-bd29a1bd9204" />

02. the X is clicked and the widget disappears
<img width="1280" height="900" alt="before-02-after-dismiss" src="https://github.com/user-attachments/assets/e1ad644c-8448-4a35-bd6a-43e24646c5f1" />

03. after leaving to `/` and returning to the queen page
<img width="1280" height="900" alt="before-03-after-navigation" src="https://github.com/user-attachments/assets/289ab7a6-1238-452f-95d2-1917d9dd6ceb" />

04. after a hard page reload
<img width="1280" height="900" alt="before-04-after-reload" src="https://github.com/user-attachments/assets/c5c0b214-ce52-4028-8cba-d190eda08155" />

05. after typing the answer in the composer, the queen resumes
<img width="1280" height="900" alt="before-05-answered" src="https://github.com/user-attachments/assets/56ff7f61-38f8-4cab-a581-6a3c44870501" />

**After the fix**

01. the queen parks on `ask_user` and the widget renders
<img width="1280" height="900" alt="after-01-question-shown" src="https://github.com/user-attachments/assets/e8e828c5-5902-45cb-a70f-f693f2910d61" />

02. the X is clicked and the widget disappears
<img width="1280" height="900" alt="after-02-after-dismiss" src="https://github.com/user-attachments/assets/a134924e-0e0f-4ac7-ae90-3f615abebc9a" />

03. after leaving to `/` and returning to the queen page
<img width="1280" height="900" alt="after-03-after-navigation" src="https://github.com/user-attachments/assets/4b96e90e-df18-4692-a456-81e0afa680ee" />

04. after a hard page reload
<img width="1280" height="900" alt="after-04-after-reload" src="https://github.com/user-attachments/assets/e7f57ce1-fc24-4753-92fa-e0603364c7c0" />

05. after typing the answer in the composer, the queen resumes
<img width="1280" height="900" alt="after-05-answered" src="https://github.com/user-attachments/assets/2cd1fdbc-02c6-4880-9e6d-0a0268b9d4d3" />

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (no new comments were needed: the helper is three small named functions, and the existing comments in `queen-dm.tsx` that explain the snapshot seeding are unchanged)
- [x] I have made corresponding changes to the documentation (not applicable: no document describes the question widget or its dismiss behavior)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dismissed pending questions remain hidden after connection updates or reconnections.
  - Dismissal tracking is maintained separately for each session.

- **Accessibility**
  - Added screen-reader labels to question dismissal buttons.

- **Bug Fixes**
  - Prevented previously dismissed questions from reappearing unexpectedly.
  - Dismissal state is cleared when a response is received.
  - Improved handling of distinct question sets with similar prompt formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

