### PR TITLE
fix(quickstart): encode Python terminal output as UTF-8 (fixes #7203)

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -29,6 +29,16 @@ BOLD='\033[1m'
 DIM='\033[2m'
 NC='\033[0m' # No Color
 
+# Make Python encode terminal output as UTF-8.
+#
+# On Windows, Python encodes stdout/stderr with the ANSI code page (cp1252 on
+# most installs), so the check marks and box glyphs this script prints from its
+# inline `python -c` blocks raise UnicodeEncodeError and abort the run part-way
+# through setup. POSIX shells are already UTF-8, so this is a no-op there.
+# Only set when the caller has not chosen an encoding themselves.
+: "${PYTHONIOENCODING:=utf-8}"
+export PYTHONIOENCODING
+
 # Get the directory where this script is located
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -35,7 +35,9 @@ NC='\033[0m' # No Color
 # most installs), so the check marks and box glyphs this script prints from its
 # inline `python -c` blocks raise UnicodeEncodeError and abort the run part-way
 # through setup. POSIX shells are already UTF-8, so this is a no-op there.
-# Only set when the caller has not chosen an encoding themselves.
+# Only set when the caller has not already chosen an encoding. An empty
+# value is not a choice: Python ignores it and falls back to the ANSI code
+# page, which is the crash above, so `:=` defaults it too.
 : "${PYTHONIOENCODING:=utf-8}"
 export PYTHONIOENCODING
 


### PR DESCRIPTION
Fixes #7203

Claimed on the issue first per the assignment policy: https://github.com/aden-hive/hive/issues/7203#issuecomment-5562433369 — still unassigned at the time of opening, so I expect the linked-issue check to stay red until a maintainer assigns it. Flagging that rather than working around it.

### Cause

`quickstart.sh` prints its progress markers from inline `python -c` blocks. Step 3 (lines 463–491) does:

```python
print(f'{GREEN}  ✓ {label}{NC}')
```

On Windows, Python encodes stdout with the ANSI code page instead of UTF-8, so `✓` (U+2713) has no representation, the write raises `UnicodeEncodeError`, and `set -e` aborts setup part-way through.

Step 3 is only where it bites first. The same failure is latent in every other inline Python block in the script that prints a glyph (`⚠`, `✗`, the box characters), so patching just the Step 3 heredoc would leave the rest to trip later in the wizard.

### Change

One block after the colour definitions, so every Python subprocess the script spawns inherits it:

```bash
: "${PYTHONIOENCODING:=utf-8}"
export PYTHONIOENCODING
```

Ten lines added, nothing removed or reordered.

`PYTHONIOENCODING` rather than the `PYTHONUTF8=1` from the workaround in the issue: `PYTHONUTF8` also changes the default encoding for file I/O, which reaches well beyond this bug and overlaps ground issues 505, 1161 and 1676 already covered, while `PYTHONIOENCODING` touches only stdin/stdout/stderr — which is exactly what fails here. `:=` leaves an encoding the caller set themselves alone. UTF-8 can encode every character, so this closes the failure mode rather than narrowing it.

Happy to switch to `PYTHONUTF8` if you'd rather have the broader setting, or move the block elsewhere in the script.

### Verification

Run on the platform from the report — Windows 11, Git Bash, Python 3.12.10, `sys.stdout.encoding` = `cp1252`:

```
$ python -c "print('  ✓ framework imports OK')"
UnicodeEncodeError: 'charmap' codec can't encode character '\u2713' in position 2: character maps to <undefined>
exit=1

$ PYTHONIOENCODING=utf-8 python -c "print('  ✓ framework imports OK')"
  ✓ framework imports OK
exit=0
```

Also checked:

- `bash -n quickstart.sh` on the patched file parses clean
- the defaulting idiom preserves a caller's value (verified with `PYTHONIOENCODING=latin-1` preset)
- a child `python` under the export reports `stdout enc: utf-8`

No test added: this is shell-level environment setup for the onboarding script, and there's no harness covering `quickstart.sh` to hang one off. The three checks above are what I could verify directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line output compatibility by defaulting Python subprocess encoding to UTF-8 when no encoding is configured, including when the setting is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->