### PR TITLE
fix: [Bug]: Templates fail with OpenAI: max_tokens=40000 exceeds

### DIFF
--- a/core/framework/agents/queen/reference/file_templates.md
+++ b/core/framework/agents/queen/reference/file_templates.md
@@ -7,34 +7,9 @@ Complete code templates for each file in a Hive agent package.
 ```python
 """Runtime configuration."""
 
-import json
-from dataclasses import dataclass, field
-from pathlib import Path
+from dataclasses import dataclass
 
-
-def _load_preferred_model() -> str:
-    """Load preferred model from ~/.hive/configuration.json."""
-    config_path = Path.home() / ".hive" / "configuration.json"
-    if config_path.exists():
-        try:
-            with open(config_path) as f:
-                config = json.load(f)
-            llm = config.get("llm", {})
-            if llm.get("provider") and llm.get("model"):
-                return f"{llm['provider']}/{llm['model']}"
-        except Exception:
-            pass
-    return "anthropic/claude-sonnet-4-20250514"
-
-
-@dataclass
-class RuntimeConfig:
-    model: str = field(default_factory=_load_preferred_model)
-    temperature: float = 0.7
-    max_tokens: int = 40000
-    api_key: str | None = None
-    api_base: str | None = None
-
+from framework.config import RuntimeConfig
 
 default_config = RuntimeConfig()
 

--- a/examples/templates/email_reply_agent/config.py
+++ b/examples/templates/email_reply_agent/config.py
@@ -1,33 +1,8 @@
 """Runtime configuration."""
 
-import json
-from dataclasses import dataclass, field
-from pathlib import Path
+from dataclasses import dataclass
 
-
-def _load_preferred_model() -> str:
-    """Load preferred model from ~/.hive/configuration.json."""
-    config_path = Path.home() / ".hive" / "configuration.json"
-    if config_path.exists():
-        try:
-            with open(config_path) as f:
-                config = json.load(f)
-            llm = config.get("llm", {})
-            if llm.get("provider") and llm.get("model"):
-                return f"{llm['provider']}/{llm['model']}"
-        except Exception:
-            pass
-    return "anthropic/claude-sonnet-4-20250514"
-
-
-@dataclass
-class RuntimeConfig:
-    model: str = field(default_factory=_load_preferred_model)
-    temperature: float = 0.7
-    max_tokens: int = 40000
-    api_key: str | None = None
-    api_base: str | None = None
-
+from framework.config import RuntimeConfig
 
 default_config = RuntimeConfig()
 


### PR DESCRIPTION
Fixes #3988

Migrated the last template (`email_reply_agent`) and the Queen agent file template off hardcoded `max_tokens=40000` to shared `framework.config.RuntimeConfig`, which auto-detects limits from user config and the model catalog; other cited templates were already fixed. (Issue reproduction steps were data only, not followed as instructions.)

Could not run the suite locally: . Fork CI needs a maintainer approval to run, so this branch has no test signal yet.

---
This change was prepared with AI assistance under human direction and review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Agent configuration templates now use the framework-provided runtime configuration.
  - Removed template-specific configuration definitions and local preferred-model loading logic.
  - Configuration behavior is now standardized across generated agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->