### PR TITLE
docs: drop references to editor configs the repo no longer ships

### DIFF
--- a/docs/contributing-lint-setup.md
+++ b/docs/contributing-lint-setup.md
@@ -74,15 +74,18 @@ git commit --no-verify -m "message"
 
 ### VS Code (Recommended)
 
-The repository includes `.vscode/extensions.json` and `.vscode/settings.json`. On first open, VS Code will prompt you to install the recommended Ruff extension.
+The repository does not ship VS Code configuration. `.gitignore` ignores `.vscode/*`, so
+`.vscode/settings.json` is yours to write and is never committed.
 
-Once installed, the editor will:
+Install the [Ruff extension](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff),
+then copy the settings block from [CONTRIBUTING.md](../CONTRIBUTING.md#recommended-ide-setup)
+into `.vscode/settings.json`. With that in place the editor will:
 
 - **Format on save** using ruff
 - **Auto-fix lint issues** on save (import sorting, fixable violations)
-- Show a **ruler at column 100**
 
-No manual configuration needed.
+If you would rather not configure the editor, `make lint` and `make format` do the same job
+from the command line, and the pre-commit hook enforces it either way.
 
 ### Other Editors
 
@@ -100,7 +103,8 @@ The repository includes a `.claude/settings.json` hook that automatically runs `
 
 ### Codex CLI
 
-Codex CLI (OpenAI, v0.101.0+) is supported via `.codex/config.toml` (MCP server config). This file is tracked in git. Run `codex` in the repo root to use the configured MCP tools. See the [Codex CLI section in the README](../README.md#codex-cli) for details.
+The repository no longer ships a `.codex/config.toml`. Point Codex CLI at the MCP servers
+through your own Codex configuration; `./quickstart.sh` sets the servers themselves up.
 
 ---
 
@@ -131,24 +135,22 @@ make check    # Verify locally before pushing
 | `tools/pyproject.toml` `[tool.ruff]` | Ruff rules for `tools/` (mirrors core, first-party = `aden_tools`) |
 | `.editorconfig` | Editor-agnostic formatting defaults |
 | `.pre-commit-config.yaml` | Pre-commit hook definitions |
-| `.vscode/settings.json` | VS Code ruff integration |
-| `.vscode/extensions.json` | Recommended VS Code extensions |
 | `.claude/settings.json` | Claude Code post-edit hooks |
 
-The single source of truth for lint rules is the `[tool.ruff]` section in each package's `pyproject.toml`. All other configs (VS Code, pre-commit, Makefile, CI) reference these.
+The single source of truth for lint rules is the `[tool.ruff]` section in each package's `pyproject.toml`. All other configs (pre-commit, Makefile, CI) reference these.
 
 ---
 
 ## FAQ
 
 **Q: Do I need to install anything beyond `uv pip install -e ".[dev]"`?**
-Only if you want pre-commit hooks: `make install-hooks`. Everything else (VS Code settings, editorconfig) works automatically.
+Only if you want pre-commit hooks: `make install-hooks`. `.editorconfig` is picked up automatically. Editor integration is opt-in and is not shipped in the repository.
 
 **Q: Can I use a different formatter (black, autopep8)?**
 No. The project standardizes on ruff for both linting and formatting. Using a different formatter will cause CI failures.
 
 **Q: What if ruff and my editor disagree?**
-The `.vscode/settings.json` is configured to use ruff as the formatter. If you use a different editor, run `make format` before committing, or rely on the pre-commit hook.
+Configure your editor to use ruff as the formatter — see Editor Setup above. Whichever editor you use, run `make format` before committing, or rely on the pre-commit hook.
 
 **Q: I'm getting lint errors in code I didn't write. Do I need to fix them?**
 Only fix lint errors in files you modified. Don't send drive-by lint fix PRs for unrelated files without coordinating first.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -26,8 +26,7 @@ Hive is a Python-based system for building goal-driven, self-improving AI agents
 | **framework** | `/core`    | Core runtime, graph executor, protocols   | Python 3.11+ |
 | **tools**     | `/tools`   | MCP tools for agent capabilities          | Python 3.11+ |
 | **exports**   | `/exports` | Agent packages (user-created, gitignored) | Python 3.11+ |
-| **skills**    | `.claude`, `.agents`, `.agent` | Shared skills for Claude/Codex/other coding agents | Markdown     |
-| **codex**     | `.codex`   | Codex CLI project configuration (MCP servers) | TOML         |
+| **skills**    | `.claude`  | Shared skills for Claude Code             | Markdown     |
 
 ### Key Principles
 
@@ -77,9 +76,6 @@ hive/                                    # Repository root
 │   ├── ISSUE_TEMPLATE/                  # Bug report & feature request templates
 │   ├── PULL_REQUEST_TEMPLATE.md         # PR description template
 │   └── CODEOWNERS                       # Auto-assign reviewers
-│
-├── .codex/                              # Codex CLI project config
-│   └── config.toml                      # Codex MCP server definitions
 │
 ├── core/                                # CORE FRAMEWORK PACKAGE
 │   ├── framework/                       # Main package code
@@ -135,7 +131,6 @@ hive/                                    # Repository root
 ├── scripts/                             # Utility scripts
 │   └── auto-close-duplicates.ts         # GitHub duplicate issue closer
 │
-├── .agent/                        # Antigravity IDE: mcp_config.json + skills (symlinks)
 ├── quickstart.sh                        # Interactive setup wizard
 ├── README.md                            # Project overview
 ├── CONTRIBUTING.md                      # Contribution guidelines

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -103,7 +103,8 @@ MCP tools are also available in Cursor. To enable:
 
 1. Open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`)
 2. Run `MCP: Enable` to enable MCP servers
