### PR TITLE
fix: resolve ruff lint errors in core/ (B023, F401, I001, UP041)

### DIFF
--- a/core/framework/agent_loop/agent_loop.py
+++ b/core/framework/agent_loop/agent_loop.py
@@ -6575,7 +6575,7 @@ class AgentLoop(AgentProtocol):
                 # shield: a grace-window timeout must not cancel the in-flight
                 # work — it still has the full `timeout` budget to finish in.
                 result = await asyncio.wait_for(asyncio.shield(task), timeout=grace)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 pass  # genuinely slow — fall through and hand back the handle
             except Exception:
                 # Failed fast. Let collect_result surface it rather than

--- a/core/framework/agents/queen/recall_selector.py
+++ b/core/framework/agents/queen/recall_selector.py
@@ -19,12 +19,12 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from framework.config import get_aux_max_tokens
 from framework.agents.queen.queen_memory_v2 import (
     format_memory_manifest,
     global_memory_dir as _default_global_memory_dir,
     scan_memory_files,
 )
+from framework.config import get_aux_max_tokens
 
 logger = logging.getLogger(__name__)
 

--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -37,8 +37,7 @@ except ImportError:
     RateLimitError = Exception  # type: ignore[assignment, misc]
     CustomLogger = object  # type: ignore[assignment, misc]
 
-from framework.config import HIVE_LLM_ENDPOINT as HIVE_API_BASE
-from framework.config import get_aux_max_tokens, get_max_tokens
+from framework.config import HIVE_LLM_ENDPOINT as HIVE_API_BASE, get_aux_max_tokens, get_max_tokens
 from framework.llm.model_catalog import get_model_pricing
 from framework.llm.provider import LLMProvider, LLMResponse, Tool
 from framework.llm.stream_events import StreamEvent

