### PR TITLE
fix(quickbooks_create_invoice): validate each line item is an object (fixes #7408)

### DIFF
--- a/docs/agent_runtime.md
+++ b/docs/agent_runtime.md
@@ -1,53 +1,64 @@
 # Agent Runtime
 
-> **Scope:** this describes the **standalone agent** execution stack (`AgentRunner` → `AgentRuntime` → `GraphExecutor`), used for single, exportable agents defined with the legacy `nodes`/`edges` format. The **live colony runtime** is different: a session starts a `ColonyRuntime` whose Queen and workers are each an `AgentLoop`, coordinating through the shared [tracker](key_concepts/coordination.md#the-tracker) with no graph traversal. Read the [Architecture Overview](architecture/README.md) for the colony model; read on here for the standalone path.
+> **Scope:** this describes the **standalone agent** execution stack (`AgentLoader` → `AgentHost` → `Orchestrator`), used for single, exportable agents defined with the legacy `nodes`/`edges` format. The **live colony runtime** is different: a session starts a `ColonyRuntime` whose Queen and workers are each an `AgentLoop`, coordinating through the shared [tracker](key_concepts/coordination.md#the-tracker) with no graph traversal. Read the [Architecture Overview](architecture/README.md) for the colony model; read on here for the standalone path.
+>
+> **Name history:** older revisions of this document (and some code docstrings / log
+> strings) call these `AgentRunner`, `AgentRuntime`, `ExecutionStream`, and
+> `GraphExecutor`. Those names no longer exist as modules or classes: `AgentRunner`
+> is now `AgentLoader`, the runtime class is `AgentHost`, the per-entry-point
+> stream is `ExecutionManager`, and graph traversal is `Orchestrator`. The table
+> below maps each old name to its current location.
 
 Execution system for standalone Hive agents. A standalone agent — single-entry or multi-entry, headless or TUI — runs through the runtime stack below.
 
 ## Topology
 
 ```
-                     AgentRunner.load(agent_path)
-                              |
-                         AgentRunner
-                     (factory + public API)
-                              |
-                       _setup_agent_runtime()
-                              |
-                        AgentRuntime
-                   (lifecycle + orchestration)
-                      /       |       \\
-               Stream A   Stream B   Stream C    ← one per entry point
-                  |           |          |
-            GraphExecutor  GraphExecutor  GraphExecutor
-                  |           |          |
-              Node → Node → Node  (graph traversal)
+                     AgentLoader.load(agent_path)
+                               |
+                          AgentLoader
+                     (loader + public API)
+                               |
+                            _setup()
+                               |
+                           AgentHost
+                    (lifecycle + orchestration)
+                       /       |       \
+                Stream A   Stream B   Stream C    ← one per entry point
+                   |           |          |
+              Orchestrator Orchestrator Orchestrator
+                   |           |          |
+               Node → Node → Node  (graph traversal)
 ```
 
-Single-entry agents get a `"default"` entry point automatically. There is no separate code path.
+Single-entry agents get a `"default"` entry point automatically (registered from `graph.entry_node` during `AgentLoader._setup()`). There is no separate code path.
 
 ## Components
 
 | Component | File | Role |
 | --- | --- | --- |
-| `AgentRunner` | `runner/runner.py` | Load agents, configure tools/LLM, expose high-level API |
-| `AgentRuntime` | `runtime/agent_runtime.py` | Lifecycle management, entry point routing, event bus |
-| `ExecutionStream` | `runtime/execution_stream.py` | Per-entry-point execution queue, session persistence |
-| `GraphExecutor` | `graph/executor.py` | Node traversal, tool dispatch, checkpointing |
-| `EventBus` | `runtime/event_bus.py` | Pub/sub for execution events (streaming, I/O) |
-| `SharedBufferManager` | `runtime/shared_state.py` | Cross-stream state with isolation levels |
-| `OutcomeAggregator` | `runtime/outcome_aggregator.py` | Goal progress tracking across streams |
+| `AgentLoader` (was `AgentRunner`) | `loader/agent_loader.py` | Load agents, configure tools/LLM, expose high-level API |
+| `AgentHost` (was `AgentRuntime`) | `host/agent_host.py` | Lifecycle management, entry point routing, event bus |
+| `ExecutionManager` (was `ExecutionStream`) | `host/execution_manager.py` | Per-entry-point execution queue, session persistence |
+| `Orchestrator` (was `GraphExecutor`) | `orchestrator/orchestrator.py` | Node traversal, tool dispatch, checkpointing |
+| `EventBus` | `host/event_bus.py` | Pub/sub for execution events (streaming, I/O) |
+| `SharedBufferManager` | `host/shared_state.py` | Cross-stream state with isolation levels |
+| `OutcomeAggregator` | `host/outcome_aggregator.py` | Goal progress tracking across streams |
 | `SessionStore` | `storage/session_store.py` | Session state persistence (`sessions/{id}/state.json`) |
+
+Paths are relative to `core/framework/`. `core/framework/runtime/` contains only
+`tests/` — there is no `framework.runtime` package, so any `framework.runtime.*`
+or `framework.runner.*` import is stale.
 
 ## Programming Interface
 
-### AgentRunner (high-level)
+### AgentLoader (high-level)
 
 ```python
-from framework.runner import AgentRunner
+from framework.loader.agent_loader import AgentLoader
 
 # Load and run
-runner = AgentRunner.load("exports/my_agent", model="anthropic/claude-sonnet-4-20250514")
+runner = AgentLoader.load("exports/my_agent", model="anthropic/claude-sonnet-4-20250514")
 result = await runner.run({"query": "hello"})
 
 # Resume from paused session
@@ -60,7 +71,7 @@ exec_id = await runner.trigger("default", {})  # Non-blocking trigger
 entry_points = runner.get_entry_points()       # List entry points
 
 # Context manager
-async with AgentRunner.load("exports/my_agent") as runner:
+async with AgentLoader.load("exports/my_agent") as runner:
     result = await runner.run({"query": "hello"})
 
 # Cleanup
@@ -68,24 +79,26 @@ runner.cleanup()          # Synchronous
 await runner.cleanup_async()  # Asynchronous
 ```
 
-### AgentRuntime (lower-level)
+### AgentHost (lower-level)
 
 ```python
-from framework.runtime.agent_runtime import AgentRuntime, create_agent_runtime
-from framework.runtime.execution_stream import EntryPointSpec
+from pathlib import Path
 
-# Create runtime with entry points
-runtime = create_agent_runtime(
+from framework.host.agent_host import AgentHost
+from framework.host.execution_manager import EntryPointSpec
+
+# Create runtime and register entry points
+runtime = AgentHost(
     graph=graph,
     goal=goal,
     storage_path=Path("~/.hive/agents/my_agent"),
-    entry_points=[
-        EntryPointSpec(id="default", name="Default", entry_node="start", trigger_type="manual"),
-    ],
     llm=llm,
     tools=tools,
     tool_executor=tool_executor,
     checkpoint_config=checkpoint_config,
+)
+runtime.register_entry_point(
+    EntryPointSpec(id="default", name="Default", entry_node="start", trigger_type="manual"),
 )
 
 # Lifecycle
@@ -116,12 +129,12 @@ runtime.get_stats()          # Runtime statistics
 
 ## Execution Flow
 
-1. `AgentRunner.run()` calls `AgentRuntime.trigger_and_wait()`
-2. `AgentRuntime` routes to the `ExecutionStream` for the entry point
-3. `ExecutionStream` creates a `GraphExecutor` and calls `execute()`
-4. `GraphExecutor` traverses nodes, dispatches tools, manages checkpoints
+1. `AgentLoader.run()` calls `AgentHost.trigger_and_wait()`
+2. `AgentHost` routes to the `ExecutionManager` for the entry point
+3. `ExecutionManager` creates an `Orchestrator` and calls `execute()`
+4. `Orchestrator` traverses nodes, dispatches tools, manages checkpoints
 5. `ExecutionResult` flows back up through the stack
-6. `ExecutionStream` writes session state to disk
+6. `ExecutionManager` writes session state to disk
 
 ## Session Resume
 
@@ -137,7 +150,7 @@ result = await runner.run({"query": "start task"})
 result = await runner.run({"input": "approved"}, session_state=result.session_state)
 ```
 
-Session state flows: `AgentRunner.run()` → `AgentRuntime.trigger_and_wait()` → `ExecutionStream.execute()` → `GraphExecutor.execute()`.
+Session state flows: `AgentLoader.run()` → `AgentHost.trigger_and_wait()` → `ExecutionManager` execution → `Orchestrator.execute()`.
 
 Checkpoints are saved at node boundaries (`sessions/{id}/checkpoints/`) for crash recovery.
 
@@ -155,7 +168,7 @@ The `EventBus` provides real-time execution visibility:
 | `CLIENT_INPUT_REQUESTED` | Agent needs user input |
 | `EXECUTION_COMPLETED` | Full execution finishes |
 
-In headless mode, `AgentRunner` subscribes to `CLIENT_OUTPUT_DELTA` and `CLIENT_INPUT_REQUESTED` to print output and read stdin. In TUI mode, `AdenTUI` subscribes to route events to UI widgets.
+In headless mode, `AgentLoader` subscribes to `CLIENT_OUTPUT_DELTA` and `CLIENT_INPUT_REQUESTED` to print output and read stdin. In TUI mode, `AdenTUI` subscribes to route events to UI widgets.
 
 ## Storage Layout
 

--- a/docs/agent_runtime.md
+++ b/docs/agent_runtime.md
@@ -13,8 +13,8 @@ Execution system for standalone Hive agents. A standalone agent — single-entry
 
 ## Topology
 
-```
-                     AgentLoader.load(agent_path)
+```text
+                      AgentLoader.load(agent_path)
                                |
                           AgentLoader
                      (loader + public API)

--- a/tools/src/aden_tools/tools/quickbooks_tool/quickbooks_tool.py
+++ b/tools/src/aden_tools/tools/quickbooks_tool/quickbooks_tool.py
@@ -197,7 +197,9 @@ def register_tools(mcp: FastMCP, credentials: Any = None) -> None:
             return {"error": "line_items must be a non-empty JSON array"}
 
         lines = []
-        for item in items:
+        for i, item in enumerate(items):
+            if not isinstance(item, dict):
+                return {"error": f"line_items[{i}] must be an object, got {type(item).__name__}"}
             line: dict[str, Any] = {
                 "Amount": item.get("amount", 0),
                 "DetailType": "SalesItemLineDetail",


### PR DESCRIPTION
## Summary\n- Closes #7408\n- Previously passing a non-object element (string, number, null) in line_items caused AttributeError on item.get()\n- Now returns a clear error naming the offending index and type\n\n## Tests\nAll 12 quickbooks tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated standalone agent runtime documentation with clearer component names, architecture diagrams, scope guidance, and component references.
  - Revised programming examples to reflect the current loading, hosting, registration, execution, session-state, and event-flow interfaces.

- **Bug Fixes**
  - Improved invoice creation validation by reporting a clear error when a line item is not provided in the expected object format, instead of failing unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->