### PR TITLE
fix(cli): report a busy port instead of an OSError traceback

### DIFF
--- a/core/framework/loader/cli.py
+++ b/core/framework/loader/cli.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import errno
 import json
 import logging
 import os
@@ -26,6 +27,30 @@ import threading
 from pathlib import Path
 from typing import Any
 from urllib import error as urlerror, parse as urlparse, request as urlrequest
+
+
+class PortAlreadyInUseError(RuntimeError):
+    """Raised when the address the server was asked to bind is taken."""
+
+    def __init__(self, host: str, port: int) -> None:
+        self.host = host
+        self.port = port
+        super().__init__(
+            f"Port {port} on {host} is already in use.\n"
+            f"A Hive server is probably running there already — open http://{host}:{port}\n"
+            f"To run a second one, pick another port: hive serve --port {port + 1}"
+        )
+
+
+async def start_site_or_raise_port_in_use(site: Any, runner: Any, host: str, port: int) -> None:
+    try:
+        await site.start()
+    except OSError as exc:
+        if exc.errno != errno.EADDRINUSE:
+            raise
+        await runner.cleanup()
+        raise PortAlreadyInUseError(host, port) from exc
+
 
 # ---------------------------------------------------------------------------
 # Public registration
@@ -218,7 +243,7 @@ def cmd_serve(args: argparse.Namespace) -> int:
         runner = web.AppRunner(app, access_log=None)
         await runner.setup()
         site = web.TCPSite(runner, args.host, args.port)
-        await site.start()
+        await start_site_or_raise_port_in_use(site, runner, args.host, args.port)
 
         # Sentinel: colony-queen autopilot. The manager owns outbound
         # escalation delivery + the inbound Telegram/Slack listeners and
@@ -278,6 +303,9 @@ def cmd_serve(args: argparse.Namespace) -> int:
         asyncio.run(run_server())
     except KeyboardInterrupt:
         print("\nServer stopped.")
+    except PortAlreadyInUseError as exc:
+        print(exc)
+        return 1
     return 0
 
 

--- a/core/tests/test_serve_port_in_use.py
+++ b/core/tests/test_serve_port_in_use.py
@@ -1,0 +1,97 @@
+"""Tests for the busy-port diagnostic in `hive serve` / `hive open`."""
+
+import argparse
+import asyncio
+import atexit
+import errno
+import socket
+
+import pytest
+from aiohttp import web
+
+from framework.loader import cli
+
+
+def _occupied_port() -> tuple[socket.socket, int]:
+    holder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    holder.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    holder.bind(("127.0.0.1", 0))
+    holder.listen(1)
+    return holder, holder.getsockname()[1]
+
+
+async def _start_on(host: str, port: int) -> None:
+    runner = web.AppRunner(web.Application(), access_log=None)
+    await runner.setup()
+    site = web.TCPSite(runner, host, port)
+    try:
+        await cli.start_site_or_raise_port_in_use(site, runner, host, port)
+    finally:
+        await runner.cleanup()
+
+
+def test_binding_a_busy_port_raises_a_readable_error_instead_of_oserror():
+    holder, port = _occupied_port()
+    try:
+        with pytest.raises(cli.PortAlreadyInUseError) as raised:
+            asyncio.run(_start_on("127.0.0.1", port))
+    finally:
+        holder.close()
+
+    message = str(raised.value)
+    assert str(port) in message
+    assert "already in use" in message.lower()
+    assert "--port" in message
+    assert f"http://127.0.0.1:{port}" in message
+
+
+def test_other_bind_errors_are_not_swallowed():
+    class FailingSite:
+        async def start(self) -> None:
+            raise OSError(errno.EACCES, "permission denied")
+
+    class NoopRunner:
+        async def cleanup(self) -> None:
+            return None
+
+    with pytest.raises(OSError) as raised:
+        asyncio.run(cli.start_site_or_raise_port_in_use(FailingSite(), NoopRunner(), "127.0.0.1", 8787))
+
+    assert raised.value.errno == errno.EACCES
+    assert not isinstance(raised.value, cli.PortAlreadyInUseError)
+
+
+def test_the_runner_is_cleaned_up_when_the_port_is_busy():
+    cleaned: list[bool] = []
+
+    class FailingSite:
+        async def start(self) -> None:
+            raise OSError(errno.EADDRINUSE, "address already in use")
+
+    class RecordingRunner:
+        async def cleanup(self) -> None:
+            cleaned.append(True)
+
+    with pytest.raises(cli.PortAlreadyInUseError):
+        asyncio.run(cli.start_site_or_raise_port_in_use(FailingSite(), RecordingRunner(), "127.0.0.1", 8787))
+
+    assert cleaned == [True]
+
+
+def test_cmd_serve_exits_non_zero_and_prints_no_traceback(monkeypatch, capsys):
+    monkeypatch.setattr("framework.server.app.create_app", lambda **kwargs: web.Application())
+    monkeypatch.setattr(atexit, "register", lambda func: func)
+
+    def fake_run(coro):
+        coro.close()
+        raise cli.PortAlreadyInUseError("127.0.0.1", 8787)
+
+    monkeypatch.setattr(asyncio, "run", fake_run)
+    args = argparse.Namespace(host="127.0.0.1", port=8787, model=None, debug=False, colony=[])
+
+    assert cli.cmd_serve(args) == 1
+
+    out = capsys.readouterr().out
+    assert "8787" in out
+    assert "already in use" in out.lower()
+    assert "Traceback" not in out


