### PR TITLE
fix: bug: LLMNode token usage still undercounted in success/error

### DIFF
--- a/core/framework/agent_loop/agent_loop.py
+++ b/core/framework/agent_loop/agent_loop.py
@@ -2041,7 +2041,9 @@ class AgentLoop(AgentProtocol):
             # 6d. Pre-turn compaction check (tiered)
             _compacted_this_iter = False
             if conversation.needs_compaction():
-                await self._compact(ctx, conversation, accumulator)
+                compact_input, compact_output = await self._compact(ctx, conversation, accumulator)
+                total_input_tokens += compact_input
+                total_output_tokens += compact_output
                 _compacted_this_iter = True
 
             # 6e. Run single LLM turn (with transient error retry)
@@ -2415,7 +2417,9 @@ class AgentLoop(AgentProtocol):
             # iteration's pre-turn compaction handles the bloat once the
             # user has actually responded.
             if not _compacted_this_iter and not user_input_requested and not queen_input_requested and conversation.needs_compaction():
-                await self._compact(ctx, conversation, accumulator)
+                compact_input, compact_output = await self._compact(ctx, conversation, accumulator)
+                total_input_tokens += compact_input
+                total_output_tokens += compact_output
 
             # Reset auto-block grace streak when real work happens
             if real_tool_results or outputs_set:
@@ -3974,7 +3978,9 @@ class AgentLoop(AgentProtocol):
                     "Pre-send guard: context at %.0f%% of budget, compacting",
                     conversation.usage_ratio() * 100,
                 )
-                await self._compact(ctx, conversation, accumulator)
+                compact_input, compact_output = await self._compact(ctx, conversation, accumulator)
+                token_counts["input"] += compact_input
+                token_counts["output"] += compact_output
 
             messages = conversation.to_llm_messages(getattr(ctx.llm, "model", None))
 
@@ -6762,7 +6768,7 @@ class AgentLoop(AgentProtocol):
         ctx: AgentContext,
         conversation: NodeConversation,
         accumulator: OutputAccumulator | None = None,
-    ) -> None:
+    ) -> tuple[int, int]:
         """Compact conversation history to stay within token budget.
 
         0. Microcompaction — count-based clearing of old compactable tool results.
@@ -6775,7 +6781,7 @@ class AgentLoop(AgentProtocol):
         # Reminder hook: let sources re-assert context that compaction
         # would otherwise summarize away (e.g. the open task list).
         await self._fire_reminder(ReminderPoint.PRE_COMPACT, ctx, conversation)
-        result = await compact(
+        compact_input, compact_output = await compact(
             ctx=ctx,
             conversation=conversation,
             accumulator=accumulator,
@@ -6789,7 +6795,7 @@ class AgentLoop(AgentProtocol):
         # post-summary context so the first post-compact turn has them — the
         # summary itself does not faithfully reproduce a tool/skill listing.
         await self._fire_reminder(ReminderPoint.POST_COMPACT, ctx, conversation)
-        return result
+        return compact_input, compact_output
 
     # --- LLM compaction with binary-search splitting ----------------------
 
@@ -6807,7 +6813,7 @@ class AgentLoop(AgentProtocol):
         in half and each half is summarised independently.  Tool history is
         appended once at the top-level call (``_depth == 0``).
         """
-        return await llm_compact(
+        summary, _, _ = await llm_compact(
             ctx=ctx,
             messages=messages,
             accumulator=accumulator,
@@ -6816,6 +6822,7 @@ class AgentLoop(AgentProtocol):
             max_depth=self._LLM_COMPACT_MAX_DEPTH,
             max_context_tokens=self._config.max_context_tokens,
         )
+        return summary
 
     # --- Compaction helpers ------------------------------------------------
 

--- a/core/framework/agent_loop/agent_loop.py
+++ b/core/framework/agent_loop/agent_loop.py
@@ -1337,6 +1337,20 @@ class AgentLoop(AgentProtocol):
         start_time = time.time()
         total_input_tokens = 0
         total_output_tokens = 0
+        iteration_tokens: dict[str, int] = {"input": 0, "output": 0}
+
+        def record_usage(input_tokens: int, output_tokens: int) -> None:
+            """Record usage immediately so later retry/error paths retain it."""
+            nonlocal total_input_tokens, total_output_tokens
+            if not isinstance(input_tokens, int):
+                input_tokens = 0
+            if not isinstance(output_tokens, int):
+                output_tokens = 0
+            total_input_tokens += input_tokens
+            total_output_tokens += output_tokens
+            iteration_tokens["input"] += input_tokens
+            iteration_tokens["output"] += output_tokens
+
         stream_id = ctx.stream_id or ctx.agent_id
         node_id = ctx.agent_id
         execution_id = ctx.execution_id or ""
@@ -1661,6 +1675,7 @@ class AgentLoop(AgentProtocol):
         )
         for iteration in range(start_iteration, _total_iterations):
             iter_start = time.time()
+            iteration_tokens = {"input": 0, "output": 0}
             # Flip into grace mode once the work budget is spent — by EITHER
             # the iteration budget OR the cumulative (lifetime) tool-call
             # budget (LoopConfig.tool_call_lifetime_budget; 0 disables). The
@@ -2032,18 +2047,19 @@ class AgentLoop(AgentProtocol):
             # prune/summary budgets instead of collapsing to 32k under them.
             from framework.config import get_max_context_tokens as _live_mct
 
-            conversation._max_context_tokens = _live_mct(
-                fallback=self._config.max_context_tokens
-            )
+            conversation._max_context_tokens = _live_mct(fallback=self._config.max_context_tokens)
 
             await self._publish_context_usage(ctx, conversation, "iteration_start", tools=tools)
 
             # 6d. Pre-turn compaction check (tiered)
             _compacted_this_iter = False
             if conversation.needs_compaction():
-                compact_input, compact_output = await self._compact(ctx, conversation, accumulator)
-                total_input_tokens += compact_input
-                total_output_tokens += compact_output
+                await self._compact(
+                    ctx,
+                    conversation,
+                    accumulator,
+                    usage_callback=record_usage,
+                )
                 _compacted_this_iter = True
 
             # 6e. Run single LLM turn (with transient error retry)
