### PR TITLE
fix(command_guard): block PowerShell kill alias for Stop-Process (fixes #7419)

### DIFF
--- a/tools/src/terminal_tools/common/command_guard.py
+++ b/tools/src/terminal_tools/common/command_guard.py
@@ -70,8 +70,14 @@ _BLOCK_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
         "kills browser/runtime processes (PowerShell Stop-Process)",
     ),
     (
-        re.compile(rf"\bget-process\b[^\n]*{_PROTECTED}[^\n]*\|\s*(?:[^|\n]*\|\s*)?stop-process\b", re.IGNORECASE),
-        "kills browser/runtime processes (PowerShell Get-Process | Stop-Process)",
+        # PowerShell alias: `kill` is an alias for Stop-Process. Catch
+        # `Get-Process chrome | kill` and `kill -Name chrome` spellings.
+        re.compile(rf"\bkill\b[^\n]*{_PROTECTED}", re.IGNORECASE),
+        "kills browser/runtime processes (PowerShell kill alias for Stop-Process)",
+    ),
+    (
+        re.compile(rf"\bget-process\b[^\n]*{_PROTECTED}[^\n]*\|\s*(?:[^|\n]*\|\s*)?(?:stop-process|kill)\b", re.IGNORECASE),
+        "kills browser/runtime processes (PowerShell Get-Process | Stop-Process/kill)",
     ),
     (
         # cmd / Windows: taskkill /IM chrome.exe  (or /F /IM ...)


### PR DESCRIPTION
## Summary\n- Closes #7419\n- PowerShell defines  as a built-in alias for \n-  bypassed the guard that only matched the canonical spelling\n- Adds a dedicated pattern for the alias and extends the pipeline pattern to also match  as the terminal verb\n\n## Before\n passed the command guard unblocked.\n\n## After\nBlocked with the same message as .\n\n## Tests\nAll 35 tests in  pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PowerShell command safeguards to also block pipelines using the `kill` alias with `Get-Process`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->