### PR TITLE
fix(excel-tool): match excel_sql write keywords on word boundaries

### DIFF
--- a/tools/src/aden_tools/tools/excel_tool/excel_tool.py
+++ b/tools/src/aden_tools/tools/excel_tool/excel_tool.py
@@ -1,12 +1,42 @@
 """Excel Tool - Read and manipulate Excel files (.xlsx, .xlsm)."""
 
 import os
+import re
 from datetime import datetime
 from typing import Any
 
 from fastmcp import FastMCP
 
 from ..file_system_toolkits.security import get_sandboxed_path
+
+# Write/DDL keywords that must not appear as SQL keywords in an excel_sql query.
+# Matched on word boundaries, the same way csv_sql does it, so an ordinary
+# identifier that merely contains one of them is not mistaken for a write:
+# "created_at" is not CREATE, "updated_at" is not UPDATE, and a status value of
+# 'DELETED' is not DELETE. A bare substring test rejected all three.
+_WRITE_KEYWORD_PATTERN = re.compile(
+    r"\b(INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|TRUNCATE|EXEC|EXECUTE)\b",
+    re.IGNORECASE,
+)
+
+
+def _validate_select_query(query: str) -> str | None:
+    """Check that *query* is a read-only SELECT.
+
+    Returns an error message describing the first problem found, or ``None``
+    when the query is acceptable.
+    """
+    if not query or not query.strip():
+        return "query cannot be empty"
+
+    if not query.strip().upper().startswith("SELECT"):
+        return "Only SELECT queries are allowed for security reasons"
+
+    match = _WRITE_KEYWORD_PATTERN.search(query)
+    if match:
+        return f"'{match.group().upper()}' is not allowed in queries"
+
+    return None
 
 
 def register_tools(mcp: FastMCP) -> None:
@@ -466,29 +496,10 @@ def register_tools(mcp: FastMCP) -> None:
             if not path.lower().endswith((".xlsx", ".xlsm")):
                 return {"error": "File must have .xlsx or .xlsm extension"}
 
-            if not query or not query.strip():
-                return {"error": "query cannot be empty"}
-
-            # Security: only allow SELECT statements
-            query_upper = query.strip().upper()
-            if not query_upper.startswith("SELECT"):
-                return {"error": "Only SELECT queries are allowed for security reasons"}
-
-            # Disallowed keywords
-            disallowed = [
-                "INSERT",
-                "UPDATE",
-                "DELETE",
-                "DROP",
-                "CREATE",
-                "ALTER",
-                "TRUNCATE",
-                "EXEC",
-                "EXECUTE",
-            ]
-            for keyword in disallowed:
-                if keyword in query_upper:
-                    return {"error": f"'{keyword}' is not allowed in queries"}
+            # Security: only allow read-only SELECT statements
+            query_error = _validate_select_query(query)
+            if query_error:
+                return {"error": query_error}
 
             # Load workbook
             wb = load_workbook(secure_path, read_only=True, data_only=True)

