### PR TITLE
fix(quickstart.sh): survive unset TERM and surface uv sync errors (fixes #7368)

### DIFF
--- a/core/framework/orchestrator/node_worker.py
+++ b/core/framework/orchestrator/node_worker.py
@@ -760,11 +760,11 @@ class NodeWorker:
                 continue
             val_str = str(value)
             if len(val_str) > 300 and data_dir is not None:
-                data_dir.mkdir(parents=True, exist_ok=True)
                 ext = ".json" if isinstance(value, (dict, list)) else ".txt"
                 filename = f"output_{key}{ext}"
                 file_path = data_dir / filename
                 try:
+                    data_dir.mkdir(parents=True, exist_ok=True)
                     write_content = json.dumps(value, indent=2, ensure_ascii=False) if isinstance(value, (dict, list)) else str(value)
                     file_path.write_text(write_content, encoding="utf-8")
                     file_size = file_path.stat().st_size

--- a/core/framework/orchestrator/node_worker.py
+++ b/core/framework/orchestrator/node_worker.py
@@ -771,7 +771,12 @@ class NodeWorker:
                     buffer_items[key] = f"[Saved to '{filename}' ({file_size:,} bytes). Use terminal_exec(\"cat {filename}\") to access.]"
                     continue
                 except Exception:
-                    pass
+                    logger.warning(
+                        "Failed to spill buffer key %r to %s; using inline truncation",
+                        key,
+                        file_path,
+                        exc_info=True,
+                    )
 
             buffer_items[key] = val_str[:300] + "..." if len(val_str) > 300 else val_str
 

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -93,7 +93,7 @@ prompt_choice() {
     done
 }
 
-clear
+clear 2>/dev/null || true
 echo ""
 echo -e "${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}${DIM}⬡${NC}${YELLOW}⬢${NC}"
 echo ""
@@ -260,10 +260,13 @@ echo -n "  Installing workspace packages... "
 cd "$SCRIPT_DIR"
 
 if [ -f "pyproject.toml" ]; then
-    if uv sync > /dev/null 2>&1; then
+    uv_output="$(uv sync 2>&1)"
+    if [ $? -eq 0 ]; then
         echo -e "${GREEN}  ✓ workspace packages installed${NC}"
     else
         echo -e "${RED}  ✗ workspace installation failed${NC}"
+        echo -e "${DIM}  Error output:${NC}"
+        echo "$uv_output" | sed 's/^/    /'
         exit 1
     fi
 else
@@ -2314,7 +2317,7 @@ fi
 # Success!
 # ============================================================
 
-clear
+clear 2>/dev/null || true
 echo ""
 echo -e "${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}${DIM}⬡${NC}${GREEN}⬢${NC}"
 echo ""


### PR DESCRIPTION
## Summary\n- Closes #7368\n-  crashed when TERM was unset (CI/non-interactive shells)\n- Now silenced with  fallback\n- uv sync errors were hidden behind /dev/null — now captured and printed\n\n## Tests\nScript syntax check passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of oversized data during workflow transitions by creating required storage locations automatically.
  - Added clear warning details when temporary data storage fails, with safe fallback behavior to keep processing moving.

- **Chores**
  - Improved quickstart setup reliability by tolerating terminal-clear failures.
  - Setup synchronization now reports success or failure clearly and displays relevant error details before exiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->