@@ -2083,7 +2099,14 @@ class AgentLoop(AgentProtocol):
                         request_system_prompt,
                         request_messages,
                         _,
-                    ) = await self._run_turn_loop(ctx, conversation, tools, iteration, accumulator)
+                    ) = await self._run_turn_loop(
+                        ctx,
+                        conversation,
+                        tools,
+                        iteration,
+                        accumulator,
+                        usage_callback=record_usage,
+                    )
                     logger.debug(
                         "[AgentLoop.execute] iteration=%d: _run_turn_loop completed successfully",
                         iteration,
@@ -2106,9 +2129,6 @@ class AgentLoop(AgentProtocol):
                         turn_tokens,
                         {k: ("set" if v is not None else "None") for k, v in accumulator.to_dict().items()},
                     )
-                    total_input_tokens += turn_tokens.get("input", 0)
-                    total_output_tokens += turn_tokens.get("output", 0)
-
                     # Reminder STOP point: the turn loop just ended on a
                     # text-only turn (no tool result to ride a tail on),
                     # so fire STOP as an injected message. Per-turn drift
@@ -2319,6 +2339,17 @@ class AgentLoop(AgentProtocol):
                                 inner_turn=0,
                             )
                         await conversation.add_assistant_message(visible_error)
+                        if ctx.runtime_logger:
+                            ctx.runtime_logger.log_step(
+                                node_id=node_id,
+                                node_type="event_loop",
+                                step_index=iteration,
+                                error=error_msg,
+                                is_partial=True,
+                                input_tokens=iteration_tokens.get("input", 0),
+                                output_tokens=iteration_tokens.get("output", 0),
+                                latency_ms=int((time.time() - iter_start) * 1000),
+                            )
                         await self._await_user_input(ctx, reason=ParkReason.LLM_ERROR)
                         _llm_turn_failed_waiting_input = True
                         break  # exit retry loop, continue outer iteration
@@ -2339,8 +2370,8 @@ class AgentLoop(AgentProtocol):
                             error=error_msg,
                             stacktrace=stack_trace,
                             is_partial=True,
-                            input_tokens=0,
-                            output_tokens=0,
+                            input_tokens=iteration_tokens.get("input", 0),
+                            output_tokens=iteration_tokens.get("output", 0),
                             latency_ms=iter_latency_ms,
                         )
                         ctx.runtime_logger.log_node_complete(
@@ -2367,6 +2398,17 @@ class AgentLoop(AgentProtocol):
 
             if _turn_cancelled:
                 logger.info("[%s] iter=%d: turn cancelled by user", node_id, iteration)
+                if ctx.runtime_logger:
+                    ctx.runtime_logger.log_step(
+                        node_id=node_id,
+                        node_type="event_loop",
+                        step_index=iteration,
+                        error="Turn cancelled by user",
+                        is_partial=True,
+                        input_tokens=iteration_tokens.get("input", 0),
+                        output_tokens=iteration_tokens.get("output", 0),
+                        latency_ms=int((time.time() - iter_start) * 1000),
+                    )
                 if ctx.supports_direct_user_io:
                     # Persist the user-stop park BEFORE we block. Without
                     # this, killing the runtime mid-wait loses both the
@@ -2417,9 +2459,12 @@ class AgentLoop(AgentProtocol):
             # iteration's pre-turn compaction handles the bloat once the
             # user has actually responded.
             if not _compacted_this_iter and not user_input_requested and not queen_input_requested and conversation.needs_compaction():
-                compact_input, compact_output = await self._compact(ctx, conversation, accumulator)
-                total_input_tokens += compact_input
-                total_output_tokens += compact_output
+                await self._compact(
+                    ctx,
+                    conversation,
+                    accumulator,
+                    usage_callback=record_usage,
+                )
 
             # Reset auto-block grace streak when real work happens
             if real_tool_results or outputs_set:
@@ -2548,8 +2593,8 @@ class AgentLoop(AgentProtocol):
                         verdict_feedback="Stall detected before judge evaluation",
                         tool_calls=logged_tool_calls,
                         llm_text=assistant_text,
-                        input_tokens=turn_tokens.get("input", 0),
-                        output_tokens=turn_tokens.get("output", 0),
+                        input_tokens=iteration_tokens.get("input", 0),
+                        output_tokens=iteration_tokens.get("output", 0),
                         latency_ms=iter_latency_ms,
                     )
                     ctx.runtime_logger.log_node_complete(
@@ -2731,8 +2776,8 @@ class AgentLoop(AgentProtocol):
                             verdict_feedback=(f"Worker stall grace ({_worker_text_only_streak}/{self._config.worker_escalation_grace_turns})"),
                             tool_calls=logged_tool_calls,
                             llm_text=assistant_text,
-                            input_tokens=turn_tokens.get("input", 0),
-                            output_tokens=turn_tokens.get("output", 0),
+                            input_tokens=iteration_tokens.get("input", 0),
+                            output_tokens=iteration_tokens.get("output", 0),
                             latency_ms=iter_latency_ms,
                         )
                     continue
@@ -2797,8 +2842,8 @@ class AgentLoop(AgentProtocol):
                             verdict_feedback=(f"Auto-failed: stall {_worker_text_only_streak}/{self._config.worker_escalation_grace_turns}"),
                             tool_calls=logged_tool_calls,
                             llm_text=assistant_text,
-                            input_tokens=turn_tokens.get("input", 0),
-                            output_tokens=turn_tokens.get("output", 0),
+                            input_tokens=iteration_tokens.get("input", 0),
+                            output_tokens=iteration_tokens.get("output", 0),
                             latency_ms=iter_latency_ms,
                         )
                     continue
@@ -2902,8 +2947,8 @@ class AgentLoop(AgentProtocol):
                                     verdict_feedback=(f"Auto-block grace ({_cf_text_only_streak}/{self._config.cf_grace_turns})"),
                                     tool_calls=logged_tool_calls,
                                     llm_text=assistant_text,
