### PR TITLE
fix(janitor): resume worker deep-clean until every target is gone

### DIFF
--- a/core/framework/maintenance/retention.py
+++ b/core/framework/maintenance/retention.py
@@ -609,6 +609,22 @@ def _extract_worker_summary(wdir: Path) -> tuple[str, str]:
     return "unknown", ""
 
 
+def _message_index_subtrees(session_id: str) -> list[Path]:
+    """Index copies of one session: .message_index/{events,data,meta}/*/*/<id>.
+
+    Read by both the deleter and the completion check, so the two cannot
+    disagree about whether the index side is finished.
+    """
+    index_root = config.HIVE_HOME / ".message_index"
+    subs: list[Path] = []
+    for tree in ("events", "data", "meta"):
+        base = index_root / tree
+        if not base.is_dir():
+            continue
+        subs.extend(base.glob(f"*/*/{session_id}"))
+    return subs
+
+
 def _delete_message_index_subtrees(session_id: str, disposer: Disposer, manifest: Manifest, tier: int, target: str) -> int:
     """Remove .message_index/{events,data,meta}/*/*/<session_id> subtrees.
 
@@ -616,50 +632,51 @@ def _delete_message_index_subtrees(session_id: str, disposer: Disposer, manifest
     so leaving it behind both strands bytes and serves ghost results
     from search_messages after the source is pruned.
     """
-    index_root = config.HIVE_HOME / ".message_index"
     freed = 0
-    for tree in ("events", "data", "meta"):
-        base = index_root / tree
-        if not base.is_dir():
-            continue
-        for sub in base.glob(f"*/*/{session_id}"):
-            item = PruneItem(
-                path=str(sub),
-                bytes=0,
-                tier=tier,
-                target=target,
-                action="delete",
-                reason="message index copy of pruned session",
-            )
-            try:
-                _, item.bytes = disposer.dispose_dir(sub)
-                item.outcome = "candidate" if disposer.dry_run else "done"
-                freed += item.bytes
-            except (OSError, ValueError) as exc:
-                item.outcome = "error"
-                item.error = str(exc)
-            manifest.add(item)
+    for sub in _message_index_subtrees(session_id):
+        item = PruneItem(
+            path=str(sub),
+            bytes=0,
+            tier=tier,
+            target=target,
+            action="delete",
+            reason="message index copy of pruned session",
+        )
+        try:
+            _, item.bytes = disposer.dispose_dir(sub)
+            item.outcome = "candidate" if disposer.dry_run else "done"
+            freed += item.bytes
+        except (OSError, ValueError) as exc:
+            item.outcome = "error"
+            item.error = str(exc)
+        manifest.add(item)
     return freed
 
 
-def _deep_clean_targets(wdir: Path) -> list[Path]:
+def _deep_clean_targets(wdir: Path) -> tuple[list[Path], bool]:
     """Everything :func:`deep_clean_worker` is responsible for removing.
 
     Used both to decide whether a previous run finished and to drive the
     deletion loop, so the two can never disagree.
+
+    Returns the targets and whether the scan actually completed. An
+    unreadable directory yields no targets, which is indistinguishable
+    from a finished worker unless the failure is reported separately --
+    and treating it as finished would strand the contents permanently.
     """
     targets: list[Path] = []
     for sub in ("conversations", "data"):
         p = wdir / sub
         if p.exists():
             targets.append(p)
+    scan_complete = True
     try:
         for p in wdir.iterdir():
             if p.is_file() and p.name not in _WORKER_KEEP_FILES:
                 targets.append(p)
     except OSError:
