### PR TITLE
fix(port_scanner): reject out-of-range ports with clear error (fixes #7409)

### DIFF
--- a/tools/src/aden_tools/tools/port_scanner/port_scanner.py
+++ b/tools/src/aden_tools/tools/port_scanner/port_scanner.py
@@ -190,6 +190,9 @@ def register_tools(mcp: FastMCP) -> None:
                 port_list = sorted({int(p.strip()) for p in ports.split(",") if p.strip()})
             except ValueError:
                 return {"error": f"Invalid port list: {ports}. Use 'top20', 'top100', or '80,443'"}
+            invalid = [p for p in port_list if not (1 <= p <= 65535)]
+            if invalid:
+                return {"error": f"Ports out of range (1-65535): {invalid}"}
 
         # Resolve hostname
         try:


### PR DESCRIPTION
## Summary\n- Closes #7409\n-  now validates that every port in a comma-separated custom port list is within 1-65535 before scanning\n- Returns a clear error listing the offending values instead of silently scanning and reporting them as closed\n\n## Before\n would attempt the connection and return them in  with no indication the input was invalid.\n\n## After\nReturns  immediately.\n\n## Tests\nAll 52 existing tests in  and  still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Custom port lists are now validated before scanning begins.
  - Invalid ports outside the 1–65,535 range return a clear error instead of proceeding with hostname resolution or scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->