### PR DESCRIPTION
## Description

`hive serve` (and `hive open`, which delegates to it) called `await site.start()` bare and only caught `KeyboardInterrupt`, so aiohttp's `OSError: [Errno 48] address already in use` walked all the way out as an eleven-frame traceback. That is exactly what `quickstart.sh` hits when it prints "Launching dashboard..." and runs `./hive open` while a Hive server is already listening on 8787 — the transcript in the issue's screenshot.

This translates that one errno into a message naming the port, the URL of the server that already holds it, and the `--port` flag, cleans the `AppRunner` up, and exits 1. Every other `OSError` propagates untouched.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #6968

## Changes Made

- `core/framework/loader/cli.py`: add `PortAlreadyInUseError` and `start_site_or_raise_port_in_use`, which wraps `site.start()`, re-raises anything that is not `EADDRINUSE`, cleans up the runner and raises the readable error. `cmd_serve` catches it, prints it and returns 1.
- `core/tests/test_serve_port_in_use.py`: new tests covering a real bind against an occupied port, that other `OSError`s are not swallowed, that the runner is cleaned up, and that `cmd_serve` exits non-zero without a traceback.

## Testing

- [x] Unit tests pass (`cd core && uv run python -m pytest tests/test_serve_port_in_use.py`) — 4 passed
- [x] Lint passes (`cd core && uv run ruff check . && uv run ruff format --check .` on the touched files) — clean
- [x] Manual testing performed (see Evidence)

```
cd core && uv run python -m pytest tests/ --ignore=tests/dummy_agents
  1 failed, 2498 passed, 15 skipped
  the single failure is tests/test_janitor_review_fixes.py::test_global_lock_not_leaked_on_disposer_setup_failure,
  which fails the same way on a clean checkout of main @ 0c387492 (verified with the change stashed)
```

## Evidence

Ran with a dummy listener holding the port, then `HIVE_HOME=/tmp/hive_issue_6968 uv run hive serve --host 127.0.0.1 --port 8901`.

Before — eleven frames and an `OSError`, nothing telling the user what to do:

![before: hive serve dies with a raw OSError traceback when the port is taken](https://github.com/rodrigogaraujo/hive/releases/download/evidence-6968/before-01-traceback.png)

After — three lines and exit code 1:

![after: hive serve reports the busy port, the existing dashboard URL and the --port flag](https://github.com/rodrigogaraujo/hive/releases/download/evidence-6968/after-01-clean-message.png)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (no new comments were needed; the exception and helper names carry the intent)
- [x] I have made corresponding changes to the documentation (not applicable: no document describes this failure path)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