-        pass
-    return targets
+        scan_complete = False
+    return targets, scan_complete
 
 
 def deep_clean_worker(
@@ -683,8 +700,13 @@ def deep_clean_worker(
     result_path = wdir / "result.json"
 
     tombstone_exists = result_path.exists()
-    targets = _deep_clean_targets(wdir)
-    already_cleaned = tombstone_exists and not targets
+    targets, scan_complete = _deep_clean_targets(wdir)
+    # Index copies are removed further down, after this return, so a worker
+    # with no local targets left can still owe the index side. Skipping on
+    # an incomplete scan for the same reason: unknown is not done.
+    already_cleaned = (
+        tombstone_exists and scan_complete and not targets and not _message_index_subtrees(worker_id)
+    )
     if already_cleaned:
         return report
 

--- a/core/framework/maintenance/retention.py
+++ b/core/framework/maintenance/retention.py
@@ -642,6 +642,26 @@ def _delete_message_index_subtrees(session_id: str, disposer: Disposer, manifest
     return freed
 
 
+def _deep_clean_targets(wdir: Path) -> list[Path]:
+    """Everything :func:`deep_clean_worker` is responsible for removing.
+
+    Used both to decide whether a previous run finished and to drive the
+    deletion loop, so the two can never disagree.
+    """
+    targets: list[Path] = []
+    for sub in ("conversations", "data"):
+        p = wdir / sub
+        if p.exists():
+            targets.append(p)
+    try:
+        for p in wdir.iterdir():
+            if p.is_file() and p.name not in _WORKER_KEEP_FILES:
+                targets.append(p)
+    except OSError:
+        pass
+    return targets
+
+
 def deep_clean_worker(
     colony_id: str,
     worker_id: str,
@@ -654,13 +674,17 @@ def deep_clean_worker(
 
     Order is crash-safe: the tombstone is written before any deletion so
     (a) resume_worker refuses the worker from that point on and (b) a
-    rerun after a crash simply finishes the deletions.
+    rerun after a crash simply finishes the deletions. The short-circuit
+    for an already-cleaned worker therefore checks every target this
+    function removes, not just ``conversations/`` — a crash between two
+    targets would otherwise strand the rest permanently.
     """
     report = TargetReport(name="worker_deep_clean", tier=2)
     result_path = wdir / "result.json"
 
     tombstone_exists = result_path.exists()
-    already_cleaned = tombstone_exists and not (wdir / "conversations").exists()
+    targets = _deep_clean_targets(wdir)
+    already_cleaned = tombstone_exists and not targets
     if already_cleaned:
         return report
 
@@ -693,18 +717,6 @@ def deep_clean_worker(
         )
 
     report.bytes_freed += _delete_message_index_subtrees(worker_id, disposer, manifest, 2, "worker_deep_clean")
-
-    targets: list[Path] = []
-    for sub in ("conversations", "data"):
-        p = wdir / sub
-        if p.exists():
-            targets.append(p)
-    try:
-        for p in wdir.iterdir():
-            if p.is_file() and p.name not in _WORKER_KEEP_FILES:
-                targets.append(p)
-    except OSError:
-        pass
 
     for p in targets:
         item = PruneItem(

--- a/core/framework/maintenance/retention.py
+++ b/core/framework/maintenance/retention.py
@@ -665,11 +665,15 @@ def _deep_clean_targets(wdir: Path) -> tuple[list[Path], bool]:
     and treating it as finished would strand the contents permanently.
     """
     targets: list[Path] = []
+    scan_complete = True
     for sub in ("conversations", "data"):
         p = wdir / sub
-        if p.exists():
-            targets.append(p)
-    scan_complete = True
+        try:
+            if p.exists():
+                targets.append(p)
+        except OSError:
+            # Child probes can fail just like the root enumeration below.
+            scan_complete = False
     try:
         for p in wdir.iterdir():
             if p.is_file() and p.name not in _WORKER_KEEP_FILES:
@@ -704,9 +708,7 @@ def deep_clean_worker(
     # Index copies are removed further down, after this return, so a worker
     # with no local targets left can still owe the index side. Skipping on
     # an incomplete scan for the same reason: unknown is not done.
-    already_cleaned = (
-        tombstone_exists and scan_complete and not targets and not _message_index_subtrees(worker_id)
-    )
+    already_cleaned = tombstone_exists and scan_complete and not targets and not _message_index_subtrees(worker_id)
     if already_cleaned:
         return report
 

--- a/core/tests/test_janitor_worker_deepclean.py
+++ b/core/tests/test_janitor_worker_deepclean.py
@@ -364,3 +364,61 @@ def test_failed_target_scan_is_not_a_clean_worker(monkeypatch: pytest.MonkeyPatc
     targets, scan_complete = _retention._deep_clean_targets(wdir)
     assert targets == []
     assert scan_complete is False, "a failed scan must be reported, not swallowed"
+
+
+@pytest.mark.parametrize("failed_name", ["conversations", "data"])
+def test_child_stat_failure_marks_scan_incomplete(monkeypatch: pytest.MonkeyPatch, failed_name: str) -> None:
+    """A child existence probe can fail before root enumeration starts."""
+    from framework.maintenance import retention
+
+    wdir = _build_worker()
+    blocked = wdir / failed_name
+    healthy = wdir / ("data" if failed_name == "conversations" else "conversations")
+    real_exists = Path.exists
+
+    def fail_child_probe(self):
+        if self == blocked:
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_exists(self)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(Path, "exists", fail_child_probe)
+        targets, scan_complete = retention._deep_clean_targets(wdir)
+
+    assert scan_complete is False
+    assert blocked not in targets
+    assert healthy in targets, "one failed probe must not hide the other child"
+    assert all(p.name not in {"meta.json", "tasks.json", "result.json"} for p in targets)
+    targets, scan_complete = retention._deep_clean_targets(wdir)
+    assert scan_complete is True
+    assert blocked in targets and healthy in targets
+
+
+@pytest.mark.parametrize("failed_name", ["conversations", "data"])
+def test_child_stat_failure_allows_cleanup_and_retry(monkeypatch: pytest.MonkeyPatch, failed_name: str) -> None:
+    """Keep an unreadable child for retry without aborting known cleanup."""
+    wdir = _build_worker()
+    tombstone = b'{"status":"completed","summary":"preserve existing result"}'
+    (wdir / "result.json").write_bytes(tombstone)
+    blocked = wdir / failed_name
+    healthy = wdir / ("data" if failed_name == "conversations" else "conversations")
+    real_exists = Path.exists
+
+    def fail_child_probe(self):
+        if self == blocked:
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_exists(self)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(Path, "exists", fail_child_probe)
+        report = deep_clean_worker("c1", _WID, wdir, disposer=DeleteDisposer(), manifest=Manifest())
+
+    assert blocked.exists(), "the failed probe must not become a deletion target"
+    assert not healthy.exists()
+    assert not any(sub.exists() for sub in _index_subtrees())
+    assert report.bytes_freed > 0
+    assert (wdir / "result.json").read_bytes() == tombstone
+
+    deep_clean_worker("c1", _WID, wdir, disposer=DeleteDisposer(), manifest=Manifest())
+    assert sorted(p.name for p in wdir.iterdir()) == ["meta.json", "result.json", "tasks.json"]
+    assert (wdir / "result.json").read_bytes() == tombstone

--- a/core/tests/test_janitor_worker_deepclean.py
+++ b/core/tests/test_janitor_worker_deepclean.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import sys
 import tarfile
 import time
@@ -155,6 +156,65 @@ def test_crash_resume_converges() -> None:
     assert not (wdir / "data").exists()
     assert json.loads((wdir / "result.json").read_text(encoding="utf-8")) == tombstone
     assert report.bytes_freed > 0
+
+
+def test_crash_resume_after_conversations_removed() -> None:
+    """Crash landed between the conversations/ and data/ deletions.
+
+    The tombstone is written before any deletion, so a resume check that
+    only looks at conversations/ treats this worker as finished and leaves
+    data/ and the stray files unswept forever.
+    """
+    wdir = _build_worker()
+    tombstone = {"status": "completed", "summary": "s", "_janitor": {"pruned_at": "x"}}
+    (wdir / "result.json").write_text(json.dumps(tombstone), encoding="utf-8")
+    shutil.rmtree(wdir / "conversations")
+    _age_tree(wdir, 30)
+    assert (wdir / "data").exists()
+    assert (wdir / "os").exists()
+
+    report = deep_clean_worker("c1", _WID, wdir, disposer=DeleteDisposer(), manifest=Manifest())
+
+    assert not (wdir / "data").exists()
+    assert not (wdir / "os").exists()
+    assert not (wdir / "reminder_state.json").exists()
+    assert sorted(p.name for p in wdir.iterdir()) == ["meta.json", "result.json", "tasks.json"]
+    assert json.loads((wdir / "result.json").read_text(encoding="utf-8")) == tombstone
+    assert report.bytes_freed > 0
+
+
+def test_crash_resume_with_only_stray_files_left() -> None:
+    """Both subtrees gone but stray session-root files still present."""
+    wdir = _build_worker()
+    tombstone = {"status": "completed", "summary": "s", "_janitor": {"pruned_at": "x"}}
+    (wdir / "result.json").write_text(json.dumps(tombstone), encoding="utf-8")
+    shutil.rmtree(wdir / "conversations")
+    shutil.rmtree(wdir / "data")
+    _age_tree(wdir, 30)
+
+    report = deep_clean_worker("c1", _WID, wdir, disposer=DeleteDisposer(), manifest=Manifest())
+
+    assert sorted(p.name for p in wdir.iterdir()) == ["meta.json", "result.json", "tasks.json"]
+    assert report.files > 0
+
+
+def test_fully_cleaned_worker_short_circuits() -> None:
+    """Nothing left to remove: no work done, tombstone left untouched."""
+    wdir = _build_worker()
+    tombstone = {"status": "completed", "summary": "s", "_janitor": {"pruned_at": "x"}}
+    (wdir / "result.json").write_text(json.dumps(tombstone), encoding="utf-8")
+    shutil.rmtree(wdir / "conversations")
+    shutil.rmtree(wdir / "data")
+    (wdir / "os").unlink()
+    (wdir / "reminder_state.json").unlink()
+    _age_tree(wdir, 30)
+
+    report = deep_clean_worker("c1", _WID, wdir, disposer=DeleteDisposer(), manifest=Manifest())
+
+    assert report.files == 0
+    assert report.bytes_freed == 0
+    assert sorted(p.name for p in wdir.iterdir()) == ["meta.json", "result.json", "tasks.json"]
+    assert json.loads((wdir / "result.json").read_text(encoding="utf-8")) == tombstone
 
 
 def test_recent_worker_is_skipped() -> None:

--- a/core/tests/test_janitor_worker_deepclean.py
+++ b/core/tests/test_janitor_worker_deepclean.py
@@ -198,6 +198,12 @@ def test_crash_resume_with_only_stray_files_left() -> None:
     assert report.files > 0
 
 
+def _index_subtrees(wid: str = _WID, colony: str = "c1") -> list[Path]:
+    """The message-index copies _build_worker() plants for a worker."""
+    root = config.HIVE_HOME / ".message_index"
+    return [root / tree / "colonies" / colony / wid for tree in ("events", "data", "meta")]
+
+
 def test_fully_cleaned_worker_short_circuits() -> None:
     """Nothing left to remove: no work done, tombstone left untouched."""
     wdir = _build_worker()
@@ -207,6 +213,9 @@ def test_fully_cleaned_worker_short_circuits() -> None:
     shutil.rmtree(wdir / "data")
     (wdir / "os").unlink()
     (wdir / "reminder_state.json").unlink()
+    # Fully cleaned means the index side too, not just the worker directory.
+    for sub in _index_subtrees():
+        shutil.rmtree(sub)
     _age_tree(wdir, 30)
 
     report = deep_clean_worker("c1", _WID, wdir, disposer=DeleteDisposer(), manifest=Manifest())
@@ -299,3 +308,59 @@ def test_archive_failure_keeps_source(monkeypatch) -> None:
     with pytest.raises(OSError):
         disposer.dispose_dir(wdir / "conversations")
     assert (wdir / "conversations" / "parts" / "0000000004.json").exists()
+
+
+def test_pending_index_copies_block_the_short_circuit() -> None:
+    """Worker directory is clean but index copies remain: still work to do.
+
+    deep_clean_worker deletes the index subtrees *after* the short-circuit,
+    so a tombstoned worker with nothing left locally would otherwise return
+    early and strand them -- stranded bytes plus ghost search_messages hits.
+    """
+    wdir = _build_worker()
+    tombstone = {"status": "completed", "summary": "s", "_janitor": {"pruned_at": "x"}}
+    (wdir / "result.json").write_text(json.dumps(tombstone), encoding="utf-8")
+    shutil.rmtree(wdir / "conversations")
+    shutil.rmtree(wdir / "data")
+    (wdir / "os").unlink()
+    (wdir / "reminder_state.json").unlink()
+    _age_tree(wdir, 30)
+
+    assert all(sub.exists() for sub in _index_subtrees())
+
+    report = deep_clean_worker("c1", _WID, wdir, disposer=DeleteDisposer(), manifest=Manifest())
+
+    assert not any(sub.exists() for sub in _index_subtrees()), "index copies were stranded"
+    assert report.bytes_freed > 0
+    # The tombstone and keep-set are untouched by the index pass.
+    assert sorted(p.name for p in wdir.iterdir()) == ["meta.json", "result.json", "tasks.json"]
+
+
+def test_failed_target_scan_is_not_a_clean_worker(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unreadable worker directory must not read as 'already finished'.
+
+    iterdir() failing yields no targets, which is byte-identical to a
+    finished worker. Short-circuiting on that strands whatever is really
+    in there, permanently, because the tombstone stops any later pass.
+    """
+    from framework.maintenance import retention as _retention
+
+    wdir = _build_worker()
+    tombstone = {"status": "completed", "summary": "s", "_janitor": {"pruned_at": "x"}}
+    (wdir / "result.json").write_text(json.dumps(tombstone), encoding="utf-8")
+    shutil.rmtree(wdir / "conversations")
+    shutil.rmtree(wdir / "data")
+    _age_tree(wdir, 30)
+
+    real_iterdir = Path.iterdir
+
+    def boom(self):
+        if self == wdir:
+            raise OSError(13, "Permission denied")
+        return real_iterdir(self)
+
+    monkeypatch.setattr(Path, "iterdir", boom)
+
+    targets, scan_complete = _retention._deep_clean_targets(wdir)
+    assert targets == []
+    assert scan_complete is False, "a failed scan must be reported, not swallowed"


### PR DESCRIPTION
Fixes #7375

`deep_clean_worker()` removes three things — `conversations/`, `data/`, and stray session-root files — but its crash-resume short-circuit only asked about the first one:

```python
already_cleaned = tombstone_exists and not (wdir / "conversations").exists()
```

The tombstone is written before any deletion, so if the janitor dies between the `conversations/` and `data/` disposals, the next run sees a tombstone plus a missing `conversations/`, returns immediately, and nothing ever revisits that worker. `data/` and the stray files stay on disk permanently.

## Reproduction, against the unmodified function

Building a finished worker, writing the tombstone, removing `conversations/` — the exact state a crash between the two `for sub in ("conversations", "data")` iterations leaves behind — then running `deep_clean_worker()` again:

| | leftovers after the rerun |
| --- | --- |
| before | `['data', 'stray_session_file.log']` |
| after | `[]` |

## Change

The list of things this function is responsible for removing is now computed once, by a small helper, and used for both decisions:

```python
def _deep_clean_targets(wdir: Path) -> list[Path]:
    """Everything deep_clean_worker is responsible for removing."""
    ...

targets = _deep_clean_targets(wdir)
already_cleaned = tombstone_exists and not targets
```

The deletion loop then iterates that same list instead of rebuilding it, so the resume check and the loop cannot drift apart if a fourth target is ever added.

Moving the enumeration above the tombstone write is safe: `result.json` is in `_WORKER_KEEP_FILES`, so writing it never adds a target. Everything else — tombstone-first ordering, the keep-set, `_delete_message_index_subtrees`, dry-run behaviour, archive mode, per-target `try/except` — is untouched.

The docstring's crash-safety promise now holds as written, so I extended it to say what makes it hold rather than leaving the claim bare.

## Tests

Three cases added to `core/tests/test_janitor_worker_deepclean.py`:

- `test_crash_resume_after_conversations_removed` — the reported state. Asserts `data/`, the stray `os` file and `reminder_state.json` are all gone, only the keep-set remains, and the existing tombstone is preserved byte-for-byte.
- `test_crash_resume_with_only_stray_files_left` — both subtrees already gone, strays remaining.
- `test_fully_cleaned_worker_short_circuits` — nothing left to remove still does zero work and leaves the tombstone alone, so the fix does not turn the short-circuit into a no-op.

Run against the module before and after the change: the first two **fail** on the current code (`data/ still present`) and pass after; the third passes both ways, which is the point of including it.

The existing `test_crash_resume_converges` passes unchanged — it leaves `conversations/` in place, so it never reached this path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup recovery after interruptions, ensuring remaining worker data and pending index copies are removed on subsequent runs.
  - Prevented incomplete or failed scans from being treated as finished.
  - Preserved cleanup markers when no further work is required.
  - Ensured cleanup continues when leftover index data remains, even if the main worker directory appears clean.
  - Allowed healthy data to be cleaned while inaccessible data is retried later.

- **Tests**
  - Added coverage for interrupted cleanup, scan failures, resume scenarios, and pending index data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->