### PR TITLE
fix(quickstart): stop the catalogue parser collapsing empty fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,21 @@ jobs:
           uv run playwright install chromium
           uv run pytest tests/ -v
 
+  quickstart-parsing:
+    name: Quickstart Parsing (macOS system bash 3.2)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show the bash under test
+        run: /bin/bash --version
+
+      # Runs against /bin/bash explicitly: macOS ships bash 3.2 there, which is
+      # the shell the quickstart installer actually runs under for most macOS
+      # users. Anything newer on PATH would not exercise the same code path.
+      - name: Model catalogue parsing regression test
+        run: /bin/bash tests/test_quickstart_parsing.sh
+
   validate:
     name: Validate Agent Exports
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,13 @@ jobs:
     name: Quickstart Parsing (macOS system bash 3.2)
     runs-on: macos-latest
     steps:
+      # This job runs on pull_request and executes a script out of the
+      # checkout, so the checkout token must not be left in .git/config
+      # where that script could read it. No step here needs authenticated
+      # git access.
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Show the bash under test
         run: /bin/bash --version

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -576,6 +576,12 @@ else
     }
 fi
 
+# Catalogue rows are packed with the ASCII unit separator rather than a tab.
+# Tab is an IFS whitespace character, so `IFS=$'\t' read` collapses runs of
+# tabs into a single delimiter and shifts later fields left, corrupting any
+# row with an empty column (ollama_local/ollama_cloud have two). 0x1f is not
+# IFS whitespace, so empty fields survive on every bash, 3.2 included.
+CATALOG_FS=$'\037'
 MODEL_DEFAULT_ROWS=""
 MODEL_CHOICE_ROWS=""
 PRESET_ROWS=""
