### PR TITLE
fix(subdomain-enumerator): validate max_results lower bound

### DIFF
--- a/tools/src/aden_tools/tools/subdomain_enumerator/subdomain_enumerator.py
+++ b/tools/src/aden_tools/tools/subdomain_enumerator/subdomain_enumerator.py
@@ -100,6 +100,9 @@ def register_tools(mcp: FastMCP) -> None:
 
         max_results = min(max_results, 200)
 
+        if max_results < 1:
+            return {"error": "max_results must be at least 1", "domain": domain}
+
         try:
             async with httpx.AsyncClient(timeout=30) as client:
                 response = await client.get(


### PR DESCRIPTION
## Description

Rejects non-positive `max_results` in `subdomain_enumerate` before any network request.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #7406

## What was wrong

`subdomain_enumerate` only applied an upper clamp (`max_results = min(max_results, 200)`) and then sliced with `subdomains[:max_results]`. A negative value like `max_results=-1` therefore returned every discovered subdomain except the last one (via `subdomains[:-1]`), and `0` silently returned empty — all after needlessly querying crt.sh.

## Changes Made

- `tools/src/aden_tools/tools/subdomain_enumerator/subdomain_enumerator.py` (lines 103-104): added a lower-bound guard after domain cleaning and the existing 200-cap — `if max_results < 1: return {"error": "max_results must be at least 1", "domain": domain}` — using the same `{error, domain}` shape as the timeout/non-200 errors in that function. Positive behavior and the 200 cap are unchanged.

## Testing

- `py -m py_compile tools/src/aden_tools/tools/subdomain_enumerator/subdomain_enumerator.py` — passes.
- `tools/tests/tools/test_subdomain_enumerator.py` — all 15 existing tests pass.
- Functional check with mocked crt.sh (3 records): `max_results` of `-1`, `0`, `-50` each return `{"error": "max_results must be at least 1", "domain": "example.com"}` with `httpx.AsyncClient` never constructed; `max_results=1` returns 1 subdomain; `max_results=500` still clamps without error.
- `ruff check` and `ruff format --check` on the touched file — clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation to prevent subdomain enumeration requests with invalid result limits.
  - Requests specifying fewer than one result now return a clear error message instead of proceeding.
  - The existing maximum limit of 200 results remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->