### PR TITLE
fix(huggingface): validate response content-type and persist task override

### DIFF
--- a/tools/src/aden_tools/tools/huggingface_tool/huggingface_tool.py
+++ b/tools/src/aden_tools/tools/huggingface_tool/huggingface_tool.py
@@ -60,6 +60,12 @@ def _get(path: str, token: str | None, params: dict[str, Any] | None = None) -> 
         return {"error": f"HuggingFace request failed: {e!s}"}
 
 
+def _is_json_response(resp: httpx.Response) -> bool:
+    """Check whether the response advertises a JSON content-type."""
+    content_type = resp.headers.get("content-type", "")
+    return content_type.startswith("application/json") or content_type.startswith("text/json")
+
+
 def _post(
     url: str,
     token: str | None,
@@ -82,7 +88,34 @@ def _post(
         if resp.status_code == 404:
             return {"error": f"Model not found: {url}"}
         if resp.status_code == 503:
-            body = resp.json() if resp.headers.get("content-type", "").startswith("application/json") else {}
+            content_type = resp.headers.get("content-type", "")
+            if not _is_json_response(resp):
+                return {
+                    "error": (
+                        f"HuggingFace Inference API returned 503 with unexpected content-type "
+                        f"'{content_type or 'unknown'}': {resp.text[:500]}"
+                    )
+                }
+            try:
+                body: Any = resp.json()
+            except Exception:
+                return {
+                    "error": (
+                        f"HuggingFace Inference API returned 503 with malformed JSON: "
+                        f"{resp.text[:500]}"
+                    )
+                }
+            # Only treat as "model is loading" when the payload indicates it;
+            # otherwise surface the body as a regular API error.
+            is_loading = isinstance(body, dict) and (
+                "estimated_time" in body or body.get("error") == "model is loading"
+            )
+            if not is_loading:
+                return {
+                    "error": (
+                        f"HuggingFace Inference API error 503: {resp.text[:500]}"
+                    )
+                }
             estimated = body.get("estimated_time", "unknown")
             return {
                 "error": "Model is loading",
@@ -91,6 +124,14 @@ def _post(
             }
         if resp.status_code != 200:
             return {"error": (f"HuggingFace Inference API error {resp.status_code}: {resp.text[:500]}")}
+        if not _is_json_response(resp):
+            content_type = resp.headers.get("content-type", "unknown")
+            return {
+                "error": (
+                    f"Unexpected response from HuggingFace Inference API "
+                    f"(content-type: {content_type}): {resp.text[:500]}"
+                )
+            }
         return resp.json()
     except httpx.TimeoutException:
         return {"error": "Inference request timed out. Try a smaller input or a faster model."}
@@ -401,6 +442,9 @@ def register_tools(
             return {"error": "inputs is required"}
 
         payload: dict[str, Any] = {"inputs": inputs}
+
+        if task:
+            payload["task"] = task
 
         if parameters:
             import json as _json

--- a/tools/tests/tools/test_huggingface_tool.py
+++ b/tools/tests/tools/test_huggingface_tool.py
@@ -286,6 +286,118 @@ class TestHuggingFaceRunInference:
         assert result["error"] == "Model is loading"
         assert result["estimated_time"] == 30.5
 
+    def test_malformed_503_without_loading_payload(self, tool_fns):
+        """503 responses that lack the expected loading payload should NOT be reported as 'loading'."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 503
+        mock_resp.headers = {"content-type": "application/json"}
+        mock_resp.json.return_value = {"error": "Backend unavailable", "details": "queue overflow"}
+        mock_resp.text = '{"error": "Backend unavailable", "details": "queue overflow"}'
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.huggingface_tool.huggingface_tool.httpx.post",
+                return_value=mock_resp,
+            ),
+        ):
+            result = tool_fns["huggingface_run_inference"](model_id="some/repo", inputs="Hello")
+
+        assert "error" in result
+        # Must NOT be classified as the "model is loading" condition.
+        assert result["error"] != "Model is loading"
+        assert "503" in result["error"]
+        # Body content should be surfaced.
+        assert "Backend unavailable" in result["error"]
+
+    def test_503_non_json_content_type(self, tool_fns):
+        """503 responses with a non-JSON content-type should surface a clear error."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 503
+        mock_resp.headers = {"content-type": "text/html"}
+        mock_resp.text = "<html><body>Service Unavailable</body></html>"
+        # If code accidentally calls .json(), raise to surface the bug.
+        mock_resp.json.side_effect = ValueError("not json")
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.huggingface_tool.huggingface_tool.httpx.post",
+                return_value=mock_resp,
+            ),
+        ):
+            result = tool_fns["huggingface_run_inference"](model_id="some/repo", inputs="Hello")
+
+        assert "error" in result
+        assert result["error"] != "Model is loading"
+        assert "503" in result["error"]
+        assert "text/html" in result["error"]
+        assert "Service Unavailable" in result["error"]
+
+    def test_503_loading_payload_with_error_field(self, tool_fns):
+        """503 with `error: "model is loading"` is also treated as loading."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 503
+        mock_resp.headers = {"content-type": "application/json"}
+        mock_resp.json.return_value = {"error": "model is loading", "estimated_time": 12.0}
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.huggingface_tool.huggingface_tool.httpx.post",
+                return_value=mock_resp,
+            ),
+        ):
+            result = tool_fns["huggingface_run_inference"](model_id="some/repo", inputs="Hello")
+
+        assert result["error"] == "Model is loading"
+        assert result["estimated_time"] == 12.0
+
+    def test_task_override_included_in_payload(self, tool_fns):
+        """`task` override must be sent in the JSON request payload."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-type": "application/json"}
+        mock_resp.json.return_value = [{"generated_text": "ok"}]
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.huggingface_tool.huggingface_tool.httpx.post",
+                return_value=mock_resp,
+            ) as mock_post,
+        ):
+            result = tool_fns["huggingface_run_inference"](
+                model_id="meta-llama/Llama-3.1-8B-Instruct",
+                inputs="Hello",
+                task="text-generation",
+            )
+
+        assert "output" in result
+        assert result["task"] == "text-generation"
+        sent_payload = mock_post.call_args.kwargs["json"]
+        assert sent_payload.get("task") == "text-generation"
+        assert sent_payload["inputs"] == "Hello"
+
+    def test_non_json_success_content_type(self, tool_fns):
+        """Success responses with a non-JSON content-type should be surfaced as a clear error."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-type": "text/plain"}
+        mock_resp.text = "plain text body"
+        mock_resp.json.side_effect = ValueError("not json")
+        with (
+            patch.dict("os.environ", ENV),
+            patch(
+                "aden_tools.tools.huggingface_tool.huggingface_tool.httpx.post",
+                return_value=mock_resp,
+            ),
+        ):
+            result = tool_fns["huggingface_run_inference"](
+                model_id="meta-llama/Llama-3.1-8B-Instruct",
+                inputs="Hello",
+            )
+
+        assert "error" in result
+        assert "content-type" in result["error"]
+        assert "text/plain" in result["error"]
+
 
 class TestHuggingFaceRunEmbedding:
     def test_missing_token(self, tool_fns):


### PR DESCRIPTION
## Problem

The HuggingFace inference tool (`tools/src/aden_tools/tools/huggingface_tool/huggingface_tool.py`) mis-handles malformed or unexpected API responses:

1. **HTTP 503 over-classification.** Any 503 response was unconditionally mapped to a "Model is loading" error, even when the body lacked the expected loading fields (`estimated_time` or `error: "model is loading"`), producing misleading results.
2. **No content-type validation.** The success path called `resp.json()` without verifying `Content-Type: application/json`, and the 503 path silently swallowed non-JSON responses.
3. **`task` override not persisted.** `huggingface_run_inference` accepted `task` only as a label on the response — it was never included in the request payload sent to the Inference API.

## What changed

- Added a small helper `_is_json_response(resp)` that checks the response `Content-Type` (`application/json` or `text/json`).
- In `_post`, the 503 handler now:
  - Returns a clear error when content-type is not JSON (and includes the actual content-type + body snippet).
  - Returns a clear error when the JSON body is malformed.
  - Only maps to "Model is loading" when the payload actually indicates loading (`estimated_time` present or `error == "model is loading"`); otherwise surfaces the body as a regular API error.
- In `_post`, the success path now validates content-type before calling `resp.json()`; non-JSON success bodies are surfaced as a clear error with the actual content-type + body snippet.
- In `huggingface_run_inference`, the `task` parameter is now included in the JSON request payload when supplied.

## Files touched

- `tools/src/aden_tools/tools/huggingface_tool/huggingface_tool.py`
- `tools/tests/tools/test_huggingface_tool.py`

## Test additions

New tests in `TestHuggingFaceRunInference`:

- `test_malformed_503_without_loading_payload` — 503 with a non-loading JSON body is NOT classified as "Model is loading" and the body is surfaced.
- `test_503_non_json_content_type` — 503 with `Content-Type: text/html` produces a clear error including the content-type and a snippet.
- `test_503_loading_payload_with_error_field` — 503 with `error: "model is loading"` is still treated as loading.
- `test_task_override_included_in_payload` — caller-supplied `task` is present in `httpx.post`'s `json=` payload.
- `test_non_json_success_content_type` — non-JSON success responses produce a clear error including the actual content-type.

All 29 tests in `test_huggingface_tool.py` pass (24 existing + 5 new). `ruff check` is clean.

Closes #7267

## Checklist

- [x] Tests added for new behavior and pass
- [x] `ruff check` clean
- [x] Existing tests still pass
- [x] Single PR, no force-push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Hugging Face API responses when models are loading or return unexpected status content.
  * Added clearer errors for non-JSON responses and unrelated service-unavailable errors.
  * Ensured inference requests include the selected task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->