--- a/core/framework/server/queen_orchestrator.py
+++ b/core/framework/server/queen_orchestrator.py
@@ -730,13 +730,12 @@ async def create_queen(
     from framework.llm.capabilities import supports_image_tool_results
     from framework.loader.mcp_registry import MCPRegistry
     from framework.loader.tool_registry import ToolRegistry
+    from framework.server import boot_status
     from framework.tools.queen_lifecycle_tools import (
         QueenPhaseState,
         normalize_legacy_phase,
         register_queen_lifecycle_tools,
     )
-
-    from framework.server import boot_status
 
     # ---- Tool registry ------------------------------------------------
     # Use pre-loaded cached registry if available (fast path)

--- a/core/framework/server/routes_config.py
+++ b/core/framework/server/routes_config.py
@@ -23,7 +23,6 @@ from framework.agents.queen.queen_memory_v2 import (
 from framework.config import (
     _PROVIDER_CRED_MAP,
     HIVE_CONFIG_FILE,
-    HIVE_HOME,
     OPENROUTER_API_BASE,
     get_hive_config,
 )

--- a/core/framework/server/routes_execution.py
+++ b/core/framework/server/routes_execution.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 from datetime import UTC
+from pathlib import Path
 from typing import Any
 
 from aiohttp import web
@@ -356,7 +357,11 @@ async def handle_chat(request: web.Request) -> web.Response:
                 # 1000-page PDF is still megabytes of text otherwise).
                 _pdf_bytes = raw_bytes
 
-                def _inspect_pdf() -> tuple[int, list[str]]:
+                def _inspect_pdf(
+                    _pdf_bytes: bytes | None = _pdf_bytes,
+                    pdf_filepath: Path = pdf_filepath,
+                    is_large: bool = is_large,
+                ) -> tuple[int, list[str]]:
                     page_count = 0
                     parts: list[str] = []
                     try:
@@ -470,7 +475,11 @@ async def handle_chat(request: web.Request) -> web.Response:
                 # 100 MB CSV is seconds of loop-stalling work otherwise.
                 _csv_bytes = raw_bytes
 
-                def _parse_csv() -> tuple[int, str | None]:
+                def _parse_csv(
+                    _csv_bytes: bytes | None = _csv_bytes,
+                    csv_filepath: Path = csv_filepath,
+                    csv_filename: str = csv_filename,
+                ) -> tuple[int, str | None]:
                     row_count = 0
                     text_part: str | None = None
                     try:
@@ -538,7 +547,11 @@ async def handle_chat(request: web.Request) -> web.Response:
                 is_large = attachment_size > LARGE_TEXT_THRESHOLD_BYTES
                 _text_bytes = raw_bytes
 
-                def _read_text_attachment() -> tuple[str, int]:
+                def _read_text_attachment(
+                    _text_bytes: bytes | None = _text_bytes,
+                    is_large: bool = is_large,
+                    text_filepath: Path = text_filepath,
+                ) -> tuple[str, int]:
                     if _text_bytes is not None:
                         t = _text_bytes.decode("utf-8", errors="replace")
                         return t, (t.count("\n") + 1 if t else 0)
@@ -629,7 +642,7 @@ async def handle_chat(request: web.Request) -> web.Response:
 
                     _img_bytes = raw_bytes
 
-                    def _probe_dims() -> str:
+                    def _probe_dims(_img_bytes: bytes | None = _img_bytes) -> str:
                         with Image.open(io.BytesIO(_img_bytes)) as im:
                             return f"{im.size[0]}×{im.size[1]}, "
 

--- a/core/framework/server/session_manager.py
+++ b/core/framework/server/session_manager.py
@@ -22,8 +22,8 @@ from typing import Any, Literal
 
 from framework.config import COLONIES_DIR, QUEENS_DIR
 from framework.host.colony_binding import ColonyBinding
-from framework.server import boot_status
 from framework.host.triggers import TriggerDefinition
+from framework.server import boot_status
 from framework.utils.text import humanize_slug
 
 logger = logging.getLogger(__name__)

--- a/core/tests/test_llm_judge.py
+++ b/core/tests/test_llm_judge.py
@@ -12,8 +12,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from framework.llm.provider import LLMProvider, LLMResponse
 from framework.config import get_aux_max_tokens
+from framework.llm.provider import LLMProvider, LLMResponse
 from framework.testing.llm_judge import LLMJudge
 
 # ============================================================================


### PR DESCRIPTION
## Description
Fixes the standing `Lint Python` failure on main by resolving ruff findings in `core/` (B023 loop-variable closures, F401 unused import, I001 import order, UP041 asyncio.TimeoutError alias).

## Motivation
Per #7429, the `Lint Python` CI job has been failing on main, so every PR inherits a red check unrelated to its own diff. This restores the gate signal for `core/`.

## Changes
- `routes_execution.py`: bind loop-captured names as default args in `_inspect_pdf`, `_parse_csv`, `_read_text_attachment`, `_probe_dims` (B023; no behaviour change — each closure is awaited in the same iteration that defines it)
- `routes_config.py`: drop unused `HIVE_HOME` import (F401)
- `recall_selector.py`, `litellm.py`, `queen_orchestrator.py`, `session_manager.py`, `test_llm_judge.py`: import sorting (I001)
- `agent_loop.py`: use builtin `TimeoutError` over `asyncio.TimeoutError` (UP041)

## Testing
- [x] `ruff check core/` passes (ruff 0.15.0)
- [x] `python -m py_compile` clean on touched files
- [ ] CI lint + tests

## Checklist
- [x] Code follows style guidelines (ruff)
- [x] Self-review completed
- [x] No breaking changes
- [x] Conventional commit format used

Closes #7429

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed asynchronous attachment processing so PDF, CSV, text, and image files consistently use the correct file data and paths.
  - Improved handling of slow background tools so they continue returning a usable reference after the grace period.

- **Maintenance**
  - Cleaned up internal import organization and removed an unused configuration reference without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->