### PR TITLE
fix(excel-tool): match disallowed SQL keywords on word boundaries

### DIFF
--- a/tools/src/aden_tools/tools/excel_tool/excel_tool.py
+++ b/tools/src/aden_tools/tools/excel_tool/excel_tool.py
@@ -1,6 +1,7 @@
 """Excel Tool - Read and manipulate Excel files (.xlsx, .xlsm)."""
 
 import os
+import re
 from datetime import datetime
 from typing import Any
 
@@ -487,7 +488,7 @@ def register_tools(mcp: FastMCP) -> None:
                 "EXECUTE",
             ]
             for keyword in disallowed:
-                if keyword in query_upper:
+                if re.search(rf"\b{keyword}\b", query_upper):
                     return {"error": f"'{keyword}' is not allowed in queries"}
 
             # Load workbook


### PR DESCRIPTION
## Description

Fixes `excel_sql` rejecting legitimate read-only SELECTs when a column name or string literal merely contains a blocked SQL keyword as a substring (e.g. `updated_at` triggering `UPDATE`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #7412

## What was wrong

The disallowed-keyword check used naive substring matching (`if keyword in query_upper`), so `SELECT created_at, updated_at FROM data` was rejected with `{"error": "'CREATE' is not allowed in queries"}`, and likewise `updated_at` (UPDATE), `WHERE status = 'DELETED'` (DELETE), or an alias like `total_created` (CREATE) — all normal SELECTs that never ran.

## Changes Made

- `tools/src/aden_tools/tools/excel_tool/excel_tool.py` (line 4: added `import re`; line 491: `if keyword in query_upper` → `if re.search(rf"\b{keyword}\b", query_upper)`), so only standalone keywords match — the same word-boundary approach `csv_sql` uses (`tools/src/aden_tools/tools/csv_tool/csv_tool.py:283-289`). The error message format (`'{KEYWORD}' is not allowed in queries`) is unchanged.

## Testing

- `py -m py_compile tools/src/aden_tools/tools/excel_tool/excel_tool.py` — passes.
- End-to-end functional check with a real workbook (DuckDB + openpyxl, columns `created_at`/`updated_at`/`status`): all three issue queries now run (`SELECT created_at, updated_at FROM data` → 2 rows; `... WHERE status = 'DELETED'` → 1 row; `SELECT id AS total_created FROM data` → 2 rows); real writes still blocked with the same message (`; DROP TABLE ...` → `'DROP' is not allowed in queries`, incl. lowercase; `; delete ...` → `'DELETE' ...`; `EXEC(...)` → `'EXEC' ...`; `EXECUTE(...)` → `'EXECUTE' ...`); non-SELECT input still rejected by the prefix check.
- Guard-logic comparison over every SELECT query in the existing `TestExcelSql` suite: old vs new check agree on all of them (no standalone keywords), so no existing-test behavior changes.
- Note: `tools/tests/tools/test_excel_tool.py` currently cannot run on `main` either — all 58 tests error in fixture setup because the fixture patches `aden_tools.tools.file_system_toolkits.security.WORKSPACES_DIR`, which does not exist (the module defines `AGENT_SANDBOXES_DIR`), before any `excel_tool` code executes. Pre-existing failure, untouched by this diff (verified: only `excel_tool.py` modified).
- `ruff check` and `ruff format --check` on the touched file — clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (existing `test_excel_tool.py` errors in fixture setup on `main` too — pre-existing, see Testing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL keyword validation in Excel queries to avoid incorrectly flagging allowed words that merely contain prohibited terms.
  * Standalone prohibited SQL commands continue to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->