-                                    input_tokens=turn_tokens.get("input", 0),
-                                    output_tokens=turn_tokens.get("output", 0),
+                                    input_tokens=iteration_tokens.get("input", 0),
+                                    output_tokens=iteration_tokens.get("output", 0),
                                     latency_ms=iter_latency_ms,
                                 )
                             continue
@@ -2924,8 +2969,8 @@ class AgentLoop(AgentProtocol):
                             verdict_feedback="Shutdown signaled (queen interaction)",
                             tool_calls=logged_tool_calls,
                             llm_text=assistant_text,
-                            input_tokens=turn_tokens.get("input", 0),
-                            output_tokens=turn_tokens.get("output", 0),
+                            input_tokens=iteration_tokens.get("input", 0),
+                            output_tokens=iteration_tokens.get("output", 0),
                             latency_ms=iter_latency_ms,
                         )
                         ctx.runtime_logger.log_node_complete(
@@ -3021,8 +3066,8 @@ class AgentLoop(AgentProtocol):
                             verdict_feedback="No input received (shutdown during wait)",
                             tool_calls=logged_tool_calls,
                             llm_text=assistant_text,
-                            input_tokens=turn_tokens.get("input", 0),
-                            output_tokens=turn_tokens.get("output", 0),
+                            input_tokens=iteration_tokens.get("input", 0),
+                            output_tokens=iteration_tokens.get("output", 0),
                             latency_ms=iter_latency_ms,
                         )
                         ctx.runtime_logger.log_node_complete(
@@ -3108,7 +3153,7 @@ class AgentLoop(AgentProtocol):
                             "Blocked for ask_user input (skip judge)",
                             logged_tool_calls,
                             assistant_text,
-                            turn_tokens,
+                            iteration_tokens,
                             iter_start,
                         )
                         continue
@@ -3134,7 +3179,7 @@ class AgentLoop(AgentProtocol):
                         "Shutdown signaled (waiting for queen input)",
                         logged_tool_calls,
                         assistant_text,
-                        turn_tokens,
+                        iteration_tokens,
                         iter_start,
                     )
                     if ctx.runtime_logger:
@@ -3207,7 +3252,7 @@ class AgentLoop(AgentProtocol):
                         "No queen input received (shutdown during wait)",
                         logged_tool_calls,
                         assistant_text,
-                        turn_tokens,
+                        iteration_tokens,
                         iter_start,
                     )
                     if ctx.runtime_logger:
@@ -3256,7 +3301,7 @@ class AgentLoop(AgentProtocol):
                     "Blocked for queen input (skip judge)",
                     logged_tool_calls,
                     assistant_text,
-                    turn_tokens,
+                    iteration_tokens,
                     iter_start,
                 )
                 continue
@@ -3277,7 +3322,7 @@ class AgentLoop(AgentProtocol):
                     "Unjudged (judge_every_n_turns skip)",
                     logged_tool_calls,
                     assistant_text,
-                    turn_tokens,
+                    iteration_tokens,
                     iter_start,
                 )
                 continue
@@ -3290,6 +3335,10 @@ class AgentLoop(AgentProtocol):
                 assistant_text,
                 real_tool_results,
                 iteration,
+            )
+            record_usage(
+                getattr(verdict, "input_tokens", 0),
+                getattr(verdict, "output_tokens", 0),
             )
             fb_preview = (verdict.feedback or "")[:200]
             logger.info(
@@ -3338,8 +3387,8 @@ class AgentLoop(AgentProtocol):
                             verdict_feedback=(f"Judge accepted but missing output keys: {missing}"),
                             tool_calls=logged_tool_calls,
                             llm_text=assistant_text,
-                            input_tokens=turn_tokens.get("input", 0),
-                            output_tokens=turn_tokens.get("output", 0),
+                            input_tokens=iteration_tokens.get("input", 0),
+                            output_tokens=iteration_tokens.get("output", 0),
                             latency_ms=iter_latency_ms,
                         )
                     continue
@@ -3362,8 +3411,8 @@ class AgentLoop(AgentProtocol):
                         verdict_feedback=verdict.feedback or "",
                         tool_calls=logged_tool_calls,
                         llm_text=assistant_text,
-                        input_tokens=turn_tokens.get("input", 0),
-                        output_tokens=turn_tokens.get("output", 0),
+                        input_tokens=iteration_tokens.get("input", 0),
+                        output_tokens=iteration_tokens.get("output", 0),
                         latency_ms=iter_latency_ms,
                     )
                     ctx.runtime_logger.log_node_complete(
@@ -3405,8 +3454,8 @@ class AgentLoop(AgentProtocol):
                         verdict_feedback=verdict.feedback or "",
                         tool_calls=logged_tool_calls,
                         llm_text=assistant_text,
-                        input_tokens=turn_tokens.get("input", 0),
-                        output_tokens=turn_tokens.get("output", 0),
+                        input_tokens=iteration_tokens.get("input", 0),
+                        output_tokens=iteration_tokens.get("output", 0),
                         latency_ms=iter_latency_ms,
                     )
                     ctx.runtime_logger.log_node_complete(
@@ -3447,8 +3496,8 @@ class AgentLoop(AgentProtocol):
                         verdict_feedback=verdict.feedback or "",
                         tool_calls=logged_tool_calls,
                         llm_text=assistant_text,
-                        input_tokens=turn_tokens.get("input", 0),
-                        output_tokens=turn_tokens.get("output", 0),
+                        input_tokens=iteration_tokens.get("input", 0),
+                        output_tokens=iteration_tokens.get("output", 0),
                         latency_ms=iter_latency_ms,
                     )
                 if verdict.feedback is not None:
@@ -3871,6 +3920,7 @@ class AgentLoop(AgentProtocol):
         tools: list[Tool],
         iteration: int,
         accumulator: OutputAccumulator,
+        usage_callback: Callable[[int, int], None] | None = None,
     ) -> tuple[
         str,
         list[dict],
@@ -3922,6 +3972,18 @@ class AgentLoop(AgentProtocol):
             "cost": 0.0,
             "credits": None,
         }
