### PR TITLE
fix(port-scanner): reject out-of-range custom ports

### DIFF
--- a/tools/src/aden_tools/tools/port_scanner/port_scanner.py
+++ b/tools/src/aden_tools/tools/port_scanner/port_scanner.py
@@ -190,6 +190,9 @@ def register_tools(mcp: FastMCP) -> None:
                 port_list = sorted({int(p.strip()) for p in ports.split(",") if p.strip()})
             except ValueError:
                 return {"error": f"Invalid port list: {ports}. Use 'top20', 'top100', or '80,443'"}
+            invalid_ports = sorted(p for p in port_list if p < 1 or p > 65535)
+            if invalid_ports:
+                return {"error": f"Invalid port(s) out of range (1-65535): {invalid_ports}. Use 'top20', 'top100', or '80,443'"}
 
         # Resolve hostname
         try:


### PR DESCRIPTION
## Description

Rejects custom ports outside the valid TCP range (1-65535) before any DNS resolution or connection attempt.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #7409

## What was wrong

The custom port parser converted every integer string without range-checking, so `ports="70000"` was counted as scanned and reported in `closed_ports` (`{'ports_scanned': 1, 'closed_ports': [70000], ...}`) even though 70000 cannot identify a TCP port. Invalid input was presented as a legitimate scan result.

## Changes Made

- `tools/src/aden_tools/tools/port_scanner/port_scanner.py` (lines 193-195): after the existing integer parsing, collects `invalid_ports = sorted(p for p in port_list if p < 1 or p > 65535)` and returns `{"error": "Invalid port(s) out of range (1-65535): [...]..."}` in the same style as the existing invalid-list error, listing the offending ports. The check runs before hostname resolution, so bad ports are never counted as scanned. `top20`/`top100` paths are untouched.

## Testing

- `py -m py_compile tools/src/aden_tools/tools/port_scanner/port_scanner.py` — passes.
- `tools/tests/tools/test_port_scanner.py` — all 17 existing tests pass.
- Functional check (mocked DNS/scan): `"70000"`, `"0"`, `"-1"`, `"80,70000,0"` each return the range error naming the offenders, with no DNS resolution or port probes attempted and no `ports_scanned`/`closed_ports` in the result; boundaries `"1"`, `"65535"`, `"22,80,443"` still scan normally; non-integer input still returns the original `Invalid port list` error.
- `ruff check` and `ruff format --check` on the touched file — clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom port scans now reject port numbers outside the valid 1–65,535 range with a clear error message.
  * The `top20` and `top100` scan presets continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->