### PR TITLE
fix(micro-fix): resolve lint hygiene in core/ (F401, I001, UP041)

### DIFF
--- a/core/framework/agent_loop/agent_loop.py
+++ b/core/framework/agent_loop/agent_loop.py
@@ -6575,7 +6575,7 @@ class AgentLoop(AgentProtocol):
                 # shield: a grace-window timeout must not cancel the in-flight
                 # work — it still has the full `timeout` budget to finish in.
                 result = await asyncio.wait_for(asyncio.shield(task), timeout=grace)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 pass  # genuinely slow — fall through and hand back the handle
             except Exception:
                 # Failed fast. Let collect_result surface it rather than

--- a/core/framework/agents/queen/recall_selector.py
+++ b/core/framework/agents/queen/recall_selector.py
@@ -19,12 +19,12 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from framework.config import get_aux_max_tokens
 from framework.agents.queen.queen_memory_v2 import (
     format_memory_manifest,
     global_memory_dir as _default_global_memory_dir,
     scan_memory_files,
 )
+from framework.config import get_aux_max_tokens
 
 logger = logging.getLogger(__name__)
 

--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -37,8 +37,7 @@ except ImportError:
     RateLimitError = Exception  # type: ignore[assignment, misc]
     CustomLogger = object  # type: ignore[assignment, misc]
 
-from framework.config import HIVE_LLM_ENDPOINT as HIVE_API_BASE
-from framework.config import get_aux_max_tokens, get_max_tokens
+from framework.config import HIVE_LLM_ENDPOINT as HIVE_API_BASE, get_aux_max_tokens, get_max_tokens
 from framework.llm.model_catalog import get_model_pricing
 from framework.llm.provider import LLMProvider, LLMResponse, Tool
 from framework.llm.stream_events import StreamEvent

--- a/core/framework/server/queen_orchestrator.py
+++ b/core/framework/server/queen_orchestrator.py
@@ -730,13 +730,12 @@ async def create_queen(
     from framework.llm.capabilities import supports_image_tool_results
     from framework.loader.mcp_registry import MCPRegistry
     from framework.loader.tool_registry import ToolRegistry
+    from framework.server import boot_status
     from framework.tools.queen_lifecycle_tools import (
         QueenPhaseState,
         normalize_legacy_phase,
         register_queen_lifecycle_tools,
     )
-
-    from framework.server import boot_status
 
     # ---- Tool registry ------------------------------------------------
     # Use pre-loaded cached registry if available (fast path)

--- a/core/framework/server/routes_config.py
+++ b/core/framework/server/routes_config.py
@@ -23,7 +23,6 @@ from framework.agents.queen.queen_memory_v2 import (
 from framework.config import (
     _PROVIDER_CRED_MAP,
     HIVE_CONFIG_FILE,
-    HIVE_HOME,
     OPENROUTER_API_BASE,
     get_hive_config,
 )

--- a/core/framework/server/session_manager.py
+++ b/core/framework/server/session_manager.py
@@ -22,8 +22,8 @@ from typing import Any, Literal
 
 from framework.config import COLONIES_DIR, QUEENS_DIR
 from framework.host.colony_binding import ColonyBinding
-from framework.server import boot_status
 from framework.host.triggers import TriggerDefinition
+from framework.server import boot_status
 from framework.utils.text import humanize_slug
 
 logger = logging.getLogger(__name__)

--- a/core/tests/test_llm_judge.py
+++ b/core/tests/test_llm_judge.py
@@ -12,8 +12,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from framework.llm.provider import LLMProvider, LLMResponse
 from framework.config import get_aux_max_tokens
+from framework.llm.provider import LLMProvider, LLMResponse
 from framework.testing.llm_judge import LLMJudge
 
 # ============================================================================


### PR DESCRIPTION
Micro-fix bypass: pure lint hygiene, no behavior change (15-line diff across 7 files).

Rules addressed:
- UP041 (1 file): core/framework/agent_loop/agent_loop.py — asyncio.TimeoutError to TimeoutError (deprecated alias).
- I001 (5 files): import sorting in recall_selector.py, litellm.py, queen_orchestrator.py, session_manager.py, tests/test_llm_judge.py.
- F401 (1 file): routes_config.py — remove unused HIVE_HOME import.

Verified: ruff check passes on all 7 files.

Note: this is a hygiene subset split out of #7438; the B023 loop-closure fixes ship separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized import organization across internal components and tests.
  * Normalized timeout exception handling for Python compatibility.
  * Removed an unused configuration import.
* **Tests**
  * Updated test import ordering without changing test coverage or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->