### PR TITLE
fix(host): replace print with logger in agent_host and event_bus #7244

### DIFF
--- a/core/framework/host/agent_host.py
+++ b/core/framework/host/agent_host.py
@@ -116,7 +116,7 @@ class AgentHost:
 
         # Check goal progress
         progress = await runtime.get_goal_progress()
-        print(f"Progress: {progress['overall_progress']:.1%}")
+        logger.info("Progress: %.1f%%", progress['overall_progress'] * 100)
 
         # Stop runtime
         await runtime.stop()

--- a/core/framework/host/event_bus.py
+++ b/core/framework/host/event_bus.py
@@ -389,7 +389,7 @@ class EventBus:
 
         # Subscribe to execution events
         async def on_execution_complete(event: AgentEvent):
-            print(f"Execution {event.execution_id} completed")
+            logger.info("Execution %s completed", event.execution_id)
 
         bus.subscribe(
             event_types=[EventType.EXECUTION_COMPLETED],


### PR DESCRIPTION
Closes #7244

Changed files:
- core/framework/host/agent_host.py (docstring example: print -> logger.info with lazy % formatting)
- core/framework/host/event_bus.py (docstring example: print -> logger.info with lazy % formatting)

Verification:
- rg print( on both files -> no matches remain
- uv run --project core ruff check on both files -> All checks passed
- Both files already define logger = logging.getLogger(__name__); no new imports needed

Behavior: example snippets now demonstrate logger usage so headless operators see progress/completion via the logging framework instead of stdout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated usage examples to record progress and completion through the module logger instead of printing directly to standard output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->