### PR TITLE
docs: [micro-fix] remove stale MCP/editor config references (#7383)

### DIFF
--- a/docs/contributing-lint-setup.md
+++ b/docs/contributing-lint-setup.md
@@ -74,8 +74,6 @@ git commit --no-verify -m "message"
 
 ### VS Code (Recommended)
 
-The repository includes `.vscode/extensions.json` and `.vscode/settings.json`. On first open, VS Code will prompt you to install the recommended Ruff extension.
-
 Once installed, the editor will:
 
 - **Format on save** using ruff
@@ -97,10 +95,6 @@ For any editor, you can always rely on `make lint` and `make format` from the co
 ### Claude Code
 
 The repository includes a `.claude/settings.json` hook that automatically runs `ruff check --fix` and `ruff format` after every file edit made by Claude Code. No setup needed — it works out of the box.
-
-### Codex CLI
-
-Codex CLI (OpenAI, v0.101.0+) is supported via `.codex/config.toml` (MCP server config). This file is tracked in git. Run `codex` in the repo root to use the configured MCP tools. See the [Codex CLI section in the README](../README.md#codex-cli) for details.
 
 ---
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -78,9 +78,6 @@ hive/                                    # Repository root
 │   ├── PULL_REQUEST_TEMPLATE.md         # PR description template
 │   └── CODEOWNERS                       # Auto-assign reviewers
 │
-├── .codex/                              # Codex CLI project config
-│   └── config.toml                      # Codex MCP server definitions
-│
 ├── core/                                # CORE FRAMEWORK PACKAGE
 │   ├── framework/                       # Main package code
 │   │   ├── agents/                      # Agent definitions and helpers
@@ -135,7 +132,6 @@ hive/                                    # Repository root
 ├── scripts/                             # Utility scripts
 │   └── auto-close-duplicates.ts         # GitHub duplicate issue closer
 │
-├── .agent/                        # Antigravity IDE: mcp_config.json + skills (symlinks)
 ├── quickstart.sh                        # Interactive setup wizard
 ├── README.md                            # Project overview
 ├── CONTRIBUTING.md                      # Contribution guidelines

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -103,8 +103,7 @@ MCP tools are also available in Cursor. To enable:
 
 1. Open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`)
 2. Run `MCP: Enable` to enable MCP servers
-3. Restart Cursor to load the MCP servers from `.cursor/mcp.json`
-4. Open Agent chat and verify MCP tools are available
+3. Open Agent chat and verify MCP tools are available
 
 ### 2. Build an Agent
 


### PR DESCRIPTION
## Summary
- Remove the obsolete VS Code config sentence and Codex CLI config paragraph from `docs/contributing-lint-setup.md`.
- Remove the deleted Cursor MCP config restart step from `docs/environment-setup.md`.
- Remove the deleted Codex and Antigravity config entries from the project tree in `docs/developer-guide.md`.

These configs were deleted by commit `13a8e28a`, so the documentation references were stale.

## Checklist
- [x] Docs-only
- [x] No behavior change
- [x] No broken markdown

Closes #7383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contributor and developer guides to remove outdated references to editor configuration files, Codex CLI support, and project-specific IDE configuration entries.
  - Revised Cursor setup instructions to have users verify MCP tool availability in Agent chat instead of restarting Cursor.
  - Streamlined environment and repository setup documentation for a more current development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->