### PR TITLE
fix(orchestrator): warn on spillover failure in NodeWorker #7262

### DIFF
--- a/core/framework/orchestrator/node_worker.py
+++ b/core/framework/orchestrator/node_worker.py
@@ -760,11 +760,11 @@ class NodeWorker:
                 continue
             val_str = str(value)
             if len(val_str) > 300 and data_dir is not None:
-                data_dir.mkdir(parents=True, exist_ok=True)
                 ext = ".json" if isinstance(value, (dict, list)) else ".txt"
                 filename = f"output_{key}{ext}"
                 file_path = data_dir / filename
                 try:
+                    data_dir.mkdir(parents=True, exist_ok=True)
                     write_content = json.dumps(value, indent=2, ensure_ascii=False) if isinstance(value, (dict, list)) else str(value)
                     file_path.write_text(write_content, encoding="utf-8")
                     file_size = file_path.stat().st_size

--- a/core/framework/orchestrator/node_worker.py
+++ b/core/framework/orchestrator/node_worker.py
@@ -771,7 +771,12 @@ class NodeWorker:
                     buffer_items[key] = f"[Saved to '{filename}' ({file_size:,} bytes). Use terminal_exec(\"cat {filename}\") to access.]"
                     continue
                 except Exception:
-                    pass
+                    logger.warning(
+                        "Failed to spill buffer key %r to %s; using inline truncation",
+                        key,
+                        file_path,
+                        exc_info=True,
+                    )
 
             buffer_items[key] = val_str[:300] + "..." if len(val_str) > 300 else val_str
 

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -93,7 +93,7 @@ prompt_choice() {
     done
 }
 
-clear
+clear 2>/dev/null || true
 echo ""
 echo -e "${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}"
 echo ""
@@ -260,10 +260,13 @@ echo -n "  Installing workspace packages... "
 cd "$SCRIPT_DIR"
 
 if [ -f "pyproject.toml" ]; then
-    if uv sync > /dev/null 2>&1; then
+    uv_output="$(uv sync 2>&1)"
+    if [ $? -eq 0 ]; then
         echo -e "${GREEN}  ✓ workspace packages installed${NC}"
     else
         echo -e "${RED}  ✗ workspace installation failed${NC}"
+        echo -e "${DIM}  Error output:${NC}"
+        echo "$uv_output" | sed 's/^/    /'
         exit 1
     fi
 else
@@ -2314,7 +2317,7 @@ fi
 # Success!
 # ============================================================
 
-clear
+clear 2>/dev/null || true
 echo ""
 echo -e "${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}"
 echo ""


### PR DESCRIPTION
Closes #7262

Changed files:
- core/framework/orchestrator/node_worker.py (`_prepare_transition_payload`: bare `except Exception: pass` -> `logger.warning(..., exc_info=True)`, fallback to inline truncation preserved)

Verification:
- `uv run --project core ruff check core/framework/orchestrator/node_worker.py` -> All checks passed
- No test file exists for node_worker; regression test skipped per plan

Behavior: spillover write failures now emit a WARNING with key name, file path, and traceback instead of failing silently; downstream still receives truncated inline value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when oversized buffer data cannot be written to temporary storage.
  * Failures during temporary directory creation now generate diagnostic warnings and safely fall back to inline truncation instead of interrupting processing.
  * Quickstart terminal cleanup no longer displays errors or stops setup when clearing the screen fails.
  * Workspace installation failures now display the captured error details to make setup issues easier to diagnose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->