+
+        def record_turn_usage(input_tokens: int, output_tokens: int) -> None:
+            """Record each completed request before later turn work can fail."""
+            if not isinstance(input_tokens, int):
+                input_tokens = 0
+            if not isinstance(output_tokens, int):
+                output_tokens = 0
+            token_counts["input"] += input_tokens
+            token_counts["output"] += output_tokens
+            if usage_callback is not None:
+                usage_callback(input_tokens, output_tokens)
+
         # Running tool-call count for this turn-loop (one judge
         # iteration). Drives both the soft checkpoint reminders and the
         # hard stop; resets here, per turn-loop. `soft_budget_reminders`
@@ -3978,9 +4040,12 @@ class AgentLoop(AgentProtocol):
                     "Pre-send guard: context at %.0f%% of budget, compacting",
                     conversation.usage_ratio() * 100,
                 )
-                compact_input, compact_output = await self._compact(ctx, conversation, accumulator)
-                token_counts["input"] += compact_input
-                token_counts["output"] += compact_output
+                await self._compact(
+                    ctx,
+                    conversation,
+                    accumulator,
+                    usage_callback=record_turn_usage,
+                )
 
             messages = conversation.to_llm_messages(getattr(ctx.llm, "model", None))
 
@@ -4252,8 +4317,7 @@ class AgentLoop(AgentProtocol):
                         # delta; flush any accumulated reasoning here so it
                         # still reaches monitors.
                         await _flush_reasoning()
-                        token_counts["input"] += event.input_tokens
-                        token_counts["output"] += event.output_tokens
+                        record_turn_usage(event.input_tokens, event.output_tokens)
                         token_counts["cached"] += event.cached_tokens
                         token_counts["cache_creation"] += event.cache_creation_tokens
                         token_counts["cost"] = token_counts.get("cost", 0.0) + event.cost_usd
@@ -6581,7 +6645,7 @@ class AgentLoop(AgentProtocol):
                 # shield: a grace-window timeout must not cancel the in-flight
                 # work — it still has the full `timeout` budget to finish in.
                 result = await asyncio.wait_for(asyncio.shield(task), timeout=grace)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 pass  # genuinely slow — fall through and hand back the handle
             except Exception:
                 # Failed fast. Let collect_result surface it rather than
@@ -6768,6 +6832,7 @@ class AgentLoop(AgentProtocol):
         ctx: AgentContext,
         conversation: NodeConversation,
         accumulator: OutputAccumulator | None = None,
+        usage_callback: Callable[[int, int], None] | None = None,
     ) -> tuple[int, int]:
         """Compact conversation history to stay within token budget.
 
@@ -6787,6 +6852,7 @@ class AgentLoop(AgentProtocol):
             accumulator=accumulator,
             config=self._config,
             event_bus=self._event_bus,
+            usage_callback=usage_callback,
             char_limit=self._compact_char_limit(),
             max_depth=self._LLM_COMPACT_MAX_DEPTH,
         )
@@ -7172,7 +7238,7 @@ class AgentLoop(AgentProtocol):
         feedback: str,
         tool_calls: list[dict],
         llm_text: str,
-        turn_tokens: dict[str, int],
+        iteration_tokens: dict[str, int],
         iter_start: float,
     ) -> None:
         """Log a CONTINUE step that skips judge evaluation (e.g., waiting for input)."""
@@ -7183,7 +7249,7 @@ class AgentLoop(AgentProtocol):
             feedback=feedback,
             tool_calls=tool_calls,
             llm_text=llm_text,
-            turn_tokens=turn_tokens,
+            iteration_tokens=iteration_tokens,
             iter_start=iter_start,
         )
 

--- a/core/framework/agent_loop/internals/compaction.py
+++ b/core/framework/agent_loop/internals/compaction.py
@@ -324,7 +324,7 @@ async def compact(
     event_bus: EventBus | None,
     char_limit: int | None = None,
     max_depth: int = LLM_COMPACT_MAX_DEPTH,
-) -> None:
+) -> tuple[int, int]:
     """Run the full compaction pipeline if conversation needs compaction.
 
     Pipeline stages (in order, short-circuits when budget is restored):
