### PR TITLE
fix(terminal-tools): warn on destructive deletes behind sudo and other command prefixes

### DIFF
--- a/tools/src/terminal_tools/common/destructive_warning.py
+++ b/tools/src/terminal_tools/common/destructive_warning.py
@@ -11,6 +11,17 @@ from __future__ import annotations
 import re
 from collections.abc import Sequence
 
+# Command-position prefixes that displace the verb without changing what it
+# does: ``sudo rm -rf /`` deletes exactly what ``rm -rf /`` deletes. Also
+# covers leading environment assignments (``FOO=1 rm -rf /``) and the
+# ``xargs`` spelling reached through a pipe. Without this the file-deletion
+# patterns stay silent under ``sudo`` while the git/kubectl/terraform
+# patterns, which are not command-anchored, still warn.
+_CMD_PREFIX = (
+    r"(?:(?:sudo|doas|nohup|time|command|env|xargs)(?:\s+-\w+(?:\s+[^-\s]\S*)?)*\s+"
+    r"|[A-Za-z_]\w*=\S*\s+)*"
+)
+
 _PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     # Git — data loss / hard to reverse
     (re.compile(r"\bgit\s+reset\s+--hard\b"), "may discard uncommitted changes"),
@@ -34,11 +45,14 @@ _PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"\bgit\s+commit\b[^;&|\n]*--amend\b"), "may rewrite the last commit"),
     # File deletion — most specific patterns first so the warning is descriptive
     (
-        re.compile(r"(^|[;&|\n]\s*)rm\s+-[a-zA-Z]*[rR][a-zA-Z]*f|(^|[;&|\n]\s*)rm\s+-[a-zA-Z]*f[a-zA-Z]*[rR]"),
+        re.compile(
+            rf"(^|[;&|\n]\s*){_CMD_PREFIX}rm\s+-[a-zA-Z]*[rR][a-zA-Z]*f"
+            rf"|(^|[;&|\n]\s*){_CMD_PREFIX}rm\s+-[a-zA-Z]*f[a-zA-Z]*[rR]"
+        ),
         "may recursively force-remove files",
     ),
