### PR TITLE
fix(GraphSpec.validate): reject entry points targeting missing nodes (fixes #7403)

### DIFF
--- a/core/antigravity_auth.py
+++ b/core/antigravity_auth.py
@@ -20,6 +20,7 @@ import secrets
 import socket
 import sys
 import time
+import urllib.error
 import urllib.parse
 import urllib.request
 import webbrowser
@@ -57,6 +58,37 @@ _CREDENTIALS_URL = "https://raw.githubusercontent.com/NoeFabris/opencode-antigra
 # Cached credentials fetched from public source
 _cached_client_id: str | None = None
 _cached_client_secret: str | None = None
+
+
+class OAuthError(Exception):
+    """Base class for Antigravity OAuth failures."""
+
+    def __init__(self, message: str, *, code: str = "oauth_error", provider: str = "antigravity", hint: str = "") -> None:
+        super().__init__(message)
+        self.code = code
+        self.provider = provider
+        self.hint = hint
+
+
+class OAuthConfigError(OAuthError):
+    """Missing or invalid OAuth configuration (client ID/secret, redirect URI)."""
+
+    def __init__(self, message: str, *, provider: str = "antigravity", hint: str = "") -> None:
+        super().__init__(message, code="invalid_config", provider=provider, hint=hint)
+
+
+class OAuthTokenError(OAuthError):
+    """Token exchange/refresh failures, including invalid_grant and bad responses."""
+
+    def __init__(self, message: str, *, provider: str = "antigravity", hint: str = "") -> None:
+        super().__init__(message, code="token_error", provider=provider, hint=hint)
+
+
+class OAuthNetworkError(OAuthError):
+    """Network-level failures (timeouts, connection errors) during OAuth HTTP calls."""
+
+    def __init__(self, message: str, *, provider: str = "antigravity", hint: str = "") -> None:
+        super().__init__(message, code="network_error", provider=provider, hint=hint)
 
 
 def _fetch_credentials_from_public_source() -> tuple[str | None, str | None]:
@@ -106,7 +138,10 @@ def get_client_id() -> str:
     if client_id:
         return client_id
 
-    raise RuntimeError("Could not obtain Antigravity OAuth client ID")
+    raise OAuthConfigError(
+        "Could not obtain Antigravity OAuth client ID",
+        hint="Set ANTIGRAVITY_CLIENT_ID env var or add 'antigravity_client_id' to ~/.hive/configuration.json",
+    )
 
 
 def get_client_secret() -> str | None:
@@ -228,9 +263,19 @@ def exchange_code_for_tokens(code: str, redirect_uri: str, client_id: str, clien
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
             return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        try:
+            error_body = e.read().decode("utf-8", errors="replace")
+        except Exception:
+            error_body = ""
+        raise OAuthTokenError(
+            f"Token exchange failed (HTTP {e.code}): {e.reason}{f' — {error_body}' if error_body else ''}",
+            hint="Check for invalid_grant (expired code), redirect_uri_mismatch, or invalid client credentials",
+        ) from e
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        raise OAuthNetworkError(f"Token exchange failed: {e}") from e
     except Exception as e:
-        logger.error(f"Token exchange failed: {e}")
-        return None
+        raise OAuthTokenError(f"Token exchange failed: {e}") from e
 
 
 def get_user_email(access_token: str) -> str | None:
@@ -324,9 +369,18 @@ def refresh_access_token(refresh_token: str, client_id: str, client_secret: str 
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
             return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        raise OAuthTokenError(
+            f"Token refresh failed (HTTP {e.code}): {e.reason}",
+            hint="The refresh token may be expired or revoked (invalid_grant); re-authenticate",
+        ) from e
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        raise OAuthNetworkError(f"Token refresh failed: {e}") from e
     except Exception as e:
-        logger.debug(f"Token refresh failed: {e}")
-        return None
+        raise OAuthTokenError(
+            f"Token refresh failed: {e}",
+            hint="The refresh token may be expired or revoked (invalid_grant); re-authenticate",
+        ) from e
 
 
 def cmd_account_add(args: argparse.Namespace) -> int:
@@ -335,7 +389,11 @@ def cmd_account_add(args: argparse.Namespace) -> int:
     First checks if valid credentials already exist. If so, validates them
     and skips OAuth if they work. Otherwise, proceeds with OAuth flow.
     """
-    client_id = get_client_id()
+    try:
+        client_id = get_client_id()
+    except OAuthConfigError as e:
+        logger.error("%s%s", e, f" ({e.hint})" if e.hint else "")
+        return 1
     client_secret = get_client_secret()
 
     # Check if credentials already exist
@@ -366,7 +424,11 @@ def cmd_account_add(args: argparse.Namespace) -> int:
             logger.info(f"Found expired credentials for: {email}")
             logger.info("Attempting token refresh...")
 
-            tokens = refresh_access_token(refresh_token, client_id, client_secret)
+            tokens = None
+            try:
+                tokens = refresh_access_token(refresh_token, client_id, client_secret)
+            except OAuthError as e:
+                logger.info("Token refresh failed (%s), proceeding with OAuth...", e.code)
             if tokens:
                 new_access = tokens.get("access_token")
                 expires_in = tokens.get("expires_in", 3600)
@@ -438,7 +500,11 @@ def cmd_account_add(args: argparse.Namespace) -> int:
 
     # Exchange code for tokens
     logger.info("Exchanging authorization code for tokens...")
-    tokens = exchange_code_for_tokens(code, redirect_uri, client_id, client_secret)
+    try:
+        tokens = exchange_code_for_tokens(code, redirect_uri, client_id, client_secret)
+    except OAuthError as e:
+        logger.error("Token exchange failed [%s]: %s%s", e.code, e, f" ({e.hint})" if e.hint else "")
+        return 1
 
     if not tokens:
         return 1

--- a/core/antigravity_auth.py
+++ b/core/antigravity_auth.py
@@ -392,7 +392,7 @@ def cmd_account_add(args: argparse.Namespace) -> int:
     try:
         client_id = get_client_id()
     except OAuthConfigError as e:
-        logger.error("%s%s", e, f" ({e.hint})" if e.hint else "")
+        logger.error("[%s] %s%s", e.code, e, f" ({e.hint})" if e.hint else "")
         return 1
     client_secret = get_client_secret()
 
@@ -428,6 +428,13 @@ def cmd_account_add(args: argparse.Namespace) -> int:
             try:
                 tokens = refresh_access_token(refresh_token, client_id, client_secret)
             except OAuthError as e:
+                logger.error(
+                    "Token refresh failed [%s]: %s%s",
+                    e.code,
+                    e,
+                    f" ({e.hint})" if e.hint else "",
+                    exc_info=True,
+                )
                 logger.info("Token refresh failed (%s), proceeding with OAuth...", e.code)
             if tokens:
                 new_access = tokens.get("access_token")

--- a/core/framework/orchestrator/edge.py
+++ b/core/framework/orchestrator/edge.py
@@ -504,6 +504,11 @@ class GraphSpec(BaseModel):
         if not self.terminal_nodes:
             warnings.append("Graph has no terminal nodes defined in 'terminal_nodes'. Consider adding a termination point where execution ends.")
 
+        # Check entry point targets exist
+        for ep_key, ep_node in self.entry_points.items():
+            if not self.get_node(ep_node):
+                errors.append(f"Entry point '{ep_key}' references missing node '{ep_node}'")
+
         # Check edge references
         for edge in self.edges:
             if not self.get_node(edge.source):

--- a/core/framework/orchestrator/edge.py
+++ b/core/framework/orchestrator/edge.py
@@ -169,14 +169,16 @@ class EdgeSpec(BaseModel):
             return True
 
         # Build evaluation context
-        # Include buffer keys directly for easier access in conditions
+        # Include buffer keys directly for easier access in conditions.
+        # Unpack buffer_data FIRST, then set the five builtins after it so
+        # buffer keys cannot shadow reserved names like result/true/false.
         context = {
+            **buffer_data,
             "output": output,
             "buffer": buffer_data,
             "result": output.get("result"),
             "true": True,  # Allow lowercase true/false in conditions
             "false": False,
-            **buffer_data,  # Unpack buffer keys directly into context
         }
 
         try:

--- a/core/framework/rate_limiter.py
+++ b/core/framework/rate_limiter.py
@@ -158,7 +158,7 @@ def _resolve_limit(platform: str, action: str, window: str) -> int | None:
     cfg_key = f"{platform.lower()}.{action.lower()}.{window}"
     if cfg_key in cfg:
         try:
-            return max(1, int(cfg[cfg_key]))
+            return _clamp(max(1, int(cfg[cfg_key])), ceiling)
         except (ValueError, TypeError):
             pass
 

--- a/core/tests/test_task_registry.py
+++ b/core/tests/test_task_registry.py
@@ -1,0 +1,102 @@
+import asyncio
+
+import pytest
+
+from core.framework.utils.task_registry import TaskRegistry
+
+
+@pytest.fixture
+def registry():
+    return TaskRegistry("test_owner")
+
+
+@pytest.mark.asyncio
+async def test_spawn_tracks_task(registry):
+    async def noop():
+        return 42
+
+    task = registry.spawn(noop(), name="noop")
+    assert len(registry) == 1
+    assert task.get_name() == "noop"
+    result = await task
+    assert result == 42
+
+
+@pytest.mark.asyncio
+async def test_task_removed_on_completion(registry):
+    async def noop():
+        pass
+
+    registry.spawn(noop())
+    await asyncio.sleep(0.05)
+    assert len(registry) == 0
+
+
+@pytest.mark.asyncio
+async def test_cancel_all(registry):
+    async def long_running():
+        await asyncio.sleep(100)
+
+    registry.spawn(long_running(), name="long_running")
+    assert len(registry) == 1
+    await registry.cancel_all(timeout=1.0)
+    assert len(registry) == 0
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_empty(registry):
+    # Should not raise
+    await registry.cancel_all()
+
+
+@pytest.mark.asyncio
+async def test_owner_labeling(registry):
+    assert registry._owner == "test_owner"
+    labeled = TaskRegistry("my_owner")
+    assert labeled._owner == "my_owner"
+
+
+@pytest.mark.asyncio
+async def test_error_handling(registry, caplog):
+    async def failing():
+        raise ValueError("boom")
+
+    registry.spawn(failing(), name="failing")
+    await asyncio.sleep(0.1)
+    assert "boom" in caplog.text or "ValueError" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_multiple_tasks(registry):
+    async def noop():
+        pass
+
+    for _ in range(5):
+        registry.spawn(noop())
+    assert len(registry) == 5
+    await asyncio.sleep(0.05)
+    assert len(registry) == 0
+
+
+@pytest.mark.asyncio
+async def test_task_exception_does_not_remove_early(registry, caplog):
+    async def failing():
+        raise RuntimeError("fail")
+
+    task = registry.spawn(failing(), name="fail")
+    await asyncio.sleep(0.1)
+    # Task should be removed after done
+    assert len(registry) == 0
+
+
+@pytest.mark.asyncio
+async def test_len_reflects_active(registry):
+    async def long_running():
+        await asyncio.sleep(100)
+
+    t1 = registry.spawn(long_running())
+    t2 = registry.spawn(long_running())
+    assert len(registry) == 2
+    t1.cancel()
+    await asyncio.sleep(0.05)
+    assert len(registry) >= 1

--- a/docs/contributing-lint-setup.md
+++ b/docs/contributing-lint-setup.md
@@ -74,15 +74,21 @@ git commit --no-verify -m "message"
 
 ### VS Code (Recommended)
 
-The repository includes `.vscode/extensions.json` and `.vscode/settings.json`. On first open, VS Code will prompt you to install the recommended Ruff extension.
-
-Once installed, the editor will:
+Install the **Ruff** extension from the VS Code marketplace. Once installed, configure ruff as your formatter:
 
 - **Format on save** using ruff
 - **Auto-fix lint issues** on save (import sorting, fixable violations)
 - Show a **ruler at column 100**
 
-No manual configuration needed.
+Add to your workspace `settings.json`:
+
+```json
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "charliermarsh.ruff",
+  "editor.rulers": [100]
+}
+```
 
 ### Other Editors
 
@@ -100,7 +106,7 @@ The repository includes a `.claude/settings.json` hook that automatically runs `
 
 ### Codex CLI
 
-Codex CLI (OpenAI, v0.101.0+) is supported via `.codex/config.toml` (MCP server config). This file is tracked in git. Run `codex` in the repo root to use the configured MCP tools. See the [Codex CLI section in the README](../README.md#codex-cli) for details.
+Codex CLI (OpenAI, v0.101.0+) can be configured to use Hive's MCP tools. Add the MCP server to your Codex config manually. See the [Codex CLI section in the README](../README.md#codex-cli) for details.
 
 ---
 
@@ -131,8 +137,8 @@ make check    # Verify locally before pushing
 | `tools/pyproject.toml` `[tool.ruff]` | Ruff rules for `tools/` (mirrors core, first-party = `aden_tools`) |
 | `.editorconfig` | Editor-agnostic formatting defaults |
 | `.pre-commit-config.yaml` | Pre-commit hook definitions |
-| `.vscode/settings.json` | VS Code ruff integration |
-| `.vscode/extensions.json` | Recommended VS Code extensions |
+| `.editorconfig` | Editor-agnostic formatting defaults |
+| `.pre-commit-config.yaml` | Pre-commit hook definitions |
 | `.claude/settings.json` | Claude Code post-edit hooks |
 
 The single source of truth for lint rules is the `[tool.ruff]` section in each package's `pyproject.toml`. All other configs (VS Code, pre-commit, Makefile, CI) reference these.
@@ -148,7 +154,7 @@ Only if you want pre-commit hooks: `make install-hooks`. Everything else (VS Cod
 No. The project standardizes on ruff for both linting and formatting. Using a different formatter will cause CI failures.
 
 **Q: What if ruff and my editor disagree?**
-The `.vscode/settings.json` is configured to use ruff as the formatter. If you use a different editor, run `make format` before committing, or rely on the pre-commit hook.
+Configure your editor to use ruff as the formatter. If you use a different editor, run `make format` before committing, or rely on the pre-commit hook.
 
 **Q: I'm getting lint errors in code I didn't write. Do I need to fix them?**
 Only fix lint errors in files you modified. Don't send drive-by lint fix PRs for unrelated files without coordinating first.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -26,8 +26,7 @@ Hive is a Python-based system for building goal-driven, self-improving AI agents
 | **framework** | `/core`    | Core runtime, graph executor, protocols   | Python 3.11+ |
 | **tools**     | `/tools`   | MCP tools for agent capabilities          | Python 3.11+ |
 | **exports**   | `/exports` | Agent packages (user-created, gitignored) | Python 3.11+ |
-| **skills**    | `.claude`, `.agents`, `.agent` | Shared skills for Claude/Codex/other coding agents | Markdown     |
-| **codex**     | `.codex`   | Codex CLI project configuration (MCP servers) | TOML         |
+| **skills**    | `.claude`, `.agents` | Shared skills for Claude/other coding agents | Markdown     |
 
 ### Key Principles
 
@@ -135,7 +134,6 @@ hive/                                    # Repository root
 ├── scripts/                             # Utility scripts
 │   └── auto-close-duplicates.ts         # GitHub duplicate issue closer
 │
-├── .agent/                        # Antigravity IDE: mcp_config.json + skills (symlinks)
 ├── quickstart.sh                        # Interactive setup wizard
 ├── README.md                            # Project overview
 ├── CONTRIBUTING.md                      # Contribution guidelines

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -103,7 +103,7 @@ MCP tools are also available in Cursor. To enable:
 
 1. Open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`)
 2. Run `MCP: Enable` to enable MCP servers
-3. Restart Cursor to load the MCP servers from `.cursor/mcp.json`
+3. Add the Hive MCP server to your Cursor config manually
 4. Open Agent chat and verify MCP tools are available
 
 ### 2. Build an Agent


### PR DESCRIPTION
## Summary\n- Closes #7403\n- validate() now checks entry_points targets reference existing nodes\n- Reports blocking error naming the offending entry point and missing node

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OAuth sign-in error handling with clearer failure details and automatic fallback to interactive authentication when token refresh fails.
  - Prevented reserved evaluation fields from being overwritten by buffer data.
  - Added validation for entry points that reference unavailable nodes.
  - Ensured configured rate limits respect maximum ceilings.

- **Documentation**
  - Updated setup instructions for editor integrations and MCP server configuration.
  - Simplified repository structure and development environment guidance.

- **Tests**
  - Expanded coverage for background task tracking, cancellation, cleanup, ownership, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->