@@ -334,6 +334,8 @@ async def compact(
     3. Emergency deterministic summary (fallback)
     """
     conv_id = id(conversation)
+    llm_input_tokens = 0
+    llm_output_tokens = 0
 
     # Circuit breaker: stop LLM-based compaction after repeated failures,
     # but still fall through to the emergency deterministic summary so
@@ -417,7 +419,7 @@ async def compact(
             event_bus,
             pre_inventory=pre_inventory,
         )
-        return
+        return 0, 0
 
     # --- Step 1: Prune old tool results (free, fast) ---
     protect = max(2000, config.max_context_tokens // 12)
@@ -441,7 +443,7 @@ async def compact(
             event_bus,
             pre_inventory=pre_inventory,
         )
-        return
+        return 0, 0
 
     # --- Step 2: LLM summary compaction ---
     if ctx.llm is not None and not _llm_compaction_skipped:
@@ -450,7 +452,7 @@ async def compact(
             conversation.usage_ratio() * 100,
         )
         try:
-            summary = await llm_compact(
+            summary, compact_input, compact_output = await llm_compact(
                 ctx,
                 list(conversation.messages),
                 accumulator,
@@ -458,6 +460,8 @@ async def compact(
                 max_depth=max_depth,
                 max_context_tokens=config.max_context_tokens,
             )
+            llm_input_tokens += compact_input
+            llm_output_tokens += compact_output
             await conversation.compact(
                 summary,
                 keep_recent=2,
@@ -491,6 +495,7 @@ async def compact(
         event_bus,
         pre_inventory=pre_inventory,
     )
+    return llm_input_tokens, llm_output_tokens
 
 
 def _record_success(conv_id: int, timestamp: float) -> None:
@@ -543,7 +548,7 @@ async def llm_compact(
     max_depth: int = LLM_COMPACT_MAX_DEPTH,
     max_context_tokens: int = 128_000,
     preserve_user_messages: bool = False,
-) -> str:
+) -> tuple[str, int, int]:
     """Summarise *messages* with LLM, splitting recursively if too large.
 
     If the formatted text exceeds the window-derived char limit or the LLM
@@ -569,10 +574,12 @@ async def llm_compact(
         messages = strip_images_from_messages(messages)
 
     formatted = format_messages_for_summary(messages)
+    input_tokens = 0
+    output_tokens = 0
 
     # Proactive split: avoid wasting an API call on oversized input
     if len(formatted) > char_limit and len(messages) > 1:
-        summary = await _llm_compact_split(
+        summary, input_tokens, output_tokens = await _llm_compact_split(
             ctx,
             messages,
             accumulator,
@@ -625,6 +632,8 @@ async def llm_compact(
                 max_tokens=summary_budget,
             )
             summary = response.content
+            input_tokens = response.input_tokens
+            output_tokens = response.output_tokens
         except Exception as e:
             if is_context_too_large_error(e) and len(messages) > 1:
                 logger.info(
@@ -632,7 +641,7 @@ async def llm_compact(
                     _depth,
                     len(messages),
                 )
-                summary = await _llm_compact_split(
+                summary, input_tokens, output_tokens = await _llm_compact_split(
                     ctx,
                     messages,
                     accumulator,
@@ -651,7 +660,7 @@ async def llm_compact(
         if tool_history and "TOOLS ALREADY CALLED" not in summary:
             summary += "\n\n" + tool_history
 
-    return summary
+    return summary, input_tokens, output_tokens
 
 
 async def _llm_compact_split(
@@ -664,12 +673,12 @@ async def _llm_compact_split(
     max_depth: int = LLM_COMPACT_MAX_DEPTH,
     max_context_tokens: int = 128_000,
     preserve_user_messages: bool = False,
-) -> str:
+) -> tuple[str, int, int]:
     """Split messages in half and summarise each half independently."""
     if char_limit is None:
         char_limit = llm_compact_char_limit(max_context_tokens)
     mid = max(1, len(messages) // 2)
-    s1 = await llm_compact(
+    s1, in1, out1 = await llm_compact(
         ctx,
         messages[:mid],
         None,
@@ -679,7 +688,7 @@ async def _llm_compact_split(
         max_context_tokens=max_context_tokens,
         preserve_user_messages=preserve_user_messages,
     )
-    s2 = await llm_compact(
+    s2, in2, out2 = await llm_compact(
         ctx,
         messages[mid:],
         accumulator,
@@ -689,7 +698,7 @@ async def _llm_compact_split(
         max_context_tokens=max_context_tokens,
         preserve_user_messages=preserve_user_messages,
     )
-    return s1 + "\n\n" + s2
+    return s1 + "\n\n" + s2, in1 + in2, out1 + out2
 
 
 # --- Compaction helpers ------------------------------------------------

--- a/core/framework/agent_loop/internals/compaction.py
+++ b/core/framework/agent_loop/internals/compaction.py
@@ -16,6 +16,7 @@ import logging
 import os
 import re
 import time
+from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any
 
@@ -41,6 +42,8 @@ def llm_compact_char_limit(max_context_tokens: int) -> int:
     keeps tiny windows from splitting into confetti.
     """
     return max(20_000, (max_context_tokens * 4) // 3)
+
+
 # Max output tokens for a single compaction summary call. A summary must be a
 # small fraction of the window — using ``max_context_tokens // 2`` (e.g. 90k on a
 # 180k window) lets the model emit a "summary" nearly as large as the input, which
@@ -322,6 +325,7 @@ async def compact(
     *,
     config: LoopConfig,
     event_bus: EventBus | None,
+    usage_callback: Callable[[int, int], None] | None = None,
     char_limit: int | None = None,
     max_depth: int = LLM_COMPACT_MAX_DEPTH,
 ) -> tuple[int, int]:
@@ -336,6 +340,14 @@ async def compact(
     conv_id = id(conversation)
     llm_input_tokens = 0
     llm_output_tokens = 0
+
+    def record_llm_usage(input_tokens: int, output_tokens: int) -> None:
+        """Keep usage visible if a later compaction step fails."""
+        nonlocal llm_input_tokens, llm_output_tokens
+        llm_input_tokens += input_tokens
+        llm_output_tokens += output_tokens
+        if usage_callback is not None:
+            usage_callback(input_tokens, output_tokens)
 
     # Circuit breaker: stop LLM-based compaction after repeated failures,
     # but still fall through to the emergency deterministic summary so
@@ -452,16 +464,15 @@ async def compact(
             conversation.usage_ratio() * 100,
         )
         try:
-            summary, compact_input, compact_output = await llm_compact(
+            summary, _, _ = await llm_compact(
                 ctx,
                 list(conversation.messages),
                 accumulator,
                 char_limit=char_limit,
                 max_depth=max_depth,
                 max_context_tokens=config.max_context_tokens,
+                usage_callback=record_llm_usage,
             )
-            llm_input_tokens += compact_input
-            llm_output_tokens += compact_output
             await conversation.compact(
                 summary,
                 keep_recent=2,
@@ -548,6 +559,7 @@ async def llm_compact(
     max_depth: int = LLM_COMPACT_MAX_DEPTH,
     max_context_tokens: int = 128_000,
     preserve_user_messages: bool = False,
+    usage_callback: Callable[[int, int], None] | None = None,
 ) -> tuple[str, int, int]:
     """Summarise *messages* with LLM, splitting recursively if too large.
 
@@ -588,6 +600,7 @@ async def llm_compact(
             max_depth=max_depth,
             max_context_tokens=max_context_tokens,
             preserve_user_messages=preserve_user_messages,
+            usage_callback=usage_callback,
         )
     else:
         prompt = build_llm_compaction_prompt(
@@ -632,8 +645,12 @@ async def llm_compact(
                 max_tokens=summary_budget,
             )
             summary = response.content
-            input_tokens = response.input_tokens
-            output_tokens = response.output_tokens
+            response_input_tokens = getattr(response, "input_tokens", 0)
+            response_output_tokens = getattr(response, "output_tokens", 0)
+            input_tokens = response_input_tokens if isinstance(response_input_tokens, int) else 0
+            output_tokens = response_output_tokens if isinstance(response_output_tokens, int) else 0
+            if usage_callback is not None:
+                usage_callback(input_tokens, output_tokens)
         except Exception as e:
             if is_context_too_large_error(e) and len(messages) > 1:
                 logger.info(
@@ -650,6 +667,7 @@ async def llm_compact(
                     max_depth=max_depth,
                     max_context_tokens=max_context_tokens,
                     preserve_user_messages=preserve_user_messages,
+                    usage_callback=usage_callback,
                 )
             else:
                 raise
@@ -673,6 +691,7 @@ async def _llm_compact_split(
     max_depth: int = LLM_COMPACT_MAX_DEPTH,
     max_context_tokens: int = 128_000,
     preserve_user_messages: bool = False,
+    usage_callback: Callable[[int, int], None] | None = None,
 ) -> tuple[str, int, int]:
     """Split messages in half and summarise each half independently."""
     if char_limit is None:
@@ -687,6 +706,7 @@ async def _llm_compact_split(
         max_depth=max_depth,
         max_context_tokens=max_context_tokens,
         preserve_user_messages=preserve_user_messages,
+        usage_callback=usage_callback,
     )
     s2, in2, out2 = await llm_compact(
         ctx,
@@ -697,6 +717,7 @@ async def _llm_compact_split(
         max_depth=max_depth,
         max_context_tokens=max_context_tokens,
         preserve_user_messages=preserve_user_messages,
+        usage_callback=usage_callback,
     )
     return s1 + "\n\n" + s2, in1 + in2, out1 + out2
 

--- a/core/framework/agent_loop/internals/event_publishing.py
+++ b/core/framework/agent_loop/internals/event_publishing.py
@@ -98,7 +98,7 @@ def log_skip_judge(
     feedback: str,
     tool_calls: list[dict],
     llm_text: str,
-    turn_tokens: dict[str, int],
+    iteration_tokens: dict[str, int],
     iter_start: float,
 ) -> None:
     """Log a CONTINUE step that skips judge evaluation (e.g., waiting for input)."""
@@ -111,8 +111,8 @@ def log_skip_judge(
             verdict_feedback=feedback,
             tool_calls=tool_calls,
             llm_text=llm_text,
-            input_tokens=turn_tokens.get("input", 0),
-            output_tokens=turn_tokens.get("output", 0),
+            input_tokens=iteration_tokens.get("input", 0),
+            output_tokens=iteration_tokens.get("output", 0),
             latency_ms=int((time.time() - iter_start) * 1000),
         )
 

--- a/core/framework/agent_loop/internals/judge_pipeline.py
+++ b/core/framework/agent_loop/internals/judge_pipeline.py
@@ -92,7 +92,12 @@ async def judge_turn(
         verdict = await judge.evaluate(context)
         # Ensure evaluated RETRY always carries feedback for logging.
         if verdict.action == "RETRY" and not verdict.feedback:
-            return JudgeVerdict(action="RETRY", feedback="Custom judge returned RETRY.")
+            return JudgeVerdict(
+                action="RETRY",
+                feedback="Custom judge returned RETRY.",
+                input_tokens=verdict.input_tokens,
+                output_tokens=verdict.output_tokens,
+            )
         return verdict
 
     # --- Level 2: implicit judge ---------------------------------------
@@ -140,6 +145,14 @@ async def judge_turn(
             return JudgeVerdict(
                 action=verdict.action,
                 feedback=verdict.feedback or "Phase criteria not met.",
+                input_tokens=verdict.input_tokens,
+                output_tokens=verdict.output_tokens,
             )
+        return JudgeVerdict(
+            action="ACCEPT",
+            feedback="",
+            input_tokens=verdict.input_tokens,
+            output_tokens=verdict.output_tokens,
+        )
 
     return JudgeVerdict(action="ACCEPT", feedback="")

--- a/core/framework/agent_loop/internals/types.py
+++ b/core/framework/agent_loop/internals/types.py
@@ -36,6 +36,10 @@ class JudgeVerdict:
     # ""    = evaluated but no feedback; logged with default text.
     # "..." = evaluated with feedback; logged as-is.
     feedback: str | None = None
+    # Usage from an optional validation LLM call. Custom judges can leave these
+    # at zero; the implicit quality judge populates them.
+    input_tokens: int = 0
+    output_tokens: int = 0
 
 
 @runtime_checkable

--- a/core/framework/orchestrator/conversation_judge.py
+++ b/core/framework/orchestrator/conversation_judge.py
@@ -28,6 +28,8 @@ class PhaseVerdict:
     action: str  # "ACCEPT" or "RETRY"
     confidence: float = 0.8
     feedback: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
 
 
 async def evaluate_phase_completion(
@@ -91,10 +93,23 @@ FEEDBACK: (reason if RETRY, empty if ACCEPT)"""
             max_tokens=max(1024, max_context_tokens // 5),
             max_retries=1,
         )
+        response_input_tokens = getattr(response, "input_tokens", 0)
+        response_output_tokens = getattr(response, "output_tokens", 0)
+        input_tokens = response_input_tokens if isinstance(response_input_tokens, int) else 0
+        output_tokens = response_output_tokens if isinstance(response_output_tokens, int) else 0
         if not response.content or not response.content.strip():
             logger.debug("Level 2 judge: empty response, accepting by default")
-            return PhaseVerdict(action="ACCEPT", confidence=0.5, feedback="")
-        return _parse_verdict(response.content)
+            return PhaseVerdict(
+                action="ACCEPT",
+                confidence=0.5,
+                feedback="",
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+            )
+        verdict = _parse_verdict(response.content)
+        verdict.input_tokens = input_tokens
+        verdict.output_tokens = output_tokens
+        return verdict
     except Exception as e:
         logger.warning(f"Level 2 judge failed, accepting by default: {e}")
         # On failure, don't block — Level 0 already passed

--- a/core/framework/server/routes_execution.py
+++ b/core/framework/server/routes_execution.py
@@ -1193,7 +1193,7 @@ async def _compact_queen_conversation_in_place(
     if loop_cfg is not None and getattr(loop_cfg, "max_context_tokens", None):
         max_ctx_tokens = int(loop_cfg.max_context_tokens)
 
-    summary = await llm_compact(
+    summary, _, _ = await llm_compact(
         queen_ctx,
         messages,
         accumulator=None,

--- a/core/tests/test_event_loop_node.py
+++ b/core/tests/test_event_loop_node.py
@@ -252,6 +252,35 @@ class TestJudgeIntegration:
         judge.evaluate.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_quality_judge_usage_is_in_totals_and_step_log(self, runtime, node_spec, buffer):
+        """The implicit quality judge's LLM usage is included in totals."""
+        node_spec.output_keys = []
+        node_spec.success_criteria = "The response is complete."
+        llm = MockStreamingLLM(scenarios=[text_scenario("Done")])
+        llm.complete = MagicMock(
+            return_value=LLMResponse(
+                content="ACTION: ACCEPT\nCONFIDENCE: 1.0\nFEEDBACK:",
+                model="mock-judge",
+                input_tokens=13,
+                output_tokens=4,
+            )
+        )
+        ctx = build_ctx(runtime, node_spec, buffer, llm)
+        ctx.runtime_logger = MagicMock()
+
+        node = EventLoopNode(config=LoopConfig(max_iterations=5))
+        result = await node.execute(ctx)
+
+        # Main turn: 10 + 5. Quality judge: 13 + 4.
+        assert result.tokens_used == 32
+        complete = ctx.runtime_logger.log_node_complete.call_args.kwargs
+        assert complete["input_tokens"] == 23
+        assert complete["output_tokens"] == 9
+        step = ctx.runtime_logger.log_step.call_args.kwargs
+        assert step["input_tokens"] == 23
+        assert step["output_tokens"] == 9
+
+    @pytest.mark.asyncio
     async def test_judge_escalate(self, runtime, node_spec, buffer):
         """Mock judge ESCALATE -> failure."""
         node_spec.output_keys = []
@@ -298,6 +327,30 @@ class TestJudgeIntegration:
 
         assert result.success is True
         assert call_count == 3
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("feedback", [None, ""])
+    async def test_empty_feedback_retry_preserves_judge_usage(self, runtime, node_spec, buffer, feedback):
+        node_spec.output_keys = []
+        llm = MockStreamingLLM(scenarios=[text_scenario("First attempt"), text_scenario("Done")])
+        judge = AsyncMock(spec=JudgeProtocol)
+        judge.evaluate.side_effect = [
+            JudgeVerdict(action="RETRY", feedback=feedback, input_tokens=13, output_tokens=4),
+            JudgeVerdict(action="ACCEPT", input_tokens=17, output_tokens=6),
+        ]
+        ctx = build_ctx(runtime, node_spec, buffer, llm)
+        ctx.runtime_logger = MagicMock()
+        node = EventLoopNode(judge=judge, config=LoopConfig(max_iterations=2))
+
+        result = await node.execute(ctx)
+
+        assert result.success is True
+        assert result.tokens_used == 70
+        steps = [call.kwargs for call in ctx.runtime_logger.log_step.call_args_list]
+        assert [(step["input_tokens"], step["output_tokens"]) for step in steps] == [(23, 9), (27, 11)]
+        assert steps[0]["verdict_feedback"] == "Custom judge returned RETRY."
+        complete = ctx.runtime_logger.log_node_complete.call_args.kwargs
+        assert (complete["input_tokens"], complete["output_tokens"]) == (50, 20)
 
 
 # ===========================================================================
@@ -1370,6 +1423,138 @@ class TestTransientErrorRetry:
         result = await node.execute(ctx)
         assert result.success is True
         assert llm._call_index == 2  # 1 failure + 1 success
+
+    @pytest.mark.asyncio
+    async def test_pre_send_compaction_usage_survives_stream_failure(self, runtime, node_spec, buffer):
+        """Usage recorded before a failed stream is not lost."""
+        node_spec.output_keys = []
+        llm = ErrorThenSuccessLLM(
+            error=ConnectionError("connection reset"),
+            fail_count=1,
+            success_scenario=text_scenario("unreachable"),
+        )
+        ctx = build_ctx(runtime, node_spec, buffer, llm)
+        conversation = NodeConversation()
+        conversation.usage_ratio = MagicMock(return_value=1.0)
+        node = EventLoopNode(config=LoopConfig(max_stream_retries=0))
+
+        async def compact_with_usage(*args, usage_callback=None, **kwargs):
+            usage_callback(12, 6)
+            return 12, 6
+
+        node._compact = compact_with_usage
+        usage: list[tuple[int, int]] = []
+
+        with pytest.raises(ConnectionError, match="connection reset"):
+            await node._run_turn_loop(
+                ctx,
+                conversation,
+                [],
+                0,
+                OutputAccumulator(),
+                usage_callback=lambda input_tokens, output_tokens: usage.append((input_tokens, output_tokens)),
+            )
+
+        assert usage == [(12, 6)]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("interruption", ["cancel", "failure"])
+    async def test_interrupted_iteration_usage_logged_before_park(self, runtime, node_spec, buffer, interruption):
+        node_spec.output_keys = []
+
+        class InterruptedLLM(MockStreamingLLM):
+            async def stream(self, *args, **kwargs):
+                if self._call_index == 1:
+                    self._call_index += 1
+                    if interruption == "cancel":
+                        node.cancel_current_turn()
+                        await asyncio.sleep(0)
+                    raise ValueError("bad request")
+                async for event in super().stream(*args, **kwargs):
+                    yield event
+
+        llm = InterruptedLLM(
+            scenarios=[
+                tool_call_scenario("search", {}),
+                [],
+                text_scenario("Recovered", input_tokens=20, output_tokens=7),
+            ]
+        )
+        ctx = build_ctx(
+            runtime,
+            node_spec,
+            buffer,
+            llm,
+            stream_id="queen",
+            tools=[Tool(name="search", description="Search", parameters={})],
+        )
+        ctx.runtime_logger = MagicMock()
+        node = EventLoopNode(
+            tool_executor=MagicMock(return_value=ToolResult(tool_use_id="call_1", content="Found")),
+            config=LoopConfig(max_iterations=2, max_stream_retries=0),
+        )
+        steps_at_park = []
+
+        async def resume_once(*args, **kwargs):
+            steps_at_park.append(ctx.runtime_logger.log_step.call_count)
+            # Resume the interrupted iteration, then end the queen's next wait.
+            return len(steps_at_park) == 1
+
+        node._await_user_input = AsyncMock(side_effect=resume_once)
+
+        result = await asyncio.wait_for(node.execute(ctx), timeout=5)
+
+        assert result.success is True
+        assert result.tokens_used == 42
+        assert llm._call_index == 3
+        assert steps_at_park == [1, 1]
+        steps = [call.kwargs for call in ctx.runtime_logger.log_step.call_args_list]
+        assert [step["step_index"] for step in steps] == [0, 1]
+        assert [(step["input_tokens"], step["output_tokens"]) for step in steps] == [(10, 5), (20, 7)]
+        assert steps[0]["is_partial"] is True
+        assert steps[0]["error"] == ("Turn cancelled by user" if interruption == "cancel" else "LLM call failed: bad request")
+        complete = ctx.runtime_logger.log_node_complete.call_args.kwargs
+        assert (complete["input_tokens"], complete["output_tokens"]) == (30, 12)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("exhaust_retries", [False, True])
+    async def test_completed_inner_turn_usage_survives_retry(self, runtime, node_spec, buffer, exhaust_retries):
+        node_spec.output_keys = []
+        failed_stream = [StreamErrorEvent(error="connection reset", recoverable=True)]
+        llm = MockStreamingLLM(
+            scenarios=[
+                tool_call_scenario("search", {}),
+                failed_stream,
+                failed_stream if exhaust_retries else text_scenario("Recovered", input_tokens=20, output_tokens=7),
+            ]
+        )
+        ctx = build_ctx(runtime, node_spec, buffer, llm, tools=[Tool(name="search", description="Search", parameters={})])
+        ctx.runtime_logger = MagicMock()
+        node = EventLoopNode(
+            tool_executor=MagicMock(return_value=ToolResult(tool_use_id="call_1", content="Found")),
+            config=LoopConfig(max_iterations=2, max_stream_retries=1, stream_retry_backoff_base=0.01),
+        )
+
+        if exhaust_retries:
+            with pytest.raises(ConnectionError, match="connection reset"):
+                await node.execute(ctx)
+        else:
+            result = await node.execute(ctx)
+            assert result.success is True
+            assert result.tokens_used == 42
+
+        assert llm._call_index == 3
+        ctx.runtime_logger.log_step.assert_called_once()
+        step = ctx.runtime_logger.log_step.call_args.kwargs
+        assert step["step_index"] == 0
+        expected_usage = (10, 5) if exhaust_retries else (30, 12)
+        assert (step["input_tokens"], step["output_tokens"]) == expected_usage
+        if exhaust_retries:
+            assert step["is_partial"] is True
+        ctx.runtime_logger.log_node_complete.assert_called_once()
+        complete = ctx.runtime_logger.log_node_complete.call_args.kwargs
+        assert (complete["input_tokens"], complete["output_tokens"]) == expected_usage
+        assert complete["tokens_used"] == sum(expected_usage)
 
     @pytest.mark.asyncio
     async def test_permanent_error_no_retry(self, runtime, node_spec, buffer):

--- a/core/tests/test_node_conversation.py
+++ b/core/tests/test_node_conversation.py
@@ -1555,6 +1555,35 @@ class TestLlmCompact:
         assert "TOOLS ALREADY CALLED" in result
         assert "web_search" in result
 
+    @pytest.mark.asyncio
+    async def test_split_usage_callback_keeps_completed_branch_on_failure(self):
+        """Usage from a completed split branch survives a later failure."""
+        from unittest.mock import MagicMock
+
+        from framework.agent_loop.internals.compaction import llm_compact
+
+        ctx = self._make_ctx()
+        ctx.llm.acomplete.side_effect = [
+            MagicMock(content="Part 1 summary", input_tokens=11, output_tokens=7),
+            RuntimeError("second branch failed"),
+        ]
+        messages = [
+            Message(seq=0, role="user", content="x" * 80),
+            Message(seq=1, role="user", content="y" * 80),
+        ]
+        usage: list[tuple[int, int]] = []
+
+        with pytest.raises(RuntimeError, match="second branch failed"):
+            await llm_compact(
+                ctx,
+                messages,
+                char_limit=100,
+                usage_callback=lambda input_tokens, output_tokens: usage.append((input_tokens, output_tokens)),
+            )
+
+        assert usage == [(11, 7)]
+        assert ctx.llm.acomplete.await_count == 2
+
 
 # ---------------------------------------------------------------------------
 # Orphaned tool result repair


### PR DESCRIPTION
Fixes #4566

Fixed AgentLoop token undercounting by accumulating compaction LLM usage into node totals; the issue’s cited `LLMNode`/`graph/node.py` paths no longer exist on current main (note: issue body referenced removed code). https://github.com/aden-hive/hive/issues/4566

Could not run the suite locally: . Fork CI needs a maintainer approval to run, so this branch has no test signal yet.

---
This change was prepared with AI assistance under human direction and review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token usage tracking during conversation compaction, including multi-step summarization.
  * Ensured usage from quality checks and validation steps is included in totals and activity logs.
  * Preserved token usage records when interruptions, retries, stream failures, or compaction errors occur.
  * Improved handling of incomplete or unavailable usage data so reporting remains reliable.
  * Preserved existing conversation compaction behavior while improving consistency across execution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->