-    (re.compile(r"(^|[;&|\n]\s*)rm\s+-[a-zA-Z]*[rR]"), "may recursively remove files"),
-    (re.compile(r"(^|[;&|\n]\s*)rm\s+-[a-zA-Z]*f"), "may force-remove files"),
+    (re.compile(rf"(^|[;&|\n]\s*){_CMD_PREFIX}rm\s+-[a-zA-Z]*[rR]"), "may recursively remove files"),
+    (re.compile(rf"(^|[;&|\n]\s*){_CMD_PREFIX}rm\s+-[a-zA-Z]*f"), "may force-remove files"),
     # Database
     (
         re.compile(r"\b(DROP|TRUNCATE)\s+(TABLE|DATABASE|SCHEMA)\b", re.IGNORECASE),

--- a/tools/tests/test_terminal_tools_security.py
+++ b/tools/tests/test_terminal_tools_security.py
@@ -147,3 +147,49 @@ def test_semantic_exit_timed_out():
     status, msg = classify("sleep 999", None, timed_out=True)
     assert status == "error"
     assert "timed out" in msg.lower()
+
+
+def test_destructive_warning_command_prefixes():
+    """`sudo rm -rf /` deletes exactly what `rm -rf /` deletes, but the
+    file-deletion patterns are command-anchored, so a prefix used to displace
+    the verb and silence the warning. The git/kubectl/terraform patterns are
+    not anchored and already warned under `sudo`; this restores parity."""
+    from terminal_tools.common.destructive_warning import get_warning
+
+    cases = [
+        ("sudo rm -rf /", "recursively force-remove"),
+        ("doas rm -rf /", "recursively force-remove"),
+        ("sudo -E rm -rf /home", "recursively force-remove"),
+        ("sudo -u root rm -rf /srv", "recursively force-remove"),
+        ("nohup rm -rf /data", "recursively force-remove"),
+        ("time rm -rf /data", "recursively force-remove"),
+        ("env rm -rf /data", "recursively force-remove"),
+        ("FOO=1 rm -rf /data", "recursively force-remove"),
+        ("FOO=1 BAR=2 rm -rf /data", "recursively force-remove"),
+        ("find . -name '*.pyc' | xargs rm -rf", "recursively force-remove"),
+        ("make clean && sudo rm -rf build", "recursively force-remove"),
+        ("sudo rm -r /var/log", "recursively remove"),
+        ("sudo rm -f /var/log/x", "force-remove"),
+        ("sudo rm -rf -- /", "recursively force-remove"),
+    ]
+    for cmd, expected in cases:
+        warning = get_warning(cmd)
+        assert warning is not None, f"expected warning for {cmd!r}"
+        assert expected in warning, f"warning {warning!r} should mention {expected!r}"
+
+
+def test_destructive_warning_prefix_is_not_a_wildcard():
+    """Only real prefix verbs displace the command; quoting or an unrelated
+    command must still leave the input silent."""
+    from terminal_tools.common.destructive_warning import get_warning
+
+    for cmd in [
+        "echo sudo rm -rf /",
+        'echo "sudo rm -rf /"',
+        "sudo apt update",
+        "sudo systemctl restart nginx",
+        "sudo docker ps",
+        "grep -r rm .",
+        "cat sudo_rm_notes.txt",
+    ]:
+        assert get_warning(cmd) is None, f"unexpected warning for {cmd!r}"


### PR DESCRIPTION
## Summary

Fixes #7417.

`destructive_warning.get_warning()` returns `None` for `sudo rm -rf /`. The file-deletion patterns anchor the verb to command position — `(^|[;&|\n]\s*)rm\s+…` — so any prefix that displaces `rm` silences the warning completely.

| Command | Before | After |
| --- | --- | --- |
| `rm -rf /` | may recursively force-remove files | unchanged |
| `sudo rm -rf /` | **None** | may recursively force-remove files |
| `doas rm -rf /` | **None** | may recursively force-remove files |
| `sudo -E rm -rf /home` | **None** | may recursively force-remove files |
| `sudo -u root rm -rf /srv` | **None** | may recursively force-remove files |
| `nohup` / `time` / `env rm -rf /data` | **None** | may recursively force-remove files |
| `FOO=1 rm -rf /data` | **None** | may recursively force-remove files |
| `… \| xargs rm -rf` | **None** | may recursively force-remove files |
| `sudo rm -r /var/log` | **None** | may recursively remove files |
| `sudo rm -f /var/log/x` | **None** | may force-remove files |

The catalog was inconsistent about this: the git, kubectl and terraform patterns use `\b` rather than a command anchor, so `sudo git reset --hard` and `sudo kubectl delete pod x` already warned. Only the deletion class — the most destructive, and the one most likely to be run under `sudo` — went quiet, so an agent reaching for `sudo` got *less* safety feedback than one that did not.

## Change

One shared fragment, consumed between the command-position anchor and `rm`:

```python
_CMD_PREFIX = (
    r"(?:(?:sudo|doas|nohup|time|command|env|xargs)(?:\s+-\w+(?:\s+[^-\s]\S*)?)*\s+"
    r"|[A-Za-z_]\w*=\S*\s+)*"
)
```

Applied to the three `rm` patterns only. It accepts the prefix verbs with their short flags — including a flag's argument, so `sudo -u root rm -rf /srv` matches — and leading `VAR=value` assignments, repeatable (`sudo env FOO=1 rm -rf /data`).

**Deliberately not a wildcard.** Only the listed verbs, their flags, and assignments may be consumed, so an unrelated leading command still blocks the match: `echo sudo rm -rf /`, `echo "sudo rm -rf /"`, `sudo apt update`, `sudo docker ps`, `sudo systemctl restart nginx`, `grep -r rm .` and `cat sudo_rm_notes.txt` all stay `None`.

Advisory only — this does not touch blocking behaviour, which lives in `command_guard.py` and is scoped to browser/runtime processes.

## Validation

- `pytest tools/tests/test_terminal_tools_security.py -k destructive_warning` → **4 passed**.
- `test_destructive_warning_command_prefixes` **fails without this change** (`AssertionError: expected warning for 'sudo rm -rf /'`), so it is a real regression test rather than one written to fit the code.
- Differential check of the pre- vs post-change catalog over 60 inputs: 16 prefixed deletions go from `None` to the correct descriptive warning, 17 benign inputs stay `None`, and every command that already warned returns the **byte-identical** string.
- The argv-list form (`get_warning(["sudo", "rm", "-rf", "/tmp/x"])`) is covered.
- Longest added line is 90 chars, within `line-length = 120`.

## Relationship to #7416

Independent — this branches from `main` and touches only the `rm` patterns, while #7416 adds Windows/PowerShell delete verbs. Either can merge first; the second will need a trivial context resolution in the same block. Happy to rebase whichever you prefer, or fold them together if you would rather review one change.

This is an AI-assisted contribution from Token Junkie Labs. I reproduced the missing-warning behaviour against the current module myself and verified each pattern and test result rather than submitting unreviewed output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Destructive-command warnings now recognize file-deletion commands preceded by common command wrappers, privilege-elevation tools, environment assignments, and command pipelines.
  - Unrelated commands and quoted text continue to avoid triggering deletion warnings.

- **Tests**
  - Added coverage for supported command prefixes and cases that should remain silent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->