--- a/tools/tests/test_excel_tool_sql_guard.py
+++ b/tools/tests/test_excel_tool_sql_guard.py
@@ -1,0 +1,75 @@
+"""excel_sql query guard: word-boundary matching of write/DDL keywords."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_select_with_keyword_inside_column_names_is_allowed():
+    """A column whose name contains a keyword is not a write.
+
+    `created_at` contains CREATE and `updated_at` contains UPDATE. The guard
+    used a bare substring test, so these ordinary SELECTs never ran.
+    """
+    from aden_tools.tools.excel_tool.excel_tool import _validate_select_query
+
+    assert _validate_select_query("SELECT created_at, updated_at FROM data") is None
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT created_at FROM data",
+        "SELECT updated_at FROM data",
+        "SELECT * FROM data WHERE status = 'DELETED'",
+        "SELECT total AS total_created FROM data",
+        "SELECT deleted_flag, dropped_count FROM data",
+        "SELECT alteration, execution_time FROM data",
+        "SELECT truncated_name FROM data",
+        "  SELECT a FROM data",
+        "select lower_case_keyword FROM data",
+    ],
+)
+def test_read_only_selects_are_allowed(query):
+    from aden_tools.tools.excel_tool.excel_tool import _validate_select_query
+
+    assert _validate_select_query(query) is None, query
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("SELECT * FROM data; DROP TABLE data", "'DROP'"),
+        ("SELECT * FROM data UNION SELECT 1; DELETE FROM data", "'DELETE'"),
+        ("SELECT * FROM (INSERT INTO x VALUES (1))", "'INSERT'"),
+        ("SELECT * FROM data WHERE 1=1 alter table x", "'ALTER'"),
+        ("SELECT exec(1)", "'EXEC'"),
+        ("SELECT truncate(x) FROM data", "'TRUNCATE'"),
+    ],
+)
+def test_write_keywords_are_still_blocked(query, expected):
+    """Relaxing to word boundaries must not let a real write through."""
+    from aden_tools.tools.excel_tool.excel_tool import _validate_select_query
+
+    error = _validate_select_query(query)
+    assert error is not None, query
+    assert expected in error, error
+
+
+@pytest.mark.parametrize(
+    "query",
+    ["DROP TABLE data", "UPDATE data SET a = 1", "INSERT INTO data VALUES (1)"],
+)
+def test_non_select_statements_are_rejected(query):
+    from aden_tools.tools.excel_tool.excel_tool import _validate_select_query
+
+    error = _validate_select_query(query)
+    assert error is not None
+    assert "Only SELECT queries are allowed" in error
+
+
+@pytest.mark.parametrize("query", ["", "   ", "\n\t "])
+def test_empty_query_is_rejected(query):
+    from aden_tools.tools.excel_tool.excel_tool import _validate_select_query
+
+    assert _validate_select_query(query) == "query cannot be empty"


### PR DESCRIPTION
Fixes #7412.

`excel_sql` tested each blocked keyword with `keyword in query_upper`, so any query
containing one as a *substring* was rejected — including ordinary read-only SELECTs:

```
SELECT created_at, updated_at FROM data
-> {"error": "'CREATE' is not allowed in queries"}
```

`created_at` contains CREATE, `updated_at` contains UPDATE, a status value of
`'DELETED'` contains DELETE, and an alias like `total_created` contains CREATE.

## The fix

Switched to the word-boundary pattern `csv_sql` already uses
(`tools/src/aden_tools/tools/csv_tool/csv_tool.py:283`), so the two SQL tools now
agree on what counts as a write — which is what the issue asked for.

The checks also moved into a module-level `_validate_select_query()`. `excel_sql`
needs a real workbook, DuckDB, pandas and a sandboxed path before it reaches the
guard, so inline the guard had no way to be tested; as a plain function it does.
Nothing else about the behaviour changed — empty queries, statements that do not
start with SELECT, and real write/DDL keywords are all still rejected with the
same messages.

## Checks

`tools/tests/test_excel_tool_sql_guard.py`, 22 cases: the four reported spellings
plus `deleted_flag` / `dropped_count` / `alteration` / `execution_time` /
`truncated_name`, leading whitespace and a lowercase `select`; and — the half that
matters for a guard being relaxed — that every write keyword is *still* caught,
including when it trails a `;`, sits inside a subquery, or is lowercase.

```
22/22 passed
```

Locally I ran those cases against the real module rather than through pytest:
`aden_tools/tools/__init__.py` eagerly imports every tool, so importing
`excel_tool` pulls in `arxiv`, `duckdb`, `pandas` and the rest of the suite, which
this machine does not have installed (that eager-import cost is #7323). The test
file itself is written the normal way and imports from the package, so it runs as
written in CI. Also clean:

```
ruff check   -> All checks passed!
ruff format  -> 2 files already formatted
```

## One thing I did not change

`csv_sql` additionally rejects `;`, `--`, `/*` and `*/`; `excel_sql` has never had
that check. Switching to word boundaries does not weaken anything here — the cases
above confirm a trailing `; DROP TABLE data` is still caught by the keyword
pattern — but the two tools do still differ on that point. I left it alone because
adding it would start rejecting `SELECT * FROM data;`, which works today and which
this issue is about *unblocking*, not restricting. Happy to add it in a separate PR
if you would rather they match exactly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SQL query validation for spreadsheet queries.
  - Valid `SELECT` queries using field names or aliases such as `created_at` and `updated_at` are no longer incorrectly rejected.
  - Queries containing write or data-definition commands remain blocked, with clearer validation errors.
  - Empty and non-`SELECT` queries continue to be rejected with appropriate messages.

- **Tests**
  - Added coverage for valid identifiers, blocked SQL commands, non-`SELECT` statements, and empty queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->