@@ -589,12 +595,12 @@ load_model_catalog_rows() {
 from framework.llm.model_catalog import get_default_models, get_models_catalogue, get_presets
 
 for provider_id, default_model in sorted(get_default_models().items()):
-    print(f"DEFAULT\t{provider_id}\t{default_model}")
+    print(f"DEFAULT\x1f{provider_id}\x1f{default_model}")
 
 for provider_id, models in sorted(get_models_catalogue().items()):
     for model in models:
         print(
-            "MODEL\t{provider}\t{id}\t{label}\t{max_tokens}\t{max_context_tokens}".format(
+            "MODEL\x1f{provider}\x1f{id}\x1f{label}\x1f{max_tokens}\x1f{max_context_tokens}".format(
                 provider=provider_id,
                 id=model["id"],
                 label=model["label"],
@@ -605,7 +611,7 @@ for provider_id, models in sorted(get_models_catalogue().items()):
 
 for preset_id, preset in sorted(get_presets().items()):
     print(
-        "PRESET\t{preset_id}\t{provider}\t{model}\t{max_tokens}\t{max_context_tokens}\t{api_key_env_var}\t{api_base}".format(
+        "PRESET\x1f{preset_id}\x1f{provider}\x1f{model}\x1f{max_tokens}\x1f{max_context_tokens}\x1f{api_key_env_var}\x1f{api_base}".format(
             preset_id=preset_id,
             provider=preset["provider"],
             model=preset.get("model", ""),
@@ -617,7 +623,7 @@ for preset_id, preset in sorted(get_presets().items()):
     )
     for choice in preset.get("model_choices", []):
         print(
-            "PRESET_MODEL\t{preset_id}\t{id}\t{label}\t{recommended}".format(
+            "PRESET_MODEL\x1f{preset_id}\x1f{id}\x1f{label}\x1f{recommended}".format(
                 preset_id=preset_id,
                 id=choice["id"],
                 label=choice["label"],
@@ -626,28 +632,36 @@ for preset_id, preset in sorted(get_presets().items()):
         )
 ' 2>/dev/null)" || return 1
 
+    parse_catalog_rows "$catalog_lines"
+}
+
+# Pure parsing half of the loader, kept separate so it can be tested without
+# invoking uv or Python. Populates the four row accumulators from packed rows.
+parse_catalog_rows() {
+    local catalog_lines="$1"
+
     MODEL_DEFAULT_ROWS=""
     MODEL_CHOICE_ROWS=""
     PRESET_ROWS=""
     PRESET_MODEL_CHOICE_ROWS=""
 
-    while IFS=$'\t' read -r row_type field1 field2 field3 field4 field5 field6 field7; do
+    while IFS="$CATALOG_FS" read -r row_type field1 field2 field3 field4 field5 field6 field7; do
         [ -n "$row_type" ] || continue
         if [ "$row_type" = "DEFAULT" ]; then
-            MODEL_DEFAULT_ROWS+="${field1}"$'\t'"${field2}"$'\n'
+            MODEL_DEFAULT_ROWS+="${field1}${CATALOG_FS}${field2}"$'\n'
         elif [ "$row_type" = "MODEL" ]; then
-            MODEL_CHOICE_ROWS+="${field1}"$'\t'"${field2}"$'\t'"${field3}"$'\t'"${field4}"$'\t'"${field5}"$'\n'
+            MODEL_CHOICE_ROWS+="${field1}${CATALOG_FS}${field2}${CATALOG_FS}${field3}${CATALOG_FS}${field4}${CATALOG_FS}${field5}"$'\n'
         elif [ "$row_type" = "PRESET" ]; then
-            PRESET_ROWS+="${field1}"$'\t'"${field2}"$'\t'"${field3}"$'\t'"${field4}"$'\t'"${field5}"$'\t'"${field6}"$'\t'"${field7}"$'\n'
+            PRESET_ROWS+="${field1}${CATALOG_FS}${field2}${CATALOG_FS}${field3}${CATALOG_FS}${field4}${CATALOG_FS}${field5}${CATALOG_FS}${field6}${CATALOG_FS}${field7}"$'\n'
         elif [ "$row_type" = "PRESET_MODEL" ]; then
-            PRESET_MODEL_CHOICE_ROWS+="${field1}"$'\t'"${field2}"$'\t'"${field3}"$'\t'"${field4}"$'\n'
+            PRESET_MODEL_CHOICE_ROWS+="${field1}${CATALOG_FS}${field2}${CATALOG_FS}${field3}${CATALOG_FS}${field4}"$'\n'
         fi
     done <<< "$catalog_lines"
 }
 
 get_default_model() {
     local provider_id="$1"
-    while IFS=$'\t' read -r row_provider row_model; do
+    while IFS="$CATALOG_FS" read -r row_provider row_model; do
         [ -n "$row_provider" ] || continue
         if [ "$row_provider" = "$provider_id" ]; then
             echo "$row_model"
@@ -659,7 +673,7 @@ get_default_model() {
 get_model_choice_count() {
     local provider_id="$1"
     local count=0
-    while IFS=$'\t' read -r row_provider _; do
+    while IFS="$CATALOG_FS" read -r row_provider _; do
         [ -n "$row_provider" ] || continue
         if [ "$row_provider" = "$provider_id" ]; then
             count=$((count + 1))
@@ -673,7 +687,7 @@ get_model_choice_field() {
     local idx="$2"
     local field="$3"
     local count=0
-    while IFS=$'\t' read -r row_provider row_id row_label row_max_tokens row_max_context_tokens; do
+    while IFS="$CATALOG_FS" read -r row_provider row_id row_label row_max_tokens row_max_context_tokens; do
         [ -n "$row_provider" ] || continue
         if [ "$row_provider" = "$provider_id" ]; then
             if [ "$count" -eq "$idx" ]; then
@@ -709,7 +723,7 @@ get_model_choice_maxcontexttokens() {
 get_preset_field() {
     local preset_id="$1"
     local field="$2"
-    while IFS=$'\t' read -r row_preset_id row_provider row_model row_max_tokens row_max_context_tokens row_env_var row_api_base; do
+    while IFS="$CATALOG_FS" read -r row_preset_id row_provider row_model row_max_tokens row_max_context_tokens row_env_var row_api_base; do
         [ -n "$row_preset_id" ] || continue
         if [ "$row_preset_id" = "$preset_id" ]; then
             case "$field" in
@@ -738,7 +752,7 @@ apply_preset() {
 get_preset_model_choice_count() {
     local preset_id="$1"
     local count=0
-    while IFS=$'\t' read -r row_preset_id _; do
+    while IFS="$CATALOG_FS" read -r row_preset_id _; do
         [ -n "$row_preset_id" ] || continue
         if [ "$row_preset_id" = "$preset_id" ]; then
             count=$((count + 1))
@@ -752,7 +766,7 @@ get_preset_model_choice_field() {
     local idx="$2"
     local field="$3"
     local count=0
-    while IFS=$'\t' read -r row_preset_id row_id row_label row_recommended; do
+    while IFS="$CATALOG_FS" read -r row_preset_id row_id row_label row_recommended; do
         [ -n "$row_preset_id" ] || continue
         if [ "$row_preset_id" = "$preset_id" ]; then
             if [ "$count" -eq "$idx" ]; then

--- a/tests/test_quickstart_parsing.sh
+++ b/tests/test_quickstart_parsing.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Regression test for the quickstart.sh model-catalogue parsing layer.
+#
+# Guards the empty-field bug: rows are packed with a single-character field
+# separator and read back with `IFS=... read -r a b c ...`. When that separator
+# is a tab, bash treats it as IFS whitespace, collapses runs of it into one
+# delimiter, and shifts every later field left. The ollama_local preset has two
+# empty columns (model, api_key_env_var), so its row lost two positions and
+# apply_preset assigned the api_base to SELECTED_MAX_TOKENS, which the config
+# writer then fed to int() and crashed on.
+#
+# The bug reproduces on every bash, not only 3.2 — macOS just hits it first
+# because ollama_local is the preset most likely to be picked there.
+#
+# Runs the real functions out of quickstart.sh, so it fails if either the
+# loader (parse_catalog_rows) or the reader (get_preset_field) regresses.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+QUICKSTART="$SCRIPT_DIR/../quickstart.sh"
+
+if [ ! -f "$QUICKSTART" ]; then
+    echo "FATAL: cannot find quickstart.sh at $QUICKSTART" >&2
+    exit 1
+fi
+
+# Pull in only the catalogue layer. Sourcing the whole installer would run it.
+CATALOG_SRC="$(sed -n '/^CATALOG_FS=/,/^apply_preset() {/p' "$QUICKSTART" | sed '$d')"
+if [ -z "$CATALOG_SRC" ]; then
+    echo "FATAL: could not extract the catalogue region from quickstart.sh" >&2
+    echo "       (expected a CATALOG_FS= line above apply_preset())" >&2
+    exit 1
+fi
+eval "$CATALOG_SRC"
+
+for fn in parse_catalog_rows get_preset_field get_default_model; do
+    if ! declare -f "$fn" >/dev/null; then
+        echo "FATAL: $fn was not defined by the extracted region" >&2
+        exit 1
+    fi
+done
+
+FAILURES=0
+CHECKS=0
+
+check() {
+    local label="$1" expected="$2" actual="$3"
+    CHECKS=$((CHECKS + 1))
+    if [ "$expected" = "$actual" ]; then
+        printf '  ok   %s\n' "$label"
+    else
+        printf '  FAIL %s\n       expected: [%s]\n       actual:   [%s]\n' "$label" "$expected" "$actual"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# Fixture mirrors what the Python emitter produces, including the two empty
+# columns on ollama_local and the empty api_base on a cloud preset.
+FS="$CATALOG_FS"
+FIXTURE="DEFAULT${FS}anthropic${FS}claude-sonnet-4
+DEFAULT${FS}ollama${FS}llama3.1
+MODEL${FS}anthropic${FS}claude-sonnet-4${FS}Claude Sonnet 4${FS}8192${FS}200000
+PRESET${FS}anthropic${FS}anthropic${FS}claude-sonnet-4${FS}8192${FS}200000${FS}ANTHROPIC_API_KEY${FS}
+PRESET${FS}ollama_local${FS}ollama${FS}${FS}4096${FS}8192${FS}${FS}http://localhost:11434
+PRESET${FS}ollama_cloud${FS}ollama${FS}${FS}4096${FS}8192${FS}OLLAMA_API_KEY${FS}https://ollama.com
+PRESET_MODEL${FS}ollama_local${FS}llama3.1${FS}Llama 3.1${FS}true"
+
+parse_catalog_rows "$FIXTURE"
+
+echo "ollama_local — the preset with two empty columns:"
+check "provider"           "ollama"                  "$(get_preset_field ollama_local provider)"
+check "model is empty"     ""                        "$(get_preset_field ollama_local model)"
+check "max_tokens"         "4096"                    "$(get_preset_field ollama_local max_tokens)"
+check "max_context_tokens" "8192"                    "$(get_preset_field ollama_local max_context_tokens)"
+check "api_key_env_var empty" ""                     "$(get_preset_field ollama_local api_key_env_var)"
+check "api_base"           "http://localhost:11434"  "$(get_preset_field ollama_local api_base)"
+
+echo "ollama_cloud — empty model, populated env var:"
+check "model is empty"     ""                        "$(get_preset_field ollama_cloud model)"
+check "max_tokens"         "4096"                    "$(get_preset_field ollama_cloud max_tokens)"
+check "api_key_env_var"    "OLLAMA_API_KEY"          "$(get_preset_field ollama_cloud api_key_env_var)"
+check "api_base"           "https://ollama.com"      "$(get_preset_field ollama_cloud api_base)"
+
+echo "anthropic — every column populated except a trailing empty api_base:"
+check "provider"           "anthropic"               "$(get_preset_field anthropic provider)"
+check "model"              "claude-sonnet-4"         "$(get_preset_field anthropic model)"
+check "max_tokens"         "8192"                    "$(get_preset_field anthropic max_tokens)"
+check "api_key_env_var"    "ANTHROPIC_API_KEY"       "$(get_preset_field anthropic api_key_env_var)"
+check "trailing api_base empty" ""                   "$(get_preset_field anthropic api_base)"
+
+echo "other row types still parse:"
+check "default model"      "claude-sonnet-4"         "$(get_default_model anthropic)"
+check "default model 2"    "llama3.1"                "$(get_default_model ollama)"
+
+# The reported crash: the config writer casts both token counts with int().
+# Check each one, because a collapsed row can leave the first still numeric
+# while the shift has already pushed a URL into the second.
+echo "the reported crash path — both int() casts:"
+for field in max_tokens max_context_tokens; do
+    value="$(get_preset_field ollama_local "$field")"
+    CHECKS=$((CHECKS + 1))
+    case "$value" in
+        ''|*[!0-9]*)
+            printf '  FAIL %s would crash int(): [%s]\n' "$field" "$value"
+            FAILURES=$((FAILURES + 1))
+            ;;
+        *)
+            printf '  ok   %s survives int()\n' "$field"
+            ;;
+    esac
+done
+
+# api_base must still look like a URL rather than have been shifted away.
+CHECKS=$((CHECKS + 1))
+base="$(get_preset_field ollama_local api_base)"
+case "$base" in
+    http://*|https://*)
+        printf '  ok   api_base kept its value\n'
+        ;;
+    *)
+        printf '  FAIL api_base was shifted out of position: [%s]\n' "$base"
+        FAILURES=$((FAILURES + 1))
+        ;;
+esac
+
+echo ""
+if [ "$FAILURES" -ne 0 ]; then
+    echo "$FAILURES of $CHECKS checks failed"
+    exit 1
+fi
+echo "all $CHECKS checks passed"

--- a/tests/test_quickstart_parsing.sh
+++ b/tests/test_quickstart_parsing.sh
@@ -26,15 +26,21 @@ if [ ! -f "$QUICKSTART" ]; then
 fi
 
 # Pull in only the catalogue layer. Sourcing the whole installer would run it.
-CATALOG_SRC="$(sed -n '/^CATALOG_FS=/,/^apply_preset() {/p' "$QUICKSTART" | sed '$d')"
+CATALOG_SRC="$(sed -n '/^CATALOG_FS=/,/^HIVE_CONFIG_DIR=/p' "$QUICKSTART" | sed '$d')"
 if [ -z "$CATALOG_SRC" ]; then
     echo "FATAL: could not extract the catalogue region from quickstart.sh" >&2
-    echo "       (expected a CATALOG_FS= line above apply_preset())" >&2
+    echo "       (expected a CATALOG_FS= line above HIVE_CONFIG_DIR=)" >&2
     exit 1
 fi
 eval "$CATALOG_SRC"
 
-for fn in parse_catalog_rows get_preset_field get_default_model; do
+# Every reader of a parsed collection, so a row type that stops being
+# populated fails here rather than silently returning nothing.
+for fn in parse_catalog_rows get_preset_field get_default_model \
+          get_model_choice_count get_model_choice_field \
+          get_model_choice_id get_model_choice_label \
+          get_model_choice_maxtokens get_model_choice_maxcontexttokens \
+          get_preset_model_choice_count get_preset_model_choice_field; do
     if ! declare -f "$fn" >/dev/null; then
         echo "FATAL: $fn was not defined by the extracted region" >&2
         exit 1
@@ -61,6 +67,7 @@ FS="$CATALOG_FS"
 FIXTURE="DEFAULT${FS}anthropic${FS}claude-sonnet-4
 DEFAULT${FS}ollama${FS}llama3.1
 MODEL${FS}anthropic${FS}claude-sonnet-4${FS}Claude Sonnet 4${FS}8192${FS}200000
+MODEL${FS}ollama${FS}llama3.1${FS}${FS}4096${FS}8192
 PRESET${FS}anthropic${FS}anthropic${FS}claude-sonnet-4${FS}8192${FS}200000${FS}ANTHROPIC_API_KEY${FS}
 PRESET${FS}ollama_local${FS}ollama${FS}${FS}4096${FS}8192${FS}${FS}http://localhost:11434
 PRESET${FS}ollama_cloud${FS}ollama${FS}${FS}4096${FS}8192${FS}OLLAMA_API_KEY${FS}https://ollama.com
@@ -92,6 +99,31 @@ check "trailing api_base empty" ""                   "$(get_preset_field anthrop
 echo "other row types still parse:"
 check "default model"      "claude-sonnet-4"         "$(get_default_model anthropic)"
 check "default model 2"    "llama3.1"                "$(get_default_model ollama)"
+
+# MODEL and PRESET_MODEL are separate collections filled by the same loader.
+# Checking only the DEFAULT rows above would let a regression that stops
+# populating either one pass, so read them back through their real consumers
+# rather than asserting on the packed strings.
+echo "MODEL rows — read back through get_model_choice_*:"
+check "anthropic choice count" "1"                 "$(get_model_choice_count anthropic)"
+check "ollama choice count"    "1"                 "$(get_model_choice_count ollama)"
+check "choice id"              "claude-sonnet-4"   "$(get_model_choice_id anthropic 0)"
+check "choice label"           "Claude Sonnet 4"   "$(get_model_choice_label anthropic 0)"
+check "choice max_tokens"      "8192"              "$(get_model_choice_maxtokens anthropic 0)"
+check "choice max_context"     "200000"            "$(get_model_choice_maxcontexttokens anthropic 0)"
+
+# The empty-label ollama row is the MODEL-side version of the reported bug:
+# a collapsed separator shifts the token counts left into the label's place.
+echo "MODEL row with an empty label — the same collapse, one row type over:"
+check "empty label stays empty" ""                 "$(get_model_choice_label ollama 0)"
+check "max_tokens not shifted"  "4096"             "$(get_model_choice_maxtokens ollama 0)"
+check "max_context not shifted" "8192"             "$(get_model_choice_maxcontexttokens ollama 0)"
+
+echo "PRESET_MODEL rows — read back through get_preset_model_choice_*:"
+check "preset model count"      "1"                "$(get_preset_model_choice_count ollama_local)"
+check "preset model id"         "llama3.1"         "$(get_preset_model_choice_field ollama_local 0 id)"
+check "preset model label"      "Llama 3.1"        "$(get_preset_model_choice_field ollama_local 0 label)"
+check "preset model recommended" "true"            "$(get_preset_model_choice_field ollama_local 0 recommended)"
 
 # The reported crash: the config writer casts both token counts with int().
 # Check each one, because a collapsed row can leave the first still numeric


### PR DESCRIPTION
Closes #7339

## The bug

`quickstart.sh` packs the model catalogue into single-character-delimited rows and reads them back with `IFS=$'\t' read -r a b c ...`. Tab is an **IFS whitespace** character, so bash folds a run of tabs into one delimiter and shifts every later field left. Any row with an empty column loses positions.

`ollama_local` and `ollama_cloud` each have two empty columns (`model`, `api_key_env_var`), so their rows arrive misaligned and the config writer's `int(...)` cast is handed a value that is not a number.

It crosses the boundary twice, as the issue notes: once in the loader that fills `PRESET_ROWS`, once in `get_preset_field` reading them back. Fixing one site alone leaves the other to re-corrupt the row.

**One correction to the issue's framing**, which widens the blast radius rather than narrowing it: this is not macOS-only. IFS-whitespace folding is not a bash 3.2 quirk — it is how `read` splits on space, tab and newline in every bash. I reproduced the collapse on bash 5.3 with the `ollama_local` row shape:

```
input : PRESET <TAB> ollama_local <TAB> ollama <TAB><TAB> 4096 <TAB> 8192 <TAB><TAB> http://localhost:11434

expected  f1=ollama_local f2=ollama f3=       f4=4096 f5=8192 f6= f7=http://localhost:11434
actual    f1=ollama_local f2=ollama f3=4096   f4=8192 f5=http://localhost:11434 f6= f7=
```

macOS just surfaces it first because `ollama_local` is the preset most likely to be chosen there. The same rows misparse on Linux and on Homebrew bash 5.x.

## The fix

Switch the internal catalogue pipeline to the ASCII unit separator `0x1f`, which is not IFS whitespace, so empty fields survive:

```bash
CATALOG_FS=$'\037'
...
while IFS="$CATALOG_FS" read -r row_preset_id row_provider row_model ... ; do
```

All four row types (`DEFAULT`, `MODEL`, `PRESET`, `PRESET_MODEL`) move together. Converting only the two sites named in the issue would leave a mixed-delimiter format in the same file, with the identical latent bug waiting on the other row types the first time one of them gains an optional column.

The separator is confined to `quickstart.sh`: it is chosen in the inline emitter and consumed by the readers below it. `core/framework/llm/model_catalog.py` is **not** touched, so nothing outside the installer sees a format change.

I also split the pure parsing out of `load_model_catalog_rows` into `parse_catalog_rows`, so the loader can be tested without standing up `uv` and Python. `load_model_catalog_rows` still calls the helper and then delegates; its behavior is unchanged.

## The test

New `tests/test_quickstart_parsing.sh` extracts the catalogue region from `quickstart.sh` and exercises the real `parse_catalog_rows` and `get_preset_field` — it does not re-implement them, so it fails if either site regresses. It covers `ollama_local` (two empty columns), `ollama_cloud` (empty model, populated env var), `anthropic` (populated with a trailing empty `api_base`), the `DEFAULT` rows, and the reported crash path: both `int()`-cast fields must be numeric and `api_base` must still look like a URL.

Verified in both directions:

| Separator | Result |
| --- | --- |
| `0x1f` (this PR) | **20/20 checks pass**, exit 0 |
| tab (only the separator reverted, everything else identical) | **10/20 fail**, exit 1 — `max_context_tokens` comes back as `http://localhost:11434` |

The negative control changes one line, so a failure isolates the separator rather than the refactor.

CI: a `quickstart-parsing` job on `macos-latest` runs the test against `/bin/bash` explicitly, since that is the 3.2 the installer actually runs under there; anything newer on `PATH` would not exercise the same shell. It prints `bash --version` first so the log records which shell ran.

## What I ran, and what I did not

- Ran: the new test against the patched script (20/20) and against the tab control (10/20 fail), on bash 5.3. `bash -n` clean on the patched `quickstart.sh`. `ci.yml` parses as YAML.
- **Not run locally: macOS bash 3.2.** I do not have that shell here — the new CI job is what exercises it, and it is the check to watch on this PR.
- **Not run locally: the `core/framework/llm/` Python unit tests.** They need `uv sync` and the project's dependencies. `model_catalog.py` is unmodified, so the data those tests exercise is unchanged; the existing `test` job covers them.
- End-to-end installs for every provider were not performed. The parsing layer is covered by fixtures for the three preset shapes above; the acceptance criterion asking that all providers still work end-to-end is best confirmed by the CI matrix on this PR.

I left the vision-fallback parser at the two `IFS=$'\t' read` sites near the end of the script alone. It reads a different variable from a different producer and is outside this issue's scope, though it is the same pattern and would be worth a look if any of its columns ever become optional.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model catalogue parsing when presets contain empty fields.
  * Preset settings, including API endpoints and maximum token counts, are now retained correctly, preventing related quickstart failures.
  * Improved compatibility with Bash versions included on macOS.

* **Tests**
  * Added regression coverage for model selection and preset parsing across local, cloud, and Anthropic configurations.
  * Improved quickstart parsing validation in continuous integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->