### PR TITLE
fix(subdomain-enumerator): reject non-positive max_results before querying crt.sh

### DIFF
--- a/tools/src/aden_tools/tools/subdomain_enumerator/subdomain_enumerator.py
+++ b/tools/src/aden_tools/tools/subdomain_enumerator/subdomain_enumerator.py
@@ -86,7 +86,7 @@ def register_tools(mcp: FastMCP) -> None:
 
         Args:
             domain: Base domain to enumerate (e.g., "example.com"). No protocol prefix.
-            max_results: Maximum number of subdomains to return (default 50, max 200).
+            max_results: Maximum number of subdomains to return (default 50, min 1, max 200).
 
         Returns:
             Dict with discovered subdomains, interesting findings,
@@ -97,6 +97,12 @@ def register_tools(mcp: FastMCP) -> None:
         domain = domain.split("/")[0]
         if ":" in domain:
             domain = domain.split(":")[0]
+
+        if max_results < 1:
+            return {
+                "error": f"max_results must be a positive integer (got {max_results})",
+                "domain": domain,
+            }
 
         max_results = min(max_results, 200)
 

--- a/tools/tests/tools/test_subdomain_enumerator.py
+++ b/tools/tests/tools/test_subdomain_enumerator.py
@@ -90,6 +90,54 @@ class TestInputValidation:
             # Result should not error
             assert "error" not in result
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("max_results", [-1, 0, -50])
+    async def test_non_positive_max_results_rejected(self, enumerate_fn, max_results):
+        with patch("httpx.AsyncClient") as MockClient:
+            result = await enumerate_fn("example.com", max_results=max_results)
+
+            # Rejected before any network work is attempted
+            MockClient.assert_not_called()
+            assert "error" in result
+            assert "max_results" in result["error"]
+            assert result["domain"] == "example.com"
+            assert "subdomains" not in result
+
+    @pytest.mark.asyncio
+    async def test_negative_max_results_does_not_slice_off_last_subdomain(self, enumerate_fn):
+        """max_results=-1 previously fell through to subdomains[:-1]."""
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = _mock_crtsh_response(
+                ["a.example.com", "b.example.com", "c.example.com"]
+            )
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await enumerate_fn("example.com", max_results=-1)
+
+            assert "error" in result
+            assert "subdomains" not in result
+            mock_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_max_results_one_is_accepted(self, enumerate_fn):
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = _mock_crtsh_response(
+                ["a.example.com", "b.example.com", "c.example.com"]
+            )
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            MockClient.return_value = mock_client
+
+            result = await enumerate_fn("example.com", max_results=1)
+
+            assert "error" not in result
+            assert result["subdomains"] == ["a.example.com"]
+            assert result["total_found"] == 1
+
 
 # ---------------------------------------------------------------------------
 # Connection Errors


### PR DESCRIPTION
Fixes #7406

`subdomain_enumerate` bounded `max_results` from above but not from below, so a non-positive value fell through to a Python slice and the crt.sh request went out regardless.

## Reproduction, before the change

Driving the current `subdomain_enumerate` with a mocked crt.sh returning `a.example.com`, `b.example.com`, `c.example.com`:

| Call | crt.sh queried | Error | `subdomains` | `total_found` |
| --- | --- | --- | --- | --- |
| `max_results=-1` | **yes** | no | `['a.example.com', 'b.example.com']` | 2 |
| `max_results=0` | **yes** | no | `[]` | 0 |

`-1` returns everything except the final subdomain, because `min(-1, 200)` is `-1` and line 139 evaluates `subdomains[:-1]`. `0` silently yields an empty list. Both spend a network round trip first.

## Change

One guard, placed after the domain is cleaned and before the client is constructed:

```python
if max_results < 1:
    return {
        "error": f"max_results must be a positive integer (got {max_results})",
        "domain": domain,
    }

max_results = min(max_results, 200)
```

The error shape matches the ones already returned by this tool for timeouts and non-200 responses — `error` plus `domain` — so callers that already branch on `"error" in result` need no change. The 200 cap and every positive-value path are untouched.

## Tests

Three cases added to `TestInputValidation`, using the mocking style already in that file:

- `test_non_positive_max_results_rejected` — parametrized over `-1`, `0`, `-50`; asserts `MockClient.assert_not_called()`, so the rejection is proven to happen before any network work, plus the error text, the `domain` echo, and the absence of a `subdomains` key.
- `test_negative_max_results_does_not_slice_off_last_subdomain` — the exact scenario from the issue, asserting `mock_client.get.assert_not_called()`.
- `test_max_results_one_is_accepted` — guards the boundary, so `< 1` cannot drift into `<= 1`.

The existing `test_max_results_clamped` still passes unchanged.

Verified locally against the patched module: non-positive limits error with no client constructed; `max_results=1` returns exactly one subdomain; `max_results=500` still clamps and returns all available; the default path is unaffected.

## Note on the earlier PR

#7407 covered this issue and was closed by the requirements bot for the linked-issue assignment rule, not for anything found in the code — CodeRabbit reported no actionable comments on it. I do not have rights to self-assign #7406 (the API returns 403 "Must have admin rights to Repository"), so I have asked on the issue for the assignment that the requirements check needs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject `max_results` values below 1.
  * Invalid values now return a clear error without performing network requests.
  * `max_results=1` is accepted and correctly limits results to one subdomain.
* **Documentation**
  * Updated the tool documentation to specify that `max_results` must be at least 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->