### PR TITLE
fix: resolve ruff lint errors in core/ and tools/

### DIFF
--- a/core/framework/agent_loop/agent_loop.py
+++ b/core/framework/agent_loop/agent_loop.py
@@ -2032,9 +2032,7 @@ class AgentLoop(AgentProtocol):
             # prune/summary budgets instead of collapsing to 32k under them.
             from framework.config import get_max_context_tokens as _live_mct
 
-            conversation._max_context_tokens = _live_mct(
-                fallback=self._config.max_context_tokens
-            )
+            conversation._max_context_tokens = _live_mct(fallback=self._config.max_context_tokens)
 
             await self._publish_context_usage(ctx, conversation, "iteration_start", tools=tools)
 
@@ -6575,7 +6573,7 @@ class AgentLoop(AgentProtocol):
                 # shield: a grace-window timeout must not cancel the in-flight
                 # work — it still has the full `timeout` budget to finish in.
                 result = await asyncio.wait_for(asyncio.shield(task), timeout=grace)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 pass  # genuinely slow — fall through and hand back the handle
             except Exception:
                 # Failed fast. Let collect_result surface it rather than

--- a/core/framework/agent_loop/internals/compaction.py
+++ b/core/framework/agent_loop/internals/compaction.py
@@ -41,6 +41,8 @@ def llm_compact_char_limit(max_context_tokens: int) -> int:
     keeps tiny windows from splitting into confetti.
     """
     return max(20_000, (max_context_tokens * 4) // 3)
+
+
 # Max output tokens for a single compaction summary call. A summary must be a
 # small fraction of the window — using ``max_context_tokens // 2`` (e.g. 90k on a
 # 180k window) lets the model emit a "summary" nearly as large as the input, which

--- a/core/framework/agent_loop/internals/vision_fallback.py
+++ b/core/framework/agent_loop/internals/vision_fallback.py
@@ -326,10 +326,7 @@ async def caption_tool_image(
     kwargs: dict[str, Any] = {
         "model": rewritten_model,
         "messages": messages,
-        "max_tokens": int(
-            get_hive_config().get("vision_fallback", {}).get("max_tokens")
-            or get_aux_max_tokens()
-        ),
+        "max_tokens": int(get_hive_config().get("vision_fallback", {}).get("max_tokens") or get_aux_max_tokens()),
         "timeout": timeout_s,
     }
     # Always pass api_key when we have one, even alongside proxy-rewritten

--- a/core/framework/agents/queen/queen_profiles.py
+++ b/core/framework/agents/queen/queen_profiles.py
@@ -265,9 +265,7 @@ def create_queen_profile(
         raise ValueError("name is required")
     qid = (queen_id or "").strip() or _slugify_queen_id(name)
     if not _QUEEN_ID_RE.match(qid):
-        raise ValueError(
-            "queen_id must match [a-z0-9][a-z0-9_-]{0,62} (lowercase slug)"
-        )
+        raise ValueError("queen_id must match [a-z0-9][a-z0-9_-]{0,62} (lowercase slug)")
     if qid in DEFAULT_QUEENS or (QUEENS_DIR / qid / "profile.yaml").exists():
         raise FileExistsError(qid)
     profile: dict[str, Any] = {"name": name, "title": (title or "").strip()}

--- a/core/framework/agents/queen/recall_selector.py
+++ b/core/framework/agents/queen/recall_selector.py
@@ -19,12 +19,12 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from framework.config import get_aux_max_tokens
 from framework.agents.queen.queen_memory_v2 import (
     format_memory_manifest,
     global_memory_dir as _default_global_memory_dir,
     scan_memory_files,
 )
+from framework.config import get_aux_max_tokens
 
 logger = logging.getLogger(__name__)
 

--- a/core/framework/agents/queen/tests/test_deferred_handle_redeemers.py
+++ b/core/framework/agents/queen/tests/test_deferred_handle_redeemers.py
@@ -51,8 +51,7 @@ def test_emitter_categories_ship_their_redeemers(emitter: str):
         tools = set(qtd._TOOL_CATEGORIES[category])
         missing = _REDEEMERS[emitter] - tools
         assert not missing, (
-            f"category {category!r} offers {emitter} but not {sorted(missing)} — "
-            f"an agent in this tier receives handles it cannot redeem"
+            f"category {category!r} offers {emitter} but not {sorted(missing)} — an agent in this tier receives handles it cannot redeem"
         )
 
 
@@ -74,9 +73,7 @@ def test_always_enabled_tiers_ship_their_redeemers(emitter: str):
         if emitter not in enabled:
             continue  # this tier doesn't hand out the handle; nothing to redeem
         missing = _REDEEMERS[emitter] - enabled
-        assert not missing, (
-            f"{label} always-enabled set has {emitter} but not {sorted(missing)}"
-        )
+        assert not missing, f"{label} always-enabled set has {emitter} but not {sorted(missing)}"
 
 
 def test_terminal_exec_is_dispatched_in_background():
@@ -93,7 +90,4 @@ def test_terminal_exec_is_dispatched_in_background():
     assert "terminal_exec" in cfg.background_tools
     # collect_result is only attached when background_tools is non-empty.
     assert cfg.background_tools, "collect_result would not be offered to the agent"
-    assert cfg.background_tool_grace_seconds > 0, (
-        "grace window disabled — every quick command would pay a full "
-        "collect_result model turn"
-    )
+    assert cfg.background_tool_grace_seconds > 0, "grace window disabled — every quick command would pay a full collect_result model turn"

--- a/core/framework/host/colony_runtime.py
+++ b/core/framework/host/colony_runtime.py
@@ -1467,9 +1467,7 @@ class ColonyRuntime:
         # default. Skipped entirely when the spawner passed an explicit
         # per-worker budget (whitelisted override) — runtime intent wins.
         if "max_context_tokens" not in (loop_config_overrides or {}):
-            _spawn_loop_config.max_context_tokens = _get_worker_max_ctx(
-                fallback=_spawn_loop_config.max_context_tokens
-            )
+            _spawn_loop_config.max_context_tokens = _get_worker_max_ctx(fallback=_spawn_loop_config.max_context_tokens)
         agent_loop = AgentLoop(
             event_bus=self._scoped_event_bus,
             tool_executor=spawn_executor,

--- a/core/framework/llm/litellm.py
+++ b/core/framework/llm/litellm.py
@@ -37,8 +37,7 @@ except ImportError:
     RateLimitError = Exception  # type: ignore[assignment, misc]
     CustomLogger = object  # type: ignore[assignment, misc]
 
-from framework.config import HIVE_LLM_ENDPOINT as HIVE_API_BASE
-from framework.config import get_aux_max_tokens, get_max_tokens
+from framework.config import HIVE_LLM_ENDPOINT as HIVE_API_BASE, get_aux_max_tokens, get_max_tokens
 from framework.llm.model_catalog import get_model_pricing
 from framework.llm.provider import LLMProvider, LLMResponse, Tool
 from framework.llm.stream_events import StreamEvent

--- a/core/framework/server/app.py
+++ b/core/framework/server/app.py
@@ -817,9 +817,7 @@ async def handle_browser_status(request: web.Request) -> web.Response:
     sockets; the stream endpoint remains for the desktop shell, whose SSE
     rides IPC and is exempt from that cap).
     """
