### PR TITLE
fix: bind loop-captured values as closure defaults in routes_execution (ruff B023)

### DIFF
--- a/core/framework/server/routes_execution.py
+++ b/core/framework/server/routes_execution.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 from datetime import UTC
+from pathlib import Path
 from typing import Any
 
 from aiohttp import web
@@ -356,7 +357,12 @@ async def handle_chat(request: web.Request) -> web.Response:
                 # 1000-page PDF is still megabytes of text otherwise).
                 _pdf_bytes = raw_bytes
 
-                def _inspect_pdf() -> tuple[int, list[str]]:
+                def _inspect_pdf(
+                    _pdf_bytes: bytes | None = _pdf_bytes,
+                    pdf_filepath: Path = pdf_filepath,
+                    is_large: bool = is_large,
+                ) -> tuple[int, list[str]]:
+                    """Extract PDF page count and text prepend in a worker thread."""
                     page_count = 0
                     parts: list[str] = []
                     try:
@@ -470,7 +476,12 @@ async def handle_chat(request: web.Request) -> web.Response:
                 # 100 MB CSV is seconds of loop-stalling work otherwise.
                 _csv_bytes = raw_bytes
 
-                def _parse_csv() -> tuple[int, str | None]:
+                def _parse_csv(
+                    _csv_bytes: bytes | None = _csv_bytes,
+                    csv_filepath: Path = csv_filepath,
+                    csv_filename: str = csv_filename,
+                ) -> tuple[int, str | None]:
+                    """Parse CSV rows and build the text prepend in a worker thread."""
                     row_count = 0
                     text_part: str | None = None
                     try:
@@ -538,7 +549,12 @@ async def handle_chat(request: web.Request) -> web.Response:
                 is_large = attachment_size > LARGE_TEXT_THRESHOLD_BYTES
                 _text_bytes = raw_bytes
 
-                def _read_text_attachment() -> tuple[str, int]:
+                def _read_text_attachment(
+                    _text_bytes: bytes | None = _text_bytes,
+                    is_large: bool = is_large,
+                    text_filepath: Path = text_filepath,
+                ) -> tuple[str, int]:
+                    """Read text attachment bytes and count lines in a worker thread."""
                     if _text_bytes is not None:
                         t = _text_bytes.decode("utf-8", errors="replace")
                         return t, (t.count("\n") + 1 if t else 0)
@@ -629,7 +645,8 @@ async def handle_chat(request: web.Request) -> web.Response:
 
                     _img_bytes = raw_bytes
 
-                    def _probe_dims() -> str:
+                    def _probe_dims(_img_bytes: bytes | None = _img_bytes) -> str:
+                        """Probe image dimensions in a worker thread."""
                         with Image.open(io.BytesIO(_img_bytes)) as im:
                             return f"{im.size[0]}×{im.size[1]}, "
 


### PR DESCRIPTION
Fixes #7429 (requesting maintainer assignment — self-assignment is blocked without triage perms).

What: the attachment helpers in core/framework/server/routes_execution.py (_inspect_pdf, _parse_csv, _read_text_attachment, _probe_dims) are defined inside the per-attachment loop and close over iteration-scoped names (_pdf_bytes/pdf_filepath/is_large, _csv_bytes/csv_filepath/csv_filename, _text_bytes/text_filepath, _img_bytes). Ruff flags this as B023 (function-uses-loop-variable): closures bind outer names by reference, so a deferred call could observe a later iteration's values.

Fix: bind each captured value as a default argument (the canonical ruff-prescribed B023 fix). This snapshots the defining-iteration value at def time.

Semantics-preserving because each closure is awaited in its defining iteration via asyncio.to_thread before the loop advances:
- _inspect_pdf defined ~L360, awaited L392
- _parse_csv defined ~L478, awaited L515
- _read_text_attachment defined ~L550, awaited L571
- _probe_dims defined ~L645, awaited L649

Also adds brief one-line docstrings to all four helpers (addresses docstring-coverage feedback on touched functions). Also imports Path from pathlib for the default-arg annotations.

Verified: ruff check passes on routes_execution.py; file parses clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of attachment-processing helpers without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->