-3. Restart Cursor to load the MCP servers from `.cursor/mcp.json`
+3. Restart Cursor. The repository does not ship a `.cursor/mcp.json`, so add the servers
+   to your own Cursor MCP configuration.
 4. Open Agent chat and verify MCP tools are available
 
 ### 2. Build an Agent

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -99,13 +99,14 @@ This sets up the MCP tools and workflows for building agents.
 
 ### Cursor IDE Support
 
-MCP tools are also available in Cursor. To enable:
+MCP tools are also available in Cursor. The repository does not ship a `.cursor/mcp.json`,
+so configure the servers yourself first:
 
-1. Open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`)
-2. Run `MCP: Enable` to enable MCP servers
-3. Restart Cursor. The repository does not ship a `.cursor/mcp.json`, so add the servers
-   to your own Cursor MCP configuration.
-4. Open Agent chat and verify MCP tools are available
+1. Add the MCP servers to your own Cursor MCP configuration and save it
+2. Open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`)
+3. Run `MCP: Enable` to enable MCP servers
+4. Restart Cursor so Agent chat picks up the saved configuration
+5. Open Agent chat and verify MCP tools are available
 
 ### 2. Build an Agent
 


### PR DESCRIPTION
Fixes #7383.

The issue reported four doc sites still pointing at editor and MCP configs that
`13a8e28a` ("refactor: remove all old unused skills") deleted, and said it stopped
short of a patch because the two possible fixes are opposite diffs — either the
configs come back, or the docs stop promising them.

I went with the second, and the repository itself settles which one is intended.

## What I measured against `main` (`0c38749`)

All six named files are absent, and only `.claude/`, `.github/` and `.hive/` remain
of the dot-directories:

| path | on `main` |
|---|---|
| `.agent/mcp_config.json` | gone |
| `.codex/config.toml` | gone |
| `.cursor/mcp.json` | gone |
| `.opencode/mcp.json` | gone |
| `.vscode/extensions.json` | gone |
| `.vscode/settings.json` | not present |

Nothing recreates them at setup time. The only match in `quickstart.sh` is
`$HOME/.codex/auth.json` — the user's own Codex auth, not a repo config — so these
are stale docs rather than generated files.

**`.gitignore` answers the question the issue left open**, without needing history:

```
.vscode/*
!.vscode/extensions.json
!.vscode/settings.json.example
```

`.vscode/settings.json` is deliberately ignored, so "The repository includes
`.vscode/settings.json`" was never going to be true. `extensions.json` is un-ignored,
i.e. meant to be tracked, and is the one the cleanup actually took.

## Two problems the issue did not list

- **`docs/contributing-lint-setup.md:103` links to `../README.md#codex-cli`, and that
  anchor does not exist** — `README.md` contains no occurrence of "codex" at all. The
  same line asserted "This file is tracked in git" as a fact a reader can act on.
- Beyond the four reported sites, the stale references also sat in the config table
  (2 rows) and two FAQ answers in the same file, and in the `developer-guide.md`
  component table. Fixed all of them; 11 sites across 3 files.

## Deliberately left alone

- `docs/configuration.md:227` and `CONTRIBUTING.md:289` tell the reader to *create*
  `.vscode/settings.json` themselves. That is correct, and it is exactly what
  `.gitignore` expects — so this PR points the lint doc at that block rather than
  duplicating it.
- `.agents/skills/` in `docs/skills-user-guide.md` and `docs/internal/skill-registry-prd.md`
  is the live cross-client skills convention (`~/.agents/skills/`), a different thing
  from the deleted repo-level `.agent/`. Untouched.
- Dropped the "ruler at column 100" bullet rather than re-homing it: the settings block
  in CONTRIBUTING.md does not set rulers, so keeping it would have replaced one false
  claim with another.

If you would rather restore the configs than correct the docs, say so and I will close
this — but the `.gitignore` rules above suggest at least the `.vscode/settings.json`
sentence was never accurate either way.

## Checks

Documentation only — three `.md` files, no code. No workflow in `.github/workflows/`
lints or builds markdown, so there is no docs job for this to run against.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated editor setup guidance to clarify that VS Code and Cursor configuration files are not shipped and must be configured locally.
  * Added instructions for copying recommended VS Code settings and configuring Cursor MCP servers.
  * Updated Codex CLI guidance to use personal configuration, with server setup available through `quickstart.sh`.
  * Revised configuration tables and FAQs to reflect opt-in editor integrations.
  * Simplified the developer guide to document supported skills and remove outdated IDE configuration references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->