-    return web.json_response(
-        await _browser_status_payload(request.query.get("session_id"))
-    )
+    return web.json_response(await _browser_status_payload(request.query.get("session_id")))
 
 
 async def handle_browser_status_stream(request: web.Request) -> web.StreamResponse:

--- a/core/framework/server/queen_orchestrator.py
+++ b/core/framework/server/queen_orchestrator.py
@@ -730,13 +730,12 @@ async def create_queen(
     from framework.llm.capabilities import supports_image_tool_results
     from framework.loader.mcp_registry import MCPRegistry
     from framework.loader.tool_registry import ToolRegistry
+    from framework.server import boot_status
     from framework.tools.queen_lifecycle_tools import (
         QueenPhaseState,
         normalize_legacy_phase,
         register_queen_lifecycle_tools,
     )
-
-    from framework.server import boot_status
 
     # ---- Tool registry ------------------------------------------------
     # Use pre-loaded cached registry if available (fast path)

--- a/core/framework/server/routes_config.py
+++ b/core/framework/server/routes_config.py
@@ -23,7 +23,6 @@ from framework.agents.queen.queen_memory_v2 import (
 from framework.config import (
     _PROVIDER_CRED_MAP,
     HIVE_CONFIG_FILE,
-    HIVE_HOME,
     OPENROUTER_API_BASE,
     get_hive_config,
 )
@@ -469,16 +468,9 @@ async def handle_update_llm_config(request: web.Request) -> web.Response:
             return web.json_response({"error": "'model' is required"}, status=400)
         config = get_hive_config()
         llm_section = config.setdefault("llm", {})
-        provider = str(
-            body.get("provider") or llm_section.get("provider") or "openai"
-        )
-        api_base = (
-            str(body.get("api_base") or llm_section.get("api_base") or "").strip()
-            or None
-        )
-        env_var = str(
-            body.get("api_key_env_var") or llm_section.get("api_key_env_var") or ""
-        ).strip()
+        provider = str(body.get("provider") or llm_section.get("provider") or "openai")
+        api_base = str(body.get("api_base") or llm_section.get("api_base") or "").strip() or None
+        env_var = str(body.get("api_key_env_var") or llm_section.get("api_key_env_var") or "").strip()
         api_key = os.environ.get(env_var) if env_var else None
         if api_key is None:
             api_key = _resolve_api_key(provider, request)
@@ -498,12 +490,9 @@ async def handle_update_llm_config(request: web.Request) -> web.Response:
         _write_config_atomic(config)
 
         full_model = f"{provider}/{model}"
-        swapped = _hot_swap_sessions(
-            request, full_model, api_key=api_key, api_base=api_base
-        )
+        swapped = _hot_swap_sessions(request, full_model, api_key=api_key, api_base=api_base)
         logger.info(
-            "LLM config updated (custom endpoint): provider=%s model=%s base=%s, "
-            "hot-swapped %d session(s)",
+            "LLM config updated (custom endpoint): provider=%s model=%s base=%s, hot-swapped %d session(s)",
             provider,
             model,
             api_base,
@@ -1155,14 +1144,10 @@ _ROLE_SECTIONS = ("llm", "worker_llm", "vision_fallback")
 async def handle_get_llm_sections(request: web.Request) -> web.Response:
     """GET /api/config/llm-sections — the three provider slots, verbatim."""
     cfg = get_hive_config()
-    return web.json_response(
-        {role: (cfg.get(role) or None) for role in _ROLE_SECTIONS}
-    )
+    return web.json_response({role: (cfg.get(role) or None) for role in _ROLE_SECTIONS})
 
 
-async def _write_role_section(
-    request: web.Request, role: str, section: dict, validate: bool
-) -> web.Response:
+async def _write_role_section(request: web.Request, role: str, section: dict, validate: bool) -> web.Response:
     """Validate + commit one provider section into a slot, verbatim.
 
     Shared by the direct slot editor (PUT /llm-sections) and the library
@@ -1181,13 +1166,10 @@ async def _write_role_section(
             api_key = os.environ.get(str(env_var), "")
 
     if validate and api_key and api_base:
-        check = await _validate_provider_key(
-            provider, api_key, api_base=api_base, model=str(section["model"])
-        )
+        check = await _validate_provider_key(provider, api_key, api_base=api_base, model=str(section["model"]))
         if check.get("valid") is False:
             return web.json_response(
-                {"error": f"Key check failed against {api_base}: "
-                          f"{check.get('message', 'unknown error')}"},
+                {"error": f"Key check failed against {api_base}: {check.get('message', 'unknown error')}"},
                 status=400,
             )
 
@@ -1198,9 +1180,7 @@ async def _write_role_section(
     swapped = 0
     if role == "llm":
         full_model = f"{provider}/{section['model']}"
-        swapped = _hot_swap_sessions(
-            request, full_model, api_key=api_key or None, api_base=api_base
-        )
+        swapped = _hot_swap_sessions(request, full_model, api_key=api_key or None, api_base=api_base)
     logger.info(
         "Provider slot %s written: %s/%s @ %s, hot-swapped %d session(s)",
         role,
@@ -1209,9 +1189,7 @@ async def _write_role_section(
         api_base,
         swapped,
     )
-    return web.json_response(
-        {"role": role, "section": section, "sessions_swapped": swapped}
-    )
+    return web.json_response({"role": role, "section": section, "sessions_swapped": swapped})
 
 
 async def handle_put_llm_section(request: web.Request) -> web.Response:
@@ -1239,8 +1217,7 @@ async def handle_put_llm_section(request: web.Request) -> web.Response:
     if section is None:
         if role == "llm":
             return web.json_response(
-                {"error": "The llm slot cannot be cleared - the runtime "
-                          "always needs a main model."},
+                {"error": "The llm slot cannot be cleared - the runtime always needs a main model."},
                 status=400,
             )
         config = get_hive_config()
@@ -1251,12 +1228,8 @@ async def handle_put_llm_section(request: web.Request) -> web.Response:
         return web.json_response({"role": role, "section": None})
 
     if not isinstance(section, dict):
-        return web.json_response(
-            {"error": "'section' must be a JSON object or null"}, status=400
-        )
-    return await _write_role_section(
-        request, role, section, validate=bool(body.get("validate", True))
-    )
+        return web.json_response({"error": "'section' must be a JSON object or null"}, status=400)
+    return await _write_role_section(request, role, section, validate=bool(body.get("validate", True)))
 
 
 # ---------------------------------------------------------------------------
@@ -1312,9 +1285,7 @@ async def handle_put_provider_library(request: web.Request) -> web.Response:
         return web.json_response({"name": name, "section": None})
 
     if not isinstance(section, dict):
-        return web.json_response(
-            {"error": "'section' must be a JSON object or null"}, status=400
-        )
+        return web.json_response({"error": "'section' must be a JSON object or null"}, status=400)
     if not str(section.get("model") or "").strip():
         return web.json_response({"error": "'model' is required"}, status=400)
 
@@ -1351,12 +1322,8 @@ async def handle_apply_provider_library(request: web.Request) -> web.Response:
     name = str(body.get("name") or "").strip()
     section = _get_provider_library().get(name)
     if section is None:
-        return web.json_response(
-            {"error": f"No provider library entry named '{name}'"}, status=404
-        )
-    return await _write_role_section(
-        request, role, section, validate=bool(body.get("validate", True))
-    )
+        return web.json_response({"error": f"No provider library entry named '{name}'"}, status=404)
+    return await _write_role_section(request, role, section, validate=bool(body.get("validate", True)))
 
 
 # ---------------------------------------------------------------------------
@@ -1378,9 +1345,7 @@ def _resolve_external_skills(paths: list) -> list[dict]:
             ext = Path(os.path.expandvars(str(raw))).expanduser()
             entry["resolved"] = str(ext)
             entry["exists"] = ext.is_dir()
-            entry["skills"] = (
-                len(d._scan_scope(ext, "user")) if ext.is_dir() else 0
-            )
+            entry["skills"] = len(d._scan_scope(ext, "user")) if ext.is_dir() else 0
         except Exception as exc:
             entry["exists"] = False
             entry["skills"] = 0
@@ -1394,16 +1359,17 @@ def _resolve_external_skills(paths: list) -> list[dict]:
 # AND contain at least one parseable skill are surfaced. ~/.agents/skills
 # is absent on purpose — Hive scans it natively already.
 _KNOWN_AGENT_SKILL_DIRS = (
-    "~/.claude/skills",     # Claude Code
-    "~/.codex/skills",      # OpenAI Codex CLI
-    "~/.cursor/skills",     # Cursor
-    "~/.openclaw/skills",   # OpenClaw
-    "~/.gemini/skills",     # Gemini CLI
+    "~/.claude/skills",  # Claude Code
+    "~/.codex/skills",  # OpenAI Codex CLI
+    "~/.cursor/skills",  # Cursor
+    "~/.openclaw/skills",  # OpenClaw
+    "~/.gemini/skills",  # Gemini CLI
 )
 
 
 def _suggest_external_skills(configured: list[str]) -> list[dict]:
     """Probe known agent skill dirs not yet configured; keep real finds only."""
+
     def _norm(raw: str) -> str:
         try:
             return str(Path(os.path.expandvars(raw)).expanduser().resolve())
@@ -1430,9 +1396,7 @@ async def handle_get_external_skills(request: web.Request) -> web.Response:
     # parses (up to ~10 roots including the auto-discovery probes).
     resolved = await asyncio.to_thread(_resolve_external_skills, paths)
     suggestions = await asyncio.to_thread(_suggest_external_skills, paths)
-    return web.json_response(
-        {"paths": paths, "resolved": resolved, "suggestions": suggestions}
-    )
+    return web.json_response({"paths": paths, "resolved": resolved, "suggestions": suggestions})
 
 
 async def handle_put_external_skills(request: web.Request) -> web.Response:
@@ -1447,9 +1411,7 @@ async def handle_put_external_skills(request: web.Request) -> web.Response:
         return web.json_response({"error": "Invalid JSON body"}, status=400)
     paths = body.get("paths")
     if not isinstance(paths, list) or not all(isinstance(x, str) for x in paths):
-        return web.json_response(
-            {"error": "'paths' must be a list of strings"}, status=400
-        )
+        return web.json_response({"error": "'paths' must be a list of strings"}, status=400)
     paths = [x.strip() for x in paths if x.strip()]
     config = get_hive_config()
     if paths:

--- a/core/framework/server/routes_execution.py
+++ b/core/framework/server/routes_execution.py
@@ -356,7 +356,11 @@ async def handle_chat(request: web.Request) -> web.Response:
                 # 1000-page PDF is still megabytes of text otherwise).
                 _pdf_bytes = raw_bytes
 
-                def _inspect_pdf() -> tuple[int, list[str]]:
+                def _inspect_pdf(
+                    _pdf_bytes=_pdf_bytes,
+                    pdf_filepath=pdf_filepath,
+                    is_large=is_large,
+                ) -> tuple[int, list[str]]:
                     page_count = 0
                     parts: list[str] = []
                     try:
@@ -470,7 +474,11 @@ async def handle_chat(request: web.Request) -> web.Response:
                 # 100 MB CSV is seconds of loop-stalling work otherwise.
                 _csv_bytes = raw_bytes
 
-                def _parse_csv() -> tuple[int, str | None]:
+                def _parse_csv(
+                    _csv_bytes=_csv_bytes,
+                    csv_filepath=csv_filepath,
+                    csv_filename=csv_filename,
+                ) -> tuple[int, str | None]:
                     row_count = 0
                     text_part: str | None = None
                     try:
@@ -538,7 +546,11 @@ async def handle_chat(request: web.Request) -> web.Response:
                 is_large = attachment_size > LARGE_TEXT_THRESHOLD_BYTES
                 _text_bytes = raw_bytes
 
-                def _read_text_attachment() -> tuple[str, int]:
+                def _read_text_attachment(
+                    _text_bytes=_text_bytes,
+                    is_large=is_large,
+                    text_filepath=text_filepath,
+                ) -> tuple[str, int]:
                     if _text_bytes is not None:
                         t = _text_bytes.decode("utf-8", errors="replace")
                         return t, (t.count("\n") + 1 if t else 0)
@@ -629,7 +641,7 @@ async def handle_chat(request: web.Request) -> web.Response:
 
                     _img_bytes = raw_bytes
 
-                    def _probe_dims() -> str:
+                    def _probe_dims(_img_bytes=_img_bytes) -> str:
                         with Image.open(io.BytesIO(_img_bytes)) as im:
                             return f"{im.size[0]}×{im.size[1]}, "
 

--- a/core/framework/server/routes_queens.py
+++ b/core/framework/server/routes_queens.py
@@ -146,9 +146,7 @@ async def handle_create_queen(request: web.Request) -> web.Response:
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
     except FileExistsError as e:
-        return web.json_response(
-            {"error": f"queen id already exists: {e}"}, status=409
-        )
+        return web.json_response({"error": f"queen id already exists: {e}"}, status=409)
     schedule_push()
     return web.json_response({"queen": entry}, status=201)
 

--- a/core/framework/server/routes_sessions.py
+++ b/core/framework/server/routes_sessions.py
@@ -2176,9 +2176,7 @@ async def handle_session_history(request: web.Request) -> web.Response:
     # conversation part of any summary-stale session and rewrites its
     # summary.json — hundreds of ms to seconds of disk+CPU that used to
     # stall every SSE stream on each sidebar refresh.
-    disk_sessions = await asyncio.get_running_loop().run_in_executor(
-        _history_read_executor(), SessionManager.list_cold_sessions
-    )
+    disk_sessions = await asyncio.get_running_loop().run_in_executor(_history_read_executor(), SessionManager.list_cold_sessions)
     for s in disk_sessions:
         if s["session_id"] in live_sessions:
             live = live_sessions[s["session_id"]]
@@ -2229,9 +2227,7 @@ async def handle_list_colony_sessions(request: web.Request) -> web.Response:
 
     # Off-loop for the same reason as handle_session_history: summary
     # rebuilds parse every part file of stale sessions.
-    sessions = await asyncio.get_running_loop().run_in_executor(
-        _history_read_executor(), SessionManager.list_colony_sessions, colony_id
-    )
+    sessions = await asyncio.get_running_loop().run_in_executor(_history_read_executor(), SessionManager.list_colony_sessions, colony_id)
     for s in sessions:
         sid = s.get("session_id")
         if sid in live_sessions:

--- a/core/framework/server/session_manager.py
+++ b/core/framework/server/session_manager.py
@@ -22,8 +22,8 @@ from typing import Any, Literal
 
 from framework.config import COLONIES_DIR, QUEENS_DIR
 from framework.host.colony_binding import ColonyBinding
-from framework.server import boot_status
 from framework.host.triggers import TriggerDefinition
+from framework.server import boot_status
 from framework.utils.text import humanize_slug
 
 logger = logging.getLogger(__name__)

--- a/core/framework/server/tests/test_optional_crm_imports.py
+++ b/core/framework/server/tests/test_optional_crm_imports.py
@@ -47,9 +47,7 @@ def _try_ranges(tree: ast.AST):
     for node in ast.walk(tree):
         if isinstance(node, ast.Try):
             body_start = node.body[0].lineno
-            body_end = max(
-                getattr(stmt, "end_lineno", stmt.lineno) for stmt in node.body
-            )
+            body_end = max(getattr(stmt, "end_lineno", stmt.lineno) for stmt in node.body)
             yield node, body_start, body_end
 
 
@@ -65,16 +63,12 @@ def test_framework_crm_imports_are_guarded():
             # handlers), and near the top of that body — a try that does a
             # page of unrelated work before/after the import is the swallowed
             # -context bug this file exists to prevent.
-            directly_guarded = any(
-                body_start <= imp.lineno <= body_end and imp.lineno - body_start <= 2
-                for _, body_start, body_end in tries
-            )
+            directly_guarded = any(body_start <= imp.lineno <= body_end and imp.lineno - body_start <= 2 for _, body_start, body_end in tries)
             if not directly_guarded:
                 rel = path.relative_to(FRAMEWORK_ROOT)
                 offenders.append(f"{rel}:{imp.lineno}")
     assert not offenders, (
         "framework.crm is optional (desktop-only); these imports are not "
         "directly wrapped in their own try block and will either crash or — "
-        "worse — silently abort unrelated work in an outer try:\n  "
-        + "\n  ".join(offenders)
+        "worse — silently abort unrelated work in an outer try:\n  " + "\n  ".join(offenders)
     )

--- a/core/tests/test_llm_judge.py
+++ b/core/tests/test_llm_judge.py
@@ -12,8 +12,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from framework.llm.provider import LLMProvider, LLMResponse
 from framework.config import get_aux_max_tokens
+from framework.llm.provider import LLMProvider, LLMResponse
 from framework.testing.llm_judge import LLMJudge
 
 # ============================================================================

--- a/core/tests/test_routes_provider_library.py
+++ b/core/tests/test_routes_provider_library.py
@@ -94,9 +94,7 @@ async def test_get_library_empty(make_client) -> None:
 
 async def test_put_saves_entry_verbatim(make_client, _isolated_config: Path) -> None:
     client = await make_client()
-    resp = await client.put(
-        "/api/config/provider-library", json={"name": "ds-prod", "section": ENTRY}
-    )
+    resp = await client.put("/api/config/provider-library", json={"name": "ds-prod", "section": ENTRY})
     assert resp.status == 200
     assert (await resp.json())["section"] == ENTRY
 
@@ -119,15 +117,11 @@ async def test_put_validation(make_client) -> None:
     )
     assert resp.status == 400
     # Non-object section.
-    resp = await client.put(
-        "/api/config/provider-library", json={"name": "x", "section": [1]}
-    )
+    resp = await client.put("/api/config/provider-library", json={"name": "x", "section": [1]})
     assert resp.status == 400
 
 
-async def test_put_null_deletes_and_prunes_empty_library(
-    make_client, _isolated_config: Path
-) -> None:
+async def test_put_null_deletes_and_prunes_empty_library(make_client, _isolated_config: Path) -> None:
     client = await make_client()
     await client.put("/api/config/provider-library", json={"name": "a", "section": ENTRY})
     resp = await client.put("/api/config/provider-library", json={"name": "a", "section": None})
@@ -149,9 +143,7 @@ async def test_put_null_deletes_and_prunes_empty_library(
 async def test_apply_to_worker_slot(make_client, _isolated_config: Path) -> None:
     client = await make_client()
     await client.put("/api/config/provider-library", json={"name": "ds", "section": ENTRY})
-    resp = await client.post(
-        "/api/config/provider-library/apply", json={"name": "ds", "role": "worker_llm"}
-    )
+    resp = await client.post("/api/config/provider-library/apply", json={"name": "ds", "role": "worker_llm"})
     assert resp.status == 200
     body = await resp.json()
     assert body["role"] == "worker_llm"
@@ -172,9 +164,7 @@ async def test_apply_to_llm_slot_hot_swaps_sessions(make_client) -> None:
     manager = _StubManager([SimpleNamespace(llm=provider, colony=None)])
     client = await make_client(manager)
     await client.put("/api/config/provider-library", json={"name": "ds", "section": ENTRY})
-    resp = await client.post(
-        "/api/config/provider-library/apply", json={"name": "ds", "role": "llm"}
-    )
+    resp = await client.post("/api/config/provider-library/apply", json={"name": "ds", "role": "llm"})
     assert resp.status == 200
     assert (await resp.json())["sessions_swapped"] == 1
     assert provider.reconfigured_with == ("deepseek/deepseek-chat", "sk-test-1234", None)
@@ -183,20 +173,14 @@ async def test_apply_to_llm_slot_hot_swaps_sessions(make_client) -> None:
 
 async def test_apply_unknown_name_and_role(make_client) -> None:
     client = await make_client()
-    resp = await client.post(
-        "/api/config/provider-library/apply", json={"name": "nope", "role": "llm"}
-    )
+    resp = await client.post("/api/config/provider-library/apply", json={"name": "nope", "role": "llm"})
     assert resp.status == 404
     await client.put("/api/config/provider-library", json={"name": "ds", "section": ENTRY})
-    resp = await client.post(
-        "/api/config/provider-library/apply", json={"name": "ds", "role": "bogus"}
-    )
+    resp = await client.post("/api/config/provider-library/apply", json={"name": "ds", "role": "bogus"})
     assert resp.status == 400
 
 
-async def test_apply_health_checks_key_against_base(
-    make_client, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_apply_health_checks_key_against_base(make_client, monkeypatch: pytest.MonkeyPatch) -> None:
     """An entry with api_key + api_base runs the same health check as the
     slot editor; a failing check must not touch the slot."""
     calls: list[tuple] = []
@@ -213,9 +197,7 @@ async def test_apply_health_checks_key_against_base(
     assert resp.status == 200
     assert calls == []
 
-    resp = await client.post(
-        "/api/config/provider-library/apply", json={"name": "ds", "role": "worker_llm"}
-    )
+    resp = await client.post("/api/config/provider-library/apply", json={"name": "ds", "role": "worker_llm"})
     assert resp.status == 400
     assert calls == [("deepseek", "sk-test-1234", "https://ds.example.com/v1", "deepseek-chat")]
     resp = await client.get("/api/config/llm-sections")

--- a/tools/src/aden_tools/file_ops.py
+++ b/tools/src/aden_tools/file_ops.py
@@ -1447,10 +1447,7 @@ def register_file_tools(
             # actually look at. Say so, or an agent that reads a screenshot
             # here concludes it has no way to see the file at all.
             if os.path.splitext(resolved)[1].lower() in _VIEWABLE_BINARY_EXT:
-                return (
-                    f"Binary file: {path} ({size:,} bytes). Not displayable as text — "
-                    f'view it with attach_file(paths="{path}").'
-                )
+                return f'Binary file: {path} ({size:,} bytes). Not displayable as text — view it with attach_file(paths="{path}").'
             return f"Binary file: {path} ({size:,} bytes). Cannot display binary content."
 
         try:


### PR DESCRIPTION
Closes #7429

## Summary
- Bind loop-captured variables as closure default arguments (B023) in routes_execution.py
- Remove unused HIVE_HOME import (F401) in routes_config.py
- Replace aliased asyncio.TimeoutError with builtin (UP041) in agent_loop.py
- Sort import blocks (I001) across 5 files
- Apply ruff format to 13 files for consistent styling

## Verification
All four CI lint steps now pass:
- ruff check core/ passed
- ruff check tools/ passed
- ruff format --check core/ passed
- ruff format --check tools/ passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when processing attachments asynchronously, including PDFs, CSVs, text files, and images.

- **Refactor**
  - Standardized code formatting and import organization across the application.
  - Cleaned up unused configuration imports.

- **Tests**
  - Reformatted test code and assertions without changing coverage or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->